### PR TITLE
Handle missing OpenAI user IDs during ingestion

### DIFF
--- a/cartography/intel/openai/users.py
+++ b/cartography/intel/openai/users.py
@@ -50,17 +50,27 @@ def load_users(
     ORG_ID: str,
     update_tag: int,
 ) -> None:
+    valid_users = [user for user in data if user.get("id")]
+    dropped_users = len(data) - len(valid_users)
+
+    if dropped_users:
+        logger.warning(
+            "Skipping %d OpenAI users missing an id; received %d users from API.",
+            dropped_users,
+            len(data),
+        )
+
     load(
         neo4j_session,
         OpenAIOrganizationSchema(),
         [{"id": ORG_ID}],
         lastupdated=update_tag,
     )
-    logger.info("Loading %d OpenAI User into Neo4j.", len(data))
+    logger.info("Loading %d OpenAI User into Neo4j.", len(valid_users))
     load(
         neo4j_session,
         OpenAIUserSchema(),
-        data,
+        valid_users,
         lastupdated=update_tag,
         ORG_ID=ORG_ID,
     )

--- a/tests/data/openai/users.py
+++ b/tests/data/openai/users.py
@@ -15,4 +15,12 @@ OPENAI_USERS = [
         "role": "member",
         "added_at": 1670089719,
     },
+    {
+        "object": "organization.user",
+        "id": None,
+        "name": "Missing Id",
+        "email": "missing-id@example.com",
+        "role": "member",
+        "added_at": 1670089719,
+    },
 ]

--- a/tests/integration/cartography/intel/openai/test_users.py
+++ b/tests/integration/cartography/intel/openai/test_users.py
@@ -1,6 +1,5 @@
-from unittest.mock import patch
-
 import requests
+from unittest.mock import patch
 
 import cartography.intel.openai.users
 import tests.data.openai.users


### PR DESCRIPTION
## Summary
- filter out OpenAI users lacking IDs before loading into Neo4j to avoid merge errors
- log when invalid users are dropped and adjust tests with representative fixture data

## Testing
- pytest tests/integration/cartography/intel/openai/test_users.py *(fails: neo4j package missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f3a4486288323a30b842c9035c2e6)