### PR TITLE
Add sync test for GCP storage buckets

### DIFF
--- a/tests/integration/cartography/intel/gcp/test_storage.py
+++ b/tests/integration/cartography/intel/gcp/test_storage.py
@@ -1,5 +1,10 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
 import cartography.intel.gcp.storage
 import tests.data.gcp.storage
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
 
@@ -62,3 +67,39 @@ def test_attach_storage_bucket_labels(neo4j_session):
         (expected_id, expected_label_key, expected_label_value),
     }
     assert actual_nodes == expected_nodes
+
+
+@patch.object(
+    cartography.intel.gcp.storage,
+    "get_gcp_buckets",
+    return_value=tests.data.gcp.storage.STORAGE_RESPONSE,
+)
+def test_sync_gcp_buckets(mock_get_buckets, neo4j_session):
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "PROJECT_ID": "project-abc"}
+
+    cartography.intel.gcp.storage.sync_gcp_buckets(
+        neo4j_session,
+        MagicMock(),
+        "project-abc",
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "GCPBucket",
+        ["id", "project_number", "kind"],
+    ) == {
+        ("bucket_name", 9999, "storage#bucket"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "GCPProject",
+        "projectnumber",
+        "GCPBucket",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (9999, "bucket_name"),
+    }


### PR DESCRIPTION
## Summary
- add integration test for sync_gcp_buckets validating node and relationship creation

## Testing
- `pytest tests/integration/cartography/intel/gcp/test_storage.py::test_sync_gcp_buckets -q` *(fails: neo4j.exceptions.ServiceUnavailable: Couldn't connect to localhost:7687)*

------
https://chatgpt.com/codex/tasks/task_b_68b8ccb04a48832faf9135de9e2adb92