### PR TITLE
fix: #1852: Handle missing PrivateIpAddress in EC2 transform

### DIFF
--- a/cartography/intel/aws/ec2/instances.py
+++ b/cartography/intel/aws/ec2/instances.py
@@ -163,7 +163,9 @@ def transform_ec2_instances(
                             "MacAddress": network_interface["MacAddress"],
                             "Description": network_interface["Description"],
                             "PrivateDnsName": network_interface.get("PrivateDnsName"),
-                            "PrivateIpAddress": network_interface["PrivateIpAddress"],
+                            "PrivateIpAddress": network_interface.get(
+                                "PrivateIpAddress"
+                            ),
                             "InstanceId": instance_id,
                             "SubnetId": subnet_id,
                             "GroupId": security_group["GroupId"],

--- a/tests/data/aws/ec2/instances_missing_private_ip.py
+++ b/tests/data/aws/ec2/instances_missing_private_ip.py
@@ -1,0 +1,26 @@
+DESCRIBE_INSTANCES_MISSING_PRIVATE_IP = {
+    "Reservations": [
+        {
+            "ReservationId": "r-1",
+            "OwnerId": "123456789012",
+            "Instances": [
+                {
+                    "InstanceId": "i-missing",
+                    "NetworkInterfaces": [
+                        {
+                            "NetworkInterfaceId": "eni-1",
+                            "Status": "in-use",
+                            "MacAddress": "00:00:00:00:00:00",
+                            "Description": "",
+                            "Groups": [
+                                {"GroupId": "sg-1", "GroupName": "group1"},
+                            ],
+                            # PrivateIpAddress intentionally missing
+                        }
+                    ],
+                    "BlockDeviceMappings": [],
+                }
+            ],
+        }
+    ]
+}

--- a/tests/unit/cartography/intel/aws/ec2/test_instances_transform.py
+++ b/tests/unit/cartography/intel/aws/ec2/test_instances_transform.py
@@ -1,0 +1,26 @@
+from cartography.intel.aws.ec2.instances import transform_ec2_instances
+from tests.data.aws.ec2.instances_missing_private_ip import (
+    DESCRIBE_INSTANCES_MISSING_PRIVATE_IP,
+)
+
+FAKE_REGION = "us-east-1"
+FAKE_ACCOUNT_ID = "123456789012"
+
+
+def test_transform_ec2_instances_handles_missing_private_ip():
+    reservations = DESCRIBE_INSTANCES_MISSING_PRIVATE_IP["Reservations"]
+    data = transform_ec2_instances(reservations, FAKE_REGION, FAKE_ACCOUNT_ID)
+
+    assert data.network_interface_list == [
+        {
+            "NetworkInterfaceId": "eni-1",
+            "Status": "in-use",
+            "MacAddress": "00:00:00:00:00:00",
+            "Description": "",
+            "PrivateDnsName": None,
+            "PrivateIpAddress": None,
+            "InstanceId": "i-missing",
+            "SubnetId": None,
+            "GroupId": "sg-1",
+        }
+    ]


### PR DESCRIPTION
- Avoid KeyError when EC2 network interface lacks PrivateIpAddress
- Add unit test covering transform for missing PrivateIpAddress