### PR TITLE
Added in Identity Center Nodes + relationship mapping

### DIFF
--- a/cartography/intel/aws/identitycenter.py
+++ b/cartography/intel/aws/identitycenter.py
@@ -1,0 +1,371 @@
+import logging
+from typing import Dict
+from typing import List
+
+import boto3
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.models.aws.identitycenter.identitycenter import IdentityCenterInstanceSchema
+from cartography.models.aws.identitycenter.permissionsets import PermissionSetSchema
+from cartography.models.aws.identitycenter.ssouser import SSOUserSchema
+from cartography.util import aws_handle_regions
+from cartography.util import run_cleanup_job
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+@aws_handle_regions
+def get_identity_center_instances(boto3_session: boto3.session.Session, region: str) -> List[Dict]:
+    """
+    Get all AWS IAM Identity Center instances in the current region
+    """
+    client = boto3_session.client('sso-admin', region_name=region)
+    instances = []
+
+    try:
+        paginator = client.get_paginator('list_instances')
+        for page in paginator.paginate():
+            instances.extend(page.get('Instances', []))
+    except client.exceptions.ClientError as e:
+        logger.warning(f"Failed to get Identity Center instances in region {region}: {e}")
+        return []
+
+    return instances
+
+
+@timeit
+def load_identity_center_instances(
+    neo4j_session: neo4j.Session,
+    instance_data: List[Dict],
+    region: str,
+    current_aws_account_id: str,
+    aws_update_tag: int,
+) -> None:
+    """
+    Load Identity Center instances into the graph
+    """
+    logger.info(f"Loading {len(instance_data)} Identity Center instances for region {region}")
+    load(
+        neo4j_session,
+        IdentityCenterInstanceSchema(),
+        instance_data,
+        lastupdated=aws_update_tag,
+        Region=region,
+        AWS_ID=current_aws_account_id,
+    )
+
+
+@timeit
+def cleanup_identity_center_instances(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: Dict,
+) -> None:
+    """
+    Remove stale Identity Center instance nodes and relationships
+    """
+    run_cleanup_job(
+        'aws_import_identity_center_cleanup.json',
+        neo4j_session,
+        common_job_parameters,
+    )
+
+
+@timeit
+def get_permission_sets(boto3_session: boto3.session.Session, instance_arn: str, region: str) -> List[Dict]:
+    """
+    Get all permission sets for a given Identity Center instance
+    """
+    client = boto3_session.client('sso-admin', region_name=region)
+    permission_sets = []
+
+    try:
+        paginator = client.get_paginator('list_permission_sets')
+        for page in paginator.paginate(InstanceArn=instance_arn):
+            # Get detailed info for each permission set
+            for arn in page.get('PermissionSets', []):
+                try:
+                    details = client.describe_permission_set(
+                        InstanceArn=instance_arn,
+                        PermissionSetArn=arn,
+                    )
+                    permission_sets.append(details.get('PermissionSet', {}))
+                except client.exceptions.ClientError as e:
+                    logger.warning(f"Failed to get details for permission set {arn}: {e}")
+    except client.exceptions.ClientError as e:
+        logger.warning(f"Failed to get permission sets for instance {instance_arn} in region {region}: {e}")
+        return []
+
+    return permission_sets
+
+
+@timeit
+def get_permission_set_roles(
+    boto3_session: boto3.session.Session,
+    instance_arn: str,
+    permission_set_arn: str,
+    region: str,
+) -> List[Dict]:
+    """
+    Get all accounts associated with a given permission set
+    """
+    client = boto3_session.client('sso-admin', region_name=region)
+    accounts = []
+
+    try:
+        paginator = client.get_paginator('list_accounts_for_provisioned_permission_set')
+        for page in paginator.paginate(InstanceArn=instance_arn, PermissionSetArn=permission_set_arn):
+            accounts.extend(page.get('AccountIds', []))
+    except client.exceptions.ClientError as e:
+        logger.warning(f"Failed to get roles for permission set {permission_set_arn}: {e}")
+        return []
+
+    return accounts
+
+
+@timeit
+def load_permission_sets(
+    neo4j_session: neo4j.Session,
+    permission_sets: List[Dict],
+    instance_arn: str,
+    region: str,
+    aws_update_tag: int,
+) -> None:
+    """
+    Load Identity Center permission sets into the graph
+    """
+    logger.info(f"Loading {len(permission_sets)} permission sets for instance {instance_arn} in region {region}")
+
+    load(
+        neo4j_session,
+        PermissionSetSchema(),
+        permission_sets,
+        lastupdated=aws_update_tag,
+        InstanceArn=instance_arn,
+        Region=region,
+    )
+
+
+@timeit
+def get_permission_set_role_assignments(
+    boto3_session: boto3.session.Session,
+    instance_arn: str,
+    permission_sets: List[Dict],
+    region: str,
+) -> List[Dict]:
+    """
+    Get role assignments for Identity Center permission sets
+    """
+    role_assignments = []
+    for ps in permission_sets:
+        permission_set_arn = str(ps.get('PermissionSetArn'))
+        accounts = get_permission_set_roles(boto3_session, instance_arn, permission_set_arn, region)
+        for account_id in accounts:
+            arn = f"arn:aws:iam::{account_id}:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_{ps.get('Name')}"
+            role_assignments.append({
+                'PermissionSetArn': ps.get('PermissionSetArn'),
+                'RoleArn': arn,
+            })
+    return role_assignments
+
+
+@timeit
+def load_permission_set_role_assignments(
+    neo4j_session: neo4j.Session,
+    role_assignments: List[Dict],
+    aws_update_tag: int,
+) -> None:
+    """
+    Load Identity Center permission set role assignments into the graph
+    """
+    logger.info(f"Loading {len(role_assignments)} permission set role assignments")
+
+    neo4j_session.run(
+        """
+        UNWIND $role_assignments AS ra
+        MATCH (ps:AWSPermissionSet {arn: ra.PermissionSetArn})
+        MATCH (role:AWSRole)
+        WHERE role.arn STARTS WITH ra.RoleArn
+        MERGE (ps)-[r:ASSIGNED_TO_ROLE]->(role)
+        SET r.lastupdated = $aws_update_tag
+        """,
+        role_assignments=role_assignments,
+        aws_update_tag=aws_update_tag,
+    )
+
+
+@timeit
+def get_sso_users(boto3_session: boto3.session.Session, identity_store_id: str, region: str) -> List[Dict]:
+    """
+    Get all SSO users for a given Identity Store
+    """
+    client = boto3_session.client('identitystore', region_name=region)
+    users = []
+
+    try:
+        paginator = client.get_paginator('list_users')
+        for page in paginator.paginate(IdentityStoreId=identity_store_id):
+            user_page = page.get('Users', [])
+            for user in user_page:
+                if user.get('ExternalIds', None):
+                    user['ExternalId'] = user.get('ExternalIds')[0].get('Id')
+                users.append(user)
+    except client.exceptions.ClientError as e:
+        logger.warning(f"Failed to get SSO users for identity store {identity_store_id} in region {region}: {e}")
+        return []
+
+    return users
+
+
+@timeit
+def load_sso_users(
+    neo4j_session: neo4j.Session,
+    users: List[Dict],
+    identity_store_id: str,
+    region: str,
+    aws_update_tag: int,
+) -> None:
+    """
+    Load SSO users into the graph
+    """
+    logger.info(f"Loading {len(users)} SSO users for identity store {identity_store_id} in region {region}")
+
+    load(
+        neo4j_session,
+        SSOUserSchema(),
+        users,
+        lastupdated=aws_update_tag,
+        IdentityStoreId=identity_store_id,
+        Region=region,
+    )
+
+
+@timeit
+def get_role_assignments(
+    boto3_session: boto3.session.Session,
+    users: List[Dict],
+    instance_arn: str,
+    region: str,
+) -> List[Dict]:
+    """
+    Get role assignments for SSO users
+    """
+
+    logger.info(f"Getting role assignments for {len(users)} users")
+    client = boto3_session.client('sso-admin', region_name=region)
+    role_assignments = []
+
+    for user in users:
+        user_id = user['UserId']
+        try:
+            paginator = client.get_paginator('list_account_assignments_for_principal')
+            for page in paginator.paginate(InstanceArn=instance_arn, PrincipalId=user_id, PrincipalType='USER'):
+                for assignment in page.get('AccountAssignments', []):
+                    role_assignments.append({
+                        'UserId': user_id,
+                        'PermissionSetArn': assignment.get('PermissionSetArn'),
+                        'AccountId': assignment.get('AccountId'),
+                    })
+        except client.exceptions.ClientError as e:
+            logger.warning(f"Failed to get account assignments for user {user_id}: {e}")
+
+    return role_assignments
+
+
+@timeit
+def load_role_assignments(
+    neo4j_session: neo4j.Session,
+    role_assignments: List[Dict],
+    aws_update_tag: int,
+) -> None:
+    """
+    Load role assignments into the graph
+    """
+    logger.info(f"Loading {len(role_assignments)} role assignments")
+    if role_assignments:
+        neo4j_session.run(
+            """
+            UNWIND $role_assignments AS ra
+            MATCH (acc:AWSAccount{id:ra.AccountId}) -[:RESOURCE]->
+            (role:AWSRole)<-[:ASSIGNED_TO_ROLE]-
+            (permset:AWSPermissionSet {id: ra.PermissionSetArn})
+            MATCH (sso:AWSSSOUser {id: ra.UserId})
+            MERGE (role)-[r:ALLOWED_BY]->(sso)
+            SET r.lastupdated = $aws_update_tag,
+            r.permission_set_arn = ra.PermissionSetArn
+            """,
+            role_assignments=role_assignments,
+            aws_update_tag=aws_update_tag,
+        )
+
+
+def sync_identity_center_instances(
+    neo4j_session: neo4j.Session,
+    boto3_session: boto3.session.Session,
+    regions: List[str],
+    current_aws_account_id: str,
+    update_tag: int,
+    common_job_parameters: Dict,
+) -> None:
+    """
+    Sync Identity Center instances, their permission sets, and SSO users
+    """
+    logger.info(f"Syncing Identity Center instances for regions {regions}")
+    for region in regions:
+        logger.info(f"Syncing Identity Center instances for region {region}")
+        instances = get_identity_center_instances(boto3_session, region)
+        load_identity_center_instances(
+            neo4j_session,
+            instances,
+            region,
+            current_aws_account_id,
+            update_tag,
+        )
+
+        # For each instance, get and load its permission sets and SSO users
+        for instance in instances:
+            instance_arn = instance['InstanceArn']
+            identity_store_id = instance['IdentityStoreId']
+
+            permission_sets = get_permission_sets(boto3_session, instance_arn, region)
+            load_permission_sets(
+                neo4j_session,
+                permission_sets,
+                instance_arn,
+                region,
+                update_tag,
+            )
+
+            permission_set_assignments = get_permission_set_role_assignments(
+                boto3_session,
+                instance_arn,
+                permission_sets,
+                region,
+            )
+            load_permission_set_role_assignments(neo4j_session, permission_set_assignments, update_tag)
+
+            users = get_sso_users(boto3_session, identity_store_id, region)
+            load_sso_users(
+                neo4j_session,
+                users,
+                identity_store_id,
+                region,
+                update_tag,
+            )
+
+            # Get and load role assignments
+            role_assignments = get_role_assignments(
+                boto3_session,
+                users,
+                instance_arn,
+                region,
+            )
+            load_role_assignments(
+                neo4j_session,
+                role_assignments,
+                update_tag,
+            )
+
+    cleanup_identity_center_instances(neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/resources.py
+++ b/cartography/intel/aws/resources.py
@@ -10,6 +10,7 @@ from . import elasticache
 from . import elasticsearch
 from . import emr
 from . import iam
+from . import identitycenter
 from . import inspector
 from . import kms
 from . import lambda_function
@@ -86,4 +87,5 @@ RESOURCE_FUNCTIONS: Dict = {
     'ssm': ssm.sync,
     'inspector': inspector.sync,
     'config': config.sync,
+    'identitycenter': identitycenter.sync_identity_center_instances,
 }

--- a/cartography/models/aws/identitycenter/identitycenter.py
+++ b/cartography/models/aws/identitycenter/identitycenter.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class IdentityCenterInstanceProperties(CartographyNodeProperties):
+    identity_store_id: PropertyRef = PropertyRef('IdentityStoreId')
+    arn: PropertyRef = PropertyRef('InstanceArn')
+    created_date: PropertyRef = PropertyRef('CreatedDate')
+    id: PropertyRef = PropertyRef('InstanceArn')
+    status: PropertyRef = PropertyRef('Status')
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class IdentiyCenterToAwsAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:IdentiyCenter)<-[:RESOURCE]-(:AWSAccount)
+class IdentiyCenterToAWSAccount(CartographyRelSchema):
+    target_node_label: str = 'AWSAccount'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('AWS_ID', set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: IdentiyCenterToAwsAccountRelProperties = IdentiyCenterToAwsAccountRelProperties()
+
+
+@dataclass(frozen=True)
+class IdentityCenterInstanceSchema(CartographyNodeSchema):
+    label: str = 'AWSIdentityCenter'
+    properties: IdentityCenterInstanceProperties = IdentityCenterInstanceProperties()
+    sub_resource_relationship: IdentiyCenterToAWSAccount = IdentiyCenterToAWSAccount()

--- a/cartography/models/aws/identitycenter/permissionsets.py
+++ b/cartography/models/aws/identitycenter/permissionsets.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class PermissionSetProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef('PermissionSetArn')
+    name: PropertyRef = PropertyRef('Name')
+    arn: PropertyRef = PropertyRef('PermissionSetArn')
+    description: PropertyRef = PropertyRef('Description')
+    session_duration: PropertyRef = PropertyRef('SessionDuration')
+    instance_arn: PropertyRef = PropertyRef('InstanceArn', set_in_kwargs=True)
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class PermissionSetToInstanceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class PermissionSetToInstance(CartographyRelSchema):
+    target_node_label: str = 'AWSIdentityCenter'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'arn': PropertyRef('InstanceArn', set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_PERMISSION_SET"
+    properties: PermissionSetToInstanceRelProperties = PermissionSetToInstanceRelProperties()
+
+
+@dataclass(frozen=True)
+class PermissionSetSchema(CartographyNodeSchema):
+    label: str = 'AWSPermissionSet'
+    properties: PermissionSetProperties = PermissionSetProperties()
+    sub_resource_relationship: PermissionSetToInstance = PermissionSetToInstance()

--- a/cartography/models/aws/identitycenter/ssouser.py
+++ b/cartography/models/aws/identitycenter/ssouser.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class SSOUserProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef('UserId', extra_index=True)
+    user_name: PropertyRef = PropertyRef('UserName')
+    identity_store_id: PropertyRef = PropertyRef('IdentityStoreId')
+    external_id: PropertyRef = PropertyRef('ExternalId', extra_index=True)
+    region: PropertyRef = PropertyRef('Region')
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class SSOUserToOktaUserRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class SSOUserToOktaUser(CartographyRelSchema):
+    target_node_label: str = 'OktaUser'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('ExternalId')},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "CAN_ASSUME_IDENTITY"
+    properties: SSOUserToOktaUserRelProperties = SSOUserToOktaUserRelProperties()
+
+
+@dataclass(frozen=True)
+class SSOUserSchema(CartographyNodeSchema):
+    label: str = 'AWSSSOUser'
+    properties: SSOUserProperties = SSOUserProperties()
+    # role_relationship: SSOUserToRole = SSOUserToRole()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            SSOUserToOktaUser(),
+        ],
+    )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -3297,3 +3297,89 @@ Representation of an AWS SSM [PatchComplianceData](https://docs.aws.amazon.com/s
         ```
         (EC2Instance)-[HAS_INFORMATION]->(SSMInstancePatch)
         ```
+
+### AWSIdentityCenter
+
+Representation of an AWS Identity Center.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Unique identifier for the Identity Center instance |
+| firstseen | Timestamp of when a sync job first discovered this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| identity_store_id | The identity store ID of the Identity Center instance |
+| instance_status | The status of the Identity Center instance |
+| created_date | The date the Identity Center instance was created |
+| last_modified_date | The date the Identity Center instance was last modified |
+
+#### Relationships
+- AWSIdentityCenter is part of an AWSAccount.
+
+    ```
+    (AWSAccount)-[RESOURCE]->(AWSIdentityCenter)
+    ```
+
+- AWSIdentityCenter has permission sets.
+
+    ```
+    (AWSIdentityCenter)-[HAS_PERMISSION_SET]->(AWSPermissionSet)
+    ```
+
+### AWSSSOUser
+
+Representation of an AWS SSO User.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Unique identifier for the SSO user |
+| firstseen | Timestamp of when a sync job first discovered this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| user_name | The username of the SSO user |
+| external_id | The external ID of the SSO user |
+| identity_store_id | The identity store ID of the SSO user |
+
+#### Relationships
+- AWSSSOUser is part of an AWSAccount.
+
+    ```
+    (AWSAccount)-[RESOURCE]->(AWSSSOUser)
+    ```
+
+- AWSSSOUser can have roles assigned.
+
+    ```
+    (AWSSSOUser)<-[ALLOWED_BY]-(AWSRole)
+    ```
+- OktaUser can be assumed by AWSSSOUser.
+
+    ```
+    (OktaUser)<-[CAN_ASSUME_IDENTITY]-(AWSSSOUser)
+    ```
+
+### AWSPermissionSet
+
+Representation of an AWS Identity Center Permission Set.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Unique identifier for the Permission Set |
+
+| name | The name of the Permission Set |
+| arn | The Amazon Resource Name (ARN) of the Permission Set |
+| description | The description of the Permission Set |
+| session_duration | The session duration of the Permission Set |
+| instance_arn | The ARN of the Identity Center instance the Permission Set belongs to |
+| firstseen | Timestamp of when a sync job first discovered this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+- AWSPermissionSet is part of an AWSIdentityCenter.
+
+    ```
+    (AWSIdentityCenter)<-[HAS_PERMISSION_SET]-(AWSPermissionSet)
+    ```
+- AWSPermissionSet can be assigned to roles.
+
+    ```
+    (AWSPermissionSet)-[ASSIGNED_TO_ROLE]->(AWSRole)
+    ```

--- a/tests/data/aws/identitycenter.py
+++ b/tests/data/aws/identitycenter.py
@@ -1,0 +1,53 @@
+LIST_USERS = [
+    {
+        "UserName": "nobody@nobody.com",
+        "UserId": "aaaaaaaa-a0d1-aaac-5af0-59c813ec7671",
+        "ExternalIds": [
+            {
+                    "Issuer": "https://scim.aws.com/1223122",
+                    "Id": "00aaaaabbbbb",
+            },
+        ],
+        "Name": {
+            "FamilyName": "Jones",
+            "GivenName": "Mr.",
+        },
+        "DisplayName": "Mr. Jones",
+        "NickName": "Jonsey",
+        "Emails": [
+            {
+                    "Value": "mr.jones@mycompany.com",
+                    "Type": "work",
+                    "Primary": True,
+            },
+        ],
+        "Addresses": [
+            {
+                "Country": "US",
+                "Primary": True,
+            },
+        ],
+        "Title": "Singer, On the Internet",
+        "IdentityStoreId": "d-12345",
+    },
+]
+
+LIST_INSTANCES = [
+    {
+        "InstanceArn": "arn:aws:sso:::instance/ssoins-12345678901234567",
+        "IdentityStoreId": "d-1234567890",
+        "InstanceStatus": "ACTIVE",
+        "CreatedDate": "2023-01-01T00:00:00Z",
+        "LastModifiedDate": "2023-01-01T00:00:00Z",
+    },
+]
+
+LIST_PERMISSION_SETS = [
+    {
+        "Name": "AdministratorAccess",
+        "PermissionSetArn": "arn:aws:sso:::permissionSet/ssoins-12345678901234567/ps-12345678901234567",
+        "Description": "Provides full access to AWS services and resources.",
+        "CreatedDate": "2023-01-01T00:00:00Z",
+        "SessionDuration": "PT12H",
+    },
+]

--- a/tests/integration/cartography/intel/aws/test_identitycenter.py
+++ b/tests/integration/cartography/intel/aws/test_identitycenter.py
@@ -1,0 +1,61 @@
+import tests.data.aws.identitycenter
+from cartography.intel.aws.identitycenter import load_identity_center_instances
+from cartography.intel.aws.identitycenter import load_permission_sets
+from cartography.intel.aws.identitycenter import load_sso_users
+from tests.integration.util import check_nodes
+
+TEST_ACCOUNT_ID = '1234567890'
+
+
+def test_load_sso_users(neo4j_session):
+    """Test loading SSO users into Neo4j."""
+    # Use predefined data from tests.data.aws.identitycenter
+    users = tests.data.aws.identitycenter.LIST_USERS
+
+    # Load SSO users into the Neo4j session
+    load_sso_users(
+        neo4j_session,
+        users,
+        'd-1234567890',
+        'us-west-2',
+        TEST_ACCOUNT_ID,
+    )
+
+    # Use check_nodes to verify that the SSO users are correctly loaded
+    check_nodes(neo4j_session, 'AWSSSOUser', ['id', 'external_id'])
+
+
+def test_load_identity_center_instances(neo4j_session):
+    """Test loading Identity Center instances into Neo4j."""
+    # Use predefined data from tests.data.aws.identitycenter
+    instances = tests.data.aws.identitycenter.LIST_INSTANCES
+
+    # Load Identity Center instances into the Neo4j session
+    load_identity_center_instances(
+        neo4j_session,
+        instances,
+        'us-west-2',
+        '123456789012',
+        TEST_ACCOUNT_ID,
+    )
+
+    # Verify that the instances are correctly loaded
+    check_nodes(neo4j_session, 'AWSIdentityCenterInstance', ['id', 'identity_store_id'])
+
+
+def test_load_permission_sets(neo4j_session):
+    """Test loading Identity Center permission sets into Neo4j."""
+    # Use predefined data from tests.data.aws.identitycenter
+    permission_sets = tests.data.aws.identitycenter.LIST_PERMISSION_SETS
+
+    # Load permission sets into the Neo4j session
+    load_permission_sets(
+        neo4j_session,
+        permission_sets,
+        "arn:aws:sso:::instance/ssoins-12345678901234567",
+        "us-west-2",
+        TEST_ACCOUNT_ID,
+    )
+
+    # Verify that the permission sets are correctly loaded
+    check_nodes(neo4j_session, 'AWSPermissionSet', ['id', 'name'])


### PR DESCRIPTION
**Summary**
Mapped in [AWS Identity Center](https://aws.amazon.com/iam/identity-center/) and the access it provides to AWS accounts.
New Nodes: (AWSIdentityCenter), (AWSPermissionSet), (AWSSSOUser)
New Relationships:
(AWSAccount)-[RESOURCE]->(AWSIdentityCenter)
(AWSIdentityCenter)-[HAS_PERMISSION_SET]->(AWSPermissionSet)
(AWSSSOUser)<-[ALLOWED_BY]-(AWSRole)
(OktaUser)<-[CAN_ASSUME_IDENTITY]-(AWSSSOUser)
(AWSPermissionSet)-[ASSIGNED_TO_ROLE]->(AWSRole)

![image](https://github.com/user-attachments/assets/e0e6c746-8ef6-4c89-b08a-d5192277fbda)
![image](https://github.com/user-attachments/assets/6ec645b8-6157-4001-b6f6-f44dbc3df2cc)

**Console Trace**
INFO:cartography.intel.aws.identitycenter:Syncing Identity Center instances for region us-east-1 INFO:cartography.intel.aws.identitycenter:Loading 1 Identity Center instances for region us-east-1 INFO:cartography.intel.aws.identitycenter:Loading 32 permission sets for instance arn:aws:sso:::instance/ssoins-72237a0dcb8c6df7 in region us-east-1 INFO:cartography.intel.aws.identitycenter:Loading 777 permission set role assignments INFO:cartography.intel.aws.identitycenter:Loading 803 SSO users for identity store d-906747a0b9 in region us-east-1 INFO:cartography.intel.aws.identitycenter:Getting role assignments for 803 users INFO:cartography.intel.aws.identitycenter:Loading 24292 role assignments INFO:cartography.intel.aws.identitycenter:Syncing Identity Center instances for region us-east-2 INFO:cartography.intel.aws.identitycenter:Loading 0 Identity Center instances for region us-east-2 INFO:cartography.intel.aws.identitycenter:Syncing Identity Center instances for region us-west-1 INFO:cartography.intel.aws.identitycenter:Loading 0 Identity Center instances for region us-west-1 INFO:cartography.intel.aws.identitycenter:Syncing Identity Center instances for region us-west-2 INFO:cartography.intel.aws.identitycenter:Loading 0 Identity Center instances for region us-west-2 INFO:cartography.graph.statement:Completed aws_import_identity_center_cleanup statement #1 INFO:cartography.graph.statement:Completed aws_import_identity_center_cleanup statement #2 INFO:cartography.graph.statement:Completed aws_import_identity_center_cleanup statement #3 INFO:cartography.graph.statement:Completed aws_import_identity_center_cleanup statement #4 INFO:cartography.graph.statement:Completed aws_import_identity_center_cleanup statement #5 INFO:cartography.graph.statement:Completed aws_import_identity_center_cleanup statement #6

**Related issues or links**

Fixes - https://github.com/cartography-cncf/cartography/issues/990

Checklist
Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:

[ x ] Update/add unit or integration tests.
[ X ] Include a screenshot showing what the graph looked like before and after your changes.
[ X ] Include console log trace showing what happened before and after your changes.
If you are changing a node or relationship:

[ x ] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).
If you are implementing a new intel module:

[ X ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).