### PR TITLE
fix(gcp): Gracefully handle all 403 errors in CAI fallback

### DIFF
--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -229,18 +229,12 @@ def _sync_project_resources(
                     predefined_roles=predefined_roles,
                 )
             except HttpError as e:
-                error_str = str(e)
-                if e.resp.status == 403 and "USER_PROJECT_DENIED" in error_str:
+                if e.resp.status == 403:
                     logger.warning(
-                        "CAI fallback skipped for project %s: USER_PROJECT_DENIED. "
-                        "The identity may lack serviceusage.serviceUsageConsumer on the quota project.",
+                        "CAI fallback skipped for project %s: %s. "
+                        "Ensure Cloud Asset API is enabled and roles/cloudasset.viewer is granted.",
                         project_id,
-                    )
-                elif e.resp.status == 403 and "SERVICE_DISABLED" in error_str:
-                    logger.warning(
-                        "CAI fallback skipped for project %s: Cloud Asset API is not enabled "
-                        "on the service account's host project. Enable it to use CAI fallback.",
-                        project_id,
+                        e.reason,
                     )
                 else:
                     raise


### PR DESCRIPTION
### Summary

Simplify CAI fallback error handling to gracefully handle all 403 errors instead of just specific error codes.

Previously, when the CAI (Cloud Asset Inventory) fallback encountered a 403 error, we checked for specific error strings like `USER_PROJECT_DENIED`, `SERVICE_DISABLED`, and `PERMISSION_DENIED` in the error message. However, the `PERMISSION_DENIED` status is returned in the JSON response body's `error.status` field, not in the string representation of the `HttpError`, causing the sync to crash instead of warning and continuing.

Rather than adding JSON parsing to extract the status, we simplified to catch any 403 error and warn gracefully - the operational outcome is the same regardless of the specific 403 reason.

**Before:** Sync crashes on CAI permission errors
**After:** Sync logs a warning and continues


### Related issues or links
- https://github.com/cartography-cncf/cartography/pull/2096
- https://github.com/cartography-cncf/cartography/pull/2116
- https://github.com/cartography-cncf/cartography/pull/2129 

Trace
```
INFO:cartography.intel.gcp:IAM API not enabled. Attempting IAM sync for project vast-signifier-445218-g0 via Cloud Asset Inventory.
INFO:cartography.intel.gcp.cai:Syncing GCP IAM for project blahblah via Cloud Asset Inventory
WARNING:googleapiclient.http:Encountered 403 Forbidden with reason "PERMISSION_DENIED"
WARNING:cartography.intel.gcp:CAI fallback skipped for project blahblah: The caller does not have permission. Ensure Cloud Asset API is enabled and roles/cloudasset.viewer is granted.
INFO:cartography.intel.gcp.permission_relationships:Syncing GCP Permission Relationships for project 'blahblah'.
...
INFO:cartography.intel.gcp:Syncing GCP project beepboop for Compute.
```
