### PR TITLE
Inspector to account relationship for delegated accounts

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+Cartography is a security tool, and its community of course takes security very seriously.
+
+We appreciate your efforts to disclose your findings responsibly and will make every effort to acknowledge your contributions.
+
+## Supported versions
+Security updates will typically only be applied to the latest release (at least until Cartography reaches the first stable major version).
+
+## Reporting a vulnerability
+To report a security issue, email cncf-cartography-maintainers@lists.cncf.io and include the word "SECURITY" in the subject line.
+
+Maintainers will send a response indicating the next steps in handling your report. After the initial reply to your report, we will keep you informed of the progress towards a fix and full announcement and may ask for additional information or guidance.

--- a/cartography/models/aws/inspector/findings.py
+++ b/cartography/models/aws/inspector/findings.py
@@ -65,6 +65,7 @@ class InspectorFindingToAWSAccount(CartographyRelSchema):
 class InspectorFindingToAwsAccountDelegateRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
 
+
 @dataclass(frozen=True)
 class InspectorFindingToAWSAccountDelegate(CartographyRelSchema):
     target_node_label: str = 'AWSAccount'
@@ -74,6 +75,7 @@ class InspectorFindingToAWSAccountDelegate(CartographyRelSchema):
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "DELEGATE"
     properties: InspectorFindingToAwsAccountDelegateRelProperties = InspectorFindingToAwsAccountDelegateRelProperties()
+
 
 @dataclass(frozen=True)
 class InspectorFindingToEC2InstanceRelProperties(CartographyRelProperties):

--- a/cartography/models/aws/inspector/findings.py
+++ b/cartography/models/aws/inspector/findings.py
@@ -62,6 +62,20 @@ class InspectorFindingToAWSAccount(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class InspectorFindingToAwsAccountDelegateRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+@dataclass(frozen=True)
+class InspectorFindingToAWSAccountDelegate(CartographyRelSchema):
+    target_node_label: str = 'AWSAccount'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('awsaccount')},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "DELEGATE"
+    properties: InspectorFindingToAwsAccountDelegateRelProperties = InspectorFindingToAwsAccountDelegateRelProperties()
+
+@dataclass(frozen=True)
 class InspectorFindingToEC2InstanceRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
 
@@ -120,5 +134,6 @@ class AWSInspectorFindingSchema(CartographyNodeSchema):
             InspectorFindingToEC2Instance(),
             InspectorFindingToECRRepository(),
             InspectorFindingToECRImage(),
+            InspectorFindingToAWSAccountDelegate(),
         ],
     )

--- a/cartography/models/aws/inspector/findings.py
+++ b/cartography/models/aws/inspector/findings.py
@@ -73,7 +73,7 @@ class InspectorFindingToAWSAccountDelegate(CartographyRelSchema):
         {'id': PropertyRef('awsaccount')},
     )
     direction: LinkDirection = LinkDirection.INWARD
