### PR TITLE
Refactor AWS SQS to new data model

### DIFF
--- a/cartography/intel/aws/sqs.py
+++ b/cartography/intel/aws/sqs.py
@@ -9,8 +9,10 @@ import boto3
 import neo4j
 from botocore.exceptions import ClientError
 
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.models.aws.sqs.queue import SQSQueueSchema
 from cartography.util import aws_handle_regions
-from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -33,9 +35,7 @@ def get_sqs_queue_attributes(
     boto3_session: boto3.session.Session,
     queue_urls: List[str],
 ) -> List[Tuple[str, Any]]:
-    """
-    Iterates over all SQS queues. Returns a dict with url as key, and attributes as value.
-    """
+    """Iterates over all SQS queues and returns a list of (url, attributes)."""
     client = boto3_session.client("sqs")
 
     queue_attributes = []
@@ -58,108 +58,53 @@ def get_sqs_queue_attributes(
     return queue_attributes
 
 
-@timeit
-def load_sqs_queues(
-    neo4j_session: neo4j.Session,
-    data: List[Tuple[str, Any]],
-    region: str,
-    current_aws_account_id: str,
-    aws_update_tag: int,
-) -> None:
-    ingest_queues = """
-    UNWIND $Queues as sqs_queue
-        MERGE (queue:SQSQueue{id: sqs_queue.QueueArn})
-        ON CREATE SET queue.firstseen = timestamp(), queue.url = sqs_queue.url
-        SET queue.name = sqs_queue.name, queue.region = $Region, queue.arn = sqs_queue.QueueArn,
-            queue.created_timestamp = sqs_queue.CreatedTimestamp, queue.delay_seconds = sqs_queue.DelaySeconds,
-            queue.last_modified_timestamp = sqs_queue.LastModifiedTimestamp,
-            queue.maximum_message_size = sqs_queue.MaximumMessageSize,
-            queue.message_retention_period = sqs_queue.MessageRetentionPeriod,
-            queue.policy = sqs_queue.Policy, queue.arn = sqs_queue.QueueArn,
-            queue.receive_message_wait_time_seconds = sqs_queue.ReceiveMessageWaitTimeSeconds,
-            queue.redrive_policy_dead_letter_target_arn = sqs_queue.RedrivePolicy.deadLetterTargetArn,
-            queue.redrive_policy_max_receive_count = sqs_queue.RedrivePolicy.maxReceiveCount,
-            queue.visibility_timeout = sqs_queue.VisibilityTimeout,
-            queue.kms_master_key_id = sqs_queue.KmsMasterKeyId,
-            queue.kms_data_key_reuse_period_seconds = sqs_queue.KmsDataKeyReusePeriodSeconds,
-            queue.fifo_queue = sqs_queue.FifoQueue,
-            queue.content_based_deduplication = sqs_queue.ContentBasedDeduplication,
-            queue.deduplication_scope = sqs_queue.DeduplicationScope,
-            queue.fifo_throughput_limit = sqs_queue.FifoThroughputLimit,
-            queue.lastupdated = $aws_update_tag
-        WITH queue
-        MATCH (owner:AWSAccount{id: $AWS_ACCOUNT_ID})
-        MERGE (owner)-[r:RESOURCE]->(queue)
-        ON CREATE SET r.firstseen = timestamp()
-        SET r.lastupdated = $aws_update_tag
-    """
-    dead_letter_queues: List[Dict] = []
-    queues: List[Dict] = []
-    for url, queue in data:
+def transform_sqs_queues(data: List[Tuple[str, Any]]) -> List[Dict[str, Any]]:
+    transformed: List[Dict[str, Any]] = []
+    for url, attrs in data:
+        queue = dict(attrs)
         queue["url"] = url
-        queue["name"] = queue["QueueArn"].split(":")[-1]
-        queue["CreatedTimestamp"] = int(queue["CreatedTimestamp"])
-        queue["LastModifiedTimestamp"] = int(queue["LastModifiedTimestamp"])
-        redrive_policy = queue.get("RedrivePolicy")
+        queue["name"] = attrs["QueueArn"].split(":")[-1]
+        queue["CreatedTimestamp"] = int(attrs.get("CreatedTimestamp", 0))
+        queue["LastModifiedTimestamp"] = int(attrs.get("LastModifiedTimestamp", 0))
+        redrive_policy = attrs.get("RedrivePolicy")
         if redrive_policy:
             try:
                 rp = json.loads(redrive_policy)
             except TypeError:
                 rp = {}
-            queue["RedrivePolicy"] = rp
-            dead_letter_arn = rp.get("deadLetterTargetArn")
-            if dead_letter_arn:
-                dead_letter_queues.append(
-                    {
-                        "arn": queue["QueueArn"],
-                        "dead_letter_arn": dead_letter_arn,
-                    },
-                )
-        queues.append(queue)
-
-    neo4j_session.run(
-        ingest_queues,
-        Queues=queues,
-        Region=region,
-        AWS_ACCOUNT_ID=current_aws_account_id,
-        aws_update_tag=aws_update_tag,
-    )
-
-    _attach_dead_letter_queues(neo4j_session, dead_letter_queues, aws_update_tag)
+            queue["redrive_policy_dead_letter_target_arn"] = rp.get(
+                "deadLetterTargetArn"
+            )
+            queue["redrive_policy_max_receive_count"] = rp.get("maxReceiveCount")
+        transformed.append(queue)
+    return transformed
 
 
 @timeit
-def _attach_dead_letter_queues(
+def load_sqs_queues(
     neo4j_session: neo4j.Session,
-    data: List[Dict[str, str]],
+    data: List[Dict[str, Any]],
+    region: str,
+    current_aws_account_id: str,
     aws_update_tag: int,
 ) -> None:
-    """
-    Attach deadletter queues to their queues.
-    """
-    attach_deadletter_to_queue = """
-    UNWIND $Relations as relation
-        MATCH (queue:SQSQueue{id: relation.arn}), (deadletter:SQSQueue{id: relation.dead_letter_arn})
-        MERGE (queue)-[r:HAS_DEADLETTER_QUEUE]->(deadletter)
-        ON CREATE SET r.firstseen = timestamp()
-        SET r.lastupdated = $aws_update_tag
-    """
-    neo4j_session.run(
-        attach_deadletter_to_queue,
-        Relations=data,
-        aws_update_tag=aws_update_tag,
+    load(
+        neo4j_session,
+        SQSQueueSchema(),
+        data,
+        lastupdated=aws_update_tag,
+        Region=region,
+        AWS_ID=current_aws_account_id,
     )
 
 
 @timeit
 def cleanup_sqs_queues(
     neo4j_session: neo4j.Session,
-    common_job_parameters: Dict,
+    common_job_parameters: Dict[str, Any],
 ) -> None:
-    run_cleanup_job(
-        "aws_import_sqs_queues_cleanup.json",
-        neo4j_session,
-        common_job_parameters,
+    GraphJob.from_node_schema(SQSQueueSchema(), common_job_parameters).run(
+        neo4j_session
     )
 
 
@@ -170,7 +115,7 @@ def sync(
     regions: List[str],
     current_aws_account_id: str,
     update_tag: int,
-    common_job_parameters: Dict,
+    common_job_parameters: Dict[str, Any],
 ) -> None:
     for region in regions:
         logger.info(
@@ -179,12 +124,13 @@ def sync(
             current_aws_account_id,
         )
         queue_urls = get_sqs_queue_list(boto3_session, region)
-        if len(queue_urls) == 0:
+        if not queue_urls:
             continue
         queue_attributes = get_sqs_queue_attributes(boto3_session, queue_urls)
+        transformed = transform_sqs_queues(queue_attributes)
         load_sqs_queues(
             neo4j_session,
-            queue_attributes,
+            transformed,
             region,
             current_aws_account_id,
             update_tag,

--- a/cartography/models/aws/sqs/queue.py
+++ b/cartography/models/aws/sqs/queue.py
@@ -1,0 +1,90 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class SQSQueueNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("QueueArn")
+    arn: PropertyRef = PropertyRef("QueueArn", extra_index=True)
+    name: PropertyRef = PropertyRef("name")
+    url: PropertyRef = PropertyRef("url")
+    created_timestamp: PropertyRef = PropertyRef("CreatedTimestamp")
+    delay_seconds: PropertyRef = PropertyRef("DelaySeconds")
+    last_modified_timestamp: PropertyRef = PropertyRef("LastModifiedTimestamp")
+    maximum_message_size: PropertyRef = PropertyRef("MaximumMessageSize")
+    message_retention_period: PropertyRef = PropertyRef("MessageRetentionPeriod")
+    policy: PropertyRef = PropertyRef("Policy")
+    receive_message_wait_time_seconds: PropertyRef = PropertyRef(
+        "ReceiveMessageWaitTimeSeconds"
+    )
+    redrive_policy_dead_letter_target_arn: PropertyRef = PropertyRef(
+        "redrive_policy_dead_letter_target_arn"
+    )
+    redrive_policy_max_receive_count: PropertyRef = PropertyRef(
+        "redrive_policy_max_receive_count"
+    )
+    visibility_timeout: PropertyRef = PropertyRef("VisibilityTimeout")
+    kms_master_key_id: PropertyRef = PropertyRef("KmsMasterKeyId")
+    kms_data_key_reuse_period_seconds: PropertyRef = PropertyRef(
+        "KmsDataKeyReusePeriodSeconds"
+    )
+    fifo_queue: PropertyRef = PropertyRef("FifoQueue")
+    content_based_deduplication: PropertyRef = PropertyRef("ContentBasedDeduplication")
+    deduplication_scope: PropertyRef = PropertyRef("DeduplicationScope")
+    fifo_throughput_limit: PropertyRef = PropertyRef("FifoThroughputLimit")
+    region: PropertyRef = PropertyRef("Region", set_in_kwargs=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class SQSQueueToAWSAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class SQSQueueToAWSAccountRel(CartographyRelSchema):
+    target_node_label: str = "AWSAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AWS_ID", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: SQSQueueToAWSAccountRelProperties = SQSQueueToAWSAccountRelProperties()
+
+
+@dataclass(frozen=True)
+class SQSQueueToDeadLetterQueueRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class SQSQueueToDeadLetterQueueRel(CartographyRelSchema):
+    target_node_label: str = "SQSQueue"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("redrive_policy_dead_letter_target_arn")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_DEADLETTER_QUEUE"
+    properties: SQSQueueToDeadLetterQueueRelProperties = (
+        SQSQueueToDeadLetterQueueRelProperties()
+    )
+    conditional_match_property: str = "redrive_policy_dead_letter_target_arn"
+
+
+@dataclass(frozen=True)
+class SQSQueueSchema(CartographyNodeSchema):
+    label: str = "SQSQueue"
+    properties: SQSQueueNodeProperties = SQSQueueNodeProperties()
+    sub_resource_relationship: SQSQueueToAWSAccountRel = SQSQueueToAWSAccountRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [SQSQueueToDeadLetterQueueRel()]
+    )

--- a/tests/data/aws/sqs.py
+++ b/tests/data/aws/sqs.py
@@ -19,3 +19,5 @@ GET_SQS_QUEUE_ATTRIBUTES = [
         },
     ),
 ]
+
+LIST_SQS_QUEUE_URLS = [url for url, _ in GET_SQS_QUEUE_ATTRIBUTES]

--- a/tests/integration/cartography/intel/aws/test_sqs.py
+++ b/tests/integration/cartography/intel/aws/test_sqs.py
@@ -1,5 +1,12 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
 import cartography.intel.aws.sqs
 import tests.data.aws.sqs
+from cartography.intel.aws.sqs import sync
+from tests.integration.cartography.intel.aws.common import create_test_account
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
 
 TEST_ACCOUNT_ID = "000000000000"
 TEST_REGION = "us-east-1"
@@ -10,10 +17,11 @@ def test_load_sqs_queues(neo4j_session, *args):
     """
     Ensure that expected queues get loaded with their key fields.
     """
-    data = tests.data.aws.sqs.GET_SQS_QUEUE_ATTRIBUTES
+    raw_data = tests.data.aws.sqs.GET_SQS_QUEUE_ATTRIBUTES
+    transformed = cartography.intel.aws.sqs.transform_sqs_queues(raw_data)
     cartography.intel.aws.sqs.load_sqs_queues(
         neo4j_session,
-        data,
+        transformed,
         TEST_REGION,
         TEST_ACCOUNT_ID,
         TEST_UPDATE_TAG,
@@ -85,3 +93,70 @@ def test_load_sqs_queues(neo4j_session, *args):
         for r in relation
     }
     assert actual_relationship == expected_relationship
+
+
+@patch.object(
+    cartography.intel.aws.sqs,
+    "get_sqs_queue_list",
+    return_value=[url for url, _ in tests.data.aws.sqs.GET_SQS_QUEUE_ATTRIBUTES],
+)
+@patch.object(
+    cartography.intel.aws.sqs,
+    "get_sqs_queue_attributes",
+    return_value=tests.data.aws.sqs.GET_SQS_QUEUE_ATTRIBUTES,
+)
+def test_sync_sqs(mock_get_attrs, mock_get_list, neo4j_session):
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+    sync(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "SQSQueue",
+        ["arn"],
+    ) == {
+        ("arn:aws:secretsmanager:us-east-1:000000000000:test-queue-1",),
+        ("arn:aws:secretsmanager:us-east-1:000000000000:test-queue-2",),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "AWSAccount",
+        "id",
+        "SQSQueue",
+        "arn",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (
+            TEST_ACCOUNT_ID,
+            "arn:aws:secretsmanager:us-east-1:000000000000:test-queue-1",
+        ),
+        (
+            TEST_ACCOUNT_ID,
+            "arn:aws:secretsmanager:us-east-1:000000000000:test-queue-2",
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "SQSQueue",
+        "arn",
+        "SQSQueue",
+        "arn",
+        "HAS_DEADLETTER_QUEUE",
+        rel_direction_right=True,
+    ) == {
+        (
+            "arn:aws:secretsmanager:us-east-1:000000000000:test-queue-1",
+            "arn:aws:secretsmanager:us-east-1:000000000000:test-queue-2",
+        ),
+    }


### PR DESCRIPTION
## Summary
- refactor `cartography/intel/aws/sqs.py` to use the datamodel schemas
- add `SQSQueueSchema` with node and relationship definitions
- update integration tests for SQS and add new sync test

## Testing
- `uv run --frozen pre-commit run --files cartography/intel/aws/sqs.py cartography/models/aws/sqs/queue.py tests/data/aws/sqs.py tests/integration/cartography/intel/aws/test_sqs.py`
- `uv run --frozen pytest -vvv --cov-report term-missing --cov=cartography tests/unit`
- `make test_integration` *(fails: Couldn't connect to localhost:7687)*

------
https://chatgpt.com/codex/tasks/task_b_68475e7693b0832f8d1adee253132858