### PR TITLE
feat: Add nested Entra group support

### DIFF
--- a/cartography/intel/entra/groups.py
+++ b/cartography/intel/entra/groups.py
@@ -36,26 +36,31 @@ async def get_entra_groups(client: GraphServiceClient) -> list[Group]:
 
 
 @timeit
-async def get_group_members(client: GraphServiceClient, group_id: str) -> list[str]:
-    """Get member user IDs for a given group."""
-    members: list[str] = []
+async def get_group_members(client: GraphServiceClient, group_id: str) -> tuple[list[str], list[str]]:
+    """Get member user IDs and subgroup IDs for a given group."""
+    user_ids: list[str] = []
+    group_ids: list[str] = []
     request_builder = client.groups.by_group_id(group_id).members
     page = await request_builder.get()
     while page:
         if page.value:
             for obj in page.value:
                 if isinstance(obj, DirectoryObject):
-                    # Filter to user objects based on odata_type
-                    if getattr(obj, "odata_type", "") == "#microsoft.graph.user":
-                        members.append(obj.id)
+                    odata_type = getattr(obj, "odata_type", "")
+                    if odata_type == "#microsoft.graph.user":
+                        user_ids.append(obj.id)
+                    elif odata_type == "#microsoft.graph.group":
+                        group_ids.append(obj.id)
         if not page.odata_next_link:
             break
         page = await request_builder.with_url(page.odata_next_link).get()
-    return members
+    return user_ids, group_ids
 
 
 def transform_groups(
-    groups: list[Group], member_map: dict[str, list[str]]
+    groups: list[Group],
+    user_member_map: dict[str, list[str]],
+    group_member_map: dict[str, list[str]],
 ) -> list[dict[str, Any]]:
     """Transform API responses into dictionaries for ingestion."""
     result: list[dict[str, Any]] = []
@@ -73,7 +78,8 @@ def transform_groups(
             "is_assignable_to_role": g.is_assignable_to_role,
             "created_date_time": g.created_date_time,
             "deleted_date_time": g.deleted_date_time,
-            "member_ids": member_map.get(g.id, []),
+            "member_ids": user_member_map.get(g.id, []),
+            "member_group_ids": group_member_map.get(g.id, []),
         }
         result.append(transformed)
     return result
@@ -124,15 +130,19 @@ async def sync_entra_groups(
 
     groups = await get_entra_groups(client)
 
-    member_map: dict[str, list[str]] = {}
+    user_member_map: dict[str, list[str]] = {}
+    group_member_map: dict[str, list[str]] = {}
     for group in groups:
         try:
-            member_map[group.id] = await get_group_members(client, group.id)
+            users, subgroups = await get_group_members(client, group.id)
+            user_member_map[group.id] = users
+            group_member_map[group.id] = subgroups
         except Exception as e:
             logger.error(f"Failed to fetch members for group {group.id}: {e}")
-            member_map[group.id] = []
+            user_member_map[group.id] = []
+            group_member_map[group.id] = []
 
-    transformed_groups = transform_groups(groups, member_map)
+    transformed_groups = transform_groups(groups, user_member_map, group_member_map)
 
     load_tenant(neo4j_session, {"id": tenant_id}, update_tag)
     load_groups(neo4j_session, transformed_groups, update_tag, tenant_id)

--- a/cartography/intel/entra/groups.py
+++ b/cartography/intel/entra/groups.py
@@ -36,7 +36,9 @@ async def get_entra_groups(client: GraphServiceClient) -> list[Group]:
 
 
 @timeit
-async def get_group_members(client: GraphServiceClient, group_id: str) -> tuple[list[str], list[str]]:
+async def get_group_members(
+    client: GraphServiceClient, group_id: str
+) -> tuple[list[str], list[str]]:
     """Get member user IDs and subgroup IDs for a given group."""
     user_ids: list[str] = []
     group_ids: list[str] = []

--- a/cartography/models/entra/group.py
+++ b/cartography/models/entra/group.py
@@ -62,12 +62,30 @@ class EntraGroupToUserRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class EntraGroupToGroupRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:EntraGroup)-[:MEMBER_OF]->(:EntraGroup)
+class EntraGroupToGroupRel(CartographyRelSchema):
+    target_node_label: str = "EntraGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("member_group_ids", one_to_many=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "MEMBER_OF"
+    properties: EntraGroupToGroupRelProperties = EntraGroupToGroupRelProperties()
+
+
+@dataclass(frozen=True)
 class EntraGroupSchema(CartographyNodeSchema):
     label: str = "EntraGroup"
     properties: EntraGroupNodeProperties = EntraGroupNodeProperties()
     sub_resource_relationship: EntraGroupToTenantRel = EntraGroupToTenantRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
+            EntraGroupToGroupRel(),
             EntraGroupToUserRel(),
         ]
     )

