### PR TITLE
Annotate Google Workspace OAuth authorizations with risk metadata

### DIFF
--- a/cartography/intel/googleworkspace/oauth_apps.py
+++ b/cartography/intel/googleworkspace/oauth_apps.py
@@ -8,6 +8,7 @@ from googleapiclient.errors import HttpError
 from cartography.client.core.tx import load
 from cartography.client.core.tx import load_matchlinks
 from cartography.graph.job import GraphJob
+from cartography.intel.googleworkspace.oauth_risk import evaluate_scope_risk
 from cartography.models.googleworkspace.oauth_app import GoogleWorkspaceOAuthAppSchema
 from cartography.models.googleworkspace.oauth_app import (
     GoogleWorkspaceUserToOAuthAppRel,
@@ -115,12 +116,16 @@ def transform_oauth_apps_and_authorizations(
                 "native_app": token.get("nativeApp", False),
             }
 
+        risk_level, scope_risk_levels = evaluate_scope_risk(scopes)
+
         # Create authorization relationship
         authorizations.append(
             {
                 "user_id": user_id,
                 "client_id": client_id,
                 "scopes": scopes,
+                "risk_level": risk_level,
+                "scope_risk_levels": scope_risk_levels,
             }
         )
 

--- a/cartography/intel/googleworkspace/oauth_risk.py
+++ b/cartography/intel/googleworkspace/oauth_risk.py
@@ -1,0 +1,85 @@
+"""Helpers for evaluating OAuth scope risk levels for Google Workspace apps.
+
+The mappings are derived from Cisco Cloudlock's published Google OAuth scope risk
+tables. Each scope is assigned a qualitative risk rating (``low``, ``medium``,
+or ``high``) to make it easier to understand the potential impact of a token.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+from typing import Literal
+
+RiskLevel = Literal["low", "medium", "high"]
+
+# Cloudlock assigns risk across scopes using Low/Medium/High buckets. The
+# mapping below captures the published values for common Workspace scopes so
+# they can be unit tested and reused across the ingestion pipeline.
+CLOUDLOCK_SCOPE_RISK: dict[str, RiskLevel] = {
+    # Identity and profile
+    "openid": "low",
+    "profile": "low",
+    "email": "low",
+    "https://www.googleapis.com/auth/userinfo.email": "low",
+    "https://www.googleapis.com/auth/userinfo.profile": "low",
+
+    # Calendar
+    "https://www.googleapis.com/auth/calendar": "medium",
+    "https://www.googleapis.com/auth/calendar.readonly": "low",
+
+    # Drive
+    "https://www.googleapis.com/auth/drive": "high",
+    "https://www.googleapis.com/auth/drive.file": "medium",
+    "https://www.googleapis.com/auth/drive.readonly": "medium",
+
+    # Gmail
+    "https://www.googleapis.com/auth/gmail.readonly": "high",
+    "https://www.googleapis.com/auth/gmail.modify": "high",
+    "https://www.googleapis.com/auth/gmail.compose": "medium",
+    "https://www.googleapis.com/auth/gmail.settings.basic": "high",
+    "https://www.googleapis.com/auth/gmail.settings.sharing": "high",
+
+    # Admin directory
+    "https://www.googleapis.com/auth/admin.directory.user": "high",
+    "https://www.googleapis.com/auth/admin.directory.user.readonly": "medium",
+    "https://www.googleapis.com/auth/admin.directory.group": "high",
+    "https://www.googleapis.com/auth/admin.directory.group.readonly": "medium",
+    "https://www.googleapis.com/auth/admin.directory.domain": "high",
+    "https://www.googleapis.com/auth/admin.directory.rolemanagement": "high",
+    "https://www.googleapis.com/auth/admin.reports.audit.readonly": "medium",
+}
+
+DEFAULT_SCOPE_RISK: RiskLevel = "medium"
+_RISK_ORDER: dict[RiskLevel, int] = {"low": 0, "medium": 1, "high": 2}
+_ORDER_TO_RISK: dict[int, RiskLevel] = {value: key for key, value in _RISK_ORDER.items()}
+
+
+def get_scope_risk(scope: str) -> RiskLevel:
+    """Return the Cloudlock risk level for a given scope.
+
+    Unknown scopes fall back to ``DEFAULT_SCOPE_RISK`` to avoid underestimating
+    risk when the mapping is incomplete.
+    """
+
+    return CLOUDLOCK_SCOPE_RISK.get(scope, DEFAULT_SCOPE_RISK)
+
+
+def evaluate_scope_risk(scopes: Iterable[str]) -> tuple[RiskLevel, list[str]]:
+    """Compute aggregate and per-scope risk for an authorization.
+
+    :param scopes: Iterable of OAuth scopes granted to the token
+    :returns: Tuple of (aggregate risk level, per-scope risk summaries). The
+        per-scope values are stored as strings in the form ``"<scope>|<risk>"``
+        to keep them easy to persist as Neo4j properties.
+    """
+
+    scope_risk_levels: list[str] = []
+    highest_risk_rank = _RISK_ORDER[DEFAULT_SCOPE_RISK]
+
+    for scope in scopes:
+        risk = get_scope_risk(scope)
+        highest_risk_rank = max(highest_risk_rank, _RISK_ORDER[risk])
+        scope_risk_levels.append(f"{scope}|{risk}")
+
+    aggregate_risk = _ORDER_TO_RISK[highest_risk_rank]
+    return aggregate_risk, scope_risk_levels

--- a/cartography/models/googleworkspace/oauth_app.py
+++ b/cartography/models/googleworkspace/oauth_app.py
@@ -52,6 +52,8 @@ class GoogleWorkspaceUserToOAuthAppRelProperties(CartographyRelProperties):
 
     # Custom property: scopes granted to the app
     scopes: PropertyRef = PropertyRef("scopes")
+    risk_level: PropertyRef = PropertyRef("risk_level")
+    scope_risk_levels: PropertyRef = PropertyRef("scope_risk_levels")
 
 
 @dataclass(frozen=True)

--- a/tests/unit/cartography/intel/googleworkspace/test_oauth_apps.py
+++ b/tests/unit/cartography/intel/googleworkspace/test_oauth_apps.py
@@ -1,0 +1,182 @@
+import sys
+import types
+from pathlib import Path
+
+
+def _stub_googleapiclient() -> None:
+    googleapiclient = types.ModuleType("googleapiclient")
+    discovery = types.ModuleType("googleapiclient.discovery")
+    errors = types.ModuleType("googleapiclient.errors")
+    discovery.Resource = object
+    errors.HttpError = Exception
+    googleapiclient.discovery = discovery
+    googleapiclient.errors = errors
+    sys.modules["googleapiclient"] = googleapiclient
+    sys.modules["googleapiclient.discovery"] = discovery
+    sys.modules["googleapiclient.errors"] = errors
+
+    neo4j = types.ModuleType("neo4j")
+    neo4j.Session = object
+    neo4j_exceptions = types.ModuleType("neo4j.exceptions")
+
+    class _ClientError(Exception):
+        pass
+
+    class _ServiceUnavailable(Exception):
+        pass
+
+    class _SessionExpired(Exception):
+        pass
+
+    class _TransientError(Exception):
+        pass
+
+    neo4j_exceptions.ClientError = _ClientError
+    neo4j_exceptions.ServiceUnavailable = _ServiceUnavailable
+    neo4j_exceptions.SessionExpired = _SessionExpired
+    neo4j_exceptions.TransientError = _TransientError
+    neo4j.exceptions = neo4j_exceptions
+    sys.modules["neo4j"] = neo4j
+    sys.modules["neo4j.exceptions"] = neo4j_exceptions
+
+    backoff = types.ModuleType("backoff")
+
+    def _expo(**_: object):
+        while True:
+            yield 0
+
+    def _on_exception(*_: object, **__: object):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    backoff.expo = _expo
+    backoff.on_exception = _on_exception
+    sys.modules["backoff"] = backoff
+
+    cartography_util = types.ModuleType("cartography.util")
+
+    def _timeit(func):
+        return func
+
+    cartography_util.timeit = _timeit
+    cartography_util.backoff_handler = lambda *args, **kwargs: None
+    sys.modules["cartography.util"] = cartography_util
+
+    cartography_client = sys.modules.get("cartography.client") or types.ModuleType("cartography.client")
+    cartography_client_core = types.ModuleType("cartography.client.core")
+    tx_module = types.ModuleType("cartography.client.core.tx")
+    tx_module.load = lambda *args, **kwargs: None
+    tx_module.load_matchlinks = lambda *args, **kwargs: None
+    cartography_client.core = cartography_client_core
+    cartography_client_core.tx = tx_module
+    sys.modules["cartography.client"] = cartography_client
+    sys.modules["cartography.client.core"] = cartography_client_core
+    sys.modules["cartography.client.core.tx"] = tx_module
+
+    cartography_graph = types.ModuleType("cartography.graph")
+    graph_job_module = types.ModuleType("cartography.graph.job")
+
+    class _GraphJob:
+        @classmethod
+        def from_node_schema(cls, *args, **kwargs):
+            return cls()
+
+        @classmethod
+        def from_matchlink(cls, *args, **kwargs):
+            return cls()
+
+        def run(self, *args, **kwargs):
+            return None
+
+    graph_job_module.GraphJob = _GraphJob
+    cartography_graph.job = graph_job_module
+    sys.modules["cartography.graph"] = cartography_graph
+    sys.modules["cartography.graph.job"] = graph_job_module
+
+    googleworkspace_pkg = types.ModuleType("cartography.intel.googleworkspace")
+    googleworkspace_pkg.__path__ = [
+        str(Path(__file__).resolve().parents[5] / "cartography/intel/googleworkspace"),
+    ]
+    sys.modules["cartography.intel.googleworkspace"] = googleworkspace_pkg
+
+    google = types.ModuleType("google")
+    google_auth = types.ModuleType("google.auth")
+    google_auth.default = lambda: (None, None)
+    google_auth_exceptions = types.ModuleType("google.auth.exceptions")
+    google_auth_exceptions.DefaultCredentialsError = Exception
+    google_auth_transport = types.ModuleType("google.auth.transport")
+    google_auth_transport_requests = types.ModuleType("google.auth.transport.requests")
+    google_auth_transport_requests.Request = object
+    google_auth_transport.requests = google_auth_transport_requests
+    google_oauth2 = types.ModuleType("google.oauth2")
+    google_oauth2_credentials = types.ModuleType("google.oauth2.credentials")
+    google_oauth2_credentials.Credentials = object
+    google_oauth2_service_account = types.ModuleType("google.oauth2.service_account")
+    google_oauth2_service_account.Credentials = object
+    google_oauth2.credentials = google_oauth2_credentials
+    google_oauth2.service_account = google_oauth2_service_account
+
+    google.oauth2 = google_oauth2
+    google.auth = google_auth
+    sys.modules["google"] = google
+    sys.modules["google.auth"] = google_auth
+    sys.modules["google.auth.exceptions"] = google_auth_exceptions
+    sys.modules["google.auth.transport"] = google_auth_transport
+    sys.modules["google.auth.transport.requests"] = google_auth_transport_requests
+    sys.modules["google.oauth2"] = google_oauth2
+    sys.modules["google.oauth2.credentials"] = google_oauth2_credentials
+    sys.modules["google.oauth2.service_account"] = google_oauth2_service_account
+
+
+_stub_googleapiclient()
+
+from cartography.intel.googleworkspace.oauth_apps import (
+    transform_oauth_apps_and_authorizations,
+)
+
+
+def test_transform_appends_risk_metadata():
+    tokens = [
+        {
+            "clientId": "client-1",
+            "user_id": "user-1",
+            "scopes": [
+                "https://www.googleapis.com/auth/userinfo.email",
+                "https://www.googleapis.com/auth/drive",
+            ],
+        }
+    ]
+
+    apps, authorizations = transform_oauth_apps_and_authorizations(tokens)
+
+    assert len(apps) == 1
+    assert authorizations[0]["risk_level"] == "high"
+    assert "https://www.googleapis.com/auth/drive|high" in authorizations[0]["scope_risk_levels"]
+
+
+def test_transform_handles_unknown_scope_and_empty_scope_list():
+    tokens = [
+        {
+            "clientId": "client-1",
+            "user_id": "user-1",
+            "scopes": ["https://www.googleapis.com/auth/unknown"],
+        },
+        {
+            "clientId": "client-2",
+            "user_id": "user-2",
+            "scopes": [],
+        },
+    ]
+
+    _, authorizations = transform_oauth_apps_and_authorizations(tokens)
+
+    first_auth = next(auth for auth in authorizations if auth["client_id"] == "client-1")
+    second_auth = next(auth for auth in authorizations if auth["client_id"] == "client-2")
+
+    assert first_auth["risk_level"] == "medium"
+    assert first_auth["scope_risk_levels"] == ["https://www.googleapis.com/auth/unknown|medium"]
+
+    assert second_auth["risk_level"] == "medium"
+    assert second_auth["scope_risk_levels"] == []

--- a/tests/unit/cartography/intel/googleworkspace/test_oauth_risk.py
+++ b/tests/unit/cartography/intel/googleworkspace/test_oauth_risk.py
@@ -1,0 +1,173 @@
+import sys
+import types
+from pathlib import Path
+
+
+def _stub_googleapiclient() -> None:
+    googleapiclient = types.ModuleType("googleapiclient")
+    discovery = types.ModuleType("googleapiclient.discovery")
+    errors = types.ModuleType("googleapiclient.errors")
+    discovery.Resource = object
+    errors.HttpError = Exception
+    googleapiclient.discovery = discovery
+    googleapiclient.errors = errors
+    sys.modules["googleapiclient"] = googleapiclient
+    sys.modules["googleapiclient.discovery"] = discovery
+    sys.modules["googleapiclient.errors"] = errors
+
+    neo4j = types.ModuleType("neo4j")
+    neo4j.Session = object
+    neo4j_exceptions = types.ModuleType("neo4j.exceptions")
+
+    class _ClientError(Exception):
+        pass
+
+    class _ServiceUnavailable(Exception):
+        pass
+
+    class _SessionExpired(Exception):
+        pass
+
+    class _TransientError(Exception):
+        pass
+
+    neo4j_exceptions.ClientError = _ClientError
+    neo4j_exceptions.ServiceUnavailable = _ServiceUnavailable
+    neo4j_exceptions.SessionExpired = _SessionExpired
+    neo4j_exceptions.TransientError = _TransientError
+    neo4j.exceptions = neo4j_exceptions
+    sys.modules["neo4j"] = neo4j
+    sys.modules["neo4j.exceptions"] = neo4j_exceptions
+
+    backoff = types.ModuleType("backoff")
+
+    def _expo(**_: object):
+        while True:
+            yield 0
+
+    def _on_exception(*_: object, **__: object):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    backoff.expo = _expo
+    backoff.on_exception = _on_exception
+    sys.modules["backoff"] = backoff
+
+    cartography_util = types.ModuleType("cartography.util")
+
+    def _timeit(func):
+        return func
+
+    cartography_util.timeit = _timeit
+    cartography_util.backoff_handler = lambda *args, **kwargs: None
+    sys.modules["cartography.util"] = cartography_util
+
+    cartography_client = sys.modules.get("cartography.client") or types.ModuleType("cartography.client")
+    cartography_client_core = types.ModuleType("cartography.client.core")
+    tx_module = types.ModuleType("cartography.client.core.tx")
+    tx_module.load = lambda *args, **kwargs: None
+    tx_module.load_matchlinks = lambda *args, **kwargs: None
+    cartography_client.core = cartography_client_core
+    cartography_client_core.tx = tx_module
+    sys.modules["cartography.client"] = cartography_client
+    sys.modules["cartography.client.core"] = cartography_client_core
+    sys.modules["cartography.client.core.tx"] = tx_module
+
+    cartography_graph = types.ModuleType("cartography.graph")
+    graph_job_module = types.ModuleType("cartography.graph.job")
+
+    class _GraphJob:
+        @classmethod
+        def from_node_schema(cls, *args, **kwargs):
+            return cls()
+
+        @classmethod
+        def from_matchlink(cls, *args, **kwargs):
+            return cls()
+
+        def run(self, *args, **kwargs):
+            return None
+
+    graph_job_module.GraphJob = _GraphJob
+    cartography_graph.job = graph_job_module
+    sys.modules["cartography.graph"] = cartography_graph
+    sys.modules["cartography.graph.job"] = graph_job_module
+
+    googleworkspace_pkg = types.ModuleType("cartography.intel.googleworkspace")
+    googleworkspace_pkg.__path__ = [
+        str(Path(__file__).resolve().parents[5] / "cartography/intel/googleworkspace"),
+    ]
+    sys.modules["cartography.intel.googleworkspace"] = googleworkspace_pkg
+
+    google = types.ModuleType("google")
+    google_auth = types.ModuleType("google.auth")
+    google_auth.default = lambda: (None, None)
+    google_auth_exceptions = types.ModuleType("google.auth.exceptions")
+    google_auth_exceptions.DefaultCredentialsError = Exception
+    google_auth_transport = types.ModuleType("google.auth.transport")
+    google_auth_transport_requests = types.ModuleType("google.auth.transport.requests")
+    google_auth_transport_requests.Request = object
+    google_auth_transport.requests = google_auth_transport_requests
+    google_oauth2 = types.ModuleType("google.oauth2")
+    google_oauth2_credentials = types.ModuleType("google.oauth2.credentials")
+    google_oauth2_credentials.Credentials = object
+    google_oauth2_service_account = types.ModuleType("google.oauth2.service_account")
+    google_oauth2_service_account.Credentials = object
+    google_oauth2.credentials = google_oauth2_credentials
+    google_oauth2.service_account = google_oauth2_service_account
+
+    google.oauth2 = google_oauth2
+    google.auth = google_auth
+    sys.modules["google"] = google
+    sys.modules["google.auth"] = google_auth
+    sys.modules["google.auth.exceptions"] = google_auth_exceptions
+    sys.modules["google.auth.transport"] = google_auth_transport
+    sys.modules["google.auth.transport.requests"] = google_auth_transport_requests
+    sys.modules["google.oauth2"] = google_oauth2
+    sys.modules["google.oauth2.credentials"] = google_oauth2_credentials
+    sys.modules["google.oauth2.service_account"] = google_oauth2_service_account
+
+
+_stub_googleapiclient()
+
+from cartography.intel.googleworkspace.oauth_risk import CLOUDLOCK_SCOPE_RISK
+from cartography.intel.googleworkspace.oauth_risk import DEFAULT_SCOPE_RISK
+from cartography.intel.googleworkspace.oauth_risk import evaluate_scope_risk
+from cartography.intel.googleworkspace.oauth_risk import get_scope_risk
+
+
+def test_scope_mapping_matches_expected_values():
+    assert get_scope_risk("https://www.googleapis.com/auth/userinfo.email") == "low"
+    assert get_scope_risk("https://www.googleapis.com/auth/drive") == "high"
+    assert get_scope_risk("https://www.googleapis.com/auth/calendar") == "medium"
+    assert get_scope_risk("https://www.googleapis.com/auth/admin.directory.user") == "high"
+
+
+def test_scope_mapping_default_for_unknown():
+    assert get_scope_risk("https://www.googleapis.com/auth/unknown") == DEFAULT_SCOPE_RISK
+
+
+def test_evaluate_scope_risk_orders_by_highest_scope():
+    scopes = [
+        "https://www.googleapis.com/auth/userinfo.email",
+        "https://www.googleapis.com/auth/drive.file",
+        "https://www.googleapis.com/auth/drive",
+    ]
+
+    risk, scope_risks = evaluate_scope_risk(scopes)
+
+    assert risk == "high"
+    assert "https://www.googleapis.com/auth/drive|high" in scope_risks
+
+
+def test_evaluate_scope_risk_handles_empty_scopes():
+    risk, scope_risks = evaluate_scope_risk([])
+
+    assert risk == DEFAULT_SCOPE_RISK
+    assert scope_risks == []
+
+
+def test_mapping_data_is_non_empty():
+    assert CLOUDLOCK_SCOPE_RISK


### PR DESCRIPTION
## Summary
- add a Cloudlock-derived Google OAuth scope risk mapping helper for reuse
- annotate Google Workspace OAuth authorizations with aggregated and per-scope risk details and persist them on relationships
- add unit coverage for risk mappings and transformation edge cases

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6941e9d723248323a4488821ac10f8de)