### PR TITLE
Add CVE information from 1999 and onwards

### DIFF
--- a/cartography/intel/cve/__init__.py
+++ b/cartography/intel/cve/__init__.py
@@ -39,7 +39,7 @@ def _sync_year_archives(
     existing_years = feed.get_cve_sync_metadata(neo4j_session)
     current_year = datetime.now().year
     logger.info(f"Syncing CVE data for year archives. Existing years: {existing_years}. Current year: {current_year}")
-    for year in range(2002, current_year + 1):
+    for year in range(1999, current_year + 1):
         if year in existing_years:
             continue
         logger.info(f"Syncing CVE data for year {year}")


### PR DESCRIPTION
### Summary
We had hardcoded `2002` as the initial year of CVE NVD to ingest.
Recently NVD updated CVE information from 1999.
Starting year per yer ingestion from 1999 onwards.


### Related issues or links
N/A


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [] Update/add unit or integration tests.
- [] Include a screenshot showing what the graph looked like before and after your changes.
- [] Include console log trace showing what happened before and after your changes.
