### PR TITLE
feat(aws): add attach_time on network interfaces 

### DIFF
--- a/cartography/intel/aws/ec2/network_interfaces.py
+++ b/cartography/intel/aws/ec2/network_interfaces.py
@@ -99,6 +99,9 @@ def transform_network_interface_data(
                 "Status": network_interface["Status"],
                 "SubnetId": network_interface["SubnetId"],
                 "AttachTime": network_interface.get("Attachment", {}).get("AttachTime"),
+                "DeviceIndex": network_interface.get("Attachment", {}).get(
+                    "DeviceIndex"
+                ),
                 "ElbV1Id": elb_v1_id,
                 "ElbV2Id": elb_v2_id,
             },

--- a/cartography/models/aws/ec2/networkinterfaces.py
+++ b/cartography/models/aws/ec2/networkinterfaces.py
@@ -48,6 +48,7 @@ class EC2NetworkInterfaceNodeProperties(CartographyNodeProperties):
     subnetid: PropertyRef = PropertyRef("SubnetId", extra_index=True)
     subnet_id: PropertyRef = PropertyRef("SubnetId", extra_index=True)
     attach_time: PropertyRef = PropertyRef("AttachTime")
+    device_index: PropertyRef = PropertyRef("DeviceIndex")
 
 
 @dataclass(frozen=True)

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -2525,8 +2525,25 @@ Representation of a generic Network Interface.  Currently however, we only creat
 | requester_managed  |  Indicates whether the interface is managed by the requester |
 | source_dest_check   | Indicates whether to validate network traffic to or from this network interface.  |
 | public_ip   | Public IPv4 address attached to the interface  |
-| attach_time | The timestamp when the network interface was attached to an EC2 instance. This is the time when the instance was launched [according to AWS](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Instance.html)(see the `launchTime` field there). |
+| attach_time | The timestamp when the network interface was attached to an EC2 instance. For primary interfaces (device_index=0), this reveals the first launch time of the instance [according to AWS](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Instance.html). |
+| device_index | The index of the device on the instance for the network interface attachment. A value of `0` indicates the primary (eth0) network interface, which is created when the instance is launched. |
 
+#### Usage Notes
+
+**Finding the True First Launch Time:**
+
+The `LaunchTime` field on EC2Instance nodes shows the *last* launch time (e.g., if an instance was stopped and restarted). To find when an instance was *originally* created, use the `attach_time` of the primary network interface (`device_index: 0`):
+
+```cypher
+// Get the true first launch time for EC2 instances
+MATCH (i:EC2Instance)-[:NETWORK_INTERFACE]->(ni:NetworkInterface {device_index: 0})
+WHERE ni.attach_time IS NOT NULL
+RETURN i.instanceid, i.launchtime as last_launch, ni.attach_time as first_launch
+```
+
+**Primary vs Secondary Interfaces:**
+- **Primary interfaces** (`device_index: 0`): Created when the instance is launched, cannot be detached. The `attach_time` represents the instance's original creation time.
+- **Secondary interfaces** (`device_index: 1+`): Can be attached and detached at any time. The `attach_time` represents when the secondary interface was attached, not when the instance was created.
 
 #### Relationships
 

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_network_interfaces.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_network_interfaces.py
@@ -116,3 +116,11 @@ def test_load_network_interfaces(mock_get_network_interfaces, neo4j_session):
         ("eni-0d9877f559c240362", "2020-10-09 06:47:06+00:00"),
         ("eni-04b4289e1be7634e4", "2020-10-09 06:46:17+00:00"),
     }
+
+    # Assert NetworkInterface device_index property is set correctly
+    # DeviceIndex 0 indicates the primary network interface
+    assert check_nodes(neo4j_session, "NetworkInterface", ["id", "device_index"]) == {
+        ("eni-0e106a07c15ff7d14", 0),  # Primary interface
+        ("eni-0d9877f559c240362", 1),  # Secondary interface
+        ("eni-04b4289e1be7634e4", 0),  # Primary interface
+    }


### PR DESCRIPTION
### Summary

  Adds `attach_time` and `device_index` properties to EC2 NetworkInterface nodes to capture the timestamp when a
  network interface was attached and its device position. This enables users to determine the **true first launch 
  time** of an EC2 instance by identifying the primary network interface (`device_index: 0`).

   [According to AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Instance.html), the `LaunchTime` property on EC2 instances reflects the *last* launch time, but the
   **primary network interface's** `AttachTime` reveals when the instance was *originally* created. The
  `device_index` field is critical for distinguishing primary interfaces (created at instance launch) from secondary
  interfaces (which can be attached later).

  **Use Case:**
  - Correlating instance creation with CloudTrail logs
  - Identifying instance ownership based on creation timing
  - Security investigations that require accurate first-seen timestamps
  - Distinguishing between instance launch time vs. secondary interface attachment time

  **Implementation Details:**
  - Added `attach_time: PropertyRef` to `EC2NetworkInterfaceNodeProperties` data model
  - Added `device_index: PropertyRef` to `EC2NetworkInterfaceNodeProperties` data model
  - Updated `transform_network_interface_data()` to extract `AttachTime` and `DeviceIndex` from the `Attachment`
  object
  - Handles optional fields gracefully (some network interfaces may not be attached)
  - Data types:
    - `attach_time`: Python `datetime.datetime` from boto3, stored as Neo4j native datetime
    - `device_index`: Integer (0 = primary interface, 1+ = secondary interfaces)

  **Example Query:**
  To get the true first launch time of instances:
  ```cypher
  MATCH (ni:NetworkInterface {device_index: 0})-[:NETWORK_INTERFACE]-(i:EC2Instance)
  WHERE ni.attach_time IS NOT NULL
  RETURN i.id, ni.attach_time as first_launch_time
```
  Related issues or links

  - https://github.com/cartography-cncf/cartography/issues/2001

  Checklist

  Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
  - Update/add unit or integration tests.
  - Include a screenshot showing what the graph looked like before and after your changes.
  - Include console log trace showing what happened before and after your changes.

  If you are changing a node or relationship:
  - Update the https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules and
  https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md.

  If you are implementing a new intel module:
  - Use the NodeSchema https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node.
  - Confirm that the linter actually passes (submitting a PR where the linter actually fails shows reviewers that you
   did not test your code and will delay your review).

  Test Results:
  tests/integration/cartography/intel/aws/ec2/test_ec2_network_interfaces.py::test_load_network_interfaces PASSED
  [100%]

  The integration test verifies that all network interfaces have their properties correctly populated:

  attach_time values:
  - eni-0e106a07c15ff7d14: 2020-10-09 06:51:30+00:00
  - eni-0d9877f559c240362: 2020-10-09 06:47:06+00:00
  - eni-04b4289e1be7634e4: 2020-10-09 06:46:17+00:00

  device_index values:
  - eni-0e106a07c15ff7d14: 0 (primary interface)
  - eni-0d9877f559c240362: 1 (secondary interface - ELB managed)
  - eni-04b4289e1be7634e4: 0 (primary interface)
