### PR TITLE
feat(rules): consider denies in iam manipulation rules

### DIFF
--- a/cartography/rules/data/frameworks/mitre_attack/requirements/t1098_account_manipulation/__init__.py
+++ b/cartography/rules/data/frameworks/mitre_attack/requirements/t1098_account_manipulation/__init__.py
@@ -112,13 +112,13 @@ _aws_trust_relationship_manipulation = Fact(
 
         UNWIND matched_allow_actions AS action
         RETURN DISTINCT
-        a.name AS account,
-        principal.name AS principal_name,
-        principal.arn AS principal_arn,
-        policy.name AS policy_name,
-        principal_type,
-        collect(DISTINCT action) AS action,
-        stmt.resource AS resource
+            a.name AS account,
+            principal.name AS principal_name,
+            principal.arn AS principal_arn,
+            policy.name AS policy_name,
+            principal_type,
+            collect(DISTINCT action) AS action,
+            stmt.resource AS resource
         ORDER BY account, principal_name
     """,
     cypher_visual_query="""


### PR DESCRIPTION
Fixes a couple of problems with the iam rules queries:

1. Accounts for deny statements
2. effect='Allow' was not getting applied to the correct clause because the `where` clause was placed incorrectly
3. we were matching on iamusers optionally and not using that result, causing the query to take over 15 seconds unnecessarily

Also includes the policy name in the returned result.