### PR TITLE
Feat: Conditional target relations and custom resource arn schema for permission_mapping module [WIP]

### DIFF
--- a/cartography/data/permission_relationships.yaml
+++ b/cartography/data/permission_relationships.yaml
@@ -27,15 +27,3 @@
   - redshift:GetClusterCredentials
   - redshift:JoinGroup
   relationship_name: CAN_ADMINISTER
-
-
-# Map principals that can start SSM sessions on EC2 instances.
-# The resource_arn_schema field defines how to construct the resource ARN from node properties.
-# Properties in {{}} will be substituted with actual node property values.
-- target_label: EC2Instance
-  permissions:
-  - ssm:StartSession
-  relationship_name: CAN_SSM_ACCESS
-#  conditional_target_relations:
-#   - HAS_INFORMATION
-  resource_arn_schema: "arn:aws:ec2:{{region}}:*:instance/{{instanceid}}"

--- a/cartography/data/permission_relationships.yaml
+++ b/cartography/data/permission_relationships.yaml
@@ -27,3 +27,15 @@
   - redshift:GetClusterCredentials
   - redshift:JoinGroup
   relationship_name: CAN_ADMINISTER
+
+
+# Map principals that can start SSM sessions on EC2 instances.
+# The resource_arn_schema field defines how to construct the resource ARN from node properties.
+# Properties in {{}} will be substituted with actual node property values.
+- target_label: EC2Instance
+  permissions:
+  - ssm:StartSession
+  relationship_name: CAN_SSM_ACCESS
+  conditional_target_relations:
+   - HAS_INFORMATION
+  resource_arn_schema: "arn:aws:ec2:{{region}}:*:instance/{{instanceid}}"

--- a/cartography/data/permission_relationships.yaml
+++ b/cartography/data/permission_relationships.yaml
@@ -36,6 +36,6 @@
   permissions:
   - ssm:StartSession
   relationship_name: CAN_SSM_ACCESS
-  conditional_target_relations:
-   - HAS_INFORMATION
+#  conditional_target_relations:
+#   - HAS_INFORMATION
   resource_arn_schema: "arn:aws:ec2:{{region}}:*:instance/{{instanceid}}"

--- a/cartography/intel/aws/permission_relationships.py
+++ b/cartography/intel/aws/permission_relationships.py
@@ -5,6 +5,7 @@ from string import Template
 from typing import Any
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Pattern
 from typing import Tuple
 
@@ -314,7 +315,9 @@ def safe_substitute_schema(schema: str, properties: Dict[str, Any]) -> str:
     return template.safe_substitute(properties)
 
 
