### PR TITLE
Attempt to fix version_specifier in GHCR publish step

### DIFF
--- a/.github/workflows/publish-to-ghcr-and-pypi.yml
+++ b/.github/workflows/publish-to-ghcr-and-pypi.yml
@@ -86,4 +86,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # e.g. '==0.98.0'
-          build-args: VERSION_SPECIFIER='==${{ env.VERSION }}'
+          build-args: VERSION_SPECIFIER===${{ env.VERSION }}


### PR DESCRIPTION
The publish to GHCR step is currently failing with this error:
![image](https://github.com/user-attachments/assets/2bd96bee-3acd-49df-8ece-8a7d2920288a)

## Actual
The resulting command generated is `RUN pip install cartography'==0.98.0rc3'`..

## Expected
.. when I wanted it to be `RUN pip install cartography==0.98.0rc3`.


## In this PR
I adjusted the version specifier and re-tested it locally and _think_ that this will now work in GitHub actions.

![image](https://github.com/user-attachments/assets/fe40c3bf-c12c-4a2b-94d3-78235850018b)