--- a/docs/root/modules/entra/schema.md
+++ b/docs/root/modules/entra/schema.md
@@ -131,3 +131,9 @@ Representation of an Entra [Group](https://learn.microsoft.com/en-us/graph/api/g
     ```cypher
     (:EntraUser)-[:MEMBER_OF]->(:EntraGroup)
     ```
+
+- Entra groups can be members of other groups
+
+    ```cypher
+    (:EntraGroup)-[:MEMBER_OF]->(:EntraGroup)
+    ```

--- a/docs/root/modules/entra/schema.md
+++ b/docs/root/modules/entra/schema.md
@@ -72,6 +72,21 @@ Representation of an Entra [User](https://learn.microsoft.com/en-us/graph/api/us
 |on_premises_sync_enabled | Whether on-premises directory sync is enabled|
 |on_premises_user_principal_name | User Principal Name in on-premises directory|
 
+#### Relationships
+
+- All Entra users are linked to an Entra Tenant
+
+    ```cypher
+    (:EntraUser)-[:RESOURCE]->(:EntraTenant)
+    ```
+
+- Entra users are members of groups
+
+    ```cypher
+    (:EntraUser)-[:MEMBER_OF]->(:EntraGroup)
+    ```
+
+
 ### EntraOU
 Representation of an Entra [OU](https://learn.microsoft.com/en-us/graph/api/administrativeunit-get?view=graph-rest-1.0&tabs=http).
 
@@ -87,12 +102,6 @@ Representation of an Entra [OU](https://learn.microsoft.com/en-us/graph/api/admi
 
 
 #### Relationships
-
-- All Entra users are linked to an Entra Tenant
-
-    ```cypher
-    (:EntraUser)-[:RESOURCE]->(:EntraTenant)
-    ```
 
 - All Entra OUs are linked to an Entra Tenant
 

--- a/tests/data/entra/groups.py
+++ b/tests/data/entra/groups.py
@@ -43,6 +43,11 @@ MOCK_GROUP_MEMBERS = {
             odata_type="#microsoft.graph.user",
             display_name="Entra Test User 1",
         ),
+        Group(
+            id="22222222-2222-2222-2222-222222222222",
+            odata_type="#microsoft.graph.group",
+            display_name="Developers",
+        ),
     ],
     "22222222-2222-2222-2222-222222222222": [],
 }

--- a/tests/integration/cartography/intel/entra/test_groups.py
+++ b/tests/integration/cartography/intel/entra/test_groups.py
@@ -19,11 +19,15 @@ from tests.integration.util import check_rels
 TEST_UPDATE_TAG = 1234567890
 
 
-def mock_get_group_members_side_effect(client, group_id: str) -> tuple[list[str], list[str]]:
-    """Mock side effect function to return member user IDs and subgroup IDs for a given group."""
+def mock_get_group_members_side_effect(
+    client, group_id: str
+) -> tuple[list[str], list[str]]:
+    """
+    Mock side effect function to return member user IDs and subgroup IDs for a given group.
+    """
     members = MOCK_GROUP_MEMBERS[group_id]
-    user_ids = [o.id for o in members if hasattr(o, "odata_type") and o.odata_type == "#microsoft.graph.user"]
-    group_ids = [o.id for o in members if hasattr(o, "odata_type") and o.odata_type == "#microsoft.graph.group"]
+    user_ids = [o.id for o in members if o.odata_type == "#microsoft.graph.user"]
+    group_ids = [o.id for o in members if o.odata_type == "#microsoft.graph.group"]
     return user_ids, group_ids
 
 
@@ -108,7 +112,7 @@ async def test_sync_entra_groups(mock_get_members, mock_get_groups, neo4j_sessio
     )
 
     expected_group_membership = {
-        ("22222222-2222-2222-2222-222222222222", "11111111-1111-1111-1111-111111111111")
+        ("11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222")
     }
     assert (
         check_rels(

--- a/tests/integration/cartography/intel/entra/test_groups.py
+++ b/tests/integration/cartography/intel/entra/test_groups.py
@@ -19,9 +19,12 @@ from tests.integration.util import check_rels
 TEST_UPDATE_TAG = 1234567890
 
 
-def mock_get_group_members_side_effect(client, group_id: str) -> list[str]:
-    """Mock side effect function to return member IDs for a given group."""
-    return [u.id for u in MOCK_GROUP_MEMBERS[group_id]]
+def mock_get_group_members_side_effect(client, group_id: str) -> tuple[list[str], list[str]]:
+    """Mock side effect function to return member user IDs and subgroup IDs for a given group."""
+    members = MOCK_GROUP_MEMBERS[group_id]
+    user_ids = [o.id for o in members if hasattr(o, "odata_type") and o.odata_type == "#microsoft.graph.user"]
+    group_ids = [o.id for o in members if hasattr(o, "odata_type") and o.odata_type == "#microsoft.graph.group"]
+    return user_ids, group_ids
 
 
 @patch.object(
@@ -102,4 +105,20 @@ async def test_sync_entra_groups(mock_get_members, mock_get_groups, neo4j_sessio
             "MEMBER_OF",
         )
         == expected_membership
+    )
+
+    expected_group_membership = {
+        ("22222222-2222-2222-2222-222222222222", "11111111-1111-1111-1111-111111111111")
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "EntraGroup",
+            "id",
+            "EntraGroup",
+            "id",
+            "MEMBER_OF",
+            rel_direction_right=False,
+        )
+        == expected_group_membership
     )

--- a/tests/unit/cartography/intel/entra/test_groups.py
+++ b/tests/unit/cartography/intel/entra/test_groups.py
@@ -6,7 +6,14 @@ from tests.data.entra.groups import MOCK_GROUP_MEMBERS
 def test_transform_groups():
     result = transform_groups(
         MOCK_ENTRA_GROUPS,
-        {gid: [u.id for u in users] for gid, users in MOCK_GROUP_MEMBERS.items()},
+        {
+            gid: [u.id for u in members if hasattr(u, "odata_type") and u.odata_type == "#microsoft.graph.user"]
+            for gid, members in MOCK_GROUP_MEMBERS.items()
+        },
+        {
+            gid: [g.id for g in members if hasattr(g, "odata_type") and g.odata_type == "#microsoft.graph.group"]
+            for gid, members in MOCK_GROUP_MEMBERS.items()
+        },
     )
     assert len(result) == 2
     group1 = next(
@@ -17,3 +24,4 @@ def test_transform_groups():
         "ae4ac864-4433-4ba6-96a6-20f8cffdadcb",
         "11dca63b-cb03-4e53-bb75-fa8060285550",
     ]
+    assert group1["member_group_ids"] == ["22222222-2222-2222-2222-222222222222"]

--- a/tests/unit/cartography/intel/entra/test_groups.py
+++ b/tests/unit/cartography/intel/entra/test_groups.py
@@ -7,11 +7,11 @@ def test_transform_groups():
     result = transform_groups(
         MOCK_ENTRA_GROUPS,
         {
-            gid: [u.id for u in members if hasattr(u, "odata_type") and u.odata_type == "#microsoft.graph.user"]
+            gid: [u.id for u in members if u.odata_type == "#microsoft.graph.user"]
             for gid, members in MOCK_GROUP_MEMBERS.items()
         },
         {
-            gid: [g.id for g in members if hasattr(g, "odata_type") and g.odata_type == "#microsoft.graph.group"]
+            gid: [g.id for g in members if g.odata_type == "#microsoft.graph.group"]
             for gid, members in MOCK_GROUP_MEMBERS.items()
         },
     )


### PR DESCRIPTION
### Summary
- Support nested groups in Entra ingestion
- Add EntraGroup->EntraGroup relationship
- Document nested group relationship
- Update tests for nested groups



### Related issues or links
> Include links to relevant issues or other pages.

- Follow-up of https://github.com/cartography-cncf/cartography/pull/1614: we support groups of groups now.

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.

Groups of groups:
![Screenshot 2025-06-09 at 5 25 55 PM](https://github.com/user-attachments/assets/a6f718f9-2332-4799-9fd6-057acbc941cd)


And in Entra it looks like:
![Screenshot 2025-06-09 at 5 26 31 PM](https://github.com/user-attachments/assets/dc127398-8945-4b3a-b911-8c30125e88da)
![Screenshot 2025-06-09 at 5 26 42 PM](https://github.com/user-attachments/assets/8316c43d-4a1e-4f54-984b-559cf664392c)

- [x] Include console log trace showing what happened before and after your changes.

```
INFO:cartography.sync:Starting sync with update tag '1749516786'
INFO:cartography.sync:Starting sync stage 'entra'
INFO:cartography.intel.entra.users:Loading 6 Entra users
INFO:cartography.graph.statement:Completed EntraUser statement #1
INFO:cartography.graph.statement:Completed EntraUser statement #2
INFO:cartography.graph.job:Finished job EntraUser
INFO:cartography.intel.entra.groups:Loading 6 Entra groups
INFO:cartography.graph.statement:Completed EntraGroup statement #1
INFO:cartography.graph.statement:Completed EntraGroup statement #2
INFO:cartography.graph.statement:Completed EntraGroup statement #3
INFO:cartography.graph.statement:Completed EntraGroup statement #4
INFO:cartography.graph.job:Finished job EntraGroup
INFO:cartography.intel.entra.ou:Loading 0 Entra OUs
INFO:cartography.graph.statement:Completed EntraOU statement #1
INFO:cartography.graph.statement:Completed EntraOU statement #2
INFO:cartography.graph.job:Finished job EntraOU
INFO:cartography.sync:Finishing sync stage 'entra'
INFO:cartography.sync:Finishing sync with update tag '1749516786'
```

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [x] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


