### PR TITLE
closing the driver session explicitely

### DIFF
--- a/demo/__main__.py
+++ b/demo/__main__.py
@@ -30,14 +30,13 @@ def main(force_flag: bool) -> None:
         )
     else:
         neo4j_driver = neo4j.GraphDatabase.driver(NEO4J_URL)
-    neo4j_session = neo4j_driver.session()
-
+    with neo4j_driver.session() as neo4j_session:
     # Config
-    config = Config(
-        neo4j_uri=NEO4J_URL,
-        neo4j_user=NEO4J_USER,
-        neo4j_password=NEO4J_PASSWORD,
-    )
+        config = Config(
+            neo4j_uri=NEO4J_URL,
+            neo4j_user=NEO4J_USER,
+            neo4j_password=NEO4J_PASSWORD,
+        )
 
     # Check if the database is empty
     logger.info("Checking if the database is empty...")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,9 @@ logging.getLogger("neo4j").setLevel(logging.WARNING)
 @pytest.fixture(scope="module")
 def neo4j_session():
     driver = neo4j.GraphDatabase.driver(settings.get("NEO4J_URL"))
-    with driver.session() as session:
-        yield session
-        session.run("MATCH (n) DETACH DELETE n;")
+    try:
+        with driver.session() as session:
+            yield session
+            session.run("MATCH (n) DETACH DELETE n;")
+    finally:
+        driver.close()


### PR DESCRIPTION
### Summary
> Describe your changes.

I have added the with key word where it was not present at the time of making the session and expliitely closed the session in contest.py

### Related issues or links
> Include links to relevant issues or other pages.
I was facing this warning at the time of testing this .\tests\integration\cartography\intel\okta\test_awssaml.py

DeprecationWarning: Relying on Driver's destructor to close the session is deprecated. Please make sure to close the session. Use it as a context (`with` statement) or make sure to call `.close()` explicitly. Future versions of the driver will not close drivers automatically.


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
