### PR TITLE
chore: enforce sub_resource_relationship convention

### DIFF
--- a/cartography/models/digitalocean/droplet.py
+++ b/cartography/models/digitalocean/droplet.py
@@ -38,13 +38,13 @@ class DODropletToAccountRelProperties(CartographyRelProperties):
 
 
 @dataclass(frozen=True)
-# (:DOProject)<-[:RESOURCE]-(:DODroplet)
+# (:DOProject)-[:RESOURCE]->(:DODroplet)
 class DODropletToAccountRel(CartographyRelSchema):
     target_node_label: str = "DOProject"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
     )
-    direction: LinkDirection = LinkDirection.OUTWARD
+    direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
     properties: DODropletToAccountRelProperties = DODropletToAccountRelProperties()
 

--- a/cartography/models/digitalocean/project.py
+++ b/cartography/models/digitalocean/project.py
@@ -30,13 +30,13 @@ class DOProjectToAccountRelProperties(CartographyRelProperties):
 
 
 @dataclass(frozen=True)
-# (:DOAccount)<-[:RESOURCE]-(:DOProject)
+# (:DOAccount)-[:RESOURCE]->(:DOProject)
 class DOProjectToAccountRel(CartographyRelSchema):
     target_node_label: str = "DOAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("ACCOUNT_ID", set_in_kwargs=True)},
     )
-    direction: LinkDirection = LinkDirection.OUTWARD
+    direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
     properties: DOProjectToAccountRelProperties = DOProjectToAccountRelProperties()
 

--- a/cartography/models/kandji/device.py
+++ b/cartography/models/kandji/device.py
@@ -30,14 +30,14 @@ class KandjiTenantToKandjiDeviceRelProperties(CartographyRelProperties):
 
 
 @dataclass(frozen=True)
-# (:KandjiDevice)-[:ENROLLED_TO]->(:KandjiTenant)
+# (:KandjiDevice)<-[:RESOURCE]->(:KandjiTenant)
 class KandjiTenantToKandjiDeviceRel(CartographyRelSchema):
     target_node_label: str = "KandjiTenant"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("TENANT_ID", set_in_kwargs=True)},
     )
-    direction: LinkDirection = LinkDirection.OUTWARD
-    rel_label: str = "ENROLLED_TO"
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
     properties: KandjiTenantToKandjiDeviceRelProperties = (
         KandjiTenantToKandjiDeviceRelProperties()
     )

--- a/cartography/models/lastpass/user.py
+++ b/cartography/models/lastpass/user.py
@@ -57,13 +57,13 @@ class LastpassTenantToLastpassUserRelProperties(CartographyRelProperties):
 
 
 @dataclass(frozen=True)
-# (:LastpassTenant)<-[:RESOURCE]-(:LastpassUser)
+# (:LastpassTenant)-[:RESOURCE]->(:LastpassUser)
 class LastpassTenantToUserRel(CartographyRelSchema):
     target_node_label: str = "LastpassTenant"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("TENANT_ID", set_in_kwargs=True)},
     )
