### PR TITLE
feat: Added APIGatewayMethod ingestion and relationship

### DIFF
--- a/cartography/models/aws/apigateway_method.py
+++ b/cartography/models/aws/apigateway_method.py
@@ -1,0 +1,114 @@
+from dataclasses import dataclass, field
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.aws.apigatewayresource import APIGatewayResourceSchema
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class APIGatewayMethodProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef('id')
+    api_key_required: PropertyRef = PropertyRef('api_key_required')
+    authorization_scopes: PropertyRef = PropertyRef('authorization_scopes')
+    authorization_type: PropertyRef = PropertyRef('authorization_type')
+    authorizer_id: PropertyRef = PropertyRef('authorizerId') 
+    http_method: PropertyRef = PropertyRef('http_method')
+    operation_name: PropertyRef = PropertyRef('operation_name')
+    request_validator_id: PropertyRef = PropertyRef('request_validator_id')
+    method_integration_json: PropertyRef = PropertyRef('method_integration_json')
+    method_responses_json: PropertyRef = PropertyRef('method_responses_json')
+    request_models_json: PropertyRef = PropertyRef('request_models_json')
+    request_parameters_json: PropertyRef = PropertyRef('request_parameters_json')
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+    account_id: PropertyRef = PropertyRef('account_id', set_in_kwargs=True)
+    rest_api_id: PropertyRef = PropertyRef('rest_api_id', set_in_kwargs=True)
+    resource_id: PropertyRef = PropertyRef('resource_id', set_in_kwargs=True)
+    lambda_function_arn: PropertyRef = PropertyRef('lambda_function_arn')
+    s3_bucket_name: PropertyRef = PropertyRef('s3_bucket_name') 
+    dynamodb_table_arn: PropertyRef = PropertyRef('dynamodb_table_arn')
+
+
+
+@dataclass(frozen=True)
+class APIGatewayResourceHasMethodRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class APIGatewayMethodInvokesLambdaRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+@dataclass(frozen=True)
+class APIGatewayMethodAccessesServiceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+# (:APIGatewayResource)-[RESOURCE]->(:APIGatewayMethod)
+@dataclass(frozen=True)
+class APIGatewayResourceHasMethodRel(CartographyRelSchema):
+    target_node_label: str = APIGatewayResourceSchema.label
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher({
+        "id": PropertyRef('resource_id', set_in_kwargs=True),
+    })
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: APIGatewayResourceHasMethodRelProperties = APIGatewayResourceHasMethodRelProperties()
+
+
+# (:APIGatewayMethod)-[INVOKES]->(:AWSLambda)
+@dataclass(frozen=True)
+class APIGatewayMethodInvokesLambdaRel(CartographyRelSchema):
+
+    target_node_label: str = 'AWSLambda' 
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher({
+        "id": PropertyRef('lambda_function_arn', set_in_kwargs=False),
+    })
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "INVOKES"
+    properties: APIGatewayMethodInvokesLambdaRelProperties = APIGatewayMethodInvokesLambdaRelProperties()
+
+
+# (:APIGatewayMethod)-[ACCESSES]->(:S3Bucket)
+@dataclass(frozen=True)
+class APIGatewayMethodAccessesS3Rel(CartographyRelSchema):
+  
+    target_node_label: str = 'S3Bucket' 
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher({
+        "id": PropertyRef('s3_bucket_name', set_in_kwargs=False),
+    })
+    direction: LinkDirection = LinkDirection.OUTWARD  
+    rel_label: str = "ACCESSES" 
+    properties: APIGatewayMethodAccessesServiceRelProperties = APIGatewayMethodAccessesServiceRelProperties() 
+
+
+# (:APIGatewayMethod)-[ACCESSES]->(:DynamoDBTable)
+@dataclass(frozen=True)
+class APIGatewayMethodAccessesDynamoDBRel(CartographyRelSchema):
+    target_node_label: str = 'DynamoDBTable' 
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher({
+        "id": PropertyRef('dynamodb_table_arn', set_in_kwargs=False),
+    })
+    direction: LinkDirection = LinkDirection.OUTWARD  
+    rel_label: str = "ACCESSES" 
+    properties: APIGatewayMethodAccessesServiceRelProperties = APIGatewayMethodAccessesServiceRelProperties()
+
+
+@dataclass(frozen=True)
+class APIGatewayMethodSchema(CartographyNodeSchema):
+    label: str = 'APIGatewayMethod'
+    properties: APIGatewayMethodProperties = APIGatewayMethodProperties()
+    sub_resource_relationship: APIGatewayResourceHasMethodRel = APIGatewayResourceHasMethodRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            APIGatewayMethodInvokesLambdaRel(),
+            APIGatewayMethodAccessesS3Rel(),          
+            APIGatewayMethodAccessesDynamoDBRel(), 
+        ],
+    )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -2473,6 +2473,56 @@ Representation of an AWS [API Gateway Resource](https://docs.aws.amazon.com/apig
     (APIGatewayRestAPI)-[RESOURCE]->(APIGatewayResource)
     ```
 
+### APIGatewayMethod
+
+Representation of an AWS [API Gateway Method](https://docs.aws.amazon.com/apigateway/latest/api/API_Method.html).
+
+| Field | Description |
+|-------|-------------|
+| firstseen | Timestamp of when a sync job first discovered this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| **id** | Composite ID: `rest_api_id|resource_id|http_method` |
+| http_method | The HTTP verb (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, ANY). |
+| authorization_type | The method's authorization type (e.g., NONE, AWS_IAM, CUSTOM, COGNITO_USER_POOLS). |
+| api_key_required | Boolean flag indicating whether a valid ApiKey is required to invoke this method. |
+| authorizer_id | The identifier of an authorizer used on this method (property only). |
+| operation_name | A human-friendly operation identifier for the method. |
+| request_validator_id | The identifier of a RequestValidator for request validation (property only). |
+| method_integration_json | JSON string representing the method's integration configuration. |
+| method_responses_json | JSON string representing the method's method responses configuration. |
+| request_models_json | JSON string representing the method's request models configuration. |
+| request_parameters_json | JSON string representing the method's request parameters configuration. |
+| lambda_function_arn | Extracted ARN of the AWS Lambda Function if the method's integration type is AWS/AWS_PROXY and the URI points to a Lambda. |
+| s3_bucket_name | Extracted name of the S3 Bucket if the method's integration type is AWS/AWS_PROXY and the URI points to S3. |
+| dynamodb_table_arn | Extracted ARN of the DynamoDB Table if the method's integration type is AWS/AWS_PROXY and the URI points to DynamoDB. |
+
+#### Relationships
+
+- API Gateway Methods are sub-resources of API Gateway Resources.
+    ```
+    (APIGatewayResource)-[RESOURCE]->(APIGatewayMethod)
+    ```
+    Description: An API Gateway Resource contains a Method.
+
+- An API Gateway Method may invoke an AWS Lambda Function.
+    ```
+    (APIGatewayMethod)-[INVOKES]->(AWSLambda)
+    ```
+    Description: Derived from the method's integration URI when the type is AWS/AWS_PROXY and the URI points to a Lambda function.
+
+- An API Gateway Method may access an S3 Bucket.
+    ```
+    (APIGatewayMethod)-[ACCESSES]->(S3Bucket)
+    ```
+    Description: Derived from the method's integration URI when the type is AWS/AWS_PROXY and the URI points to an S3 Bucket.
+
+- An API Gateway Method may access a DynamoDB Table.
+    ```
+    (APIGatewayMethod)-[ACCESSES]->(DynamoDBTable)
+    ```
+    Description: Derived from the method's integration URI when the type is AWS/AWS_PROXY and the URI points to a DynamoDB Table.
+
+
 ### AutoScalingGroup
 
 Representation of an AWS [Auto Scaling Group Resource](https://docs.aws.amazon.com/autoscaling/ec2/userguide/AutoScalingGroup.html).

--- a/tests/data/aws/apigateway.py
+++ b/tests/data/aws/apigateway.py
@@ -194,3 +194,177 @@ GET_REST_API_DETAILS = [
         ),
     ),
 ]
+
+METHOD_RESPONSE_GET = {
+    "authorizationType": "NONE",
+    "apiKeyRequired": False,
+    "operationName": "RetrieveResource",
+    "methodIntegration_json": json.dumps(
+        {
+            "type": "AWS_PROXY",
+            "httpMethod": "GET",
+            "uri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:000000000000:function:sample-function-1/invocations",
+            "passthroughBehavior": "WHEN_NO_MATCH",
+            "connectionType": "INTERNET",
+            "timeoutInMillis": 29000,
+        }
+    ),
+    "methodResponses_json": json.dumps(
+        {
+            "200": {
+                "statusCode": "200",
+                "responseModels": {
+                    "application/json": "Empty",
+                },
+                "responseParameters": {
+                    "method.response.header.Access-Control-Allow-Origin": False,
+                },
+            },
+        }
+    ),
+    "requestModels_json": json.dumps(
+        {
+            "application/json": "Empty",
+        }
+    ),
+    "requestParameters_json": json.dumps(
+        {
+            "method.request.querystring.param1": False,
+        }
+    ),
+    "requestValidatorId": "validator-id-1",
+    "authorizerId": None,
+    "RestApiId": "test-001",
+    "ResourceId": "3kzxbg5sa2",
+    "HttpMethod": "GET",
+}
+
+
+METHOD_RESPONSE_POST = {
+    "authorizationType": "AWS_IAM",
+    "apiKeyRequired": True,
+    "operationName": "CreateResource",
+    "methodIntegration_json": json.dumps(
+        {
+            "type": "AWS_PROXY",
+            "httpMethod": "POST",
+            "uri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:000000000000:function:sample-function-2/invocations",
+            "passthroughBehavior": "WHEN_NO_MATCH",
+            "connectionType": "INTERNET",
+            "timeoutInMillis": 29000,
+        }
+    ),
+    "methodResponses_json": json.dumps(
+        {
+            "200": {
+                "statusCode": "200",
+                "responseModels": {},
+            },
+        }
+    ),
+    "requestModels_json": json.dumps({}),
+    "requestParameters_json": json.dumps({}),
+    "requestValidatorId": None,
+    "authorizerId": None,
+    "RestApiId": "test-001",
+    "ResourceId": "3kzxbg5sa2",
+    "HttpMethod": "POST",
+}
+
+METHOD_RESPONSE_PUT = {
+    "authorizationType": "CUSTOM",
+    "authorizerId": "ab12cdefgh",
+    "apiKeyRequired": False,
+    "operationName": "UpdateResource",
+    "methodIntegration_json": json.dumps(
+        {
+            "type": "MOCK",
+            "httpMethod": "PUT",
+            "uri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/",
+            "passthroughBehavior": "WHEN_NO_MATCH",
+        }
+    ),
+    "methodResponses_json": json.dumps(
+        {
+            "200": {
+                "statusCode": "200",
+            },
+        }
+    ),
+    "requestModels_json": json.dumps({}),
+    "requestParameters_json": json.dumps({}),
+    "requestValidatorId": None,
+    "RestApiId": "test-001",
+    "ResourceId": "3kzxbg5sa2",
+    "HttpMethod": "PUT",
+}
+
+
+METHOD_RESPONSE_S3 = {
+    "authorizationType": "AWS_IAM",
+    "apiKeyRequired": False,
+    "operationName": "DeleteObject",
+    "methodIntegration_json": json.dumps(
+        {
+            "type": "AWS",
+            "httpMethod": "DELETE",
+            "uri": "arn:aws:s3:::bucket-1/some/object",
+            "passthroughBehavior": "WHEN_NO_MATCH",
+            "timeoutInMillis": 29000,
+        }
+    ),
+    "methodResponses_json": json.dumps(
+        {
+            "204": {
+                "statusCode": "204",
+            },
+        }
+    ),
+    "requestModels_json": json.dumps({}),
+    "requestParameters_json": json.dumps(
+        {"integration.request.header.x-amz-acl": True}
+    ),
+    "requestValidatorId": None,
+    "authorizerId": None,
+    "RestApiId": "test-001",
+    "ResourceId": "3kzxbg5sa2",
+    "HttpMethod": "DELETE",
+}
+
+METHOD_RESPONSE_DDB = {
+    "authorizationType": "AWS_IAM",
+    "apiKeyRequired": True,
+    "operationName": "UpdateItem",
+    "methodIntegration_json": json.dumps(
+        {
+            "type": "AWS",
+            "httpMethod": "POST",
+            "uri": "arn:aws:dynamodb:us-east-1:000000000000:table/example-table",
+            "passthroughBehavior": "WHEN_NO_MATCH",
+            "timeoutInMillis": 29000,
+        }
+    ),
+    "methodResponses_json": json.dumps(
+        {
+            "200": {
+                "statusCode": "200",
+            }
+        }
+    ),
+    "requestModels_json": json.dumps({}),
+    "requestParameters_json": json.dumps({}),
+    "requestValidatorId": None,
+    "authorizerId": None,
+    "RestApiId": "test-001",
+    "ResourceId": "3kzxbg5sa2",
+    "HttpMethod": "PATCH",
+}
+
+
+MOCK_GET_METHOD_RESPONSES = {
+    ("test-001", "3kzxbg5sa2", "GET"): METHOD_RESPONSE_GET,
+    ("test-001", "3kzxbg5sa2", "POST"): METHOD_RESPONSE_POST,
+    ("test-001", "3kzxbg5sa2", "PUT"): METHOD_RESPONSE_PUT,
+    ("test-001", "3kzxbg5sa2", "DELETE"): METHOD_RESPONSE_S3,
+    ("test-001", "3kzxbg5sa2", "PATCH"): METHOD_RESPONSE_DDB,
+}


### PR DESCRIPTION
### Summary
This PR adds ingestion and relationships for AWS API Gateway Methods. Relationships include:
- (:APIGatewayResource)-[:RESOURCE]->(:APIGatewayMethod) 
- (:APIGatewayMethod)-[:INVOKES]->(:AWSLambda) 
- (:APIGatewayMethod)-[:ACCESSES]->(:S3Bucket) 
- (:APIGatewayMethod)-[:ACCESSES]->(:DynamoDBTable) 



### Related issues or links
( #1552 )


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [x] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
