### PR TITLE
Fix IAM policy naming for inline policies with empty string Sid field.

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -539,11 +539,12 @@ def _transform_policy_statements(statements: Any, policy_id: str) -> List[Dict]:
     if not isinstance(statements, list):
         statements = [statements]
     for stmt in statements:
-        if "Sid" not in stmt:
+        if "Sid" in stmt and stmt["Sid"]:
+            statement_id = stmt["Sid"]
+        else:
             statement_id = count
             count += 1
-        else:
-            statement_id = stmt["Sid"]
+
         stmt["id"] = f"{policy_id}/statement/{statement_id}"
         if "Resource" in stmt:
             stmt["Resource"] = ensure_list(stmt["Resource"])


### PR DESCRIPTION
### Summary
  > AWS is breaking its own rules for some roles it has created in IdentityCenter. IdentityCenter created roles with inline policies that can have multiple statements, all with the Sid of an empty string. This means cartography will only load the last statement as they will all have the same AWSPolicyStatement.id. This change checks if the Sid is an empty string and uses the index numbering if it is encountered. 



### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/lyft/cartography/issues/...


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
