### PR TITLE
Fix 1597: Fix for list_secret_versions_ids not paginatable

### DIFF
--- a/cartography/intel/aws/secretsmanager.py
+++ b/cartography/intel/aws/secretsmanager.py
@@ -91,16 +91,30 @@ def get_secret_versions(
 ) -> List[Dict]:
     """
     Get all versions of a secret from AWS Secrets Manager.
+
+    Note: list_secret_version_ids is not paginatable through boto3's paginator,
+    so we implement manual pagination.
     """
     client = boto3_session.client("secretsmanager", region_name=region)
-    paginator = client.get_paginator("list_secret_version_ids")
+    next_token = None
     versions = []
 
-    for page in paginator.paginate(SecretId=secret_arn, IncludeDeprecated=True):
-        for version in page["Versions"]:
+    while True:
+        params = {"SecretId": secret_arn, "IncludeDeprecated": True}
+        if next_token:
+            params["NextToken"] = next_token
+
+        response = client.list_secret_version_ids(**params)
+
+        for version in response.get("Versions", []):
             version["SecretId"] = secret_arn
             version["ARN"] = f"{secret_arn}:version:{version['VersionId']}"
-        versions.extend(page["Versions"])
+
+        versions.extend(response.get("Versions", []))
+
+        next_token = response.get("NextToken")
+        if not next_token:
+            break
 
     return versions
 


### PR DESCRIPTION
### Summary
This is fix  for the list_secret_versions_id not  paginatable error. I have approached it with manual pagination.

### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/cartography-cncf/cartography/issues/1597


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
