### PR TITLE
Handle AWS TooManyRequestsException

### DIFF
--- a/cartography/util.py
+++ b/cartography/util.py
@@ -273,6 +273,7 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
         "UnauthorizedOperation",
         "UnrecognizedClientException",
         "InternalServerErrorException",
+        "TooManyRequestsException",
     ]
 
     @wraps(func)

--- a/tests/unit/cartography/test_util.py
+++ b/tests/unit/cartography/test_util.py
@@ -86,6 +86,22 @@ def test_aws_handle_regions(mocker):
     with pytest.raises(RuntimeError):
         raises_invalid_token(1, 2)
 
+    # TooManyRequestsException should return default []
+    @aws_handle_regions
+    def raises_too_many_requests(a, b):
+        e = botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "TooManyRequestsException",
+                    "Message": "Too many requests",
+                },
+            },
+            "FakeOperation",
+        )
+        raise e
+
+    assert raises_too_many_requests(1, 2) == []
+
     # unhandled type of ClientError
     @aws_handle_regions
     def raises_unsupported_client_error(a, b):


### PR DESCRIPTION
## Summary
- avoid sync failures by skipping when AWS returns TooManyRequestsException
- add regression test for aws_handle_regions decorator

## Testing
- `pre-commit run --files cartography/util.py tests/unit/cartography/test_util.py`
- `pytest tests/unit/cartography/test_util.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ac4174f6008323a6bf0a02c1ea51a1