### PR TITLE
Revert "ECR: add describe_images to get image size information."

### DIFF
--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -36,10 +36,7 @@ def get_ecr_repository_images(boto3_session: boto3.session.Session, region: str,
     paginator = client.get_paginator('list_images')
     ecr_repository_images: List[Dict] = []
     for page in paginator.paginate(repositoryName=repository_name):
-        image_ids = page['imageIds']
-        if image_ids:
-            response = client.describe_images(repositoryName=repository_name, imageIds=image_ids)
-            ecr_repository_images.extend(response['imageDetails'])
+        ecr_repository_images.extend(page['imageIds'])
     return ecr_repository_images
 
 
@@ -106,12 +103,7 @@ def _load_ecr_repo_img_tx(
         ON CREATE SET ri.firstseen = timestamp()
         SET ri.lastupdated = $aws_update_tag,
             ri.tag = repo_img.imageTag,
-            ri.uri = repo_img.repo_uri + COALESCE(":" + repo_img.imageTag, ''),
-            ri.image_size_bytes = repo_img.imageSizeInBytes,
-            ri.image_pushed_at = repo_img.imagePushedAt,
-            ri.image_manifest_media_type = repo_img.imageManifestMediaType,
-            ri.artifact_media_type = repo_img.artifactMediaType,
-            ri.last_recorded_pull_time = repo_img.lastRecordedPullTime
+            ri.uri = repo_img.repo_uri + COALESCE(":" + repo_img.imageTag, '')
         WITH ri, repo_img
 
         MERGE (img:ECRImage{id: repo_img.imageDigest})

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1379,11 +1379,6 @@ This way, more than one `ECRRepositoryImage` can reference/be connected to the s
 | tag | The tag applied to the repository image, e.g. "latest" |
 | uri | The URI where the repository image is stored |
 | **id** | same as uri |
-| image_size_bytes | The size of the image in bytes |
-| image_pushed_at | The date and time the image was pushed to the repository |
-| image_manifest_media_type | The media type of the image manifest, see [opencontainers image spec](https://github.com/opencontainers/image-spec/blob/main/media-types.md) |
-| artifact_media_type | The media type of the image artifact |
-| last_recorded_pull_time | The date and time the image was last pulled |
 
 #### Relationships
 


### PR DESCRIPTION
Reverts cartography-cncf/cartography#1471

This change is causing `ECRRepositoryImage` id doesn't contain the hash expected to create `(repo_img:ECRRepositoryImage)-[:IMAGE]->(img:ECRImage)` relationship.

Rolling back to mitigate the regression