-    rel_label: str = "DELEGATE"
+    rel_label: str = "MEMBER"
     properties: InspectorFindingToAwsAccountDelegateRelProperties = InspectorFindingToAwsAccountDelegateRelProperties()
 
 

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -192,16 +192,17 @@ Representation of an AWS [Inspector Finding](https://docs.aws.amazon.com/inspect
     ```
     (AWSInspectorFinding)-[:AFFECTS]->(ECRImage)
     ```
-- AWSInspectorFinding may be delegated from AWSAccounts.
-
-        ```
-        (AWSAccount)-[DELEGATE]->(AWSInspectorFinding)
-        ```
-- AWSInspectorFindings belong to AWSAccounts.
+- AWSInspectorFindings managed by AWSAccount.
 
         ```
         (AWSAccount)-[RESOURCE]->(AWSInspectorFinding)
         ```
+- AWSInspectorFinding was found at an AWSAccounts. `MEMBER` accounts are where the finding is attached to, while `RESOURCE` accounts can be a delegated administrator. [Understanding the delegated administrator account and member account in Amazon Inspector](https://docs.aws.amazon.com/inspector/latest/user/admin-member-relationship.html) .
+
+        ```
+        (AWSAccount)-[MEMBER]->(AWSInspectorFinding)
+        ```
+
 
 ### AWSInspectorPackage
 

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -192,7 +192,11 @@ Representation of an AWS [Inspector Finding](https://docs.aws.amazon.com/inspect
     ```
     (AWSInspectorFinding)-[:AFFECTS]->(ECRImage)
     ```
+- AWSInspectorFinding may be delegated from AWSAccounts.
 
+        ```
+        (AWSAccount)-[DELEGATE]->(AWSInspectorFinding)
+        ```
 - AWSInspectorFindings belong to AWSAccounts.
 
         ```

--- a/tests/data/aws/inspector.py
+++ b/tests/data/aws/inspector.py
@@ -191,4 +191,78 @@ LIST_FINDINGS_EC2_PACKAGE = [
         'type': 'PACKAGE_VULNERABILITY',
         'updatedAt': datetime(2022, 5, 4, 16, 23, 3, 692000),
     },
+   {
+    'awsAccountId': '123456789011',
+    'description': 'A buffer overflow vulnerability in OpenSSL allows remote attackers '
+        'to execute arbitrary code or cause a denial of service via crafted '
+        'SSL/TLS handshake messages.',
+    'findingArn': 'arn:aws:test789',
+    'firstObservedAt': datetime(2022, 5, 4, 16, 23, 3, 692000),
+    'inspectorScore': 7.5,
+    'inspectorScoreDetails': {
+        'adjustedCvss': {
+            'adjustments': [],
+            'cvssSource': 'NVD',
+            'score': 7.5,
+            'scoreSource': 'NVD',
+            'scoringVector': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N',
+            'version': '3.1',
+        },
+    },
+    'lastObservedAt': datetime(2022, 5, 4, 16, 23, 3, 692000),
+    'packageVulnerabilityDetails': {
+        'cvss': [
+            {
+                'baseScore': 7.5,
+                'scoringVector': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N',
+                'source': 'NVD',
+                'version': '3.1',
+            }
+        ],
+        'referenceUrls': ['https://nvd.nist.gov/vuln/detail/CVE-2023-1234'],
+        'relatedVulnerabilities': [],
+        'source': 'NVD',
+        'sourceUrl': 'https://nvd.nist.gov/vuln/detail/CVE-2023-1234',
+        'vendorCreatedAt': datetime(2023, 1, 15, 10, 0),
+        'vendorSeverity': 'High',
+        'vulnerabilityId': 'CVE-2023-1234',
+        'vulnerablePackages': [
+            {
+                'arch': 'X86_64',
+                'epoch': 0,
+                'name': 'openssl',
+                'packageManager': 'OS',
+                'release': '1.amzn2',
+                'version': '1.0.2k',
+            }
+        ],
+    },
+    'remediation': {'recommendation': {'text': 'Update to the latest version of OpenSSL'}},
+    'resources': [{
+        'details': {
+            'awsEc2Instance': {
+                'iamInstanceProfileArn': 'arn:aws:iam::123456789011:instance-profile/InspectorTestingRole',
+                'imageId': 'ami-00800800',
+                'ipV4Addresses': ['10.0.1.4'],
+                'ipV6Addresses': [],
+                'keyName': 'InspectorTest',
+                'launchedAt': datetime(2022, 5, 4, 16, 15, 41),
+                'platform': 'AMAZON_LINUX_2',
+                'subnetId': 'subnet-11203981029833100',
+                'type': 't2.micro',
+                'vpcId': 'vpc-11203981029822100',
+            },
+        },
+        'id': 'i-88503981029833101',
+        'partition': 'aws',
+        'region': 'us-west-2',
+        'tags': {},
+        'type': 'AWS_EC2_INSTANCE',
+    }],
+    'severity': 'HIGH',
+    'status': 'ACTIVE',
+    'title': 'CVE-2023-1234 - openssl',
+    'type': 'PACKAGE_VULNERABILITY',
+    'updatedAt': datetime(2022, 5, 4, 16, 23, 3, 692000)
+   }
 ]

--- a/tests/data/aws/inspector.py
+++ b/tests/data/aws/inspector.py
@@ -191,78 +191,78 @@ LIST_FINDINGS_EC2_PACKAGE = [
         'type': 'PACKAGE_VULNERABILITY',
         'updatedAt': datetime(2022, 5, 4, 16, 23, 3, 692000),
     },
-   {
-    'awsAccountId': '123456789011',
-    'description': 'A buffer overflow vulnerability in OpenSSL allows remote attackers '
+    {
+        'awsAccountId': '123456789011',
+        'description': 'A buffer overflow vulnerability in OpenSSL allows remote attackers '
         'to execute arbitrary code or cause a denial of service via crafted '
         'SSL/TLS handshake messages.',
-    'findingArn': 'arn:aws:test789',
-    'firstObservedAt': datetime(2022, 5, 4, 16, 23, 3, 692000),
-    'inspectorScore': 7.5,
-    'inspectorScoreDetails': {
-        'adjustedCvss': {
-            'adjustments': [],
-            'cvssSource': 'NVD',
-            'score': 7.5,
-            'scoreSource': 'NVD',
-            'scoringVector': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N',
-            'version': '3.1',
-        },
-    },
-    'lastObservedAt': datetime(2022, 5, 4, 16, 23, 3, 692000),
-    'packageVulnerabilityDetails': {
-        'cvss': [
-            {
-                'baseScore': 7.5,
+        'findingArn': 'arn:aws:test789',
+        'firstObservedAt': datetime(2022, 5, 4, 16, 23, 3, 692000),
+        'inspectorScore': 7.5,
+        'inspectorScoreDetails': {
+            'adjustedCvss': {
+                'adjustments': [],
+                'cvssSource': 'NVD',
+                'score': 7.5,
+                'scoreSource': 'NVD',
                 'scoringVector': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N',
-                'source': 'NVD',
                 'version': '3.1',
-            }
-        ],
-        'referenceUrls': ['https://nvd.nist.gov/vuln/detail/CVE-2023-1234'],
-        'relatedVulnerabilities': [],
-        'source': 'NVD',
-        'sourceUrl': 'https://nvd.nist.gov/vuln/detail/CVE-2023-1234',
-        'vendorCreatedAt': datetime(2023, 1, 15, 10, 0),
-        'vendorSeverity': 'High',
-        'vulnerabilityId': 'CVE-2023-1234',
-        'vulnerablePackages': [
-            {
-                'arch': 'X86_64',
-                'epoch': 0,
-                'name': 'openssl',
-                'packageManager': 'OS',
-                'release': '1.amzn2',
-                'version': '1.0.2k',
-            }
-        ],
-    },
-    'remediation': {'recommendation': {'text': 'Update to the latest version of OpenSSL'}},
-    'resources': [{
-        'details': {
-            'awsEc2Instance': {
-                'iamInstanceProfileArn': 'arn:aws:iam::123456789011:instance-profile/InspectorTestingRole',
-                'imageId': 'ami-00800800',
-                'ipV4Addresses': ['10.0.1.4'],
-                'ipV6Addresses': [],
-                'keyName': 'InspectorTest',
-                'launchedAt': datetime(2022, 5, 4, 16, 15, 41),
-                'platform': 'AMAZON_LINUX_2',
-                'subnetId': 'subnet-11203981029833100',
-                'type': 't2.micro',
-                'vpcId': 'vpc-11203981029822100',
             },
         },
-        'id': 'i-88503981029833101',
-        'partition': 'aws',
-        'region': 'us-west-2',
-        'tags': {},
-        'type': 'AWS_EC2_INSTANCE',
-    }],
-    'severity': 'HIGH',
-    'status': 'ACTIVE',
-    'title': 'CVE-2023-1234 - openssl',
-    'type': 'PACKAGE_VULNERABILITY',
-    'updatedAt': datetime(2022, 5, 4, 16, 23, 3, 692000)
-   }
+        'lastObservedAt': datetime(2022, 5, 4, 16, 23, 3, 692000),
+        'packageVulnerabilityDetails': {
+            'cvss': [
+                {
+                    'baseScore': 7.5,
+                    'scoringVector': 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N',
+                    'source': 'NVD',
+                    'version': '3.1',
+                },
+            ],
+            'referenceUrls': ['https://nvd.nist.gov/vuln/detail/CVE-2023-1234'],
+            'relatedVulnerabilities': [],
+            'source': 'NVD',
+            'sourceUrl': 'https://nvd.nist.gov/vuln/detail/CVE-2023-1234',
+            'vendorCreatedAt': datetime(2023, 1, 15, 10, 0),
+            'vendorSeverity': 'High',
+            'vulnerabilityId': 'CVE-2023-1234',
+            'vulnerablePackages': [
+                {
+                    'arch': 'X86_64',
+                    'epoch': 0,
+                    'name': 'openssl',
+                    'packageManager': 'OS',
+                    'release': '1.amzn2',
+                    'version': '1.0.2k',
+                },
+            ],
+        },
+        'remediation': {'recommendation': {'text': 'Update to the latest version of OpenSSL'}},
+        'resources': [{
+            'details': {
+                'awsEc2Instance': {
+                    'iamInstanceProfileArn': 'arn:aws:iam::123456789011:instance-profile/InspectorTestingRole',
+                    'imageId': 'ami-00800800',
+                    'ipV4Addresses': ['10.0.1.4'],
+                    'ipV6Addresses': [],
+                    'keyName': 'InspectorTest',
+                    'launchedAt': datetime(2022, 5, 4, 16, 15, 41),
+                    'platform': 'AMAZON_LINUX_2',
+                    'subnetId': 'subnet-11203981029833100',
+                    'type': 't2.micro',
+                    'vpcId': 'vpc-11203981029822100',
+                },
+            },
+            'id': 'i-88503981029833101',
+            'partition': 'aws',
+            'region': 'us-west-2',
+            'tags': {},
+            'type': 'AWS_EC2_INSTANCE',
+        }],
+        'severity': 'HIGH',
+        'status': 'ACTIVE',
+        'title': 'CVE-2023-1234 - openssl',
+        'type': 'PACKAGE_VULNERABILITY',
+        'updatedAt': datetime(2022, 5, 4, 16, 23, 3, 692000),
+    },
 ]

--- a/tests/integration/cartography/intel/aws/inspector/test_inspector_sync.py
+++ b/tests/integration/cartography/intel/aws/inspector/test_inspector_sync.py
@@ -145,14 +145,14 @@ def test_sync_inspector_ec2_package_findings(mock_get, neo4j_session):
         ('123456789012', 'arn:aws:test789'),
     }
 
-    # Assert AWSAccount DELEGATE to Finding exists
+    # Assert AWSAccount MEMBER to Finding exists
     assert check_rels(
         neo4j_session,
         'AWSAccount',
         'id',
         'AWSInspectorFinding',
         'id',
-        'DELEGATE',
+        'MEMBER',
         rel_direction_right=True,
     ) == {
         ('123456789011', 'arn:aws:test789'),

--- a/tests/integration/cartography/intel/aws/inspector/test_inspector_sync.py
+++ b/tests/integration/cartography/intel/aws/inspector/test_inspector_sync.py
@@ -89,6 +89,7 @@ def test_sync_inspector_ec2_package_findings(mock_get, neo4j_session):
     neo4j_session.run(
         """
         MERGE (:EC2Instance{id: 'i-88503981029833100', instanceid: 'i-88503981029833100'})
+        MERGE (:EC2Instance{id: 'i-88503981029833101', instanceid: 'i-88503981029833101'})
         """,
     )
 
@@ -113,6 +114,7 @@ def test_sync_inspector_ec2_package_findings(mock_get, neo4j_session):
         rel_direction_right=True,
     ) == {
         ('arn:aws:test456', 'i-88503981029833100'),
+        ('arn:aws:test789', 'i-88503981029833101')
     }
 
     assert check_rels(
@@ -126,9 +128,10 @@ def test_sync_inspector_ec2_package_findings(mock_get, neo4j_session):
     ) == {
         ('arn:aws:test456', 'kernel-tools|X86_64|4.9.17|6.29.amzn1|0'),
         ('arn:aws:test456', 'kernel|X86_64|4.9.17|6.29.amzn1|0'),
+        ('arn:aws:test789', 'openssl|X86_64|1.0.2k|1.amzn2|0')
     }
 
-    # Assert AWSAccount to Finding exists
+    # Assert AWSAccount RESOURCE to Finding exists
     assert check_rels(
         neo4j_session,
         'AWSAccount',
@@ -138,5 +141,20 @@ def test_sync_inspector_ec2_package_findings(mock_get, neo4j_session):
         'RESOURCE',
         rel_direction_right=True,
     ) == {
+        ('123456789012', 'arn:aws:test456'),
+        ('123456789012', 'arn:aws:test789'),
+    }
+
+    # Assert AWSAccount DELEGATE to Finding exists
+    assert check_rels(
+        neo4j_session,
+        'AWSAccount',
+        'id',
+        'AWSInspectorFinding',
+        'id',
+        'DELEGATE',
+        rel_direction_right=True,
+    ) == {
+        ('123456789011', 'arn:aws:test789'),
         ('123456789012', 'arn:aws:test456'),
     }

--- a/tests/integration/cartography/intel/aws/inspector/test_inspector_sync.py
+++ b/tests/integration/cartography/intel/aws/inspector/test_inspector_sync.py
@@ -114,7 +114,7 @@ def test_sync_inspector_ec2_package_findings(mock_get, neo4j_session):
         rel_direction_right=True,
     ) == {
         ('arn:aws:test456', 'i-88503981029833100'),
-        ('arn:aws:test789', 'i-88503981029833101')
+        ('arn:aws:test789', 'i-88503981029833101'),
     }
 
     assert check_rels(
@@ -128,7 +128,7 @@ def test_sync_inspector_ec2_package_findings(mock_get, neo4j_session):
     ) == {
         ('arn:aws:test456', 'kernel-tools|X86_64|4.9.17|6.29.amzn1|0'),
         ('arn:aws:test456', 'kernel|X86_64|4.9.17|6.29.amzn1|0'),
-        ('arn:aws:test789', 'openssl|X86_64|1.0.2k|1.amzn2|0')
+        ('arn:aws:test789', 'openssl|X86_64|1.0.2k|1.amzn2|0'),
     }
 
     # Assert AWSAccount RESOURCE to Finding exists

--- a/tests/unit/cartography/intel/aws/test_inspector.py
+++ b/tests/unit/cartography/intel/aws/test_inspector.py
@@ -67,6 +67,34 @@ def test_transform_inspector_findings_package():
                 'kernel|X86_64|4.9.17|6.29.amzn1|0',
             ],
         },
+        {
+            'id': 'arn:aws:test789',
+            'arn': 'arn:aws:test789',
+            'vulnerabilityid': 'CVE-2023-1234',
+            'instanceid': 'i-88503981029833101',
+            'severity': 'HIGH',
+            'name': 'CVE-2023-1234 - openssl',
+            'firstobservedat': datetime(2022, 5, 4, 16, 23, 3, 692000),
+            'updatedat': datetime(2022, 5, 4, 16, 23, 3, 692000),
+            'awsaccount': '123456789011',
+            'description': 'A buffer overflow vulnerability in OpenSSL allows remote attackers '
+            'to execute arbitrary code or cause a denial of service via crafted '
+            'SSL/TLS handshake messages.',
+            'cvssscore': 7.5,
+            'type': 'PACKAGE_VULNERABILITY',
+            'referenceurls': ['https://nvd.nist.gov/vuln/detail/CVE-2023-1234'],
+            'relatedvulnerabilities': [],
+            'source': 'NVD',
+            'vendorcreatedat': datetime(2023, 1, 15, 10, 0),
+            'vendorupdatedat': None,
+            'vendorseverity': 'High',
+            'sourceurl': 'https://nvd.nist.gov/vuln/detail/CVE-2023-1234',
+            'status': 'ACTIVE',
+
+            'vulnerablepackageids': [
+                'openssl|X86_64|1.0.2k|1.amzn2|0',
+            ],
+        },
     ]
     assert packages == [
         {
@@ -96,5 +124,19 @@ def test_transform_inspector_findings_package():
             'release': '6.29.amzn1',
             'sourcelayerhash': None,
             'version': '4.9.17',
+        },
+        {
+            'arch': 'X86_64',
+            'awsaccount': '123456789011',
+            'epoch': 0,
+            'filepath': None,
+            'findingarn': 'arn:aws:test789',
+            'fixedinversion': None,
+            'id': 'openssl|X86_64|1.0.2k|1.amzn2|0',
+            'manager': 'OS',
+            'name': 'openssl',
+            'release': '1.amzn2',
+            'sourcelayerhash': None,
+            'version': '1.0.2k',
         },
     ]


### PR DESCRIPTION
### Summary
> Describe your changes.
Add relationship to `:AWSAccount` and `:AWSInspectorFinding` when the finding is ingested via a delegated account.


### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/cartography-cncf/cartography/issues/1439
- https://docs.aws.amazon.com/inspector/latest/user/admin-member-relationship.html
- https://docs.aws.amazon.com/organizations/latest/userguide/services-that-can-integrate-inspector2.html

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
