### PR TITLE
fix: handle empty groups response in Google Workspace sync

### DIFF
--- a/cartography/intel/gsuite/api.py
+++ b/cartography/intel/gsuite/api.py
@@ -65,7 +65,7 @@ def transform_groups(response_objects: List[Dict]) -> List[Dict]:
     """
     groups: List[Dict] = []
     for response_object in response_objects:
-        for group in response_object["groups"]:
+        for group in response_object.get("groups", []):
             groups.append(group)
     return groups
 


### PR DESCRIPTION
Fixes #2017

## Summary
Fixed a crash that occurred when syncing a Google Workspace directory with zero groups.

## Problem
When the Google Workspace Directory API returned no groups, Cartography crashed with `KeyError: 'groups'` because the code assumed the `groups` key would always be present in the response.

## Solution
- Changed `response_object["groups"]` to `response_object.get("groups", [])` in the `transform_groups()` function
- This safely handles API responses that don't contain the `groups` key
- Returns an empty list when no groups exist, allowing the sync to continue gracefully

## Changes
- Modified `cartography/intel/gsuite/api.py` line 68

## Testing
- The fix allows Cartography to handle empty group responses without crashing
- Existing tests continue to pass
- Manually verified the fix handles the empty response case

## Future Work
A test case for empty API responses could be added in a follow-up PR to ensure this scenario is covered.