### PR TITLE
feat(azure): add support for Data Factory

### DIFF
--- a/cartography/intel/azure/__init__.py
+++ b/cartography/intel/azure/__init__.py
@@ -10,6 +10,7 @@ from cartography.util import timeit
 from . import app_service
 from . import compute
 from . import cosmosdb
+from . import data_factory
 from . import functions
 from . import logic_apps
 from . import resource_groups
@@ -80,6 +81,13 @@ def _sync_one_subscription(
         common_job_parameters,
     )
     resource_groups.sync(
+        neo4j_session,
+        credentials,
+        subscription_id,
+        update_tag,
+        common_job_parameters,
+    )
+    data_factory.sync(
         neo4j_session,
         credentials,
         subscription_id,

--- a/cartography/intel/azure/data_factory.py
+++ b/cartography/intel/azure/data_factory.py
@@ -1,0 +1,195 @@
+import logging
+from typing import Any
+
+import neo4j
+from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
+from azure.mgmt.datafactory import DataFactoryManagementClient
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.models.azure.data_factory import AzureDataFactorySchema
+from cartography.models.azure.data_factory_dataset import AzureDataFactoryDatasetSchema
+from cartography.models.azure.data_factory_linked_service import AzureDataFactoryLinkedServiceSchema
+from cartography.models.azure.data_factory_pipeline import AzureDataFactoryPipelineSchema
+from cartography.util import timeit
+
+from .util.credentials import Credentials
+
+logger = logging.getLogger(__name__)
+
+
+def _get_resource_group_from_id(resource_id: str) -> str:
+    parts = resource_id.lower().split('/')
+    try:
+        rg_index = parts.index('resourcegroups')
+        return parts[rg_index + 1]
+    except (ValueError, IndexError):
+        logger.warning("Could not parse resource group name from a resource ID.")
+        return ""
+
+
+@timeit
+def get_factories(client: DataFactoryManagementClient) -> list[dict]:
+    try:
+        return [f.as_dict() for f in client.factories.list()]
+    except (ClientAuthenticationError, HttpResponseError) as e:
+        logger.warning(f"Failed to get Data Factories: {str(e)}")
+        return []
+
+
+@timeit
+def get_pipelines(client: DataFactoryManagementClient, rg_name: str, factory_name: str) -> list[dict]:
+    try:
+        return [p.as_dict() for p in client.pipelines.list_by_factory(rg_name, factory_name)]
+    except (ClientAuthenticationError, HttpResponseError) as e:
+        logger.warning(f"Failed to get pipelines for factory {factory_name}: {str(e)}")
+        return []
+
+
+@timeit
+def get_datasets(client: DataFactoryManagementClient, rg_name: str, factory_name: str) -> list[dict]:
+    try:
+        return [d.as_dict() for d in client.datasets.list_by_factory(rg_name, factory_name)]
+    except (ClientAuthenticationError, HttpResponseError) as e:
+        logger.warning(f"Failed to get datasets for factory {factory_name}: {str(e)}")
+        return []
+
+
+@timeit
+def get_linked_services(client: DataFactoryManagementClient, rg_name: str, factory_name: str) -> list[dict]:
+    try:
+        return [ls.as_dict() for ls in client.linked_services.list_by_factory(rg_name, factory_name)]
+    except (ClientAuthenticationError, HttpResponseError) as e:
+        logger.warning(f"Failed to get linked services for factory {factory_name}: {str(e)}")
+        return []
+
+
+@timeit
+def transform_factories(factories: list[dict]) -> list[dict]:
+    transformed: list[dict[str, Any]] = []
+    for f in factories:
+        transformed.append({
+            'id': f.get('id'),
+            'name': f.get('name'),
+            'location': f.get('location'),
+            'provisioning_state': f.get('properties', {}).get('provisioning_state'),
+            'create_time': f.get('properties', {}).get('create_time'),
+            'version': f.get('properties', {}).get('version'),
+        })
+    return transformed
+
+
+@timeit
+def transform_pipelines(pipelines: list[dict], factory_id: str) -> list[dict]:
+    transformed: list[dict[str, Any]] = []
+    for p in pipelines:
+        transformed.append({
+            'id': p.get('id'),
+            'name': p.get('name'),
+            'description': p.get('description'),
+            'FACTORY_ID': factory_id,
+        })
+    return transformed
+
+
+@timeit
+def transform_datasets(datasets: list[dict], factory_id: str) -> list[dict]:
+    transformed: list[dict[str, Any]] = []
+    for d in datasets:
+        transformed.append({
+            'id': d.get('id'),
+            'name': d.get('name'),
+            'type': d.get('properties', {}).get('type'),
+            'FACTORY_ID': factory_id,
+        })
+    return transformed
+
+
+@timeit
+def transform_linked_services(linked_services: list[dict], factory_id: str) -> list[dict]:
+    transformed: list[dict[str, Any]] = []
+    for ls in linked_services:
+        transformed.append({
+            'id': ls.get('id'),
+            'name': ls.get('name'),
+            'type': ls.get('properties', {}).get('type'),
+            'FACTORY_ID': factory_id,
+        })
+    return transformed
+
+
+@timeit
+def load_factories(
+    neo4j_session: neo4j.Session, data: list[dict[str, Any]], subscription_id: str, update_tag: int,
+) -> None:
+    load(neo4j_session, AzureDataFactorySchema(), data, lastupdated=update_tag, AZURE_SUBSCRIPTION_ID=subscription_id)
+
+
+@timeit
+def load_pipelines(
+    neo4j_session: neo4j.Session, data: list[dict[str, Any]], factory_id: str, update_tag: int,
+) -> None:
+    load(neo4j_session, AzureDataFactoryPipelineSchema(), data, lastupdated=update_tag, FACTORY_ID=factory_id)
+
+
+@timeit
+def load_datasets(
+    neo4j_session: neo4j.Session, data: list[dict[str, Any]], factory_id: str, update_tag: int,
+) -> None:
+    load(neo4j_session, AzureDataFactoryDatasetSchema(), data, lastupdated=update_tag, FACTORY_ID=factory_id)
+
+
+@timeit
+def load_linked_services(
+    neo4j_session: neo4j.Session, data: list[dict[str, Any]], factory_id: str, update_tag: int,
+) -> None:
+    load(neo4j_session, AzureDataFactoryLinkedServiceSchema(), data, lastupdated=update_tag, FACTORY_ID=factory_id)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    credentials: Credentials,
+    subscription_id: str,
+    update_tag: int,
+    common_job_parameters: dict,
+) -> None:
+    logger.info(f"Syncing Azure Data Factory for subscription {subscription_id}.")
+    client = DataFactoryManagementClient(credentials.credential, subscription_id)
+
+    factories = get_factories(client)
+    transformed_factories = transform_factories(factories)
+    load_factories(neo4j_session, transformed_factories, subscription_id, update_tag)
+
+    for factory in factories:
+        factory_id = factory.get('id')
+        if not factory_id:
+            continue
+
+        rg_name = _get_resource_group_from_id(factory_id)
+        if rg_name:
+            # Sync Pipelines
+            pipelines = get_pipelines(client, rg_name, factory['name'])
+            transformed_pipelines = transform_pipelines(pipelines, factory_id)
+            load_pipelines(neo4j_session, transformed_pipelines, factory_id, update_tag)
+            pipeline_cleanup_params = common_job_parameters.copy()
+            pipeline_cleanup_params["FACTORY_ID"] = factory_id
+            GraphJob.from_node_schema(AzureDataFactoryPipelineSchema(), pipeline_cleanup_params).run(neo4j_session)
+
+            # Sync Datasets
+            datasets = get_datasets(client, rg_name, factory['name'])
+            transformed_datasets = transform_datasets(datasets, factory_id)
+            load_datasets(neo4j_session, transformed_datasets, factory_id, update_tag)
+            dataset_cleanup_params = common_job_parameters.copy()
+            dataset_cleanup_params["FACTORY_ID"] = factory_id
+            GraphJob.from_node_schema(AzureDataFactoryDatasetSchema(), dataset_cleanup_params).run(neo4j_session)
+
+            # Sync Linked Services
+            linked_services = get_linked_services(client, rg_name, factory['name'])
+            transformed_linked_services = transform_linked_services(linked_services, factory_id)
+            load_linked_services(neo4j_session, transformed_linked_services, factory_id, update_tag)
+            ls_cleanup_params = common_job_parameters.copy()
+            ls_cleanup_params["FACTORY_ID"] = factory_id
+            GraphJob.from_node_schema(AzureDataFactoryLinkedServiceSchema(), ls_cleanup_params).run(neo4j_session)
+
+    GraphJob.from_node_schema(AzureDataFactorySchema(), common_job_parameters).run(neo4j_session)

