### PR TITLE
Fix #522, #702: use managed write transactions in AWS ECR and IAM

### DIFF
--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -89,8 +89,10 @@ def transform_ecr_repository_images(repo_data: Dict) -> List[Dict]:
     return repo_images_list
 
 
-def _load_ecr_repo_img_tx(tx: neo4j.Transaction, repo_images_list: List[Dict], aws_update_tag: int,
-                          region: str) -> None:
+def _load_ecr_repo_img_tx(
+    tx: neo4j.Transaction, repo_images_list: List[Dict], aws_update_tag: int,
+    region: str,
+) -> None:
     query = """
     UNWIND {RepoList} as repo_img
         MERGE (ri:ECRRepositoryImage{id: repo_img.repo_uri + COALESCE(":" + repo_img.imageTag, '')})
@@ -121,8 +123,10 @@ def _load_ecr_repo_img_tx(tx: neo4j.Transaction, repo_images_list: List[Dict], a
 
 
 @timeit
-def load_ecr_repository_images(neo4j_session: neo4j.Session, repo_images_list: List[Dict], region: str,
-                               aws_update_tag: int) -> None:
+def load_ecr_repository_images(
+    neo4j_session: neo4j.Session, repo_images_list: List[Dict], region: str,
+    aws_update_tag: int,
+) -> None:
     logger.info(f"Loading {len(repo_images_list)} ECR repository images in {region} into graph.")
     neo4j_session.write_transaction(_load_ecr_repo_img_tx, repo_images_list, aws_update_tag, region)
 

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -493,8 +493,10 @@ def transform_policy_id(principal_arn: str, policy_type: str, name: str) -> str:
     return f"{principal_arn}/{policy_type}_policy/{name}"
 
 
-def _load_policy_tx(tx: neo4j.Transaction, policy_id:str, policy_name: str, policy_type: str, principal_arn: str,
-                    aws_update_tag: int) -> None:
+def _load_policy_tx(
+    tx: neo4j.Transaction, policy_id: str, policy_name: str, policy_type: str, principal_arn: str,
+    aws_update_tag: int,
+) -> None:
     ingest_policy = """
     MERGE (policy:AWSPolicy{id: {PolicyId}})
     ON CREATE SET


### PR DESCRIPTION
Bandaid fix for #522 and #702: Uses neo4j managed write transaction function for automatic retries.