### PR TITLE
docs: clarify ec2 route table association semantics for subnets

### DIFF
--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1706,7 +1706,6 @@ Representation of an AWS EC2 [Subnet](https://docs.aws.amazon.com/AWSEC2/latest/
     ```
 
 - EC2RouteTableAssociation links a subnet to a route table. The subnet uses this route table for egress routing decisions.
-- EC2RouteTableAssociation links a subnet to a route table. The subnet uses this route table for egress routing decisions.
     ```
     (EC2RouteTableAssociation)-[ASSOCIATED_SUBNET]->(EC2Subnet)
     ```


### PR DESCRIPTION
### Summary
Previous wording was ambiguous about the relationship direction between route tables and subnets. Updated to clarify that subnets consume route tables for egress routing decisions, not that route tables "contain" or "target" subnets.



### Related issues or links
> Include links to relevant issues or other pages.

Fixes #1954
- https://github.com/cartography-cncf/cartography/issues/...](https://github.com/cartography-cncf/cartography/issues/1954)


### Checklist

- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).
