### PR TITLE
Add support for AWS EC2 Network ACLs

### DIFF
--- a/cartography/intel/aws/ec2/network_acls.py
+++ b/cartography/intel/aws/ec2/network_acls.py
@@ -1,0 +1,213 @@
+import logging
+import re
+from collections import namedtuple
+from typing import Any
+from typing import Dict
+from typing import List
+
+import boto3
+import neo4j
+
+from cartography.models.aws.ec2.network_acl_rules import EC2NetworkAclInboundRuleSchema, EC2NetworkAclEgressRuleSchema
+from cartography.models.aws.ec2.network_acls import EC2NetworkAclSchema
+from .util import get_botocore_config
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.models.aws.ec2.networkinterfaces import EC2NetworkInterfaceSchema
+from cartography.models.aws.ec2.privateip_networkinterface import EC2PrivateIpNetworkInterfaceSchema
+from cartography.models.aws.ec2.securitygroup_networkinterface import EC2SecurityGroupNetworkInterfaceSchema
+from cartography.models.aws.ec2.subnet_networkinterface import EC2SubnetNetworkInterfaceSchema
+from cartography.util import aws_handle_regions
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+Ec2AclObjects = namedtuple(
+    "Ec2AclObjects", [
+        'network_acls',
+        'inbound_rules',
+        'outbound_rules',
+    ],
+)
+
+
+@timeit
+@aws_handle_regions
+def get_network_acl_data(boto3_session: boto3.session.Session, region: str) -> list[dict[str, Any]]:
+    client = boto3_session.client('ec2', region_name=region, config=get_botocore_config())
+    paginator = client.get_paginator('describe_network_acls')
+    acls = []
+    for page in paginator.paginate():
+        acls.extend(page['NetworkAcls'])
+    return acls
+
+
+def transform_network_acl_data(
+        data_list: list[dict[str, Any]],
+        region: str,
+        current_aws_account_id: str,
+) -> Ec2AclObjects:
+    network_acls = []
+    inbound_rules = []
+    outbound_rules = []
+
+    for network_acl in data_list:
+        network_acl_id = network_acl['NetworkAclId']
+        base_network_acl = {
+            'Id': network_acl_id,
+            'Arn': f'arn:aws:ec2:{region}:{current_aws_account_id}:network-acl/{network_acl_id}',
+            'IsDefault': network_acl['IsDefault'],
+            'VpcId': network_acl['VpcId'],
+            'OwnerId': network_acl['OwnerId'],
+        }
+        if network_acl.get('Associations') and network_acl['Associations']:
+            # Include subnet associations in the data object if they exist
+            for association in network_acl['Associations']:
+                base_network_acl['NetworkAclAssociationId'] = association['NetworkAclAssociationId']
+                base_network_acl['SubnetId'] = association['SubnetId']
+                network_acls.append(base_network_acl)
+        else:
+            # Otherwise if there's no associations then don't include that in the data object
+            network_acls.append(base_network_acl)
+
+        if network_acl.get("Entries"):
+            for rule in network_acl["Entries"]:
+                direction = 'egress' if rule['Egress'] else 'inbound'
+                transformed_rule = {
+                    'Id': f"{network_acl['NetworkAclId']}/{direction}/{rule['RuleNumber']}",
+                    'CidrBlock': rule['CidrBlock'],
+                    'Egress': rule['Egress'],
+                    'Protocol': rule['Protocol'],
+                    'RuleAction': rule['RuleAction'],
+                    'RuleNumber': rule['RuleNumber'],
+                    # Add pointer back to the nacl to create an edge
+                    'NetworkAclId': network_acl_id,
+                    'FromPort': rule.get('PortRange', {}).get('FromPort'),
+                    'ToPort': rule.get('PortRange', {}).get('ToPort'),
+                }
+                if transformed_rule['Egress']:
+                    outbound_rules.append(transformed_rule)
+                else:
+                    inbound_rules.append(transformed_rule)
+    return Ec2AclObjects(
+        network_acls=network_acls,
+        inbound_rules=inbound_rules,
+        outbound_rules=outbound_rules,
+    )
+
+
+@timeit
+def load_all_nacl_data(
+        neo4j_session: neo4j.Session,
+        ec2_acl_objects: Ec2AclObjects,
+        region: str,
+        aws_account_id: str,
+        update_tag: int,
+) -> None:
+    load_network_acls(
+        neo4j_session,
+        ec2_acl_objects.network_acls,
+        region,
+        aws_account_id,
+        update_tag,
+    )
+    load_network_acl_inbound_rules(
+        neo4j_session,
+        ec2_acl_objects.inbound_rules,
+        region,
+        aws_account_id,
+        update_tag,
+    )
+    load_network_acl_egress_rules(
+        neo4j_session,
+        ec2_acl_objects.outbound_rules,
+        region,
+        aws_account_id,
+        update_tag,
+    )
+
+
+@timeit
+def load_network_acls(
+        neo4j_session: neo4j.Session,
+        data: list[dict[str, Any]],
+        region: str,
+        aws_account_id: str,
+        update_tag: int,
+) -> None:
+    logger.info(f"Loading {len(data)} network acls in {region}.")
+    load(
+        neo4j_session,
+        EC2NetworkAclSchema(),
+        data,
+        Region=region,
+        AWS_ID=aws_account_id,
+        lastupdated=update_tag,
+    )
+
+
+@timeit
+def load_network_acl_inbound_rules(
+        neo4j_session: neo4j.Session,
+        data: list[dict[str, Any]],
+        region: str,
+        aws_account_id: str,
+        update_tag: int,
+) -> None:
+    logger.info(f"Loading {len(data)} network acl inbound rules in {region}.")
+    load(
+        neo4j_session,
+        EC2NetworkAclInboundRuleSchema(),
+        data,
+        Region=region,
+        AWS_ID=aws_account_id,
+        lastupdated=update_tag,
+    )
+
+
+@timeit
+def load_network_acl_egress_rules(
+        neo4j_session: neo4j.Session,
+        data: list[dict[str, Any]],
+        region: str,
+        aws_account_id: str,
+        update_tag: int,
+) -> None:
+    logger.info(f"Loading {len(data)} network acl egress rules in {region}.")
+    load(
+        neo4j_session,
+        EC2NetworkAclEgressRuleSchema(),
+        data,
+        Region=region,
+        AWS_ID=aws_account_id,
+        lastupdated=update_tag,
+    )
+
+@timeit
+def cleanup_network_acls(neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]) -> None:
+    GraphJob.from_node_schema(EC2NetworkAclSchema(), common_job_parameters).run(neo4j_session)
+    GraphJob.from_node_schema(EC2NetworkAclInboundRuleSchema(), common_job_parameters).run(neo4j_session)
+    GraphJob.from_node_schema(EC2NetworkAclEgressRuleSchema(), common_job_parameters).run(neo4j_session)
+
+
+@timeit
+def sync_network_acls(
+        neo4j_session: neo4j.Session,
+        boto3_session: boto3.session.Session,
+        regions: list[str],
+        current_aws_account_id: str,
+        update_tag: int,
+        common_job_parameters: Dict,
+) -> None:
+    for region in regions:
+        logger.info(f"Syncing EC2 network ACLs for region '{region}' in account '{current_aws_account_id}'.")
+        data = get_network_acl_data(boto3_session, region)
+        ec2_acl_data = transform_network_acl_data(data, region, current_aws_account_id)
+        load_all_nacl_data(
+            neo4j_session,
+            ec2_acl_data,
+            region,
+            current_aws_account_id,
+            update_tag,
+        )
+        cleanup_network_acls(neo4j_session, common_job_parameters)

