### PR TITLE
feat(azure): add support for Conatainer instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can learn more about the story behind Cartography in our [presentation at BS
 - [Keycloak](https://cartography-cncf.github.io/cartography/modules/keycloak/index.html) - Realms, Users, Groups, Roles, Scopes, Clients, IdentityProviders, Authentication Flows, Authentication Executions, Organizations, Organization Domains
 - [Kubernetes](https://cartography-cncf.github.io/cartography/modules/kubernetes/index.html) - Cluster, Namespace, Service, Pod, Container, ServiceAccount, Role, RoleBinding, ClusterRole, ClusterRoleBinding, OIDCProvider
 - [Lastpass](https://cartography-cncf.github.io/cartography/modules/lastpass/index.html) - users
-- [Microsoft Azure](https://cartography-cncf.github.io/cartography/modules/azure/index.html) - App Service, CosmosDB, Functions, Logic Apps, Resource Group, SQL, Storage, Virtual Machine
+- [Microsoft Azure](https://cartography-cncf.github.io/cartography/modules/azure/index.html) - App Service, Container Instance, CosmosDB, Functions, Logic Apps, Resource Group, SQL, Storage, Virtual Machine
 - [Microsoft Entra ID](https://cartography-cncf.github.io/cartography/modules/entra/index.html) -  Users, Groups, Applications, OUs, App Roles, federation to AWS Identity Center
 - [NIST CVE](https://cartography-cncf.github.io/cartography/modules/cve/index.html) - Common Vulnerabilities and Exposures (CVE) data from NIST database
 - [Okta](https://cartography-cncf.github.io/cartography/modules/okta/index.html) - users, groups, organizations, roles, applications, factors, trusted origins, reply URIs, federation to AWS roles, federation to AWS Identity Center

--- a/cartography/intel/azure/__init__.py
+++ b/cartography/intel/azure/__init__.py
@@ -9,6 +9,7 @@ from cartography.util import timeit
 
 from . import app_service
 from . import compute
+from . import container_instances
 from . import cosmosdb
 from . import functions
 from . import logic_apps
@@ -30,6 +31,13 @@ def _sync_one_subscription(
     update_tag: int,
     common_job_parameters: Dict,
 ) -> None:
+    container_instances.sync(
+        neo4j_session,
+        credentials,
+        subscription_id,
+        update_tag,
+        common_job_parameters,
+    )
     compute.sync(
         neo4j_session,
         credentials.credential,

--- a/cartography/intel/azure/container_instances.py
+++ b/cartography/intel/azure/container_instances.py
@@ -1,0 +1,76 @@
+import logging
+from typing import Any
+
+import neo4j
+from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
+from azure.mgmt.containerinstance import ContainerInstanceManagementClient
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.models.azure.container_instance import AzureContainerInstanceSchema
+from cartography.util import timeit
+
+from .util.credentials import Credentials
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def get_container_instances(credentials: Credentials, subscription_id: str) -> list[dict]:
+    try:
+        client = ContainerInstanceManagementClient(credentials.credential, subscription_id)
+        # NOTE: Azure Container Instances are called "Container Groups" in the SDK
+        return [cg.as_dict() for cg in client.container_groups.list()]
+    except (ClientAuthenticationError, HttpResponseError) as e:
+        logger.warning(f"Failed to get Container Instances for subscription {subscription_id}: {str(e)}")
+        return []
+
+
+@timeit
+def transform_container_instances(container_groups: list[dict]) -> list[dict]:
+    transformed_instances: list[dict[str, Any]] = []
+    for group in container_groups:
+        transformed_instance = {
+            'id': group.get('id'),
+            'name': group.get('name'),
+            'location': group.get('location'),
+            'type': group.get('type'),
+            'provisioning_state': group.get('properties', {}).get('provisioning_state'),
+            'ip_address': group.get('properties', {}).get('ip_address', {}).get('ip'),
+            'os_type': group.get('properties', {}).get('os_type'),
+        }
+        transformed_instances.append(transformed_instance)
+    return transformed_instances
+
+
+@timeit
+def load_container_instances(
+    neo4j_session: neo4j.Session, data: list[dict[str, Any]], subscription_id: str, update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AzureContainerInstanceSchema(),
+        data,
+        lastupdated=update_tag,
+        AZURE_SUBSCRIPTION_ID=subscription_id,
+    )
+
+
+@timeit
+def cleanup_container_instances(neo4j_session: neo4j.Session, common_job_parameters: dict) -> None:
+    GraphJob.from_node_schema(AzureContainerInstanceSchema(), common_job_parameters).run(neo4j_session)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    credentials: Credentials,
+    subscription_id: str,
+    update_tag: int,
+    common_job_parameters: dict,
+) -> None:
+    logger.info(f"Syncing Azure Container Instances for subscription {subscription_id}.")
+    raw_groups = get_container_instances(credentials, subscription_id)
+    transformed_groups = transform_container_instances(raw_groups)
+    load_container_instances(neo4j_session, transformed_groups, subscription_id, update_tag)
+    cleanup_container_instances(neo4j_session, common_job_parameters)

--- a/cartography/models/azure/container_instance.py
+++ b/cartography/models/azure/container_instance.py
@@ -1,0 +1,47 @@
+import logging
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties, CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties, CartographyRelSchema, LinkDirection, \
+    make_target_node_matcher, TargetNodeMatcher
+
+logger = logging.getLogger(__name__)
+
+
+# --- Node Definitions ---
+@dataclass(frozen=True)
+class AzureContainerInstanceProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef('id')
+    name: PropertyRef = PropertyRef('name')
+    location: PropertyRef = PropertyRef('location')
+    type: PropertyRef = PropertyRef('type')
+    provisioning_state: PropertyRef = PropertyRef('provisioning_state')
+    ip_address: PropertyRef = PropertyRef('ip_address')
+    os_type: PropertyRef = PropertyRef('os_type')
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+# --- Relationship Definitions ---
+@dataclass(frozen=True)
+class AzureContainerInstanceToSubscriptionRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AzureContainerInstanceToSubscriptionRel(CartographyRelSchema):
+    target_node_label: str = 'AzureSubscription'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('AZURE_SUBSCRIPTION_ID', set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = 'RESOURCE'
+    properties: AzureContainerInstanceToSubscriptionRelProperties = AzureContainerInstanceToSubscriptionRelProperties()
+
+
+# --- Main Schema ---
+@dataclass(frozen=True)
+class AzureContainerInstanceSchema(CartographyNodeSchema):
+    label: str = 'AzureContainerInstance'
+    properties: AzureContainerInstanceProperties = AzureContainerInstanceProperties()
+    sub_resource_relationship: AzureContainerInstanceToSubscriptionRel = AzureContainerInstanceToSubscriptionRel()

--- a/docs/root/modules/azure/schema.md
+++ b/docs/root/modules/azure/schema.md
@@ -1261,3 +1261,26 @@ Representation of an [Azure Resource Group](https://learn.microsoft.com/en-us/re
     ```cypher
     (AzureSubscription)-[RESOURCE]->(:AzureResourceGroup)
     ```
+
+### AzureContainerInstance
+
+Representation of an [Azure Container Instance](https://learn.microsoft.com/en-us/rest/api/container-instances/container-groups/get).
+
+| Field | Description |
+|---|---|
+|firstseen| Timestamp of when a sync job discovered this node|
+|lastupdated| Timestamp of the last time the node was updated|
+|**id**| The full resource ID of the Container Instance. |
+|name| The name of the Container Instance. |
+|location| The Azure region where the Container Instance is deployed. |
+|type| The type of the resource (e.g., `Microsoft.ContainerInstance/containerGroups`). |
+|provisioning_state| The deployment status of the Container Instance (e.g., Succeeded). |
+|ip_address| The public IP address of the Container Instance, if one is assigned. |
+|os_type| The operating system type of the Container Instance (e.g., Linux or Windows). |
+
+#### Relationships
+
+- An Azure Container Instance is a resource within an Azure Subscription.
+    ```cypher
+    (AzureSubscription)-[:RESOURCE]->(:AzureContainerInstance)
+    ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "adal>=1.2.4",
     "azure-cli-core>=2.26.0",
     "azure-mgmt-compute>=5.0.0",
+    "azure-mgmt-containerinstance>=10.0.0",
     "azure-mgmt-resource>=10.2.0",
     "azure-mgmt-cosmosdb>=6.0.0",
     "azure-mgmt-web>=7.0.0",
@@ -90,6 +91,7 @@ dev = [
     "types-requests<2.32.4.20250914",
     "azure-mgmt-web>=7.0.0",
     "azure-mgmt-logic>=10.0.0",
+    "azure-mgmt-containerinstance>=10.0.0",
 ]
 doc = [
     "myst-parser[linkify]>=4.0.1",

--- a/tests/data/azure/container_instances.py
+++ b/tests/data/azure/container_instances.py
@@ -1,0 +1,15 @@
+MOCK_CONTAINER_GROUPS = [
+    {
+        'id': '/subscriptions/00-00-00-00/resourceGroups/TestRG/providers/Microsoft.ContainerInstance/containerGroups/my-test-aci',
+        'name': 'my-test-aci',
+        'location': 'eastus',
+        'type': 'Microsoft.ContainerInstance/containerGroups',
+        'properties': {
+            'provisioning_state': 'Succeeded',
+            'ip_address': {
+                'ip': '20.245.100.1',
+            },
+            'os_type': 'Linux',
+        },
+    },
+]

--- a/tests/integration/cartography/intel/azure/test_container_instances.py
+++ b/tests/integration/cartography/intel/azure/test_container_instances.py
@@ -1,0 +1,69 @@
+from unittest.mock import MagicMock, patch
+
+import cartography.intel.azure.container_instances as container_instances
+from tests.data.azure.container_instances import MOCK_CONTAINER_GROUPS
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_SUBSCRIPTION_ID = "00-00-00-00"
+TEST_UPDATE_TAG = 123456789
+
+
+@patch("cartography.intel.azure.container_instances.get_container_instances")
+def test_sync_container_instances(mock_get, neo4j_session):
+    """
+    Test that we can correctly sync Azure Container Instance data and relationships.
+    """
+    # Arrange
+    mock_get.return_value = MOCK_CONTAINER_GROUPS
+
+    # Create the prerequisite AzureSubscription node
+    neo4j_session.run(
+        """
+        MERGE (s:AzureSubscription{id: $sub_id})
+        SET s.lastupdated = $update_tag
+        """,
+        sub_id=TEST_SUBSCRIPTION_ID,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "AZURE_SUBSCRIPTION_ID": TEST_SUBSCRIPTION_ID,
+    }
+
+    # Act
+    container_instances.sync(
+        neo4j_session,
+        MagicMock(),
+        TEST_SUBSCRIPTION_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    # Assert Nodes
+    expected_nodes = {
+        (
+            "/subscriptions/00-00-00-00/resourceGroups/TestRG/providers/Microsoft.ContainerInstance/containerGroups/my-test-aci",
+            "my-test-aci",
+        ),
+    }
+    actual_nodes = check_nodes(neo4j_session, "AzureContainerInstance", ["id", "name"])
+    assert actual_nodes == expected_nodes
+
+    # Assert Relationships
+    expected_rels = {
+        (
+            TEST_SUBSCRIPTION_ID,
+            "/subscriptions/00-00-00-00/resourceGroups/TestRG/providers/Microsoft.ContainerInstance/containerGroups/my-test-aci",
+        ),
+    }
+    actual_rels = check_rels(
+        neo4j_session,
+        "AzureSubscription",
+        "id",
+        "AzureContainerInstance",
+        "id",
+        "RESOURCE",
+    )
+    assert actual_rels == expected_rels

--- a/uv.lock
+++ b/uv.lock
@@ -300,6 +300,20 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-mgmt-containerinstance"
+version = "10.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-common" },
+    { name = "azure-mgmt-core" },
+    { name = "isodate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/19/cdb22d87560238893f5c014176b4e6868c3befbd6585bb5c44bdb1ddc997/azure-mgmt-containerinstance-10.1.0.zip", hash = "sha256:78d437adb28574f448c838ed5f01f9ced378196098061deb59d9f7031704c17e", size = 106507, upload-time = "2023-04-21T03:30:50.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/11/3bfa586ac0514e1fe224879c065dbec39c0d9d2653b74549ac8080408f07/azure_mgmt_containerinstance-10.1.0-py3-none-any.whl", hash = "sha256:ee7977b7b70f2233e44ec6ce8c99027f3f7892bb3452b4bad46df340d9f98959", size = 87314, upload-time = "2023-04-21T03:30:52.379Z" },
+]
+
+[[package]]
 name = "azure-mgmt-core"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -540,6 +554,7 @@ dependencies = [
     { name = "azure-cli-core" },
     { name = "azure-identity" },
     { name = "azure-mgmt-compute" },
+    { name = "azure-mgmt-containerinstance" },
     { name = "azure-mgmt-cosmosdb" },
     { name = "azure-mgmt-logic" },
     { name = "azure-mgmt-resource" },
@@ -577,6 +592,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "azure-mgmt-containerinstance" },
     { name = "azure-mgmt-logic" },
     { name = "azure-mgmt-web" },
     { name = "backoff" },
@@ -606,6 +622,7 @@ requires-dist = [
     { name = "azure-cli-core", specifier = ">=2.26.0" },
     { name = "azure-identity", specifier = ">=1.5.0" },
     { name = "azure-mgmt-compute", specifier = ">=5.0.0" },
+    { name = "azure-mgmt-containerinstance", specifier = ">=10.0.0" },
     { name = "azure-mgmt-cosmosdb", specifier = ">=6.0.0" },
     { name = "azure-mgmt-logic", specifier = ">=10.0.0" },
     { name = "azure-mgmt-resource", specifier = ">=10.2.0" },
@@ -643,6 +660,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "azure-mgmt-containerinstance", specifier = ">=10.0.0" },
     { name = "azure-mgmt-logic", specifier = ">=10.0.0" },
     { name = "azure-mgmt-web", specifier = ">=7.0.0" },
     { name = "backoff", specifier = ">=2.1.2" },


### PR DESCRIPTION
### Summary

This pull request introduces a new intel module to ingest Azure Container Instances (ACI). This change adds a new `:AzureContainerInstance` node and connects it to the existing `:AzureSubscription` node with a `:RESOURCE` relationship.

The implementation follows the project's modern, schema-based pattern and includes integration tests and schema documentation.

### Related issues or links

- Addresses part of #1736

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
  
<img width="1020" height="815" alt="Screenshot 2025-09-28 154525" src="https://github.com/user-attachments/assets/ccbe5cdd-c45c-4d4d-bc60-267b8aa104f1" />

- [x] Include console log trace showing what happened before and after your changes.
  
<img width="1618" height="411" alt="Screenshot 2025-09-28 152844" src="https://github.com/user-attachments/assets/f8ce83fe-4af8-4950-87cb-b78141c95e64" />


If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [x] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

- [x] Confirm that the linter actually passes (submitting a PR where the linter fails shows reviewers that you did not test your code and will delay your review).