### PR TITLE
Fix SentinelOne CLI config token attribute

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -1130,6 +1130,8 @@ class CLI:
             config.sentinelone_api_token = os.environ.get(
                 config.sentinelone_api_token_env_var
             )
+        else:
+            config.sentinelone_api_token = None
 
         # Run cartography
         try:


### PR DESCRIPTION
## Summary
- ensure `sentinelone_api_token` is always defined in CLI configuration

## Testing
- `make test_lint`
- `make test_unit`

------
https://chatgpt.com/codex/tasks/task_b_688c3f67a290832fb957162d1a1410d7