### PR TITLE
Replaced direct requests.session() instantiation with build_session()…

### DIFF
--- a/cartography/intel/anthropic/__init__.py
+++ b/cartography/intel/anthropic/__init__.py
@@ -1,13 +1,12 @@
 import logging
 
 import neo4j
-import requests
 
 import cartography.intel.anthropic.apikeys
 import cartography.intel.anthropic.users
 import cartography.intel.anthropic.workspaces
 from cartography.config import Config
-from cartography.util import timeit
+from cartography.util import timeit, build_session
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +28,7 @@ def start_anthropic_ingestion(neo4j_session: neo4j.Session, config: Config) -> N
         return
 
     # Create requests sessions
-    api_session = requests.session()
+    api_session = build_session()
     api_session.headers.update(
         {
             "X-Api-Key": config.anthropic_apikey,

--- a/cartography/intel/cve/__init__.py
+++ b/cartography/intel/cve/__init__.py
@@ -9,15 +9,14 @@ from urllib3 import Retry
 from cartography.config import Config
 from cartography.intel.cve import feed
 from cartography.stats import get_stats_client
-from cartography.util import merge_module_sync_metadata
-from cartography.util import timeit
+from cartography.util import merge_module_sync_metadata, timeit, build_session
 
 logger = logging.getLogger(__name__)
 stat_handler = get_stats_client(__name__)
 
 
 def _retryable_session() -> Session:
-    session = Session()
+    session = build_session()
     retry_policy = Retry(
         total=8,
         connect=1,

--- a/cartography/intel/kandji/devices.py
+++ b/cartography/intel/kandji/devices.py
@@ -10,7 +10,7 @@ from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.models.kandji.device import KandjiDeviceSchema
 from cartography.models.kandji.tenant import KandjiTenantSchema
-from cartography.util import timeit
+from cartography.util import timeit, build_session
 
 logger = logging.getLogger(__name__)
 _TIMEOUT = (60, 60)
@@ -33,7 +33,7 @@ def get(kandji_base_uri: str, kandji_token: str) -> List[Dict[str, Any]]:
     }
 
     devices: List[Dict[str, Any]] = []
-    session = Session()
+    session = build_session()
     while True:
         logger.debug("Kandji device offset: %s", offset)
 

--- a/cartography/intel/openai/__init__.py
+++ b/cartography/intel/openai/__init__.py
@@ -1,7 +1,6 @@
 import logging
 
 import neo4j
-import requests
 
 import cartography.intel.openai.adminapikeys
 import cartography.intel.openai.apikeys
@@ -9,7 +8,7 @@ import cartography.intel.openai.projects
 import cartography.intel.openai.serviceaccounts
 import cartography.intel.openai.users
 from cartography.config import Config
-from cartography.util import timeit
+from cartography.util import timeit, build_session
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +30,7 @@ def start_openai_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         return
 
     # Create requests sessions
-    api_session = requests.session()
+    api_session = build_session()
     api_session.headers.update(
         {
             "Authorization": f"Bearer {config.openai_apikey}",

--- a/cartography/intel/tailscale/__init__.py
+++ b/cartography/intel/tailscale/__init__.py
@@ -1,7 +1,6 @@
 import logging
 
 import neo4j
-import requests
 
 import cartography.intel.tailscale.acls
 import cartography.intel.tailscale.devices
@@ -9,7 +8,7 @@ import cartography.intel.tailscale.postureintegrations
 import cartography.intel.tailscale.tailnets
 import cartography.intel.tailscale.users
 from cartography.config import Config
-from cartography.util import timeit
+from cartography.util import timeit, build_session
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +30,7 @@ def start_tailscale_ingestion(neo4j_session: neo4j.Session, config: Config) -> N
         return
 
     # Create requests sessions
-    api_session = requests.session()
+    api_session = build_session()
     api_session.headers.update({"Authorization": f"Bearer {config.tailscale_token}"})
 
     common_job_parameters = {

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -25,6 +25,7 @@ import backoff
 import boto3
 import botocore
 import neo4j
+import requests
 
 from cartography.graph.job import GraphJob
 from cartography.graph.statement import get_job_shortname
@@ -466,3 +467,18 @@ def to_synchronous(*awaitables: Awaitable[Any]) -> List[Any]:
     results = to_synchronous(future_1, future_2)
     """
     return asyncio.get_event_loop().run_until_complete(asyncio.gather(*awaitables))
+
+
+try:
+    from cartography._version import version as cartography_version
+except ImportError:
+    cartography_version = "unknown"
+
+def build_session() -> requests.Session:
+    """
+    Create a requests.Session with a custom User-Agent header that includes the Cartography version.
+    """
+    session = requests.Session()
+    user_agent = f"Cartography/{cartography_version}"
+    session.headers.update({"User-Agent": user_agent})
+    return session


### PR DESCRIPTION
… in all relevant intel modules.

### Summary
> Describe your changes.

Replaced direct requests.Session/session() instantiation with build_session() in all relevant intel modules.
Ensures all outbound HTTP requests use a standardized User-Agent with the Cartography version.
Affects Anthropic, OpenAI, Tailscale, CVE, and Kandji integrations.

### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/cartography-cncf/cartography/issues/1665

