### PR TITLE
Add EfsAccessPoint as Resource

### DIFF
--- a/cartography/models/aws/efs/access_point.py
+++ b/cartography/models/aws/efs/access_point.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class EfsAccessPointNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("AccessPointArn")
+    arn: PropertyRef = PropertyRef("AccessPointArn", extra_index=True)
+    region: PropertyRef = PropertyRef("Region", set_in_kwargs=True)
+    access_point_id: PropertyRef = PropertyRef("AccessPointId")
+    file_system_id: PropertyRef = PropertyRef("FileSystemId")
+    lifecycle_state: PropertyRef = PropertyRef("LifeCycleState")
+    name: PropertyRef = PropertyRef("Name")
+    owner_id: PropertyRef = PropertyRef("OwnerId")
+    posix_gid: PropertyRef = PropertyRef("Gid")
+    posix_uid: PropertyRef = PropertyRef("Uid")
+    root_directory_path: PropertyRef = PropertyRef("RootDirectoryPath")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EfsAccessPointToAwsAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EfsAccessPointToAWSAccountRel(CartographyRelSchema):
+    target_node_label: str = "AWSAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: EfsAccessPointToAwsAccountRelProperties = (
+        EfsAccessPointToAwsAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class EfsAccessPointToEfsFileSystemRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EfsAccessPointToEfsFileSystemRel(CartographyRelSchema):
+    target_node_label: str = "EfsFileSystem"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("FileSystemId")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "ACCESS_POINT_OF"
+    properties: EfsAccessPointToEfsFileSystemRelProperties = (
+        EfsAccessPointToEfsFileSystemRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class EfsAccessPointSchema(CartographyNodeSchema):
+    label: str = "EfsAccessPoint"
+    properties: EfsAccessPointNodeProperties = EfsAccessPointNodeProperties()
+    sub_resource_relationship: EfsAccessPointToAWSAccountRel = (
+        EfsAccessPointToAWSAccountRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            EfsAccessPointToEfsFileSystemRel(),
+        ]
+    )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -3369,6 +3369,33 @@ Representation of an AWS [EFS Mount Target](https://docs.aws.amazon.com/efs/late
     (EfsMountTarget)-[ATTACHED_TO]->(EfsFileSystem)
     ```
 
+### EfsAccessPoint
+Representation of an AWS [EFS Access Point](https://docs.aws.amazon.com/efs/latest/ug/API_AccessPointDescription.html)
+| Field | Description |
+|-------|-------------|
+| firstseen | Timestamp of when a sync job first discovered this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| **id** | System-assigned access point ARN |
+| arn | The unique Amazon Resource Name (ARN) associated with the access point |
+| region | The region of the access point |
+|access_point_id | The ID of the access point, assigned by Amazon EFS |
+| file_system_id | The ID of the EFS file system that the access point applies to |
+| lifecycle_state | Identifies the lifecycle phase of the access point |
+| name | The name of the access point |
+| owner_id | AWS account ID that owns the resource |
+| posix_gid | The POSIX group ID used for all file system operations using this access point |
+| posix_uid | The POSIX user ID used for all file system operations using this access point |
+| root_directory_path | Specifies the path on the EFS file system to expose as the root directory to NFS clients using the access point to access the EFS file system |
+#### Relationships
+- Efs AccessPoints are a resource under the AWS Account.
+    ```
+    (AWSAccount)-[RESOURCE]->(EfsAccessPoint)
+    ```
+- EFS Access Points are entry points into EFS File Systems.
+    ```
+    (EfsAccessPoint)-[ACCESS_POINT_OF]->(EfsFileSystem)
+    ```
+
 ### SNSTopic
 Representation of an AWS [SNS Topic](https://docs.aws.amazon.com/sns/latest/api/API_Topic.html)
 | Field | Description |

--- a/tests/data/aws/efs.py
+++ b/tests/data/aws/efs.py
@@ -87,3 +87,51 @@ GET_EFS_MOUNT_TARGETS = [
         "VpcId": "vpc-abc123def456ghi78",
     },
 ]
+
+
+GET_EFS_ACCESS_POINTS = [
+    {
+        "ClientToken": "client-token-001",
+        "Name": "AccessPoint1",
+        "Tags": [
+            {"Key": "Environment", "Value": "Dev"},
+            {"Key": "Project", "Value": "TestProject1"},
+        ],
+        "AccessPointId": "fsap-111aaa222bbb333cc",
+        "AccessPointArn": "arn:aws:elasticfilesystem:us-west-2:123456789012:access-point/fsap-111aaa222bbb333cc",
+        "FileSystemId": "fs-abc12345",
+        "PosixUser": {
+            "Uid": 1001,
+            "Gid": 1001,
+            "SecondaryGids": [1002, 1003],
+        },
+        "RootDirectory": {
+            "Path": "/app/data1",
+            "CreationInfo": {"OwnerUid": 1001, "OwnerGid": 1001, "Permissions": "755"},
+        },
+        "OwnerId": "123456789012",
+        "LifeCycleState": "available",
+    },
+    {
+        "ClientToken": "client-token-002",
+        "Name": "AccessPoint2",
+        "Tags": [
+            {"Key": "Environment", "Value": "Prod"},
+            {"Key": "Project", "Value": "TestProject2"},
+        ],
+        "AccessPointId": "fsap-444ddd555eee666ff",
+        "AccessPointArn": "arn:aws:elasticfilesystem:us-west-2:123456789012:access-point/fsap-444ddd555eee666ff",
+        "FileSystemId": "fs-def67890",
+        "PosixUser": {
+            "Uid": 2001,
+            "Gid": 2001,
+            "SecondaryGids": [2002],
+        },
+        "RootDirectory": {
+            "Path": "/app/data2",
+            "CreationInfo": {"OwnerUid": 2001, "OwnerGid": 2001, "Permissions": "700"},
+        },
+        "OwnerId": "123456789012",
+        "LifeCycleState": "updating",
+    },
+]

--- a/tests/integration/cartography/intel/aws/test_efs.py
+++ b/tests/integration/cartography/intel/aws/test_efs.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import cartography.intel.aws.efs
 from cartography.intel.aws.efs import sync
+from tests.data.aws.efs import GET_EFS_ACCESS_POINTS
 from tests.data.aws.efs import GET_EFS_FILE_SYSTEMS
 from tests.data.aws.efs import GET_EFS_MOUNT_TARGETS
 from tests.integration.cartography.intel.aws.common import create_test_account
@@ -16,6 +17,11 @@ TEST_UPDATE_TAG = 123456789
 
 @patch.object(
     cartography.intel.aws.efs,
+    "get_efs_access_points",
+    return_value=GET_EFS_ACCESS_POINTS,
+)
+@patch.object(
+    cartography.intel.aws.efs,
     "get_efs_mount_targets",
     return_value=GET_EFS_MOUNT_TARGETS,
 )
@@ -24,7 +30,12 @@ TEST_UPDATE_TAG = 123456789
     "get_efs_file_systems",
     return_value=GET_EFS_FILE_SYSTEMS,
 )
-def test_sync_efs(mock_get_file_systems, mock_get_mount_targets, neo4j_session):
+def test_sync_efs(
+    moct_get_efs_access_points,
+    mock_get_file_systems,
+    mock_get_mount_targets,
+    neo4j_session,
+):
     # Arrange
     boto3_session = MagicMock()
     create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
@@ -48,6 +59,15 @@ def test_sync_efs(mock_get_file_systems, mock_get_mount_targets, neo4j_session):
     assert check_nodes(neo4j_session, "EfsFileSystem", ["arn"]) == {
         ("arn:aws:elasticfilesystem:us-west-2:123456789012:file-system/fs-abc12345",),
         ("arn:aws:elasticfilesystem:us-west-2:123456789012:file-system/fs-def67890",),
+    }
+
+    assert check_nodes(neo4j_session, "EfsAccessPoint", ["arn"]) == {
+        (
+            "arn:aws:elasticfilesystem:us-west-2:123456789012:access-point/fsap-111aaa222bbb333cc",
+        ),
+        (
+            "arn:aws:elasticfilesystem:us-west-2:123456789012:access-point/fsap-444ddd555eee666ff",
+        ),
     }
 
     # Assert
@@ -105,5 +125,43 @@ def test_sync_efs(mock_get_file_systems, mock_get_mount_targets, neo4j_session):
         (
             "fsmt-abcdef1234567890",
             "arn:aws:elasticfilesystem:us-west-2:123456789012:file-system/fs-def67890",
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "AWSAccount",
+        "id",
+        "EfsAccessPoint",
+        "arn",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (
+            TEST_ACCOUNT_ID,
+            "arn:aws:elasticfilesystem:us-west-2:123456789012:access-point/fsap-111aaa222bbb333cc",
+        ),
+        (
+            TEST_ACCOUNT_ID,
+            "arn:aws:elasticfilesystem:us-west-2:123456789012:access-point/fsap-444ddd555eee666ff",
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "EfsAccessPoint",
+        "arn",
+        "EfsFileSystem",
+        "id",
+        "ACCESS_POINT_OF",
+        rel_direction_right=True,
+    ) == {
+        (
+            "arn:aws:elasticfilesystem:us-west-2:123456789012:access-point/fsap-111aaa222bbb333cc",
+            "fs-abc12345",
+        ),
+        (
+            "arn:aws:elasticfilesystem:us-west-2:123456789012:access-point/fsap-444ddd555eee666ff",
+            "fs-def67890",
         ),
     }


### PR DESCRIPTION
Add EfsAccessPoint as Resource and relationship between EfsAccessPoint -> EfsFileSystem


### Related issues or links
[#1552](
https://github.com/cartography-cncf/cartography/issues/1552)


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [x] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).



![image](https://github.com/user-attachments/assets/70c8dc2e-3f1e-4398-b4d9-76156cbff9a3)
