### PR TITLE
Github "Immediate" User Team Membership

### DIFF
--- a/cartography/intel/github/teams.py
+++ b/cartography/intel/github/teams.py
@@ -35,10 +35,10 @@ def get_teams(org: str, api_url: str, token: str) -> Tuple[PaginatedGraphqlData,
                         slug
                         url
                         description
-                        repositories(first: 100) {
+                        repositories {
                             totalCount
                         }
-                        members(first: 100, membership: IMMEDIATE) {
+                        members(membership: IMMEDIATE) {
                             totalCount
                         }
                     }
@@ -98,7 +98,11 @@ def _get_team_repos_for_multiple_teams(
                 )
                 if current_try == max_tries:
                     raise RuntimeError(f"GitHub returned a None repo url for team {team_name}, retries exhausted.")
-                sleep(current_try ** 2)
+                sleep_time_seconds = current_try ** 2
+                logger.warning(
+                    f"Waiting {sleep_time_seconds} seconds before retrying to find repo/perm for team {team_name}.",
+                )
+                sleep(sleep_time_seconds)
 
         # Shape = [(repo_url, 'WRITE'), ...]]
         result[team_name] = [RepoPermission(url, perm) for url, perm in zip(repo_urls, repo_permissions)]
@@ -192,7 +196,11 @@ def _get_team_users_for_multiple_teams(
                 )
                 if current_try == max_tries:
                     raise RuntimeError(f"GitHub returned a None member url for team {team_name}, retries exhausted.")
-                sleep(current_try ** 2)
+                sleep_time_seconds = current_try ** 2
+                logger.warning(
+                    f"Waiting {sleep_time_seconds} seconds before retrying to find user or role for team {team_name}.",
+                )
+                sleep(sleep_time_seconds)
 
         # Shape = [(user_url, 'MAINTAINER'), ...]]
         result[team_name] = [UserRole(url, role) for url, role in zip(user_urls, user_roles)]

--- a/cartography/models/github/teams.py
+++ b/cartography/models/github/teams.py
@@ -81,6 +81,33 @@ class GitHubTeamWriteRepoRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class GitHubTeamToUserRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitHubTeamMaintainerUserRel(CartographyRelSchema):
+    target_node_label: str = 'GitHubUser'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('MAINTAINER')},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "MAINTAINER"
+    properties: GitHubTeamToUserRelProperties = GitHubTeamToUserRelProperties()
+
+
+@dataclass(frozen=True)
+class GitHubTeamMemberUserRel(CartographyRelSchema):
+    target_node_label: str = 'GitHubUser'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('MEMBER')},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "MEMBER"
+    properties: GitHubTeamToUserRelProperties = GitHubTeamToUserRelProperties()
+
+
+@dataclass(frozen=True)
 class GitHubTeamToOrganizationRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
 
@@ -107,6 +134,8 @@ class GitHubTeamSchema(CartographyNodeSchema):
             GitHubTeamReadRepoRel(),
             GitHubTeamTriageRepoRel(),
             GitHubTeamWriteRepoRel(),
+            GitHubTeamMaintainerUserRel(),
+            GitHubTeamMemberUserRel(),
         ],
     )
     sub_resource_relationship: GitHubTeamToOrganizationRel = GitHubTeamToOrganizationRel()

