### PR TITLE
feat(azure): add support for Resource Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can learn more about the story behind Cartography in our [presentation at BS
 - [Keycloak](https://cartography-cncf.github.io/cartography/modules/keycloak/index.html) - Realms, Users, Groups, Roles, Scopes, Clients, IdentityProviders, Authentication Flows, Authentication Executions, Organizations, Organization Domains
 - [Kubernetes](https://cartography-cncf.github.io/cartography/modules/kubernetes/index.html) - Cluster, Namespace, Service, Pod, Container, ServiceAccount, Role, RoleBinding, ClusterRole, ClusterRoleBinding, OIDCProvider
 - [Lastpass](https://cartography-cncf.github.io/cartography/modules/lastpass/index.html) - users
-- [Microsoft Azure](https://cartography-cncf.github.io/cartography/modules/azure/index.html) - App Service, CosmosDB, Functions, Logic Apps, SQL, Storage, Virtual Machine
+- [Microsoft Azure](https://cartography-cncf.github.io/cartography/modules/azure/index.html) - App Service, CosmosDB, Functions, Logic Apps, Resource Group, SQL, Storage, Virtual Machine
 - [Microsoft Entra ID](https://cartography-cncf.github.io/cartography/modules/entra/index.html) -  Users, Groups, Applications, OUs, App Roles, federation to AWS Identity Center
 - [NIST CVE](https://cartography-cncf.github.io/cartography/modules/cve/index.html) - Common Vulnerabilities and Exposures (CVE) data from NIST database
 - [Okta](https://cartography-cncf.github.io/cartography/modules/okta/index.html) - users, groups, organizations, roles, applications, factors, trusted origins, reply URIs, federation to AWS roles, federation to AWS Identity Center

--- a/cartography/intel/azure/__init__.py
+++ b/cartography/intel/azure/__init__.py
@@ -12,6 +12,7 @@ from . import compute
 from . import cosmosdb
 from . import functions
 from . import logic_apps
+from . import resource_groups
 from . import sql
 from . import storage
 from . import subscription
@@ -74,6 +75,13 @@ def _sync_one_subscription(
     storage.sync(
         neo4j_session,
         credentials.credential,
+        subscription_id,
+        update_tag,
+        common_job_parameters,
+    )
+    resource_groups.sync(
+        neo4j_session,
+        credentials,
         subscription_id,
         update_tag,
         common_job_parameters,

--- a/cartography/intel/azure/resource_groups.py
+++ b/cartography/intel/azure/resource_groups.py
@@ -2,7 +2,8 @@ import logging
 from typing import Any
 
 import neo4j
-from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
+from azure.core.exceptions import ClientAuthenticationError
+from azure.core.exceptions import HttpResponseError
 from azure.mgmt.resource import ResourceManagementClient
 
 from cartography.client.core.tx import load
@@ -21,7 +22,9 @@ def get_resource_groups(credentials: Credentials, subscription_id: str) -> list[
         client = ResourceManagementClient(credentials.credential, subscription_id)
         return [rg.as_dict() for rg in client.resource_groups.list()]
     except (ClientAuthenticationError, HttpResponseError) as e:
-        logger.warning(f"Failed to get Resource Groups for subscription {subscription_id}: {str(e)}")
+        logger.warning(
+            f"Failed to get Resource Groups for subscription {subscription_id}: {str(e)}"
+        )
         return []
 
 
@@ -30,10 +33,10 @@ def transform_resource_groups(resource_groups_response: list[dict]) -> list[dict
     transformed_groups: list[dict[str, Any]] = []
     for rg in resource_groups_response:
         transformed_group = {
-            'id': rg.get('id'),
-            'name': rg.get('name'),
-            'location': rg.get('location'),
-            'provisioning_state': rg.get('properties', {}).get('provisioning_state'),
+            "id": rg.get("id"),
+            "name": rg.get("name"),
+            "location": rg.get("location"),
+            "provisioning_state": rg.get("properties", {}).get("provisioning_state"),
         }
         transformed_groups.append(transformed_group)
     return transformed_groups
@@ -41,7 +44,10 @@ def transform_resource_groups(resource_groups_response: list[dict]) -> list[dict
 
 @timeit
 def load_resource_groups(
-    neo4j_session: neo4j.Session, data: list[dict[str, Any]], subscription_id: str, update_tag: int,
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    subscription_id: str,
+    update_tag: int,
 ) -> None:
     load(
         neo4j_session,
@@ -53,8 +59,12 @@ def load_resource_groups(
 
 
 @timeit
-def cleanup_resource_groups(neo4j_session: neo4j.Session, common_job_parameters: dict) -> None:
-    GraphJob.from_node_schema(AzureResourceGroupSchema(), common_job_parameters).run(neo4j_session)
+def cleanup_resource_groups(
+    neo4j_session: neo4j.Session, common_job_parameters: dict
+) -> None:
+    GraphJob.from_node_schema(AzureResourceGroupSchema(), common_job_parameters).run(
+        neo4j_session
+    )
 
 
 @timeit

--- a/cartography/intel/azure/resource_groups.py
+++ b/cartography/intel/azure/resource_groups.py
@@ -1,0 +1,72 @@
+import logging
+from typing import Any
+
+import neo4j
+from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
+from azure.mgmt.resource import ResourceManagementClient
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.models.azure.resource_groups import AzureResourceGroupSchema
+from cartography.util import timeit
+
+from .util.credentials import Credentials
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def get_resource_groups(credentials: Credentials, subscription_id: str) -> list[dict]:
+    try:
+        client = ResourceManagementClient(credentials.credential, subscription_id)
+        return [rg.as_dict() for rg in client.resource_groups.list()]
+    except (ClientAuthenticationError, HttpResponseError) as e:
+        logger.warning(f"Failed to get Resource Groups for subscription {subscription_id}: {str(e)}")
+        return []
+
+
+@timeit
+def transform_resource_groups(resource_groups_response: list[dict]) -> list[dict]:
+    transformed_groups: list[dict[str, Any]] = []
+    for rg in resource_groups_response:
+        transformed_group = {
+            'id': rg.get('id'),
+            'name': rg.get('name'),
+            'location': rg.get('location'),
+            'provisioning_state': rg.get('properties', {}).get('provisioning_state'),
+        }
+        transformed_groups.append(transformed_group)
+    return transformed_groups
+
+
+@timeit
+def load_resource_groups(
+    neo4j_session: neo4j.Session, data: list[dict[str, Any]], subscription_id: str, update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AzureResourceGroupSchema(),
+        data,
+        lastupdated=update_tag,
+        AZURE_SUBSCRIPTION_ID=subscription_id,
+    )
+
+
+@timeit
+def cleanup_resource_groups(neo4j_session: neo4j.Session, common_job_parameters: dict) -> None:
+    GraphJob.from_node_schema(AzureResourceGroupSchema(), common_job_parameters).run(neo4j_session)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    credentials: Credentials,
+    subscription_id: str,
+    update_tag: int,
+    common_job_parameters: dict,
+) -> None:
+    logger.info(f"Syncing Azure Resource Groups for subscription {subscription_id}.")
+    raw_groups = get_resource_groups(credentials, subscription_id)
+    transformed_groups = transform_resource_groups(raw_groups)
+    load_resource_groups(neo4j_session, transformed_groups, subscription_id, update_tag)
+    cleanup_resource_groups(neo4j_session, common_job_parameters)

--- a/cartography/models/azure/resource_groups.py
+++ b/cartography/models/azure/resource_groups.py
@@ -1,0 +1,44 @@
+import logging
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties, CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties, CartographyRelSchema, LinkDirection, \
+    make_target_node_matcher, TargetNodeMatcher
+
+logger = logging.getLogger(__name__)
+
+
+# --- Node Definitions ---
+@dataclass(frozen=True)
+class AzureResourceGroupProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef('id')
+    name: PropertyRef = PropertyRef('name')
+    location: PropertyRef = PropertyRef('location')
+    provisioning_state: PropertyRef = PropertyRef('provisioning_state')
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+# --- Relationship Definitions ---
+@dataclass(frozen=True)
+class AzureResourceGroupToSubscriptionRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AzureResourceGroupToSubscriptionRel(CartographyRelSchema):
+    target_node_label: str = 'AzureSubscription'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('AZURE_SUBSCRIPTION_ID', set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = 'RESOURCE'
+    properties: AzureResourceGroupToSubscriptionRelProperties = AzureResourceGroupToSubscriptionRelProperties()
+
+
+# --- Main Schema ---
+@dataclass(frozen=True)
+class AzureResourceGroupSchema(CartographyNodeSchema):
+    label: str = 'AzureResourceGroup'
+    properties: AzureResourceGroupProperties = AzureResourceGroupProperties()
+    sub_resource_relationship: AzureResourceGroupToSubscriptionRel = AzureResourceGroupToSubscriptionRel()

--- a/cartography/models/azure/resource_groups.py
+++ b/cartography/models/azure/resource_groups.py
@@ -2,9 +2,13 @@ import logging
 from dataclasses import dataclass
 
 from cartography.models.core.common import PropertyRef
-from cartography.models.core.nodes import CartographyNodeProperties, CartographyNodeSchema
-from cartography.models.core.relationships import CartographyRelProperties, CartographyRelSchema, LinkDirection, \
-    make_target_node_matcher, TargetNodeMatcher
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
 
 logger = logging.getLogger(__name__)
 
@@ -12,33 +16,37 @@ logger = logging.getLogger(__name__)
 # --- Node Definitions ---
 @dataclass(frozen=True)
 class AzureResourceGroupProperties(CartographyNodeProperties):
-    id: PropertyRef = PropertyRef('id')
-    name: PropertyRef = PropertyRef('name')
-    location: PropertyRef = PropertyRef('location')
-    provisioning_state: PropertyRef = PropertyRef('provisioning_state')
-    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    location: PropertyRef = PropertyRef("location")
+    provisioning_state: PropertyRef = PropertyRef("provisioning_state")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 # --- Relationship Definitions ---
 @dataclass(frozen=True)
 class AzureResourceGroupToSubscriptionRelProperties(CartographyRelProperties):
-    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
 class AzureResourceGroupToSubscriptionRel(CartographyRelSchema):
-    target_node_label: str = 'AzureSubscription'
+    target_node_label: str = "AzureSubscription"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {'id': PropertyRef('AZURE_SUBSCRIPTION_ID', set_in_kwargs=True)},
+        {"id": PropertyRef("AZURE_SUBSCRIPTION_ID", set_in_kwargs=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
-    rel_label: str = 'RESOURCE'
-    properties: AzureResourceGroupToSubscriptionRelProperties = AzureResourceGroupToSubscriptionRelProperties()
+    rel_label: str = "RESOURCE"
+    properties: AzureResourceGroupToSubscriptionRelProperties = (
+        AzureResourceGroupToSubscriptionRelProperties()
+    )
 
 
 # --- Main Schema ---
 @dataclass(frozen=True)
 class AzureResourceGroupSchema(CartographyNodeSchema):
-    label: str = 'AzureResourceGroup'
+    label: str = "AzureResourceGroup"
     properties: AzureResourceGroupProperties = AzureResourceGroupProperties()
-    sub_resource_relationship: AzureResourceGroupToSubscriptionRel = AzureResourceGroupToSubscriptionRel()
+    sub_resource_relationship: AzureResourceGroupToSubscriptionRel = (
+        AzureResourceGroupToSubscriptionRel()
+    )

--- a/docs/root/modules/azure/schema.md
+++ b/docs/root/modules/azure/schema.md
@@ -1241,3 +1241,23 @@ Representation of an [Azure Logic App](https://learn.microsoft.com/en-us/rest/ap
     ```cypher
     (AzureSubscription)-[RESOURCE]->(AzureLogicApp)
     ```
+
+### AzureResourceGroup
+
+Representation of an [Azure Resource Group](https://learn.microsoft.com/en-us/rest/api/resources/resource-groups/get).
+
+| Field | Description |
+|---|---|
+|firstseen| Timestamp of when a sync job discovered this node|
+|lastupdated| Timestamp of the last time the node was updated|
+|**id**| The full resource ID of the Resource Group. |
+|name| The name of the Resource Group. |
+|location| The Azure region where the Resource Group is deployed. |
+|provisioning_state| The deployment status of the Resource Group (e.g., Succeeded). |
+
+#### Relationships
+
+- An Azure Resource Group is a resource within an Azure Subscription.
+    ```cypher
+    (AzureSubscription)-[RESOURCE]->(:AzureResourceGroup)
+    ```

--- a/tests/data/azure/resource_group.py
+++ b/tests/data/azure/resource_group.py
@@ -1,0 +1,18 @@
+MOCK_RESOURCE_GROUPS = [
+    {
+        'id': '/subscriptions/00-00-00-00/resourceGroups/TestRG1',
+        'name': 'TestRG1',
+        'location': 'eastus',
+        'properties': {
+            'provisioning_state': 'Succeeded',
+        },
+    },
+    {
+        'id': '/subscriptions/00-00-00-00/resourceGroups/TestRG2',
+        'name': 'TestRG2',
+        'location': 'westus2',
+        'properties': {
+            'provisioning_state': 'Succeeded',
+        },
+    },
+]

--- a/tests/data/azure/resource_group.py
+++ b/tests/data/azure/resource_group.py
@@ -1,18 +1,18 @@
 MOCK_RESOURCE_GROUPS = [
     {
-        'id': '/subscriptions/00-00-00-00/resourceGroups/TestRG1',
-        'name': 'TestRG1',
-        'location': 'eastus',
-        'properties': {
-            'provisioning_state': 'Succeeded',
+        "id": "/subscriptions/00-00-00-00/resourceGroups/TestRG1",
+        "name": "TestRG1",
+        "location": "eastus",
+        "properties": {
+            "provisioning_state": "Succeeded",
         },
     },
     {
-        'id': '/subscriptions/00-00-00-00/resourceGroups/TestRG2',
-        'name': 'TestRG2',
-        'location': 'westus2',
-        'properties': {
-            'provisioning_state': 'Succeeded',
+        "id": "/subscriptions/00-00-00-00/resourceGroups/TestRG2",
+        "name": "TestRG2",
+        "location": "westus2",
+        "properties": {
+            "provisioning_state": "Succeeded",
         },
     },
 ]

--- a/tests/integration/cartography/intel/azure/test_resource_groups.py
+++ b/tests/integration/cartography/intel/azure/test_resource_groups.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock, patch
+
+import cartography.intel.azure.resource_groups as resource_groups
+from tests.data.azure.resource_group import MOCK_RESOURCE_GROUPS
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_SUBSCRIPTION_ID = "00-00-00-00"
+TEST_UPDATE_TAG = 123456789
+
+
+@patch("cartography.intel.azure.resource_groups.get_resource_groups")
+def test_sync_resource_groups(mock_get, neo4j_session):
+    """
+    Test that we can correctly sync Azure Resource Group data and relationships.
+    """
+    # Arrange
+    mock_get.return_value = MOCK_RESOURCE_GROUPS
+
+    # Create the prerequisite AzureSubscription node
+    neo4j_session.run(
+        """
+        MERGE (s:AzureSubscription{id: $sub_id})
+        SET s.lastupdated = $update_tag
+        """,
+        sub_id=TEST_SUBSCRIPTION_ID,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "AZURE_SUBSCRIPTION_ID": TEST_SUBSCRIPTION_ID,
+    }
+
+    # Act
+    resource_groups.sync(
+        neo4j_session,
+        MagicMock(),
+        TEST_SUBSCRIPTION_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    # Assert Nodes
+    expected_nodes = {
+        ("/subscriptions/00-00-00-00/resourceGroups/TestRG1", "TestRG1"),
+        ("/subscriptions/00-00-00-00/resourceGroups/TestRG2", "TestRG2"),
+    }
+    actual_nodes = check_nodes(neo4j_session, "AzureResourceGroup", ["id", "name"])
+    assert actual_nodes == expected_nodes
+
+    # Assert Relationships
+    expected_rels = {
+        (TEST_SUBSCRIPTION_ID, "/subscriptions/00-00-00-00/resourceGroups/TestRG1"),
+        (TEST_SUBSCRIPTION_ID, "/subscriptions/00-00-00-00/resourceGroups/TestRG2"),
+    }
+    actual_rels = check_rels(
+        neo4j_session,
+        "AzureSubscription",
+        "id",
+        "AzureResourceGroup",
+        "id",
+        "RESOURCE",
+    )
+    assert actual_rels == expected_rels

--- a/tests/integration/cartography/intel/azure/test_resource_groups.py
+++ b/tests/integration/cartography/intel/azure/test_resource_groups.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import cartography.intel.azure.resource_groups as resource_groups
 from tests.data.azure.resource_group import MOCK_RESOURCE_GROUPS


### PR DESCRIPTION
### Summary

This pull request introduces a new, simple intel module to ingest Azure Resource Groups. This change adds a new `:AzureResourceGroup` node and connects it to the existing `:AzureSubscription` node with a `:RESOURCE` relationship.

The implementation follows the project's modern, schema-based pattern and includes integration tests and schema documentation.

### Related issues or links

- Addresses part of #1736

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
  
<img width="1055" height="692" alt="Screenshot 2025-09-27 230018" src="https://github.com/user-attachments/assets/44f989d4-1b6c-4a06-a339-c64b2e4daa0a" />

- [x] Include console log trace showing what happened before and after your changes.
  
<img width="1470" height="528" alt="Screenshot 2025-09-27 223751" src="https://github.com/user-attachments/assets/120819ba-c0b6-4213-b30e-3030cd4f77a7" />


If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [x] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

- [x] Confirm that the linter actually passes (submitting a PR where the linter fails shows reviewers that you did not test your code and will delay your review).