### PR TITLE
Refactor AWS Inspector: reduce memory and add parallel ingestion

### DIFF
--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -222,7 +222,7 @@ def load_graph_data(
     :param kwargs: Allows additional keyword args to be supplied to the Neo4j query.
     :return: None
     """
-    for data_batch in list(batch(dict_list, size=10000)):
+    for data_batch in batch(dict_list, size=10000):
         neo4j_session.write_transaction(
             write_list_of_dicts_tx,
             query,

--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -182,7 +182,7 @@ def load_ecr_repository_images(
     logger.info(
         f"Loading {len(repo_images_list)} ECR repository images in {region} into graph.",
     )
-    for repo_image_batch in list(batch(repo_images_list, size=10000)):
+    for repo_image_batch in batch(repo_images_list, size=10000):
         neo4j_session.write_transaction(
             _load_ecr_repo_img_tx,
             repo_image_batch,

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -235,7 +235,7 @@ def load_tags(
     if len(tag_data) == 0:
         # If there is no data to load, save some time.
         return
-    for tag_data_batch in list(batch(tag_data, size=100)):
+    for tag_data_batch in batch(tag_data, size=100):
         neo4j_session.write_transaction(
             _load_tags_tx,
             tag_data=tag_data_batch,

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -229,7 +229,7 @@ def aws_paginate(
                 f"""aws_paginate: Key "{object_name}" is not present, check if this is a typo.
 If not, then the AWS datatype somehow does not have this key.""",
             )
-        if max_pages and i >= max_pages:
+        if max_pages is not None and i >= max_pages:
             logger.warning(f"Reached max batch size of {max_pages} pages")
             break
 
@@ -359,7 +359,7 @@ def camel_to_snake(name: str) -> str:
 
 def batch(items: Iterable, size: int = DEFAULT_BATCH_SIZE) -> Iterable[List[Any]]:
     """
-    Takes an Iterable of items and returns an Iterator of lists of the same items,
+    Takes an Iterable of items and returns a Generator of lists of the same items,
      batched into chunks of the provided `size`.
 
     Use:
@@ -367,10 +367,7 @@ def batch(items: Iterable, size: int = DEFAULT_BATCH_SIZE) -> Iterable[List[Any]
     batch(x, size=3) -> Iterator yielding [1, 2, 3], [4, 5, 6], [7, 8]
     """
     it = iter(items)
-    while True:
-        chunk = list(islice(it, size))
-        if not chunk:
-            return
+    while chunk := list(islice(it, size)):
         yield chunk
 
 

--- a/tests/unit/cartography/test_util.py
+++ b/tests/unit/cartography/test_util.py
@@ -105,7 +105,6 @@ def test_batch(mocker):
     ]
     # Act
     actual = list(batch(x, 5))
-    print(actual)
     # Assert
     assert actual == expected
     # Also check for empty input


### PR DESCRIPTION
### Summary
There is a memory issue with AWS Inspector module. The pagination only returns results until findings are retrieved from one account and all those objects are added to one single list. Considering there can be millions of findings, this can consume all the memory of the job running it.
This PR refactors this module to:
- Provide a maximum number of pages to `aws_paginate`
- Transform `aws_paginate` and `batch` into [generators](https://wiki.python.org/moin/Generators) to get results in batches of iterators.
- Breaks inspector findings ingestion in batches of 1000 elements.
- Adds aysnc processing to ingest multiple accounts in parallel

This processed ~110,000 findings using a max of ~350 MiB

```
INFO:cartography.intel.aws.inspector:Loading 1000 findings from account XXXXXXX
INFO:cartography.intel.aws.inspector:Loading 88 packages
INFO:cartography.intel.aws.inspector:Loading 766 findings from account XXXXXXX
INFO:cartography.intel.aws.inspector:Loading 86 packages

Filename: /Users/eryxp/src/cartography/cartography/intel/aws/inspector.py

Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
   276    289.1 MiB    289.1 MiB           1   @profile
   277                                         def _sync_findings_for_account(
   278                                             neo4j_session: neo4j.Session,
   279                                             boto3_session: boto3.session.Session,
   280                                             region: str,
   281                                             account_id: str,
   282                                             update_tag: int,
   283                                             current_aws_account_id: str,
   284                                         ) -> None:
   285                                             """
   286                                             Syncs the findings for a given account in a given region.
   287                                             """
   288    289.1 MiB      0.0 MiB           1       findings = get_inspector_findings(boto3_session, region, account_id)
   289    289.1 MiB      0.0 MiB           1       print(type(findings))
   290    289.1 MiB      0.0 MiB           1       if not findings:
   291                                                 logger.info(f"No findings to sync for account {account_id} in region {region}")
   292                                                 return
   293    354.9 MiB  -2599.7 MiB         109       for f_batch in findings:
   294    355.0 MiB  -2588.2 MiB         108           finding_data, package_data = transform_inspector_findings(f_batch)
   295    355.0 MiB  -2592.9 MiB         108           logger.info(f"Loading {len(finding_data)} findings from account {account_id}")
   296    355.0 MiB  -5150.9 MiB         216           load_inspector_findings(
   297    355.0 MiB  -2592.9 MiB         108               neo4j_session,
   298    355.0 MiB  -2592.9 MiB         108               finding_data,
   299    355.0 MiB  -2592.9 MiB         108               region,
   300    355.0 MiB  -2592.9 MiB         108               update_tag,
   301    355.0 MiB  -2592.9 MiB         108               current_aws_account_id,
   302                                                 )
   303    355.0 MiB  -2588.1 MiB         108           logger.info(f"Loading {len(package_data)} packages")
   304    355.0 MiB  -5176.1 MiB         216           load_inspector_packages(
   305    355.0 MiB  -2588.1 MiB         108               neo4j_session,
   306    355.0 MiB  -2588.1 MiB         108               package_data,
   307    355.0 MiB  -2588.1 MiB         108               region,
   308    355.0 MiB  -2588.1 MiB         108               update_tag,
   309    355.0 MiB  -2588.1 MiB         108               current_aws_account_id,
   310                                                 )
```

<img width="1399" alt="Screenshot 2025-06-25 at 10 31 24 p m" src="https://github.com/user-attachments/assets/5810cf3b-5b50-40a3-853a-15d85483fee3" />

### Related issues or links
https://github.com/cartography-cncf/cartography/issues/1025
https://github.com/cartography-cncf/cartography/issues/988


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [x] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