--- a/docs/root/modules/github/schema.md
+++ b/docs/root/modules/github/schema.md
@@ -129,6 +129,12 @@ A GitHubTeam [organization object](https://docs.github.com/en/graphql/reference/
     (GitHubOrganization)-[RESOURCE]->(GitHubTeam)
     ```
 
+- GitHubUsers may be ['immediate'](https://docs.github.com/en/graphql/reference/enums#teammembershiptype) members of a team (as opposed to being members via membership in a child team), with their membership [role](https://docs.github.com/en/graphql/reference/enums#teammemberrole) being MEMBER or MAINTAINER.
+
+    ```
+    (GitHubUser)-[MEMBER|MAINTAINER]->(GitHubTeam)
+    ```
+
 ### GitHubUser
 
 Representation of a single GitHubUser [user object](https://developer.github.com/v4/object/user/). This node contains minimal data for the GitHub User.
@@ -177,6 +183,13 @@ WRITE, MAINTAIN, TRIAGE, and READ ([Reference](https://docs.github.com/en/graphq
     ```
     (GitHubUser)-[MEMBER_OF|UNAFFILIATED]->(GitHubOrganization)
     ```
+
+- GitHubUsers may be ['immediate'](https://docs.github.com/en/graphql/reference/enums#teammembershiptype) members of a team (as opposed to being members via membership in a child team), with their membership [role](https://docs.github.com/en/graphql/reference/enums#teammemberrole) being MEMBER or MAINTAINER.
+
+    ```
+    (GitHubUser)-[MEMBER|MAINTAINER]->(GitHubTeam)
+    ```
+
 
 ### GitHubBranch
 

--- a/tests/data/github/teams.py
+++ b/tests/data/github/teams.py
@@ -8,30 +8,35 @@ GH_TEAM_DATA = (
                 'url': 'https://github.com/orgs/example_org/teams/team-a',
                 'description': None,
                 'repositories': {'totalCount': 0},
+                'members': {'totalCount': 0},
             },
             {
                 'slug': 'team-b',
                 'url': 'https://github.com/orgs/example_org/teams/team-b',
                 'description': None,
                 'repositories': {'totalCount': 3},
+                'members': {'totalCount': 0},
             },
             {
                 'slug': 'team-c',
                 'url': 'https://github.com/orgs/example_org/teams/team-c',
                 'description': None,
                 'repositories': {'totalCount': 0},
+                'members': {'totalCount': 3},
             },
             {
                 'slug': 'team-d',
                 'url': 'https://github.com/orgs/example_org/teams/team-d',
                 'description': 'Team D',
                 'repositories': {'totalCount': 0},
+                'members': {'totalCount': 0},
             },
             {
                 'slug': 'team-e',
                 'url': 'https://github.com/orgs/example_org/teams/team-e',
                 'description': 'some description here',
                 'repositories': {'totalCount': 0},
+                'members': {'totalCount': 0},
             },
         ],
         edges=[],
@@ -51,5 +56,18 @@ GH_TEAM_REPOS = PaginatedGraphqlData(
         {'permission': 'ADMIN'},
         {'permission': 'WRITE'},
         {'permission': 'READ'},
+    ],
+)
+
+GH_TEAM_USERS = PaginatedGraphqlData(
+    nodes=[
+        {'url': 'https://example.com/hjsimpson'},
+        {'url': 'https://example.com/lmsimpson'},
+        {'url': 'https://example.com/mbsimpson'},
+    ],
+    edges=[
+        {'role': 'MEMBER'},
+        {'role': 'MAINTAINER'},
+        {'role': 'MAINTAINER'},
     ],
 )

--- a/tests/integration/cartography/intel/github/test_users.py
+++ b/tests/integration/cartography/intel/github/test_users.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import cartography.intel.github.users
+from cartography.models.github.users import GitHubOrganizationUserSchema
 from tests.data.github.users import GITHUB_ENTERPRISE_OWNER_DATA
 from tests.data.github.users import GITHUB_ORG_DATA
 from tests.data.github.users import GITHUB_USER_DATA
@@ -10,6 +11,24 @@ TEST_JOB_PARAMS = {'UPDATE_TAG': TEST_UPDATE_TAG}
 TEST_GITHUB_URL = GITHUB_ORG_DATA['url']
 TEST_GITHUB_ORG = GITHUB_ORG_DATA['login']
 FAKE_API_KEY = 'asdf'
+
+
+def _ensure_local_neo4j_has_test_data(neo4j_session):
+    """
+    Not needed for this test file, but used to set up users for other tests that need them
+    """
+    processed_affiliated_user_data, _ = (
+        cartography.intel.github.users.transform_users(
+            GITHUB_USER_DATA[0], GITHUB_ENTERPRISE_OWNER_DATA[0], GITHUB_ORG_DATA,
+        )
+    )
+    cartography.intel.github.users.load_users(
+        neo4j_session,
+        GitHubOrganizationUserSchema(),
+        processed_affiliated_user_data,
+        GITHUB_ORG_DATA,
+        TEST_UPDATE_TAG,
+    )
 
 
 @patch.object(cartography.intel.github.users, 'get_users', return_value=GITHUB_USER_DATA)

--- a/tests/unit/cartography/intel/github/test_teams.py
+++ b/tests/unit/cartography/intel/github/test_teams.py
@@ -4,8 +4,10 @@ from unittest.mock import patch
 import pytest
 
 from cartography.intel.github.teams import _get_team_repos_for_multiple_teams
+from cartography.intel.github.teams import _get_team_users_for_multiple_teams
 from cartography.intel.github.teams import RepoPermission
 from cartography.intel.github.teams import transform_teams
+from cartography.intel.github.teams import UserRole
 from cartography.intel.github.util import PaginatedGraphqlData
 
 TEST_ORG_DATA = {
@@ -26,6 +28,18 @@ def test_get_team_repos_empty_team_list(mock_get_team_repos):
     mock_get_team_repos.assert_not_called()
 
 
+@patch('cartography.intel.github.teams._get_team_users')
+def test_get_team_users_empty_team_list(mock_get_team_users):
+    # Assert that if we pass in empty data then we get back empty data
+    assert _get_team_users_for_multiple_teams(
+        [],
+        'test-org',
+        'https://api.github.com',
+        'test-token',
+    ) == {}
+    mock_get_team_users.assert_not_called()
+
+
 @patch('cartography.intel.github.teams._get_team_repos')
 def test_get_team_repos_team_with_no_repos(mock_get_team_repos):
     # Arrange
@@ -39,6 +53,21 @@ def test_get_team_repos_team_with_no_repos(mock_get_team_repos):
         'test-token',
     ) == {'team1': []}
     mock_get_team_repos.assert_not_called()
+
+
+@patch('cartography.intel.github.teams._get_team_users')
+def test_get_team_users_team_with_no_users(mock_get_team_users):
+    # Arrange
+    team_data = [{'slug': 'team1', 'members': {'totalCount': 0}}]
+
+    # Assert that we retrieve data where a team has no repos
+    assert _get_team_users_for_multiple_teams(
+        team_data,
+        'test-org',
+        'https://api.github.com',
+        'test-token',
+    ) == {'team1': []}
+    mock_get_team_users.assert_not_called()
 
 
 @patch('cartography.intel.github.teams._get_team_repos')
@@ -67,6 +96,32 @@ def test_get_team_repos_happy_path(mock_get_team_repos):
     mock_get_team_repos.assert_called_once_with('test-org', 'https://api.github.com', 'test-token', 'team1')
 
 
+@patch('cartography.intel.github.teams._get_team_users')
+def test_get_team_users_happy_path(mock_get_team_users):
+    # Arrange
+    team_data = [{'slug': 'team1', 'members': {'totalCount': 2}}]
+    mock_team_users = MagicMock()
+    mock_team_users.nodes = [{'url': 'https://github.com/user1'}, {'url': 'https://github.com/user2'}]
+    mock_team_users.edges = [{'role': 'MAINTAINER'}, {'role': 'MEMBER'}]
+    mock_get_team_users.return_value = mock_team_users
+
+    # Act + assert that the returned data is correct
+    assert _get_team_users_for_multiple_teams(
+        team_data,
+        'test-org',
+        'https://api.github.com',
+        'test-token',
+    ) == {
+        'team1': [
+            UserRole('https://github.com/user1', 'MAINTAINER'),
+            UserRole('https://github.com/user2', 'MEMBER'),
+        ],
+    }
+
+    # Assert that we did not retry because this was the happy path
+    mock_get_team_users.assert_called_once_with('test-org', 'https://api.github.com', 'test-token', 'team1')
+
+
 @patch('cartography.intel.github.teams._get_team_repos')
 @patch('cartography.intel.github.teams.sleep')
 def test_get_team_repos_github_returns_none(mock_sleep, mock_get_team_repos):
@@ -92,16 +147,42 @@ def test_get_team_repos_github_returns_none(mock_sleep, mock_get_team_repos):
     assert mock_sleep.call_count == 4
 
 
+@patch('cartography.intel.github.teams._get_team_users')
+@patch('cartography.intel.github.teams.sleep')
+def test_get_team_users_github_returns_none(mock_sleep, mock_get_team_users):
+    # Arrange
+    team_data = [{'slug': 'team1', 'members': {'totalCount': 1}}]
+    mock_team_users = MagicMock()
+    # Set up the condition where GitHub returns a None url and None edge as in #1334.
+    mock_team_users.nodes = [None]
+    mock_team_users.edges = [None]
+    mock_get_team_users.return_value = mock_team_users
+
+    # Assert we raise an exception
+    with pytest.raises(RuntimeError):
+        _get_team_users_for_multiple_teams(
+            team_data,
+            'test-org',
+            'https://api.github.com',
+            'test-token',
+        )
+
+    # Assert that we retry and give up
+    assert mock_get_team_users.call_count == 5
+    assert mock_sleep.call_count == 4
+
+
 def test_transform_teams_empty_team_data():
     # Arrange
     team_paginated_data = PaginatedGraphqlData(nodes=[], edges=[])
     team_repo_data: dict[str, list[RepoPermission]] = {}
+    team_user_data: dict[str, list[UserRole]] = {}
 
     # Act + assert
-    assert transform_teams(team_paginated_data, TEST_ORG_DATA, team_repo_data) == []
+    assert transform_teams(team_paginated_data, TEST_ORG_DATA, team_repo_data, team_user_data) == []
 
 
-def test_transform_teams_team_with_no_repos():
+def test_transform_teams_team_with_no_repos_no_users():
     # Arrange
     team_paginated_data = PaginatedGraphqlData(
         nodes=[
@@ -110,19 +191,22 @@ def test_transform_teams_team_with_no_repos():
                 'url': 'https://github.com/testorg/team1',
                 'description': 'Test Team 1',
                 'repositories': {'totalCount': 0},
+                'members': {'totalCount': 0},
             },
         ],
         edges=[],
     )
     team_repo_data = {'team1': []}
+    team_user_data = {'team1': []}
 
     # Act + Assert
-    assert transform_teams(team_paginated_data, TEST_ORG_DATA, team_repo_data) == [
+    assert transform_teams(team_paginated_data, TEST_ORG_DATA, team_repo_data, team_user_data) == [
         {
             'name': 'team1',
             'url': 'https://github.com/testorg/team1',
             'description': 'Test Team 1',
             'repo_count': 0,
+            'member_count': 0,
             'org_url': 'https://github.com/testorg',
             'org_login': 'testorg',
         },
@@ -138,6 +222,7 @@ def test_transform_teams_team_with_repos():
                 'url': 'https://github.com/testorg/team1',
                 'description': 'Test Team 1',
                 'repositories': {'totalCount': 2},
+                'members': {'totalCount': 0},
             },
         ],
         edges=[],
@@ -148,14 +233,16 @@ def test_transform_teams_team_with_repos():
             RepoPermission('https://github.com/testorg/repo2', 'WRITE'),
         ],
     }
+    team_user_data = {'team1': []}
 
     # Act
-    assert transform_teams(team_paginated_data, TEST_ORG_DATA, team_repo_data) == [
+    assert transform_teams(team_paginated_data, TEST_ORG_DATA, team_repo_data, team_user_data) == [
         {
             'name': 'team1',
             'url': 'https://github.com/testorg/team1',
             'description': 'Test Team 1',
             'repo_count': 2,
+            'member_count': 0,
             'org_url': 'https://github.com/testorg',
             'org_login': 'testorg',
             'READ': 'https://github.com/testorg/repo1',
@@ -165,9 +252,129 @@ def test_transform_teams_team_with_repos():
             'url': 'https://github.com/testorg/team1',
             'description': 'Test Team 1',
             'repo_count': 2,
+            'member_count': 0,
             'org_url': 'https://github.com/testorg',
             'org_login': 'testorg',
             'WRITE': 'https://github.com/testorg/repo2',
+        },
+    ]
+
+
+def test_transform_teams_team_with_members():
+    # Arrange
+    team_paginated_data = PaginatedGraphqlData(
+        nodes=[
+            {
+                'slug': 'team1',
+                'url': 'https://github.com/testorg/team1',
+                'description': 'Test Team 1',
+                'repositories': {'totalCount': 0},
+                'members': {'totalCount': 2},
+            },
+        ],
+        edges=[],
+    )
+    team_repo_data = {'team1': []}
+    team_user_data = {
+        'team1': [
+            UserRole('https://github.com/user1', 'MEMBER'),
+            UserRole('https://github.com/user2', 'MAINTAINER'),
+        ],
+    }
+
+    # Act
+    assert transform_teams(team_paginated_data, TEST_ORG_DATA, team_repo_data, team_user_data) == [
+        {
+            'name': 'team1',
+            'url': 'https://github.com/testorg/team1',
+            'description': 'Test Team 1',
+            'repo_count': 0,
+            'member_count': 2,
+            'org_url': 'https://github.com/testorg',
+            'org_login': 'testorg',
+            'MEMBER': 'https://github.com/user1',
+        },
+        {
+            'name': 'team1',
+            'url': 'https://github.com/testorg/team1',
+            'description': 'Test Team 1',
+            'repo_count': 0,
+            'member_count': 2,
+            'org_url': 'https://github.com/testorg',
+            'org_login': 'testorg',
+            'MAINTAINER': 'https://github.com/user2',
+        },
+    ]
+
+
+def test_transform_teams_team_with_repos_and_members():
+    # Arrange
+    team_paginated_data = PaginatedGraphqlData(
+        nodes=[
+            {
+                'slug': 'team1',
+                'url': 'https://github.com/testorg/team1',
+                'description': 'Test Team 1',
+                'repositories': {'totalCount': 2},
+                'members': {'totalCount': 2},
+            },
+        ],
+        edges=[],
+    )
+    team_repo_data = {
+        'team1': [
+            RepoPermission('https://github.com/testorg/repo1', 'READ'),
+            RepoPermission('https://github.com/testorg/repo2', 'WRITE'),
+        ],
+    }
+    team_user_data = {
+        'team1': [
+            UserRole('https://github.com/user1', 'MEMBER'),
+            UserRole('https://github.com/user2', 'MAINTAINER'),
+        ],
+    }
+
+    # Act
+    assert transform_teams(team_paginated_data, TEST_ORG_DATA, team_repo_data, team_user_data) == [
+        {
+            'name': 'team1',
+            'url': 'https://github.com/testorg/team1',
+            'description': 'Test Team 1',
+            'repo_count': 2,
+            'member_count': 2,
+            'org_url': 'https://github.com/testorg',
+            'org_login': 'testorg',
+            'READ': 'https://github.com/testorg/repo1',
+        },
+        {
+            'name': 'team1',
+            'url': 'https://github.com/testorg/team1',
+            'description': 'Test Team 1',
+            'repo_count': 2,
+            'member_count': 2,
+            'org_url': 'https://github.com/testorg',
+            'org_login': 'testorg',
+            'WRITE': 'https://github.com/testorg/repo2',
+        },
+        {
+            'name': 'team1',
+            'url': 'https://github.com/testorg/team1',
+            'description': 'Test Team 1',
+            'repo_count': 2,
+            'member_count': 2,
+            'org_url': 'https://github.com/testorg',
+            'org_login': 'testorg',
+            'MEMBER': 'https://github.com/user1',
+        },
+        {
+            'name': 'team1',
+            'url': 'https://github.com/testorg/team1',
+            'description': 'Test Team 1',
+            'repo_count': 2,
+            'member_count': 2,
+            'org_url': 'https://github.com/testorg',
+            'org_login': 'testorg',
+            'MAINTAINER': 'https://github.com/user2',
         },
     ]
 
@@ -181,12 +388,14 @@ def test_transform_teams_multiple_teams():
                 'url': 'https://github.com/testorg/team1',
                 'description': 'Test Team 1',
                 'repositories': {'totalCount': 1},
+                'members': {'totalCount': 0},
             },
             {
                 'slug': 'team2',
                 'url': 'https://github.com/testorg/team2',
                 'description': 'Test Team 2',
                 'repositories': {'totalCount': 0},
+                'members': {'totalCount': 1},
             },
         ],
         edges=[],
@@ -197,14 +406,21 @@ def test_transform_teams_multiple_teams():
         ],
         'team2': [],
     }
+    team_user_data = {
+        'team1': [],
+        'team2': [
+            UserRole('https://github.com/user1', 'MEMBER'),
+        ],
+    }
 
     # Act + assert
-    assert transform_teams(team_paginated_data, TEST_ORG_DATA, team_repo_data) == [
+    assert transform_teams(team_paginated_data, TEST_ORG_DATA, team_repo_data, team_user_data) == [
         {
             'name': 'team1',
             'url': 'https://github.com/testorg/team1',
             'description': 'Test Team 1',
             'repo_count': 1,
+            'member_count': 0,
             'org_url': 'https://github.com/testorg',
             'org_login': 'testorg',
             'ADMIN': 'https://github.com/testorg/repo1',
@@ -214,7 +430,9 @@ def test_transform_teams_multiple_teams():
             'url': 'https://github.com/testorg/team2',
             'description': 'Test Team 2',
             'repo_count': 0,
+            'member_count': 1,
             'org_url': 'https://github.com/testorg',
             'org_login': 'testorg',
+            'MEMBER': 'https://github.com/user1',
         },
     ]

--- a/tests/unit/cartography/intel/github/test_teams.py
+++ b/tests/unit/cartography/intel/github/test_teams.py
@@ -123,8 +123,8 @@ def test_get_team_users_happy_path(mock_get_team_users):
 
 
 @patch('cartography.intel.github.teams._get_team_repos')
-@patch('cartography.intel.github.teams.sleep')
-def test_get_team_repos_github_returns_none(mock_sleep, mock_get_team_repos):
+@patch('cartography.intel.github.teams.backoff_handler', spec=True)
+def test_get_team_repos_github_returns_none(mock_backoff_handler, mock_get_team_repos):
     # Arrange
     team_data = [{'slug': 'team1', 'repositories': {'totalCount': 1}}]
     mock_team_repos = MagicMock()
@@ -134,7 +134,7 @@ def test_get_team_repos_github_returns_none(mock_sleep, mock_get_team_repos):
     mock_get_team_repos.return_value = mock_team_repos
 
     # Assert we raise an exception
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TypeError):
         _get_team_repos_for_multiple_teams(
             team_data,
             'test-org',
@@ -144,12 +144,12 @@ def test_get_team_repos_github_returns_none(mock_sleep, mock_get_team_repos):
 
     # Assert that we retry and give up
     assert mock_get_team_repos.call_count == 5
-    assert mock_sleep.call_count == 4
+    assert mock_backoff_handler.call_count == 4
 
 
 @patch('cartography.intel.github.teams._get_team_users')
-@patch('cartography.intel.github.teams.sleep')
-def test_get_team_users_github_returns_none(mock_sleep, mock_get_team_users):
+@patch('cartography.intel.github.teams.backoff_handler', spec=True)
+def test_get_team_users_github_returns_none(mock_backoff_handler, mock_get_team_users):
     # Arrange
     team_data = [{'slug': 'team1', 'members': {'totalCount': 1}}]
     mock_team_users = MagicMock()
@@ -159,7 +159,7 @@ def test_get_team_users_github_returns_none(mock_sleep, mock_get_team_users):
     mock_get_team_users.return_value = mock_team_users
 
     # Assert we raise an exception
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TypeError):
         _get_team_users_for_multiple_teams(
             team_data,
             'test-org',
@@ -169,7 +169,7 @@ def test_get_team_users_github_returns_none(mock_sleep, mock_get_team_users):
 
     # Assert that we retry and give up
     assert mock_get_team_users.call_count == 5
-    assert mock_sleep.call_count == 4
+    assert mock_backoff_handler.call_count == 4
 
 
 def test_transform_teams_empty_team_data():


### PR DESCRIPTION
### Summary

This PR adds to the Github graph, adding user membership in teams, for users who are 'immediate' members of a team.

In case it is unclear or for people newer to Github, note: this is focusing on ['immediate'](https://docs.github.com/en/graphql/reference/enums#teammembershiptype) membership to a team, meaning a member is in the team directly as opposed to being in a child team.  A user could be considered a member of a team if they are members of a child team, but this PR maps only 'immediate' membership.  (In a follow-up PR we'd like to add child teams to the graph, which we think will complete the membership picture.)

We think this is a valuable addition to the graph because our broad intent is to understand all access a user has, and (at least in our org) most access to repos is granted via team.  If we do not know who is in the team, then, we do not know who has access.

#### Illustration of the intention
![Cartography AMPS User Direct Team Membership](https://github.com/user-attachments/assets/7d3d70ab-ab16-4a21-8970-3f9d2b8fe525)

#### Screencaps

**EXAMPLE USER LOOKUP**

BEFORE
(empty result because nothing exists)
![Screenshot 2024-12-03 at 5 07 00 PM](https://github.com/user-attachments/assets/908e8e96-179d-494a-ac7d-acc03ee54ab1)

AFTER
![Screenshot 2024-12-03 at 5 06 04 PM](https://github.com/user-attachments/assets/073376ee-b8d6-4b68-8d7e-246e9f9601a2)

**OVERVIEW OF COUNTS OF EACH TYPE**

BEFORE
(empty result because nothing exists)
![Screenshot 2024-12-03 at 5 09 03 PM](https://github.com/user-attachments/assets/c4758f8f-71ec-49b5-a94a-c3d464a9a51e)

AFTER
![Screenshot 2024-12-03 at 5 08 44 PM](https://github.com/user-attachments/assets/cc0be586-c1bf-440b-a8a0-6bc236272509)


### Related issues or links

None


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

**N/A** If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
