### PR TITLE
Update AWS EC2 keypair sync to use the new data model

### DIFF
--- a/cartography/intel/aws/ec2/instances.py
+++ b/cartography/intel/aws/ec2/instances.py
@@ -13,7 +13,7 @@ from cartography.graph.job import GraphJob
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.models.aws.ec2.auto_scaling_groups import EC2InstanceAutoScalingGroupSchema
 from cartography.models.aws.ec2.instances import EC2InstanceSchema
-from cartography.models.aws.ec2.keypairs import EC2KeyPairSchema
+from cartography.models.aws.ec2.keypairs import EC2KeypairInstanceSchema
 from cartography.models.aws.ec2.networkinterface_instance import EC2NetworkInterfaceInstanceSchema
 from cartography.models.aws.ec2.reservations import EC2ReservationSchema
 from cartography.models.aws.ec2.securitygroup_instance import EC2SecurityGroupInstanceSchema
@@ -202,7 +202,7 @@ def load_ec2_key_pairs(
 ) -> None:
     load(
         neo4j_session,
-        EC2KeyPairSchema(),
+        EC2KeypairInstanceSchema(),
         key_pair_list,
         Region=region,
         AWS_ID=current_aws_account_id,

--- a/cartography/intel/aws/ec2/instances.py
+++ b/cartography/intel/aws/ec2/instances.py
@@ -13,7 +13,7 @@ from cartography.graph.job import GraphJob
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.models.aws.ec2.auto_scaling_groups import EC2InstanceAutoScalingGroupSchema
 from cartography.models.aws.ec2.instances import EC2InstanceSchema
-from cartography.models.aws.ec2.keypair_instance import EC2KeypairInstanceSchema
+from cartography.models.aws.ec2.keypair_instance import EC2KeyPairInstanceSchema
 from cartography.models.aws.ec2.networkinterface_instance import EC2NetworkInterfaceInstanceSchema
 from cartography.models.aws.ec2.reservations import EC2ReservationSchema
 from cartography.models.aws.ec2.securitygroup_instance import EC2SecurityGroupInstanceSchema
@@ -203,7 +203,7 @@ def load_ec2_keypair_instances(
     # Load EC2 keypairs as known by describe-instances.
     load(
         neo4j_session,
-        EC2KeypairInstanceSchema(),
+        EC2KeyPairInstanceSchema(),
         key_pair_list,
         Region=region,
         AWS_ID=current_aws_account_id,

--- a/cartography/intel/aws/ec2/instances.py
+++ b/cartography/intel/aws/ec2/instances.py
@@ -13,7 +13,7 @@ from cartography.graph.job import GraphJob
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.models.aws.ec2.auto_scaling_groups import EC2InstanceAutoScalingGroupSchema
 from cartography.models.aws.ec2.instances import EC2InstanceSchema
-from cartography.models.aws.ec2.keypairs import EC2KeypairInstanceSchema
+from cartography.models.aws.ec2.keypair_instance import EC2KeypairInstanceSchema
 from cartography.models.aws.ec2.networkinterface_instance import EC2NetworkInterfaceInstanceSchema
 from cartography.models.aws.ec2.reservations import EC2ReservationSchema
 from cartography.models.aws.ec2.securitygroup_instance import EC2SecurityGroupInstanceSchema
@@ -193,13 +193,14 @@ def load_ec2_subnets(
 
 
 @timeit
-def load_ec2_key_pairs(
+def load_ec2_keypair_instances(
         neo4j_session: neo4j.Session,
         key_pair_list: List[Dict[str, Any]],
         region: str,
         current_aws_account_id: str,
         update_tag: int,
 ) -> None:
+    # Load EC2 keypairs as known by describe-instances.
     load(
         neo4j_session,
         EC2KeypairInstanceSchema(),
@@ -299,7 +300,7 @@ def load_ec2_instance_data(
     load_ec2_instance_nodes(neo4j_session, instance_list, region, current_aws_account_id, update_tag)
     load_ec2_subnets(neo4j_session, subnet_list, region, current_aws_account_id, update_tag)
     load_ec2_security_groups(neo4j_session, sg_list, region, current_aws_account_id, update_tag)
-    load_ec2_key_pairs(neo4j_session, key_pair_list, region, current_aws_account_id, update_tag)
+    load_ec2_keypair_instances(neo4j_session, key_pair_list, region, current_aws_account_id, update_tag)
     load_ec2_network_interfaces(neo4j_session, nic_list, region, current_aws_account_id, update_tag)
     load_ec2_instance_ebs_volumes(neo4j_session, ebs_volumes_list, region, current_aws_account_id, update_tag)
 

--- a/cartography/intel/aws/ec2/key_pairs.py
+++ b/cartography/intel/aws/ec2/key_pairs.py
@@ -7,7 +7,7 @@ import neo4j
 
 from .util import get_botocore_config
 from cartography.graph.job import GraphJob
-from cartography.models.aws.ec2.keypairs import EC2KeypairInstanceSchema
+from cartography.models.aws.ec2.keypair_instance import EC2KeypairInstanceSchema
 from cartography.util import aws_handle_regions
 from cartography.util import timeit
 

--- a/cartography/intel/aws/ec2/key_pairs.py
+++ b/cartography/intel/aws/ec2/key_pairs.py
@@ -1,13 +1,14 @@
 import logging
+from typing import Any
 from typing import Dict
-from typing import List
 
 import boto3
 import neo4j
 
 from .util import get_botocore_config
+from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
-from cartography.models.aws.ec2.keypair_instance import EC2KeypairInstanceSchema
+from cartography.models.aws.ec2.keypair import EC2KeyPairSchema
 from cartography.util import aws_handle_regions
 from cartography.util import timeit
 
@@ -16,56 +17,59 @@ logger = logging.getLogger(__name__)
 
 @timeit
 @aws_handle_regions
-def get_ec2_key_pairs(boto3_session: boto3.session.Session, region: str) -> List[Dict]:
+def get_ec2_key_pairs(boto3_session: boto3.session.Session, region: str) -> list[dict[str, Any]]:
     client = boto3_session.client('ec2', region_name=region, config=get_botocore_config())
     return client.describe_key_pairs()['KeyPairs']
 
 
+def transform_ec2_key_pairs(
+        key_pairs: list[dict[str, Any]],
+        region: str,
+        current_aws_account_id: str,
+) -> list[dict[str, Any]]:
+    transformed_key_pairs = []
+    for key_pair in key_pairs:
+        key_name = key_pair["KeyName"]
+        transformed_key_pairs.append({
+            'KeyPairArn': f'arn:aws:ec2:{region}:{current_aws_account_id}:key-pair/{key_name}',
+            'KeyName': key_name,
+            'KeyFingerprint': key_pair.get("KeyFingerprint"),
+        })
+    return transformed_key_pairs
+
+
 @timeit
 def load_ec2_key_pairs(
-    neo4j_session: neo4j.Session, data: List[Dict], region: str, current_aws_account_id: str,
-    update_tag: int,
+        neo4j_session: neo4j.Session,
+        data: list[dict[str, Any]],
+        region: str,
+        current_aws_account_id: str,
+        update_tag: int,
 ) -> None:
-    ingest_key_pair = """
-    MERGE (keypair:KeyPair:EC2KeyPair{arn: $ARN, id: $ARN})
-    ON CREATE SET keypair.firstseen = timestamp()
-    SET
-        keypair.keyname = $KeyName,
-        keypair.keyfingerprint = $KeyFingerprint,
-        keypair.region = $Region,
-    keypair.lastupdated = $update_tag
-    WITH keypair
-    MATCH (aa:AWSAccount{id: $AWS_ACCOUNT_ID})
-    MERGE (aa)-[r:RESOURCE]->(keypair)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = $update_tag
-    """
-
-    for key_pair in data:
-        key_name = key_pair["KeyName"]
-        key_fingerprint = key_pair.get("KeyFingerprint")
-        key_pair_arn = f'arn:aws:ec2:{region}:{current_aws_account_id}:key-pair/{key_name}'
-
-        neo4j_session.run(
-            ingest_key_pair,
-            ARN=key_pair_arn,
-            KeyName=key_name,
-            KeyFingerprint=key_fingerprint,
-            AWS_ACCOUNT_ID=current_aws_account_id,
-            Region=region,
-            update_tag=update_tag,
-        )
+    # Load EC2 keypairs as known by describe-key-pairs
+    load(
+        neo4j_session,
+        EC2KeyPairSchema(),
+        data,
+        Region=region,
+        AWS_ID=current_aws_account_id,
+        lastupdated=update_tag,
+    )
 
 
 @timeit
 def cleanup_ec2_key_pairs(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:
-    GraphJob.from_node_schema(EC2KeypairInstanceSchema(), common_job_parameters).run(neo4j_session)
+    GraphJob.from_node_schema(EC2KeyPairSchema(), common_job_parameters).run(neo4j_session)
 
 
 @timeit
 def sync_ec2_key_pairs(
-    neo4j_session: neo4j.Session, boto3_session: boto3.session.Session, regions: List[str], current_aws_account_id: str,
-    update_tag: int, common_job_parameters: Dict,
+    neo4j_session: neo4j.Session,
+    boto3_session: boto3.session.Session,
+    regions: list[str],
+    current_aws_account_id: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
 ) -> None:
     for region in regions:
         logger.info("Syncing EC2 key pairs for region '%s' in account '%s'.", region, current_aws_account_id)

--- a/cartography/intel/aws/ec2/key_pairs.py
+++ b/cartography/intel/aws/ec2/key_pairs.py
@@ -5,9 +5,9 @@ from typing import Dict
 import boto3
 import neo4j
 
-from .util import get_botocore_config
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.models.aws.ec2.keypair import EC2KeyPairSchema
 from cartography.util import aws_handle_regions
 from cartography.util import timeit
@@ -74,5 +74,6 @@ def sync_ec2_key_pairs(
     for region in regions:
         logger.info("Syncing EC2 key pairs for region '%s' in account '%s'.", region, current_aws_account_id)
         data = get_ec2_key_pairs(boto3_session, region)
-        load_ec2_key_pairs(neo4j_session, data, region, current_aws_account_id, update_tag)
+        transformed_data = transform_ec2_key_pairs(data, region, current_aws_account_id)
+        load_ec2_key_pairs(neo4j_session, transformed_data, region, current_aws_account_id, update_tag)
     cleanup_ec2_key_pairs(neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/ec2/key_pairs.py
+++ b/cartography/intel/aws/ec2/key_pairs.py
@@ -47,6 +47,7 @@ def load_ec2_key_pairs(
         update_tag: int,
 ) -> None:
     # Load EC2 keypairs as known by describe-key-pairs
+    logger.info(f"Loading {len(data)} EC2 keypairs for region '{region}' into graph.")
     load(
         neo4j_session,
         EC2KeyPairSchema(),

--- a/cartography/intel/aws/ec2/key_pairs.py
+++ b/cartography/intel/aws/ec2/key_pairs.py
@@ -7,7 +7,7 @@ import neo4j
 
 from .util import get_botocore_config
 from cartography.graph.job import GraphJob
-from cartography.models.aws.ec2.keypairs import EC2KeyPairSchema
+from cartography.models.aws.ec2.keypairs import EC2KeypairInstanceSchema
 from cartography.util import aws_handle_regions
 from cartography.util import timeit
 
@@ -29,7 +29,10 @@ def load_ec2_key_pairs(
     ingest_key_pair = """
     MERGE (keypair:KeyPair:EC2KeyPair{arn: $ARN, id: $ARN})
     ON CREATE SET keypair.firstseen = timestamp()
-    SET keypair.keyname = $KeyName, keypair.keyfingerprint = $KeyFingerprint, keypair.region = $Region,
+    SET
+        keypair.keyname = $KeyName,
+        keypair.keyfingerprint = $KeyFingerprint,
+        keypair.region = $Region,
     keypair.lastupdated = $update_tag
     WITH keypair
     MATCH (aa:AWSAccount{id: $AWS_ACCOUNT_ID})
@@ -56,7 +59,7 @@ def load_ec2_key_pairs(
 
 @timeit
 def cleanup_ec2_key_pairs(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:
-    GraphJob.from_node_schema(EC2KeyPairSchema(), common_job_parameters).run(neo4j_session)
+    GraphJob.from_node_schema(EC2KeypairInstanceSchema(), common_job_parameters).run(neo4j_session)
 
 
 @timeit

--- a/cartography/models/aws/ec2/keypair.py
+++ b/cartography/models/aws/ec2/keypair.py
@@ -8,62 +8,47 @@ from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
-from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
 @dataclass(frozen=True)
-class EC2KeypairInstanceNodeProperties(CartographyNodeProperties):
+class EC2KeyPairNodeProperties(CartographyNodeProperties):
+    """
+    Properties for EC2 keypairs from describe-key-pairs
+    """
     id: PropertyRef = PropertyRef('KeyPairArn')
     arn: PropertyRef = PropertyRef('KeyPairArn', extra_index=True)
     keyname: PropertyRef = PropertyRef('KeyName')
+    key_fingerprint: PropertyRef = PropertyRef('KeyFingerprint')
     region: PropertyRef = PropertyRef('Region', set_in_kwargs=True)
     lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2KeypairInstanceToAwsAccountRelProperties(CartographyRelProperties):
+class EC2KeyPairToAwsAccountRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2KeypairInstanceToAWSAccount(CartographyRelSchema):
+class EC2KeyPairToAWSAccount(CartographyRelSchema):
+    """
+    Relationship schema for EC2 keypairs to AWS Accounts
+    """
     target_node_label: str = 'AWSAccount'
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {'id': PropertyRef('AWS_ID', set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
-    rel_label: str = "RESOURCE"
-    properties: EC2KeypairInstanceToAwsAccountRelProperties = EC2KeypairInstanceToAwsAccountRelProperties()
+    rel_label: str = 'RESOURCE'
+    properties: EC2KeyPairToAwsAccountRelProperties = EC2KeyPairToAwsAccountRelProperties()
 
 
 @dataclass(frozen=True)
-class EC2KeypairInstanceToEC2InstanceRelProperties(CartographyRelProperties):
-    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
-
-
-@dataclass(frozen=True)
-class EC2KeypairInstanceToEC2Instance(CartographyRelSchema):
-    target_node_label: str = 'EC2Instance'
-    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {'id': PropertyRef('InstanceId')},
-    )
-    direction: LinkDirection = LinkDirection.OUTWARD
-    rel_label: str = "SSH_LOGIN_TO"
-    properties: EC2KeypairInstanceToEC2InstanceRelProperties = EC2KeypairInstanceToEC2InstanceRelProperties()
-
-
-@dataclass(frozen=True)
-class EC2KeypairInstanceSchema(CartographyNodeSchema):
+class EC2KeyPairSchema(CartographyNodeSchema):
     """
-    EC2 keypairs as known by describe-instances.
+    Schema for EC2 keypairs from describe-key-pairs
     """
     label: str = 'EC2KeyPair'
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(['KeyPair'])
-    properties: EC2KeypairInstanceNodeProperties = EC2KeypairInstanceNodeProperties()
-    sub_resource_relationship: EC2KeypairInstanceToAWSAccount = EC2KeypairInstanceToAWSAccount()
-    other_relationships: OtherRelationships = OtherRelationships(
-        [
-            EC2KeypairInstanceToEC2Instance(),
-        ],
-    )
+    properties: EC2KeyPairNodeProperties = EC2KeyPairNodeProperties()
+    sub_resource_relationship: EC2KeyPairToAWSAccount = EC2KeyPairToAWSAccount()

--- a/cartography/models/aws/ec2/keypair.py
+++ b/cartography/models/aws/ec2/keypair.py
@@ -19,7 +19,7 @@ class EC2KeyPairNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef('KeyPairArn')
     arn: PropertyRef = PropertyRef('KeyPairArn', extra_index=True)
     keyname: PropertyRef = PropertyRef('KeyName')
-    key_fingerprint: PropertyRef = PropertyRef('KeyFingerprint')
+    keyfingerprint: PropertyRef = PropertyRef('KeyFingerprint')
     region: PropertyRef = PropertyRef('Region', set_in_kwargs=True)
     lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
 

--- a/cartography/models/aws/ec2/keypair_instance.py
+++ b/cartography/models/aws/ec2/keypair_instance.py
@@ -13,7 +13,7 @@ from cartography.models.core.relationships import TargetNodeMatcher
 
 
 @dataclass(frozen=True)
-class EC2KeypairInstanceNodeProperties(CartographyNodeProperties):
+class EC2KeyPairInstanceNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef('KeyPairArn')
     arn: PropertyRef = PropertyRef('KeyPairArn', extra_index=True)
     keyname: PropertyRef = PropertyRef('KeyName')
@@ -22,48 +22,48 @@ class EC2KeypairInstanceNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2KeypairInstanceToAwsAccountRelProperties(CartographyRelProperties):
+class EC2KeyPairInstanceToAwsAccountRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2KeypairInstanceToAWSAccount(CartographyRelSchema):
+class EC2KeyPairInstanceToAWSAccount(CartographyRelSchema):
     target_node_label: str = 'AWSAccount'
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {'id': PropertyRef('AWS_ID', set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2KeypairInstanceToAwsAccountRelProperties = EC2KeypairInstanceToAwsAccountRelProperties()
+    properties: EC2KeyPairInstanceToAwsAccountRelProperties = EC2KeyPairInstanceToAwsAccountRelProperties()
 
 
 @dataclass(frozen=True)
-class EC2KeypairInstanceToEC2InstanceRelProperties(CartographyRelProperties):
+class EC2KeyPairInstanceToEC2InstanceRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2KeypairInstanceToEC2Instance(CartographyRelSchema):
+class EC2KeyPairInstanceToEC2Instance(CartographyRelSchema):
     target_node_label: str = 'EC2Instance'
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {'id': PropertyRef('InstanceId')},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "SSH_LOGIN_TO"
-    properties: EC2KeypairInstanceToEC2InstanceRelProperties = EC2KeypairInstanceToEC2InstanceRelProperties()
+    properties: EC2KeyPairInstanceToEC2InstanceRelProperties = EC2KeyPairInstanceToEC2InstanceRelProperties()
 
 
 @dataclass(frozen=True)
-class EC2KeypairInstanceSchema(CartographyNodeSchema):
+class EC2KeyPairInstanceSchema(CartographyNodeSchema):
     """
     EC2 keypairs as known by describe-instances.
     """
     label: str = 'EC2KeyPair'
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(['KeyPair'])
-    properties: EC2KeypairInstanceNodeProperties = EC2KeypairInstanceNodeProperties()
-    sub_resource_relationship: EC2KeypairInstanceToAWSAccount = EC2KeypairInstanceToAWSAccount()
+    properties: EC2KeyPairInstanceNodeProperties = EC2KeyPairInstanceNodeProperties()
+    sub_resource_relationship: EC2KeyPairInstanceToAWSAccount = EC2KeyPairInstanceToAWSAccount()
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2KeypairInstanceToEC2Instance(),
+            EC2KeyPairInstanceToEC2Instance(),
         ],
     )

--- a/cartography/models/aws/ec2/keypair_instance.py
+++ b/cartography/models/aws/ec2/keypair_instance.py
@@ -54,6 +54,9 @@ class EC2KeypairInstanceToEC2Instance(CartographyRelSchema):
 
 @dataclass(frozen=True)
 class EC2KeypairInstanceSchema(CartographyNodeSchema):
+    """
+    EC2 keypairs as known by describe-instances.
+    """
     label: str = 'EC2KeyPair'
     properties: EC2KeypairInstanceNodeProperties = EC2KeypairInstanceNodeProperties()
     sub_resource_relationship: EC2KeypairInstanceToAWSAccount = EC2KeypairInstanceToAWSAccount()

--- a/cartography/models/aws/ec2/keypairs.py
+++ b/cartography/models/aws/ec2/keypairs.py
@@ -12,7 +12,7 @@ from cartography.models.core.relationships import TargetNodeMatcher
 
 
 @dataclass(frozen=True)
-class EC2KeyPairNodeProperties(CartographyNodeProperties):
+class EC2KeypairInstanceNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef('KeyPairArn')
     arn: PropertyRef = PropertyRef('KeyPairArn', extra_index=True)
     keyname: PropertyRef = PropertyRef('KeyName')
@@ -21,44 +21,44 @@ class EC2KeyPairNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2KeyPairToAwsAccountRelProperties(CartographyRelProperties):
+class EC2KeypairInstanceToAwsAccountRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2KeyPairToAWSAccount(CartographyRelSchema):
+class EC2KeypairInstanceToAWSAccount(CartographyRelSchema):
     target_node_label: str = 'AWSAccount'
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {'id': PropertyRef('AWS_ID', set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2KeyPairToAwsAccountRelProperties = EC2KeyPairToAwsAccountRelProperties()
+    properties: EC2KeypairInstanceToAwsAccountRelProperties = EC2KeypairInstanceToAwsAccountRelProperties()
 
 
 @dataclass(frozen=True)
-class EC2KeyPairToEC2InstanceRelProperties(CartographyRelProperties):
+class EC2KeypairInstanceToEC2InstanceRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2KeyPairToEC2Instance(CartographyRelSchema):
+class EC2KeypairInstanceToEC2Instance(CartographyRelSchema):
     target_node_label: str = 'EC2Instance'
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {'id': PropertyRef('InstanceId')},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "SSH_LOGIN_TO"
-    properties: EC2KeyPairToEC2InstanceRelProperties = EC2KeyPairToEC2InstanceRelProperties()
+    properties: EC2KeypairInstanceToEC2InstanceRelProperties = EC2KeypairInstanceToEC2InstanceRelProperties()
 
 
 @dataclass(frozen=True)
-class EC2KeyPairSchema(CartographyNodeSchema):
+class EC2KeypairInstanceSchema(CartographyNodeSchema):
     label: str = 'EC2KeyPair'
-    properties: EC2KeyPairNodeProperties = EC2KeyPairNodeProperties()
-    sub_resource_relationship: EC2KeyPairToAWSAccount = EC2KeyPairToAWSAccount()
+    properties: EC2KeypairInstanceNodeProperties = EC2KeypairInstanceNodeProperties()
+    sub_resource_relationship: EC2KeypairInstanceToAWSAccount = EC2KeypairInstanceToAWSAccount()
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2KeyPairToEC2Instance(),
+            EC2KeypairInstanceToEC2Instance(),
         ],
     )


### PR DESCRIPTION
### Summary
> Describe your changes.

Updates EC2 key pair sync to use the data model.

Fixes an issue that created duplicate key pairs because the older version of the key pair sync had extra node labels but the EC2KeyPairInstance model did not:
![image](https://github.com/user-attachments/assets/b9a004bc-de4a-458d-a7d1-9c6728548ba8)

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [x] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
