### PR TITLE
Address config option mismatch in SnipeIT authentication flow

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -914,7 +914,7 @@ class CLI:
                 config.snipeit_token = os.environ.get("SNIPEIT_TOKEN")
             else:
                 logger.warning("A SnipeIT base URI was provided but a token was not.")
-                config.kandji_token = None
+                config.snipeit_token = None
         else:
             logger.warning("A SnipeIT base URI was not provided.")
             config.snipeit_base_uri = None


### PR DESCRIPTION
### Summary
This PR addresses a configuration bug in the CLI where the SnipeIT integration was incorrectly referencing `config.kandji_token` instead of the intended `config.snipeit_token`. The fix ensures that the correct token is used for SnipeIT-related operations, improving authentication accuracy and preventing potential misconfigurations. I believe this bug happened due to copy-paste from the Kandji section.

### Related issues or links

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
