### PR TITLE
feat: allow node_schema without sub resources to be cleaned up

### DIFF
--- a/cartography/graph/cleanupbuilder.py
+++ b/cartography/graph/cleanupbuilder.py
@@ -15,6 +15,7 @@ from cartography.models.core.relationships import TargetNodeMatcher
 def build_cleanup_queries(node_schema: CartographyNodeSchema) -> List[str]:
     """
     Generates queries to clean up stale nodes and relationships from the given CartographyNodeSchema.
+    Properly handles cases where a node schema has a scoped cleanup or not.
     Note that auto-cleanups for a node with no relationships is not currently supported.
 
     Algorithm:
@@ -22,16 +23,17 @@ def build_cleanup_queries(node_schema: CartographyNodeSchema) -> List[str]:
 
     Otherwise,
 
-    1. If node_schema doesn't have a sub_resource relationship, generate queries only to clean up its other
-    relationships. No nodes will be cleaned up.
+    1. If node_schema doesn't have a sub_resource relationship and if scoped_cleanup is true, generate queries
+    only to clean up its other_relationships. No nodes will be cleaned up. This is the case for SyncMetadata nodes.
 
-    Otherwise,
+    Otherwise, clean up stale nodes, properly handling whether the node's scoped_cleanup flag is set. Specifically:
 
-    1. First delete all stale nodes attached to the node_schema's sub resource
-    2. Delete all stale node to sub resource relationships
+    1. First delete all stale nodes. In the case of a scoped cleanup, ensure that we only do this for the nodes in the
+    sub resource currently being synced.
+    2. If this is a scoped cleanup, delete all stale node to sub resource relationships
         - We don't expect this to be very common (never for AWS resources, at least), but in case it is possible for an
           asset to change sub resources, we want to handle it properly.
-    3. For all relationships defined on the node schema, delete all stale ones.
+    3. For all other relationships defined on the node schema, delete all stale ones.
     :param node_schema: The given CartographyNodeSchema
     :return: A list of Neo4j queries to clean up nodes and relationships.
     """
@@ -41,7 +43,7 @@ def build_cleanup_queries(node_schema: CartographyNodeSchema) -> List[str]:
     ):
         return []
 
