### PR TITLE
fix(docs): Fix tailscale/schema.md links

### DIFF
--- a/docs/root/modules/tailscale/schema.md
+++ b/docs/root/modules/tailscale/schema.md
@@ -95,23 +95,23 @@ A Tailscale device (sometimes referred to as *node* or *machine*), is any comput
 | id | The preferred identifier for a device |
 | firstseen| Timestamp of when a sync job first created this node  |
 | lastupdated |  Timestamp of the last time the node was updated |
-| name | The MagicDNS name of the device.<br/>Learn more about MagicDNS at https://tailscale.com/https://tailscale.com/kb/1081/. |
-| hostname | The machine name in the admin console.<br/>Learn more about machine names at https://tailscale.com/https://tailscale.com/kb/1098/. |
+| name | The MagicDNS name of the device.<br/>Learn more about MagicDNS at https://tailscale.com/kb/1081/. |
+| hostname | The machine name in the admin console.<br/>Learn more about machine names at https://tailscale.com/kb/1098/. |
 | client_version | The version of the Tailscale client<br/>software; this is empty for external devices. |
 | update_available | 'true' if a Tailscale client version<br/>upgrade is available. This value is empty for external devices. |
 | os | The operating system that the device is running. |
 | created | The date on which the device was added<br/>to the tailnet; this is empty for external devices. |
 | last_seen | When device was last active on the tailnet. |
-| key_expiry_disabled | 'true' if the keys for the device will not expire.<br/>Learn more at https://tailscale.com/https://tailscale.com/kb/1028/. |
-| expires | The expiration date of the device's auth key.<br/>Learn more about key expiry at https://tailscale.com/https://tailscale.com/kb/1028/. |
-| authorized | 'true' if the device has been authorized to join the tailnet; otherwise, 'false'.<br/>Learn more about device authorization at https://tailscale.com/https://tailscale.com/kb/1099/. |
-| is_external | 'true', indicates that a device is not a member of the tailnet, but is shared in to the tailnet;<br/>if 'false', the device is a member of the tailnet.<br/>Learn more about node sharing at https://tailscale.com/https://tailscale.com/kb/1084/. |
-| node_key | Mostly for internal use, required for select operations, such as adding a node to a locked tailnet.<br/>Learn about tailnet locks at https://tailscale.com/https://tailscale.com/kb/1226/. |
-| blocks_incoming_connections | 'true' if the device is not allowed to accept any connections over Tailscale, including pings.<br/>Learn more in the "Allow incoming connections" section of https://tailscale.com/https://tailscale.com/kb/1072/. |
+| key_expiry_disabled | 'true' if the keys for the device will not expire.<br/>Learn more at https://tailscale.com/kb/1028/. |
+| expires | The expiration date of the device's auth key.<br/>Learn more about key expiry at https://tailscale.com/kb/1028/. |
+| authorized | 'true' if the device has been authorized to join the tailnet; otherwise, 'false'.<br/>Learn more about device authorization at https://tailscale.com/kb/1099/. |
+| is_external | 'true', indicates that a device is not a member of the tailnet, but is shared in to the tailnet;<br/>if 'false', the device is a member of the tailnet.<br/>Learn more about node sharing at https://tailscale.com/kb/1084/. |
+| node_key | Mostly for internal use, required for select operations, such as adding a node to a locked tailnet.<br/>Learn about tailnet locks at https://tailscale.com/kb/1226/. |
+| blocks_incoming_connections | 'true' if the device is not allowed to accept any connections over Tailscale, including pings.<br/>Learn more in the "Allow incoming connections" section of https://tailscale.com/kb/1072/. |
 | client_connectivity_endpoints | Client's magicsock UDP IP:port endpoints (IPv4 or IPv6). |
 | client_connectivity_mapping_varies_by_dest_ip | 'true' if the host's NAT mappings vary based on the destination IP. |
 | tailnet_lock_error | Indicates an issue with the tailnet lock node-key signature on this device.<br/>This field is only populated when tailnet lock is enabled. |
-| tailnet_lock_key | The node's tailnet lock key.<br/>Every node generates a tailnet lock key (so the value will be present) even if tailnet lock is not enabled.<br/>Learn more about tailnet lock at https://tailscale.com/https://tailscale.com/kb/1226/. |
+| tailnet_lock_key | The node's tailnet lock key.<br/>Every node generates a tailnet lock key (so the value will be present) even if tailnet lock is not enabled.<br/>Learn more about tailnet lock at https://tailscale.com/kb/1226/. |
 | posture_identity_serial_numbers | Posture identification collection |
 | posture_identity_disabled |  Device posture identification collection enabled |
 


### PR DESCRIPTION
fix broken links in tailscale schema documentation (`/` before `https://` that breaks navigation)

### Summary
remove instances of `/` from before `https://` in schema.md



### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/cartography-cncf/cartography/issues/...


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
- [ ] Confirm that the linter actually passes (submitting a PR where the linter fails shows reviewers that you did not test your code and will delay your review).