-    direction: LinkDirection = LinkDirection.OUTWARD
+    direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
     properties: LastpassTenantToLastpassUserRelProperties = (
         LastpassTenantToLastpassUserRelProperties()

--- a/cartography/models/snipeit/asset.py
+++ b/cartography/models/snipeit/asset.py
@@ -31,9 +31,7 @@ class SnipeitAssetNodeProperties(CartographyNodeProperties):
     serial: PropertyRef = PropertyRef("serial", extra_index=True)
 
 
-###
-# (:SnipeitAsset)<-[:ASSET]-(:SnipeitTenant)
-###
+# (:SnipeitAsset)<-[:RESOURCE]-(:SnipeitTenant)
 @dataclass(frozen=True)
 class SnipeitTenantToSnipeitAssetRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
@@ -46,15 +44,13 @@ class SnipeitTenantToSnipeitAssetRel(CartographyRelSchema):
         {"id": PropertyRef("TENANT_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
-    rel_label: str = "HAS_ASSET"
+    rel_label: str = "RESOURCE"
     properties: SnipeitTenantToSnipeitAssetRelProperties = (
         SnipeitTenantToSnipeitAssetRelProperties()
     )
 
 
-###
 # (:SnipeitUser)-[:HAS_CHECKED_OUT]->(:SnipeitAsset)
-###
 @dataclass(frozen=True)
 class SnipeitUserToSnipeitAssetRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
@@ -73,7 +69,6 @@ class SnipeitUserToSnipeitAssetRel(CartographyRelSchema):
     )
 
 
-###
 @dataclass(frozen=True)
 class SnipeitAssetSchema(CartographyNodeSchema):
     label: str = "SnipeitAsset"  # The label of the node

--- a/cartography/models/snipeit/user.py
+++ b/cartography/models/snipeit/user.py
@@ -32,14 +32,14 @@ class SnipeitTenantToSnipeitUserRelProperties(CartographyRelProperties):
 
 
 @dataclass(frozen=True)
-# (:SnipeitTenant)-[:HAS_USER]->(:SnipeitUser)
+# (:SnipeitTenant)-[:RESOURCE]->(:SnipeitUser)
 class SnipeitTenantToSnipeitUserRel(CartographyRelSchema):
     target_node_label: str = "SnipeitTenant"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("TENANT_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
-    rel_label: str = "HAS_USER"
+    rel_label: str = "RESOURCE"
     properties: SnipeitTenantToSnipeitUserRelProperties = (
         SnipeitTenantToSnipeitUserRelProperties()
     )

--- a/docs/root/modules/digitalocean/schema.md
+++ b/docs/root/modules/digitalocean/schema.md
@@ -1,5 +1,12 @@
 ## DigitalOcean Schema
 
+```mermaid
+graph LR
+A(DOAccount) -- RESOURCE --> P(DOProject)
+P(DOProject) -- RESOURCE --> D(DODroplet)
+```
+
+
 ### DOAccount
 Representation of a DigitalOcean [Account](https://developers.digitalocean.com/documentation/v2/#account) object.
 
@@ -18,7 +25,7 @@ Representation of a DigitalOcean [Account](https://developers.digitalocean.com/d
 - DOAccount contains DOProjects.
 
     ```
-    (DOAccount)-[RESOURCE]->(DOProjects)
+    (DOAccount)-[RESOURCE]->(DOProject)
     ```
 
 ### DOProject

--- a/docs/root/modules/kandji/schema.md
+++ b/docs/root/modules/kandji/schema.md
@@ -28,5 +28,5 @@ Representation of a Kandji device.
 - Kandji devices are enrolled to a Kandji Tenant
 
     ```
-    (KandjiDevice)-[ENROLLED_TO]->(KandjiTenant)
+    (KandjiDevice)<-[RESOURCE]-(KandjiTenant)
     ```

--- a/docs/root/modules/lastpass/schema.md
+++ b/docs/root/modules/lastpass/schema.md
@@ -72,4 +72,3 @@ Representation of a single User in Lastpass
     ```
     (:LastpassTenant)-[:RESOURCE]->(:LastpassUser)
     ```
-

--- a/docs/root/modules/lastpass/schema.md
+++ b/docs/root/modules/lastpass/schema.md
@@ -2,8 +2,10 @@
 
 ```mermaid
 graph LR
-A(Human) -- IDENTITY_LASTPASS --> B(LastpassUser)
+T(LastpassTenant) -- RESOURCE --> U(LastpassUser)
+A(Human) -- IDENTITY_LASTPASS --> U
 ```
+
 
 ### Human
 
@@ -19,6 +21,24 @@ Human nodes are not created by Lastpass module, link is made using analysis job.
     ```
     (Human)-[IDENTITY_LASTPASS]->(LastpassUser)
     ```
+
+
+### LastpassTenant
+
+Representation of a Lastpass Tenant
+
+| Field | Description |
+|-------|--------------|
+| firstseen| Timestamp of when a sync job first created this node  |
+| lastupdated |  Timestamp of the last time the node was updated |
+| id | Lastpass Tenant ID |
+
+#### Relationships
+- `User` belongs to a `Tenant`.
+    ```
+    (:LastpassTenant)-[:RESOURCE]->(:LastpassUser)
+    ```
+
 
 ### LastpassUser
 
@@ -46,3 +66,10 @@ Representation of a single User in Lastpass
 | attachments | Number of file attachments stored |
 | password_reset_required | Flag indicating user requested password reset |
 | multifactor | MFA method (null if None) |
+
+#### Relationships
+- `User` belongs to a `Tenant`.
+    ```
+    (:LastpassTenant)-[:RESOURCE]->(:LastpassUser)
+    ```
+

--- a/docs/root/modules/snipeit/schema.md
+++ b/docs/root/modules/snipeit/schema.md
@@ -1,5 +1,14 @@
 ## SnipeIT Schema
 
+```mermaid
+graph LR
+T(SnipeitTenant) -- RESOURCE --> U(SnipeitUser)
+T -- RESOURCE --> A(SnipeitAsset)
+U -- HAS_CHECKED_OUT --> A
+```
+
+
+
 ### SnipeitTenant
 
 Representation of a SnipeIT Tenant.
@@ -7,6 +16,18 @@ Representation of a SnipeIT Tenant.
 |Field | Description|
 |-------|-------------|
 |id | SnipeIT Tenant ID e.g. "company name"|
+
+#### Relationships
+
+- All SnipeIT users and asset are linked to a SnipeIT Tenant
+
+    ```cypher
+    (:SnipeitUser)<-[:RESOURCE]-(:SnipeitTenant)
+    ```
+
+    ```cypher
+    (:SnipeitAsset)<-[:RESOURCE]-(:SnipeitTenant)
+    ```
 
 ### SnipeitUser
 
@@ -18,6 +39,21 @@ Representation of a SnipeIT User.
 |company | Company the SnipeIT user is linked to|
 |username | Username of the user |
 |email | Email of the user |
+
+#### Relationships
+
+- All SnipeIT users are linked to a SnipeIT Tenant
+
+    ```cypher
+    (:SnipeitUser)<-[:RESOURCE]-(:SnipeitTenant)
+    ```
+
+- A SnipeIT user can check-out one or more assets
+
+    ```cypher
+    (:SnipeitAsset)<-[:HAS_CHECKED_OUT]-(:SnipeitUser)
+    ```
+
 
 ### SnipeitAsset
 
@@ -39,11 +75,11 @@ Representation of a SnipeIT asset.
 - All SnipeIT users and asset are linked to a SnipeIT Tenant
 
     ```cypher
-    (:SnipeitUser)<-[:HAS_USER]-(:SnipeitTenant)
+    (:SnipeitUser)<-[:RESOURCE]-(:SnipeitTenant)
     ```
 
     ```cypher
-    (:SnipeitAsset)<-[:HAS_ASSET]-(:SnipeitTenant)
+    (:SnipeitAsset)<-[:RESOURCE]-(:SnipeitTenant)
     ```
 
 - A SnipeIT user can check-out one or more assets

--- a/docs/root/usage/schema.md
+++ b/docs/root/usage/schema.md
@@ -22,6 +22,70 @@
 
 - In these docs, more specific nodes will be decorated with `GenericNode::SpecificNode` notation. For example, if we have a `Car` node and a `RaceCar` node, we will refer to the `RaceCar` as `Car::RaceCar`.
 
+## Conventions
+
+### Python Object Naming Conventions
+
+* **Node classes** should end with `Schema`
+* **Relationship classes** should end with `Rel`
+* **Node property classes** should end with `Properties`
+* **Relationship property classes** should end with `RelProperties`
+
+### Sub-Resources
+
+A *sub-resource* is a specific type of composition relationship in which a node "belongs to" a higher-level entity such as an Account, Subscription, etc.
+
+Examples:
+
+* In **AWS**, the parent is typically an `AWSAccount`.
+* In **Azure**, it's a `Tenant` or `Subscription`.
+* In **GCP**, it's a `GCPProject`.
+
+To define a sub-resource relationship, use the `sub_resource_relationship` property on the node class. It must follow these constraints:
+
+* The target node matcher must have `set_in_kwargs=True` (required for auto-cleanup functionality).
+* All `sub_resource_relationship`s must:
+
+  * Use the label `RESOURCE`
+  * Have the direction set to `INWARD`
+* Each module:
+
+  * **Must have at least one root node** (a node without a `sub_resource_relationship`)
+  * **Must have at most one root node**
+
+### Common Relationship Types
+
+While you're free to define custom relationships, using standardized types improves maintainability and facilitates querying and analysis.
+
+#### Composition
+
+* `(:Parent)-[:CONTAINS]->(:Child)`
+* `(:Parent)-[:HAS]->(:Child)`
+
+#### Tagging
+
+* `(:Entity)-[:TAGGED]->(:Tag)`
+
+#### Group Membership
+
+* `(:Element)-[:MEMBER_OF]->(:Group)`
+* `(:Element)-[:ADMIN_OF]->(:Group)`
+    ```{note}
+    If an element is an admin, both relationships (`MEMBER_OF` and `ADMIN_OF`) should be present for consistency.
+    ```
+
+#### Ownership
+
+* `(:Entity)-[:OWNS]->(:OtherEntity)`
+
+#### Permissions (ACL)
+
+* `(:Actor)-[:CAN_ACCESS]->(:Entity)`
+* `(:Actor)-[:CAN_READ]->(:Entity)`
+* `(:Actor)-[:CAN_WRITE]->(:Entity)`
+* `(:Actor)-[:CAN_ADD]->(:Entity)`
+* `(:Actor)-[:CAN_DELETE]->(:Entity)`
+
 
 ```{include} ../modules/_cartography-metadata/schema.md
 ```
@@ -45,6 +109,9 @@
 ```
 
 ```{include} ../modules/duo/schema.md
+```
+
+```{include} ../modules/entra/schema.md
 ```
 
 ```{include} ../modules/gcp/schema.md

--- a/tests/integration/cartography/intel/digitalocean/test_compute.py
+++ b/tests/integration/cartography/intel/digitalocean/test_compute.py
@@ -61,7 +61,7 @@ def test_transform_and_load_droplets(mock_do_manager, mock_api, neo4j_session):
         "DOProject",
         "id",
         "RESOURCE",
-        rel_direction_right=True,
+        rel_direction_right=False,
     ) == {
         (
             test_droplet.id,

--- a/tests/integration/cartography/intel/digitalocean/test_management.py
+++ b/tests/integration/cartography/intel/digitalocean/test_management.py
@@ -71,7 +71,7 @@ def test_transform_and_load_projects(
         "DOAccount",
         "id",
         "RESOURCE",
-        rel_direction_right=True,
+        rel_direction_right=False,
     ) == {
         (
             test_project.id,

--- a/tests/integration/cartography/intel/kandji/test_kandji.py
+++ b/tests/integration/cartography/intel/kandji/test_kandji.py
@@ -64,8 +64,8 @@ def test_load_kandji_devices_relationship(neo4j_session):
             "id",
             "KandjiDevice",
             "id",
-            "ENROLLED_TO",
-            rel_direction_right=False,
+            "RESOURCE",
+            rel_direction_right=True,
         )
         == expected_nodes_relationships
     )
@@ -129,8 +129,8 @@ def test_cleanup_kandji_devices(neo4j_session):
             "id",
             "KandjiDevice",
             "id",
-            "ENROLLED_TO",
-            rel_direction_right=False,
+            "RESOURCE",
+            rel_direction_right=True,
         )
         == expected_nodes_relationships
     )

--- a/tests/integration/cartography/intel/lastpass/test_users.py
+++ b/tests/integration/cartography/intel/lastpass/test_users.py
@@ -82,7 +82,7 @@ def test_load_lastpass_users(mock_api, neo4j_session):
             "LastpassTenant",
             "id",
             "RESOURCE",
-            rel_direction_right=True,
+            rel_direction_right=False,
         )
         == expected_rels
     )

--- a/tests/integration/cartography/intel/snipeit/test_snipeit_assets.py
+++ b/tests/integration/cartography/intel/snipeit/test_snipeit_assets.py
@@ -74,7 +74,7 @@ def test_load_snipeit_assets_relationship(neo4j_session):
             "id",
             "SnipeitAsset",
             "serial",
-            "HAS_ASSET",
+            "RESOURCE",
             rel_direction_right=True,
         )
         == expected_nodes_relationships
@@ -155,7 +155,7 @@ def test_cleanup_snipeit_assets(neo4j_session):
             "id",
             "SnipeitAsset",
             "id",
-            "HAS_ASSET",
+            "RESOURCE",
             rel_direction_right=True,
         )
         == expected_nodes_relationships

