### PR TITLE
Revert "chore: bump sphinx from 8.1.3 to 8.2.3 in the minor-and-patch group"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==8.2.3
+sphinx==8.1.3
 sphinx-material==0.0.36
 sphinx-mdinclude==0.6.2


### PR DESCRIPTION
Reverts cartography-cncf/cartography#1474

Updating to 8.2.3 break the doc generation because Sphinx now require python 3.11 (https://github.com/sphinx-doc/sphinx/blob/2fa51bb49351cff4e3c67adafbe51ecfd0fdb43b/pyproject.toml#L20)

Due to loose comparison (>=3.10 on cartography & >= 3.11 on Sphinx), this has not been detected on local tests :(