### PR TITLE
Track root MFA via IAM account summary

### DIFF
--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -12,6 +12,7 @@ Representation of an AWS Account.
 |inscope| Indicates that the account is part of the sync scope (true or false).
 |foreign| Indicates if the account is not part of the sync scope (true or false). One such example is an account that is trusted as part of cross-account AWSRole trust not in scope for sync.
 |lastupdated| Timestamp of the last time the node was updated|
+|root_mfa_enabled| Indicates whether the account's root user has MFA enabled (true or false).|
 |**id**| The AWS Account ID number|
 
 #### Relationships

--- a/tests/data/aws/iam/__init__.py
+++ b/tests/data/aws/iam/__init__.py
@@ -188,3 +188,8 @@ INSTACE = {
         },
     ],
 }
+
+
+GET_ACCOUNT_SUMMARY = {
+    "SummaryMap": {"AccountMFAEnabled": 1},
+}


### PR DESCRIPTION
## Summary
- collect IAM account summary to track whether the account's root user has MFA enabled
- document new `root_mfa_enabled` field on `AWSAccount`
- add test coverage for account summary loading

## Testing
- `pytest tests/integration/cartography/intel/aws/iam/test_iam.py::test_load_account_summary -q` *(fails: Couldn't connect to localhost:7687)*

------
https://chatgpt.com/codex/tasks/task_b_68c594a11674832fa496f731e1edf8c2