### PR TITLE
refactor: use transactional writes in AWS, GSuite, Okta loaders

### DIFF
--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -19,7 +19,9 @@ from cartography.util import batch
 logger = logging.getLogger(__name__)
 
 
-def run_write_query(neo4j_session: neo4j.Session, query: str, **parameters: Any) -> None:
+def run_write_query(
+    neo4j_session: neo4j.Session, query: str, **parameters: Any
+) -> None:
     """Execute a write query inside a managed transaction."""
 
     def _run_query_tx(tx: neo4j.Transaction) -> None:

--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -19,6 +19,15 @@ from cartography.util import batch
 logger = logging.getLogger(__name__)
 
 
+def run_write_query(neo4j_session: neo4j.Session, query: str, **parameters: Any) -> None:
+    """Execute a write query inside a managed transaction."""
+
+    def _run_query_tx(tx: neo4j.Transaction) -> None:
+        tx.run(query, **parameters).consume()
+
+    neo4j_session.execute_write(_run_query_tx)
+
+
 def read_list_of_values_tx(
     tx: neo4j.Transaction,
     query: str,

--- a/cartography/intel/aws/config.py
+++ b/cartography/intel/aws/config.py
@@ -5,6 +5,7 @@ from typing import List
 import boto3
 import neo4j
 
+from cartography.client.core.tx import run_write_query
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -80,7 +81,8 @@ def load_configuration_recorders(
     for recorder in data:
         recorder["_id"] = f'{recorder["name"]}:{current_aws_account_id}:{region}'
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_configuration_recorders,
         Recorders=data,
         Region=region,
@@ -120,7 +122,8 @@ def load_delivery_channels(
     for channel in data:
         channel["_id"] = f'{channel["name"]}:{current_aws_account_id}:{region}'
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_delivery_channels,
         Channels=data,
         Region=region,
@@ -167,7 +170,8 @@ def load_config_rules(
             for detail in rule["Source"]["SourceDetails"]:
                 details.append(f"{detail}")
         rule["_source_details"] = details
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_config_rules,
         Rules=data,
         Region=region,

--- a/cartography/intel/aws/organizations.py
+++ b/cartography/intel/aws/organizations.py
@@ -5,6 +5,7 @@ import boto3
 import botocore.exceptions
 import neo4j
 
+from cartography.client.core.tx import run_write_query
 from cartography.intel.aws.iam import sync_root_principal
 from cartography.util import timeit
 
@@ -114,7 +115,8 @@ def load_aws_accounts(
     """
     for account_name, account_id in aws_accounts.items():
         root_arn = f"arn:aws:iam::{account_id}:root"
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             query,
             ACCOUNT_ID=account_id,
             ACCOUNT_NAME=account_name,

--- a/cartography/intel/aws/permission_relationships.py
+++ b/cartography/intel/aws/permission_relationships.py
@@ -13,6 +13,7 @@ import neo4j
 import yaml
 
 from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.client.core.tx import run_write_query
 from cartography.graph.statement import GraphStatement
 from cartography.util import timeit
 
@@ -329,7 +330,8 @@ def load_principal_mappings(
         node_label=node_label,
         relationship_name=relationship_name,
     )
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         map_policy_query_template,
         Mapping=principal_mappings,
         aws_update_tag=update_tag,

--- a/cartography/intel/aws/redshift.py
+++ b/cartography/intel/aws/redshift.py
@@ -5,6 +5,7 @@ from typing import List
 import boto3
 import neo4j
 
+from cartography.client.core.tx import run_write_query
 from cartography.util import aws_handle_regions
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
@@ -88,7 +89,8 @@ def load_redshift_cluster_data(
     SET r.lastupdated = $aws_update_tag
     """
     for cluster in clusters:
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             ingest_cluster,
             Arn=cluster["arn"],
             AZ=cluster["AvailabilityZone"],
@@ -128,7 +130,8 @@ def _attach_ec2_security_groups(
     SET m.lastupdated = $aws_update_tag
     """
     for group in cluster.get("VpcSecurityGroups", []):
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             attach_cluster_to_group,
             ClusterArn=cluster["arn"],
             GroupId=group["VpcSecurityGroupId"],
@@ -150,7 +153,8 @@ def _attach_iam_roles(
     SET s.lastupdated = $aws_update_tag
     """
     for role in cluster.get("IamRoles", []):
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             attach_cluster_to_role,
             ClusterArn=cluster["arn"],
             RoleArn=role["IamRoleArn"],
@@ -172,7 +176,8 @@ def _attach_aws_vpc(
     SET m.lastupdated = $aws_update_tag
     """
     if cluster.get("VpcId"):
-        neo4j_session.run(
+        run_write_query(
+            neo4j_session,
             attach_cluster_to_vpc,
             ClusterArn=cluster["arn"],
             VpcId=cluster["VpcId"],

--- a/cartography/intel/aws/securityhub.py
+++ b/cartography/intel/aws/securityhub.py
@@ -6,6 +6,7 @@ import boto3
 import neo4j
 from dateutil import parser
 
+from cartography.client.core.tx import run_write_query
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
@@ -50,7 +51,8 @@ def load_hub(
     ON CREATE SET r.firstseen = timestamp()
     SET r.lastupdated = $aws_update_tag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_hub,
         Hub=data,
         AWS_ACCOUNT_ID=current_aws_account_id,

--- a/cartography/intel/create_indexes.py
+++ b/cartography/intel/create_indexes.py
@@ -3,6 +3,7 @@ from typing import List
 
 import neo4j
 
+from cartography.client.core.tx import run_write_query
 from cartography.config import Config
 from cartography.util import load_resource_binary
 
@@ -23,4 +24,4 @@ def run(neo4j_session: neo4j.Session, config: Config) -> None:
     logger.info("Creating indexes for cartography node types.")
     for statement in get_index_statements():
         logger.debug("Executing statement: %s", statement)
-        neo4j_session.run(statement)
+        run_write_query(neo4j_session, statement)

--- a/cartography/intel/dns.py
+++ b/cartography/intel/dns.py
@@ -8,6 +8,7 @@ import dns.rdatatype
 import dns.resolver
 import neo4j
 
+from cartography.client.core.tx import run_write_query
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -104,7 +105,8 @@ def _link_ip_to_A_record(
     SET r.lastupdated = $update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest,
         ParentId=parent_record,
         IP_LIST=ip_list,
@@ -151,7 +153,8 @@ def ingest_dns_record(
 
     record_id = f"{name}+{type}"
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         template.safe_substitute(
             record_label=record_label,
             dns_node_additional_label=dns_node_additional_label,

--- a/cartography/intel/gsuite/api.py
+++ b/cartography/intel/gsuite/api.py
@@ -6,6 +6,7 @@ import neo4j
 from googleapiclient.discovery import Resource
 from googleapiclient.errors import HttpError
 
+from cartography.client.core.tx import run_write_query
 from cartography.util import run_cleanup_job
 from cartography.util import timeit
 
@@ -171,7 +172,12 @@ def load_gsuite_groups(
         g.lastupdated = $UpdateTag
     """
     logger.info(f"Ingesting {len(groups)} gsuite groups")
-    neo4j_session.run(ingestion_qry, GroupData=groups, UpdateTag=gsuite_update_tag)
+    run_write_query(
+        neo4j_session,
+        ingestion_qry,
+        GroupData=groups,
+        UpdateTag=gsuite_update_tag,
+    )
 
 
 @timeit
@@ -215,7 +221,12 @@ def load_gsuite_users(
         u.lastupdated = $UpdateTag
     """
     logger.info(f"Ingesting {len(users)} gsuite users")
-    neo4j_session.run(ingestion_qry, UserData=users, UpdateTag=gsuite_update_tag)
+    run_write_query(
+        neo4j_session,
+        ingestion_qry,
+        UserData=users,
+        UpdateTag=gsuite_update_tag,
+    )
 
 
 @timeit
@@ -234,7 +245,8 @@ def load_gsuite_members(
         SET
         r.lastupdated = $UpdateTag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingestion_qry,
         MemberData=members,
         GroupID=group.get("id"),
@@ -249,7 +261,8 @@ def load_gsuite_members(
         SET
         r.lastupdated = $UpdateTag
     """
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         membership_qry,
         MemberData=members,
         GroupID=group.get("id"),

--- a/cartography/intel/okta/applications.py
+++ b/cartography/intel/okta/applications.py
@@ -10,6 +10,7 @@ import neo4j
 from okta.framework.ApiClient import ApiClient
 from okta.framework.OktaError import OktaError
 
+from cartography.client.core.tx import run_write_query
 from cartography.intel.okta.utils import check_rate_limit
 from cartography.intel.okta.utils import create_api_client
 from cartography.intel.okta.utils import is_last_page
@@ -293,7 +294,8 @@ def _load_okta_applications(
     SET org_r.lastupdated = $okta_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_statement,
         ORG_ID=okta_org_id,
         APP_LIST=app_list,
@@ -327,7 +329,8 @@ def _load_application_user(
     SET r.lastupdated = $okta_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest,
         APP_ID=app_id,
         USER_LIST=user_list,
@@ -361,7 +364,8 @@ def _load_application_group(
     SET r.lastupdated = $okta_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest,
         APP_ID=app_id,
         GROUP_LIST=group_list,
@@ -400,7 +404,8 @@ def _load_application_reply_urls(
     SET r.lastupdated = $okta_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest,
         APP_ID=app_id,
         URL_LIST=reply_urls,

--- a/cartography/intel/okta/awssaml.py
+++ b/cartography/intel/okta/awssaml.py
@@ -10,6 +10,7 @@ import neo4j
 
 from cartography.client.core.tx import read_list_of_dicts_tx
 from cartography.client.core.tx import read_single_value_tx
+from cartography.client.core.tx import run_write_query
 from cartography.util import timeit
 
 AccountRole = namedtuple("AccountRole", ["account_id", "role_name"])
@@ -116,7 +117,8 @@ def _load_okta_group_to_aws_roles(
     SET r.lastupdated = $okta_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_statement,
         GROUP_TO_ROLE=group_to_role,
         okta_update_tag=okta_update_tag,
@@ -140,7 +142,8 @@ def _load_human_can_assume_role(
     SET r.lastupdated = $okta_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_statement,
         okta_update_tag=okta_update_tag,
     )

--- a/cartography/intel/okta/factors.py
+++ b/cartography/intel/okta/factors.py
@@ -8,6 +8,7 @@ from okta import FactorsClient
 from okta.framework.OktaError import OktaError
 from okta.models.factor.Factor import Factor
 
+from cartography.client.core.tx import run_write_query
 from cartography.intel.okta.sync_state import OktaSyncState
 from cartography.util import timeit
 
@@ -130,7 +131,8 @@ def _load_user_factors(
     SET r.lastupdated = $okta_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest,
         USER_ID=user_id,
         FACTOR_LIST=factors,

--- a/cartography/intel/okta/groups.py
+++ b/cartography/intel/okta/groups.py
@@ -11,6 +11,7 @@ from okta.framework.OktaError import OktaError
 from okta.framework.PagedResults import PagedResults
 from okta.models.usergroup import UserGroup
 
+from cartography.client.core.tx import run_write_query
 from cartography.intel.okta.sync_state import OktaSyncState
 from cartography.intel.okta.utils import check_rate_limit
 from cartography.intel.okta.utils import create_api_client
@@ -204,7 +205,8 @@ def _load_okta_groups(
     SET org_r.lastupdated = $okta_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_statement,
         ORG_ID=okta_org_id,
         GROUP_LIST=group_list,
@@ -251,7 +253,8 @@ def load_okta_group_members(
         SET r.lastupdated = $okta_update_tag
     """
     logging.info(f"Loading {len(member_list)} members of group {group_id}")
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest,
         GROUP_ID=group_id,
         MEMBER_LIST=member_list,

--- a/cartography/intel/okta/organization.py
+++ b/cartography/intel/okta/organization.py
@@ -3,6 +3,7 @@ import logging
 
 import neo4j
 
+from cartography.client.core.tx import run_write_query
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -27,7 +28,8 @@ def create_okta_organization(
     SET org.lastupdated = $okta_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest,
         ORG_NAME=organization,
         okta_update_tag=okta_update_tag,

--- a/cartography/intel/okta/origins.py
+++ b/cartography/intel/okta/origins.py
@@ -7,6 +7,7 @@ from typing import List
 import neo4j
 from okta.framework.ApiClient import ApiClient
 
+from cartography.client.core.tx import run_write_query
 from cartography.intel.okta.utils import create_api_client
 from cartography.util import timeit
 
@@ -96,7 +97,8 @@ def _load_trusted_origins(
     SET r.lastupdated = $okta_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest,
         ORG_ID=okta_org_id,
         TRUSTED_LIST=trusted_list,

--- a/cartography/intel/okta/roles.py
+++ b/cartography/intel/okta/roles.py
@@ -7,6 +7,7 @@ from typing import List
 import neo4j
 from okta.framework.ApiClient import ApiClient
 
+from cartography.client.core.tx import run_write_query
 from cartography.intel.okta.sync_state import OktaSyncState
 from cartography.intel.okta.utils import check_rate_limit
 from cartography.intel.okta.utils import create_api_client
@@ -117,7 +118,8 @@ def _load_user_role(
     SET r2.lastupdated = $okta_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest,
         USER_ID=user_id,
         ROLES_DATA=roles_data,
@@ -149,7 +151,8 @@ def _load_group_role(
     SET r2.lastupdated = $okta_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest,
         GROUP_ID=group_id,
         ROLES_DATA=roles_data,

--- a/cartography/intel/okta/users.py
+++ b/cartography/intel/okta/users.py
@@ -8,6 +8,7 @@ import neo4j
 from okta import UsersClient
 from okta.models.user import User
 
+from cartography.client.core.tx import run_write_query
 from cartography.intel.okta.sync_state import OktaSyncState
 from cartography.intel.okta.utils import check_rate_limit
 from cartography.util import timeit
@@ -174,7 +175,8 @@ def _load_okta_users(
     SET h.lastupdated = $okta_update_tag
     """
 
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         ingest_statement,
         ORG_ID=okta_org_id,
         USER_LIST=user_list,

--- a/tests/unit/cartography/intel/gsuite/test_api.py
+++ b/tests/unit/cartography/intel/gsuite/test_api.py
@@ -144,7 +144,8 @@ def test_sync_gsuite_groups(
     )
 
 
-def test_load_gsuite_groups():
+@patch("cartography.intel.gsuite.api.run_write_query")
+def test_load_gsuite_groups(mock_run_write_query):
     ingestion_qry = """
         UNWIND $GroupData as group
         MERGE (g:GSuiteGroup{id: group.id})
@@ -166,14 +167,16 @@ def test_load_gsuite_groups():
     update_tag = 1
     session = mock.MagicMock()
     api.load_gsuite_groups(session, groups, update_tag)
-    session.run.assert_called_with(
+    mock_run_write_query.assert_called_once_with(
+        session,
         ingestion_qry,
         GroupData=groups,
         UpdateTag=update_tag,
     )
 
 
-def test_load_gsuite_users():
+@patch("cartography.intel.gsuite.api.run_write_query")
+def test_load_gsuite_users(mock_run_write_query):
     ingestion_qry = """
         UNWIND $UserData as user
         MERGE (u:GSuiteUser{id: user.id})
@@ -212,7 +215,8 @@ def test_load_gsuite_users():
     update_tag = 1
     session = mock.MagicMock()
     api.load_gsuite_users(session, users, update_tag)
-    session.run.assert_called_with(
+    mock_run_write_query.assert_called_once_with(
+        session,
         ingestion_qry,
         UserData=users,
         UpdateTag=update_tag,


### PR DESCRIPTION
## Summary
- last week, we introduced a change that introduced transactions to the GitHub loader and eliminated a bunch of transient errors: https://github.com/cartography-cncf/cartography/pull/1927
- this PR brings that same goodness to AWS, GSuite, and Okta, the last users of non-transactional loads in the graph. we add a reusable `run_write_query` helper that wraps `neo4j.Session.execute_write`

## Testing
- unit / integration tests

------
https://chatgpt.com/codex/tasks/task_b_68cdbeb6b28c8323bc1827d64e81072f