### PR TITLE
Add Entra groups intel module

### DIFF
--- a/cartography/intel/entra/__init__.py
+++ b/cartography/intel/entra/__init__.py
@@ -6,6 +6,7 @@ import neo4j
 from cartography.config import Config
 from cartography.intel.entra.ou import sync_entra_ous
 from cartography.intel.entra.users import sync_entra_users
+from cartography.intel.entra.groups import sync_entra_groups
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,16 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     async def main() -> None:
         # Run user sync
         await sync_entra_users(
+            neo4j_session,
+            config.entra_tenant_id,
+            config.entra_client_id,
+            config.entra_client_secret,
+            config.update_tag,
+            common_job_parameters,
+        )
+
+        # Run group sync
+        await sync_entra_groups(
             neo4j_session,
             config.entra_tenant_id,
             config.entra_client_id,

--- a/cartography/intel/entra/groups.py
+++ b/cartography/intel/entra/groups.py
@@ -1,0 +1,130 @@
+import logging
+from typing import Any, Dict, List
+
+import neo4j
+from azure.identity import ClientSecretCredential
+from msgraph import GraphServiceClient
+from msgraph.generated.models.group import Group
+from msgraph.generated.models.directory_object import DirectoryObject
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.entra.users import load_tenant
+from cartography.models.entra.group import EntraGroupSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+async def get_entra_groups(client: GraphServiceClient) -> List[Group]:
+    """Get all groups from Microsoft Graph API with pagination."""
+    all_groups: List[Group] = []
+
+    request_configuration = client.groups.GroupsRequestBuilderGetRequestConfiguration(
+        query_parameters=client.groups.GroupsRequestBuilderGetQueryParameters(top=999)
+    )
+    page = await client.groups.get(request_configuration=request_configuration)
+    while page:
+        if page.value:
+            all_groups.extend(page.value)
+        if not page.odata_next_link:
+            break
+        page = await client.groups.with_url(page.odata_next_link).get()
+
+    return all_groups
+
+
+@timeit
+async def get_group_members(client: GraphServiceClient, group_id: str) -> List[str]:
+    """Get member user IDs for a given group."""
+    members: List[str] = []
+    request_builder = client.groups.by_group_id(group_id).members
+    page = await request_builder.get()
+    while page:
+        if page.value:
+            for obj in page.value:
+                if isinstance(obj, DirectoryObject):
+                    # Filter to user objects based on odata_type
+                    if getattr(obj, "odata_type", "") == "#microsoft.graph.user":
+                        members.append(obj.id)
+        if not page.odata_next_link:
+            break
+        page = await request_builder.with_url(page.odata_next_link).get()
+    return members
+
+
+@timeit
+def transform_groups(groups: List[Group], member_map: Dict[str, List[str]]) -> List[Dict[str, Any]]:
+    """Transform API responses into dictionaries for ingestion."""
+    result: List[Dict[str, Any]] = []
+    for g in groups:
+        transformed = {
+            "id": g.id,
+            "display_name": g.display_name,
+            "description": g.description,
+            "mail": g.mail,
+            "mail_nickname": g.mail_nickname,
+            "mail_enabled": g.mail_enabled,
+            "security_enabled": g.security_enabled,
+            "group_types": g.group_types,
+            "visibility": g.visibility,
+            "is_assignable_to_role": g.is_assignable_to_role,
+            "created_date_time": g.created_date_time,
+            "deleted_date_time": g.deleted_date_time,
+            "member_ids": member_map.get(g.id, []),
+        }
+        result.append(transformed)
+    return result
+
+
+@timeit
+def load_groups(
+    neo4j_session: neo4j.Session,
+    groups: List[Dict[str, Any]],
+    update_tag: int,
+    tenant_id: str,
+) -> None:
+    logger.info(f"Loading {len(groups)} Entra groups")
+    load(
+        neo4j_session,
+        EntraGroupSchema(),
+        groups,
+        lastupdated=update_tag,
+        TENANT_ID=tenant_id,
+    )
+
+
+@timeit
+def cleanup_groups(neo4j_session: neo4j.Session, common_job_parameters: Dict[str, Any]) -> None:
+    GraphJob.from_node_schema(EntraGroupSchema(), common_job_parameters).run(neo4j_session)
+
+
+@timeit
+async def sync_entra_groups(
+    neo4j_session: neo4j.Session,
+    tenant_id: str,
+    client_id: str,
+    client_secret: str,
+    update_tag: int,
+    common_job_parameters: Dict[str, Any],
+) -> None:
+    """Sync Entra groups."""
+    credential = ClientSecretCredential(tenant_id=tenant_id, client_id=client_id, client_secret=client_secret)
+    client = GraphServiceClient(credential, scopes=["https://graph.microsoft.com/.default"])
+
+    groups = await get_entra_groups(client)
+
+    member_map: Dict[str, List[str]] = {}
+    for group in groups:
+        try:
+            member_map[group.id] = await get_group_members(client, group.id)
+        except Exception as e:
+            logger.error(f"Failed to fetch members for group {group.id}: {e}")
+            member_map[group.id] = []
+
+    transformed_groups = transform_groups(groups, member_map)
+
+    load_tenant(neo4j_session, {"id": tenant_id}, update_tag)
+    load_groups(neo4j_session, transformed_groups, update_tag, tenant_id)
+    cleanup_groups(neo4j_session, common_job_parameters)

--- a/cartography/models/entra/group.py
+++ b/cartography/models/entra/group.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class EntraGroupNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    display_name: PropertyRef = PropertyRef("display_name")
+    description: PropertyRef = PropertyRef("description")
+    mail: PropertyRef = PropertyRef("mail")
+    mail_nickname: PropertyRef = PropertyRef("mail_nickname")
+    mail_enabled: PropertyRef = PropertyRef("mail_enabled")
+    security_enabled: PropertyRef = PropertyRef("security_enabled")
+    group_types: PropertyRef = PropertyRef("group_types")
+    visibility: PropertyRef = PropertyRef("visibility")
+    is_assignable_to_role: PropertyRef = PropertyRef("is_assignable_to_role")
+    created_date_time: PropertyRef = PropertyRef("created_date_time")
+    deleted_date_time: PropertyRef = PropertyRef("deleted_date_time")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EntraGroupToTenantRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EntraGroupToTenantRel(CartographyRelSchema):
+    target_node_label: str = "EntraTenant"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher({
+        "id": PropertyRef("TENANT_ID", set_in_kwargs=True)
+    })
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: EntraGroupToTenantRelProperties = EntraGroupToTenantRelProperties()
+
+
+@dataclass(frozen=True)
+class EntraGroupToUserRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:EntraUser)-[:MEMBER_OF]->(:EntraGroup)
+class EntraGroupToUserRel(CartographyRelSchema):
+    target_node_label: str = "EntraUser"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher({
+        "id": PropertyRef("member_ids", one_to_many=True)
+    })
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "MEMBER_OF"
+    properties: EntraGroupToUserRelProperties = EntraGroupToUserRelProperties()
+
+
+@dataclass(frozen=True)
+class EntraGroupSchema(CartographyNodeSchema):
+    label: str = "EntraGroup"
+    properties: EntraGroupNodeProperties = EntraGroupNodeProperties()
+    sub_resource_relationship: EntraGroupToTenantRel = EntraGroupToTenantRel()
+    other_relationships: OtherRelationships = OtherRelationships([
+        EntraGroupToUserRel(),
+    ])

