### PR TITLE
[Fix #1519] Error handling for launch templates sync

### DIFF
--- a/cartography/intel/aws/ec2/launch_templates.py
+++ b/cartography/intel/aws/ec2/launch_templates.py
@@ -64,7 +64,6 @@ def get_launch_template_versions_by_template(
         if error_code == 'InvalidLaunchTemplateId.NotFound':
             logger.warning("Launch template %s no longer exists in region %s", launch_template_id, region)
         else:
-            # Re-raise other client errors
             raise
     return template_versions
 

--- a/cartography/intel/aws/ec2/launch_templates.py
+++ b/cartography/intel/aws/ec2/launch_templates.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 import boto3
+import botocore
 import neo4j
 
 from .util import get_botocore_config
@@ -59,7 +60,7 @@ def get_launch_template_versions_by_template(
     try:
         for versions in v_paginator.paginate(LaunchTemplateId=launch_template_id):
             template_versions.extend(versions['LaunchTemplateVersions'])
-    except client.exceptions.ClientError as e:
+    except botocore.exceptions.ClientError as e:
         error_code = e.response['Error']['Code']
         if error_code == 'InvalidLaunchTemplateId.NotFound':
             logger.warning("Launch template %s no longer exists in region %s", launch_template_id, region)

--- a/tests/unit/cartography/intel/aws/ec2/test_launch_templates.py
+++ b/tests/unit/cartography/intel/aws/ec2/test_launch_templates.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import botocore
+import pytest
+
+from cartography.intel.aws.ec2.launch_templates import get_launch_template_versions_by_template
+
+
+@patch('cartography.intel.aws.ec2.launch_templates.logger')
+def test_get_launch_template_versions_by_template_not_found(mock_logger):
+    """
+    Test that a ClientError with code 'InvalidLaunchTemplateId.NotFound' logs a warning
+    but doesn't raise an exception.
+    """
+    # Arrange
+    mock_session = MagicMock()
+    mock_client = MagicMock()
+    mock_paginator = MagicMock()
+    mock_session.client.return_value = mock_client
+    mock_client.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.side_effect = botocore.exceptions.ClientError(
+        error_response={'Error': {'Code': 'InvalidLaunchTemplateId.NotFound', 'Message': 'Launch template not found'}},
+        operation_name='DescribeLaunchTemplateVersions',
+    )
+
+    # Act
+    result = get_launch_template_versions_by_template(
+        mock_session,
+        'fake-template-id',
+        'us-east-1',
+    )
+
+    # Assert
+    assert result == []
+    mock_logger.warning.assert_called_once_with(
+        "Launch template %s no longer exists in region %s",
+        'fake-template-id',
+        'us-east-1',
+    )
+
+
+def test_get_launch_template_versions_by_template_other_error():
+    """
+    Test that a ClientError with any other code is re-raised.
+    """
+    # Arrange
+    mock_session = MagicMock()
+    mock_client = MagicMock()
+    mock_paginator = MagicMock()
+    mock_session.client.return_value = mock_client
+    mock_client.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.side_effect = botocore.exceptions.ClientError(
+        error_response={'Error': {'Code': 'SomeOtherError', 'Message': 'Some other error'}},
+        operation_name='FakeDescribeLaunchTemplateVersions',
+    )
+
+    # Act & Assert
+    with pytest.raises(botocore.exceptions.ClientError):
+        get_launch_template_versions_by_template(
+            mock_session,
+            'fake-template-id',
+            'us-east-1',
+        )
+
+
+def test_get_launch_template_versions_by_template_success():
+    """
+    Test successful API call returns template versions.
+    """
+    # Arrange
+    mock_session = MagicMock()
+    mock_client = MagicMock()
+    mock_paginator = MagicMock()
+    mock_session.client.return_value = mock_client
+    mock_client.get_paginator.return_value = mock_paginator
+    mock_template_version = {'LaunchTemplateVersions': [{'VersionNumber': 1}]}
+    mock_paginator.paginate.return_value = [mock_template_version]
+
+    # Act
+    result = get_launch_template_versions_by_template(
+        mock_session,
+        'valid-template-id',
+        'us-east-1',
+    )
+
+    # Assert
+    assert result == [{'VersionNumber': 1}]
+    mock_client.get_paginator.assert_called_once_with('describe_launch_template_versions')
+    mock_paginator.paginate.assert_called_once_with(LaunchTemplateId='valid-template-id')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,7 @@
+def unwrapper(func):
+    """
+    Unwraps a function to get past decorators to the original function.
+    """
+    if not hasattr(func, '__wrapped__'):
+        return func
+    return unwrapper(func.__wrapped__)


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added error handling for AWS launch templates that no longer exist during synchronization. This prevents process interruption when short-lived launch templates disappear between discovery and version fetching.

**Bug Fixes**
- Added try/except block to catch and handle missing launch template errors
- Added specific error handling for `InvalidLaunchTemplateId.NotFound` errors
- Added warning log when templates no longer exist instead of failing
- Preserved normal exception handling for other types of errors

<!-- End of auto-generated description by mrge. -->

<!-- MRGE_STACK_DESCRIPTION_START -->
This PR is part of a [stack](https://docs.mrge.io/overview), managed by [mrge](https://mrge.io):

* `master` (default branch)
* [#1143: Use arg to select aws session type (#1142)](https://github.com/cartography-cncf/cartography/pull/1143)
* **[#1520: [Fix #1519] Error handling for launch templates sync](https://github.com/cartography-cncf/cartography/pull/1520)** ⬅️ Current PR ([View on mrge](https://mrge.io/pr/cartography-cncf/cartography/pull/1520))

---
<!-- MRGE_STACK_DESCRIPTION_END -->









### Summary

Added error handling to the function that fetches the launch template versions so that the process doesn't get interrumpted when we can't find the launch template anymore. 

Some setups will have very short lived launch templates that will cause this part to fail if the launch template previously fetched doesn't exist anymore. More details in the bug issue. 

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
