### PR TITLE
fix #1640: check_nodes is used without `assert` instruction in some tests 

### DIFF
--- a/tests/integration/cartography/intel/aws/test_identitycenter.py
+++ b/tests/integration/cartography/intel/aws/test_identitycenter.py
@@ -23,7 +23,9 @@ def test_load_sso_users(neo4j_session):
     )
 
     # Use check_nodes to verify that the SSO users are correctly loaded
-    check_nodes(neo4j_session, "AWSSSOUser", ["id", "external_id"])
+    assert check_nodes(neo4j_session, "AWSSSOUser", ["id", "external_id"]) == {
+        ("aaaaaaaa-a0d1-aaac-5af0-59c813ec7671", "")
+    }
 
 
 def test_load_identity_center_instances(neo4j_session):
@@ -41,7 +43,11 @@ def test_load_identity_center_instances(neo4j_session):
     )
 
     # Verify that the instances are correctly loaded
-    check_nodes(neo4j_session, "AWSIdentityCenterInstance", ["id", "identity_store_id"])
+    assert check_nodes(
+        neo4j_session, "AWSIdentityCenter", ["id", "identity_store_id"]
+    ) == {
+        ("arn:aws:sso:::instance/ssoins-12345678901234567", "d-1234567890"),
+    }
 
 
 def test_load_permission_sets(neo4j_session):
@@ -60,4 +66,9 @@ def test_load_permission_sets(neo4j_session):
     )
 
     # Verify that the permission sets are correctly loaded
-    check_nodes(neo4j_session, "AWSPermissionSet", ["id", "name"])
+    assert check_nodes(neo4j_session, "AWSPermissionSet", ["id", "name"]) == {
+        (
+            "arn:aws:sso:::permissionSet/ssoins-12345678901234567/ps-12345678901234567",
+            "AdministratorAccess",
+        ),
+    }

--- a/tests/integration/cartography/intel/kandji/test_kandji.py
+++ b/tests/integration/cartography/intel/kandji/test_kandji.py
@@ -32,10 +32,13 @@ def test_load_kandji_devices_relationship(neo4j_session):
     expected_nodes = {
         ("SimpsonCorp",),
     }
-    check_nodes(
-        neo4j_session,
-        "KandjiTenant",
-        ["id"],
+    assert (
+        check_nodes(
+            neo4j_session,
+            "KandjiTenant",
+            ["id"],
+        )
+        == expected_nodes
     )
 
     # Make sure the expected Devices are created

--- a/tests/integration/cartography/intel/snipeit/test_snipeit_assets.py
+++ b/tests/integration/cartography/intel/snipeit/test_snipeit_assets.py
@@ -37,15 +37,17 @@ def test_load_snipeit_assets_relationship(neo4j_session):
     )
 
     # Assert
-
     # Make sure the expected Tenant is created
     expected_nodes = {
         ("SimpsonCorp",),
     }
-    check_nodes(
-        neo4j_session,
-        "snipeitTenant",
-        ["id"],
+    assert (
+        check_nodes(
+            neo4j_session,
+            "SnipeitTenant",
+            ["id"],
+        )
+        == expected_nodes
     )
 
     # Make sure the expected assets are created

--- a/tests/integration/cartography/intel/snipeit/test_snipeit_users.py
+++ b/tests/integration/cartography/intel/snipeit/test_snipeit_users.py
@@ -27,15 +27,17 @@ def test_load_snipeit_user_relationship(neo4j_session):
     )
 
     # Assert
-
     # Make sure the expected Tenant is created
     expected_nodes = {
         ("SimpsonCorp",),
     }
-    check_nodes(
-        neo4j_session,
-        "SnipeitTenant",
-        ["id"],
+    assert (
+        check_nodes(
+            neo4j_session,
+            "SnipeitTenant",
+            ["id"],
+        )
+        == expected_nodes
     )
 
     # Make sure the expected Devices are created


### PR DESCRIPTION
### Summary
Fixes #1640

---

While fixing the issue I discovered that the untested AWSSSOUser has an issue:
- test data stub refering to `ExternalIds` with is a list of dict (ref: https://github.com/cartography-cncf/cartography/blob/97678da15d5f8c3ff3cd496e14498b2959b893d0/tests/data/aws/identitycenter.py#L5)
- SSOUser model refering to `EternalId` (ref: https://github.com/cartography-cncf/cartography/blob/97678da15d5f8c3ff3cd496e14498b2959b893d0/cartography/models/aws/identitycenter/awsssouser.py#L20)
- by the way the link between SSOUser and Okta `UserAccount` should not work

I do not use it in production so I do not know if there is an issue with our test data or if the module do not work at all.
Any help is welcome :)