### PR TITLE
fix(aws): Handle missing PrivateIpAddress in EC2 network interface sync #1870

### DIFF
--- a/cartography/intel/aws/ec2/network_interfaces.py
+++ b/cartography/intel/aws/ec2/network_interfaces.py
@@ -91,7 +91,6 @@ def transform_network_interface_data(
                 "InterfaceType": network_interface["InterfaceType"],
                 "MacAddress": network_interface["MacAddress"],
                 "PrivateDnsName": network_interface.get("PrivateDnsName"),
-                # PrivateIpAddress may be absent for some network interfaces.
                 "PrivateIpAddress": network_interface.get("PrivateIpAddress"),
                 "PublicIp": network_interface.get("Association", {}).get("PublicIp"),
                 "RequesterId": network_interface.get("RequesterId"),

--- a/cartography/intel/aws/ec2/network_interfaces.py
+++ b/cartography/intel/aws/ec2/network_interfaces.py
@@ -91,7 +91,8 @@ def transform_network_interface_data(
                 "InterfaceType": network_interface["InterfaceType"],
                 "MacAddress": network_interface["MacAddress"],
                 "PrivateDnsName": network_interface.get("PrivateDnsName"),
-                "PrivateIpAddress": network_interface["PrivateIpAddress"],
+                # PrivateIpAddress may be absent for some network interfaces.
+                "PrivateIpAddress": network_interface.get("PrivateIpAddress"),
                 "PublicIp": network_interface.get("Association", {}).get("PublicIp"),
                 "RequesterId": network_interface.get("RequesterId"),
                 "RequesterManaged": network_interface["RequesterManaged"],


### PR DESCRIPTION
## Summary
- handle missing `PrivateIpAddress` when transforming EC2 network interfaces
- remove test updates for network interfaces

Fixes #1870.

Similar to #1852 