### PR TITLE
fix: update keypair_analysis query to use nested matches

### DIFF
--- a/cartography/data/jobs/analysis/aws_ec2_keypair_analysis.json
+++ b/cartography/data/jobs/analysis/aws_ec2_keypair_analysis.json
@@ -23,7 +23,7 @@
         },
         {
             "__comment__": "Attach EC2KeyPairs with matching fingerprints to eachother and set duplicate_keyfingerprint = True",
-            "query": "MATCH (k1:EC2KeyPair), (k2:EC2KeyPair) WHERE k1.id <> k2.id AND k1.keyfingerprint = k2.keyfingerprint SET k1.duplicate_keyfingerprint = True, k2.duplicate_keyfingerprint = True MERGE (k1)-[r:MATCHING_FINGERPRINT]-(k2) ON CREATE SET r.firstseen = $UPDATE_TAG SET r.lastupdated = $UPDATE_TAG return COUNT(*) as TotalCompleted",
+            "query": "MATCH (k1:EC2KeyPair) MATCH (k2:EC2KeyPair) WHERE k1.id <> k2.id AND k1.keyfingerprint = k2.keyfingerprint SET k1.duplicate_keyfingerprint = True, k2.duplicate_keyfingerprint = True MERGE (k1)-[r:MATCHING_FINGERPRINT]-(k2) ON CREATE SET r.firstseen = $UPDATE_TAG SET r.lastupdated = $UPDATE_TAG return COUNT(*) as TotalCompleted",
             "iterative": false
         }
     ]


### PR DESCRIPTION
### Summary
> Describe your changes.

This PR fixes the bug where keypair analysis causes a Cartesian product 

This is fixed by matching k1 and k2 separately with individual MATCH clauses


### Related issues or links
https://github.com/cartography-cncf/cartography/issues/1777

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [x] Include console log trace showing what happened before and after your changes.
```
INFO:cartography.graph.statement:Completed aws_ec2_keypair_analysis statement #1
INFO:cartography.graph.statement:Completed aws_ec2_keypair_analysis statement #2
INFO:cartography.graph.statement:Completed aws_ec2_keypair_analysis statement #3
INFO:cartography.graph.statement:Completed aws_ec2_keypair_analysis statement #4
WARNING:neo4j.notifications:Received notification from DBMS server: {severity: WARNING} {code: Neo.ClientNotification.Statement.CartesianProductWarning} {category: } {title: This query builds a cartesian product between disconnected patterns.} {description: If a part of a query contains multiple disconnected patterns, this will build a cartesian product between all those parts. This may produce a large amount of data and slow down query processing. While occasionally intended, it may often be possible to reformulate the query that avoids the use of this cross product, perhaps by adding a relationship between the different parts or by using OPTIONAL MATCH (identifier is: (k2))} {position: line: 1, column: 1, offset: 0} for query: 'MATCH (k1:EC2KeyPair), (k2:EC2KeyPair) WHERE k1.id <> k2.id AND k1.keyfingerprint = k2.keyfingerprint SET k1.duplicate_keyfingerprint = True, k2.duplicate_keyfingerprint = True MERGE (k1)-[r:MATCHING_FINGERPRINT]-(k2) ON CREATE SET r.firstseen = $UPDATE_TAG SET r.lastupdated = $UPDATE_TAG return COUNT(*) as TotalCompleted'
```

```
INFO:cartography.graph.statement:Completed aws_ec2_keypair_analysis statement #1
INFO:cartography.graph.statement:Completed aws_ec2_keypair_analysis statement #2
INFO:cartography.graph.statement:Completed aws_ec2_keypair_analysis statement #3
INFO:cartography.graph.statement:Completed aws_ec2_keypair_analysis statement #4
INFO:cartography.graph.statement:Completed aws_ec2_keypair_analysis statement #5
INFO:cartography.graph.job:Finished job aws_ec2_keypair_analysis
```

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
