### PR TITLE
Don't fail on LB v2 DNSName KeyError

### DIFF
--- a/cartography/intel/aws/ec2/load_balancer_v2s.py
+++ b/cartography/intel/aws/ec2/load_balancer_v2s.py
@@ -99,7 +99,10 @@ def load_load_balancer_v2s(
     SET r.lastupdated = $update_tag
     """
     for lb in data:
-        load_balancer_id = lb["DNSName"]
+        load_balancer_id = lb.get("DNSName")
+        if not load_balancer_id:
+            logger.warning("Skipping load balancer entry with missing DNSName: %r", lb)
+            continue
 
         neo4j_session.run(
             ingest_load_balancer_v2,

--- a/tests/data/aws/ec2/load_balancers.py
+++ b/tests/data/aws/ec2/load_balancers.py
@@ -109,6 +109,28 @@ LOAD_BALANCER_DATA = [
         "Listeners": LOAD_BALANCER_LISTENERS,
         "TargetGroups": TARGET_GROUPS,
     },
+    # Entry with missing DNSName to test skip/warning logic
+    {
+        "CreatedTime": "10-27-2019 12:35AM",
+        "LoadBalancerName": "missingdnsnamelb",
+        "Type": "application",
+        "Scheme": "internet-facing",
+        "AvailabilityZones": [
+            {
+                "ZoneName": "myAZ",
+                "SubnetId": "mysubnetIdB",
+                "LoadBalancerAddresses": [
+                    {
+                        "IpAddress": "50.0.2.0",
+                        "AllocationId": "someId2",
+                    },
+                ],
+            },
+        ],
+        "SecurityGroups": ["sg-345678"],
+        "Listeners": LOAD_BALANCER_LISTENERS,
+        "TargetGroups": TARGET_GROUPS,
+    },
 ]
 
 # 'LoadBalancers': [

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_load_balancers.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_load_balancers.py
@@ -485,13 +485,10 @@ def test_load_balancer_v2s_skips_missing_dnsname(neo4j_session, *args):
         TEST_ACCOUNT_ID,
         TEST_UPDATE_TAG,
     )
-    # Only the valid load balancer should be present
-    nodes = neo4j_session.run(
-        """
-        MATCH (elbv2:LoadBalancerV2) RETURN elbv2.id as id
-        """
-    )
-    actual_ids = {n["id"] for n in nodes}
-    assert "myawesomeloadbalancer.amazonaws.com" in actual_ids
-    # The one with missing DNSName should not be present
-    assert "missingdnsnamelb" not in actual_ids
+    # The valid load balancer should be present
+    valid_lb_id = ("myawesomeloadbalancer.amazonaws.com",)
+    # The invalid load balancer should not be present
+    invalid_lb_id = ("missingdnsnamelb",)
+    actual = check_nodes(neo4j_session, "LoadBalancerV2", ["id"])
+    assert valid_lb_id in actual
+    assert invalid_lb_id not in actual

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_load_balancers.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_load_balancers.py
@@ -449,3 +449,49 @@ def test_sync_load_balancers(mock_get_instances, mock_get_loadbalancers, neo4j_s
         ("test-lb-1-1234567890.us-east-1.elb.amazonaws.com443HTTPS", "000000000000"),
         ("test-lb-2-1234567890.us-east-1.elb.amazonaws.com8080TCP", "000000000000"),
     }
+
+
+def test_load_balancer_v2s_skips_missing_dnsname(neo4j_session, *args):
+    load_balancer_data = tests.data.aws.ec2.load_balancers.LOAD_BALANCER_DATA
+    # Setup required nodes
+    neo4j_session.run(
+        """
+        MERGE (ec2:EC2Instance{instanceid: $ec2_instance_id})
+        ON CREATE SET ec2.firstseen = timestamp()
+        SET ec2.lastupdated = $aws_update_tag
+
+        MERGE (aws:AWSAccount{id: $aws_account_id})
+        ON CREATE SET aws.firstseen = timestamp()
+        SET aws.lastupdated = $aws_update_tag
+
+        MERGE (group:EC2SecurityGroup{groupid: $GROUP_ID_1})
+        ON CREATE SET group.firstseen = timestamp()
+        SET group.last_updated = $aws_update_tag
+
+        MERGE (group2:EC2SecurityGroup{groupid: $GROUP_ID_2})
+        ON CREATE SET group2.firstseen = timestamp()
+        SET group2.last_updated = $aws_update_tag
+        """,
+        ec2_instance_id="i-0f76fade",
+        aws_account_id=TEST_ACCOUNT_ID,
+        aws_update_tag=TEST_UPDATE_TAG,
+        GROUP_ID_1="sg-123456",
+        GROUP_ID_2="sg-234567",
+    )
+    cartography.intel.aws.ec2.load_balancer_v2s.load_load_balancer_v2s(
+        neo4j_session,
+        load_balancer_data,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+    # Only the valid load balancer should be present
+    nodes = neo4j_session.run(
+        """
+        MATCH (elbv2:LoadBalancerV2) RETURN elbv2.id as id
+        """
+    )
+    actual_ids = {n["id"] for n in nodes}
+    assert "myawesomeloadbalancer.amazonaws.com" in actual_ids
+    # The one with missing DNSName should not be present
+    assert "missingdnsnamelb" not in actual_ids


### PR DESCRIPTION
### Summary
Saw this KeyError in load balancer v2
```
File "/app/.venv/lib/python3.13/site-packages/cartography/intel/aws/ec2/load_balancer_v2s.py", line 80, 
load_balancer_id = lb["DNSName"]
KeyError: 'DNSName'
```

### Related issues or links
> Include links to relevant issues or other pages.
https://github.com/cartography-cncf/cartography/issues/996