-    if not node_schema.sub_resource_relationship:
+    if not node_schema.sub_resource_relationship and node_schema.scoped_cleanup:
         queries = []
         other_rels = (
             node_schema.other_relationships.rels
@@ -53,15 +55,24 @@ def build_cleanup_queries(node_schema: CartographyNodeSchema) -> List[str]:
             queries.append(query)
         return queries
 
-    result = _build_cleanup_node_and_rel_queries(
-        node_schema,
-        node_schema.sub_resource_relationship,
-    )
+    result = []
+    if not node_schema.scoped_cleanup:
+        result = [_build_unscoped_cleanup_node_query(node_schema)]
+    # keep mypy happy by ensuring that the sub_resource_rel is not None here
+    elif node_schema.sub_resource_relationship:
+        result = _build_cleanup_node_and_rel_queries(
+            node_schema,
+            node_schema.sub_resource_relationship,
+        )
+
     if node_schema.other_relationships:
         for rel in node_schema.other_relationships.rels:
-            # [0] is the delete node query, [1] is the delete relationship query. We only want the latter.
-            _, rel_query = _build_cleanup_node_and_rel_queries(node_schema, rel)
-            result.append(rel_query)
+            if node_schema.scoped_cleanup:
+                # [0] is the delete node query, [1] is the delete relationship query. We only want the latter.
+                _, rel_query = _build_cleanup_node_and_rel_queries(node_schema, rel)
+                result.append(rel_query)
+            else:
+                result.append(_build_cleanup_rel_queries_unscoped(node_schema, rel))
 
     return result
 
@@ -94,6 +105,46 @@ def _build_cleanup_rel_query_no_sub_resource(
     )
 
 
+def _build_match_statement_for_cleanup(node_schema: CartographyNodeSchema) -> str:
+    """
+    Helper function to build a MATCH statement for a given node schema for cleanup.
+    """
+    if not node_schema.sub_resource_relationship and not node_schema.scoped_cleanup:
+        template = Template("MATCH (n:$node_label)")
+        return template.safe_substitute(
+            node_label=node_schema.label,
+        )
+
+    # if it has a sub resource relationship defined, we need to match on the sub resource to make sure we only delete
+    # nodes that are attached to the sub resource.
+    template = Template(
+        "MATCH (n:$node_label)$sub_resource_link(:$sub_resource_label{$match_sub_res_clause})"
+    )
+    sub_resource_link = ""
+    sub_resource_label = ""
+    match_sub_res_clause = ""
+
+    if node_schema.sub_resource_relationship:
+        # Draw sub resource rel with correct direction
+        if node_schema.sub_resource_relationship.direction == LinkDirection.INWARD:
+            sub_resource_link_template = Template("<-[s:$SubResourceRelLabel]-")
+        else:
+            sub_resource_link_template = Template("-[s:$SubResourceRelLabel]->")
+        sub_resource_link = sub_resource_link_template.safe_substitute(
+            SubResourceRelLabel=node_schema.sub_resource_relationship.rel_label,
+        )
+        sub_resource_label = node_schema.sub_resource_relationship.target_node_label
+        match_sub_res_clause = _build_match_clause(
+            node_schema.sub_resource_relationship.target_node_matcher,
+        )
+    return template.safe_substitute(
+        node_label=node_schema.label,
+        sub_resource_link=sub_resource_link,
+        sub_resource_label=sub_resource_label,
+        match_sub_res_clause=match_sub_res_clause,
+    )
+
+
 def _build_cleanup_node_and_rel_queries(
     node_schema: CartographyNodeSchema,
     selected_relationship: CartographyRelSchema,
@@ -119,15 +170,6 @@ def _build_cleanup_node_and_rel_queries(
             f"relationship {selected_relationship.rel_label} but that relationship is not present on the node. Please "
             "verify the node class definition for the relationships that it has.",
         )
-
-    # Draw sub resource rel with correct direction
-    if node_schema.sub_resource_relationship.direction == LinkDirection.INWARD:
-        sub_resource_link_template = Template("<-[s:$SubResourceRelLabel]-")
-    else:
-        sub_resource_link_template = Template("-[s:$SubResourceRelLabel]->")
-    sub_resource_link = sub_resource_link_template.safe_substitute(
-        SubResourceRelLabel=node_schema.sub_resource_relationship.rel_label,
-    )
 
     # The cleanup node query must always be before the cleanup rel query
     delete_action_clauses = [
@@ -161,19 +203,14 @@ def _build_cleanup_node_and_rel_queries(
     # Ensure the node is attached to the sub resource and delete the node
     query_template = Template(
         """
-        MATCH (n:$node_label)$sub_resource_link(:$sub_resource_label{$match_sub_res_clause})
+        $match_statement
         $selected_rel_clause
         $delete_action_clause
         """,
     )
     return [
         query_template.safe_substitute(
-            node_label=node_schema.label,
-            sub_resource_link=sub_resource_link,
-            sub_resource_label=node_schema.sub_resource_relationship.target_node_label,
-            match_sub_res_clause=_build_match_clause(
-                node_schema.sub_resource_relationship.target_node_matcher,
-            ),
+            match_statement=_build_match_statement_for_cleanup(node_schema),
             selected_rel_clause=(
                 ""
                 if selected_relationship == node_schema.sub_resource_relationship
@@ -183,6 +220,80 @@ def _build_cleanup_node_and_rel_queries(
         )
         for delete_action_clause in delete_action_clauses
     ]
+
+
+def _build_unscoped_cleanup_node_query(
+    node_schema: CartographyNodeSchema,
+) -> str:
+    """
+    Generates a cleanup query for a node_schema to allow unscoped cleanup.
+    """
+    if node_schema.scoped_cleanup:
+        raise ValueError(
+            f"_build_cleanup_node_query_for_unscoped_cleanup() failed: '{node_schema.label}' does not have "
+            "scoped_cleanup=False, so we cannot generate a query to clean it up. Please verify that the class "
+            "definition is what you expect.",
+        )
+
+    # The cleanup node query must always be before the cleanup rel query
+    delete_action_clause = """
+        WHERE n.lastupdated <> $UPDATE_TAG
+        WITH n LIMIT $LIMIT_SIZE
+        DETACH DELETE n;
+    """
+
+    # Ensure the node is attached to the sub resource and delete the node
+    query_template = Template(
+        """
+        $match_statement
+        $delete_action_clause
+        """,
+    )
+    return query_template.safe_substitute(
+        match_statement=_build_match_statement_for_cleanup(node_schema),
+        delete_action_clause=delete_action_clause,
+    )
+
+
+def _build_cleanup_rel_queries_unscoped(
+    node_schema: CartographyNodeSchema,
+    selected_relationship: CartographyRelSchema,
+) -> str:
+    """
+    Generates relationship cleanup query for a node_schema with scoped_cleanup=False.
+    """
+    if node_schema.scoped_cleanup:
+        raise ValueError(
+            f"_build_cleanup_node_and_rel_queries_unscoped() failed: '{node_schema.label}' does not have "
+            "scoped_cleanup=False, so we cannot generate a query to clean it up. Please verify that the class "
+            "definition is what you expect.",
+        )
+    if not rel_present_on_node_schema(node_schema, selected_relationship):
+        raise ValueError(
+            f"_build_cleanup_node_query(): Attempted to build cleanup query for node '{node_schema.label}' and "
+            f"relationship {selected_relationship.rel_label} but that relationship is not present on the node. Please "
+            "verify the node class definition for the relationships that it has.",
+        )
+
+    # The cleanup node query must always be before the cleanup rel query
+    delete_action_clause = """WHERE r.lastupdated <> $UPDATE_TAG
+        WITH r LIMIT $LIMIT_SIZE
+        DELETE r;
+        """
+
+    # Ensure the node is attached to the sub resource and delete the node
+    query_template = Template(
+        """
+        $match_statement
+        $selected_rel_clause
+        $delete_action_clause
+        """,
+    )
+    return query_template.safe_substitute(
+        match_statement=_build_match_statement_for_cleanup(node_schema),
+        selected_rel_clause=_build_selected_rel_clause(selected_relationship),
+        delete_action_clause=delete_action_clause,
+    )
 
 
 def _build_selected_rel_clause(selected_relationship: CartographyRelSchema) -> str:

--- a/cartography/graph/cleanupbuilder.py
+++ b/cartography/graph/cleanupbuilder.py
@@ -62,7 +62,7 @@ def build_cleanup_queries(node_schema: CartographyNodeSchema) -> List[str]:
 
     # Case 4: The node has no sub resource and scoped cleanup is false => clean up the stale nodes. Continue on to clean up the other_relationships too.
     else:
-        queries = [_build_unscoped_cleanup_node_query(node_schema)]
+        queries = [_build_cleanup_node_query_unscoped(node_schema)]
 
     if node_schema.other_relationships:
         for rel in node_schema.other_relationships.rels:
@@ -221,7 +221,7 @@ def _build_cleanup_node_and_rel_queries(
     ]
 
 
-def _build_unscoped_cleanup_node_query(
+def _build_cleanup_node_query_unscoped(
     node_schema: CartographyNodeSchema,
 ) -> str:
     """

--- a/cartography/models/core/nodes.py
+++ b/cartography/models/core/nodes.py
@@ -103,3 +103,16 @@ class CartographyNodeSchema(abc.ABC):
         :return: None if not overriden. Else return the ExtraNodeLabels specified on the node.
         """
         return None
+
+    @property
+    def scoped_cleanup(self) -> bool:
+        """
+        Optional.
+        Allows specifying whether cleanups of this node must be scoped to the sub resource relationship.
+        If True (default), when we clean up nodes of this type, we will only delete stale nodes in the current sub
+        resource. This is how our AWS sync behaves.
+        If False, when we clean up node of this type, we will delete all stale nodes. This is designed for resource
+        types that don't have a "tenant"-like entity.
+        :return: True if not overriden. Else return the boolean value specified on the node.
+        """
+        return True

--- a/cartography/models/core/nodes.py
+++ b/cartography/models/core/nodes.py
@@ -91,7 +91,7 @@ class CartographyNodeSchema(abc.ABC):
         """
         Optional.
         Allows subclasses to specify additional cartography relationships on the node.
-        :return: None if not overriden. Else return the node's OtherRelationships.
+        :return: None if not overridden. Else return the node's OtherRelationships.
         """
         return None
 
@@ -100,7 +100,7 @@ class CartographyNodeSchema(abc.ABC):
         """
         Optional.
         Allows specifying extra labels on the node.
-        :return: None if not overriden. Else return the ExtraNodeLabels specified on the node.
+        :return: None if not overridden. Else return the ExtraNodeLabels specified on the node.
         """
         return None
 
@@ -113,6 +113,6 @@ class CartographyNodeSchema(abc.ABC):
         resource. This is how our AWS sync behaves.
         If False, when we clean up node of this type, we will delete all stale nodes. This is designed for resource
         types that don't have a "tenant"-like entity.
-        :return: True if not overriden. Else return the boolean value specified on the node.
+        :return: True if not overridden. Else return the boolean value specified on the node.
         """
         return True

--- a/docs/root/dev/writing-intel-modules.md
+++ b/docs/root/dev/writing-intel-modules.md
@@ -354,6 +354,19 @@ def cleanup(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:
     cleanup_job.run(neo4j_session)
 ```
 
+#### Scoped cleanups
+
+By default, a node_schema has `scoped_cleanup` flag set to True. This means that when we run a clean up job on that
+node type, then we will only delete stale nodes that are connected to the current sub-resource being synced. This is
+designed for modules like AWS or GCP where there a clear definition of a "tenant"-like object because each account or
+project gets synced in one at a time and it doesn't make sense to delete objects outside of the current tenant being
+synced.
+
+For some other modules that don't have a clear tenant-like relationship, you can set `scoped_cleanup` to False on the
+node_schema. This might make sense for a vuln scanner module where there is no logcal tenant object.
+
+#### Legacy notes
+
 Older intel modules still do this process with hand-written cleanup jobs that work like this:
 
 - Delete all old nodes

--- a/docs/root/dev/writing-intel-modules.md
+++ b/docs/root/dev/writing-intel-modules.md
@@ -363,7 +363,7 @@ project gets synced in one at a time and it doesn't make sense to delete objects
 synced.
 
 For some other modules that don't have a clear tenant-like relationship, you can set `scoped_cleanup` to False on the
-node_schema. This might make sense for a vuln scanner module where there is no logcal tenant object.
+node_schema. This might make sense for a vuln scanner module where there is no logical tenant object.
 
 #### Legacy notes
 

--- a/tests/data/graph/querybuilder/sample_models/allow_unscoped.py
+++ b/tests/data/graph/querybuilder/sample_models/allow_unscoped.py
@@ -3,12 +3,12 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
-from cartography.models.core.relationships import CartographyRelProperties, OtherRelationships
+from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
-from tests.data.graph.querybuilder.sample_models.simple_node import SimpleNodeSchema
 
 
 @dataclass(frozen=True)
@@ -40,8 +40,9 @@ class UnscopedNodeSchema(CartographyNodeSchema):
     properties: UnscopedNodeProperties = UnscopedNodeProperties()
     # This node can be cleaned up without being attached to a sub-resource
     scoped_cleanup: bool = False
-    # No sub-resource relationship defined
-    sub_resource_relationship: CartographyRelSchema = None
-    other_relationships: OtherRelationships = OtherRelationships(rels=[
-        UnscopedToSimpleRel(),
-    ])
+    # Note that sub-resource relationship is not defined
+    other_relationships: OtherRelationships = OtherRelationships(
+        rels=[
+            UnscopedToSimpleRel(),
+        ]
+    )

--- a/tests/data/graph/querybuilder/sample_models/allow_unscoped.py
+++ b/tests/data/graph/querybuilder/sample_models/allow_unscoped.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties, OtherRelationships
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+from tests.data.graph.querybuilder.sample_models.simple_node import SimpleNodeSchema
+
+
+@dataclass(frozen=True)
+class UnscopedNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("Id")
+    name: PropertyRef = PropertyRef("name")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class UnscopedToSimpleRelProps(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class UnscopedToSimpleRel(CartographyRelSchema):
+    target_node_label: str = "SimpleNode"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RELATES_TO"
+    properties: UnscopedToSimpleRelProps = UnscopedToSimpleRelProps()
+
+
+@dataclass(frozen=True)
+class UnscopedNodeSchema(CartographyNodeSchema):
+    label: str = "UnscopedNode"
+    properties: UnscopedNodeProperties = UnscopedNodeProperties()
+    # This node can be cleaned up without being attached to a sub-resource
+    scoped_cleanup: bool = False
+    # No sub-resource relationship defined
+    sub_resource_relationship: CartographyRelSchema = None
+    other_relationships: OtherRelationships = OtherRelationships(rels=[
+        UnscopedToSimpleRel(),
+    ])

--- a/tests/data/graph/querybuilder/sample_models/allow_unscoped.py
+++ b/tests/data/graph/querybuilder/sample_models/allow_unscoped.py
@@ -13,7 +13,7 @@ from cartography.models.core.relationships import TargetNodeMatcher
 
 @dataclass(frozen=True)
 class UnscopedNodeProperties(CartographyNodeProperties):
-    id: PropertyRef = PropertyRef("Id")
+    id: PropertyRef = PropertyRef("id")
     name: PropertyRef = PropertyRef("name")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
@@ -27,7 +27,7 @@ class UnscopedToSimpleRelProps(CartographyRelProperties):
 class UnscopedToSimpleRel(CartographyRelSchema):
     target_node_label: str = "SimpleNode"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("id")},
+        {"id": PropertyRef("simple_node_id")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "RELATES_TO"

--- a/tests/data/graph/querybuilder/sample_models/allow_unscoped.py
+++ b/tests/data/graph/querybuilder/sample_models/allow_unscoped.py
@@ -38,7 +38,7 @@ class UnscopedToSimpleRel(CartographyRelSchema):
 class UnscopedNodeSchema(CartographyNodeSchema):
     label: str = "UnscopedNode"
     properties: UnscopedNodeProperties = UnscopedNodeProperties()
-    # This node can be cleaned up without being attached to a sub-resource
+    # This node can be cleaned up without being attached as a sub-resource of a parent node.
     scoped_cleanup: bool = False
     # Note that sub-resource relationship is not defined
     other_relationships: OtherRelationships = OtherRelationships(

--- a/tests/data/graph/querybuilder/sample_models/invalid_unscoped.py
+++ b/tests/data/graph/querybuilder/sample_models/invalid_unscoped.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class InvalidUnscopedNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("Id")
+    name: PropertyRef = PropertyRef("name")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class InvalidUnscopedToSimpleRelProps(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class InvalidUnscopedToSimpleRel(CartographyRelSchema):
+    target_node_label: str = "SimpleNode"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RELATES_TO"
+    properties: InvalidUnscopedToSimpleRelProps = InvalidUnscopedToSimpleRelProps()
+
+
+@dataclass(frozen=True)
+class InvalidUnscopedNodeSchema(CartographyNodeSchema):
+    label: str = "InvalidUnscopedNode"
+    properties: InvalidUnscopedNodeProperties = InvalidUnscopedNodeProperties()
+    # This node has scoped_cleanup=False but also has a sub_resource_relationship
+    # which should trigger the ValueError
+    scoped_cleanup: bool = False
+    sub_resource_relationship: CartographyRelSchema = InvalidUnscopedToSimpleRel() 

--- a/tests/data/graph/querybuilder/sample_models/invalid_unscoped.py
+++ b/tests/data/graph/querybuilder/sample_models/invalid_unscoped.py
@@ -12,7 +12,7 @@ from cartography.models.core.relationships import TargetNodeMatcher
 
 @dataclass(frozen=True)
 class InvalidUnscopedNodeProperties(CartographyNodeProperties):
-    id: PropertyRef = PropertyRef("Id")
+    id: PropertyRef = PropertyRef("id")
     name: PropertyRef = PropertyRef("name")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 

--- a/tests/data/graph/querybuilder/sample_models/invalid_unscoped.py
+++ b/tests/data/graph/querybuilder/sample_models/invalid_unscoped.py
@@ -40,4 +40,4 @@ class InvalidUnscopedNodeSchema(CartographyNodeSchema):
     # This node has scoped_cleanup=False but also has a sub_resource_relationship
     # which should trigger the ValueError
     scoped_cleanup: bool = False
-    sub_resource_relationship: CartographyRelSchema = InvalidUnscopedToSimpleRel() 
+    sub_resource_relationship: CartographyRelSchema = InvalidUnscopedToSimpleRel()

--- a/tests/integration/cartography/graph/test_cleanupbuilder_unscoped.py
+++ b/tests/integration/cartography/graph/test_cleanupbuilder_unscoped.py
@@ -1,0 +1,84 @@
+from cartography.client.core.tx import load_graph_data
+from cartography.graph.job import GraphJob
+from cartography.graph.querybuilder import build_ingestion_query
+from tests.data.graph.querybuilder.sample_models.allow_unscoped import (
+    UnscopedNodeSchema,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+
+def test_cleanup_unscoped_node_end_to_end(neo4j_session):
+    """
+    Arrange
+        Create paths
+        (u:UnscopedNode{id:'unscoped-node-id'})-[:RELATES_TO]->(:SimpleNode{id: 'simple-node-id'})
+        at timestamp lastupdated 1.
+
+    Act
+        Run cleanup with UPDATE_TAG=2.
+
+    Assert
+        That the UnscopedNode is deleted because it was stale and had scoped_cleanup=False.
+        The SimpleNode should remain since it's not part of the cleanup scope.
+    """
+    # Arrange: Create the SimpleNode first
+    neo4j_session.run(
+        """
+        MERGE (s:SimpleNode{id: 'simple-node-id'})
+        ON CREATE SET s.lastupdated = 1
+        """
+    )
+
+    # Arrange: Create the UnscopedNode and its relationship to SimpleNode
+    query = build_ingestion_query(UnscopedNodeSchema())
+    load_graph_data(
+        neo4j_session,
+        query,
+        [
+            {
+                "Id": "unscoped-node-id",
+                "name": "test-node",
+                "id": "simple-node-id",  # This will be used to create the RELATES_TO relationship
+            }
+        ],
+        lastupdated=1,
+    )
+
+    # Sanity check: Verify that the relationship exists
+    assert check_rels(
+        neo4j_session,
+        "UnscopedNode",
+        "id",
+        "SimpleNode",
+        "id",
+        "RELATES_TO",
+        rel_direction_right=True,
+    ) == {("unscoped-node-id", "simple-node-id")}
+
+    # Act: Run the cleanup job with UPDATE_TAG=2
+    cleanup_job = GraphJob.from_node_schema(
+        UnscopedNodeSchema(),
+        {"UPDATE_TAG": 2},
+    )
+    cleanup_job.run(neo4j_session)
+
+    # Assert: The UnscopedNode should be deleted because it was stale and had scoped_cleanup=False
+    assert check_nodes(neo4j_session, "UnscopedNode", ["id"]) == set()
+
+    # Assert: The SimpleNode should still exist since it's not part of the cleanup scope
+    assert check_nodes(neo4j_session, "SimpleNode", ["id"]) == {("simple-node-id",)}
+
+    # Assert: The relationship should be gone since the UnscopedNode was deleted
+    assert (
+        check_rels(
+            neo4j_session,
+            "UnscopedNode",
+            "id",
+            "SimpleNode",
+            "id",
+            "RELATES_TO",
+            rel_direction_right=True,
+        )
+        == set()
+    )

--- a/tests/integration/cartography/graph/test_cleanupbuilder_unscoped.py
+++ b/tests/integration/cartography/graph/test_cleanupbuilder_unscoped.py
@@ -37,9 +37,9 @@ def test_cleanup_unscoped_node_end_to_end(neo4j_session):
         query,
         [
             {
-                "Id": "unscoped-node-id",
+                "id": "unscoped-node-id",
                 "name": "test-node",
-                "id": "simple-node-id",  # This will be used to create the RELATES_TO relationship
+                "simple_node_id": "simple-node-id",  # This will be used to create the RELATES_TO relationship
             }
         ],
         lastupdated=1,

--- a/tests/unit/cartography/graph/test_cleanupbuilder.py
+++ b/tests/unit/cartography/graph/test_cleanupbuilder.py
@@ -23,6 +23,9 @@ from tests.data.graph.querybuilder.sample_models.interesting_asset import (
 from tests.data.graph.querybuilder.sample_models.interesting_asset import (
     InterestingAssetToSubResourceRel,
 )
+from tests.data.graph.querybuilder.sample_models.invalid_unscoped import (
+    InvalidUnscopedNodeSchema,
+)
 from tests.data.graph.querybuilder.sample_models.simple_node import SimpleNodeSchema
 from tests.unit.cartography.graph.helpers import clean_query_list
 
@@ -188,3 +191,21 @@ def test_build_cleanup_rel_query_no_sub_resource_raises_on_sub_resource():
 
     with pytest.raises(ValueError, match="Expected InterestingAsset to not exist"):
         _build_cleanup_rel_query_no_sub_resource(node_schema, rel_schema)
+
+
+def test_build_cleanup_queries_raises_error_for_invalid_unscoped():
+    """
+    Test that build_cleanup_queries raises a ValueError when a node schema has both
+    sub_resource_relationship and scoped_cleanup=False.
+    """
+    node_schema = InvalidUnscopedNodeSchema()
+    with pytest.raises(ValueError) as excinfo:
+        build_cleanup_queries(node_schema)
+
+    expected_error = (
+        f"This is not expected: {node_schema.label} has a sub_resource_relationship but scoped_cleanup=False."
+        "Please check the class definition for this node schema. It doesn't make sense for a node to have a "
+        "sub resource relationship and an unscoped cleanup. Doing this will cause all stale nodes of this type "
+        "to be deleted regardless of the sub resource they are attached to."
+    )
+    assert str(excinfo.value) == expected_error

--- a/tests/unit/cartography/graph/test_cleanupbuilder_unscoped.py
+++ b/tests/unit/cartography/graph/test_cleanupbuilder_unscoped.py
@@ -31,7 +31,7 @@ def test_build_ingestion_query_unscoped():
 
     expected = """
         UNWIND $DictList AS item
-            MERGE (i:UnscopedNode{id: item.Id})
+            MERGE (i:UnscopedNode{id: item.id})
             ON CREATE SET i.firstseen = timestamp()
             SET
                 i.lastupdated = $lastupdated,
@@ -42,7 +42,7 @@ def test_build_ingestion_query_unscoped():
                 WITH i, item
                 OPTIONAL MATCH (n0:SimpleNode)
                 WHERE
-                    n0.id = item.id
+                    n0.id = item.simple_node_id
                 WITH i, item, n0 WHERE n0 IS NOT NULL
                 MERGE (i)-[r0:RELATES_TO]->(n0)
                 ON CREATE SET r0.firstseen = timestamp()

--- a/tests/unit/cartography/graph/test_cleanupbuilder_unscoped.py
+++ b/tests/unit/cartography/graph/test_cleanupbuilder_unscoped.py
@@ -1,6 +1,8 @@
-from cartography.graph.querybuilder import build_ingestion_query
 from cartography.graph.cleanupbuilder import build_cleanup_queries
-from tests.data.graph.querybuilder.sample_models.allow_unscoped import UnscopedNodeSchema
+from cartography.graph.querybuilder import build_ingestion_query
+from tests.data.graph.querybuilder.sample_models.allow_unscoped import (
+    UnscopedNodeSchema,
+)
 from tests.unit.cartography.graph.helpers import (
     remove_leading_whitespace_and_empty_lines,
 )
@@ -81,5 +83,9 @@ def test_build_cleanup_queries_unscoped():
     """
 
     # Assert
-    assert actual_delete_node == remove_leading_whitespace_and_empty_lines(expected_delete_node)
-    assert actual_delete_rel == remove_leading_whitespace_and_empty_lines(expected_delete_rel)
+    assert actual_delete_node == remove_leading_whitespace_and_empty_lines(
+        expected_delete_node
+    )
+    assert actual_delete_rel == remove_leading_whitespace_and_empty_lines(
+        expected_delete_rel
+    )

--- a/tests/unit/cartography/graph/test_querybuilder_unscoped.py
+++ b/tests/unit/cartography/graph/test_querybuilder_unscoped.py
@@ -1,0 +1,85 @@
+from cartography.graph.querybuilder import build_ingestion_query
+from cartography.graph.cleanupbuilder import build_cleanup_queries
+from tests.data.graph.querybuilder.sample_models.allow_unscoped import UnscopedNodeSchema
+from tests.unit.cartography.graph.helpers import (
+    remove_leading_whitespace_and_empty_lines,
+)
+
+
+def test_unscoped_node_sanity_checks():
+    """
+    Test creating an unscoped node schema and ensure that the optional attributes are set correctly.
+    """
+    schema: UnscopedNodeSchema = UnscopedNodeSchema()
+    assert schema.extra_node_labels is None
+    assert schema.scoped_cleanup is False
+    assert schema.sub_resource_relationship is None
+
+    assert schema.other_relationships is not None
+    assert len(schema.other_relationships.rels) == 1
+    assert schema.other_relationships.rels[0].target_node_label == "SimpleNode"
+
+
+def test_build_ingestion_query_unscoped():
+    """
+    Test creating a query for an unscoped node schema.
+    """
+    # Act
+    query = build_ingestion_query(UnscopedNodeSchema())
+
+    expected = """
+        UNWIND $DictList AS item
+            MERGE (i:UnscopedNode{id: item.Id})
+            ON CREATE SET i.firstseen = timestamp()
+            SET
+                i.lastupdated = $lastupdated,
+                i.name = item.name
+
+            WITH i, item
+            CALL {
+                WITH i, item
+                OPTIONAL MATCH (n0:SimpleNode)
+                WHERE
+                    n0.id = item.id
+                WITH i, item, n0 WHERE n0 IS NOT NULL
+                MERGE (i)-[r0:RELATES_TO]->(n0)
+                ON CREATE SET r0.firstseen = timestamp()
+                SET
+                    r0.lastupdated = $lastupdated
+            }
+    """
+
+    # Assert: compare query outputs while ignoring leading whitespace.
+    actual_query = remove_leading_whitespace_and_empty_lines(query)
+    expected_query = remove_leading_whitespace_and_empty_lines(expected)
+    assert actual_query == expected_query
+
+
+def test_build_cleanup_queries_unscoped():
+    """
+    Test creating cleanup queries for an unscoped node schema.e
+    Since allow_unscoped_cleanup is True, it should clean up both nodes and relationships.
+    """
+    # Act
+    queries = build_cleanup_queries(UnscopedNodeSchema())
+
+    actual_delete_node = remove_leading_whitespace_and_empty_lines(queries[0])
+    expected_delete_node = """
+        MATCH (n:UnscopedNode)
+        WHERE n.lastupdated <> $UPDATE_TAG
+        WITH n LIMIT $LIMIT_SIZE
+        DETACH DELETE n;
+    """
+
+    actual_delete_rel = remove_leading_whitespace_and_empty_lines(queries[1])
+    expected_delete_rel = """
+        MATCH (n:UnscopedNode)
+        MATCH (n)-[r:RELATES_TO]->(:SimpleNode)
+        WHERE r.lastupdated <> $UPDATE_TAG
+        WITH r LIMIT $LIMIT_SIZE
+        DELETE r;
+    """
+
+    # Assert
+    assert actual_delete_node == remove_leading_whitespace_and_empty_lines(expected_delete_node)
+    assert actual_delete_rel == remove_leading_whitespace_and_empty_lines(expected_delete_rel)


### PR DESCRIPTION
### Summary
Enable cleanup jobs for node_schema objects without sub resource objects -- adds a `scoped_cleanup` flag to the node_schema. This allows a great deal of flexibility for future modules.

This PR is best understood by reading the tests.

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
  - Added new integration test `test_cleanup_unscoped_node_end_to_end` in `tests/integration/cartography/graph/test_cleanupbuilder_unscoped.py`
  - Test verifies the complete cleanup flow for unscoped nodes
  - Test includes assertions for node deletion, relationship cleanup, and preservation of unrelated nodes
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
  - Not applicable 
- [ ] Include console log trace showing what happened before and after your changes.
  - Not applicable 

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).
  - Not applicable 

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
  - Not applicable 