### PR TITLE
CI: Wait for PyPI to publish before building Dockerfile

### DIFF
--- a/.github/workflows/publish-to-ghcr-and-pypi.yml
+++ b/.github/workflows/publish-to-ghcr-and-pypi.yml
@@ -73,10 +73,12 @@ jobs:
           # for more detailed information.
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Get the cartography version from the GitHub release event metadata
-      - name: Extract version
+      # Get the cartography version from the GitHub release event metadata and sleep to wait for PyPI to finish publishing
+      - name: Extract version and sleep
         id: version
-        run: echo "VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+        run: |
+          echo "VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+          sleep 10
 
       - name: Build and push
         uses: docker/build-push-action@v3


### PR DESCRIPTION
### Summary
> Describe your changes.

When making a new release, we 
1. publish the release to PyPI
2. install it from PyPI to the Dockerfile
3. publish that Dockerfile to GHCR

After publishing to PyPI however we need a few more seconds for the package to be available. Currently we skip over this and the latest release is not available, causing the build to fail.
![image](https://github.com/user-attachments/assets/4d7aa967-d0e6-4ed8-8ef1-be25b573eb06)
https://github.com/cartography-cncf/cartography/actions/runs/12577359450/job/35054696773

This PR makes it so that we now wait 10 seconds for PyPI before attempting to build the image.