### PR TITLE
0.96.2: Fix #1404: allow GitHub sync to continue when we can't list collaborators

### DIFF
--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -7,6 +7,7 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+import backoff
 import neo4j
 from packaging.requirements import InvalidRequirement
 from packaging.requirements import Requirement
@@ -140,22 +141,40 @@ def _get_repo_collaborators_inner_func(
         org: str,
         api_url: str,
         token: str,
-        repo_name: str,
+        repo_raw_data: list[dict[str, Any]],
         affiliation: str,
         collab_users: list[dict[str, Any]],
         collab_permission: list[str],
-) -> None:
-    logger.info(f"Loading {affiliation} collaborators for repo {repo_name}.")
-    collaborators = _get_repo_collaborators(token, api_url, org, repo_name, affiliation)
+) -> dict[str, list[UserAffiliationAndRepoPermission]]:
+    result: dict[str, list[UserAffiliationAndRepoPermission]] = {}
 
-    # nodes and edges are expected to always be present given that we only call for them if totalCount is > 0
-    # however sometimes GitHub returns None, as in issue 1334 and 1404.
-    for collab in collaborators.nodes or []:
-        collab_users.append(collab)
+    for repo in repo_raw_data:
+        repo_name = repo['name']
+        repo_url = repo['url']
 
