### PR TITLE
Resolve Python logger warnings

### DIFF
--- a/cartography/intel/aws/apigateway.py
+++ b/cartography/intel/aws/apigateway.py
@@ -94,7 +94,7 @@ def get_rest_api_client_certificate(
                 response["stageName"] = stage["stageName"]
             except ClientError as e:
                 logger.warning(
-                    f"Failed to retrive Client Certificate for Stage {stage['stageName']} - {e}",
+                    f"Failed to retrieve Client Certificate for Stage {stage['stageName']} - {e}",
                 )
                 raise
         else:
@@ -303,7 +303,7 @@ def parse_policy(api_id: str, policy: Policy) -> Optional[Dict[Any, Any]]:
             else:
                 return None
         except json.JSONDecodeError:
-            logger.warn(f"failed to decode policy json : {policy}")
+            logger.warning(f"failed to decode policy json : {policy}")
             return None
     else:
         return None

--- a/cartography/intel/okta/awssaml.py
+++ b/cartography/intel/okta/awssaml.py
@@ -85,7 +85,7 @@ def query_for_okta_to_aws_role_mapping(
             group_to_role_mapping.append(mapping)
 
     if has_results and not group_to_role_mapping:
-        logger.warn(
+        logger.warning(
             "AWS Okta Application present, but no mappings were found. "
             "Please verify the mapping regex is correct",
         )


### PR DESCRIPTION
### Summary
This small PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```



### Related issues or links

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
