### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
     target-branch: "master"
     commit-message:
       # Prefix all commit messages with "chore: "
-      prefix: "chore"
+      prefix: "chore: "
     groups:
       # Group all minor and patch updates for Python
       # Keep individual updates for major updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,7 +47,7 @@ updates:
     target-branch: "master"
     commit-message:
       # Prefix all commit messages with "chore: "
-      prefix: "chore"
+      prefix: "chore: "
     # Ignore major & minor updates to stay on python:3.10
     # TODO: Remove when ready to upgrade to python:3.11
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,6 @@ updates:
     # TODO: Remove when ready to upgrade to python:3.11
     ignore:
       - dependency-name: "*"
-      - update-types:
+        update-types:
         - version-update:semver-major
         - version-update:semver-minor

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,6 +36,9 @@ updates:
     # This should be removed if we stick to a pinned version strategy
     # Ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#defining-a-versioning-strategy
     versioning-strategy: increase-if-necessary
+    # TODO: Remove when #857 is fixed
+    ignore:
+      - dependency-name: "okta"
   # Maintain dependencies for Docker
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,7 +46,9 @@ updates:
       # Prefix all commit messages with "chore: "
       prefix: "chore"
     # Ignore major & minor updates to stay on python:3.10
+    # TODO: Remove when ready to upgrade to python:3.11
     ignore:
+      - dependency-name: "*"
       - update-types:
         - version-update:semver-major
         - version-update:semver-minor

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,6 @@ updates:
       prefix: "chore"
     # Ignore major & minor updates to stay on python:3.10
     ignore:
-      - update-types: 
+      - update-types:
         - version-update:semver-major
         - version-update:semver-minor

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "master"
+    commit-message:
+      # Prefix all commit messages with "chore: "
+      prefix: "chore"
+    groups:
+      # Group all minor and patch updates for GitHub Actions
+      # Keep individual updates for major updates
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+  # Maintain dependencies for Python
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "master"
+    commit-message:
+      # Prefix all commit messages with "chore: "
+      prefix: "chore"
+    groups:
+      # Group all minor and patch updates for Python
+      # Keep individual updates for major updates
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    # Loose versioning strategy, increase the version only if necessary
+    # This should be removed if we stick to a pinned version strategy
+    # Ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#defining-a-versioning-strategy
+    versioning-strategy: increase-if-necessary
+  # Maintain dependencies for Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "master"
+    commit-message:
+      # Prefix all commit messages with "chore: "
+      prefix: "chore"
+    # Ignore major & minor updates to stay on python:3.10
+    ignore:
+      - update-types: 
+        - version-update:semver-major
+        - version-update:semver-minor

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     target-branch: "master"
     commit-message:
       # Prefix all commit messages with "chore: "
-      prefix: "chore"
+      prefix: "chore: "
     groups:
       # Group all minor and patch updates for GitHub Actions
       # Keep individual updates for major updates


### PR DESCRIPTION
### Summary
This PR adds Dependabot configuration for updating dependencies in GitHub Actions, Dockerfiles, and Python libraries.

Updates will be checked weekly, with PRs:
- Prefixed with `chore:`
- Labeled as `dependencies`

**GitHub Actions**
- Minor and patch updates will be grouped into a single PR
- Major updates will be handled in dedicated PRs

**Python**
- Minor and patch updates will be grouped into a single PR
- Major updates will be handled in dedicated PRs
- The strategy is "loose": requirements files will only be updated if necessary (e.g., if the current version constraint is `^1.0.0` and already includes the new version `1.2.0`, no update will be made)

**Docker**
- Only patch updates will be applied to maintain the image on Python 3.10