### PR TITLE
Fix broken Neo4j URI doc link and add login credential information

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ Here are some points that can help you decide if adopting Cartography is a good 
 ### Trying out Cartography on a test machine
 Start [here](https://cartography-cncf.github.io/cartography/install.html) to set up a test graph and get data into it.
 
+### Neo4j credentials
+
+Cartography connects to a Neo4j database using a username and password.
+
+By default, Neo4j uses:
+
+- **Username**: `neo4j`
+- **Password**: `neo4j` (you will be prompted to change it on first login)
+
+You can override the password by setting the `NEO4J_PASSWORD` environment variable, or by using the `--neo4j-password-env-var` CLI flag. For example:
+
+```bash
+export NEO4J_PASSWORD='your-password'
+cartography --neo4j-uri bolt://localhost:7687 --neo4j-user neo4j --neo4j-password-env-var NEO4J_PASSWORD
+```
+
+You can find more connection options in the [official Neo4j documentation](https://neo4j.com/docs/api/python-driver/current/).
+
 ### Setting up Cartography in production
 When you are ready to try it in production, read [here](https://cartography-cncf.github.io/cartography/ops.html) for recommendations on getting cartography spun up in your environment.
 

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -67,7 +67,7 @@ class CLI:
             default='bolt://localhost:7687',
             help=(
                 'A valid Neo4j URI to sync against. See '
-                'https://neo4j.com/docs/api/python-driver/current/driver.html#uri for complete documentation on the '
+                'https://neo4j.com/docs/api/python-driver/current/ for complete documentation on the '
                 'structure of a Neo4j URI.'
             ),
         )

--- a/cartography/driftdetect/cli.py
+++ b/cartography/driftdetect/cli.py
@@ -64,7 +64,7 @@ class CLI:
             default='bolt://localhost:7687',
             help=(
                 'A valid Neo4j URI to sync against. See '
-                'https://neo4j.com/docs/api/python-driver/current/driver.html#uri for complete documentation on the '
+                'https://neo4j.com/docs/api/python-driver/current/ for complete documentation on the '
                 'structure of a Neo4j URI.'
             ),
         )


### PR DESCRIPTION
This PR addresses [#1232](https://github.com/cartography-cncf/cartography/issues/1232).

- Updated outdated Neo4j link in cli.py
- Added a new section to the README to explain default Neo4j credentials (`neo4j` / `neo4j`) and how to override with environment variable

Let me know if any adjustments are needed!