### PR TITLE
feat: Attach ECS tasks to NetworkInterfaces

### DIFF
--- a/cartography/intel/aws/ecs.py
+++ b/cartography/intel/aws/ecs.py
@@ -159,7 +159,7 @@ def get_ecs_tasks(
             tasks=task_arn_chunk,
         )
         tasks.extend(task_chunk.get("tasks", []))
-    
+
     _enrich_tasks_with_network_interface_id(tasks)
     return tasks
 

--- a/cartography/intel/aws/ecs.py
+++ b/cartography/intel/aws/ecs.py
@@ -173,8 +173,7 @@ def _get_containers_from_tasks(tasks: list[dict[str, Any]]) -> list[dict[str, An
 
 def _enrich_tasks_with_network_interface_id(tasks: list[dict[str, Any]]) -> None:
     """
-    Extract network interface ID from task attachments for tasks with awsvpc network mode.
-    Modifies tasks in-place by adding networkInterfaceId field.
+    Extract network interface ID from task attachments.
     """
     for task in tasks:
         for attachment in task.get("attachments", []):

--- a/cartography/intel/aws/ecs.py
+++ b/cartography/intel/aws/ecs.py
@@ -159,8 +159,6 @@ def get_ecs_tasks(
             tasks=task_arn_chunk,
         )
         tasks.extend(task_chunk.get("tasks", []))
-
-    _enrich_tasks_with_network_interface_id(tasks)
     return tasks
 
 
@@ -171,7 +169,7 @@ def _get_containers_from_tasks(tasks: list[dict[str, Any]]) -> list[dict[str, An
     return containers
 
 
-def _enrich_tasks_with_network_interface_id(tasks: list[dict[str, Any]]) -> None:
+def transform_ecs_tasks(tasks: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """
     Extract network interface ID from task attachments.
     """
@@ -184,6 +182,7 @@ def _enrich_tasks_with_network_interface_id(tasks: list[dict[str, Any]]) -> None
                         task["networkInterfaceId"] = detail.get("value")
                         break
                 break
+    return tasks
 
 
 @timeit
@@ -424,6 +423,7 @@ def _sync_ecs_task_and_container_defns(
         boto3_session,
         region,
     )
+    tasks = transform_ecs_tasks(tasks)
     containers = _get_containers_from_tasks(tasks)
     load_ecs_tasks(
         neo4j_session,

--- a/cartography/models/aws/ecs/tasks.py
+++ b/cartography/models/aws/ecs/tasks.py
@@ -114,7 +114,9 @@ class ECSTaskToNetworkInterfaceRel(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "NETWORK_INTERFACE"
-    properties: ECSTaskToNetworkInterfaceRelProperties = ECSTaskToNetworkInterfaceRelProperties()
+    properties: ECSTaskToNetworkInterfaceRelProperties = (
+        ECSTaskToNetworkInterfaceRelProperties()
+    )
 
 
 @dataclass(frozen=True)
@@ -123,5 +125,9 @@ class ECSTaskSchema(CartographyNodeSchema):
     properties: ECSTaskNodeProperties = ECSTaskNodeProperties()
     sub_resource_relationship: ECSTaskToAWSAccountRel = ECSTaskToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
-        [ECSTaskToContainerInstanceRel(), ECSTaskToECSClusterRel(), ECSTaskToNetworkInterfaceRel()]
+        [
+            ECSTaskToContainerInstanceRel(),
+            ECSTaskToECSClusterRel(),
+            ECSTaskToNetworkInterfaceRel(),
+        ]
     )

--- a/cartography/models/aws/ecs/tasks.py
+++ b/cartography/models/aws/ecs/tasks.py
@@ -46,6 +46,7 @@ class ECSTaskNodeProperties(CartographyNodeProperties):
     ephemeral_storage_size_in_gib: PropertyRef = PropertyRef(
         "ephemeralStorage.sizeInGiB"
     )
+    network_interface_id: PropertyRef = PropertyRef("networkInterfaceId")
     region: PropertyRef = PropertyRef("Region", set_in_kwargs=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
@@ -101,10 +102,26 @@ class ECSTaskToAWSAccountRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class ECSTaskToNetworkInterfaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ECSTaskToNetworkInterfaceRel(CartographyRelSchema):
+    target_node_label: str = "NetworkInterface"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("networkInterfaceId")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "NETWORK_INTERFACE"
+    properties: ECSTaskToNetworkInterfaceRelProperties = ECSTaskToNetworkInterfaceRelProperties()
+
+
+@dataclass(frozen=True)
 class ECSTaskSchema(CartographyNodeSchema):
     label: str = "ECSTask"
     properties: ECSTaskNodeProperties = ECSTaskNodeProperties()
     sub_resource_relationship: ECSTaskToAWSAccountRel = ECSTaskToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
-        [ECSTaskToContainerInstanceRel(), ECSTaskToECSClusterRel()]
+        [ECSTaskToContainerInstanceRel(), ECSTaskToECSClusterRel(), ECSTaskToNetworkInterfaceRel()]
     )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -3311,8 +3311,14 @@ Representation of an AWS ECS [Task](https://docs.aws.amazon.com/AmazonECS/latest
 | task\_definition\_arn | The ARN of the task definition that creates the task. |
 | version | The version counter for the task. |
 | ephemeral\_storage\_size\_in\_gib | The total amount, in GiB, of ephemeral storage to set for the task. |
+| network\_interface\_id | The network interface ID for tasks running in awsvpc network mode. |
 
 #### Relationships
+
+- ECSTasks are a resource under the AWS Account
+    ```
+    (:AWSAccount)-[:RESOURCE]->(:ECSTask)
+    ```
 
 - ECSClusters have ECSTasks
     ```
@@ -3327,6 +3333,11 @@ Representation of an AWS ECS [Task](https://docs.aws.amazon.com/AmazonECS/latest
 - ECSTasks have ECSTaskDefinitions
     ```
     (:ECSTask)-[:HAS_TASK_DEFINITION]->(:ECSTaskDefinition)
+    ```
+
+- ECSTasks in awsvpc network mode have NetworkInterfaces
+    ```
+    (:ECSTask)-[:NETWORK_INTERFACE]->(:NetworkInterface)
     ```
 
 ### ECSContainer

--- a/tests/integration/cartography/intel/aws/test_ecs.py
+++ b/tests/integration/cartography/intel/aws/test_ecs.py
@@ -252,11 +252,12 @@ def test_ecs_task_network_interface_relationship(neo4j_session):
         NetworkInterfaceId="eni-00000000000000000",
         aws_update_tag=TEST_UPDATE_TAG,
     )
-    
+
     import copy
+
     task_data = copy.deepcopy(tests.data.aws.ecs.GET_ECS_TASKS)
     cartography.intel.aws.ecs._enrich_tasks_with_network_interface_id(task_data)
-    
+
     # Act
     cartography.intel.aws.ecs.load_ecs_tasks(
         neo4j_session,
@@ -266,7 +267,7 @@ def test_ecs_task_network_interface_relationship(neo4j_session):
         TEST_ACCOUNT_ID,
         TEST_UPDATE_TAG,
     )
-    
+
     # Assert
     nodes = neo4j_session.run(
         """
@@ -274,10 +275,7 @@ def test_ecs_task_network_interface_relationship(neo4j_session):
         RETURN t.id as task_id, ni.id as ni_id
         """,
     )
-    actual_relationships = {
-        (n["task_id"], n["ni_id"])
-        for n in nodes
-    }
+    actual_relationships = {(n["task_id"], n["ni_id"]) for n in nodes}
     expected_relationships = {
         (
             "arn:aws:ecs:us-east-1:000000000000:task/test_task/00000000000000000000000000000000",


### PR DESCRIPTION
### Summary
This will allow us to see which subnets ECS tasks are part of and whether they are internet exposed

### Related issues or links
Somewhat related: https://github.com/cartography-cncf/cartography/issues/1610

### Checklist
Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [x] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

Screenshot
<img width="1187" height="543" alt="Screenshot 2025-07-14 at 11 26 14 PM" src="https://github.com/user-attachments/assets/45c27aa7-b16a-48c0-82f5-59a55ce9613a" />

Redacted Trace
```
(cartography) ➜  cartography git:(master) ✗ cartography --selected-modules aws --aws-requested-syncs "ec2:subnet,ec2:network_interface,ec2:security_group,ecs" --neo4j-uri bolt://localhost:7687 --neo4j-user neo4j --neo4j-password-env-var NEO4J_PASSWORD 
  --aws-regions us-east-1
  WARNING:cartography.cli:A Kandji base URI was not provided.
  WARNING:cartography.cli:A SnipeIT base URI was not provided.
  INFO:cartography.sync:Starting sync with update tag 'XXXXXXXXXX'
  INFO:cartography.sync:Starting sync stage 'aws'
  INFO:cartography.intel.aws:Syncing AWS accounts: XXXXXXXXXXXX
  INFO:cartography.intel.aws:Syncing AWS account with ID 'XXXXXXXXXXXX' using configured profile 'AdministratorAccess-XXXXXXXXXXXX'.
  INFO:cartography.intel.aws:Trying to autodiscover accounts.
  WARNING:cartography.intel.aws:The current account (XXXXXXXXXXXX) doesn't have enough permissions to perform autodiscovery.
  INFO:cartography.intel.aws.ec2.subnets:Syncing EC2 subnets for region 'us-east-1' in account 'XXXXXXXXXXXX'.
  INFO:cartography.graph.statement:Completed aws_ingest_subnets_cleanup statement #1
  INFO:cartography.graph.statement:Completed aws_ingest_subnets_cleanup statement #2
  INFO:cartography.graph.job:Finished job aws_ingest_subnets_cleanup
  INFO:cartography.graph.statement:Completed EC2Subnet statement #1
  INFO:cartography.graph.statement:Completed EC2Subnet statement #2
  INFO:cartography.graph.statement:Completed EC2Subnet statement #3
  INFO:cartography.graph.job:Finished job EC2Subnet
  INFO:cartography.graph.statement:Completed EC2Subnet statement #1
  INFO:cartography.graph.statement:Completed EC2Subnet statement #2
  INFO:cartography.graph.statement:Completed EC2Subnet statement #3
  INFO:cartography.graph.job:Finished job EC2Subnet
  INFO:cartography.intel.aws.ec2.network_interfaces:Syncing EC2 network interfaces for region 'us-east-1' in account 'XXXXXXXXXXXX'.
  INFO:cartography.intel.aws.ec2.network_interfaces:Loading 21 network interfaces in us-east-1.
  INFO:cartography.intel.aws.ec2.network_interfaces:Loading 21 private IPs in us-east-1.
  INFO:cartography.intel.aws.ec2.network_interfaces:Loading 21 subnets in us-east-1.
  INFO:cartography.intel.aws.ec2.network_interfaces:Loading 31 security groups in us-east-1.
  INFO:cartography.graph.statement:Completed NetworkInterface statement #1
  INFO:cartography.graph.statement:Completed NetworkInterface statement #2
  INFO:cartography.graph.statement:Completed NetworkInterface statement #3
  INFO:cartography.graph.statement:Completed NetworkInterface statement #4
  INFO:cartography.graph.statement:Completed NetworkInterface statement #5
  INFO:cartography.graph.statement:Completed NetworkInterface statement #6
  INFO:cartography.graph.statement:Completed NetworkInterface statement #7
  INFO:cartography.graph.job:Finished job NetworkInterface
  INFO:cartography.graph.statement:Completed EC2PrivateIp statement #1
  INFO:cartography.graph.statement:Completed EC2PrivateIp statement #2
  INFO:cartography.graph.statement:Completed EC2PrivateIp statement #3
  INFO:cartography.graph.job:Finished job EC2PrivateIp
  INFO:cartography.intel.aws.ec2.security_groups:Syncing EC2 security groups for region 'us-east-1' in account 'XXXXXXXXXXXX'.
  INFO:cartography.graph.statement:Completed aws_import_ec2_security_groupinfo_cleanup statement #1
  INFO:cartography.graph.statement:Completed aws_import_ec2_security_groupinfo_cleanup statement #2
  INFO:cartography.graph.statement:Completed aws_import_ec2_security_groupinfo_cleanup statement #3
  INFO:cartography.graph.statement:Completed aws_import_ec2_security_groupinfo_cleanup statement #4
  INFO:cartography.graph.job:Finished job aws_import_ec2_security_groupinfo_cleanup
  INFO:cartography.graph.statement:Completed EC2SecurityGroup statement #1
  INFO:cartography.graph.statement:Completed EC2SecurityGroup statement #2
  INFO:cartography.graph.statement:Completed EC2SecurityGroup statement #3
  INFO:cartography.graph.job:Finished job EC2SecurityGroup
  INFO:cartography.intel.aws.ecs:Syncing ECS for region 'us-east-1' in account 'XXXXXXXXXXXX'.
  INFO:cartography.graph.statement:Completed ECSContainer statement #1
  INFO:cartography.graph.statement:Completed ECSContainer statement #2
  INFO:cartography.graph.statement:Completed ECSContainer statement #3
  INFO:cartography.graph.statement:Completed ECSContainer statement #4
  INFO:cartography.graph.job:Finished job ECSContainer
  INFO:cartography.graph.statement:Completed ECSTask statement #1
  INFO:cartography.graph.statement:Completed ECSTask statement #2
  INFO:cartography.graph.statement:Completed ECSTask statement #3
  INFO:cartography.graph.statement:Completed ECSTask statement #4
  INFO:cartography.graph.statement:Completed ECSTask statement #5
  INFO:cartography.graph.job:Finished job ECSTask
  INFO:cartography.graph.statement:Completed ECSContainerInstance statement #1
  INFO:cartography.graph.statement:Completed ECSContainerInstance statement #2
  INFO:cartography.graph.statement:Completed ECSContainerInstance statement #3
  INFO:cartography.graph.job:Finished job ECSContainerInstance
  INFO:cartography.graph.statement:Completed ECSService statement #1
  INFO:cartography.graph.statement:Completed ECSService statement #2
  INFO:cartography.graph.statement:Completed ECSService statement #3
  INFO:cartography.graph.statement:Completed ECSService statement #4
  INFO:cartography.graph.job:Finished job ECSService
  INFO:cartography.graph.statement:Completed ECSContainerDefinition statement #1
  INFO:cartography.graph.statement:Completed ECSContainerDefinition statement #2
  INFO:cartography.graph.statement:Completed ECSContainerDefinition statement #3
  INFO:cartography.graph.job:Finished job ECSContainerDefinition
  INFO:cartography.graph.statement:Completed ECSTaskDefinition statement #1
  INFO:cartography.graph.statement:Completed ECSTaskDefinition statement #2
  INFO:cartography.graph.statement:Completed ECSTaskDefinition statement #3
  INFO:cartography.graph.statement:Completed ECSTaskDefinition statement #4
  INFO:cartography.graph.statement:Completed ECSTaskDefinition statement #5
  INFO:cartography.graph.job:Finished job ECSTaskDefinition
  INFO:cartography.graph.statement:Completed ECSCluster statement #1
  INFO:cartography.graph.statement:Completed ECSCluster statement #2
  INFO:cartography.graph.job:Finished job ECSCluster
  INFO:cartography.graph.statement:Completed aws_ec2_iaminstanceprofile statement #1
  INFO:cartography.graph.statement:Completed aws_ec2_iaminstanceprofile statement #2
  INFO:cartography.graph.job:Finished job aws_ec2_iaminstanceprofile
  INFO:cartography.graph.statement:Completed aws_lambda_ecr statement #1
  INFO:cartography.graph.statement:Completed aws_lambda_ecr statement #2
  INFO:cartography.graph.job:Finished job aws_lambda_ecr
  INFO:cartography.graph.statement:Completed aws_post_ingestion_principals_cleanup statement #1
  INFO:cartography.graph.job:Finished job aws_post_ingestion_principals_cleanup
  INFO:cartography.util:Did not run aws_ec2_asset_exposure.json because it needs {'ec2:instance', 'ec2:load_balancer', 'ec2:security_group', 'ec2:load_balancer_v2'} to be included as a requested sync. You specified: {'ecs', 'ec2:network_interface', 'ec2:security_group',
  'ec2:subnet'}. If you want this job to run, please change your CLI args/cartography config so that all required resources are included.
  INFO:cartography.util:Did not run aws_ec2_keypair_analysis.json because it needs {'ec2:keypair'} to be included as a requested sync. You specified: {'ecs', 'ec2:network_interface', 'ec2:security_group', 'ec2:subnet'}. If you want this job to run, please change your CLI 
  args/cartography config so that all required resources are included.
  INFO:cartography.util:Did not run aws_eks_asset_exposure.json because it needs {'eks'} to be included as a requested sync. You specified: {'ecs', 'ec2:network_interface', 'ec2:security_group', 'ec2:subnet'}. If you want this job to run, please change your CLI
  args/cartography config so that all required resources are included.
  INFO:cartography.graph.statement:Completed aws_foreign_accounts statement #1
  INFO:cartography.graph.statement:Completed aws_foreign_accounts statement #2
  INFO:cartography.graph.job:Finished job aws_foreign_accounts
  INFO:cartography.sync:Finishing sync stage 'aws'
  INFO:cartography.sync:Finishing sync with update tag 'XXXXXXXXXX'
```