-    # The `or []` is because `.edges` can be None.
-    for perm in collaborators.edges or []:
-        collab_permission.append(perm['permission'])
+        if ((affiliation == 'OUTSIDE' and repo['outsideCollaborators']['totalCount'] == 0) or
+                (affiliation == 'DIRECT' and repo['directCollaborators']['totalCount'] == 0)):
+            # repo has no collabs of the affiliation type we're looking for, so don't waste time making an API call
+            result[repo_url] = []
+            continue
+
+        logger.info(f"Loading {affiliation} collaborators for repo {repo_name}.")
+        collaborators = _get_repo_collaborators(token, api_url, org, repo_name, affiliation)
+
+        # nodes and edges are expected to always be present given that we only call for them if totalCount is > 0
+        # however sometimes GitHub returns None, as in issue 1334 and 1404.
+        for collab in collaborators.nodes or []:
+            collab_users.append(collab)
+
+        # The `or []` is because `.edges` can be None.
+        for perm in collaborators.edges or []:
+            collab_permission.append(perm['permission'])
+
+        result[repo_url] = [
+            UserAffiliationAndRepoPermission(user, permission, affiliation)
+            for user, permission in zip(collab_users, collab_permission)
+        ]
+    return result
 
 
 def _get_repo_collaborators_for_multiple_repos(
@@ -175,39 +194,24 @@ def _get_repo_collaborators_for_multiple_repos(
     :param token: The Github API token as string.
     :return: A dictionary of repo URL to list of UserAffiliationAndRepoPermission
     """
-    result: dict[str, list[UserAffiliationAndRepoPermission]] = {}
-    for repo in repo_raw_data:
-        repo_name = repo['name']
-        repo_url = repo['url']
+    logger.info(f'Retrieving repo collaborators for affiliation "{affiliation}" on org "{org}".')
+    collab_users: List[dict[str, Any]] = []
+    collab_permission: List[str] = []
 
-        if ((affiliation == 'OUTSIDE' and repo['outsideCollaborators']['totalCount'] == 0) or
-                (affiliation == 'DIRECT' and repo['directCollaborators']['totalCount'] == 0)):
-            # repo has no collabs of the affiliation type we're looking for, so don't waste time making an API call
-            result[repo_url] = []
-            continue
-
-        collab_users: List[dict[str, Any]] = []
-        collab_permission: List[str] = []
-
-        retries_with_backoff(
-            _get_repo_collaborators_inner_func,
-            TypeError,
-            5,
-            backoff_handler,
-        )(
-            org=org,
-            api_url=api_url,
-            token=token,
-            repo_name=repo_name,
-            affiliation=affiliation,
-            collab_users=collab_users,
-            collab_permission=collab_permission,
-        )
-
-        result[repo_url] = [
-            UserAffiliationAndRepoPermission(user, permission, affiliation)
-            for user, permission in zip(collab_users, collab_permission)
-        ]
+    result = retries_with_backoff(
+        _get_repo_collaborators_inner_func,
+        TypeError,
+        5,
+        backoff_handler,
+    )(
+        org=org,
+        api_url=api_url,
+        token=token,
+        repo_raw_data=repo_raw_data,
+        affiliation=affiliation,
+        collab_users=collab_users,
+        collab_permission=collab_permission,
+    )
     return result
 
 
@@ -260,8 +264,9 @@ def get(token: str, api_url: str, organization: str) -> List[Dict]:
 
 
 def transform(
-    repos_json: List[Dict], direct_collaborators: dict[str, List[UserAffiliationAndRepoPermission]],
-    outside_collaborators: dict[str, List[UserAffiliationAndRepoPermission]],
+        repos_json: List[Dict],
+        direct_collaborators: dict[str, List[UserAffiliationAndRepoPermission]],
+        outside_collaborators: dict[str, List[UserAffiliationAndRepoPermission]],
 ) -> Dict:
     """
     Parses the JSON returned from GitHub API to create data for graph ingestion
@@ -289,16 +294,24 @@ def transform(
         _transform_repo_languages(repo_object['url'], repo_object, transformed_repo_languages)
         _transform_repo_objects(repo_object, transformed_repo_list)
         _transform_repo_owners(repo_object['owner']['url'], repo_object, transformed_repo_owners)
-        _transform_collaborators(
-            repo_object['url'], outside_collaborators[repo_object['url']],
-            transformed_outside_collaborators,
-        )
-        _transform_collaborators(
-            repo_object['url'], direct_collaborators[repo_object['url']],
-            transformed_direct_collaborators,
-        )
-        _transform_requirements_txt(repo_object['requirements'], repo_object['url'], transformed_requirements_files)
-        _transform_setup_cfg_requirements(repo_object['setupCfg'], repo_object['url'], transformed_requirements_files)
+
+        # Allow sync to continue if we didn't have permissions to list collaborators
+        repo_url = repo_object['url']
+        if repo_url in outside_collaborators:
+            _transform_collaborators(
+                repo_object['url'],
+                outside_collaborators[repo_object['url']],
+                transformed_outside_collaborators,
+            )
+        if repo_url in direct_collaborators:
+            _transform_collaborators(
+                repo_object['url'],
+                direct_collaborators[repo_object['url']],
+                transformed_direct_collaborators,
+            )
+
+        _transform_requirements_txt(repo_object['requirements'], repo_url, transformed_requirements_files)
+        _transform_setup_cfg_requirements(repo_object['setupCfg'], repo_url, transformed_requirements_files)
     results = {
         'repos': transformed_repo_list,
         'repo_languages': transformed_repo_languages,
@@ -737,12 +750,18 @@ def sync(
     """
     logger.info("Syncing GitHub repos")
     repos_json = get(github_api_key, github_url, organization)
-    direct_collabs = _get_repo_collaborators_for_multiple_repos(
-        repos_json, "DIRECT", organization, github_url, github_api_key,
-    )
-    outside_collabs = _get_repo_collaborators_for_multiple_repos(
-        repos_json, "OUTSIDE", organization, github_url, github_api_key,
-    )
+    direct_collabs: dict[str, list[UserAffiliationAndRepoPermission]] = {}
+    outside_collabs: dict[str, list[UserAffiliationAndRepoPermission]] = {}
+    try:
+        direct_collabs = _get_repo_collaborators_for_multiple_repos(
+            repos_json, "DIRECT", organization, github_url, github_api_key,
+        )
+        outside_collabs = _get_repo_collaborators_for_multiple_repos(
+            repos_json, "OUTSIDE", organization, github_url, github_api_key,
+        )
+    except TypeError as e:
+        # due to permission errors or transient network error or some other nonsense
+        logger.warning('Unable to list repo collaborators due to permission errors; continuing on.', exc_info=True)
     repo_data = transform(repos_json, direct_collabs, outside_collabs)
     load(neo4j_session, common_job_parameters, repo_data)
     run_cleanup_job('github_repos_cleanup.json', neo4j_session, common_job_parameters)

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -7,7 +7,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-import backoff
 import neo4j
 from packaging.requirements import InvalidRequirement
 from packaging.requirements import Requirement
@@ -198,7 +197,7 @@ def _get_repo_collaborators_for_multiple_repos(
     collab_users: List[dict[str, Any]] = []
     collab_permission: List[str] = []
 
-    result = retries_with_backoff(
+    result: dict[str, list[UserAffiliationAndRepoPermission]] = retries_with_backoff(
         _get_repo_collaborators_inner_func,
         TypeError,
         5,
@@ -759,7 +758,7 @@ def sync(
         outside_collabs = _get_repo_collaborators_for_multiple_repos(
             repos_json, "OUTSIDE", organization, github_url, github_api_key,
         )
-    except TypeError as e:
+    except TypeError:
         # due to permission errors or transient network error or some other nonsense
         logger.warning('Unable to list repo collaborators due to permission errors; continuing on.', exc_info=True)
     repo_data = transform(repos_json, direct_collabs, outside_collabs)

--- a/cartography/intel/github/users.py
+++ b/cartography/intel/github/users.py
@@ -90,6 +90,7 @@ def get_users(token: str, api_url: str, organization: str) -> Tuple[List[Dict], 
         2. data on the owning GitHub organization
         see tests.data.github.users.GITHUB_USER_DATA for shape of both
     """
+    logger.info(f"Retrieving users from GitHub organization {organization}")
     users, org = fetch_all(
         token,
         api_url,
@@ -112,6 +113,7 @@ def get_enterprise_owners(token: str, api_url: str, organization: str) -> Tuple[
         3. data on the owning GitHub organization
         see tests.data.github.users.GITHUB_ENTERPRISE_OWNER_DATA for shape
     """
+    logger.info(f"Retrieving enterprise owners from GitHub organization {organization}")
     owners, org = fetch_all(
         token,
         api_url,

--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -163,7 +163,8 @@ def fetch_all(
 
         if retry >= retries:
             logger.error(
-                f"GitHub: Could not retrieve page of resource `{resource_type}` due to HTTP error.",
+                f"GitHub: Could not retrieve page of resource `{resource_type}` due to HTTP error "
+                f"after {retry} retries. Raising exception.",
                 exc_info=True,
             )
             raise exc

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-__version__ = '0.96.1'
+__version__ = '0.96.2'
 
 
 setup(


### PR DESCRIPTION
### Summary
> Describe your changes.

Allows the GitHub sync to continue if the user is unable to list repository collaborators.


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
