### PR TITLE
feat(AWS): added functionality to check service last accessed

### DIFF
--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -4573,3 +4573,24 @@ Representation of an AWS [Secrets Manager Secret Version](https://docs.aws.amazo
     ```
     (SecretsManagerSecretVersion)-[ENCRYPTED_BY]->(AWSKMSKey)
     ```
+
+### ServiceLastAccessed
+
+Representation of AWS service access information from [get_service_last_accessed_details](https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetServiceLastAccessedDetails.html).
+
+| Field | Description |
+|-------|-------------|
+| firstseen| Timestamp of when a sync job first discovered this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| **id** | Unique identifier: `{principal_arn}|{service_name}` |
+| service_name | The name of the service (e.g., "Amazon S3") |
+| service_namespace | The service namespace (e.g., "s3") |
+| last_authenticated | The date and time when the service was last accessed |
+| last_authenticated_entity | The entity that last accessed the service |
+| last_authenticated_region | The region where the service was last accessed |
+| total_authenticated_entities | The total `number` of authenticated entities for this service |
+
+#### Relationships
+- AWS Principals have service access records.
+```cypher
+    (AWSPrincipal)-[LAST_ACCESSED_SERVICE]->(ServiceLastAccessed)

--- a/tests/data/aws/iam/__init__.py
+++ b/tests/data/aws/iam/__init__.py
@@ -207,3 +207,28 @@ INSTACE = {
         },
     ],
 }
+
+
+SERVICE_LAST_ACCESSED_DETAILS = {
+    'JobStatus': 'COMPLETED',
+    'JobCreationDate': datetime.datetime(2019, 1, 1, 0, 0, 1),
+    'JobCompletionDate': datetime.datetime(2019, 1, 1, 0, 0, 2),
+    'ServicesLastAccessed': [
+        {
+            'ServiceName': 'Amazon S3',
+            'ServiceNamespace': 's3',
+            'LastAuthenticated': datetime.datetime(2019, 1, 1, 0, 0, 1),
+            'LastAuthenticatedEntity': 'user/example-user-0',
+            'LastAuthenticatedRegion': 'us-east-1',
+            'TotalAuthenticatedEntities': 1,
+        },
+        {
+            'ServiceName': 'Amazon EC2',
+            'ServiceNamespace': 'ec2',
+            'LastAuthenticated': datetime.datetime(2019, 1, 2, 0, 0, 1),
+            'LastAuthenticatedEntity': 'role/example-role-0',
+            'LastAuthenticatedRegion': 'us-west-2',
+            'TotalAuthenticatedEntities': 2,
+        },
+    ]
+}


### PR DESCRIPTION
### Summary
> Describe your changes.
This PR adds support for AWS IAM `get_service_last_accessed_details`.

<img width="1357" height="714" alt="Untitled design (2)" src="https://github.com/user-attachments/assets/221990aa-7c0e-4d1b-b0fe-66d9fb8a75c8" />



### Related issues or links
> Include links to relevant issues or other pages.
- https://github.com/cartography-cncf/cartography/issues/1889


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

- [ ] Confirm that the linter actually passes (submitting a PR where the linter fails shows reviewers that you did not test your code and will delay your review).
