### PR TITLE
feat: allow update schema without updating nodes

### DIFF
--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -387,7 +387,8 @@ def build_ingestion_query(
         if property_ref is None:
             raise ValueError(
                 f"build_ingestion_query() failed: The CartographyNodeSchema {node_schema.__class__.__name__} does not "
-                "have a 'lastupdated' property. Please ensure that the 'lastupdated' property is defined on the node.")
+                "have a 'lastupdated' property. Please ensure that the 'lastupdated' property is defined on the node.",
+            )
         query_template = Template(
             """
             UNWIND $DictList AS item


### PR DESCRIPTION
### Summary
This PR adds an `only_relationships` flag to the `build_ingestion_query()` function.  
The goal is to update the relationships between nodes without risking overwriting their properties.  

Here’s the use case where I need this:  
- I retrieve users from GitHub  
- I retrieve repositories from GitHub  
- I also retrieve User/Repository links  

To avoid a complex transformation that could be hard to maintain, I believe the simplest approach is:  
- One ingestion call with all user data  
- One ingestion call with all repository data  
- One ingestion call on Repositories (which contains the link) with minimal information (Repo ID + User ID as defined in the model)  

The flag allow to run this last ingestion call without deleting all properties of Repo node