### PR TITLE
Add ECSService to ECSTask relation

### DIFF
--- a/cartography/intel/aws/ecs.py
+++ b/cartography/intel/aws/ecs.py
@@ -182,6 +182,9 @@ def transform_ecs_tasks(tasks: list[dict[str, Any]]) -> list[dict[str, Any]]:
                         task["networkInterfaceId"] = detail.get("value")
                         break
                 break
+        group = task.get("group")
+        if group and group.startswith("service:"):
+            task["serviceName"] = group.split("service:", 1)[1]
     return tasks
 
 

--- a/cartography/intel/aws/ecs.py
+++ b/cartography/intel/aws/ecs.py
@@ -171,9 +171,15 @@ def _get_containers_from_tasks(tasks: list[dict[str, Any]]) -> list[dict[str, An
 
 def transform_ecs_tasks(tasks: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """
-    Extract network interface ID from task attachments.
+    Extract network interface ID from task attachments and service name from group.
     """
     for task in tasks:
+        # Extract serviceName from group field
+        group = task.get("group")
+        if group and group.startswith("service:"):
+            task["serviceName"] = group.split("service:", 1)[1]
+
+        # Extract network interface ID from task attachments
         for attachment in task.get("attachments", []):
             if attachment.get("type") == "ElasticNetworkInterface":
                 details = attachment.get("details", [])
@@ -182,9 +188,6 @@ def transform_ecs_tasks(tasks: list[dict[str, Any]]) -> list[dict[str, Any]]:
                         task["networkInterfaceId"] = detail.get("value")
                         break
                 break
-        group = task.get("group")
-        if group and group.startswith("service:"):
-            task["serviceName"] = group.split("service:", 1)[1]
     return tasks
 
 

--- a/cartography/models/aws/ecs/services.py
+++ b/cartography/models/aws/ecs/services.py
@@ -105,6 +105,22 @@ class ECSServiceToAWSAccountRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class ECSServiceToECSTaskRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ECSServiceToECSTaskRel(CartographyRelSchema):
+    target_node_label: str = "ECSTask"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"service_name": PropertyRef("serviceName")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_TASK"
+    properties: ECSServiceToECSTaskRelProperties = ECSServiceToECSTaskRelProperties()
+
+
+@dataclass(frozen=True)
 class ECSServiceSchema(CartographyNodeSchema):
     label: str = "ECSService"
     properties: ECSServiceNodeProperties = ECSServiceNodeProperties()
@@ -113,5 +129,6 @@ class ECSServiceSchema(CartographyNodeSchema):
         [
             ECSServiceToECSClusterRel(),
             ECSServiceToTaskDefinitionRel(),
+            ECSServiceToECSTaskRel(),
         ]
     )

--- a/cartography/models/aws/ecs/tasks.py
+++ b/cartography/models/aws/ecs/tasks.py
@@ -27,6 +27,7 @@ class ECSTaskNodeProperties(CartographyNodeProperties):
     enable_execute_command: PropertyRef = PropertyRef("enableExecuteCommand")
     execution_stopped_at: PropertyRef = PropertyRef("executionStoppedAt")
     group: PropertyRef = PropertyRef("group")
+    service_name: PropertyRef = PropertyRef("serviceName")
     health_status: PropertyRef = PropertyRef("healthStatus")
     last_status: PropertyRef = PropertyRef("lastStatus")
     launch_type: PropertyRef = PropertyRef("launchType")
@@ -120,6 +121,25 @@ class ECSTaskToNetworkInterfaceRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class ECSTaskToECSServiceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ECSTaskToECSServiceRel(CartographyRelSchema):
+    target_node_label: str = "ECSService"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "cluster_arn": PropertyRef("clusterArn"),
+            "name": PropertyRef("serviceName"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_TASK"
+    properties: ECSTaskToECSServiceRelProperties = ECSTaskToECSServiceRelProperties()
+
+
+@dataclass(frozen=True)
 class ECSTaskSchema(CartographyNodeSchema):
     label: str = "ECSTask"
     properties: ECSTaskNodeProperties = ECSTaskNodeProperties()
@@ -129,5 +149,6 @@ class ECSTaskSchema(CartographyNodeSchema):
             ECSTaskToContainerInstanceRel(),
             ECSTaskToECSClusterRel(),
             ECSTaskToNetworkInterfaceRel(),
+            ECSTaskToECSServiceRel(),
         ]
     )

--- a/cartography/models/aws/ecs/tasks.py
+++ b/cartography/models/aws/ecs/tasks.py
@@ -121,25 +121,6 @@ class ECSTaskToNetworkInterfaceRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
-class ECSTaskToECSServiceRelProperties(CartographyRelProperties):
-    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
-
-
-@dataclass(frozen=True)
-class ECSTaskToECSServiceRel(CartographyRelSchema):
-    target_node_label: str = "ECSService"
-    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {
-            "cluster_arn": PropertyRef("clusterArn"),
-            "name": PropertyRef("serviceName"),
-        }
-    )
-    direction: LinkDirection = LinkDirection.INWARD
-    rel_label: str = "HAS_TASK"
-    properties: ECSTaskToECSServiceRelProperties = ECSTaskToECSServiceRelProperties()
-
-
-@dataclass(frozen=True)
 class ECSTaskSchema(CartographyNodeSchema):
     label: str = "ECSTask"
     properties: ECSTaskNodeProperties = ECSTaskNodeProperties()
