### PR TITLE
Allow only specific aws regions to be synced with --aws-regions

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -164,6 +164,7 @@ class CLI:
                 'regions that are not in the list of regions you are specifying here, those assets will be deleted. '
                 'This is because cartography\'s cleanup jobs use "lastupdated" and "account id" as freshness keys '
                 'and not regions.'
+                'If not specified, cartography will autodiscover the regions supported by each account you are syncing.'
             ),
         )
         parser.add_argument(

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -159,7 +159,11 @@ class CLI:
             action='store_true',
             help=(
                 '[EXPERIMENTAL!] Comma-separated list of AWS regions to sync. Example 1: "us-east-1,us-east-2" for US '
-                'East 1 and 2. Note that this syncs the same regions in ALL accounts.'
+                'East 1 and 2. Note that this syncs the same regions in ALL accounts. '
+                'CAUTION: if you have already synced in assets in a previous sync, if that previous sync includes '
+                'regions that are not in the list of regions you are specifying here, those assets will be deleted. '
+                'This is because cartography\'s cleanup jobs use "lastupdated" and "account id" as freshness keys '
+                'and not regions.'
             ),
         )
         parser.add_argument(

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -167,7 +167,7 @@ class CLI:
                 'This is because cartography\'s cleanup process uses "lastupdated" and "account id" to determine data '
                 'freshness and not regions. So, if a previously synced region is missing in the current sync, '
                 'Cartography assumes the associated assets are stale and removes them. '
-                'Default behahvior: If not `--aws-regions` is not specified, cartography will _autodiscover_ the '
+                'Default behavior: If `--aws-regions` is not specified, cartography will _autodiscover_ the '
                 'regions supported by each account being synced.'
             ),
         )

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -159,13 +159,16 @@ class CLI:
             type=str,
             default=None,
             help=(
-                '[EXPERIMENTAL!] Comma-separated list of AWS regions to sync. Example 1: "us-east-1,us-east-2" for US '
-                'East 1 and 2. Note that this syncs the same regions in ALL accounts. '
-                'CAUTION: if you have already synced in assets in a previous sync, if that previous sync includes '
-                'regions that are not in the list of regions you are specifying here, those assets will be deleted. '
-                'This is because cartography\'s cleanup jobs use "lastupdated" and "account id" as freshness keys '
-                'and not regions.'
-                'If not specified, cartography will autodiscover the regions supported by each account you are syncing.'
+                '[EXPERIMENTAL!] Comma-separated list of AWS regions to sync. Example: specify "us-east-1,us-east-2" '
+                'to sync US East 1 and 2. Note that this syncs the same regions in ALL accounts and it is currently '
+                'not possible to specify different regions per account. '
+                'CAUTION: if you previously synced assets from regions that are _not_ included in your current list, '
+                'those assets will be _deleted_ during this sync. '
+                'This is because cartography\'s cleanup process uses "lastupdated" and "account id" to determine data '
+                'freshness and not regions. So, if a previously synced region is missing in the current sync, '
+                'Cartography assumes the associated assets are stale and removes them. '
+                'Default behahvior: If not `--aws-regions` is not specified, cartography will _autodiscover_ the '
+                'regions supported by each account being synced.'
             ),
         )
         parser.add_argument(

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -156,7 +156,8 @@ class CLI:
         )
         parser.add_argument(
             '--aws-regions',
-            action='store_true',
+            type=str,
+            default=None,
             help=(
                 '[EXPERIMENTAL!] Comma-separated list of AWS regions to sync. Example 1: "us-east-1,us-east-2" for US '
                 'East 1 and 2. Note that this syncs the same regions in ALL accounts. '

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -8,6 +8,7 @@ from typing import Optional
 import cartography.config
 import cartography.sync
 import cartography.util
+from cartography.intel.aws.util.common import parse_and_validate_aws_regions
 from cartography.intel.aws.util.common import parse_and_validate_aws_requested_syncs
 from cartography.intel.semgrep.dependencies import parse_and_validate_semgrep_ecosystems
 
@@ -151,6 +152,14 @@ class CLI:
                 'account you want to sync and use the AWS_CONFIG_FILE environment variable to point to that config '
                 'file (see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html). cartography '
                 'respects the AWS CLI/SDK environment variables and does not override them.'
+            ),
+        )
+        parser.add_argument(
+            '--aws-regions',
+            action='store_true',
+            help=(
+                '[EXPERIMENTAL!] Comma-separated list of AWS regions to sync. Example 1: "us-east-1,us-east-2" for US '
+                'East 1 and 2. Note that this syncs the same regions in ALL accounts.'
             ),
         )
         parser.add_argument(
@@ -628,6 +637,11 @@ class CLI:
         if config.aws_requested_syncs:
             # No need to store the returned value; we're using this for input validation.
             parse_and_validate_aws_requested_syncs(config.aws_requested_syncs)
+
+        # AWS regions
+        if config.aws_regions:
+            # No need to store the returned value; we're using this for input validation.
+            parse_and_validate_aws_regions(config.aws_regions)
 
         # Azure config
         if config.azure_sp_auth and config.azure_client_secret_env_var:

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -23,6 +23,8 @@ class Config:
     :param selected_modules: Comma-separated list of cartography top-level modules to sync. Optional.
     :type update_tag: int
     :param update_tag: Update tag for a cartography sync run. Optional.
+    :type aws_regions: str
+    :param aws_regions: Comma-separated list of AWS regions to sync. Optional.
     :type aws_sync_all_profiles: bool
     :param aws_sync_all_profiles: If True, AWS sync will run for all non-default profiles in the AWS_CONFIG_FILE. If
         False (default), AWS sync will run using the default credentials only. Optional.

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -133,6 +133,7 @@ class Config:
         selected_modules=None,
         update_tag=None,
         aws_sync_all_profiles=False,
+        aws_regions=None,
         aws_best_effort_mode=False,
         azure_sync_all_subscriptions=False,
         azure_sp_auth=None,
@@ -194,6 +195,7 @@ class Config:
         self.selected_modules = selected_modules
         self.update_tag = update_tag
         self.aws_sync_all_profiles = aws_sync_all_profiles
+        self.aws_regions = aws_regions
         self.aws_best_effort_mode = aws_best_effort_mode
         self.azure_sync_all_subscriptions = azure_sync_all_subscriptions
         self.azure_sp_auth = azure_sp_auth

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -23,11 +23,11 @@ class Config:
     :param selected_modules: Comma-separated list of cartography top-level modules to sync. Optional.
     :type update_tag: int
     :param update_tag: Update tag for a cartography sync run. Optional.
-    :type aws_regions: str
-    :param aws_regions: Comma-separated list of AWS regions to sync. Optional.
     :type aws_sync_all_profiles: bool
     :param aws_sync_all_profiles: If True, AWS sync will run for all non-default profiles in the AWS_CONFIG_FILE. If
         False (default), AWS sync will run using the default credentials only. Optional.
+    :type aws_regions: str
+    :param aws_regions: Comma-separated list of AWS regions to sync. Optional.
     :type aws_best_effort_mode: bool
     :param aws_best_effort_mode: If True, AWS sync will not raise any exceptions, just log. If False (default),
         exceptions will be raised.

--- a/cartography/intel/aws/util/common.py
+++ b/cartography/intel/aws/util/common.py
@@ -19,3 +19,17 @@ def parse_and_validate_aws_requested_syncs(aws_requested_syncs: str) -> List[str
                 f'Our full list of valid values is: {valid_syncs}.',
             )
     return validated_resources
+
+
+def parse_and_validate_aws_regions(aws_regions: str) -> list[str]:
+    """
+    Parse and validate a comma-separated string of AWS regions.
+    :param aws_regions: Comma-separated string of AWS regions
+    :return: A validated list of AWS regions
+    """
+    validated_regions: List[str] = []
+    for region in aws_regions.split(','):
+        region = region.strip()
+        if region:
+            validated_regions.append(region)
+    return validated_regions

--- a/cartography/intel/aws/util/common.py
+++ b/cartography/intel/aws/util/common.py
@@ -37,10 +37,12 @@ def parse_and_validate_aws_regions(aws_regions: str) -> list[str]:
             validated_regions.append(region)
         else:
             logger.warning(
-                f'Unable to parse string "{region}". Please check the value you passed to --aws-regions:'
-                f'{aws_regions}. Continuing on.',
+                f'Unable to parse string "{region}". Please check the value you passed to `aws-regions`. '
+                f'You specified "{aws_regions}". Continuing on with sync.',
             )
 
     if not validated_regions:
-        raise ValueError(f'--aws-regions was set but no regions were specified. Value = "{aws_regions}"')
+        raise ValueError(
+            f'`aws-regions` was set but no regions were specified. You provided this string: "{aws_regions}"',
+        )
     return validated_regions

--- a/cartography/intel/aws/util/common.py
+++ b/cartography/intel/aws/util/common.py
@@ -1,6 +1,9 @@
+import logging
 from typing import List
 
 from cartography.intel.aws.resources import RESOURCE_FUNCTIONS
+
+logger = logging.getLogger(__name__)
 
 
 def parse_and_validate_aws_requested_syncs(aws_requested_syncs: str) -> List[str]:
@@ -32,4 +35,12 @@ def parse_and_validate_aws_regions(aws_regions: str) -> list[str]:
         region = region.strip()
         if region:
             validated_regions.append(region)
+        else:
+            logger.warning(
+                f'Unable to parse string "{region}". Please check the value you passed to --aws-regions:'
+                f'{aws_regions}. Continuing on.',
+            )
+
+    if not validated_regions:
+        raise ValueError(f'--aws-regions was set but no regions were specified. Value = "{aws_regions}"')
     return validated_regions

--- a/tests/integration/cartography/intel/aws/test_init.py
+++ b/tests/integration/cartography/intel/aws/test_init.py
@@ -59,15 +59,15 @@ def test_sync_multiple_accounts(
     # Ensure we call _sync_one_account on all accounts in our list.
     mock_sync_one.assert_any_call(
         neo4j_session, mock_boto3_session(), '000000000000', TEST_UPDATE_TAG, GRAPH_JOB_PARAMETERS,
-        aws_requested_syncs=[],
+        regions=None, aws_requested_syncs=[],
     )
     mock_sync_one.assert_any_call(
         neo4j_session, mock_boto3_session(), '000000000001', TEST_UPDATE_TAG, GRAPH_JOB_PARAMETERS,
-        aws_requested_syncs=[],
+        regions=None, aws_requested_syncs=[],
     )
     mock_sync_one.assert_any_call(
         neo4j_session, mock_boto3_session(), '000000000002', TEST_UPDATE_TAG, GRAPH_JOB_PARAMETERS,
-        aws_requested_syncs=[],
+        regions=None, aws_requested_syncs=[],
     )
 
     # Ensure _sync_one_account and _autodiscover is called once for each account

--- a/tests/unit/cartography/intel/aws/test_util.py
+++ b/tests/unit/cartography/intel/aws/test_util.py
@@ -31,7 +31,7 @@ def test_parse_and_validate_aws_regions():
 
     # Test empty input
     empty_input = ""
-    with pytest.raises(ValueError, match='--aws-regions was set but no regions were specified'):
+    with pytest.raises(ValueError, match='`aws-regions` was set but no regions were specified'):
         parse_and_validate_aws_regions(empty_input)
 
     # Test input with empty elements
@@ -44,5 +44,5 @@ def test_parse_and_validate_aws_regions():
 
     # Test input with only empty elements
     only_empty = ",,"
-    with pytest.raises(ValueError, match='--aws-regions was set but no regions were specified'):
+    with pytest.raises(ValueError, match='`aws-regions` was set but no regions were specified'):
         parse_and_validate_aws_regions(only_empty)

--- a/tests/unit/cartography/intel/aws/test_util.py
+++ b/tests/unit/cartography/intel/aws/test_util.py
@@ -1,5 +1,6 @@
 import pytest
 
+from cartography.intel.aws.util.common import parse_and_validate_aws_regions
 from cartography.intel.aws.util.common import parse_and_validate_aws_requested_syncs
 
 
@@ -17,3 +18,31 @@ def test_parse_and_validate_requested_syncs():
     absolute_garbage = '#@$@#RDFFHKjsdfkjsd,KDFJHW#@,'
     with pytest.raises(ValueError):
         parse_and_validate_aws_requested_syncs(absolute_garbage)
+
+
+def test_parse_and_validate_aws_regions():
+    # Test basic comma-separated input
+    basic_input = "us-east-1,us-west-2,eu-west-1"
+    assert parse_and_validate_aws_regions(basic_input) == ["us-east-1", "us-west-2", "eu-west-1"]
+
+    # Test input with spaces
+    spaced_input = "us-east-1, us-west-2, eu-west-1"
+    assert parse_and_validate_aws_regions(spaced_input) == ["us-east-1", "us-west-2", "eu-west-1"]
+
+    # Test empty input
+    empty_input = ""
+    with pytest.raises(ValueError, match='--aws-regions was set but no regions were specified'):
+        parse_and_validate_aws_regions(empty_input)
+
+    # Test input with empty elements
+    empty_elements = "us-east-1,,us-west-2,"
+    assert parse_and_validate_aws_regions(empty_elements) == ["us-east-1", "us-west-2"]
+
+    # Test single region input
+    single_region = "us-east-1"
+    assert parse_and_validate_aws_regions(single_region) == ["us-east-1"]
+
+    # Test input with only empty elements
+    only_empty = ",,"
+    with pytest.raises(ValueError, match='--aws-regions was set but no regions were specified'):
+        parse_and_validate_aws_regions(only_empty)


### PR DESCRIPTION
### Summary
> Describe your changes.

Adds `--aws-regions` CLI switch to support syncing of only specific regions as an experimental feature.

At this time, this feature only supports syncing the same regions for all accounts. Specifying this on a per-account basis is not currently supported.

Also see https://cloud-native.slack.com/archives/C080M2LRLDA/p1745250103100609 and https://docs.google.com/document/d/1VyRKmB0dpX185I15BmNJZpfAJ_Ooobwz0U1WIhjDxvw/edit?tab=t.0#heading=h.orecc9yg8l30.

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
![Screenshot 2025-04-26 at 4 25 54 PM](https://github.com/user-attachments/assets/1430e23f-41d2-46b8-9d08-122c935884cc)



- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/lyft/cartography/tree/master/docs/root/modules) and [readme](https://github.com/lyft/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
