### PR TITLE
feat: EntraID best effort mode

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -255,6 +255,14 @@ class CLI:
             ),
         )
         parser.add_argument(
+            "--entra-best-effort-mode",
+            action="store_true",
+            help=(
+                "Enable Entra ID sync best effort mode. This will allow cartography to continue "
+                "syncing other Entra ID entities and delay raising an exception until the end of the sync."
+            ),
+        )
+        parser.add_argument(
             "--aws-requested-syncs",
             type=str,
             default=None,
@@ -1130,6 +1138,8 @@ class CLI:
             config.sentinelone_api_token = os.environ.get(
                 config.sentinelone_api_token_env_var
             )
+        else:
+            config.sentinelone_api_token = None
 
         # Run cartography
         try:

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -51,6 +51,9 @@ class Config:
     :param entra_client_id: Client Id for connecting in a Service Principal Authentication approach. Optional.
     :type entra_client_secret: str
     :param entra_client_secret: Client Secret for connecting in a Service Principal Authentication approach. Optional.
+    :type entra_best_effort_mode: bool
+    :param entra_best_effort_mode: If True, Entra ID sync will continue on errors and raise an aggregated
+        exception at the end of the sync. If False (default), exceptions will be raised immediately.
     :type aws_requested_syncs: str
     :param aws_requested_syncs: Comma-separated list of AWS resources to sync. Optional.
     :type aws_guardduty_severity_threshold: str
@@ -164,6 +167,8 @@ class Config:
     :param sentinelone_api_url: SentinelOne API URL. Optional.
     :type sentinelone_api_token: string
     :param sentinelone_api_token: SentinelOne API token for authentication. Optional.
+    :type sentinelone_api_token_env_var: string
+    :param sentinelone_api_token_env_var: The name of an environment variable containing the SentinelOne API token. Optional.
     :type sentinelone_account_ids: list[str]
     :param sentinelone_account_ids: List of SentinelOne account IDs to sync. Optional.
     """
@@ -189,6 +194,7 @@ class Config:
         entra_tenant_id=None,
         entra_client_id=None,
         entra_client_secret=None,
+        entra_best_effort_mode=False,
         aws_requested_syncs=None,
         aws_guardduty_severity_threshold=None,
         analysis_job_directory=None,
@@ -251,6 +257,7 @@ class Config:
         scaleway_org=None,
         sentinelone_api_url=None,
         sentinelone_api_token=None,
+        sentinelone_api_token_env_var=None,
         sentinelone_account_ids=None,
     ):
         self.neo4j_uri = neo4j_uri
@@ -274,6 +281,7 @@ class Config:
         self.entra_tenant_id = entra_tenant_id
         self.entra_client_id = entra_client_id
         self.entra_client_secret = entra_client_secret
+        self.entra_best_effort_mode = entra_best_effort_mode
         self.aws_requested_syncs = aws_requested_syncs
         self.aws_guardduty_severity_threshold = aws_guardduty_severity_threshold
         self.analysis_job_directory = analysis_job_directory
@@ -336,4 +344,5 @@ class Config:
         self.scaleway_org = scaleway_org
         self.sentinelone_api_url = sentinelone_api_url
         self.sentinelone_api_token = sentinelone_api_token
+        self.sentinelone_api_token_env_var = sentinelone_api_token_env_var
         self.sentinelone_account_ids = sentinelone_account_ids

--- a/cartography/intel/entra/__init__.py
+++ b/cartography/intel/entra/__init__.py
@@ -1,13 +1,14 @@
 import asyncio
+import datetime
 import logging
+from traceback import TracebackException
+from typing import Awaitable
+from typing import Callable
 
 import neo4j
 
 from cartography.config import Config
-from cartography.intel.entra.applications import sync_entra_applications
-from cartography.intel.entra.groups import sync_entra_groups
-from cartography.intel.entra.ou import sync_entra_ous
-from cartography.intel.entra.users import sync_entra_users
+from cartography.intel.entra.resources import RESOURCE_FUNCTIONS
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -39,45 +40,46 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     }
 
     async def main() -> None:
-        # Run user sync
-        await sync_entra_users(
-            neo4j_session,
-            config.entra_tenant_id,
-            config.entra_client_id,
-            config.entra_client_secret,
-            config.update_tag,
-            common_job_parameters,
-        )
+        failed_stages = []
+        exception_tracebacks = []
 
-        # Run group sync
-        await sync_entra_groups(
-            neo4j_session,
-            config.entra_tenant_id,
-            config.entra_client_id,
-            config.entra_client_secret,
-            config.update_tag,
-            common_job_parameters,
-        )
+        async def run_stage(name: str, func: Callable[..., Awaitable[None]]) -> None:
+            try:
+                await func(
+                    neo4j_session,
+                    config.entra_tenant_id,
+                    config.entra_client_id,
+                    config.entra_client_secret,
+                    config.update_tag,
+                    common_job_parameters,
+                )
+            except Exception as e:
+                if config.entra_best_effort_mode:
+                    timestamp = datetime.datetime.now()
+                    failed_stages.append(name)
+                    exception_traceback = TracebackException.from_exception(e)
+                    traceback_string = "".join(exception_traceback.format())
+                    exception_tracebacks.append(
+                        f"{timestamp} - Exception for stage {name}\n{traceback_string}"
+                    )
+                    logger.warning(
+                        f"Caught exception syncing {name}. entra-best-effort-mode is on so we are continuing "
+                        "on to the next Entra sync. All exceptions will be aggregated and re-logged at the end of the sync.",
+                        exc_info=True,
+                    )
+                else:
+                    logger.error(f"Error during Entra sync: {str(e)}")
+                    raise
 
-        # Run OU sync
-        await sync_entra_ous(
-            neo4j_session,
-            config.entra_tenant_id,
-            config.entra_client_id,
-            config.entra_client_secret,
-            config.update_tag,
-            common_job_parameters,
-        )
+        for name, func in RESOURCE_FUNCTIONS:
+            await run_stage(name, func)
 
-        # Run application sync
-        await sync_entra_applications(
-            neo4j_session,
-            config.entra_tenant_id,
-            config.entra_client_id,
-            config.entra_client_secret,
-            config.update_tag,
-            common_job_parameters,
-        )
+        if failed_stages:
+            logger.error(
+                f"Entra sync failed for the following stages: {', '.join(failed_stages)}. "
+                "See the logs for more details.",
+            )
+            raise Exception("\n".join(exception_tracebacks))
 
-    # Execute both syncs in sequence
+    # Execute all syncs in sequence
     asyncio.run(main())

--- a/cartography/intel/entra/__init__.py
+++ b/cartography/intel/entra/__init__.py
@@ -68,7 +68,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
                         exc_info=True,
                     )
                 else:
-                    logger.error(f"Error during Entra sync: {str(e)}")
+                    logger.error("Error during Entra sync", exc_info=True)
                     raise
 
         for name, func in RESOURCE_FUNCTIONS:

--- a/cartography/intel/entra/applications.py
+++ b/cartography/intel/entra/applications.py
@@ -172,12 +172,11 @@ async def get_app_role_assignments(
             )
             continue
         except Exception as e:
-            # Only catch truly unexpected errors - these should be rare
             logger.error(
                 f"Unexpected error when fetching app role assignments for application {app.app_id} ({app.display_name}): {e}",
                 exc_info=True,
             )
-            continue
+            raise
 
     logger.info(f"Retrieved {len(assignments)} app role assignments total")
     return assignments

--- a/cartography/intel/entra/ou.py
+++ b/cartography/intel/entra/ou.py
@@ -43,7 +43,7 @@ async def get_entra_ous(client: GraphServiceClient) -> list[AdministrativeUnit]:
                 current_request = None
         except Exception as e:
             logger.error(f"Failed to retrieve administrative units: {str(e)}")
-            current_request = None
+            raise
 
     return all_units
 

--- a/cartography/intel/entra/resources.py
+++ b/cartography/intel/entra/resources.py
@@ -1,0 +1,20 @@
+from cartography.intel.entra.applications import sync_entra_applications
+from cartography.intel.entra.groups import sync_entra_groups
+from cartography.intel.entra.ou import sync_entra_ous
+from cartography.intel.entra.users import sync_entra_users
+
+# This is a list so that we sync these resources in order.
+# Data shape: [("resource_name", sync_function), ...]
+# Each sync function will be called with the following arguments:
+#   - neo4j_session
+#   - config.entra_tenant_id
+#   - config.entra_client_id
+#   - config.entra_client_secret
+#   - config.update_tag
+#   - common_job_parameters
+RESOURCE_FUNCTIONS = [
+    ("users", sync_entra_users),
+    ("groups", sync_entra_groups),
+    ("ous", sync_entra_ous),
+    ("applications", sync_entra_applications),
+]

--- a/docs/root/dev/writing-intel-modules.md
+++ b/docs/root/dev/writing-intel-modules.md
@@ -398,6 +398,10 @@ Older intel modules still do this process with hand-written cleanup jobs that wo
 
 - Only catch exceptions when your code can resolve the issue. Otherwise, allow exceptions to bubble up.
 
+When encountering errors, Cartography tries to fail loudly and as early as possible. This way, the sync job does not continue to run with partial or incorrect data. This is especially important because Cartography has cleanup jobs that delete nodes and relationships that it believes are stale, so if we don't fail early, we may delete nodes and relationships that we should not have.
+
+This behavior can be overriden with a `--*-best-effort-mode` flag. For example, some modules like AWS and Entra ID have `--aws-best-effort-mode` and `--entra-best-effort-mode` flags that instruct Cartography to continue running even if exceptions are encountered.
+
 ## Schema
 
 - Update the [schema](https://github.com/cartography-cncf/cartography/tree/8d60311a10156cd8aa16de7e1fe3e109cc3eca0f/docs/schema)

--- a/tests/unit/cartography/intel/entra/test_init.py
+++ b/tests/unit/cartography/intel/entra/test_init.py
@@ -1,0 +1,135 @@
+from typing import Callable
+from typing import List
+from typing import Tuple
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from pytest import raises
+
+import cartography.config
+import cartography.intel.entra
+
+TEST_UPDATE_TAG = 123456789
+
+# Create stub functions for testing. Each func raises a KeyError to simulate failure.
+ENTRA_RESOURCE_FUNCTIONS_STUB: List[Tuple[str, Callable]] = [
+    ("users", AsyncMock(side_effect=KeyError("users"))),
+    ("groups", AsyncMock(side_effect=KeyError("groups"))),
+    ("ous", AsyncMock(side_effect=KeyError("ous"))),
+    ("applications", AsyncMock(side_effect=KeyError("applications"))),
+]
+
+
+@patch.object(
+    cartography.intel.entra,
+    "RESOURCE_FUNCTIONS",
+    ENTRA_RESOURCE_FUNCTIONS_STUB,
+)
+def test_start_entra_ingestion_aggregates_exceptions_with_best_effort():
+    # Arrange
+    neo4j_session = MagicMock()
+    config = cartography.config.Config(
+        neo4j_uri="bolt://localhost:7687",
+        update_tag=TEST_UPDATE_TAG,
+        entra_best_effort_mode=True,
+        entra_tenant_id="tenant",
+        entra_client_id="client",
+        entra_client_secret="secret",
+    )
+
+    # Act
+    with raises(Exception) as e:
+        cartography.intel.entra.start_entra_ingestion(neo4j_session, config)
+
+    message = str(e.value)
+    assert message.count("KeyError") == 4
+    # Assert that each stage was called exactly once even though the previous function raised an exception
+    assert ENTRA_RESOURCE_FUNCTIONS_STUB[0][1].call_count == 1
+    assert ENTRA_RESOURCE_FUNCTIONS_STUB[1][1].call_count == 1
+    assert ENTRA_RESOURCE_FUNCTIONS_STUB[2][1].call_count == 1
+    assert ENTRA_RESOURCE_FUNCTIONS_STUB[3][1].call_count == 1
+
+
+def test_start_entra_ingestion_raises_first_exception_without_best_effort():
+    # Arrange
+    neo4j_session = MagicMock()
+    config = cartography.config.Config(
+        neo4j_uri="bolt://localhost:7687",
+        update_tag=TEST_UPDATE_TAG,
+        entra_best_effort_mode=False,
+        entra_tenant_id="tenant",
+        entra_client_id="client",
+        entra_client_secret="secret",
+    )
+
+    # Create mock objects that we can reference later
+    mock_users = AsyncMock(side_effect=KeyError("users"))
+    mock_groups = AsyncMock()
+    mock_ous = AsyncMock()
+    mock_applications = AsyncMock()
+
+    test_resource_functions = [
+        ("users", mock_users),
+        ("groups", mock_groups),
+        ("ous", mock_ous),
+        ("applications", mock_applications),
+    ]
+
+    # Act
+    with patch.object(
+        cartography.intel.entra,
+        "RESOURCE_FUNCTIONS",
+        test_resource_functions,
+    ):
+        with raises(Exception) as e:
+            cartography.intel.entra.start_entra_ingestion(neo4j_session, config)
+
+        assert isinstance(e.value, KeyError)
+        # Assert that the first function was called exactly once and the rest were not called because
+        # best effort mode is off.
+        assert mock_users.call_count == 1
+        assert mock_groups.call_count == 0
+        assert mock_ous.call_count == 0
+        assert mock_applications.call_count == 0
+        assert str(e.value) == "'users'"
+
+
+def test_start_entra_ingestion_runs_all_syncs():
+    # Arrange
+    neo4j_session = MagicMock()
+    config = cartography.config.Config(
+        neo4j_uri="bolt://localhost:7687",
+        update_tag=TEST_UPDATE_TAG,
+        entra_best_effort_mode=False,
+        entra_tenant_id="tenant",
+        entra_client_id="client",
+        entra_client_secret="secret",
+    )
+
+    # Create mock objects that we can reference later
+    mock_users = AsyncMock()
+    mock_groups = AsyncMock()
+    mock_ous = AsyncMock()
+    mock_applications = AsyncMock()
+
+    test_resource_functions = [
+        ("users", mock_users),
+        ("groups", mock_groups),
+        ("ous", mock_ous),
+        ("applications", mock_applications),
+    ]
+
+    # Act
+    with patch.object(
+        cartography.intel.entra,
+        "RESOURCE_FUNCTIONS",
+        test_resource_functions,
+    ):
+        cartography.intel.entra.start_entra_ingestion(neo4j_session, config)
+
+        # Assert that all functions were called.
+        assert mock_users.call_count == 1
+        assert mock_groups.call_count == 1
+        assert mock_ous.call_count == 1
+        assert mock_applications.call_count == 1


### PR DESCRIPTION
### Summary
> Describe your changes.

Adds `--entra-best-effort-mode` switch to cartography CLI so that we can skip over failed syncs.

Clarifies cartography's error handling strategy in docs.

### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/cartography-cncf/cartography/issues/...


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [x] Include console log trace showing what happened before and after your changes.

If I create an Entra app with 0 permissions,

Without `--entra-best-effort-mode` it crashes immediately on the users sync:
<img width="1065" height="1427" alt="image" src="https://github.com/user-attachments/assets/e7ce3d26-0129-47da-ab5b-afaba93f5d60" />


With `--entra-best-effort-mode` it continues on to all 4 entra modules, failing on each:
<img width="1068" height="1399" alt="image" src="https://github.com/user-attachments/assets/01cbf33e-55e5-4a57-b927-1ad1e268ed17" />


If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
