### PR TITLE
Paginate and extract image tag when using describe_images at ECR module

### DIFF
--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -41,10 +41,10 @@ def get_ecr_repository_images(boto3_session: boto3.session.Session, region: str,
         describe_response = describe_paginator.paginate(repositoryName=repository_name, imageIds=image_ids)
         for response in describe_response:
             image_details = response['imageDetails']
-            if len(image_details) != len(image_ids):
-                raise ValueError("Expected the same number of image details as image IDs")
-            for detail in image_details:
-                detail['imageTag'] = detail['imageTags'][0]
+            image_details = [
+                {**detail, 'imageTag': detail['imageTags'][0]} if detail.get('imageTags') else detail
+                for detail in image_details
+            ]
             ecr_repository_images.extend(image_details)
     return ecr_repository_images
 

--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -33,13 +33,19 @@ def get_ecr_repositories(boto3_session: boto3.session.Session, region: str) -> L
 def get_ecr_repository_images(boto3_session: boto3.session.Session, region: str, repository_name: str) -> List[Dict]:
     logger.debug("Getting ECR images in repository '%s' for region '%s'.", repository_name, region)
     client = boto3_session.client('ecr', region_name=region)
-    paginator = client.get_paginator('list_images')
+    list_paginator = client.get_paginator('list_images')
     ecr_repository_images: List[Dict] = []
-    for page in paginator.paginate(repositoryName=repository_name):
+    for page in list_paginator.paginate(repositoryName=repository_name):
         image_ids = page['imageIds']
-        if image_ids:
-            response = client.describe_images(repositoryName=repository_name, imageIds=image_ids)
-            ecr_repository_images.extend(response['imageDetails'])
+        describe_paginator = client.get_paginator('describe_images')
+        describe_response = describe_paginator.paginate(repositoryName=repository_name, imageIds=image_ids)
+        for response in describe_response:
+            image_details = response['imageDetails']
+            if len(image_details) != len(image_ids):
+                raise ValueError("Expected the same number of image details as image IDs")
+            for detail in image_details:
+                detail['imageTag'] = detail['imageTags'][0]
+            ecr_repository_images.extend(image_details)
     return ecr_repository_images
 
 

--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -37,6 +37,8 @@ def get_ecr_repository_images(boto3_session: boto3.session.Session, region: str,
     ecr_repository_images: List[Dict] = []
     for page in list_paginator.paginate(repositoryName=repository_name):
         image_ids = page['imageIds']
+        if not image_ids:
+            continue
         describe_paginator = client.get_paginator('describe_images')
         describe_response = describe_paginator.paginate(repositoryName=repository_name, imageIds=image_ids)
         for response in describe_response:

--- a/tests/data/aws/ecr.py
+++ b/tests/data/aws/ecr.py
@@ -28,29 +28,29 @@ DESCRIBE_REPOSITORIES = {
 }
 DESCRIBE_IMAGES = {
     'imageDetails':
-         {
-             "registryId": "000000000000",
-             "imageSizeInBytes": 1024,
-             "imagePushedAt": "2025-01-01T00:00:00.000000-00:00",
-             "imageScanStatus": {
-                 "status": "COMPLETE",
-                 "description": "The scan was completed successfully."
-             },
-             "imageScanFindingsSummary": {
-                 "imageScanCompletedAt": "2025-01-01T00:00:00-00:00",
-                 "vulnerabilitySourceUpdatedAt": "2025-01-01T00:00:00-00:00",
-                 "findingSeverityCounts": {
-                     "CRITICAL": 1,
-                     "HIGH": 1,
-                     "MEDIUM": 1,
-                     "INFORMATIONAL": 1,
-                     "LOW": 1
-                 }
-             },
-             "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
-             "artifactMediaType": "application/vnd.docker.container.image.v1+json",
-             "lastRecordedPullTime": "2025-01-01T01:01:01.000000-00:00"
-         }
+    {
+        "registryId": "000000000000",
+        "imageSizeInBytes": 1024,
+        "imagePushedAt": "2025-01-01T00:00:00.000000-00:00",
+        "imageScanStatus": {
+            "status": "COMPLETE",
+            "description": "The scan was completed successfully."
+        },
+        "imageScanFindingsSummary": {
+            "imageScanCompletedAt": "2025-01-01T00:00:00-00:00",
+            "vulnerabilitySourceUpdatedAt": "2025-01-01T00:00:00-00:00",
+            "findingSeverityCounts": {
+                "CRITICAL": 1,
+                "HIGH": 1,
+                "MEDIUM": 1,
+                "INFORMATIONAL": 1,
+                "LOW": 1
+            }
+        },
+        "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "artifactMediaType": "application/vnd.docker.container.image.v1+json",
+        "lastRecordedPullTime": "2025-01-01T01:01:01.000000-00:00"
+    }
  }
 
 LIST_REPOSITORY_IMAGES = {

--- a/tests/data/aws/ecr.py
+++ b/tests/data/aws/ecr.py
@@ -26,47 +26,80 @@ DESCRIBE_REPOSITORIES = {
         },
     ],
 }
-
+DESCRIBE_IMAGES = {
+    'imageDetails':
+         {
+             "registryId": "000000000000",
+             "imageSizeInBytes": 1024,
+             "imagePushedAt": "2025-01-01T00:00:00.000000-00:00",
+             "imageScanStatus": {
+                 "status": "COMPLETE",
+                 "description": "The scan was completed successfully."
+             },
+             "imageScanFindingsSummary": {
+                 "imageScanCompletedAt": "2025-01-01T00:00:00-00:00",
+                 "vulnerabilitySourceUpdatedAt": "2025-01-01T00:00:00-00:00",
+                 "findingSeverityCounts": {
+                     "CRITICAL": 1,
+                     "HIGH": 1,
+                     "MEDIUM": 1,
+                     "INFORMATIONAL": 1,
+                     "LOW": 1
+                 }
+             },
+             "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
+             "artifactMediaType": "application/vnd.docker.container.image.v1+json",
+             "lastRecordedPullTime": "2025-01-01T01:01:01.000000-00:00"
+         }
+ }
 
 LIST_REPOSITORY_IMAGES = {
     '000000000000.dkr.ecr.us-east-1/example-repository': [
         {
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
-            'imageTag': '1',
-        },
+            'imageTags': '1',
+            'repositoryName': 'example-repository',
+        }.update(DESCRIBE_IMAGES['imageDetails']),
         {
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000001',
             'imageTag': '2',
-        },
+            'repositoryName': 'example-repository',
+        }.update(DESCRIBE_IMAGES['imageDetails']),
     ],
     '000000000000.dkr.ecr.us-east-1/sample-repository': [
         {
             # NOTE same digest and tag as image in example-repository
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
             'imageTag': '1',
-        },
+            'repositoryName': 'sample-repository',
+        }.update(DESCRIBE_IMAGES['imageDetails']),
         {
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000011',
             'imageTag': '2',
-        },
+            'repositoryName': 'sample-repository',
+        }.update(DESCRIBE_IMAGES['imageDetails']),
     ],
     '000000000000.dkr.ecr.us-east-1/test-repository': [
         {
             # NOTE same digest but different tag from image in example-repository
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
             'imageTag': '1234567890',
-        },
+            'repositoryName': 'test-repository',
+        }.update(DESCRIBE_IMAGES['imageDetails']),
         {
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000021',
             'imageTag': '1',
-        },
+            'repositoryName': 'test-repository',
+        }.update(DESCRIBE_IMAGES['imageDetails']),
         # Item without an imageDigest: will get filtered out and not ingested.
         {
             'imageTag': '1',
-        },
+            'repositoryName': 'test-repository',
+        }.update(DESCRIBE_IMAGES['imageDetails']),
         # Item without an imageTag
         {
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000031',
-        },
+            'repositoryName': 'test-repository',
+        }.update(DESCRIBE_IMAGES['imageDetails']),
     ],
 }