-def calculate_condition_clause(conditional_target_relations: List[str] = None) -> str:
+def calculate_condition_clause(
+    conditional_target_relations: Optional[List[str]] = None,
+) -> str:
     if not conditional_target_relations:
         return ""
     return " WHERE " + " AND ".join(
@@ -334,7 +337,7 @@ def get_resource_arns(
     neo4j_session: neo4j.Session,
     account_id: str,
     node_label: str,
-    conditional_target_relations: List[str] = None,
+    conditional_target_relations: Optional[List[str]] = None,
     resource_arn_schema: str = "{{arn}}",
 ) -> List[str]:
     if not isinstance(resource_arn_schema, str):
@@ -433,6 +436,9 @@ def extract_properties_from_arn(arn: str, schema: str) -> Dict[str, str]:
 
     pattern = re.compile(schema_regex)
     match = pattern.match(arn)
+
+    if match is None:
+        return {}
 
     return match.groupdict()
 
@@ -606,8 +612,6 @@ def sync(
             conditional_target_relations,
             resource_arn_schema,
         )
-
-        logger.info(f"Resource ARNs: {resource_arns}")
 
         allowed_mappings = calculate_permission_relationships(
             principals,

--- a/docs/root/modules/aws/permissions-mapping.md
+++ b/docs/root/modules/aws/permissions-mapping.md
@@ -54,3 +54,4 @@ This example shows how to map SSM access permissions for EC2 instances with cond
   - HAS_INFORMATION
   resource_arn_schema: "arn:aws:ec2:{{region}}:*:instance/{{instanceid}}"
 ```
+If the principal has any of the permission, the target node has the required relation (skips if relation is not valid) and resource_arn_schema matches that of the policy resource arn, it will be mapped

--- a/docs/root/modules/aws/permissions-mapping.md
+++ b/docs/root/modules/aws/permissions-mapping.md
@@ -19,7 +19,7 @@ Each RPR consists of
 - ResourceType (string) - The node Label that permissions will be built for
 - Permissions (list(string)) - The list of permissions to map. If any of these permissions are present between a resource and a permission then the relationship is created.
 - RelationshipName (string) - The name of the relationship cartography will create
-- **[OPTIONAL]** ConditionalRelations (list(string)) - Additional relations the node label must have when defining relationships. Defaults to None.
+- **[OPTIONAL]** conditional_target_relations (list(string)) - Additional relations the node label must have when defining relationships. Defaults to None.
 - **[OPTIONAL]** resource_arn_schema (string) - The schema pattern for constructing resource ARNs from node properties. Uses `{{property}}` placeholders to reference node properties. Defaults to '{{arn}}'.
 
 #### Resource ARN Schema

--- a/docs/root/modules/aws/permissions-mapping.md
+++ b/docs/root/modules/aws/permissions-mapping.md
@@ -20,7 +20,7 @@ Each RPR consists of
 - Permissions (list(string)) - The list of permissions to map. If any of these permissions are present between a resource and a permission then the relationship is created.
 - RelationshipName (string) - The name of the relationship cartography will create
 - **[OPTIONAL]** ConditionalRelations (list(string)) - Additional relations the node label must have when defining relationships. Defaults to None.
-- **[OPTIONAL]** ResourceArnSchema (string) - The schema pattern for constructing resource ARNs from node properties. Uses `{{property}}` placeholders to reference node properties. Defaults to '{{arn}}'.
+- **[OPTIONAL]** resource_arn_schema (string) - The schema pattern for constructing resource ARNs from node properties. Uses `{{property}}` placeholders to reference node properties. Defaults to '{{arn}}'.
 
 #### Resource ARN Schema
 The `resource_arn_schema` field allows you to define how resource ARNs should be constructed from target node properties. This is useful when the node's `arn` property doesn't match the format expected by IAM policies. Like in the case of EC2 instances.

--- a/tests/unit/cartography/intel/aws/test_permission_relationships.py
+++ b/tests/unit/cartography/intel/aws/test_permission_relationships.py
@@ -558,7 +558,9 @@ def test_extract_properties_from_arn_s3path():
 
 
 def test_calculate_condition_clause_with_relations():
-    """Test calculate_condition_clause with conditional target relations"""
+    ###
+    # Test calculate_condition_clause with conditional target relations
+    ###
     conditional_target_relations = ["HAS_INFORMATION", "BELONGS_TO"]
 
     result = permission_relationships.calculate_condition_clause(
@@ -614,3 +616,17 @@ def test_validate_resource_arn_schema_without_properties():
     result = permission_relationships.validate_resource_arn_schema(schema)
 
     assert result == "{{arn}}"
+
+
+def test_extract_properties_from_arn_with_invalid_match():
+    ###
+    # Test extract_properties_from_arn when regex match fails, to ensure regex pattern functions as intended.
+    ###
+
+    schema = "arn:aws:ec2:{{region}}:*:instance/{{instanceid}}"
+    arn = "invalid-arn-format"  # Doesn't match the schema
+
+    result = permission_relationships.extract_properties_from_arn(arn, schema)
+
+    # Should return empty dict when no match
+    assert result == {}


### PR DESCRIPTION
### Summary
> Describe your changes.

In order to address these issues and extend functionality of the permission relationships, I have devised some solution fragments that can help for this.

2 OPTIONAL but new properties for permission relationships (YAML) : 

- conditional_target_relations: Basically a list of node relations to ensure that only map a relation when the target also has there relations protruding out. ( ISSUE : https://github.com/cartography-cncf/cartography/issues/1643 ).
Other example use case: Map relation from principal to resource that have DLQ.
- resource_arn_schema : By default, the cypher queries map relations and fetch resources based on arn property of the target resource. However, not every target resource node has arn. I stumbled on a  error when trying to create a relation for my ec2 instances. 

<img width="1743" height="1271" alt="image" src="https://github.com/user-attachments/assets/4e62bb2e-e1cf-4a42-8641-a3ccfce16c3d" />


In order to define a custom target resource arn join to resemble your own pricinipal policies arn: added this field. This potentially addresses  https://github.com/cartography-cncf/cartography/issues/1639 ( have added a test unit and tried out on my end). The documentation for this has been updated in docs/root/modules/aws/permissions-mapping.md .

Additional Changes: 
- Added logger warning and tackled permission_relationships failing for nodes without arn property(Mentioned Error). Did not change arn property of ec2 instance since did not want this pr to go all over the place.
-  Additional regex pattern to devise property dict (yaml) -> arn string -> then back to property dict(yaml).
- These changes are only added functionality and previous layout, structuring of permissions,functionality and tests are entirely preserved.

Possibly to do:
- Update extract_properties_from_arn() regex pattern, or implement a better node property pass (will have to make changes to existing unit tests and functions a bit)
- Wildcards and SingleCharacters chars (* or ?) are escaped and dont act as wildcards -> for resource_arn_schema. 

### Related issues or links
> Include links to relevant issues or other pages.

- Addresses https://github.com/cartography-cncf/cartography/issues/1639
- Addresses https://github.com/cartography-cncf/cartography/issues/1643


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
Before:
<img width="1419" height="892" alt="image" src="https://github.com/user-attachments/assets/aef42bd3-dcda-4d69-b346-cdc644f815c2" />
(Tweaked neo4j queries in permission_relationships.py for temporarily  trying out on ec2 instances.)

After: 
<img width="1427" height="759" alt="image" src="https://github.com/user-attachments/assets/3cff2a42-02ed-4218-a95f-66fbbd22c45c" />

- [x] Include console log trace showing what happened before and after your changes.
<img width="1729" height="551" alt="image" src="https://github.com/user-attachments/assets/a94cd021-ad67-4285-a9f4-9c72215805f9" />


If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
