### PR TITLE
fix: make shai-hulud query only return vulnerable pkgs

### DIFF
--- a/cartography/rules/data/rules/malicious_npm_dependencies_shai_hulud.py
+++ b/cartography/rules/data/rules/malicious_npm_dependencies_shai_hulud.py
@@ -2180,7 +2180,6 @@ class MaliciousNpmDependenciesShaiHuludOutput(Finding):
     name: str | None = None
     current_version: str | None = None
     vulnerable_version: str | None = None
-    is_vulnerable: bool | None = None
 
 
 malicious_npm_dependencies_shai_hulud = Rule(


### PR DESCRIPTION
### Summary
> Describe your changes.

Makes the Shai-Hulud query return only rows where a vulnerable package is present. Removes the is_vulnerable flag. Previous version returned rows where we matched on a package name but not the package version.


- [x] Confirm that the linter actually passes (submitting a PR where the linter fails shows reviewers that you did not test your code and will delay your review).
