### PR TITLE
EC2 network ACL: Use get method to access dict keys to prevent exception

### DIFF
--- a/cartography/intel/aws/ec2/network_acls.py
+++ b/cartography/intel/aws/ec2/network_acls.py
@@ -69,7 +69,8 @@ def transform_network_acl_data(
                 direction = 'egress' if rule['Egress'] else 'inbound'
                 transformed_rule = {
                     'Id': f"{network_acl['NetworkAclId']}/{direction}/{rule['RuleNumber']}",
-                    'CidrBlock': rule['CidrBlock'],
+                    'CidrBlock': rule.get('CidrBlock'),
+                    'Ipv6CidrBlock': rule.get('Ipv6CidrBlock'),
                     'Egress': rule['Egress'],
                     'Protocol': rule['Protocol'],
                     'RuleAction': rule['RuleAction'],

--- a/cartography/models/aws/ec2/network_acl_rules.py
+++ b/cartography/models/aws/ec2/network_acl_rules.py
@@ -21,6 +21,7 @@ class EC2NetworkAclRuleNodeProperties(CartographyNodeProperties):
     fromport: PropertyRef = PropertyRef('FromPort')
     toport: PropertyRef = PropertyRef('ToPort')
     cidrblock: PropertyRef = PropertyRef('CidrBlock')
+    Ipv6CidrBlock: PropertyRef = PropertyRef('Ipv6CidrBlock')
     egress: PropertyRef = PropertyRef('Egress')
     rulenumber: PropertyRef = PropertyRef('RuleNumber')
     ruleaction: PropertyRef = PropertyRef('RuleAction')

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1324,18 +1324,19 @@ Representation of an AWS Elastic Container Registry [Repository](https://docs.aw
 Representation of an AWS [EC2 Network ACL Rule Entry](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_NetworkAclEntry.html)
 For additional explanation see https://docs.aws.amazon.com/vpc/latest/userguide/nacl-rules.html.
 
-| Field          | Description                                                                                 |
-|----------------|---------------------------------------------------------------------------------------------|
-| **id**         | The ID of this rule: `{network_acl_id}/{egress or inbound}/{rule_number}`                   |
-| network_acl_id | The ID of the network ACL that this belongs to                                              |
-| protocol       | Indicates whether this is the default network ACL for the VPC.                              |
-| fromport       | First port in the range that this rule applies to                                           |
-| toport         | Last port in the range that this rule applies to                                            |
-| cidrblock      | The IPv4 network range to allow or deny, in CIDR notation.                                  |
-| egress         | Indicates whether the rule is an egress rule (applied to traffic leaving the subnet).       |
-| rulenumber     | The rule number for the entry. ACL entries are processed in ascending order by rule number. |
-| ruleaction     | Indicates whether to `allow` or `den` the traffic that matches the rule.                    |
-| region         | The region                                                                                  |
+| Field          | Description                                                                                                                  |
+|----------------|------------------------------------------------------------------------------------------------------------------------------|
+| **id**         | The ID of this rule: `{network_acl_id}/{egress or inbound}/{rule_number}`                                                    |
+| network_acl_id | The ID of the network ACL that this belongs to                                                                               |
+| protocol       | Indicates whether this is the default network ACL for the VPC.                                                               |
+| fromport       | First port in the range that this rule applies to                                                                            |
+| toport         | Last port in the range that this rule applies to                                                                             |
+| cidrblock      | The IPv4 network range to allow or deny, in CIDR notation.                                                                   |
+| Ipv6CidrBlock  | The IPv6 network range to allow or deny, in CIDR notation. You must specify an IPv4 CIDR block or an IPv6 CIDR block.        |
+| egress         | Indicates whether the rule is an egress rule (applied to traffic leaving the subnet).                                        |
+| rulenumber     | The rule number for the entry. ACL entries are processed in ascending order by rule number.                                  |
+| ruleaction     | Indicates whether to `allow` or `den` the traffic that matches the rule.                                                     |
+| region         | The region                                                                                                                   |
 
 
 #### Relationships

--- a/tests/data/aws/ec2/network_acls/network_acls.py
+++ b/tests/data/aws/ec2/network_acls/network_acls.py
@@ -46,6 +46,13 @@ DESCRIBE_NETWORK_ACLS = [
                 "RuleAction": "deny",
                 "RuleNumber": 32767,
             },
+            {
+                "Ipv6CidrBlock": "2001:db8:1234:1a00::/64",
+                "Egress": True,
+                "Protocol": "-1",
+                "RuleAction": "allow",
+                "RuleNumber": 100,
+            },
         ],
         "IsDefault": True,
         "NetworkAclId": "acl-077e",


### PR DESCRIPTION
### Summary
Correcting error:
```
File "/code/venvs/venv/lib/python3.10/site-packages/cartography/intel/aws/ec2/network_acls.py", line 72, in transform_network_acl_data
    'CidrBlock': rule['CidrBlock'],
KeyError: 'CidrBlock'
```

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