--- a/cartography/models/aws/ec2/network_acl_rules.py
+++ b/cartography/models/aws/ec2/network_acl_rules.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass
+
+from cartography.models.core.relationships import CartographyRelSchema, TargetNodeMatcher, make_target_node_matcher, \
+    LinkDirection, OtherRelationships, CartographyRelProperties
+
+from cartography.models.core.common import PropertyRef
+
+from cartography.models.core.nodes import CartographyNodeProperties, CartographyNodeSchema, ExtraNodeLabels
+
+
+@dataclass(frozen=True)
+class EC2NetworkAclRuleNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef('Id')
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+    network_acl_id: PropertyRef = PropertyRef('NetworkAclId')
+    protocol: PropertyRef = PropertyRef('Protocol')
+    fromport: PropertyRef = PropertyRef('FromPort')
+    toport: PropertyRef = PropertyRef('ToPort')
+    cidrblock: PropertyRef = PropertyRef('CidrBlock')
+    egress: PropertyRef = PropertyRef('Egress')
+    rulenumber: PropertyRef = PropertyRef('RuleNumber')
+    ruleaction: PropertyRef = PropertyRef('RuleAction')
+    region: PropertyRef = PropertyRef('Region', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EC2NetworkAclRuleAclRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EC2NetworkAclRuleToAcl(CartographyRelSchema):
+    target_node_label: str = 'EC2NetworkAcl'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'network_acl_id': PropertyRef('NetworkAclId')},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MEMBER_OF_NACL"
+    properties: EC2NetworkAclRuleAclRelProperties = EC2NetworkAclRuleAclRelProperties()
+
+
+@dataclass(frozen=True)
+class EC2NetworkAclRuleToAwsAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EC2NetworkAclRuleToAWSAccount(CartographyRelSchema):
+    target_node_label: str = 'AWSAccount'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('AWS_ID', set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: EC2NetworkAclRuleToAwsAccountRelProperties = EC2NetworkAclRuleToAwsAccountRelProperties()
+
+
+@dataclass(frozen=True)
+class EC2NetworkAclInboundRuleSchema(CartographyNodeSchema):
+    """
+    Network interface as known by describe-network-interfaces.
+    """
+    label: str = 'EC2NetworkAclRule'
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        ['IpPermissionInbound']
+    )
+    properties: EC2NetworkAclRuleNodeProperties = EC2NetworkAclRuleNodeProperties()
+    sub_resource_relationship: EC2NetworkAclRuleToAWSAccount = EC2NetworkAclRuleToAWSAccount()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            EC2NetworkAclRuleToAcl(),
+        ]
+    )
+
+@dataclass(frozen=True)
+class EC2NetworkAclEgressRuleSchema(CartographyNodeSchema):
+    """
+    Network interface as known by describe-network-interfaces.
+    """
+    label: str = 'EC2NetworkAclRule'
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        [
+            'IpPermissionEgress',
+        ],
+    )
+    properties: EC2NetworkAclRuleNodeProperties = EC2NetworkAclRuleNodeProperties()
+    sub_resource_relationship: EC2NetworkAclRuleToAWSAccount = EC2NetworkAclRuleToAWSAccount()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            EC2NetworkAclRuleToAcl(),
+        ]
+    )

