### PR TITLE
fix: subnetid vs subnet_id inconsistency (#1687)

### DIFF
--- a/cartography/intel/aws/ec2/subnets.py
+++ b/cartography/intel/aws/ec2/subnets.py
@@ -45,15 +45,22 @@ def load_subnets(
 
     ingest_subnets = """
     UNWIND $subnets as subnet
-    MERGE (snet:EC2Subnet{subnetid: subnet.SubnetId})
+    MERGE (snet:EC2Subnet{id: subnet.SubnetId})
     ON CREATE SET snet.firstseen = timestamp()
-    SET snet.lastupdated = $aws_update_tag, snet.name = subnet.CidrBlock, snet.cidr_block = subnet.CidrBlock,
-    snet.available_ip_address_count = subnet.AvailableIpAddressCount, snet.default_for_az = subnet.DefaultForAz,
-    snet.map_customer_owned_ip_on_launch = subnet.MapCustomerOwnedIpOnLaunch,
-    snet.state = subnet.State, snet.assignipv6addressoncreation = subnet.AssignIpv6AddressOnCreation,
-    snet.map_public_ip_on_launch = subnet.MapPublicIpOnLaunch, snet.subnet_arn = subnet.SubnetArn,
-    snet.availability_zone = subnet.AvailabilityZone, snet.availability_zone_id = subnet.AvailabilityZoneId,
-    snet.subnetid = subnet.SubnetId
+    SET snet.lastupdated = $aws_update_tag,
+        snet.name = subnet.CidrBlock,
+        snet.cidr_block = subnet.CidrBlock,
+        snet.available_ip_address_count = subnet.AvailableIpAddressCount,
+        snet.default_for_az = subnet.DefaultForAz,
+        snet.map_customer_owned_ip_on_launch = subnet.MapCustomerOwnedIpOnLaunch,
+        snet.state = subnet.State,
+        snet.assignipv6addressoncreation = subnet.AssignIpv6AddressOnCreation,
+        snet.map_public_ip_on_launch = subnet.MapPublicIpOnLaunch,
+        snet.subnet_arn = subnet.SubnetArn,
+        snet.availability_zone = subnet.AvailabilityZone,
+        snet.availability_zone_id = subnet.AvailabilityZoneId,
+        snet.subnetid = subnet.SubnetId,
+        snet.subnet_id = subnet.SubnetId
     """
 
     ingest_subnet_vpc_relations = """

--- a/cartography/intel/aws/ec2/subnets.py
+++ b/cartography/intel/aws/ec2/subnets.py
@@ -47,19 +47,13 @@ def load_subnets(
     UNWIND $subnets as subnet
     MERGE (snet:EC2Subnet{subnetid: subnet.SubnetId})
     ON CREATE SET snet.firstseen = timestamp()
-    SET snet.lastupdated = $aws_update_tag,
-        snet.name = subnet.CidrBlock,
-        snet.cidr_block = subnet.CidrBlock,
-        snet.available_ip_address_count = subnet.AvailableIpAddressCount,
-        snet.default_for_az = subnet.DefaultForAz,
-        snet.map_customer_owned_ip_on_launch = subnet.MapCustomerOwnedIpOnLaunch,
-        snet.state = subnet.State,
-        snet.assignipv6addressoncreation = subnet.AssignIpv6AddressOnCreation,
-        snet.map_public_ip_on_launch = subnet.MapPublicIpOnLaunch,
-        snet.subnet_arn = subnet.SubnetArn,
-        snet.availability_zone = subnet.AvailabilityZone,
-        snet.availability_zone_id = subnet.AvailabilityZoneId,
-        snet.subnet_id = subnet.SubnetId
+    SET snet.lastupdated = $aws_update_tag, snet.name = subnet.CidrBlock, snet.cidr_block = subnet.CidrBlock,
+    snet.available_ip_address_count = subnet.AvailableIpAddressCount, snet.default_for_az = subnet.DefaultForAz,
+    snet.map_customer_owned_ip_on_launch = subnet.MapCustomerOwnedIpOnLaunch,
+    snet.state = subnet.State, snet.assignipv6addressoncreation = subnet.AssignIpv6AddressOnCreation,
+    snet.map_public_ip_on_launch = subnet.MapPublicIpOnLaunch, snet.subnet_arn = subnet.SubnetArn,
+    snet.availability_zone = subnet.AvailabilityZone, snet.availability_zone_id = subnet.AvailabilityZoneId,
+    snet.subnet_id = subnet.SubnetId
     """
 
     ingest_subnet_vpc_relations = """

--- a/cartography/intel/aws/ec2/subnets.py
+++ b/cartography/intel/aws/ec2/subnets.py
@@ -45,7 +45,7 @@ def load_subnets(
 
     ingest_subnets = """
     UNWIND $subnets as subnet
-    MERGE (snet:EC2Subnet{id: subnet.SubnetId})
+    MERGE (snet:EC2Subnet{subnetid: subnet.SubnetId})
     ON CREATE SET snet.firstseen = timestamp()
     SET snet.lastupdated = $aws_update_tag,
         snet.name = subnet.CidrBlock,
@@ -59,7 +59,6 @@ def load_subnets(
         snet.subnet_arn = subnet.SubnetArn,
         snet.availability_zone = subnet.AvailabilityZone,
         snet.availability_zone_id = subnet.AvailabilityZoneId,
-        snet.subnetid = subnet.SubnetId,
         snet.subnet_id = subnet.SubnetId
     """
 

--- a/cartography/models/aws/ec2/networkinterfaces.py
+++ b/cartography/models/aws/ec2/networkinterfaces.py
@@ -44,7 +44,9 @@ class EC2NetworkInterfaceNodeProperties(CartographyNodeProperties):
     requester_id: PropertyRef = PropertyRef("RequesterId", extra_index=True)
     requester_managed: PropertyRef = PropertyRef("RequesterManaged")
     source_dest_check: PropertyRef = PropertyRef("SourceDestCheck")
+    # TODO: remove subnetid once we have migrated to subnet_id
     subnetid: PropertyRef = PropertyRef("SubnetId", extra_index=True)
+    subnet_id: PropertyRef = PropertyRef("SubnetId", extra_index=True)
 
 
 @dataclass(frozen=True)

--- a/cartography/models/aws/ec2/subnet_instance.py
+++ b/cartography/models/aws/ec2/subnet_instance.py
@@ -15,7 +15,9 @@ from cartography.models.core.relationships import TargetNodeMatcher
 class EC2SubnetInstanceNodeProperties(CartographyNodeProperties):
     # arn: PropertyRef = PropertyRef('Arn', extra_index=True) TODO use arn; issue #1024
     id: PropertyRef = PropertyRef("SubnetId")
+    # TODO: remove subnetid once we have migrated to subnet_id
     subnetid: PropertyRef = PropertyRef("SubnetId", extra_index=True)
+    subnet_id: PropertyRef = PropertyRef("SubnetId", extra_index=True)
     region: PropertyRef = PropertyRef("Region", set_in_kwargs=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 

--- a/cartography/models/aws/ec2/subnet_networkinterface.py
+++ b/cartography/models/aws/ec2/subnet_networkinterface.py
@@ -16,6 +16,8 @@ from cartography.models.core.relationships import TargetNodeMatcher
 @dataclass(frozen=True)
 class EC2SubnetNetworkInterfaceNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef("SubnetId")
+    # TODO: remove subnetid once we have migrated to subnet_id
+    subnetid: PropertyRef = PropertyRef("SubnetId", extra_index=True)
     subnet_id: PropertyRef = PropertyRef("SubnetId", extra_index=True)
     region: PropertyRef = PropertyRef("Region", set_in_kwargs=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1278,6 +1278,7 @@ Representation of an AWS EC2 [Subnet](https://docs.aws.amazon.com/AWSEC2/latest/
 | firstseen| Timestamp of when a sync job first discovered this node  |
 | lastupdated |  Timestamp of the last time the node was updated |
 | **subnetid** | The ID of the subnet|
+| **subnet_id** | The ID of the subnet|
 | **id** | same as subnetid |
 | region| The AWS region the subnet is installed on|
 | name | The IPv4 CIDR block assigned to the subnet|
@@ -1969,6 +1970,7 @@ Representation of a generic Network Interface.  Currently however, we only creat
 | private\_dns\_name| The private DNS name |
 | status | Status of the network interface.  Valid Values: ``available \| associated \| attaching \| in-use \| detaching `` |
 | subnetid | The ID of the subnet |
+| subnet_id | The ID of the subnet |
 | interface_type  |  Describes the type of network interface. Valid values: `` interface \| efa `` |
 | requester_id  | Id of the requester, e.g. `amazon-elb` for ELBs |
 | requester_managed  |  Indicates whether the interface is managed by the requester |

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_instances.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_instances.py
@@ -92,9 +92,9 @@ def test_sync_ec2_instances(mock_get_instances, neo4j_session):
         ("eni-87", "SOME_SUBNET_1"),
     }
 
-    # #1316: Assert the fields of the subnet are as expected and that subnet_id does not exist
+    # #1316: Assert the fields of the subnet are as expected
     assert check_nodes(neo4j_session, "EC2Subnet", ["id", "subnetid", "subnet_id"]) == {
-        ("SOME_SUBNET_1", "SOME_SUBNET_1", None),
+        ("SOME_SUBNET_1", "SOME_SUBNET_1", "SOME_SUBNET_1"),
     }
 
     # Assert network interface to security group


### PR DESCRIPTION
### Summary
> Describe your changes.

Temp non-breaking change for #1687. In some cases, we refer to EC2 subnet ids with `subnetid` and `subnet_id` in others.

I first created a test to detect the inconsistency by running all possible module tests that create a node with a `subnetid` or a `subnet_id`. Before any code changes, it fails:

Before:
<img width="678" height="117" alt="Screenshot 2025-07-16 at 4 19 31 PM" src="https://github.com/user-attachments/assets/55fa43bc-42dc-4bf6-b6c4-7108897f33b3" />

To fix, I made `subnetid` and `subnet_id` present on all nodes. In future we can standardize on one but this way we at least don't break any callers.

After:
<img width="672" height="583" alt="Screenshot 2025-07-16 at 4 19 53 PM" src="https://github.com/user-attachments/assets/e11aeb25-c6b4-42b6-b202-4370e34c4046" />



### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/cartography-cncf/cartography/issues/1687


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [x] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
