### PR TITLE
chore: CI Improvment

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,9 +1,9 @@
-name: Publish Docker 🐳 images 📦 to GitHub Container Registry
+name: Build &
 
 on:
-  release:
-    types: [created]
-  workflow_dispatch: {}
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+(-\w*\.?\w)?'
 
 # Explicitly grant the `secrets.GITHUB_TOKEN` no permissions.
 permissions: {}
@@ -15,6 +15,8 @@ jobs:
       # Grant the ability to write to GitHub Packages (push Docker images to
       # GitHub Container Registry).
       packages: write
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write  
     name: Build and publish Python 🐍 distributions 📦 to PyPI, and Docker 🐳 images 📦 to GitHub Container Registry
     runs-on: ubuntu-latest
     steps:
@@ -45,9 +47,15 @@ jobs:
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
+
+      # Get the cartography version from the GitHub release event metadata and sleep to wait for PyPI to finish publishing
+      - name: Extract version and sleep
+        id: version
+        run: |
+          echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          sleep 10
+
       # 2. Publish to GHCR
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Extract metadata (tags, labels) for Docker
@@ -55,10 +63,8 @@ jobs:
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ghcr.io/${{ github.repository }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
@@ -73,14 +79,6 @@ jobs:
           # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           # for more detailed information.
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Get the cartography version from the GitHub release event metadata and sleep to wait for PyPI to finish publishing
-      - name: Extract version and sleep
-        id: version
-        run: |
-          echo "VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
-          sleep 10
-
       - name: Build and push
         uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
         with:
@@ -91,3 +89,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # e.g. '==0.98.0'
           build-args: VERSION_SPECIFIER===${{ env.VERSION }}
+
+      # 3. Create GitHub release
+      - name: Create Release
+        if: startsWith(github.ref, 'refs/tags')
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
+        with:
+            artifacts: "dist/*"
+            generateReleaseNotes: "true"
+            makeLatest: "true"

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -16,7 +16,7 @@ jobs:
       # GitHub Container Registry).
       packages: write
       # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write  
+      id-token: write
     name: Build and publish Python 🐍 distributions 📦 to PyPI, and Docker 🐳 images 📦 to GitHub Container Registry
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cartography-cncf/cartography/badge)](https://scorecard.dev/viewer/?uri=github.com/cartography-cncf/cartography)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9637/badge)](https://www.bestpractices.dev/projects/9637)
-![build](https://github.com/cartography-cncf/cartography/actions/workflows/publish-to-ghcr-and-pypi.yml/badge.svg)
+![build](https://github.com/cartography-cncf/cartography/actions/workflows/build-publish.yml/badge.svg)
 
 
 


### PR DESCRIPTION
**This PR updates the CI workflow to trigger on tag pushes instead of release publications.**
The release is now created automatically by the CI once a tag is pushed. This change enables us to enrich releases with additional metadata directly from the CI pipeline—such as SBOMs, signatures, and other artifacts.

While the modification may seem minor, it's a key step toward aligning with open-source best practices, including automated SBOM publishing and release signing.

_You can find an example of generated release here: https://github.com/jychp/cartography-openapi/releases/tag/0.5.1_

### Updated CI Workflow:

* Push a SemVer tag
* Build and publish the Python package to PyPI

  * Now using a *trusted publisher* — no need to store a PyPI token in secrets
  * Enables release signing via [attestations](https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#generating-and-uploading-attestations)
* Build and push the Docker image to GHCR
* Automatically create the GitHub release

To trigger the pipeline:

```bash
git tag 1.2.3 && git push origin 1.2.3
```

### Before merging this PR:

- [ ] Enable the trusted publisher on [PyPI](https://pypi.org/manage/account/publishing/)
- [ ] Set up a ruleset to restrict tag creation to a limited group of maintainers

--- 
**Note:** As recommended by the CNCF, it's a good time to start formalizing contributor roles. Proposed structure (based on [CNCF’s contributor ladder](https://github.com/cncf/project-template/blob/main/CONTRIBUTOR_LADDER.md).

* **Contributor**
* **Reviewer** (can approve PRs to merge into `main`)
* **Publisher** (can push tags and trigger releases)

This structure will help us scale governance as the project grows.