### PR TITLE
Add GuardDuty detector coverage

### DIFF
--- a/cartography/models/aws/guardduty/detectors.py
+++ b/cartography/models/aws/guardduty/detectors.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GuardDutyDetectorNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    accountid: PropertyRef = PropertyRef("accountid")
+    region: PropertyRef = PropertyRef("Region", set_in_kwargs=True)
+    status: PropertyRef = PropertyRef("status")
+    findingpublishingfrequency: PropertyRef = PropertyRef("findingpublishingfrequency")
+    service_role: PropertyRef = PropertyRef("service_role")
+    createdat: PropertyRef = PropertyRef("createdat")
+    updatedat: PropertyRef = PropertyRef("updatedat")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GuardDutyDetectorToAWSAccountRelRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GuardDutyDetectorToAWSAccountRel(CartographyRelSchema):
+    target_node_label: str = "AWSAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GuardDutyDetectorToAWSAccountRelRelProperties = (
+        GuardDutyDetectorToAWSAccountRelRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GuardDutyDetectorSchema(CartographyNodeSchema):
+    label: str = "GuardDutyDetector"
+    properties: GuardDutyDetectorNodeProperties = GuardDutyDetectorNodeProperties()
+    sub_resource_relationship: GuardDutyDetectorToAWSAccountRel = (
+        GuardDutyDetectorToAWSAccountRel()
+    )

--- a/cartography/models/aws/guardduty/findings.py
+++ b/cartography/models/aws/guardduty/findings.py
@@ -69,6 +69,24 @@ class GuardDutyFindingToEC2InstanceRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class GuardDutyFindingToGuardDutyDetectorRelRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GuardDutyFindingToGuardDutyDetectorRel(CartographyRelSchema):
+    target_node_label: str = "GuardDutyDetector"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("detectorid")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "DETECTED_BY"
+    properties: GuardDutyFindingToGuardDutyDetectorRelRelProperties = (
+        GuardDutyFindingToGuardDutyDetectorRelRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class GuardDutyFindingToS3BucketRelRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
@@ -96,6 +114,7 @@ class GuardDutyFindingSchema(CartographyNodeSchema):
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
+            GuardDutyFindingToGuardDutyDetectorRel(),
             GuardDutyFindingToEC2InstanceRel(),
             GuardDutyFindingToS3BucketRel(),
         ],

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -41,6 +41,7 @@ Representation of an AWS Account.
                                 :EC2SecurityGroup,
                                 :ElasticIPAddress,
                                 :ESDomain,
+                                :GuardDutyDetector,
                                 :GuardDutyFinding,
                                 :KMSAlias,
                                 :LaunchConfiguration,
