### PR TITLE
Handle each image id separately

### DIFF
--- a/cartography/intel/aws/ec2/images.py
+++ b/cartography/intel/aws/ec2/images.py
@@ -49,7 +49,7 @@ def get_images(boto3_session: boto3.session.Session, region: str, image_ids: Lis
         logger.warning(f"Failed retrieve self owned images for region - {region}. Error - {e}")
     images.extend(self_images)
     if image_ids:
-        ids_retrieved = {image['ImageId'] for image in images}
+        self_image_ids = {image['ImageId'] for image in images}
         ids_pending = [id for id in image_ids if id not in ids_retrieved]
         # Go one by one to avoid losing all images if one fails
         for image in ids_pending:

--- a/cartography/intel/aws/ec2/images.py
+++ b/cartography/intel/aws/ec2/images.py
@@ -50,14 +50,15 @@ def get_images(boto3_session: boto3.session.Session, region: str, image_ids: Lis
     images.extend(self_images)
     if image_ids:
         self_image_ids = {image['ImageId'] for image in images}
-        ids_pending = [id for id in image_ids if id not in ids_retrieved]
         # Go one by one to avoid losing all images if one fails
-        for image in ids_pending:
+        for image in image_ids:
+            if image in self_image_ids:
+                continue
             try:
                 public_images = client.describe_images(ImageIds=[image])['Images']
                 images.extend(public_images)
             except ClientError as e:
-                logger.warning(f"Failed retrieve non-self image for region - {region}. Error - {e}")
+                logger.warning(f"Failed retrieve image id {image} for region - {region}. Error - {e}")
     return images
 
 

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_images.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_images.py
@@ -1,5 +1,8 @@
+import boto3.session
 import cartography.intel.aws.ec2.images
 import tests.data.aws.ec2.images
+import boto3
+from moto import mock_aws
 
 TEST_ACCOUNT_ID = '000000000000'
 TEST_REGION = 'us-west-1'
@@ -67,3 +70,15 @@ def test_load_images_relationships(neo4j_session):
     }
 
     assert actual == expected
+
+
+@mock_aws
+def test_get_images():
+    boto3_session = boto3.session.Session()
+    ec2 = boto3_session.client('ec2', region_name=TEST_REGION)
+    image_id = ec2.register_image(Name='test-image')['ImageId']
+    image_ids = [image_id, "ami-invalid"]
+    images = cartography.intel.aws.ec2.images.get_images(boto3_session, TEST_REGION, image_ids)
+    assert isinstance(images, list)
+    assert len(images) == 1
+    assert images[0]['ImageId'] == image_id

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_images.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_images.py
@@ -1,8 +1,8 @@
 import boto3.session
+from moto import mock_aws
+
 import cartography.intel.aws.ec2.images
 import tests.data.aws.ec2.images
-import boto3
-from moto import mock_aws
 
 TEST_ACCOUNT_ID = '000000000000'
 TEST_REGION = 'us-west-1'


### PR DESCRIPTION
### Summary
Previous code handled any client exception at `client.describe_images(ImageIds=[image_ids])['Images']` as a full failure.
If for any reason (e.g. the image id is no longer found) the API call failed, all the id's from the set were skipped.

This PR splits the calls one per image id. There is a small performance degradation due to latency, but it was not perceptible during my tests with +200 images.

### Related issues or links
> Include links to relevant issues or other pages.
This was tried to fix at 
- https://github.com/cartography-cncf/cartography/pull/1441
But it was reverted since didn't fix the root cause.

Logs after:
```
2025-02-11 14:26:50,379 - cartography.intel.aws.ec2.images - INFO - Syncing images for region 'us-east-1' in account '277829364062'.
2025-02-11 14:27:00,234 - cartography.intel.aws.ec2.images - WARNING - Failed retrieve image id ami-03be86ff62fe082ad for region - us-east-1. Error - An error occurred (InvalidAMIID.NotFound) when calling the DescribeImages operation: The image id '[ami-03be86ff62fe082ad]' does not exist
2025-02-11 14:27:02,763 - cartography.intel.aws.ec2.images - INFO - Syncing images for region 'us-east-2' in account '277829364062'.
2025-02-11 14:27:03,143 - cartography.intel.aws.ec2.images - INFO - Syncing images for region 'us-west-1' in account '277829364062'.
2025-02-11 14:27:03,561 - cartography.intel.aws.ec2.images - INFO - Syncing images for region 'us-west-2' in account '277829364062'.
```

Example error before the change using https://github.com/cartography-cncf/cartography/pull/1441:
```
Failed to retrieve public images for region - us-east-1. Error - An error occurred (InvalidAMIID.NotFound) when calling the DescribeImages operation: The image ids '[ami-0d4e924e774f7d54a, ami-0b3126f23ad61defc, ami-0644dffc72cee3960, ami-09ca115a458c43d7a, ami-064a36b42c8203d8d, ami-073cf29d5b46bb2ba, ami-0cdc91d6f6d45591f, ami-03fe03bbcbfde1c1e, ami-0cfd0e38c0448c98c, ami-0af76f69b0f541ca0, ami-04c6260c832afa746, ami-0c346f96131f30a3b, ami-0fb9c9fc5db3e5a84, ami-07a6b49ef075534f9, ami-06dfde5c1a402f710, ami-072309c05e170f9a4]' do not exist
```

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [x] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
