### PR TITLE
Add EfsMountTarget resource to AWS Module

### DIFF
--- a/cartography/intel/aws/efs.py
+++ b/cartography/intel/aws/efs.py
@@ -1,0 +1,93 @@
+import logging
+from typing import Any
+from typing import Dict
+from typing import List
+
+import boto3
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.aws.ec2.util import get_botocore_config
+from cartography.models.aws.efs.mount_target import EfsMountTargetSchema
+from cartography.util import aws_handle_regions
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+@aws_handle_regions
+def get_efs_mount_targets(
+    boto3_session: boto3.Session, region: str
+) -> List[Dict[str, Any]]:
+    client = boto3_session.client(
+        "efs", region_name=region, config=get_botocore_config()
+    )
+    paginator = client.get_paginator("describe_mount_targets")
+    mountTargets = []
+    for page in paginator.paginate():
+        mountTargets.extend(page["MountTargets"])
+    return mountTargets
+
+
+@timeit
+def load_efs_mount_targets(
+    neo4j_session: neo4j.Session,
+    data: List[Dict[str, Any]],
+    region: str,
+    current_aws_account_id: str,
+    aws_update_tag: int,
+) -> None:
+    logger.info(
+        f"Loading Efs {len(data)} mount targets for region '{region}' into graph.",
+    )
+    load(
+        neo4j_session,
+        EfsMountTargetSchema(),
+        data,
+        lastupdated=aws_update_tag,
+        Region=region,
+        AWS_ID=current_aws_account_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: Dict[str, Any],
+) -> None:
+    logger.debug("Running Efs cleanup job.")
+    cleanup_job = GraphJob.from_node_schema(
+        EfsMountTargetSchema(), common_job_parameters
+    )
+    cleanup_job.run(neo4j_session)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    boto3_session: boto3.session.Session,
+    regions: List[str],
+    current_aws_account_id: str,
+    update_tag: int,
+    common_job_parameters: Dict[str, Any],
+) -> None:
+    for region in regions:
+        logger.info(
+            f"Syncing Efs for region '{region}' in account '{current_aws_account_id}'.",
+        )
+        mountTargets = get_efs_mount_targets(boto3_session, region)
+        mount_target_data: List[Dict[str, Any]] = []
+        for mountTarget in mountTargets:
+            mount_target_data.append(mountTarget)
+
+        load_efs_mount_targets(
+            neo4j_session,
+            mount_target_data,
+            region,
+            current_aws_account_id,
+            update_tag,
+        )
+
+    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/resources.py
+++ b/cartography/intel/aws/resources.py
@@ -10,6 +10,7 @@ from . import config
 from . import dynamodb
 from . import ecr
 from . import ecs
+from . import efs
 from . import eks
 from . import elasticache
 from . import elasticsearch
@@ -104,4 +105,5 @@ RESOURCE_FUNCTIONS: Dict[str, Callable[..., None]] = {
     "identitycenter": identitycenter.sync_identity_center_instances,
     "cloudtrail": cloudtrail.sync,
     "cloudwatch": cloudwatch.sync,
+    "efs": efs.sync,
 }

