### PR TITLE
Fix #1481: Separate EC2 template version fetching from template fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ cartography/_version.py
 uv.lock
 .cursor-server
 .gitconfig
+.python-version

--- a/cartography/intel/aws/ec2/launch_templates.py
+++ b/cartography/intel/aws/ec2/launch_templates.py
@@ -3,7 +3,6 @@ from typing import Any
 
 import boto3
 import neo4j
-from botocore.exceptions import ClientError
 
 from .util import get_botocore_config
 from cartography.client.core.tx import load
@@ -36,20 +35,13 @@ def get_launch_templates(
 def get_launch_template_versions(
     boto3_session: boto3.session.Session,
     region: str,
-    templates: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
+    client = boto3_session.client('ec2', region_name=region, config=get_botocore_config())
+    paginator = client.get_paginator('describe_launch_template_versions')
     template_versions: list[dict[str, Any]] = []
-    for template in templates:
-        template_id = template['LaunchTemplateId']
-        try:
-            versions = get_launch_template_versions_by_template(boto3_session, template_id, region)
-        except ClientError as e:
-            logger.warning(
-                f"Failed to get launch template versions for {template_id}: {e}",
-                exc_info=True,
-            )
-            versions = []
-        template_versions.extend(versions)
+    for page in paginator.paginate():
+        paginated_versions = page['LaunchTemplateVersions']
+        template_versions.extend(paginated_versions)
     return template_versions
 
 
@@ -78,21 +70,6 @@ def load_launch_templates(
         AWS_ID=current_aws_account_id,
         lastupdated=update_tag,
     )
-
-
-@timeit
-@aws_handle_regions
-def get_launch_template_versions_by_template(
-        boto3_session: boto3.session.Session,
-        template: str,
-        region: str,
-) -> list[dict[str, Any]]:
-    client = boto3_session.client('ec2', region_name=region, config=get_botocore_config())
-    v_paginator = client.get_paginator('describe_launch_template_versions')
-    template_versions = []
-    for versions in v_paginator.paginate(LaunchTemplateId=template):
-        template_versions.extend(versions['LaunchTemplateVersions'])
-    return template_versions
 
 
 def transform_launch_template_versions(versions: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -163,7 +140,7 @@ def sync_ec2_launch_templates(
     for region in regions:
         logger.info(f"Syncing launch templates for region '{region}' in account '{current_aws_account_id}'.")
         templates = get_launch_templates(boto3_session, region)
-        versions = get_launch_template_versions(boto3_session, region, templates)
+        versions = get_launch_template_versions(boto3_session, region)
         templates = transform_launch_templates(templates)
         load_launch_templates(neo4j_session, templates, region, current_aws_account_id, update_tag)
         versions = transform_launch_template_versions(versions)

--- a/cartography/intel/aws/ec2/launch_templates.py
+++ b/cartography/intel/aws/ec2/launch_templates.py
@@ -21,27 +21,36 @@ logger = logging.getLogger(__name__)
 def get_launch_templates(
     boto3_session: boto3.session.Session,
     region: str,
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+) -> list[dict[str, Any]]:
     client = boto3_session.client('ec2', region_name=region, config=get_botocore_config())
     paginator = client.get_paginator('describe_launch_templates')
     templates: list[dict[str, Any]] = []
-    template_versions: list[dict[str, Any]] = []
     for page in paginator.paginate():
         paginated_templates = page['LaunchTemplates']
-        for template in paginated_templates:
-            template_id = template['LaunchTemplateId']
-            try:
-                versions = get_launch_template_versions_by_template(boto3_session, template_id, region)
-            except ClientError as e:
-                logger.warning(
-                    f"Failed to get launch template versions for {template_id}: {e}",
-                    exc_info=True,
-                )
-                versions = []
-            # Using a key not defined in latest boto3 documentation
-            template_versions.extend(versions)
         templates.extend(paginated_templates)
-    return templates, template_versions
+    return templates
+
+
+@timeit
+@aws_handle_regions
+def get_launch_template_versions(
+    boto3_session: boto3.session.Session,
+    region: str,
+    templates: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    template_versions: list[dict[str, Any]] = []
+    for template in templates:
+        template_id = template['LaunchTemplateId']
+        try:
+            versions = get_launch_template_versions_by_template(boto3_session, template_id, region)
+        except ClientError as e:
+            logger.warning(
+                f"Failed to get launch template versions for {template_id}: {e}",
+                exc_info=True,
+            )
+            versions = []
+        template_versions.extend(versions)
+    return template_versions
 
 
 def transform_launch_templates(templates: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -153,7 +162,8 @@ def sync_ec2_launch_templates(
 ) -> None:
     for region in regions:
         logger.info(f"Syncing launch templates for region '{region}' in account '{current_aws_account_id}'.")
-        templates, versions = get_launch_templates(boto3_session, region)
+        templates = get_launch_templates(boto3_session, region)
+        versions = get_launch_template_versions(boto3_session, region, templates)
         templates = transform_launch_templates(templates)
         load_launch_templates(neo4j_session, templates, region, current_aws_account_id, update_tag)
         versions = transform_launch_template_versions(versions)

--- a/tests/integration/cartography/intel/aws/ec2/test_launch_templates.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_launch_templates.py
@@ -5,6 +5,7 @@ from botocore.exceptions import ClientError
 from moto import mock_aws
 
 import cartography.intel.aws.ec2.launch_templates
+from cartography.intel.aws.ec2.launch_templates import get_launch_template_versions
 from cartography.intel.aws.ec2.launch_templates import get_launch_templates
 from cartography.intel.aws.ec2.launch_templates import load_launch_template_versions
 from cartography.intel.aws.ec2.launch_templates import load_launch_templates
@@ -54,7 +55,8 @@ def test_get_launch_template_throws_exception(mock_get_template_versions, *args)
     session = boto3.Session(region_name=TEST_REGION)
     # Act: get the launch template versions
 
-    templates, versions = get_launch_templates(session, TEST_REGION)
+    templates = get_launch_templates(session, TEST_REGION)
+    versions = get_launch_template_versions(session, TEST_REGION, templates)
 
     # Assert: the launch template versions are as expected
     assert len(templates) == 1

--- a/tests/integration/cartography/intel/aws/ec2/test_launch_templates.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_launch_templates.py
@@ -1,12 +1,3 @@
-from unittest.mock import patch
-
-import boto3
-from botocore.exceptions import ClientError
-from moto import mock_aws
-
-import cartography.intel.aws.ec2.launch_templates
-from cartography.intel.aws.ec2.launch_templates import get_launch_template_versions
-from cartography.intel.aws.ec2.launch_templates import get_launch_templates
 from cartography.intel.aws.ec2.launch_templates import load_launch_template_versions
 from cartography.intel.aws.ec2.launch_templates import load_launch_templates
 from cartography.intel.aws.ec2.launch_templates import transform_launch_template_versions
@@ -18,49 +9,6 @@ from tests.integration.util import check_rels
 TEST_ACCOUNT_ID = '000000000000'
 TEST_REGION = 'us-east-1'
 TEST_UPDATE_TAG = 123456789
-
-
-@mock_aws(config={'core': {'reset_boto3_session': True, 'mock_credentials': True}})
-@patch.object(
-    cartography.intel.aws.ec2.launch_templates,
-    'get_launch_template_versions_by_template',
-)
-def test_get_launch_template_throws_exception(mock_get_template_versions, *args):
-    # Arrange
-    template_data = {
-        "ImageId": "ami-abc123",
-        "TagSpecifications": [
-            {
-                "ResourceType": "instance", "Tags": [
-                    {"Key": "eks:cluster-name", "Value": "eks-cluster-example"},
-                    {"Key": "eks:nodegroup-name", "Value": "private-node-group-example"},
-                ],
-            },
-        ],
-        "SecurityGroupIds": ["sg-1234"],
-    }
-    client = boto3.client('ec2', region_name=TEST_REGION)
-    mock_template = client.create_launch_template(
-        LaunchTemplateName='eks-00000000-0000-0000-0000-000000000000',
-        LaunchTemplateData=template_data,
-    )
-    template_id = mock_template['LaunchTemplate']['LaunchTemplateId']
-    error_response = {
-        "Error": {
-            "Code": "InvalidLaunchTemplateId.NotFound",
-            "Message": f"The specified launch template, with template ID {template_id}, does not exist.",
-        },
-    }
-    mock_get_template_versions.side_effect = ClientError(error_response, "DescribeLaunchTemplateVersions")
-    session = boto3.Session(region_name=TEST_REGION)
-    # Act: get the launch template versions
-
-    templates = get_launch_templates(session, TEST_REGION)
-    versions = get_launch_template_versions(session, TEST_REGION, templates)
-
-    # Assert: the launch template versions are as expected
-    assert len(templates) == 1
-    assert len(versions) == 0
 
 
 def test_load_launch_templates(neo4j_session, *args):


### PR DESCRIPTION
### Summary
> Describe your changes.

This change separates the retrieval of launch templates and their versions into distinct functions, resolving an issue where the `aws_handle_regions` decorator returns an empty list instead of a tuple, leading to a `ValueError` when unpacking.

I see that #845 specifically reverted a change that made `aws_handle_regions` polymorphic in return type.


### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/lyft/cartography/issues/...


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
