### PR TITLE
test: Add unit tests for DNS zones and record sets loading

### DIFF
--- a/tests/unit/cartography/intel/gcp/test_dns.py
+++ b/tests/unit/cartography/intel/gcp/test_dns.py
@@ -1,0 +1,56 @@
+import cartography.intel.gcp.dns
+import tests.data.gcp.dns
+
+
+def test_load_dns_zones(mocker):
+    mock_session = mocker.Mock()
+    zones = tests.data.gcp.dns.DNS_ZONES
+    project_id = "project-x"
+    update_tag = 42
+    cartography.intel.gcp.dns.load_dns_zones(mock_session, zones, project_id, update_tag)
+    mock_session.run.assert_called_once()
+    query = mock_session.run.call_args[0][0]
+    params = mock_session.run.call_args[1]
+    assert "UNWIND $records as record" in query
+    assert "MERGE(zone:GCPDNSZone{id:record.id})" in query
+    assert params["records"] == zones
+
+
+def test_load_rrs(mocker):
+   
+    mock_session = mocker.Mock()
+    rrs = tests.data.gcp.dns.DNS_RRS
+    project_id = "project-x"
+    update_tag = 42
+    cartography.intel.gcp.dns.load_rrs(mock_session, rrs, project_id, update_tag)
+    mock_session.run.assert_called_once()
+    query = mock_session.run.call_args[0][0]
+    params = mock_session.run.call_args[1]
+    assert "UNWIND $records as record" in query
+    assert "MERGE(rrs:GCPRecordSet{id:record.name})" in query
+    assert params["records"] == rrs
+
+
+def test_load_dns_zones_single_zone(mocker):
+  
+    mock_session = mocker.Mock()
+    single_zone = [tests.data.gcp.dns.DNS_ZONES[0]]
+    project_id = "project-x"
+    update_tag = 42
+    cartography.intel.gcp.dns.load_dns_zones(mock_session, single_zone, project_id, update_tag)
+    mock_session.run.assert_called_once()
+    query = mock_session.run.call_args[0][0]
+    assert "UNWIND $records as record" in query
+    assert "MERGE(zone:GCPDNSZone{id:record.id})" in query
+
+
+def test_load_rrs_single_record(mocker):
+    mock_session = mocker.Mock()
+    single_rr = [tests.data.gcp.dns.DNS_RRS[0]]
+    project_id = "project-x"
+    update_tag = 42
+    cartography.intel.gcp.dns.load_rrs(mock_session, single_rr, project_id, update_tag)
+    mock_session.run.assert_called_once()
+    query = mock_session.run.call_args[0][0]
+    assert "UNWIND $records as record" in query
+    assert "MERGE(rrs:GCPRecordSet{id:record.name})" in query


### PR DESCRIPTION
### Summary
I have added unit test of GCP DNS load functions `load_dns_zones` and `load_rrs` in the `cartography.intel.gcp.dns` module.

**Tests cover:**

- Functionality for loading multiple and single DNS zones and record sets  
- Proper Cypher query structure and parameter handling  
- Mocking Neo4j session to avoid dependency on a live database


### Related issues or links
> No issue have been made

## Screenshot
<img width="1424" height="295" alt="dns-gcp" src="https://github.com/user-attachments/assets/1df91a4c-711d-482f-91bf-1d0f01045304" />


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [X] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).