### PR TITLE
Make PyPI publish step idempotent

### DIFF
--- a/.github/workflows/publish-to-ghcr-and-pypi.yml
+++ b/.github/workflows/publish-to-ghcr-and-pypi.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+          skip_existing: true
 
       # 2. Publish to GHCR
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Summary
> Describe your changes.

For security reasons, PyPI does not allow us to overwrite a previously released version of cartography when publishing. Our GitHub actions publish job currently (1) publishes to PyPI and then (2) installs that PyPI release on a Docker image and (3) pushes that image to GHCR.

Step (2) is prone to race conditions where PyPI is not immediately ready to serve the newly published package, causing the job to fail. Then when we retry, step (1) will fail because the PyPI version is already present in PyPIP, causing steps (2) and (3) to be unreachable.

This PR makes step (1) idempotent so that we can retry steps (2) and (3).


## Reference

https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#tolerating-release-package-file-duplicates 
