### PR TITLE
Implemented the GSuite Group owners feature

### DIFF
--- a/cartography/data/jobs/cleanup/gsuite_ingest_groups_cleanup.json
+++ b/cartography/data/jobs/cleanup/gsuite_ingest_groups_cleanup.json
@@ -17,6 +17,18 @@
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Remove GSuite Group-to-Group relationships that are out of date."
+    },
+    {
+      "query": "MATCH (:GSuiteUser)-[r:OWNER_OF]->(:GSuiteGroup) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "iterative": true,
+      "iterationsize": 100,
+      "__comment__": "Remove GSuite User-to-Group owner relationships that are out of date."
+    },
+    {
+      "query": "MATCH (:GSuiteGroup)-[r:OWNER_OF]->(:GSuiteGroup) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "iterative": true,
+      "iterationsize": 100,
+      "__comment__": "Remove GSuite Group-to-Group owner relationships that are out of date."
     }
   ],
   "name": "cleanup GSuite"

--- a/demo/__main__.py
+++ b/demo/__main__.py
@@ -30,14 +30,13 @@ def main(force_flag: bool) -> None:
         )
     else:
         neo4j_driver = neo4j.GraphDatabase.driver(NEO4J_URL)
-    neo4j_session = neo4j_driver.session()
-
+    with neo4j_driver.session() as neo4j_session:
     # Config
-    config = Config(
-        neo4j_uri=NEO4J_URL,
-        neo4j_user=NEO4J_USER,
-        neo4j_password=NEO4J_PASSWORD,
-    )
+        config = Config(
+            neo4j_uri=NEO4J_URL,
+            neo4j_user=NEO4J_USER,
+            neo4j_password=NEO4J_PASSWORD,
+        )
 
     # Check if the database is empty
     logger.info("Checking if the database is empty...")

--- a/docs/root/modules/gsuite/schema.md
+++ b/docs/root/modules/gsuite/schema.md
@@ -76,3 +76,10 @@ https://developers.google.com/admin-sdk/directory/v1/reference/groups
     ```
     (GSuiteUser)-[MEMBER_OF]->(GSuiteGroup)
     ```
+
+- GSuiteGroup can have owners that are GSuiteUsers or GSuiteGroups.
+
+    ```
+    (GSuiteUser)-[OWNER_OF]->(GSuiteGroup)
+    (GSuiteGroup)-[OWNER_OF]->(GSuiteGroup)
+    ```

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,9 @@ logging.getLogger("neo4j").setLevel(logging.WARNING)
 @pytest.fixture(scope="module")
 def neo4j_session():
     driver = neo4j.GraphDatabase.driver(settings.get("NEO4J_URL"))
-    with driver.session() as session:
-        yield session
-        session.run("MATCH (n) DETACH DELETE n;")
+    try:
+        with driver.session() as session:
+            yield session
+            session.run("MATCH (n) DETACH DELETE n;")
+    finally:
+        driver.close()


### PR DESCRIPTION
### Summary
> Describe your changes.
This PR Implement GSuite group owners feature . it helps in providing the relation that which users are owners of the following group , as in some cases group can also be the owner of any group so that is also being added.


### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/cartography-cncf/cartography/issues/1732


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [x] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

`pytest tests/unit/cartography/intel/gsuite/ -v
=============================================== test session starts ===============================================
platform win32 -- Python 3.11.2, pytest-8.4.1, pluggy-1.6.0 -- J:\cartography\cartography\venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: J:\cartography\cartography
configfile: setup.cfg
plugins: anyio-4.9.0, cov-6.2.1    
collected 12 items

tests/unit/cartography/intel/gsuite/test_api.py::test_get_all_users PASSED                                   [  8%]
tests/unit/cartography/intel/gsuite/test_api.py::test_get_all_groups PASSED                                  [ 16%]
tests/unit/cartography/intel/gsuite/test_api.py::test_sync_gsuite_users PASSED                               [ 25%] 
tests/unit/cartography/intel/gsuite/test_api.py::test_sync_gsuite_groups PASSED                              [ 33%] 
tests/unit/cartography/intel/gsuite/test_api.py::test_load_gsuite_groups PASSED                              [ 41%]
tests/unit/cartography/intel/gsuite/test_api.py::test_load_gsuite_users PASSED                               [ 50%]
tests/unit/cartography/intel/gsuite/test_api.py::test_transform_groups PASSED                                [ 58%] 
tests/unit/cartography/intel/gsuite/test_api.py::test_transform_users PASSED                                 [ 66%] 
tests/unit/cartography/intel/gsuite/test_api.py::test_get_owners_for_group PASSED                            [ 75%]
tests/unit/cartography/intel/gsuite/test_api.py::test_get_owners_for_group_permission_denied PASSED          [ 83%] 
tests/unit/cartography/intel/gsuite/test_api.py::test_load_gsuite_owners PASSED                              [ 91%] 
tests/unit/cartography/intel/gsuite/test_api.py::test_sync_gsuite_owners PASSED                              [100%]

=============================================== 12 passed in 2.67s ================================================ `

