### PR TITLE
fix(gcp): Handle absolute paths in permission_relationships file parsing

### DIFF
--- a/cartography/intel/gcp/permission_relationships.py
+++ b/cartography/intel/gcp/permission_relationships.py
@@ -253,7 +253,9 @@ def get_resource_ids(
 
 def parse_permission_relationships_file(file_path: str) -> list[dict[str, Any]]:
     try:
-        if not os.path.isabs(file_path):
+        if os.path.isabs(file_path):
+            resolved_file_path = file_path
+        else:
             resolved_file_path = os.path.join(os.getcwd(), file_path)
         with open(resolved_file_path) as f:
             relationship_mapping = yaml.load(f, Loader=yaml.FullLoader)


### PR DESCRIPTION
### Summary
Fix `UnboundLocalError` in `parse_permission_relationships_file()` when an absolute path is provided.

The function had a bug where `resolved_file_path` was only assigned when the input path was relative (inside the `if not os.path.isabs(file_path):` block). When an absolute path was provided (e.g., from `importlib.resources.files()`), the variable was never set, causing:

```
UnboundLocalError: cannot access local variable 'resolved_file_path' where it is not associated with a value
```

This fix ensures `resolved_file_path` is always assigned regardless of whether the input path is absolute or relative.

### Related issues or links

N/A - Bug discovered while integrating cartography's GCP permission_relationships module.

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Include console log trace showing what happened before and after your changes.

**Before:**
```python
# When passing an absolute path like '/path/to/gcp_permission_relationships.yaml'
parse_permission_relationships_file('/path/to/file.yaml')
# Raises: UnboundLocalError: cannot access local variable 'resolved_file_path'
```

**After:**
```python
# Now works correctly with absolute paths
parse_permission_relationships_file('/path/to/file.yaml')
# Returns: list of permission relationship mappings
```

- [x] Confirm that the linter actually passes (submitting a PR where the linter fails shows reviewers that you did not test your code and will delay your review).