--- a/docs/root/modules/entra/schema.md
+++ b/docs/root/modules/entra/schema.md
@@ -99,3 +99,35 @@ Representation of an Entra [OU](https://learn.microsoft.com/en-us/graph/api/admi
     ```cypher
     (:EntraOU)-[:RESOURCE]->(:EntraTenant)
     ```
+
+### EntraGroup
+Representation of an Entra [Group](https://learn.microsoft.com/en-us/graph/api/group-get?view=graph-rest-1.0&tabs=http).
+
+|Field | Description|
+|-------|-------------|
+|id | Entra Group ID (GUID)|
+|display_name | Display name of the group|
+|description | Description of the group|
+|mail | Primary email address of the group|
+|mail_nickname | Mail nickname|
+|mail_enabled | Whether the group has a mailbox|
+|security_enabled | Whether the group is security enabled|
+|group_types | List of group types|
+|visibility | Group visibility setting|
+|is_assignable_to_role | Whether the group can be assigned to roles|
+|created_date_time | Creation timestamp|
+|deleted_date_time | Deletion timestamp if applicable|
+
+#### Relationships
+
+- All Entra groups are linked to an Entra Tenant
+
+    ```cypher
+    (:EntraGroup)-[:RESOURCE]->(:EntraTenant)
+    ```
+
+- Entra users are members of groups
+
+    ```cypher
+    (:EntraUser)-[:MEMBER_OF]->(:EntraGroup)
+    ```

--- a/tests/data/entra/groups.py
+++ b/tests/data/entra/groups.py
@@ -1,0 +1,48 @@
+from msgraph.generated.models.group import Group
+from msgraph.generated.models.user import User
+
+TEST_TENANT_ID = "02b2b7cc-fb03-4324-bf6b-eb207b39c479"
+TEST_CLIENT_ID = "02b2b7cc-fb03-4324-bf6b-eb207b39c479"
+TEST_CLIENT_SECRET = "abcdefghijklmnopqrstuvwxyz"
+
+MOCK_ENTRA_GROUPS = [
+    Group(
+        id="11111111-1111-1111-1111-111111111111",
+        odata_type="#microsoft.graph.group",
+        display_name="Security Team",
+        description="Security group",
+        mail="security@example.com",
+        mail_enabled=True,
+        mail_nickname="security",
+        security_enabled=True,
+        group_types=["Unified"],
+        visibility="Private",
+    ),
+    Group(
+        id="22222222-2222-2222-2222-222222222222",
+        odata_type="#microsoft.graph.group",
+        display_name="Developers",
+        mail="devs@example.com",
+        mail_enabled=False,
+        mail_nickname="devs",
+        security_enabled=True,
+        group_types=["DynamicMembership"],
+        visibility="Public",
+    ),
+]
+
+MOCK_GROUP_MEMBERS = {
+    "11111111-1111-1111-1111-111111111111": [
+        User(
+            id="ae4ac864-4433-4ba6-96a6-20f8cffdadcb",
+            odata_type="#microsoft.graph.user",
+            display_name="Homer Simpson",
+        ),
+        User(
+            id="11dca63b-cb03-4e53-bb75-fa8060285550",
+            odata_type="#microsoft.graph.user",
+            display_name="Entra Test User 1",
+        ),
+    ],
+    "22222222-2222-2222-2222-222222222222": [],
+}

--- a/tests/integration/cartography/intel/entra/test_groups.py
+++ b/tests/integration/cartography/intel/entra/test_groups.py
@@ -1,0 +1,80 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import cartography.intel.entra.groups
+from cartography.intel.entra.groups import sync_entra_groups
+from cartography.intel.entra.users import load_users, transform_users
+from tests.data.entra.groups import MOCK_ENTRA_GROUPS, MOCK_GROUP_MEMBERS, TEST_TENANT_ID, TEST_CLIENT_ID, TEST_CLIENT_SECRET
+from tests.data.entra.users import MOCK_ENTRA_USERS
+from tests.integration.util import check_nodes, check_rels
+
+TEST_UPDATE_TAG = 1234567890
+
+
+@patch.object(
+    cartography.intel.entra.groups,
+    "get_entra_groups",
+    new_callable=AsyncMock,
+    return_value=MOCK_ENTRA_GROUPS,
+)
+@patch.object(
+    cartography.intel.entra.groups,
+    "get_group_members",
+    new_callable=AsyncMock,
+    side_effect=lambda client, gid: [u.id for u in MOCK_GROUP_MEMBERS[gid]],
+)
+@pytest.mark.asyncio
+async def test_sync_entra_groups(mock_get_members, mock_get_groups, neo4j_session):
+    """Ensure groups and relationships load"""
+    # Load users first for membership relationships
+    load_users(neo4j_session, transform_users(MOCK_ENTRA_USERS), TEST_TENANT_ID, TEST_UPDATE_TAG)
+
+    await sync_entra_groups(
+        neo4j_session,
+        TEST_TENANT_ID,
+        TEST_CLIENT_ID,
+        TEST_CLIENT_SECRET,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "TENANT_ID": TEST_TENANT_ID},
+    )
+
+    expected_nodes = {
+        ("11111111-1111-1111-1111-111111111111", "Security Team"),
+        ("22222222-2222-2222-2222-222222222222", "Developers"),
+    }
+    assert check_nodes(neo4j_session, "EntraGroup", ["id", "display_name"]) == expected_nodes
+
+    expected_rels = {
+        ("11111111-1111-1111-1111-111111111111", TEST_TENANT_ID),
+        ("22222222-2222-2222-2222-222222222222", TEST_TENANT_ID),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "EntraGroup",
+            "id",
+            "EntraTenant",
+            "id",
+            "RESOURCE",
+            rel_direction_right=False,
+        )
+        == expected_rels
+    )
+
+    expected_membership = {
+        ("ae4ac864-4433-4ba6-96a6-20f8cffdadcb", "11111111-1111-1111-1111-111111111111"),
+        ("11dca63b-cb03-4e53-bb75-fa8060285550", "11111111-1111-1111-1111-111111111111"),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "EntraUser",
+            "id",
+            "EntraGroup",
+            "id",
+            "MEMBER_OF",
+        )
+        == expected_membership
+    )
+