--- a/tests/data/aws/ecr.py
+++ b/tests/data/aws/ecr.py
@@ -59,12 +59,14 @@ LIST_REPOSITORY_IMAGES = {
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
             'imageTags': '1',
             'repositoryName': 'example-repository',
-        }.update(DESCRIBE_IMAGES['imageDetails']),
+            **DESCRIBE_IMAGES['imageDetails'],
+        },
         {
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000001',
             'imageTag': '2',
             'repositoryName': 'example-repository',
-        }.update(DESCRIBE_IMAGES['imageDetails']),
+            **DESCRIBE_IMAGES['imageDetails'],
+        },
     ],
     '000000000000.dkr.ecr.us-east-1/sample-repository': [
         {
@@ -72,12 +74,14 @@ LIST_REPOSITORY_IMAGES = {
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
             'imageTag': '1',
             'repositoryName': 'sample-repository',
-        }.update(DESCRIBE_IMAGES['imageDetails']),
+            **DESCRIBE_IMAGES['imageDetails'],
+        },
         {
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000011',
             'imageTag': '2',
             'repositoryName': 'sample-repository',
-        }.update(DESCRIBE_IMAGES['imageDetails']),
+            **DESCRIBE_IMAGES['imageDetails'],
+        },
     ],
     '000000000000.dkr.ecr.us-east-1/test-repository': [
         {
@@ -85,21 +89,25 @@ LIST_REPOSITORY_IMAGES = {
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
             'imageTag': '1234567890',
             'repositoryName': 'test-repository',
-        }.update(DESCRIBE_IMAGES['imageDetails']),
+            **DESCRIBE_IMAGES['imageDetails'],
+        },
         {
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000021',
             'imageTag': '1',
             'repositoryName': 'test-repository',
-        }.update(DESCRIBE_IMAGES['imageDetails']),
+            **DESCRIBE_IMAGES['imageDetails'],
+        },
         # Item without an imageDigest: will get filtered out and not ingested.
         {
             'imageTag': '1',
             'repositoryName': 'test-repository',
-        }.update(DESCRIBE_IMAGES['imageDetails']),
+            **DESCRIBE_IMAGES['imageDetails'],
+        },
         # Item without an imageTag
         {
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000031',
             'repositoryName': 'test-repository',
-        }.update(DESCRIBE_IMAGES['imageDetails']),
+            **DESCRIBE_IMAGES['imageDetails'],
+        },
     ],
 }