--- a/cartography/models/azure/data_factory.py
+++ b/cartography/models/azure/data_factory.py
@@ -1,0 +1,43 @@
+import logging
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties, CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties, CartographyRelSchema, LinkDirection, \
+    make_target_node_matcher, TargetNodeMatcher
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AzureDataFactoryProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef('id')
+    name: PropertyRef = PropertyRef('name')
+    location: PropertyRef = PropertyRef('location')
+    provisioning_state: PropertyRef = PropertyRef('provisioning_state')
+    create_time: PropertyRef = PropertyRef('create_time')
+    version: PropertyRef = PropertyRef('version')
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AzureDataFactoryToSubscriptionRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AzureDataFactoryToSubscriptionRel(CartographyRelSchema):
+    target_node_label: str = 'AzureSubscription'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('AZURE_SUBSCRIPTION_ID', set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = 'RESOURCE'
+    properties: AzureDataFactoryToSubscriptionRelProperties = AzureDataFactoryToSubscriptionRelProperties()
+
+
+@dataclass(frozen=True)
+class AzureDataFactorySchema(CartographyNodeSchema):
+    label: str = 'AzureDataFactory'
+    properties: AzureDataFactoryProperties = AzureDataFactoryProperties()
+    sub_resource_relationship: AzureDataFactoryToSubscriptionRel = AzureDataFactoryToSubscriptionRel()

--- a/cartography/models/azure/data_factory_dataset.py
+++ b/cartography/models/azure/data_factory_dataset.py
@@ -1,0 +1,40 @@
+import logging
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties, CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties, CartographyRelSchema, LinkDirection, \
+    make_target_node_matcher, TargetNodeMatcher
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AzureDataFactoryDatasetProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef('id')
+    name: PropertyRef = PropertyRef('name')
+    type: PropertyRef = PropertyRef('type')
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AzureDataFactoryDatasetToFactoryRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AzureDataFactoryDatasetToFactoryRel(CartographyRelSchema):
+    target_node_label: str = 'AzureDataFactory'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('FACTORY_ID', set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = 'CONTAINS'
+    properties: AzureDataFactoryDatasetToFactoryRelProperties = AzureDataFactoryDatasetToFactoryRelProperties()
+
+
+@dataclass(frozen=True)
+class AzureDataFactoryDatasetSchema(CartographyNodeSchema):
+    label: str = 'AzureDataFactoryDataset'
+    properties: AzureDataFactoryDatasetProperties = AzureDataFactoryDatasetProperties()
+    sub_resource_relationship: AzureDataFactoryDatasetToFactoryRel = AzureDataFactoryDatasetToFactoryRel()

--- a/cartography/models/azure/data_factory_linked_service.py
+++ b/cartography/models/azure/data_factory_linked_service.py
@@ -1,0 +1,40 @@
+import logging
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties, CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties, CartographyRelSchema, LinkDirection, \
+    make_target_node_matcher, TargetNodeMatcher
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AzureDataFactoryLinkedServiceProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef('id')
+    name: PropertyRef = PropertyRef('name')
+    type: PropertyRef = PropertyRef('type')
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AzureDataFactoryLinkedServiceToFactoryRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AzureDataFactoryLinkedServiceToFactoryRel(CartographyRelSchema):
+    target_node_label: str = 'AzureDataFactory'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('FACTORY_ID', set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = 'CONTAINS'
+    properties: AzureDataFactoryLinkedServiceToFactoryRelProperties = AzureDataFactoryLinkedServiceToFactoryRelProperties()
+
+
+@dataclass(frozen=True)
+class AzureDataFactoryLinkedServiceSchema(CartographyNodeSchema):
+    label: str = 'AzureDataFactoryLinkedService'
+    properties: AzureDataFactoryLinkedServiceProperties = AzureDataFactoryLinkedServiceProperties()
+    sub_resource_relationship: AzureDataFactoryLinkedServiceToFactoryRel = AzureDataFactoryLinkedServiceToFactoryRel()

--- a/cartography/models/azure/data_factory_pipeline.py
+++ b/cartography/models/azure/data_factory_pipeline.py
@@ -1,0 +1,40 @@
+import logging
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties, CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties, CartographyRelSchema, LinkDirection, \
+    make_target_node_matcher, TargetNodeMatcher
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AzureDataFactoryPipelineProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef('id')
+    name: PropertyRef = PropertyRef('name')
+    description: PropertyRef = PropertyRef('description')
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AzureDataFactoryPipelineToFactoryRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef('lastupdated', set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AzureDataFactoryPipelineToFactoryRel(CartographyRelSchema):
+    target_node_label: str = 'AzureDataFactory'
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {'id': PropertyRef('FACTORY_ID', set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = 'CONTAINS'
+    properties: AzureDataFactoryPipelineToFactoryRelProperties = AzureDataFactoryPipelineToFactoryRelProperties()
+
+
+@dataclass(frozen=True)
+class AzureDataFactoryPipelineSchema(CartographyNodeSchema):
+    label: str = 'AzureDataFactoryPipeline'
+    properties: AzureDataFactoryPipelineProperties = AzureDataFactoryPipelineProperties()
+    sub_resource_relationship: AzureDataFactoryPipelineToFactoryRel = AzureDataFactoryPipelineToFactoryRel()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "azure-mgmt-cosmosdb>=6.0.0",
     "azure-mgmt-web>=7.0.0",
     "azure-mgmt-logic>=10.0.0",
+    "azure-mgmt-datafactory>=8.0.0",
     "msrestazure >= 0.6.4",
     "azure-mgmt-storage>=16.0.0",
     "azure-mgmt-sql<=1.0.0",
@@ -93,7 +94,8 @@ dev = [
     "black==25.9.0",
     "types-requests<2.32.4.20250914",
     "azure-mgmt-web>=7.0.0",
-    "azure-mgmt-logic>=10.0.0"
+    "azure-mgmt-logic>=10.0.0",
+    "azure-mgmt-datafactory>=8.0.0",
 ]
 doc = [
     "myst-parser[linkify]>=4.0.1",

--- a/tests/data/azure/data_factory.py
+++ b/tests/data/azure/data_factory.py
@@ -1,0 +1,40 @@
+MOCK_FACTORIES = [
+    {
+        'id': '/subscriptions/00-00-00-00/resourceGroups/TestRG/providers/Microsoft.DataFactory/factories/my-test-adf',
+        'name': 'my-test-adf',
+        'location': 'eastus',
+        'properties': {
+            'provisioning_state': 'Succeeded',
+            'create_time': '2025-01-01T12:00:00.000Z',
+            'version': '2018-06-01',
+        },
+    },
+]
+
+MOCK_PIPELINES = [
+    {
+        'id': '/subscriptions/00-00-00-00/resourceGroups/TestRG/providers/Microsoft.DataFactory/factories/my-test-adf/pipelines/MyPipeline',
+        'name': 'MyPipeline',
+        'description': 'A test pipeline.',
+    },
+]
+
+MOCK_DATASETS = [
+    {
+        'id': '/subscriptions/00-00-00-00/resourceGroups/TestRG/providers/Microsoft.DataFactory/factories/my-test-adf/datasets/MyDataset',
+        'name': 'MyDataset',
+        'properties': {
+            'type': 'AzureBlob',
+        },
+    },
+]
+
+MOCK_LINKED_SERVICES = [
+    {
+        'id': '/subscriptions/00-00-00-00/resourceGroups/TestRG/providers/Microsoft.DataFactory/factories/my-test-adf/linkedservices/MyLinkedService',
+        'name': 'MyLinkedService',
+        'properties': {
+            'type': 'AzureBlobStorage',
+        },
+    },
+]

--- a/tests/integration/cartography/intel/azure/test_data_factory.py
+++ b/tests/integration/cartography/intel/azure/test_data_factory.py
@@ -1,0 +1,100 @@
+from unittest.mock import MagicMock, patch
+
+import cartography.intel.azure.data_factory as data_factory
+from tests.data.azure.data_factory import MOCK_DATASETS, MOCK_FACTORIES, MOCK_LINKED_SERVICES, MOCK_PIPELINES
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_SUBSCRIPTION_ID = "00-00-00-00"
+TEST_UPDATE_TAG = 123456789
+
+
+@patch("cartography.intel.azure.data_factory.get_linked_services")
+@patch("cartography.intel.azure.data_factory.get_datasets")
+@patch("cartography.intel.azure.data_factory.get_pipelines")
+@patch("cartography.intel.azure.data_factory.get_factories")
+def test_sync_data_factory(mock_get_factories, mock_get_pipelines, mock_get_datasets, mock_get_ls, neo4j_session):
+    """
+    Test that we can correctly sync Data Factory and its child components.
+    """
+    # Arrange
+    mock_get_factories.return_value = MOCK_FACTORIES
+    mock_get_pipelines.return_value = MOCK_PIPELINES
+    mock_get_datasets.return_value = MOCK_DATASETS
+    mock_get_ls.return_value = MOCK_LINKED_SERVICES
+
+    # Create the prerequisite AzureSubscription node
+    neo4j_session.run(
+        """
+        MERGE (s:AzureSubscription{id: $sub_id})
+        SET s.lastupdated = $update_tag
+        """,
+        sub_id=TEST_SUBSCRIPTION_ID,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "AZURE_SUBSCRIPTION_ID": TEST_SUBSCRIPTION_ID,
+    }
+
+    # Act
+    data_factory.sync(
+        neo4j_session,
+        MagicMock(),
+        TEST_SUBSCRIPTION_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    # Assert Factories
+    expected_factories = {(MOCK_FACTORIES[0]['id'], MOCK_FACTORIES[0]['name'])}
+    actual_factories = check_nodes(neo4j_session, "AzureDataFactory", ["id", "name"])
+    assert actual_factories == expected_factories
+
+    # Assert Pipelines
+    expected_pipelines = {(MOCK_PIPELINES[0]['id'], MOCK_PIPELINES[0]['name'])}
+    actual_pipelines = check_nodes(neo4j_session, "AzureDataFactoryPipeline", ["id", "name"])
+    assert actual_pipelines == expected_pipelines
+
+    # Assert Datasets
+    expected_datasets = {(MOCK_DATASETS[0]['id'], MOCK_DATASETS[0]['name'])}
+    actual_datasets = check_nodes(neo4j_session, "AzureDataFactoryDataset", ["id", "name"])
+    assert actual_datasets == expected_datasets
+
+    # Assert Linked Services
+    expected_ls = {(MOCK_LINKED_SERVICES[0]['id'], MOCK_LINKED_SERVICES[0]['name'])}
+    actual_ls = check_nodes(neo4j_session, "AzureDataFactoryLinkedService", ["id", "name"])
+    assert actual_ls == expected_ls
+
+    # Assert Relationships
+    factory_id = MOCK_FACTORIES[0]['id']
+    pipeline_id = MOCK_PIPELINES[0]['id']
+    dataset_id = MOCK_DATASETS[0]['id']
+    ls_id = MOCK_LINKED_SERVICES[0]['id']
+
+    expected_rels = {
+        (TEST_SUBSCRIPTION_ID, factory_id),
+        (factory_id, pipeline_id),
+        (factory_id, dataset_id),
+        (factory_id, ls_id),
+    }
+    actual_rels = check_rels(
+        neo4j_session, "AzureSubscription", "id", "AzureDataFactory", "id", "RESOURCE",
+    )
+    actual_rels.update(
+        check_rels(
+            neo4j_session, "AzureDataFactory", "id", "AzureDataFactoryPipeline", "id", "CONTAINS",
+        ),
+    )
+    actual_rels.update(
+        check_rels(
+            neo4j_session, "AzureDataFactory", "id", "AzureDataFactoryDataset", "id", "CONTAINS",
+        ),
+    )
+    actual_rels.update(
+        check_rels(
+            neo4j_session, "AzureDataFactory", "id", "AzureDataFactoryLinkedService", "id", "CONTAINS",
+        ),
+    )
+    assert actual_rels == expected_rels

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -381,6 +381,21 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-mgmt-datafactory"
+version = "9.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-common" },
+    { name = "azure-mgmt-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/7a/253f8d0b4c3971ad0f11408b80c3429dc75408834e219ed2f0d928b4a586/azure_mgmt_datafactory-9.2.0.tar.gz", hash = "sha256:5132e9c24c441ac225f2a60225924baa55079ca81eff7db99a70d661d64bb0d7", size = 484275, upload-time = "2025-04-21T04:21:28.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/dd/2e7b6bac7420a05bc4ad17cb64099948117b12ca50ea68d6d4665867085e/azure_mgmt_datafactory-9.2.0-py3-none-any.whl", hash = "sha256:d870a7a6099227e91d1c258a956c2aa32c2ea4c0a4409913d8f215887349f128", size = 554231, upload-time = "2025-04-21T04:21:30.956Z" },
+]
+
+[[package]]
 name = "azure-mgmt-logic"
 version = "10.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -596,6 +611,7 @@ dependencies = [
     { name = "azure-identity" },
     { name = "azure-mgmt-compute" },
     { name = "azure-mgmt-cosmosdb" },
+    { name = "azure-mgmt-datafactory" },
     { name = "azure-mgmt-logic" },
     { name = "azure-mgmt-resource" },
     { name = "azure-mgmt-sql" },
@@ -635,6 +651,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "azure-mgmt-datafactory" },
     { name = "azure-mgmt-logic" },
     { name = "azure-mgmt-web" },
     { name = "backoff" },
@@ -666,6 +683,7 @@ requires-dist = [
     { name = "azure-identity", specifier = ">=1.5.0" },
     { name = "azure-mgmt-compute", specifier = ">=5.0.0" },
     { name = "azure-mgmt-cosmosdb", specifier = ">=6.0.0" },
+    { name = "azure-mgmt-datafactory", specifier = ">=8.0.0" },
     { name = "azure-mgmt-logic", specifier = ">=10.0.0" },
     { name = "azure-mgmt-resource", specifier = ">=10.2.0" },
     { name = "azure-mgmt-sql", specifier = "<=1.0.0" },
@@ -705,6 +723,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "azure-mgmt-datafactory", specifier = ">=8.0.0" },
     { name = "azure-mgmt-logic", specifier = ">=10.0.0" },
     { name = "azure-mgmt-web", specifier = ">=7.0.0" },
     { name = "backoff", specifier = ">=2.1.2" },


### PR DESCRIPTION
### Summary

This pull request introduces a new intel module to ingest Azure Data Factory resources. This change adds four new node types to model the hierarchy of the service:
- `:AzureDataFactory`
- `:AzureDataFactoryPipeline`
- `:AzureDataFactoryDataset`
- `:AzureDataFactoryLinkedService`

The implementation follows the project's modern, schema-based pattern, ingests all child resources for each factory, and includes full integration test coverage and schema documentation.

### Related issues or links

- Addresses part of #1736

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [x] Include a screenshot showing what the graph looked like before and after your changes.
<img width="840" height="818" alt="Screenshot 2025-10-06 204050" src="https://github.com/user-attachments/assets/9b7b6333-cd8c-4957-a805-4554f5b5eee2" />

- [x] Include console log trace showing what happened before and after your changes.
<img width="1621" height="442" alt="Screenshot 2025-10-06 203646" src="https://github.com/user-attachments/assets/4d7b1e2a-5032-4a73-a285-6486eb5d0716" />


If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [x] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

- [x] Confirm that the linter actually passes (submitting a PR where the linter fails shows reviewers that you did not test your code and will delay your review).