### PR TITLE
feat: Add ALLOWS_TRAFFIC_FROM between EC2 security groups (#67)

### DIFF
--- a/cartography/models/aws/ec2/security_groups.py
+++ b/cartography/models/aws/ec2/security_groups.py
@@ -58,6 +58,24 @@ class EC2SecurityGroupToVpcRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class EC2SecurityGroupToSourceGroupRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EC2SecurityGroupToSourceGroupRel(CartographyRelSchema):
+    target_node_label: str = "EC2SecurityGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"groupid": PropertyRef("SOURCE_GROUP_IDS", one_to_many=True)}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "ALLOWS_TRAFFIC_FROM"
+    properties: EC2SecurityGroupToSourceGroupRelProperties = (
+        EC2SecurityGroupToSourceGroupRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class EC2SecurityGroupSchema(CartographyNodeSchema):
     label: str = "EC2SecurityGroup"
     properties: EC2SecurityGroupNodeProperties = EC2SecurityGroupNodeProperties()
@@ -65,5 +83,8 @@ class EC2SecurityGroupSchema(CartographyNodeSchema):
         EC2SecurityGroupToAWSAccountRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
-        [EC2SecurityGroupToVpcRel()]
+        [
+            EC2SecurityGroupToVpcRel(),
+            EC2SecurityGroupToSourceGroupRel(),
+        ]
     )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1227,7 +1227,7 @@ Representation of an AWS EC2 [Security Group](https://docs.aws.amazon.com/AWSEC2
 |-------|-------------|
 | firstseen| Timestamp of when a sync job first discovered this node  |
 | lastupdated |  Timestamp of the last time the node was updated |
-| groupid | The ID of the security group|
+| groupid | The ID of the security group. Note that these are globally unique in AWS.|
 | name | The name of the security group|
 | description | A description of the security group|
 | **id** | Same as `groupid` |
@@ -1251,6 +1251,11 @@ Representation of an AWS EC2 [Security Group](https://docs.aws.amazon.com/AWSEC2
 - Load balancers can define inbound [Source Security Groups](https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-groups.html).
     ```
     (LoadBalancer)-[SOURCE_SECURITY_GROUP]->(EC2SecurityGroup)
+    ```
+
+- Security Groups can allow traffic from other security groups. This relationship can also be self-referential, meaning that a security group can allow traffic from itself (as security groups are default-deny).
+    ```
+    (:EC2SecurityGroup)-[:ALLOWS_TRAFFIC_FROM]->(:EC2SecurityGroup)
     ```
 
 - AWS Accounts contain EC2 Security Groups.

--- a/tests/data/aws/ec2/security_groups.py
+++ b/tests/data/aws/ec2/security_groups.py
@@ -215,4 +215,57 @@ DESCRIBE_SGS = [
         ],
         "VpcId": "vpc-05326141848d1c681",
     },
+    {
+        "Description": "web server security group",
+        "GroupName": "web-server-sg",
+        "IpPermissions": [
+            {
+                "FromPort": 22,
+                "IpProtocol": "tcp",
+                "IpRanges": [
+                    {
+                        "CidrIp": "10.0.0.0/8",
+                    },
+                ],
+                "Ipv6Ranges": [],
+                "PrefixListIds": [],
+                "ToPort": 22,
+                "UserIdGroupPairs": [
+                    {
+                        "GroupId": "sg-028e2522c72719996",
+                        "UserId": "000000000000",
+                    },
+                ],
+            },
+            {
+                "FromPort": 80,
+                "IpProtocol": "tcp",
+                "IpRanges": [
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                    },
+                ],
+                "Ipv6Ranges": [],
+                "PrefixListIds": [],
+                "ToPort": 80,
+                "UserIdGroupPairs": [],
+            },
+        ],
+        "OwnerId": "000000000000",
+        "GroupId": "sg-web-server-12345",
+        "IpPermissionsEgress": [
+            {
+                "IpProtocol": "-1",
+                "IpRanges": [
+                    {
+                        "CidrIp": "0.0.0.0/0",
+                    },
+                ],
+                "Ipv6Ranges": [],
+                "PrefixListIds": [],
+                "UserIdGroupPairs": [],
+            },
+        ],
+        "VpcId": "vpc-05326141848d1c681",
+    },
 ]

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_security_groups.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_security_groups.py
@@ -34,6 +34,7 @@ def test_load_security_groups(neo4j_session):
         "sg-028e2522c72719996",
         "sg-06c795c66be8937be",
         "sg-053dba35430032a0d",
+        "sg-web-server-12345",
     }
 
     nodes = neo4j_session.run(
@@ -87,6 +88,9 @@ def test_load_security_groups_relationships(neo4j_session):
         ("sg-06c795c66be8937be", "sg-06c795c66be8937be/IpPermissions/8080tcp"),
         ("sg-0fd4fff275d63600f", "sg-0fd4fff275d63600f/IpPermissionsEgress/NoneNone-1"),
         ("sg-0fd4fff275d63600f", "sg-0fd4fff275d63600f/IpPermissions/NoneNone-1"),
+        ("sg-web-server-12345", "sg-web-server-12345/IpPermissionsEgress/NoneNone-1"),
+        ("sg-web-server-12345", "sg-web-server-12345/IpPermissions/2222tcp"),
+        ("sg-web-server-12345", "sg-web-server-12345/IpPermissions/8080tcp"),
     }
 
     # Fetch relationships