--- a/tests/integration/cartography/intel/snipeit/test_snipeit_users.py
+++ b/tests/integration/cartography/intel/snipeit/test_snipeit_users.py
@@ -64,7 +64,7 @@ def test_load_snipeit_user_relationship(neo4j_session):
             "id",
             "SnipeitUser",
             "id",
-            "HAS_USER",
+            "RESOURCE",
             rel_direction_right=True,
         )
         == expected_nodes_relationships
@@ -129,7 +129,7 @@ def test_cleanup_snipeit_users(neo4j_session):
             "id",
             "SnipeitUser",
             "id",
-            "HAS_USER",
+            "RESOURCE",
             rel_direction_right=True,
         )
         == expected_nodes_relationships

--- a/tests/unit/cartography/graph/test_model.py
+++ b/tests/unit/cartography/graph/test_model.py
@@ -1,5 +1,4 @@
 import inspect
-import logging
 import warnings
 from pkgutil import iter_modules
 from typing import Dict
@@ -15,7 +14,6 @@ from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 
-logger = logging.getLogger(__name__)
 
 MODEL_CLASSES = (
     CartographyNodeSchema,

--- a/tests/unit/cartography/graph/test_model.py
+++ b/tests/unit/cartography/graph/test_model.py
@@ -14,7 +14,6 @@ from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 
-
 MODEL_CLASSES = (
     CartographyNodeSchema,
     CartographyRelSchema,

--- a/tests/unit/cartography/test_doc.py
+++ b/tests/unit/cartography/test_doc.py
@@ -3,19 +3,21 @@ import re
 from cartography.sync import Sync
 
 
-
 def test_schema_doc():
     # DOC
     include_regex = re.compile(r"{include} ../modules/(\w+)/schema.md")
-    
-    with open(f"./docs/root/usage/schema.md", "r") as f:
+
+    with open("./docs/root/usage/schema.md") as f:
         content = f.read()
-    
+
     included_modules = include_regex.findall(content)
     existing_modules = []
     for m in Sync.list_intel_modules():
-        if m in ('analysis', 'create-indexes',):
+        if m in (
+            "analysis",
+            "create-indexes",
+        ):
             continue
         existing_modules.append(m)
-            
+
     assert sorted(included_modules) == sorted(existing_modules)

--- a/tests/unit/cartography/test_doc.py
+++ b/tests/unit/cartography/test_doc.py
@@ -1,0 +1,21 @@
+import re
+
+from cartography.sync import Sync
+
+
+
+def test_schema_doc():
+    # DOC
+    include_regex = re.compile(r"{include} ../modules/(\w+)/schema.md")
+    
+    with open(f"./docs/root/usage/schema.md", "r") as f:
+        content = f.read()
+    
+    included_modules = include_regex.findall(content)
+    existing_modules = []
+    for m in Sync.list_intel_modules():
+        if m in ('analysis', 'create-indexes',):
+            continue
+        existing_modules.append(m)
+            
+    assert sorted(included_modules) == sorted(existing_modules)


### PR DESCRIPTION
### Summary
This PR builds on top of PR #1563  and includes the following changes:

* **Improves documentation** by adding missing elements across several modules.
* **Enhances clarity** around naming conventions used in the data model, with detailed notes added to relevant sections.
* **Adds a test** to detect missing references to module schemas in `docs/root/usage/schema.md`.
* **Migrates 4 modules** to align with current naming conventions for consistency and clarity.

### ⚠️ Breaking Changes to the Data Model
This PR introduces several **breaking changes** in graph relationships:
**DigitalOcean**
* `(:DOProject)<-[:RESOURCE]-(:DODroplet)` ➡️ `(:DOProject)-[:RESOURCE]->(:DODroplet)`
* `(:DOAccount)<-[:RESOURCE]-(:DOProject)` ➡️ `(:DOAccount)-[:RESOURCE]->(:DOProject)`
**Lastpass**
* `(:LastpassUser)-[:RESOURCE]->(:LastpassTenant)` ➡️ `(:LastpassUser)<-[:RESOURCE]-(:LastpassTenant)`
**SnipeIt**
* `(:SnipeitAsset)<-[:HAS_ASSET]-(:SnipeitTenant)` ➡️ `(:SnipeitAsset)<-[:RESOURCE]-(:SnipeitTenant)`
* `(:SnipeitTenant)-[:HAS_USER]->(:SnipeitUser)` ➡️ `(:SnipeitTenant)-[:RESOURCE]->(:SnipeitUser)`
**Kandji**
* `(:KandjiDevice)-[:ENROLLED_TO]->(:KandjiTenant)` ➡️ `(:KandjiDevice)<-[:RESOURCE]-(:KandjiTenant)`

### Related issues or links
- #1261