@@ -149,6 +130,5 @@ class ECSTaskSchema(CartographyNodeSchema):
             ECSTaskToContainerInstanceRel(),
             ECSTaskToECSClusterRel(),
             ECSTaskToNetworkInterfaceRel(),
-            ECSTaskToECSServiceRel(),
         ]
     )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -3429,9 +3429,9 @@ Representation of an AWS ECS [Service](https://docs.aws.amazon.com/AmazonECS/lat
     (:ECSCluster)-[:HAS_SERVICE]->(:ECSService)
     ```
 
-- An ECSCluster has ECSContainerInstances
+- An ECSService has ECSTasks
     ```
-    (:ECSCluster)-[:HAS_CONTAINER_INSTANCE]->(:ECSContainerInstance)
+    (:ECSService)-[:HAS_TASK]->(:ECSTask)
     ```
 
 ### ECSTaskDefinition

--- a/tests/integration/cartography/intel/aws/test_ecs.py
+++ b/tests/integration/cartography/intel/aws/test_ecs.py
@@ -675,7 +675,7 @@ def test_sync_ecs_comprehensive(
         ),
     }, "ECSContainers to ECRImage (HAS_IMAGE)"
 
-    # ECSService to ECSTasks (new relationship)
+    # ECSService to ECSTasks
     assert check_rels(
         neo4j_session,
         "ECSService",

--- a/tests/integration/cartography/intel/aws/test_ecs.py
+++ b/tests/integration/cartography/intel/aws/test_ecs.py
@@ -22,29 +22,17 @@ def test_load_ecs_clusters(neo4j_session, *args):
         TEST_UPDATE_TAG,
     )
 
-    expected_nodes = {
+    assert check_nodes(
+        neo4j_session,
+        "ECSCluster",
+        ["id", "name", "status"],
+    ) == {
         (
             CLUSTER_ARN,
             "test_cluster",
             "ACTIVE",
         ),
     }
-
-    nodes = neo4j_session.run(
-        """
-        MATCH (n:ECSCluster)
-        RETURN n.id, n.name, n.status
-        """,
-    )
-    actual_nodes = {
-        (
-            n["n.id"],
-            n["n.name"],
-            n["n.status"],
-        )
-        for n in nodes
-    }
-    assert actual_nodes == expected_nodes
 
 
 def test_load_ecs_container_instances(neo4j_session, *args):
@@ -65,7 +53,11 @@ def test_load_ecs_container_instances(neo4j_session, *args):
         TEST_UPDATE_TAG,
     )
 
-    expected_nodes = {
+    assert check_nodes(
+        neo4j_session,
+        "ECSContainerInstance",
+        ["id", "ec2_instance_id", "status", "version"],
+    ) == {
         (
             "arn:aws:ecs:us-east-1:000000000000:container-instance/test_instance/a0000000000000000000000000000000",
             "i-00000000000000000",
@@ -74,31 +66,20 @@ def test_load_ecs_container_instances(neo4j_session, *args):
         ),
     }
 
-    nodes = neo4j_session.run(
-        """
-        MATCH (n:ECSContainerInstance)
-        RETURN n.id, n.ec2_instance_id, n.status, n.version
-        """,
-    )
-    actual_nodes = {
+    assert check_rels(
+        neo4j_session,
+        "ECSCluster",
+        "id",
+        "ECSContainerInstance",
+        "id",
+        "HAS_CONTAINER_INSTANCE",
+        rel_direction_right=True,
+    ) == {
         (
-            n["n.id"],
-            n["n.ec2_instance_id"],
-            n["n.status"],
-            n["n.version"],
-        )
-        for n in nodes
+            CLUSTER_ARN,
+            "arn:aws:ecs:us-east-1:000000000000:container-instance/test_instance/a0000000000000000000000000000000",
+        ),
     }
-    assert actual_nodes == expected_nodes
-
-    nodes = neo4j_session.run(
-        """
-        MATCH (:ECSCluster)-[:HAS_CONTAINER_INSTANCE]->(n:ECSContainerInstance)
-        RETURN count(n.id) AS c
-        """,
-    )
-    for n in nodes:
-        assert n["c"] == 1
 
 
 def test_load_ecs_services(neo4j_session, *args):
@@ -119,7 +100,11 @@ def test_load_ecs_services(neo4j_session, *args):
         TEST_UPDATE_TAG,
     )
 
-    expected_nodes = {
+    assert check_nodes(
+        neo4j_session,
+        "ECSService",
+        ["id", "name", "cluster_arn", "status"],
+    ) == {
         (
             "arn:aws:ecs:us-east-1:000000000000:service/test_instance/test_service",
             "test_service",
@@ -128,31 +113,20 @@ def test_load_ecs_services(neo4j_session, *args):
         ),
     }
 
-    nodes = neo4j_session.run(
-        """
-        MATCH (n:ECSService)
-        RETURN n.id, n.name, n.cluster_arn, n.status
-        """,
-    )
-    actual_nodes = {
+    assert check_rels(
+        neo4j_session,
+        "ECSCluster",
+        "id",
+        "ECSService",
+        "id",
+        "HAS_SERVICE",
+        rel_direction_right=True,
+    ) == {
         (
-            n["n.id"],
-            n["n.name"],
-            n["n.cluster_arn"],
-            n["n.status"],
-        )
-        for n in nodes
+            CLUSTER_ARN,
+            "arn:aws:ecs:us-east-1:000000000000:service/test_instance/test_service",
+        ),
     }
-    assert actual_nodes == expected_nodes
-
-    nodes = neo4j_session.run(
-        """
-        MATCH (:ECSCluster)-[:HAS_SERVICE]->(n:ECSService)
-        RETURN count(n.id) AS c
-        """,
-    )
-    for n in nodes:
-        assert n["c"] == 1
 
 
 def test_load_ecs_tasks(neo4j_session, *args):
@@ -178,7 +152,11 @@ def test_load_ecs_tasks(neo4j_session, *args):
     )
 
     # Assert
-    expected_nodes = {
+    assert check_nodes(
+        neo4j_session,
+        "ECSTask",
+        ["id", "task_definition_arn", "cluster_arn", "group"],
+    ) == {
         (
             "arn:aws:ecs:us-east-1:000000000000:task/test_task/00000000000000000000000000000000",
             "arn:aws:ecs:us-east-1:000000000000:task-definition/test_definition:0",
@@ -187,24 +165,11 @@ def test_load_ecs_tasks(neo4j_session, *args):
         ),
     }
 
-    nodes = neo4j_session.run(
-        """
-        MATCH (n:ECSTask)
-        RETURN n.id, n.task_definition_arn, n.cluster_arn, n.group
-        """,
-    )
-    actual_nodes = {
-        (
-            n["n.id"],
-            n["n.task_definition_arn"],
-            n["n.cluster_arn"],
-            n["n.group"],
-        )
-        for n in nodes
-    }
-    assert actual_nodes == expected_nodes
-
-    expected_nodes = {
+    assert check_nodes(
+        neo4j_session,
+        "ECSContainer",
+        ["id", "name", "image", "image_digest"],
+    ) == {
         (
             "arn:aws:ecs:us-east-1:000000000000:container/test_instance/00000000000000000000000000000000/00000000-0000-0000-0000-000000000000",  # noqa:E501
             "test-task_container",
@@ -213,31 +178,20 @@ def test_load_ecs_tasks(neo4j_session, *args):
         ),
     }
 
-    nodes = neo4j_session.run(
-        """
-        MATCH (n:ECSContainer)
-        RETURN n.id, n.name, n.image, n.image_digest
-        """,
-    )
-    actual_nodes = {
+    assert check_rels(
+        neo4j_session,
+        "ECSTask",
+        "id",
+        "ECSContainer",
+        "id",
+        "HAS_CONTAINER",
+        rel_direction_right=True,
+    ) == {
         (
-            n["n.id"],
-            n["n.name"],
-            n["n.image"],
-            n["n.image_digest"],
-        )
-        for n in nodes
+            "arn:aws:ecs:us-east-1:000000000000:task/test_task/00000000000000000000000000000000",
+            "arn:aws:ecs:us-east-1:000000000000:container/test_instance/00000000000000000000000000000000/00000000-0000-0000-0000-000000000000",
+        ),
     }
-    assert actual_nodes == expected_nodes
-
-    nodes = neo4j_session.run(
-        """
-        MATCH (:ECSTask)-[:HAS_CONTAINER]->(n:ECSContainer)
-        RETURN count(n.id) AS c
-        """,
-    )
-    for n in nodes:
-        assert n["c"] == 1
 
 
 def test_transform_ecs_tasks(neo4j_session):
@@ -281,17 +235,6 @@ def test_transform_ecs_tasks(neo4j_session):
         ),
     }
 
-    assert check_nodes(
-        neo4j_session,
-        "ECSTask",
-        ["id", "service_name"],
-    ) == {
-        (
-            "arn:aws:ecs:us-east-1:000000000000:task/test_task/00000000000000000000000000000000",
-            "test_service",
-        ),
-    }
-
 
 def test_load_ecs_task_definitions(neo4j_session, *args):
     # Arrange
@@ -317,7 +260,11 @@ def test_load_ecs_task_definitions(neo4j_session, *args):
     )
 
     # Assert
-    expected_nodes = {
+    assert check_nodes(
+        neo4j_session,
+        "ECSTaskDefinition",
+        ["id", "family", "status", "revision"],
+    ) == {
         (
             "arn:aws:ecs:us-east-1:000000000000:task-definition/test_definition:0",
             "test_family",
@@ -326,24 +273,11 @@ def test_load_ecs_task_definitions(neo4j_session, *args):
         ),
     }
 
-    nodes = neo4j_session.run(
-        """
-        MATCH (n:ECSTaskDefinition)
-        RETURN n.id, n.family, n.status, n.revision
-        """,
-    )
-    actual_nodes = {
-        (
-            n["n.id"],
-            n["n.family"],
-            n["n.status"],
-            n["n.revision"],
-        )
-        for n in nodes
-    }
-    assert actual_nodes == expected_nodes
-
-    expected_nodes = {
+    assert check_nodes(
+        neo4j_session,
+        "ECSContainerDefinition",
+        ["id", "name", "image"],
+    ) == {
         (
             "arn:aws:ecs:us-east-1:000000000000:task-definition/test_definition:0-test",
             "test",
@@ -351,30 +285,20 @@ def test_load_ecs_task_definitions(neo4j_session, *args):
         ),
     }
 
-    nodes = neo4j_session.run(
-        """
-        MATCH (n:ECSContainerDefinition)
-        RETURN n.id, n.name, n.image
-        """,
-    )
-    actual_nodes = {
+    assert check_rels(
+        neo4j_session,
+        "ECSTaskDefinition",
+        "id",
+        "ECSContainerDefinition",
+        "id",
+        "HAS_CONTAINER_DEFINITION",
+        rel_direction_right=True,
+    ) == {
         (
-            n["n.id"],
-            n["n.name"],
-            n["n.image"],
-        )
-        for n in nodes
+            "arn:aws:ecs:us-east-1:000000000000:task-definition/test_definition:0",
+            "arn:aws:ecs:us-east-1:000000000000:task-definition/test_definition:0-test",
+        ),
     }
-    assert actual_nodes == expected_nodes
-
-    nodes = neo4j_session.run(
-        """
-        MATCH (:ECSTaskDefinition)-[:HAS_CONTAINER_DEFINITION]->(n:ECSContainerDefinition)
-        RETURN count(n.id) AS c
-        """,
-    )
-    for n in nodes:
-        assert n["c"] == 1
 
 
 @patch.object(
@@ -578,22 +502,6 @@ def test_sync_ecs_comprehensive(
         ),
     }, "ECSService to ECSTaskDefinitions"
 
-    # ECSService to ECSTasks
-    assert check_rels(
-        neo4j_session,
-        "ECSService",
-        "id",
-        "ECSTask",
-        "id",
-        "HAS_TASK",
-        rel_direction_right=True,
-    ) == {
-        (
-            "arn:aws:ecs:us-east-1:000000000000:service/test_instance/test_service",
-            "arn:aws:ecs:us-east-1:000000000000:task/test_task/00000000000000000000000000000000",
-        ),
-    }, "ECSService to ECSTasks"
-
     # 8. ECSTasks to ECSClusters (sub-resource relationship)
     assert check_rels(
         neo4j_session,
@@ -766,6 +674,22 @@ def test_sync_ecs_comprehensive(
             "sha256:0000000000000000000000000000000000000000000000000000000000000000",
         ),
     }, "ECSContainers to ECRImage (HAS_IMAGE)"
+
+    # ECSService to ECSTasks (new relationship)
+    assert check_rels(
+        neo4j_session,
+        "ECSService",
+        "id",
+        "ECSTask",
+        "id",
+        "HAS_TASK",
+        rel_direction_right=True,
+    ) == {
+        (
+            "arn:aws:ecs:us-east-1:000000000000:service/test_instance/test_service",
+            "arn:aws:ecs:us-east-1:000000000000:task/test_task/00000000000000000000000000000000",
+        ),
+    }, "ECSService to ECSTasks"
 
     # Verify that all expected nodes were created
     assert check_nodes(

--- a/tests/integration/cartography/intel/aws/test_ecs.py
+++ b/tests/integration/cartography/intel/aws/test_ecs.py
@@ -281,6 +281,17 @@ def test_transform_ecs_tasks(neo4j_session):
         ),
     }
 
+    assert check_nodes(
+        neo4j_session,
+        "ECSTask",
+        ["id", "service_name"],
+    ) == {
+        (
+            "arn:aws:ecs:us-east-1:000000000000:task/test_task/00000000000000000000000000000000",
+            "test_service",
+        ),
+    }
+
 
 def test_load_ecs_task_definitions(neo4j_session, *args):
     # Arrange
@@ -566,6 +577,22 @@ def test_sync_ecs_comprehensive(
             "arn:aws:ecs:us-east-1:000000000000:task-definition/test_definition:0",
         ),
     }, "ECSService to ECSTaskDefinitions"
+
+    # ECSService to ECSTasks
+    assert check_rels(
+        neo4j_session,
+        "ECSService",
+        "id",
+        "ECSTask",
+        "id",
+        "HAS_TASK",
+        rel_direction_right=True,
+    ) == {
+        (
+            "arn:aws:ecs:us-east-1:000000000000:service/test_instance/test_service",
+            "arn:aws:ecs:us-east-1:000000000000:task/test_task/00000000000000000000000000000000",
+        ),
+    }, "ECSService to ECSTasks"
 
     # 8. ECSTasks to ECSClusters (sub-resource relationship)
     assert check_rels(


### PR DESCRIPTION
## Summary
- relate tasks to the ECS service they run in
- expose service name in ECSTask nodes
- update ECS task transformation
- test new ECSService-ECSTask link

## Testing
- `pytest tests/unit/cartography/graph/test_querybuilder_build_attach_links_excs.py -q`


## Graph showing new Relationship
<img width="1963" height="536" alt="image" src="https://github.com/user-attachments/assets/c32052ea-2d21-4f4f-9d50-340ad45c49b5" />

------
https://chatgpt.com/codex/tasks/task_b_688bf38b23408323a6a0f0b7190a5073