### PR TITLE
Replace deprecated Azure CLI auth

### DIFF
--- a/cartography/intel/azure/__init__.py
+++ b/cartography/intel/azure/__init__.py
@@ -119,13 +119,22 @@ def start_azure_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             credentials = Authenticator().authenticate_cli()
 
     except Exception as e:
-        logger.error(
-            (
-                "Unable to authenticate with Azure Service Principal, an error occurred: %s."
-                "Make sure your Azure Service Principal details are provided correctly."
-            ),
-            e,
-        )
+        if config.azure_sp_auth:
+            logger.error(
+                (
+                    "Unable to authenticate with Azure Service Principal, an error occurred: %s."
+                    "Make sure your Azure Service Principal details are provided correctly."
+                ),
+                e,
+            )
+        else:
+            logger.error(
+                (
+                    "Unable to authenticate with Azure CLI, an error occurred: %s."
+                    "Make sure you have logged in using 'az login'."
+                ),
+                e,
+            )
         return
 
     _sync_tenant(

--- a/tests/unit/cartography/intel/azure/test_credentials.py
+++ b/tests/unit/cartography/intel/azure/test_credentials.py
@@ -1,0 +1,19 @@
+from cartography.intel.azure.util.credentials import Credentials
+
+
+class DummyWithToken:
+    token = {"tenant_id": "token-tenant"}
+
+
+class DummyNoToken:
+    pass
+
+
+def test_get_tenant_id_from_token():
+    cred = Credentials(DummyWithToken(), DummyWithToken())
+    assert cred.get_tenant_id() == "token-tenant"
+
+
+def test_get_tenant_id_without_token():
+    cred = Credentials(DummyNoToken(), DummyNoToken(), tenant_id="fallback-tenant")
+    assert cred.get_tenant_id() == "fallback-tenant"


### PR DESCRIPTION
## Summary
- replace deprecated azure-cli-core credentials with AzureCliCredential
- clarify Azure CLI vs service principal auth failures
- test tenant ID resolution without Azure token

## Testing
- `uv run --frozen pre-commit run --files cartography/intel/azure/util/credentials.py cartography/intel/azure/__init__.py tests/unit/cartography/intel/azure/test_credentials.py`
- `make test` *(fails: Couldn't connect to localhost:7687...)*

------
https://chatgpt.com/codex/tasks/task_b_68a7401706308323a531ce8894523c0a