### PR TITLE
0.96.0rc3: fix identitycenter import error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.96.0rc2'
+__version__ = '0.96.0rc3'
 
 
 setup(


### PR DESCRIPTION
### Summary
> Describe your changes.

Adds a missing `__init__.py` file to AWS identitycenter's model directory.

Without this, running

```
import cartography.intel.aws
```
in a separate script will cause the script to fail with a `ModuleNotFoundError`.

Crash dump:
```
 from cartography.sync import Sync
..
    import cartography.intel.aws
..
    from .resources import RESOURCE_FUNCTIONS
..
    from . import identitycenter
..
    from cartography.models.aws.identitycenter.awsidentitycenter import AWSIdentityCenterInstanceSchema
E   ModuleNotFoundError: No module named 'cartography.models.aws.identitycenter'
```
