### PR TITLE
Feature: Support for Cloudtrail Management events

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -183,6 +183,14 @@ class CLI:
             ),
         )
         parser.add_argument(
+            "--aws-cloudtrail-management-events-lookback-hours",
+            type=int,
+            default=None,
+            help=(
+                "Number of hours back to retrieve CloudTrail management events from. If not specified, CloudTrail management events will not be retrieved."
+            ),
+        )
+        parser.add_argument(
             "--oci-sync-all-profiles",
             action="store_true",
             help=(

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -31,6 +31,8 @@ class Config:
     :type aws_best_effort_mode: bool
     :param aws_best_effort_mode: If True, AWS sync will not raise any exceptions, just log. If False (default),
         exceptions will be raised.
+    :type aws_cloudtrail_management_events_lookback_hours: int
+    :param aws_cloudtrail_management_events_lookback_hours: Number of hours back to retrieve CloudTrail management events from. Optional.
     :type azure_sync_all_subscriptions: bool
     :param azure_sync_all_subscriptions: If True, Azure sync will run for all profiles in azureProfile.json. If
         False (default), Azure sync will run using current user session via CLI credentials. Optional.
@@ -155,6 +157,7 @@ class Config:
         aws_sync_all_profiles=False,
         aws_regions=None,
         aws_best_effort_mode=False,
+        aws_cloudtrail_management_events_lookback_hours=None,
         azure_sync_all_subscriptions=False,
         azure_sp_auth=None,
         azure_tenant_id=None,
@@ -226,6 +229,7 @@ class Config:
         self.aws_sync_all_profiles = aws_sync_all_profiles
         self.aws_regions = aws_regions
         self.aws_best_effort_mode = aws_best_effort_mode
+        self.aws_cloudtrail_management_events_lookback_hours = aws_cloudtrail_management_events_lookback_hours
         self.azure_sync_all_subscriptions = azure_sync_all_subscriptions
         self.azure_sp_auth = azure_sp_auth
         self.azure_tenant_id = azure_tenant_id

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -229,7 +229,9 @@ class Config:
         self.aws_sync_all_profiles = aws_sync_all_profiles
         self.aws_regions = aws_regions
         self.aws_best_effort_mode = aws_best_effort_mode
-        self.aws_cloudtrail_management_events_lookback_hours = aws_cloudtrail_management_events_lookback_hours
+        self.aws_cloudtrail_management_events_lookback_hours = (
+            aws_cloudtrail_management_events_lookback_hours
+        )
         self.azure_sync_all_subscriptions = azure_sync_all_subscriptions
         self.azure_sp_auth = azure_sp_auth
         self.azure_tenant_id = azure_tenant_id

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -5,6 +5,7 @@ from typing import Any
 from typing import Dict
 from typing import Iterable
 from typing import List
+from typing import Union
 
 import boto3
 import botocore.exceptions
@@ -53,7 +54,7 @@ def _sync_one_account(
     current_aws_account_id: str,
     update_tag: int,
     common_job_parameters: Dict[str, Any],
-    regions: list[str] | None = None,
+    regions: Union[List[str], None] = None,
     aws_requested_syncs: Iterable[str] = RESOURCE_FUNCTIONS.keys(),
 ) -> None:
     # Autodiscover the regions supported by the account unless the user has specified the regions to sync.
@@ -177,7 +178,7 @@ def _sync_multiple_accounts(
     common_job_parameters: Dict[str, Any],
     aws_best_effort_mode: bool,
     aws_requested_syncs: List[str] = [],
-    regions: list[str] | None = None,
+    regions: Union[List[str], None] = None,
 ) -> bool:
     logger.info("Syncing AWS accounts: %s", ", ".join(accounts.values()))
     organizations.sync(neo4j_session, accounts, sync_tag, common_job_parameters)
@@ -310,6 +311,7 @@ def start_aws_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     common_job_parameters = {
         "UPDATE_TAG": config.update_tag,
         "permission_relationships_file": config.permission_relationships_file,
+        "aws_cloudtrail_management_events_lookback_hours": config.aws_cloudtrail_management_events_lookback_hours,
     }
     try:
         boto3_session = boto3.Session()

--- a/cartography/intel/aws/cloudtrail_management_events.py
+++ b/cartography/intel/aws/cloudtrail_management_events.py
@@ -1,15 +1,18 @@
 import json
 import logging
-from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from datetime import datetime
+from datetime import timedelta
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
 
 import boto3
 import neo4j
 
-from cartography.client.core.tx import load
 from cartography.intel.aws.ec2.util import get_botocore_config
-from cartography.models.aws.cloudtrail.management_events import AssumedRoleRel
-from cartography.util import aws_handle_regions, timeit
+from cartography.util import aws_handle_regions
+from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
@@ -17,13 +20,11 @@ logger = logging.getLogger(__name__)
 @timeit
 @aws_handle_regions
 def get_cloudtrail_events(
-    boto3_session: boto3.Session, 
-    region: str,
-    lookback_hours: int = 24
+    boto3_session: boto3.Session, region: str, lookback_hours: int = 24
 ) -> List[Dict[str, Any]]:
     """
     Fetch CloudTrail management events from the specified time period.
-    
+
     :type boto3_session: boto3.Session
     :param boto3_session: The boto3 session to use for API calls
     :type region: str
@@ -34,51 +35,48 @@ def get_cloudtrail_events(
     :return: List of CloudTrail events
     """
     client = boto3_session.client(
-        "cloudtrail", 
-        region_name=region, 
-        config=get_botocore_config()
+        "cloudtrail", region_name=region, config=get_botocore_config()
     )
-    
+
     # Calculate time range
     end_time = datetime.utcnow()
     start_time = end_time - timedelta(hours=lookback_hours)
-    
+
     logger.info(
         f"Fetching CloudTrail management events for region '{region}' "
         f"from {start_time} to {end_time} ({lookback_hours} hours)"
     )
-    
+
     events = []
-    
+
     try:
         # Focus on STS events for role assumptions
-        paginator = client.get_paginator('lookup_events')
-        
+        paginator = client.get_paginator("lookup_events")
+
         page_iterator = paginator.paginate(
             LookupAttributes=[
-                {
-                    'AttributeKey': 'EventSource',
-                    'AttributeValue': 'sts.amazonaws.com'
-                }
+                {"AttributeKey": "EventSource", "AttributeValue": "sts.amazonaws.com"}
             ],
             StartTime=start_time,
             EndTime=end_time,
             PaginationConfig={
-                'MaxItems': 10000,  # Reasonable limit to prevent excessive API calls
-                'PageSize': 50      # CloudTrail API limit per page
-            }
+                "MaxItems": 10000,  # Reasonable limit to prevent excessive API calls
+                "PageSize": 50,  # CloudTrail API limit per page
+            },
         )
-        
+
         for page in page_iterator:
-            events.extend(page.get('Events', []))
-            
-        logger.info(f"Retrieved {len(events)} CloudTrail management events from region '{region}'")
-        
+            events.extend(page.get("Events", []))
+
+        logger.info(
+            f"Retrieved {len(events)} CloudTrail management events from region '{region}'"
+        )
+
     except Exception as e:
         logger.warning(
             f"Failed to retrieve CloudTrail management events for region '{region}': {str(e)}"
         )
-    
+
     return events
 
 
@@ -90,7 +88,7 @@ def transform_cloudtrail_events_to_role_assumptions(
 ) -> List[Dict[str, Any]]:
     """
     Transform raw CloudTrail events into role assumption relationships.
-    
+
     :type events: List[Dict[str, Any]]
     :param events: List of raw CloudTrail events from lookup_events API
     :type region: str
@@ -101,12 +99,16 @@ def transform_cloudtrail_events_to_role_assumptions(
     :return: List of role assumption records in standardized format
     """
     role_assumptions = []
-    
-    logger.info(f"Transforming {len(events)} CloudTrail events to role assumptions for region '{region}'")
-    
+
+    logger.info(
+        f"Transforming {len(events)} CloudTrail events to role assumptions for region '{region}'"
+    )
+
     for event in events:
         try:
-            assumption = _extract_role_assumption_from_event(event, region, current_aws_account_id)
+            assumption = _extract_role_assumption_from_event(
+                event, region, current_aws_account_id
+            )
             if assumption:
                 role_assumptions.append(assumption)
         except Exception as e:
@@ -114,8 +116,10 @@ def transform_cloudtrail_events_to_role_assumptions(
                 f"Failed to transform CloudTrail event {event.get('EventId', 'unknown')}: {str(e)}"
             )
             continue
-    
-    logger.info(f"Successfully transformed {len(role_assumptions)} role assumptions from {len(events)} events")
+
+    logger.info(
+        f"Successfully transformed {len(role_assumptions)} role assumptions from {len(events)} events"
+    )
     return role_assumptions
 
 
@@ -129,12 +133,12 @@ def load_role_assumptions(
 ) -> None:
     """
     Load role assumption relationships into Neo4j using hybrid approach:
-    - Uses AssumedRoleRel schema for structure and indexes  
+    - Uses AssumedRoleRel schema for structure and indexes
     - Uses raw Cypher for complex aggregation logic
-    
+
     Creates direct ASSUMED_ROLE relationships with aggregated properties:
     (AWSUser|AWSRole|AWSPrincipal)-[:ASSUMED_ROLE {lastused, times_used, first_seen, last_seen}]->(AWSRole)
-    
+
     :type neo4j_session: neo4j.Session
     :param neo4j_session: The Neo4j session to use for database operations
     :type role_assumptions: List[Dict[str, Any]]
@@ -150,24 +154,26 @@ def load_role_assumptions(
     if not role_assumptions:
         logger.info("No role assumption events to load")
         return
-    
+
     # Aggregate role assumptions by (source, destination) pairs
     aggregated_assumptions = _aggregate_role_assumptions(role_assumptions)
-    
-    logger.info(f"Loading {len(aggregated_assumptions)} aggregated role assumption relationships")
-    
+
+    logger.info(
+        f"Loading {len(aggregated_assumptions)} aggregated role assumption relationships"
+    )
+
     # Use raw Cypher for complex aggregation logic that cartography's query builder can't handle
     query = """
     UNWIND $assumptions AS assumption
-    
+
     // Convert assumed role ARNs to IAM role ARNs for source matching
     WITH assumption,
-         CASE 
+         CASE
             WHEN assumption.source_principal_arn CONTAINS ':sts:' AND assumption.source_principal_arn CONTAINS 'assumed-role'
             THEN 'arn:aws:iam::' + split(assumption.source_principal_arn, ':')[4] + ':role/' + split(split(assumption.source_principal_arn, '/')[1], '/')[0]
             ELSE assumption.source_principal_arn
          END as source_role_arn
-    
+
     // Find the source principal node (could be AWSUser, AWSRole, or AWSPrincipal)
     CALL {
         WITH source_role_arn
@@ -182,23 +188,23 @@ def load_role_assumptions(
         MATCH (source:AWSPrincipal {arn: source_role_arn})
         RETURN source as source_node
     }
-    
+
     // Find or create the destination role (handles cross-account roles)
     MERGE (dest:AWSRole {arn: assumption.destination_principal_arn})
-    ON CREATE SET 
+    ON CREATE SET
         dest.name = split(split(assumption.destination_principal_arn, '/')[1], '/')[0],
         dest.accountid = split(assumption.destination_principal_arn, ':')[4],
         dest.created_time = datetime(),
         dest.lastupdated = $aws_update_tag
     ON MATCH SET
         dest.lastupdated = $aws_update_tag
-    
+
     // Create or update the ASSUMED_ROLE relationship with aggregated properties
     MERGE (source_node)-[rel:ASSUMED_ROLE]->(dest)
     SET rel.lastused = COALESCE(
         CASE WHEN assumption.last_seen > COALESCE(rel.lastused, datetime('1970-01-01T00:00:00Z'))
-        THEN assumption.last_seen 
-        ELSE rel.lastused END, 
+        THEN assumption.last_seen
+        ELSE rel.lastused END,
         assumption.last_seen
     ),
     rel.times_used = COALESCE(rel.times_used, 0) + assumption.times_used,
@@ -216,69 +222,75 @@ def load_role_assumptions(
     ),
     rel.lastupdated = $aws_update_tag
     """
-    
+
     """Executes the query"""
     neo4j_session.run(
         query,
         assumptions=aggregated_assumptions,
         aws_update_tag=aws_update_tag,
     )
-    
-    logger.info(f"Successfully loaded {len(aggregated_assumptions)} role assumption relationships")
+
+    logger.info(
+        f"Successfully loaded {len(aggregated_assumptions)} role assumption relationships"
+    )
 
 
-def _aggregate_role_assumptions(role_assumptions: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def _aggregate_role_assumptions(
+    role_assumptions: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
     """
     Aggregate role assumption events by (source_principal, destination_principal) pairs.
-    
+
     This creates the aggregated data needed for direct ASSUMED_ROLE relationships with
     properties like times_used, first_seen, last_seen, and lastused.
-    
+
     :type role_assumptions: List[Dict[str, Any]]
     :param role_assumptions: List of individual role assumption records
     :rtype: List[Dict[str, Any]]
     :return: List of aggregated role assumption relationships
     """
     aggregated = {}
-    
+
     for assumption in role_assumptions:
-        source_arn = assumption.get('SourcePrincipal')
-        dest_arn = assumption.get('DestinationPrincipal')
-        event_time = assumption.get('EventTime')
-        
+        source_arn = assumption.get("SourcePrincipal")
+        dest_arn = assumption.get("DestinationPrincipal")
+        event_time = assumption.get("EventTime")
+
         if not source_arn or not dest_arn or not event_time:
             logger.warning(f"Skipping incomplete assumption record: {assumption}")
             continue
-        
+
         # Create aggregation key
         key = (source_arn, dest_arn)
-        
+
         if key not in aggregated:
             aggregated[key] = {
-                'source_principal_arn': source_arn,
-                'destination_principal_arn': dest_arn,
-                'times_used': 1,
-                'first_seen': event_time,
-                'last_seen': event_time,
+                "source_principal_arn": source_arn,
+                "destination_principal_arn": dest_arn,
+                "times_used": 1,
+                "first_seen": event_time,
+                "last_seen": event_time,
             }
         else:
             # Update aggregated values
             agg_data = aggregated[key]
-            agg_data['times_used'] += 1
-            
+            agg_data["times_used"] += 1
+
             # Update temporal bounds
-            if event_time < agg_data['first_seen']:
-                agg_data['first_seen'] = event_time
-            if event_time > agg_data['last_seen']:
-                agg_data['last_seen'] = event_time
-    
+            if event_time < agg_data["first_seen"]:
+                agg_data["first_seen"] = event_time
+            if event_time > agg_data["last_seen"]:
+                agg_data["last_seen"] = event_time
+
     # Convert to list and ensure lastused equals last_seen
     result = []
     for agg_data in aggregated.values():
-        agg_data['lastused'] = agg_data['last_seen']
+        agg_data["lastused"] = agg_data["last_seen"]
         result.append(agg_data)
-    
-    logger.info(f"Aggregated {len(role_assumptions)} events into {len(result)} unique role assumption relationships")
+
+    logger.info(
+        f"Aggregated {len(role_assumptions)} events into {len(result)} unique role assumption relationships"
+    )
     return result
 
 
@@ -289,7 +301,7 @@ def _extract_role_assumption_from_event(
 ) -> Optional[Dict[str, Any]]:
     """
     Extract role assumption details from a single CloudTrail event.
-    
+
     :type event: Dict[str, Any]
     :param event: Single CloudTrail event from lookup_events API
     :type region: str
@@ -299,136 +311,150 @@ def _extract_role_assumption_from_event(
     :rtype: Optional[Dict[str, Any]]
     :return: Role assumption record or None if event is not a role assumption
     """
-    event_name = event.get('EventName')
-    
+    event_name = event.get("EventName")
+
     # Only process STS role assumption events
-    if event_name not in ['AssumeRole', 'AssumeRoleWithSAML', 'AssumeRoleWithWebIdentity']:
+    if event_name not in [
+        "AssumeRole",
+        "AssumeRoleWithSAML",
+        "AssumeRoleWithWebIdentity",
+    ]:
         return None
-    
+
     # Extract source principal (who is assuming the role)
     source_principal = _extract_source_principal(event)
     if not source_principal:
-        logger.debug(f"Could not extract source principal from event {event.get('EventId')}")
+        logger.debug(
+            f"Could not extract source principal from event {event.get('EventId')}"
+        )
         return None
-    
+
     # Extract destination principal (role being assumed)
     destination_principal = _extract_destination_principal(event)
     if not destination_principal:
-        logger.debug(f"Could not extract destination principal from event {event.get('EventId')}")
+        logger.debug(
+            f"Could not extract destination principal from event {event.get('EventId')}"
+        )
         return None
-    
+
     # Build the standardized role assumption record
     assumption = {
-        'SourcePrincipal': source_principal,
-        'DestinationPrincipal': destination_principal,
-        'Action': event_name,
-        'EventId': event.get('EventId'),
-        'EventTime': event.get('EventTime'),
-        'SourceIPAddress': event.get('SourceIPAddress'),
-        'UserAgent': event.get('UserAgent'),
-        'AwsRegion': event.get('AwsRegion', region),
-        'AccountId': current_aws_account_id,
-        'AssumedRoleArn': destination_principal,  # For relationship targeting
-        'PrincipalArn': source_principal,        # For relationship targeting
+        "SourcePrincipal": source_principal,
+        "DestinationPrincipal": destination_principal,
+        "Action": event_name,
+        "EventId": event.get("EventId"),
+        "EventTime": event.get("EventTime"),
+        "SourceIPAddress": event.get("SourceIPAddress"),
+        "UserAgent": event.get("UserAgent"),
+        "AwsRegion": event.get("AwsRegion", region),
+        "AccountId": current_aws_account_id,
+        "AssumedRoleArn": destination_principal,  # For relationship targeting
+        "PrincipalArn": source_principal,  # For relationship targeting
     }
-    
+
     # Add additional context from CloudTrail event JSON
-    cloudtrail_event = _parse_cloudtrail_event_json(event.get('CloudTrailEvent'))
+    cloudtrail_event = _parse_cloudtrail_event_json(event.get("CloudTrailEvent"))
     if cloudtrail_event:
-        assumption.update({
-            'SessionName': _extract_session_name(cloudtrail_event, event_name),
-            'RequestId': cloudtrail_event.get('requestID'),
-            'RecipientAccountId': cloudtrail_event.get('recipientAccountId'),
-        })
-    
+        assumption.update(
+            {
+                "SessionName": _extract_session_name(cloudtrail_event, event_name),
+                "RequestId": cloudtrail_event.get("requestID"),
+                "RecipientAccountId": cloudtrail_event.get("recipientAccountId"),
+            }
+        )
+
     return assumption
 
 
 def _extract_source_principal(event: Dict[str, Any]) -> Optional[str]:
     """Extract the source principal (who is assuming the role) from a CloudTrail event."""
-    user_identity = event.get('UserIdentity', {})
-    
+    user_identity = event.get("UserIdentity", {})
+
     # Try to get ARN from UserIdentity
-    if user_identity.get('arn'):
-        return user_identity['arn']
-    
+    if user_identity.get("arn"):
+        return user_identity["arn"]
+
     # For SAML users, construct ARN from available info
-    if user_identity.get('type') == 'SAMLUser':
-        principal_id = user_identity.get('principalId')
+    if user_identity.get("type") == "SAMLUser":
+        principal_id = user_identity.get("principalId")
         if principal_id:
             return principal_id
-    
+
     # For Web Identity users, use the assumed role ARN if available
-    if user_identity.get('type') == 'WebIdentityUser':
-        return user_identity.get('arn')
-    
+    if user_identity.get("type") == "WebIdentityUser":
+        return user_identity.get("arn")
+
     # Fallback to UserName if available
-    user_name = event.get('UserName')
+    user_name = event.get("UserName")
     if user_name:
         return user_name
-    
+
     # For AWS service role assumptions, UserIdentity is often empty
     # Try to extract source from CloudTrail event JSON
-    cloudtrail_event = _parse_cloudtrail_event_json(event.get('CloudTrailEvent'))
+    cloudtrail_event = _parse_cloudtrail_event_json(event.get("CloudTrailEvent"))
     if cloudtrail_event:
         # Check for source identity in userIdentity field of CloudTrail JSON
-        ct_user_identity = cloudtrail_event.get('userIdentity', {})
-        if ct_user_identity.get('arn'):
-            return ct_user_identity['arn']
-        
+        ct_user_identity = cloudtrail_event.get("userIdentity", {})
+        if ct_user_identity.get("arn"):
+            return ct_user_identity["arn"]
+
         # For AWS service calls, the source is often the service itself
-        if ct_user_identity.get('type') == 'AWSService':
-            service_name = ct_user_identity.get('invokedBy')
+        if ct_user_identity.get("type") == "AWSService":
+            service_name = ct_user_identity.get("invokedBy")
             if service_name:
                 # Return the service as the source principal
                 return f"service:{service_name}"
-        
+
         # Check if this is a service-linked role assumption
         # In this case, we can use the account root as the source
-        account_id = cloudtrail_event.get('recipientAccountId')
-        if account_id and ct_user_identity.get('type') in ['Root', 'AWSAccount']:
+        account_id = cloudtrail_event.get("recipientAccountId")
+        if account_id and ct_user_identity.get("type") in ["Root", "AWSAccount"]:
             return f"arn:aws:iam::{account_id}:root"
-    
+
     return None
 
 
 def _extract_destination_principal(event: Dict[str, Any]) -> Optional[str]:
     """Extract the destination principal (role being assumed) from a CloudTrail event."""
     # Parse the CloudTrail event JSON for detailed information
-    cloudtrail_event = _parse_cloudtrail_event_json(event.get('CloudTrailEvent'))
+    cloudtrail_event = _parse_cloudtrail_event_json(event.get("CloudTrailEvent"))
     if not cloudtrail_event:
         return None
-    
+
     # Extract role ARN from request parameters
-    request_params = cloudtrail_event.get('requestParameters', {})
-    role_arn = request_params.get('roleArn')
-    
+    request_params = cloudtrail_event.get("requestParameters", {})
+    role_arn = request_params.get("roleArn")
+
     if role_arn:
         return role_arn
-    
+
     # Fallback: try to extract from response elements for some STS calls
-    response_elements = cloudtrail_event.get('responseElements', {})
-    assumed_role_user = response_elements.get('assumedRoleUser', {})
-    if assumed_role_user.get('arn'):
+    response_elements = cloudtrail_event.get("responseElements", {})
+    assumed_role_user = response_elements.get("assumedRoleUser", {})
+    if assumed_role_user.get("arn"):
         # Convert assumed role ARN back to role ARN
         # e.g., "arn:aws:sts::123456789012:assumed-role/MyRole/session" -> "arn:aws:iam::123456789012:role/MyRole"
-        assumed_role_arn = assumed_role_user['arn']
+        assumed_role_arn = assumed_role_user["arn"]
         return _convert_assumed_role_arn_to_role_arn(assumed_role_arn)
-    
+
     return None
 
 
-def _extract_session_name(cloudtrail_event: Dict[str, Any], event_name: str) -> Optional[str]:
+def _extract_session_name(
+    cloudtrail_event: Dict[str, Any], event_name: str
+) -> Optional[str]:
     """Extract the role session name from CloudTrail event details."""
-    request_params = cloudtrail_event.get('requestParameters', {})
-    return request_params.get('roleSessionName')
+    request_params = cloudtrail_event.get("requestParameters", {})
+    return request_params.get("roleSessionName")
 
 
-def _parse_cloudtrail_event_json(cloudtrail_event_str: Optional[str]) -> Optional[Dict[str, Any]]:
+def _parse_cloudtrail_event_json(
+    cloudtrail_event_str: Optional[str],
+) -> Optional[Dict[str, Any]]:
     """Parse the CloudTrail event JSON string into a dictionary."""
     if not cloudtrail_event_str:
         return None
-    
+
     try:
         return json.loads(cloudtrail_event_str)
     except (json.JSONDecodeError, TypeError) as e:
@@ -439,25 +465,31 @@ def _parse_cloudtrail_event_json(cloudtrail_event_str: Optional[str]) -> Optiona
 def _convert_assumed_role_arn_to_role_arn(assumed_role_arn: str) -> str:
     """
     Convert an assumed role ARN to the original role ARN.
-    
+
     Example:
     Input:  "arn:aws:sts::123456789012:assumed-role/MyRole/session-name"
     Output: "arn:aws:iam::123456789012:role/MyRole"
     """
     try:
         # Split the ARN into parts
-        arn_parts = assumed_role_arn.split(':')
-        if len(arn_parts) >= 6 and arn_parts[2] == 'sts' and 'assumed-role' in arn_parts[5]:
+        arn_parts = assumed_role_arn.split(":")
+        if (
+            len(arn_parts) >= 6
+            and arn_parts[2] == "sts"
+            and "assumed-role" in arn_parts[5]
+        ):
             # Extract account ID and role name
             account_id = arn_parts[4]
             resource_part = arn_parts[5]  # "assumed-role/MyRole/session-name"
-            role_name = resource_part.split('/')[1]  # Extract "MyRole"
-            
+            role_name = resource_part.split("/")[1]  # Extract "MyRole"
+
             # Construct the IAM role ARN
             return f"arn:aws:iam::{account_id}:role/{role_name}"
     except (IndexError, AttributeError):
-        logger.debug(f"Could not convert assumed role ARN to role ARN: {assumed_role_arn}")
-    
+        logger.debug(
+            f"Could not convert assumed role ARN to role ARN: {assumed_role_arn}"
+        )
+
     # Return original ARN if conversion fails
     return assumed_role_arn
 
@@ -473,15 +505,15 @@ def sync(
 ) -> None:
     """
     Sync CloudTrail management events to create ASSUMED_ROLE relationships.
-    
+
     This function orchestrates the complete process:
     1. Fetch CloudTrail management events from all regions
-    2. Transform events into role assumption records  
+    2. Transform events into role assumption records
     3. Load aggregated role assumption relationships into Neo4j
-    
+
     The resulting graph contains direct relationships like:
     (AWSUser|AWSRole|AWSPrincipal)-[:ASSUMED_ROLE {times_used, first_seen, last_seen, lastused}]->(AWSRole)
-    
+
     :type neo4j_session: neo4j.Session
     :param neo4j_session: The Neo4j session
     :type boto3_session: boto3.Session
@@ -495,17 +527,25 @@ def sync(
     :rtype: None
     """
     # Extract lookback hours from common_job_parameters (set by CLI parameter)
-    lookback_hours = common_job_parameters.get('aws_cloudtrail_management_events_lookback_hours')
-    
+    lookback_hours = common_job_parameters.get(
+        "aws_cloudtrail_management_events_lookback_hours"
+    )
+
     if not lookback_hours:
-        logger.info("CloudTrail management events sync skipped - no lookback period specified")
+        logger.info(
+            "CloudTrail management events sync skipped - no lookback period specified"
+        )
         return
-    
-    logger.info(f"Starting CloudTrail management events sync for account {current_aws_account_id}")
-    logger.info(f"Syncing {len(regions)} regions with {lookback_hours} hour lookback period")
-    
+
+    logger.info(
+        f"Starting CloudTrail management events sync for account {current_aws_account_id}"
+    )
+    logger.info(
+        f"Syncing {len(regions)} regions with {lookback_hours} hour lookback period"
+    )
+
     all_role_assumptions = []
-    
+
     # Fetch events from all regions
     for region in regions:
         try:
@@ -515,20 +555,22 @@ def sync(
                 region=region,
                 lookback_hours=lookback_hours,
             )
-            
+
             # Transform to role assumptions
             role_assumptions = transform_cloudtrail_events_to_role_assumptions(
                 events=events,
                 region=region,
                 current_aws_account_id=current_aws_account_id,
             )
-            
+
             all_role_assumptions.extend(role_assumptions)
-            
+
         except Exception as e:
-            logger.warning(f"Failed to process CloudTrail events for region {region}: {str(e)}")
+            logger.warning(
+                f"Failed to process CloudTrail events for region {region}: {str(e)}"
+            )
             continue
-    
+
     # Load all role assumptions into Neo4j
     if all_role_assumptions:
         load_role_assumptions(
@@ -538,10 +580,12 @@ def sync(
             current_aws_account_id=current_aws_account_id,
             aws_update_tag=update_tag,
         )
-        
+
         logger.info(
             f"CloudTrail management events sync completed successfully. "
             f"Processed {len(all_role_assumptions)} role assumption events."
         )
     else:
-        logger.info("CloudTrail management events sync completed - no role assumptions found")
+        logger.info(
+            "CloudTrail management events sync completed - no role assumptions found"
+        )

--- a/cartography/intel/aws/cloudtrail_management_events.py
+++ b/cartography/intel/aws/cloudtrail_management_events.py
@@ -78,7 +78,7 @@ def get_cloudtrail_events(
         logger.warning(
             f"Failed to retrieve CloudTrail management events for region '{region}': {str(e)}"
         )
-    print(events)
+    
     return events
 
 

--- a/cartography/intel/aws/cloudtrail_management_events.py
+++ b/cartography/intel/aws/cloudtrail_management_events.py
@@ -1,0 +1,275 @@
+import json
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+import boto3
+import neo4j
+
+from cartography.intel.aws.ec2.util import get_botocore_config
+from cartography.util import aws_handle_regions, timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+@aws_handle_regions
+def get_cloudtrail_events(
+    boto3_session: boto3.Session, 
+    region: str,
+    lookback_hours: int = 24
+) -> List[Dict[str, Any]]:
+    """
+    Fetch CloudTrail management events from the specified time period.
+    
+    :type boto3_session: boto3.Session
+    :param boto3_session: The boto3 session to use for API calls
+    :type region: str
+    :param region: The AWS region to fetch events from
+    :type lookback_hours: int
+    :param lookback_hours: Number of hours back to retrieve events from
+    :rtype: List[Dict[str, Any]]
+    :return: List of CloudTrail events
+    """
+    client = boto3_session.client(
+        "cloudtrail", 
+        region_name=region, 
+        config=get_botocore_config()
+    )
+    
+    # Calculate time range
+    end_time = datetime.utcnow()
+    start_time = end_time - timedelta(hours=lookback_hours)
+    
+    logger.info(
+        f"Fetching CloudTrail management events for region '{region}' "
+        f"from {start_time} to {end_time} ({lookback_hours} hours)"
+    )
+    
+    events = []
+    
+    try:
+        # Focus on STS events for role assumptions
+        paginator = client.get_paginator('lookup_events')
+        
+        page_iterator = paginator.paginate(
+            LookupAttributes=[
+                {
+                    'AttributeKey': 'EventSource',
+                    'AttributeValue': 'sts.amazonaws.com'
+                }
+            ],
+            StartTime=start_time,
+            EndTime=end_time,
+            PaginationConfig={
+                'MaxItems': 10000,  # Reasonable limit to prevent excessive API calls
+                'PageSize': 50      # CloudTrail API limit per page
+            }
+        )
+        
+        for page in page_iterator:
+            events.extend(page.get('Events', []))
+            
+        logger.info(f"Retrieved {len(events)} CloudTrail management events from region '{region}'")
+        
+    except Exception as e:
+        logger.warning(
+            f"Failed to retrieve CloudTrail management events for region '{region}': {str(e)}"
+        )
+        
+    return events
+
+
+@timeit
+def transform_cloudtrail_events_to_role_assumptions(
+    events: List[Dict[str, Any]],
+    region: str,
+    current_aws_account_id: str,
+) -> List[Dict[str, Any]]:
+    """
+    Transform raw CloudTrail events into role assumption relationships.
+    
+    :type events: List[Dict[str, Any]]
+    :param events: List of raw CloudTrail events from lookup_events API
+    :type region: str
+    :param region: The AWS region where events were retrieved from
+    :type current_aws_account_id: str
+    :param current_aws_account_id: The AWS account ID being synced
+    :rtype: List[Dict[str, Any]]
+    :return: List of role assumption records in standardized format
+    """
+    role_assumptions = []
+    
+    logger.info(f"Transforming {len(events)} CloudTrail events to role assumptions for region '{region}'")
+    
+    for event in events:
+        try:
+            assumption = _extract_role_assumption_from_event(event, region, current_aws_account_id)
+            if assumption:
+                role_assumptions.append(assumption)
+        except Exception as e:
+            logger.warning(
+                f"Failed to transform CloudTrail event {event.get('EventId', 'unknown')}: {str(e)}"
+            )
+            continue
+    
+    logger.info(f"Successfully transformed {len(role_assumptions)} role assumptions from {len(events)} events")
+    return role_assumptions
+
+
+def _extract_role_assumption_from_event(
+    event: Dict[str, Any],
+    region: str,
+    current_aws_account_id: str,
+) -> Optional[Dict[str, Any]]:
+    """
+    Extract role assumption details from a single CloudTrail event.
+    
+    :type event: Dict[str, Any]
+    :param event: Single CloudTrail event from lookup_events API
+    :type region: str
+    :param region: The AWS region where the event occurred
+    :type current_aws_account_id: str
+    :param current_aws_account_id: The AWS account ID being synced
+    :rtype: Optional[Dict[str, Any]]
+    :return: Role assumption record or None if event is not a role assumption
+    """
+    event_name = event.get('EventName')
+    
+    # Only process STS role assumption events
+    if event_name not in ['AssumeRole', 'AssumeRoleWithSAML', 'AssumeRoleWithWebIdentity']:
+        return None
+    
+    # Extract source principal (who is assuming the role)
+    source_principal = _extract_source_principal(event)
+    if not source_principal:
+        logger.debug(f"Could not extract source principal from event {event.get('EventId')}")
+        return None
+    
+    # Extract destination principal (role being assumed)
+    destination_principal = _extract_destination_principal(event)
+    if not destination_principal:
+        logger.debug(f"Could not extract destination principal from event {event.get('EventId')}")
+        return None
+    
+    # Build the standardized role assumption record
+    assumption = {
+        'SourcePrincipal': source_principal,
+        'DestinationPrincipal': destination_principal,
+        'Action': event_name,
+        'EventId': event.get('EventId'),
+        'EventTime': event.get('EventTime'),
+        'SourceIPAddress': event.get('SourceIPAddress'),
+        'UserAgent': event.get('UserAgent'),
+        'AwsRegion': event.get('AwsRegion', region),
+        'AccountId': current_aws_account_id,
+        'AssumedRoleArn': destination_principal,  # For relationship targeting
+        'PrincipalArn': source_principal,        # For relationship targeting
+    }
+    
+    # Add additional context from CloudTrail event JSON
+    cloudtrail_event = _parse_cloudtrail_event_json(event.get('CloudTrailEvent'))
+    if cloudtrail_event:
+        assumption.update({
+            'SessionName': _extract_session_name(cloudtrail_event, event_name),
+            'RequestId': cloudtrail_event.get('requestID'),
+            'RecipientAccountId': cloudtrail_event.get('recipientAccountId'),
+        })
+    
+    return assumption
+
+
+def _extract_source_principal(event: Dict[str, Any]) -> Optional[str]:
+    """Extract the source principal (who is assuming the role) from a CloudTrail event."""
+    user_identity = event.get('UserIdentity', {})
+    
+    # Try to get ARN from UserIdentity
+    if user_identity.get('arn'):
+        return user_identity['arn']
+    
+    # For SAML users, construct ARN from available info
+    if user_identity.get('type') == 'SAMLUser':
+        principal_id = user_identity.get('principalId')
+        if principal_id:
+            return principal_id
+    
+    # For Web Identity users, use the assumed role ARN if available
+    if user_identity.get('type') == 'WebIdentityUser':
+        return user_identity.get('arn')
+    
+    # Fallback to UserName if available
+    user_name = event.get('UserName')
+    if user_name:
+        return user_name
+    
+    return None
+
+
+def _extract_destination_principal(event: Dict[str, Any]) -> Optional[str]:
+    """Extract the destination principal (role being assumed) from a CloudTrail event."""
+    # Parse the CloudTrail event JSON for detailed information
+    cloudtrail_event = _parse_cloudtrail_event_json(event.get('CloudTrailEvent'))
+    if not cloudtrail_event:
+        return None
+    
+    # Extract role ARN from request parameters
+    request_params = cloudtrail_event.get('requestParameters', {})
+    role_arn = request_params.get('roleArn')
+    
+    if role_arn:
+        return role_arn
+    
+    # Fallback: try to extract from response elements for some STS calls
+    response_elements = cloudtrail_event.get('responseElements', {})
+    assumed_role_user = response_elements.get('assumedRoleUser', {})
+    if assumed_role_user.get('arn'):
+        # Convert assumed role ARN back to role ARN
+        # e.g., "arn:aws:sts::123456789012:assumed-role/MyRole/session" -> "arn:aws:iam::123456789012:role/MyRole"
+        assumed_role_arn = assumed_role_user['arn']
+        return _convert_assumed_role_arn_to_role_arn(assumed_role_arn)
+    
+    return None
+
+
+def _extract_session_name(cloudtrail_event: Dict[str, Any], event_name: str) -> Optional[str]:
+    """Extract the role session name from CloudTrail event details."""
+    request_params = cloudtrail_event.get('requestParameters', {})
+    return request_params.get('roleSessionName')
+
+
+def _parse_cloudtrail_event_json(cloudtrail_event_str: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Parse the CloudTrail event JSON string into a dictionary."""
+    if not cloudtrail_event_str:
+        return None
+    
+    try:
+        return json.loads(cloudtrail_event_str)
+    except (json.JSONDecodeError, TypeError) as e:
+        logger.debug(f"Failed to parse CloudTrail event JSON: {str(e)}")
+        return None
+
+
+def _convert_assumed_role_arn_to_role_arn(assumed_role_arn: str) -> str:
+    """
+    Convert an assumed role ARN to the original role ARN.
+    
+    Example:
+    Input:  "arn:aws:sts::123456789012:assumed-role/MyRole/session-name"
+    Output: "arn:aws:iam::123456789012:role/MyRole"
+    """
+    try:
+        # Split the ARN into parts
+        arn_parts = assumed_role_arn.split(':')
+        if len(arn_parts) >= 6 and arn_parts[2] == 'sts' and 'assumed-role' in arn_parts[5]:
+            # Extract account ID and role name
+            account_id = arn_parts[4]
+            resource_part = arn_parts[5]  # "assumed-role/MyRole/session-name"
+            role_name = resource_part.split('/')[1]  # Extract "MyRole"
+            
+            # Construct the IAM role ARN
+            return f"arn:aws:iam::{account_id}:role/{role_name}"
+    except (IndexError, AttributeError):
+        logger.debug(f"Could not convert assumed role ARN to role ARN: {assumed_role_arn}")
+    
+    # Return original ARN if conversion fails
+    return assumed_role_arn

--- a/cartography/intel/aws/resources.py
+++ b/cartography/intel/aws/resources.py
@@ -6,6 +6,7 @@ from cartography.intel.aws.ec2.route_tables import sync_route_tables
 from . import acm
 from . import apigateway
 from . import cloudtrail
+from . import cloudtrail_management_events
 from . import cloudwatch
 from . import config
 from . import dynamodb
@@ -105,5 +106,6 @@ RESOURCE_FUNCTIONS: Dict[str, Callable[..., None]] = {
     "config": config.sync,
     "identitycenter": identitycenter.sync_identity_center_instances,
     "cloudtrail": cloudtrail.sync,
+    "cloudtrail_management_events": cloudtrail_management_events.sync,
     "cloudwatch": cloudwatch.sync,
 }

--- a/cartography/models/aws/cloudtrail/management_events.py
+++ b/cartography/models/aws/cloudtrail/management_events.py
@@ -14,6 +14,7 @@ class AssumedRoleRelProperties(CartographyRelProperties):
     Properties for the ASSUMED_ROLE relationship representing role assumption events.
     Matches the cloudtrail_management_events spec and adds enhanced temporal precision.
     """
+
     lastused: PropertyRef = PropertyRef("lastused")
     times_used: PropertyRef = PropertyRef("times_used")
     first_seen: PropertyRef = PropertyRef("first_seen")
@@ -27,20 +28,19 @@ class AssumedRoleRel(CartographyRelSchema):
     Unified relationship schema for role assumptions from any AWS Principal to AWSRole.
     Handles User->Role, Role->Role, and Principal->Role relationships in one class.
     Creates relationships like: (AWSUser|AWSRole|AWSPrincipal)-[:ASSUMED_ROLE]->(AWSRole)
-    
+
     This schema is used for:
     1. Index creation (performance optimization)
     2. Documentation of the relationship structure
     3. Validation of target node matching
-    
+
     Note: The actual loading uses custom Cypher queries due to complex aggregation requirements.
     """
+
     target_node_label: str = "AWSRole"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"arn": PropertyRef("destination_principal_arn")},
     )
-    direction: LinkDirection = LinkDirection.OUTWARD   
+    direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "ASSUMED_ROLE"
     properties: AssumedRoleRelProperties = AssumedRoleRelProperties()
-
-

--- a/cartography/models/aws/cloudtrail/management_events.py
+++ b/cartography/models/aws/cloudtrail/management_events.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AssumedRoleRelProperties(CartographyRelProperties):
+    """
+    Properties for the ASSUMED_ROLE relationship representing role assumption events.
+    Matches the cloudtrail_management_events spec and adds enhanced temporal precision.
+    """
+    lastused: PropertyRef = PropertyRef("lastused")
+    times_used: PropertyRef = PropertyRef("times_used")
+    first_seen: PropertyRef = PropertyRef("first_seen")
+    last_seen: PropertyRef = PropertyRef("last_seen")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AssumedRoleRel(CartographyRelSchema):
+    """
+    Unified relationship schema for role assumptions from any AWS Principal to AWSRole.
+    Handles User->Role, Role->Role, and Principal->Role relationships in one class.
+    Creates relationships like: (AWSUser|AWSRole|AWSPrincipal)-[:ASSUMED_ROLE]->(AWSRole)
+    
+    This schema is used for:
+    1. Index creation (performance optimization)
+    2. Documentation of the relationship structure
+    3. Validation of target node matching
+    
+    Note: The actual loading uses custom Cypher queries due to complex aggregation requirements.
+    """
+    target_node_label: str = "AWSRole"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("destination_principal_arn")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD   
+    rel_label: str = "ASSUMED_ROLE"
+    properties: AssumedRoleRelProperties = AssumedRoleRelProperties()
+
+

--- a/tests/data/aws/cloudtrail_management_events.py
+++ b/tests/data/aws/cloudtrail_management_events.py
@@ -3,192 +3,187 @@ from datetime import datetime
 
 # Realistic STS AssumeRole event
 STS_ASSUME_ROLE_EVENT = {
-    'EventId': 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
-    'EventName': 'AssumeRole',
-    'EventTime': datetime(2024, 1, 15, 10, 30, 15, 123000),
-    'EventSource': 'sts.amazonaws.com',
-    'UserName': 'arn:aws:iam::123456789012:user/john.doe',
-    'UserIdentity': {
-        'type': 'IAMUser',
-        'principalId': 'AIDACKCEVSQ6C2EXAMPLE',
-        'arn': 'arn:aws:iam::123456789012:user/john.doe',
-        'accountId': '123456789012',
-        'userName': 'john.doe'
+    "EventId": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "EventName": "AssumeRole",
+    "EventTime": datetime(2024, 1, 15, 10, 30, 15, 123000),
+    "EventSource": "sts.amazonaws.com",
+    "UserName": "arn:aws:iam::123456789012:user/john.doe",
+    "UserIdentity": {
+        "type": "IAMUser",
+        "principalId": "AIDACKCEVSQ6C2EXAMPLE",
+        "arn": "arn:aws:iam::123456789012:user/john.doe",
+        "accountId": "123456789012",
+        "userName": "john.doe",
     },
-    'AwsRegion': 'us-east-1',
-    'SourceIPAddress': '192.168.1.100',
-    'UserAgent': 'aws-cli/2.0.0 Python/3.8.0 Linux/5.4.0-26-generic botocore/2.0.0dev0',
-    'Resources': [
+    "AwsRegion": "us-east-1",
+    "SourceIPAddress": "192.168.1.100",
+    "UserAgent": "aws-cli/2.0.0 Python/3.8.0 Linux/5.4.0-26-generic botocore/2.0.0dev0",
+    "Resources": [
         {
-            'ResourceType': 'AWS::IAM::Role',
-            'ResourceName': 'arn:aws:iam::987654321098:role/CrossAccountRole',
-            'AccountId': '987654321098'
+            "ResourceType": "AWS::IAM::Role",
+            "ResourceName": "arn:aws:iam::987654321098:role/CrossAccountRole",
+            "AccountId": "987654321098",
         }
     ],
-    'CloudTrailEvent': json.dumps({
-        'eventVersion': '1.05',
-        'userIdentity': {
-            'type': 'IAMUser',
-            'principalId': 'AIDACKCEVSQ6C2EXAMPLE',
-            'arn': 'arn:aws:iam::123456789012:user/john.doe',
-            'accountId': '123456789012',
-            'userName': 'john.doe'
-        },
-        'eventTime': '2024-01-15T10:30:15Z',
-        'eventSource': 'sts.amazonaws.com',
-        'eventName': 'AssumeRole',
-        'awsRegion': 'us-east-1',
-        'sourceIPAddress': '192.168.1.100',
-        'userAgent': 'aws-cli/2.0.0 Python/3.8.0 Linux/5.4.0-26-generic botocore/2.0.0dev0',
-        'requestParameters': {
-            'roleArn': 'arn:aws:iam::987654321098:role/CrossAccountRole',
-            'roleSessionName': 'john-doe-session-1642251015'
-        },
-        'responseElements': {
-            'credentials': {
-                'sessionToken': 'REDACTED',
-                'accessKeyId': 'ASIACKCEVSQ6C2EXAMPLE',
-                'expiration': 'Jan 15, 2024 11:30:15 AM'
+    "CloudTrailEvent": json.dumps(
+        {
+            "eventVersion": "1.05",
+            "userIdentity": {
+                "type": "IAMUser",
+                "principalId": "AIDACKCEVSQ6C2EXAMPLE",
+                "arn": "arn:aws:iam::123456789012:user/john.doe",
+                "accountId": "123456789012",
+                "userName": "john.doe",
             },
-            'assumedRoleUser': {
-                'assumedRoleId': 'AROACKCEVSQ6C2EXAMPLE:john-doe-session-1642251015',
-                'arn': 'arn:aws:sts::987654321098:assumed-role/CrossAccountRole/john-doe-session-1642251015'
-            }
-        },
-        'requestID': 'c2d4638c-24b8-11e7-b13c-298444c2bb30',
-        'eventID': 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
-        'eventType': 'AwsApiCall',
-        'recipientAccountId': '987654321098',
-        'serviceEventDetails': {
-            'responseElements': {
-                'credentials': {
-                    'sessionToken': 'REDACTED'
-                }
-            }
+            "eventTime": "2024-01-15T10:30:15Z",
+            "eventSource": "sts.amazonaws.com",
+            "eventName": "AssumeRole",
+            "awsRegion": "us-east-1",
+            "sourceIPAddress": "192.168.1.100",
+            "userAgent": "aws-cli/2.0.0 Python/3.8.0 Linux/5.4.0-26-generic botocore/2.0.0dev0",
+            "requestParameters": {
+                "roleArn": "arn:aws:iam::987654321098:role/CrossAccountRole",
+                "roleSessionName": "john-doe-session-1642251015",
+            },
+            "responseElements": {
+                "credentials": {
+                    "sessionToken": "REDACTED",
+                    "accessKeyId": "ASIACKCEVSQ6C2EXAMPLE",
+                    "expiration": "Jan 15, 2024 11:30:15 AM",
+                },
+                "assumedRoleUser": {
+                    "assumedRoleId": "AROACKCEVSQ6C2EXAMPLE:john-doe-session-1642251015",
+                    "arn": "arn:aws:sts::987654321098:assumed-role/CrossAccountRole/john-doe-session-1642251015",
+                },
+            },
+            "requestID": "c2d4638c-24b8-11e7-b13c-298444c2bb30",
+            "eventID": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+            "eventType": "AwsApiCall",
+            "recipientAccountId": "987654321098",
+            "serviceEventDetails": {
+                "responseElements": {"credentials": {"sessionToken": "REDACTED"}}
+            },
         }
-    })
+    ),
 }
 
 # STS AssumeRoleWithSAML event
 STS_ASSUME_ROLE_WITH_SAML_EVENT = {
-    'EventId': 'a1b2c3d4-e5f6-7890-1234-567890abcdef',
-    'EventName': 'AssumeRoleWithSAML',
-    'EventTime': datetime(2024, 1, 15, 11, 15, 30, 456000),
-    'EventSource': 'sts.amazonaws.com',
-    'UserName': 'SAML:jane.smith@company.com',
-    'UserIdentity': {
-        'type': 'SAMLUser',
-        'principalId': 'SAML:jane.smith@company.com',
-        'arn': 'arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com',
-        'accountId': '123456789012'
+    "EventId": "a1b2c3d4-e5f6-7890-1234-567890abcdef",
+    "EventName": "AssumeRoleWithSAML",
+    "EventTime": datetime(2024, 1, 15, 11, 15, 30, 456000),
+    "EventSource": "sts.amazonaws.com",
+    "UserName": "SAML:jane.smith@company.com",
+    "UserIdentity": {
+        "type": "SAMLUser",
+        "principalId": "SAML:jane.smith@company.com",
+        "arn": "arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com",
+        "accountId": "123456789012",
     },
-    'AwsRegion': 'us-east-1',
-    'SourceIPAddress': '10.0.1.50',
-    'UserAgent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
-    'Resources': [
+    "AwsRegion": "us-east-1",
+    "SourceIPAddress": "10.0.1.50",
+    "UserAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+    "Resources": [
         {
-            'ResourceType': 'AWS::IAM::Role',
-            'ResourceName': 'arn:aws:iam::123456789012:role/SAMLRole',
-            'AccountId': '123456789012'
+            "ResourceType": "AWS::IAM::Role",
+            "ResourceName": "arn:aws:iam::123456789012:role/SAMLRole",
+            "AccountId": "123456789012",
         }
     ],
-    'CloudTrailEvent': json.dumps({
-        'eventVersion': '1.05',
-        'userIdentity': {
-            'type': 'SAMLUser',
-            'principalId': 'SAML:jane.smith@company.com',
-            'arn': 'arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com',
-            'accountId': '123456789012'
-        },
-        'eventTime': '2024-01-15T11:15:30Z',
-        'eventSource': 'sts.amazonaws.com',
-        'eventName': 'AssumeRoleWithSAML',
-        'awsRegion': 'us-east-1',
-        'sourceIPAddress': '10.0.1.50',
-        'requestParameters': {
-            'roleArn': 'arn:aws:iam::123456789012:role/SAMLRole',
-            'principalArn': 'arn:aws:iam::123456789012:saml-provider/CompanySAML'
-        },
-        'responseElements': {
-            'assumedRoleUser': {
-                'assumedRoleId': 'AROACKCEVSQ6C2EXAMPLE:jane.smith@company.com',
-                'arn': 'arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com'
-            }
+    "CloudTrailEvent": json.dumps(
+        {
+            "eventVersion": "1.05",
+            "userIdentity": {
+                "type": "SAMLUser",
+                "principalId": "SAML:jane.smith@company.com",
+                "arn": "arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com",
+                "accountId": "123456789012",
+            },
+            "eventTime": "2024-01-15T11:15:30Z",
+            "eventSource": "sts.amazonaws.com",
+            "eventName": "AssumeRoleWithSAML",
+            "awsRegion": "us-east-1",
+            "sourceIPAddress": "10.0.1.50",
+            "requestParameters": {
+                "roleArn": "arn:aws:iam::123456789012:role/SAMLRole",
+                "principalArn": "arn:aws:iam::123456789012:saml-provider/CompanySAML",
+            },
+            "responseElements": {
+                "assumedRoleUser": {
+                    "assumedRoleId": "AROACKCEVSQ6C2EXAMPLE:jane.smith@company.com",
+                    "arn": "arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com",
+                }
+            },
         }
-    })
+    ),
 }
 
 # STS AssumeRoleWithWebIdentity event
 STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT = {
-    'EventId': '9876543210abcdef-1234-5678-90ab-cdef12345678',
-    'EventName': 'AssumeRoleWithWebIdentity',
-    'EventTime': datetime(2024, 1, 15, 12, 45, 0, 789000),
-    'EventSource': 'sts.amazonaws.com',
-    'UserName': 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300',
-    'UserIdentity': {
-        'type': 'WebIdentityUser',
-        'principalId': 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300',
-        'arn': 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300',
-        'accountId': '123456789012'
+    "EventId": "9876543210abcdef-1234-5678-90ab-cdef12345678",
+    "EventName": "AssumeRoleWithWebIdentity",
+    "EventTime": datetime(2024, 1, 15, 12, 45, 0, 789000),
+    "EventSource": "sts.amazonaws.com",
+    "UserName": "arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300",
+    "UserIdentity": {
+        "type": "WebIdentityUser",
+        "principalId": "arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300",
+        "arn": "arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300",
+        "accountId": "123456789012",
     },
-    'AwsRegion': 'us-west-2',
-    'SourceIPAddress': '203.0.113.1',
-    'UserAgent': 'Boto3/1.26.0 Python/3.9.0 Linux/5.15.0 Botocore/1.29.0',
-    'Resources': [
+    "AwsRegion": "us-west-2",
+    "SourceIPAddress": "203.0.113.1",
+    "UserAgent": "Boto3/1.26.0 Python/3.9.0 Linux/5.15.0 Botocore/1.29.0",
+    "Resources": [
         {
-            'ResourceType': 'AWS::IAM::Role',
-            'ResourceName': 'arn:aws:iam::123456789012:role/WebIdentityRole',
-            'AccountId': '123456789012'
+            "ResourceType": "AWS::IAM::Role",
+            "ResourceName": "arn:aws:iam::123456789012:role/WebIdentityRole",
+            "AccountId": "123456789012",
         }
     ],
-    'CloudTrailEvent': json.dumps({
-        'eventVersion': '1.05',
-        'userIdentity': {
-            'type': 'WebIdentityUser',
-            'principalId': 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300',
-            'arn': 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300',
-            'accountId': '123456789012'
-        },
-        'eventTime': '2024-01-15T12:45:00Z',
-        'eventSource': 'sts.amazonaws.com',
-        'eventName': 'AssumeRoleWithWebIdentity',
-        'awsRegion': 'us-west-2',
-        'sourceIPAddress': '203.0.113.1',
-        'requestParameters': {
-            'roleArn': 'arn:aws:iam::123456789012:role/WebIdentityRole',
-            'roleSessionName': 'web-session-1642254300'
+    "CloudTrailEvent": json.dumps(
+        {
+            "eventVersion": "1.05",
+            "userIdentity": {
+                "type": "WebIdentityUser",
+                "principalId": "arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300",
+                "arn": "arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300",
+                "accountId": "123456789012",
+            },
+            "eventTime": "2024-01-15T12:45:00Z",
+            "eventSource": "sts.amazonaws.com",
+            "eventName": "AssumeRoleWithWebIdentity",
+            "awsRegion": "us-west-2",
+            "sourceIPAddress": "203.0.113.1",
+            "requestParameters": {
+                "roleArn": "arn:aws:iam::123456789012:role/WebIdentityRole",
+                "roleSessionName": "web-session-1642254300",
+            },
         }
-    })
+    ),
 }
 
 # First page of paginated response
 LOOKUP_EVENTS_RESPONSE_PAGE1 = {
-    'Events': [
-        STS_ASSUME_ROLE_EVENT,
-        STS_ASSUME_ROLE_WITH_SAML_EVENT
-    ],
-    'NextToken': 'eyJOZXh0VG9rZW4iOiBudWxsLCAiYm90b190cnVuY2F0ZV9hbW91bnQiOiAyfQ=='
+    "Events": [STS_ASSUME_ROLE_EVENT, STS_ASSUME_ROLE_WITH_SAML_EVENT],
+    "NextToken": "eyJOZXh0VG9rZW4iOiBudWxsLCAiYm90b190cnVuY2F0ZV9hbW91bnQiOiAyfQ==",
 }
 
 # Second page of paginated response
 LOOKUP_EVENTS_RESPONSE_PAGE2 = {
-    'Events': [
-        STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT
-    ]
+    "Events": [STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT]
     # No NextToken indicates this is the last page
 }
 
 # Empty response (no events found)
-LOOKUP_EVENTS_EMPTY_RESPONSE = {
-    'Events': []
-}
+LOOKUP_EVENTS_EMPTY_RESPONSE: dict = {"Events": []}
 
 # Single page response (all events fit in one page)
 LOOKUP_EVENTS_SINGLE_PAGE_RESPONSE = {
-    'Events': [
+    "Events": [
         STS_ASSUME_ROLE_EVENT,
         STS_ASSUME_ROLE_WITH_SAML_EVENT,
-        STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT
+        STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT,
     ]
 }
 
@@ -196,74 +191,74 @@ LOOKUP_EVENTS_SINGLE_PAGE_RESPONSE = {
 EXPECTED_PAGINATED_EVENTS = [
     STS_ASSUME_ROLE_EVENT,
     STS_ASSUME_ROLE_WITH_SAML_EVENT,
-    STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT
+    STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT,
 ]
 
 # CloudTrail API error responses
 CLOUDTRAIL_ACCESS_DENIED_ERROR = {
-    'Error': {
-        'Code': 'AccessDenied',
-        'Message': 'User is not authorized to perform: cloudtrail:LookupEvents'
+    "Error": {
+        "Code": "AccessDenied",
+        "Message": "User is not authorized to perform: cloudtrail:LookupEvents",
     }
 }
 
 CLOUDTRAIL_INVALID_TIME_RANGE_ERROR = {
-    'Error': {
-        'Code': 'InvalidTimeRangeException',
-        'Message': 'Start time must be before end time'
+    "Error": {
+        "Code": "InvalidTimeRangeException",
+        "Message": "Start time must be before end time",
     }
 }
 
 # Expected transformation results
 EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE = {
-    'SourcePrincipal': 'arn:aws:iam::123456789012:user/john.doe',
-    'DestinationPrincipal': 'arn:aws:iam::987654321098:role/CrossAccountRole',
-    'Action': 'AssumeRole',
-    'EventId': 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
-    'EventTime': datetime(2024, 1, 15, 10, 30, 15, 123000),
-    'SourceIPAddress': '192.168.1.100',
-    'UserAgent': 'aws-cli/2.0.0 Python/3.8.0 Linux/5.4.0-26-generic botocore/2.0.0dev0',
-    'AwsRegion': 'us-east-1',
-    'AccountId': '123456789012',
-    'AssumedRoleArn': 'arn:aws:iam::987654321098:role/CrossAccountRole',
-    'PrincipalArn': 'arn:aws:iam::123456789012:user/john.doe',
-    'SessionName': 'john-doe-session-1642251015',
-    'RequestId': 'c2d4638c-24b8-11e7-b13c-298444c2bb30',
-    'RecipientAccountId': '987654321098',
+    "SourcePrincipal": "arn:aws:iam::123456789012:user/john.doe",
+    "DestinationPrincipal": "arn:aws:iam::987654321098:role/CrossAccountRole",
+    "Action": "AssumeRole",
+    "EventId": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "EventTime": datetime(2024, 1, 15, 10, 30, 15, 123000),
+    "SourceIPAddress": "192.168.1.100",
+    "UserAgent": "aws-cli/2.0.0 Python/3.8.0 Linux/5.4.0-26-generic botocore/2.0.0dev0",
+    "AwsRegion": "us-east-1",
+    "AccountId": "123456789012",
+    "AssumedRoleArn": "arn:aws:iam::987654321098:role/CrossAccountRole",
+    "PrincipalArn": "arn:aws:iam::123456789012:user/john.doe",
+    "SessionName": "john-doe-session-1642251015",
+    "RequestId": "c2d4638c-24b8-11e7-b13c-298444c2bb30",
+    "RecipientAccountId": "987654321098",
 }
 
 EXPECTED_ROLE_ASSUMPTION_FROM_SAML = {
-    'SourcePrincipal': 'arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com',
-    'DestinationPrincipal': 'arn:aws:iam::123456789012:role/SAMLRole',
-    'Action': 'AssumeRoleWithSAML',
-    'EventId': 'a1b2c3d4-e5f6-7890-1234-567890abcdef',
-    'EventTime': datetime(2024, 1, 15, 11, 15, 30, 456000),
-    'SourceIPAddress': '10.0.1.50',
-    'UserAgent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
-    'AwsRegion': 'us-east-1',
-    'AccountId': '123456789012',
-    'AssumedRoleArn': 'arn:aws:iam::123456789012:role/SAMLRole',
-    'PrincipalArn': 'arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com',
-    'SessionName': None,  # SAML events might not have session names
-    'RequestId': None,    # Not present in this test event
-    'RecipientAccountId': None,  # Not present in this test event
+    "SourcePrincipal": "arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com",
+    "DestinationPrincipal": "arn:aws:iam::123456789012:role/SAMLRole",
+    "Action": "AssumeRoleWithSAML",
+    "EventId": "a1b2c3d4-e5f6-7890-1234-567890abcdef",
+    "EventTime": datetime(2024, 1, 15, 11, 15, 30, 456000),
+    "SourceIPAddress": "10.0.1.50",
+    "UserAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+    "AwsRegion": "us-east-1",
+    "AccountId": "123456789012",
+    "AssumedRoleArn": "arn:aws:iam::123456789012:role/SAMLRole",
+    "PrincipalArn": "arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com",
+    "SessionName": None,  # SAML events might not have session names
+    "RequestId": None,  # Not present in this test event
+    "RecipientAccountId": None,  # Not present in this test event
 }
 
 EXPECTED_ROLE_ASSUMPTION_FROM_WEB_IDENTITY = {
-    'SourcePrincipal': 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300',
-    'DestinationPrincipal': 'arn:aws:iam::123456789012:role/WebIdentityRole',
-    'Action': 'AssumeRoleWithWebIdentity',
-    'EventId': '9876543210abcdef-1234-5678-90ab-cdef12345678',
-    'EventTime': datetime(2024, 1, 15, 12, 45, 0, 789000),
-    'SourceIPAddress': '203.0.113.1',
-    'UserAgent': 'Boto3/1.26.0 Python/3.9.0 Linux/5.15.0 Botocore/1.29.0',
-    'AwsRegion': 'us-west-2',
-    'AccountId': '123456789012',
-    'AssumedRoleArn': 'arn:aws:iam::123456789012:role/WebIdentityRole',
-    'PrincipalArn': 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300',
-    'SessionName': 'web-session-1642254300',
-    'RequestId': None,    # Not present in this test event
-    'RecipientAccountId': None,  # Not present in this test event
+    "SourcePrincipal": "arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300",
+    "DestinationPrincipal": "arn:aws:iam::123456789012:role/WebIdentityRole",
+    "Action": "AssumeRoleWithWebIdentity",
+    "EventId": "9876543210abcdef-1234-5678-90ab-cdef12345678",
+    "EventTime": datetime(2024, 1, 15, 12, 45, 0, 789000),
+    "SourceIPAddress": "203.0.113.1",
+    "UserAgent": "Boto3/1.26.0 Python/3.9.0 Linux/5.15.0 Botocore/1.29.0",
+    "AwsRegion": "us-west-2",
+    "AccountId": "123456789012",
+    "AssumedRoleArn": "arn:aws:iam::123456789012:role/WebIdentityRole",
+    "PrincipalArn": "arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300",
+    "SessionName": "web-session-1642254300",
+    "RequestId": None,  # Not present in this test event
+    "RecipientAccountId": None,  # Not present in this test event
 }
 
 # Expected combined transformation results
@@ -275,154 +270,154 @@ EXPECTED_TRANSFORMED_ROLE_ASSUMPTIONS = [
 
 # Non-STS event that should be filtered out
 NON_STS_EVENT = {
-    'EventId': 'non-sts-event-id',
-    'EventName': 'CreateUser',
-    'EventTime': datetime(2024, 1, 15, 9, 0, 0),
-    'EventSource': 'iam.amazonaws.com',
-    'UserName': 'admin-user',
+    "EventId": "non-sts-event-id",
+    "EventName": "CreateUser",
+    "EventTime": datetime(2024, 1, 15, 9, 0, 0),
+    "EventSource": "iam.amazonaws.com",
+    "UserName": "admin-user",
 }
 
 # Malformed event (missing required fields)
 MALFORMED_EVENT = {
-    'EventId': 'malformed-event-id',
+    "EventId": "malformed-event-id",
     # Missing EventName and other critical fields
-    'EventSource': 'sts.amazonaws.com',
+    "EventSource": "sts.amazonaws.com",
 }
 
 # Test data for aggregation scenarios
 MULTIPLE_ASSUME_ROLE_EVENTS_SAME_PAIR = [
     {
-        'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
-        'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
-        'Action': 'AssumeRole',
-        'EventId': 'alice-ds-event-1',
-        'EventTime': datetime(2024, 1, 15, 9, 0, 0),
-        'SourceIPAddress': '192.168.1.100',
-        'UserAgent': 'aws-cli/2.0.0',
-        'AwsRegion': 'us-east-1',
-        'AccountId': '123456789012',
-        'AssumedRoleArn': 'arn:aws:iam::123456789012:role/DataScientist',
-        'PrincipalArn': 'arn:aws:iam::123456789012:user/alice',
+        "SourcePrincipal": "arn:aws:iam::123456789012:user/alice",
+        "DestinationPrincipal": "arn:aws:iam::123456789012:role/DataScientist",
+        "Action": "AssumeRole",
+        "EventId": "alice-ds-event-1",
+        "EventTime": datetime(2024, 1, 15, 9, 0, 0),
+        "SourceIPAddress": "192.168.1.100",
+        "UserAgent": "aws-cli/2.0.0",
+        "AwsRegion": "us-east-1",
+        "AccountId": "123456789012",
+        "AssumedRoleArn": "arn:aws:iam::123456789012:role/DataScientist",
+        "PrincipalArn": "arn:aws:iam::123456789012:user/alice",
     },
     {
-        'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
-        'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
-        'Action': 'AssumeRole',
-        'EventId': 'alice-ds-event-2',
-        'EventTime': datetime(2024, 1, 15, 13, 30, 0),
-        'SourceIPAddress': '192.168.1.100',
-        'UserAgent': 'aws-cli/2.0.0',
-        'AwsRegion': 'us-east-1',
-        'AccountId': '123456789012',
-        'AssumedRoleArn': 'arn:aws:iam::123456789012:role/DataScientist',
-        'PrincipalArn': 'arn:aws:iam::123456789012:user/alice',
+        "SourcePrincipal": "arn:aws:iam::123456789012:user/alice",
+        "DestinationPrincipal": "arn:aws:iam::123456789012:role/DataScientist",
+        "Action": "AssumeRole",
+        "EventId": "alice-ds-event-2",
+        "EventTime": datetime(2024, 1, 15, 13, 30, 0),
+        "SourceIPAddress": "192.168.1.100",
+        "UserAgent": "aws-cli/2.0.0",
+        "AwsRegion": "us-east-1",
+        "AccountId": "123456789012",
+        "AssumedRoleArn": "arn:aws:iam::123456789012:role/DataScientist",
+        "PrincipalArn": "arn:aws:iam::123456789012:user/alice",
     },
     {
-        'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
-        'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
-        'Action': 'AssumeRole',
-        'EventId': 'alice-ds-event-3',
-        'EventTime': datetime(2024, 1, 15, 17, 15, 0),
-        'SourceIPAddress': '192.168.1.100',
-        'UserAgent': 'aws-cli/2.0.0',
-        'AwsRegion': 'us-east-1',
-        'AccountId': '123456789012',
-        'AssumedRoleArn': 'arn:aws:iam::123456789012:role/DataScientist',
-        'PrincipalArn': 'arn:aws:iam::123456789012:user/alice',
-    }
+        "SourcePrincipal": "arn:aws:iam::123456789012:user/alice",
+        "DestinationPrincipal": "arn:aws:iam::123456789012:role/DataScientist",
+        "Action": "AssumeRole",
+        "EventId": "alice-ds-event-3",
+        "EventTime": datetime(2024, 1, 15, 17, 15, 0),
+        "SourceIPAddress": "192.168.1.100",
+        "UserAgent": "aws-cli/2.0.0",
+        "AwsRegion": "us-east-1",
+        "AccountId": "123456789012",
+        "AssumedRoleArn": "arn:aws:iam::123456789012:role/DataScientist",
+        "PrincipalArn": "arn:aws:iam::123456789012:user/alice",
+    },
 ]
 
 # Expected aggregation result for the above events
 EXPECTED_AGGREGATED_ALICE_DATASCIENTIST = {
-    'source_principal_arn': 'arn:aws:iam::123456789012:user/alice',
-    'destination_principal_arn': 'arn:aws:iam::123456789012:role/DataScientist',
-    'times_used': 3,
-    'first_seen': datetime(2024, 1, 15, 9, 0, 0),
-    'last_seen': datetime(2024, 1, 15, 17, 15, 0),
-    'lastused': datetime(2024, 1, 15, 17, 15, 0),
+    "source_principal_arn": "arn:aws:iam::123456789012:user/alice",
+    "destination_principal_arn": "arn:aws:iam::123456789012:role/DataScientist",
+    "times_used": 3,
+    "first_seen": datetime(2024, 1, 15, 9, 0, 0),
+    "last_seen": datetime(2024, 1, 15, 17, 15, 0),
+    "lastused": datetime(2024, 1, 15, 17, 15, 0),
 }
 
 # Test data for different source types (User, Role, Principal)
 CROSS_ACCOUNT_ROLE_ASSUMPTION_EVENTS = [
     {
-        'SourcePrincipal': 'arn:aws:iam::123456789012:user/service-account',
-        'DestinationPrincipal': 'arn:aws:iam::987654321098:role/CrossAccountRole',
-        'Action': 'AssumeRole',
-        'EventId': 'cross-account-event-1',
-        'EventTime': datetime(2024, 1, 15, 10, 0, 0),
-        'SourceIPAddress': '10.0.1.100',
-        'UserAgent': 'boto3/1.26.0',
-        'AwsRegion': 'us-west-2',
-        'AccountId': '123456789012',
-        'AssumedRoleArn': 'arn:aws:iam::987654321098:role/CrossAccountRole',
-        'PrincipalArn': 'arn:aws:iam::123456789012:user/service-account',
+        "SourcePrincipal": "arn:aws:iam::123456789012:user/service-account",
+        "DestinationPrincipal": "arn:aws:iam::987654321098:role/CrossAccountRole",
+        "Action": "AssumeRole",
+        "EventId": "cross-account-event-1",
+        "EventTime": datetime(2024, 1, 15, 10, 0, 0),
+        "SourceIPAddress": "10.0.1.100",
+        "UserAgent": "boto3/1.26.0",
+        "AwsRegion": "us-west-2",
+        "AccountId": "123456789012",
+        "AssumedRoleArn": "arn:aws:iam::987654321098:role/CrossAccountRole",
+        "PrincipalArn": "arn:aws:iam::123456789012:user/service-account",
     },
     {
-        'SourcePrincipal': 'arn:aws:iam::123456789012:role/ApplicationRole',
-        'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataAccessRole',
-        'Action': 'AssumeRole',
-        'EventId': 'role-to-role-event-1',
-        'EventTime': datetime(2024, 1, 15, 11, 0, 0),
-        'SourceIPAddress': '172.16.1.50',
-        'UserAgent': 'aws-sdk-java/1.12.0',
-        'AwsRegion': 'us-east-1',
-        'AccountId': '123456789012',
-        'AssumedRoleArn': 'arn:aws:iam::123456789012:role/DataAccessRole',
-        'PrincipalArn': 'arn:aws:iam::123456789012:role/ApplicationRole',
+        "SourcePrincipal": "arn:aws:iam::123456789012:role/ApplicationRole",
+        "DestinationPrincipal": "arn:aws:iam::123456789012:role/DataAccessRole",
+        "Action": "AssumeRole",
+        "EventId": "role-to-role-event-1",
+        "EventTime": datetime(2024, 1, 15, 11, 0, 0),
+        "SourceIPAddress": "172.16.1.50",
+        "UserAgent": "aws-sdk-java/1.12.0",
+        "AwsRegion": "us-east-1",
+        "AccountId": "123456789012",
+        "AssumedRoleArn": "arn:aws:iam::123456789012:role/DataAccessRole",
+        "PrincipalArn": "arn:aws:iam::123456789012:role/ApplicationRole",
     },
     {
-        'SourcePrincipal': 'arn:aws:sts::123456789012:federated-user/external-user',
-        'DestinationPrincipal': 'arn:aws:iam::123456789012:role/FederatedRole',
-        'Action': 'AssumeRoleWithSAML',
-        'EventId': 'federated-event-1',
-        'EventTime': datetime(2024, 1, 15, 12, 0, 0),
-        'SourceIPAddress': '203.0.113.100',
-        'UserAgent': 'Mozilla/5.0',
-        'AwsRegion': 'eu-west-1',
-        'AccountId': '123456789012',
-        'AssumedRoleArn': 'arn:aws:iam::123456789012:role/FederatedRole',
-        'PrincipalArn': 'arn:aws:sts::123456789012:federated-user/external-user',
-    }
+        "SourcePrincipal": "arn:aws:sts::123456789012:federated-user/external-user",
+        "DestinationPrincipal": "arn:aws:iam::123456789012:role/FederatedRole",
+        "Action": "AssumeRoleWithSAML",
+        "EventId": "federated-event-1",
+        "EventTime": datetime(2024, 1, 15, 12, 0, 0),
+        "SourceIPAddress": "203.0.113.100",
+        "UserAgent": "Mozilla/5.0",
+        "AwsRegion": "eu-west-1",
+        "AccountId": "123456789012",
+        "AssumedRoleArn": "arn:aws:iam::123456789012:role/FederatedRole",
+        "PrincipalArn": "arn:aws:sts::123456789012:federated-user/external-user",
+    },
 ]
 
 # Events with incomplete data for testing error handling
 INCOMPLETE_ROLE_ASSUMPTION_EVENTS = [
     {
-        'SourcePrincipal': 'arn:aws:iam::123456789012:user/incomplete-user',
+        "SourcePrincipal": "arn:aws:iam::123456789012:user/incomplete-user",
         # Missing DestinationPrincipal
-        'Action': 'AssumeRole',
-        'EventId': 'incomplete-event-1',
-        'EventTime': datetime(2024, 1, 15, 10, 0, 0),
+        "Action": "AssumeRole",
+        "EventId": "incomplete-event-1",
+        "EventTime": datetime(2024, 1, 15, 10, 0, 0),
     },
     {
         # Missing SourcePrincipal
-        'DestinationPrincipal': 'arn:aws:iam::123456789012:role/IncompleteRole',
-        'Action': 'AssumeRole',
-        'EventId': 'incomplete-event-2',
-        'EventTime': datetime(2024, 1, 15, 11, 0, 0),
+        "DestinationPrincipal": "arn:aws:iam::123456789012:role/IncompleteRole",
+        "Action": "AssumeRole",
+        "EventId": "incomplete-event-2",
+        "EventTime": datetime(2024, 1, 15, 11, 0, 0),
     },
     {
-        'SourcePrincipal': 'arn:aws:iam::123456789012:user/no-time-user',
-        'DestinationPrincipal': 'arn:aws:iam::123456789012:role/NoTimeRole',
-        'Action': 'AssumeRole',
-        'EventId': 'incomplete-event-3',
+        "SourcePrincipal": "arn:aws:iam::123456789012:user/no-time-user",
+        "DestinationPrincipal": "arn:aws:iam::123456789012:role/NoTimeRole",
+        "Action": "AssumeRole",
+        "EventId": "incomplete-event-3",
         # Missing EventTime
-    }
+    },
 ]
 
 # Expected Cypher query patterns for testing
 EXPECTED_CYPHER_QUERY_PATTERNS = {
-    'unwind': 'UNWIND $assumptions AS assumption',
-    'arn_conversion': 'Convert assumed role ARNs to IAM role ARNs for source matching',
-    'union_call': 'CALL {',
-    'aws_user_match': 'MATCH (source:AWSUser {arn: source_role_arn})',
-    'aws_role_match': 'MATCH (source:AWSRole {arn: source_role_arn})',
-    'aws_principal_match': 'MATCH (source:AWSPrincipal {arn: source_role_arn})',
-    'destination_merge': 'MERGE (dest:AWSRole {arn: assumption.destination_principal_arn})',
-    'relationship_merge': 'MERGE (source_node)-[rel:ASSUMED_ROLE]->(dest)',
-    'times_used_aggregation': 'rel.times_used = COALESCE(rel.times_used, 0) + assumption.times_used',
-    'first_seen_aggregation': 'CASE WHEN assumption.first_seen <',
-    'last_seen_aggregation': 'CASE WHEN assumption.last_seen >',
-    'lastused_aggregation': 'CASE WHEN assumption.last_seen >',
-    'lastupdated_set': 'rel.lastupdated = $aws_update_tag'
-} 
+    "unwind": "UNWIND $assumptions AS assumption",
+    "arn_conversion": "Convert assumed role ARNs to IAM role ARNs for source matching",
+    "union_call": "CALL {",
+    "aws_user_match": "MATCH (source:AWSUser {arn: source_role_arn})",
+    "aws_role_match": "MATCH (source:AWSRole {arn: source_role_arn})",
+    "aws_principal_match": "MATCH (source:AWSPrincipal {arn: source_role_arn})",
+    "destination_merge": "MERGE (dest:AWSRole {arn: assumption.destination_principal_arn})",
+    "relationship_merge": "MERGE (source_node)-[rel:ASSUMED_ROLE]->(dest)",
+    "times_used_aggregation": "rel.times_used = COALESCE(rel.times_used, 0) + assumption.times_used",
+    "first_seen_aggregation": "CASE WHEN assumption.first_seen <",
+    "last_seen_aggregation": "CASE WHEN assumption.last_seen >",
+    "lastused_aggregation": "CASE WHEN assumption.last_seen >",
+    "lastupdated_set": "rel.lastupdated = $aws_update_tag",
+}

--- a/tests/data/aws/cloudtrail_management_events.py
+++ b/tests/data/aws/cloudtrail_management_events.py
@@ -1,0 +1,290 @@
+import json
+from datetime import datetime
+
+# Realistic STS AssumeRole event
+STS_ASSUME_ROLE_EVENT = {
+    'EventId': 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+    'EventName': 'AssumeRole',
+    'EventTime': datetime(2024, 1, 15, 10, 30, 15, 123000),
+    'EventSource': 'sts.amazonaws.com',
+    'UserName': 'arn:aws:iam::123456789012:user/john.doe',
+    'UserIdentity': {
+        'type': 'IAMUser',
+        'principalId': 'AIDACKCEVSQ6C2EXAMPLE',
+        'arn': 'arn:aws:iam::123456789012:user/john.doe',
+        'accountId': '123456789012',
+        'userName': 'john.doe'
+    },
+    'AwsRegion': 'us-east-1',
+    'SourceIPAddress': '192.168.1.100',
+    'UserAgent': 'aws-cli/2.0.0 Python/3.8.0 Linux/5.4.0-26-generic botocore/2.0.0dev0',
+    'Resources': [
+        {
+            'ResourceType': 'AWS::IAM::Role',
+            'ResourceName': 'arn:aws:iam::987654321098:role/CrossAccountRole',
+            'AccountId': '987654321098'
+        }
+    ],
+    'CloudTrailEvent': json.dumps({
+        'eventVersion': '1.05',
+        'userIdentity': {
+            'type': 'IAMUser',
+            'principalId': 'AIDACKCEVSQ6C2EXAMPLE',
+            'arn': 'arn:aws:iam::123456789012:user/john.doe',
+            'accountId': '123456789012',
+            'userName': 'john.doe'
+        },
+        'eventTime': '2024-01-15T10:30:15Z',
+        'eventSource': 'sts.amazonaws.com',
+        'eventName': 'AssumeRole',
+        'awsRegion': 'us-east-1',
+        'sourceIPAddress': '192.168.1.100',
+        'userAgent': 'aws-cli/2.0.0 Python/3.8.0 Linux/5.4.0-26-generic botocore/2.0.0dev0',
+        'requestParameters': {
+            'roleArn': 'arn:aws:iam::987654321098:role/CrossAccountRole',
+            'roleSessionName': 'john-doe-session-1642251015'
+        },
+        'responseElements': {
+            'credentials': {
+                'sessionToken': 'REDACTED',
+                'accessKeyId': 'ASIACKCEVSQ6C2EXAMPLE',
+                'expiration': 'Jan 15, 2024 11:30:15 AM'
+            },
+            'assumedRoleUser': {
+                'assumedRoleId': 'AROACKCEVSQ6C2EXAMPLE:john-doe-session-1642251015',
+                'arn': 'arn:aws:sts::987654321098:assumed-role/CrossAccountRole/john-doe-session-1642251015'
+            }
+        },
+        'requestID': 'c2d4638c-24b8-11e7-b13c-298444c2bb30',
+        'eventID': 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        'eventType': 'AwsApiCall',
+        'recipientAccountId': '987654321098',
+        'serviceEventDetails': {
+            'responseElements': {
+                'credentials': {
+                    'sessionToken': 'REDACTED'
+                }
+            }
+        }
+    })
+}
+
+# STS AssumeRoleWithSAML event
+STS_ASSUME_ROLE_WITH_SAML_EVENT = {
+    'EventId': 'a1b2c3d4-e5f6-7890-1234-567890abcdef',
+    'EventName': 'AssumeRoleWithSAML',
+    'EventTime': datetime(2024, 1, 15, 11, 15, 30, 456000),
+    'EventSource': 'sts.amazonaws.com',
+    'UserName': 'SAML:jane.smith@company.com',
+    'UserIdentity': {
+        'type': 'SAMLUser',
+        'principalId': 'SAML:jane.smith@company.com',
+        'arn': 'arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com',
+        'accountId': '123456789012'
+    },
+    'AwsRegion': 'us-east-1',
+    'SourceIPAddress': '10.0.1.50',
+    'UserAgent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+    'Resources': [
+        {
+            'ResourceType': 'AWS::IAM::Role',
+            'ResourceName': 'arn:aws:iam::123456789012:role/SAMLRole',
+            'AccountId': '123456789012'
+        }
+    ],
+    'CloudTrailEvent': json.dumps({
+        'eventVersion': '1.05',
+        'userIdentity': {
+            'type': 'SAMLUser',
+            'principalId': 'SAML:jane.smith@company.com',
+            'arn': 'arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com',
+            'accountId': '123456789012'
+        },
+        'eventTime': '2024-01-15T11:15:30Z',
+        'eventSource': 'sts.amazonaws.com',
+        'eventName': 'AssumeRoleWithSAML',
+        'awsRegion': 'us-east-1',
+        'sourceIPAddress': '10.0.1.50',
+        'requestParameters': {
+            'roleArn': 'arn:aws:iam::123456789012:role/SAMLRole',
+            'principalArn': 'arn:aws:iam::123456789012:saml-provider/CompanySAML'
+        },
+        'responseElements': {
+            'assumedRoleUser': {
+                'assumedRoleId': 'AROACKCEVSQ6C2EXAMPLE:jane.smith@company.com',
+                'arn': 'arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com'
+            }
+        }
+    })
+}
+
+# STS AssumeRoleWithWebIdentity event
+STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT = {
+    'EventId': '9876543210abcdef-1234-5678-90ab-cdef12345678',
+    'EventName': 'AssumeRoleWithWebIdentity',
+    'EventTime': datetime(2024, 1, 15, 12, 45, 0, 789000),
+    'EventSource': 'sts.amazonaws.com',
+    'UserName': 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300',
+    'UserIdentity': {
+        'type': 'WebIdentityUser',
+        'principalId': 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300',
+        'arn': 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300',
+        'accountId': '123456789012'
+    },
+    'AwsRegion': 'us-west-2',
+    'SourceIPAddress': '203.0.113.1',
+    'UserAgent': 'Boto3/1.26.0 Python/3.9.0 Linux/5.15.0 Botocore/1.29.0',
+    'Resources': [
+        {
+            'ResourceType': 'AWS::IAM::Role',
+            'ResourceName': 'arn:aws:iam::123456789012:role/WebIdentityRole',
+            'AccountId': '123456789012'
+        }
+    ],
+    'CloudTrailEvent': json.dumps({
+        'eventVersion': '1.05',
+        'userIdentity': {
+            'type': 'WebIdentityUser',
+            'principalId': 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300',
+            'arn': 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300',
+            'accountId': '123456789012'
+        },
+        'eventTime': '2024-01-15T12:45:00Z',
+        'eventSource': 'sts.amazonaws.com',
+        'eventName': 'AssumeRoleWithWebIdentity',
+        'awsRegion': 'us-west-2',
+        'sourceIPAddress': '203.0.113.1',
+        'requestParameters': {
+            'roleArn': 'arn:aws:iam::123456789012:role/WebIdentityRole',
+            'roleSessionName': 'web-session-1642254300'
+        }
+    })
+}
+
+# First page of paginated response
+LOOKUP_EVENTS_RESPONSE_PAGE1 = {
+    'Events': [
+        STS_ASSUME_ROLE_EVENT,
+        STS_ASSUME_ROLE_WITH_SAML_EVENT
+    ],
+    'NextToken': 'eyJOZXh0VG9rZW4iOiBudWxsLCAiYm90b190cnVuY2F0ZV9hbW91bnQiOiAyfQ=='
+}
+
+# Second page of paginated response
+LOOKUP_EVENTS_RESPONSE_PAGE2 = {
+    'Events': [
+        STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT
+    ]
+    # No NextToken indicates this is the last page
+}
+
+# Empty response (no events found)
+LOOKUP_EVENTS_EMPTY_RESPONSE = {
+    'Events': []
+}
+
+# Single page response (all events fit in one page)
+LOOKUP_EVENTS_SINGLE_PAGE_RESPONSE = {
+    'Events': [
+        STS_ASSUME_ROLE_EVENT,
+        STS_ASSUME_ROLE_WITH_SAML_EVENT,
+        STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT
+    ]
+}
+
+# Expected combined results from pagination
+EXPECTED_PAGINATED_EVENTS = [
+    STS_ASSUME_ROLE_EVENT,
+    STS_ASSUME_ROLE_WITH_SAML_EVENT,
+    STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT
+]
+
+# CloudTrail API error responses
+CLOUDTRAIL_ACCESS_DENIED_ERROR = {
+    'Error': {
+        'Code': 'AccessDenied',
+        'Message': 'User is not authorized to perform: cloudtrail:LookupEvents'
+    }
+}
+
+CLOUDTRAIL_INVALID_TIME_RANGE_ERROR = {
+    'Error': {
+        'Code': 'InvalidTimeRangeException',
+        'Message': 'Start time must be before end time'
+    }
+}
+
+# Expected transformation results
+EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE = {
+    'SourcePrincipal': 'arn:aws:iam::123456789012:user/john.doe',
+    'DestinationPrincipal': 'arn:aws:iam::987654321098:role/CrossAccountRole',
+    'Action': 'AssumeRole',
+    'EventId': 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+    'EventTime': datetime(2024, 1, 15, 10, 30, 15, 123000),
+    'SourceIPAddress': '192.168.1.100',
+    'UserAgent': 'aws-cli/2.0.0 Python/3.8.0 Linux/5.4.0-26-generic botocore/2.0.0dev0',
+    'AwsRegion': 'us-east-1',
+    'AccountId': '123456789012',
+    'AssumedRoleArn': 'arn:aws:iam::987654321098:role/CrossAccountRole',
+    'PrincipalArn': 'arn:aws:iam::123456789012:user/john.doe',
+    'SessionName': 'john-doe-session-1642251015',
+    'RequestId': 'c2d4638c-24b8-11e7-b13c-298444c2bb30',
+    'RecipientAccountId': '987654321098',
+}
+
+EXPECTED_ROLE_ASSUMPTION_FROM_SAML = {
+    'SourcePrincipal': 'arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com',
+    'DestinationPrincipal': 'arn:aws:iam::123456789012:role/SAMLRole',
+    'Action': 'AssumeRoleWithSAML',
+    'EventId': 'a1b2c3d4-e5f6-7890-1234-567890abcdef',
+    'EventTime': datetime(2024, 1, 15, 11, 15, 30, 456000),
+    'SourceIPAddress': '10.0.1.50',
+    'UserAgent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+    'AwsRegion': 'us-east-1',
+    'AccountId': '123456789012',
+    'AssumedRoleArn': 'arn:aws:iam::123456789012:role/SAMLRole',
+    'PrincipalArn': 'arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com',
+    'SessionName': None,  # SAML events might not have session names
+    'RequestId': None,    # Not present in this test event
+    'RecipientAccountId': None,  # Not present in this test event
+}
+
+EXPECTED_ROLE_ASSUMPTION_FROM_WEB_IDENTITY = {
+    'SourcePrincipal': 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300',
+    'DestinationPrincipal': 'arn:aws:iam::123456789012:role/WebIdentityRole',
+    'Action': 'AssumeRoleWithWebIdentity',
+    'EventId': '9876543210abcdef-1234-5678-90ab-cdef12345678',
+    'EventTime': datetime(2024, 1, 15, 12, 45, 0, 789000),
+    'SourceIPAddress': '203.0.113.1',
+    'UserAgent': 'Boto3/1.26.0 Python/3.9.0 Linux/5.15.0 Botocore/1.29.0',
+    'AwsRegion': 'us-west-2',
+    'AccountId': '123456789012',
+    'AssumedRoleArn': 'arn:aws:iam::123456789012:role/WebIdentityRole',
+    'PrincipalArn': 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300',
+    'SessionName': 'web-session-1642254300',
+    'RequestId': None,    # Not present in this test event
+    'RecipientAccountId': None,  # Not present in this test event
+}
+
+# Expected combined transformation results
+EXPECTED_TRANSFORMED_ROLE_ASSUMPTIONS = [
+    EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE,
+    EXPECTED_ROLE_ASSUMPTION_FROM_SAML,
+    EXPECTED_ROLE_ASSUMPTION_FROM_WEB_IDENTITY,
+]
+
+# Non-STS event that should be filtered out
+NON_STS_EVENT = {
+    'EventId': 'non-sts-event-id',
+    'EventName': 'CreateUser',
+    'EventTime': datetime(2024, 1, 15, 9, 0, 0),
+    'EventSource': 'iam.amazonaws.com',
+    'UserName': 'admin-user',
+}
+
+# Malformed event (missing required fields)
+MALFORMED_EVENT = {
+    'EventId': 'malformed-event-id',
+    # Missing EventName and other critical fields
+    'EventSource': 'sts.amazonaws.com',
+} 

--- a/tests/integration/cartography/intel/aws/test_cloudtrail_management_events.py
+++ b/tests/integration/cartography/intel/aws/test_cloudtrail_management_events.py
@@ -1,0 +1,523 @@
+from unittest.mock import MagicMock, patch
+import datetime
+
+import cartography.intel.aws.cloudtrail_management_events
+import cartography.intel.aws.iam
+from cartography.intel.aws.cloudtrail_management_events import sync
+from tests.data.aws.cloudtrail_management_events import EXPECTED_TRANSFORMED_ROLE_ASSUMPTIONS
+from tests.integration.cartography.intel.aws.common import create_test_account
+from tests.integration.util import check_nodes, check_rels
+
+TEST_ACCOUNT_ID = "123456789012"
+TEST_REGION = "us-east-1"
+TEST_UPDATE_TAG = 123456789
+
+
+def _cleanup_neo4j(neo4j_session):
+    """Clean up any existing data in Neo4j before running a test."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n;")
+
+
+# Test IAM Users data
+TEST_IAM_USERS = [
+    {
+        "UserName": "john.doe",
+        "UserId": "AIDACKCEVSQ6C2EXAMPLE",
+        "Arn": "arn:aws:iam::123456789012:user/john.doe",
+        "Path": "/",
+        "CreateDate": datetime.datetime(2024, 1, 1, 10, 0, 0),
+    },
+    {
+        "UserName": "alice",
+        "UserId": "AIDACKCEVSQ6C2ALICE",
+        "Arn": "arn:aws:iam::123456789012:user/alice",
+        "Path": "/",
+        "CreateDate": datetime.datetime(2024, 1, 1, 10, 0, 0),
+    }
+]
+
+# Test IAM Roles data
+TEST_IAM_ROLES = [
+    {
+        "RoleName": "CrossAccountRole",
+        "RoleId": "AROA00000000000000000",
+        "Arn": "arn:aws:iam::987654321098:role/CrossAccountRole",
+        "Path": "/",
+        "CreateDate": datetime.datetime(2024, 1, 1, 10, 0, 0),
+        "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {
+                        "AWS": "arn:aws:iam::123456789012:root"
+                    },
+                    "Action": "sts:AssumeRole"
+                }
+            ]
+        },
+    },
+    {
+        "RoleName": "SAMLRole",
+        "RoleId": "AROA00000000000000001",
+        "Arn": "arn:aws:iam::123456789012:role/SAMLRole",
+        "Path": "/",
+        "CreateDate": datetime.datetime(2024, 1, 1, 10, 0, 0),
+        "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {
+                        "Federated": "arn:aws:iam::123456789012:saml-provider/CompanySAML"
+                    },
+                    "Action": "sts:AssumeRoleWithSAML"
+                }
+            ]
+        },
+    },
+    {
+        "RoleName": "WebIdentityRole",
+        "RoleId": "AROA00000000000000002",
+        "Arn": "arn:aws:iam::123456789012:role/WebIdentityRole",
+        "Path": "/",
+        "CreateDate": datetime.datetime(2024, 1, 1, 10, 0, 0),
+        "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {
+                        "Federated": "arn:aws:iam::123456789012:oidc-provider/example.com"
+                    },
+                    "Action": "sts:AssumeRoleWithWebIdentity"
+                }
+            ]
+        },
+    }
+]
+
+
+def _ensure_local_neo4j_has_test_iam_data(neo4j_session):
+    """
+    Set up test IAM users and roles in Neo4j for the test.
+    """
+    # Load test users
+    cartography.intel.aws.iam.load_users(
+        neo4j_session,
+        TEST_IAM_USERS,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+    
+    # Load test roles
+    cartography.intel.aws.iam.load_roles(
+        neo4j_session,
+        TEST_IAM_ROLES,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+    
+    # Create cross-account role manually since it's in a different account
+    neo4j_session.run(
+        """
+        MERGE (role:AWSRole:AWSPrincipal {arn: $role_arn})
+        SET role.roleid = $role_id,
+            role.name = $role_name,
+            role.lastupdated = $update_tag
+        """,
+        role_arn="arn:aws:iam::987654321098:role/CrossAccountRole",
+        role_id="AROA00000000CROSSACCOUNT",
+        role_name="CrossAccountRole",
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.aws.cloudtrail_management_events,
+    "get_cloudtrail_events",
+    return_value=[],  # We'll override this in the test
+)
+@patch.object(
+    cartography.intel.aws.cloudtrail_management_events,
+    "transform_cloudtrail_events_to_role_assumptions",
+    return_value=[
+        # User john.doe assumes cross-account role
+        {
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/john.doe',
+            'DestinationPrincipal': 'arn:aws:iam::987654321098:role/CrossAccountRole',
+            'Action': 'AssumeRole',
+            'EventId': 'test-event-1',
+            'EventTime': '2024-01-15T10:30:15.123000',
+        },
+        # User alice assumes SAMLRole  
+        {
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/SAMLRole',
+            'Action': 'AssumeRole',
+            'EventId': 'test-event-2',
+            'EventTime': '2024-01-15T11:15:30.456000',
+        },
+        # User alice also assumes WebIdentityRole
+        {
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/WebIdentityRole',
+            'Action': 'AssumeRole',
+            'EventId': 'test-event-3',
+            'EventTime': '2024-01-15T12:45:00.789000',
+        },
+    ],
+)
+def test_sync_cloudtrail_management_events_creates_assumed_role_relationships(
+    mock_transform, mock_get_events, neo4j_session
+):
+    """
+    Test that the CloudTrail management events sync creates ASSUMED_ROLE relationships
+    with correct aggregated properties.
+    """
+    # Arrange
+    _cleanup_neo4j(neo4j_session)
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    _ensure_local_neo4j_has_test_iam_data(neo4j_session)
+    
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "AWS_ID": TEST_ACCOUNT_ID,
+        "aws_cloudtrail_management_events_lookback_hours": 24,
+    }
+
+    # Act
+    sync(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    # Assert - Check that ASSUMED_ROLE relationships were created
+    assumed_role_rels = neo4j_session.run(
+        """
+        MATCH (source)-[rel:ASSUMED_ROLE]->(dest:AWSRole)
+        RETURN source.arn as source_arn, dest.arn as dest_arn, 
+               rel.times_used as times_used, rel.lastused as lastused,
+               rel.first_seen as first_seen, rel.last_seen as last_seen
+        """
+    ).data()
+
+    # Should have 3 relationships from our test data
+    assert len(assumed_role_rels) == 3
+    
+    # Verify each relationship has the expected properties
+    rels_by_source_dest = {(rel['source_arn'], rel['dest_arn']): rel for rel in assumed_role_rels}
+    
+    # Check john.doe -> CrossAccountRole relationship
+    john_rel = rels_by_source_dest.get(('arn:aws:iam::123456789012:user/john.doe', 'arn:aws:iam::987654321098:role/CrossAccountRole'))
+    assert john_rel is not None
+    assert john_rel['times_used'] == 1
+    assert john_rel['lastused'] is not None
+    assert john_rel['first_seen'] is not None
+    assert john_rel['last_seen'] is not None
+    
+    # Check alice -> SAMLRole relationship  
+    alice_saml_rel = rels_by_source_dest.get(('arn:aws:iam::123456789012:user/alice', 'arn:aws:iam::123456789012:role/SAMLRole'))
+    assert alice_saml_rel is not None
+    assert alice_saml_rel['times_used'] == 1
+    
+    # Check alice -> WebIdentityRole relationship
+    alice_web_rel = rels_by_source_dest.get(('arn:aws:iam::123456789012:user/alice', 'arn:aws:iam::123456789012:role/WebIdentityRole'))
+    assert alice_web_rel is not None
+    assert alice_web_rel['times_used'] == 1
+
+
+@patch.object(
+    cartography.intel.aws.cloudtrail_management_events,
+    "get_cloudtrail_events",
+    return_value=[],
+)
+@patch.object(
+    cartography.intel.aws.cloudtrail_management_events,
+    "transform_cloudtrail_events_to_role_assumptions",
+    return_value=[],
+)
+def test_sync_cloudtrail_management_events_with_no_events(
+    mock_transform, mock_get_events, neo4j_session
+):
+    """
+    Test that the sync works correctly when no CloudTrail events are found.
+    """
+    # Arrange
+    _cleanup_neo4j(neo4j_session)
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    _ensure_local_neo4j_has_test_iam_data(neo4j_session)
+    
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "AWS_ID": TEST_ACCOUNT_ID,
+        "aws_cloudtrail_management_events_lookback_hours": 24,
+    }
+
+    # Act
+    sync(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    # Assert - Should have no ASSUMED_ROLE relationships
+    assumed_role_rels = neo4j_session.run(
+        """
+        MATCH ()-[rel:ASSUMED_ROLE]->()
+        RETURN count(rel) as count
+        """
+    ).single()['count']
+    
+    assert assumed_role_rels == 0
+
+
+def test_sync_cloudtrail_management_events_skipped_when_no_lookback_hours(neo4j_session):
+    """
+    Test that the sync is skipped when no lookback hours are configured.
+    """
+    # Arrange
+    _cleanup_neo4j(neo4j_session)
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "AWS_ID": TEST_ACCOUNT_ID,
+        # No aws_cloudtrail_management_events_lookback_hours specified
+    }
+
+    # Act
+    with patch.object(
+        cartography.intel.aws.cloudtrail_management_events,
+        "get_cloudtrail_events"
+    ) as mock_get_events:
+        sync(
+            neo4j_session,
+            boto3_session,
+            [TEST_REGION],
+            TEST_ACCOUNT_ID,
+            TEST_UPDATE_TAG,
+            common_job_parameters,
+        )
+        
+        # Assert - get_cloudtrail_events should not be called
+        mock_get_events.assert_not_called()
+
+
+@patch.object(
+    cartography.intel.aws.cloudtrail_management_events,
+    "get_cloudtrail_events",
+    return_value=[],
+)
+@patch.object(
+    cartography.intel.aws.cloudtrail_management_events,
+    "transform_cloudtrail_events_to_role_assumptions",
+    side_effect=[
+        # First region succeeds
+        [{
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/john.doe',
+            'DestinationPrincipal': 'arn:aws:iam::987654321098:role/CrossAccountRole',
+            'Action': 'AssumeRole',
+            'EventId': 'test-event-1',
+            'EventTime': '2024-01-15T10:30:15.123000',
+        }],
+        # Second region fails
+        Exception("Access denied"),
+        # Third region succeeds
+        [{
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/SAMLRole',
+            'Action': 'AssumeRole',
+            'EventId': 'test-event-2',
+            'EventTime': '2024-01-15T11:15:30.456000',
+        }],
+    ]
+)
+def test_sync_cloudtrail_management_events_continues_on_region_failure(
+    mock_transform, mock_get_events, neo4j_session
+):
+    """
+    Test that the sync continues processing other regions when one region fails.
+    """
+    # Arrange
+    _cleanup_neo4j(neo4j_session)
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    _ensure_local_neo4j_has_test_iam_data(neo4j_session)
+    
+    regions = ["us-east-1", "us-west-2", "eu-west-1"]
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "AWS_ID": TEST_ACCOUNT_ID,
+        "aws_cloudtrail_management_events_lookback_hours": 24,
+    }
+
+    # Act
+    sync(
+        neo4j_session,
+        boto3_session,
+        regions,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    # Assert - Should have processed successful regions only
+    assumed_role_rels = neo4j_session.run(
+        """
+        MATCH ()-[rel:ASSUMED_ROLE]->()
+        RETURN count(rel) as count
+        """
+    ).single()['count']
+    
+    # Should have 2 relationships from the 2 successful regions
+    assert assumed_role_rels == 2
+
+
+@patch.object(
+    cartography.intel.aws.cloudtrail_management_events,
+    "get_cloudtrail_events", 
+    return_value=[],
+)
+@patch.object(
+    cartography.intel.aws.cloudtrail_management_events,
+    "transform_cloudtrail_events_to_role_assumptions",
+    return_value=[
+        # Simulate multiple events for the same (source, destination) pair
+        {
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/SAMLRole',
+            'EventTime': '2024-01-15T09:00:00.000000',
+            'Action': 'AssumeRole',
+            'EventId': 'event-1'
+        },
+        {
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/SAMLRole',
+            'EventTime': '2024-01-15T14:00:00.000000',
+            'Action': 'AssumeRole',
+            'EventId': 'event-2'
+        },
+        {
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/SAMLRole',
+            'EventTime': '2024-01-15T17:00:00.000000',
+            'Action': 'AssumeRole', 
+            'EventId': 'event-3'
+        }
+    ]
+)
+def test_sync_cloudtrail_management_events_aggregates_multiple_events(
+    mock_transform, mock_get_events, neo4j_session
+):
+    """
+    Test that multiple events for the same (source, destination) pair are properly aggregated.
+    """
+    # Arrange
+    _cleanup_neo4j(neo4j_session)
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    _ensure_local_neo4j_has_test_iam_data(neo4j_session)
+    
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "AWS_ID": TEST_ACCOUNT_ID,
+        "aws_cloudtrail_management_events_lookback_hours": 24,
+    }
+
+    # Act
+    sync(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    # Assert - Should have aggregated the multiple events into one relationship
+    assumed_role_rel = neo4j_session.run(
+        """
+        MATCH (source {arn: 'arn:aws:iam::123456789012:user/alice'})
+              -[rel:ASSUMED_ROLE]->
+              (dest {arn: 'arn:aws:iam::123456789012:role/SAMLRole'})
+        RETURN rel.times_used as times_used, rel.first_seen as first_seen, 
+               rel.last_seen as last_seen, rel.lastused as lastused
+        """
+    ).single()
+
+    assert assumed_role_rel is not None
+    assert assumed_role_rel['times_used'] == 3  # Aggregated from 3 events
+    assert assumed_role_rel['first_seen'] is not None
+    assert assumed_role_rel['last_seen'] is not None
+    assert assumed_role_rel['lastused'] == assumed_role_rel['last_seen']
+
+
+def test_sync_cloudtrail_management_events_cross_account_relationships(neo4j_session):
+    """
+    Test that cross-account role assumptions are handled correctly.
+    """
+    # Arrange
+    _cleanup_neo4j(neo4j_session)
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    _ensure_local_neo4j_has_test_iam_data(neo4j_session)
+    
+    # Use only the cross-account assumption from our test data
+    cross_account_assumption = {
+        'SourcePrincipal': 'arn:aws:iam::123456789012:user/john.doe',
+        'DestinationPrincipal': 'arn:aws:iam::987654321098:role/CrossAccountRole',
+        'Action': 'AssumeRole',
+        'EventId': 'test-cross-account-event',
+        'EventTime': '2024-01-15T10:30:15.123000',
+    }
+    
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "AWS_ID": TEST_ACCOUNT_ID,
+        "aws_cloudtrail_management_events_lookback_hours": 24,
+    }
+
+    # Act
+    with patch.object(
+        cartography.intel.aws.cloudtrail_management_events,
+        "get_cloudtrail_events",
+        return_value=[],
+    ), patch.object(
+        cartography.intel.aws.cloudtrail_management_events,
+        "transform_cloudtrail_events_to_role_assumptions",
+        return_value=[cross_account_assumption],
+    ):
+        sync(
+            neo4j_session,
+            boto3_session,
+            [TEST_REGION],
+            TEST_ACCOUNT_ID,
+            TEST_UPDATE_TAG,
+            common_job_parameters,
+        )
+
+    # Assert - Check cross-account relationship was created
+    cross_account_rel = neo4j_session.run(
+        """
+        MATCH (source {arn: 'arn:aws:iam::123456789012:user/john.doe'})
+              -[rel:ASSUMED_ROLE]->
+              (dest {arn: 'arn:aws:iam::987654321098:role/CrossAccountRole'})
+        RETURN rel.times_used as times_used, source.arn as source_arn, dest.arn as dest_arn
+        """
+    ).single()
+
+    assert cross_account_rel is not None
+    assert cross_account_rel['times_used'] == 1
+    assert cross_account_rel['source_arn'] == 'arn:aws:iam::123456789012:user/john.doe'
+    assert cross_account_rel['dest_arn'] == 'arn:aws:iam::987654321098:role/CrossAccountRole' 

--- a/tests/unit/cartography/intel/aws/test_cloudtrail_management_events.py
+++ b/tests/unit/cartography/intel/aws/test_cloudtrail_management_events.py
@@ -1,30 +1,58 @@
-from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch, call
+from datetime import datetime
+from datetime import timedelta
+from unittest.mock import call
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import boto3
-import pytest
 from botocore.exceptions import ClientError
 
-from cartography.intel.aws.cloudtrail_management_events import get_cloudtrail_events, transform_cloudtrail_events_to_role_assumptions, _aggregate_role_assumptions, load_role_assumptions, sync
+from cartography.intel.aws.cloudtrail_management_events import (
+    _aggregate_role_assumptions,
+)
+from cartography.intel.aws.cloudtrail_management_events import get_cloudtrail_events
+from cartography.intel.aws.cloudtrail_management_events import load_role_assumptions
+from cartography.intel.aws.cloudtrail_management_events import sync
+from cartography.intel.aws.cloudtrail_management_events import (
+    transform_cloudtrail_events_to_role_assumptions,
+)
 from tests.data.aws.cloudtrail_management_events import (
     CROSS_ACCOUNT_ROLE_ASSUMPTION_EVENTS,
+)
+from tests.data.aws.cloudtrail_management_events import (
     EXPECTED_AGGREGATED_ALICE_DATASCIENTIST,
-    EXPECTED_CYPHER_QUERY_PATTERNS,
-    EXPECTED_PAGINATED_EVENTS,
+)
+from tests.data.aws.cloudtrail_management_events import EXPECTED_CYPHER_QUERY_PATTERNS
+from tests.data.aws.cloudtrail_management_events import EXPECTED_PAGINATED_EVENTS
+from tests.data.aws.cloudtrail_management_events import (
     EXPECTED_ROLE_ASSUMPTION_FROM_SAML,
+)
+from tests.data.aws.cloudtrail_management_events import (
     EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE,
+)
+from tests.data.aws.cloudtrail_management_events import (
     EXPECTED_ROLE_ASSUMPTION_FROM_WEB_IDENTITY,
+)
+from tests.data.aws.cloudtrail_management_events import (
     EXPECTED_TRANSFORMED_ROLE_ASSUMPTIONS,
+)
+from tests.data.aws.cloudtrail_management_events import (
     INCOMPLETE_ROLE_ASSUMPTION_EVENTS,
-    LOOKUP_EVENTS_EMPTY_RESPONSE,
-    LOOKUP_EVENTS_RESPONSE_PAGE1,
-    LOOKUP_EVENTS_RESPONSE_PAGE2,
+)
+from tests.data.aws.cloudtrail_management_events import LOOKUP_EVENTS_EMPTY_RESPONSE
+from tests.data.aws.cloudtrail_management_events import LOOKUP_EVENTS_RESPONSE_PAGE1
+from tests.data.aws.cloudtrail_management_events import LOOKUP_EVENTS_RESPONSE_PAGE2
+from tests.data.aws.cloudtrail_management_events import (
     LOOKUP_EVENTS_SINGLE_PAGE_RESPONSE,
-    MALFORMED_EVENT,
+)
+from tests.data.aws.cloudtrail_management_events import MALFORMED_EVENT
+from tests.data.aws.cloudtrail_management_events import (
     MULTIPLE_ASSUME_ROLE_EVENTS_SAME_PAIR,
-    NON_STS_EVENT,
-    STS_ASSUME_ROLE_EVENT,
-    STS_ASSUME_ROLE_WITH_SAML_EVENT,
+)
+from tests.data.aws.cloudtrail_management_events import NON_STS_EVENT
+from tests.data.aws.cloudtrail_management_events import STS_ASSUME_ROLE_EVENT
+from tests.data.aws.cloudtrail_management_events import STS_ASSUME_ROLE_WITH_SAML_EVENT
+from tests.data.aws.cloudtrail_management_events import (
     STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT,
 )
 
@@ -32,278 +60,286 @@ from tests.data.aws.cloudtrail_management_events import (
 class TestGetCloudTrailEvents:
     """Test suite for get_cloudtrail_events function."""
 
-    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    @patch("cartography.intel.aws.cloudtrail_management_events.get_botocore_config")
     def test_get_cloudtrail_events_success_single_page(self, mock_botocore_config):
         """Test successful retrieval of CloudTrail events in a single page."""
         # Arrange
         mock_session = MagicMock(spec=boto3.Session)
         mock_client = MagicMock()
         mock_paginator = MagicMock()
-        
+
         mock_session.client.return_value = mock_client
         mock_client.get_paginator.return_value = mock_paginator
         mock_paginator.paginate.return_value = [LOOKUP_EVENTS_SINGLE_PAGE_RESPONSE]
-        
-        region = 'us-east-1'
+
+        region = "us-east-1"
         lookback_hours = 24
-        
+
         # Act
         result = get_cloudtrail_events(mock_session, region, lookback_hours)
-        
+
         # Assert - Verify client creation
         mock_session.client.assert_called_once_with(
-            'cloudtrail',
-            region_name=region,
-            config=mock_botocore_config.return_value
+            "cloudtrail", region_name=region, config=mock_botocore_config.return_value
         )
-        
+
         # Assert - Verify paginator creation
-        mock_client.get_paginator.assert_called_once_with('lookup_events')
-        
+        mock_client.get_paginator.assert_called_once_with("lookup_events")
+
         # Assert - Verify API call parameters
         expected_end_time = datetime.utcnow()
         expected_start_time = expected_end_time - timedelta(hours=lookback_hours)
-        
+
         mock_paginator.paginate.assert_called_once()
         call_args = mock_paginator.paginate.call_args
-        
-        assert call_args[1]['LookupAttributes'] == [
-            {'AttributeKey': 'EventSource', 'AttributeValue': 'sts.amazonaws.com'}
+
+        assert call_args[1]["LookupAttributes"] == [
+            {"AttributeKey": "EventSource", "AttributeValue": "sts.amazonaws.com"}
         ]
-        assert call_args[1]['PaginationConfig'] == {
-            'MaxItems': 10000,
-            'PageSize': 50
-        }
-        
+        assert call_args[1]["PaginationConfig"] == {"MaxItems": 10000, "PageSize": 50}
+
         # Verify time range (allow small tolerance for test execution time)
-        start_time_diff = abs((call_args[1]['StartTime'] - expected_start_time).total_seconds())
-        end_time_diff = abs((call_args[1]['EndTime'] - expected_end_time).total_seconds())
+        start_time_diff = abs(
+            (call_args[1]["StartTime"] - expected_start_time).total_seconds()
+        )
+        end_time_diff = abs(
+            (call_args[1]["EndTime"] - expected_end_time).total_seconds()
+        )
         assert start_time_diff < 5  # Allow 5 seconds tolerance
         assert end_time_diff < 5
-        
+
         # Assert - Verify results
         assert len(result) == 3
-        assert result[0]['EventName'] == 'AssumeRole'
-        assert result[1]['EventName'] == 'AssumeRoleWithSAML'
-        assert result[2]['EventName'] == 'AssumeRoleWithWebIdentity'
+        assert result[0]["EventName"] == "AssumeRole"
+        assert result[1]["EventName"] == "AssumeRoleWithSAML"
+        assert result[2]["EventName"] == "AssumeRoleWithWebIdentity"
         assert result == EXPECTED_PAGINATED_EVENTS
 
-    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    @patch("cartography.intel.aws.cloudtrail_management_events.get_botocore_config")
     def test_get_cloudtrail_events_success_with_pagination(self, mock_botocore_config):
         """Test successful retrieval of CloudTrail events across multiple pages."""
         # Arrange
         mock_session = MagicMock(spec=boto3.Session)
         mock_client = MagicMock()
         mock_paginator = MagicMock()
-        
+
         mock_session.client.return_value = mock_client
         mock_client.get_paginator.return_value = mock_paginator
         mock_paginator.paginate.return_value = [
             LOOKUP_EVENTS_RESPONSE_PAGE1,
-            LOOKUP_EVENTS_RESPONSE_PAGE2
+            LOOKUP_EVENTS_RESPONSE_PAGE2,
         ]
-        
-        region = 'us-west-2'
+
+        region = "us-west-2"
         lookback_hours = 72
-        
+
         # Act
         result = get_cloudtrail_events(mock_session, region, lookback_hours)
-        
+
         # Assert - Verify pagination handling
         assert len(result) == 3
         assert result[0] == STS_ASSUME_ROLE_EVENT
         assert result[1] == STS_ASSUME_ROLE_WITH_SAML_EVENT
         assert result[2] == STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT
         assert result == EXPECTED_PAGINATED_EVENTS
-        
+
         # Verify the time range reflects the 72-hour lookback
         call_args = mock_paginator.paginate.call_args
-        time_diff = call_args[1]['EndTime'] - call_args[1]['StartTime']
-        assert abs(time_diff.total_seconds() - (72 * 3600)) < 60  # Allow 1 minute tolerance
+        time_diff = call_args[1]["EndTime"] - call_args[1]["StartTime"]
+        assert (
+            abs(time_diff.total_seconds() - (72 * 3600)) < 60
+        )  # Allow 1 minute tolerance
 
-    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    @patch("cartography.intel.aws.cloudtrail_management_events.get_botocore_config")
     def test_get_cloudtrail_events_empty_response(self, mock_botocore_config):
         """Test handling of empty CloudTrail response."""
         # Arrange
         mock_session = MagicMock(spec=boto3.Session)
         mock_client = MagicMock()
         mock_paginator = MagicMock()
-        
+
         mock_session.client.return_value = mock_client
         mock_client.get_paginator.return_value = mock_paginator
         mock_paginator.paginate.return_value = [LOOKUP_EVENTS_EMPTY_RESPONSE]
-        
+
         # Act
-        result = get_cloudtrail_events(mock_session, 'eu-west-1', 12)
-        
+        result = get_cloudtrail_events(mock_session, "eu-west-1", 12)
+
         # Assert
         assert result == []
         assert len(result) == 0
 
-    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    @patch("cartography.intel.aws.cloudtrail_management_events.get_botocore_config")
     def test_get_cloudtrail_events_default_lookback_hours(self, mock_botocore_config):
         """Test that default lookback hours parameter works correctly."""
         # Arrange
         mock_session = MagicMock(spec=boto3.Session)
         mock_client = MagicMock()
         mock_paginator = MagicMock()
-        
+
         mock_session.client.return_value = mock_client
         mock_client.get_paginator.return_value = mock_paginator
         mock_paginator.paginate.return_value = [LOOKUP_EVENTS_SINGLE_PAGE_RESPONSE]
-        
+
         # Act - Don't specify lookback_hours, should use default of 24
-        result = get_cloudtrail_events(mock_session, 'us-east-1')
-        
+        result = get_cloudtrail_events(mock_session, "us-east-1")
+
         # Assert - Verify default 24 hour time range
         call_args = mock_paginator.paginate.call_args
-        time_diff = call_args[1]['EndTime'] - call_args[1]['StartTime']
-        assert abs(time_diff.total_seconds() - (24 * 3600)) < 60  # Allow 1 minute tolerance
+        time_diff = call_args[1]["EndTime"] - call_args[1]["StartTime"]
+        assert (
+            abs(time_diff.total_seconds() - (24 * 3600)) < 60
+        )  # Allow 1 minute tolerance
 
-    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+        # Assert - Verify results are returned correctly
+        assert result == EXPECTED_PAGINATED_EVENTS
+
+    @patch("cartography.intel.aws.cloudtrail_management_events.get_botocore_config")
     def test_get_cloudtrail_events_api_error_access_denied(self, mock_botocore_config):
         """Test handling of CloudTrail API access denied error."""
         # Arrange
         mock_session = MagicMock(spec=boto3.Session)
         mock_client = MagicMock()
         mock_paginator = MagicMock()
-        
+
         mock_session.client.return_value = mock_client
         mock_client.get_paginator.return_value = mock_paginator
-        
+
         # Simulate AccessDenied error
         mock_paginator.paginate.side_effect = ClientError(
             error_response={
-                'Error': {
-                    'Code': 'AccessDenied',
-                    'Message': 'User is not authorized to perform: cloudtrail:LookupEvents'
+                "Error": {
+                    "Code": "AccessDenied",
+                    "Message": "User is not authorized to perform: cloudtrail:LookupEvents",
                 }
             },
-            operation_name='LookupEvents'
+            operation_name="LookupEvents",
         )
-        
+
         # Act
-        result = get_cloudtrail_events(mock_session, 'us-east-1', 24)
-        
+        result = get_cloudtrail_events(mock_session, "us-east-1", 24)
+
         # Assert - Should return empty list and log warning (not raise exception)
         assert result == []
 
-    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
-    def test_get_cloudtrail_events_api_error_invalid_time_range(self, mock_botocore_config):
+    @patch("cartography.intel.aws.cloudtrail_management_events.get_botocore_config")
+    def test_get_cloudtrail_events_api_error_invalid_time_range(
+        self, mock_botocore_config
+    ):
         """Test handling of CloudTrail API invalid time range error."""
         # Arrange
         mock_session = MagicMock(spec=boto3.Session)
         mock_client = MagicMock()
         mock_paginator = MagicMock()
-        
+
         mock_session.client.return_value = mock_client
         mock_client.get_paginator.return_value = mock_paginator
-        
+
         # Simulate InvalidTimeRangeException
         mock_paginator.paginate.side_effect = ClientError(
             error_response={
-                'Error': {
-                    'Code': 'InvalidTimeRangeException',
-                    'Message': 'Start time must be before end time'
+                "Error": {
+                    "Code": "InvalidTimeRangeException",
+                    "Message": "Start time must be before end time",
                 }
             },
-            operation_name='LookupEvents'
+            operation_name="LookupEvents",
         )
-        
+
         # Act
-        result = get_cloudtrail_events(mock_session, 'ap-southeast-1', 24)
-        
+        result = get_cloudtrail_events(mock_session, "ap-southeast-1", 24)
+
         # Assert - Should return empty list and log warning (not raise exception)
         assert result == []
 
-    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    @patch("cartography.intel.aws.cloudtrail_management_events.get_botocore_config")
     def test_get_cloudtrail_events_generic_exception(self, mock_botocore_config):
         """Test handling of generic exceptions."""
         # Arrange
         mock_session = MagicMock(spec=boto3.Session)
         mock_client = MagicMock()
         mock_paginator = MagicMock()
-        
+
         mock_session.client.return_value = mock_client
         mock_client.get_paginator.return_value = mock_paginator
-        
+
         # Simulate generic exception
         mock_paginator.paginate.side_effect = Exception("Network timeout")
-        
+
         # Act
-        result = get_cloudtrail_events(mock_session, 'ca-central-1', 24)
-        
+        result = get_cloudtrail_events(mock_session, "ca-central-1", 24)
+
         # Assert - Should return empty list and log warning (not raise exception)
         assert result == []
 
-    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    @patch("cartography.intel.aws.cloudtrail_management_events.get_botocore_config")
     def test_get_cloudtrail_events_region_parameter_usage(self, mock_botocore_config):
         """Test that the region parameter is correctly passed to the boto3 client."""
         # Arrange
         mock_session = MagicMock(spec=boto3.Session)
         mock_client = MagicMock()
         mock_paginator = MagicMock()
-        
+
         mock_session.client.return_value = mock_client
         mock_client.get_paginator.return_value = mock_paginator
         mock_paginator.paginate.return_value = [LOOKUP_EVENTS_EMPTY_RESPONSE]
-        
-        test_region = 'eu-central-1'
-        
+
+        test_region = "eu-central-1"
+
         # Act
         get_cloudtrail_events(mock_session, test_region, 24)
-        
+
         # Assert - Verify region is passed correctly
         mock_session.client.assert_called_once_with(
-            'cloudtrail',
+            "cloudtrail",
             region_name=test_region,
-            config=mock_botocore_config.return_value
+            config=mock_botocore_config.return_value,
         )
 
-    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    @patch("cartography.intel.aws.cloudtrail_management_events.get_botocore_config")
     def test_get_cloudtrail_events_filters_sts_events_only(self, mock_botocore_config):
         """Test that the function correctly filters for STS events only."""
         # Arrange
         mock_session = MagicMock(spec=boto3.Session)
         mock_client = MagicMock()
         mock_paginator = MagicMock()
-        
+
         mock_session.client.return_value = mock_client
         mock_client.get_paginator.return_value = mock_paginator
         mock_paginator.paginate.return_value = [LOOKUP_EVENTS_SINGLE_PAGE_RESPONSE]
-        
+
         # Act
-        get_cloudtrail_events(mock_session, 'us-east-1', 24)
-        
+        get_cloudtrail_events(mock_session, "us-east-1", 24)
+
         # Assert - Verify STS event filtering
         call_args = mock_paginator.paginate.call_args
-        lookup_attributes = call_args[1]['LookupAttributes']
-        
-        assert len(lookup_attributes) == 1
-        assert lookup_attributes[0]['AttributeKey'] == 'EventSource'
-        assert lookup_attributes[0]['AttributeValue'] == 'sts.amazonaws.com'
+        lookup_attributes = call_args[1]["LookupAttributes"]
 
-    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+        assert len(lookup_attributes) == 1
+        assert lookup_attributes[0]["AttributeKey"] == "EventSource"
+        assert lookup_attributes[0]["AttributeValue"] == "sts.amazonaws.com"
+
+    @patch("cartography.intel.aws.cloudtrail_management_events.get_botocore_config")
     def test_get_cloudtrail_events_pagination_config(self, mock_botocore_config):
         """Test that pagination configuration is set correctly."""
         # Arrange
         mock_session = MagicMock(spec=boto3.Session)
         mock_client = MagicMock()
         mock_paginator = MagicMock()
-        
+
         mock_session.client.return_value = mock_client
         mock_client.get_paginator.return_value = mock_paginator
         mock_paginator.paginate.return_value = [LOOKUP_EVENTS_EMPTY_RESPONSE]
-        
+
         # Act
-        get_cloudtrail_events(mock_session, 'us-east-1', 24)
-        
+        get_cloudtrail_events(mock_session, "us-east-1", 24)
+
         # Assert - Verify pagination configuration
         call_args = mock_paginator.paginate.call_args
-        pagination_config = call_args[1]['PaginationConfig']
-        
-        assert pagination_config['MaxItems'] == 10000
-        assert pagination_config['PageSize'] == 50
+        pagination_config = call_args[1]["PaginationConfig"]
+
+        assert pagination_config["MaxItems"] == 10000
+        assert pagination_config["PageSize"] == 50
 
 
 class TestTransformCloudTrailEvents:
@@ -315,18 +351,20 @@ class TestTransformCloudTrailEvents:
         events = [
             STS_ASSUME_ROLE_EVENT,
             STS_ASSUME_ROLE_WITH_SAML_EVENT,
-            STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT
+            STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT,
         ]
-        region = 'us-east-1'
-        account_id = '123456789012'
-        
+        region = "us-east-1"
+        account_id = "123456789012"
+
         # Act
-        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
-        
+        result = transform_cloudtrail_events_to_role_assumptions(
+            events, region, account_id
+        )
+
         # Assert
         assert len(result) == 3
         assert result == EXPECTED_TRANSFORMED_ROLE_ASSUMPTIONS
-        
+
         # Verify each transformation individually
         assert result[0] == EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE
         assert result[1] == EXPECTED_ROLE_ASSUMPTION_FROM_SAML
@@ -336,60 +374,83 @@ class TestTransformCloudTrailEvents:
         """Test transformation of a single AssumeRole event."""
         # Arrange
         events = [STS_ASSUME_ROLE_EVENT]
-        region = 'us-east-1'
-        account_id = '123456789012'
-        
+        region = "us-east-1"
+        account_id = "123456789012"
+
         # Act
-        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
-        
+        result = transform_cloudtrail_events_to_role_assumptions(
+            events, region, account_id
+        )
+
         # Assert
         assert len(result) == 1
         assumption = result[0]
-        
-        assert assumption['SourcePrincipal'] == 'arn:aws:iam::123456789012:user/john.doe'
-        assert assumption['DestinationPrincipal'] == 'arn:aws:iam::987654321098:role/CrossAccountRole'
-        assert assumption['Action'] == 'AssumeRole'
-        assert assumption['EventId'] == 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
-        assert assumption['AccountId'] == account_id
-        assert assumption['AwsRegion'] == 'us-east-1'
+
+        assert (
+            assumption["SourcePrincipal"] == "arn:aws:iam::123456789012:user/john.doe"
+        )
+        assert (
+            assumption["DestinationPrincipal"]
+            == "arn:aws:iam::987654321098:role/CrossAccountRole"
+        )
+        assert assumption["Action"] == "AssumeRole"
+        assert assumption["EventId"] == "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+        assert assumption["AccountId"] == account_id
+        assert assumption["AwsRegion"] == "us-east-1"
 
     def test_transform_assume_role_with_saml_event(self):
         """Test transformation of AssumeRoleWithSAML event."""
         # Arrange
         events = [STS_ASSUME_ROLE_WITH_SAML_EVENT]
-        region = 'us-east-1'
-        account_id = '123456789012'
-        
+        region = "us-east-1"
+        account_id = "123456789012"
+
         # Act
-        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
-        
+        result = transform_cloudtrail_events_to_role_assumptions(
+            events, region, account_id
+        )
+
         # Assert
         assert len(result) == 1
         assumption = result[0]
-        
-        assert assumption['SourcePrincipal'] == 'arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com'
-        assert assumption['DestinationPrincipal'] == 'arn:aws:iam::123456789012:role/SAMLRole'
-        assert assumption['Action'] == 'AssumeRoleWithSAML'
-        assert assumption['EventId'] == 'a1b2c3d4-e5f6-7890-1234-567890abcdef'
+
+        assert (
+            assumption["SourcePrincipal"]
+            == "arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com"
+        )
+        assert (
+            assumption["DestinationPrincipal"]
+            == "arn:aws:iam::123456789012:role/SAMLRole"
+        )
+        assert assumption["Action"] == "AssumeRoleWithSAML"
+        assert assumption["EventId"] == "a1b2c3d4-e5f6-7890-1234-567890abcdef"
 
     def test_transform_assume_role_with_web_identity_event(self):
         """Test transformation of AssumeRoleWithWebIdentity event."""
         # Arrange
         events = [STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT]
-        region = 'us-west-2'
-        account_id = '123456789012'
-        
+        region = "us-west-2"
+        account_id = "123456789012"
+
         # Act
-        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
-        
+        result = transform_cloudtrail_events_to_role_assumptions(
+            events, region, account_id
+        )
+
         # Assert
         assert len(result) == 1
         assumption = result[0]
-        
-        assert assumption['SourcePrincipal'] == 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300'
-        assert assumption['DestinationPrincipal'] == 'arn:aws:iam::123456789012:role/WebIdentityRole'
-        assert assumption['Action'] == 'AssumeRoleWithWebIdentity'
-        assert assumption['AwsRegion'] == 'us-west-2'
+
+        assert (
+            assumption["SourcePrincipal"]
+            == "arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300"
+        )
+        assert (
+            assumption["DestinationPrincipal"]
+            == "arn:aws:iam::123456789012:role/WebIdentityRole"
+        )
+        assert assumption["Action"] == "AssumeRoleWithWebIdentity"
+        assert assumption["AwsRegion"] == "us-west-2"
 
     def test_transform_filters_non_sts_events(self):
         """Test that non-STS events are filtered out."""
@@ -397,18 +458,20 @@ class TestTransformCloudTrailEvents:
         events = [
             STS_ASSUME_ROLE_EVENT,
             NON_STS_EVENT,  # This should be filtered out
-            STS_ASSUME_ROLE_WITH_SAML_EVENT
+            STS_ASSUME_ROLE_WITH_SAML_EVENT,
         ]
-        region = 'us-east-1'
-        account_id = '123456789012'
-        
+        region = "us-east-1"
+        account_id = "123456789012"
+
         # Act
-        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
-        
+        result = transform_cloudtrail_events_to_role_assumptions(
+            events, region, account_id
+        )
+
         # Assert
         assert len(result) == 2  # Only 2 STS events should be processed
-        assert result[0]['Action'] == 'AssumeRole'
-        assert result[1]['Action'] == 'AssumeRoleWithSAML'
+        assert result[0]["Action"] == "AssumeRole"
+        assert result[1]["Action"] == "AssumeRoleWithSAML"
 
     def test_transform_handles_malformed_events(self):
         """Test that malformed events are handled gracefully."""
@@ -416,29 +479,33 @@ class TestTransformCloudTrailEvents:
         events = [
             STS_ASSUME_ROLE_EVENT,
             MALFORMED_EVENT,  # This should be skipped
-            STS_ASSUME_ROLE_WITH_SAML_EVENT
+            STS_ASSUME_ROLE_WITH_SAML_EVENT,
         ]
-        region = 'us-east-1'
-        account_id = '123456789012'
-        
+        region = "us-east-1"
+        account_id = "123456789012"
+
         # Act
-        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
-        
+        result = transform_cloudtrail_events_to_role_assumptions(
+            events, region, account_id
+        )
+
         # Assert
         assert len(result) == 2  # Malformed event should be skipped
-        assert result[0]['Action'] == 'AssumeRole'
-        assert result[1]['Action'] == 'AssumeRoleWithSAML'
+        assert result[0]["Action"] == "AssumeRole"
+        assert result[1]["Action"] == "AssumeRoleWithSAML"
 
     def test_transform_empty_events_list(self):
         """Test transformation of empty events list."""
         # Arrange
         events = []
-        region = 'us-east-1'
-        account_id = '123456789012'
-        
+        region = "us-east-1"
+        account_id = "123456789012"
+
         # Act
-        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
-        
+        result = transform_cloudtrail_events_to_role_assumptions(
+            events, region, account_id
+        )
+
         # Assert
         assert result == []
         assert len(result) == 0
@@ -447,24 +514,36 @@ class TestTransformCloudTrailEvents:
         """Test that additional context fields are included in the transformation."""
         # Arrange
         events = [STS_ASSUME_ROLE_EVENT]
-        region = 'us-east-1'
-        account_id = '123456789012'
-        
+        region = "us-east-1"
+        account_id = "123456789012"
+
         # Act
-        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
-        
+        result = transform_cloudtrail_events_to_role_assumptions(
+            events, region, account_id
+        )
+
         # Assert
         assert len(result) == 1
         assumption = result[0]
-        
+
         # Check that all expected fields are present
         expected_fields = [
-            'SourcePrincipal', 'DestinationPrincipal', 'Action', 'EventId',
-            'EventTime', 'SourceIPAddress', 'UserAgent', 'AwsRegion',
-            'AccountId', 'AssumedRoleArn', 'PrincipalArn', 'SessionName',
-            'RequestId', 'RecipientAccountId'
+            "SourcePrincipal",
+            "DestinationPrincipal",
+            "Action",
+            "EventId",
+            "EventTime",
+            "SourceIPAddress",
+            "UserAgent",
+            "AwsRegion",
+            "AccountId",
+            "AssumedRoleArn",
+            "PrincipalArn",
+            "SessionName",
+            "RequestId",
+            "RecipientAccountId",
         ]
-        
+
         for field in expected_fields:
             assert field in assumption
 
@@ -472,38 +551,44 @@ class TestTransformCloudTrailEvents:
         """Test that cross-account role assumptions are correctly identified."""
         # Arrange
         events = [STS_ASSUME_ROLE_EVENT]  # Cross-account assumption
-        region = 'us-east-1'
-        account_id = '123456789012'
-        
+        region = "us-east-1"
+        account_id = "123456789012"
+
         # Act
-        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
-        
+        result = transform_cloudtrail_events_to_role_assumptions(
+            events, region, account_id
+        )
+
         # Assert
         assert len(result) == 1
         assumption = result[0]
-        
+
         # Source account: 123456789012, Destination account: 987654321098
-        assert '123456789012' in assumption['SourcePrincipal']
-        assert '987654321098' in assumption['DestinationPrincipal']
-        assert assumption['RecipientAccountId'] == '987654321098'
+        assert "123456789012" in assumption["SourcePrincipal"]
+        assert "987654321098" in assumption["DestinationPrincipal"]
+        assert assumption["RecipientAccountId"] == "987654321098"
 
     def test_transform_handles_different_regions(self):
         """Test that region parameter is correctly applied."""
         # Arrange
         events = [STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT]
-        test_region = 'ap-southeast-1'
-        account_id = '123456789012'
-        
+        test_region = "ap-southeast-1"
+        account_id = "123456789012"
+
         # Act
-        result = transform_cloudtrail_events_to_role_assumptions(events, test_region, account_id)
-        
+        result = transform_cloudtrail_events_to_role_assumptions(
+            events, test_region, account_id
+        )
+
         # Assert
         assert len(result) == 1
         assumption = result[0]
-        
+
         # Event has AwsRegion: 'us-west-2', but if missing it should fallback to test_region
-        assert assumption['AwsRegion'] == 'us-west-2'  # Should preserve original event region
-        assert assumption['AccountId'] == account_id 
+        assert (
+            assumption["AwsRegion"] == "us-west-2"
+        )  # Should preserve original event region
+        assert assumption["AccountId"] == account_id
 
 
 class TestAggregateRoleAssumptions:
@@ -513,121 +598,153 @@ class TestAggregateRoleAssumptions:
         """Test aggregation of a single role assumption event."""
         # Arrange
         role_assumptions = [EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE]
-        
+
         # Act
         result = _aggregate_role_assumptions(role_assumptions)
-        
+
         # Assert
         assert len(result) == 1
         aggregated = result[0]
-        
-        assert aggregated['source_principal_arn'] == 'arn:aws:iam::123456789012:user/john.doe'
-        assert aggregated['destination_principal_arn'] == 'arn:aws:iam::987654321098:role/CrossAccountRole'
-        assert aggregated['times_used'] == 1
-        assert aggregated['first_seen'] == datetime(2024, 1, 15, 10, 30, 15, 123000)
-        assert aggregated['last_seen'] == datetime(2024, 1, 15, 10, 30, 15, 123000)
-        assert aggregated['lastused'] == datetime(2024, 1, 15, 10, 30, 15, 123000)
+
+        assert (
+            aggregated["source_principal_arn"]
+            == "arn:aws:iam::123456789012:user/john.doe"
+        )
+        assert (
+            aggregated["destination_principal_arn"]
+            == "arn:aws:iam::987654321098:role/CrossAccountRole"
+        )
+        assert aggregated["times_used"] == 1
+        assert aggregated["first_seen"] == datetime(2024, 1, 15, 10, 30, 15, 123000)
+        assert aggregated["last_seen"] == datetime(2024, 1, 15, 10, 30, 15, 123000)
+        assert aggregated["lastused"] == datetime(2024, 1, 15, 10, 30, 15, 123000)
 
     def test_aggregate_multiple_events_same_pair(self):
         """Test aggregation of multiple events for the same (source, destination) pair."""
         # Arrange - Create multiple events with same source/dest but different times
         event1 = {
-            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
-            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
-            'EventTime': datetime(2024, 1, 15, 10, 0, 0),
-            'Action': 'AssumeRole',
-            'EventId': 'event-1'
+            "SourcePrincipal": "arn:aws:iam::123456789012:user/alice",
+            "DestinationPrincipal": "arn:aws:iam::123456789012:role/DataScientist",
+            "EventTime": datetime(2024, 1, 15, 10, 0, 0),
+            "Action": "AssumeRole",
+            "EventId": "event-1",
         }
         event2 = {
-            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
-            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
-            'EventTime': datetime(2024, 1, 15, 14, 30, 0),
-            'Action': 'AssumeRole',
-            'EventId': 'event-2'
+            "SourcePrincipal": "arn:aws:iam::123456789012:user/alice",
+            "DestinationPrincipal": "arn:aws:iam::123456789012:role/DataScientist",
+            "EventTime": datetime(2024, 1, 15, 14, 30, 0),
+            "Action": "AssumeRole",
+            "EventId": "event-2",
         }
         event3 = {
-            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
-            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist', 
-            'EventTime': datetime(2024, 1, 15, 12, 15, 0),
-            'Action': 'AssumeRole',
-            'EventId': 'event-3'
+            "SourcePrincipal": "arn:aws:iam::123456789012:user/alice",
+            "DestinationPrincipal": "arn:aws:iam::123456789012:role/DataScientist",
+            "EventTime": datetime(2024, 1, 15, 12, 15, 0),
+            "Action": "AssumeRole",
+            "EventId": "event-3",
         }
-        
+
         role_assumptions = [event1, event2, event3]
-        
+
         # Act
         result = _aggregate_role_assumptions(role_assumptions)
-        
+
         # Assert
         assert len(result) == 1  # Should aggregate into one relationship
         aggregated = result[0]
-        
-        assert aggregated['source_principal_arn'] == 'arn:aws:iam::123456789012:user/alice'
-        assert aggregated['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/DataScientist'
-        assert aggregated['times_used'] == 3  # Count of events
-        assert aggregated['first_seen'] == datetime(2024, 1, 15, 10, 0, 0)  # Earliest time
-        assert aggregated['last_seen'] == datetime(2024, 1, 15, 14, 30, 0)  # Latest time
-        assert aggregated['lastused'] == datetime(2024, 1, 15, 14, 30, 0)   # Same as last_seen
+
+        assert (
+            aggregated["source_principal_arn"] == "arn:aws:iam::123456789012:user/alice"
+        )
+        assert (
+            aggregated["destination_principal_arn"]
+            == "arn:aws:iam::123456789012:role/DataScientist"
+        )
+        assert aggregated["times_used"] == 3  # Count of events
+        assert aggregated["first_seen"] == datetime(
+            2024, 1, 15, 10, 0, 0
+        )  # Earliest time
+        assert aggregated["last_seen"] == datetime(
+            2024, 1, 15, 14, 30, 0
+        )  # Latest time
+        assert aggregated["lastused"] == datetime(
+            2024, 1, 15, 14, 30, 0
+        )  # Same as last_seen
 
     def test_aggregate_multiple_events_different_pairs(self):
         """Test aggregation of events for different (source, destination) pairs."""
         # Arrange - Different users and roles
         event1 = {
-            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
-            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
-            'EventTime': datetime(2024, 1, 15, 10, 0, 0),
-            'Action': 'AssumeRole',
-            'EventId': 'event-1'
+            "SourcePrincipal": "arn:aws:iam::123456789012:user/alice",
+            "DestinationPrincipal": "arn:aws:iam::123456789012:role/DataScientist",
+            "EventTime": datetime(2024, 1, 15, 10, 0, 0),
+            "Action": "AssumeRole",
+            "EventId": "event-1",
         }
         event2 = {
-            'SourcePrincipal': 'arn:aws:iam::123456789012:user/bob',
-            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/Developer',
-            'EventTime': datetime(2024, 1, 15, 11, 0, 0),
-            'Action': 'AssumeRole',
-            'EventId': 'event-2'
+            "SourcePrincipal": "arn:aws:iam::123456789012:user/bob",
+            "DestinationPrincipal": "arn:aws:iam::123456789012:role/Developer",
+            "EventTime": datetime(2024, 1, 15, 11, 0, 0),
+            "Action": "AssumeRole",
+            "EventId": "event-2",
         }
         event3 = {
-            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
-            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/Developer',  # Alice also assumes Developer
-            'EventTime': datetime(2024, 1, 15, 12, 0, 0),
-            'Action': 'AssumeRole',
-            'EventId': 'event-3'
+            "SourcePrincipal": "arn:aws:iam::123456789012:user/alice",
+            "DestinationPrincipal": "arn:aws:iam::123456789012:role/Developer",  # Alice also assumes Developer
+            "EventTime": datetime(2024, 1, 15, 12, 0, 0),
+            "Action": "AssumeRole",
+            "EventId": "event-3",
         }
-        
+
         role_assumptions = [event1, event2, event3]
-        
+
         # Act
         result = _aggregate_role_assumptions(role_assumptions)
-        
+
         # Assert
         assert len(result) == 3  # Three unique (source, destination) pairs
-        
+
         # Sort for consistent testing
-        result.sort(key=lambda x: (x['source_principal_arn'], x['destination_principal_arn']))
-        
+        result.sort(
+            key=lambda x: (x["source_principal_arn"], x["destination_principal_arn"])
+        )
+
         # Check alice -> DataScientist
-        assert result[0]['source_principal_arn'] == 'arn:aws:iam::123456789012:user/alice'
-        assert result[0]['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/DataScientist'
-        assert result[0]['times_used'] == 1
-        
+        assert (
+            result[0]["source_principal_arn"] == "arn:aws:iam::123456789012:user/alice"
+        )
+        assert (
+            result[0]["destination_principal_arn"]
+            == "arn:aws:iam::123456789012:role/DataScientist"
+        )
+        assert result[0]["times_used"] == 1
+
         # Check alice -> Developer
-        assert result[1]['source_principal_arn'] == 'arn:aws:iam::123456789012:user/alice'
-        assert result[1]['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/Developer'
-        assert result[1]['times_used'] == 1
-        
+        assert (
+            result[1]["source_principal_arn"] == "arn:aws:iam::123456789012:user/alice"
+        )
+        assert (
+            result[1]["destination_principal_arn"]
+            == "arn:aws:iam::123456789012:role/Developer"
+        )
+        assert result[1]["times_used"] == 1
+
         # Check bob -> Developer
-        assert result[2]['source_principal_arn'] == 'arn:aws:iam::123456789012:user/bob'
-        assert result[2]['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/Developer'
-        assert result[2]['times_used'] == 1
+        assert result[2]["source_principal_arn"] == "arn:aws:iam::123456789012:user/bob"
+        assert (
+            result[2]["destination_principal_arn"]
+            == "arn:aws:iam::123456789012:role/Developer"
+        )
+        assert result[2]["times_used"] == 1
 
     def test_aggregate_empty_list(self):
         """Test aggregation of empty role assumptions list."""
         # Arrange
         role_assumptions = []
-        
+
         # Act
         result = _aggregate_role_assumptions(role_assumptions)
-        
+
         # Assert
         assert result == []
         assert len(result) == 0
@@ -636,123 +753,155 @@ class TestAggregateRoleAssumptions:
         """Test that incomplete events (missing required fields) are skipped."""
         # Arrange
         incomplete_event1 = {
-            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+            "SourcePrincipal": "arn:aws:iam::123456789012:user/alice",
             # Missing DestinationPrincipal
-            'EventTime': datetime(2024, 1, 15, 10, 0, 0),
+            "EventTime": datetime(2024, 1, 15, 10, 0, 0),
         }
         incomplete_event2 = {
             # Missing SourcePrincipal
-            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
-            'EventTime': datetime(2024, 1, 15, 10, 0, 0),
+            "DestinationPrincipal": "arn:aws:iam::123456789012:role/DataScientist",
+            "EventTime": datetime(2024, 1, 15, 10, 0, 0),
         }
         incomplete_event3 = {
-            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
-            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
+            "SourcePrincipal": "arn:aws:iam::123456789012:user/alice",
+            "DestinationPrincipal": "arn:aws:iam::123456789012:role/DataScientist",
             # Missing EventTime
         }
         complete_event = {
-            'SourcePrincipal': 'arn:aws:iam::123456789012:user/bob',
-            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/Developer',
-            'EventTime': datetime(2024, 1, 15, 11, 0, 0),
-            'Action': 'AssumeRole',
-            'EventId': 'complete-event'
+            "SourcePrincipal": "arn:aws:iam::123456789012:user/bob",
+            "DestinationPrincipal": "arn:aws:iam::123456789012:role/Developer",
+            "EventTime": datetime(2024, 1, 15, 11, 0, 0),
+            "Action": "AssumeRole",
+            "EventId": "complete-event",
         }
-        
-        role_assumptions = [incomplete_event1, incomplete_event2, incomplete_event3, complete_event]
-        
+
+        role_assumptions = [
+            incomplete_event1,
+            incomplete_event2,
+            incomplete_event3,
+            complete_event,
+        ]
+
         # Act
         result = _aggregate_role_assumptions(role_assumptions)
-        
+
         # Assert - Only the complete event should be processed
         assert len(result) == 1
-        assert result[0]['source_principal_arn'] == 'arn:aws:iam::123456789012:user/bob'
-        assert result[0]['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/Developer'
+        assert result[0]["source_principal_arn"] == "arn:aws:iam::123456789012:user/bob"
+        assert (
+            result[0]["destination_principal_arn"]
+            == "arn:aws:iam::123456789012:role/Developer"
+        )
 
     def test_aggregate_mixed_event_types(self):
         """Test aggregation with different STS event types."""
         # Arrange - Use the predefined test data
         role_assumptions = EXPECTED_TRANSFORMED_ROLE_ASSUMPTIONS
-        
+
         # Act
         result = _aggregate_role_assumptions(role_assumptions)
-        
+
         # Assert - Each should create a separate aggregated relationship
         assert len(result) == 3
-        
+
         # Verify each aggregated relationship has correct structure
         for aggregated in result:
-            assert 'source_principal_arn' in aggregated
-            assert 'destination_principal_arn' in aggregated
-            assert aggregated['times_used'] == 1  # Each is a single event
-            assert 'first_seen' in aggregated
-            assert 'last_seen' in aggregated
-            assert 'lastused' in aggregated
-            assert aggregated['lastused'] == aggregated['last_seen']
+            assert "source_principal_arn" in aggregated
+            assert "destination_principal_arn" in aggregated
+            assert aggregated["times_used"] == 1  # Each is a single event
+            assert "first_seen" in aggregated
+            assert "last_seen" in aggregated
+            assert "lastused" in aggregated
+            assert aggregated["lastused"] == aggregated["last_seen"]
 
     def test_aggregate_with_predefined_multiple_events(self):
         """Test aggregation using predefined test data for multiple events of same pair."""
         # Arrange - Use predefined test data with multiple events for same (source, destination)
         role_assumptions = MULTIPLE_ASSUME_ROLE_EVENTS_SAME_PAIR
-        
+
         # Act
         result = _aggregate_role_assumptions(role_assumptions)
-        
+
         # Assert
         assert len(result) == 1  # Should aggregate into single relationship
         aggregated = result[0]
-        
+
         # Compare against expected aggregated result
         expected = EXPECTED_AGGREGATED_ALICE_DATASCIENTIST
-        assert aggregated['source_principal_arn'] == expected['source_principal_arn']
-        assert aggregated['destination_principal_arn'] == expected['destination_principal_arn']
-        assert aggregated['times_used'] == expected['times_used']
-        assert aggregated['first_seen'] == expected['first_seen']
-        assert aggregated['last_seen'] == expected['last_seen']
-        assert aggregated['lastused'] == expected['lastused']
+        assert aggregated["source_principal_arn"] == expected["source_principal_arn"]
+        assert (
+            aggregated["destination_principal_arn"]
+            == expected["destination_principal_arn"]
+        )
+        assert aggregated["times_used"] == expected["times_used"]
+        assert aggregated["first_seen"] == expected["first_seen"]
+        assert aggregated["last_seen"] == expected["last_seen"]
+        assert aggregated["lastused"] == expected["lastused"]
 
     def test_aggregate_cross_account_and_different_source_types(self):
         """Test aggregation with cross-account events and different source types."""
         # Arrange - Use predefined test data with different source types
         role_assumptions = CROSS_ACCOUNT_ROLE_ASSUMPTION_EVENTS
-        
+
         # Act
         result = _aggregate_role_assumptions(role_assumptions)
-        
+
         # Assert
         assert len(result) == 3  # Each should be a separate relationship
-        
+
         # Sort for consistent testing
-        result.sort(key=lambda x: x['source_principal_arn'])
-        
+        result.sort(key=lambda x: x["source_principal_arn"])
+
         # Check Role -> Role (appears first alphabetically)
-        assert result[0]['source_principal_arn'] == 'arn:aws:iam::123456789012:role/ApplicationRole'
-        assert result[0]['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/DataAccessRole'
-        
+        assert (
+            result[0]["source_principal_arn"]
+            == "arn:aws:iam::123456789012:role/ApplicationRole"
+        )
+        assert (
+            result[0]["destination_principal_arn"]
+            == "arn:aws:iam::123456789012:role/DataAccessRole"
+        )
+
         # Check User -> CrossAccountRole
-        assert result[1]['source_principal_arn'] == 'arn:aws:iam::123456789012:user/service-account'
-        assert result[1]['destination_principal_arn'] == 'arn:aws:iam::987654321098:role/CrossAccountRole'
-        
+        assert (
+            result[1]["source_principal_arn"]
+            == "arn:aws:iam::123456789012:user/service-account"
+        )
+        assert (
+            result[1]["destination_principal_arn"]
+            == "arn:aws:iam::987654321098:role/CrossAccountRole"
+        )
+
         # Check Federated -> Role
-        assert result[2]['source_principal_arn'] == 'arn:aws:sts::123456789012:federated-user/external-user'
-        assert result[2]['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/FederatedRole'
-        
+        assert (
+            result[2]["source_principal_arn"]
+            == "arn:aws:sts::123456789012:federated-user/external-user"
+        )
+        assert (
+            result[2]["destination_principal_arn"]
+            == "arn:aws:iam::123456789012:role/FederatedRole"
+        )
+
         # Verify all have single usage count
         for aggregated in result:
-            assert aggregated['times_used'] == 1
+            assert aggregated["times_used"] == 1
 
     def test_aggregate_with_incomplete_events_using_test_data(self):
         """Test aggregation with incomplete events using predefined test data."""
         # Arrange - Mix complete and incomplete events
         complete_event = EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE
         role_assumptions = INCOMPLETE_ROLE_ASSUMPTION_EVENTS + [complete_event]
-        
+
         # Act
         result = _aggregate_role_assumptions(role_assumptions)
-        
+
         # Assert - Only the complete event should be processed
         assert len(result) == 1
-        assert result[0]['source_principal_arn'] == complete_event['SourcePrincipal']
-        assert result[0]['destination_principal_arn'] == complete_event['DestinationPrincipal']
+        assert result[0]["source_principal_arn"] == complete_event["SourcePrincipal"]
+        assert (
+            result[0]["destination_principal_arn"]
+            == complete_event["DestinationPrincipal"]
+        )
 
 
 class TestLoadRoleAssumptions:
@@ -764,56 +913,68 @@ class TestLoadRoleAssumptions:
         mock_session = MagicMock()
         role_assumptions = [
             {
-                'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
-                'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
-                'EventTime': datetime(2024, 1, 15, 10, 0, 0),
-                'Action': 'AssumeRole',
-                'EventId': 'event-1'
+                "SourcePrincipal": "arn:aws:iam::123456789012:user/alice",
+                "DestinationPrincipal": "arn:aws:iam::123456789012:role/DataScientist",
+                "EventTime": datetime(2024, 1, 15, 10, 0, 0),
+                "Action": "AssumeRole",
+                "EventId": "event-1",
             }
         ]
-        region = 'us-east-1'
-        account_id = '123456789012'
+        region = "us-east-1"
+        account_id = "123456789012"
         update_tag = 1705312345
-        
+
         # Act
-        load_role_assumptions(mock_session, role_assumptions, region, account_id, update_tag)
-        
+        load_role_assumptions(
+            mock_session, role_assumptions, region, account_id, update_tag
+        )
+
         # Assert - Verify Neo4j session was called with correct query
         mock_session.run.assert_called_once()
         call_args = mock_session.run.call_args
-        
+
         # Check that the Cypher query contains expected patterns
         query = call_args[0][0]
-        assert 'UNWIND $assumptions AS assumption' in query
-        assert 'CALL {' in query  # UNION subquery for source node discovery
-        assert 'MATCH (source:AWSUser' in query
-        assert 'MATCH (source:AWSRole' in query
-        assert 'MATCH (source:AWSPrincipal' in query
-        assert 'MERGE (dest:AWSRole {arn: assumption.destination_principal_arn})' in query
-        assert 'MERGE (source_node)-[rel:ASSUMED_ROLE]->(dest)' in query
-        
+        assert "UNWIND $assumptions AS assumption" in query
+        assert "CALL {" in query  # UNION subquery for source node discovery
+        assert "MATCH (source:AWSUser" in query
+        assert "MATCH (source:AWSRole" in query
+        assert "MATCH (source:AWSPrincipal" in query
+        assert (
+            "MERGE (dest:AWSRole {arn: assumption.destination_principal_arn})" in query
+        )
+        assert "MERGE (source_node)-[rel:ASSUMED_ROLE]->(dest)" in query
+
         # Check parameters
         params = call_args[1]
-        assert 'assumptions' in params
-        assert 'aws_update_tag' in params
-        assert params['aws_update_tag'] == update_tag
-        
+        assert "assumptions" in params
+        assert "aws_update_tag" in params
+        assert params["aws_update_tag"] == update_tag
+
         # Check aggregated data structure
-        aggregated_data = params['assumptions']
+        aggregated_data = params["assumptions"]
         assert len(aggregated_data) == 1
-        assert aggregated_data[0]['source_principal_arn'] == 'arn:aws:iam::123456789012:user/alice'
-        assert aggregated_data[0]['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/DataScientist'
-        assert aggregated_data[0]['times_used'] == 1
+        assert (
+            aggregated_data[0]["source_principal_arn"]
+            == "arn:aws:iam::123456789012:user/alice"
+        )
+        assert (
+            aggregated_data[0]["destination_principal_arn"]
+            == "arn:aws:iam::123456789012:role/DataScientist"
+        )
+        assert aggregated_data[0]["times_used"] == 1
 
     def test_load_role_assumptions_empty_list(self):
         """Test that empty role assumptions list is handled gracefully."""
         # Arrange
         mock_session = MagicMock()
         role_assumptions = []
-        
+
         # Act
-        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
-        
+        load_role_assumptions(
+            mock_session, role_assumptions, "us-east-1", "123456789012", 1705312345
+        )
+
         # Assert - Should return early without calling Neo4j
         mock_session.run.assert_not_called()
 
@@ -821,153 +982,179 @@ class TestLoadRoleAssumptions:
         """Test loading with complex aggregation scenarios."""
         # Arrange
         mock_session = MagicMock()
-        
+
         # Multiple events that should aggregate
         role_assumptions = [
             {
-                'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
-                'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
-                'EventTime': datetime(2024, 1, 15, 10, 0, 0),
-                'Action': 'AssumeRole',
-                'EventId': 'event-1'
+                "SourcePrincipal": "arn:aws:iam::123456789012:user/alice",
+                "DestinationPrincipal": "arn:aws:iam::123456789012:role/DataScientist",
+                "EventTime": datetime(2024, 1, 15, 10, 0, 0),
+                "Action": "AssumeRole",
+                "EventId": "event-1",
             },
             {
-                'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
-                'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
-                'EventTime': datetime(2024, 1, 15, 14, 0, 0),
-                'Action': 'AssumeRole',
-                'EventId': 'event-2'
+                "SourcePrincipal": "arn:aws:iam::123456789012:user/alice",
+                "DestinationPrincipal": "arn:aws:iam::123456789012:role/DataScientist",
+                "EventTime": datetime(2024, 1, 15, 14, 0, 0),
+                "Action": "AssumeRole",
+                "EventId": "event-2",
             },
             {
-                'SourcePrincipal': 'arn:aws:iam::123456789012:user/bob',
-                'DestinationPrincipal': 'arn:aws:iam::123456789012:role/Developer',
-                'EventTime': datetime(2024, 1, 15, 12, 0, 0),
-                'Action': 'AssumeRole',
-                'EventId': 'event-3'
-            }
+                "SourcePrincipal": "arn:aws:iam::123456789012:user/bob",
+                "DestinationPrincipal": "arn:aws:iam::123456789012:role/Developer",
+                "EventTime": datetime(2024, 1, 15, 12, 0, 0),
+                "Action": "AssumeRole",
+                "EventId": "event-3",
+            },
         ]
-        
+
         # Act
-        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
-        
+        load_role_assumptions(
+            mock_session, role_assumptions, "us-east-1", "123456789012", 1705312345
+        )
+
         # Assert
         mock_session.run.assert_called_once()
         call_args = mock_session.run.call_args
         params = call_args[1]
-        
+
         # Should have 2 aggregated relationships (alice->DataScientist aggregated, bob->Developer separate)
-        aggregated_data = params['assumptions']
+        aggregated_data = params["assumptions"]
         assert len(aggregated_data) == 2
-        
+
         # Find alice's aggregated relationship
         alice_relationship = next(
-            (item for item in aggregated_data 
-             if item['source_principal_arn'] == 'arn:aws:iam::123456789012:user/alice'), 
-            None
+            (
+                item
+                for item in aggregated_data
+                if item["source_principal_arn"]
+                == "arn:aws:iam::123456789012:user/alice"
+            ),
+            None,
         )
         assert alice_relationship is not None
-        assert alice_relationship['times_used'] == 2  # Two events aggregated
-        assert alice_relationship['first_seen'] == datetime(2024, 1, 15, 10, 0, 0)  # Earlier time
-        assert alice_relationship['last_seen'] == datetime(2024, 1, 15, 14, 0, 0)   # Later time
-        
+        assert alice_relationship["times_used"] == 2  # Two events aggregated
+        assert alice_relationship["first_seen"] == datetime(
+            2024, 1, 15, 10, 0, 0
+        )  # Earlier time
+        assert alice_relationship["last_seen"] == datetime(
+            2024, 1, 15, 14, 0, 0
+        )  # Later time
+
         # Find bob's relationship
         bob_relationship = next(
-            (item for item in aggregated_data 
-             if item['source_principal_arn'] == 'arn:aws:iam::123456789012:user/bob'), 
-            None
+            (
+                item
+                for item in aggregated_data
+                if item["source_principal_arn"] == "arn:aws:iam::123456789012:user/bob"
+            ),
+            None,
         )
         assert bob_relationship is not None
-        assert bob_relationship['times_used'] == 1  # Single event
+        assert bob_relationship["times_used"] == 1  # Single event
 
     def test_load_role_assumptions_cypher_query_structure(self):
         """Test that the generated Cypher query has the correct structure for temporal aggregation."""
         # Arrange
         mock_session = MagicMock()
         role_assumptions = [EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE]
-        
+
         # Act
-        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
-        
+        load_role_assumptions(
+            mock_session, role_assumptions, "us-east-1", "123456789012", 1705312345
+        )
+
         # Assert - Check detailed query structure
         call_args = mock_session.run.call_args
         query = call_args[0][0]
-        
+
         # Verify temporal aggregation logic is present
-        assert 'SET rel.lastused = COALESCE(' in query
-        assert 'CASE WHEN assumption.last_seen >' in query
-        assert 'rel.times_used = COALESCE(rel.times_used, 0) + assumption.times_used' in query
-        assert 'rel.first_seen = COALESCE(' in query
-        assert 'CASE WHEN assumption.first_seen <' in query
-        assert 'rel.last_seen = COALESCE(' in query
-        assert 'rel.lastupdated = $aws_update_tag' in query
-        
+        assert "SET rel.lastused = COALESCE(" in query
+        assert "CASE WHEN assumption.last_seen >" in query
+        assert (
+            "rel.times_used = COALESCE(rel.times_used, 0) + assumption.times_used"
+            in query
+        )
+        assert "rel.first_seen = COALESCE(" in query
+        assert "CASE WHEN assumption.first_seen <" in query
+        assert "rel.last_seen = COALESCE(" in query
+        assert "rel.lastupdated = $aws_update_tag" in query
+
         # Verify UNION structure for source node discovery
-        assert 'UNION' in query
-        assert query.count('UNION') == 2  # Two UNION clauses for three branches
+        assert "UNION" in query
+        assert query.count("UNION") == 2  # Two UNION clauses for three branches
 
     def test_load_role_assumptions_with_real_test_data(self):
         """Test loading using the predefined test data."""
         # Arrange
         mock_session = MagicMock()
         role_assumptions = EXPECTED_TRANSFORMED_ROLE_ASSUMPTIONS
-        
+
         # Act
-        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
-        
+        load_role_assumptions(
+            mock_session, role_assumptions, "us-east-1", "123456789012", 1705312345
+        )
+
         # Assert
         mock_session.run.assert_called_once()
         call_args = mock_session.run.call_args
         params = call_args[1]
-        
+
         # Should have 3 aggregated relationships (one for each different assumption)
-        aggregated_data = params['assumptions']
+        aggregated_data = params["assumptions"]
         assert len(aggregated_data) == 3
-        
+
         # Verify each has the required structure
         for assumption in aggregated_data:
-            assert 'source_principal_arn' in assumption
-            assert 'destination_principal_arn' in assumption
-            assert 'times_used' in assumption
-            assert 'first_seen' in assumption
-            assert 'last_seen' in assumption
-            assert 'lastused' in assumption
-            
+            assert "source_principal_arn" in assumption
+            assert "destination_principal_arn" in assumption
+            assert "times_used" in assumption
+            assert "first_seen" in assumption
+            assert "last_seen" in assumption
+            assert "lastused" in assumption
+
             # Verify lastused equals last_seen
-            assert assumption['lastused'] == assumption['last_seen']
+            assert assumption["lastused"] == assumption["last_seen"]
 
     def test_load_role_assumptions_query_patterns_comprehensive(self):
         """Test that all expected Cypher query patterns are present."""
         # Arrange
         mock_session = MagicMock()
         role_assumptions = [EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE]
-        
+
         # Act
-        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
-        
+        load_role_assumptions(
+            mock_session, role_assumptions, "us-east-1", "123456789012", 1705312345
+        )
+
         # Assert - Check all expected patterns are in the query
         call_args = mock_session.run.call_args
         query = call_args[0][0]
-        
+
         for pattern_name, pattern in EXPECTED_CYPHER_QUERY_PATTERNS.items():
-            assert pattern in query, f"Expected pattern '{pattern_name}' not found in query"
+            assert (
+                pattern in query
+            ), f"Expected pattern '{pattern_name}' not found in query"
 
     def test_load_role_assumptions_with_multiple_events_same_pair(self):
         """Test loading with multiple events that should aggregate into one relationship."""
         # Arrange
         mock_session = MagicMock()
         role_assumptions = MULTIPLE_ASSUME_ROLE_EVENTS_SAME_PAIR
-        
+
         # Act
-        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
-        
+        load_role_assumptions(
+            mock_session, role_assumptions, "us-east-1", "123456789012", 1705312345
+        )
+
         # Assert
         call_args = mock_session.run.call_args
         params = call_args[1]
-        
+
         # Should have 1 aggregated relationship (all events for same pair)
-        aggregated_data = params['assumptions']
+        aggregated_data = params["assumptions"]
         assert len(aggregated_data) == 1
-        
+
         # Verify aggregation matches expected
         aggregated = aggregated_data[0]
         expected = EXPECTED_AGGREGATED_ALICE_DATASCIENTIST
@@ -978,105 +1165,129 @@ class TestLoadRoleAssumptions:
         # Arrange
         mock_session = MagicMock()
         role_assumptions = CROSS_ACCOUNT_ROLE_ASSUMPTION_EVENTS
-        
+
         # Act
-        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
-        
+        load_role_assumptions(
+            mock_session, role_assumptions, "us-east-1", "123456789012", 1705312345
+        )
+
         # Assert
         call_args = mock_session.run.call_args
         params = call_args[1]
-        
+
         # Should have 3 separate relationships (different source-destination pairs)
-        aggregated_data = params['assumptions']
+        aggregated_data = params["assumptions"]
         assert len(aggregated_data) == 3
-        
+
         # Check that we have the expected ARN patterns
-        source_arns = {item['source_principal_arn'] for item in aggregated_data}
-        dest_arns = {item['destination_principal_arn'] for item in aggregated_data}
-        
+        source_arns = {item["source_principal_arn"] for item in aggregated_data}
+        dest_arns = {item["destination_principal_arn"] for item in aggregated_data}
+
         # Verify we have different source types
-        assert 'arn:aws:iam::123456789012:user/service-account' in source_arns  # User
-        assert 'arn:aws:iam::123456789012:role/ApplicationRole' in source_arns  # Role
-        assert 'arn:aws:sts::123456789012:federated-user/external-user' in source_arns  # Federated
-        
+        assert "arn:aws:iam::123456789012:user/service-account" in source_arns  # User
+        assert "arn:aws:iam::123456789012:role/ApplicationRole" in source_arns  # Role
+        assert (
+            "arn:aws:sts::123456789012:federated-user/external-user" in source_arns
+        )  # Federated
+
         # Verify we have cross-account destination
-        assert 'arn:aws:iam::987654321098:role/CrossAccountRole' in dest_arns
+        assert "arn:aws:iam::987654321098:role/CrossAccountRole" in dest_arns
 
     def test_load_role_assumptions_parameter_validation(self):
         """Test that the correct parameters are passed to Neo4j session."""
         # Arrange
         mock_session = MagicMock()
         role_assumptions = [EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE]
-        region = 'eu-west-1'
-        account_id = '999888777666'
+        region = "eu-west-1"
+        account_id = "999888777666"
         update_tag = 1234567890
-        
+
         # Act
-        load_role_assumptions(mock_session, role_assumptions, region, account_id, update_tag)
-        
+        load_role_assumptions(
+            mock_session, role_assumptions, region, account_id, update_tag
+        )
+
         # Assert - Verify exact parameter values
         call_args = mock_session.run.call_args
         params = call_args[1]
-        
-        assert params['aws_update_tag'] == update_tag
-        assert 'assumptions' in params
-        assert isinstance(params['assumptions'], list)
-        assert len(params['assumptions']) == 1
-        
+
+        assert params["aws_update_tag"] == update_tag
+        assert "assumptions" in params
+        assert isinstance(params["assumptions"], list)
+        assert len(params["assumptions"]) == 1
+
         # Verify the aggregated assumption structure
-        assumption = params['assumptions'][0]
-        assert assumption['source_principal_arn'] == 'arn:aws:iam::123456789012:user/john.doe'
-        assert assumption['destination_principal_arn'] == 'arn:aws:iam::987654321098:role/CrossAccountRole'
-        assert assumption['times_used'] == 1
+        assumption = params["assumptions"][0]
+        assert (
+            assumption["source_principal_arn"]
+            == "arn:aws:iam::123456789012:user/john.doe"
+        )
+        assert (
+            assumption["destination_principal_arn"]
+            == "arn:aws:iam::987654321098:role/CrossAccountRole"
+        )
+        assert assumption["times_used"] == 1
 
     def test_load_role_assumptions_handles_incomplete_data_gracefully(self):
         """Test that incomplete events are filtered out during aggregation."""
         # Arrange
         mock_session = MagicMock()
-        
+
         # Mix incomplete and complete events
         complete_event = EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE
         role_assumptions = INCOMPLETE_ROLE_ASSUMPTION_EVENTS + [complete_event]
-        
+
         # Act
-        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
-        
+        load_role_assumptions(
+            mock_session, role_assumptions, "us-east-1", "123456789012", 1705312345
+        )
+
         # Assert - Only complete event should be processed
         call_args = mock_session.run.call_args
         params = call_args[1]
-        
-        aggregated_data = params['assumptions']
+
+        aggregated_data = params["assumptions"]
         assert len(aggregated_data) == 1  # Only the complete event
-        assert aggregated_data[0]['source_principal_arn'] == complete_event['SourcePrincipal']
-        assert aggregated_data[0]['destination_principal_arn'] == complete_event['DestinationPrincipal']
+        assert (
+            aggregated_data[0]["source_principal_arn"]
+            == complete_event["SourcePrincipal"]
+        )
+        assert (
+            aggregated_data[0]["destination_principal_arn"]
+            == complete_event["DestinationPrincipal"]
+        )
 
 
 class TestSyncFunction:
     """Test suite for the main sync orchestration function."""
 
-    @patch('cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events')
-    @patch('cartography.intel.aws.cloudtrail_management_events.transform_cloudtrail_events_to_role_assumptions')
-    @patch('cartography.intel.aws.cloudtrail_management_events.load_role_assumptions')
-    def test_sync_success_with_lookback_hours(self, mock_load, mock_transform, mock_get_events):
+    @patch("cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events")
+    @patch(
+        "cartography.intel.aws.cloudtrail_management_events.transform_cloudtrail_events_to_role_assumptions"
+    )
+    @patch("cartography.intel.aws.cloudtrail_management_events.load_role_assumptions")
+    def test_sync_success_with_lookback_hours(
+        self, mock_load, mock_transform, mock_get_events
+    ):
         """Test successful sync with lookback hours specified."""
         # Arrange
         mock_neo4j_session = MagicMock()
         mock_boto3_session = MagicMock()
-        regions = ['us-east-1', 'us-west-2']
-        account_id = '123456789012'
+        regions = ["us-east-1", "us-west-2"]
+        account_id = "123456789012"
         update_tag = 1705312345
         common_job_parameters = {
-            'aws_cloudtrail_management_events_lookback_hours': 24,
-            'UPDATE_TAG': update_tag,
+            "aws_cloudtrail_management_events_lookback_hours": 24,
+            "UPDATE_TAG": update_tag,
         }
-        
+
         # Mock return values
         mock_events = [STS_ASSUME_ROLE_EVENT, STS_ASSUME_ROLE_WITH_SAML_EVENT]
         mock_role_assumptions = [EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE]
-        
+
         mock_get_events.return_value = mock_events
         mock_transform.return_value = mock_role_assumptions
-        
+
         # Act
         sync(
             neo4j_session=mock_neo4j_session,
@@ -1086,35 +1297,47 @@ class TestSyncFunction:
             update_tag=update_tag,
             common_job_parameters=common_job_parameters,
         )
-        
+
         # Assert - Verify all components were called correctly
         assert mock_get_events.call_count == 2  # Called for each region
-        assert mock_transform.call_count == 2   # Called for each region
+        assert mock_transform.call_count == 2  # Called for each region
         mock_load.assert_called_once()
-        
+
         # Verify get_cloudtrail_events calls
         expected_calls = [
-            call(boto3_session=mock_boto3_session, region='us-east-1', lookback_hours=24),
-            call(boto3_session=mock_boto3_session, region='us-west-2', lookback_hours=24)
+            call(
+                boto3_session=mock_boto3_session, region="us-east-1", lookback_hours=24
+            ),
+            call(
+                boto3_session=mock_boto3_session, region="us-west-2", lookback_hours=24
+            ),
         ]
         mock_get_events.assert_has_calls(expected_calls, any_order=True)
-        
+
         # Verify transform calls
         transform_calls = [
-            call(events=mock_events, region='us-east-1', current_aws_account_id=account_id),
-            call(events=mock_events, region='us-west-2', current_aws_account_id=account_id)
+            call(
+                events=mock_events,
+                region="us-east-1",
+                current_aws_account_id=account_id,
+            ),
+            call(
+                events=mock_events,
+                region="us-west-2",
+                current_aws_account_id=account_id,
+            ),
         ]
         mock_transform.assert_has_calls(transform_calls, any_order=True)
-        
+
         # Verify load call
         load_call_args = mock_load.call_args
-        assert load_call_args[1]['neo4j_session'] == mock_neo4j_session
-        assert load_call_args[1]['region'] == 'all'  # Cross-region aggregation
-        assert load_call_args[1]['current_aws_account_id'] == account_id
-        assert load_call_args[1]['aws_update_tag'] == update_tag
-        
+        assert load_call_args[1]["neo4j_session"] == mock_neo4j_session
+        assert load_call_args[1]["region"] == "all"  # Cross-region aggregation
+        assert load_call_args[1]["current_aws_account_id"] == account_id
+        assert load_call_args[1]["aws_update_tag"] == update_tag
+
         # Verify role assumptions were aggregated from all regions
-        role_assumptions_arg = load_call_args[1]['role_assumptions']
+        role_assumptions_arg = load_call_args[1]["role_assumptions"]
         assert len(role_assumptions_arg) == 2  # One from each region
 
     def test_sync_skipped_when_no_lookback_hours(self):
@@ -1123,21 +1346,23 @@ class TestSyncFunction:
         mock_neo4j_session = MagicMock()
         mock_boto3_session = MagicMock()
         common_job_parameters = {
-            'UPDATE_TAG': 1705312345,
+            "UPDATE_TAG": 1705312345,
             # No aws_cloudtrail_management_events_lookback_hours specified
         }
-        
+
         # Act
-        with patch('cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events') as mock_get_events:
+        with patch(
+            "cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events"
+        ) as mock_get_events:
             sync(
                 neo4j_session=mock_neo4j_session,
                 boto3_session=mock_boto3_session,
-                regions=['us-east-1'],
-                current_aws_account_id='123456789012',
+                regions=["us-east-1"],
+                current_aws_account_id="123456789012",
                 update_tag=1705312345,
                 common_job_parameters=common_job_parameters,
             )
-        
+
         # Assert - No CloudTrail API calls should be made
         mock_get_events.assert_not_called()
 
@@ -1147,51 +1372,57 @@ class TestSyncFunction:
         mock_neo4j_session = MagicMock()
         mock_boto3_session = MagicMock()
         common_job_parameters = {
-            'aws_cloudtrail_management_events_lookback_hours': None,
-            'UPDATE_TAG': 1705312345,
+            "aws_cloudtrail_management_events_lookback_hours": None,
+            "UPDATE_TAG": 1705312345,
         }
-        
+
         # Act
-        with patch('cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events') as mock_get_events:
+        with patch(
+            "cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events"
+        ) as mock_get_events:
             sync(
                 neo4j_session=mock_neo4j_session,
                 boto3_session=mock_boto3_session,
-                regions=['us-east-1'],
-                current_aws_account_id='123456789012',
+                regions=["us-east-1"],
+                current_aws_account_id="123456789012",
                 update_tag=1705312345,
                 common_job_parameters=common_job_parameters,
             )
-        
+
         # Assert - No CloudTrail API calls should be made
         mock_get_events.assert_not_called()
 
-    @patch('cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events')
-    @patch('cartography.intel.aws.cloudtrail_management_events.transform_cloudtrail_events_to_role_assumptions')
-    @patch('cartography.intel.aws.cloudtrail_management_events.load_role_assumptions')
-    def test_sync_continues_on_region_failure(self, mock_load, mock_transform, mock_get_events):
+    @patch("cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events")
+    @patch(
+        "cartography.intel.aws.cloudtrail_management_events.transform_cloudtrail_events_to_role_assumptions"
+    )
+    @patch("cartography.intel.aws.cloudtrail_management_events.load_role_assumptions")
+    def test_sync_continues_on_region_failure(
+        self, mock_load, mock_transform, mock_get_events
+    ):
         """Test that sync continues processing other regions when one region fails."""
         # Arrange
         mock_neo4j_session = MagicMock()
         mock_boto3_session = MagicMock()
-        regions = ['us-east-1', 'us-west-2', 'eu-west-1']
-        account_id = '123456789012'
+        regions = ["us-east-1", "us-west-2", "eu-west-1"]
+        account_id = "123456789012"
         update_tag = 1705312345
         common_job_parameters = {
-            'aws_cloudtrail_management_events_lookback_hours': 24,
-            'UPDATE_TAG': update_tag,
+            "aws_cloudtrail_management_events_lookback_hours": 24,
+            "UPDATE_TAG": update_tag,
         }
-        
+
         # Mock get_cloudtrail_events to fail on second region
         mock_events = [STS_ASSUME_ROLE_EVENT]
         mock_role_assumptions = [EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE]
-        
+
         mock_get_events.side_effect = [
             mock_events,  # Success for us-east-1
             Exception("Access denied for us-west-2"),  # Failure for us-west-2
             mock_events,  # Success for eu-west-1
         ]
         mock_transform.return_value = mock_role_assumptions
-        
+
         # Act
         sync(
             neo4j_session=mock_neo4j_session,
@@ -1201,39 +1432,43 @@ class TestSyncFunction:
             update_tag=update_tag,
             common_job_parameters=common_job_parameters,
         )
-        
+
         # Assert - Should have attempted all 3 regions
         assert mock_get_events.call_count == 3
-        
+
         # Should have transformed and loaded data from successful regions only
         assert mock_transform.call_count == 2  # Only successful regions
         mock_load.assert_called_once()
-        
+
         # Verify the aggregated role assumptions include data from successful regions
         load_call_args = mock_load.call_args
-        role_assumptions_arg = load_call_args[1]['role_assumptions']
+        role_assumptions_arg = load_call_args[1]["role_assumptions"]
         assert len(role_assumptions_arg) == 2  # From 2 successful regions
 
-    @patch('cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events')
-    @patch('cartography.intel.aws.cloudtrail_management_events.transform_cloudtrail_events_to_role_assumptions')
-    @patch('cartography.intel.aws.cloudtrail_management_events.load_role_assumptions')
-    def test_sync_with_no_events_found(self, mock_load, mock_transform, mock_get_events):
+    @patch("cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events")
+    @patch(
+        "cartography.intel.aws.cloudtrail_management_events.transform_cloudtrail_events_to_role_assumptions"
+    )
+    @patch("cartography.intel.aws.cloudtrail_management_events.load_role_assumptions")
+    def test_sync_with_no_events_found(
+        self, mock_load, mock_transform, mock_get_events
+    ):
         """Test sync behavior when no CloudTrail events are found."""
         # Arrange
         mock_neo4j_session = MagicMock()
         mock_boto3_session = MagicMock()
-        regions = ['us-east-1']
-        account_id = '123456789012'
+        regions = ["us-east-1"]
+        account_id = "123456789012"
         update_tag = 1705312345
         common_job_parameters = {
-            'aws_cloudtrail_management_events_lookback_hours': 72,
-            'UPDATE_TAG': update_tag,
+            "aws_cloudtrail_management_events_lookback_hours": 72,
+            "UPDATE_TAG": update_tag,
         }
-        
+
         # Mock empty results
         mock_get_events.return_value = []
         mock_transform.return_value = []
-        
+
         # Act
         sync(
             neo4j_session=mock_neo4j_session,
@@ -1243,36 +1478,38 @@ class TestSyncFunction:
             update_tag=update_tag,
             common_job_parameters=common_job_parameters,
         )
-        
+
         # Assert - Functions should be called but no data loaded
         mock_get_events.assert_called_once()
         mock_transform.assert_called_once()
         mock_load.assert_not_called()  # Should not load empty data
 
-    @patch('cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events')
-    @patch('cartography.intel.aws.cloudtrail_management_events.transform_cloudtrail_events_to_role_assumptions')
-    @patch('cartography.intel.aws.cloudtrail_management_events.load_role_assumptions')
+    @patch("cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events")
+    @patch(
+        "cartography.intel.aws.cloudtrail_management_events.transform_cloudtrail_events_to_role_assumptions"
+    )
+    @patch("cartography.intel.aws.cloudtrail_management_events.load_role_assumptions")
     def test_sync_parameter_passing(self, mock_load, mock_transform, mock_get_events):
         """Test that sync function passes parameters correctly to sub-functions."""
         # Arrange
         mock_neo4j_session = MagicMock()
         mock_boto3_session = MagicMock()
-        regions = ['eu-central-1']
-        account_id = '999888777666'
+        regions = ["eu-central-1"]
+        account_id = "999888777666"
         update_tag = 1234567890
         lookback_hours = 168  # 7 days
         common_job_parameters = {
-            'aws_cloudtrail_management_events_lookback_hours': lookback_hours,
-            'UPDATE_TAG': update_tag,
+            "aws_cloudtrail_management_events_lookback_hours": lookback_hours,
+            "UPDATE_TAG": update_tag,
         }
-        
+
         # Mock return values
         mock_events = [STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT]
         mock_role_assumptions = [EXPECTED_ROLE_ASSUMPTION_FROM_WEB_IDENTITY]
-        
+
         mock_get_events.return_value = mock_events
         mock_transform.return_value = mock_role_assumptions
-        
+
         # Act
         sync(
             neo4j_session=mock_neo4j_session,
@@ -1282,24 +1519,24 @@ class TestSyncFunction:
             update_tag=update_tag,
             common_job_parameters=common_job_parameters,
         )
-        
+
         # Assert - Verify exact parameter values passed to sub-functions
         mock_get_events.assert_called_once_with(
             boto3_session=mock_boto3_session,
-            region='eu-central-1',
+            region="eu-central-1",
             lookback_hours=lookback_hours,
         )
-        
+
         mock_transform.assert_called_once_with(
             events=mock_events,
-            region='eu-central-1',
+            region="eu-central-1",
             current_aws_account_id=account_id,
         )
-        
+
         mock_load.assert_called_once_with(
             neo4j_session=mock_neo4j_session,
             role_assumptions=mock_role_assumptions,
-            region='all',
+            region="all",
             current_aws_account_id=account_id,
             aws_update_tag=update_tag,
-        ) 
+        )

--- a/tests/unit/cartography/intel/aws/test_cloudtrail_management_events.py
+++ b/tests/unit/cartography/intel/aws/test_cloudtrail_management_events.py
@@ -1,0 +1,501 @@
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from cartography.intel.aws.cloudtrail_management_events import get_cloudtrail_events, transform_cloudtrail_events_to_role_assumptions
+from tests.data.aws.cloudtrail_management_events import (
+    EXPECTED_PAGINATED_EVENTS,
+    EXPECTED_ROLE_ASSUMPTION_FROM_SAML,
+    EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE,
+    EXPECTED_ROLE_ASSUMPTION_FROM_WEB_IDENTITY,
+    EXPECTED_TRANSFORMED_ROLE_ASSUMPTIONS,
+    LOOKUP_EVENTS_EMPTY_RESPONSE,
+    LOOKUP_EVENTS_RESPONSE_PAGE1,
+    LOOKUP_EVENTS_RESPONSE_PAGE2,
+    LOOKUP_EVENTS_SINGLE_PAGE_RESPONSE,
+    MALFORMED_EVENT,
+    NON_STS_EVENT,
+    STS_ASSUME_ROLE_EVENT,
+    STS_ASSUME_ROLE_WITH_SAML_EVENT,
+    STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT,
+)
+
+
+class TestGetCloudTrailEvents:
+    """Test suite for get_cloudtrail_events function."""
+
+    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    def test_get_cloudtrail_events_success_single_page(self, mock_botocore_config):
+        """Test successful retrieval of CloudTrail events in a single page."""
+        # Arrange
+        mock_session = MagicMock(spec=boto3.Session)
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        
+        mock_session.client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [LOOKUP_EVENTS_SINGLE_PAGE_RESPONSE]
+        
+        region = 'us-east-1'
+        lookback_hours = 24
+        
+        # Act
+        result = get_cloudtrail_events(mock_session, region, lookback_hours)
+        
+        # Assert - Verify client creation
+        mock_session.client.assert_called_once_with(
+            'cloudtrail',
+            region_name=region,
+            config=mock_botocore_config.return_value
+        )
+        
+        # Assert - Verify paginator creation
+        mock_client.get_paginator.assert_called_once_with('lookup_events')
+        
+        # Assert - Verify API call parameters
+        expected_end_time = datetime.utcnow()
+        expected_start_time = expected_end_time - timedelta(hours=lookback_hours)
+        
+        mock_paginator.paginate.assert_called_once()
+        call_args = mock_paginator.paginate.call_args
+        
+        assert call_args[1]['LookupAttributes'] == [
+            {'AttributeKey': 'EventSource', 'AttributeValue': 'sts.amazonaws.com'}
+        ]
+        assert call_args[1]['PaginationConfig'] == {
+            'MaxItems': 10000,
+            'PageSize': 50
+        }
+        
+        # Verify time range (allow small tolerance for test execution time)
+        start_time_diff = abs((call_args[1]['StartTime'] - expected_start_time).total_seconds())
+        end_time_diff = abs((call_args[1]['EndTime'] - expected_end_time).total_seconds())
+        assert start_time_diff < 5  # Allow 5 seconds tolerance
+        assert end_time_diff < 5
+        
+        # Assert - Verify results
+        assert len(result) == 3
+        assert result[0]['EventName'] == 'AssumeRole'
+        assert result[1]['EventName'] == 'AssumeRoleWithSAML'
+        assert result[2]['EventName'] == 'AssumeRoleWithWebIdentity'
+        assert result == EXPECTED_PAGINATED_EVENTS
+
+    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    def test_get_cloudtrail_events_success_with_pagination(self, mock_botocore_config):
+        """Test successful retrieval of CloudTrail events across multiple pages."""
+        # Arrange
+        mock_session = MagicMock(spec=boto3.Session)
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        
+        mock_session.client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            LOOKUP_EVENTS_RESPONSE_PAGE1,
+            LOOKUP_EVENTS_RESPONSE_PAGE2
+        ]
+        
+        region = 'us-west-2'
+        lookback_hours = 72
+        
+        # Act
+        result = get_cloudtrail_events(mock_session, region, lookback_hours)
+        
+        # Assert - Verify pagination handling
+        assert len(result) == 3
+        assert result[0] == STS_ASSUME_ROLE_EVENT
+        assert result[1] == STS_ASSUME_ROLE_WITH_SAML_EVENT
+        assert result[2] == STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT
+        assert result == EXPECTED_PAGINATED_EVENTS
+        
+        # Verify the time range reflects the 72-hour lookback
+        call_args = mock_paginator.paginate.call_args
+        time_diff = call_args[1]['EndTime'] - call_args[1]['StartTime']
+        assert abs(time_diff.total_seconds() - (72 * 3600)) < 60  # Allow 1 minute tolerance
+
+    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    def test_get_cloudtrail_events_empty_response(self, mock_botocore_config):
+        """Test handling of empty CloudTrail response."""
+        # Arrange
+        mock_session = MagicMock(spec=boto3.Session)
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        
+        mock_session.client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [LOOKUP_EVENTS_EMPTY_RESPONSE]
+        
+        # Act
+        result = get_cloudtrail_events(mock_session, 'eu-west-1', 12)
+        
+        # Assert
+        assert result == []
+        assert len(result) == 0
+
+    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    def test_get_cloudtrail_events_default_lookback_hours(self, mock_botocore_config):
+        """Test that default lookback hours parameter works correctly."""
+        # Arrange
+        mock_session = MagicMock(spec=boto3.Session)
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        
+        mock_session.client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [LOOKUP_EVENTS_SINGLE_PAGE_RESPONSE]
+        
+        # Act - Don't specify lookback_hours, should use default of 24
+        result = get_cloudtrail_events(mock_session, 'us-east-1')
+        
+        # Assert - Verify default 24 hour time range
+        call_args = mock_paginator.paginate.call_args
+        time_diff = call_args[1]['EndTime'] - call_args[1]['StartTime']
+        assert abs(time_diff.total_seconds() - (24 * 3600)) < 60  # Allow 1 minute tolerance
+
+    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    def test_get_cloudtrail_events_api_error_access_denied(self, mock_botocore_config):
+        """Test handling of CloudTrail API access denied error."""
+        # Arrange
+        mock_session = MagicMock(spec=boto3.Session)
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        
+        mock_session.client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+        
+        # Simulate AccessDenied error
+        mock_paginator.paginate.side_effect = ClientError(
+            error_response={
+                'Error': {
+                    'Code': 'AccessDenied',
+                    'Message': 'User is not authorized to perform: cloudtrail:LookupEvents'
+                }
+            },
+            operation_name='LookupEvents'
+        )
+        
+        # Act
+        result = get_cloudtrail_events(mock_session, 'us-east-1', 24)
+        
+        # Assert - Should return empty list and log warning (not raise exception)
+        assert result == []
+
+    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    def test_get_cloudtrail_events_api_error_invalid_time_range(self, mock_botocore_config):
+        """Test handling of CloudTrail API invalid time range error."""
+        # Arrange
+        mock_session = MagicMock(spec=boto3.Session)
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        
+        mock_session.client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+        
+        # Simulate InvalidTimeRangeException
+        mock_paginator.paginate.side_effect = ClientError(
+            error_response={
+                'Error': {
+                    'Code': 'InvalidTimeRangeException',
+                    'Message': 'Start time must be before end time'
+                }
+            },
+            operation_name='LookupEvents'
+        )
+        
+        # Act
+        result = get_cloudtrail_events(mock_session, 'ap-southeast-1', 24)
+        
+        # Assert - Should return empty list and log warning (not raise exception)
+        assert result == []
+
+    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    def test_get_cloudtrail_events_generic_exception(self, mock_botocore_config):
+        """Test handling of generic exceptions."""
+        # Arrange
+        mock_session = MagicMock(spec=boto3.Session)
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        
+        mock_session.client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+        
+        # Simulate generic exception
+        mock_paginator.paginate.side_effect = Exception("Network timeout")
+        
+        # Act
+        result = get_cloudtrail_events(mock_session, 'ca-central-1', 24)
+        
+        # Assert - Should return empty list and log warning (not raise exception)
+        assert result == []
+
+    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    def test_get_cloudtrail_events_region_parameter_usage(self, mock_botocore_config):
+        """Test that the region parameter is correctly passed to the boto3 client."""
+        # Arrange
+        mock_session = MagicMock(spec=boto3.Session)
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        
+        mock_session.client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [LOOKUP_EVENTS_EMPTY_RESPONSE]
+        
+        test_region = 'eu-central-1'
+        
+        # Act
+        get_cloudtrail_events(mock_session, test_region, 24)
+        
+        # Assert - Verify region is passed correctly
+        mock_session.client.assert_called_once_with(
+            'cloudtrail',
+            region_name=test_region,
+            config=mock_botocore_config.return_value
+        )
+
+    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    def test_get_cloudtrail_events_filters_sts_events_only(self, mock_botocore_config):
+        """Test that the function correctly filters for STS events only."""
+        # Arrange
+        mock_session = MagicMock(spec=boto3.Session)
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        
+        mock_session.client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [LOOKUP_EVENTS_SINGLE_PAGE_RESPONSE]
+        
+        # Act
+        get_cloudtrail_events(mock_session, 'us-east-1', 24)
+        
+        # Assert - Verify STS event filtering
+        call_args = mock_paginator.paginate.call_args
+        lookup_attributes = call_args[1]['LookupAttributes']
+        
+        assert len(lookup_attributes) == 1
+        assert lookup_attributes[0]['AttributeKey'] == 'EventSource'
+        assert lookup_attributes[0]['AttributeValue'] == 'sts.amazonaws.com'
+
+    @patch('cartography.intel.aws.cloudtrail_management_events.get_botocore_config')
+    def test_get_cloudtrail_events_pagination_config(self, mock_botocore_config):
+        """Test that pagination configuration is set correctly."""
+        # Arrange
+        mock_session = MagicMock(spec=boto3.Session)
+        mock_client = MagicMock()
+        mock_paginator = MagicMock()
+        
+        mock_session.client.return_value = mock_client
+        mock_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [LOOKUP_EVENTS_EMPTY_RESPONSE]
+        
+        # Act
+        get_cloudtrail_events(mock_session, 'us-east-1', 24)
+        
+        # Assert - Verify pagination configuration
+        call_args = mock_paginator.paginate.call_args
+        pagination_config = call_args[1]['PaginationConfig']
+        
+        assert pagination_config['MaxItems'] == 10000
+        assert pagination_config['PageSize'] == 50
+
+
+class TestTransformCloudTrailEvents:
+    """Test suite for transform_cloudtrail_events_to_role_assumptions function."""
+
+    def test_transform_cloudtrail_events_success_all_types(self):
+        """Test successful transformation of all STS event types."""
+        # Arrange
+        events = [
+            STS_ASSUME_ROLE_EVENT,
+            STS_ASSUME_ROLE_WITH_SAML_EVENT,
+            STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT
+        ]
+        region = 'us-east-1'
+        account_id = '123456789012'
+        
+        # Act
+        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
+        
+        # Assert
+        assert len(result) == 3
+        assert result == EXPECTED_TRANSFORMED_ROLE_ASSUMPTIONS
+        
+        # Verify each transformation individually
+        assert result[0] == EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE
+        assert result[1] == EXPECTED_ROLE_ASSUMPTION_FROM_SAML
+        assert result[2] == EXPECTED_ROLE_ASSUMPTION_FROM_WEB_IDENTITY
+
+    def test_transform_single_assume_role_event(self):
+        """Test transformation of a single AssumeRole event."""
+        # Arrange
+        events = [STS_ASSUME_ROLE_EVENT]
+        region = 'us-east-1'
+        account_id = '123456789012'
+        
+        # Act
+        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
+        
+        # Assert
+        assert len(result) == 1
+        assumption = result[0]
+        
+        assert assumption['SourcePrincipal'] == 'arn:aws:iam::123456789012:user/john.doe'
+        assert assumption['DestinationPrincipal'] == 'arn:aws:iam::987654321098:role/CrossAccountRole'
+        assert assumption['Action'] == 'AssumeRole'
+        assert assumption['EventId'] == 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+        assert assumption['AccountId'] == account_id
+        assert assumption['AwsRegion'] == 'us-east-1'
+
+    def test_transform_assume_role_with_saml_event(self):
+        """Test transformation of AssumeRoleWithSAML event."""
+        # Arrange
+        events = [STS_ASSUME_ROLE_WITH_SAML_EVENT]
+        region = 'us-east-1'
+        account_id = '123456789012'
+        
+        # Act
+        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
+        
+        # Assert
+        assert len(result) == 1
+        assumption = result[0]
+        
+        assert assumption['SourcePrincipal'] == 'arn:aws:sts::123456789012:assumed-role/SAMLRole/jane.smith@company.com'
+        assert assumption['DestinationPrincipal'] == 'arn:aws:iam::123456789012:role/SAMLRole'
+        assert assumption['Action'] == 'AssumeRoleWithSAML'
+        assert assumption['EventId'] == 'a1b2c3d4-e5f6-7890-1234-567890abcdef'
+
+    def test_transform_assume_role_with_web_identity_event(self):
+        """Test transformation of AssumeRoleWithWebIdentity event."""
+        # Arrange
+        events = [STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT]
+        region = 'us-west-2'
+        account_id = '123456789012'
+        
+        # Act
+        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
+        
+        # Assert
+        assert len(result) == 1
+        assumption = result[0]
+        
+        assert assumption['SourcePrincipal'] == 'arn:aws:sts::123456789012:assumed-role/WebIdentityRole/web-session-1642254300'
+        assert assumption['DestinationPrincipal'] == 'arn:aws:iam::123456789012:role/WebIdentityRole'
+        assert assumption['Action'] == 'AssumeRoleWithWebIdentity'
+        assert assumption['AwsRegion'] == 'us-west-2'
+
+    def test_transform_filters_non_sts_events(self):
+        """Test that non-STS events are filtered out."""
+        # Arrange
+        events = [
+            STS_ASSUME_ROLE_EVENT,
+            NON_STS_EVENT,  # This should be filtered out
+            STS_ASSUME_ROLE_WITH_SAML_EVENT
+        ]
+        region = 'us-east-1'
+        account_id = '123456789012'
+        
+        # Act
+        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
+        
+        # Assert
+        assert len(result) == 2  # Only 2 STS events should be processed
+        assert result[0]['Action'] == 'AssumeRole'
+        assert result[1]['Action'] == 'AssumeRoleWithSAML'
+
+    def test_transform_handles_malformed_events(self):
+        """Test that malformed events are handled gracefully."""
+        # Arrange
+        events = [
+            STS_ASSUME_ROLE_EVENT,
+            MALFORMED_EVENT,  # This should be skipped
+            STS_ASSUME_ROLE_WITH_SAML_EVENT
+        ]
+        region = 'us-east-1'
+        account_id = '123456789012'
+        
+        # Act
+        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
+        
+        # Assert
+        assert len(result) == 2  # Malformed event should be skipped
+        assert result[0]['Action'] == 'AssumeRole'
+        assert result[1]['Action'] == 'AssumeRoleWithSAML'
+
+    def test_transform_empty_events_list(self):
+        """Test transformation of empty events list."""
+        # Arrange
+        events = []
+        region = 'us-east-1'
+        account_id = '123456789012'
+        
+        # Act
+        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
+        
+        # Assert
+        assert result == []
+        assert len(result) == 0
+
+    def test_transform_includes_additional_context_fields(self):
+        """Test that additional context fields are included in the transformation."""
+        # Arrange
+        events = [STS_ASSUME_ROLE_EVENT]
+        region = 'us-east-1'
+        account_id = '123456789012'
+        
+        # Act
+        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
+        
+        # Assert
+        assert len(result) == 1
+        assumption = result[0]
+        
+        # Check that all expected fields are present
+        expected_fields = [
+            'SourcePrincipal', 'DestinationPrincipal', 'Action', 'EventId',
+            'EventTime', 'SourceIPAddress', 'UserAgent', 'AwsRegion',
+            'AccountId', 'AssumedRoleArn', 'PrincipalArn', 'SessionName',
+            'RequestId', 'RecipientAccountId'
+        ]
+        
+        for field in expected_fields:
+            assert field in assumption
+
+    def test_transform_cross_account_role_assumption(self):
+        """Test that cross-account role assumptions are correctly identified."""
+        # Arrange
+        events = [STS_ASSUME_ROLE_EVENT]  # Cross-account assumption
+        region = 'us-east-1'
+        account_id = '123456789012'
+        
+        # Act
+        result = transform_cloudtrail_events_to_role_assumptions(events, region, account_id)
+        
+        # Assert
+        assert len(result) == 1
+        assumption = result[0]
+        
+        # Source account: 123456789012, Destination account: 987654321098
+        assert '123456789012' in assumption['SourcePrincipal']
+        assert '987654321098' in assumption['DestinationPrincipal']
+        assert assumption['RecipientAccountId'] == '987654321098'
+
+    def test_transform_handles_different_regions(self):
+        """Test that region parameter is correctly applied."""
+        # Arrange
+        events = [STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT]
+        test_region = 'ap-southeast-1'
+        account_id = '123456789012'
+        
+        # Act
+        result = transform_cloudtrail_events_to_role_assumptions(events, test_region, account_id)
+        
+        # Assert
+        assert len(result) == 1
+        assumption = result[0]
+        
+        # Event has AwsRegion: 'us-west-2', but if missing it should fallback to test_region
+        assert assumption['AwsRegion'] == 'us-west-2'  # Should preserve original event region
+        assert assumption['AccountId'] == account_id 

--- a/tests/unit/cartography/intel/aws/test_cloudtrail_management_events.py
+++ b/tests/unit/cartography/intel/aws/test_cloudtrail_management_events.py
@@ -1,22 +1,27 @@
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
 
-from cartography.intel.aws.cloudtrail_management_events import get_cloudtrail_events, transform_cloudtrail_events_to_role_assumptions
+from cartography.intel.aws.cloudtrail_management_events import get_cloudtrail_events, transform_cloudtrail_events_to_role_assumptions, _aggregate_role_assumptions, load_role_assumptions, sync
 from tests.data.aws.cloudtrail_management_events import (
+    CROSS_ACCOUNT_ROLE_ASSUMPTION_EVENTS,
+    EXPECTED_AGGREGATED_ALICE_DATASCIENTIST,
+    EXPECTED_CYPHER_QUERY_PATTERNS,
     EXPECTED_PAGINATED_EVENTS,
     EXPECTED_ROLE_ASSUMPTION_FROM_SAML,
     EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE,
     EXPECTED_ROLE_ASSUMPTION_FROM_WEB_IDENTITY,
     EXPECTED_TRANSFORMED_ROLE_ASSUMPTIONS,
+    INCOMPLETE_ROLE_ASSUMPTION_EVENTS,
     LOOKUP_EVENTS_EMPTY_RESPONSE,
     LOOKUP_EVENTS_RESPONSE_PAGE1,
     LOOKUP_EVENTS_RESPONSE_PAGE2,
     LOOKUP_EVENTS_SINGLE_PAGE_RESPONSE,
     MALFORMED_EVENT,
+    MULTIPLE_ASSUME_ROLE_EVENTS_SAME_PAIR,
     NON_STS_EVENT,
     STS_ASSUME_ROLE_EVENT,
     STS_ASSUME_ROLE_WITH_SAML_EVENT,
@@ -499,3 +504,802 @@ class TestTransformCloudTrailEvents:
         # Event has AwsRegion: 'us-west-2', but if missing it should fallback to test_region
         assert assumption['AwsRegion'] == 'us-west-2'  # Should preserve original event region
         assert assumption['AccountId'] == account_id 
+
+
+class TestAggregateRoleAssumptions:
+    """Test suite for _aggregate_role_assumptions function."""
+
+    def test_aggregate_single_event(self):
+        """Test aggregation of a single role assumption event."""
+        # Arrange
+        role_assumptions = [EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE]
+        
+        # Act
+        result = _aggregate_role_assumptions(role_assumptions)
+        
+        # Assert
+        assert len(result) == 1
+        aggregated = result[0]
+        
+        assert aggregated['source_principal_arn'] == 'arn:aws:iam::123456789012:user/john.doe'
+        assert aggregated['destination_principal_arn'] == 'arn:aws:iam::987654321098:role/CrossAccountRole'
+        assert aggregated['times_used'] == 1
+        assert aggregated['first_seen'] == datetime(2024, 1, 15, 10, 30, 15, 123000)
+        assert aggregated['last_seen'] == datetime(2024, 1, 15, 10, 30, 15, 123000)
+        assert aggregated['lastused'] == datetime(2024, 1, 15, 10, 30, 15, 123000)
+
+    def test_aggregate_multiple_events_same_pair(self):
+        """Test aggregation of multiple events for the same (source, destination) pair."""
+        # Arrange - Create multiple events with same source/dest but different times
+        event1 = {
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
+            'EventTime': datetime(2024, 1, 15, 10, 0, 0),
+            'Action': 'AssumeRole',
+            'EventId': 'event-1'
+        }
+        event2 = {
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
+            'EventTime': datetime(2024, 1, 15, 14, 30, 0),
+            'Action': 'AssumeRole',
+            'EventId': 'event-2'
+        }
+        event3 = {
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist', 
+            'EventTime': datetime(2024, 1, 15, 12, 15, 0),
+            'Action': 'AssumeRole',
+            'EventId': 'event-3'
+        }
+        
+        role_assumptions = [event1, event2, event3]
+        
+        # Act
+        result = _aggregate_role_assumptions(role_assumptions)
+        
+        # Assert
+        assert len(result) == 1  # Should aggregate into one relationship
+        aggregated = result[0]
+        
+        assert aggregated['source_principal_arn'] == 'arn:aws:iam::123456789012:user/alice'
+        assert aggregated['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/DataScientist'
+        assert aggregated['times_used'] == 3  # Count of events
+        assert aggregated['first_seen'] == datetime(2024, 1, 15, 10, 0, 0)  # Earliest time
+        assert aggregated['last_seen'] == datetime(2024, 1, 15, 14, 30, 0)  # Latest time
+        assert aggregated['lastused'] == datetime(2024, 1, 15, 14, 30, 0)   # Same as last_seen
+
+    def test_aggregate_multiple_events_different_pairs(self):
+        """Test aggregation of events for different (source, destination) pairs."""
+        # Arrange - Different users and roles
+        event1 = {
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
+            'EventTime': datetime(2024, 1, 15, 10, 0, 0),
+            'Action': 'AssumeRole',
+            'EventId': 'event-1'
+        }
+        event2 = {
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/bob',
+            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/Developer',
+            'EventTime': datetime(2024, 1, 15, 11, 0, 0),
+            'Action': 'AssumeRole',
+            'EventId': 'event-2'
+        }
+        event3 = {
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/Developer',  # Alice also assumes Developer
+            'EventTime': datetime(2024, 1, 15, 12, 0, 0),
+            'Action': 'AssumeRole',
+            'EventId': 'event-3'
+        }
+        
+        role_assumptions = [event1, event2, event3]
+        
+        # Act
+        result = _aggregate_role_assumptions(role_assumptions)
+        
+        # Assert
+        assert len(result) == 3  # Three unique (source, destination) pairs
+        
+        # Sort for consistent testing
+        result.sort(key=lambda x: (x['source_principal_arn'], x['destination_principal_arn']))
+        
+        # Check alice -> DataScientist
+        assert result[0]['source_principal_arn'] == 'arn:aws:iam::123456789012:user/alice'
+        assert result[0]['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/DataScientist'
+        assert result[0]['times_used'] == 1
+        
+        # Check alice -> Developer
+        assert result[1]['source_principal_arn'] == 'arn:aws:iam::123456789012:user/alice'
+        assert result[1]['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/Developer'
+        assert result[1]['times_used'] == 1
+        
+        # Check bob -> Developer
+        assert result[2]['source_principal_arn'] == 'arn:aws:iam::123456789012:user/bob'
+        assert result[2]['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/Developer'
+        assert result[2]['times_used'] == 1
+
+    def test_aggregate_empty_list(self):
+        """Test aggregation of empty role assumptions list."""
+        # Arrange
+        role_assumptions = []
+        
+        # Act
+        result = _aggregate_role_assumptions(role_assumptions)
+        
+        # Assert
+        assert result == []
+        assert len(result) == 0
+
+    def test_aggregate_incomplete_events_skipped(self):
+        """Test that incomplete events (missing required fields) are skipped."""
+        # Arrange
+        incomplete_event1 = {
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+            # Missing DestinationPrincipal
+            'EventTime': datetime(2024, 1, 15, 10, 0, 0),
+        }
+        incomplete_event2 = {
+            # Missing SourcePrincipal
+            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
+            'EventTime': datetime(2024, 1, 15, 10, 0, 0),
+        }
+        incomplete_event3 = {
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
+            # Missing EventTime
+        }
+        complete_event = {
+            'SourcePrincipal': 'arn:aws:iam::123456789012:user/bob',
+            'DestinationPrincipal': 'arn:aws:iam::123456789012:role/Developer',
+            'EventTime': datetime(2024, 1, 15, 11, 0, 0),
+            'Action': 'AssumeRole',
+            'EventId': 'complete-event'
+        }
+        
+        role_assumptions = [incomplete_event1, incomplete_event2, incomplete_event3, complete_event]
+        
+        # Act
+        result = _aggregate_role_assumptions(role_assumptions)
+        
+        # Assert - Only the complete event should be processed
+        assert len(result) == 1
+        assert result[0]['source_principal_arn'] == 'arn:aws:iam::123456789012:user/bob'
+        assert result[0]['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/Developer'
+
+    def test_aggregate_mixed_event_types(self):
+        """Test aggregation with different STS event types."""
+        # Arrange - Use the predefined test data
+        role_assumptions = EXPECTED_TRANSFORMED_ROLE_ASSUMPTIONS
+        
+        # Act
+        result = _aggregate_role_assumptions(role_assumptions)
+        
+        # Assert - Each should create a separate aggregated relationship
+        assert len(result) == 3
+        
+        # Verify each aggregated relationship has correct structure
+        for aggregated in result:
+            assert 'source_principal_arn' in aggregated
+            assert 'destination_principal_arn' in aggregated
+            assert aggregated['times_used'] == 1  # Each is a single event
+            assert 'first_seen' in aggregated
+            assert 'last_seen' in aggregated
+            assert 'lastused' in aggregated
+            assert aggregated['lastused'] == aggregated['last_seen']
+
+    def test_aggregate_with_predefined_multiple_events(self):
+        """Test aggregation using predefined test data for multiple events of same pair."""
+        # Arrange - Use predefined test data with multiple events for same (source, destination)
+        role_assumptions = MULTIPLE_ASSUME_ROLE_EVENTS_SAME_PAIR
+        
+        # Act
+        result = _aggregate_role_assumptions(role_assumptions)
+        
+        # Assert
+        assert len(result) == 1  # Should aggregate into single relationship
+        aggregated = result[0]
+        
+        # Compare against expected aggregated result
+        expected = EXPECTED_AGGREGATED_ALICE_DATASCIENTIST
+        assert aggregated['source_principal_arn'] == expected['source_principal_arn']
+        assert aggregated['destination_principal_arn'] == expected['destination_principal_arn']
+        assert aggregated['times_used'] == expected['times_used']
+        assert aggregated['first_seen'] == expected['first_seen']
+        assert aggregated['last_seen'] == expected['last_seen']
+        assert aggregated['lastused'] == expected['lastused']
+
+    def test_aggregate_cross_account_and_different_source_types(self):
+        """Test aggregation with cross-account events and different source types."""
+        # Arrange - Use predefined test data with different source types
+        role_assumptions = CROSS_ACCOUNT_ROLE_ASSUMPTION_EVENTS
+        
+        # Act
+        result = _aggregate_role_assumptions(role_assumptions)
+        
+        # Assert
+        assert len(result) == 3  # Each should be a separate relationship
+        
+        # Sort for consistent testing
+        result.sort(key=lambda x: x['source_principal_arn'])
+        
+        # Check Role -> Role (appears first alphabetically)
+        assert result[0]['source_principal_arn'] == 'arn:aws:iam::123456789012:role/ApplicationRole'
+        assert result[0]['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/DataAccessRole'
+        
+        # Check User -> CrossAccountRole
+        assert result[1]['source_principal_arn'] == 'arn:aws:iam::123456789012:user/service-account'
+        assert result[1]['destination_principal_arn'] == 'arn:aws:iam::987654321098:role/CrossAccountRole'
+        
+        # Check Federated -> Role
+        assert result[2]['source_principal_arn'] == 'arn:aws:sts::123456789012:federated-user/external-user'
+        assert result[2]['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/FederatedRole'
+        
+        # Verify all have single usage count
+        for aggregated in result:
+            assert aggregated['times_used'] == 1
+
+    def test_aggregate_with_incomplete_events_using_test_data(self):
+        """Test aggregation with incomplete events using predefined test data."""
+        # Arrange - Mix complete and incomplete events
+        complete_event = EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE
+        role_assumptions = INCOMPLETE_ROLE_ASSUMPTION_EVENTS + [complete_event]
+        
+        # Act
+        result = _aggregate_role_assumptions(role_assumptions)
+        
+        # Assert - Only the complete event should be processed
+        assert len(result) == 1
+        assert result[0]['source_principal_arn'] == complete_event['SourcePrincipal']
+        assert result[0]['destination_principal_arn'] == complete_event['DestinationPrincipal']
+
+
+class TestLoadRoleAssumptions:
+    """Test suite for load_role_assumptions function."""
+
+    def test_load_role_assumptions_success(self):
+        """Test successful loading of role assumptions into Neo4j."""
+        # Arrange
+        mock_session = MagicMock()
+        role_assumptions = [
+            {
+                'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+                'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
+                'EventTime': datetime(2024, 1, 15, 10, 0, 0),
+                'Action': 'AssumeRole',
+                'EventId': 'event-1'
+            }
+        ]
+        region = 'us-east-1'
+        account_id = '123456789012'
+        update_tag = 1705312345
+        
+        # Act
+        load_role_assumptions(mock_session, role_assumptions, region, account_id, update_tag)
+        
+        # Assert - Verify Neo4j session was called with correct query
+        mock_session.run.assert_called_once()
+        call_args = mock_session.run.call_args
+        
+        # Check that the Cypher query contains expected patterns
+        query = call_args[0][0]
+        assert 'UNWIND $assumptions AS assumption' in query
+        assert 'CALL {' in query  # UNION subquery for source node discovery
+        assert 'MATCH (source:AWSUser' in query
+        assert 'MATCH (source:AWSRole' in query
+        assert 'MATCH (source:AWSPrincipal' in query
+        assert 'MERGE (dest:AWSRole {arn: assumption.destination_principal_arn})' in query
+        assert 'MERGE (source_node)-[rel:ASSUMED_ROLE]->(dest)' in query
+        
+        # Check parameters
+        params = call_args[1]
+        assert 'assumptions' in params
+        assert 'aws_update_tag' in params
+        assert params['aws_update_tag'] == update_tag
+        
+        # Check aggregated data structure
+        aggregated_data = params['assumptions']
+        assert len(aggregated_data) == 1
+        assert aggregated_data[0]['source_principal_arn'] == 'arn:aws:iam::123456789012:user/alice'
+        assert aggregated_data[0]['destination_principal_arn'] == 'arn:aws:iam::123456789012:role/DataScientist'
+        assert aggregated_data[0]['times_used'] == 1
+
+    def test_load_role_assumptions_empty_list(self):
+        """Test that empty role assumptions list is handled gracefully."""
+        # Arrange
+        mock_session = MagicMock()
+        role_assumptions = []
+        
+        # Act
+        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
+        
+        # Assert - Should return early without calling Neo4j
+        mock_session.run.assert_not_called()
+
+    def test_load_role_assumptions_complex_aggregation(self):
+        """Test loading with complex aggregation scenarios."""
+        # Arrange
+        mock_session = MagicMock()
+        
+        # Multiple events that should aggregate
+        role_assumptions = [
+            {
+                'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+                'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
+                'EventTime': datetime(2024, 1, 15, 10, 0, 0),
+                'Action': 'AssumeRole',
+                'EventId': 'event-1'
+            },
+            {
+                'SourcePrincipal': 'arn:aws:iam::123456789012:user/alice',
+                'DestinationPrincipal': 'arn:aws:iam::123456789012:role/DataScientist',
+                'EventTime': datetime(2024, 1, 15, 14, 0, 0),
+                'Action': 'AssumeRole',
+                'EventId': 'event-2'
+            },
+            {
+                'SourcePrincipal': 'arn:aws:iam::123456789012:user/bob',
+                'DestinationPrincipal': 'arn:aws:iam::123456789012:role/Developer',
+                'EventTime': datetime(2024, 1, 15, 12, 0, 0),
+                'Action': 'AssumeRole',
+                'EventId': 'event-3'
+            }
+        ]
+        
+        # Act
+        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
+        
+        # Assert
+        mock_session.run.assert_called_once()
+        call_args = mock_session.run.call_args
+        params = call_args[1]
+        
+        # Should have 2 aggregated relationships (alice->DataScientist aggregated, bob->Developer separate)
+        aggregated_data = params['assumptions']
+        assert len(aggregated_data) == 2
+        
+        # Find alice's aggregated relationship
+        alice_relationship = next(
+            (item for item in aggregated_data 
+             if item['source_principal_arn'] == 'arn:aws:iam::123456789012:user/alice'), 
+            None
+        )
+        assert alice_relationship is not None
+        assert alice_relationship['times_used'] == 2  # Two events aggregated
+        assert alice_relationship['first_seen'] == datetime(2024, 1, 15, 10, 0, 0)  # Earlier time
+        assert alice_relationship['last_seen'] == datetime(2024, 1, 15, 14, 0, 0)   # Later time
+        
+        # Find bob's relationship
+        bob_relationship = next(
+            (item for item in aggregated_data 
+             if item['source_principal_arn'] == 'arn:aws:iam::123456789012:user/bob'), 
+            None
+        )
+        assert bob_relationship is not None
+        assert bob_relationship['times_used'] == 1  # Single event
+
+    def test_load_role_assumptions_cypher_query_structure(self):
+        """Test that the generated Cypher query has the correct structure for temporal aggregation."""
+        # Arrange
+        mock_session = MagicMock()
+        role_assumptions = [EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE]
+        
+        # Act
+        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
+        
+        # Assert - Check detailed query structure
+        call_args = mock_session.run.call_args
+        query = call_args[0][0]
+        
+        # Verify temporal aggregation logic is present
+        assert 'SET rel.lastused = COALESCE(' in query
+        assert 'CASE WHEN assumption.last_seen >' in query
+        assert 'rel.times_used = COALESCE(rel.times_used, 0) + assumption.times_used' in query
+        assert 'rel.first_seen = COALESCE(' in query
+        assert 'CASE WHEN assumption.first_seen <' in query
+        assert 'rel.last_seen = COALESCE(' in query
+        assert 'rel.lastupdated = $aws_update_tag' in query
+        
+        # Verify UNION structure for source node discovery
+        assert 'UNION' in query
+        assert query.count('UNION') == 2  # Two UNION clauses for three branches
+
+    def test_load_role_assumptions_with_real_test_data(self):
+        """Test loading using the predefined test data."""
+        # Arrange
+        mock_session = MagicMock()
+        role_assumptions = EXPECTED_TRANSFORMED_ROLE_ASSUMPTIONS
+        
+        # Act
+        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
+        
+        # Assert
+        mock_session.run.assert_called_once()
+        call_args = mock_session.run.call_args
+        params = call_args[1]
+        
+        # Should have 3 aggregated relationships (one for each different assumption)
+        aggregated_data = params['assumptions']
+        assert len(aggregated_data) == 3
+        
+        # Verify each has the required structure
+        for assumption in aggregated_data:
+            assert 'source_principal_arn' in assumption
+            assert 'destination_principal_arn' in assumption
+            assert 'times_used' in assumption
+            assert 'first_seen' in assumption
+            assert 'last_seen' in assumption
+            assert 'lastused' in assumption
+            
+            # Verify lastused equals last_seen
+            assert assumption['lastused'] == assumption['last_seen']
+
+    def test_load_role_assumptions_query_patterns_comprehensive(self):
+        """Test that all expected Cypher query patterns are present."""
+        # Arrange
+        mock_session = MagicMock()
+        role_assumptions = [EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE]
+        
+        # Act
+        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
+        
+        # Assert - Check all expected patterns are in the query
+        call_args = mock_session.run.call_args
+        query = call_args[0][0]
+        
+        for pattern_name, pattern in EXPECTED_CYPHER_QUERY_PATTERNS.items():
+            assert pattern in query, f"Expected pattern '{pattern_name}' not found in query"
+
+    def test_load_role_assumptions_with_multiple_events_same_pair(self):
+        """Test loading with multiple events that should aggregate into one relationship."""
+        # Arrange
+        mock_session = MagicMock()
+        role_assumptions = MULTIPLE_ASSUME_ROLE_EVENTS_SAME_PAIR
+        
+        # Act
+        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
+        
+        # Assert
+        call_args = mock_session.run.call_args
+        params = call_args[1]
+        
+        # Should have 1 aggregated relationship (all events for same pair)
+        aggregated_data = params['assumptions']
+        assert len(aggregated_data) == 1
+        
+        # Verify aggregation matches expected
+        aggregated = aggregated_data[0]
+        expected = EXPECTED_AGGREGATED_ALICE_DATASCIENTIST
+        assert aggregated == expected
+
+    def test_load_role_assumptions_with_cross_account_events(self):
+        """Test loading with cross-account role assumptions."""
+        # Arrange
+        mock_session = MagicMock()
+        role_assumptions = CROSS_ACCOUNT_ROLE_ASSUMPTION_EVENTS
+        
+        # Act
+        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
+        
+        # Assert
+        call_args = mock_session.run.call_args
+        params = call_args[1]
+        
+        # Should have 3 separate relationships (different source-destination pairs)
+        aggregated_data = params['assumptions']
+        assert len(aggregated_data) == 3
+        
+        # Check that we have the expected ARN patterns
+        source_arns = {item['source_principal_arn'] for item in aggregated_data}
+        dest_arns = {item['destination_principal_arn'] for item in aggregated_data}
+        
+        # Verify we have different source types
+        assert 'arn:aws:iam::123456789012:user/service-account' in source_arns  # User
+        assert 'arn:aws:iam::123456789012:role/ApplicationRole' in source_arns  # Role
+        assert 'arn:aws:sts::123456789012:federated-user/external-user' in source_arns  # Federated
+        
+        # Verify we have cross-account destination
+        assert 'arn:aws:iam::987654321098:role/CrossAccountRole' in dest_arns
+
+    def test_load_role_assumptions_parameter_validation(self):
+        """Test that the correct parameters are passed to Neo4j session."""
+        # Arrange
+        mock_session = MagicMock()
+        role_assumptions = [EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE]
+        region = 'eu-west-1'
+        account_id = '999888777666'
+        update_tag = 1234567890
+        
+        # Act
+        load_role_assumptions(mock_session, role_assumptions, region, account_id, update_tag)
+        
+        # Assert - Verify exact parameter values
+        call_args = mock_session.run.call_args
+        params = call_args[1]
+        
+        assert params['aws_update_tag'] == update_tag
+        assert 'assumptions' in params
+        assert isinstance(params['assumptions'], list)
+        assert len(params['assumptions']) == 1
+        
+        # Verify the aggregated assumption structure
+        assumption = params['assumptions'][0]
+        assert assumption['source_principal_arn'] == 'arn:aws:iam::123456789012:user/john.doe'
+        assert assumption['destination_principal_arn'] == 'arn:aws:iam::987654321098:role/CrossAccountRole'
+        assert assumption['times_used'] == 1
+
+    def test_load_role_assumptions_handles_incomplete_data_gracefully(self):
+        """Test that incomplete events are filtered out during aggregation."""
+        # Arrange
+        mock_session = MagicMock()
+        
+        # Mix incomplete and complete events
+        complete_event = EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE
+        role_assumptions = INCOMPLETE_ROLE_ASSUMPTION_EVENTS + [complete_event]
+        
+        # Act
+        load_role_assumptions(mock_session, role_assumptions, 'us-east-1', '123456789012', 1705312345)
+        
+        # Assert - Only complete event should be processed
+        call_args = mock_session.run.call_args
+        params = call_args[1]
+        
+        aggregated_data = params['assumptions']
+        assert len(aggregated_data) == 1  # Only the complete event
+        assert aggregated_data[0]['source_principal_arn'] == complete_event['SourcePrincipal']
+        assert aggregated_data[0]['destination_principal_arn'] == complete_event['DestinationPrincipal']
+
+
+class TestSyncFunction:
+    """Test suite for the main sync orchestration function."""
+
+    @patch('cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events')
+    @patch('cartography.intel.aws.cloudtrail_management_events.transform_cloudtrail_events_to_role_assumptions')
+    @patch('cartography.intel.aws.cloudtrail_management_events.load_role_assumptions')
+    def test_sync_success_with_lookback_hours(self, mock_load, mock_transform, mock_get_events):
+        """Test successful sync with lookback hours specified."""
+        # Arrange
+        mock_neo4j_session = MagicMock()
+        mock_boto3_session = MagicMock()
+        regions = ['us-east-1', 'us-west-2']
+        account_id = '123456789012'
+        update_tag = 1705312345
+        common_job_parameters = {
+            'aws_cloudtrail_management_events_lookback_hours': 24,
+            'UPDATE_TAG': update_tag,
+        }
+        
+        # Mock return values
+        mock_events = [STS_ASSUME_ROLE_EVENT, STS_ASSUME_ROLE_WITH_SAML_EVENT]
+        mock_role_assumptions = [EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE]
+        
+        mock_get_events.return_value = mock_events
+        mock_transform.return_value = mock_role_assumptions
+        
+        # Act
+        sync(
+            neo4j_session=mock_neo4j_session,
+            boto3_session=mock_boto3_session,
+            regions=regions,
+            current_aws_account_id=account_id,
+            update_tag=update_tag,
+            common_job_parameters=common_job_parameters,
+        )
+        
+        # Assert - Verify all components were called correctly
+        assert mock_get_events.call_count == 2  # Called for each region
+        assert mock_transform.call_count == 2   # Called for each region
+        mock_load.assert_called_once()
+        
+        # Verify get_cloudtrail_events calls
+        expected_calls = [
+            call(boto3_session=mock_boto3_session, region='us-east-1', lookback_hours=24),
+            call(boto3_session=mock_boto3_session, region='us-west-2', lookback_hours=24)
+        ]
+        mock_get_events.assert_has_calls(expected_calls, any_order=True)
+        
+        # Verify transform calls
+        transform_calls = [
+            call(events=mock_events, region='us-east-1', current_aws_account_id=account_id),
+            call(events=mock_events, region='us-west-2', current_aws_account_id=account_id)
+        ]
+        mock_transform.assert_has_calls(transform_calls, any_order=True)
+        
+        # Verify load call
+        load_call_args = mock_load.call_args
+        assert load_call_args[1]['neo4j_session'] == mock_neo4j_session
+        assert load_call_args[1]['region'] == 'all'  # Cross-region aggregation
+        assert load_call_args[1]['current_aws_account_id'] == account_id
+        assert load_call_args[1]['aws_update_tag'] == update_tag
+        
+        # Verify role assumptions were aggregated from all regions
+        role_assumptions_arg = load_call_args[1]['role_assumptions']
+        assert len(role_assumptions_arg) == 2  # One from each region
+
+    def test_sync_skipped_when_no_lookback_hours(self):
+        """Test that sync is skipped when no lookback hours are specified."""
+        # Arrange
+        mock_neo4j_session = MagicMock()
+        mock_boto3_session = MagicMock()
+        common_job_parameters = {
+            'UPDATE_TAG': 1705312345,
+            # No aws_cloudtrail_management_events_lookback_hours specified
+        }
+        
+        # Act
+        with patch('cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events') as mock_get_events:
+            sync(
+                neo4j_session=mock_neo4j_session,
+                boto3_session=mock_boto3_session,
+                regions=['us-east-1'],
+                current_aws_account_id='123456789012',
+                update_tag=1705312345,
+                common_job_parameters=common_job_parameters,
+            )
+        
+        # Assert - No CloudTrail API calls should be made
+        mock_get_events.assert_not_called()
+
+    def test_sync_skipped_when_lookback_hours_is_none(self):
+        """Test that sync is skipped when lookback hours is explicitly None."""
+        # Arrange
+        mock_neo4j_session = MagicMock()
+        mock_boto3_session = MagicMock()
+        common_job_parameters = {
+            'aws_cloudtrail_management_events_lookback_hours': None,
+            'UPDATE_TAG': 1705312345,
+        }
+        
+        # Act
+        with patch('cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events') as mock_get_events:
+            sync(
+                neo4j_session=mock_neo4j_session,
+                boto3_session=mock_boto3_session,
+                regions=['us-east-1'],
+                current_aws_account_id='123456789012',
+                update_tag=1705312345,
+                common_job_parameters=common_job_parameters,
+            )
+        
+        # Assert - No CloudTrail API calls should be made
+        mock_get_events.assert_not_called()
+
+    @patch('cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events')
+    @patch('cartography.intel.aws.cloudtrail_management_events.transform_cloudtrail_events_to_role_assumptions')
+    @patch('cartography.intel.aws.cloudtrail_management_events.load_role_assumptions')
+    def test_sync_continues_on_region_failure(self, mock_load, mock_transform, mock_get_events):
+        """Test that sync continues processing other regions when one region fails."""
+        # Arrange
+        mock_neo4j_session = MagicMock()
+        mock_boto3_session = MagicMock()
+        regions = ['us-east-1', 'us-west-2', 'eu-west-1']
+        account_id = '123456789012'
+        update_tag = 1705312345
+        common_job_parameters = {
+            'aws_cloudtrail_management_events_lookback_hours': 24,
+            'UPDATE_TAG': update_tag,
+        }
+        
+        # Mock get_cloudtrail_events to fail on second region
+        mock_events = [STS_ASSUME_ROLE_EVENT]
+        mock_role_assumptions = [EXPECTED_ROLE_ASSUMPTION_FROM_STS_ASSUME_ROLE]
+        
+        mock_get_events.side_effect = [
+            mock_events,  # Success for us-east-1
+            Exception("Access denied for us-west-2"),  # Failure for us-west-2
+            mock_events,  # Success for eu-west-1
+        ]
+        mock_transform.return_value = mock_role_assumptions
+        
+        # Act
+        sync(
+            neo4j_session=mock_neo4j_session,
+            boto3_session=mock_boto3_session,
+            regions=regions,
+            current_aws_account_id=account_id,
+            update_tag=update_tag,
+            common_job_parameters=common_job_parameters,
+        )
+        
+        # Assert - Should have attempted all 3 regions
+        assert mock_get_events.call_count == 3
+        
+        # Should have transformed and loaded data from successful regions only
+        assert mock_transform.call_count == 2  # Only successful regions
+        mock_load.assert_called_once()
+        
+        # Verify the aggregated role assumptions include data from successful regions
+        load_call_args = mock_load.call_args
+        role_assumptions_arg = load_call_args[1]['role_assumptions']
+        assert len(role_assumptions_arg) == 2  # From 2 successful regions
+
+    @patch('cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events')
+    @patch('cartography.intel.aws.cloudtrail_management_events.transform_cloudtrail_events_to_role_assumptions')
+    @patch('cartography.intel.aws.cloudtrail_management_events.load_role_assumptions')
+    def test_sync_with_no_events_found(self, mock_load, mock_transform, mock_get_events):
+        """Test sync behavior when no CloudTrail events are found."""
+        # Arrange
+        mock_neo4j_session = MagicMock()
+        mock_boto3_session = MagicMock()
+        regions = ['us-east-1']
+        account_id = '123456789012'
+        update_tag = 1705312345
+        common_job_parameters = {
+            'aws_cloudtrail_management_events_lookback_hours': 72,
+            'UPDATE_TAG': update_tag,
+        }
+        
+        # Mock empty results
+        mock_get_events.return_value = []
+        mock_transform.return_value = []
+        
+        # Act
+        sync(
+            neo4j_session=mock_neo4j_session,
+            boto3_session=mock_boto3_session,
+            regions=regions,
+            current_aws_account_id=account_id,
+            update_tag=update_tag,
+            common_job_parameters=common_job_parameters,
+        )
+        
+        # Assert - Functions should be called but no data loaded
+        mock_get_events.assert_called_once()
+        mock_transform.assert_called_once()
+        mock_load.assert_not_called()  # Should not load empty data
+
+    @patch('cartography.intel.aws.cloudtrail_management_events.get_cloudtrail_events')
+    @patch('cartography.intel.aws.cloudtrail_management_events.transform_cloudtrail_events_to_role_assumptions')
+    @patch('cartography.intel.aws.cloudtrail_management_events.load_role_assumptions')
+    def test_sync_parameter_passing(self, mock_load, mock_transform, mock_get_events):
+        """Test that sync function passes parameters correctly to sub-functions."""
+        # Arrange
+        mock_neo4j_session = MagicMock()
+        mock_boto3_session = MagicMock()
+        regions = ['eu-central-1']
+        account_id = '999888777666'
+        update_tag = 1234567890
+        lookback_hours = 168  # 7 days
+        common_job_parameters = {
+            'aws_cloudtrail_management_events_lookback_hours': lookback_hours,
+            'UPDATE_TAG': update_tag,
+        }
+        
+        # Mock return values
+        mock_events = [STS_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT]
+        mock_role_assumptions = [EXPECTED_ROLE_ASSUMPTION_FROM_WEB_IDENTITY]
+        
+        mock_get_events.return_value = mock_events
+        mock_transform.return_value = mock_role_assumptions
+        
+        # Act
+        sync(
+            neo4j_session=mock_neo4j_session,
+            boto3_session=mock_boto3_session,
+            regions=regions,
+            current_aws_account_id=account_id,
+            update_tag=update_tag,
+            common_job_parameters=common_job_parameters,
+        )
+        
+        # Assert - Verify exact parameter values passed to sub-functions
+        mock_get_events.assert_called_once_with(
+            boto3_session=mock_boto3_session,
+            region='eu-central-1',
+            lookback_hours=lookback_hours,
+        )
+        
+        mock_transform.assert_called_once_with(
+            events=mock_events,
+            region='eu-central-1',
+            current_aws_account_id=account_id,
+        )
+        
+        mock_load.assert_called_once_with(
+            neo4j_session=mock_neo4j_session,
+            role_assumptions=mock_role_assumptions,
+            region='all',
+            current_aws_account_id=account_id,
+            aws_update_tag=update_tag,
+        ) 


### PR DESCRIPTION
### Summary

- Implemented CloudTrail management events module for AWS role assumption visibility


Key Features:
- Fetches STS events (AssumeRole, AssumeRoleWithSAML, AssumeRoleWithWebIdentity)
- Creates ASSUMED_ROLE relationships between principals and roles
- Handles role-to-role, user-to-role, and service-to-role assumptions
- Supports configurable lookback periods (default 24 hours)




### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/cartography-cncf/cartography/issues/...


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] -Unit Tests
<img width="1550" alt="image" src="https://github.com/user-attachments/assets/20396056-86b3-46ce-bb94-4fef7a59156c" />
- [ ] -Integration Tests
<img width="1553" alt="image" src="https://github.com/user-attachments/assets/c13bf5a7-8bf9-4a99-924a-2c9317a7da39" />

- [ ] Include a screenshot showing what the graph looked like before and after your changes.
<img width="1816" alt="image" src="https://github.com/user-attachments/assets/7561911e-0b37-4af0-a290-93ae073e9c75" />

- [ ] Cartography Log (**AWS account id replaced with placeholder**)
WARNING:cartography.cli:A Kandji base URI was not provided.
WARNING:cartography.cli:A SnipeIT base URI was not provided.
INFO:cartography.sync:Starting sync with update tag '1751323749'
INFO:cartography.sync:Starting sync stage 'aws'
INFO:cartography.intel.aws:Syncing AWS accounts: 0123456789012
INFO:cartography.intel.aws:Syncing AWS account with ID '0123456789012' using configured profile 'ReadOnlyAccess-0123456789012'.
INFO:cartography.intel.aws:Trying to autodiscover accounts.
WARNING:cartography.intel.aws:The current account (0123456789012) doesn't have enough permissions to perform autodiscovery.
INFO:cartography.intel.aws.cloudtrail_management_events:Starting CloudTrail management events sync for account 0123456789012
INFO:cartography.intel.aws.cloudtrail_management_events:Syncing 1 regions with 24 hour lookback period
INFO:cartography.intel.aws.cloudtrail_management_events:Fetching CloudTrail management events for region 'us-east-1' from 2025-06-29 22:49:12.635056 to 2025-06-30 22:49:12.635056 (24 hours)
INFO:cartography.intel.aws.cloudtrail_management_events:Retrieved 2400 CloudTrail management events from region 'us-east-1'
INFO:cartography.intel.aws.cloudtrail_management_events:Transforming 2400 CloudTrail events to role assumptions for region 'us-east-1'
WARNING:cartography.intel.aws.cloudtrail_management_events:Failed to transform CloudTrail event 83d124e3-d114-43ac-a0ea-f89432bb365a: 'NoneType' object has no attribute 'get'
WARNING:cartography.intel.aws.cloudtrail_management_events:Failed to transform CloudTrail event 8f5e5304-34f2-456b-b4a4-33c56ec1881b: 'NoneType' object has no attribute 'get'
INFO:cartography.intel.aws.cloudtrail_management_events:Successfully transformed 2356 role assumptions from 2400 events
INFO:cartography.intel.aws.cloudtrail_management_events:Aggregated 2356 events into 12 unique role assumption relationships
INFO:cartography.intel.aws.cloudtrail_management_events:Loading 12 aggregated role assumption relationships
INFO:cartography.intel.aws.cloudtrail_management_events:Successfully loaded 12 role assumption relationships
INFO:cartography.intel.aws.cloudtrail_management_events:CloudTrail management events sync completed successfully. Processed 2356 role assumption events.
INFO:cartography.graph.statement:Completed aws_ec2_iaminstanceprofile statement #1
INFO:cartography.graph.statement:Completed aws_ec2_iaminstanceprofile statement #2
INFO:cartography.graph.job:Finished job aws_ec2_iaminstanceprofile
INFO:cartography.graph.statement:Completed aws_lambda_ecr statement #1
INFO:cartography.graph.statement:Completed aws_lambda_ecr statement #2
INFO:cartography.graph.job:Finished job aws_lambda_ecr
INFO:cartography.graph.statement:Completed aws_post_ingestion_principals_cleanup statement #1
INFO:cartography.graph.job:Finished job aws_post_ingestion_principals_cleanup
INFO:cartography.util:Did not run aws_ec2_asset_exposure.json because it needs {'ec2:security_group', 'ec2:load_balancer', 'ec2:load_balancer_v2', 'ec2:instance'} to be included as a requested sync. You specified: {'cloudtrail_management_events'}. If you want this job to run, please change your CLI args/cartography config so that all required resources are included.
INFO:cartography.util:Did not run aws_ec2_keypair_analysis.json because it needs {'ec2:keypair'} to be included as a requested sync. You specified: {'cloudtrail_management_events'}. If you want this job to run, please change your CLI args/cartography config so that all required resources are included.
INFO:cartography.util:Did not run aws_eks_asset_exposure.json because it needs {'eks'} to be included as a requested sync. You specified: {'cloudtrail_management_events'}. If you want this job to run, please change your CLI args/cartography config so that all required resources are included.
INFO:cartography.graph.statement:Completed aws_foreign_accounts statement #1
INFO:cartography.graph.statement:Completed aws_foreign_accounts statement #2
INFO:cartography.graph.job:Finished job aws_foreign_accounts
INFO:cartography.sync:Finishing sync stage 'aws'
INFO:cartography.sync:Finishing sync with update tag '1751323749'

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