--- a/tests/unit/cartography/intel/entra/test_groups.py
+++ b/tests/unit/cartography/intel/entra/test_groups.py
@@ -1,0 +1,16 @@
+from cartography.intel.entra.groups import transform_groups
+from tests.data.entra.groups import MOCK_ENTRA_GROUPS, MOCK_GROUP_MEMBERS
+
+
+def test_transform_groups():
+    result = transform_groups(MOCK_ENTRA_GROUPS, {
+        gid: [u.id for u in users] for gid, users in MOCK_GROUP_MEMBERS.items()
+    })
+    assert len(result) == 2
+    group1 = next(g for g in result if g["id"] == "11111111-1111-1111-1111-111111111111")
+    assert group1["display_name"] == "Security Team"
+    assert group1["member_ids"] == [
+        "ae4ac864-4433-4ba6-96a6-20f8cffdadcb",
+        "11dca63b-cb03-4e53-bb75-fa8060285550",
+    ]
+


### PR DESCRIPTION
## Summary
- add new `groups` intel module for Entra
- define `EntraGroup` schema and membership relationship
- wire up group sync in Entra ingestion pipeline
- document new nodes and relationships
- provide unit and integration tests

## Testing
- `pytest tests/unit/cartography/intel/entra/test_groups.py -q`
- `pytest tests/integration/cartography/intel/entra/test_groups.py -q` *(fails: Couldn't connect to localhost:7687)*

------
https://chatgpt.com/codex/tasks/task_b_684717327ff48323ac8180b132c81718