### PR TITLE
Fix #1597: list-secret-versions pagination and keyerror

### DIFF
--- a/cartography/intel/aws/secretsmanager.py
+++ b/cartography/intel/aws/secretsmanager.py
@@ -91,16 +91,30 @@ def get_secret_versions(
 ) -> List[Dict]:
     """
     Get all versions of a secret from AWS Secrets Manager.
+
+    Note: list_secret_version_ids is not paginatable through boto3's paginator,
+    so we implement manual pagination.
     """
     client = boto3_session.client("secretsmanager", region_name=region)
-    paginator = client.get_paginator("list_secret_version_ids")
+    next_token = None
     versions = []
 
-    for page in paginator.paginate(SecretId=secret_arn, IncludeDeprecated=True):
-        for version in page["Versions"]:
+    while True:
+        params = {"SecretId": secret_arn, "IncludeDeprecated": True}
+        if next_token:
+            params["NextToken"] = next_token
+
+        response = client.list_secret_version_ids(**params)
+
+        for version in response.get("Versions", []):
             version["SecretId"] = secret_arn
             version["ARN"] = f"{secret_arn}:version:{version['VersionId']}"
-        versions.extend(page["Versions"])
+
+        versions.extend(response.get("Versions", []))
+
+        next_token = response.get("NextToken")
+        if not next_token:
+            break
 
     return versions
 

--- a/cartography/intel/aws/secretsmanager.py
+++ b/cartography/intel/aws/secretsmanager.py
@@ -133,7 +133,7 @@ def transform_secret_versions(
             "ARN": version["ARN"],
             "SecretId": version["SecretId"],
             "VersionId": version["VersionId"],
-            "VersionStages": version["VersionStages"],
+            "VersionStages": version.get("VersionStages"),
             "CreatedDate": dict_date_to_epoch(version, "CreatedDate"),
         }
 


### PR DESCRIPTION
### Summary
> Describe your changes.

Supercedes #1598 (thank you to @AdityaPandeyCN)


### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/cartography-cncf/cartography/issues/1597


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [x] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

Proof this works
```
INFO:cartography.intel.aws.secretsmanager:Syncing Secrets Manager for region 'us-east-1' in account 'ACCOUNT_ID'.
INFO:cartography.intel.aws.secretsmanager:Getting versions for secret MY/PATH/SECRET1 (arn:aws:secretsmanager:us-east-1:ACCOUNT_ID:secret:MY/PATH/SECRET1-yH8YBG)
INFO:cartography.intel.aws.secretsmanager:Found 3 versions for secret MY/PATH/SECRET1
INFO:cartography.intel.aws.secretsmanager:Getting versions for secret MY/PATH/API_KEY (arn:aws:secretsmanager:us-east-1:ACCOUNT_ID:secret:MY/PATH/API_KEY-D4cUqK)
INFO:cartography.intel.aws.secretsmanager:Found 2 versions for secret MY/PATH/API_KEY
INFO:cartography.intel.aws.secretsmanager:Getting versions for secret MY/PATH/entra_client_secret (arn:aws:secretsmanager:us-east-1:ACCOUNT_ID:secret:MY/PATH/entra_client_secret-NajW6K)
INFO:cartography.intel.aws.secretsmanager:Found 1 versions for secret MY/PATH/entra_client_secret
INFO:cartography.intel.aws.secretsmanager:Getting versions for secret MY/PATH/OTHER_KEY (arn:aws:secretsmanager:us-east-1:ACCOUNT_ID:secret:MY/PATH/OTHER_KEY-aFGWlA)
INFO:cartography.intel.aws.secretsmanager:Found 1 versions for secret MY/PATH/OTHER_KEY
INFO:cartography.intel.aws.secretsmanager:Getting versions for secret MY/PATH/KEY_3 (arn:aws:secretsmanager:us-east-1:ACCOUNT_ID:secret:MY/PATH/KEY_3-1biQ3W)
INFO:cartography.intel.aws.secretsmanager:Found 1 versions for secret MY/PATH/KEY_3
INFO:cartography.intel.aws.secretsmanager:Loading 8 Secret Versions for region us-east-1 into graph.
```
![Screenshot 2025-05-28 at 3 27 54 PM](https://github.com/user-attachments/assets/fd04d351-f18d-4358-ad12-7ddd7c2c7d04)
