### PR TITLE
 fix: docker-compose run error on fresh clone #1632

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,9 +58,11 @@ services:
 
 # Intended to run local automated tests, custom sync scripts, and local changes.
   cartography-dev:
-    # See dev instructions: we assume that you have built this with
-    # `docker build -t cartography-cncf/cartography-dev -f dev.Dockerfile ./`
     image: cartography-cncf/cartography-dev
+    build:
+      context: .
+      dockerfile: dev.Dockerfile
+    pull_policy: never # SECURITY: this prevents pulling the image from the registry that does not exist (prevents takeover)
     init: true
     restart: on-failure
     depends_on:


### PR DESCRIPTION
Fixes #1632

### Summary
The docker-compose file:

* still uses the `cartography-dev` image if it exists
* now builds the image automatically if it's missing (no more need to build it manually first)
* prevents pulling the non-existent `cartography-dev` image (security safeguard)

**Before:**
![Screenshot From 2025-06-15 11-14-19](https://github.com/user-attachments/assets/b8171453-cfcf-47b4-a0dd-bc96486e9ad2)


**After:**
![Screenshot From 2025-06-17 10-11-20](https://github.com/user-attachments/assets/0d779dd0-7fe6-4d6c-96c3-12e4747161b6)
