### PR TITLE
feat: Add EventBridge Target Resource in AWS Module

### DIFF
--- a/cartography/intel/aws/eventbridge.py
+++ b/cartography/intel/aws/eventbridge.py
@@ -10,6 +10,7 @@ from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.ec2.util import get_botocore_config
 from cartography.models.aws.eventbridge.rule import EventBridgeRuleSchema
+from cartography.models.aws.eventbridge.target import EventBridgeTargetSchema
 from cartography.util import aws_handle_regions
 from cartography.util import timeit
 
@@ -34,6 +35,44 @@ def get_eventbridge_rules(
 
 
 @timeit
+@aws_handle_regions
+def get_eventbridge_targets(
+    boto3_session: boto3.Session, region: str, rules: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    client = boto3_session.client(
+        "events", region_name=region, config=get_botocore_config()
+    )
+    targets = []
+    for rule in rules:
+        paginator = client.get_paginator("list_targets_by_rule")
+        for page in paginator.paginate(Rule=rule["Name"]):
+            for target in page.get("Targets", []):
+                target["RuleName"] = rule["Name"]
+                targets.append(target)
+    return targets
+
+
+def transform_eventbridge_targets(
+    targets: List[Dict[str, Any]],
+    region: str,
+) -> List[Dict[str, Any]]:
+    """
+    Transform EventBridge target data for ingestion into Neo4j.
+    """
+    transformed_data = []
+    for target in targets:
+        transformed_target = {
+            "Id": target["Id"],
+            "Arn": target["Arn"],
+            "RuleName": target["RuleName"],
+            "RoleArn": target.get("RoleArn"),
+            "Region": region,
+        }
+        transformed_data.append(transformed_target)
+    return transformed_data
+
+
+@timeit
 def load_eventbridge_rules(
     neo4j_session: neo4j.Session,
     data: List[Dict[str, Any]],
@@ -55,12 +94,36 @@ def load_eventbridge_rules(
 
 
 @timeit
+def load_eventbridge_targets(
+    neo4j_session: neo4j.Session,
+    data: List[Dict[str, Any]],
+    region: str,
+    current_aws_account_id: str,
+    aws_update_tag: int,
+) -> None:
+    logger.info(
+        f"Loading EventBridge {len(data)} targets for region '{region}' into graph.",
+    )
+    load(
+        neo4j_session,
+        EventBridgeTargetSchema(),
+        data,
+        lastupdated=aws_update_tag,
+        Region=region,
+        AWS_ID=current_aws_account_id,
+    )
+
+
+@timeit
 def cleanup(
     neo4j_session: neo4j.Session,
     common_job_parameters: Dict[str, Any],
 ) -> None:
     logger.debug("Running EventBridge cleanup job.")
     GraphJob.from_node_schema(EventBridgeRuleSchema(), common_job_parameters).run(
+        neo4j_session
+    )
+    GraphJob.from_node_schema(EventBridgeTargetSchema(), common_job_parameters).run(
         neo4j_session
     )
 
@@ -83,6 +146,16 @@ def sync(
         load_eventbridge_rules(
             neo4j_session,
             rules,
+            region,
+            current_aws_account_id,
+            update_tag,
+        )
+
+        targets = get_eventbridge_targets(boto3_session, region, rules)
+        transformed_targets = transform_eventbridge_targets(targets, region)
+        load_eventbridge_targets(
+            neo4j_session,
+            transformed_targets,
             region,
             current_aws_account_id,
             update_tag,

--- a/cartography/models/aws/eventbridge/target.py
+++ b/cartography/models/aws/eventbridge/target.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class EventBridgeTargetNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("Id")
+    arn: PropertyRef = PropertyRef("Arn", extra_index=True)
+    rule_name: PropertyRef = PropertyRef("RuleName")
+    role_arn: PropertyRef = PropertyRef("RoleArn")
+    region: PropertyRef = PropertyRef("Region", set_in_kwargs=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EventBridgeTargetToAwsAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EventBridgeTargetToAWSAccountRel(CartographyRelSchema):
+    target_node_label: str = "AWSAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: EventBridgeTargetToAwsAccountRelProperties = (
+        EventBridgeTargetToAwsAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class EventBridgeTargetToEventBridgeRuleRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class EventBridgeTargetToEventBridgeRuleRel(CartographyRelSchema):
+    target_node_label: str = "EventBridgeRule"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"name": PropertyRef("RuleName")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "LINKED_TO_RULE"
+    properties: EventBridgeTargetToEventBridgeRuleRelProperties = (
+        EventBridgeTargetToEventBridgeRuleRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class EventBridgeTargetSchema(CartographyNodeSchema):
+    label: str = "EventBridgeTarget"
+    properties: EventBridgeTargetNodeProperties = EventBridgeTargetNodeProperties()
+    sub_resource_relationship: EventBridgeTargetToAWSAccountRel = (
+        EventBridgeTargetToAWSAccountRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            EventBridgeTargetToEventBridgeRuleRel(),
+        ]
+    )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1915,6 +1915,27 @@ Representation of an AWS [EventBridge Rule](https://docs.aws.amazon.com/eventbri
     (EventBridgeRule)-[ASSOCIATED_WITH]->(AWSRole)
     ```
 
+### EventBridgeTarget
+Representation of an AWS [EventBridge Rule](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_ListTargetsByRule.html)
+| Field | Description |
+|-------|-------------|
+| firstseen| Timestamp of when a sync job first discovered this node  |
+| lastupdated |  Timestamp of the last time the node was updated |
+| **id** | System-assigned eventbridge target ID |
+| arn | The Amazon Resource Name (ARN) of the target |
+| region | The region of the target |
+| rule_name | The name of the rule which is associated with target |
+| role_arn | The Amazon Resource Name (ARN) of the role that is used for target invocation |
+#### Relationships
+- EventBridge Targets are resource under the AWS Account.
+    ```
+    (AWSAccount)-[RESOURCE]->(EventBridgeTarget)
+    ```
+ - EventBridge Targets are linked with the EventBridge Rules.
+    ```
+    (EventBridgeTarget)-[LINKED_TO_RULE]->(EventBridgeRule)
+    ```
+
 ### Ip
 
 Represents a generic IP address.

--- a/tests/data/aws/eventbridge.py
+++ b/tests/data/aws/eventbridge.py
@@ -22,3 +22,26 @@ GET_EVENTBRIDGE_RULES = [
         "EventBusName": "default",
     },
 ]
+
+GET_EVENTBRIDGE_TARGETS = [
+    {
+        "Id": "Target1",
+        "Arn": "arn:aws:lambda:us-east-1:123456789012:function:ProcessSignup",
+        "RuleName": "UserSignupRule",
+        "RoleArn": "arn:aws:iam::1234:role/cartography-read-only",
+        "Input": '{"userId": "$.detail.userId"}',
+        "InputPath": "$.detail",
+        "InputTransformer": None,
+        "Region": "us-east-1",
+    },
+    {
+        "Id": "Target2",
+        "Arn": "arn:aws:sns:us-east-1:123456789012:NotifyAdmin",
+        "RuleName": "DailyCleanupRule",
+        "RoleArn": "arn:aws:iam::1234:role/cartography-service",
+        "Input": None,
+        "InputPath": None,
+        "InputTransformer": None,
+        "Region": "us-east-1",
+    },
+]

--- a/tests/integration/cartography/intel/aws/test_eventbridge.py
+++ b/tests/integration/cartography/intel/aws/test_eventbridge.py
@@ -5,6 +5,7 @@ import cartography.intel.aws.eventbridge
 from cartography.intel.aws.eventbridge import sync
 from cartography.intel.aws.iam import load_roles
 from tests.data.aws.eventbridge import GET_EVENTBRIDGE_RULES
+from tests.data.aws.eventbridge import GET_EVENTBRIDGE_TARGETS
 from tests.data.aws.iam.roles import ROLES
 from tests.integration.cartography.intel.aws.common import create_test_account
 from tests.integration.util import check_nodes
@@ -23,7 +24,14 @@ TEST_UPDATE_TAG = 123456789
 @patch.object(
     cartography.intel.aws.iam, "get_role_list_data", return_value=ROLES["Roles"]
 )
-def test_sync_eventbridge(mock_get_rules, mock_get_roles, neo4j_session):
+@patch.object(
+    cartography.intel.aws.eventbridge,
+    "get_eventbridge_targets",
+    return_value=GET_EVENTBRIDGE_TARGETS,
+)
+def test_sync_eventbridge(
+    mock_get_targets, mock_get_roles, mock_get_rules, neo4j_session
+):
     # Arrange
     boto3_session = MagicMock()
     create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
@@ -49,6 +57,11 @@ def test_sync_eventbridge(mock_get_rules, mock_get_roles, neo4j_session):
     assert check_nodes(neo4j_session, "EventBridgeRule", ["arn"]) == {
         ("arn:aws:events:us-east-1:123456789012:rule/UserSignupRule",),
         ("arn:aws:events:us-east-1:123456789012:rule/DailyCleanupRule",),
+    }
+
+    assert check_nodes(neo4j_session, "EventBridgeTarget", ["arn"]) == {
+        ("arn:aws:lambda:us-east-1:123456789012:function:ProcessSignup",),
+        ("arn:aws:sns:us-east-1:123456789012:NotifyAdmin",),
     }
 
     # Assert
@@ -87,5 +100,43 @@ def test_sync_eventbridge(mock_get_rules, mock_get_roles, neo4j_session):
         (
             "arn:aws:events:us-east-1:123456789012:rule/DailyCleanupRule",
             "arn:aws:iam::1234:role/cartography-service",
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "AWSAccount",
+        "id",
+        "EventBridgeTarget",
+        "arn",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (
+            TEST_ACCOUNT_ID,
+            "arn:aws:lambda:us-east-1:123456789012:function:ProcessSignup",
+        ),
+        (
+            TEST_ACCOUNT_ID,
+            "arn:aws:sns:us-east-1:123456789012:NotifyAdmin",
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "EventBridgeTarget",
+        "arn",
+        "EventBridgeRule",
+        "name",
+        "LINKED_TO_RULE",
+        rel_direction_right=True,
+    ) == {
+        (
+            "arn:aws:lambda:us-east-1:123456789012:function:ProcessSignup",
+            "UserSignupRule",
+        ),
+        (
+            "arn:aws:sns:us-east-1:123456789012:NotifyAdmin",
+            "DailyCleanupRule",
         ),
     }


### PR DESCRIPTION
### Add EventBridge Target Resource in AWS Module and Relationship between EventBridgeTarget -> EventBridgeRule



### Related issues or links
[#1552](https://github.com/cartography-cncf/cartography/issues/1552)



### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [x] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

