### PR TITLE
feat: add serial number and remove duplicate assignment

### DIFF
--- a/cartography/intel/crowdstrike/endpoints.py
+++ b/cartography/intel/crowdstrike/endpoints.py
@@ -34,8 +34,8 @@ def load_host_data(
     UNWIND $Hosts AS host
         MERGE (h:CrowdstrikeHost{id: host.device_id})
         ON CREATE SET h.cid = host.cid,
-            h.cid = host.cid,
             h.instance_id = host.instance_id,
+            h.serial_number = host.serial_number,
             h.firstseen = timestamp()
         SET h.status = host.status,
             h.hostname = host.hostname,


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added serial number property to CrowdstrikeHost nodes and fixed a duplicate property assignment. This enables relationship mapping between Crowdstrike devices and other services like Kandji.

**Bug Fixes**
- Removed duplicate assignment of the `cid` property that was being set twice.

**New Features**
- Added `serial_number` property to CrowdstrikeHost nodes from device data.

<!-- End of auto-generated description by mrge. -->

### Summary
The Crowdstrike module currently does not fetch device serial which is essential for creating relationship with other services such as Kandji.

### Related issues or links

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Include a screenshot showing what the graph looked like before and after your changes.

Before
There were no `serial_number` property to show.

After
Property `serial_number` shows up
![image](https://github.com/user-attachments/assets/46c0892f-664b-4015-b8f1-51763a04cf38)
