### PR TITLE
Add integration tests for AWS VPC and IGW

### DIFF
--- a/tests/data/aws/ec2/internet_gateways.py
+++ b/tests/data/aws/ec2/internet_gateways.py
@@ -1,0 +1,13 @@
+TEST_INTERNET_GATEWAYS = [
+    {
+        'Attachments': [{'State': 'available', 'VpcId': 'vpc-038cf'}],
+        'InternetGatewayId': 'igw-013cb',
+        'OwnerId': '12345',
+        'Tags': [],
+    },
+    {
+        'Attachments': [{'State': 'available', 'VpcId': 'vpc-0f510'}],
+        'InternetGatewayId': 'igw-0387',
+        'OwnerId': '12345',
+    },
+]

--- a/tests/data/aws/ec2/vpcs.py
+++ b/tests/data/aws/ec2/vpcs.py
@@ -23,12 +23,6 @@ TEST_VPCS = [
             'CidrBlockState': {'State': 'associated'},
         }],
         'IsDefault': False,
-        'Tags': [
-            {'Key': 'Environment', 'Value': 'staging'},
-            {'Key': 'Customer', 'Value': 'subimage'},
-            {'Key': 'Name', 'Value': 'subimage-vpc'},
-            {'Key': 'ManagedBy', 'Value': 'terraform'},
-        ],
         'BlockPublicAccessStates': {'InternetGatewayBlockMode': 'off'},
         'VpcId': 'vpc-0f510',
         'State': 'available',

--- a/tests/data/aws/ec2/vpcs.py
+++ b/tests/data/aws/ec2/vpcs.py
@@ -1,0 +1,38 @@
+TEST_VPCS = [
+    {
+        'OwnerId': '12345',
+        'InstanceTenancy': 'default',
+        'CidrBlockAssociationSet': [{
+            'AssociationId': 'vpc-cidr-assoc-0daea',
+            'CidrBlock': '172.31.0.0/16',
+            'CidrBlockState': {'State': 'associated'},
+        }],
+        'IsDefault': True,
+        'BlockPublicAccessStates': {'InternetGatewayBlockMode': 'off'},
+        'VpcId': 'vpc-038cf',
+        'State': 'available',
+        'CidrBlock': '172.31.0.0/16',
+        'DhcpOptionsId': 'dopt-036d',
+    },
+    {
+        'OwnerId': '12345',
+        'InstanceTenancy': 'default',
+        'CidrBlockAssociationSet': [{
+            'AssociationId': 'vpc-cidr-assoc-087ee',
+            'CidrBlock': '10.1.0.0/16',
+            'CidrBlockState': {'State': 'associated'},
+        }],
+        'IsDefault': False,
+        'Tags': [
+            {'Key': 'Environment', 'Value': 'staging'},
+            {'Key': 'Customer', 'Value': 'subimage'},
+            {'Key': 'Name', 'Value': 'subimage-vpc'},
+            {'Key': 'ManagedBy', 'Value': 'terraform'},
+        ],
+        'BlockPublicAccessStates': {'InternetGatewayBlockMode': 'off'},
+        'VpcId': 'vpc-0f510',
+        'State': 'available',
+        'CidrBlock': '10.1.0.0/16',
+        'DhcpOptionsId': 'dopt-036d',
+    },
+]

