### PR TITLE
chore: update doc generation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.ifconfig",
     "sphinx.ext.githubpages",
-    "m2r2",
+    "sphinx_mdinclude",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==5.0.0
+sphinx==8.1.3
 sphinx-material==0.0.35
-m2r2==0.3.2
+sphinx-mdinclude==0.6.2


### PR DESCRIPTION
### Summary

`m2r2` dependency is no longer maintained and have incompatibility with latest version of `docutils` that is required for supported version of `sphinx`

This PR replace `m2r2` by `sphinx-mdinclude`.

### Related issues or links
- https://github.com/cartography-cncf/cartography/pull/1456
- https://github.com/cartography-cncf/cartography/pull/1454