### PR TITLE
fix: #1842: Handle CodeBuild endpoint connection errors

### DIFF
--- a/cartography/intel/aws/codebuild.py
+++ b/cartography/intel/aws/codebuild.py
@@ -21,13 +21,12 @@ logger = logging.getLogger(__name__)
 def get_all_codebuild_projects(
     boto3_session: boto3.Session, region: str
 ) -> List[Dict[str, Any]]:
-
     client = boto3_session.client(
         "codebuild", region_name=region, config=get_botocore_config()
     )
     paginator = client.get_paginator("list_projects")
 
-    all_projects = []
+    all_projects: List[Dict[str, Any]] = []
 
     for page in paginator.paginate():
         project_names = page.get("projects", [])

--- a/cartography/intel/aws/codebuild.py
+++ b/cartography/intel/aws/codebuild.py
@@ -21,12 +21,13 @@ logger = logging.getLogger(__name__)
 def get_all_codebuild_projects(
     boto3_session: boto3.Session, region: str
 ) -> List[Dict[str, Any]]:
+
     client = boto3_session.client(
         "codebuild", region_name=region, config=get_botocore_config()
     )
     paginator = client.get_paginator("list_projects")
 
-    all_projects: List[Dict[str, Any]] = []
+    all_projects = []
 
     for page in paginator.paginate():
         project_names = page.get("projects", [])

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -25,6 +25,7 @@ import backoff
 import boto3
 import botocore
 import neo4j
+from botocore.exceptions import EndpointConnectionError
 
 from cartography.graph.job import GraphJob
 from cartography.graph.statement import get_job_shortname
@@ -269,6 +270,7 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
         "AccessDenied",
         "AccessDeniedException",
         "AuthFailure",
+        "EndpointConnectionError",
         "InvalidClientTokenId",
         "UnauthorizedOperation",
         "UnrecognizedClientException",
@@ -309,9 +311,12 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
                 return []
             else:
                 raise
-        except botocore.exceptions.EndpointConnectionError as e:
+        except EndpointConnectionError as e:
+            # Handle cases where a particular AWS endpoint is not deployed for a given region
             logger.warning(
-                f"{e}. Skipping...",
+                "EndpointConnectionError in this region: {}. Service not available here. Skipping...".format(
+                    str(e)
+                ),
             )
             return []
 

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -310,12 +310,11 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
                 return []
             else:
                 raise
-        except EndpointConnectionError as e:
-            # Handle cases where a particular AWS endpoint is not deployed for a given region
+        except EndpointConnectionError:
             logger.warning(
-                "EndpointConnectionError in this region: {}. Service not available here. Skipping...".format(
-                    str(e)
-                ),
+                "Encountered an EndpointConnectionError. This means that the AWS "
+                "resource is not available in this region. Skipping.",
+                exc_info=True,
             )
             return []
 

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -270,7 +270,6 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
         "AccessDenied",
         "AccessDeniedException",
         "AuthFailure",
-        "EndpointConnectionError",
         "InvalidClientTokenId",
         "UnauthorizedOperation",
         "UnrecognizedClientException",

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -309,6 +309,11 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
                 return []
             else:
                 raise
+        except botocore.exceptions.EndpointConnectionError as e:
+            logger.warning(
+                f"{e}. Skipping...",
+            )
+            return []
 
     return cast(AWSGetFunc, inner_function)
 

--- a/tests/unit/cartography/intel/aws/test_apigateway.py
+++ b/tests/unit/cartography/intel/aws/test_apigateway.py
@@ -23,10 +23,13 @@ def test_none_policy():
     assert (res) is None
 
 
+@patch("time.sleep")
 @patch("cartography.intel.aws.apigateway.logger")
 @patch("botocore.client.BaseClient.get_paginator")
 def test_get_rest_api_resources_retries_on_too_many_requests(
-    mock_get_paginator, mock_logger
+    mock_get_paginator,
+    mock_logger,
+    mock_sleep,
 ):
     """
     Test that get_rest_api_resources retries on TooManyRequestsException

--- a/tests/unit/cartography/intel/aws/test_codebuild.py
+++ b/tests/unit/cartography/intel/aws/test_codebuild.py
@@ -7,12 +7,17 @@ from cartography.intel.aws import codebuild
 
 def test_get_all_codebuild_projects_endpoint_connection_error():
     """Ensure EndpointConnectionError is handled gracefully."""
+    # Arrange
     boto3_session = MagicMock()
     paginator = boto3_session.client.return_value.get_paginator.return_value
     paginator.paginate.side_effect = EndpointConnectionError(
         endpoint_url="https://codebuild.mx-central-1.amazonaws.com"
     )
 
+    # Act
     result = codebuild.get_all_codebuild_projects(boto3_session, "mx-central-1")
 
+    # Assert that we return nothing. In AWS region processing, endpoint connection
+    # failures are often about service availability in that region, not client/server
+    # network issues
     assert result == []

--- a/tests/unit/cartography/intel/aws/test_codebuild.py
+++ b/tests/unit/cartography/intel/aws/test_codebuild.py
@@ -1,0 +1,16 @@
+from unittest.mock import MagicMock
+
+from botocore.exceptions import EndpointConnectionError
+
+from cartography.intel.aws import codebuild
+
+
+def test_get_all_codebuild_projects_endpoint_connection_error():
+    """Ensure EndpointConnectionError is handled gracefully."""
+    boto3_session = MagicMock()
+    paginator = boto3_session.client.return_value.get_paginator.return_value
+    paginator.paginate.side_effect = EndpointConnectionError(endpoint_url="https://codebuild.mx-central-1.amazonaws.com")
+
+    result = codebuild.get_all_codebuild_projects(boto3_session, "mx-central-1")
+
+    assert result == []

--- a/tests/unit/cartography/intel/aws/test_codebuild.py
+++ b/tests/unit/cartography/intel/aws/test_codebuild.py
@@ -9,7 +9,9 @@ def test_get_all_codebuild_projects_endpoint_connection_error():
     """Ensure EndpointConnectionError is handled gracefully."""
     boto3_session = MagicMock()
     paginator = boto3_session.client.return_value.get_paginator.return_value
-    paginator.paginate.side_effect = EndpointConnectionError(endpoint_url="https://codebuild.mx-central-1.amazonaws.com")
+    paginator.paginate.side_effect = EndpointConnectionError(
+        endpoint_url="https://codebuild.mx-central-1.amazonaws.com"
+    )
 
     result = codebuild.get_all_codebuild_projects(boto3_session, "mx-central-1")
 


### PR DESCRIPTION
Fixes #1842 

- Handles EndpointConnectionError when listing AWS CodeBuild projects (and now for all similar AWS offerings) by using the `aws_handle_regions` decorator

Why update aws_handle_regions:
- Regional context: In AWS region processing, endpoint connection failures are often about service availability in that region, not network issues between client and server, in this case it is better to skip one region than fail the entire sync
- If there were truly serious network connectivity issues, they would likely manifest across multiple AWS calls and be caught elsewhere in the application.