--- a/tests/integration/cartography/intel/aws/ec2/test_internet_gateways.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_internet_gateways.py
@@ -1,0 +1,87 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.aws.ec2.internet_gateways
+from cartography.intel.aws.ec2.internet_gateways import sync_internet_gateways
+from cartography.intel.aws.ec2.vpc import sync_vpc
+from tests.data.aws.ec2.internet_gateways import TEST_INTERNET_GATEWAYS
+from tests.data.aws.ec2.vpcs import TEST_VPCS
+from tests.integration.cartography.intel.aws.common import create_test_account
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_ACCOUNT_ID = '12345'
+TEST_REGION = 'us-east-1'
+TEST_UPDATE_TAG = 123456789
+
+
+@patch.object(
+    cartography.intel.aws.ec2.vpc,
+    'get_ec2_vpcs',
+    return_value=TEST_VPCS,
+)
+@patch.object(
+    cartography.intel.aws.ec2.internet_gateways,
+    'get_internet_gateways',
+    return_value=TEST_INTERNET_GATEWAYS,
+)
+def test_sync_internet_gateways(mock_get_vpcs, mock_get_gateways, neo4j_session):
+    """
+    Ensure that internet gateways actually get loaded and have their key fields
+    """
+    # Arrange
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    # Add in fake VPC data for igw to be attached to
+    sync_vpc(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {'UPDATE_TAG': TEST_UPDATE_TAG, 'AWS_ID': TEST_ACCOUNT_ID},
+    )
+
+    # Act
+    sync_internet_gateways(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {'UPDATE_TAG': TEST_UPDATE_TAG, 'AWS_ID': TEST_ACCOUNT_ID},
+    )
+
+    # Assert Internet Gateways exist
+    assert check_nodes(neo4j_session, 'AWSInternetGateway', ['id', 'arn']) == {
+        ("igw-013cb", "arn:aws:ec2:us-east-1:12345:internet-gateway/igw-013cb"),
+        ("igw-0387", "arn:aws:ec2:us-east-1:12345:internet-gateway/igw-0387"),
+    }
+
+    # Assert Internet Gateways are connected to AWS Account
+    assert check_rels(
+        neo4j_session,
+        'AWSAccount',
+        'id',
+        'AWSInternetGateway',
+        'id',
+        'RESOURCE',
+        rel_direction_right=True,
+    ) == {
+        ('12345', 'igw-013cb'),
+        ('12345', 'igw-0387'),
+    }
+
+    # Assert Internet Gateways are connected to VPCs
+    assert check_rels(
+        neo4j_session,
+        'AWSInternetGateway',
+        'id',
+        'AWSVpc',
+        'id',
+        'ATTACHED_TO',
+        rel_direction_right=True,
+    ) == {
+        ('igw-013cb', 'vpc-038cf'),
+        ('igw-0387', 'vpc-0f510'),
+    }

--- a/tests/integration/cartography/intel/aws/ec2/test_vpc.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_vpc.py
@@ -1,0 +1,77 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.aws.ec2.vpc
+from cartography.intel.aws.ec2.vpc import sync_vpc
+from tests.data.aws.ec2.vpcs import TEST_VPCS
+from tests.integration.cartography.intel.aws.common import create_test_account
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_ACCOUNT_ID = '12345'
+TEST_REGION = 'us-east-1'
+TEST_UPDATE_TAG = 123456789
+
+
+@patch.object(
+    cartography.intel.aws.ec2.vpc,
+    'get_ec2_vpcs',
+    return_value=TEST_VPCS,
+)
+def test_sync_vpc(mock_get_vpcs, neo4j_session):
+    """
+    Ensure that VPCs actually get loaded and have their key fields
+    """
+    # Arrange
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+    # Act
+    sync_vpc(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {'UPDATE_TAG': TEST_UPDATE_TAG, 'AWS_ID': TEST_ACCOUNT_ID},
+    )
+
+    # Assert VPCs exist with correct properties
+    assert check_nodes(neo4j_session, 'AWSVpc', ['id', 'primary_cidr_block', 'is_default']) == {
+        ("vpc-038cf", "172.31.0.0/16", True),
+        ("vpc-0f510", "10.1.0.0/16", False),
+    }
+
+    # Assert VPCs are connected to AWS Account
+    assert check_rels(
+        neo4j_session,
+        'AWSAccount',
+        'id',
+        'AWSVpc',
+        'id',
+        'RESOURCE',
+        rel_direction_right=True,
+    ) == {
+        ('12345', 'vpc-038cf'),
+        ('12345', 'vpc-0f510'),
+    }
+
+    # Assert CIDR blocks are properly associated with VPCs
+    assert check_rels(
+        neo4j_session,
+        'AWSVpc',
+        'id',
+        'AWSCidrBlock',
+        'id',
+        'BLOCK_ASSOCIATION',
+        rel_direction_right=True,
+    ) == {
+        ('vpc-038cf', 'vpc-038cf|172.31.0.0/16'),
+        ('vpc-0f510', 'vpc-0f510|10.1.0.0/16'),
+    }
+
+    # Assert CIDR blocks have correct properties
+    assert check_nodes(neo4j_session, 'AWSCidrBlock', ['id', 'cidr_block', 'association_id', 'block_state']) == {
+        ("vpc-038cf|172.31.0.0/16", "172.31.0.0/16", "vpc-cidr-assoc-0daea", "associated"),
+        ("vpc-0f510|10.1.0.0/16", "10.1.0.0/16", "vpc-cidr-assoc-087ee", "associated"),
+    }


### PR DESCRIPTION
### Summary
> Describe your changes.

Adds integ tests for AWS VPC and IGW to unblock #1530.

Paying back some debt.

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
