### PR TITLE
chore: enable `uv.lock` updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
           - "minor"
           - "patch"
   # Maintain dependencies for Python
+  # TODO: Remove when uv ecosystem supports updating pyproject.toml
+  # https://github.com/dependabot/dependabot-core/issues/12609
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -33,9 +35,26 @@ updates:
           - "minor"
           - "patch"
     # Loose versioning strategy, increase the version only if necessary
-    # This should be removed if we stick to a pinned version strategy
-    # Ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated#defining-a-versioning-strategy
+    # As we use uv.lock for build reproducibility, we can be more permissive with version updates
     versioning-strategy: increase-if-necessary
+    # TODO: Remove when #857 is fixed
+    ignore:
+      - dependency-name: "okta"
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "master"
+    commit-message:
+      # Prefix all commit messages with "chore: "
+      prefix: "chore: "
+    groups:
+      # Group all minor and patch updates for Python
+      # Keep individual updates for major updates
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
     # TODO: Remove when #857 is fixed
     ignore:
       - dependency-name: "okta"


### PR DESCRIPTION
### Summary
Enable Dependabot updates for `uv.lock` in addition to the existing `pip` ecosystem configuration.

### Context
Dependabot recently added support for the `uv` package ecosystem, allowing automated updates of `uv.lock`.  
This change introduces a dual strategy to keep both `pyproject.toml` and `uv.lock` aligned until full `uv` ecosystem support for `pyproject.toml` is available (refer to linked issue)

### Related issues or links
- https://github.com/dependabot/dependabot-core/issues/12609

### Changes proposed
- **Add Dependabot configuration for `uv` ecosystem** to update `uv.lock` with the latest available package versions.
- **Keep `pip` ecosystem enabled** to update `pyproject.toml` weekly when required (compatibility, security) using `increase-if-necessary` strategy.
- Maintain both configurations to ensure dependencies stay aligned without breaking builds.

_Note: The CI will be run before all dependabote updates, ensuring we do not break anything, so this `dual stragery` is acceptable IMHO._