### PR TITLE
cve_feed: Correct the retry and sleep time

### DIFF
--- a/cartography/intel/cve/__init__.py
+++ b/cartography/intel/cve/__init__.py
@@ -2,6 +2,9 @@ import logging
 from datetime import datetime
 
 import neo4j
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
 
 from cartography.config import Config
 from cartography.intel.cve import feed
@@ -11,6 +14,71 @@ from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 stat_handler = get_stats_client(__name__)
+
+
+def _retryable_session() -> Session:
+    session = Session()
+    retry_policy = Retry(
+        total=8,
+        connect=1,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
+    session.mount("https://", HTTPAdapter(max_retries=retry_policy))
+    logger.info(f"Configured session with retry policy: {retry_policy}")
+    return session
+
+
+def _sync_year_archives(
+    http_session: Session,
+    neo4j_session: neo4j.Session,
+    config: Config,
+    cve_api_key: str | None,
+) -> None:
+    existing_years = feed.get_cve_sync_metadata(neo4j_session)
+    current_year = datetime.now().year
+    logger.info(f"Syncing CVE data for year archives. Existing years: {existing_years}. Current year: {current_year}")
+    for year in range(2002, current_year + 1):
+        if year in existing_years:
+            continue
+        logger.info(f"Syncing CVE data for year {year}")
+        cves = feed.get_published_cves_per_year(http_session, config.nist_cve_url, str(year), cve_api_key)
+        feed_metadata = feed.transform_cve_feed(cves)
+        feed.load_cve_feed(neo4j_session, [feed_metadata], config.update_tag)
+        published_cves = feed.transform_cves(cves)
+        feed.load_cves(neo4j_session, published_cves, feed_metadata['FEED_ID'], config.update_tag)
+        merge_module_sync_metadata(
+            neo4j_session,
+            group_type='CVE',
+            group_id=year,
+            synced_type='year',
+            update_tag=config.update_tag,
+            stat_handler=stat_handler,
+        )
+
+
+def _sync_modified_data(
+    http_session: Session,
+    neo4j_session: neo4j.Session,
+    config: Config,
+    cve_api_key: str | None,
+) -> None:
+    logger.info("Syncing CVE data for modified data")
+    last_modified_date = feed.get_last_modified_cve_date(neo4j_session)
+    cves = feed.get_modified_cves(http_session, config.nist_cve_url, last_modified_date, cve_api_key)
+    feed_metadata = feed.transform_cve_feed(cves)
+    feed.load_cve_feed(neo4j_session, [feed_metadata], config.update_tag)
+    modified_cves = feed.transform_cves(cves)
+    feed.load_cves(neo4j_session, modified_cves, feed_metadata['FEED_ID'], config.update_tag)
+    merge_module_sync_metadata(
+        neo4j_session,
+        group_type='CVE',
+        group_id=feed_metadata['timestamp'][:4],
+        synced_type='modified',
+        update_tag=config.update_tag,
+        stat_handler=stat_handler,
+    )
 
 
 @timeit
@@ -26,43 +94,7 @@ def start_cve_ingestion(
     if not config.cve_enabled:
         return
     cve_api_key: str | None = config.cve_api_key if config.cve_api_key else None
-
-    # sync CVE year archives, if not yet synced
-    existing_years = feed.get_cve_sync_metadata(neo4j_session)
-    current_year = datetime.now().year
-    for year in range(2002, current_year + 1):
-        if year in existing_years:
-            continue
-        logger.info(f"Syncing CVE data for year {year}")
-        cves = feed.get_published_cves_per_year(config.nist_cve_url, str(year), cve_api_key)
-        feed_metadata = feed.transform_cve_feed(cves)
-        feed.load_cve_feed(neo4j_session, [feed_metadata], config.update_tag)
-        published_cves = feed.transform_cves(cves)
-        feed.load_cves(neo4j_session, published_cves, feed_metadata['FEED_ID'], config.update_tag)
-        merge_module_sync_metadata(
-            neo4j_session,
-            group_type='CVE',
-            group_id=year,
-            synced_type='year',
-            update_tag=config.update_tag,
-            stat_handler=stat_handler,
-        )
-
-    # sync modified data
-    logger.info("Syncing CVE data for modified data")
-    last_modified_date = feed.get_last_modified_cve_date(neo4j_session)
-    cves = feed.get_modified_cves(config.nist_cve_url, last_modified_date, cve_api_key)
-    feed_metadata = feed.transform_cve_feed(cves)
-    feed.load_cve_feed(neo4j_session, [feed_metadata], config.update_tag)
-    modified_cves = feed.transform_cves(cves)
-    feed.load_cves(neo4j_session, modified_cves, feed_metadata['FEED_ID'], config.update_tag)
-    merge_module_sync_metadata(
-        neo4j_session,
-        group_type='CVE',
-        group_id=feed_metadata['timestamp'][:4],
-        synced_type='modified',
-        update_tag=config.update_tag,
-        stat_handler=stat_handler,
-    )
-
-    # CVEs are never deleted, so we don't need to run a cleanup job
+    with _retryable_session() as http_session:
+        _sync_year_archives(http_session, neo4j_session=neo4j_session, config=config, cve_api_key=cve_api_key)
+        _sync_modified_data(http_session, neo4j_session=neo4j_session, config=config, cve_api_key=cve_api_key)
+        # CVEs are never deleted, so we don't need to run a cleanup job

--- a/cartography/intel/cve/feed.py
+++ b/cartography/intel/cve/feed.py
@@ -101,7 +101,7 @@ def _call_cves_api(url: str, api_key: str | None, params: Dict[str, Any]) -> Dic
     with requests.Session() as session:
         _configure_session(session)
         while params["resultsPerPage"] > 0 or params["startIndex"] < totalResults:
-            logger.error(f"Calling NIST NVD API at {url} with params {params}")
+            logger.info(f"Calling NIST NVD API at {url} with params {params}")
             res = session.get(url, params=params, headers=headers, timeout=CONNECT_AND_READ_TIMEOUT)
             res.raise_for_status()
             data = res.json()


### PR DESCRIPTION
### Summary

The [current code](https://github.com/cartography-cncf/cartography/blob/4d53bce6d9f3f6703b709b70071cbcc36820a5bb/cartography/intel/cve/feed.py#L73-L113) uses of variable `sleep_time` for both retries and sleep between requests. Furthermore, the `sleep_time` was not reset in the next request, meaning that if the first request increases it to 16 seconds, the second request will continue to take that up to every bigger number (the `retries` count is reset though which makes it worse).

Two changes here:
- The sleep between requests is set to be a dedicated variable `sleep_between_requests`.
- I decided to rewrite the request retry logic more properly using HttpAdapter's retry policy.

Unfortunately, I tried pretty hard to see if we can keep `test_call_cves_api_with_error` which tests the retry logic but it's not very feasible. Also it doesn't make a lot of sense to test something managed by the Session object itself. So I had to drop it.

### Testing

I think existing integ test can confirm the code is still working. The retry change itself will need some manual review to see if it makes sense.