### PR TITLE
Add CloudTrail event selector ingestion

### DIFF
--- a/cartography/intel/aws/cloudtrail.py
+++ b/cartography/intel/aws/cloudtrail.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 from typing import Dict
 from typing import List
+import json
 
 import boto3
 import neo4j
@@ -26,7 +27,15 @@ def get_cloudtrail_trails(
     )
 
     trails = client.describe_trails()["trailList"]
-    trails_filtered = [trail for trail in trails if trail.get("HomeRegion") == region]
+    trails_filtered = []
+    for trail in trails:
+        if trail.get("HomeRegion") == region:
+            selectors = client.get_event_selectors(TrailName=trail["TrailARN"])
+            trail["EventSelectors"] = selectors.get("EventSelectors", [])
+            trail["AdvancedEventSelectors"] = selectors.get(
+                "AdvancedEventSelectors", [],
+            )
+            trails_filtered.append(trail)
 
     return trails_filtered
 
@@ -41,6 +50,10 @@ def transform_cloudtrail_trails(
         arn = trail.get("CloudWatchLogsLogGroupArn")
         if arn:
             trail["CloudWatchLogsLogGroupArn"] = arn.split(":*")[0]
+        trail["EventSelectors"] = json.dumps(trail.get("EventSelectors", []))
+        trail["AdvancedEventSelectors"] = json.dumps(
+            trail.get("AdvancedEventSelectors", []),
+        )
 
     return trails
 

--- a/cartography/models/aws/cloudtrail/trail.py
+++ b/cartography/models/aws/cloudtrail/trail.py
@@ -21,6 +21,8 @@ class CloudTrailTrailNodeProperties(CartographyNodeProperties):
         "CloudWatchLogsLogGroupArn"
     )
     cloudwatch_logs_role_arn: PropertyRef = PropertyRef("CloudWatchLogsRoleArn")
+    event_selectors: PropertyRef = PropertyRef("EventSelectors")
+    advanced_event_selectors: PropertyRef = PropertyRef("AdvancedEventSelectors")
     has_custom_event_selectors: PropertyRef = PropertyRef("HasCustomEventSelectors")
     has_insight_selectors: PropertyRef = PropertyRef("HasInsightSelectors")
     home_region: PropertyRef = PropertyRef("HomeRegion")

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -863,6 +863,8 @@ Representation of an AWS [CloudTrail Trail](https://docs.aws.amazon.com/awscloud
 | is_organization_trail | Indicates if the CloudTrailTrail is an organization trail. |
 | kms_key_id | The AWS KMS key ID that encrypts the CloudTrailTrail's delivered logs. |
 | log_file_validation_enabled | Indicates if log file validation is enabled for the CloudTrailTrail. |
+| event_selectors | JSON array of event selectors configured for the CloudTrailTrail. |
+| advanced_event_selectors | JSON array of advanced event selectors configured for the CloudTrailTrail. |
 | name | The name of the CloudTrailTrail. |
 | s3_bucket_name | The Amazon S3 bucket name where the CloudTrailTrail delivers files. |
 | s3_key_prefix | The S3 key prefix used after the bucket name for the CloudTrailTrail's log files. |

--- a/tests/data/aws/cloudtrail.py
+++ b/tests/data/aws/cloudtrail.py
@@ -13,6 +13,19 @@ DESCRIBE_CLOUDTRAIL_TRAILS = [
         "HasInsightSelectors": False,
         "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/test-key",
         "CloudWatchLogsLogGroupArn": "arn:aws:logs:eu-west-1:123456789012:log-group:/aws/lambda/process-orders:*",
+        "EventSelectors": [
+            {
+                "ReadWriteType": "All",
+                "IncludeManagementEvents": True,
+                "DataResources": [
+                    {
+                        "Type": "AWS::S3::Object",
+                        "Values": ["arn:aws:s3:::example-bucket/"],
+                    }
+                ],
+            }
+        ],
+        "AdvancedEventSelectors": [],
     }
 ]
 

--- a/tests/integration/cartography/intel/aws/test_cloudtrail.py
+++ b/tests/integration/cartography/intel/aws/test_cloudtrail.py
@@ -6,6 +6,7 @@ import cartography.intel.aws.cloudwatch
 from cartography.intel.aws.cloudtrail import sync
 from tests.data.aws.cloudtrail import BUCKETS
 from tests.data.aws.cloudtrail import DESCRIBE_CLOUDTRAIL_TRAILS
+import json
 from tests.data.aws.cloudwatch import GET_CLOUDWATCH_LOG_GROUPS
 from tests.integration.cartography.intel.aws.common import create_test_account
 from tests.integration.util import check_nodes
@@ -58,8 +59,18 @@ def test_sync_cloudtrail(mock_get_trails, neo4j_session):
     )
 
     # Assert
-    assert check_nodes(neo4j_session, "CloudTrailTrail", ["arn"]) == {
-        ("arn:aws:cloudtrail:us-east-1:123456789012:trail/test-trail",),
+    expected_selectors = json.dumps(
+        DESCRIBE_CLOUDTRAIL_TRAILS[0]["EventSelectors"],
+    )
+    assert check_nodes(
+        neo4j_session,
+        "CloudTrailTrail",
+        ["arn", "event_selectors"],
+    ) == {
+        (
+            "arn:aws:cloudtrail:us-east-1:123456789012:trail/test-trail",
+            expected_selectors,
+        ),
     }
 
     # Assert


### PR DESCRIPTION
## Summary
- collect CloudTrail event selectors for each trail
- expose event selectors on CloudTrailTrail nodes
- document event selector fields in schema

## Testing
- `python -m pytest tests/unit/cartography/graph/test_querybuilder_metadata.py -q`
- `python -m pytest tests/integration/cartography/intel/aws/test_cloudtrail.py::test_sync_cloudtrail -q` *(fails: Couldn't connect to localhost:7687)*

------
https://chatgpt.com/codex/tasks/task_b_68c35e7d9a1083238864a4e4628eb718