### PR TITLE
Fix EBS cleanup job typo

### DIFF
--- a/cartography/data/jobs/cleanup/aws_import_ec2_instances_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_import_ec2_instances_cleanup.json
@@ -50,17 +50,17 @@
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(n:EBSVolume)-[:ATTACHED_TO]->(:EC2Instance) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "query": "MATCH (:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(n:EBSVolume)-[:ATTACHED_TO_EC2_INSTANCE]->(:EC2Instance) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(:EBSVolume)-[r:ATTACHED_TO]->(:EC2Instance) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "query": "MATCH (:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(:EBSVolume)-[r:ATTACHED_TO_EC2_INSTANCE]->(:EC2Instance) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:AWSAccount{id: $AWS_ID})-[r:RESOURCE]->(:EBSVolume)-[:ATTACHED_TO]->(:EC2Instance) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "query": "MATCH (:AWSAccount{id: $AWS_ID})-[r:RESOURCE]->(:EBSVolume)-[:ATTACHED_TO_EC2_INSTANCE]->(:EC2Instance) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
       "iterative": true,
       "iterationsize": 100
     }],

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -973,7 +973,7 @@ Our representation of an AWS [EC2 Instance](https://docs.aws.amazon.com/AWSEC2/l
 - AWS EBS Volumes are attached to an EC2 Instance
 
         ```
-        (EBSVolume)-[ATTACHED_TO]->(EC2Instance)
+        (EBSVolume)-[ATTACHED_TO_EC2_INSTANCE]->(EC2Instance)
         ```
 
 -  EC2 Instances can assume IAM Roles.


### PR DESCRIPTION
Fix: changes EBS volume cleanup job from `ATTACHED_TO` => `ATTACHED_TO_EC2_INSTANCE`.

---

This is already annotated in docs here as `ATTACHED_TO_EC2_INSTANCE`: https://github.com/lyft/cartography/blob/master/docs/root/modules/aws/schema.md#relationships-69

and this is created in the code itself as `ATTACHED_TO_EC2_INSTANCE`: https://github.com/lyft/cartography/blob/2903dbe5693efe43dcd578397ef2d864571d5946/cartography/intel/aws/ec2/volumes.py#L82

So the cleanup job here is wrong.