@@ -129,6 +133,7 @@ def test_sync_ec2_security_groupinfo(mock_get_security_groups, neo4j_session):
         ("sg-053dba35430032a0d", "sg-053dba35430032a0d"),
         ("sg-06c795c66be8937be", "sg-06c795c66be8937be"),
         ("sg-0fd4fff275d63600f", "sg-0fd4fff275d63600f"),
+        ("sg-web-server-12345", "sg-web-server-12345"),
     }
 
     # Assert security groups are connected to AWS account
@@ -145,6 +150,7 @@ def test_sync_ec2_security_groupinfo(mock_get_security_groups, neo4j_session):
         ("sg-053dba35430032a0d", "000000000000"),
         ("sg-06c795c66be8937be", "000000000000"),
         ("sg-0fd4fff275d63600f", "000000000000"),
+        ("sg-web-server-12345", "000000000000"),
     }
 
     # Assert IpPermissionInbound rules exist (only inbound rules)
@@ -155,6 +161,8 @@ def test_sync_ec2_security_groupinfo(mock_get_security_groups, neo4j_session):
         ("sg-06c795c66be8937be/IpPermissions/8080tcp", "sg-06c795c66be8937be"),
         ("sg-06c795c66be8937be/IpPermissions/443443tcp", "sg-06c795c66be8937be"),
         ("sg-0fd4fff275d63600f/IpPermissions/NoneNone-1", "sg-0fd4fff275d63600f"),
+        ("sg-web-server-12345/IpPermissions/2222tcp", "sg-web-server-12345"),
+        ("sg-web-server-12345/IpPermissions/8080tcp", "sg-web-server-12345"),
     }
     assert (
         check_nodes(neo4j_session, "IpPermissionInbound", ["ruleid", "groupid"])
@@ -177,6 +185,9 @@ def test_sync_ec2_security_groupinfo(mock_get_security_groups, neo4j_session):
         ("sg-06c795c66be8937be/IpPermissions/443443tcp", "sg-06c795c66be8937be"),
         ("sg-0fd4fff275d63600f/IpPermissionsEgress/NoneNone-1", "sg-0fd4fff275d63600f"),
         ("sg-0fd4fff275d63600f/IpPermissions/NoneNone-1", "sg-0fd4fff275d63600f"),
+        ("sg-web-server-12345/IpPermissionsEgress/NoneNone-1", "sg-web-server-12345"),
+        ("sg-web-server-12345/IpPermissions/2222tcp", "sg-web-server-12345"),
+        ("sg-web-server-12345/IpPermissions/8080tcp", "sg-web-server-12345"),
     }
     assert (
         check_nodes(neo4j_session, "IpRule", ["ruleid", "groupid"]) == expected_ip_rules
@@ -206,9 +217,11 @@ def test_sync_ec2_security_groupinfo(mock_get_security_groups, neo4j_session):
         ("sg-06c795c66be8937be/IpPermissions/443443tcp", "000000000000"),
         ("sg-0fd4fff275d63600f/IpPermissionsEgress/NoneNone-1", "000000000000"),
         ("sg-0fd4fff275d63600f/IpPermissions/NoneNone-1", "000000000000"),
+        ("sg-web-server-12345/IpPermissionsEgress/NoneNone-1", "000000000000"),
+        ("sg-web-server-12345/IpPermissions/2222tcp", "000000000000"),
+        ("sg-web-server-12345/IpPermissions/8080tcp", "000000000000"),
     }
 
-    # Test self-referential security groups
     assert check_rels(
         neo4j_session,
         "EC2SecurityGroup",
@@ -218,6 +231,9 @@ def test_sync_ec2_security_groupinfo(mock_get_security_groups, neo4j_session):
         "ALLOWS_TRAFFIC_FROM",
         rel_direction_right=True,
     ) == {
+        # Test self-referential security groups
         ("sg-053dba35430032a0d", "sg-053dba35430032a0d"),
         ("sg-0fd4fff275d63600f", "sg-0fd4fff275d63600f"),
+        # Test cross-security group relationships
+        ("sg-web-server-12345", "sg-028e2522c72719996"),
     }

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_security_groups.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_security_groups.py
@@ -207,3 +207,17 @@ def test_sync_ec2_security_groupinfo(mock_get_security_groups, neo4j_session):
         ("sg-0fd4fff275d63600f/IpPermissionsEgress/NoneNone-1", "000000000000"),
         ("sg-0fd4fff275d63600f/IpPermissions/NoneNone-1", "000000000000"),
     }
+
+    # Test self-referential security groups
+    assert check_rels(
+        neo4j_session,
+        "EC2SecurityGroup",
+        "id",
+        "EC2SecurityGroup",
+        "id",
+        "ALLOWS_TRAFFIC_FROM",
+        rel_direction_right=True,
+    ) == {
+        ("sg-053dba35430032a0d", "sg-053dba35430032a0d"),
+        ("sg-0fd4fff275d63600f", "sg-0fd4fff275d63600f"),
+    }


### PR DESCRIPTION
### Summary
> Describe your changes.

Addresses https://github.com/cartography-cncf/cartography/issues/67.

Maps AWS security groups allowing traffic from each other, including self referential ones. If sg A ALLOWS_TRAFFIC_FROM sg B, that means that (at least from a sg rules perspective) all assets in sg B will be able to reach sg A.

<img width="1262" height="537" alt="Screenshot 2025-07-17 at 3 05 54 PM" src="https://github.com/user-attachments/assets/de32ee7b-5329-4ecf-9f7b-f68abc9e8819" />



### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [x] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
