### PR TITLE
rules: find regions where aws guarduty is disabled

### DIFF
--- a/cartography/rules/data/rules/__init__.py
+++ b/cartography/rules/data/rules/__init__.py
@@ -1,3 +1,6 @@
+from cartography.rules.data.rules.cloud_security_product_deactivated import (
+    cloud_security_product_deactivated,
+)
 from cartography.rules.data.rules.compute_instance_exposed import (
     compute_instance_exposed,
 )
@@ -18,9 +21,6 @@ from cartography.rules.data.rules.policy_administration_privileges import (
 from cartography.rules.data.rules.unmanaged_accounts import unmanaged_accounts
 from cartography.rules.data.rules.workload_identity_admin_capabilities import (
     workload_identity_admin_capabilities,
-)
-from cartography.rules.data.rules.cloud_security_product_deactivated import (
-    cloud_security_product_deactivated,
 )
 
 # Rule registry - all available rules

--- a/cartography/rules/data/rules/cloud_security_product_deactivated.py
+++ b/cartography/rules/data/rules/cloud_security_product_deactivated.py
@@ -43,7 +43,7 @@ cloud_security_product_deactivated = Rule(
     name="Cloud Security Product Deactivated",
     description="Detects accounts (or regions) where cloud security products are deactivated.",
     output_model=CloudSecurityProductDeactivated,
-    tags=("cloud_security"),
+    tags=("cloud_security",),
     facts=(aws_guard_duty_detector_disabled,),
     version="0.1.0",
 )


### PR DESCRIPTION
Add a rule that detect all regions where Finds regions where GuardDuty Detector is disabled.

<img width="824" height="305" alt="Screenshot 2025-11-20 at 4 27 33 PM" src="https://github.com/user-attachments/assets/e97d4020-b150-4bfd-82a6-d9ffe7c09336" />
