### PR TITLE
cartography 0.47.1; Use azure-cli-core>=2.26.0 to fix pyjwt dependency problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.48.0'
+__version__ = '0.47.1'
 
 
 setup(


### PR DESCRIPTION
- cartography used azure-cli-core>=2.12.0
- azure-cli-core<2.26.0 was [pinned to PyJWT 1.7.1](https://github.com/Azure/azure-cli/commit/3b17a5fb2fd9eb3c35c83cc94245c11d268e7323#diff-37e5a736993fcaf4777f4364e5ac8788749b56f7b28e64bd7ee9f1d4b3e6eb22).
- Most other libraries that use PyJWT now require version 2.0+.
- This created an impossible to resolve dependency issue where cartography users were unable to use these libraries together in the same environment with cartography.

This PR
- updates cartography from azure-cli-core>=2.12.0 to >=2.26.0 to fix this dependency problem.
- bumps cartography's version to 0.47.1 so others may consume this patch.

Other links
- https://github.com/Azure/azure-cli/pull/18506
- https://github.com/PyGithub/PyGithub/pull/1891
- https://github.com/PyGithub/PyGithub/issues/1832
