### PR TITLE
fix(aws): no exec info on EndpointConnectError

### DIFF
--- a/cartography/util.py
+++ b/cartography/util.py
@@ -347,7 +347,6 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
             logger.warning(
                 "Encountered an EndpointConnectionError. This means that the AWS "
                 "resource is not available in this region. Skipping.",
-                exc_info=True,
             )
             return []
 


### PR DESCRIPTION
### Summary
We catch EndpointConnection errors but we are printing stack traces that make it look like we dont handle them. This PR fixes that

Trace:
```
[2025-10-31T18:19:40Z] WARNING cartography.util: Encountered an EndpointConnectionError. This means that the AWS resource is not available in this region. Skipping.
Traceback (most recent call last):
  File "/app/.venv/lib/python3.13/site-packages/urllib3/connection.py", line 198, in _new_conn
    sock = connection.create_connection(
        (self._dns_host, self.port),
    ...<2 lines>...
        socket_options=self.socket_options,
    )
  File "/app/.venv/lib/python3.13/site-packages/urllib3/util/connection.py", line 60, in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
               ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/socket.py", line 977, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
               ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
socket.gaierror: [Errno -2] Name or service not known

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/.venv/lib/python3.13/site-packages/botocore/httpsession.py", line 464, in send
    urllib_response = conn.urlopen(
        method=request.method,
    ...<7 lines>...
        chunked=self._chunked(request.headers),
    )
  File "/app/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py", line 841, in urlopen
    retries = retries.increment(
        method, url, error=new_e, _pool=self, _stacktrace=sys.exc_info()[2]
    )
  File "/app/.venv/lib/python3.13/site-packages/urllib3/util/retry.py", line 449, in increment
    raise reraise(type(error), error, _stacktrace)
          ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/urllib3/util/util.py", line 39, in reraise
    raise value
  File "/app/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py", line 787, in urlopen
    response = self._make_request(
        conn,
    ...<10 lines>...
        **response_kw,
    )
  File "/app/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py", line 488, in _make_request
    raise new_e
  File "/app/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py", line 464, in _make_request
    self._validate_conn(conn)
    ~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/urllib3/connectionpool.py", line 1093, in _validate_conn
    conn.connect()
    ~~~~~~~~~~~~^^
  File "/app/.venv/lib/python3.13/site-packages/urllib3/connection.py", line 704, in connect
    self.sock = sock = self._new_conn()
                       ~~~~~~~~~~~~~~^^
  File "/app/.venv/lib/python3.13/site-packages/urllib3/connection.py", line 205, in _new_conn
    raise NameResolutionError(self.host, self, e) from e
urllib3.exceptions.NameResolutionError: <botocore.awsrequest.AWSHTTPSConnection object at 0x7f4b73792e90>: Failed to resolve 'codebuild.mx-central-1.amazonaws.com' ([Errno -2] Name or service not known)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/.venv/lib/python3.13/site-packages/cartography/util.py", line 335, in inner_function
    return func(*args, **kwargs)
  File "/app/.venv/lib/python3.13/site-packages/cartography/intel/aws/codebuild.py", line 32, in get_all_codebuild_projects
    for page in paginator.paginate():
                ~~~~~~~~~~~~~~~~~~^^
  File "/app/.venv/lib/python3.13/site-packages/botocore/paginate.py", line 272, in __iter__
    response = self._make_request(current_kwargs)
  File "/app/.venv/lib/python3.13/site-packages/botocore/context.py", line 123, in wrapper
    return func(*args, **kwargs)
  File "/app/.venv/lib/python3.13/site-packages/botocore/paginate.py", line 360, in _make_request
    return self._method(**current_kwargs)
           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/botocore/client.py", line 602, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/botocore/context.py", line 123, in wrapper
    return func(*args, **kwargs)
  File "/app/.venv/lib/python3.13/site-packages/botocore/client.py", line 1060, in _make_api_call
    http, parsed_response = self._make_request(
                            ~~~~~~~~~~~~~~~~~~^
        operation_model, request_dict, request_context
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/app/.venv/lib/python3.13/site-packages/botocore/client.py", line 1084, in _make_request
    return self._endpoint.make_request(operation_model, request_dict)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/botocore/endpoint.py", line 119, in make_request
    return self._send_request(request_dict, operation_model)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/botocore/endpoint.py", line 200, in _send_request
    while self._needs_retry(
          ~~~~~~~~~~~~~~~~~^
        attempts,
        ^^^^^^^^^
    ...<3 lines>...
        exception,
        ^^^^^^^^^^
    ):
    ^
  File "/app/.venv/lib/python3.13/site-packages/botocore/endpoint.py", line 360, in _needs_retry
    responses = self._event_emitter.emit(
        event_name,
    ...<5 lines>...
        request_dict=request_dict,
    )
  File "/app/.venv/lib/python3.13/site-packages/botocore/hooks.py", line 412, in emit
    return self._emitter.emit(aliased_event_name, **kwargs)
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/botocore/hooks.py", line 256, in emit
    return self._emit(event_name, kwargs)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/botocore/hooks.py", line 239, in _emit
    response = handler(**kwargs)
  File "/app/.venv/lib/python3.13/site-packages/botocore/retryhandler.py", line 207, in __call__
    if self._checker(**checker_kwargs):
       ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/botocore/retryhandler.py", line 284, in __call__
    should_retry = self._should_retry(
        attempt_number, response, caught_exception
    )
  File "/app/.venv/lib/python3.13/site-packages/botocore/retryhandler.py", line 320, in _should_retry
    return self._checker(attempt_number, response, caught_exception)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/botocore/retryhandler.py", line 363, in __call__
    checker_response = checker(
        attempt_number, response, caught_exception
    )
  File "/app/.venv/lib/python3.13/site-packages/botocore/retryhandler.py", line 247, in __call__
    return self._check_caught_exception(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        attempt_number, caught_exception
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/app/.venv/lib/python3.13/site-packages/botocore/retryhandler.py", line 416, in _check_caught_exception
    raise caught_exception
  File "/app/.venv/lib/python3.13/site-packages/botocore/endpoint.py", line 279, in _do_get_response
    http_response = self._send(request)
  File "/app/.venv/lib/python3.13/site-packages/botocore/endpoint.py", line 383, in _send
    return self.http_session.send(request)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/app/.venv/lib/python3.13/site-packages/botocore/httpsession.py", line 493, in send
    raise EndpointConnectionError(endpoint_url=request.url, error=e)
botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "https://codebuild.mx-central-1.amazonaws.com/"
```