### PR TITLE
fix: isort was missing from precommit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,10 @@ repos:
     -   id: debug-statements
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+-   repo: https://github.com/pycqa/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
 -   repo: https://github.com/psf/black-pre-commit-mirror
     rev: 25.1.0
     hooks:

--- a/cartography/intel/digitalocean/compute.py
+++ b/cartography/intel/digitalocean/compute.py
@@ -1,14 +1,16 @@
 import logging
+from typing import Any
+from typing import Dict
+from typing import List
 from typing import Optional
-from typing import Dict, Any, List
 
 import neo4j
 from digitalocean import Manager
 
-from cartography.util import timeit
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.models.digitalocean.droplet import DODropletSchema
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 

--- a/cartography/intel/digitalocean/management.py
+++ b/cartography/intel/digitalocean/management.py
@@ -1,14 +1,15 @@
 import logging
-from typing import Dict, Any, List
+from typing import Any
+from typing import Dict
+from typing import List
 
 import neo4j
 from digitalocean import Manager
 
-from cartography.util import timeit
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.models.digitalocean.project import DOProjectSchema
-
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 

--- a/cartography/intel/digitalocean/platform.py
+++ b/cartography/intel/digitalocean/platform.py
@@ -1,13 +1,16 @@
 import logging
-from typing import Dict, Any, List
+from typing import Any
+from typing import Dict
+from typing import List
 
 import neo4j
-from digitalocean import Account, Manager
+from digitalocean import Account
+from digitalocean import Manager
 
-from cartography.util import timeit
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.models.digitalocean.account import DOAccountSchema
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/cartography/intel/digitalocean/test_compute.py
+++ b/tests/integration/cartography/intel/digitalocean/test_compute.py
@@ -2,13 +2,11 @@ from unittest.mock import patch
 
 import cartography.intel.digitalocean.compute
 import tests.data.digitalocean.compute
-
-from tests.integration.util import check_nodes
-from tests.integration.util import check_rels
 from tests.integration.cartography.intel.digitalocean.test_management import (
     _ensure_local_neo4j_has_project_data,
 )
-
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
 

--- a/tests/integration/cartography/intel/digitalocean/test_management.py
+++ b/tests/integration/cartography/intel/digitalocean/test_management.py
@@ -4,11 +4,11 @@ import digitalocean
 
 import cartography.intel.digitalocean.management
 import tests.data.digitalocean.management
-from tests.integration.util import check_nodes
-from tests.integration.util import check_rels
 from tests.integration.cartography.intel.digitalocean.test_platform import (
     _ensure_local_neo4j_has_account_data,
 )
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
 

--- a/tests/integration/cartography/intel/digitalocean/test_platform.py
+++ b/tests/integration/cartography/intel/digitalocean/test_platform.py
@@ -4,7 +4,6 @@ import cartography.intel.digitalocean.platform
 import tests.data.digitalocean.platform
 from tests.integration.util import check_nodes
 
-
 TEST_UPDATE_TAG = 123456789
 
 


### PR DESCRIPTION
### Summary
precommit config file with `isort` was not commited in #1466 