### PR TITLE
fix: pagination to fetch more than 300 devices

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.2.0
     hooks:
     -   id: flake8
 -   repo: https://github.com/hhatto/autopep8
@@ -39,7 +39,7 @@ repos:
     -   id: reorder-python-imports
         args: [--py3-plus]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.15.0
     hooks:
     -   id: mypy
         additional_dependencies:

--- a/cartography/intel/kandji/devices.py
+++ b/cartography/intel/kandji/devices.py
@@ -19,7 +19,6 @@ _TIMEOUT = (60, 60)
 
 @timeit
 def get(kandji_base_uri: str, kandji_token: str) -> List[Dict[str, Any]]:
-    # Ref: https://github.com/kandji-inc/support/blob/main/api-tools/code-examples/pagination_with_limit_and_offset_example.py#L190
     api_endpoint = f"{kandji_base_uri}/api/v1/devices"
     headers = {
         'Accept': 'application/json',

--- a/cartography/intel/kandji/devices.py
+++ b/cartography/intel/kandji/devices.py
@@ -40,6 +40,7 @@ def get(kandji_base_uri: str, kandji_token: str) -> List[Dict[str, Any]]:
 
         params["offset"] = offset
         response = session.get(api_endpoint, headers=headers, timeout=_TIMEOUT, params=params)
+        response.raise_for_status()
 
         result = response.json()
         # If no more result, we are done

--- a/cartography/intel/kandji/devices.py
+++ b/cartography/intel/kandji/devices.py
@@ -82,6 +82,7 @@ def load_devices(
         lastupdated=update_tag,
     )
 
+    logger.info(f"Loading {len(data)} kandji devices.")
     load(
         neo4j_session,
         KandjiDeviceSchema(),

--- a/cartography/intel/kandji/devices.py
+++ b/cartography/intel/kandji/devices.py
@@ -19,6 +19,7 @@ _TIMEOUT = (60, 60)
 
 @timeit
 def get(kandji_base_uri: str, kandji_token: str) -> List[Dict[str, Any]]:
+    # Ref: https://github.com/kandji-inc/support/blob/main/api-tools/code-examples/pagination_with_limit_and_offset_example.py#L190
     api_endpoint = f"{kandji_base_uri}/api/v1/devices"
     headers = {
         'Accept': 'application/json',
@@ -26,10 +27,9 @@ def get(kandji_base_uri: str, kandji_token: str) -> List[Dict[str, Any]]:
     }
 
     offset = 0
-    limit = 300
-    params: dict[str, str | int] = {
+    params = {
         "sort": "serial_number",
-        "limit": limit,
+        "limit": 300,
         "offset": offset,
     }
 
@@ -40,7 +40,6 @@ def get(kandji_base_uri: str, kandji_token: str) -> List[Dict[str, Any]]:
 
         params["offset"] = offset
         response = session.get(api_endpoint, headers=headers, timeout=_TIMEOUT, params=params)
-        response.raise_for_status()
 
         result = response.json()
         # If no more result, we are done
@@ -49,7 +48,7 @@ def get(kandji_base_uri: str, kandji_token: str) -> List[Dict[str, Any]]:
 
         devices.extend(result)
 
-        offset += limit
+        offset += params["limit"]
 
     logger.debug("Kandji device count: %d", len(devices))
     return devices
@@ -82,7 +81,6 @@ def load_devices(
         lastupdated=update_tag,
     )
 
-    logger.info(f"Loading {len(data)} kandji devices.")
     load(
         neo4j_session,
         KandjiDeviceSchema(),

--- a/cartography/intel/kandji/devices.py
+++ b/cartography/intel/kandji/devices.py
@@ -26,9 +26,10 @@ def get(kandji_base_uri: str, kandji_token: str) -> List[Dict[str, Any]]:
     }
 
     offset = 0
-    params = {
+    limit = 300
+    params: dict[str, str | int] = {
         "sort": "serial_number",
-        "limit": 300,
+        "limit": limit,
         "offset": offset,
     }
 
@@ -48,7 +49,7 @@ def get(kandji_base_uri: str, kandji_token: str) -> List[Dict[str, Any]]:
 
         devices.extend(result)
 
-        offset += params["limit"]
+        offset += limit
 
     logger.debug("Kandji device count: %d", len(devices))
     return devices

--- a/cartography/models/crowdstrike/hosts.py
+++ b/cartography/models/crowdstrike/hosts.py
@@ -1,4 +1,3 @@
-# cartography/models/crowdstrike/host_schema.py
 from dataclasses import dataclass
 
 from cartography.models.core.common import PropertyRef

--- a/cartography/stats.py
+++ b/cartography/stats.py
@@ -97,7 +97,9 @@ def set_stats_client(stats_client: StatsClient) -> None:
     """
     This is used to set the module level stats client configured to talk with a statsd host
     """
-    global _scoped_stats_client
+    # global _scoped_stats_client
+    # Above line is throwing below error, so commenting the code for now
+    # [F824] `global _scoped_stats_client` is unused: name is never assigned in scope
     _scoped_stats_client.set_stats_client(stats_client)
 
 

--- a/cartography/stats.py
+++ b/cartography/stats.py
@@ -97,9 +97,7 @@ def set_stats_client(stats_client: StatsClient) -> None:
     """
     This is used to set the module level stats client configured to talk with a statsd host
     """
-    # global _scoped_stats_client
-    # Above line is throwing below error, so commenting the code for now
-    # [F824] `global _scoped_stats_client` is unused: name is never assigned in scope
+    global _scoped_stats_client  # noqa: F824
     _scoped_stats_client.set_stats_client(stats_client)
 
 

--- a/tests/unit/cartography/intel/kandji/test_devices.py
+++ b/tests/unit/cartography/intel/kandji/test_devices.py
@@ -1,0 +1,95 @@
+from typing import Any
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+
+from cartography.intel.kandji.devices import get
+
+
+@pytest.fixture  # type: ignore[misc]
+def mock_device_data_page1() -> list[dict[str, Any]]:
+    return [
+        {
+            "device_id": str(i),
+            "serial_number": f"SN{i:03d}",
+            "name": f"Test Device {i}",
+            "platform": "macOS",
+        }
+        for i in range(300)
+    ]
+
+
+@pytest.fixture  # type: ignore[misc]
+def mock_device_data_page2() -> list[dict[str, Any]]:
+    return [
+        {
+            "device_id": str(i),
+            "serial_number": f"SN{i:03d}",
+            "name": f"Test Device {i}",
+            "platform": "macOS",
+        }
+        for i in range(300, 305)
+    ]
+
+
+@pytest.fixture  # type: ignore[misc]
+def mock_empty_response() -> Mock:
+    mock = Mock()
+    mock.json.return_value = []
+    mock.raise_for_status.return_value = None
+    return mock
+
+
+@patch("cartography.intel.kandji.devices.Session")
+def test_get_devices_single_page(
+    mock_session: Mock,
+    mock_device_data_page1: list[dict[str, Any]],
+    mock_empty_response: Mock,
+) -> None:
+    # Arrange
+    mock_session.return_value.get.side_effect = [
+        Mock(json=lambda: mock_device_data_page1, raise_for_status=lambda: None),
+        mock_empty_response,
+    ]
+    base_uri = "https://test.kandji.io"
+    token = "test-token"
+
+    # Act
+    result = get(base_uri, token)
+
+    # Assert
+    assert len(result) == 300
+    assert result == mock_device_data_page1
+    # Called twice: once for data, once for empty response
+    assert mock_session.return_value.get.call_count == 2
+
+
+@patch("cartography.intel.kandji.devices.Session")
+def test_get_devices_with_pagination(
+    mock_session: Mock,
+    mock_device_data_page1: list[dict[str, Any]],
+    mock_device_data_page2: list[dict[str, Any]],
+    mock_empty_response: Mock,
+) -> None:
+    # Arrange
+    # Map of offset to mock response
+    mock_responses = {
+        0: Mock(json=lambda: mock_device_data_page1, raise_for_status=lambda: None),
+        300: Mock(json=lambda: mock_device_data_page2, raise_for_status=lambda: None),
+    }
+    mock_session.return_value.get.side_effect = lambda *args, **kwargs: mock_responses.get(
+        kwargs.get('params', {}).get('offset', 0),
+        mock_empty_response,
+    )
+    base_uri = "https://test.kandji.io"
+    token = "test-token"
+
+    # Act
+    result = get(base_uri, token)
+
+    # Assert that we return all the mock devices
+    assert len(result) == 305
+    assert result == mock_device_data_page1 + mock_device_data_page2
+    # Called three times: twice for data, once for empty response
+    assert mock_session.return_value.get.call_count == 3


### PR DESCRIPTION
### Summary
The Kandji device module currently does not use pagination which cause it to return maximum 300 devices.

### Related issues or links

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:

Query to get KandjiDevice count
```MATCH (n:KandjiDevice) RETURN COUNT(n)```

#### Before
The query will return 300 even when there are more than 300 devices.

#### After
The query will return more than 300 if there are that many devices


