### PR TITLE
Add support for AWS IAM list_server_certificates

### DIFF
--- a/cartography/intel/aws/resources.py
+++ b/cartography/intel/aws/resources.py
@@ -60,6 +60,7 @@ from .ec2.volumes import sync_ebs_volumes
 from .ec2.vpc import sync_vpc
 from .ec2.vpc_peerings import sync_vpc_peerings
 from .iam_instance_profiles import sync_iam_instance_profiles
+from .iam import sync_server_certificates
 
 RESOURCE_FUNCTIONS: Dict[str, Callable[..., None]] = {
     "iam": iam.sync,
@@ -122,4 +123,5 @@ RESOURCE_FUNCTIONS: Dict[str, Callable[..., None]] = {
     "cognito": cognito.sync,
     "eventbridge": eventbridge.sync,
     "glue": glue.sync,
+    "server_certificates": sync_server_certificates,
 }


### PR DESCRIPTION
### Summary
> Describe your changes.

Adds support for syncing AWS IAM Server Certificates into Cartography. Creates AWSServerCertificate nodes in Neo4j with properties like arn, name, path, upload_date, aws_account_id, and update_tag. Includes incremental sync support via update_tag and adds the function to RESOURCE_FUNCTIONS for AWS syncs.

Issue:
Closes #1886

### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/cartography-cncf/cartography/issues/...


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

- [ ] Confirm that the linter actually passes (submitting a PR where the linter fails shows reviewers that you did not test your code and will delay your review).
