### PR TITLE
feat: Add GlueJob as resource in AWS Module

### DIFF
--- a/cartography/models/aws/glue/job.py
+++ b/cartography/models/aws/glue/job.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GlueJobNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("Name")
+    arn: PropertyRef = PropertyRef("Name", extra_index=True)
+    profile_name: PropertyRef = PropertyRef("ProfileName")
+    job_mode: PropertyRef = PropertyRef("JobMode")
+    connections: PropertyRef = PropertyRef("Connections")
+    region: PropertyRef = PropertyRef("Region", set_in_kwargs=True)
+    description: PropertyRef = PropertyRef("Description")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GlueJobToAwsAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GlueJobToAWSAccountRel(CartographyRelSchema):
+    target_node_label: str = "AWSAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GlueJobToAwsAccountRelProperties = (
+        GlueJobToAwsAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GlueJobToGlueConnectionRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GlueJobToGlueConnectionRel(CartographyRelSchema):
+    target_node_label: str = "GlueConnection"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("Connections", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "USES"
+    properties: GlueJobToGlueConnectionRelProperties = (
+        GlueJobToGlueConnectionRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GlueJobSchema(CartographyNodeSchema):
+    label: str = "GlueJob"
+    properties: GlueJobNodeProperties = GlueJobNodeProperties()
+    sub_resource_relationship: GlueJobToAWSAccountRel = (
+        GlueJobToAWSAccountRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            GlueJobToGlueConnectionRel(),
+        ]
+    )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -966,6 +966,31 @@ Representation of an AWS [Glue Connection](https://docs.aws.amazon.com/glue/late
     (AWSAccount)-[RESOURCE]->(GlueConnection)
     ```
 
+### GlueJob
+Representation of an AWS [Glue Job](https://docs.aws.amazon.com/glue/latest/webapi/API_GetJobs.html)
+
+| Field | Description |
+|-------|-------------|
+| firstseen| Timestamp of when a sync job first discovered this node  |
+| lastupdated |  Timestamp of the last time the node was updated |
+| id | The name you assign to this job definition |
+| arn | The name you assign to this job definition |
+| region | The region of the Glue job |
+| description | The description of the job |
+| profile_name | The name of an AWS Glue usage profile associated with the job |
+| job_mode | A mode that describes how a job was created |
+| connections | The connections used for this job |
+#### Relationships
+- Glue Jobs are a resource under the AWS Account.
+    ```
+    (AWSAccount)-[RESOURCE]->(GlueJob)
+    ```
+- Glue Jobs are used by Glue Connections.
+    ```
+    (GlueConnection)-[USES]->(GlueJob)
+    ```
+
+
 ### CodeBuildProject
 Representation of an AWS [CodeBuild Project](https://docs.aws.amazon.com/codebuild/latest/APIReference/API_Project.html)
 

--- a/tests/data/aws/glue.py
+++ b/tests/data/aws/glue.py
@@ -32,3 +32,50 @@ GET_GLUE_CONNECTIONS_LIST = [
         "CompatibleComputeEnvironments": ["SPARK", "PYTHON"],
     }
 ]
+
+GET_GLUE_JOBS_LIST = [
+    {
+        "Name": "sample-etl-job",
+        "CreatedOn": "2025-08-01T10:30:00",
+        "LastModifiedOn": "2025-08-05T14:15:00",
+        "GlueVersion": "3.0",
+        "Command": {
+            "Name": "glueetl",
+            "ScriptLocation": "s3://my-glue-scripts/sample-etl-script.py",
+            "PythonVersion": "3",
+        },
+        "DefaultArguments": {
+            "--job-language": "python",
+            "--TempDir": "s3://my-temp-bucket/temp-dir/",
+        },
+        "MaxCapacity": 10.0,
+        "WorkerType": "G.1X",
+        "NumberOfWorkers": 5,
+        "ExecutionProperty": {"MaxConcurrentRuns": 2},
+        "Timeout": 2880,
+        "MaxRetries": 1,
+        "Description": "ETL job for processing sales data",
+        "Connections": {"Connections": ["test-jdbc-connection"]},
+    },
+    {
+        "Name": "sample-streaming-job",
+        "CreatedOn": "2025-08-02T09:00:00",
+        "LastModifiedOn": "2025-08-06T12:45:00",
+        "GlueVersion": "4.0",
+        "Command": {
+            "Name": "gluestreaming",
+            "ScriptLocation": "s3://my-glue-scripts/sample-streaming-script.py",
+            "PythonVersion": "3",
+        },
+        "DefaultArguments": {
+            "--job-language": "python",
+            "--TempDir": "s3://my-temp-bucket/temp-dir/",
+        },
+        "WorkerType": "G.025X",
+        "NumberOfWorkers": 2,
+        "ExecutionProperty": {"MaxConcurrentRuns": 1},
+        "Timeout": 1440,
+        "MaxRetries": 0,
+        "Description": "Streaming ETL job for processing real-time events",
+    },
+]

--- a/tests/integration/cartography/intel/aws/test_glue.py
+++ b/tests/integration/cartography/intel/aws/test_glue.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import cartography.intel.aws.glue
 from cartography.intel.aws.glue import sync
 from tests.data.aws.glue import GET_GLUE_CONNECTIONS_LIST
+from tests.data.aws.glue import GET_GLUE_JOBS_LIST
 from tests.integration.cartography.intel.aws.common import create_test_account
 from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
@@ -15,11 +16,17 @@ TEST_UPDATE_TAG = 123456789
 
 @patch.object(
     cartography.intel.aws.glue,
+    "get_glue_jobs",
+    return_value=GET_GLUE_JOBS_LIST,
+)
+@patch.object(
+    cartography.intel.aws.glue,
     "get_glue_connections",
     return_value=GET_GLUE_CONNECTIONS_LIST,
 )
 def test_sync_glue(
-    moct_get_glue_connections,
+    mock_get_glue_connections,
+    mock_get_glue_jobs,
     neo4j_session,
 ):
     # Arrange
@@ -41,6 +48,11 @@ def test_sync_glue(
         ("test-jdbc-connection",),
     }
 
+    assert check_nodes(neo4j_session, "GlueJob", ["arn"]) == {
+        ("sample-etl-job",),
+        ("sample-streaming-job",),
+    }
+
     # Assert
     assert check_rels(
         neo4j_session,
@@ -55,4 +67,29 @@ def test_sync_glue(
             TEST_ACCOUNT_ID,
             "test-jdbc-connection",
         ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "AWSAccount",
+        "id",
+        "GlueJob",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (TEST_ACCOUNT_ID, "sample-etl-job"),
+        (TEST_ACCOUNT_ID, "sample-streaming-job"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "GlueConnection",
+        "id",
+        "GlueJob",
+        "id",
+        "USES",
+        rel_direction_right=True,
+    ) == {
+        ("test-jdbc-connection", "sample-etl-job"),
     }


### PR DESCRIPTION
### This PR Add GlueJob as resource in AWS Module



### Related issues or links
[#1552](https://github.com/cartography-cncf/cartography/issues/1552)



### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [x] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
