### PR TITLE
GitHub: introduce ADMIN_OF relationship between users and orgs

### DIFF
--- a/cartography/intel/github/users.py
+++ b/cartography/intel/github/users.py
@@ -144,10 +144,13 @@ def transform_users(user_data: List[Dict], owners_data: List[Dict], org_data: Di
 
     users_dict = {}
     for user in user_data:
+        # all members get the 'MEMBER_OF' relationship
         processed_user = deepcopy(user['node'])
-        processed_user['role'] = user['role']
         processed_user['hasTwoFactorEnabled'] = user['hasTwoFactorEnabled']
         processed_user['MEMBER_OF'] = org_data['url']
+        # admins get a second relationship expressing them as such
+        if user['role'] == 'ADMIN':
+            processed_user['ADMIN_OF'] = org_data['url']
         users_dict[processed_user['url']] = processed_user
 
     owners_dict = {}

--- a/cartography/models/github/orgs.py
+++ b/cartography/models/github/orgs.py
@@ -1,7 +1,7 @@
 """
 This schema does not handle the org's relationships.  Those are handled by other schemas, for example:
 * GitHubTeamSchema defines (GitHubOrganization)-[RESOURCE]->(GitHubTeam)
-* GitHubUserSchema defines (GitHubUser)-[MEMBER_OF|UNAFFILIATED]->(GitHubOrganization)
+* GitHubUserSchema defines (GitHubUser)-[MEMBER_OF|ADMIN_OF|UNAFFILIATED]->(GitHubOrganization)
 (There may be others, these are just two examples.)
 """
 from dataclasses import dataclass

--- a/docs/root/modules/github/schema.md
+++ b/docs/root/modules/github/schema.md
@@ -94,10 +94,21 @@ Representation of a single GitHubOrganization [organization object](https://deve
     (GitHubOrganization)-[RESOURCE]->(GitHubTeam)
     ```
 
-- GitHubUsers are members of an organization.  In some cases there may be a user who is "unaffiliated" with an org, for example if the user is an enterprise owner, but not member of, the org.  [Enterprise owners](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/roles-in-an-enterprise#enterprise-owners) have complete control over the enterprise (i.e. they can manage all enterprise settings, members, and policies) yet may not show up on member lists of the GitHub org.
+- GitHubUsers relate to GitHubOrganizations in a few ways:
+  - Most typically, they are members of an organization.
+  - They may also be org admins (aka org owners), with broad permissions over repo and team settings.  In these cases, they will be graphed with two relationships between GitHubUser and GitHubOrganization, both `MEMBER_OF` and `ADMIN_OF`.
+  - In some cases there may be a user who is "unaffiliated" with an org, for example if the user is an enterprise owner, but not member of, the org.  [Enterprise owners](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/roles-in-an-enterprise#enterprise-owners) have complete control over the enterprise (i.e. they can manage all enterprise settings, members, and policies) yet may not show up on member lists of the GitHub org.
 
     ```
-    (GitHubUser)-[MEMBER_OF|UNAFFILIATED]->(GitHubOrganization)
+    # a typical member
+    (GitHubUser)-[MEMBER_OF]->(GitHubOrganization)
+
+    # an admin member has two relationships to the org
+    (GitHubUser)-[MEMBER_OF]->(GitHubOrganization)
+    (GitHubUser)-[ADMIN_OF]->(GitHubOrganization)
+
+    # an unaffiliated user (e.g. an enterprise owner)
+    (GitHubUser)-[UNAFFILIATED]->(GitHubOrganization)
     ```
 
 
@@ -148,7 +159,6 @@ Representation of a single GitHubUser [user object](https://developer.github.com
 | username | Name of the user |
 | fullname | The full name |
 | has_2fa_enabled | Whether the user has 2-factor authentication enabled |
-| role | Either 'ADMIN' (denoting that the user is an owner of a Github organization) or 'MEMBER' |
 | is_site_admin | Whether the user is a site admin |
 | is_enterprise_owner | Whether the user is an [enterprise owner](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/roles-in-an-enterprise#enterprise-owners) |
 | permission | Only present if the user is an [outside collaborator](https://docs.github.com/en/graphql/reference/objects#repositorycollaboratorconnection) of this repo.  `permission` is either ADMIN, MAINTAIN, READ, TRIAGE, or WRITE ([ref](https://docs.github.com/en/graphql/reference/enums#repositorypermission)). |
@@ -178,10 +188,21 @@ WRITE, MAINTAIN, TRIAGE, and READ ([Reference](https://docs.github.com/en/graphq
     (GitHubUser)-[:DIRECT_COLLAB_{ACTION}]->(GitHubRepository)
     ```
 
-- GitHubUsers are members of an organization.  In some cases there may be a user who is "unaffiliated" with an org, for example if the user is an enterprise owner, but not member of, the org.  [Enterprise owners](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/roles-in-an-enterprise#enterprise-owners) have complete control over the enterprise (i.e. they can manage all enterprise settings, members, and policies) yet may not show up on member lists of the GitHub org.
+- GitHubUsers relate to GitHubOrganizations in a few ways:
+  - Most typically, they are members of an organization.
+  - They may also be org admins (aka org owners), with broad permissions over repo and team settings.  In these cases, they will be graphed with two relationships between GitHubUser and GitHubOrganization, both `MEMBER_OF` and `ADMIN_OF`.
+  - In some cases there may be a user who is "unaffiliated" with an org, for example if the user is an enterprise owner, but not member of, the org.  [Enterprise owners](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-accounts-and-repositories/managing-users-in-your-enterprise/roles-in-an-enterprise#enterprise-owners) have complete control over the enterprise (i.e. they can manage all enterprise settings, members, and policies) yet may not show up on member lists of the GitHub org.
 
     ```
-    (GitHubUser)-[MEMBER_OF|UNAFFILIATED]->(GitHubOrganization)
+    # a typical member
+    (GitHubUser)-[MEMBER_OF]->(GitHubOrganization)
+
+    # an admin member has two relationships to the org
+    (GitHubUser)-[MEMBER_OF]->(GitHubOrganization)
+    (GitHubUser)-[ADMIN_OF]->(GitHubOrganization)
+
+    # an unaffiliated user (e.g. an enterprise owner)
+    (GitHubUser)-[UNAFFILIATED]->(GitHubOrganization)
     ```
 
 - GitHubUsers may be ['immediate'](https://docs.github.com/en/graphql/reference/enums#teammembershiptype) members of a team (as opposed to being members via membership in a child team), with their membership [role](https://docs.github.com/en/graphql/reference/enums#teammemberrole) being MEMBER or MAINTAINER.

--- a/tests/integration/cartography/intel/github/test_users.py
+++ b/tests/integration/cartography/intel/github/test_users.py
@@ -48,22 +48,21 @@ def test_sync(mock_owners, mock_users, neo4j_session):
 
     # Assert
 
-    # Ensure users got loaded
+    # Ensure the expected users are there
     nodes = neo4j_session.run(
         """
-        MATCH (g:GitHubUser) RETURN g.id, g.role;
+        MATCH (g:GitHubUser) RETURN g.id;
         """,
     )
     expected_nodes = {
-        ("https://example.com/hjsimpson", 'MEMBER'),
-        ("https://example.com/lmsimpson", 'MEMBER'),
-        ("https://example.com/mbsimpson", 'ADMIN'),
-        ("https://example.com/kbroflovski", None),
+        ("https://example.com/hjsimpson",),
+        ("https://example.com/lmsimpson",),
+        ("https://example.com/mbsimpson",),
+        ("https://example.com/kbroflovski",),
     }
     actual_nodes = {
         (
             n['g.id'],
-            n['g.role'],
         ) for n in nodes
     }
     assert actual_nodes == expected_nodes
@@ -94,6 +93,10 @@ def test_sync(mock_owners, mock_users, neo4j_session):
         ), (
             'https://example.com/mbsimpson',
             'MEMBER_OF',
+            'https://example.com/my_org',
+        ), (
+            'https://example.com/mbsimpson',
+            'ADMIN_OF',
             'https://example.com/my_org',
         ), (
             'https://example.com/kbroflovski',


### PR DESCRIPTION
### Summary

This PR fixes the issue described in issue #1374—please see the issue and discussion there for details, but here it is in summary:

The 'role' property on a GitHubUser node expresses whether a user is an 'ADMIN' (aka Owner) or a 'MEMBER' of a GitHubOrganization.  For a graph with multiple orgs, however, the role property will reflect only one of the user-org relationships.  If the user is an admin in one org and a member in another, for example, the 'role' property will be wrong for one of those relationships.  To fix this, this PR shifts the role to be expressed in the relationship between GitHubUser and GitHubOrganization.

Below are a few before/after screen caps to show intent and the PR working.

#### **USER IS AN OWNER OF ONE ORG, MEMBER OF ANOTHER**

BEFORE
Here the user is graphed as 'MEMBER_OF' to both orgs.  The 'role' property (not pictured) is set to reflect one of those relationships, so it is partly wrong.
![Screenshot 2024-12-09 at 5 22 15 PM](https://github.com/user-attachments/assets/4b1094ba-0020-4d10-a397-52653e0214e9)

AFTER
The relationship is now updated to reflect that the user is an admin of one of the orgs.  And, as suggested by @achantavy  in #1374, admins now get two user-org relationships "so that we can determine what org a user belongs to in a uniform way".
![Screenshot 2024-12-09 at 5 08 04 PM](https://github.com/user-attachments/assets/6c654b5f-0363-4045-9167-2f6459371cbc)

#### **MEMBERS AND UNAFFILIATEDS REMAIN THE SAME**

BEFORE & AFTER
This user is handy for demonstration purposes because they are a member of one org, and unaffiliated to another (the user in question is an enterprise owner, and is not a member of the second org).  These relationships remain untouched by this PR, and so the before and after results for the query shown are identical.
![Screenshot 2024-12-09 at 5 07 20 PM](https://github.com/user-attachments/assets/4dffb9a5-691d-4099-9169-9f4195814c7b)


#### **RELATIONSHIP COUNTS**

BEFORE
Only MEMBER_OF and UNAFFILIATED is graphed, and to know who is an ADMIN you have to look at a property:
![Screenshot 2024-12-11 at 8 44 21 PM](https://github.com/user-attachments/assets/ec8c7675-13d1-4ecd-a059-2154a3e9beb1)
![Screenshot 2024-12-11 at 9 03 52 PM](https://github.com/user-attachments/assets/c78d5db8-7ff4-44b1-b76d-67ab6bd5011f)
(Note there are 16 admins, but also note how I had to specify folks who are 'UNAFFILIATED' in my query.  If I hadn't done that, I would've gotten a higher number, as some of those folks are admins but of a different org.  So the result would have been wrong.)

AFTER
In addition to the exiting relationships that were there before, there are 16 new ADMIN_OF relationships for every node that _had_ an ADMIN role property.
![Screenshot 2024-12-11 at 8 41 56 PM](https://github.com/user-attachments/assets/d70a5583-9366-42f9-82b7-5c51d426a7f8)



### Related issues or links

- #1374 


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

**NOT APPLICABLE** you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
