### PR TITLE
Fix: Cloudtrail Github Username Parsing

### DIFF
--- a/cartography/intel/aws/cloudtrail_management_events.py
+++ b/cartography/intel/aws/cloudtrail_management_events.py
@@ -388,7 +388,7 @@ def transform_web_identity_role_events_to_role_assumptions(
                         f"Missing userName in GitHub WebIdentity event: {event.get('EventId', 'unknown')}"
                     )
                     continue
-                
+
                 # Parse GitHub repo fullname from format like "repo:owner/repo:pull_request"
                 github_repo = _extract_github_repo_from_username(user_name)
                 key = (github_repo, destination_principal)
@@ -587,23 +587,23 @@ def _extract_github_repo_from_username(user_name: str) -> str:
 
     # Split by colon - expected format: "repo:owner/repo:context"
     parts = user_name.split(":")
-    
+
     # Need at least 3 parts: ["repo", "owner/repo", "context"]
     if len(parts) < 3 or parts[0] != "repo":
         return ""
-    
+
     # Extract the owner/repo part (second element)
     repo_fullname = parts[1]
-    
+
     # Validate it looks like owner/repo format
     if "/" not in repo_fullname or repo_fullname.count("/") != 1:
         return ""
-    
+
     # Additional validation - ensure both owner and repo parts exist
     owner, repo = repo_fullname.split("/")
     if not owner or not repo:
         return ""
-    
+
     return repo_fullname
 
 

--- a/tests/data/aws/cloudtrail_management_events.py
+++ b/tests/data/aws/cloudtrail_management_events.py
@@ -191,7 +191,7 @@ GITHUB_WEB_IDENTITY_CLOUDTRAIL_EVENTS = [
             "type": "WebIdentityUser",
             "principalId": "repo:sublimagesec/sublimage:ref:refs/heads/main",
             "identityProvider": "token.actions.githubusercontent.com",
-            "userName": "sublimagesec/sublimage",
+            "userName": "repo:sublimagesec/sublimage:ref:refs/heads/main",
         },
         "Resources": [
             {
@@ -200,7 +200,7 @@ GITHUB_WEB_IDENTITY_CLOUDTRAIL_EVENTS = [
                 "AccountId": "123456789012",
             }
         ],
-        "CloudTrailEvent": '{"userIdentity": {"type": "WebIdentityUser", "principalId": "repo:sublimagesec/sublimage:ref:refs/heads/main", "identityProvider": "token.actions.githubusercontent.com", "userName": "sublimagesec/sublimage"}, "requestParameters": {"roleArn": "arn:aws:iam::123456789012:role/GitHubActionsRole"}, "responseElements": {"assumedRoleUser": {"arn": "arn:aws:sts::123456789012:assumed-role/GitHubActionsRole/sublimage"}}}',
+        "CloudTrailEvent": '{"userIdentity": {"type": "WebIdentityUser", "principalId": "repo:sublimagesec/sublimage:ref:refs/heads/main", "identityProvider": "token.actions.githubusercontent.com", "userName": "repo:sublimagesec/sublimage:ref:refs/heads/main"}, "requestParameters": {"roleArn": "arn:aws:iam::123456789012:role/GitHubActionsRole"}, "responseElements": {"assumedRoleUser": {"arn": "arn:aws:sts::123456789012:assumed-role/GitHubActionsRole/sublimage"}}}',
     },
     {
         "EventName": "AssumeRoleWithWebIdentity",
@@ -209,7 +209,7 @@ GITHUB_WEB_IDENTITY_CLOUDTRAIL_EVENTS = [
             "type": "WebIdentityUser",
             "principalId": "repo:myorg/demo-app:ref:refs/heads/develop",
             "identityProvider": "token.actions.githubusercontent.com",
-            "userName": "myorg/demo-app",
+            "userName": "repo:myorg/demo-app:ref:refs/heads/develop",
         },
         "Resources": [
             {
@@ -218,7 +218,7 @@ GITHUB_WEB_IDENTITY_CLOUDTRAIL_EVENTS = [
                 "AccountId": "987654321098",
             }
         ],
-        "CloudTrailEvent": '{"userIdentity": {"type": "WebIdentityUser", "principalId": "repo:myorg/demo-app:ref:refs/heads/develop", "identityProvider": "token.actions.githubusercontent.com", "userName": "myorg/demo-app"}, "requestParameters": {"roleArn": "arn:aws:iam::987654321098:role/CrossAccountGitHubRole"}, "responseElements": {"assumedRoleUser": {"arn": "arn:aws:sts::987654321098:assumed-role/CrossAccountGitHubRole/demo-app"}}}',
+        "CloudTrailEvent": '{"userIdentity": {"type": "WebIdentityUser", "principalId": "repo:myorg/demo-app:ref:refs/heads/develop", "identityProvider": "token.actions.githubusercontent.com", "userName": "repo:myorg/demo-app:ref:refs/heads/develop"}, "requestParameters": {"roleArn": "arn:aws:iam::987654321098:role/CrossAccountGitHubRole"}, "responseElements": {"assumedRoleUser": {"arn": "arn:aws:sts::987654321098:assumed-role/CrossAccountGitHubRole/demo-app"}}}',
     },
 ]
 