--- a/tests/data/aws/ecr.py
+++ b/tests/data/aws/ecr.py
@@ -34,7 +34,7 @@ DESCRIBE_IMAGES = {
         "imagePushedAt": "2025-01-01T00:00:00.000000-00:00",
         "imageScanStatus": {
             "status": "COMPLETE",
-            "description": "The scan was completed successfully."
+            "description": "The scan was completed successfully.",
         },
         "imageScanFindingsSummary": {
             "imageScanCompletedAt": "2025-01-01T00:00:00-00:00",
@@ -44,12 +44,12 @@ DESCRIBE_IMAGES = {
                 "HIGH": 1,
                 "MEDIUM": 1,
                 "INFORMATIONAL": 1,
-                "LOW": 1
+                "LOW": 1,
             }
         },
         "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "artifactMediaType": "application/vnd.docker.container.image.v1+json",
-        "lastRecordedPullTime": "2025-01-01T01:01:01.000000-00:00"
+        "lastRecordedPullTime": "2025-01-01T01:01:01.000000-00:00",
     }
  }
 

--- a/tests/data/aws/ecr.py
+++ b/tests/data/aws/ecr.py
@@ -57,7 +57,7 @@ LIST_REPOSITORY_IMAGES = {
     '000000000000.dkr.ecr.us-east-1/example-repository': [
         {
             'imageDigest': 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
-            'imageTags': '1',
+            'imageTag': '1',
             'repositoryName': 'example-repository',
             **DESCRIBE_IMAGES['imageDetails'],
         },

--- a/tests/data/aws/ecr.py
+++ b/tests/data/aws/ecr.py
@@ -45,12 +45,12 @@ DESCRIBE_IMAGES = {
                 "MEDIUM": 1,
                 "INFORMATIONAL": 1,
                 "LOW": 1,
-            }
+            },
         },
         "imageManifestMediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "artifactMediaType": "application/vnd.docker.container.image.v1+json",
         "lastRecordedPullTime": "2025-01-01T01:01:01.000000-00:00",
