### PR TITLE
AWSmappingfix-ELBv1&v2<--ENI

### DIFF
--- a/cartography/intel/aws/ec2/network_interfaces.py
+++ b/cartography/intel/aws/ec2/network_interfaces.py
@@ -54,11 +54,11 @@ def transform_network_interface_data(data_list: List[Dict[str, Any]], region: st
         elb_v2_id = None
         elb_match = re.match(r'^ELB (?:net|app)/([^\/]+)\/(.*)', network_interface.get('Description', ''))
         if elb_match:
-            elb_v1_id = f'{elb_match[1]}-{elb_match[2]}.elb.{region}.amazonaws.com'
+            elb_v2_id = elb_match[1]
         else:
             elb_match = re.match(r'^ELB (.*)', network_interface.get('Description', ''))
             if elb_match:
-                elb_v2_id = elb_match[1]
+                elb_v1_id = elb_match[1]
         # TODO issue #1024 change this to arn when ready
         network_interface_id = network_interface['NetworkInterfaceId']
         network_interface_list.append(
@@ -79,6 +79,7 @@ def transform_network_interface_data(data_list: List[Dict[str, Any]], region: st
                 'SubnetId': network_interface['SubnetId'],
                 'ElbV1Id': elb_v1_id,
                 'ElbV2Id': elb_v2_id,
+                'Region': region,
             },
         )
         if network_interface.get('PrivateIpAddresses'):

--- a/cartography/models/aws/ec2/networkinterfaces.py
+++ b/cartography/models/aws/ec2/networkinterfaces.py
@@ -63,7 +63,7 @@ class EC2NetworkInterfaceToElbV2RelProperties(CartographyRelProperties):
 class EC2NetworkInterfaceToElbV2(CartographyRelSchema):
     target_node_label: str = 'LoadBalancerV2'
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {'id': PropertyRef('ElbV2Id')},
+        {'name': PropertyRef('ElbV2Id'), 'region': PropertyRef('Region')},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "NETWORK_INTERFACE"


### PR DESCRIPTION
Some testing lead me to find that the mapping between Loadbalancer V1 and V2 was not happening correctly and in response to that, I delved into the code for the mapping. 


1. The regex used to distinguish between V1 and V2 had the variable assignment inverted ie v1's were getting assigned to elbv2_id attribute and vice versa 

2. Creating a dynamic dnsname and then matching for LoadbalancerV2 was problematic as well since the dynamically created names were always partial matches for the dnsname. The elb_match[2] attribute was never right to match to the correct node. (the regex returns the id of the loadbalancer while the dnsname always has a different value)

created using carto -> elb_match[1]-elb_match[2].elb.region.amazonaws.com
actual dnsname -> elb_match[1]-elb_match[2]-9574787.region.elb.amazonaws.com

Fix -> 

1. Swapping about the variables lead to successful mapping between LBv1 and the Network interfaces 

2. For LBV2, rather than create a dns name, I suggest using a combination of name and region for the loadbalancerv2 as the combination needs to be unique across the AWS account. 