### PR TITLE
Adding logs on 502 error for debugging in Github requests calls

### DIFF
--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -70,6 +70,14 @@ def call_github_api(query: str, variables: str, token: str, api_url: str) -> Dic
         # Add context and re-raise for callers to handle
         logger.warning("GitHub: requests.get('%s') timed out.", api_url)
         raise
+
+    if response.status_code == 502:
+        logger.error(
+            "GitHub API returned 502 Bad Gateway error. This often indicates GitHub's internal issues. "
+            "Response headers: %s, Response body: %s",
+            dict(response.headers),
+            response.text,
+        )
     response.raise_for_status()
     response_json = response.json()
     if "errors" in response_json:


### PR DESCRIPTION
### Summary
These changes are necessary to simplify and clarify the debugging and triaging of pipeline errors caused by 502 HTTP errors when making requests to the GitHub API.

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
