### PR TITLE
fix: failsafe on gcp & gsuite

### DIFF
--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -3,6 +3,7 @@ import logging
 from collections import namedtuple
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Set
 
 import googleapiclient.discovery
@@ -328,7 +329,7 @@ def _sync_multiple_projects(
 
 
 @timeit
-def get_gcp_credentials() -> GoogleCredentials:
+def get_gcp_credentials() -> Optional[GoogleCredentials]:
     """
     Gets access tokens for GCP API access.
     :param: None
@@ -338,6 +339,7 @@ def get_gcp_credentials() -> GoogleCredentials:
         # Explicitly use Application Default Credentials.
         # See https://google-auth.readthedocs.io/en/master/user-guide.html#application-default-credentials
         credentials, project_id = default()
+        return credentials
     except DefaultCredentialsError as e:
         logger.debug("Error occurred calling GoogleCredentials.get_application_default().", exc_info=True)
         logger.error(
@@ -349,7 +351,6 @@ def get_gcp_credentials() -> GoogleCredentials:
             ),
             e,
         )
-        return credentials
 
 
 @timeit
@@ -367,6 +368,9 @@ def start_gcp_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     }
 
     credentials = get_gcp_credentials()
+    if credentials is None:
+        logger.warning("Unable to initialize GCP credentials. Skipping ;odule.")
+        return
 
     resources = _initialize_resources(credentials)
 

--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -351,6 +351,7 @@ def get_gcp_credentials() -> Optional[GoogleCredentials]:
             ),
             e,
         )
+    return None
 
 
 @timeit

--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -370,7 +370,7 @@ def start_gcp_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
 
     credentials = get_gcp_credentials()
     if credentials is None:
-        logger.warning("Unable to initialize GCP credentials. Skipping ;odule.")
+        logger.warning("Unable to initialize GCP credentials. Skipping module.")
         return
 
     resources = _initialize_resources(credentials)

--- a/cartography/intel/gsuite/__init__.py
+++ b/cartography/intel/gsuite/__init__.py
@@ -67,7 +67,7 @@ def start_gsuite_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
 
     creds: OAuth2Credentials | ServiceAccountCredentials
     if config.gsuite_auth_method == 'delegated':  # Legacy delegated method
-        if config.gsuite_config is None or os.path.isfile(config.gsuite_config):
+        if config.gsuite_config is None or not os.path.isfile(config.gsuite_config):
             logger.warning(
                 (
                     "The GSuite config file is not set or is not a valid file."

--- a/cartography/intel/gsuite/__init__.py
+++ b/cartography/intel/gsuite/__init__.py
@@ -67,6 +67,14 @@ def start_gsuite_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
 
     creds: OAuth2Credentials | ServiceAccountCredentials
     if config.gsuite_auth_method == 'delegated':  # Legacy delegated method
+        if config.gsuite_config is None or os.path.isfile(config.gsuite_config):
+            logger.warning(
+                (
+                    "The GSuite config file is not set or is not a valid file."
+                    "Skipping GSuite ingestion."
+                ),
+            )
+            return
         logger.info('Attempting to authenticate to GSuite using legacy delegated method')
         try:
             creds = service_account.Credentials.from_service_account_file(


### PR DESCRIPTION
### Summary
When calling cartography without arguments, we should have a failsafe strategy, especialy modules should be skipped when arguments/settings are missing.

This PR fix 2 errors:
- gcp intel `UnboundLocalError` uncaught error
```
UnboundLocalError: cannot access local variable 'credentials' where it is not associated with a value
```
- gsuite intel `TypeError` uncaught error
```
TypeError: expected str, bytes or os.PathLike object, not NoneType
```


### Related issues or links
N/A