@@ -273,7 +273,7 @@ GITHUB_ACTIONS_AGGREGATION_CLOUDTRAIL_EVENTS = [
             "type": "WebIdentityUser",
             "principalId": "repo:myorg/test-repo:ref:refs/heads/main",
             "identityProvider": "token.actions.githubusercontent.com",
-            "userName": "myorg/test-repo",
+            "userName": "repo:myorg/test-repo:ref:refs/heads/main",
         },
         "Resources": [
             {
@@ -282,7 +282,7 @@ GITHUB_ACTIONS_AGGREGATION_CLOUDTRAIL_EVENTS = [
                 "AccountId": "111111111111",
             }
         ],
-        "CloudTrailEvent": '{"userIdentity": {"type": "WebIdentityUser", "principalId": "repo:myorg/test-repo:ref:refs/heads/main", "identityProvider": "token.actions.githubusercontent.com", "userName": "myorg/test-repo"}, "requestParameters": {"roleArn": "arn:aws:iam::111111111111:role/GitHubTestRole"}, "responseElements": {"assumedRoleUser": {"arn": "arn:aws:sts::111111111111:assumed-role/GitHubTestRole/test-repo"}}}',
+        "CloudTrailEvent": '{"userIdentity": {"type": "WebIdentityUser", "principalId": "repo:myorg/test-repo:ref:refs/heads/main", "identityProvider": "token.actions.githubusercontent.com", "userName": "repo:myorg/test-repo:ref:refs/heads/main"}, "requestParameters": {"roleArn": "arn:aws:iam::111111111111:role/GitHubTestRole"}, "responseElements": {"assumedRoleUser": {"arn": "arn:aws:sts::111111111111:assumed-role/GitHubTestRole/test-repo"}}}',
     },
     {
         "EventName": "AssumeRoleWithWebIdentity",
@@ -291,7 +291,7 @@ GITHUB_ACTIONS_AGGREGATION_CLOUDTRAIL_EVENTS = [
             "type": "WebIdentityUser",
             "principalId": "repo:myorg/test-repo:ref:refs/heads/develop",
             "identityProvider": "token.actions.githubusercontent.com",
-            "userName": "myorg/test-repo",
+            "userName": "repo:myorg/test-repo:ref:refs/heads/develop",
         },
         "Resources": [
             {
@@ -300,7 +300,7 @@ GITHUB_ACTIONS_AGGREGATION_CLOUDTRAIL_EVENTS = [
                 "AccountId": "111111111111",
             }
         ],
-        "CloudTrailEvent": '{"userIdentity": {"type": "WebIdentityUser", "principalId": "repo:myorg/test-repo:ref:refs/heads/develop", "identityProvider": "token.actions.githubusercontent.com", "userName": "myorg/test-repo"}, "requestParameters": {"roleArn": "arn:aws:iam::111111111111:role/GitHubTestRole"}, "responseElements": {"assumedRoleUser": {"arn": "arn:aws:sts::111111111111:assumed-role/GitHubTestRole/test-repo"}}}',
+        "CloudTrailEvent": '{"userIdentity": {"type": "WebIdentityUser", "principalId": "repo:myorg/test-repo:ref:refs/heads/develop", "identityProvider": "token.actions.githubusercontent.com", "userName": "repo:myorg/test-repo:ref:refs/heads/develop"}, "requestParameters": {"roleArn": "arn:aws:iam::111111111111:role/GitHubTestRole"}, "responseElements": {"assumedRoleUser": {"arn": "arn:aws:sts::111111111111:assumed-role/GitHubTestRole/test-repo"}}}',
     },
     {
         "EventName": "AssumeRoleWithWebIdentity",
@@ -309,7 +309,7 @@ GITHUB_ACTIONS_AGGREGATION_CLOUDTRAIL_EVENTS = [
             "type": "WebIdentityUser",
             "principalId": "repo:myorg/test-repo:ref:refs/heads/main",
             "identityProvider": "token.actions.githubusercontent.com",
-            "userName": "myorg/test-repo",
+            "userName": "repo:myorg/test-repo:ref:refs/heads/main",
         },
         "Resources": [
             {
@@ -318,7 +318,7 @@ GITHUB_ACTIONS_AGGREGATION_CLOUDTRAIL_EVENTS = [
                 "AccountId": "111111111111",
             }
         ],
-        "CloudTrailEvent": '{"userIdentity": {"type": "WebIdentityUser", "principalId": "repo:myorg/test-repo:ref:refs/heads/main", "identityProvider": "token.actions.githubusercontent.com", "userName": "myorg/test-repo"}, "requestParameters": {"roleArn": "arn:aws:iam::111111111111:role/GitHubTestRole"}, "responseElements": {"assumedRoleUser": {"arn": "arn:aws:sts::111111111111:assumed-role/GitHubTestRole/test-repo"}}}',
+        "CloudTrailEvent": '{"userIdentity": {"type": "WebIdentityUser", "principalId": "repo:myorg/test-repo:ref:refs/heads/main", "identityProvider": "token.actions.githubusercontent.com", "userName": "repo:myorg/test-repo:ref:refs/heads/main"}, "requestParameters": {"roleArn": "arn:aws:iam::111111111111:role/GitHubTestRole"}, "responseElements": {"assumedRoleUser": {"arn": "arn:aws:sts::111111111111:role/GitHubTestRole/test-repo"}}}',
     },
 ]
 

--- a/tests/unit/cartography/intel/aws/test_cloudtrail_management_events.py
+++ b/tests/unit/cartography/intel/aws/test_cloudtrail_management_events.py
@@ -38,10 +38,10 @@ SAMPLE_GITHUB_ASSUME_ROLE_WITH_WEB_IDENTITY_EVENT = {
     "UserIdentity": {
         "type": "WebIdentityUser",
         "principalId": "repo:sublimagesec/sublimage:ref:refs/heads/main",
-        "userName": "sublimagesec/sublimage",
+        "userName": "repo:sublimagesec/sublimage:ref:refs/heads/main",
         "identityProvider": "token.actions.githubusercontent.com",
     },
-    "CloudTrailEvent": '{"userIdentity": {"type": "WebIdentityUser", "principalId": "repo:sublimagesec/sublimage:ref:refs/heads/main", "userName": "sublimagesec/sublimage", "identityProvider": "token.actions.githubusercontent.com"}, "requestParameters": {"roleArn": "arn:aws:iam::987654321098:role/GitHubActionsRole", "roleSessionName": "GitHubActions"}}',
+    "CloudTrailEvent": '{"userIdentity": {"type": "WebIdentityUser", "principalId": "repo:sublimagesec/sublimage:ref:refs/heads/main", "userName": "repo:sublimagesec/sublimage:ref:refs/heads/main", "identityProvider": "token.actions.githubusercontent.com"}, "requestParameters": {"roleArn": "arn:aws:iam::987654321098:role/GitHubActionsRole", "roleSessionName": "GitHubActions"}}',
 }
 
 


### PR DESCRIPTION
### Summary
Fixed source principal for Github Web Identity events to parse the username so we can match on the actual repo itself



### Related issues or links
> Include links to relevant issues or other pages.

-  OG PR:  https://github.com/cartography-cncf/cartography/pull/1685


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Graph shows Assumed_Role_With_Web_Identity rel between the repo node and the AWS Role
<img width="1683" height="534" alt="image" src="https://github.com/user-attachments/assets/d84d426d-de9d-44ee-a5f8-2f96c02f8fed" />
