### PR TITLE
fix(github, core): add retries for index creation

### DIFF
--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -269,7 +269,7 @@ def ensure_indexes(
             raise ValueError(
                 'Query provided to `ensure_indexes()` does not start with "CREATE INDEX IF NOT EXISTS".',
             )
-        neo4j_session.run(query)
+        run_write_query(neo4j_session, query)
 
 
 def ensure_indexes_for_matchlinks(
@@ -288,7 +288,7 @@ def ensure_indexes_for_matchlinks(
             raise ValueError(
                 'Query provided to `ensure_indexes_for_matchlinks()` does not start with "CREATE INDEX IF NOT EXISTS".',
             )
-        neo4j_session.run(query)
+        run_write_query(neo4j_session, query)
 
 
 def load(

--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -23,7 +23,12 @@ logger = logging.getLogger(__name__)
 
 @backoff.on_exception(  # type: ignore
     backoff.expo,
-    (ConnectionResetError),
+    (
+        ConnectionResetError,
+        neo4j.exceptions.ServiceUnavailable,
+        neo4j.exceptions.SessionExpired,
+        neo4j.exceptions.TransientError,
+    ),
     max_tries=5,
     on_backoff=backoff_handler,
 )

--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -6,6 +6,7 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
+import backoff
 import neo4j
 
 from cartography.graph.querybuilder import build_create_index_queries
@@ -14,9 +15,24 @@ from cartography.graph.querybuilder import build_ingestion_query
 from cartography.graph.querybuilder import build_matchlink_query
 from cartography.models.core.nodes import CartographyNodeSchema
 from cartography.models.core.relationships import CartographyRelSchema
+from cartography.util import backoff_handler
 from cartography.util import batch
 
 logger = logging.getLogger(__name__)
+
+
+@backoff.on_exception(  # type: ignore
+    backoff.expo,
+    (ConnectionResetError),
+    max_tries=5,
+    on_backoff=backoff_handler,
+)
+def _run_index_query_with_retry(neo4j_session: neo4j.Session, query: str) -> None:
+    """
+    Execute an index creation query with retry logic.
+    Index creation requires autocommit transactions and can experience transient errors.
+    """
+    neo4j_session.run(query)
 
 
 def run_write_query(
@@ -269,7 +285,7 @@ def ensure_indexes(
             raise ValueError(
                 'Query provided to `ensure_indexes()` does not start with "CREATE INDEX IF NOT EXISTS".',
             )
-        run_write_query(neo4j_session, query)
+        _run_index_query_with_retry(neo4j_session, query)
 
 
 def ensure_indexes_for_matchlinks(
@@ -288,7 +304,7 @@ def ensure_indexes_for_matchlinks(
             raise ValueError(
                 'Query provided to `ensure_indexes_for_matchlinks()` does not start with "CREATE INDEX IF NOT EXISTS".',
             )
-        run_write_query(neo4j_session, query)
+        _run_index_query_with_retry(neo4j_session, query)
 
 
 def load(

--- a/cartography/intel/github/teams.py
+++ b/cartography/intel/github/teams.py
@@ -84,7 +84,7 @@ def _get_teams_repos_inner_func(
     repo_urls: list[str],
     repo_permissions: list[str],
 ) -> None:
-    logger.info(f"Loading team repos for {team_name}.")
+    logger.info(f"Retrieving team repos for {team_name}.")
     team_repos = _get_team_repos(org, api_url, token, team_name)
 
     # The `or []` is because `.nodes` can be None. See:
@@ -192,7 +192,7 @@ def _get_teams_users_inner_func(
     user_urls: List[str],
     user_roles: List[str],
 ) -> None:
-    logger.info(f"Loading team users for {team_name}.")
+    logger.info(f"Retrieving team users for {team_name}.")
     team_users = _get_team_users(org, api_url, token, team_name)
     # The `or []` is because `.nodes` can be None. See:
     # https://docs.github.com/en/graphql/reference/objects#teammemberconnection
@@ -299,7 +299,7 @@ def _get_child_teams_inner_func(
     team_name: str,
     team_urls: List[str],
 ) -> None:
-    logger.info(f"Loading child teams for {team_name}.")
+    logger.info(f"Retrieving child teams for {team_name}.")
     child_teams = _get_child_teams(org, api_url, token, team_name)
     # The `or []` is because `.nodes` can be None. See:
     # https://docs.github.com/en/graphql/reference/objects#teammemberconnection


### PR DESCRIPTION
### Summary
> Describe your changes.

Adds retries to ensure_Indexes() to fix connectionreseterror during github team sync.


### Related issues or links
> Include links to relevant issues or other pages.

#1957 

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [x] Include console log trace showing what happened before and after your changes.

I can confirm that this fixes #1957:
```
[2025-10-07T02:34:45Z] INFO cartography.intel.github.teams: Loading 39145 GitHub team-repos to the graph
[2025-10-07T02:34:45Z] WARNING cartography.util: Backing off 0.2 seconds after 1 tries. Calling function <function _run_index_query_with_retry at 0x7fc011db2700>
[2025-10-07T02:34:45Z] WARNING cartography.util: Backing off 0.1 seconds after 2 tries. Calling function <function _run_index_query_with_retry at 0x7fc011db2700>
[2025-10-07T02:34:53Z] INFO cartography.graph.statement: Completed GitHubTeam statement #1
[2025-10-07T02:34:53Z] INFO cartography.graph.statement: Completed GitHubTeam statement #2
[2025-10-07T02:34:53Z] INFO cartography.graph.statement: Completed GitHubTeam statement #3
[2025-10-07T02:34:53Z] INFO cartography.graph.statement: Completed GitHubTeam statement #4
[2025-10-07T02:34:53Z] INFO cartography.graph.statement: Completed GitHubTeam statement #5
[2025-10-07T02:34:53Z] INFO cartography.graph.statement: Completed GitHubTeam statement #6
[2025-10-07T02:34:53Z] INFO cartography.graph.statement: Completed GitHubTeam statement #7
[2025-10-07T02:34:53Z] INFO cartography.graph.statement: Completed GitHubTeam statement #8
[2025-10-07T02:34:53Z] INFO cartography.graph.statement: Completed GitHubTeam statement #9
[2025-10-07T02:34:53Z] INFO cartography.graph.statement: Completed GitHubTeam statement #10
[2025-10-07T02:34:53Z] INFO cartography.graph.job: Finished job GitHubTeam
```

I think the retries force the connection back open (or something).

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

- [x] Confirm that the linter actually passes (submitting a PR where the linter fails shows reviewers that you did not test your code and will delay your review).
