### PR TITLE
fix: Keys with AccessDenied are logged and skipped preventing crash

### DIFF
--- a/tests/data/aws/kms.py
+++ b/tests/data/aws/kms.py
@@ -1,4 +1,7 @@
 import datetime
+from typing import Any
+from typing import List
+from typing import Tuple
 
 DESCRIBE_KEYS = [
     {
@@ -78,4 +81,21 @@ DESCRIBE_GRANTS = [
             "Encrypt",
         ],
     },
+]
+
+# Mock KMS key details data with None policy (simulating AccessDenied error)
+# This simulates the data structure returned by get_kms_key_details() when get_policy() returns None
+ACCESS_DENIED_KMS_KEY_DETAILS: List[Tuple[str, None, List[Any], List[Any]]] = [
+    (
+        "9a1ad414-6e3b-47ce-8366-6b8f26ba467d",  # key_id
+        None,  # policy - None due to AccessDenied on get_key_policy
+        [],  # aliases - empty for simplicity
+        [],  # grants - empty for simplicity
+    ),
+    (
+        "1b2cd345-7e8f-49ab-cdef-0123456789ab",  # key_id
+        None,  # policy - None due to AccessDenied on get_key_policy
+        [],  # aliases - empty for simplicity
+        [],  # grants - empty for simplicity
+    ),
 ]

--- a/tests/unit/cartography/intel/aws/test_kms.py
+++ b/tests/unit/cartography/intel/aws/test_kms.py
@@ -1,0 +1,29 @@
+import pytest
+
+from cartography.intel.aws.kms import transform_kms_key_policies
+from tests.data.aws.kms import ACCESS_DENIED_KMS_KEY_DETAILS
+
+
+def test_transform_kms_key_policies_with_null_policy():
+    """Test that KMS key policies with None values are gracefully handled."""
+    # Arrange
+    policy_alias_grants_data = ACCESS_DENIED_KMS_KEY_DETAILS
+
+    # Act - This should fail initially due to NoneType error
+    # After fix, this should gracefully skip keys with None policy
+    result = transform_kms_key_policies(policy_alias_grants_data)
+
+    # Assert - Keys with None policy should have default empty policy data
+    assert len(result) == 2
+    
+    # First key
+    key1_data = result["9a1ad414-6e3b-47ce-8366-6b8f26ba467d"]
+    assert key1_data["kms_key"] == "9a1ad414-6e3b-47ce-8366-6b8f26ba467d"
+    assert key1_data["anonymous_access"] is False
+    assert key1_data["anonymous_actions"] == []
+    
+    # Second key
+    key2_data = result["1b2cd345-7e8f-49ab-cdef-0123456789ab"]
+    assert key2_data["kms_key"] == "1b2cd345-7e8f-49ab-cdef-0123456789ab"
+    assert key2_data["anonymous_access"] is False
+    assert key2_data["anonymous_actions"] == [] 


### PR DESCRIPTION
### Summary
> Describe your changes.

- Added null check in transform_kms_key_policies to handle none
- Logging included at get_policy() and get_grants() level 
- unit test testing mock AccessDenied scenarios

### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/cartography-cncf/cartography/issues/1769


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include console log trace showing what happened after your changes.
<img width="913" height="85" alt="Screenshot 2025-08-04 at 4 02 25 PM" src="https://github.com/user-attachments/assets/0cb20194-5847-4b7d-8ea5-7beebf1e6ff1" />


