### PR TITLE
feat(aws): add support for route53 AAAA records

### DIFF
--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1289,7 +1289,7 @@ Representation of an AWS DNS [ResourceRecordSet](https://docs.aws.amazon.com/Rou
 |lastupdated| Timestamp of the last time the node was updated|
 |**id**| The zoneid for the record, the value of the record, and the type concatenated together|
 |type| The record type of the DNS record (A, AAAA, ALIAS, CNAME, NS, etc.)|
-|value| If it is an A, AAAA, ALIAS, or CNAME record, this is the IP address that the DNSRecord points to. If it is an NS record, the `name` is used here.|
+|value| If it is an A or AAAA record, this is the IP address the DNSRecord resolves to. For CNAME or ALIAS records, this is the target hostname or AWS resource name. If it is an NS record, the `name` is used here.|
 
 #### Relationships
 - AWSDNSRecords can point to IP addresses.

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1292,7 +1292,7 @@ Representation of an AWS DNS [ResourceRecordSet](https://docs.aws.amazon.com/Rou
 |value| If it is an A, AAAA, ALIAS, or CNAME record, this is the IP address that the DNSRecord points to. If it is an NS record, the `name` is used here.|
 
 #### Relationships
-- AWSDNSRecords can point to IP addresses (both IPv4 and IPv6).
+- AWSDNSRecords can point to IP addresses.
     ```
     (:AWSDNSRecord)-[:DNS_POINTS_TO]->(:Ip)
     ```

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1288,29 +1288,34 @@ Representation of an AWS DNS [ResourceRecordSet](https://docs.aws.amazon.com/Rou
 |name| The name of the DNSRecord|
 |lastupdated| Timestamp of the last time the node was updated|
 |**id**| The zoneid for the record, the value of the record, and the type concatenated together|
-|type| The record type of the DNS record|
-|value| If it is an A, ALIAS, or CNAME record, this is the IP address that the DNSRecord points to. If it is an NS record, the `name` is used here.|
+|type| The record type of the DNS record (A, AAAA, ALIAS, CNAME, NS, etc.)|
+|value| If it is an A, AAAA, ALIAS, or CNAME record, this is the IP address that the DNSRecord points to. If it is an NS record, the `name` is used here.|
 
 #### Relationships
+- AWSDNSRecords can point to IP addresses (both IPv4 and IPv6).
+    ```
+    (:AWSDNSRecord)-[:DNS_POINTS_TO]->(:Ip)
+    ```
+
 - DNSRecords/AWSDNSRecords can point to each other.
     ```
-    (AWSDNSRecord, DNSRecord)-[DNS_POINTS_TO]->(AWSDNSRecord, DNSRecord)
+    (:AWSDNSRecord, :DNSRecord)-[:DNS_POINTS_TO]->(:AWSDNSRecord, :DNSRecord)
     ```
 
 
 - AWSDNSRecords can point to LoadBalancers.
     ```
-    (AWSDNSRecord)-[DNS_POINTS_TO]->(LoadBalancer, ESDomain)
+    (:AWSDNSRecord)-[:DNS_POINTS_TO]->(:LoadBalancer, :ESDomain)
     ```
 
 - AWSDNSRecords can point to ElasticIPAddresses.
     ```
-    (AWSDNSRecord)-[DNS_POINTS_TO]->(ElasticIPAddress)
+    (:AWSDNSRecord)-[:DNS_POINTS_TO]->(:ElasticIPAddress)
     ```
 
 - AWSDNSRecords can be members of AWSDNSZones.
     ```
-    (AWSDNSRecord)-[MEMBER_OF_DNS_ZONE]->(AWSDNSZone)
+    (:AWSDNSRecord)-[:MEMBER_OF_DNS_ZONE]->(:AWSDNSZone)
     ```
 
 

--- a/tests/data/aws/route53.py
+++ b/tests/data/aws/route53.py
@@ -33,6 +33,27 @@ CNAME_RECORD = {
     },
 }
 
+AAAA_RECORD = {
+    "Name": "ipv6.example.com.",
+    "Type": "AAAA",
+    "TTL": 300,
+    "ResourceRecords": [
+        {"Value": "2001:db8::1"},
+        {"Value": "2001:db8::2"},
+    ],
+}
+
+AAAA_ALIAS_RECORD = {
+    "Name": "aliasv6.example.com.",
+    "Type": "AAAA",
+    "TTL": 60,
+    "AliasTarget": {
+        "HostedZoneId": "HOSTED_ZONE_2",
+        "DNSName": "target-ipv6.example.com.",
+        "EvaluateTargetHealth": False,
+    },
+}
+
 ZONE_RECORDS = [
     {
         "Id": "/hostedzone/FAKEZONEID1",
@@ -77,6 +98,15 @@ GET_ZONES_SAMPLE_RESPONSE = [
                 "Type": "A",
             },
             {
+                "Name": "ipv6.example.com.",
+                "ResourceRecords": [
+                    {"Value": "2001:db8::1"},
+                    {"Value": "2001:db8::2"},
+                ],
+                "TTL": 300,
+                "Type": "AAAA",
+            },
+            {
                 "Name": "example.com.",
                 "ResourceRecords": [
                     {
@@ -116,6 +146,16 @@ GET_ZONES_SAMPLE_RESPONSE = [
                 },
                 "TTL": 60,
                 "Type": "A",
+            },
+            {
+                "Name": "aliasv6.example.com.",
+                "AliasTarget": {
+                    "HostedZoneId": "HOSTED_ZONE_2",
+                    "DNSName": "target-ipv6.example.com.",
+                    "EvaluateTargetHealth": False,
+                },
+                "TTL": 60,
+                "Type": "AAAA",
             },
             {
                 "AliasTarget": {


### PR DESCRIPTION
Adds initial support for route53 AAAA (IPv6) DNS records for issue #1945.

Added integ tests.

To-do for next time: properly create `:Ip` nodes from `cartography.intel.dns` so that route53 connects to them. For now, we at least have the IPv6 records in the graph.