--- a/cartography/models/aws/efs/mount_target.py
+++ b/cartography/models/aws/efs/mount_target.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class EfsMountTargetNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("MountTargetId")
+    arn: PropertyRef = PropertyRef("MountTargetId", extra_index=True)
+    fileSystem_id: PropertyRef = PropertyRef("FileSystemId")
+    lifecycle_state: PropertyRef = PropertyRef("LifeCycleState")
+    mount_target_id: PropertyRef = PropertyRef("MountTargetId")
+    subnet_id: PropertyRef = PropertyRef("SubnetId")
+    availability_zone_id: PropertyRef = PropertyRef("AvailabilityZoneId")
+    availability_zone_name: PropertyRef = PropertyRef("AvailabilityZoneName")
+    ip_address: PropertyRef = PropertyRef("IpAddress")
+    network_interface_id: PropertyRef = PropertyRef("NetworkInterfaceId")
+    owner_id: PropertyRef = PropertyRef("OwnerId")
+    vpc_id: PropertyRef = PropertyRef("VpcId")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EfsMountTargetToAwsAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EfsToAWSAccountRel(CartographyRelSchema):
+    target_node_label: str = "AWSAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: EfsMountTargetToAwsAccountRelProperties = (
+        EfsMountTargetToAwsAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class EfsMountTargetSchema(CartographyNodeSchema):
+    label: str = "EfsMountTarget"
+    properties: EfsMountTargetNodeProperties = EfsMountTargetNodeProperties()
+    sub_resource_relationship: EfsToAWSAccountRel = EfsToAWSAccountRel()

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -3273,6 +3273,29 @@ Representation of an AWS ECS [Container](https://docs.aws.amazon.com/AmazonECS/l
     ```
     (ECSTask)-[HAS_CONTAINER]->(ECSContainer)
     ```
+
+### EfsMountTarget
+Representation of an AWS [EFS Mount Target](https://docs.aws.amazon.com/efs/latest/ug/API_MountTargetDescription.html)
+| Field | Description |
+|-------|-------------|
+| **id** | System-assigned mount target ID |
+| arn | System-assigned mount target ID |
+| fileSystem_id | The ID of the file system for which the mount target is intended |
+| lifecycle_state | Lifecycle state of the mount target |
+| mount_target_id | System-assigned mount target ID |
+| subnet_id | The ID of the mount target's subnet |
+| availability_zone_id | The unique and consistent identifier of the Availability Zone that the mount target resides in |
+| availability_zone_name | The name of the Availability Zone in which the mount target is located |
+| ip_address | Address at which the file system can be mounted by using the mount target |
+| network_interface_id | The ID of the network interface that Amazon EFS created when it created the mount target |
+| owner_id | AWS account ID that owns the resource |
+| vpc_id | The virtual private cloud (VPC) ID that the mount target is configured in |
+#### Relationships
+- Efs MountTargets are a resource under the AWS Account.
+    ```
+    (AWSAccount)-[RESOURCE]->(EfsMountTarget)
+    ```
+
 ### SNSTopic
 Representation of an AWS [SNS Topic](https://docs.aws.amazon.com/sns/latest/api/API_Topic.html)
 | Field | Description |

--- a/tests/data/aws/efs.py
+++ b/tests/data/aws/efs.py
@@ -1,0 +1,26 @@
+GET_EFS_MOUNT_TARGETS = [
+    {
+        "OwnerId": "123456789012",
+        "MountTargetId": "fsmt-9f8e7d6c5b4a3z2x",
+        "FileSystemId": "arn:aws:elasticfilesystem:us-west-2:123456789012:file-system/fs-9876543210fedcba",
+        "SubnetId": "subnet-9z8y7x6w",
+        "LifeCycleState": "creating",
+        "IpAddress": "192.168.1.20",
+        "NetworkInterfaceId": "eni-789xyz123lmn456op",
+        "AvailabilityZoneId": "usw2-az1",
+        "AvailabilityZoneName": "us-west-2a",
+        "VpcId": "vpc-1xyz234abc567defg",
+    },
+    {
+        "OwnerId": "987654321098",
+        "MountTargetId": "fsmt-abcdef1234567890",
+        "FileSystemId": "arn:aws:elasticfilesystem:us-west-2:987654321098:file-system/fs-abcd1234efgh5678",
+        "SubnetId": "subnet-abcd1234",
+        "LifeCycleState": "deleting",
+        "IpAddress": "10.0.0.25",
+        "NetworkInterfaceId": "eni-456abc789def123gh",
+        "AvailabilityZoneId": "usw2-az1",
+        "AvailabilityZoneName": "us-west-2a",
+        "VpcId": "vpc-abc123def456ghi78",
+    },
+]

--- a/tests/integration/cartography/intel/aws/test_efs.py
+++ b/tests/integration/cartography/intel/aws/test_efs.py
@@ -1,0 +1,60 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.aws.efs
+from cartography.intel.aws.efs import sync
+from tests.data.aws.efs import GET_EFS_MOUNT_TARGETS
+from tests.integration.cartography.intel.aws.common import create_test_account
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_ACCOUNT_ID = "000000000000"
+TEST_REGION = "us-west-2"
+TEST_UPDATE_TAG = 123456789
+
+
+@patch.object(
+    cartography.intel.aws.efs,
+    "get_efs_mount_targets",
+    return_value=GET_EFS_MOUNT_TARGETS,
+)
+def test_sync_efs(mock_get_mount_targets, neo4j_session):
+    # Arrange
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+    # Act
+    sync(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+
+    # Assert
+    assert check_nodes(neo4j_session, "EfsMountTarget", ["arn"]) == {
+        ("fsmt-9f8e7d6c5b4a3z2x",),
+        ("fsmt-abcdef1234567890",),
+    }
+
+    # Assert
+    assert check_rels(
+        neo4j_session,
+        "AWSAccount",
+        "id",
+        "EfsMountTarget",
+        "arn",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (
+            TEST_ACCOUNT_ID,
+            "fsmt-9f8e7d6c5b4a3z2x",
+        ),
+        (
+            TEST_ACCOUNT_ID,
+            "fsmt-abcdef1234567890",
+        ),
+    }


### PR DESCRIPTION
### Summary
This PR adds the AWS Efs MountTarget as a supported resource for the
AWS Module.


### Related issues or links
[Issue](https://github.com/cartography-cncf/cartography/issues/1552)


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [x] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
