### PR TITLE
Allow overriding load batch size

### DIFF
--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -14,6 +14,7 @@ from cartography.graph.querybuilder import build_ingestion_query
 from cartography.graph.querybuilder import build_matchlink_query
 from cartography.models.core.nodes import CartographyNodeSchema
 from cartography.models.core.relationships import CartographyRelSchema
+from cartography.util import DEFAULT_BATCH_SIZE
 from cartography.util import batch
 
 logger = logging.getLogger(__name__)
@@ -228,6 +229,7 @@ def load_graph_data(
     neo4j_session: neo4j.Session,
     query: str,
     dict_list: List[Dict[str, Any]],
+    batch_size: int = DEFAULT_BATCH_SIZE,
     **kwargs,
 ) -> None:
     """
@@ -236,10 +238,14 @@ def load_graph_data(
     :param query: The Neo4j write query to run. This query is not meant to be handwritten, rather it should be generated
     with cartography.graph.querybuilder.build_ingestion_query().
     :param dict_list: The data to load to the graph represented as a list of dicts.
+    :param batch_size: Number of rows to include in each Bolt message when loading data.
     :param kwargs: Allows additional keyword args to be supplied to the Neo4j query.
     :return: None
     """
-    for data_batch in batch(dict_list, size=10000):
+    # Keep batches small enough that we don't exceed the Neo4j Bolt message size limit
+    # when the payload contains large relationship fan-out (for example GitHub teams
+    # with tens of thousands of repo links).
+    for data_batch in batch(dict_list, size=batch_size):
         neo4j_session.write_transaction(
             write_list_of_dicts_tx,
             query,
@@ -295,6 +301,7 @@ def load(
     neo4j_session: neo4j.Session,
     node_schema: CartographyNodeSchema,
     dict_list: List[Dict[str, Any]],
+    batch_size: int = DEFAULT_BATCH_SIZE,
     **kwargs,
 ) -> None:
     """
@@ -303,6 +310,7 @@ def load(
     :param neo4j_session: The Neo4j session
     :param node_schema: The CartographyNodeSchema object to create indexes for and generate a query.
     :param dict_list: The data to load to the graph represented as a list of dicts.
+    :param batch_size: Number of rows to include in each Bolt message when loading data.
     :param kwargs: Allows additional keyword args to be supplied to the Neo4j query.
     :return: None
     """
@@ -311,13 +319,20 @@ def load(
         return
     ensure_indexes(neo4j_session, node_schema)
     ingestion_query = build_ingestion_query(node_schema)
-    load_graph_data(neo4j_session, ingestion_query, dict_list, **kwargs)
+    load_graph_data(
+        neo4j_session,
+        ingestion_query,
+        dict_list,
+        batch_size=batch_size,
+        **kwargs,
+    )
 
 
 def load_matchlinks(
     neo4j_session: neo4j.Session,
     rel_schema: CartographyRelSchema,
     dict_list: list[dict[str, Any]],
+    batch_size: int = DEFAULT_BATCH_SIZE,
     **kwargs,
 ) -> None:
     """
@@ -326,6 +341,7 @@ def load_matchlinks(
     :param rel_schema: The CartographyRelSchema object to generate a query.
     :param dict_list: The data to load to the graph represented as a list of dicts. The dicts must contain the source and
     target node ids.
+    :param batch_size: Number of rows to include in each Bolt message when loading data.
     :param kwargs: Allows additional keyword args to be supplied to the Neo4j query.
     :return: None
     """
@@ -348,4 +364,10 @@ def load_matchlinks(
     ensure_indexes_for_matchlinks(neo4j_session, rel_schema)
     matchlink_query = build_matchlink_query(rel_schema)
     logger.debug(f"Matchlink query: {matchlink_query}")
-    load_graph_data(neo4j_session, matchlink_query, dict_list, **kwargs)
+    load_graph_data(
+        neo4j_session,
+        matchlink_query,
+        dict_list,
+        batch_size=batch_size,
+        **kwargs,
+    )


### PR DESCRIPTION
## Summary
- allow callers to override the generalized loader batch size via a new `batch_size` argument on `load_graph_data`, `load()`, and `load_matchlinks()` while keeping the default cap
- remove the previously added unit test that covered batching behaviour

## Testing
- PYTHONPATH=. pytest tests/integration/cartography/graph/test_querybuilder_rel_subsets.py *(fails: ModuleNotFoundError: No module named 'neo4j')*


------
https://chatgpt.com/codex/tasks/task_b_68decfc66030832fb0080b295f9c065f