### PR TITLE
Add object_ownership property to S3 Buckets

### DIFF
--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -2261,6 +2261,7 @@ Representation of an AWS S3 [Bucket](https://docs.aws.amazon.com/AmazonS3/latest
 | ignore\_public\_acls | Specifies whether Amazon S3 should ignore public ACLs for this bucket and objects in this bucket. |
 | block\_public\_acls | Specifies whether Amazon S3 should block public bucket policies for this bucket. |
 | restrict\_public\_buckets | Specifies whether Amazon S3 should restrict public bucket policies for this bucket. |
+| object_ownership | The bucket's [Object Ownership](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html) setting, which affects how ACLs take effect. |
 
 #### Relationships
 

--- a/tests/data/aws/s3.py
+++ b/tests/data/aws/s3.py
@@ -136,3 +136,8 @@ LIST_STATEMENTS = {
         },
     ),
 }
+
+GET_BUCKET_OWNERSHIP_CONTROLS = {
+    "bucket": "bucket-1",
+    "object_ownership": "BucketOwnerPreferred",
+}

--- a/tests/integration/cartography/intel/aws/test_s3.py
+++ b/tests/integration/cartography/intel/aws/test_s3.py
@@ -175,3 +175,36 @@ def test_load_s3_policies(neo4j_session, *args):
     )
 
     assert actual_relationships.single().value() == 3
+
+
+def test_load_s3_bucket_ownership(neo4j_session, *args):
+    """
+    Ensure that expected bucket gets loaded with their bucke ownership controls fields.
+    """
+    data = tests.data.aws.s3.GET_BUCKET_OWNERSHIP_CONTROLS
+    cartography.intel.aws.s3._load_bucket_ownership_controls(
+        neo4j_session, data, TEST_UPDATE_TAG
+    )
+
+    expected_nodes = {
+        (
+            "bucket-1",
+            "BucketOwnerPreferred",
+        ),
+    }
+
+    nodes = neo4j_session.run(
+        """
+        MATCH (s:S3Bucket)
+        WHERE s.id = 'bucket-1'
+        RETURN s.id, s.object_ownership
+        """,
+    )
+    actual_nodes = {
+        (
+            n["s.id"],
+            n["s.object_ownership"],
+        )
+        for n in nodes
+    }
+    assert actual_nodes == expected_nodes


### PR DESCRIPTION
### Summary
This PR adds the [object ownership](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html) S3 bucket setting as a property on S3Bucket nodes. It calls the [GetBucketOwnershipControls](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketOwnershipControls.html) API action, which currently returns a list with exactly one entry, the bucket's object ownership rule. The value of that rule is added to the S3Bucket node as the `object_ownership` property. I'm open to renaming the property if you think it's confusing.
If the Cartography job doesn't have permission to call `GetBucketOwnershipControls`, the API returns `OwnershipControlsNotFoundError`, which this logs as a warning.

See [https://github.com/cartography-cncf/cartography/issues/1625] for why I think this property is useful.


### Related issues or links
- https://github.com/cartography-cncf/cartography/issues/1625


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

![cartography_s3_properties](https://github.com/user-attachments/assets/82bc22c6-445d-43e7-b8e8-5bbdcc808b4b)
]