### PR TITLE
Use `pip install` with `--no-cache-dir` inside the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /var/cartography
 ENV HOME=/var/cartography
 
 # Install cartography at the given version specifier. Can be ''.
-RUN pip install cartography${VERSION_SPECIFIER}
+RUN pip install --no-cache-dir cartography${VERSION_SPECIFIER}
 
 USER ${uid}:${gid}
 


### PR DESCRIPTION
### Summary

This will help minimize the Docker image size by avoiding pip's package cache. Which is kind of Dockerfile best practices ;)

### Related issues or links



### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
