### PR TITLE
fix(github): Reduce GitHub repo page size on 502 errors

### DIFF
--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -41,12 +41,12 @@ UserAffiliationAndRepoPermission = namedtuple(
 
 
 GITHUB_ORG_REPOS_PAGINATED_GRAPHQL = """
-    query($login: String!, $cursor: String) {
+    query($login: String!, $cursor: String, $count: Int!) {
     organization(login: $login)
         {
             url
             login
-            repositories(first: 50, after: $cursor){
+            repositories(first: $count, after: $cursor){
                 pageInfo{
                     endCursor
                     hasNextPage
@@ -290,6 +290,7 @@ def get(token: str, api_url: str, organization: str) -> List[Dict]:
         organization,
         GITHUB_ORG_REPOS_PAGINATED_GRAPHQL,
         "repositories",
+        count=50,
     )
     return repos.nodes
 

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -168,14 +168,22 @@ def _get_repo_collaborators_inner_func(
         repo_name = repo["name"]
         repo_url = repo["url"]
 
-        if (
-            affiliation == "OUTSIDE" and repo["outsideCollaborators"]["totalCount"] == 0
-        ) or (
-            affiliation == "DIRECT" and repo["directCollaborators"]["totalCount"] == 0
-        ):
-            # repo has no collabs of the affiliation type we're looking for, so don't waste time making an API call
-            result[repo_url] = []
-            continue
+        # Guard against None when collaborator fields are not accessible due to permissions.
+        direct_info = repo.get("directCollaborators")
+        outside_info = repo.get("outsideCollaborators")
+
+        if affiliation == "OUTSIDE":
+            total_outside = 0 if not outside_info else outside_info.get("totalCount", 0)
+            if total_outside == 0:
+                # No outside collaborators or not permitted to view; skip API calls for this repo.
+                result[repo_url] = []
+                continue
+        else:  # DIRECT
+            total_direct = 0 if not direct_info else direct_info.get("totalCount", 0)
+            if total_direct == 0:
+                # No direct collaborators or not permitted to view; skip API calls for this repo.
+                result[repo_url] = []
+                continue
 
         logger.info(f"Loading {affiliation} collaborators for repo {repo_name}.")
         collaborators = _get_repo_collaborators(

--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -157,6 +157,18 @@ def fetch_all(
             retry += 1
             exc = err
         except requests.exceptions.HTTPError as err:
+            if (
+                err.response is not None
+                and err.response.status_code == 502
+                and kwargs.get("count")
+                and kwargs["count"] > 1
+            ):
+                kwargs["count"] = max(1, kwargs["count"] // 2)
+                logger.warning(
+                    "GitHub: Received 502 response. Reducing page size to %s and retrying.",
+                    kwargs["count"],
+                )
+                continue
             retry += 1
             exc = err
         except requests.exceptions.ChunkedEncodingError as err:

--- a/docs/root/modules/github/config.md
+++ b/docs/root/modules/github/config.md
@@ -4,7 +4,13 @@ Follow these steps to analyze GitHub repos and other objects with Cartography.
 
 1. Prepare your GitHub credentials.
 
-    1. Make a GitHub user. Prepare a token on that user with the following scopes at minimum: `repo`, `read:org`, `read:user`, `user:email`
+    1. Create a Personal Access Token (classic) on an org member account. Required scopes: `repo`, `read:org`, `read:user`, `user:email`.
+
+    1. Permissions and visibility
+
+       - Collaborators: Returned only if the token’s user is an Organization Owner or has Admin access on the repos. Scopes don’t grant privileges; the user must already have the rights. If not, Cartography continues ingest and logs `FORBIDDEN` warnings while skipping collaborator details.
+       - GitHub Enterprise: Use the same scopes; set `url` to your enterprise GraphQL endpoint (e.g., `https://github.example.com/api/graphql`).
+       - Fine‑grained PATs: Ensure “Organization members: Read” and repository-level “Metadata: Read”, plus admin rights where collaborator enumeration is needed.
 
     1. GitHub ingest supports multiple endpoints, such as a public instance and an enterprise instance by taking a base64-encoded config object structured as
 


### PR DESCRIPTION
## Summary
- reduce repository GraphQL page size when GitHub returns 502
- make repo query page size configurable via variable
- test fetch_all reduces count on 502
- update docs to mention the org perms required for this PAT to get collaborators

## Testing
- unit test, local test

```
✗ python -m cartography --selected-modules github --github-config-env-var GITHUB_CONFIG_B64
WARNING:cartography.cli:A Kandji base URI was not provided.
WARNING:cartography.cli:A SnipeIT base URI was not provided.
INFO:cartography.sync:Starting sync with update tag '<TAG>'
INFO:cartography.sync:Starting sync stage 'github'
INFO:cartography.intel.github.users:Syncing GitHub users
INFO:cartography.intel.github.users:Retrieving users from GitHub organization <ORG>
INFO:cartography.intel.github.users:Retrieving enterprise owners from GitHub organization <ORG>
INFO:cartography.intel.github.users:Loading <COUNT> GitHub organization(s) to the graph
INFO:cartography.intel.github.users:Loading <COUNT> GitHub users to the graph
INFO:cartography.intel.github.users:Loading <COUNT> GitHub users to the graph
INFO:cartography.intel.github.users:Cleaning up GitHub users
INFO:cartography.graph.statement:Completed GitHubUser statement #1
INFO:cartography.graph.statement:Completed GitHubUser statement #2
INFO:cartography.graph.job:Finished job GitHubUser
INFO:cartography.graph.statement:Completed GitHubUser statement #1
INFO:cartography.graph.job:Finished job GitHubUser
INFO:cartography.intel.github.repos:Syncing GitHub repos
**WARNING:cartography.intel.github.util:GitHub: Received 502 response. Reducing page size to 25 and retrying.
WARNING:cartography.intel.github.util:GitHub: Received 502 response. Reducing page size to 12 and retrying.
WARNING:cartography.intel.github.util:GitHub: Received 502 response. Reducing page size to 6 and retrying.**
INFO:cartography.intel.github.repos:Retrieving repo collaborators for affiliation "DIRECT" on org "<ORG>".
INFO:cartography.intel.github.repos:Loading DIRECT collaborators for repo <REPO-001>.
INFO:cartography.intel.github.repos:Loading DIRECT collaborators for repo <REPO-002>.
INFO:cartography.intel.github.repos:Loading DIRECT collaborators for repo <REPO-003>.
INFO:cartography.intel.github.repos:Loading DIRECT collaborators for repo <REPO-004>.
INFO:cartography.intel.github.repos:Retrieving repo collaborators for affiliation "OUTSIDE" on org "<ORG>".
INFO:cartography.intel.github.repos:Loading OUTSIDE collaborators for repo <REPO-008>.
INFO:cartography.intel.github.repos:Loading OUTSIDE collaborators for repo <REPO-031>.
INFO:cartography.intel.github.repos:Processing <COUNT> GitHub repositories
INFO:cartography.intel.github.repos:Found <COUNT> dependency manifests in <REPO-001>
INFO:cartography.intel.github.repos:Found <COUNT> dependencies in <REPO-001>
INFO:cartography.intel.github.repos:Found <COUNT> dependency manifests in <REPO-032>
INFO:cartography.intel.github.repos:Found <COUNT> dependencies in <REPO-032>
INFO:cartography.intel.github.repos:Found <COUNT> dependency manifests in <REPO-003>
INFO:cartography.intel.github.repos:Found <COUNT> dependencies in <REPO-003>
INFO:cartography.intel.github.repos:Found <COUNT> dependency manifests in <REPO-033>
INFO:cartography.intel.github.repos:Found <COUNT> dependencies in <REPO-033>
INFO:cartography.intel.github.repos:Found <COUNT> dependency manifests in <REPO-034>
INFO:cartography.intel.github.repos:Found <COUNT> dependencies in <REPO-034>
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed Dependency statement #1
INFO:cartography.graph.statement:Completed Dependency statement #2
INFO:cartography.graph.statement:Completed Dependency statement #3
INFO:cartography.graph.job:Finished job Dependency
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #1
INFO:cartography.graph.statement:Completed DependencyGraphManifest statement #2
INFO:cartography.graph.job:Finished job DependencyGraphManifest
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #1
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #2
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #3
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #4
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #5
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #6
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #7
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #8
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #9
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #10
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #11
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #12
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #13
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #14
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #15
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #16
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #17
INFO:cartography.graph.statement:Completed github_repos_cleanup statement #18
INFO:cartography.graph.job:Finished job github_repos_cleanup
INFO:cartography.intel.github.teams:Loading team repos for <TEAM-001>.
INFO:cartography.intel.github.teams:Loading team repos for <TEAM-002>.
INFO:cartography.intel.github.teams:Loading team repos for <TEAM-003>.
INFO:cartography.intel.github.teams:Loading team repos for <TEAM-004>.
INFO:cartography.intel.github.teams:Loading team repos for <TEAM-005>.
INFO:cartography.intel.github.teams:Loading team repos for <TEAM-006>.
INFO:cartography.intel.github.teams:Loading team repos for <TEAM-007>.
INFO:cartography.intel.github.teams:Loading team repos for <TEAM-008>.
INFO:cartography.intel.github.teams:Loading team repos for <TEAM-009>.
INFO:cartography.intel.github.teams:Loading team repos for <TEAM-010>.
INFO:cartography.intel.github.teams:Loading team users for <TEAM-001>.
INFO:cartography.intel.github.teams:Loading team users for <TEAM-002>.
INFO:cartography.intel.github.teams:Loading team users for <TEAM-003>.
INFO:cartography.intel.github.teams:Loading child teams for <TEAM-001>.
INFO:cartography.intel.github.teams:Loading child teams for <TEAM-003>.
INFO:cartography.intel.github.teams:Loading child teams for <TEAM-005>.
INFO:cartography.intel.github.teams:Loading <COUNT> GitHub team-repos to the graph
INFO:cartography.graph.statement:Completed GitHubTeam statement #1
INFO:cartography.graph.statement:Completed GitHubTeam statement #2
INFO:cartography.graph.statement:Completed GitHubTeam statement #3
INFO:cartography.graph.statement:Completed GitHubTeam statement #4
INFO:cartography.graph.statement:Completed GitHubTeam statement #5
INFO:cartography.graph.statement:Completed GitHubTeam statement #6
INFO:cartography.graph.statement:Completed GitHubTeam statement #7
INFO:cartography.graph.statement:Completed GitHubTeam statement #8
INFO:cartography.graph.statement:Completed GitHubTeam statement #9
INFO:cartography.graph.statement:Completed GitHubTeam statement #10
INFO:cartography.graph.job:Finished job GitHubTeam
INFO:cartography.sync:Finishing sync stage 'github'
INFO:cartography.sync:Finishing sync with update tag '<TAG>'
```

------
https://chatgpt.com/codex/tasks/task_b_68a3bdff0f64832396941dcfa4f011d7