### PR TITLE
fix(ecr): Support multiple ECR image tags

### DIFF
--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -57,15 +57,15 @@ def get_ecr_repository_images(
         )
         for response in describe_response:
             image_details = response["imageDetails"]
-            image_details = [
-                (
-                    {**detail, "imageTag": detail["imageTags"][0]}
-                    if detail.get("imageTags")
-                    else detail
-                )
-                for detail in image_details
-            ]
-            ecr_repository_images.extend(image_details)
+            for detail in image_details:
+                tags = detail.get("imageTags") or []
+                if tags:
+                    for tag in tags:
+                        image_detail = {**detail, "imageTag": tag}
+                        image_detail.pop("imageTags", None)
+                        ecr_repository_images.append(image_detail)
+                else:
+                    ecr_repository_images.append({**detail})
     return ecr_repository_images
 
 

--- a/tests/data/aws/ecr.py
+++ b/tests/data/aws/ecr.py
@@ -60,6 +60,12 @@ LIST_REPOSITORY_IMAGES = {
             **DESCRIBE_IMAGES["imageDetails"],
         },
         {
+            "imageDigest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "imageTag": "latest",
+            "repositoryName": "example-repository",
+            **DESCRIBE_IMAGES["imageDetails"],
+        },
+        {
             "imageDigest": "sha256:0000000000000000000000000000000000000000000000000000000000000001",
             "imageTag": "2",
             "repositoryName": "example-repository",

--- a/tests/integration/cartography/intel/aws/test_ecr.py
+++ b/tests/integration/cartography/intel/aws/test_ecr.py
@@ -116,6 +116,12 @@ def test_sync_ecr(mock_get_images, mock_get_repos, neo4j_session):
             "2025-01-01T00:00:00.000000-00:00",
         ),
         (
+            "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository:latest",
+            "latest",
+            1024,
+            "2025-01-01T00:00:00.000000-00:00",
+        ),
+        (
             "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository:2",
             "2",
             1024,
@@ -193,6 +199,10 @@ def test_sync_ecr(mock_get_images, mock_get_repos, neo4j_session):
         ),
         (
             "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository",
+            "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository:latest",
+        ),
+        (
+            "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository",
             "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository:2",
         ),
         (
@@ -229,6 +239,10 @@ def test_sync_ecr(mock_get_images, mock_get_repos, neo4j_session):
     ) == {
         (
             "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository:1",
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        ),
+        (
+            "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository:latest",
             "sha256:0000000000000000000000000000000000000000000000000000000000000000",
         ),
         (
@@ -402,6 +416,10 @@ def test_load_ecr_repository_images(neo4j_session):
         ),
         (
             "arn:aws:ecr:us-east-1:000000000000:repository/example-repository",
+            "latest",
+        ),
+        (
+            "arn:aws:ecr:us-east-1:000000000000:repository/example-repository",
             "2",
         ),
     }
@@ -446,6 +464,10 @@ def test_load_ecr_images(neo4j_session):
         ),
         (
             "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository:1",
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        ),
+        (
+            "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository:latest",
             "sha256:0000000000000000000000000000000000000000000000000000000000000000",
         ),
     }


### PR DESCRIPTION
## Summary
- create an ECRRepositoryImage node for every tag returned by `describe_images`, ensuring multiple tags for the same digest produce distinct `ECRRepositoryImage` nodes

## Testing
- added integration test
------
https://chatgpt.com/codex/tasks/task_b_68d57e5afedc8323a389c29309ed9138