### PR TITLE
fix: add OpenAI module to rules

### DIFF
--- a/cartography/rules/spec/model.py
+++ b/cartography/rules/spec/model.py
@@ -138,6 +138,7 @@ MODULE_TO_CARTOGRAPHY_INTEL = {
     Module.LASTPASS: "lastpass",
     Module.OCI: "oci",
     Module.OKTA: "okta",
+    Module.OPENAI: "openai",
     Module.PAGERDUTY: "pagerduty",
     Module.SCALEWAY: "scaleway",
     Module.SEMGREP: "semgrep",


### PR DESCRIPTION
Only fix a missing value in Module enum in rules.