### PR TITLE
fix(aws eks): parse cluster region from arn, not name

### DIFF
--- a/cartography/intel/kubernetes/__init__.py
+++ b/cartography/intel/kubernetes/__init__.py
@@ -58,7 +58,7 @@ def start_k8s_ingestion(session: Session, config: Config) -> None:
             if config.managed_kubernetes == "eks":
                 # EKS identity provider sync
                 boto3_session = boto3.Session()
-                region = get_region_from_arn(cluster_info.get("id"))
+                region = get_region_from_arn(cluster_info.get("id", ""))
                 sync_eks(
                     session,
                     client,


### PR DESCRIPTION
### Summary
Noticed that the EKS module within Kube wasn't guarded by the `managed_eks` flag and it was using cluster name instead of the ARN which is present in the cluster ID https://github.com/cartography-cncf/cartography/pull/1825

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
```
➜  cartography git:(ksikka/eks-rbac-fixes) uv run cartography --neo4j-uri bolt://localhost:7687 --selected-modules aws,kubernetes --aws-requested-syncs iam --k8s-kubeconfig ~/.kube/config --aws-regions us-east-1

WARNING:cartography.cli:A Kandji base URI was not provided.
WARNING:cartography.cli:A SnipeIT base URI was not provided.
INFO:cartography.sync:Starting sync with update tag '1756761514'
INFO:cartography.sync:Starting sync stage 'aws'
INFO:cartography.intel.aws:Syncing AWS accounts: <AWS_ACCOUNT_ID_1>
INFO:cartography.intel.aws:Syncing AWS account with ID '<AWS_ACCOUNT_ID_1>' using configured profile 'Access-<AWS_ACCOUNT_ID_1>'.
INFO:cartography.intel.aws:Trying to autodiscover accounts.
INFO:cartography.intel.aws:Loading autodiscovered accounts.
INFO:cartography.intel.aws.iam:Syncing IAM for account '<AWS_ACCOUNT_ID_1>'.
INFO:cartography.intel.aws.iam:Syncing IAM users for account '<AWS_ACCOUNT_ID_1>'.
INFO:cartography.intel.aws.iam:Loading 0 IAM users.
INFO:cartography.graph.statement:Completed aws_import_users_cleanup statement #1
INFO:cartography.graph.job:Finished job aws_import_users_cleanup
INFO:cartography.intel.aws.iam:Syncing IAM groups for account '<AWS_ACCOUNT_ID_1>'.
INFO:cartography.intel.aws.iam:Loading 0 IAM groups to the graph.
INFO:cartography.graph.statement:Completed aws_import_groups_cleanup statement #1
INFO:cartography.graph.statement:Completed aws_import_groups_cleanup statement #2
INFO:cartography.graph.job:Finished job aws_import_groups_cleanup
INFO:cartography.intel.aws.iam:Syncing IAM roles for account '<AWS_ACCOUNT_ID_1>'.
INFO:cartography.intel.aws.iam:Loading 19 IAM roles to the graph.
INFO:cartography.intel.aws.iam:Syncing IAM role inline policies for account '<AWS_ACCOUNT_ID_1>'.
INFO:cartography.intel.aws.iam:Syncing IAM role managed policies for account '<AWS_ACCOUNT_ID_1>'.
INFO:cartography.graph.statement:Completed aws_import_roles_cleanup statement #1
INFO:cartography.graph.statement:Completed aws_import_roles_cleanup statement #2
INFO:cartography.graph.job:Finished job aws_import_roles_cleanup
INFO:cartography.intel.aws.iam:Syncing IAM group membership for account '<AWS_ACCOUNT_ID_1>'.
INFO:cartography.graph.statement:Completed aws_import_groups_membership_cleanup statement #1
INFO:cartography.graph.job:Finished job aws_import_groups_membership_cleanup
INFO:cartography.intel.aws.iam:Syncing assume role mappings for account '<AWS_ACCOUNT_ID_1>'.
INFO:cartography.graph.statement:Completed aws_import_roles_policy_cleanup statement #1
INFO:cartography.graph.job:Finished job aws_import_roles_policy_cleanup
INFO:cartography.intel.aws.iam:Syncing IAM user access keys for account '<AWS_ACCOUNT_ID_1>'.
INFO:cartography.graph.statement:Completed aws_import_account_access_key_cleanup statement #1
INFO:cartography.graph.statement:Completed aws_import_account_access_key_cleanup statement #2
INFO:cartography.graph.job:Finished job aws_import_account_access_key_cleanup
INFO:cartography.graph.statement:Completed aws_import_principals_cleanup statement #1
INFO:cartography.graph.statement:Completed aws_import_principals_cleanup statement #2
INFO:cartography.graph.statement:Completed aws_import_principals_cleanup statement #3
INFO:cartography.graph.statement:Completed aws_import_principals_cleanup statement #4
INFO:cartography.graph.statement:Completed aws_import_principals_cleanup statement #5
INFO:cartography.graph.job:Finished job aws_import_principals_cleanup
INFO:cartography.graph.statement:Completed aws_ec2_iaminstanceprofile statement #1
INFO:cartography.graph.statement:Completed aws_ec2_iaminstanceprofile statement #2
INFO:cartography.graph.job:Finished job aws_ec2_iaminstanceprofile
INFO:cartography.graph.statement:Completed aws_lambda_ecr statement #1
INFO:cartography.graph.statement:Completed aws_lambda_ecr statement #2
INFO:cartography.graph.job:Finished job aws_lambda_ecr
INFO:cartography.graph.statement:Completed aws_post_ingestion_principals_cleanup statement #1
INFO:cartography.graph.job:Finished job aws_post_ingestion_principals_cleanup
INFO:cartography.util:Did not run aws_ec2_asset_exposure.json because it needs {'ec2:load_balancer_v2', 'ec2:load_balancer', 'ec2:instance', 'ec2:security_group'} to be included as a requested sync. You specified: {'iam'}. If you want this job to run, please change your CLI args/cartography config so that all required resources are included.
INFO:cartography.util:Did not run aws_ec2_keypair_analysis.json because it needs {'ec2:keypair'} to be included as a requested sync. You specified: {'iam'}. If you want this job to run, please change your CLI args/cartography config so that all required resources are included.
INFO:cartography.util:Did not run aws_eks_asset_exposure.json because it needs {'eks'} to be included as a requested sync. You specified: {'iam'}. If you want this job to run, please change your CLI args/cartography config so that all required resources are included.
INFO:cartography.graph.statement:Completed aws_foreign_accounts statement #1
INFO:cartography.graph.statement:Completed aws_foreign_accounts statement #2
INFO:cartography.graph.job:Finished job aws_foreign_accounts
INFO:cartography.sync:Finishing sync stage 'aws'
INFO:cartography.sync:Starting sync stage 'kubernetes'
INFO:cartography.intel.kubernetes:Syncing data for k8s cluster <EKS_CLUSTER_ARN_1>...
INFO:cartography.intel.kubernetes.clusters:Loading '<EKS_CLUSTER_ARN_1>' Kubernetes cluster into graph
INFO:cartography.intel.kubernetes.namespaces:Loading 5 kubernetes namespaces.
INFO:cartography.graph.statement:Completed KubernetesNamespace statement #1
INFO:cartography.graph.statement:Completed KubernetesNamespace statement #2
INFO:cartography.graph.job:Finished job KubernetesNamespace
INFO:cartography.intel.kubernetes.rbac:Syncing Kubernetes RBAC resources for cluster <EKS_CLUSTER_ARN_1>
INFO:cartography.intel.kubernetes.rbac:Loading 27 KubernetesUsers
INFO:cartography.intel.kubernetes.rbac:Loading 14 KubernetesGroups
INFO:cartography.intel.kubernetes.rbac:Loading 41 KubernetesServiceAccounts
INFO:cartography.intel.kubernetes.rbac:Loading 20 KubernetesRoles
INFO:cartography.intel.kubernetes.rbac:Loading 88 KubernetesClusterRoles
INFO:cartography.intel.kubernetes.rbac:Loading 21 KubernetesRoleBindings
INFO:cartography.intel.kubernetes.rbac:Loading 76 KubernetesClusterRoleBindings
INFO:cartography.graph.statement:Completed KubernetesServiceAccount statement #1
INFO:cartography.graph.statement:Completed KubernetesServiceAccount statement #2
INFO:cartography.graph.statement:Completed KubernetesServiceAccount statement #3
INFO:cartography.graph.job:Finished job KubernetesServiceAccount
INFO:cartography.graph.statement:Completed KubernetesRole statement #1
INFO:cartography.graph.statement:Completed KubernetesRole statement #2
INFO:cartography.graph.statement:Completed KubernetesRole statement #3
INFO:cartography.graph.job:Finished job KubernetesRole
INFO:cartography.graph.statement:Completed KubernetesRoleBinding statement #1
INFO:cartography.graph.statement:Completed KubernetesRoleBinding statement #2
INFO:cartography.graph.statement:Completed KubernetesRoleBinding statement #3
INFO:cartography.graph.statement:Completed KubernetesRoleBinding statement #4
INFO:cartography.graph.statement:Completed KubernetesRoleBinding statement #5
INFO:cartography.graph.statement:Completed KubernetesRoleBinding statement #6
INFO:cartography.graph.statement:Completed KubernetesRoleBinding statement #7
INFO:cartography.graph.job:Finished job KubernetesRoleBinding
INFO:cartography.graph.statement:Completed KubernetesClusterRole statement #1
INFO:cartography.graph.statement:Completed KubernetesClusterRole statement #2
INFO:cartography.graph.job:Finished job KubernetesClusterRole
INFO:cartography.graph.statement:Completed KubernetesClusterRoleBinding statement #1
INFO:cartography.graph.statement:Completed KubernetesClusterRoleBinding statement #2
INFO:cartography.graph.statement:Completed KubernetesClusterRoleBinding statement #3
INFO:cartography.graph.statement:Completed KubernetesClusterRoleBinding statement #4
INFO:cartography.graph.statement:Completed KubernetesClusterRoleBinding statement #5
INFO:cartography.graph.statement:Completed KubernetesClusterRoleBinding statement #6
INFO:cartography.graph.job:Finished job KubernetesClusterRoleBinding
INFO:cartography.graph.statement:Completed KubernetesUser statement #1
INFO:cartography.graph.statement:Completed KubernetesUser statement #2
INFO:cartography.graph.statement:Completed KubernetesUser statement #3
INFO:cartography.graph.statement:Completed KubernetesUser statement #4
INFO:cartography.graph.statement:Completed KubernetesUser statement #5
INFO:cartography.graph.job:Finished job KubernetesUser
INFO:cartography.graph.statement:Completed KubernetesGroup statement #1
INFO:cartography.graph.statement:Completed KubernetesGroup statement #2
INFO:cartography.graph.statement:Completed KubernetesGroup statement #3
INFO:cartography.graph.statement:Completed KubernetesGroup statement #4
INFO:cartography.graph.statement:Completed KubernetesGroup statement #5
INFO:cartography.graph.job:Finished job KubernetesGroup
INFO:cartography.intel.kubernetes.pods:Loading 5 kubernetes pods.
INFO:cartography.intel.kubernetes.pods:Loading 6 kubernetes containers.
INFO:cartography.graph.statement:Completed KubernetesContainer statement #1
INFO:cartography.graph.statement:Completed KubernetesContainer statement #2
INFO:cartography.graph.statement:Completed KubernetesContainer statement #3
INFO:cartography.graph.statement:Completed KubernetesContainer statement #4
INFO:cartography.graph.job:Finished job KubernetesContainer
INFO:cartography.graph.statement:Completed KubernetesPod statement #1
INFO:cartography.graph.statement:Completed KubernetesPod statement #2
INFO:cartography.graph.statement:Completed KubernetesPod statement #3
INFO:cartography.graph.job:Finished job KubernetesPod
INFO:cartography.intel.kubernetes.secrets:Loading 0 KubernetesSecrets
INFO:cartography.graph.statement:Completed KubernetesSecret statement #1
INFO:cartography.graph.statement:Completed KubernetesSecret statement #2
INFO:cartography.graph.statement:Completed KubernetesSecret statement #3
INFO:cartography.graph.job:Finished job KubernetesSecret
INFO:cartography.intel.kubernetes.services:Loading 4 KubernetesServices
INFO:cartography.graph.statement:Completed KubernetesService statement #1
INFO:cartography.graph.statement:Completed KubernetesService statement #2
INFO:cartography.graph.statement:Completed KubernetesService statement #3
INFO:cartography.graph.statement:Completed KubernetesService statement #4
INFO:cartography.graph.job:Finished job KubernetesService
INFO:cartography.sync:Finishing sync stage 'kubernetes'
INFO:cartography.sync:Finishing sync with update tag '1756761514'
```