### PR TITLE
chore: add tests to enforce schema convention

### DIFF
--- a/cartography/models/aws/apigateway.py
+++ b/cartography/models/aws/apigateway.py
@@ -24,21 +24,21 @@ class APIGatewayRestAPINodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class APIGatewayRestAPIToAwsAccountRelProperties(CartographyRelProperties):
+class APIGatewayRestAPIToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
 # (:APIGatewayRestAPI)<-[:RESOURCE]-(:AWSAccount)
-class APIGatewayRestAPIToAWSAccount(CartographyRelSchema):
+class APIGatewayRestAPIToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: APIGatewayRestAPIToAwsAccountRelProperties = (
-        APIGatewayRestAPIToAwsAccountRelProperties()
+    properties: APIGatewayRestAPIToAWSAccountRelRelProperties = (
+        APIGatewayRestAPIToAWSAccountRelRelProperties()
     )
 
 
@@ -46,6 +46,6 @@ class APIGatewayRestAPIToAWSAccount(CartographyRelSchema):
 class APIGatewayRestAPISchema(CartographyNodeSchema):
     label: str = "APIGatewayRestAPI"
     properties: APIGatewayRestAPINodeProperties = APIGatewayRestAPINodeProperties()
-    sub_resource_relationship: APIGatewayRestAPIToAWSAccount = (
-        APIGatewayRestAPIToAWSAccount()
+    sub_resource_relationship: APIGatewayRestAPIToAWSAccountRel = (
+        APIGatewayRestAPIToAWSAccountRel()
     )

--- a/cartography/models/aws/apigatewaycertificate.py
+++ b/cartography/models/aws/apigatewaycertificate.py
@@ -20,42 +20,42 @@ class APIGatewayClientCertificateNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class APIGatewayClientCertificateToStageRelProperties(CartographyRelProperties):
+class APIGatewayClientCertificateToStageRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class CertToStageRelProps(CartographyRelProperties):
+class CertToStageRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
 # (:APIGatewayStage)-[:HAS_CERTIFICATE]->(:APIGatewayClientCertificate)
-class APIGatewayClientCertificateToStage(CartographyRelSchema):
+class APIGatewayClientCertificateToStageRel(CartographyRelSchema):
     target_node_label: str = "APIGatewayStage"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("stageArn")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS_CERTIFICATE"
-    properties: CertToStageRelProps = CertToStageRelProps()
+    properties: CertToStageRelProperties = CertToStageRelProperties()
 
 
 @dataclass(frozen=True)
-class CertToAccountRelProps(CartographyRelProperties):
+class CertToAccountRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
 # (:APIGatewayClientCertificate)<-[:RESOURCE]-(:AWSAccount)
-class APIGatewayClientCertificateToAWSAccount(CartographyRelSchema):
+class APIGatewayClientCertificateToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: CertToAccountRelProps = CertToAccountRelProps()
+    properties: CertToAccountRelProperties = CertToAccountRelProperties()
 
 
 @dataclass(frozen=True)
@@ -64,9 +64,9 @@ class APIGatewayClientCertificateSchema(CartographyNodeSchema):
     properties: APIGatewayClientCertificateNodeProperties = (
         APIGatewayClientCertificateNodeProperties()
     )
-    sub_resource_relationship: APIGatewayClientCertificateToAWSAccount = (
-        APIGatewayClientCertificateToAWSAccount()
+    sub_resource_relationship: APIGatewayClientCertificateToAWSAccountRel = (
+        APIGatewayClientCertificateToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
-        [APIGatewayClientCertificateToStage()],
+        [APIGatewayClientCertificateToStageRel()],
     )

--- a/cartography/models/aws/apigatewayresource.py
+++ b/cartography/models/aws/apigatewayresource.py
@@ -21,40 +21,40 @@ class APIGatewayResourceNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class APIGatewayResourceToRestAPIRelProperties(CartographyRelProperties):
+class APIGatewayResourceToRestAPIRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
 # (:APIGatewayResource)<-[:RESOURCE]-(:APIGatewayRestAPI)
-class APIGatewayResourceToRestAPI(CartographyRelSchema):
+class APIGatewayResourceToRestAPIRel(CartographyRelSchema):
     target_node_label: str = "APIGatewayRestAPI"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("apiId")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: APIGatewayResourceToRestAPIRelProperties = (
-        APIGatewayResourceToRestAPIRelProperties()
+    properties: APIGatewayResourceToRestAPIRelRelProperties = (
+        APIGatewayResourceToRestAPIRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class APIGatewayResourceToAwsAccountRelProperties(CartographyRelProperties):
+class APIGatewayResourceToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
 # (:APIGatewayResource)<-[:RESOURCE]-(:AWSAccount)
-class APIGatewayResourceToAWSAccount(CartographyRelSchema):
+class APIGatewayResourceToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: APIGatewayResourceToAwsAccountRelProperties = (
-        APIGatewayResourceToAwsAccountRelProperties()
+    properties: APIGatewayResourceToAWSAccountRelRelProperties = (
+        APIGatewayResourceToAWSAccountRelRelProperties()
     )
 
 
@@ -62,9 +62,9 @@ class APIGatewayResourceToAWSAccount(CartographyRelSchema):
 class APIGatewayResourceSchema(CartographyNodeSchema):
     label: str = "APIGatewayResource"
     properties: APIGatewayResourceNodeProperties = APIGatewayResourceNodeProperties()
-    sub_resource_relationship: APIGatewayResourceToAWSAccount = (
-        APIGatewayResourceToAWSAccount()
+    sub_resource_relationship: APIGatewayResourceToAWSAccountRel = (
+        APIGatewayResourceToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
-        [APIGatewayResourceToRestAPI()],
+        [APIGatewayResourceToRestAPIRel()],
     )

--- a/cartography/models/aws/apigatewaystage.py
+++ b/cartography/models/aws/apigatewaystage.py
@@ -26,40 +26,40 @@ class APIGatewayStageNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class APIGatewayStageToRestAPIRelProperties(CartographyRelProperties):
+class APIGatewayStageToRestAPIRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
 # (:APIGatewayStage)<-[:ASSOCIATED_WITH]-(:APIGatewayRestAPI)
-class APIGatewayStageToRestAPI(CartographyRelSchema):
+class APIGatewayStageToRestAPIRel(CartographyRelSchema):
     target_node_label: str = "APIGatewayRestAPI"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("apiId")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "ASSOCIATED_WITH"
-    properties: APIGatewayStageToRestAPIRelProperties = (
-        APIGatewayStageToRestAPIRelProperties()
+    properties: APIGatewayStageToRestAPIRelRelProperties = (
+        APIGatewayStageToRestAPIRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class APIGatewayStageToAwsAccountRelProperties(CartographyRelProperties):
+class APIGatewayStageToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
 # (:APIGatewayStage)<-[:RESOURCE]-(:AWSAccount)
-class APIGatewayStageToAWSAccount(CartographyRelSchema):
+class APIGatewayStageToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: APIGatewayStageToAwsAccountRelProperties = (
-        APIGatewayStageToAwsAccountRelProperties()
+    properties: APIGatewayStageToAWSAccountRelRelProperties = (
+        APIGatewayStageToAWSAccountRelRelProperties()
     )
 
 
@@ -67,9 +67,9 @@ class APIGatewayStageToAWSAccount(CartographyRelSchema):
 class APIGatewayStageSchema(CartographyNodeSchema):
     label: str = "APIGatewayStage"
     properties: APIGatewayStageNodeProperties = APIGatewayStageNodeProperties()
-    sub_resource_relationship: APIGatewayStageToAWSAccount = (
-        APIGatewayStageToAWSAccount()
+    sub_resource_relationship: APIGatewayStageToAWSAccountRel = (
+        APIGatewayStageToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
-        [APIGatewayStageToRestAPI()],
+        [APIGatewayStageToRestAPIRel()],
     )

--- a/cartography/models/aws/cloudtrail/trail.py
+++ b/cartography/models/aws/cloudtrail/trail.py
@@ -42,7 +42,7 @@ class CloudTrailTrailToAwsAccountRelProperties(CartographyRelProperties):
 
 
 @dataclass(frozen=True)
-class CloudTrailToAWSAccount(CartographyRelSchema):
+class CloudTrailToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
@@ -58,4 +58,4 @@ class CloudTrailToAWSAccount(CartographyRelSchema):
 class CloudTrailTrailSchema(CartographyNodeSchema):
     label: str = "CloudTrailTrail"
     properties: CloudTrailTrailNodeProperties = CloudTrailTrailNodeProperties()
-    sub_resource_relationship: CloudTrailToAWSAccount = CloudTrailToAWSAccount()
+    sub_resource_relationship: CloudTrailToAWSAccountRel = CloudTrailToAWSAccountRel()

--- a/cartography/models/aws/dynamodb/gsi.py
+++ b/cartography/models/aws/dynamodb/gsi.py
@@ -27,40 +27,40 @@ class DynamoDBGSINodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class DynamoDBGSIToAwsAccountRelProperties(CartographyRelProperties):
+class DynamoDBGSIToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
 # (:DynamoDBGlobalSecondaryIndex)<-[:RESOURCE]-(:AWSAccount)
-class DynamoDBGSIToAWSAccount(CartographyRelSchema):
+class DynamoDBGSIToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: DynamoDBGSIToAwsAccountRelProperties = (
-        DynamoDBGSIToAwsAccountRelProperties()
+    properties: DynamoDBGSIToAWSAccountRelRelProperties = (
+        DynamoDBGSIToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class DynamoDBGSIToDynamoDBTableRelProperties(CartographyRelProperties):
+class DynamoDBGSIToDynamoDBTableRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
 # (:DynamoDBGlobalSecondaryIndex)<-[:GLOBAL_SECONDARY_INDEX]-(:DynamoDBTable)
-class DynamoDBGSIToDynamoDBTable(CartographyRelSchema):
+class DynamoDBGSIToDynamoDBTableRel(CartographyRelSchema):
     target_node_label: str = "DynamoDBTable"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"arn": PropertyRef("TableArn")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "GLOBAL_SECONDARY_INDEX"
-    properties: DynamoDBGSIToDynamoDBTableRelProperties = (
-        DynamoDBGSIToDynamoDBTableRelProperties()
+    properties: DynamoDBGSIToDynamoDBTableRelRelProperties = (
+        DynamoDBGSIToDynamoDBTableRelRelProperties()
     )
 
 
@@ -68,9 +68,9 @@ class DynamoDBGSIToDynamoDBTable(CartographyRelSchema):
 class DynamoDBGSISchema(CartographyNodeSchema):
     label: str = "DynamoDBGlobalSecondaryIndex"
     properties: DynamoDBGSINodeProperties = DynamoDBGSINodeProperties()
-    sub_resource_relationship: DynamoDBGSIToAWSAccount = DynamoDBGSIToAWSAccount()
+    sub_resource_relationship: DynamoDBGSIToAWSAccountRel = DynamoDBGSIToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            DynamoDBGSIToDynamoDBTable(),
+            DynamoDBGSIToDynamoDBTableRel(),
         ],
     )

--- a/cartography/models/aws/dynamodb/tables.py
+++ b/cartography/models/aws/dynamodb/tables.py
@@ -28,21 +28,21 @@ class DynamoDBTableNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class DynamoDBTableToAwsAccountRelProperties(CartographyRelProperties):
+class DynamoDBTableToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
 # (:DynamoDBTable)<-[:RESOURCE]-(:AWSAccount)
-class DynamoDBTableToAWSAccount(CartographyRelSchema):
+class DynamoDBTableToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: DynamoDBTableToAwsAccountRelProperties = (
-        DynamoDBTableToAwsAccountRelProperties()
+    properties: DynamoDBTableToAWSAccountRelRelProperties = (
+        DynamoDBTableToAWSAccountRelRelProperties()
     )
 
 
@@ -50,4 +50,6 @@ class DynamoDBTableToAWSAccount(CartographyRelSchema):
 class DynamoDBTableSchema(CartographyNodeSchema):
     label: str = "DynamoDBTable"
     properties: DynamoDBTableNodeProperties = DynamoDBTableNodeProperties()
-    sub_resource_relationship: DynamoDBTableToAWSAccount = DynamoDBTableToAWSAccount()
+    sub_resource_relationship: DynamoDBTableToAWSAccountRel = (
+        DynamoDBTableToAWSAccountRel()
+    )

--- a/cartography/models/aws/ec2/auto_scaling_groups.py
+++ b/cartography/models/aws/ec2/auto_scaling_groups.py
@@ -39,38 +39,38 @@ class AutoScalingGroupNodeProperties(CartographyNodeProperties):
 
 # EC2 to AutoScalingGroup
 @dataclass(frozen=True)
-class EC2InstanceToAwsAccountRelProperties(CartographyRelProperties):
+class EC2InstanceToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2InstanceToAWSAccount(CartographyRelSchema):
+class EC2InstanceToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2InstanceToAwsAccountRelProperties = (
-        EC2InstanceToAwsAccountRelProperties()
+    properties: EC2InstanceToAWSAccountRelRelProperties = (
+        EC2InstanceToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class EC2InstanceToAutoScalingGroupRelProperties(CartographyRelProperties):
+class EC2InstanceToAutoScalingGroupRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2InstanceToAutoScalingGroup(CartographyRelSchema):
+class EC2InstanceToAutoScalingGroupRel(CartographyRelSchema):
     target_node_label: str = "AutoScalingGroup"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AutoScalingGroupARN")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "MEMBER_AUTO_SCALE_GROUP"
-    properties: EC2InstanceToAutoScalingGroupRelProperties = (
-        EC2InstanceToAutoScalingGroupRelProperties()
+    properties: EC2InstanceToAutoScalingGroupRelRelProperties = (
+        EC2InstanceToAutoScalingGroupRelRelProperties()
     )
 
 
@@ -88,48 +88,48 @@ class EC2InstanceAutoScalingGroupSchema(CartographyNodeSchema):
     properties: EC2InstanceAutoScalingGroupProperties = (
         EC2InstanceAutoScalingGroupProperties()
     )
-    sub_resource_relationship: EC2InstanceToAWSAccount = EC2InstanceToAWSAccount()
+    sub_resource_relationship: EC2InstanceToAWSAccountRel = EC2InstanceToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2InstanceToAutoScalingGroup(),
+            EC2InstanceToAutoScalingGroupRel(),
         ],
     )
 
 
 # EC2Subnet to AutoScalingGroup
 @dataclass(frozen=True)
-class EC2SubnetToAwsAccountRelProperties(CartographyRelProperties):
+class EC2SubnetToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2SubnetToAWSAccount(CartographyRelSchema):
+class EC2SubnetToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2SubnetToAwsAccountRelProperties = (
-        EC2SubnetToAwsAccountRelProperties()
+    properties: EC2SubnetToAWSAccountRelRelProperties = (
+        EC2SubnetToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class EC2SubnetToAutoScalingGroupRelProperties(CartographyRelProperties):
+class EC2SubnetToAutoScalingGroupRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2SubnetToAutoScalingGroup(CartographyRelSchema):
+class EC2SubnetToAutoScalingGroupRel(CartographyRelSchema):
     target_node_label: str = "AutoScalingGroup"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AutoScalingGroupARN")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "VPC_IDENTIFIER"
-    properties: EC2SubnetToAutoScalingGroupRelProperties = (
-        EC2SubnetToAutoScalingGroupRelProperties()
+    properties: EC2SubnetToAutoScalingGroupRelRelProperties = (
+        EC2SubnetToAutoScalingGroupRelRelProperties()
     )
 
 
@@ -146,66 +146,66 @@ class EC2SubnetAutoScalingGroupSchema(CartographyNodeSchema):
     properties: EC2SubnetAutoScalingGroupNodeProperties = (
         EC2SubnetAutoScalingGroupNodeProperties()
     )
-    sub_resource_relationship: EC2SubnetToAWSAccount = EC2SubnetToAWSAccount()
+    sub_resource_relationship: EC2SubnetToAWSAccountRel = EC2SubnetToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2SubnetToAutoScalingGroup(),
+            EC2SubnetToAutoScalingGroupRel(),
         ],
     )
 
 
 # AutoScalingGroup
 @dataclass(frozen=True)
-class AutoScalingGroupToAwsAccountRelProperties(CartographyRelProperties):
+class AutoScalingGroupToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class AutoScalingGroupToAWSAccount(CartographyRelSchema):
+class AutoScalingGroupToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: AutoScalingGroupToAwsAccountRelProperties = (
-        AutoScalingGroupToAwsAccountRelProperties()
+    properties: AutoScalingGroupToAWSAccountRelRelProperties = (
+        AutoScalingGroupToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class AutoScalingGroupToLaunchTemplateRelProperties(CartographyRelProperties):
+class AutoScalingGroupToLaunchTemplateRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class AutoScalingGroupToLaunchTemplate(CartographyRelSchema):
+class AutoScalingGroupToLaunchTemplateRel(CartographyRelSchema):
     target_node_label: str = "LaunchTemplate"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("LaunchTemplateId")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "HAS_LAUNCH_TEMPLATE"
-    properties: AutoScalingGroupToLaunchTemplateRelProperties = (
-        AutoScalingGroupToLaunchTemplateRelProperties()
+    properties: AutoScalingGroupToLaunchTemplateRelRelProperties = (
+        AutoScalingGroupToLaunchTemplateRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class AutoScalingGroupToLaunchConfigurationRelProperties(CartographyRelProperties):
+class AutoScalingGroupToLaunchConfigurationRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class AutoScalingGroupToLaunchConfiguration(CartographyRelSchema):
+class AutoScalingGroupToLaunchConfigurationRel(CartographyRelSchema):
     target_node_label: str = "LaunchConfiguration"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"name": PropertyRef("LaunchConfigurationName")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "HAS_LAUNCH_CONFIG"
-    properties: AutoScalingGroupToLaunchConfigurationRelProperties = (
-        AutoScalingGroupToLaunchConfigurationRelProperties()
+    properties: AutoScalingGroupToLaunchConfigurationRelRelProperties = (
+        AutoScalingGroupToLaunchConfigurationRelRelProperties()
     )
 
 
@@ -213,12 +213,12 @@ class AutoScalingGroupToLaunchConfiguration(CartographyRelSchema):
 class AutoScalingGroupSchema(CartographyNodeSchema):
     label: str = "AutoScalingGroup"
     properties: AutoScalingGroupNodeProperties = AutoScalingGroupNodeProperties()
-    sub_resource_relationship: AutoScalingGroupToAWSAccount = (
-        AutoScalingGroupToAWSAccount()
+    sub_resource_relationship: AutoScalingGroupToAWSAccountRel = (
+        AutoScalingGroupToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            AutoScalingGroupToLaunchTemplate(),
-            AutoScalingGroupToLaunchConfiguration(),
+            AutoScalingGroupToLaunchTemplateRel(),
+            AutoScalingGroupToLaunchConfigurationRel(),
         ],
     )

--- a/cartography/models/aws/ec2/images.py
+++ b/cartography/models/aws/ec2/images.py
@@ -41,23 +41,25 @@ class EC2ImageNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2ImageToAwsAccountRelProperties(CartographyRelProperties):
+class EC2ImageToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2ImageToAWSAccount(CartographyRelSchema):
+class EC2ImageToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2ImageToAwsAccountRelProperties = EC2ImageToAwsAccountRelProperties()
+    properties: EC2ImageToAWSAccountRelRelProperties = (
+        EC2ImageToAWSAccountRelRelProperties()
+    )
 
 
 @dataclass(frozen=True)
 class EC2ImageSchema(CartographyNodeSchema):
     label: str = "EC2Image"
     properties: EC2ImageNodeProperties = EC2ImageNodeProperties()
-    sub_resource_relationship: EC2ImageToAWSAccount = EC2ImageToAWSAccount()
+    sub_resource_relationship: EC2ImageToAWSAccountRel = EC2ImageToAWSAccountRel()

--- a/cartography/models/aws/ec2/instances.py
+++ b/cartography/models/aws/ec2/instances.py
@@ -40,56 +40,56 @@ class EC2InstanceNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2InstanceToAwsAccountRelProperties(CartographyRelProperties):
+class EC2InstanceToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2InstanceToAWSAccount(CartographyRelSchema):
+class EC2InstanceToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2InstanceToAwsAccountRelProperties = (
-        EC2InstanceToAwsAccountRelProperties()
+    properties: EC2InstanceToAWSAccountRelRelProperties = (
+        EC2InstanceToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class EC2InstanceToEC2ReservationRelProperties(CartographyRelProperties):
+class EC2InstanceToEC2ReservationRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2InstanceToEC2Reservation(CartographyRelSchema):
+class EC2InstanceToEC2ReservationRel(CartographyRelSchema):
     target_node_label: str = "EC2Reservation"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"reservationid": PropertyRef("ReservationId")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "MEMBER_OF_EC2_RESERVATION"
-    properties: EC2InstanceToEC2ReservationRelProperties = (
-        EC2InstanceToEC2ReservationRelProperties()
+    properties: EC2InstanceToEC2ReservationRelRelProperties = (
+        EC2InstanceToEC2ReservationRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class EC2InstanceToInstanceProfileRelProperties(CartographyRelProperties):
+class EC2InstanceToInstanceProfileRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2InstanceToInstanceProfile(CartographyRelSchema):
+class EC2InstanceToInstanceProfileRel(CartographyRelSchema):
     target_node_label: str = "AWSInstanceProfile"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"arn": PropertyRef("IamInstanceProfile")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "INSTANCE_PROFILE"
-    properties: EC2InstanceToInstanceProfileRelProperties = (
-        EC2InstanceToInstanceProfileRelProperties()
+    properties: EC2InstanceToInstanceProfileRelRelProperties = (
+        EC2InstanceToInstanceProfileRelRelProperties()
     )
 
 
@@ -97,10 +97,10 @@ class EC2InstanceToInstanceProfile(CartographyRelSchema):
 class EC2InstanceSchema(CartographyNodeSchema):
     label: str = "EC2Instance"
     properties: EC2InstanceNodeProperties = EC2InstanceNodeProperties()
-    sub_resource_relationship: EC2InstanceToAWSAccount = EC2InstanceToAWSAccount()
+    sub_resource_relationship: EC2InstanceToAWSAccountRel = EC2InstanceToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2InstanceToEC2Reservation(),
-            EC2InstanceToInstanceProfile(),  # Add the new relationship
+            EC2InstanceToEC2ReservationRel(),
+            EC2InstanceToInstanceProfileRel(),  # Add the new relationship
         ],
     )

--- a/cartography/models/aws/ec2/keypair.py
+++ b/cartography/models/aws/ec2/keypair.py
@@ -26,12 +26,12 @@ class EC2KeyPairNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2KeyPairToAwsAccountRelProperties(CartographyRelProperties):
+class EC2KeyPairToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2KeyPairToAWSAccount(CartographyRelSchema):
+class EC2KeyPairToAWSAccountRel(CartographyRelSchema):
     """
     Relationship schema for EC2 keypairs to AWS Accounts
     """
@@ -42,8 +42,8 @@ class EC2KeyPairToAWSAccount(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2KeyPairToAwsAccountRelProperties = (
-        EC2KeyPairToAwsAccountRelProperties()
+    properties: EC2KeyPairToAWSAccountRelRelProperties = (
+        EC2KeyPairToAWSAccountRelRelProperties()
     )
 
 
@@ -56,4 +56,4 @@ class EC2KeyPairSchema(CartographyNodeSchema):
     label: str = "EC2KeyPair"
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["KeyPair"])
     properties: EC2KeyPairNodeProperties = EC2KeyPairNodeProperties()
-    sub_resource_relationship: EC2KeyPairToAWSAccount = EC2KeyPairToAWSAccount()
+    sub_resource_relationship: EC2KeyPairToAWSAccountRel = EC2KeyPairToAWSAccountRel()

--- a/cartography/models/aws/ec2/keypair_instance.py
+++ b/cartography/models/aws/ec2/keypair_instance.py
@@ -22,38 +22,38 @@ class EC2KeyPairInstanceNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2KeyPairInstanceToAwsAccountRelProperties(CartographyRelProperties):
+class EC2KeyPairInstanceToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2KeyPairInstanceToAWSAccount(CartographyRelSchema):
+class EC2KeyPairInstanceToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2KeyPairInstanceToAwsAccountRelProperties = (
-        EC2KeyPairInstanceToAwsAccountRelProperties()
+    properties: EC2KeyPairInstanceToAWSAccountRelRelProperties = (
+        EC2KeyPairInstanceToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class EC2KeyPairInstanceToEC2InstanceRelProperties(CartographyRelProperties):
+class EC2KeyPairInstanceToEC2InstanceRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2KeyPairInstanceToEC2Instance(CartographyRelSchema):
+class EC2KeyPairInstanceToEC2InstanceRel(CartographyRelSchema):
     target_node_label: str = "EC2Instance"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("InstanceId")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "SSH_LOGIN_TO"
-    properties: EC2KeyPairInstanceToEC2InstanceRelProperties = (
-        EC2KeyPairInstanceToEC2InstanceRelProperties()
+    properties: EC2KeyPairInstanceToEC2InstanceRelRelProperties = (
+        EC2KeyPairInstanceToEC2InstanceRelRelProperties()
     )
 
 
@@ -66,11 +66,11 @@ class EC2KeyPairInstanceSchema(CartographyNodeSchema):
     label: str = "EC2KeyPair"
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["KeyPair"])
     properties: EC2KeyPairInstanceNodeProperties = EC2KeyPairInstanceNodeProperties()
-    sub_resource_relationship: EC2KeyPairInstanceToAWSAccount = (
-        EC2KeyPairInstanceToAWSAccount()
+    sub_resource_relationship: EC2KeyPairInstanceToAWSAccountRel = (
+        EC2KeyPairInstanceToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2KeyPairInstanceToEC2Instance(),
+            EC2KeyPairInstanceToEC2InstanceRel(),
         ],
     )

--- a/cartography/models/aws/ec2/launch_configurations.py
+++ b/cartography/models/aws/ec2/launch_configurations.py
@@ -33,20 +33,20 @@ class LaunchConfigurationNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class LaunchConfigurationToAwsAccountRelProperties(CartographyRelProperties):
+class LaunchConfigurationToAwsAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class LaunchConfigurationToAwsAccount(CartographyRelSchema):
+class LaunchConfigurationToAwsAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: LaunchConfigurationToAwsAccountRelProperties = (
-        LaunchConfigurationToAwsAccountRelProperties()
+    properties: LaunchConfigurationToAwsAccountRelRelProperties = (
+        LaunchConfigurationToAwsAccountRelRelProperties()
     )
 
 
@@ -54,6 +54,6 @@ class LaunchConfigurationToAwsAccount(CartographyRelSchema):
 class LaunchConfigurationSchema(CartographyNodeSchema):
     label: str = "LaunchConfiguration"
     properties: LaunchConfigurationNodeProperties = LaunchConfigurationNodeProperties()
-    sub_resource_relationship: LaunchConfigurationToAwsAccount = (
-        LaunchConfigurationToAwsAccount()
+    sub_resource_relationship: LaunchConfigurationToAwsAccountRel = (
+        LaunchConfigurationToAwsAccountRel()
     )

--- a/cartography/models/aws/ec2/launch_template_versions.py
+++ b/cartography/models/aws/ec2/launch_template_versions.py
@@ -40,38 +40,38 @@ class LaunchTemplateVersionNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class LaunchTemplateVersionToAwsAccountRelProperties(CartographyRelProperties):
+class LaunchTemplateVersionToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class LaunchTemplateVersionToAWSAccount(CartographyRelSchema):
+class LaunchTemplateVersionToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: LaunchTemplateVersionToAwsAccountRelProperties = (
-        LaunchTemplateVersionToAwsAccountRelProperties()
+    properties: LaunchTemplateVersionToAWSAccountRelRelProperties = (
+        LaunchTemplateVersionToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class LaunchTemplateVersionToLTRelProperties(CartographyRelProperties):
+class LaunchTemplateVersionToLTRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class LaunchTemplateVersionToLT(CartographyRelSchema):
+class LaunchTemplateVersionToLTRel(CartographyRelSchema):
     target_node_label: str = "LaunchTemplate"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("LaunchTemplateId")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "VERSION"
-    properties: LaunchTemplateVersionToLTRelProperties = (
-        LaunchTemplateVersionToLTRelProperties()
+    properties: LaunchTemplateVersionToLTRelRelProperties = (
+        LaunchTemplateVersionToLTRelRelProperties()
     )
 
 
@@ -81,11 +81,11 @@ class LaunchTemplateVersionSchema(CartographyNodeSchema):
     properties: LaunchTemplateVersionNodeProperties = (
         LaunchTemplateVersionNodeProperties()
     )
-    sub_resource_relationship: LaunchTemplateVersionToAWSAccount = (
-        LaunchTemplateVersionToAWSAccount()
+    sub_resource_relationship: LaunchTemplateVersionToAWSAccountRel = (
+        LaunchTemplateVersionToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            LaunchTemplateVersionToLT(),
+            LaunchTemplateVersionToLTRel(),
         ],
     )

--- a/cartography/models/aws/ec2/launch_templates.py
+++ b/cartography/models/aws/ec2/launch_templates.py
@@ -24,20 +24,20 @@ class LaunchTemplateNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class LaunchTemplateToAwsAccountRelProperties(CartographyRelProperties):
+class LaunchTemplateToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class LaunchTemplateToAWSAccount(CartographyRelSchema):
+class LaunchTemplateToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: LaunchTemplateToAwsAccountRelProperties = (
-        LaunchTemplateToAwsAccountRelProperties()
+    properties: LaunchTemplateToAWSAccountRelRelProperties = (
+        LaunchTemplateToAWSAccountRelRelProperties()
     )
 
 
@@ -45,4 +45,6 @@ class LaunchTemplateToAWSAccount(CartographyRelSchema):
 class LaunchTemplateSchema(CartographyNodeSchema):
     label: str = "LaunchTemplate"
     properties: LaunchTemplateNodeProperties = LaunchTemplateNodeProperties()
-    sub_resource_relationship: LaunchTemplateToAWSAccount = LaunchTemplateToAWSAccount()
+    sub_resource_relationship: LaunchTemplateToAWSAccountRel = (
+        LaunchTemplateToAWSAccountRel()
+    )

--- a/cartography/models/aws/ec2/load_balancer_listeners.py
+++ b/cartography/models/aws/ec2/load_balancer_listeners.py
@@ -24,38 +24,38 @@ class ELBListenerNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class ELBListenerToLoadBalancerRelProperties(CartographyRelProperties):
+class ELBListenerToLoadBalancerRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class ELBListenerToLoadBalancer(CartographyRelSchema):
+class ELBListenerToLoadBalancerRel(CartographyRelSchema):
     target_node_label: str = "LoadBalancer"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("LoadBalancerId")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "ELB_LISTENER"
-    properties: ELBListenerToLoadBalancerRelProperties = (
-        ELBListenerToLoadBalancerRelProperties()
+    properties: ELBListenerToLoadBalancerRelRelProperties = (
+        ELBListenerToLoadBalancerRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class ELBListenerToAWSAccountRelProperties(CartographyRelProperties):
+class ELBListenerToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class ELBListenerToAWSAccount(CartographyRelSchema):
+class ELBListenerToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: ELBListenerToAWSAccountRelProperties = (
-        ELBListenerToAWSAccountRelProperties()
+    properties: ELBListenerToAWSAccountRelRelProperties = (
+        ELBListenerToAWSAccountRelRelProperties()
     )
 
 
@@ -64,9 +64,9 @@ class ELBListenerSchema(CartographyNodeSchema):
     label: str = "ELBListener"
     properties: ELBListenerNodeProperties = ELBListenerNodeProperties()
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Endpoint"])
-    sub_resource_relationship: ELBListenerToAWSAccount = ELBListenerToAWSAccount()
+    sub_resource_relationship: ELBListenerToAWSAccountRel = ELBListenerToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            ELBListenerToLoadBalancer(),
+            ELBListenerToLoadBalancerRel(),
         ],
     )

--- a/cartography/models/aws/ec2/load_balancers.py
+++ b/cartography/models/aws/ec2/load_balancers.py
@@ -25,20 +25,20 @@ class LoadBalancerNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class LoadBalancerToAWSAccountRelProperties(CartographyRelProperties):
+class LoadBalancerToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class LoadBalancerToAWSAccount(CartographyRelSchema):
+class LoadBalancerToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: LoadBalancerToAWSAccountRelProperties = (
-        LoadBalancerToAWSAccountRelProperties()
+    properties: LoadBalancerToAWSAccountRelRelProperties = (
+        LoadBalancerToAWSAccountRelRelProperties()
     )
 
 
@@ -48,7 +48,7 @@ class LoadBalancerToSecurityGroupRelProperties(CartographyRelProperties):
 
 
 @dataclass(frozen=True)
-class LoadBalancerToSourceSecurityGroup(CartographyRelSchema):
+class LoadBalancerToSourceSecurityGroupRel(CartographyRelSchema):
     target_node_label: str = "EC2SecurityGroup"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"name": PropertyRef("GROUP_NAME")},
@@ -61,38 +61,38 @@ class LoadBalancerToSourceSecurityGroup(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
-class LoadBalancerToEC2SecurityGroupRelProperties(CartographyRelProperties):
+class LoadBalancerToEC2SecurityGroupRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class LoadBalancerToEC2SecurityGroup(CartographyRelSchema):
+class LoadBalancerToEC2SecurityGroupRel(CartographyRelSchema):
     target_node_label: str = "EC2SecurityGroup"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"groupid": PropertyRef("GROUP_IDS", one_to_many=True)},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "MEMBER_OF_EC2_SECURITY_GROUP"
-    properties: LoadBalancerToEC2SecurityGroupRelProperties = (
-        LoadBalancerToEC2SecurityGroupRelProperties()
+    properties: LoadBalancerToEC2SecurityGroupRelRelProperties = (
+        LoadBalancerToEC2SecurityGroupRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class LoadBalancerToEC2InstanceRelProperties(CartographyRelProperties):
+class LoadBalancerToEC2InstanceRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class LoadBalancerToEC2Instance(CartographyRelSchema):
+class LoadBalancerToEC2InstanceRel(CartographyRelSchema):
     target_node_label: str = "EC2Instance"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"instanceid": PropertyRef("INSTANCE_IDS", one_to_many=True)},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "EXPOSE"
-    properties: LoadBalancerToEC2InstanceRelProperties = (
-        LoadBalancerToEC2InstanceRelProperties()
+    properties: LoadBalancerToEC2InstanceRelRelProperties = (
+        LoadBalancerToEC2InstanceRelRelProperties()
     )
 
 
@@ -100,11 +100,13 @@ class LoadBalancerToEC2Instance(CartographyRelSchema):
 class LoadBalancerSchema(CartographyNodeSchema):
     label: str = "LoadBalancer"
     properties: LoadBalancerNodeProperties = LoadBalancerNodeProperties()
-    sub_resource_relationship: LoadBalancerToAWSAccount = LoadBalancerToAWSAccount()
+    sub_resource_relationship: LoadBalancerToAWSAccountRel = (
+        LoadBalancerToAWSAccountRel()
+    )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            LoadBalancerToSourceSecurityGroup(),
-            LoadBalancerToEC2SecurityGroup(),
-            LoadBalancerToEC2Instance(),
+            LoadBalancerToSourceSecurityGroupRel(),
+            LoadBalancerToEC2SecurityGroupRel(),
+            LoadBalancerToEC2InstanceRel(),
         ],
     )

--- a/cartography/models/aws/ec2/network_acl_rules.py
+++ b/cartography/models/aws/ec2/network_acl_rules.py
@@ -34,7 +34,7 @@ class EC2NetworkAclRuleAclRelProperties(CartographyRelProperties):
 
 
 @dataclass(frozen=True)
-class EC2NetworkAclRuleToAcl(CartographyRelSchema):
+class EC2NetworkAclRuleToAclRel(CartographyRelSchema):
     target_node_label: str = "EC2NetworkAcl"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"network_acl_id": PropertyRef("NetworkAclId")},
@@ -45,20 +45,20 @@ class EC2NetworkAclRuleToAcl(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
-class EC2NetworkAclRuleToAwsAccountRelProperties(CartographyRelProperties):
+class EC2NetworkAclRuleToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2NetworkAclRuleToAWSAccount(CartographyRelSchema):
+class EC2NetworkAclRuleToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2NetworkAclRuleToAwsAccountRelProperties = (
-        EC2NetworkAclRuleToAwsAccountRelProperties()
+    properties: EC2NetworkAclRuleToAWSAccountRelRelProperties = (
+        EC2NetworkAclRuleToAWSAccountRelRelProperties()
     )
 
 
@@ -73,12 +73,12 @@ class EC2NetworkAclInboundRuleSchema(CartographyNodeSchema):
         ["IpPermissionInbound"],
     )
     properties: EC2NetworkAclRuleNodeProperties = EC2NetworkAclRuleNodeProperties()
-    sub_resource_relationship: EC2NetworkAclRuleToAWSAccount = (
-        EC2NetworkAclRuleToAWSAccount()
+    sub_resource_relationship: EC2NetworkAclRuleToAWSAccountRel = (
+        EC2NetworkAclRuleToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2NetworkAclRuleToAcl(),
+            EC2NetworkAclRuleToAclRel(),
         ],
     )
 
@@ -96,11 +96,11 @@ class EC2NetworkAclEgressRuleSchema(CartographyNodeSchema):
         ],
     )
     properties: EC2NetworkAclRuleNodeProperties = EC2NetworkAclRuleNodeProperties()
-    sub_resource_relationship: EC2NetworkAclRuleToAWSAccount = (
-        EC2NetworkAclRuleToAWSAccount()
+    sub_resource_relationship: EC2NetworkAclRuleToAWSAccountRel = (
+        EC2NetworkAclRuleToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2NetworkAclRuleToAcl(),
+            EC2NetworkAclRuleToAclRel(),
         ],
     )

--- a/cartography/models/aws/ec2/network_acls.py
+++ b/cartography/models/aws/ec2/network_acls.py
@@ -23,54 +23,56 @@ class EC2NetworkAclNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2NetworkAclToVpcRelProperties(CartographyRelProperties):
+class EC2NetworkAclToVpcRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2NetworkAclToVpc(CartographyRelSchema):
+class EC2NetworkAclToVpcRel(CartographyRelSchema):
     target_node_label: str = "AWSVpc"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"vpcid": PropertyRef("VpcId")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "MEMBER_OF_AWS_VPC"
-    properties: EC2NetworkAclToVpcRelProperties = EC2NetworkAclToVpcRelProperties()
+    properties: EC2NetworkAclToVpcRelRelProperties = (
+        EC2NetworkAclToVpcRelRelProperties()
+    )
 
 
 @dataclass(frozen=True)
-class EC2NetworkAclToSubnetRelProperties(CartographyRelProperties):
+class EC2NetworkAclToSubnetRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2NetworkAclToSubnet(CartographyRelSchema):
+class EC2NetworkAclToSubnetRel(CartographyRelSchema):
     target_node_label: str = "EC2Subnet"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"subnetid": PropertyRef("SubnetId")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "PART_OF_SUBNET"
-    properties: EC2NetworkAclToSubnetRelProperties = (
-        EC2NetworkAclToSubnetRelProperties()
+    properties: EC2NetworkAclToSubnetRelRelProperties = (
+        EC2NetworkAclToSubnetRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class EC2NetworkAclToAwsAccountRelProperties(CartographyRelProperties):
+class EC2NetworkAclToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2NetworkAclToAWSAccount(CartographyRelSchema):
+class EC2NetworkAclToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2NetworkAclToAwsAccountRelProperties = (
-        EC2NetworkAclToAwsAccountRelProperties()
+    properties: EC2NetworkAclToAWSAccountRelRelProperties = (
+        EC2NetworkAclToAWSAccountRelRelProperties()
     )
 
 
@@ -82,10 +84,12 @@ class EC2NetworkAclSchema(CartographyNodeSchema):
 
     label: str = "EC2NetworkAcl"
     properties: EC2NetworkAclNodeProperties = EC2NetworkAclNodeProperties()
-    sub_resource_relationship: EC2NetworkAclToAWSAccount = EC2NetworkAclToAWSAccount()
+    sub_resource_relationship: EC2NetworkAclToAWSAccountRel = (
+        EC2NetworkAclToAWSAccountRel()
+    )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2NetworkAclToVpc(),
-            EC2NetworkAclToSubnet(),
+            EC2NetworkAclToVpcRel(),
+            EC2NetworkAclToSubnetRel(),
         ],
     )

--- a/cartography/models/aws/ec2/networkinterface_instance.py
+++ b/cartography/models/aws/ec2/networkinterface_instance.py
@@ -29,74 +29,74 @@ class EC2NetworkInterfaceInstanceNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2NetworkInterfaceToAwsAccountRelProperties(CartographyRelProperties):
+class EC2NetworkInterfaceToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2NetworkInterfaceToAWSAccount(CartographyRelSchema):
+class EC2NetworkInterfaceToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2NetworkInterfaceToAwsAccountRelProperties = (
-        EC2NetworkInterfaceToAwsAccountRelProperties()
+    properties: EC2NetworkInterfaceToAWSAccountRelRelProperties = (
+        EC2NetworkInterfaceToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class EC2NetworkInterfaceToEC2InstanceRelProperties(CartographyRelProperties):
+class EC2NetworkInterfaceToEC2InstanceRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2NetworkInterfaceToEC2Instance(CartographyRelSchema):
+class EC2NetworkInterfaceToEC2InstanceRel(CartographyRelSchema):
     target_node_label: str = "EC2Instance"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("InstanceId")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "NETWORK_INTERFACE"
-    properties: EC2NetworkInterfaceToEC2InstanceRelProperties = (
-        EC2NetworkInterfaceToEC2InstanceRelProperties()
+    properties: EC2NetworkInterfaceToEC2InstanceRelRelProperties = (
+        EC2NetworkInterfaceToEC2InstanceRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class EC2NetworkInterfaceToEC2SubnetRelProperties(CartographyRelProperties):
+class EC2NetworkInterfaceToEC2SubnetRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2NetworkInterfaceToEC2Subnet(CartographyRelSchema):
+class EC2NetworkInterfaceToEC2SubnetRel(CartographyRelSchema):
     target_node_label: str = "EC2Subnet"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("SubnetId")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "PART_OF_SUBNET"
-    properties: EC2NetworkInterfaceToEC2SubnetRelProperties = (
-        EC2NetworkInterfaceToEC2SubnetRelProperties()
+    properties: EC2NetworkInterfaceToEC2SubnetRelRelProperties = (
+        EC2NetworkInterfaceToEC2SubnetRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class EC2NetworkInterfaceToEC2SecurityGroupRelProperties(CartographyRelProperties):
+class EC2NetworkInterfaceToEC2SecurityGroupRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2NetworkInterfaceToEC2SecurityGroup(CartographyRelSchema):
+class EC2NetworkInterfaceToEC2SecurityGroupRel(CartographyRelSchema):
     target_node_label: str = "EC2SecurityGroup"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("GroupId")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "MEMBER_OF_EC2_SECURITY_GROUP"
-    properties: EC2NetworkInterfaceToEC2SecurityGroupRelProperties = (
-        EC2NetworkInterfaceToEC2SecurityGroupRelProperties()
+    properties: EC2NetworkInterfaceToEC2SecurityGroupRelRelProperties = (
+        EC2NetworkInterfaceToEC2SecurityGroupRelRelProperties()
     )
 
 
@@ -110,13 +110,13 @@ class EC2NetworkInterfaceInstanceSchema(CartographyNodeSchema):
     properties: EC2NetworkInterfaceInstanceNodeProperties = (
         EC2NetworkInterfaceInstanceNodeProperties()
     )
-    sub_resource_relationship: EC2NetworkInterfaceToAWSAccount = (
-        EC2NetworkInterfaceToAWSAccount()
+    sub_resource_relationship: EC2NetworkInterfaceToAWSAccountRel = (
+        EC2NetworkInterfaceToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2NetworkInterfaceToEC2Instance(),
-            EC2NetworkInterfaceToEC2Subnet(),
-            EC2NetworkInterfaceToEC2SecurityGroup(),
+            EC2NetworkInterfaceToEC2InstanceRel(),
+            EC2NetworkInterfaceToEC2SubnetRel(),
+            EC2NetworkInterfaceToEC2SecurityGroupRel(),
         ],
     )

--- a/cartography/models/aws/ec2/networkinterface_instance.py
+++ b/cartography/models/aws/ec2/networkinterface_instance.py
@@ -29,7 +29,7 @@ class EC2NetworkInterfaceInstanceNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2NetworkInterfaceToAWSAccountRelRelProperties(CartographyRelProperties):
+class EC2NetworkInterfaceToAWSAccountRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -41,8 +41,8 @@ class EC2NetworkInterfaceToAWSAccountRel(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2NetworkInterfaceToAWSAccountRelRelProperties = (
-        EC2NetworkInterfaceToAWSAccountRelRelProperties()
+    properties: EC2NetworkInterfaceToAWSAccountRelProperties = (
+        EC2NetworkInterfaceToAWSAccountRelProperties()
     )
 
 

--- a/cartography/models/aws/ec2/networkinterfaces.py
+++ b/cartography/models/aws/ec2/networkinterfaces.py
@@ -1,16 +1,16 @@
 from dataclasses import dataclass
 
 from cartography.models.aws.ec2.networkinterface_instance import (
-    EC2NetworkInterfaceToAWSAccount,
+    EC2NetworkInterfaceToAWSAccountRel,
 )
 from cartography.models.aws.ec2.networkinterface_instance import (
-    EC2NetworkInterfaceToEC2Instance,
+    EC2NetworkInterfaceToEC2InstanceRel,
 )
 from cartography.models.aws.ec2.networkinterface_instance import (
-    EC2NetworkInterfaceToEC2SecurityGroup,
+    EC2NetworkInterfaceToEC2SecurityGroupRel,
 )
 from cartography.models.aws.ec2.networkinterface_instance import (
-    EC2NetworkInterfaceToEC2Subnet,
+    EC2NetworkInterfaceToEC2SubnetRel,
 )
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
@@ -48,38 +48,38 @@ class EC2NetworkInterfaceNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2NetworkInterfaceToElbRelProperties(CartographyRelProperties):
+class EC2NetworkInterfaceToElbRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2NetworkInterfaceToElb(CartographyRelSchema):
+class EC2NetworkInterfaceToElbRel(CartographyRelSchema):
     target_node_label: str = "LoadBalancer"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"name": PropertyRef("ElbV1Id")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "NETWORK_INTERFACE"
-    properties: EC2NetworkInterfaceToElbRelProperties = (
-        EC2NetworkInterfaceToElbRelProperties()
+    properties: EC2NetworkInterfaceToElbRelRelProperties = (
+        EC2NetworkInterfaceToElbRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class EC2NetworkInterfaceToElbV2RelProperties(CartographyRelProperties):
+class EC2NetworkInterfaceToElbV2RelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2NetworkInterfaceToElbV2(CartographyRelSchema):
+class EC2NetworkInterfaceToElbV2Rel(CartographyRelSchema):
     target_node_label: str = "LoadBalancerV2"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("ElbV2Id")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "NETWORK_INTERFACE"
-    properties: EC2NetworkInterfaceToElbV2RelProperties = (
-        EC2NetworkInterfaceToElbV2RelProperties()
+    properties: EC2NetworkInterfaceToElbV2RelRelProperties = (
+        EC2NetworkInterfaceToElbV2RelRelProperties()
     )
 
 
@@ -91,15 +91,15 @@ class EC2NetworkInterfaceSchema(CartographyNodeSchema):
 
     label: str = "NetworkInterface"
     properties: EC2NetworkInterfaceNodeProperties = EC2NetworkInterfaceNodeProperties()
-    sub_resource_relationship: EC2NetworkInterfaceToAWSAccount = (
-        EC2NetworkInterfaceToAWSAccount()
+    sub_resource_relationship: EC2NetworkInterfaceToAWSAccountRel = (
+        EC2NetworkInterfaceToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2NetworkInterfaceToEC2Subnet(),
-            EC2NetworkInterfaceToEC2SecurityGroup(),
-            EC2NetworkInterfaceToElb(),
-            EC2NetworkInterfaceToElbV2(),
-            EC2NetworkInterfaceToEC2Instance(),
+            EC2NetworkInterfaceToEC2SubnetRel(),
+            EC2NetworkInterfaceToEC2SecurityGroupRel(),
+            EC2NetworkInterfaceToElbRel(),
+            EC2NetworkInterfaceToElbV2Rel(),
+            EC2NetworkInterfaceToEC2InstanceRel(),
         ],
     )

--- a/cartography/models/aws/ec2/privateip_networkinterface.py
+++ b/cartography/models/aws/ec2/privateip_networkinterface.py
@@ -27,20 +27,20 @@ class EC2PrivateIpNetworkInterfaceNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2PrivateIpToAwsAccountRelProperties(CartographyRelProperties):
+class EC2PrivateIpToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2PrivateIpToAWSAccount(CartographyRelSchema):
+class EC2PrivateIpToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2PrivateIpToAwsAccountRelProperties = (
-        EC2PrivateIpToAwsAccountRelProperties()
+    properties: EC2PrivateIpToAWSAccountRelRelProperties = (
+        EC2PrivateIpToAWSAccountRelRelProperties()
     )
 
 
@@ -50,7 +50,7 @@ class EC2NetworkInterfaceToPrivateIpRelProperties(CartographyRelProperties):
 
 
 @dataclass(frozen=True)
-class EC2PrivateIpToNetworkInterface(CartographyRelSchema):
+class EC2PrivateIpToNetworkInterfaceRel(CartographyRelSchema):
     target_node_label: str = "NetworkInterface"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("NetworkInterfaceId")},
@@ -72,9 +72,11 @@ class EC2PrivateIpNetworkInterfaceSchema(CartographyNodeSchema):
     properties: EC2PrivateIpNetworkInterfaceNodeProperties = (
         EC2PrivateIpNetworkInterfaceNodeProperties()
     )
-    sub_resource_relationship: EC2PrivateIpToAWSAccount = EC2PrivateIpToAWSAccount()
+    sub_resource_relationship: EC2PrivateIpToAWSAccountRel = (
+        EC2PrivateIpToAWSAccountRel()
+    )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2PrivateIpToNetworkInterface(),
+            EC2PrivateIpToNetworkInterfaceRel(),
         ],
     )

--- a/cartography/models/aws/ec2/reservations.py
+++ b/cartography/models/aws/ec2/reservations.py
@@ -21,20 +21,20 @@ class EC2ReservationNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2ReservationToAwsAccountRelProperties(CartographyRelProperties):
+class EC2ReservationToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2ReservationToAWSAccount(CartographyRelSchema):
+class EC2ReservationToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2ReservationToAwsAccountRelProperties = (
-        EC2ReservationToAwsAccountRelProperties()
+    properties: EC2ReservationToAWSAccountRelRelProperties = (
+        EC2ReservationToAWSAccountRelRelProperties()
     )
 
 
@@ -42,4 +42,6 @@ class EC2ReservationToAWSAccount(CartographyRelSchema):
 class EC2ReservationSchema(CartographyNodeSchema):
     label: str = "EC2Reservation"
     properties: EC2ReservationNodeProperties = EC2ReservationNodeProperties()
-    sub_resource_relationship: EC2ReservationToAWSAccount = EC2ReservationToAWSAccount()
+    sub_resource_relationship: EC2ReservationToAWSAccountRel = (
+        EC2ReservationToAWSAccountRel()
+    )

--- a/cartography/models/aws/ec2/route_table_associations.py
+++ b/cartography/models/aws/ec2/route_table_associations.py
@@ -27,56 +27,56 @@ class RouteTableAssociationNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class RouteTableAssociationToAwsAccountRelProperties(CartographyRelProperties):
+class RouteTableAssociationToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class RouteTableAssociationToAWSAccount(CartographyRelSchema):
+class RouteTableAssociationToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: RouteTableAssociationToAwsAccountRelProperties = (
-        RouteTableAssociationToAwsAccountRelProperties()
+    properties: RouteTableAssociationToAWSAccountRelRelProperties = (
+        RouteTableAssociationToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class RouteTableAssociationToSubnetRelProperties(CartographyRelProperties):
+class RouteTableAssociationToSubnetRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class RouteTableAssociationToSubnet(CartographyRelSchema):
+class RouteTableAssociationToSubnetRel(CartographyRelSchema):
     target_node_label: str = "EC2Subnet"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"subnetid": PropertyRef("subnet_id")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "ASSOCIATED_SUBNET"
-    properties: RouteTableAssociationToSubnetRelProperties = (
-        RouteTableAssociationToSubnetRelProperties()
+    properties: RouteTableAssociationToSubnetRelRelProperties = (
+        RouteTableAssociationToSubnetRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class RouteTableAssociationToIgwRelProperties(CartographyRelProperties):
+class RouteTableAssociationToIgwRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class RouteTableAssociationToIgw(CartographyRelSchema):
+class RouteTableAssociationToIgwRel(CartographyRelSchema):
     target_node_label: str = "AWSInternetGateway"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("gateway_id")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "ASSOCIATED_IGW_FOR_INGRESS"
-    properties: RouteTableAssociationToIgwRelProperties = (
-        RouteTableAssociationToIgwRelProperties()
+    properties: RouteTableAssociationToIgwRelRelProperties = (
+        RouteTableAssociationToIgwRelRelProperties()
     )
 
 
@@ -86,12 +86,12 @@ class RouteTableAssociationSchema(CartographyNodeSchema):
     properties: RouteTableAssociationNodeProperties = (
         RouteTableAssociationNodeProperties()
     )
-    sub_resource_relationship: RouteTableAssociationToAWSAccount = (
-        RouteTableAssociationToAWSAccount()
+    sub_resource_relationship: RouteTableAssociationToAWSAccountRel = (
+        RouteTableAssociationToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            RouteTableAssociationToSubnet(),
-            RouteTableAssociationToIgw(),
+            RouteTableAssociationToSubnetRel(),
+            RouteTableAssociationToIgwRel(),
         ],
     )

--- a/cartography/models/aws/ec2/route_tables.py
+++ b/cartography/models/aws/ec2/route_tables.py
@@ -27,89 +27,89 @@ class RouteTableNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class RouteTableToAwsAccountRelProperties(CartographyRelProperties):
+class RouteTableToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class RouteTableToAWSAccount(CartographyRelSchema):
+class RouteTableToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: RouteTableToAwsAccountRelProperties = (
-        RouteTableToAwsAccountRelProperties()
+    properties: RouteTableToAWSAccountRelRelProperties = (
+        RouteTableToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class RouteTableToVpcRelProperties(CartographyRelProperties):
+class RouteTableToVpcRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class RouteTableToVpc(CartographyRelSchema):
+class RouteTableToVpcRel(CartographyRelSchema):
     target_node_label: str = "AWSVpc"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("vpc_id")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "MEMBER_OF_AWS_VPC"
-    properties: RouteTableToVpcRelProperties = RouteTableToVpcRelProperties()
+    properties: RouteTableToVpcRelRelProperties = RouteTableToVpcRelRelProperties()
 
 
 @dataclass(frozen=True)
-class RouteTableToRouteRelProperties(CartographyRelProperties):
+class RouteTableToRouteRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class RouteTableToRoute(CartographyRelSchema):
+class RouteTableToRouteRel(CartographyRelSchema):
     target_node_label: str = "EC2Route"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("RouteIds", one_to_many=True)},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "ROUTE"
-    properties: RouteTableToRouteRelProperties = RouteTableToRouteRelProperties()
+    properties: RouteTableToRouteRelRelProperties = RouteTableToRouteRelRelProperties()
 
 
 @dataclass(frozen=True)
-class RouteTableToAssociationRelProperties(CartographyRelProperties):
+class RouteTableToAssociationRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class RouteTableToAssociation(CartographyRelSchema):
+class RouteTableToAssociationRel(CartographyRelSchema):
     target_node_label: str = "EC2RouteTableAssociation"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("RouteTableAssociationIds", one_to_many=True)},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "ASSOCIATION"
-    properties: RouteTableToAssociationRelProperties = (
-        RouteTableToAssociationRelProperties()
+    properties: RouteTableToAssociationRelRelProperties = (
+        RouteTableToAssociationRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class RouteTableToVpnGatewayRelProperties(CartographyRelProperties):
+class RouteTableToVpnGatewayRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 # TODO implement AWSVpnGateways
 @dataclass(frozen=True)
-class RouteTableToVpnGateway(CartographyRelSchema):
+class RouteTableToVpnGatewayRel(CartographyRelSchema):
     target_node_label: str = "AWSVpnGateway"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("VpnGatewayIds", one_to_many=True)},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "CONNECTED_TO"
-    properties: RouteTableToVpnGatewayRelProperties = (
-        RouteTableToVpnGatewayRelProperties()
+    properties: RouteTableToVpnGatewayRelRelProperties = (
+        RouteTableToVpnGatewayRelRelProperties()
     )
 
 
@@ -117,12 +117,12 @@ class RouteTableToVpnGateway(CartographyRelSchema):
 class RouteTableSchema(CartographyNodeSchema):
     label: str = "EC2RouteTable"
     properties: RouteTableNodeProperties = RouteTableNodeProperties()
-    sub_resource_relationship: RouteTableToAWSAccount = RouteTableToAWSAccount()
+    sub_resource_relationship: RouteTableToAWSAccountRel = RouteTableToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            RouteTableToVpc(),
-            RouteTableToRoute(),
-            RouteTableToAssociation(),
-            RouteTableToVpnGateway(),
+            RouteTableToVpcRel(),
+            RouteTableToRouteRel(),
+            RouteTableToAssociationRel(),
+            RouteTableToVpnGatewayRel(),
         ],
     )

--- a/cartography/models/aws/ec2/routes.py
+++ b/cartography/models/aws/ec2/routes.py
@@ -40,36 +40,36 @@ class RouteNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class RouteToAwsAccountRelProperties(CartographyRelProperties):
+class RouteToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class RouteToAWSAccount(CartographyRelSchema):
+class RouteToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: RouteToAwsAccountRelProperties = RouteToAwsAccountRelProperties()
+    properties: RouteToAWSAccountRelRelProperties = RouteToAWSAccountRelRelProperties()
 
 
 @dataclass(frozen=True)
-class RouteToInternetGatewayRelProperties(CartographyRelProperties):
+class RouteToInternetGatewayRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class RouteToInternetGateway(CartographyRelSchema):
+class RouteToInternetGatewayRel(CartographyRelSchema):
     target_node_label: str = "AWSInternetGateway"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("gateway_id")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "ROUTES_TO_GATEWAY"
-    properties: RouteToInternetGatewayRelProperties = (
-        RouteToInternetGatewayRelProperties()
+    properties: RouteToInternetGatewayRelRelProperties = (
+        RouteToInternetGatewayRelRelProperties()
     )
 
 
@@ -77,9 +77,9 @@ class RouteToInternetGateway(CartographyRelSchema):
 class RouteSchema(CartographyNodeSchema):
     label: str = "EC2Route"
     properties: RouteNodeProperties = RouteNodeProperties()
-    sub_resource_relationship: RouteToAWSAccount = RouteToAWSAccount()
+    sub_resource_relationship: RouteToAWSAccountRel = RouteToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            RouteToInternetGateway(),
+            RouteToInternetGatewayRel(),
         ]
     )

--- a/cartography/models/aws/ec2/securitygroup_instance.py
+++ b/cartography/models/aws/ec2/securitygroup_instance.py
@@ -21,38 +21,38 @@ class EC2SecurityGroupInstanceNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2SecurityGroupToAwsAccountRelProperties(CartographyRelProperties):
+class EC2SecurityGroupToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2SecurityGroupToAWSAccount(CartographyRelSchema):
+class EC2SecurityGroupToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2SecurityGroupToAwsAccountRelProperties = (
-        EC2SecurityGroupToAwsAccountRelProperties()
+    properties: EC2SecurityGroupToAWSAccountRelRelProperties = (
+        EC2SecurityGroupToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class EC2SecurityGroupToEC2InstanceRelProperties(CartographyRelProperties):
+class EC2SecurityGroupToEC2InstanceRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2SecurityGroupToEC2Instance(CartographyRelSchema):
+class EC2SecurityGroupToEC2InstanceRel(CartographyRelSchema):
     target_node_label: str = "EC2Instance"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("InstanceId")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "MEMBER_OF_EC2_SECURITY_GROUP"
-    properties: EC2SecurityGroupToEC2InstanceRelProperties = (
-        EC2SecurityGroupToEC2InstanceRelProperties()
+    properties: EC2SecurityGroupToEC2InstanceRelRelProperties = (
+        EC2SecurityGroupToEC2InstanceRelRelProperties()
     )
 
 
@@ -66,11 +66,11 @@ class EC2SecurityGroupInstanceSchema(CartographyNodeSchema):
     properties: EC2SecurityGroupInstanceNodeProperties = (
         EC2SecurityGroupInstanceNodeProperties()
     )
-    sub_resource_relationship: EC2SecurityGroupToAWSAccount = (
-        EC2SecurityGroupToAWSAccount()
+    sub_resource_relationship: EC2SecurityGroupToAWSAccountRel = (
+        EC2SecurityGroupToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2SecurityGroupToEC2Instance(),
+            EC2SecurityGroupToEC2InstanceRel(),
         ],
     )

--- a/cartography/models/aws/ec2/securitygroup_networkinterface.py
+++ b/cartography/models/aws/ec2/securitygroup_networkinterface.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from cartography.models.aws.ec2.securitygroup_instance import (
-    EC2SecurityGroupToAWSAccount,
+    EC2SecurityGroupToAWSAccountRel,
 )
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
@@ -24,20 +24,20 @@ class EC2SecurityGroupNetworkInterfaceNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2SubnetToNetworkInterfaceRelProperties(CartographyRelProperties):
+class EC2SubnetToNetworkInterfaceRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2SecurityGroupToNetworkInterface(CartographyRelSchema):
+class EC2SecurityGroupToNetworkInterfaceRel(CartographyRelSchema):
     target_node_label: str = "NetworkInterface"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("NetworkInterfaceId")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "MEMBER_OF_EC2_SECURITY_GROUP"
-    properties: EC2SubnetToNetworkInterfaceRelProperties = (
-        EC2SubnetToNetworkInterfaceRelProperties()
+    properties: EC2SubnetToNetworkInterfaceRelRelProperties = (
+        EC2SubnetToNetworkInterfaceRelRelProperties()
     )
 
 
@@ -51,11 +51,11 @@ class EC2SecurityGroupNetworkInterfaceSchema(CartographyNodeSchema):
     properties: EC2SecurityGroupNetworkInterfaceNodeProperties = (
         EC2SecurityGroupNetworkInterfaceNodeProperties()
     )
-    sub_resource_relationship: EC2SecurityGroupToAWSAccount = (
-        EC2SecurityGroupToAWSAccount()
+    sub_resource_relationship: EC2SecurityGroupToAWSAccountRel = (
+        EC2SecurityGroupToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2SecurityGroupToNetworkInterface(),
+            EC2SecurityGroupToNetworkInterfaceRel(),
         ],
     )

--- a/cartography/models/aws/ec2/subnet_instance.py
+++ b/cartography/models/aws/ec2/subnet_instance.py
@@ -21,38 +21,38 @@ class EC2SubnetInstanceNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2SubnetToAwsAccountRelProperties(CartographyRelProperties):
+class EC2SubnetToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2SubnetToAWSAccount(CartographyRelSchema):
+class EC2SubnetToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EC2SubnetToAwsAccountRelProperties = (
-        EC2SubnetToAwsAccountRelProperties()
+    properties: EC2SubnetToAWSAccountRelRelProperties = (
+        EC2SubnetToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class EC2SubnetToEC2InstanceRelProperties(CartographyRelProperties):
+class EC2SubnetToEC2InstanceRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2SubnetToEC2Instance(CartographyRelSchema):
+class EC2SubnetToEC2InstanceRel(CartographyRelSchema):
     target_node_label: str = "EC2Instance"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("InstanceId")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "PART_OF_SUBNET"
-    properties: EC2SubnetToEC2InstanceRelProperties = (
-        EC2SubnetToEC2InstanceRelProperties()
+    properties: EC2SubnetToEC2InstanceRelRelProperties = (
+        EC2SubnetToEC2InstanceRelRelProperties()
     )
 
 
@@ -64,9 +64,9 @@ class EC2SubnetInstanceSchema(CartographyNodeSchema):
 
     label: str = "EC2Subnet"
     properties: EC2SubnetInstanceNodeProperties = EC2SubnetInstanceNodeProperties()
-    sub_resource_relationship: EC2SubnetToAWSAccount = EC2SubnetToAWSAccount()
+    sub_resource_relationship: EC2SubnetToAWSAccountRel = EC2SubnetToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2SubnetToEC2Instance(),
+            EC2SubnetToEC2InstanceRel(),
         ],
     )

--- a/cartography/models/aws/ec2/subnet_networkinterface.py
+++ b/cartography/models/aws/ec2/subnet_networkinterface.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
-from cartography.models.aws.ec2.subnet_instance import EC2SubnetToAWSAccount
-from cartography.models.aws.ec2.subnet_instance import EC2SubnetToEC2Instance
+from cartography.models.aws.ec2.subnet_instance import EC2SubnetToAWSAccountRel
+from cartography.models.aws.ec2.subnet_instance import EC2SubnetToEC2InstanceRel
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
@@ -22,56 +22,56 @@ class EC2SubnetNetworkInterfaceNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EC2SubnetToNetworkInterfaceRelProperties(CartographyRelProperties):
+class EC2SubnetToNetworkInterfaceRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2SubnetToNetworkInterface(CartographyRelSchema):
+class EC2SubnetToNetworkInterfaceRel(CartographyRelSchema):
     target_node_label: str = "NetworkInterface"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("NetworkInterfaceId")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "PART_OF_SUBNET"
-    properties: EC2SubnetToNetworkInterfaceRelProperties = (
-        EC2SubnetToNetworkInterfaceRelProperties()
+    properties: EC2SubnetToNetworkInterfaceRelRelProperties = (
+        EC2SubnetToNetworkInterfaceRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class EC2SubnetToLoadBalancerRelProperties(CartographyRelProperties):
+class EC2SubnetToLoadBalancerRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2SubnetToLoadBalancer(CartographyRelSchema):
+class EC2SubnetToLoadBalancerRel(CartographyRelSchema):
     target_node_label: str = "LoadBalancer"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("ElbV1Id")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "PART_OF_SUBNET"
-    properties: EC2SubnetToLoadBalancerRelProperties = (
-        EC2SubnetToLoadBalancerRelProperties()
+    properties: EC2SubnetToLoadBalancerRelRelProperties = (
+        EC2SubnetToLoadBalancerRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class EC2SubnetToLoadBalancerV2RelProperties(CartographyRelProperties):
+class EC2SubnetToLoadBalancerV2RelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EC2SubnetToLoadBalancerV2(CartographyRelSchema):
+class EC2SubnetToLoadBalancerV2Rel(CartographyRelSchema):
     target_node_label: str = "LoadBalancerV2"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("ElbV2Id")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "PART_OF_SUBNET"
-    properties: EC2SubnetToLoadBalancerV2RelProperties = (
-        EC2SubnetToLoadBalancerV2RelProperties()
+    properties: EC2SubnetToLoadBalancerV2RelRelProperties = (
+        EC2SubnetToLoadBalancerV2RelRelProperties()
     )
 
 
@@ -85,12 +85,12 @@ class EC2SubnetNetworkInterfaceSchema(CartographyNodeSchema):
     properties: EC2SubnetNetworkInterfaceNodeProperties = (
         EC2SubnetNetworkInterfaceNodeProperties()
     )
-    sub_resource_relationship: EC2SubnetToAWSAccount = EC2SubnetToAWSAccount()
+    sub_resource_relationship: EC2SubnetToAWSAccountRel = EC2SubnetToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EC2SubnetToNetworkInterface(),
-            EC2SubnetToEC2Instance(),
-            EC2SubnetToLoadBalancer(),
-            EC2SubnetToLoadBalancerV2(),
+            EC2SubnetToNetworkInterfaceRel(),
+            EC2SubnetToEC2InstanceRel(),
+            EC2SubnetToLoadBalancerRel(),
+            EC2SubnetToLoadBalancerV2Rel(),
         ],
     )

--- a/cartography/models/aws/ec2/volumes.py
+++ b/cartography/models/aws/ec2/volumes.py
@@ -33,38 +33,38 @@ class EBSVolumeNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EBSVolumeToAwsAccountRelProperties(CartographyRelProperties):
+class EBSVolumeToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EBSVolumeToAWSAccount(CartographyRelSchema):
+class EBSVolumeToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EBSVolumeToAwsAccountRelProperties = (
-        EBSVolumeToAwsAccountRelProperties()
+    properties: EBSVolumeToAWSAccountRelRelProperties = (
+        EBSVolumeToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class EBSVolumeToEC2InstanceRelProperties(CartographyRelProperties):
+class EBSVolumeToEC2InstanceRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EBSVolumeToEC2Instance(CartographyRelSchema):
+class EBSVolumeToEC2InstanceRel(CartographyRelSchema):
     target_node_label: str = "EC2Instance"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("InstanceId")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "ATTACHED_TO"
-    properties: EBSVolumeToEC2InstanceRelProperties = (
-        EBSVolumeToEC2InstanceRelProperties()
+    properties: EBSVolumeToEC2InstanceRelRelProperties = (
+        EBSVolumeToEC2InstanceRelRelProperties()
     )
 
 
@@ -76,10 +76,10 @@ class EBSVolumeSchema(CartographyNodeSchema):
 
     label: str = "EBSVolume"
     properties: EBSVolumeNodeProperties = EBSVolumeNodeProperties()
-    sub_resource_relationship: EBSVolumeToAWSAccount = EBSVolumeToAWSAccount()
+    sub_resource_relationship: EBSVolumeToAWSAccountRel = EBSVolumeToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EBSVolumeToEC2Instance(),
+            EBSVolumeToEC2InstanceRel(),
         ],
     )
 
@@ -106,9 +106,9 @@ class EBSVolumeInstanceSchema(CartographyNodeSchema):
 
     label: str = "EBSVolume"
     properties: EBSVolumeInstanceProperties = EBSVolumeInstanceProperties()
-    sub_resource_relationship: EBSVolumeToAWSAccount = EBSVolumeToAWSAccount()
+    sub_resource_relationship: EBSVolumeToAWSAccountRel = EBSVolumeToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            EBSVolumeToEC2Instance(),
+            EBSVolumeToEC2InstanceRel(),
         ],
     )

--- a/cartography/models/aws/eks/clusters.py
+++ b/cartography/models/aws/eks/clusters.py
@@ -28,20 +28,20 @@ class EKSClusterNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EKSClusterToAwsAccountRelProperties(CartographyRelProperties):
+class EKSClusterToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class EKSClusterToAWSAccount(CartographyRelSchema):
+class EKSClusterToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EKSClusterToAwsAccountRelProperties = (
-        EKSClusterToAwsAccountRelProperties()
+    properties: EKSClusterToAWSAccountRelRelProperties = (
+        EKSClusterToAWSAccountRelRelProperties()
     )
 
 
@@ -49,4 +49,4 @@ class EKSClusterToAWSAccount(CartographyRelSchema):
 class EKSClusterSchema(CartographyNodeSchema):
     label: str = "EKSCluster"
     properties: EKSClusterNodeProperties = EKSClusterNodeProperties()
-    sub_resource_relationship: EKSClusterToAWSAccount = EKSClusterToAWSAccount()
+    sub_resource_relationship: EKSClusterToAWSAccountRel = EKSClusterToAWSAccountRel()

--- a/cartography/models/aws/emr.py
+++ b/cartography/models/aws/emr.py
@@ -37,21 +37,21 @@ class EMRClusterNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class EMRClusterToAwsAccountRelProperties(CartographyRelProperties):
+class EMRClusterToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
 # (:EMRCluster)<-[:RESOURCE]-(:AWSAccount)
-class EMRClusterToAWSAccount(CartographyRelSchema):
+class EMRClusterToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: EMRClusterToAwsAccountRelProperties = (
-        EMRClusterToAwsAccountRelProperties()
+    properties: EMRClusterToAWSAccountRelRelProperties = (
+        EMRClusterToAWSAccountRelRelProperties()
     )
 
 
@@ -59,4 +59,4 @@ class EMRClusterToAWSAccount(CartographyRelSchema):
 class EMRClusterSchema(CartographyNodeSchema):
     label: str = "EMRCluster"
     properties: EMRClusterNodeProperties = EMRClusterNodeProperties()
-    sub_resource_relationship: EMRClusterToAWSAccount = EMRClusterToAWSAccount()
+    sub_resource_relationship: EMRClusterToAWSAccountRel = EMRClusterToAWSAccountRel()

--- a/cartography/models/aws/iam/instanceprofile.py
+++ b/cartography/models/aws/iam/instanceprofile.py
@@ -27,38 +27,38 @@ class InstanceProfileNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class InstanceProfileToAwsAccountRelProperties(CartographyRelProperties):
+class InstanceProfileToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class InstanceProfileToAWSAccount(CartographyRelSchema):
+class InstanceProfileToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: InstanceProfileToAwsAccountRelProperties = (
-        InstanceProfileToAwsAccountRelProperties()
+    properties: InstanceProfileToAWSAccountRelRelProperties = (
+        InstanceProfileToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class InstanceProfileToAWSRoleRelProperties(CartographyRelProperties):
+class InstanceProfileToAWSRoleRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class InstanceProfileToAWSRole(CartographyRelSchema):
+class InstanceProfileToAWSRoleRel(CartographyRelSchema):
     target_node_label: str = "AWSRole"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"arn": PropertyRef("Roles", one_to_many=True)},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "ASSOCIATED_WITH"
-    properties: InstanceProfileToAWSRoleRelProperties = (
-        InstanceProfileToAWSRoleRelProperties()
+    properties: InstanceProfileToAWSRoleRelRelProperties = (
+        InstanceProfileToAWSRoleRelRelProperties()
     )
 
 
@@ -66,11 +66,11 @@ class InstanceProfileToAWSRole(CartographyRelSchema):
 class InstanceProfileSchema(CartographyNodeSchema):
     label: str = "AWSInstanceProfile"
     properties: InstanceProfileNodeProperties = InstanceProfileNodeProperties()
-    sub_resource_relationship: InstanceProfileToAWSAccount = (
-        InstanceProfileToAWSAccount()
+    sub_resource_relationship: InstanceProfileToAWSAccountRel = (
+        InstanceProfileToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            InstanceProfileToAWSRole(),
+            InstanceProfileToAWSRoleRel(),
         ]
     )

--- a/cartography/models/aws/identitycenter/awsidentitycenter.py
+++ b/cartography/models/aws/identitycenter/awsidentitycenter.py
@@ -21,21 +21,21 @@ class IdentityCenterInstanceProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class IdentityCenterToAwsAccountRelProperties(CartographyRelProperties):
+class IdentityCenterToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
 # (:IdentityCenter)<-[:RESOURCE]-(:AWSAccount)
-class IdentityCenterToAWSAccount(CartographyRelSchema):
+class IdentityCenterToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: IdentityCenterToAwsAccountRelProperties = (
-        IdentityCenterToAwsAccountRelProperties()
+    properties: IdentityCenterToAWSAccountRelRelProperties = (
+        IdentityCenterToAWSAccountRelRelProperties()
     )
 
 
@@ -43,4 +43,6 @@ class IdentityCenterToAWSAccount(CartographyRelSchema):
 class AWSIdentityCenterInstanceSchema(CartographyNodeSchema):
     label: str = "AWSIdentityCenter"
     properties: IdentityCenterInstanceProperties = IdentityCenterInstanceProperties()
-    sub_resource_relationship: IdentityCenterToAWSAccount = IdentityCenterToAWSAccount()
+    sub_resource_relationship: IdentityCenterToAWSAccountRel = (
+        IdentityCenterToAWSAccountRel()
+    )

--- a/cartography/models/aws/identitycenter/awspermissionset.py
+++ b/cartography/models/aws/identitycenter/awspermissionset.py
@@ -23,57 +23,57 @@ class PermissionSetProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class PermissionSetToInstanceRelProperties(CartographyRelProperties):
+class PermissionSetToInstanceRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class PermissionSetToInstance(CartographyRelSchema):
+class PermissionSetToInstanceRel(CartographyRelSchema):
     target_node_label: str = "AWSIdentityCenter"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"arn": PropertyRef("InstanceArn", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS_PERMISSION_SET"
-    properties: PermissionSetToInstanceRelProperties = (
-        PermissionSetToInstanceRelProperties()
+    properties: PermissionSetToInstanceRelRelProperties = (
+        PermissionSetToInstanceRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class PermissionSetToAWSRoleRelProperties(CartographyRelProperties):
+class PermissionSetToAWSRoleRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class PermissionSetToAWSRole(CartographyRelSchema):
+class PermissionSetToAWSRoleRel(CartographyRelSchema):
     target_node_label: str = "AWSRole"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"arn": PropertyRef("RoleHint", fuzzy_and_ignore_case=True)},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "ASSIGNED_TO_ROLE"
-    properties: PermissionSetToAWSRoleRelProperties = (
-        PermissionSetToAWSRoleRelProperties()
+    properties: PermissionSetToAWSRoleRelRelProperties = (
+        PermissionSetToAWSRoleRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class AWSPermissionSetToAwsAccountRelProperties(CartographyRelProperties):
+class AWSPermissionSetToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
 # (:IdentityCenter)<-[:RESOURCE]-(:AWSAccount)
-class AWSPermissionSetToAWSAccount(CartographyRelSchema):
+class AWSPermissionSetToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: AWSPermissionSetToAwsAccountRelProperties = (
-        AWSPermissionSetToAwsAccountRelProperties()
+    properties: AWSPermissionSetToAWSAccountRelRelProperties = (
+        AWSPermissionSetToAWSAccountRelRelProperties()
     )
 
 
@@ -81,12 +81,12 @@ class AWSPermissionSetToAWSAccount(CartographyRelSchema):
 class AWSPermissionSetSchema(CartographyNodeSchema):
     label: str = "AWSPermissionSet"
     properties: PermissionSetProperties = PermissionSetProperties()
-    sub_resource_relationship: AWSPermissionSetToAWSAccount = (
-        AWSPermissionSetToAWSAccount()
+    sub_resource_relationship: AWSPermissionSetToAWSAccountRel = (
+        AWSPermissionSetToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            PermissionSetToInstance(),
-            PermissionSetToAWSRole(),
+            PermissionSetToInstanceRel(),
+            PermissionSetToAWSRoleRel(),
         ],
     )

--- a/cartography/models/aws/identitycenter/awsssouser.py
+++ b/cartography/models/aws/identitycenter/awsssouser.py
@@ -23,37 +23,37 @@ class SSOUserProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class SSOUserToOktaUserRelProperties(CartographyRelProperties):
+class SSOUserToOktaUserRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class SSOUserToOktaUser(CartographyRelSchema):
+class SSOUserToOktaUserRel(CartographyRelSchema):
     target_node_label: str = "UserAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("ExternalId")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "CAN_ASSUME_IDENTITY"
-    properties: SSOUserToOktaUserRelProperties = SSOUserToOktaUserRelProperties()
+    properties: SSOUserToOktaUserRelRelProperties = SSOUserToOktaUserRelRelProperties()
 
 
 @dataclass(frozen=True)
-class AWSSSOUserToAwsAccountRelProperties(CartographyRelProperties):
+class AWSSSOUserToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
 # (:IdentityCenter)<-[:RESOURCE]-(:AWSAccount)
-class AWSSSOUserToAWSAccount(CartographyRelSchema):
+class AWSSSOUserToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: AWSSSOUserToAwsAccountRelProperties = (
-        AWSSSOUserToAwsAccountRelProperties()
+    properties: AWSSSOUserToAWSAccountRelRelProperties = (
+        AWSSSOUserToAWSAccountRelRelProperties()
     )
 
 
@@ -62,9 +62,9 @@ class AWSSSOUserSchema(CartographyNodeSchema):
     label: str = "AWSSSOUser"
     properties: SSOUserProperties = SSOUserProperties()
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["UserAccount"])
-    sub_resource_relationship: AWSSSOUserToAWSAccount = AWSSSOUserToAWSAccount()
+    sub_resource_relationship: AWSSSOUserToAWSAccountRel = AWSSSOUserToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            SSOUserToOktaUser(),
+            SSOUserToOktaUserRel(),
         ],
     )

--- a/cartography/models/aws/inspector/findings.py
+++ b/cartography/models/aws/inspector/findings.py
@@ -46,92 +46,92 @@ class AWSInspectorNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class InspectorFindingToAwsAccountRelProperties(CartographyRelProperties):
+class InspectorFindingToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class InspectorFindingToAWSAccount(CartographyRelSchema):
+class InspectorFindingToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: InspectorFindingToAwsAccountRelProperties = (
-        InspectorFindingToAwsAccountRelProperties()
+    properties: InspectorFindingToAWSAccountRelRelProperties = (
+        InspectorFindingToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class InspectorFindingToAwsAccountDelegateRelProperties(CartographyRelProperties):
+class InspectorFindingToAWSAccountRelDelegateRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class InspectorFindingToAWSAccountDelegate(CartographyRelSchema):
+class InspectorFindingToAWSAccountRelDelegateRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("awsaccount")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "MEMBER"
-    properties: InspectorFindingToAwsAccountDelegateRelProperties = (
-        InspectorFindingToAwsAccountDelegateRelProperties()
+    properties: InspectorFindingToAWSAccountRelDelegateRelRelProperties = (
+        InspectorFindingToAWSAccountRelDelegateRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class InspectorFindingToEC2InstanceRelProperties(CartographyRelProperties):
+class InspectorFindingToEC2InstanceRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class InspectorFindingToEC2Instance(CartographyRelSchema):
+class InspectorFindingToEC2InstanceRel(CartographyRelSchema):
     target_node_label: str = "EC2Instance"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("instanceid")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "AFFECTS"
-    properties: InspectorFindingToEC2InstanceRelProperties = (
-        InspectorFindingToEC2InstanceRelProperties()
+    properties: InspectorFindingToEC2InstanceRelRelProperties = (
+        InspectorFindingToEC2InstanceRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class InspectorFindingToECRRepositoryRelProperties(CartographyRelProperties):
+class InspectorFindingToECRRepositoryRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class InspectorFindingToECRRepository(CartographyRelSchema):
+class InspectorFindingToECRRepositoryRel(CartographyRelSchema):
     target_node_label: str = "ECRRepository"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("ecrrepositoryid")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "AFFECTS"
-    properties: InspectorFindingToECRRepositoryRelProperties = (
-        InspectorFindingToECRRepositoryRelProperties()
+    properties: InspectorFindingToECRRepositoryRelRelProperties = (
+        InspectorFindingToECRRepositoryRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class InspectorFindingToECRImageRelProperties(CartographyRelProperties):
+class InspectorFindingToECRImageRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class InspectorFindingToECRImage(CartographyRelSchema):
+class InspectorFindingToECRImageRel(CartographyRelSchema):
     target_node_label: str = "ECRImage"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("ecrimageid")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "AFFECTS"
-    properties: InspectorFindingToECRImageRelProperties = (
-        InspectorFindingToECRImageRelProperties()
+    properties: InspectorFindingToECRImageRelRelProperties = (
+        InspectorFindingToECRImageRelRelProperties()
     )
 
 
@@ -140,14 +140,14 @@ class AWSInspectorFindingSchema(CartographyNodeSchema):
     label: str = "AWSInspectorFinding"
     properties: AWSInspectorNodeProperties = AWSInspectorNodeProperties()
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Risk"])
-    sub_resource_relationship: InspectorFindingToAWSAccount = (
-        InspectorFindingToAWSAccount()
+    sub_resource_relationship: InspectorFindingToAWSAccountRel = (
+        InspectorFindingToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            InspectorFindingToEC2Instance(),
-            InspectorFindingToECRRepository(),
-            InspectorFindingToECRImage(),
-            InspectorFindingToAWSAccountDelegate(),
+            InspectorFindingToEC2InstanceRel(),
+            InspectorFindingToECRRepositoryRel(),
+            InspectorFindingToECRImageRel(),
+            InspectorFindingToAWSAccountRelDelegateRel(),
         ],
     )

--- a/cartography/models/aws/inspector/packages.py
+++ b/cartography/models/aws/inspector/packages.py
@@ -30,38 +30,38 @@ class AWSInspectorPackageNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class InspectorPackageToAwsAccountRelProperties(CartographyRelProperties):
+class InspectorPackageToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class InspectorPackageToAWSAccount(CartographyRelSchema):
+class InspectorPackageToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: InspectorPackageToAwsAccountRelProperties = (
-        InspectorPackageToAwsAccountRelProperties()
+    properties: InspectorPackageToAWSAccountRelRelProperties = (
+        InspectorPackageToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class InspectorPackageToFindingRelProperties(CartographyRelProperties):
+class InspectorPackageToFindingRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class InspectorPackageToFinding(CartographyRelSchema):
+class InspectorPackageToFindingRel(CartographyRelSchema):
     target_node_label: str = "AWSInspectorFinding"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("findingarn")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS"
-    properties: InspectorPackageToFindingRelProperties = (
-        InspectorPackageToFindingRelProperties()
+    properties: InspectorPackageToFindingRelRelProperties = (
+        InspectorPackageToFindingRelRelProperties()
     )
 
 
@@ -69,11 +69,11 @@ class InspectorPackageToFinding(CartographyRelSchema):
 class AWSInspectorPackageSchema(CartographyNodeSchema):
     label: str = "AWSInspectorPackage"
     properties: AWSInspectorPackageNodeProperties = AWSInspectorPackageNodeProperties()
-    sub_resource_relationship: InspectorPackageToAWSAccount = (
-        InspectorPackageToAWSAccount()
+    sub_resource_relationship: InspectorPackageToAWSAccountRel = (
+        InspectorPackageToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            InspectorPackageToFinding(),
+            InspectorPackageToFindingRel(),
         ],
     )

--- a/cartography/models/aws/ssm/instance_information.py
+++ b/cartography/models/aws/ssm/instance_information.py
@@ -43,38 +43,38 @@ class SSMInstanceInformationNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class SSMInstanceInformationToAWSAccountRelProperties(CartographyRelProperties):
+class SSMInstanceInformationToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class SSMInstanceInformationToAWSAccount(CartographyRelSchema):
+class SSMInstanceInformationToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: SSMInstanceInformationToAWSAccountRelProperties = (
-        SSMInstanceInformationToAWSAccountRelProperties()
+    properties: SSMInstanceInformationToAWSAccountRelRelProperties = (
+        SSMInstanceInformationToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class SSMInstanceInformationToEC2InstanceRelProperties(CartographyRelProperties):
+class SSMInstanceInformationToEC2InstanceRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class SSMInstanceInformationToEC2Instance(CartographyRelSchema):
+class SSMInstanceInformationToEC2InstanceRel(CartographyRelSchema):
     target_node_label: str = "EC2Instance"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("InstanceId")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS_INFORMATION"
-    properties: SSMInstanceInformationToEC2InstanceRelProperties = (
-        SSMInstanceInformationToEC2InstanceRelProperties()
+    properties: SSMInstanceInformationToEC2InstanceRelRelProperties = (
+        SSMInstanceInformationToEC2InstanceRelRelProperties()
     )
 
 
@@ -84,11 +84,11 @@ class SSMInstanceInformationSchema(CartographyNodeSchema):
     properties: SSMInstanceInformationNodeProperties = (
         SSMInstanceInformationNodeProperties()
     )
-    sub_resource_relationship: SSMInstanceInformationToAWSAccount = (
-        SSMInstanceInformationToAWSAccount()
+    sub_resource_relationship: SSMInstanceInformationToAWSAccountRel = (
+        SSMInstanceInformationToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            SSMInstanceInformationToEC2Instance(),
+            SSMInstanceInformationToEC2InstanceRel(),
         ],
     )

--- a/cartography/models/aws/ssm/instance_patch.py
+++ b/cartography/models/aws/ssm/instance_patch.py
@@ -27,38 +27,38 @@ class SSMInstancePatchNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class SSMInstancePatchToAWSAccountRelProperties(CartographyRelProperties):
+class SSMInstancePatchToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class SSMInstancePatchToAWSAccount(CartographyRelSchema):
+class SSMInstancePatchToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: SSMInstancePatchToAWSAccountRelProperties = (
-        SSMInstancePatchToAWSAccountRelProperties()
+    properties: SSMInstancePatchToAWSAccountRelRelProperties = (
+        SSMInstancePatchToAWSAccountRelRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class SSMInstancePatchToEC2InstanceRelProperties(CartographyRelProperties):
+class SSMInstancePatchToEC2InstanceRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class SSMInstancePatchToEC2Instance(CartographyRelSchema):
+class SSMInstancePatchToEC2InstanceRel(CartographyRelSchema):
     target_node_label: str = "EC2Instance"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("_instance_id")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS_PATCH"
-    properties: SSMInstancePatchToEC2InstanceRelProperties = (
-        SSMInstancePatchToEC2InstanceRelProperties()
+    properties: SSMInstancePatchToEC2InstanceRelRelProperties = (
+        SSMInstancePatchToEC2InstanceRelRelProperties()
     )
 
 
@@ -66,11 +66,11 @@ class SSMInstancePatchToEC2Instance(CartographyRelSchema):
 class SSMInstancePatchSchema(CartographyNodeSchema):
     label: str = "SSMInstancePatch"
     properties: SSMInstancePatchNodeProperties = SSMInstancePatchNodeProperties()
-    sub_resource_relationship: SSMInstancePatchToAWSAccount = (
-        SSMInstancePatchToAWSAccount()
+    sub_resource_relationship: SSMInstancePatchToAWSAccountRel = (
+        SSMInstancePatchToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            SSMInstancePatchToEC2Instance(),
+            SSMInstancePatchToEC2InstanceRel(),
         ],
     )

--- a/cartography/models/core/relationships.py
+++ b/cartography/models/core/relationships.py
@@ -19,16 +19,16 @@ class LinkDirection(Enum):
 
         class EMRCluster(CartographyNodeSchema):
             label: str = "EMRCluster"
-            sub_resource_relationship: CartographyRelSchema = EMRClusterToAWSAccount()
+            sub_resource_relationship: CartographyRelSchema = EMRClusterToAWSAccountRel()
             # ...
 
-        class EMRClusterToAWSAccount(CartographyRelSchema):
+        class EMRClusterToAWSAccountRel(CartographyRelSchema):
             target_node_label: str = "AWSAccount"
             rel_label: str = "RESOURCE"
             direction: LinkDirection = LinkDirection.INWARD
             # ...
 
-    If `EMRClusterToAWSAccount.direction` was LinkDirection.OUTWARD, then the directionality of the relationship would
+    If `EMRClusterToAWSAccountRel.direction` was LinkDirection.OUTWARD, then the directionality of the relationship would
     be `(:EMRCluster)-[:RESOURCE]->(:AWSAccount)` instead.
     """
 

--- a/cartography/models/cve/cve.py
+++ b/cartography/models/cve/cve.py
@@ -44,7 +44,7 @@ class CVEtoCVEFeedRelProperties(CartographyRelProperties):
 
 @dataclass(frozen=True)
 # (:CVE)<-[:RESOURCE]-(:CVEFeed)
-class CVEtoCVEFeedRelSchema(CartographyRelSchema):
+class CVEtoCVEFeedRel(CartographyRelSchema):
     target_node_label: str = "CVEFeed"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("FEED_ID", set_in_kwargs=True)},
@@ -77,7 +77,7 @@ class CVEToSpotlightVulnerabilityRel(CartographyRelSchema):
 class CVESchema(CartographyNodeSchema):
     label: str = "CVE"
     properties: CVENodeProperties = CVENodeProperties()
-    sub_resource_relationship: CVEtoCVEFeedRelSchema = CVEtoCVEFeedRelSchema()
+    sub_resource_relationship: CVEtoCVEFeedRel = CVEtoCVEFeedRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
             CVEToSpotlightVulnerabilityRel(),

--- a/cartography/models/duo/endpoint.py
+++ b/cartography/models/duo/endpoint.py
@@ -64,7 +64,7 @@ class DuoEndpointToDuoApiHostRel(CartographyRelSchema):
     )
 
 
-class DuoEndpointToDuoUserProperties(CartographyRelProperties):
+class DuoEndpointToDuoUserRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -76,7 +76,7 @@ class DuoEndpointToDuoUserRel(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS_DUO_ENDPOINT"
-    properties: DuoEndpointToDuoUserProperties = DuoEndpointToDuoUserProperties()
+    properties: DuoEndpointToDuoUserRelProperties = DuoEndpointToDuoUserRelProperties()
 
 
 @dataclass(frozen=True)

--- a/cartography/models/duo/phone.py
+++ b/cartography/models/duo/phone.py
@@ -49,7 +49,7 @@ class DuoPhoneToDuoApiHostRel(CartographyRelSchema):
     properties: DuoPhoneToDuoApiHostRelProperties = DuoPhoneToDuoApiHostRelProperties()
 
 
-class DuoPhoneToDuoUserProperties(CartographyRelProperties):
+class DuoPhoneToDuoUserRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -61,7 +61,7 @@ class DuoPhoneToDuoUserRel(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS_DUO_PHONE"
-    properties: DuoPhoneToDuoUserProperties = DuoPhoneToDuoUserProperties()
+    properties: DuoPhoneToDuoUserRelProperties = DuoPhoneToDuoUserRelProperties()
 
 
 @dataclass(frozen=True)

--- a/cartography/models/duo/token.py
+++ b/cartography/models/duo/token.py
@@ -38,7 +38,7 @@ class DuoTokenToDuoApiHostRel(CartographyRelSchema):
     properties: DuoTokenToDuoApiHostRelProperties = DuoTokenToDuoApiHostRelProperties()
 
 
-class DuoTokenToDuoUserProperties(CartographyRelProperties):
+class DuoTokenToDuoUserRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -50,7 +50,7 @@ class DuoTokenToDuoUserRel(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS_DUO_TOKEN"
-    properties: DuoTokenToDuoUserProperties = DuoTokenToDuoUserProperties()
+    properties: DuoTokenToDuoUserRelProperties = DuoTokenToDuoUserRelProperties()
 
 
 @dataclass(frozen=True)

--- a/cartography/models/duo/web_authn_credential.py
+++ b/cartography/models/duo/web_authn_credential.py
@@ -40,7 +40,7 @@ class DuoWebAuthnCredentialToDuoApiHostRel(CartographyRelSchema):
     )
 
 
-class DuoWebAuthnCredentialToDuoUserProperties(CartographyRelProperties):
+class DuoWebAuthnCredentialToDuoUserRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -52,8 +52,8 @@ class DuoWebAuthnCredentialToDuoUserRel(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS_DUO_WEB_AUTHN_CREDENTIAL"
-    properties: DuoWebAuthnCredentialToDuoUserProperties = (
-        DuoWebAuthnCredentialToDuoUserProperties()
+    properties: DuoWebAuthnCredentialToDuoUserRelProperties = (
+        DuoWebAuthnCredentialToDuoUserRelProperties()
     )
 
 

--- a/cartography/models/semgrep/dependencies.py
+++ b/cartography/models/semgrep/dependencies.py
@@ -29,7 +29,7 @@ class SemgrepDependencyToSemgrepDeploymentRelProperties(CartographyRelProperties
 
 @dataclass(frozen=True)
 # (:SemgrepDependency)<-[:RESOURCE]-(:SemgrepDeployment)
-class SemgrepDependencyToSemgrepDeploymentSchema(CartographyRelSchema):
+class SemgrepDependencyToSemgrepDeploymentRel(CartographyRelSchema):
     target_node_label: str = "SemgrepDeployment"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("DEPLOYMENT_ID", set_in_kwargs=True)},
@@ -75,8 +75,8 @@ class SemgrepGoLibrarySchema(CartographyNodeSchema):
         ["Dependency", "SemgrepDependency"],
     )
     properties: SemgrepDependencyNodeProperties = SemgrepDependencyNodeProperties()
-    sub_resource_relationship: SemgrepDependencyToSemgrepDeploymentSchema = (
-        SemgrepDependencyToSemgrepDeploymentSchema()
+    sub_resource_relationship: SemgrepDependencyToSemgrepDeploymentRel = (
+        SemgrepDependencyToSemgrepDeploymentRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
@@ -92,8 +92,8 @@ class SemgrepNpmLibrarySchema(CartographyNodeSchema):
         ["Dependency", "SemgrepDependency"],
     )
     properties: SemgrepDependencyNodeProperties = SemgrepDependencyNodeProperties()
-    sub_resource_relationship: SemgrepDependencyToSemgrepDeploymentSchema = (
-        SemgrepDependencyToSemgrepDeploymentSchema()
+    sub_resource_relationship: SemgrepDependencyToSemgrepDeploymentRel = (
+        SemgrepDependencyToSemgrepDeploymentRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [

--- a/cartography/models/semgrep/findings.py
+++ b/cartography/models/semgrep/findings.py
@@ -51,7 +51,7 @@ class SemgrepSCAFindingToSemgrepDeploymentRelProperties(CartographyRelProperties
 
 @dataclass(frozen=True)
 # (:SemgrepSCAFinding)<-[:RESOURCE]-(:SemgrepDeployment)
-class SemgrepSCAFindingToSemgrepDeploymentSchema(CartographyRelSchema):
+class SemgrepSCAFindingToSemgrepDeploymentRel(CartographyRelSchema):
     target_node_label: str = "SemgrepDeployment"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("DEPLOYMENT_ID", set_in_kwargs=True)},
@@ -124,8 +124,8 @@ class SemgrepSCAFindingToCVERel(CartographyRelSchema):
 class SemgrepSCAFindingSchema(CartographyNodeSchema):
     label: str = "SemgrepSCAFinding"
     properties: SemgrepSCAFindingNodeProperties = SemgrepSCAFindingNodeProperties()
-    sub_resource_relationship: SemgrepSCAFindingToSemgrepDeploymentSchema = (
-        SemgrepSCAFindingToSemgrepDeploymentSchema()
+    sub_resource_relationship: SemgrepSCAFindingToSemgrepDeploymentRel = (
+        SemgrepSCAFindingToSemgrepDeploymentRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [

--- a/cartography/models/semgrep/locations.py
+++ b/cartography/models/semgrep/locations.py
@@ -30,7 +30,7 @@ class SemgrepSCALocToSemgrepSCAFindingRelProperties(CartographyRelProperties):
 
 @dataclass(frozen=True)
 # (:SemgrepSCALocation)<-[:USAGE_AT]-(:SemgrepSCAFinding)
-class SemgrepSCALocToSemgrepSCAFindingRelSchema(CartographyRelSchema):
+class SemgrepSCALocToSemgrepSCAFindingRel(CartographyRelSchema):
     target_node_label: str = "SemgrepSCAFinding"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("SCA_ID")},
@@ -49,7 +49,7 @@ class SemgrepSCALocToSemgrepSCADeploymentRelProperties(CartographyRelProperties)
 
 @dataclass(frozen=True)
 # (:SemgrepSCALocation)<-[:RESOURCE]-(:SemgrepSCADeployment)
-class SemgrepSCALocToSCADeploymentRelSchema(CartographyRelSchema):
+class SemgrepSCALocToSCADeploymentRel(CartographyRelSchema):
     target_node_label: str = "SemgrepDeployment"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("DEPLOYMENT_ID", set_in_kwargs=True)},
@@ -65,11 +65,11 @@ class SemgrepSCALocToSCADeploymentRelSchema(CartographyRelSchema):
 class SemgrepSCALocationSchema(CartographyNodeSchema):
     label: str = "SemgrepSCALocation"
     properties: SemgrepSCALocationProperties = SemgrepSCALocationProperties()
-    sub_resource_relationship: SemgrepSCALocToSCADeploymentRelSchema = (
-        SemgrepSCALocToSCADeploymentRelSchema()
+    sub_resource_relationship: SemgrepSCALocToSCADeploymentRel = (
+        SemgrepSCALocToSCADeploymentRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
-            SemgrepSCALocToSemgrepSCAFindingRelSchema(),
+            SemgrepSCALocToSemgrepSCAFindingRel(),
         ],
     )

--- a/cartography/models/snipeit/asset.py
+++ b/cartography/models/snipeit/asset.py
@@ -56,7 +56,7 @@ class SnipeitTenantToSnipeitAssetRel(CartographyRelSchema):
 # (:SnipeitUser)-[:HAS_CHECKED_OUT]->(:SnipeitAsset)
 ###
 @dataclass(frozen=True)
-class SnipeitUserToSnipeitAssetProperties(CartographyRelProperties):
+class SnipeitUserToSnipeitAssetRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -68,8 +68,8 @@ class SnipeitUserToSnipeitAssetRel(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS_CHECKED_OUT"
-    properties: SnipeitUserToSnipeitAssetProperties = (
-        SnipeitUserToSnipeitAssetProperties()
+    properties: SnipeitUserToSnipeitAssetRelProperties = (
+        SnipeitUserToSnipeitAssetRelProperties()
     )
 
 

--- a/docs/root/dev/writing-intel-modules.md
+++ b/docs/root/dev/writing-intel-modules.md
@@ -89,7 +89,7 @@ As an example of a `CartographyNodeSchema`, you can view our [EMRClusterSchema c
 class EMRClusterSchema(CartographyNodeSchema):
     label: str = 'EMRCluster'  # The label of the node
     properties: EMRClusterNodeProperties = EMRClusterNodeProperties()  # An object representing all properties on the EMR Cluster node
-    sub_resource_relationship: EMRClusterToAWSAccount = EMRClusterToAWSAccount()
+    sub_resource_relationship: EMRClusterToAWSAccountRel = EMRClusterToAWSAccountRel()
 ```
 
 An `EMRClusterSchema` object inherits from the `CartographyNodeSchema` class and contains a node label, properties, and connection to its [sub-resource](https://github.com/cartography-cncf/cartography/blob/e6ada9a1a741b83a34c1c3207515a1863debeeb9/cartography/graph/model.py#L216-L228): an `AWSAccount`.
@@ -142,22 +142,22 @@ See [below](#indexescypher) for more information on indexes.
 
 Relationships can be defined on `CartographyNodeSchema` on either their [sub_resource_relationship](https://github.com/cartography-cncf/cartography/blob/e6ada9a1a741b83a34c1c3207515a1863debeeb9/cartography/graph/model.py#L216-L228) field or their [other_relationships](https://github.com/cartography-cncf/cartography/blob/e6ada9a1a741b83a34c1c3207515a1863debeeb9/cartography/graph/model.py#L230-L237) field (you can find an example of `other_relationships` [here in our test data](https://github.com/cartography-cncf/cartography/blob/4bfafe0e0c205909d119cc7f0bae84b9f6944bdd/tests/data/graph/querybuilder/sample_models/interesting_asset.py#L89-L94)).
 
-As seen above, an `EMRClusterSchema` only has a single relationship defined: an [EMRClusterToAWSAccount](https://github.com/cartography-cncf/cartography/blob/e6ada9a1a741b83a34c1c3207515a1863debeeb9/cartography/intel/aws/emr.py#L94-L103):
+As seen above, an `EMRClusterSchema` only has a single relationship defined: an [EMRClusterToAWSAccountRel](https://github.com/cartography-cncf/cartography/blob/e6ada9a1a741b83a34c1c3207515a1863debeeb9/cartography/intel/aws/emr.py#L94-L103):
 
 ```python
 @dataclass(frozen=True)
 # (:EMRCluster)<-[:RESOURCE]-(:AWSAccount)
-class EMRClusterToAWSAccount(CartographyRelSchema):
+class EMRClusterToAWSAccountRel(CartographyRelSchema):
     target_node_label: str = 'AWSAccount'  # (1)
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(  # (2)
         {'id': PropertyRef('AccountId', set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD  # (3)
     rel_label: str = "RESOURCE"  # (4)
-    properties: EMRClusterToAwsAccountRelProperties = EMRClusterToAwsAccountRelProperties()  #  (5)
+    properties: EMRClusterToAWSAccountRelRelProperties = EMRClusterToAWSAccountRelRelProperties()  #  (5)
 ```
 
-This class is best described by explaining how it is processed: `build_ingestion_query()` will traverse the `EMRClusterSchema` to its `sub_resource_relationship` field and find the above `EMRClusterToAWSAccount` object. With this information, we know to
+This class is best described by explaining how it is processed: `build_ingestion_query()` will traverse the `EMRClusterSchema` to its `sub_resource_relationship` field and find the above `EMRClusterToAWSAccountRel` object. With this information, we know to
 - draw a relationship to an `AWSAccount` node (1) using the label "`RESOURCE`" (4)
 - by matching on the AWSAccount's "`id`" field" (2)
 - where the relationship [directionality](https://github.com/cartography-cncf/cartography/blob/e6ada9a1a741b83a34c1c3207515a1863debeeb9/cartography/graph/model.py#L12-L34) is pointed _inward_ toward the EMRCluster (3)
@@ -165,7 +165,7 @@ This class is best described by explaining how it is processed: `build_ingestion
 
 ```python
 @dataclass(frozen=True)
-class EMRClusterToAwsAccountRelProperties(CartographyRelProperties):
+class EMRClusterToAWSAccountRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
 ```
 
@@ -316,7 +316,7 @@ Here's how to represent this in the Cartography data model:
           properties: ...
           sub_resource_relationship: ...
           other_relationships: OtherRelationships = OtherRelationships([
-              InstanceProfileToAWSRole(),
+              InstanceProfileToAWSRoleRel(),
           ])
       ```
 
@@ -324,7 +324,7 @@ Here's how to represent this in the Cartography data model:
 
       ```python
       @dataclass(frozen=True)
-      class InstanceProfileToAWSRole(CartographyRelSchema):
+      class InstanceProfileToAWSRoleRel(CartographyRelSchema):
           target_node_label: str = 'AWSRole'
           target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
               {'arn': PropertyRef('Roles', one_to_many=True)},

--- a/tests/data/graph/querybuilder/sample_models/asset_with_non_kwargs_tgm.py
+++ b/tests/data/graph/querybuilder/sample_models/asset_with_non_kwargs_tgm.py
@@ -11,12 +11,12 @@ from tests.data.graph.querybuilder.sample_models.simple_node import SimpleNodePr
 
 
 @dataclass(frozen=True)
-class FakeEC2InstanceToAWSAccountRelProps(CartographyRelProperties):
+class FakeEC2InstanceToAWSAccountRelRelProps(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class FakeEC2InstanceToAWSAccount(CartographyRelSchema):
+class FakeEC2InstanceToAWSAccountRel(CartographyRelSchema):
     """
     The PropertyRef is intentionally set to False: we expect the unit test to raise an exception.
     Auto cleanups require the sub resource target node matcher to have set_in_kwargs=True because of how the GraphJob
@@ -29,8 +29,8 @@ class FakeEC2InstanceToAWSAccount(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: FakeEC2InstanceToAWSAccountRelProps = (
-        FakeEC2InstanceToAWSAccountRelProps()
+    properties: FakeEC2InstanceToAWSAccountRelRelProps = (
+        FakeEC2InstanceToAWSAccountRelRelProps()
     )
 
 
@@ -38,6 +38,6 @@ class FakeEC2InstanceToAWSAccount(CartographyRelSchema):
 class FakeEC2InstanceSchema(CartographyNodeSchema):
     label: str = "FakeEC2Instance"
     properties: SimpleNodeProperties = SimpleNodeProperties()
-    sub_resource_relationship: FakeEC2InstanceToAWSAccount = (
-        FakeEC2InstanceToAWSAccount()
+    sub_resource_relationship: FakeEC2InstanceToAWSAccountRel = (
+        FakeEC2InstanceToAWSAccountRel()
     )

--- a/tests/unit/cartography/graph/test_cleanupbuilder.py
+++ b/tests/unit/cartography/graph/test_cleanupbuilder.py
@@ -6,13 +6,13 @@ from cartography.graph.cleanupbuilder import _build_cleanup_node_and_rel_queries
 from cartography.graph.cleanupbuilder import _build_cleanup_rel_query_no_sub_resource
 from cartography.graph.cleanupbuilder import build_cleanup_queries
 from cartography.graph.job import get_parameters
-from cartography.models.aws.emr import EMRClusterToAWSAccount
+from cartography.models.aws.emr import EMRClusterToAWSAccountRel
 from cartography.models.github.users import GitHubOrganizationUserSchema
 from tests.data.graph.querybuilder.sample_models.asset_with_non_kwargs_tgm import (
     FakeEC2InstanceSchema,
 )
 from tests.data.graph.querybuilder.sample_models.asset_with_non_kwargs_tgm import (
-    FakeEC2InstanceToAWSAccount,
+    FakeEC2InstanceToAWSAccountRel,
 )
 from tests.data.graph.querybuilder.sample_models.interesting_asset import (
     InterestingAssetSchema,
@@ -84,11 +84,11 @@ def test_cleanup_with_invalid_selected_rel_raises_exc():
     Test that we raise a ValueError if we try to cleanup a node and provide a specified rel but the rel doesn't exist on
     the node schema.
     """
-    exc_msg = "EMRClusterToAWSAccount is not defined on CartographyNodeSchema type InterestingAssetSchema"
+    exc_msg = "EMRClusterToAWSAccountRel is not defined on CartographyNodeSchema type InterestingAssetSchema"
     with pytest.raises(ValueError, match=exc_msg):
         _build_cleanup_node_and_rel_queries(
             InterestingAssetSchema(),
-            EMRClusterToAWSAccount(),
+            EMRClusterToAWSAccountRel(),
         )
 
 
@@ -143,7 +143,7 @@ def test_build_cleanup_node_and_rel_queries_sub_res_tgm_not_validated_raises_exc
     with pytest.raises(ValueError, match="must have set_in_kwargs=True"):
         _build_cleanup_node_and_rel_queries(
             FakeEC2InstanceSchema(),
-            FakeEC2InstanceToAWSAccount(),
+            FakeEC2InstanceToAWSAccountRel(),
         )
 
 

--- a/tests/unit/cartography/graph/test_model.py
+++ b/tests/unit/cartography/graph/test_model.py
@@ -1,0 +1,165 @@
+import inspect
+import logging
+import warnings
+from pkgutil import iter_modules
+from typing import Dict
+from typing import Generator
+from typing import Set
+from typing import Tuple
+from typing import Type
+
+import cartography.models
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+
+logger = logging.getLogger(__name__)
+
+MODEL_CLASSES = (
+    CartographyNodeSchema,
+    CartographyRelSchema,
+    CartographyNodeProperties,
+    CartographyRelProperties,
+)
+
+
+def load_models(module, module_name: str | None = None) -> Generator[
+    Tuple[
+        str,
+        Type[
+            CartographyNodeSchema
+            | CartographyRelSchema
+            | CartographyNodeProperties
+            | CartographyRelProperties
+        ],
+    ],
+    None,
+    None,
+]:
+    # DOC
+    for sub_module_info in iter_modules(module.__path__):
+        sub_module = __import__(
+            f"{module.__name__}.{sub_module_info.name}",
+            fromlist=[""],
+        )
+        if module_name is None:
+            sub_module_name = sub_module.__name__
+        else:
+            sub_module_name = module_name
+        for v in sub_module.__dict__.values():
+            if not inspect.isclass(v):
+                continue
+            if v in MODEL_CLASSES:
+                continue
+            if issubclass(v, MODEL_CLASSES):
+                yield (sub_module_name, v)
+
+        if hasattr(sub_module, "__path__"):
+            yield from load_models(sub_module, sub_module_name)
+
+
+def test_naming_convention():
+    # DOC
+    for module_name, element in load_models(cartography.models):
+        if issubclass(element, CartographyNodeSchema):
+            if not element.__name__.endswith("Schema"):
+                logger.warning(
+                    f"Node {element.__name__} does not comply with naming convention. "
+                    f"Node names should end with 'Schema'."
+                    f" Please rename the class to {element.__name__}Schema."
+                )
+                warnings.warn(
+                    f"Node {element.__name__} does not comply with naming convention. "
+                    f"Node names should end with 'Schema'."
+                    f" Please rename the class to {element.__name__}Schema.",
+                    UserWarning,
+                )
+            # TODO assert element.__name__.endswith("Schema")
+        elif issubclass(element, CartographyRelSchema):
+            if not element.__name__.endswith("Rel"):
+                logger.warning(
+                    f"Relationship {element.__name__} does not comply with naming convention. "
+                    f"Relationship names should end with 'Rel'."
+                    f" Please rename the class to {element.__name__}Rel."
+                )
+                warnings.warn(
+                    f"Relationship {element.__name__} does not comply with naming convention. "
+                    f"Relationship names should end with 'Rel'."
+                    f" Please rename the class to {element.__name__}Rel.",
+                    UserWarning,
+                )
+            # TODO assert element.__name__.endswith("Rel")
+        elif issubclass(element, CartographyNodeProperties):
+            if not element.__name__.endswith("Properties"):
+                logger.warning(
+                    f"Node properties {element.__name__} does not comply with naming convention. "
+                    f"Node properties names should end with 'Properties'."
+                    f" Please rename the class to {element.__name__}Properties."
+                )
+                warnings.warn(
+                    f"Node properties {element.__name__} does not comply with naming convention. "
+                    f"Node properties names should end with 'Properties'."
+                    f" Please rename the class to {element.__name__}Properties.",
+                    UserWarning,
+                )
+            # TODO assert element.__name__.endswith("Properties")
+        elif issubclass(element, CartographyRelProperties):
+            if not element.__name__.endswith("RelProperties"):
+                logger.warning(
+                    f"Relationship properties {element.__name__} does not comply with naming convention. "
+                    f"Relationship properties names should end with 'RelProperties'."
+                    f" Please rename the class to {element.__name__}RelProperties."
+                )
+                warnings.warn(
+                    f"Relationship properties {element.__name__} does not comply with naming convention. "
+                    f"Relationship properties names should end with 'RelProperties'."
+                    f" Please rename the class to {element.__name__}RelProperties.",
+                    UserWarning,
+                )
+            # TODO assert element.__name__.endswith("RelProperties")
+
+
+def test_sub_resource_relationship():
+    # DOC
+    root_node_per_modules: Dict[str, Set[Type[CartographyNodeSchema]]] = {}
+
+    for module_name, node in load_models(cartography.models):
+        if module_name not in root_node_per_modules:
+            root_node_per_modules[module_name] = set()
+        if not issubclass(node, CartographyNodeSchema):
+            continue
+        sub_resource_relationship = getattr(node, "sub_resource_relationship", None)
+        if sub_resource_relationship is None:
+            root_node_per_modules[module_name].add(node)
+            continue
+        if not isinstance(sub_resource_relationship, CartographyRelSchema):
+            root_node_per_modules[module_name].add(node)
+            continue
+        # Check that the rel_label is 'RESOURCE'
+        if sub_resource_relationship.rel_label != "RESOURCE":
+            logger.warning(
+                f"Node {node.label} has a sub_resource_relationship with rel_label {sub_resource_relationship.rel_label}. "
+                f"Expected 'RESOURCE'."
+            )
+            # TODO assert sub_resource_relationship.rel_label == "RESOURCE"
+        # Check that the direction is INWARD
+        if sub_resource_relationship.direction != LinkDirection.INWARD:
+            logger.warning(
+                f"Node {node.label} has a sub_resource_relationship with direction {sub_resource_relationship.direction}. "
+                f"Expected 'INWARD'."
+            )
+            # TODO assert sub_resource_relationship.direction == "INWARD"
+
+    for module_name, nodes in root_node_per_modules.items():
+        if len(nodes) == 0:
+            logger.warning(
+                f"Module {module_name} has no root nodes (e.g. Tenant, Subscription ...). "
+            )
+        if len(nodes) > 1:
+            logger.warning(
+                f"Module {module_name} has multiple root nodes: {', '.join([node.label for node in nodes])}. "
+                f"Please check the module."
+            )
+        # TODO: assert len(nodes) == 1

--- a/tests/unit/cartography/graph/test_model.py
+++ b/tests/unit/cartography/graph/test_model.py
@@ -60,61 +60,41 @@ def load_models(module, module_name: str | None = None) -> Generator[
             yield from load_models(sub_module, sub_module_name)
 
 
-def test_naming_convention():
+def test_model_objects_naming_convention():
     # DOC
     for module_name, element in load_models(cartography.models):
         if issubclass(element, CartographyNodeSchema):
             if not element.__name__.endswith("Schema"):
-                logger.warning(
-                    f"Node {element.__name__} does not comply with naming convention. "
-                    f"Node names should end with 'Schema'."
-                    f" Please rename the class to {element.__name__}Schema."
-                )
                 warnings.warn(
                     f"Node {element.__name__} does not comply with naming convention. "
-                    f"Node names should end with 'Schema'."
+                    "Node names should end with 'Schema'."
                     f" Please rename the class to {element.__name__}Schema.",
                     UserWarning,
                 )
             # TODO assert element.__name__.endswith("Schema")
         elif issubclass(element, CartographyRelSchema):
             if not element.__name__.endswith("Rel"):
-                logger.warning(
-                    f"Relationship {element.__name__} does not comply with naming convention. "
-                    f"Relationship names should end with 'Rel'."
-                    f" Please rename the class to {element.__name__}Rel."
-                )
                 warnings.warn(
                     f"Relationship {element.__name__} does not comply with naming convention. "
-                    f"Relationship names should end with 'Rel'."
+                    "Relationship names should end with 'Rel'."
                     f" Please rename the class to {element.__name__}Rel.",
                     UserWarning,
                 )
             # TODO assert element.__name__.endswith("Rel")
         elif issubclass(element, CartographyNodeProperties):
             if not element.__name__.endswith("Properties"):
-                logger.warning(
-                    f"Node properties {element.__name__} does not comply with naming convention. "
-                    f"Node properties names should end with 'Properties'."
-                    f" Please rename the class to {element.__name__}Properties."
-                )
                 warnings.warn(
                     f"Node properties {element.__name__} does not comply with naming convention. "
-                    f"Node properties names should end with 'Properties'."
+                    "Node properties names should end with 'Properties'."
                     f" Please rename the class to {element.__name__}Properties.",
                     UserWarning,
                 )
             # TODO assert element.__name__.endswith("Properties")
         elif issubclass(element, CartographyRelProperties):
             if not element.__name__.endswith("RelProperties"):
-                logger.warning(
-                    f"Relationship properties {element.__name__} does not comply with naming convention. "
-                    f"Relationship properties names should end with 'RelProperties'."
-                    f" Please rename the class to {element.__name__}RelProperties."
-                )
                 warnings.warn(
                     f"Relationship properties {element.__name__} does not comply with naming convention. "
-                    f"Relationship properties names should end with 'RelProperties'."
+                    "Relationship properties names should end with 'RelProperties'."
                     f" Please rename the class to {element.__name__}RelProperties.",
                     UserWarning,
                 )
@@ -139,27 +119,31 @@ def test_sub_resource_relationship():
             continue
         # Check that the rel_label is 'RESOURCE'
         if sub_resource_relationship.rel_label != "RESOURCE":
-            logger.warning(
+            warnings.warn(
                 f"Node {node.label} has a sub_resource_relationship with rel_label {sub_resource_relationship.rel_label}. "
-                f"Expected 'RESOURCE'."
+                "Expected 'RESOURCE'.",
+                UserWarning,
             )
             # TODO assert sub_resource_relationship.rel_label == "RESOURCE"
         # Check that the direction is INWARD
         if sub_resource_relationship.direction != LinkDirection.INWARD:
-            logger.warning(
+            warnings.warn(
                 f"Node {node.label} has a sub_resource_relationship with direction {sub_resource_relationship.direction}. "
-                f"Expected 'INWARD'."
+                "Expected 'INWARD'.",
+                UserWarning,
             )
             # TODO assert sub_resource_relationship.direction == "INWARD"
 
     for module_name, nodes in root_node_per_modules.items():
         if len(nodes) == 0:
-            logger.warning(
-                f"Module {module_name} has no root nodes (e.g. Tenant, Subscription ...). "
+            warnings.warn(
+                f"Module {module_name} has no root nodes (e.g. Tenant, Subscription ...). ",
+                UserWarning,
             )
         if len(nodes) > 1:
-            logger.warning(
+            warnings.warn(
                 f"Module {module_name} has multiple root nodes: {', '.join([node.label for node in nodes])}. "
-                f"Please check the module."
+                "Please check the module.",
+                UserWarning,
             )
         # TODO: assert len(nodes) == 1


### PR DESCRIPTION
### Summary

This PR adds unit tests (`<path to file>`) to enforce data schema conventions. The tests validate the following:

* Python object naming conventions:

  * Node classes end with `Schema`
  * Relationship classes end with `Rel`
  * Node properties classes end with `Properties`
  * Relationship properties classes end with `RelProperties`
* All `sub_resource_relationship`s must have the label `RESOURCE` and direction `INWARD`
* Each module must have **at least one** root node (i.e., a node with no `sub_resource_relationship`)
* Each module must have **at most one** root node

> ⚠️ During the data model migration phase, these tests will only emit warnings and are non-blocking.

### Notes

* While the naming conventions might seem like nitpicking, they greatly improve overall code consistency, readability, and make AI-assisted code completion much more relevant and effective.

* I also renamed all affected objects in this PR to align with the conventions. The only executable code added is the test itself.

✅ These changes are non-breaking and do **not** impact the underlying database schema or the end users.