### PR TITLE
fix(aws): Handle AuthorizationError in AWS region decorator #1867

### DIFF
--- a/cartography/util.py
+++ b/cartography/util.py
@@ -270,6 +270,8 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
         "AccessDenied",
         "AccessDeniedException",
         "AuthFailure",
+        "AuthorizationError",
+        "AuthorizationErrorException",
         "InvalidClientTokenId",
         "UnauthorizedOperation",
         "UnrecognizedClientException",

--- a/tests/unit/cartography/test_util.py
+++ b/tests/unit/cartography/test_util.py
@@ -69,6 +69,22 @@ def test_aws_handle_regions(mocker):
 
     assert raises_supported_client_error(1, 2) == []
 
+    # AuthorizationError should also return the default
+    @aws_handle_regions
+    def raises_authorization_error(a, b):
+        e = botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "AuthorizationError",
+                    "Message": "aws_handle_regions is not working",
+                },
+            },
+            "FakeOperation",
+        )
+        raise e
+
+    assert raises_authorization_error(1, 2) == []
+
     # InvalidToken should raise RuntimeError
     @aws_handle_regions
     def raises_invalid_token(a, b):


### PR DESCRIPTION
Avoid crashes when SCPs block AWS calls by including AuthorizationError in aws_handle_regions

## References
- https://boto3.amazonaws.com/v1/documentation/api/1.35.66/reference/services/sns/client/exceptions/AuthorizationErrorException.html
- See issue https://github.com/cartography-cncf/cartography/issues/1867 for context and rationale