### PR TITLE
fix: Remove unused SQS test variable

### DIFF
--- a/tests/data/aws/sqs.py
+++ b/tests/data/aws/sqs.py
@@ -19,5 +19,3 @@ GET_SQS_QUEUE_ATTRIBUTES = [
         },
     ),
 ]
-
-LIST_SQS_QUEUE_URLS = [url for url, _ in GET_SQS_QUEUE_ATTRIBUTES]


### PR DESCRIPTION
Fast follow of #1619

