### PR TITLE
Updates dev.Dockerfile to do an editable install of cartography with uv

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ venv/
 .compose
 .cache
 .local
+.venv

--- a/dev-entrypoint.sh
+++ b/dev-entrypoint.sh
@@ -3,8 +3,5 @@ while ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; do
   echo "Waiting for Git to be ready..."
   sleep 1
 done
-# Activate the virtual environment
-# This allow to used the virtual environment without having to specify `uv run`
-. .venv/bin/activate
 # Pass control to main container command
 exec "$@"

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -23,8 +23,12 @@ COPY --from=ghcr.io/astral-sh/uv@sha256:87a04222b228501907f487b338ca6fc1514a9336
 # Install dependencies.
 WORKDIR /var/cartography
 COPY . /var/cartography
-RUN uv sync --dev && uv venv
-RUN chmod -R a+w /var/cartography
+# Install python dev dependencies globally to the container with an editable install
+# Note that the python interpreter is located at /var/cartography/.venv/bin/python
+RUN uv sync --dev && uv pip install -e .
+
+# The following line exists only to help on Windows Subsystem for Linux permissions issues
+# RUN chmod -R a+w /var/cartography
 
 # Now copy the entire source tree.
 ENV HOME=/var/cartography


### PR DESCRIPTION
### Summary
> Describe your changes.

Updates dev.Dockerfile to do an editable install of cartography source tree with uv.

dev.Dockerfile is intended for lint, unit, and integration testing of cartography, so an editable install is necessary.

As shown in the video below, this change also fixes debug breakpoint behavior in IDEs like Pycharm.

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes. 

Before
https://github.com/user-attachments/assets/933c5292-2c2c-440b-8200-1c23a4ea6b30

After
https://github.com/user-attachments/assets/64a099a2-982d-4031-a72a-117d12327af9


- [ ] Include console log trace showing what happened before and after your changes.
