### PR TITLE
feat: Add status field to SnipeIT assets

### DIFF
--- a/cartography/models/snipeit/asset.py
+++ b/cartography/models/snipeit/asset.py
@@ -29,6 +29,7 @@ class SnipeitAssetNodeProperties(CartographyNodeProperties):
     manufacturer: PropertyRef = PropertyRef("manufacturer.name")
     model: PropertyRef = PropertyRef("model.name")
     serial: PropertyRef = PropertyRef("serial", extra_index=True)
+    status: PropertyRef = PropertyRef("status_label.name")
 
 
 ###

--- a/docs/root/modules/snipeit/schema.md
+++ b/docs/root/modules/snipeit/schema.md
@@ -33,6 +33,7 @@ Representation of a SnipeIT asset.
 |manufacturer | Manufacturer of the asset |
 |model | Model of the device|
 |serial | Serial number of the asset|
+|status | Status label of the asset |
 
 #### Relationships
 

--- a/tests/integration/cartography/intel/snipeit/test_snipeit_assets.py
+++ b/tests/integration/cartography/intel/snipeit/test_snipeit_assets.py
@@ -52,14 +52,14 @@ def test_load_snipeit_assets_relationship(neo4j_session):
 
     # Make sure the expected assets are created
     expected_nodes = {
-        (1373, "C02ZJ48XXXXX"),
-        (1372, "72ec94a8-b6dc-37f1-b2a9-0907806e8db7"),
+        (1373, "C02ZJ48XXXXX", "Ready to Deploy"),
+        (1372, "72ec94a8-b6dc-37f1-b2a9-0907806e8db7", "Ready to Deploy"),
     }
     assert (
         check_nodes(
             neo4j_session,
             "SnipeitAsset",
-            ["id", "serial"],
+            ["id", "serial", "status"],
         )
         == expected_nodes
     )


### PR DESCRIPTION
## Summary
- capture asset status from `status_label.name`
- document the status field in SnipeIT schema docs
- check asset status in integration tests
