### PR TITLE
Metric alarm

### DIFF
--- a/cartography/intel/aws/cloudwatch.py
+++ b/cartography/intel/aws/cloudwatch.py
@@ -13,6 +13,7 @@ from cartography.models.aws.cloudwatch.log_metric_filter import (
     CloudWatchLogMetricFilterSchema,
 )
 from cartography.models.aws.cloudwatch.loggroup import CloudWatchLogGroupSchema
+from cartography.models.aws.cloudwatch.metric_alarm import CloudWatchMetricAlarmSchema
 from cartography.util import aws_handle_regions
 from cartography.util import timeit
 
@@ -76,6 +77,41 @@ def transform_metric_filters(
 
 
 @timeit
+@aws_handle_regions
+def get_cloudwatch_metric_alarms(
+    boto3_session: boto3.Session, region: str
+) -> List[Dict[str, Any]]:
+    client = boto3_session.client("cloudwatch", region_name=region)
+    paginator = client.get_paginator("describe_alarms")
+    alarms = []
+    for page in paginator.paginate():
+        alarms.extend(page["MetricAlarms"])
+    return alarms
+
+
+def transform_metric_alarms(
+    metric_alarms: List[Dict[str, Any]], region: str
+) -> List[Dict[str, Any]]:
+    """
+    Transform CloudWatch metric alarm data for ingestion into Neo4j.
+    """
+    transformed_alarms = []
+    for alarm in metric_alarms:
+        transformed_alarm = {
+            "AlarmArn": alarm["AlarmArn"],
+            "AlarmName": alarm.get("AlarmName"),
+            "AlarmDescription": alarm.get("AlarmDescription"),
+            "StateValue": alarm.get("StateValue"),
+            "StateReason": alarm.get("StateReason"),
+            "ActionsEnabled": alarm.get("ActionsEnabled"),
+            "ComparisonOperator": alarm.get("ComparisonOperator"),
+            "Region": region,
+        }
+        transformed_alarms.append(transformed_alarm)
+    return transformed_alarms
+
+
+@timeit
 def load_cloudwatch_log_groups(
     neo4j_session: neo4j.Session,
     data: List[Dict[str, Any]],
@@ -118,6 +154,27 @@ def load_cloudwatch_log_metric_filters(
 
 
 @timeit
+def load_cloudwatch_metric_alarms(
+    neo4j_session: neo4j.Session,
+    data: List[Dict[str, Any]],
+    region: str,
+    current_aws_account_id: str,
+    aws_update_tag: int,
+) -> None:
+    logger.info(
+        f"Loading CloudWatch {len(data)} metric alarms for region '{region}' into graph.",
+    )
+    load(
+        neo4j_session,
+        CloudWatchMetricAlarmSchema(),
+        data,
+        lastupdated=aws_update_tag,
+        Region=region,
+        AWS_ID=current_aws_account_id,
+    )
+
+
+@timeit
 def cleanup(
     neo4j_session: neo4j.Session,
     common_job_parameters: Dict[str, Any],
@@ -130,6 +187,9 @@ def cleanup(
     GraphJob.from_node_schema(
         CloudWatchLogMetricFilterSchema(), common_job_parameters
     ).run(neo4j_session)
+    GraphJob.from_node_schema(CloudWatchMetricAlarmSchema(), common_job_parameters).run(
+        neo4j_session
+    )
 
 
 @timeit
@@ -163,6 +223,16 @@ def sync(
         load_cloudwatch_log_metric_filters(
             neo4j_session,
             transformed_filters,
+            region,
+            current_aws_account_id,
+            update_tag,
+        )
+
+        metric_alarms = get_cloudwatch_metric_alarms(boto3_session, region)
+        transformed_alarms = transform_metric_alarms(metric_alarms, region)
+        load_cloudwatch_metric_alarms(
+            neo4j_session,
+            transformed_alarms,
             region,
             current_aws_account_id,
             update_tag,

--- a/cartography/models/aws/cloudwatch/metric_alarm.py
+++ b/cartography/models/aws/cloudwatch/metric_alarm.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class CloudWatchMetricAlarmNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("AlarmArn")
+    arn: PropertyRef = PropertyRef("AlarmArn", extra_index=True)
+    alarm_name: PropertyRef = PropertyRef("AlarmName")
+    alarm_description: PropertyRef = PropertyRef("AlarmDescription")
+    state_value: PropertyRef = PropertyRef("StateValue")
+    state_reason: PropertyRef = PropertyRef("StateReason")
+    actions_enabled: PropertyRef = PropertyRef("ActionsEnabled")
+    comparison_operator: PropertyRef = PropertyRef("ComparisonOperator")
+    region: PropertyRef = PropertyRef("Region", set_in_kwargs=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class CloudWatchMetricAlarmToAwsAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class CloudWatchMetricAlarmToAWSAccountRel(CartographyRelSchema):
+    target_node_label: str = "AWSAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: CloudWatchMetricAlarmToAwsAccountRelProperties = (
+        CloudWatchMetricAlarmToAwsAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class CloudWatchMetricAlarmSchema(CartographyNodeSchema):
+    label: str = "CloudWatchMetricAlarm"
+    properties: CloudWatchMetricAlarmNodeProperties = (
+        CloudWatchMetricAlarmNodeProperties()
+    )
+    sub_resource_relationship: CloudWatchMetricAlarmToAWSAccountRel = (
+        CloudWatchMetricAlarmToAWSAccountRel()
+    )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -870,6 +870,27 @@ Representation of an AWS [CloudWatch Log Metric Filter](https://docs.aws.amazon.
 |-------|-------------|
 | firstseen| Timestamp of when a sync job first discovered this node  |
 | lastupdated |  Timestamp of the last time the node was updated |
+| id | The ARN of the CloudWatch Metric Alarm |
+| arn | The ARN of the CloudWatch Metric Alarm |
+| region | The region of the CloudWatch Metric Alarm |
+| alarm_name | The name of the alarm |
+| state_value | The state value for the alarm |
+| state_reason | An explanation for the alarm state, in text format |
+| actions_enabled | Indicates whether actions should be executed during any changes to the alarm state |
+| comparison_operator | The arithmetic operation to use when comparing the specified statistic and threshold. The specified statistic value is used as the first operand |
+#### Relationships
+- CloudWatch Metric Alarms are a resource under the AWS Account.
+    ```
+    (AWSAccount)-[RESOURCE]->(CloudWatchMetricAlarm)
+    ```
+
+### CloudWatchMetricAlarm
+Representation of an AWS [CloudWatch Metric Alarm](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DescribeAlarms.html)
+
+| Field | Description |
+|-------|-------------|
+| firstseen| Timestamp of when a sync job first discovered this node  |
+| lastupdated |  Timestamp of the last time the node was updated |
 | id | Ensures that the id field is a unique combination of logGroupName and filterName |
 | arn | Ensures that the arn field is a unique combination of logGroupName and filterName |
 | region | The region of the CloudWatch Log Metric Filter |

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -863,8 +863,8 @@ Representation of an AWS [CloudWatch Log Group](https://docs.aws.amazon.com/Amaz
     (AWSAccount)-[RESOURCE]->(CloudWatchLogGroup)
     ```
 
-### CloudWatchLogMetricFilter
-Representation of an AWS [CloudWatch Log Metric Filter](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeMetricFilters.html)
+### CloudWatchMetricAlarm
+Representation of an AWS [CloudWatch Metric Alarm](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DescribeAlarms.html)
 
 | Field | Description |
 |-------|-------------|
@@ -884,8 +884,8 @@ Representation of an AWS [CloudWatch Log Metric Filter](https://docs.aws.amazon.
     (AWSAccount)-[RESOURCE]->(CloudWatchMetricAlarm)
     ```
 
-### CloudWatchMetricAlarm
-Representation of an AWS [CloudWatch Metric Alarm](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DescribeAlarms.html)
+### CloudWatchLogMetricFilter
+Representation of an AWS [CloudWatch Log Metric Filter](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeMetricFilters.html)
 
 | Field | Description |
 |-------|-------------|

--- a/tests/data/aws/cloudwatch.py
+++ b/tests/data/aws/cloudwatch.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 GET_CLOUDWATCH_LOG_GROUPS = [
     {
         "logGroupName": "/aws/lambda/process-orders",
@@ -49,5 +51,111 @@ GET_CLOUDWATCH_LOG_METRIC_FILTERS = [
                 "metricValue": "1",
             }
         ],
+    },
+]
+
+GET_CLOUDWATCH_METRIC_ALARMS = [
+    {
+        "AlarmName": "HighErrorCountAlarm",
+        "AlarmArn": "arn:aws:cloudwatch:us-east-1:123456789012:alarm:HighErrorCountAlarm",
+        "AlarmDescription": "Triggered when error count exceeds 5",
+        "AlarmConfigurationUpdatedTimestamp": datetime(2023, 12, 1),
+        "ActionsEnabled": True,
+        "OKActions": ["arn:aws:sns:us-east-1:123456789012:ok-topic"],
+        "AlarmActions": ["arn:aws:sns:us-east-1:123456789012:alarm-topic"],
+        "InsufficientDataActions": [],
+        "StateValue": "OK",
+        "StateReason": "Threshold not breached",
+        "StateReasonData": "{}",
+        "StateUpdatedTimestamp": datetime(2023, 12, 1),
+        "MetricName": "ErrorCount",
+        "Namespace": "MyApp/Metrics",
+        "Statistic": "Sum",
+        "ExtendedStatistic": "",
+        "Dimensions": [{"Name": "LogGroupName", "Value": "/aws/lambda/serviceA"}],
+        "Period": 300,
+        "Unit": "Count",
+        "EvaluationPeriods": 1,
+        "DatapointsToAlarm": 1,
+        "Threshold": 5.0,
+        "ComparisonOperator": "GreaterThanThreshold",
+        "TreatMissingData": "missing",
+        "EvaluateLowSampleCountPercentile": "",
+        "Metrics": [],
+        "ThresholdMetricId": "",
+        "EvaluationState": "PARTIAL_DATA",
+        "StateTransitionedTimestamp": datetime(2023, 12, 1),
+    },
+    {
+        "AlarmName": "CompositeErrorRateAlarm",
+        "AlarmArn": "arn:aws:cloudwatch:us-east-1:123456789012:alarm:CompositeErrorRateAlarm",
+        "AlarmDescription": "Alarm on combined ErrorCount and WarningCount",
+        "AlarmConfigurationUpdatedTimestamp": datetime(2023, 12, 2),
+        "ActionsEnabled": True,
+        "OKActions": [],
+        "AlarmActions": ["arn:aws:sns:us-east-1:123456789012:composite-topic"],
+        "InsufficientDataActions": [],
+        "StateValue": "INSUFFICIENT_DATA",
+        "StateReason": "Waiting for datapoints",
+        "StateReasonData": "{}",
+        "StateUpdatedTimestamp": datetime(2023, 12, 2),
+        "MetricName": "",
+        "Namespace": "",
+        "Statistic": "",
+        "ExtendedStatistic": "",
+        "Dimensions": [],
+        "Period": 0,
+        "Unit": "None",
+        "EvaluationPeriods": 2,
+        "DatapointsToAlarm": 2,
+        "Threshold": 10.0,
+        "ComparisonOperator": "GreaterThanThreshold",
+        "TreatMissingData": "notBreaching",
+        "EvaluateLowSampleCountPercentile": "",
+        "Metrics": [
+            {
+                "Id": "m1",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": "MyApp/Metrics",
+                        "MetricName": "ErrorCount",
+                        "Dimensions": [
+                            {"Name": "LogGroupName", "Value": "/aws/lambda/serviceA"}
+                        ],
+                    },
+                    "Period": 300,
+                    "Stat": "Sum",
+                    "Unit": "Count",
+                },
+                "ReturnData": False,
+                "AccountId": "123456789012",
+            },
+            {
+                "Id": "m2",
+                "MetricStat": {
+                    "Metric": {
+                        "Namespace": "MyApp/Metrics",
+                        "MetricName": "WarningCount",
+                        "Dimensions": [
+                            {"Name": "LogGroupName", "Value": "/aws/lambda/serviceA"}
+                        ],
+                    },
+                    "Period": 300,
+                    "Stat": "Sum",
+                    "Unit": "Count",
+                },
+                "ReturnData": False,
+                "AccountId": "123456789012",
+            },
+            {
+                "Id": "e1",
+                "Expression": "m1 + m2",
+                "Label": "TotalIssues",
+                "ReturnData": True,
+            },
+        ],
+        "ThresholdMetricId": "e1",
+        "EvaluationState": "PARTIAL_DATA",
+        "StateTransitionedTimestamp": datetime(2023, 12, 2),
     },
 ]


### PR DESCRIPTION
### Add CloudWatch Metric Alarm as Resource in AWS Module



### Related issues or links
[#1552](https://github.com/cartography-cncf/cartography/issues/1552)



### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [x] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

<img width="1838" height="622" alt="image" src="https://github.com/user-attachments/assets/9696eba5-3ad3-48da-9f0e-5d8a8e130eb9" />

