### PR TITLE
fix: Read/Write on Entra AppRoleAssignment perm

### DIFF
--- a/docs/root/modules/entra/config.md
+++ b/docs/root/modules/entra/config.md
@@ -15,7 +15,7 @@ To set up the Entra client,
     - `AdministrativeUnit.Read.All`
         - Read all administrative units
         - Type: Application
-    - `AppRoleAssignment.Read.All`
+    - `AppRoleAssignment.ReadWrite.All`
         - Manage app permission grants and app role assignments
         - Type: Application
     - `Application.Read.All`


### PR DESCRIPTION
### Summary
Quick fix after #1716 
I said that AppRoleAssignment only allows ReadWrite, not just Read, but accidentally changed the perm to read. MS graph only has this perm:
<img width="1676" height="254" alt="image" src="https://github.com/user-attachments/assets/e07e1cf9-875d-4958-9d87-265a1698cb5b" />
