### PR TITLE
Preventing keyerror exception from cve attribute retrieval

### DIFF
--- a/cartography/intel/cve/feed.py
+++ b/cartography/intel/cve/feed.py
@@ -212,19 +212,19 @@ def transform_cves(cve_json: Dict[Any, Any]) -> List[Dict[Any, Any]]:
             if cvss31:
                 cvss31.update(cvss31["cvssData"])
                 cvss31.pop("cvssData")
-                cve["vectorString"] = cvss31["vectorString"]
-                cve["attackVector"] = cvss31["attackVector"]
-                cve["attackComplexity"] = cvss31["attackComplexity"]
-                cve["privilegesRequired"] = cvss31["privilegesRequired"]
-                cve["userInteraction"] = cvss31["userInteraction"]
-                cve["scope"] = cvss31["scope"]
-                cve["confidentialityImpact"] = cvss31["confidentialityImpact"]
-                cve["integrityImpact"] = cvss31["integrityImpact"]
-                cve["availabilityImpact"] = cvss31["availabilityImpact"]
-                cve["baseScore"] = cvss31["baseScore"]
-                cve["baseSeverity"] = cvss31["baseSeverity"]
-                cve["exploitabilityScore"] = cvss31["exploitabilityScore"]
-                cve["impactScore"] = cvss31["impactScore"]
+                cve["vectorString"] = cvss31.get("vectorString")
+                cve["attackVector"] = cvss31.get("attackVector")
+                cve["attackComplexity"] = cvss31.get("attackComplexity")
+                cve["privilegesRequired"] = cvss31.get("privilegesRequired")
+                cve["userInteraction"] = cvss31.get("userInteraction")
+                cve["scope"] = cvss31.get("scope")
+                cve["confidentialityImpact"] = cvss31.get("confidentialityImpact")
+                cve["integrityImpact"] = cvss31.get("integrityImpact")
+                cve["availabilityImpact"] = cvss31.get("availabilityImpact")
+                cve["baseScore"] = cvss31.get("baseScore")
+                cve["baseSeverity"] = cvss31.get("baseSeverity")
+                cve["exploitabilityScore"] = cvss31.get("exploitabilityScore")
+                cve["impactScore"] = cvss31.get("impactScore")
         except Exception:
             logger.error("Failed to transform CVE data {data}")
             raise


### PR DESCRIPTION
### Summary
Making this on behalf of @cmm-lyft at https://github.com/cartography-cncf/cartography/pull/1478

Recently, some objects in NVD response don't contain `attackVector` key at CVE response.
Using get dict method to prevent exceptions.

Part of the stacktrace:

```
File "/code/venvs/venv/lib/python3.10/site-packages/cartography/intel/cve/__init__.py", line 72, in _sync_modified_data
    modified_cves = feed.transform_cves(cves)
  File "/code/venvs/venv/lib/python3.10/site-packages/cartography/intel/cve/feed.py", line 216, in transform_cves
    cve["attackVector"] = cvss31["attackVector"]
KeyError: 'attackVector'
```


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