-    }
+    },
  }
 
 LIST_REPOSITORY_IMAGES = {

--- a/tests/data/aws/ecr.py
+++ b/tests/data/aws/ecr.py
@@ -51,7 +51,7 @@ DESCRIBE_IMAGES = {
         "artifactMediaType": "application/vnd.docker.container.image.v1+json",
         "lastRecordedPullTime": "2025-01-01T01:01:01.000000-00:00",
     },
- }
+}
 
 LIST_REPOSITORY_IMAGES = {
     '000000000000.dkr.ecr.us-east-1/example-repository': [

--- a/tests/integration/cartography/intel/aws/test_ecr.py
+++ b/tests/integration/cartography/intel/aws/test_ecr.py
@@ -90,13 +90,14 @@ def test_sync_ecr(mock_get_images, mock_get_repos, neo4j_session):
 
     # Assert ECR repository images exist
     assert check_nodes(neo4j_session, 'ECRRepositoryImage', ['id', 'tag', 'image_size_bytes', 'image_pushed_at']) == {
-        ('000000000000.dkr.ecr.us-east-1/example-repository:1', '1', 1024, '2025-01-01T00:00:00.000000-00:00' ),
-        ('000000000000.dkr.ecr.us-east-1/example-repository:2', '2', 1024, '2025-01-01T00:00:00.000000-00:00' ),
-        ('000000000000.dkr.ecr.us-east-1/sample-repository:1', '1', 1024, '2025-01-01T00:00:00.000000-00:00' ),
-        ('000000000000.dkr.ecr.us-east-1/sample-repository:2', '2', 1024, '2025-01-01T00:00:00.000000-00:00' ),
-        ('000000000000.dkr.ecr.us-east-1/test-repository:1234567890', '1234567890', 1024, '2025-01-01T00:00:00.000000-00:00' ),
-        ('000000000000.dkr.ecr.us-east-1/test-repository:1', '1', 1024, '2025-01-01T00:00:00.000000-00:00' ),
-        ('000000000000.dkr.ecr.us-east-1/test-repository', None, 1024, '2025-01-01T00:00:00.000000-00:00' ),
+        ('000000000000.dkr.ecr.us-east-1/example-repository:1', '1', 1024, '2025-01-01T00:00:00.000000-00:00'),
+        ('000000000000.dkr.ecr.us-east-1/example-repository:2', '2', 1024, '2025-01-01T00:00:00.000000-00:00'),
+        ('000000000000.dkr.ecr.us-east-1/sample-repository:1', '1', 1024, '2025-01-01T00:00:00.000000-00:00'),
+        ('000000000000.dkr.ecr.us-east-1/sample-repository:2', '2', 1024, '2025-01-01T00:00:00.000000-00:00'),
+        ('000000000000.dkr.ecr.us-east-1/test-repository:1234567890', '1234567890', 1024,
+         '2025-01-01T00:00:00.000000-00:00'),
+        ('000000000000.dkr.ecr.us-east-1/test-repository:1', '1', 1024, '2025-01-01T00:00:00.000000-00:00'),
+        ('000000000000.dkr.ecr.us-east-1/test-repository', None, 1024, '2025-01-01T00:00:00.000000-00:00'),
     }
 
     # Assert repository to AWS account relationship

--- a/tests/integration/cartography/intel/aws/test_ecr.py
+++ b/tests/integration/cartography/intel/aws/test_ecr.py
@@ -89,14 +89,14 @@ def test_sync_ecr(mock_get_images, mock_get_repos, neo4j_session):
     }
 
     # Assert ECR repository images exist
-    assert check_nodes(neo4j_session, 'ECRRepositoryImage', ['id', 'tag']) == {
-        ('000000000000.dkr.ecr.us-east-1/example-repository:1', '1'),
-        ('000000000000.dkr.ecr.us-east-1/example-repository:2', '2'),
-        ('000000000000.dkr.ecr.us-east-1/sample-repository:1', '1'),
-        ('000000000000.dkr.ecr.us-east-1/sample-repository:2', '2'),
-        ('000000000000.dkr.ecr.us-east-1/test-repository:1234567890', '1234567890'),
-        ('000000000000.dkr.ecr.us-east-1/test-repository:1', '1'),
-        ('000000000000.dkr.ecr.us-east-1/test-repository', None),
+    assert check_nodes(neo4j_session, 'ECRRepositoryImage', ['id', 'tag', 'image_size_bytes', 'image_pushed_at']) == {
+        ('000000000000.dkr.ecr.us-east-1/example-repository:1', '1', 1024, '2025-01-01T00:00:00.000000-00:00' ),
+        ('000000000000.dkr.ecr.us-east-1/example-repository:2', '2', 1024, '2025-01-01T00:00:00.000000-00:00' ),
+        ('000000000000.dkr.ecr.us-east-1/sample-repository:1', '1', 1024, '2025-01-01T00:00:00.000000-00:00' ),
+        ('000000000000.dkr.ecr.us-east-1/sample-repository:2', '2', 1024, '2025-01-01T00:00:00.000000-00:00' ),
+        ('000000000000.dkr.ecr.us-east-1/test-repository:1234567890', '1234567890', 1024, '2025-01-01T00:00:00.000000-00:00' ),
+        ('000000000000.dkr.ecr.us-east-1/test-repository:1', '1', 1024, '2025-01-01T00:00:00.000000-00:00' ),
+        ('000000000000.dkr.ecr.us-east-1/test-repository', None, 1024, '2025-01-01T00:00:00.000000-00:00' ),
     }
 
     # Assert repository to AWS account relationship

--- a/tests/integration/cartography/intel/aws/test_ecr.py
+++ b/tests/integration/cartography/intel/aws/test_ecr.py
@@ -94,8 +94,10 @@ def test_sync_ecr(mock_get_images, mock_get_repos, neo4j_session):
         ('000000000000.dkr.ecr.us-east-1/example-repository:2', '2', 1024, '2025-01-01T00:00:00.000000-00:00'),
         ('000000000000.dkr.ecr.us-east-1/sample-repository:1', '1', 1024, '2025-01-01T00:00:00.000000-00:00'),
         ('000000000000.dkr.ecr.us-east-1/sample-repository:2', '2', 1024, '2025-01-01T00:00:00.000000-00:00'),
-        ('000000000000.dkr.ecr.us-east-1/test-repository:1234567890', '1234567890', 1024,
-         '2025-01-01T00:00:00.000000-00:00'),
+        (
+            '000000000000.dkr.ecr.us-east-1/test-repository:1234567890', '1234567890', 1024,
+            '2025-01-01T00:00:00.000000-00:00',
+        ),
         ('000000000000.dkr.ecr.us-east-1/test-repository:1', '1', 1024, '2025-01-01T00:00:00.000000-00:00'),
         ('000000000000.dkr.ecr.us-east-1/test-repository', None, 1024, '2025-01-01T00:00:00.000000-00:00'),
     }


### PR DESCRIPTION
### Summary
Follow up from https://github.com/cartography-cncf/cartography/pull/1471/.
[describe_images](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecr/client/describe_images.html) returns `imageTags` as an array of tags, compared to the single `imageTag`returned by [list_images](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecr/client/list_images.html).
Added as well more data to include a couple of the new fields to the integration test.


### Related issues or links
- https://github.com/cartography-cncf/cartography/pull/1471


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
