### PR TITLE
(feat) Adds a job to link Cloudflare CNAMEs to AWS DNS records

### DIFF
--- a/cartography/data/jobs/analysis/cloudflare_to_route53.json
+++ b/cartography/data/jobs/analysis/cloudflare_to_route53.json
@@ -1,0 +1,9 @@
+{
+  "name": "Links Cloudflare CNAMEs to AWS Route 53",
+  "statements": [
+    {
+      "query": "MATCH (cf:CloudflareDNSRecord{type: \"CNAME\"}) WITH cf MATCH (aws:AWSDNSRecord) WHERE cf.value = aws.name MERGE (cf)-[r:DNS_POINTS_TO]->(aws) ON CREATE SET r.firstseen = $UPDATE_TAG SET r.lastupdated = $UPDATE_TAG",
+      "iterative": false
+    }
+  ]
+}

--- a/cartography/data/jobs/analysis/cloudflare_to_route53.json
+++ b/cartography/data/jobs/analysis/cloudflare_to_route53.json
@@ -1,9 +1,0 @@
-{
-  "name": "Links Cloudflare CNAMEs to AWS Route 53",
-  "statements": [
-    {
-      "query": "MATCH (cf:CloudflareDNSRecord{type: \"CNAME\"}) WITH cf MATCH (aws:AWSDNSRecord) WHERE cf.value = aws.name MERGE (cf)-[r:DNS_POINTS_TO]->(aws) ON CREATE SET r.firstseen = $UPDATE_TAG SET r.lastupdated = $UPDATE_TAG",
-      "iterative": false
-    }
-  ]
-}

--- a/cartography/data/jobs/analysis/dnsrecord_cname_linking.json
+++ b/cartography/data/jobs/analysis/dnsrecord_cname_linking.json
@@ -1,0 +1,9 @@
+{
+  "name": "Links DNSRecords of type CNAME to the DNSRecords they point to",
+  "statements": [
+    {
+      "query": "MATCH (source:DNSRecord{type: \"CNAME\"}) WITH source MATCH (target:DNSRecord) WHERE source.value = target.name MERGE (source)-[r:DNS_POINTS_TO]->(target) ON CREATE SET r.firstseen = $UPDATE_TAG SET r.lastupdated = $UPDATE_TAG",
+      "iterative": false
+    }
+  ]
+}

--- a/tests/integration/cartography/data/jobs/test_dnsrecord_cname_linking_job.py
+++ b/tests/integration/cartography/data/jobs/test_dnsrecord_cname_linking_job.py
@@ -1,0 +1,51 @@
+import pytest
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.models.cloudflare.dnsrecord import CloudflareDNSRecordSchema
+from tests.data.cloudflare.dnsrecords import CLOUDFLARE_DNSRECORDS
+
+TEST_UPDATE_TAG = 1234567890
+
+
+@pytest.fixture
+def root_dir(request):
+    return request.config.rootpath
+
+
+def test_analysis_jobs_cypher_syntax(neo4j_session, root_dir):
+    load(
+        neo4j_session,
+        CloudflareDNSRecordSchema(),
+        CLOUDFLARE_DNSRECORDS,
+        lastupdated=TEST_UPDATE_TAG,
+        zone_id="cf_zone_id",
+    )
+
+    # no links
+    assert get_dns_points_to(neo4j_session) == []
+
+    # run the job
+    job_file = (
+        root_dir
+        / "cartography"
+        / "data"
+        / "jobs"
+        / "analysis"
+        / "dnsrecord_cname_linking.json"
+    )
+    job = GraphJob.from_json_file(job_file)
+    job.merge_parameters({"UPDATE_TAG": TEST_UPDATE_TAG})
+    job.run(neo4j_session)
+
+    actual = get_dns_points_to(neo4j_session)
+    expected = [("www.simpson.corp", "simpson.corp")]
+
+    assert actual == expected
+
+
+def get_dns_points_to(neo4j_session):
+    query = neo4j_session.run(
+        "MATCH (s:DNSRecord) -[p:DNS_POINTS_TO]- (t:DNSRecord) RETURN s.name, t.name"
+    )
+    return [(r["s.name"], r["t.name"]) for r in query]


### PR DESCRIPTION
### Summary

Adds a an analysis job to link CNAME DNS records to the DNS records they point to.

-[ ] This just does Cloudflare -> AWS because that fit my usecase. I assume I should change this to just DNSRecord.
-[ ] Also needs tests.



### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/cartography-cncf/cartography/issues/...


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

- [ ] Confirm that the linter actually passes (submitting a PR where the linter fails shows reviewers that you did not test your code and will delay your review).
