### PR TITLE
feat: Add support for AWS ACM certificates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -585,12 +585,23 @@ def transform_user(user_data: dict[str, Any]) -> dict[str, Any]:
         "name": user_data.get("display_name"),
         "phone": user_data.get("phone_number"),
 
-        # ✅ Complex optional field handling (but now that Neo4j has a native timestamp type, we can just use that instead of converting to int)
-        "last_login": (
-            int(dt_parse.parse(user_data["last_login"]).timestamp() * 1000)
-            if user_data.get("last_login") else None
-        ),
+        # ✅ Neo4j handles datetime objects natively - no need for manual parsing
+        "last_login": user_data.get("last_login"),  # AWS/API returns ISO 8601 dates
     }
+```
+
+### Date Handling
+
+Neo4j 4+ supports native Python datetime objects and ISO 8601 formatted strings. Avoid manual datetime parsing:
+
+```python
+# ❌ DON'T: Manually parse dates or convert to epoch timestamps
+"created_at": int(dt_parse.parse(user_data["created_at"]).timestamp() * 1000)
+"last_login": dict_date_to_epoch({"d": dt_parse.parse(data["last_login"])}, "d")
+
+# ✅ DO: Pass datetime values directly
+"created_at": user_data.get("created_at")  # AWS/API returns ISO 8601 dates
+"last_login": user_data.get("last_login")  # Neo4j handles these natively
 ```
 
 ## 🧪 Testing Your Module {#testing}
@@ -932,6 +943,34 @@ Note though that if a field is referred to in a target node matcher, it will be 
 - **Core**: Understand `cartography/client/core/tx.py` for load function behavior
 
 ## 📝 Quick Reference Cheat Sheet {#quick-reference-cheat-sheet}
+
+### Type Hints Style Guide
+
+Use Python 3.9+ style type hints throughout your code:
+
+```python
+# ✅ DO: Use built-in type hints (Python 3.9+)
+def get_users(api_key: str) -> dict[str, Any]:
+    ...
+
+def transform(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    ...
+
+# ❌ DON'T: Use objects from typing module
+def get_users(api_key: str) -> Dict[str, Any]:
+    ...
+
+def transform(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    ...
+
+# ✅ DO: Use union operator for optional types
+def process_user(user_id: str | None) -> None:
+    ...
+
+# ❌ DON'T: Use Optional from typing
+def process_user(user_id: Optional[str]) -> None:
+    ...
+```
 
 ### Essential Imports
 ```python

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can learn more about the story behind Cartography in our [presentation at BS
 
 
 ## Supported platforms
-- [Amazon Web Services](https://cartography-cncf.github.io/cartography/modules/aws/index.html) - API Gateway, CloudWatch, Config, EC2, ECS, ECR, Elasticsearch, Elastic Kubernetes Service (EKS), DynamoDB, IAM, Inspector, KMS, Lambda, RDS, Redshift, Route53, S3, Secrets Manager(Secret Versions), Security Hub, SQS, SSM, STS, Tags
+- [Amazon Web Services](https://cartography-cncf.github.io/cartography/modules/aws/index.html) - ACM, API Gateway, CloudWatch, Config, EC2, ECS, ECR, Elasticsearch, Elastic Kubernetes Service (EKS), DynamoDB, IAM, Inspector, KMS, Lambda, RDS, Redshift, Route53, S3, Secrets Manager(Secret Versions), Security Hub, SQS, SSM, STS, Tags
 - [Google Cloud Platform](https://cartography-cncf.github.io/cartography/modules/gcp/index.html) - Cloud Resource Manager, Compute, DNS, Storage, Google Kubernetes Engine
 - [Google GSuite](https://cartography-cncf.github.io/cartography/modules/gsuite/index.html) - users, groups
 - [Oracle Cloud Infrastructure](https://cartography-cncf.github.io/cartography/modules/oci/index.html) - IAM

--- a/cartography/data/indexes.cypher
+++ b/cartography/data/indexes.cypher
@@ -1,4 +1,4 @@
-9CREATE INDEX IF NOT EXISTS FOR (n:AWSConfigurationRecorder) ON (n.id);
+CREATE INDEX IF NOT EXISTS FOR (n:AWSConfigurationRecorder) ON (n.id);
 CREATE INDEX IF NOT EXISTS FOR (n:AWSConfigurationRecorder) ON (n.lastupdated);
 CREATE INDEX IF NOT EXISTS FOR (n:AWSConfigDeliveryChannel) ON (n.id);
 CREATE INDEX IF NOT EXISTS FOR (n:AWSConfigDeliveryChannel) ON (n.lastupdated);

--- a/cartography/data/indexes.cypher
+++ b/cartography/data/indexes.cypher
@@ -1,4 +1,4 @@
-CREATE INDEX IF NOT EXISTS FOR (n:AWSConfigurationRecorder) ON (n.id);
+9CREATE INDEX IF NOT EXISTS FOR (n:AWSConfigurationRecorder) ON (n.id);
 CREATE INDEX IF NOT EXISTS FOR (n:AWSConfigurationRecorder) ON (n.lastupdated);
 CREATE INDEX IF NOT EXISTS FOR (n:AWSConfigDeliveryChannel) ON (n.id);
 CREATE INDEX IF NOT EXISTS FOR (n:AWSConfigDeliveryChannel) ON (n.lastupdated);
@@ -6,8 +6,6 @@ CREATE INDEX IF NOT EXISTS FOR (n:AWSConfigRule) ON (n.id);
 CREATE INDEX IF NOT EXISTS FOR (n:AWSConfigRule) ON (n.lastupdated);
 CREATE INDEX IF NOT EXISTS FOR (n:APIGatewayClientCertificate) ON (n.id);
 CREATE INDEX IF NOT EXISTS FOR (n:APIGatewayClientCertificate) ON (n.lastupdated);
-CREATE INDEX IF NOT EXISTS FOR (n:ACMCertificate) ON (n.id);
-CREATE INDEX IF NOT EXISTS FOR (n:ACMCertificate) ON (n.lastupdated);
 CREATE INDEX IF NOT EXISTS FOR (n:APIGatewayRestAPI) ON (n.id);
 CREATE INDEX IF NOT EXISTS FOR (n:APIGatewayRestAPI) ON (n.lastupdated);
 CREATE INDEX IF NOT EXISTS FOR (n:APIGatewayResource) ON (n.id);

--- a/cartography/data/indexes.cypher
+++ b/cartography/data/indexes.cypher
@@ -6,6 +6,8 @@ CREATE INDEX IF NOT EXISTS FOR (n:AWSConfigRule) ON (n.id);
 CREATE INDEX IF NOT EXISTS FOR (n:AWSConfigRule) ON (n.lastupdated);
 CREATE INDEX IF NOT EXISTS FOR (n:APIGatewayClientCertificate) ON (n.id);
 CREATE INDEX IF NOT EXISTS FOR (n:APIGatewayClientCertificate) ON (n.lastupdated);
+CREATE INDEX IF NOT EXISTS FOR (n:ACMCertificate) ON (n.id);
+CREATE INDEX IF NOT EXISTS FOR (n:ACMCertificate) ON (n.lastupdated);
 CREATE INDEX IF NOT EXISTS FOR (n:APIGatewayRestAPI) ON (n.id);
 CREATE INDEX IF NOT EXISTS FOR (n:APIGatewayRestAPI) ON (n.lastupdated);
 CREATE INDEX IF NOT EXISTS FOR (n:APIGatewayResource) ON (n.id);

--- a/cartography/intel/aws/acm.py
+++ b/cartography/intel/aws/acm.py
@@ -2,7 +2,6 @@ import logging
 from typing import Any
 
 import boto3
-import botocore
 import neo4j
 
 from cartography.client.core.tx import load
@@ -22,7 +21,6 @@ stat_handler = get_stats_client(__name__)
 def get_acm_certificates(
     boto3_session: boto3.session.Session, region: str
 ) -> list[dict[str, Any]]:
-    """Fetch certificate details from AWS ACM."""
     client = boto3_session.client("acm", region_name=region)
     paginator = client.get_paginator("list_certificates")
     summaries: list[dict[str, Any]] = []
@@ -32,12 +30,8 @@ def get_acm_certificates(
     details: list[dict[str, Any]] = []
     for summary in summaries:
         arn = summary["CertificateArn"]
-        try:
-            resp = client.describe_certificate(CertificateArn=arn)
-            details.append(resp["Certificate"])
-        except botocore.exceptions.ClientError as e:
-            logger.warning(f"Could not describe certificate {arn}: {e}")
-            continue
+        resp = client.describe_certificate(CertificateArn=arn)
+        details.append(resp["Certificate"])
     return details
 
 

--- a/cartography/intel/aws/acm.py
+++ b/cartography/intel/aws/acm.py
@@ -1,0 +1,140 @@
+import logging
+from typing import Any
+from typing import Dict
+from typing import List
+
+import boto3
+import botocore
+import neo4j
+from dateutil import parser as dt_parser
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.models.aws.acm.certificate import ACMCertificateSchema
+from cartography.stats import get_stats_client
+from cartography.util import aws_handle_regions
+from cartography.util import dict_date_to_epoch
+from cartography.util import merge_module_sync_metadata
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+stat_handler = get_stats_client(__name__)
+
+
+@timeit
+@aws_handle_regions
+def get_acm_certificates(
+    boto3_session: boto3.session.Session, region: str
+) -> List[Dict]:
+    """Fetch certificate details from AWS ACM."""
+    client = boto3_session.client("acm", region_name=region)
+    paginator = client.get_paginator("list_certificates")
+    summaries: List[Dict] = []
+    for page in paginator.paginate():
+        summaries.extend(page.get("CertificateSummaryList", []))
+
+    details: List[Dict] = []
+    for summary in summaries:
+        arn = summary["CertificateArn"]
+        try:
+            resp = client.describe_certificate(CertificateArn=arn)
+            details.append(resp["Certificate"])
+        except botocore.exceptions.ClientError as e:
+            logger.warning(f"Could not describe certificate {arn}: {e}")
+            continue
+    return details
+
+
+def transform_acm_certificates(certificates: List[Dict], region: str) -> List[Dict]:
+    transformed: List[Dict] = []
+    for cert in certificates:
+        item: Dict[str, Any] = {
+            "Arn": cert["CertificateArn"],
+            "DomainName": cert.get("DomainName"),
+            "Type": cert.get("Type"),
+            "Status": cert.get("Status"),
+            "KeyAlgorithm": cert.get("KeyAlgorithm"),
+            "SignatureAlgorithm": cert.get("SignatureAlgorithm"),
+            "NotBefore": (
+                dict_date_to_epoch({"d": dt_parser.parse(cert["NotBefore"])}, "d")
+                if cert.get("NotBefore")
+                else None
+            ),
+            "NotAfter": (
+                dict_date_to_epoch({"d": dt_parser.parse(cert["NotAfter"])}, "d")
+                if cert.get("NotAfter")
+                else None
+            ),
+            "InUseBy": cert.get("InUseBy", []),
+            "Region": region,
+        }
+        # Extract ELBV2 Listener ARNs for relationship creation
+        listener_arns = [a for a in item["InUseBy"] if ":listener/" in a]
+        if listener_arns:
+            item["ELBV2ListenerArns"] = listener_arns
+        transformed.append(item)
+    return transformed
+
+
+@timeit
+def load_acm_certificates(
+    neo4j_session: neo4j.Session,
+    data: List[Dict],
+    region: str,
+    current_aws_account_id: str,
+    update_tag: int,
+) -> None:
+    logger.info(f"Loading {len(data)} ACM certificates for region {region} into graph.")
+    load(
+        neo4j_session,
+        ACMCertificateSchema(),
+        data,
+        lastupdated=update_tag,
+        Region=region,
+        AWS_ID=current_aws_account_id,
+    )
+
+
+@timeit
+def cleanup_acm_certificates(
+    neo4j_session: neo4j.Session, common_job_parameters: Dict
+) -> None:
+    logger.debug("Running ACM certificate cleanup job.")
+    GraphJob.from_node_schema(ACMCertificateSchema(), common_job_parameters).run(
+        neo4j_session
+    )
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    boto3_session: boto3.session.Session,
+    regions: List[str],
+    current_aws_account_id: str,
+    update_tag: int,
+    common_job_parameters: Dict,
+) -> None:
+    for region in regions:
+        logger.info(
+            f"Syncing ACM certificates for region {region} in account {current_aws_account_id}."
+        )
+        certs = get_acm_certificates(boto3_session, region)
+        transformed = transform_acm_certificates(certs, region)
+        load_acm_certificates(
+            neo4j_session,
+            transformed,
+            region,
+            current_aws_account_id,
+            update_tag,
+        )
+
+    cleanup_acm_certificates(neo4j_session, common_job_parameters)
+
+    merge_module_sync_metadata(
+        neo4j_session,
+        group_type="AWSAccount",
+        group_id=current_aws_account_id,
+        synced_type="ACMCertificate",
+        update_tag=update_tag,
+        stat_handler=stat_handler,
+    )

--- a/cartography/intel/aws/resources.py
+++ b/cartography/intel/aws/resources.py
@@ -100,7 +100,7 @@ RESOURCE_FUNCTIONS: Dict[str, Callable[..., None]] = {
     "sns": sns.sync,
     "sqs": sqs.sync,
     "ssm": ssm.sync,
-    "acm": acm.sync,
+    "acm:certificate": acm.sync,
     "inspector": inspector.sync,
     "config": config.sync,
     "identitycenter": identitycenter.sync_identity_center_instances,

--- a/cartography/intel/aws/resources.py
+++ b/cartography/intel/aws/resources.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 from cartography.intel.aws.ec2.route_tables import sync_route_tables
 
+from . import acm
 from . import apigateway
 from . import cloudtrail
 from . import cloudwatch
@@ -99,6 +100,7 @@ RESOURCE_FUNCTIONS: Dict[str, Callable[..., None]] = {
     "sns": sns.sync,
     "sqs": sqs.sync,
     "ssm": ssm.sync,
+    "acm": acm.sync,
     "inspector": inspector.sync,
     "config": config.sync,
     "identitycenter": identitycenter.sync_identity_center_instances,

--- a/cartography/models/aws/acm/certificate.py
+++ b/cartography/models/aws/acm/certificate.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class ACMCertificateNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("Arn")
+    arn: PropertyRef = PropertyRef("Arn", extra_index=True)
+    domainname: PropertyRef = PropertyRef("DomainName")
+    type: PropertyRef = PropertyRef("Type")
+    status: PropertyRef = PropertyRef("Status")
+    key_algorithm: PropertyRef = PropertyRef("KeyAlgorithm")
+    signature_algorithm: PropertyRef = PropertyRef("SignatureAlgorithm")
+    not_before: PropertyRef = PropertyRef("NotBefore")
+    not_after: PropertyRef = PropertyRef("NotAfter")
+    in_use_by: PropertyRef = PropertyRef("InUseBy")
+    region: PropertyRef = PropertyRef("Region", set_in_kwargs=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ACMCertificateToAWSAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ACMCertificateToAWSAccountRel(CartographyRelSchema):
+    target_node_label: str = "AWSAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AWS_ID", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ACMCertificateToAWSAccountRelProperties = (
+        ACMCertificateToAWSAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ACMCertificateToELBV2ListenerRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ACMCertificateToELBV2ListenerRel(CartographyRelSchema):
+    target_node_label: str = "ELBV2Listener"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ELBV2ListenerArns", one_to_many=True)}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USED_BY"
+    properties: ACMCertificateToELBV2ListenerRelProperties = (
+        ACMCertificateToELBV2ListenerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ACMCertificateSchema(CartographyNodeSchema):
+    label: str = "ACMCertificate"
+    properties: ACMCertificateNodeProperties = ACMCertificateNodeProperties()
+    sub_resource_relationship: ACMCertificateToAWSAccountRel = (
+        ACMCertificateToAWSAccountRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [ACMCertificateToELBV2ListenerRel()]
+    )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -2490,6 +2490,7 @@ Representation of an AWS [ACM Certificate](https://docs.aws.amazon.com/acm/lates
     ```
     (:ACMCertificate)-[:USED_BY]->(:ELBV2Listener)
     ```
+  Note: the AWS ACM API may return a load balancer ARN for the `in_use_by` field instead of a listener ARN. To properly map the certificate to the listener in this situation, we need to rely on data from the ELBV2 module. This is a weird quirk of the AWS API.
 
 ### APIGatewayResource
 

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -2459,6 +2459,35 @@ Representation of an AWS [API Gateway Client Certificate](https://docs.aws.amazo
     (APIGatewayStage)-[HAS_CERTIFICATE]->(APIGatewayClientCertificate)
     ```
 
+### ACMCertificate
+
+Representation of an AWS [ACM Certificate](https://docs.aws.amazon.com/acm/latest/APIReference/API_CertificateDetail.html).
+
+| Field | Description |
+|-------|-------------|
+| firstseen| Timestamp of when a sync job first discovered this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| **id** | The ARN of the certificate |
+| domainname | The primary domain name of the certificate |
+| status | The status of the certificate |
+| type | The source of the certificate |
+| key_algorithm | The key algorithm used |
+| signature_algorithm | The signature algorithm |
+| not_before | The time before which the certificate is invalid |
+| not_after | The time after which the certificate expires |
+| in_use_by | List of ARNs of resources that use this certificate |
+
+#### Relationships
+
+- ACM Certificates are resources under the AWS Account.
+    ```
+    (AWSAccount)-[RESOURCE]->(ACMCertificate)
+    ```
+- ACM Certificates may be used by ELBV2Listeners.
+    ```
+    (ACMCertificate)-[USED_BY]->(ELBV2Listener)
+    ```
+
 ### APIGatewayResource
 
 Representation of an AWS [API Gateway Resource](https://docs.aws.amazon.com/apigateway/api-reference/resource/resource/).

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1684,15 +1684,18 @@ Representation of an AWS Elastic Load Balancer V2 [Listener](https://docs.aws.am
 | port | The port of this endpoint |
 | ssl\_policy | Only set for HTTPS or TLS listener. The security policy that defines which protocols and ciphers are supported. |
 | targetgrouparn | The ARN of the Target Group, if the Action type is `forward`. |
-
+| arn | The ARN of the ELBV2Listener |
 
 #### Relationships
 
-- A ELBV2Listener is installed on a LoadBalancerV2.
+- LoadBalancerV2's have [listeners](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_Listener.html):
     ```
-    (elbv2)-[r:ELBV2_LISTENER]->(ELBV2Listener)
+    (:LoadBalancerV2)-[:ELBV2_LISTENER]->(:ELBV2Listener)
     ```
-
+- ACM Certificates may be used by ELBV2Listeners.
+    ```
+    (:ACMCertificate)-[:USED_BY]->(:ELBV2Listener)
+    ```
 
 ### Ip
 
@@ -2481,11 +2484,11 @@ Representation of an AWS [ACM Certificate](https://docs.aws.amazon.com/acm/lates
 
 - ACM Certificates are resources under the AWS Account.
     ```
-    (AWSAccount)-[RESOURCE]->(ACMCertificate)
+    (:AWSAccount)-[:RESOURCE]->(:ACMCertificate)
     ```
 - ACM Certificates may be used by ELBV2Listeners.
     ```
-    (ACMCertificate)-[USED_BY]->(ELBV2Listener)
+    (:ACMCertificate)-[:USED_BY]->(:ELBV2Listener)
     ```
 
 ### APIGatewayResource

--- a/tests/data/aws/acm.py
+++ b/tests/data/aws/acm.py
@@ -1,0 +1,24 @@
+LIST_CERTIFICATES = {
+    "CertificateSummaryList": [
+        {
+            "CertificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/test-cert",
+            "DomainName": "example.com",
+        }
+    ]
+}
+
+DESCRIBE_CERTIFICATE = {
+    "Certificate": {
+        "CertificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/test-cert",
+        "DomainName": "example.com",
+        "InUseBy": [
+            "arn:aws:elasticloadbalancing:us-east-1:000000000000:listener/app/test-lb/abcd/efgh"
+        ],
+        "Type": "IMPORTED",
+        "Status": "ISSUED",
+        "KeyAlgorithm": "RSA_2048",
+        "SignatureAlgorithm": "SHA256WITHRSA",
+        "NotBefore": "2024-01-01T00:00:00Z",
+        "NotAfter": "2025-01-01T00:00:00Z",
+    }
+}

--- a/tests/integration/cartography/intel/aws/test_acm.py
+++ b/tests/integration/cartography/intel/aws/test_acm.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.aws.acm
+from cartography.intel.aws.acm import sync
+from tests.data.aws import acm as test_data
+from tests.integration.cartography.intel.aws.common import create_test_account
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_ACCOUNT_ID = "000000000000"
+TEST_REGION = "us-east-1"
+TEST_UPDATE_TAG = 123456789
+LISTENER_ARN = (
+    "arn:aws:elasticloadbalancing:us-east-1:000000000000:listener/app/test-lb/abcd/efgh"
+)
+
+
+@patch.object(
+    cartography.intel.aws.acm,
+    "get_acm_certificates",
+    return_value=[test_data.DESCRIBE_CERTIFICATE["Certificate"]],
+)
+def test_sync_acm(mock_get_certs, neo4j_session):
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+    # Pre-create listener node to attach relationship
+    neo4j_session.run("MERGE (:ELBV2Listener {id: $id})", id=LISTENER_ARN)
+
+    sync(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+
+    assert check_nodes(neo4j_session, "ACMCertificate", ["arn", "domainname"]) == {
+        ("arn:aws:acm:us-east-1:000000000000:certificate/test-cert", "example.com")
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "AWSAccount",
+        "id",
+        "ACMCertificate",
+        "arn",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {(TEST_ACCOUNT_ID, "arn:aws:acm:us-east-1:000000000000:certificate/test-cert")}
+
+    assert check_rels(
+        neo4j_session,
+        "ACMCertificate",
+        "arn",
+        "ELBV2Listener",
+        "id",
+        "USED_BY",
+        rel_direction_right=True,
+    ) == {("arn:aws:acm:us-east-1:000000000000:certificate/test-cert", LISTENER_ARN)}

--- a/tests/unit/cartography/intel/aws/test_acm.py
+++ b/tests/unit/cartography/intel/aws/test_acm.py
@@ -1,0 +1,20 @@
+from cartography.intel.aws import acm
+from tests.data.aws import acm as test_data
+
+
+def test_transform_acm_certificates():
+    result = acm.transform_acm_certificates(
+        [test_data.DESCRIBE_CERTIFICATE["Certificate"]],
+        "us-east-1",
+    )
+    assert len(result) == 1
+    cert = result[0]
+    assert cert["Arn"] == "arn:aws:acm:us-east-1:000000000000:certificate/test-cert"
+    assert cert["DomainName"] == "example.com"
+    assert cert["Status"] == "ISSUED"
+    assert cert["InUseBy"] == [
+        "arn:aws:elasticloadbalancing:us-east-1:000000000000:listener/app/test-lb/abcd/efgh"
+    ]
+    assert cert["ELBV2ListenerArns"] == [
+        "arn:aws:elasticloadbalancing:us-east-1:000000000000:listener/app/test-lb/abcd/efgh"
+    ]


### PR DESCRIPTION
## Summary
- ingest AWS ACM certificates
- map ACM certificates to ELBV2 listeners
- document ACMCertificate node
- index ACMCertificate
- test new ACM certificate ingestion

## Testing
Proof this works:

Ran locally with
```
WARNING:cartography.cli:A Kandji base URI was not provided.
WARNING:cartography.cli:A SnipeIT base URI was not provided.
INFO:cartography.sync:Starting sync with update tag '1749964407'
INFO:cartography.sync:Starting sync stage 'aws'
INFO:cartography.intel.aws:Syncing AWS accounts: 2345
INFO:cartography.intel.aws:Syncing AWS account with ID '2345' using configured profile 'asdf-2345'.
INFO:cartography.intel.aws:Trying to autodiscover accounts.
WARNING:cartography.intel.aws:The current account (2345) doesn't have enough permissions to perform autodiscovery.
INFO:cartography.intel.aws.ec2.load_balancer_v2s:Syncing EC2 load balancers v2 for region 'us-east-1' in account '2345'.
WARNING:neo4j.notifications:Received notification from DBMS server: {severity: WARNING} {code: Neo.ClientNotification.Statement.CartesianProductWarning} {category: } {title: This query builds a cartesian product between disconnected patterns.} {description: If a part of a query contains multiple disconnected patterns, this will build a cartesian product between all those parts. This may produce a large amount of data and slow down query processing. While occasionally intended, it may often be possible to reformulate the query that avoids the use of this cross product, perhaps by adding a relationship between the different parts or by using OPTIONAL MATCH (identifier is: (group))} {position: line: 2, column: 13, offset: 13} for query: '\n            MATCH (elbv2:LoadBalancerV2{id: $ID}),\n            (group:EC2SecurityGroup{groupid: $GROUP_ID})\n            MERGE (elbv2)-[r:MEMBER_OF_EC2_SECURITY_GROUP]->(group)\n            ON CREATE SET r.firstseen = timestamp()\n            SET r.lastupdated = $update_tag\n            '
INFO:cartography.graph.statement:Completed aws_ingest_load_balancers_v2_cleanup statement #1
INFO:cartography.graph.statement:Completed aws_ingest_load_balancers_v2_cleanup statement #2
INFO:cartography.graph.statement:Completed aws_ingest_load_balancers_v2_cleanup statement #3
INFO:cartography.graph.statement:Completed aws_ingest_load_balancers_v2_cleanup statement #4
INFO:cartography.graph.statement:Completed aws_ingest_load_balancers_v2_cleanup statement #5
INFO:cartography.graph.statement:Completed aws_ingest_load_balancers_v2_cleanup statement #6
INFO:cartography.graph.job:Finished job aws_ingest_load_balancers_v2_cleanup
INFO:cartography.intel.aws.acm:Syncing ACM certificates for region us-east-1 in accountď2345.
INFO:cartography.intel.aws.acm:Loading 1 ACM certificates for region us-east-1 into graph.
INFO:cartography.graph.statement:Completed ACMCertificate statement #1
INFO:cartography.graph.statement:Completed ACMCertificate statement #2
INFO:cartography.graph.statement:Completed ACMCertificate statement #3
INFO:cartography.graph.job:Finished job ACMCertificate
INFO:cartography.graph.statement:Completed aws_ec2_iaminstanceprofile statement #1
INFO:cartography.graph.statement:Completed aws_ec2_iaminstanceprofile statement #2
INFO:cartography.graph.job:Finished job aws_ec2_iaminstanceprofile
INFO:cartography.graph.statement:Completed aws_lambda_ecr statement #1
INFO:cartography.graph.statement:Completed aws_lambda_ecr statement #2
INFO:cartography.graph.job:Finished job aws_lambda_ecr
INFO:cartography.graph.statement:Completed aws_post_ingestion_principals_cleanup statement #1
INFO:cartography.graph.job:Finished job aws_post_ingestion_principals_cleanup
INFO:cartography.util:Did not run aws_ec2_asset_exposure.json because it needs {'ec2:load_balancer', 'ec2:load_balancer_v2', 'ec2:security_group', 'ec2:instance'} to be included as a requested sync. You specified: {'ec2:load_balancer_v2', 'acm:certificate'}. If you want this job to run, please change your CLI args/cartography config so that all required resources are included.
INFO:cartography.util:Did not run aws_ec2_keypair_analysis.json because it needs {'ec2:keypair'} to be included as a requested sync. You specified: {'ec2:load_balancer_v2', 'acm:certificate'}. If you want this job to run, please change your CLI args/cartography config so that all required resources are included.
INFO:cartography.util:Did not run aws_eks_asset_exposure.json because it needs {'eks'} to be included as a requested sync. You specified: {'ec2:load_balancer_v2', 'acm:certificate'}. If you want this job to run, please change your CLI args/cartography config so that all required resources are included.
INFO:cartography.graph.statement:Completed aws_foreign_accounts statement #1
INFO:cartography.graph.statement:Completed aws_foreign_accounts statement #2
INFO:cartography.graph.job:Finished job aws_foreign_accounts
INFO:cartography.sync:Finishing sync stage 'aws'
INFO:cartography.sync:Finishing sync with update tag '1749964407'
```

Graph:
![image](https://github.com/user-attachments/assets/3a26cde0-ec1a-44b6-abdb-c1367676b67e)



Integration and unit tests work.

------
https://chatgpt.com/codex/tasks/task_b_684c5682ce84832393b7beaaf983ec52