### PR TITLE
Add SubImage to who-uses-cartography

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Get started with our [developer documentation](https://cartography-cncf.github.i
 1. [MessageBird](https://messagebird.com)
 1. [Cloudanix](https://www.cloudanix.com/)
 1. [Corelight](https://www.corelight.com/)
+1. [SubImage](https://subimage.io)
 1. {Your company here} :-)
 
 If your organization uses Cartography, please file a PR and update this list. Say hi on Slack too!


### PR DESCRIPTION
Adds https://subimage.io to who-uses-cartography.