### PR TITLE
Fix #1494: Revert GSuite scope increase

### DIFF
--- a/cartography/intel/gsuite/__init__.py
+++ b/cartography/intel/gsuite/__init__.py
@@ -23,7 +23,6 @@ OAUTH_SCOPES = [
     'https://www.googleapis.com/auth/admin.directory.user.readonly',
     'https://www.googleapis.com/auth/admin.directory.group.readonly',
     'https://www.googleapis.com/auth/admin.directory.group.member',
-    'https://www.googleapis.com/auth/cloud-platform',
 ]
 
 logger = logging.getLogger(__name__)

--- a/docs/root/modules/gcp/config.md
+++ b/docs/root/modules/gcp/config.md
@@ -8,7 +8,7 @@ Follow these steps to analyze GCP projects with Cartography.
 
     1. Create an identity - either a User Account or a Service Account - for Cartography to run as
     1. Ensure that this identity has the following roles (https://cloud.google.com/iam/docs/understanding-roles) attached to it:
-        - `roles/iam.securityReviewer`
+        - `roles/iam.securityReviewer`: needed to list/get GCP IAM roles and service accounts
         - `roles/resourcemanager.organizationViewer`: needed to list/get GCP Organizations
         - `roles/resourcemanager.folderViewer`: needed to list/get GCP Folders
     1. Ensure that the machine you are running Cartography on can authenticate to this identity.


### PR DESCRIPTION
### Summary
As described in #1494, the recent addition of the `https://www.googleapis.com/auth/cloud-platform` OAuth scope in #1459 breaks the GSuite sync for those using delegated credentials. This conflates the needs of the GSuite and GCP modules and can be done in a more elegant way later without breaking existing users' syncs.

If folks still want to run GSuite and GCP syncs locally using just their own creds, they can still run the following to auth:
```gcloud auth application-default login --scopes="https://www.googleapis.com/auth/admin.directory.user.readonly,https://www.googleapis.com/auth/admin.directory.group.readonly,https://www.googleapis.com/auth/admin.directory.group.member.readonly,https://www.googleapis.com/auth/cloud-platform"```

They'll need to specify the GSuite auth method, ex `cartography --gsuite-auth-method default`


### Related issues or links
#1494 

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [x] Include console log trace showing what happened before and after your changes.
Trace log:
```
(cartography) ➜  cartography git:(master) ✗ gcloud auth application-default login --scopes="https://www.googleapis.com/auth/admin.directory.user.readonly,https://www.googleapis.com/auth/admin.directory.group.readonly,https://www.googleapis.com/auth/admin.directory.group.member.readonly,https://www.googleapis.com/auth/cloud-platform"

Credentials saved to file: [/Users/kunaalsikka/.config/gcloud/application_default_credentials.json]

These credentials will be used by any library that requests Application Default Credentials (ADC).

(cartography) ➜  cartography git:(master) ✗ cartography --gsuite-auth-method default
WARNING:cartography.cli:A Kandji base URI was not provided.
WARNING:cartography.cli:A SnipeIT base URI was not provided.
INFO:cartography.sync:Starting sync with update tag '1743101064'
INFO:cartography.sync:Starting sync stage 'create-indexes'
INFO:cartography.intel.create_indexes:Creating indexes for cartography node types.
INFO:cartography.sync:Finishing sync stage 'create-indexes'
INFO:cartography.sync:Starting sync stage 'aws'
ERROR:cartography.intel.aws.organizations:Unable to get AWS account number, an error occurred: 'Unable to locate credentials'. Make sure your AWS credentials are configured correctly, your AWS config file is valid, and your credentials have the SecurityAudit policy attached.
WARNING:cartography.intel.aws:No valid AWS credentials could be found. No AWS accounts can be synced. Exiting AWS sync stage.
INFO:cartography.sync:Finishing sync stage 'aws'
INFO:cartography.sync:Starting sync stage 'azure'
ERROR:cartography.intel.azure:Unable to authenticate with Azure Service Principal, an error occurred: The public API of azure-cli-core has been deprecated starting 2.21.0, and this method can no longer return a valid credential. If you need to still use this method, you need to install 'azure-cli-core<2.21.0'. You may corrupt data if you use current CLI and old azure-cli-core. See also: https://aka.ms/azsdk/python/identity/migration.Make sure your Azure Service Principal details are provided correctly.
INFO:cartography.sync:Finishing sync stage 'azure'
INFO:cartography.sync:Starting sync stage 'crowdstrike'
ERROR:cartography.intel.crowdstrike:crowdstrike config not found
INFO:cartography.sync:Finishing sync stage 'crowdstrike'
INFO:cartography.sync:Starting sync stage 'gcp'
INFO:cartography.graph.statement:Completed gcp_crm_organization_cleanup statement #1
INFO:cartography.graph.statement:Completed gcp_crm_organization_cleanup statement #2
INFO:cartography.graph.job:Finished job gcp_crm_organization_cleanup
INFO:cartography.graph.statement:Completed gcp_crm_folder_cleanup statement #1
INFO:cartography.graph.statement:Completed gcp_crm_folder_cleanup statement #2
INFO:cartography.graph.statement:Completed gcp_crm_folder_cleanup statement #3
INFO:cartography.graph.job:Finished job gcp_crm_folder_cleanup
INFO:cartography.intel.gcp:Syncing 2 GCP projects.
INFO:cartography.graph.statement:Completed gcp_crm_project_cleanup statement #1
INFO:cartography.graph.statement:Completed gcp_crm_project_cleanup statement #2
INFO:cartography.graph.statement:Completed gcp_crm_project_cleanup statement #3
INFO:cartography.graph.job:Finished job gcp_crm_project_cleanup
INFO:cartography.intel.gcp:Syncing GCP project <redact> for Compute.
INFO:cartography.intel.gcp:Syncing GCP project <redact> for Compute.
INFO:cartography.intel.gcp:Syncing GCP project <redact> for Storage
INFO:cartography.intel.gcp.storage:Syncing Storage objects for project <redact>.
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #1
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #2
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #3
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #4
INFO:cartography.graph.job:Finished job gcp_storage_bucket_cleanup
INFO:cartography.intel.gcp:Syncing GCP project <redact> for Storage
INFO:cartography.intel.gcp.storage:Syncing Storage objects for project <redact>.
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #1
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #2
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #3
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #4
INFO:cartography.graph.job:Finished job gcp_storage_bucket_cleanup
INFO:cartography.intel.gcp:Syncing GCP project <redact> for GKE
INFO:cartography.intel.gcp:Syncing GCP project <redact> for GKE
INFO:cartography.intel.gcp:Syncing GCP project <redact> for DNS
INFO:cartography.intel.gcp:Syncing GCP project <redact> for DNS
INFO:cartography.intel.gcp.iam:Syncing GCP IAM for project <redact>
INFO:cartography.intel.gcp.iam:Found 2 service accounts in project <redact>
INFO:cartography.intel.gcp.iam:Found 1835 roles in project <redact>
INFO:cartography.graph.statement:Completed GCPServiceAccount statement #1
INFO:cartography.graph.statement:Completed GCPServiceAccount statement #2
INFO:cartography.graph.job:Finished job GCPServiceAccount
INFO:cartography.graph.statement:Completed GCPRole statement #1
INFO:cartography.graph.statement:Completed GCPRole statement #2
INFO:cartography.graph.job:Finished job GCPRole
INFO:cartography.graph.statement:Completed gcp_compute_asset_inet_exposure statement #1
INFO:cartography.graph.statement:Completed gcp_compute_asset_inet_exposure statement #2
INFO:cartography.graph.statement:Completed gcp_compute_asset_inet_exposure statement #3
INFO:cartography.graph.statement:Completed gcp_compute_asset_inet_exposure statement #4
INFO:cartography.graph.statement:Completed gcp_compute_asset_inet_exposure statement #5
INFO:cartography.graph.statement:Completed gcp_compute_asset_inet_exposure statement #6
INFO:cartography.graph.statement:Completed gcp_compute_asset_inet_exposure statement #7
INFO:cartography.graph.job:Finished job gcp_compute_asset_inet_exposure
INFO:cartography.graph.statement:Completed gcp_gke_asset_exposure statement #1
INFO:cartography.graph.statement:Completed gcp_gke_asset_exposure statement #2
INFO:cartography.graph.job:Finished job gcp_gke_asset_exposure
INFO:cartography.graph.statement:Completed gcp_gke_basic_auth statement #1
INFO:cartography.graph.statement:Completed gcp_gke_basic_auth statement #2
INFO:cartography.graph.job:Finished job gcp_gke_basic_auth
INFO:cartography.sync:Finishing sync stage 'gcp'
INFO:cartography.sync:Starting sync stage 'gsuite'
INFO:cartography.intel.gsuite:Attempting to authenticate to GSuite using default credentials
INFO:cartography.intel.gsuite.api:Ingesting 3 gsuite users
INFO:cartography.graph.statement:Completed gsuite_ingest_users_cleanup statement #1
INFO:cartography.graph.job:Finished job gsuite_ingest_users_cleanup
INFO:cartography.intel.gsuite.api:Ingesting 3 gsuite groups
INFO:cartography.graph.statement:Completed gsuite_ingest_groups_cleanup statement #1
INFO:cartography.graph.statement:Completed gsuite_ingest_groups_cleanup statement #2
INFO:cartography.graph.statement:Completed gsuite_ingest_groups_cleanup statement #3
INFO:cartography.graph.job:Finished job gsuite_ingest_groups_cleanup
WARNING:neo4j.notifications:Received notification from DBMS server: {severity: WARNING} {code: Neo.ClientNotification.Statement.CartesianProductWarning} {category: } {title: This query builds a cartesian product between disconnected patterns.} {description: If a part of a query contains multiple disconnected patterns, this will build a cartesian product between all those parts. This may produce a large amount of data and slow down query processing. While occasionally intended, it may often be possible to reformulate the query that avoids the use of this cross product, perhaps by adding a relationship between the different parts or by using OPTIONAL MATCH (identifier is: (group))} {position: line: 3, column: 9, offset: 46} for query: '\n        UNWIND $MemberData as member\n        MATCH (user:GSuiteUser {id: member.id}),(group:GSuiteGroup {id: $GroupID })\n        MERGE (user)-[r:MEMBER_GSUITE_GROUP]->(group)\n        ON CREATE SET\n        r.firstseen = $UpdateTag\n        SET\n        r.lastupdated = $UpdateTag\n    '
WARNING:neo4j.notifications:Received notification from DBMS server: {severity: WARNING} {code: Neo.ClientNotification.Statement.CartesianProductWarning} {category: } {title: This query builds a cartesian product between disconnected patterns.} {description: If a part of a query contains multiple disconnected patterns, this will build a cartesian product between all those parts. This may produce a large amount of data and slow down query processing. While occasionally intended, it may often be possible to reformulate the query that avoids the use of this cross product, perhaps by adding a relationship between the different parts or by using OPTIONAL MATCH (identifier is: (group_2))} {position: line: 3, column: 9, offset: 46} for query: '\n        UNWIND $MemberData as member\n        MATCH(group_1: GSuiteGroup{id: member.id}), (group_2:GSuiteGroup {id: $GroupID})\n        MERGE (group_1)-[r:MEMBER_GSUITE_GROUP]->(group_2)\n        ON CREATE SET\n        r.firstseen = $UpdateTag\n        SET\n        r.lastupdated = $UpdateTag\n    '
WARNING:neo4j.notifications:Received notification from DBMS server: {severity: WARNING} {code: Neo.ClientNotification.Statement.CartesianProductWarning} {category: } {title: This query builds a cartesian product between disconnected patterns.} {description: If a part of a query contains multiple disconnected patterns, this will build a cartesian product between all those parts. This may produce a large amount of data and slow down query processing. While occasionally intended, it may often be possible to reformulate the query that avoids the use of this cross product, perhaps by adding a relationship between the different parts or by using OPTIONAL MATCH (identifier is: (group))} {position: line: 3, column: 9, offset: 46} for query: '\n        UNWIND $MemberData as member\n        MATCH (user:GSuiteUser {id: member.id}),(group:GSuiteGroup {id: $GroupID })\n        MERGE (user)-[r:MEMBER_GSUITE_GROUP]->(group)\n        ON CREATE SET\n        r.firstseen = $UpdateTag\n        SET\n        r.lastupdated = $UpdateTag\n    '
WARNING:neo4j.notifications:Received notification from DBMS server: {severity: WARNING} {code: Neo.ClientNotification.Statement.CartesianProductWarning} {category: } {title: This query builds a cartesian product between disconnected patterns.} {description: If a part of a query contains multiple disconnected patterns, this will build a cartesian product between all those parts. This may produce a large amount of data and slow down query processing. While occasionally intended, it may often be possible to reformulate the query that avoids the use of this cross product, perhaps by adding a relationship between the different parts or by using OPTIONAL MATCH (identifier is: (group_2))} {position: line: 3, column: 9, offset: 46} for query: '\n        UNWIND $MemberData as member\n        MATCH(group_1: GSuiteGroup{id: member.id}), (group_2:GSuiteGroup {id: $GroupID})\n        MERGE (group_1)-[r:MEMBER_GSUITE_GROUP]->(group_2)\n        ON CREATE SET\n        r.firstseen = $UpdateTag\n        SET\n        r.lastupdated = $UpdateTag\n    '
WARNING:neo4j.notifications:Received notification from DBMS server: {severity: WARNING} {code: Neo.ClientNotification.Statement.CartesianProductWarning} {category: } {title: This query builds a cartesian product between disconnected patterns.} {description: If a part of a query contains multiple disconnected patterns, this will build a cartesian product between all those parts. This may produce a large amount of data and slow down query processing. While occasionally intended, it may often be possible to reformulate the query that avoids the use of this cross product, perhaps by adding a relationship between the different parts or by using OPTIONAL MATCH (identifier is: (group))} {position: line: 3, column: 9, offset: 46} for query: '\n        UNWIND $MemberData as member\n        MATCH (user:GSuiteUser {id: member.id}),(group:GSuiteGroup {id: $GroupID })\n        MERGE (user)-[r:MEMBER_GSUITE_GROUP]->(group)\n        ON CREATE SET\n        r.firstseen = $UpdateTag\n        SET\n        r.lastupdated = $UpdateTag\n    '
INFO:cartography.sync:Finishing sync stage 'gsuite'
INFO:cartography.sync:Starting sync stage 'cve'
INFO:cartography.sync:Finishing sync stage 'cve'
INFO:cartography.sync:Starting sync stage 'oci'
ERROR:cartography.intel.oci:Unable to initialize OCI creds. If you don't have OCI data or don't want to load OCI data then you can ignore this message. Otherwise, the error code is: Could not find config file at /Users/kunaalsikka/.oci/config, please follow the instructions in the link to setup the config file https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm Make sure your OCI credentials are configured correctly, your credentials file (if any) is valid, and that the identity you are authenticating to has the required Audit policies attached (https://docs.cloud.oracle.com/iaas/Content/Identity/Concepts/commonpolicies.htm).
INFO:cartography.sync:Finishing sync stage 'oci'
INFO:cartography.sync:Starting sync stage 'okta'
WARNING:cartography.intel.okta:No valid Okta credentials could be found. Exiting Okta sync stage.
INFO:cartography.sync:Finishing sync stage 'okta'
INFO:cartography.sync:Starting sync stage 'github'
INFO:cartography.intel.github:GitHub import is not configured - skipping this module. See docs to configure.
INFO:cartography.sync:Finishing sync stage 'github'
INFO:cartography.sync:Starting sync stage 'digitalocean'
INFO:cartography.intel.digitalocean:DigitalOcean import is not configured - skipping this module. See docs to configure.
INFO:cartography.sync:Finishing sync stage 'digitalocean'
INFO:cartography.sync:Starting sync stage 'kandji'
WARNING:cartography.intel.kandji:Required parameter missing. Skipping sync. See docs to configure.
INFO:cartography.sync:Finishing sync stage 'kandji'
INFO:cartography.sync:Starting sync stage 'kubernetes'
ERROR:cartography.intel.kubernetes:kubeconfig not found.
INFO:cartography.sync:Finishing sync stage 'kubernetes'
INFO:cartography.sync:Starting sync stage 'lastpass'
INFO:cartography.intel.lastpass:Lastpass import is not configured - skipping this module. See docs to configure.
INFO:cartography.sync:Finishing sync stage 'lastpass'
INFO:cartography.sync:Starting sync stage 'bigfix'
INFO:cartography.intel.bigfix:BigFix import is not configured - skipping this module. See docs to configure.
INFO:cartography.sync:Finishing sync stage 'bigfix'
INFO:cartography.sync:Starting sync stage 'duo'
INFO:cartography.intel.duo:Duo import is not configured - skipping this module. See docs to configure.
INFO:cartography.sync:Finishing sync stage 'duo'
INFO:cartography.sync:Starting sync stage 'semgrep'
INFO:cartography.intel.semgrep:Semgrep import is not configured - skipping this module. See docs to configure.
INFO:cartography.sync:Finishing sync stage 'semgrep'
INFO:cartography.sync:Starting sync stage 'snipeit'
WARNING:cartography.intel.snipeit:Required parameter(s) missing. Skipping sync.
INFO:cartography.sync:Finishing sync stage 'snipeit'
INFO:cartography.sync:Starting sync stage 'analysis'
INFO:cartography.intel.analysis:Skipping analysis because no job path was provided.
INFO:cartography.sync:Finishing sync stage 'analysis'
```