### PR TITLE
fix: Add gh organisation id to cleanup jobs as param

### DIFF
--- a/cartography/data/jobs/cleanup/github_repos_cleanup.json
+++ b/cartography/data/jobs/cleanup/github_repos_cleanup.json
@@ -21,7 +21,7 @@
   },
 
   {
-    "query": "MATCH (:GitHubBranch)-[r:BRANCH]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubBranch)-[r:BRANCH]->(repo:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(repo)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
@@ -31,63 +31,63 @@
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubRepository)-[r:LANGUAGE]->(:ProgrammingLanguage) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (repo:GitHubRepository)-[r:LANGUAGE]->(:ProgrammingLanguage) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(repo)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubRepository)-[r:REQUIRES]->(:PythonLibrary) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (repo:GitHubRepository)-[r:REQUIRES]->(:PythonLibrary) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(repo)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
 
   {
-    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_ADMIN]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_ADMIN]->(repo:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(repo)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_MAINTAIN]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_MAINTAIN]->(repo:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(repo)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_READ]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_READ]->(repo:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(repo)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_TRIAGE]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_TRIAGE]->(repo:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(repo)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_WRITE]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_WRITE]->(repo:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(repo)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_ADMIN]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_ADMIN]->(repo:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(repo)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_MAINTAIN]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_MAINTAIN]->(repo:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(repo)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_READ]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_READ]->(repo:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(repo)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_TRIAGE]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_TRIAGE]->(repo:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(repo)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_WRITE]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_WRITE]->(repo:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(repo)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/github_repos_cleanup.json
+++ b/cartography/data/jobs/cleanup/github_repos_cleanup.json
@@ -1,93 +1,93 @@
 {
   "statements": [{
-    "query": "MATCH (n:GitHubRepository) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+    "query": "MATCH (n:GitHubRepository) WHERE n.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(n)) WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (n:GitHubBranch) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+    "query": "MATCH (n:GitHubBranch) WHERE n.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)-[:BRANCH]->(n)) WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (n:ProgrammingLanguage) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+    "query": "MATCH (n:ProgrammingLanguage) WHERE n.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)-[:LANGUAGE]->(n)) WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (n:PythonLibrary) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
-    "iterative": true,
-    "iterationsize": 100
-  },
-
-  {
-    "query": "MATCH (:GitHubBranch)-[r:BRANCH]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (:GitHubOrganization)-[r:OWNER]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (:GitHubRepository)-[r:LANGUAGE]->(:ProgrammingLanguage) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
-    "iterative": true,
-    "iterationsize": 100
-  },
-  {
-    "query": "MATCH (:GitHubRepository)-[r:REQUIRES]->(:PythonLibrary) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (n:PythonLibrary) WHERE n.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)-[:DEPENDENCY]->(n)) WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
     "iterative": true,
     "iterationsize": 100
   },
 
   {
-    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_ADMIN]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubBranch)-[r:BRANCH]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_MAINTAIN]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (org:GitHubOrganization)-[r:OWNER]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND org.id = $GITHUB_ORG_URL WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_READ]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubRepository)-[r:LANGUAGE]->(:ProgrammingLanguage) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_TRIAGE]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubRepository)-[r:REQUIRES]->(:PythonLibrary) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "iterative": true,
+    "iterationsize": 100
+  },
+
+  {
+    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_ADMIN]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_WRITE]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_MAINTAIN]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_ADMIN]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_READ]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_MAINTAIN]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_TRIAGE]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_READ]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:OUTSIDE_COLLAB_WRITE]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_TRIAGE]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_ADMIN]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   },
   {
-    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_WRITE]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_MAINTAIN]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "iterative": true,
+    "iterationsize": 100
+  },
+  {
+    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_READ]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "iterative": true,
+    "iterationsize": 100
+  },
+  {
+    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_TRIAGE]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+    "iterative": true,
+    "iterationsize": 100
+  },
+  {
+    "query": "MATCH (:GitHubUser)-[r:DIRECT_COLLAB_WRITE]->(:GitHubRepository) WHERE r.lastupdated <> $UPDATE_TAG AND EXISTS((:GitHubOrganization{id: $GITHUB_ORG_URL})-[:OWNER]->(:GitHubRepository)) WITH r LIMIT $LIMIT_SIZE DELETE (r)",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/intel/github/__init__.py
+++ b/cartography/intel/github/__init__.py
@@ -35,23 +35,29 @@ def start_github_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     # run sync for the provided github tokens
     for auth_data in auth_tokens["organization"]:
         try:
+            # Add org url to common job params for cleanup
+            gh_cleanup_params = {
+                **common_job_parameters,
+                "GITHUB_ORG_URL": f"https://github.com/{auth_data['name']}"
+            }
+            
             cartography.intel.github.users.sync(
                 neo4j_session,
-                common_job_parameters,
+                gh_cleanup_params,
                 auth_data["token"],
                 auth_data["url"],
                 auth_data["name"],
             )
             cartography.intel.github.repos.sync(
                 neo4j_session,
-                common_job_parameters,
+                gh_cleanup_params,
                 auth_data["token"],
                 auth_data["url"],
                 auth_data["name"],
             )
             cartography.intel.github.teams.sync_github_teams(
                 neo4j_session,
-                common_job_parameters,
+                gh_cleanup_params,
                 auth_data["token"],
                 auth_data["url"],
                 auth_data["name"],

--- a/cartography/intel/github/__init__.py
+++ b/cartography/intel/github/__init__.py
@@ -38,9 +38,9 @@ def start_github_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
             # Add org url to common job params for cleanup
             gh_cleanup_params = {
                 **common_job_parameters,
-                "GITHUB_ORG_URL": f"https://github.com/{auth_data['name']}"
+                "GITHUB_ORG_URL": f"https://github.com/{auth_data['name']}",
             }
-            
+
             cartography.intel.github.users.sync(
                 neo4j_session,
                 gh_cleanup_params,

--- a/tests/integration/cartography/data/jobs/test_syntax.py
+++ b/tests/integration/cartography/data/jobs/test_syntax.py
@@ -52,6 +52,7 @@ def test_cleanup_jobs_cypher_syntax(neo4j_session):
         "OKTA_ORG_ID": None,
         "DO_ACCOUNT_ID": None,
         "AZURE_SUBSCRIPTION_ID": None,
+        "GITHUB_ORG_URL": "https://github.com/test-org",
     }
 
     for job_name in contents("cartography.data.jobs.cleanup"):

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -6,7 +6,10 @@ from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
-TEST_JOB_PARAMS = {"UPDATE_TAG": TEST_UPDATE_TAG}
+TEST_JOB_PARAMS = {
+    "UPDATE_TAG": TEST_UPDATE_TAG,
+    "GITHUB_ORG_URL": "https://github.com/simpsoncorp",
+}
 TEST_GITHUB_URL = "https://fake.github.net/graphql/"
 
 


### PR DESCRIPTION
### Summary
> Describe your changes.

This pr fixes a bug which causes unintentional deletions from the graph during github repo cleanups

passing in the organisation url as a parameter and checking during each query if the node being cleaned up is a part of that organisation eliminates accidental deletion of data belonging to other orgs

### Related issues or links
> Include links to relevant issues or other pages.

https://github.com/cartography-cncf/cartography/issues/839

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [x] Include console log trace showing what happened before and after your changes.

I reproduced the bug by setting up a config file with two organisations, syncing both of them first to update the data

then start the sync again but simulate a failure during the syncing of the second org effectively causing the cleanup to trigger after org1 but not syncing the data of org2

the cleanup for org1 deleted data for org2 even though new data wasnt synced

```
INFO:cartography.cli:Reading password for Neo4j user 'neo4j' interactively.
Password: 
WARNING:cartography.cli:Neo4j username was provided but a password could not be found.
WARNING:cartography.cli:A Kandji base URI was not provided.
WARNING:cartography.cli:A SnipeIT base URI was not provided.
INFO:cartography.sync:Starting sync with update tag '1754555442'
INFO:cartography.sync:Starting sync stage 'github'
INFO:cartography.intel.github.users:Syncing GitHub users
INFO:cartography.intel.github.users:Retrieving users from GitHub organization KGP-Speedcubers
INFO:cartography.intel.github.users:Retrieving enterprise owners from GitHub organization KGP-Speedcubers
INFO:cartography.intel.github.users:Loading 1 GitHub organization to the graph
INFO:cartography.intel.github.users:Loading 2 GitHub users to the graph
INFO:cartography.intel.github.users:Loading 0 GitHub users to the graph
INFO:cartography.intel.github.users:Cleaning up GitHub users
INFO:cartography.graph.statement:Completed GitHubUser statement #1
INFO:cartography.graph.statement:Completed GitHubUser statement #2
INFO:cartography.graph.job:Finished job GitHubUser
INFO:cartography.graph.statement:Completed GitHubUser statement #1
INFO:cartography.graph.job:Finished job GitHubUser
INFO:cartography.intel.github.repos:Syncing GitHub repos
INFO:cartography.intel.github.repos:Retrieving repo collaborators for affiliation "DIRECT" on org "KGP-Speedcubers".
INFO:cartography.intel.github.repos:Loading DIRECT collaborators for repo secret.
INFO:cartography.intel.github.repos:Loading DIRECT collaborators for repo secret-backend.
INFO:cartography.intel.github.repos:Retrieving repo collaborators for affiliation "OUTSIDE" on org "KGP-Speedcubers".
INFO:cartography.intel.github.repos:Processing 6 GitHub repositories
INFO:cartography.intel.github.repos:Found 2 dependency manifests in secret
INFO:cartography.intel.github.repos:Found 110 dependencies in secret
INFO:cartography.intel.github.repos:Found 1 dependency manifests in secret-backend
INFO:cartography.intel.github.repos:Found 19 dependencies in secret-backend
INFO:cartography.intel.github.repos:Found 4 dependency manifests in live-results
INFO:cartography.intel.github.repos:Found 222 dependencies in live-results
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #1
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #2
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #3
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #4
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #5
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #6
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #7
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #8
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #9
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #10
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #11
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #12
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #13
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #14
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #15
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #16
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #17
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #18
INFO:cartography.graph.job:Finished job github_repos_cleanup
INFO:cartography.intel.github.teams:Loading 0 GitHub team-repos to the graph
INFO:cartography.graph.statement:Completed GitHubTeam statement #1
INFO:cartography.graph.statement:Completed GitHubTeam statement #2
INFO:cartography.graph.statement:Completed GitHubTeam statement #3
INFO:cartography.graph.statement:Completed GitHubTeam statement #4
INFO:cartography.graph.statement:Completed GitHubTeam statement #5
INFO:cartography.graph.statement:Completed GitHubTeam statement #6
INFO:cartography.graph.statement:Completed GitHubTeam statement #7
INFO:cartography.graph.statement:Completed GitHubTeam statement #8
INFO:cartography.graph.statement:Completed GitHubTeam statement #9
INFO:cartography.graph.statement:Completed GitHubTeam statement #10
INFO:cartography.graph.job:Finished job GitHubTeam
INFO:cartography.intel.github.users:Syncing GitHub users
INFO:cartography.intel.github.users:Retrieving users from GitHub organization kgpmask
INFO:cartography.intel.github.users:Retrieving enterprise owners from GitHub organization kgpmask
INFO:cartography.intel.github.users:Loading 1 GitHub organization to the graph
INFO:cartography.intel.github.users:Loading 36 GitHub users to the graph
INFO:cartography.intel.github.users:Loading 0 GitHub users to the graph
INFO:cartography.intel.github.users:Cleaning up GitHub users
INFO:cartography.graph.statement:Completed GitHubUser statement #1
INFO:cartography.graph.statement:Completed GitHubUser statement #2
INFO:cartography.graph.job:Finished job GitHubUser
INFO:cartography.graph.statement:Completed GitHubUser statement #1
INFO:cartography.graph.job:Finished job GitHubUser
INFO:cartography.intel.github.repos:Syncing GitHub repos
ERROR:cartography.intel.github.util:GitHub: Could not retrieve page of resource `repositories` due to HTTP error after 5 retries. Raising exception.
NoneType: None
ERROR:cartography.intel.github:Could not complete request to the GitHub API: 502 Server Error: Bad Gateway for url: https://api.github.com/graphql
INFO:cartography.sync:Finishing sync stage 'github'
INFO:cartography.sync:Finishing sync with update tag '1754555442'
~/lfx/cartography master* 3m 37s                                                                                     14:02:48
❯ kane                                
zsh: /home/zai/Applications/Cursor-1.2.2-x86_64.AppImage.zs-old: command not found...
^C
~/lfx/cartography master*                                                                                            14:04:38
❯ uv run cartography --github-config-env-var GITHUB_CONFIG --neo4j-uri bolt://localhost:7687 --neo4j-user neo4j --neo4j-password-prompt --selected-modules github
INFO:cartography.cli:Reading password for Neo4j user 'neo4j' interactively.
Password: 
WARNING:cartography.cli:Neo4j username was provided but a password could not be found.
WARNING:cartography.cli:A Kandji base URI was not provided.
WARNING:cartography.cli:A SnipeIT base URI was not provided.
INFO:cartography.sync:Starting sync with update tag '1754555702'
INFO:cartography.sync:Starting sync stage 'github'
INFO:cartography.intel.github.users:Syncing GitHub users
INFO:cartography.intel.github.users:Retrieving users from GitHub organization KGP-Speedcubers
INFO:cartography.intel.github.users:Retrieving enterprise owners from GitHub organization KGP-Speedcubers
INFO:cartography.intel.github.users:Loading 1 GitHub organization to the graph
INFO:cartography.intel.github.users:Loading 2 GitHub users to the graph
INFO:cartography.intel.github.users:Loading 0 GitHub users to the graph
INFO:cartography.intel.github.users:Cleaning up GitHub users
INFO:cartography.graph.statement:Completed GitHubUser statement #1
INFO:cartography.graph.statement:Completed GitHubUser statement #2
INFO:cartography.graph.job:Finished job GitHubUser
INFO:cartography.graph.statement:Completed GitHubUser statement #1
INFO:cartography.graph.job:Finished job GitHubUser
INFO:cartography.intel.github.repos:Syncing GitHub repos
INFO:cartography.intel.github.repos:Retrieving repo collaborators for affiliation "DIRECT" on org "KGP-Speedcubers".
INFO:cartography.intel.github.repos:Loading DIRECT collaborators for repo secret.
INFO:cartography.intel.github.repos:Loading DIRECT collaborators for repo secret-backend.
INFO:cartography.intel.github.repos:Retrieving repo collaborators for affiliation "OUTSIDE" on org "KGP-Speedcubers".
INFO:cartography.intel.github.repos:Processing 6 GitHub repositories
INFO:cartography.intel.github.repos:Found 2 dependency manifests in secret
INFO:cartography.intel.github.repos:Found 110 dependencies in secret
INFO:cartography.intel.github.repos:Found 1 dependency manifests in secret-backend
INFO:cartography.intel.github.repos:Found 19 dependencies in secret-backend
INFO:cartography.intel.github.repos:Found 4 dependency manifests in live-results
INFO:cartography.intel.github.repos:Found 222 dependencies in live-results
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #1
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #2
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #3
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #4
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #5
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #6
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #7
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #8
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #9
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #10
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #11
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #12
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #13
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #14
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #15
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #16
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #17
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #18
INFO:cartography.graph.job:Finished job github_repos_cleanup
INFO:cartography.intel.github.teams:Loading 0 GitHub team-repos to the graph
INFO:cartography.graph.statement:Completed GitHubTeam statement #1
INFO:cartography.graph.statement:Completed GitHubTeam statement #2
INFO:cartography.graph.statement:Completed GitHubTeam statement #3
INFO:cartography.graph.statement:Completed GitHubTeam statement #4
INFO:cartography.graph.statement:Completed GitHubTeam statement #5
INFO:cartography.graph.statement:Completed GitHubTeam statement #6
INFO:cartography.graph.statement:Completed GitHubTeam statement #7
INFO:cartography.graph.statement:Completed GitHubTeam statement #8
INFO:cartography.graph.statement:Completed GitHubTeam statement #9
INFO:cartography.graph.statement:Completed GitHubTeam statement #10
INFO:cartography.graph.job:Finished job GitHubTeam
INFO:cartography.intel.github.users:Syncing GitHub users
INFO:cartography.intel.github.users:Retrieving users from GitHub organization kgpmask
INFO:cartography.intel.github.users:Retrieving enterprise owners from GitHub organization kgpmask
INFO:cartography.intel.github.users:Loading 1 GitHub organization to the graph
INFO:cartography.intel.github.users:Loading 36 GitHub users to the graph
INFO:cartography.intel.github.users:Loading 0 GitHub users to the graph
INFO:cartography.intel.github.users:Cleaning up GitHub users
INFO:cartography.graph.statement:Completed GitHubUser statement #1
INFO:cartography.graph.statement:Completed GitHubUser statement #2
INFO:cartography.graph.job:Finished job GitHubUser
INFO:cartography.graph.statement:Completed GitHubUser statement #1
INFO:cartography.graph.job:Finished job GitHubUser
INFO:cartography.intel.github.repos:Syncing GitHub repos
INFO:cartography.intel.github.repos:Retrieving repo collaborators for affiliation "DIRECT" on org "kgpmask".
INFO:cartography.intel.github.repos:Loading DIRECT collaborators for repo kaneki.
INFO:cartography.intel.github.repos:Loading DIRECT collaborators for repo MASK.
INFO:cartography.intel.github.repos:Loading DIRECT collaborators for repo quiz-bot.
INFO:cartography.intel.github.repos:Retrieving repo collaborators for affiliation "OUTSIDE" on org "kgpmask".
INFO:cartography.intel.github.repos:Loading OUTSIDE collaborators for repo kaneki.
INFO:cartography.intel.github.repos:Loading OUTSIDE collaborators for repo MASK.
INFO:cartography.intel.github.repos:Processing 10 GitHub repositories
INFO:cartography.intel.github.repos:Found 2 dependency manifests in MASK
INFO:cartography.intel.github.repos:Found 19 dependencies in MASK
INFO:cartography.intel.github.repos:Found 2 dependency manifests in template-base
INFO:cartography.intel.github.repos:Found 96 dependencies in template-base
INFO:cartography.intel.github.repos:Found 2 dependency manifests in MASK-Event
INFO:cartography.intel.github.repos:Found 16 dependencies in MASK-Event
INFO:cartography.intel.github.repos:Found 2 dependency manifests in MASK-Event-Next
INFO:cartography.intel.github.repos:Found 116 dependencies in MASK-Event-Next
INFO:cartography.intel.github.repos:Found 2 dependency manifests in MASK-Next
INFO:cartography.intel.github.repos:Found 106 dependencies in MASK-Next
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #1
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #2
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #3
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #4
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #5
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #6
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #7
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #8
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #9
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #10
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #11
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #12
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #13
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #14
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #15
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #16
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #17
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #18
INFO:cartography.graph.job:Finished job github_repos_cleanup
INFO:cartography.intel.github.teams:Loading team users for dev.
INFO:cartography.intel.github.teams:Loading team users for review.
INFO:cartography.intel.github.teams:Loading team users for former-developers.
INFO:cartography.intel.github.teams:Loading 37 GitHub team-repos to the graph
INFO:cartography.graph.statement:Completed GitHubTeam statement #1
INFO:cartography.graph.statement:Completed GitHubTeam statement #2
INFO:cartography.graph.statement:Completed GitHubTeam statement #3
INFO:cartography.graph.statement:Completed GitHubTeam statement #4
INFO:cartography.graph.statement:Completed GitHubTeam statement #5
INFO:cartography.graph.statement:Completed GitHubTeam statement #6
INFO:cartography.graph.statement:Completed GitHubTeam statement #7
INFO:cartography.graph.statement:Completed GitHubTeam statement #8
INFO:cartography.graph.statement:Completed GitHubTeam statement #9
INFO:cartography.graph.statement:Completed GitHubTeam statement #10
INFO:cartography.graph.job:Finished job GitHubTeam
INFO:cartography.sync:Finishing sync stage 'github'
INFO:cartography.sync:Finishing sync with update tag '1754555702'
~/lfx/cartography master* 1m 56s                                                                                     14:06:35

```

```
INFO:cartography.cli:Reading password for Neo4j user 'neo4j' interactively.
Password: 
WARNING:cartography.cli:Neo4j username was provided but a password could not be found.
WARNING:cartography.cli:A Kandji base URI was not provided.
WARNING:cartography.cli:A SnipeIT base URI was not provided.
INFO:cartography.sync:Starting sync with update tag '1754555814'
INFO:cartography.sync:Starting sync stage 'github'
INFO:cartography.intel.github.users:Syncing GitHub users
INFO:cartography.intel.github.users:Retrieving users from GitHub organization KGP-Speedcubers
INFO:cartography.intel.github.users:Retrieving enterprise owners from GitHub organization KGP-Speedcubers
INFO:cartography.intel.github.users:Loading 1 GitHub organization to the graph
INFO:cartography.intel.github.users:Loading 2 GitHub users to the graph
INFO:cartography.intel.github.users:Loading 0 GitHub users to the graph
INFO:cartography.intel.github.users:Cleaning up GitHub users
INFO:cartography.graph.statement:Completed GitHubUser statement #1
INFO:cartography.graph.statement:Completed GitHubUser statement #2
INFO:cartography.graph.job:Finished job GitHubUser
INFO:cartography.graph.statement:Completed GitHubUser statement #1
INFO:cartography.graph.job:Finished job GitHubUser
INFO:cartography.intel.github.repos:Syncing GitHub repos
INFO:cartography.intel.github.repos:Retrieving repo collaborators for affiliation "DIRECT" on org "KGP-Speedcubers".
INFO:cartography.intel.github.repos:Loading DIRECT collaborators for repo secret.
INFO:cartography.intel.github.repos:Loading DIRECT collaborators for repo secret-backend.
INFO:cartography.intel.github.repos:Retrieving repo collaborators for affiliation "OUTSIDE" on org "KGP-Speedcubers".
INFO:cartography.intel.github.repos:Processing 6 GitHub repositories
INFO:cartography.intel.github.repos:Found 2 dependency manifests in secret
INFO:cartography.intel.github.repos:Found 110 dependencies in secret
INFO:cartography.intel.github.repos:Found 1 dependency manifests in secret-backend
INFO:cartography.intel.github.repos:Found 19 dependencies in secret-backend
INFO:cartography.intel.github.repos:Found 4 dependency manifests in live-results
INFO:cartography.intel.github.repos:Found 222 dependencies in live-results
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #1
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #2
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #3
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #4
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #5
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #6
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #7
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #8
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #9
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #10
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #11
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #12
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #13
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #14
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #15
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #16
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #17
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #18
INFO:cartography.graph.job:Finished job github_repos_cleanup
INFO:cartography.intel.github.teams:Loading 0 GitHub team-repos to the graph
INFO:cartography.graph.statement:Completed GitHubTeam statement #1
INFO:cartography.graph.statement:Completed GitHubTeam statement #2
INFO:cartography.graph.statement:Completed GitHubTeam statement #3
INFO:cartography.graph.statement:Completed GitHubTeam statement #4
INFO:cartography.graph.statement:Completed GitHubTeam statement #5
INFO:cartography.graph.statement:Completed GitHubTeam statement #6
INFO:cartography.graph.statement:Completed GitHubTeam statement #7
INFO:cartography.graph.statement:Completed GitHubTeam statement #8
INFO:cartography.graph.statement:Completed GitHubTeam statement #9
INFO:cartography.graph.statement:Completed GitHubTeam statement #10
INFO:cartography.graph.job:Finished job GitHubTeam
INFO:cartography.intel.github.users:Syncing GitHub users
INFO:cartography.intel.github.users:Retrieving users from GitHub organization kgpmask
INFO:cartography.intel.github.users:Retrieving enterprise owners from GitHub organization kgpmask
^CWARNING:cartography.sync:Sync interrupted during stage 'github'.
```

<img width="997" height="115" alt="image" src="https://github.com/user-attachments/assets/4d9517bf-0989-4121-b022-06665c7f0dde" />

only one org has repositories loaded even though they were there in the previous iteration as seen in the console log

FIX

after the fix we can see two rows with the same lastupdated value after the first run 
<img width="995" height="167" alt="image" src="https://github.com/user-attachments/assets/a41dd69f-e180-450a-90ea-02df59ab77f9" />

the second run (where we interrupt the sync)
<img width="989" height="165" alt="image" src="https://github.com/user-attachments/assets/baa947de-9eba-475c-8b7e-06c5dedc2202" />
the data of the previously updated org wasnt deleted


If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
