### PR TITLE
Export to file instead of neo4j

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -77,14 +77,6 @@ class CLI:
             ),
         )
         parser.add_argument(
-            "--export-format",
-            type=str,
-            default="ndjson",
-            help=(
-                "Export format. Currently only 'ndjson' is supported."
-            ),
-        )
-        parser.add_argument(
             "--no-neo4j-write",
             action="store_true",
             help=(

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -65,6 +65,33 @@ class CLI:
             action="store_true",
             help="Restrict cartography logging to warnings and errors only.",
         )
+        # Optional export-only sink (off by default)
+        parser.add_argument(
+            "--export-file",
+            type=str,
+            default=None,
+            help=(
+                "Write a gzipped NDJSON export of graph nodes and edges to this path. "
+                "When set, cartography will tee writes to this file while continuing to write to Neo4j unless "
+                "--no-neo4j-write is also provided."
+            ),
+        )
+        parser.add_argument(
+            "--export-format",
+            type=str,
+            default="ndjson",
+            help=(
+                "Export format. Currently only 'ndjson' is supported."
+            ),
+        )
+        parser.add_argument(
+            "--no-neo4j-write",
+            action="store_true",
+            help=(
+                "Do not write to Neo4j. Useful when generating an export file for offline processing. "
+                "Requires --export-file."
+            ),
+        )
         parser.add_argument(
             "--neo4j-uri",
             type=str,
@@ -940,6 +967,12 @@ class CLI:
         # Selected modules
         if config.selected_modules:
             self.sync = cartography.sync.build_sync(config.selected_modules)
+
+        # Validate export-only options
+        if config.no_neo4j_write and not config.export_file:
+            raise ValueError(
+                "--no-neo4j-write requires --export-file to be set."
+            )
 
         # AWS config
         if config.aws_requested_syncs:

--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -5,6 +5,7 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Union
+from typing import Iterable
 
 import backoff
 import neo4j
@@ -15,8 +16,13 @@ from cartography.graph.querybuilder import build_ingestion_query
 from cartography.graph.querybuilder import build_matchlink_query
 from cartography.models.core.nodes import CartographyNodeSchema
 from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import LinkDirection
 from cartography.util import backoff_handler
 from cartography.util import batch
+from cartography.sinks import file_export as file_export_sink
+from dataclasses import asdict
 
 logger = logging.getLogger(__name__)
 
@@ -338,6 +344,14 @@ def load(
     if len(dict_list) == 0:
         # If there is no data to load, save some time.
         return
+    # Tee export if enabled
+    if file_export_sink.is_enabled():
+        _export_node_batch(node_schema, dict_list, **kwargs)
+
+    # Optionally skip Neo4j writes for export-only runs
+    if file_export_sink.is_enabled() and file_export_sink.get_no_neo4j_write():
+        return
+
     ensure_indexes(neo4j_session, node_schema)
     ingestion_query = build_ingestion_query(node_schema)
     load_graph_data(
@@ -380,9 +394,221 @@ def load_matchlinks(
             "This is needed for cleanup queries."
         )
 
+    # Tee export if enabled
+    if file_export_sink.is_enabled():
+        _export_matchlinks_batch(rel_schema, dict_list, **kwargs)
+
+    # Optionally skip Neo4j writes for export-only runs
+    if file_export_sink.is_enabled() and file_export_sink.get_no_neo4j_write():
+        return
+
     ensure_indexes_for_matchlinks(neo4j_session, rel_schema)
     matchlink_query = build_matchlink_query(rel_schema)
     logger.debug(f"Matchlink query: {matchlink_query}")
     load_graph_data(
         neo4j_session, matchlink_query, dict_list, batch_size=batch_size, **kwargs
     )
+
+
+def _resolve_prop_value(prop: PropertyRef, item: Dict[str, Any], kwargs: Dict[str, Any]) -> Any:
+    return kwargs.get(prop.name) if prop.set_in_kwargs else item.get(prop.name)
+
+
+def _labels_from_schema(node_schema: CartographyNodeSchema) -> List[str]:
+    labels = [node_schema.label]
+    extra: Optional[ExtraNodeLabels] = node_schema.extra_node_labels
+    if extra:
+        labels.extend(extra.labels)
+    return labels
+
+
+def _export_node_batch(
+    node_schema: CartographyNodeSchema,
+    dict_list: List[Dict[str, Any]],
+    **kwargs,
+) -> None:
+    """Serialize nodes and their direct relationships (sub-resource + other_relationships)."""
+    sink = file_export_sink.get_sink()
+    if not sink:
+        return
+
+    # Prepare relationship helpers
+    sub_rel = node_schema.sub_resource_relationship
+    other_rels = node_schema.other_relationships.rels if node_schema.other_relationships else []
+
+    for item in dict_list:
+        # Node basics
+        # Resolve node id and lastupdated
+        node_props: Dict[str, PropertyRef] = {}
+        try:
+            # asdict() on dataclass instance -> mapping of prop_name -> PropertyRef
+            node_props = asdict(node_schema.properties)
+        except Exception:
+            node_props = {}
+
+        node_id_ref: PropertyRef = node_schema.properties.id  # type: ignore[attr-defined]
+        node_uid = _resolve_prop_value(node_id_ref, item, kwargs)
+        update_tag = _resolve_prop_value(node_schema.properties.lastupdated, item, kwargs)  # type: ignore[attr-defined]
+
+        # Build exported props excluding id/lastupdated
+        props: Dict[str, Any] = {}
+        for pname, pref in node_props.items():
+            if pname in ("id", "lastupdated"):
+                continue
+            props[pname] = _resolve_prop_value(pref, item, kwargs)
+
+        # Sub-resource scoping info
+        sub_label: Optional[str] = None
+        sub_id: Optional[Any] = None
+        if sub_rel is not None:
+            sub_label = sub_rel.target_node_label
+            matcher_dict: Dict[str, PropertyRef] = asdict(sub_rel.target_node_matcher)  # type: ignore
+            # Expect single-key matcher; use 'id' when present
+            if len(matcher_dict) == 1 and "id" in matcher_dict:
+                sub_id = _resolve_prop_value(matcher_dict["id"], item, kwargs)
+
+        # Write vertex
+        sink.write_vertex(
+            uid=node_uid,
+            labels=_labels_from_schema(node_schema),
+            props=props,
+            update_tag=update_tag,
+            sub_resource_label=sub_label,
+            sub_resource_id=sub_id,
+        )
+
+        # Export edges for sub-resource
+        if sub_rel is not None and sub_label is not None and sub_id is not None and node_uid is not None:
+            if sub_rel.direction == LinkDirection.INWARD:
+                sink.write_edge(
+                    from_uid=sub_id,
+                    to_uid=node_uid,
+                    rel_type=sub_rel.rel_label,
+                    update_tag=update_tag,
+                    sub_resource_label=sub_label,
+                    sub_resource_id=sub_id,
+                )
+            else:
+                sink.write_edge(
+                    from_uid=node_uid,
+                    to_uid=sub_id,
+                    rel_type=sub_rel.rel_label,
+                    update_tag=update_tag,
+                    sub_resource_label=sub_label,
+                    sub_resource_id=sub_id,
+                )
+
+        # Export edges for other relationships
+        for rel in other_rels:
+            matcher_dict: Dict[str, PropertyRef] = asdict(rel.target_node_matcher)  # type: ignore
+            # Single-key match is the common case
+            if len(matcher_dict) == 1:
+                key, pref = next(iter(matcher_dict.items()))
+                val = _resolve_prop_value(pref, item, kwargs)
+                if val is None:
+                    continue
+                # Handle one_to_many
+                values: Iterable[Any]
+                if pref.one_to_many and isinstance(val, list):
+                    values = val
+                else:
+                    values = [val]
+
+                for v in values:
+                    # Prefer direct uid linkage when key == 'id'; otherwise export a matcher fallback
+                    from_uid = node_uid
+                    to_uid = v if key == "id" else None
+                    from_match = None
+                    to_match = None
+                    if key != "id":
+                        to_match = {key: v}
+
+                    if rel.direction == LinkDirection.INWARD:
+                        sink.write_edge(
+                            from_uid=to_uid,
+                            to_uid=from_uid,
+                            rel_type=rel.rel_label,
+                            update_tag=update_tag,
+                            to_match=to_match if to_uid is None else None,
+                        )
+                    else:
+                        sink.write_edge(
+                            from_uid=from_uid,
+                            to_uid=to_uid,
+                            rel_type=rel.rel_label,
+                            update_tag=update_tag,
+                            to_match=to_match if to_uid is None else None,
+                        )
+            else:
+                # Composite matcher; export as best-effort matcher description
+                match_payload: Dict[str, Any] = {
+                    k: _resolve_prop_value(p, item, kwargs) for k, p in matcher_dict.items()
+                }
+                if rel.direction == LinkDirection.INWARD:
+                    sink.write_edge(
+                        to_uid=node_uid,
+                        rel_type=rel.rel_label,
+                        update_tag=update_tag,
+                        from_match=match_payload,
+                    )
+                else:
+                    sink.write_edge(
+                        from_uid=node_uid,
+                        rel_type=rel.rel_label,
+                        update_tag=update_tag,
+                        to_match=match_payload,
+                    )
+
+
+def _export_matchlinks_batch(
+    rel_schema: CartographyRelSchema,
+    dict_list: List[Dict[str, Any]],
+    **kwargs,
+) -> None:
+    sink = file_export_sink.get_sink()
+    if not sink:
+        return
+
+    source_matcher: Dict[str, PropertyRef] = asdict(rel_schema.source_node_matcher) if rel_schema.source_node_matcher else {}
+    target_matcher: Dict[str, PropertyRef] = asdict(rel_schema.target_node_matcher)
+
+    sub_label = kwargs.get("_sub_resource_label")
+    sub_id = kwargs.get("_sub_resource_id")
+
+    for item in dict_list:
+        # Compute update tag if present
+        update_tag = kwargs.get("lastupdated")
+
+        # Resolve matchers
+        def _resolve_matcher(m: Dict[str, PropertyRef]) -> Dict[str, Any]:
+            return {k: _resolve_prop_value(p, item, kwargs) for k, p in m.items()}
+
+        src_vals = _resolve_matcher(source_matcher) if source_matcher else {}
+        tgt_vals = _resolve_matcher(target_matcher)
+
+        # Prefer uid linkage when matching on single 'id'
+        from_uid = src_vals.get("id") if len(source_matcher) == 1 and "id" in source_matcher else None
+        to_uid = tgt_vals.get("id") if len(target_matcher) == 1 and "id" in target_matcher else None
+
+        if rel_schema.direction == LinkDirection.INWARD:
+            sink.write_edge(
+                from_uid=to_uid,
+                to_uid=from_uid,
+                rel_type=rel_schema.rel_label,
+                update_tag=update_tag,
+                from_match=None if to_uid is not None else tgt_vals,
+                to_match=None if from_uid is not None else src_vals,
+                sub_resource_label=sub_label,
+                sub_resource_id=sub_id,
+            )
+        else:
+            sink.write_edge(
+                from_uid=from_uid,
+                to_uid=to_uid,
+                rel_type=rel_schema.rel_label,
+                update_tag=update_tag,
+                from_match=None if from_uid is not None else src_vals,
+                to_match=None if to_uid is not None else tgt_vals,
+                sub_resource_label=sub_label,
+                sub_resource_id=sub_id,
+            )

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -297,7 +297,6 @@ class Config:
         keycloak_realm=None,
         keycloak_url=None,
         export_file=None,
-        export_format=None,
         no_neo4j_write=False,
     ):
         self.neo4j_uri = neo4j_uri
@@ -400,5 +399,4 @@ class Config:
         self.keycloak_url = keycloak_url
         # Optional export-only sink configuration
         self.export_file = export_file
-        self.export_format = export_format or "ndjson"
         self.no_neo4j_write = bool(no_neo4j_write)

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -296,6 +296,9 @@ class Config:
         keycloak_client_secret=None,
         keycloak_realm=None,
         keycloak_url=None,
+        export_file=None,
+        export_format=None,
+        no_neo4j_write=False,
     ):
         self.neo4j_uri = neo4j_uri
         self.neo4j_user = neo4j_user
@@ -395,3 +398,7 @@ class Config:
         self.keycloak_client_secret = keycloak_client_secret
         self.keycloak_realm = keycloak_realm
         self.keycloak_url = keycloak_url
+        # Optional export-only sink configuration
+        self.export_file = export_file
+        self.export_format = export_format or "ndjson"
+        self.no_neo4j_write = bool(no_neo4j_write)

--- a/cartography/sinks/file_export.py
+++ b/cartography/sinks/file_export.py
@@ -1,0 +1,156 @@
+import atexit
+import gzip
+import io
+import json
+import os
+import threading
+from dataclasses import asdict
+from typing import Any, Dict, Iterable, List, Optional
+
+# Minimal, opt-in export sink for append-only NDJSON.gz streams.
+
+
+class _ThreadSafeGzipWriter:
+    def __init__(self, path: str) -> None:
+        # Ensure parent directory exists
+        os.makedirs(os.path.dirname(os.path.abspath(path)) or ".", exist_ok=True)
+        # Open gzip file in text mode
+        self._fh: gzip.GzipFile = gzip.open(path, mode="wt", encoding="utf-8")  # type: ignore
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def write_line(self, line: str) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._fh.write(line)
+            if not line.endswith("\n"):
+                self._fh.write("\n")
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            try:
+                self._fh.close()
+            finally:
+                self._closed = True
+
+
+class FileExportSink:
+    """Append-only exporter for graph events.
+
+    Records are serialized as NDJSON and compressed with gzip. Thread-safe.
+    """
+
+    def __init__(self, path: str, format: str = "ndjson") -> None:
+        self._format = format.lower()
+        if self._format != "ndjson":
+            raise ValueError(f"Unsupported export format: {format}")
+        self._writer = _ThreadSafeGzipWriter(path)
+
+    def close(self) -> None:
+        self._writer.close()
+
+    def write_record(self, record: Dict[str, Any]) -> None:
+        # Keep JSON output stable and minimal
+        self._writer.write_line(json.dumps(record, separators=(",", ":"), sort_keys=False))
+
+    # Convenience helpers
+    def write_vertex(
+        self,
+        *,
+        uid: Any,
+        labels: List[str],
+        props: Dict[str, Any],
+        update_tag: Any,
+        sub_resource_label: Optional[str] = None,
+        sub_resource_id: Optional[Any] = None,
+    ) -> None:
+        rec: Dict[str, Any] = {
+            "record_type": "vertex",
+            "uid": uid,
+            "labels": labels,
+            "props": props,
+            "update_tag": update_tag,
+        }
+        # Provide cleanup-scoping hints when available
+        if sub_resource_label is not None:
+            rec["_sub_resource_label"] = sub_resource_label
+        if sub_resource_id is not None:
+            rec["_sub_resource_id"] = sub_resource_id
+        self.write_record(rec)
+
+    def write_edge(
+        self,
+        *,
+        from_uid: Optional[Any] = None,
+        to_uid: Optional[Any] = None,
+        rel_type: str,
+        update_tag: Any,
+        props: Optional[Dict[str, Any]] = None,
+        # Fallback matching description if uid is unknown
+        from_match: Optional[Dict[str, Any]] = None,
+        to_match: Optional[Dict[str, Any]] = None,
+        sub_resource_label: Optional[str] = None,
+        sub_resource_id: Optional[Any] = None,
+    ) -> None:
+        rec: Dict[str, Any] = {
+            "record_type": "edge",
+            "rel_type": rel_type,
+            "update_tag": update_tag,
+            "props": props or {},
+        }
+        if from_uid is not None:
+            rec["from_uid"] = from_uid
+        if to_uid is not None:
+            rec["to_uid"] = to_uid
+        if from_match is not None:
+            rec["from_match"] = from_match
+        if to_match is not None:
+            rec["to_match"] = to_match
+        if sub_resource_label is not None:
+            rec["_sub_resource_label"] = sub_resource_label
+        if sub_resource_id is not None:
+            rec["_sub_resource_id"] = sub_resource_id
+        self.write_record(rec)
+
+
+# Module-level lifecycle and flags
+_sink: Optional[FileExportSink] = None
+_no_neo4j_write: bool = False
+
+
+def enable(path: str, *, format: str = "ndjson") -> None:
+    global _sink
+    if _sink is not None:
+        return
+    _sink = FileExportSink(path=path, format=format)
+    atexit.register(disable)
+
+
+def disable() -> None:
+    global _sink
+    if _sink is not None:
+        try:
+            _sink.close()
+        finally:
+            _sink = None
+
+
+def get_sink() -> Optional[FileExportSink]:
+    return _sink
+
+
+def is_enabled() -> bool:
+    return _sink is not None
+
+
+def set_no_neo4j_write(flag: bool) -> None:
+    global _no_neo4j_write
+    _no_neo4j_write = bool(flag)
+
+
+def get_no_neo4j_write() -> bool:
+    return _no_neo4j_write
+

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -50,6 +50,7 @@ from cartography.config import Config
 from cartography.stats import set_stats_client
 from cartography.util import STATUS_FAILURE
 from cartography.util import STATUS_SUCCESS
+from cartography.sinks import file_export as file_export_sink
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +143,14 @@ class Sync:
         :type config: cartography.config.Config
         :param config: Configuration for the sync run.
         """
+        # Configure optional export sink
+        export_file = getattr(config, "export_file", None)
+        export_format = getattr(config, "export_format", "ndjson")
+        no_neo4j_write = bool(getattr(config, "no_neo4j_write", False))
+        if export_file:
+            file_export_sink.enable(export_file, format=export_format)
+        file_export_sink.set_no_neo4j_write(no_neo4j_write)
+
         logger.info("Starting sync with update tag '%d'", config.update_tag)
         with neo4j_driver.session(database=config.neo4j_database) as neo4j_session:
             for stage_name, stage_func in self._stages.items():
@@ -159,6 +168,9 @@ class Sync:
                     raise  # TODO this should be configurable
                 logger.info("Finishing sync stage '%s'", stage_name)
         logger.info("Finishing sync with update tag '%d'", config.update_tag)
+        # Close export sink if used
+        if file_export_sink.is_enabled():
+            file_export_sink.disable()
         return STATUS_SUCCESS
 
     @classmethod

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -145,10 +145,9 @@ class Sync:
         """
         # Configure optional export sink
         export_file = getattr(config, "export_file", None)
-        export_format = getattr(config, "export_format", "ndjson")
         no_neo4j_write = bool(getattr(config, "no_neo4j_write", False))
         if export_file:
-            file_export_sink.enable(export_file, format=export_format)
+            file_export_sink.enable(export_file)
         file_export_sink.set_no_neo4j_write(no_neo4j_write)
 
         logger.info("Starting sync with update tag '%d'", config.update_tag)

--- a/tests/test_file_export.py
+++ b/tests/test_file_export.py
@@ -1,0 +1,128 @@
+import gzip
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+
+from cartography.client.core.tx import load
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.sinks import file_export as file_export_sink
+
+
+@dataclass(frozen=True)
+class _DummyNodeProps(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    vpcId: PropertyRef = PropertyRef("vpcId")
+    subnet_id: PropertyRef = PropertyRef("subnet_id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class _DummySubRelProps(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class _DummySubRel(CartographyRelSchema):
+    target_node_label: str = "Tenant"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher({
+        "id": PropertyRef("TENANT_ID", set_in_kwargs=True),
+    })
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RESOURCE"
+    properties: _DummySubRelProps = _DummySubRelProps()
+
+
+@dataclass(frozen=True)
+class _DummyOtherRelProps(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class _DummyOtherRel(CartographyRelSchema):
+    target_node_label: str = "EC2Subnet"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher({
+        "id": PropertyRef("subnet_id"),
+    })
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "IN_SUBNET"
+    properties: _DummyOtherRelProps = _DummyOtherRelProps()
+
+
+@dataclass(frozen=True)
+class _DummySchema(CartographyNodeSchema):
+    label: str = "EC2Instance"
+    properties: _DummyNodeProps = _DummyNodeProps()
+    sub_resource_relationship: _DummySubRel = _DummySubRel()
+    other_relationships: OtherRelationships = OtherRelationships([
+        _DummyOtherRel(),
+    ])
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["AWS"])
+
+
+def _read_ndjson_gz(path: str):
+    with gzip.open(path, mode="rt", encoding="utf-8") as fh:  # type: ignore
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            yield json.loads(line)
+
+
+def test_file_export_basic_vertex_and_edges():
+    with tempfile.TemporaryDirectory() as td:
+        out_path = os.path.join(td, "graph.ndjson.gz")
+        file_export_sink.enable(out_path)
+        file_export_sink.set_no_neo4j_write(True)
+
+        data = [
+            {
+                "id": "i/i-abc",
+                "vpcId": "vpc-1",
+                "subnet_id": "subnet-1",
+            },
+        ]
+
+        # Export-only run; we pass a dummy session since no Neo4j writes will occur
+        load(  # type: ignore[arg-type]
+            neo4j_session=None,  # not used when no_neo4j_write=True
+            node_schema=_DummySchema(),
+            dict_list=data,
+            lastupdated=1700000000,
+            TENANT_ID="t1",
+        )
+
+        file_export_sink.disable()
+
+        records = list(_read_ndjson_gz(out_path))
+        assert records, "export produced no records"
+        vertices = [r for r in records if r.get("record_type") == "vertex"]
+        edges = [r for r in records if r.get("record_type") == "edge"]
+
+        assert len(vertices) == 1
+        v = vertices[0]
+        assert v["uid"] == "i/i-abc"
+        assert "EC2Instance" in v["labels"]
+        assert "AWS" in v["labels"]
+        assert v["props"]["vpcId"] == "vpc-1"
+        assert v["_sub_resource_label"] == "Tenant"
+        assert v["_sub_resource_id"] == "t1"
+
+        # Expect 2 edges: RESOURCE and IN_SUBNET
+        rel_types = sorted(e["rel_type"] for e in edges)
+        assert rel_types == ["IN_SUBNET", "RESOURCE"]
+
+        # Validate one specific edge
+        in_subnet = next(e for e in edges if e["rel_type"] == "IN_SUBNET")
+        assert in_subnet["from_uid"] == "i/i-abc"
+        assert in_subnet["to_uid"] == "subnet-1"
+


### PR DESCRIPTION
### Summary
This PR introduces the ability to export a scan result to ndjson files rather than neo4j.
The goal is to allow a database-agnostic output allowing users to write the result anywhere they want.

At this point, I am mostly asking whether this is something you'd be interested to land. If that's the case, I'll make sure all intel modules are compatible with this output format.

### Related issues or links

- https://github.com/cartography-cncf/cartography/issues/1658 
  - This would provide a DIY way of supporting any db inckuding Neptune.


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

- [ ] Confirm that the linter actually passes (submitting a PR where the linter fails shows reviewers that you did not test your code and will delay your review).