@@ -152,6 +153,35 @@ Representation of AWS [IAM Groups](https://docs.aws.amazon.com/IAM/latest/APIRef
     (:AWSGroup)-[:POLICY]->(:AWSPolicy)
     ```
 
+### GuardDutyDetector
+
+Representation of an AWS [GuardDuty Detector](https://docs.aws.amazon.com/guardduty/latest/APIReference/API_GetDetector.html).
+
+| Field | Description |
+|-------|-------------|
+| firstseen| Timestamp of when a sync job first discovered this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| **id** | The unique identifier for the GuardDuty detector |
+| accountid | The AWS Account ID the detector belongs to |
+| region | The AWS Region where the detector is deployed |
+| status | Whether the detector is enabled or disabled |
+| findingpublishingfrequency | Frequency with which GuardDuty publishes findings |
+| service_role | IAM service role used by GuardDuty |
+| createdat | Timestamp when the detector was created |
+| updatedat | Timestamp when the detector was last updated |
+
+#### Relationships
+
+- GuardDuty detectors belong to AWS Accounts
+    ```cypher
+    (:AWSAccount)-[:RESOURCE]->(:GuardDutyDetector)
+    ```
+
+- GuardDuty detectors generate GuardDuty findings
+    ```cypher
+    (:GuardDutyDetector)<-[:DETECTED_BY]-(:GuardDutyFinding)
+    ```
+
 ### GuardDutyFinding::Risk
 
 Representation of an AWS [GuardDuty Finding](https://docs.aws.amazon.com/guardduty/latest/APIReference/API_Finding.html).
@@ -181,6 +211,11 @@ Representation of an AWS [GuardDuty Finding](https://docs.aws.amazon.com/guarddu
 - GuardDuty findings belong to AWS Accounts
     ```cypher
     (:AWSAccount)-[:RESOURCE]->(:GuardDutyFinding)
+    ```
+
+- GuardDuty findings link back to the detector that produced them
+    ```cypher
+    (:GuardDutyFinding)-[:DETECTED_BY]->(:GuardDutyDetector)
     ```
 
 - GuardDuty findings may affect EC2 Instances

--- a/tests/data/aws/guardduty.py
+++ b/tests/data/aws/guardduty.py
@@ -8,6 +8,25 @@ LIST_DETECTORS = {
     ]
 }
 
+GET_DETECTOR_DETAILS = [
+    {
+        "id": "12abc34d56e78f901234567890abcdef",
+        "findingpublishingfrequency": "FIFTEEN_MINUTES",
+        "service_role": "arn:aws:iam::123456789012:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty",
+        "status": "ENABLED",
+        "createdat": datetime(2022, 12, 1, 12, 0, 0),
+        "updatedat": datetime(2023, 1, 1, 12, 0, 0),
+    },
+    {
+        "id": "98zyx76w54v32u109876543210zyxwvu",
+        "findingpublishingfrequency": "SIX_HOURS",
+        "service_role": "arn:aws:iam::123456789012:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDutySecondary",
+        "status": "DISABLED",
+        "createdat": datetime(2022, 11, 1, 9, 0, 0),
+        "updatedat": datetime(2022, 12, 1, 9, 0, 0),
+    },
+]
+
 # Mock response for list_findings API call
 LIST_FINDINGS = {
     "FindingIds": [

--- a/tests/integration/cartography/intel/aws/test_guardduty.py
+++ b/tests/integration/cartography/intel/aws/test_guardduty.py
@@ -5,6 +5,7 @@ import cartography.intel.aws.guardduty
 from cartography.intel.aws.guardduty import _get_severity_range_for_threshold
 from cartography.intel.aws.guardduty import sync
 from tests.data.aws.guardduty import GET_FINDINGS
+from tests.data.aws.guardduty import GET_DETECTOR_DETAILS
 from tests.data.aws.guardduty import LIST_DETECTORS
 from tests.integration.cartography.intel.aws.common import create_test_account
 from tests.integration.util import check_nodes
@@ -47,10 +48,17 @@ def mock_get_findings_with_severity_filter(
 )
 @patch.object(
     cartography.intel.aws.guardduty,
+    "get_detector_details",
+    return_value=GET_DETECTOR_DETAILS,
+)
+@patch.object(
+    cartography.intel.aws.guardduty,
     "get_findings",
     side_effect=mock_get_findings_with_severity_filter,
 )
-def test_sync_guardduty_findings(mock_get_findings, mock_get_detectors, neo4j_session):
+def test_sync_guardduty_findings(
+    mock_get_findings, mock_get_detector_details, mock_get_detectors, neo4j_session,
+):
     """
     Test that GuardDuty findings are correctly synced to the graph and create proper relationships.
     Also tests severity threshold filtering functionality.
@@ -100,6 +108,16 @@ def test_sync_guardduty_findings(mock_get_findings, mock_get_detectors, neo4j_se
         # Note: 85c2345678901bcdef2345678901bcdef0 (severity 5.0) should be excluded
     }
 
+    # Assert - Check that GuardDuty detectors were synced with properties
+    assert check_nodes(
+        neo4j_session,
+        "GuardDutyDetector",
+        ["id", "status", "findingpublishingfrequency"],
+    ) == {
+        ("12abc34d56e78f901234567890abcdef", "ENABLED", "FIFTEEN_MINUTES"),
+        ("98zyx76w54v32u109876543210zyxwvu", "DISABLED", "SIX_HOURS"),
+    }
+
     # Assert - Check that synced findings have the correct properties
     assert check_nodes(
         neo4j_session, "GuardDutyFinding", ["id", "severity", "resource_type"]
@@ -107,6 +125,20 @@ def test_sync_guardduty_findings(mock_get_findings, mock_get_detectors, neo4j_se
         ("74b1234567890abcdef1234567890abcdef", 8.0, "Instance"),
         ("96d3456789012cdef3456789012cdef01", 7.5, "AccessKey"),
         # Note: S3Bucket finding with severity 5.0 excluded by HIGH threshold
+    }
+
+    # Assert - Check that GuardDuty detectors are connected to the AWSAccount
+    assert check_rels(
+        neo4j_session,
+        "AWSAccount",
+        "id",
+        "GuardDutyDetector",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (TEST_ACCOUNT_ID, "12abc34d56e78f901234567890abcdef"),
+        (TEST_ACCOUNT_ID, "98zyx76w54v32u109876543210zyxwvu"),
     }
 
     # Assert - Check that HIGH severity findings are connected to the AWSAccount
@@ -129,6 +161,19 @@ def test_sync_guardduty_findings(mock_get_findings, mock_get_detectors, neo4j_se
         ("74b1234567890abcdef1234567890abcdef",),
         ("96d3456789012cdef3456789012cdef01",),
         # Note: MEDIUM severity finding excluded
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "GuardDutyFinding",
+        "id",
+        "GuardDutyDetector",
+        "id",
+        "DETECTED_BY",
+        rel_direction_right=True,
+    ) == {
+        ("74b1234567890abcdef1234567890abcdef", "12abc34d56e78f901234567890abcdef"),
+        ("96d3456789012cdef3456789012cdef01", "12abc34d56e78f901234567890abcdef"),
     }
 
     # Assert - Check that GuardDuty finding is connected to the EC2 instance


### PR DESCRIPTION
## Summary
- add ingestion of GuardDuty detector metadata and capture sync metadata alongside findings
- model GuardDuty detectors and link GuardDuty findings back to their detectors with updated documentation
- extend GuardDuty integration test data and assertions for detector coverage

## Testing
- pytest tests/integration/cartography/intel/aws/test_guardduty.py *(fails: Neo4j service not running in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691e6c065e08832f90b5eeda4cb5f183)