### PR TITLE
Fix #1595: correct wrong client name

### DIFF
--- a/cartography/intel/aws/cloudwatch.py
+++ b/cartography/intel/aws/cloudwatch.py
@@ -22,7 +22,7 @@ def get_cloudwatch_log_groups(
     boto3_session: boto3.Session, region: str
 ) -> List[Dict[str, Any]]:
     client = boto3_session.client(
-        "cloudwatch", region_name=region, config=get_botocore_config()
+        "logs", region_name=region, config=get_botocore_config()
     )
     paginator = client.get_paginator("describe_log_groups")
     logGroups = []


### PR DESCRIPTION
### Summary
> Describe your changes.

Problem: 'cloudwatch' is not a valid boto3 client name. 

Fix: it should be 'logs' instead.


### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/cartography-cncf/cartography/issues/1595


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.


Before
```
>>> client = boto3.client('cloudwatch')
>>> paginator = client.get_paginator("describe_log_groups")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/alex/src/scripts/.venv/lib/python3.12/site-packages/botocore/client.py", line 1197, in get_paginator
    if not self.can_paginate(operation_name):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/src/scripts/.venv/lib/python3.12/site-packages/botocore/client.py", line 1268, in can_paginate
    actual_operation_name = self._PY_TO_OP_NAME[operation_name]
                            ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
KeyError: 'describe_log_groups'
```

After
```
>>> paginator = client.get_paginator("describe_log_groups")
>>> for page in paginator.paginate():
...   page['logGroups']
...
[]
```