### PR TITLE
Fast follow of #1429: fix typo in version specifier

### DIFF
--- a/.github/workflows/publish-to-ghcr-and-pypi.yml
+++ b/.github/workflows/publish-to-ghcr-and-pypi.yml
@@ -86,4 +86,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # e.g. '==0.98.0'
-          build-args: VERSION_SPECIFIER='=='${{ env.VERSION }}
+          build-args: VERSION_SPECIFIER='==${{ env.VERSION }}'


### PR DESCRIPTION
Fixes a misplaced single quote.

## Before:
![image](https://github.com/user-attachments/assets/0b73bf65-4802-49bb-a64f-0d46aa2dd250)
We set `VERSION_SPECIFIER='=='${{ env.VERSION }}`, and this evaluates to `'=='0.98.0rc2`.

Instead, we need it to evaluate to `'==0.98.0rc2'`.

## After:
I can't test this in github actions unless this is merged and deployed, but I tried to test locally:
![image](https://github.com/user-attachments/assets/8831765c-3073-4823-b89c-2d779b7f62f0)

This PR moves the `'` character to what I think is the correct place for the version specifier string to be interpreted correctly by pip.
