### PR TITLE
fix(gcp): Invalid GCP OAuth scopes

### DIFF
--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -480,9 +480,13 @@ def get_gcp_credentials() -> Optional[GoogleCredentials]:
     :return: GoogleCredentials
     """
     try:
-        # Explicitly use Application Default Credentials.
-        # See https://google-auth.readthedocs.io/en/master/user-guide.html#application-default-credentials
-        credentials, project_id = default()
+        # Explicitly use Application Default Credentials with the cloud-platform scope.
+        # Some versions of google-auth/google-api-python-client require explicit scopes for service accounts;
+        # without this, token refresh may fail with `invalid_scope`.
+        # See: https://cloud.google.com/docs/authentication#calling
+        credentials, project_id = default(
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
         return credentials
     except DefaultCredentialsError as e:
         logger.debug(


### PR DESCRIPTION
### Summary
Specifying the google cloud oauth scope

I saw this error when running the GCP sync with a service account (ADC creds):
```
google.auth.exceptions.RefreshError: ('invalid_scope: Invalid OAuth scope or ID token audience provided.', {'error': 'invalid_scope', 'error_description': 'Invalid OAuth scope or ID token audience provided.'})
```

Explicitly requesting the cloud-platform scope fixed the issue:
```
(cartography) ➜  cartography git:(master) ✗ cartography --selected-modules gcp
WARNING:cartography.cli:A Kandji base URI was not provided.
WARNING:cartography.cli:A SnipeIT base URI was not provided.
INFO:cartography.sync:Starting sync with update tag '1757342904'
INFO:cartography.sync:Starting sync stage 'gcp'
INFO:cartography.graph.statement:Completed gcp_crm_organization_cleanup statement #1
INFO:cartography.graph.statement:Completed gcp_crm_organization_cleanup statement #2
INFO:cartography.graph.job:Finished job gcp_crm_organization_cleanup
INFO:cartography.graph.statement:Completed gcp_crm_folder_cleanup statement #1
INFO:cartography.graph.statement:Completed gcp_crm_folder_cleanup statement #2
INFO:cartography.graph.statement:Completed gcp_crm_folder_cleanup statement #3
INFO:cartography.graph.job:Finished job gcp_crm_folder_cleanup
INFO:cartography.intel.gcp:Syncing 2 GCP projects.
INFO:cartography.graph.statement:Completed gcp_crm_project_cleanup statement #1
INFO:cartography.graph.statement:Completed gcp_crm_project_cleanup statement #2
INFO:cartography.graph.statement:Completed gcp_crm_project_cleanup statement #3
INFO:cartography.graph.job:Finished job gcp_crm_project_cleanup
INFO:cartography.intel.gcp:Syncing GCP project beep-boop for Compute.
INFO:cartography.intel.gcp:Syncing GCP project blah-blah for Compute.
INFO:cartography.intel.gcp:Syncing GCP project beep-boop for Storage
INFO:cartography.intel.gcp.storage:Syncing Storage objects for project beep-boop.
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #1
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #2
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #3
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #4
INFO:cartography.graph.job:Finished job gcp_storage_bucket_cleanup
INFO:cartography.intel.gcp:Syncing GCP project blah-blah for Storage
INFO:cartography.intel.gcp.storage:Syncing Storage objects for project blah-blah.
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #1
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #2
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #3
INFO:cartography.graph.statement:Completed gcp_storage_bucket_cleanup statement #4
INFO:cartography.graph.job:Finished job gcp_storage_bucket_cleanup
INFO:cartography.intel.gcp:Syncing GCP project beep-boop for GKE
INFO:cartography.intel.gcp:Syncing GCP project blah-blah for GKE
INFO:cartography.intel.gcp:Syncing GCP project beep-boop for DNS
INFO:cartography.intel.gcp:Syncing GCP project blah-blah for DNS
INFO:cartography.intel.gcp:Syncing GCP project beep-boop for IAM
INFO:cartography.intel.gcp.iam:Syncing GCP IAM for project beep-boop
INFO:cartography.intel.gcp.iam:Found 5 service accounts in project beep-boop
INFO:cartography.intel.gcp.iam:Found 1974 roles in project beep-boop
INFO:cartography.graph.statement:Completed GCPServiceAccount statement #1
INFO:cartography.graph.statement:Completed GCPServiceAccount statement #2
INFO:cartography.graph.job:Finished job GCPServiceAccount
INFO:cartography.graph.statement:Completed GCPRole statement #1
INFO:cartography.graph.statement:Completed GCPRole statement #2
INFO:cartography.graph.job:Finished job GCPRole
INFO:cartography.intel.gcp:Syncing GCP project blah-blah for IAM
INFO:cartography.graph.statement:Completed gcp_compute_asset_inet_exposure statement #1
INFO:cartography.graph.statement:Completed gcp_compute_asset_inet_exposure statement #2
INFO:cartography.graph.statement:Completed gcp_compute_asset_inet_exposure statement #3
INFO:cartography.graph.statement:Completed gcp_compute_asset_inet_exposure statement #4
INFO:cartography.graph.statement:Completed gcp_compute_asset_inet_exposure statement #5
INFO:cartography.graph.statement:Completed gcp_compute_asset_inet_exposure statement #6
INFO:cartography.graph.statement:Completed gcp_compute_asset_inet_exposure statement #7
INFO:cartography.graph.job:Finished job gcp_compute_asset_inet_exposure
INFO:cartography.graph.statement:Completed gcp_gke_asset_exposure statement #1
INFO:cartography.graph.statement:Completed gcp_gke_asset_exposure statement #2
INFO:cartography.graph.job:Finished job gcp_gke_asset_exposure
INFO:cartography.graph.statement:Completed gcp_gke_basic_auth statement #1
INFO:cartography.graph.statement:Completed gcp_gke_basic_auth statement #2
INFO:cartography.graph.job:Finished job gcp_gke_basic_auth
INFO:cartography.sync:Finishing sync stage 'gcp'
INFO:cartography.sync:Finishing sync with update tag '1757342904'
```