### PR TITLE
fix: #1843: Handle APIGateway rate limit errors

### DIFF
--- a/cartography/intel/aws/apigateway.py
+++ b/cartography/intel/aws/apigateway.py
@@ -101,6 +101,7 @@ def get_rest_api_details(
 
 
 @timeit
+@aws_handle_regions
 def get_rest_api_stages(api: Dict, client: botocore.client.BaseClient) -> Any:
     """
     Gets the REST API Stage Resources.

--- a/cartography/intel/aws/apigateway.py
+++ b/cartography/intel/aws/apigateway.py
@@ -142,6 +142,7 @@ def get_rest_api_client_certificate(
 
 
 @timeit
+@aws_handle_regions
 def get_rest_api_resources(api: Dict, client: botocore.client.BaseClient) -> List[Any]:
     """
     Gets the collection of Resource resources.

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -273,6 +273,7 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
         "UnauthorizedOperation",
         "UnrecognizedClientException",
         "InternalServerErrorException",
+        "TooManyRequestsException",
     ]
 
     @wraps(func)

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -273,7 +273,6 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
         "UnauthorizedOperation",
         "UnrecognizedClientException",
         "InternalServerErrorException",
-        "TooManyRequestsException",
     ]
 
     @wraps(func)

--- a/tests/unit/cartography/intel/aws/test_apigateway.py
+++ b/tests/unit/cartography/intel/aws/test_apigateway.py
@@ -44,22 +44,16 @@ def test_get_rest_api_resources_retries_on_too_many_requests(
     # Arrange
     api = {"id": "test-api"}
     client = MagicMock()
-
-    # Configure expected resources
     expected_resources = [
         {"id": "resource1", "pathPart": "users"},
         {"id": "resource2", "pathPart": "orders"},
     ]
-
-    # Configure TooManyRequestsException via decorator mocks
     too_many_requests_error = ClientError(
         error_response={
             "Error": {"Code": "TooManyRequestsException", "Message": "Rate exceeded"}
         },
         operation_name="GetResources",
     )
-
-    # Configure paginator mock with side effects (using mocks from decorators)
     mock_paginator = MagicMock()
     mock_paginator.paginate.side_effect = [
         too_many_requests_error,  # First attempt fails

--- a/tests/unit/cartography/intel/aws/test_apigateway.py
+++ b/tests/unit/cartography/intel/aws/test_apigateway.py
@@ -23,15 +23,6 @@ def test_none_policy():
     assert (res) is None
 
 
-def test_get_rest_api_resources_handles_too_many_requests():
-    # Arrange
-    api = {"id": "test"}
-    client = MagicMock()
-
-    # Act and assert that we return an empty list when we get a TooManyRequestsException
-    assert get_rest_api_resources(api, client) == []
-
-
 @patch("cartography.intel.aws.apigateway.logger")
 @patch("botocore.client.BaseClient.get_paginator")
 def test_get_rest_api_resources_retries_on_too_many_requests(


### PR DESCRIPTION
Avoids crashing when API Gateway `get_rest_api_resources` encounters a TooManyRequestsException by decorating it with `aws_handle_regions`, which serves as a general catch-all exc handler for AWS `get` functions for retries and giving up.

Updates unit tests.