### PR TITLE
Fix Semgrep schema doc

### DIFF
--- a/docs/root/modules/semgrep/schema.md
+++ b/docs/root/modules/semgrep/schema.md
@@ -142,4 +142,4 @@ See [SemgrepDependency](#semgrepdependency) for details.
 
     - specifier: A string describing the library version required by the repo (e.g. "==1.0.2")
     - transitivity: A string describing whether the dependency is direct or [transitive](https://en.wikipedia.org/wiki/Transitive_dependency) (e.g. direct, transitive)
-    - url: The URL where the dependency is defined (e.g. https://github.com/org/repo/blob/00000000000000000000000000000000/go.mod#L6)
+    - url: The URL where the dependency is defined (e.g. `https://github.com/org/repo/blob/00000000000000000000000000000000/go.mod#L6`)

--- a/docs/root/modules/semgrep/schema.md
+++ b/docs/root/modules/semgrep/schema.md
@@ -137,10 +137,9 @@ See [SemgrepDependency](#semgrepdependency) for details.
 - A SemgrepDependency is required by a GithubRepository (optional)
 
     ```
-    (:SemgrepDependency)<-[:REQUIRES]-(:GithubRepository)
+    (:SemgrepDependency)<-[:REQUIRES{specifier, transitivity, url}]-(:GithubRepository)
     ```
 
-   Properties on REQUIRES relationship:
     - specifier: A string describing the library version required by the repo (e.g. "==1.0.2")
     - transitivity: A string describing whether the dependency is direct or [transitive](https://en.wikipedia.org/wiki/Transitive_dependency) (e.g. direct, transitive)
     - url: The URL where the dependency is defined (e.g. https://github.com/org/repo/blob/00000000000000000000000000000000/go.mod#L6)


### PR DESCRIPTION
### Summary

Small followup to https://github.com/cartography-cncf/cartography/pull/1368, noticed that the schema doc is not being rendered correctly: 

![image](https://github.com/user-attachments/assets/e3f34e94-a7c0-4b39-b243-460fe39acb57)

I'm not sure how to test that it will render correctly after this change, but this format matches the existing format used by the github schema: 
https://github.com/cartography-cncf/cartography/blob/f11d7b2ff87331ed736a5de2547cde812face1a0/docs/root/modules/github/schema.md?plain=1#L210-L218 