### PR TITLE
Add integration tests for GCP project sync

### DIFF
--- a/tests/integration/cartography/intel/gcp/test_crm.py
+++ b/tests/integration/cartography/intel/gcp/test_crm.py
@@ -1,7 +1,11 @@
+from unittest.mock import patch
+
 import cartography.intel.gcp.crm
 import tests.data.gcp.crm
+from tests.integration.util import check_nodes, check_rels
 
 TEST_UPDATE_TAG = 123456789
+COMMON_JOB_PARAMS = {"UPDATE_TAG": TEST_UPDATE_TAG}
 
 
 def test_load_gcp_projects(neo4j_session):
@@ -84,3 +88,131 @@ def test_load_gcp_projects_without_parent(neo4j_session):
     )
     actual_nodes = {(n["d.id"]) for n in nodes}
     assert actual_nodes == expected_nodes
+
+
+@patch.object(
+    cartography.intel.gcp.crm,
+    "get_gcp_organizations",
+    return_value=tests.data.gcp.crm.GCP_ORGANIZATIONS,
+)
+@patch.object(
+    cartography.intel.gcp.crm,
+    "get_gcp_folders",
+    return_value=tests.data.gcp.crm.GCP_FOLDERS,
+)
+def test_sync_gcp_projects(
+    _mock_get_folders, _mock_get_orgs, neo4j_session,
+) -> None:
+    """Test that sync_gcp_projects ingests project data and connects hierarchy."""
+    cartography.intel.gcp.crm.sync_gcp_organizations(
+        neo4j_session,
+        None,
+        TEST_UPDATE_TAG,
+        COMMON_JOB_PARAMS,
+    )
+    cartography.intel.gcp.crm.sync_gcp_folders(
+        neo4j_session,
+        None,
+        TEST_UPDATE_TAG,
+        COMMON_JOB_PARAMS,
+    )
+    cartography.intel.gcp.crm.sync_gcp_projects(
+        neo4j_session,
+        tests.data.gcp.crm.GCP_PROJECTS,
+        TEST_UPDATE_TAG,
+        COMMON_JOB_PARAMS,
+    )
+
+    assert check_nodes(neo4j_session, "GCPProject", ["id"]) == {
+        ("this-project-has-a-parent-232323",),
+    }
+
+    query = """
+        MATCH (p:GCPProject{id:$ProjectId})<-[:RESOURCE]-(f:GCPFolder)<-[:RESOURCE]-(o:GCPOrganization)
+        RETURN p.id, f.id, o.id
+    """
+    nodes = neo4j_session.run(
+        query,
+        ProjectId="this-project-has-a-parent-232323",
+    )
+    actual_nodes = {
+        (
+            n["p.id"],
+            n["f.id"],
+            n["o.id"],
+        )
+        for n in nodes
+    }
+    assert actual_nodes == {
+        (
+            "this-project-has-a-parent-232323",
+            "folders/1414",
+            "organizations/1337",
+        ),
+    }
+
+
+def test_sync_gcp_projects_without_parent(neo4j_session) -> None:
+    """Ensure sync_gcp_projects handles projects with no parent."""
+    cartography.intel.gcp.crm.sync_gcp_projects(
+        neo4j_session,
+        tests.data.gcp.crm.GCP_PROJECTS_WITHOUT_PARENT,
+        TEST_UPDATE_TAG,
+        COMMON_JOB_PARAMS,
+    )
+
+    assert check_nodes(neo4j_session, "GCPProject", ["id"]) == {
+        ("my-parentless-project-987654",),
+    }
+    assert check_rels(
+        neo4j_session,
+        "GCPFolder",
+        "id",
+        "GCPProject",
+        "id",
+        "RESOURCE",
+    ) == set()
+
+
+@patch.object(
+    cartography.intel.gcp.crm,
+    "get_gcp_organizations",
+    return_value=tests.data.gcp.crm.GCP_ORGANIZATIONS,
+)
+@patch.object(
+    cartography.intel.gcp.crm,
+    "get_gcp_folders",
+    return_value=tests.data.gcp.crm.GCP_FOLDERS,
+)
+def test_sync_gcp_projects_cleanup(
+    _mock_get_folders, _mock_get_orgs, neo4j_session,
+) -> None:
+    """Ensure sync_gcp_projects cleanup removes stale project nodes."""
+    cartography.intel.gcp.crm.load_gcp_projects(
+        neo4j_session,
+        tests.data.gcp.crm.GCP_PROJECTS_WITHOUT_PARENT,
+        TEST_UPDATE_TAG - 1,
+    )
+
+    cartography.intel.gcp.crm.sync_gcp_organizations(
+        neo4j_session,
+        None,
+        TEST_UPDATE_TAG,
+        COMMON_JOB_PARAMS,
+    )
+    cartography.intel.gcp.crm.sync_gcp_folders(
+        neo4j_session,
+        None,
+        TEST_UPDATE_TAG,
+        COMMON_JOB_PARAMS,
+    )
+    cartography.intel.gcp.crm.sync_gcp_projects(
+        neo4j_session,
+        tests.data.gcp.crm.GCP_PROJECTS,
+        TEST_UPDATE_TAG,
+        COMMON_JOB_PARAMS,
+    )
+
+    assert check_nodes(neo4j_session, "GCPProject", ["id"]) == {
+        ("this-project-has-a-parent-232323",),
+    }


### PR DESCRIPTION
## Summary
- add integration tests covering GCP project sync behavior, including parent linkage, parentless projects, and cleanup

## Testing
- `pytest tests/integration/cartography/intel/gcp/test_crm.py::test_sync_gcp_projects` *(fails: Couldn't connect to localhost:7687)*

------
https://chatgpt.com/codex/tasks/task_b_68ba75a11db8832f8254e4d337944463