--- a/cartography/models/aws/ec2/network_acls.py
+++ b/cartography/models/aws/ec2/network_acls.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass
+
+from cartography.models.aws.ec2.networkinterface_instance import EC2NetworkInterfaceToAWSAccount
+from cartography.models.aws.ec2.networkinterface_instance import EC2NetworkInterfaceToEC2Instance
+from cartography.models.aws.ec2.networkinterface_instance import EC2NetworkInterfaceToEC2SecurityGroup
+from cartography.models.aws.ec2.networkinterface_instance import EC2NetworkInterfaceToEC2Subnet
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class EC2NetworkAclNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef('Arn')
+    arn: PropertyRef = PropertyRef('Arn')
+    network_acl_id: PropertyRef = PropertyRef('Id')
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+    is_default: PropertyRef = PropertyRef('IsDefault')
+    region: PropertyRef = PropertyRef('Region', set_in_kwargs=True)
+    vpc_id: PropertyRef = PropertyRef('VpcId')
+
+
+@dataclass(frozen=True)
+class EC2NetworkAclToVpcRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EC2NetworkAclToVpc(CartographyRelSchema):
+    target_node_label: str = 'AWSVpc'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'vpcid': PropertyRef('VpcId')},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MEMBER_OF_AWS_VPC"
+    properties: EC2NetworkAclToVpcRelProperties = EC2NetworkAclToVpcRelProperties()
+
+@dataclass(frozen=True)
+class EC2NetworkAclToSubnetRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EC2NetworkAclToSubnet(CartographyRelSchema):
+    target_node_label: str = 'EC2Subnet'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'subnetid': PropertyRef('SubnetId')},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "PART_OF_SUBNET"
+    properties: EC2NetworkAclToSubnetRelProperties = EC2NetworkAclToSubnetRelProperties()
+
+
+@dataclass(frozen=True)
+class EC2NetworkAclToAwsAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EC2NetworkAclToAWSAccount(CartographyRelSchema):
+    target_node_label: str = 'AWSAccount'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('AWS_ID', set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: EC2NetworkAclToAwsAccountRelProperties = EC2NetworkAclToAwsAccountRelProperties()
+
+
+@dataclass(frozen=True)
+class EC2NetworkAclSchema(CartographyNodeSchema):
+    """
+    Network interface as known by describe-network-interfaces.
+    """
+    label: str = 'EC2NetworkAcl'
+    properties: EC2NetworkAclNodeProperties = EC2NetworkAclNodeProperties()
+    sub_resource_relationship: EC2NetworkAclToAWSAccount = EC2NetworkAclToAWSAccount()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            EC2NetworkAclToVpc(),
+            EC2NetworkAclToSubnet(),
+        ]
+    )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1274,6 +1274,89 @@ Representation of an AWS Elastic Container Registry [Repository](https://docs.aw
     ```
 
 
+### EC2NetworkAcl
+
+ Representation of an AWS [EC2 Network ACL](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_NetworkAcl.html)
+
+ | Field          | Description                                                    |
+ |----------------|----------------------------------------------------------------|
+ | **id**         | The arn of the network ACL                                     |
+ | **arn**        | Amazon Resource Name                                           |
+ | network_acl_id | The ID of the network ACL                                      |
+ | is_default     | Indicates whether this is the default network ACL for the VPC. |
+ | vpc_id         | The ID of the VPC this ACL is associated with                  |
+ | region         | The region                                                     |
+
+
+#### Relationships
+
+-  EC2 Network ACLs have ingress and egress rules
+
+      ```
+      (:EC2NetworkAcl)-[:MEMBER_OF_NACL]->(:EC2NetworkAclRule:IpPermissionInbound)
+      ```
+
+      ```
+      (:EC2NetworkAcl)-[:MEMBER_OF_NACL]->(:EC2NetworkAclRule:IpPermissionEgress)
+      ```
+
+- EC2 Network ACLs define egress and ingress rules on subnets
+
+         ```
+         (:EC2NetworkAcl)-[:PART_OF_SUBNET]->(:EC2Subnet)
+         ```
+
+- EC2 Network ACLs are attached to VPCs.
+
+         ```
+         (:EC2NetworkAcl)-[:MEMBER_OF_AWS_VPC]->(:AWSVpc)
+         ```
+
+ -  EC2 Network ACLs belong to AWS Accounts
+
+         ```
+         (:AWSAccount)-[:RESOURCE]->(:EC2NetworkAcl)
+         ```
+
+
+### EC2NetworkAclRule :: IpPermissionInbound / IpPermissionEgress
+
+Representation of an AWS [EC2 Network ACL Rule Entry](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_NetworkAclEntry.html)
+For additional explanation see https://docs.aws.amazon.com/vpc/latest/userguide/nacl-rules.html.
+
+| Field          | Description                                                                                 |
+|----------------|---------------------------------------------------------------------------------------------|
+| **id**         | The ID of this rule: `{network_acl_id}/{egress or inbound}/{rule_number}`                   |
+| network_acl_id | The ID of the network ACL that this belongs to                                              |
+| protocol       | Indicates whether this is the default network ACL for the VPC.                              |
+| fromport       | First port in the range that this rule applies to                                           |
+| toport         | Last port in the range that this rule applies to                                            |
+| cidrblock      | The IPv4 network range to allow or deny, in CIDR notation.                                  |
+| egress         | Indicates whether the rule is an egress rule (applied to traffic leaving the subnet).       |
+| rulenumber     | The rule number for the entry. ACL entries are processed in ascending order by rule number. |
+| ruleaction     | Indicates whether to `allow` or `den` the traffic that matches the rule.                    |
+| region         | The region                                                                                  |
+
+
+#### Relationships
+
+-  EC2 Network ACLs have ingress and egress rules
+
+      ```
+      (:EC2NetworkAcl)-[:MEMBER_OF_NACL]->(:EC2NetworkAclRule:IpPermissionInbound)
+      ```
+
+      ```
+      (:EC2NetworkAcl)-[:MEMBER_OF_NACL]->(:EC2NetworkAclRule:IpPermissionEgress)
+      ```
+
+ -  EC2 Network ACL Ruless belong to AWS Accounts
+
+         ```
+         (:AWSAccount)-[:RESOURCE]->(:EC2NetworkAclRule)
+         ```
+
+
 ### ECRRepositoryImage
 
 An ECR image may be referenced and tagged by more than one ECR Repository. To best represent this, we've created an

--- a/tests/data/aws/ec2/network_acls/instances.py
+++ b/tests/data/aws/ec2/network_acls/instances.py
@@ -1,0 +1,137 @@
+# EC2 instance data for use with the Network ACL test
+import datetime
+from datetime import timezone as tz
+
+INSTANCES_FOR_ACL_TEST = [{
+    "ReservationId": "r-03",
+    "OwnerId": "000000000000",
+    "Groups": [],
+    "Instances": [
+        {
+            "Architecture": "x86_64",
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/xvda",
+                    "Ebs": {
+                        "AttachTime": "2023-08-04 22:31:02+00:00",
+                        "DeleteOnTermination": True,
+                        "Status": "attached",
+                        "VolumeId": "vol-0e4"
+                    }
+                }
+            ],
+            "ClientToken": "b20f8",
+            "EbsOptimized": True,
+            "EnaSupport": True,
+            "Hypervisor": "xen",
+            "NetworkInterfaces": [
+                {
+                    "Attachment": {
+                        "AttachTime": "2023-08-04 22:31:01+00:00",
+                        "AttachmentId": "eni-attach-0f76",
+                        "DeleteOnTermination": True,
+                        "DeviceIndex": 0,
+                        "Status": "attached",
+                        "NetworkCardIndex": 0
+                    },
+                    "Description": "",
+                    "Groups": [
+                        {
+                            "GroupId": "sg-0564",
+                            "GroupName": "group-name-1"
+                        }
+                    ],
+                    "Ipv6Addresses": [],
+                    "MacAddress": "11:22:33:44:55:66",
+                    "NetworkInterfaceId": "eni-0430",
+                    "OwnerId": "000000000000",
+                    "PrivateIpAddress": "10.190.1.148",
+                    "PrivateIpAddresses": [
+                        {
+                            "Primary": True,
+                            "PrivateIpAddress": "10.190.1.148"
+                        }
+                    ],
+                    "SourceDestCheck": True,
+                    "Status": "in-use",
+                    "SubnetId": "subnet-0a1a",
+                    "VpcId": "vpc-0767",
+                    "InterfaceType": "interface"
+                }
+            ],
+            "RootDeviceName": "/dev/xvda",
+            "RootDeviceType": "ebs",
+            "SecurityGroups": [
+                {
+                    "GroupId": "sg-0564",
+                    "GroupName": "group-name-1"
+                }
+            ],
+            "SourceDestCheck": True,
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "prod-tag"
+                }
+            ],
+            "VirtualizationType": "hvm",
+            "CpuOptions": {
+                "CoreCount": 1,
+                "ThreadsPerCore": 2
+            },
+            "CapacityReservationSpecification": {
+                "CapacityReservationPreference": "open"
+            },
+            "HibernationOptions": {
+                "Configured": False
+            },
+            "MetadataOptions": {
+                "State": "applied",
+                "HttpTokens": "optional",
+                "HttpPutResponseHopLimit": 1,
+                "HttpEndpoint": "enabled",
+                "HttpProtocolIpv6": "disabled",
+                "InstanceMetadataTags": "disabled"
+            },
+            "EnclaveOptions": {
+                "Enabled": False
+            },
+            "PlatformDetails": "Linux/UNIX",
+            "UsageOperation": "RunInstances",
+            "UsageOperationUpdateTime": "2023-08-04 22:31:01+00:00",
+            "PrivateDnsNameOptions": {
+                "HostnameType": "ip-name",
+                "EnableResourceNameDnsARecord": False,
+                "EnableResourceNameDnsAAAARecord": False
+            },
+            "MaintenanceOptions": {
+                "AutoRecovery": "default"
+            },
+            "CurrentInstanceBootMode": "legacy-bios",
+            "InstanceId": "i-0ba7",
+            "ImageId": "ami-0414",
+            "State": {
+                "Code": 16,
+                "Name": "running"
+            },
+            "PrivateDnsName": "ip-10-190-1-148.ec2.internal",
+            "PublicDnsName": "",
+            "StateTransitionReason": "",
+            "AmiLaunchIndex": 0,
+            "ProductCodes": [],
+            "InstanceType": "t3.micro",
+            "LaunchTime": datetime.datetime(2023, 8, 4,22, 31, 1, tzinfo=tz.utc),
+            "Placement": {
+                "GroupName": "",
+                "Tenancy": "default",
+                "AvailabilityZone": "us-east-1b"
+            },
+            "Monitoring": {
+                "State": "disabled"
+            },
+            "SubnetId": "subnet-0a1a",
+            "VpcId": "vpc-0767",
+            "PrivateIpAddress": "10.190.1.148"
+        }
+    ]
+}]

--- a/tests/data/aws/ec2/network_acls/network_acls.py
+++ b/tests/data/aws/ec2/network_acls/network_acls.py
@@ -1,0 +1,56 @@
+DESCRIBE_NETWORK_ACLS = [
+    {
+        "Associations": [
+            {
+                "NetworkAclAssociationId": "aclassoc-080e",
+                "NetworkAclId": "acl-077e",
+                "SubnetId": "subnet-0fbc"
+            },
+            {
+                "NetworkAclAssociationId": "aclassoc-0c41",
+                "NetworkAclId": "acl-077e",
+                "SubnetId": "subnet-0a1a"
+            },
+            {
+                "NetworkAclAssociationId": "aclassoc-0d84",
+                "NetworkAclId": "acl-077e",
+                "SubnetId": "subnet-06ba"
+            }
+        ],
+        "Entries": [
+            {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": True,
+                "Protocol": "-1",
+                "RuleAction": "allow",
+                "RuleNumber": 100
+            },
+            {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": True,
+                "Protocol": "-1",
+                "RuleAction": "deny",
+                "RuleNumber": 32767
+            },
+            {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": False,
+                "Protocol": "-1",
+                "RuleAction": "allow",
+                "RuleNumber": 100
+            },
+            {
+                "CidrBlock": "0.0.0.0/0",
+                "Egress": False,
+                "Protocol": "-1",
+                "RuleAction": "deny",
+                "RuleNumber": 32767
+            }
+        ],
+        "IsDefault": True,
+        "NetworkAclId": "acl-077e",
+        "Tags": [],
+        "VpcId": "vpc-0767",
+        "OwnerId": "000000000000"
+    },
+]

--- a/tests/data/aws/ec2/network_acls/subnets.py
+++ b/tests/data/aws/ec2/network_acls/subnets.py
@@ -1,0 +1,50 @@
+# EC2 Subnet data for use with the Network ACL test
+
+DESCRIBE_SUBNETS_FOR_ACL_TEST = [
+    {
+        "AvailabilityZoneId": "use1-az1",
+        "MapCustomerOwnedIpOnLaunch": False,
+        "OwnerId": "000000000000",
+        "AssignIpv6AddressOnCreation": False,
+        "Ipv6CidrBlockAssociationSet": [],
+        "SubnetArn": "arn:aws:ec2:us-east-1:000000000000:subnet/subnet-0a1a",
+        "EnableDns64": False,
+        "Ipv6Native": False,
+        "PrivateDnsNameOptionsOnLaunch": {
+            "HostnameType": "ip-name",
+            "EnableResourceNameDnsARecord": False,
+            "EnableResourceNameDnsAAAARecord": False
+        },
+        "SubnetId": "subnet-0a1a",
+        "State": "available",
+        "VpcId": "vpc-0767",
+        "CidrBlock": "10.190.1.0/24",
+        "AvailableIpAddressCount": 250,
+        "AvailabilityZone": "us-east-1b",
+        "DefaultForAz": False,
+        "MapPublicIpOnLaunch": False
+    },
+    {
+        "AvailabilityZoneId": "use1-az4",
+        "MapCustomerOwnedIpOnLaunch": False,
+        "OwnerId": "000000000000",
+        "AssignIpv6AddressOnCreation": False,
+        "Ipv6CidrBlockAssociationSet": [],
+        "SubnetArn": "arn:aws:ec2:us-east-1:000000000000:subnet/subnet-06ba",
+        "EnableDns64": False,
+        "Ipv6Native": False,
+        "PrivateDnsNameOptionsOnLaunch": {
+            "HostnameType": "ip-name",
+            "EnableResourceNameDnsARecord": False,
+            "EnableResourceNameDnsAAAARecord": False
+        },
+        "SubnetId": "subnet-06ba",
+        "State": "available",
+        "VpcId": "vpc-0767",
+        "CidrBlock": "10.190.0.0/24",
+        "AvailableIpAddressCount": 251,
+        "AvailabilityZone": "us-east-1a",
+        "DefaultForAz": False,
+        "MapPublicIpOnLaunch": False
+    },
+]

--- a/tests/data/aws/ec2/network_acls/vpcs.py
+++ b/tests/data/aws/ec2/network_acls/vpcs.py
@@ -1,0 +1,20 @@
+DESCRIBE_VPCS_FOR_ACL_TEST = [
+    {
+        "OwnerId": "000000000000",
+        "InstanceTenancy": "default",
+        "CidrBlockAssociationSet": [
+            {
+                "AssociationId": "vpc-cidr-assoc-0348",
+                "CidrBlock": "10.190.0.0/20",
+                "CidrBlockState": {
+                    "State": "associated"
+                }
+            }
+        ],
+        "IsDefault": False,
+        "VpcId": "vpc-0767",
+        "State": "available",
+        "CidrBlock": "10.190.0.0/20",
+        "DhcpOptionsId": "dopt-aefb"
+    },
+]

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_network_acls.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_network_acls.py
@@ -1,0 +1,136 @@
+from unittest.mock import MagicMock, patch
+
+from tests.integration.cartography.intel.aws.common import create_test_account
+
+from tests.integration.util import check_rels
+
+import cartography.intel.aws.ec2
+
+from cartography.intel.aws.ec2.network_acls import sync_network_acls
+from cartography.intel.aws.ec2.subnets import sync_subnets
+
+from cartography.intel.aws.ec2.vpc import sync_vpc
+
+from cartography.intel.aws.ec2.instances import sync_ec2_instances
+from tests.data.aws.ec2.network_acls.instances import INSTANCES_FOR_ACL_TEST
+from tests.data.aws.ec2.network_acls.network_acls import DESCRIBE_NETWORK_ACLS
+from tests.data.aws.ec2.network_acls.subnets import DESCRIBE_SUBNETS_FOR_ACL_TEST
+from tests.data.aws.ec2.network_acls.vpcs import DESCRIBE_VPCS_FOR_ACL_TEST
+
+TEST_ACCOUNT_ID = '000000000000'
+TEST_REGION = 'us-east-1'
+TEST_UPDATE_TAG = 123456789
+common_job_parameters = {
+    "UPDATE_TAG": TEST_UPDATE_TAG,
+    "AWS_ID": TEST_ACCOUNT_ID,
+}
+
+
+@patch.object(cartography.intel.aws.ec2.network_acls, 'get_network_acl_data', return_value=DESCRIBE_NETWORK_ACLS)
+@patch.object(cartography.intel.aws.ec2.subnets, 'get_subnet_data', return_value=DESCRIBE_SUBNETS_FOR_ACL_TEST)
+@patch.object(cartography.intel.aws.ec2.vpc, 'get_ec2_vpcs', return_value=DESCRIBE_VPCS_FOR_ACL_TEST)
+@patch.object(cartography.intel.aws.ec2.instances, 'get_ec2_instances', return_value=INSTANCES_FOR_ACL_TEST)
+def test_sync_ec2_network_acls(
+        mock_instances: MagicMock,
+        mock_vpcs: MagicMock,
+        mock_subnets: MagicMock,
+        mock_acls: MagicMock,
+        neo4j_session,
+):
+    regions = [TEST_REGION]
+    boto3_session = MagicMock()
+
+    # Arrange: load in instances, vpc, subnets for this test
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    sync_ec2_instances(
+        neo4j_session,
+        boto3_session,
+        regions,
+        TEST_ACCOUNT_ID,
+        common_job_parameters['UPDATE_TAG'],
+        common_job_parameters,
+    )
+    sync_vpc(
+        neo4j_session,
+        boto3_session,
+        regions,
+        TEST_ACCOUNT_ID,
+        common_job_parameters['UPDATE_TAG'],
+        common_job_parameters,
+    )
+    sync_subnets(
+        neo4j_session,
+        boto3_session,
+        regions,
+        TEST_ACCOUNT_ID,
+        common_job_parameters['UPDATE_TAG'],
+        common_job_parameters,
+    )
+
+    # Act
+    sync_network_acls(
+        neo4j_session,
+        boto3_session,
+        regions,
+        TEST_ACCOUNT_ID,
+        common_job_parameters['UPDATE_TAG'],
+        common_job_parameters,
+    )
+
+    # Assert that ACLs are connected to their expected rules
+    assert check_rels(
+        neo4j_session,
+        'EC2NetworkAcl',
+        'network_acl_id',
+        'EC2NetworkAclRule',
+        'id',
+        'MEMBER_OF_NACL',
+        rel_direction_right=False,
+    ) == {
+        ('acl-077e', 'acl-077e/egress/100'),
+        ('acl-077e', 'acl-077e/egress/32767'),
+        ('acl-077e', 'acl-077e/inbound/100'),
+        ('acl-077e', 'acl-077e/inbound/32767'),
+    }
+
+    # Assert that ACL is attached to expected subnet
+    assert check_rels(
+        neo4j_session,
+        'EC2NetworkAcl',
+        'network_acl_id',
+        'EC2Subnet',
+        'subnetid',
+        'PART_OF_SUBNET',
+        rel_direction_right=True,
+    ) == {
+        ('acl-077e', 'subnet-06ba'),
+    }
+
+  # Assert that ACL is attached to account
+    assert check_rels(
+        neo4j_session,
+        'EC2NetworkAcl',
+        'network_acl_id',
+        'AWSAccount',
+        'id',
+        'RESOURCE',
+        rel_direction_right=False,
+    ) == {
+        ('acl-077e', '000000000000'),
+    }
+
+# Assert that ACL rule is attached to account
+    assert check_rels(
+        neo4j_session,
+        'EC2NetworkAclRule',
+        'id',
+        'AWSAccount',
+        'id',
+        'RESOURCE',
+        rel_direction_right=False,
+    ) == {
+        ('acl-077e/egress/100', '000000000000'),
+        ('acl-077e/egress/32767', '000000000000'),
+        ('acl-077e/inbound/100', '000000000000'),
+        ('acl-077e/inbound/32767', '000000000000'),
+    }


### PR DESCRIPTION
### Summary
> Describe your changes.

Adds support for AWS EC2 Network ACLs and their rules. Shows attachments to VPCs and subnets.

Screenshot:
![Screenshot 2024-11-15 at 6 47 44 PM](https://github.com/user-attachments/assets/2e7f16ac-ec1c-4a8a-895b-29a4198f4f87)


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [x] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
