### PR TITLE
fix: Entra OU Module: .request() was removed from MS SDK

### DIFF
--- a/cartography/intel/entra/ou.py
+++ b/cartography/intel/entra/ou.py
@@ -22,19 +22,21 @@ async def get_entra_ous(client: GraphServiceClient) -> list[AdministrativeUnit]:
     Get all OUs from Microsoft Graph API with pagination support
     """
     all_units: list[AdministrativeUnit] = []
-    
+
     # Initialize first page request
     current_request = client.directory.administrative_units
-    
+
     while current_request:
         try:
             response = await current_request.get()
             if response and response.value:
                 all_units.extend(response.value)
-                
+
                 # Handle next page using OData link
                 if response.odata_next_link:
-                    current_request = client.directory.administrative_units.with_url(response.odata_next_link)
+                    current_request = client.directory.administrative_units.with_url(
+                        response.odata_next_link
+                    )
                 else:
                     current_request = None
             else:
@@ -42,7 +44,7 @@ async def get_entra_ous(client: GraphServiceClient) -> list[AdministrativeUnit]:
         except Exception as e:
             logger.error(f"Failed to retrieve administrative units: {str(e)}")
             current_request = None
-    
+
     return all_units
 
 

--- a/cartography/intel/entra/ou.py
+++ b/cartography/intel/entra/ou.py
@@ -24,14 +24,12 @@ async def get_entra_ous(client: GraphServiceClient) -> list[AdministrativeUnit]:
     all_units: list[AdministrativeUnit] = []
     request = client.directory.administrative_units
 
-
     while request:
         response = await request.get()
         all_units.extend(response.value)
         request = client.directory.administrative_units.with_url(
             response.odata_next_link
         ) if response.odata_next_link else None
-
 
     return all_units
 

--- a/cartography/intel/entra/ou.py
+++ b/cartography/intel/entra/ou.py
@@ -22,12 +22,16 @@ async def get_entra_ous(client: GraphServiceClient) -> list[AdministrativeUnit]:
     Get all OUs from Microsoft Graph API with pagination support
     """
     all_units: list[AdministrativeUnit] = []
-    request = client.directory.administrative_units.request()
+    request = client.directory.administrative_units
+
 
     while request:
         response = await request.get()
         all_units.extend(response.value)
-        request = response.odata_next_link if response.odata_next_link else None
+        request = client.directory.administrative_units.with_url(
+            response.odata_next_link
+        ) if response.odata_next_link else None
+
 
     return all_units
 

--- a/cartography/intel/entra/ou.py
+++ b/cartography/intel/entra/ou.py
@@ -22,17 +22,27 @@ async def get_entra_ous(client: GraphServiceClient) -> list[AdministrativeUnit]:
     Get all OUs from Microsoft Graph API with pagination support
     """
     all_units: list[AdministrativeUnit] = []
-    request = client.directory.administrative_units
-
-    while request:
-        response = await request.get()
-        all_units.extend(response.value)
-        request = (
-            client.directory.administrative_units.with_url(response.odata_next_link)
-            if response.odata_next_link
-            else None
-        )
-
+    
+    # Initialize first page request
+    current_request = client.directory.administrative_units
+    
+    while current_request:
+        try:
+            response = await current_request.get()
+            if response and response.value:
+                all_units.extend(response.value)
+                
+                # Handle next page using OData link
+                if response.odata_next_link:
+                    current_request = client.directory.administrative_units.with_url(response.odata_next_link)
+                else:
+                    current_request = None
+            else:
+                current_request = None
+        except Exception as e:
+            logger.error(f"Failed to retrieve administrative units: {str(e)}")
+            current_request = None
+    
     return all_units
 
 

--- a/cartography/intel/entra/ou.py
+++ b/cartography/intel/entra/ou.py
@@ -27,9 +27,11 @@ async def get_entra_ous(client: GraphServiceClient) -> list[AdministrativeUnit]:
     while request:
         response = await request.get()
         all_units.extend(response.value)
-        request = client.directory.administrative_units.with_url(
-            response.odata_next_link
-        ) if response.odata_next_link else None
+        request = (
+            client.directory.administrative_units.with_url(response.odata_next_link)
+            if response.odata_next_link
+            else None
+        )
 
     return all_units
 

--- a/docs/root/modules/entra/config.md
+++ b/docs/root/modules/entra/config.md
@@ -11,4 +11,4 @@ To set up the Entra client,
 
 1. Go to [App Registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade) in the Azure portal
 1. Create a new app registration.
-1. Grant it `User.Read.All` and `User.Read` permissions to the Microsoft graph to audit users.
+1. Grant it `User.Read.All` and `User.Read` and 'AdministrativeUnit.Read.All' permissions to the Microsoft graph to audit users. These permissions need to be of application type.


### PR DESCRIPTION
### Summary
> Describe your changes.

Fixed Bug in EntraOU Module shown in https://github.com/cartography-cncf/cartography/issues/1594


The bug was caused by an incompatible change in the Microsoft Graph Python SDK where the .request() method was removed from AdministrativeUnitsRequestBuilder. Previous code called client.directory.administrative_units.request() which no longer exists in newer SDK versions. Code is now updated in cartography/intel/entra/ou.py so that the updated SDK API pattern is used while maintaining the same OU synchronization functionality. Also updated the entra docs to include required permissions. 

### Test Failing before Fixing Bug
> 
![Screenshot 2025-06-02 at 11 16 42 AM](https://github.com/user-attachments/assets/6f301017-efae-4bbd-9d46-aeeaa9ad4692)


### Test Passing after Fixing Bug
![Screenshot 2025-06-02 at 12 44 07 PM](https://github.com/user-attachments/assets/adcc976d-dc4e-4c7c-89a0-2369587ad19e)

### Graph After Changes
![Screenshot 2025-06-02 at 12 44 25 PM](https://github.com/user-attachments/assets/1584a105-26c6-4ba9-ba42-feafabb28b82)

