### PR TITLE
Fix #1415: handle AccessDeniedException for list-permission-sets

### DIFF
--- a/cartography/intel/aws/identitycenter.py
+++ b/cartography/intel/aws/identitycenter.py
@@ -56,6 +56,7 @@ def load_identity_center_instances(
 
 
 @timeit
+@aws_handle_regions
 def get_permission_sets(boto3_session: boto3.session.Session, instance_arn: str, region: str) -> List[Dict]:
     """
     Get all permission sets for a given Identity Center instance

--- a/tests/unit/cartography/intel/aws/test_identitycenter.py
+++ b/tests/unit/cartography/intel/aws/test_identitycenter.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock
+import botocore.exceptions
+
+from cartography.intel.aws.identitycenter import get_permission_sets
+
+
+def test_get_permission_sets_access_denied():
+    mock_session = MagicMock()
+    mock_client = MagicMock()
+    mock_paginator = MagicMock()
+    
+    # Arrange: Set up the mock chain
+    mock_session.client.return_value = mock_client
+    mock_client.get_paginator.return_value = mock_paginator
+    
+    # Make paginate raise AccessDeniedException (simulate issue #1415)
+    mock_paginator.paginate.side_effect = botocore.exceptions.ClientError(
+        error_response={'Error': {'Code': 'AccessDeniedException', 'Message': 'Access Denied'}},
+        operation_name='ListPermissionSets',
+    )
+
+    # Act: Call the function
+    result = get_permission_sets(mock_session, "arn:aws:sso:::instance/test", "us-east-1")
+    
+    # Assert:Verify we got an empty list
+    assert result == []
+    
+    # Verify our mocks were called as expected
+    mock_session.client.assert_called_once_with('sso-admin', region_name='us-east-1')
+    mock_client.get_paginator.assert_called_once_with('list_permission_sets')
+    mock_paginator.paginate.assert_called_once_with(InstanceArn="arn:aws:sso:::instance/test")

--- a/tests/unit/cartography/intel/aws/test_identitycenter.py
+++ b/tests/unit/cartography/intel/aws/test_identitycenter.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+
 import botocore.exceptions
 
 from cartography.intel.aws.identitycenter import get_permission_sets
@@ -8,11 +9,11 @@ def test_get_permission_sets_access_denied():
     mock_session = MagicMock()
     mock_client = MagicMock()
     mock_paginator = MagicMock()
-    
+
     # Arrange: Set up the mock chain
     mock_session.client.return_value = mock_client
     mock_client.get_paginator.return_value = mock_paginator
-    
+
     # Make paginate raise AccessDeniedException (simulate issue #1415)
     mock_paginator.paginate.side_effect = botocore.exceptions.ClientError(
         error_response={'Error': {'Code': 'AccessDeniedException', 'Message': 'Access Denied'}},
@@ -21,10 +22,10 @@ def test_get_permission_sets_access_denied():
 
     # Act: Call the function
     result = get_permission_sets(mock_session, "arn:aws:sso:::instance/test", "us-east-1")
-    
+
     # Assert:Verify we got an empty list
     assert result == []
-    
+
     # Verify our mocks were called as expected
     mock_session.client.assert_called_once_with('sso-admin', region_name='us-east-1')
     mock_client.get_paginator.assert_called_once_with('list_permission_sets')

--- a/tests/unit/cartography/intel/github/test_teams.py
+++ b/tests/unit/cartography/intel/github/test_teams.py
@@ -179,9 +179,10 @@ def test_get_child_teams_happy_path(mock_get_child_teams):
     mock_get_child_teams.assert_called_once_with('test-org', 'https://api.github.com', 'test-token', 'team1')
 
 
+@patch('time.sleep', return_value=None)
 @patch('cartography.intel.github.teams._get_team_repos')
 @patch('cartography.intel.github.teams.backoff_handler', spec=True)
-def test_get_team_repos_github_returns_none(mock_backoff_handler, mock_get_team_repos):
+def test_get_team_repos_github_returns_none(mock_backoff_handler, mock_get_team_repos, mock_sleep):
     # Arrange
     team_data = [{'slug': 'team1', 'repositories': {'totalCount': 1}}]
     mock_team_repos = MagicMock()
@@ -204,9 +205,10 @@ def test_get_team_repos_github_returns_none(mock_backoff_handler, mock_get_team_
     assert mock_backoff_handler.call_count == 4
 
 
+@patch('time.sleep', return_value=None)
 @patch('cartography.intel.github.teams._get_team_users')
 @patch('cartography.intel.github.teams.backoff_handler', spec=True)
-def test_get_team_users_github_returns_none(mock_backoff_handler, mock_get_team_users):
+def test_get_team_users_github_returns_none(mock_backoff_handler, mock_get_team_users, mock_sleep):
     # Arrange
     team_data = [{'slug': 'team1', 'members': {'totalCount': 1}}]
     mock_team_users = MagicMock()
@@ -229,9 +231,10 @@ def test_get_team_users_github_returns_none(mock_backoff_handler, mock_get_team_
     assert mock_backoff_handler.call_count == 4
 
 
+@patch('time.sleep', return_value=None)
 @patch('cartography.intel.github.teams._get_child_teams')
 @patch('cartography.intel.github.teams.backoff_handler', spec=True)
-def test_get_child_teams_github_returns_none(mock_backoff_handler, mock_get_child_teams):
+def test_get_child_teams_github_returns_none(mock_backoff_handler, mock_get_child_teams, mock_sleep):
     # Arrange
     team_data = [{'slug': 'team1', 'childTeams': {'totalCount': 1}}]
     mock_child_teams = MagicMock()


### PR DESCRIPTION
### Summary
> Describe your changes.

Fixes #1415.

When we call list-permission-sets on an account that does not have identitycenter enabled, the AWS API raises an AccessDeniedException.

This PR wraps our call  with `@aws_handle_regions` so that we no longer raise an unhandled exception, allowing the sync to continue.

### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/lyft/cartography/issues/1415


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.