### PR TITLE
[Feature]Ingest Okta Devices from Management API

### DIFF
--- a/cartography/data/jobs/cleanup/okta_import_cleanup.json
+++ b/cartography/data/jobs/cleanup/okta_import_cleanup.json
@@ -55,6 +55,18 @@
       "__comment__": "Delete stale OktaAdministrationRole relationships"
     },
     {
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaDevice)<-[r:OWNS]-(:OktaUser) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "iterative": true,
+      "iterationsize": 100,
+      "__comment__": "Delete stale OktaUser to OktaDevice OWNS relationship"
+    },
+    {
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(n:OktaDevice) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100,
+      "__comment__": "Delete stale OktaDevice"
+    },
+    {
       "query": "MATCH (n:OktaOrganization{id: $OKTA_ORG_ID}) WHERE n.lastupdated <> $UPDATE_TAG DELETE (n)",
       "iterative": false,
       "__comment__": "Delete stale OktaOrganization"

--- a/cartography/intel/okta/__init__.py
+++ b/cartography/intel/okta/__init__.py
@@ -7,6 +7,7 @@ from okta.framework.OktaError import OktaError
 from cartography.config import Config
 from cartography.intel.okta import applications
 from cartography.intel.okta import awssaml
+from cartography.intel.okta import devices
 from cartography.intel.okta import factors
 from cartography.intel.okta import groups
 from cartography.intel.okta import organization
@@ -105,6 +106,13 @@ def start_okta_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
         config.okta_org_id,
         config.update_tag,
         config.okta_api_key,
+    )
+    devices.sync_okta_devices(
+        neo4j_session,
+        config.okta_org_id,
+        config.update_tag,
+        config.okta_api_key,
+        state,
     )
     awssaml.sync_okta_aws_saml(
         neo4j_session,

--- a/cartography/intel/okta/devices.py
+++ b/cartography/intel/okta/devices.py
@@ -1,0 +1,207 @@
+# Okta intel module - Devices
+import json
+import logging
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+import neo4j
+from okta.framework.ApiClient import ApiClient
+from okta.framework.OktaError import OktaError
+
+from cartography.client.core.tx import run_write_query
+from cartography.intel.okta.sync_state import OktaSyncState
+from cartography.intel.okta.utils import check_rate_limit
+from cartography.intel.okta.utils import create_api_client
+from cartography.intel.okta.utils import is_last_page
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def _get_okta_devices(api_client: ApiClient) -> List[Dict[str, Any]]:
+    """
+    Get devices from Okta server
+    :param api_client: Okta api client
+    :return: Array of device information
+    """
+    device_list: List[Dict[str, Any]] = []
+    next_url: Optional[str] = None
+
+    while True:
+        # https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Device/#tag/Device/operation/listDevices
+        try:
+            if next_url:
+                paged_response = api_client.get(next_url)
+            else:
+                params = {
+                    "limit": 200,  # Okta API max limit for devices
+                    "expand": "user",  # Ensures user data is embedded in response
+                }
+                paged_response = api_client.get_path("/", params)
+
+            # Parse JSON response
+            response_data = json.loads(paged_response.text)
+            device_list.extend(response_data)
+
+            check_rate_limit(paged_response)
+
+            if not is_last_page(paged_response):
+                next_url = paged_response.links.get("next").get("url")
+            else:
+                break
+        except OktaError as okta_error:
+            logger.error(f"OktaError while listing devices: {okta_error}")
+            raise
+
+    return device_list
+
+
+@timeit
+def transform_okta_device_list(okta_device_list: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Transform okta device list to consumable format for graph
+    :param okta_device_list: List of device dictionaries from API
+    :return: List of transformed device dictionaries
+    """
+    devices: List[Dict[str, Any]] = []
+
+    for device in okta_device_list:
+        devices.append(transform_okta_device(device))
+
+    return devices
+
+
+def transform_okta_device(okta_device: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Transform okta device data
+    :param okta_device: okta device dictionary from API
+    :return: Dictionary containing device properties for ingestion
+    """
+    device_props: Dict[str, Any] = {}
+    
+    # Required fields
+    device_props["id"] = okta_device["id"]
+    
+    # Status and basic info
+    device_props["status"] = okta_device.get("status")
+    device_props["created"] = okta_device.get("created")
+    device_props["last_updated"] = okta_device.get("lastUpdated")
+    
+    # Profile information
+    profile = okta_device.get("profile", {})
+    device_props["display_name"] = profile.get("displayName")
+    device_props["platform"] = profile.get("platform")
+    device_props["manufacturer"] = profile.get("manufacturer")
+    device_props["model"] = profile.get("model")
+    device_props["serial_number"] = profile.get("serialNumber")
+    device_props["os_version"] = profile.get("osVersion")
+    device_props["user_agent"] = profile.get("userAgent")
+    device_props["device_id"] = profile.get("deviceId")
+    
+    # User association - extract from _embedded or links
+    # The device API may return user info in _embedded or we need to extract from relationships
+    embedded = okta_device.get("_embedded", {})
+    user_info = embedded.get("user", {})
+    if user_info:
+        user_id = user_info.get("id")
+        device_props["user_id"] = user_id if user_id else None
+    else:
+        # Try to extract from _links if available
+        links = okta_device.get("_links", {})
+        user_link = links.get("user", {})
+        if user_link:
+            # Extract user ID from href if available
+            href = user_link.get("href", "")
+            # Parse user ID from href like /api/v1/users/00u1abc2def3ghi4jkl5
+            if "/users/" in href:
+                device_props["user_id"] = href.split("/users/")[-1].split("?")[0]
+            else:
+                device_props["user_id"] = None
+        else:
+            device_props["user_id"] = None
+
+    return device_props
+
+
+@timeit
+def _load_okta_devices(
+    neo4j_session: neo4j.Session,
+    okta_org_id: str,
+    device_list: List[Dict[str, Any]],
+    okta_update_tag: int,
+) -> None:
+    """
+    Load Okta device information into the graph
+    :param neo4j_session: session with neo4j server
+    :param okta_org_id: okta organization id
+    :param device_list: list of devices
+    :param okta_update_tag: The timestamp value to set our new Neo4j resources with
+    :return: Nothing
+    """
+    ingest_statement = """
+    MATCH (org:OktaOrganization{id: $ORG_ID})
+    WITH org
+    UNWIND $DEVICE_LIST as device_data
+    MERGE (new_device:OktaDevice{id: device_data.id})
+    ON CREATE SET new_device.firstseen = timestamp()
+    SET new_device.status = device_data.status,
+    new_device.created = device_data.created,
+    new_device.last_updated = device_data.last_updated,
+    new_device.display_name = device_data.display_name,
+    new_device.platform = device_data.platform,
+    new_device.manufacturer = device_data.manufacturer,
+    new_device.model = device_data.model,
+    new_device.serial_number = device_data.serial_number,
+    new_device.os_version = device_data.os_version,
+    new_device.user_agent = device_data.user_agent,
+    new_device.device_id = device_data.device_id,
+    new_device.lastupdated = $okta_update_tag
+    WITH new_device, org, device_data
+    MERGE (org)-[org_r:RESOURCE]->(new_device)
+    ON CREATE SET org_r.firstseen = timestamp()
+    SET org_r.lastupdated = $okta_update_tag
+    WITH new_device, device_data
+    WHERE device_data.user_id IS NOT NULL
+    MATCH (user:OktaUser{id: device_data.user_id})
+    MERGE (user)-[owns_r:OWNS]->(new_device)
+    ON CREATE SET owns_r.firstseen = timestamp()
+    SET owns_r.lastupdated = $okta_update_tag
+    """
+
+    run_write_query(
+        neo4j_session,
+        ingest_statement,
+        ORG_ID=okta_org_id,
+        DEVICE_LIST=device_list,
+        okta_update_tag=okta_update_tag,
+    )
+
+
+@timeit
+def sync_okta_devices(
+    neo4j_session: neo4j.Session,
+    okta_org_id: str,
+    okta_update_tag: int,
+    okta_api_key: str,
+    sync_state: OktaSyncState,
+) -> None:
+    """
+    Sync okta devices
+    :param neo4j_session: Session with Neo4j server
+    :param okta_org_id: Okta organization id to sync
+    :param okta_update_tag: The timestamp value to set our new Neo4j resources with
+    :param okta_api_key: Okta API key
+    :param sync_state: Okta sync state
+    :return: Nothing
+    """
+    logger.info("Syncing Okta devices")
+    
+    api_client = create_api_client(okta_org_id, "/api/v1/devices", okta_api_key)
+    
+    okta_device_data = _get_okta_devices(api_client)
+    device_list = transform_okta_device_list(okta_device_data)
+    
+    _load_okta_devices(neo4j_session, okta_org_id, device_list, okta_update_tag)

--- a/docs/root/modules/okta/schema.md
+++ b/docs/root/modules/okta/schema.md
@@ -40,6 +40,11 @@ Representation of an [Okta Organization](https://developer.okta.com/docs/concept
     ```
     (OktaOrganization)-[RESOURCE]->(OktaAdministrationRole)
     ```
+- An OktaOrganization contains OktaDevices
+
+    ```
+    (OktaOrganization)-[RESOURCE]->(OktaDevice)
+    ```
 
 ### OktaUser :: UserAccount
 
@@ -91,6 +96,10 @@ Representation of an [Okta User](https://developer.okta.com/docs/reference/api/u
  - OktaUsers can have authentication factors
     ```
     (:OktaUser)-[:FACTOR]->(:OktaUserFactor)
+    ```
+ - OktaUsers can own OktaDevices
+    ```
+    (:OktaUser)-[:OWNS]->(:OktaDevice)
     ```
  - OktaUsers can assume AWS SSO users via SAML federation
     ```
@@ -201,6 +210,42 @@ Representation of Okta User authentication [Factors](https://developer.okta.com/
  - OktaUsers can have authentication Factors
      ```
     (OktaUser)-[FACTOR]->(OktaUserFactor)
+    ```
+ - OktaUsers can own OktaDevices
+     ```
+    (OktaUser)-[OWNS]->(OktaDevice)
+    ```
+
+### OktaDevice
+
+Representation of an [Okta Device](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Device/) enrolled, managed, or registered in Okta.
+
+| Field | Description |
+|-------|-------------|
+| id | device id |
+| status | device status (e.g., ACTIVE, INACTIVE) |
+| created | device creation date and time |
+| last_updated | date and time of last device property changes |
+| display_name | device display name |
+| platform | device platform (e.g., IOS, ANDROID, WINDOWS, MACOS) |
+| manufacturer | device manufacturer |
+| model | device model |
+| serial_number | device serial number |
+| os_version | operating system version |
+| user_agent | user agent string |
+| device_id | device identifier |
+| firstseen| Timestamp of when a sync job first discovered this node  |
+| lastupdated |  Timestamp of the last time the node was updated |
+
+#### Relationships
+
+ - An OktaOrganization contains OktaDevices
+     ```
+    (OktaOrganization)-[RESOURCE]->(OktaDevice)
+    ```
+ - OktaUsers can own OktaDevices
+     ```
+    (OktaUser)-[OWNS]->(OktaDevice)
     ```
 
 ### OktaTrustedOrigin

--- a/docs/root/modules/okta/schema.md
+++ b/docs/root/modules/okta/schema.md
@@ -211,10 +211,6 @@ Representation of Okta User authentication [Factors](https://developer.okta.com/
      ```
     (OktaUser)-[FACTOR]->(OktaUserFactor)
     ```
- - OktaUsers can own OktaDevices
-     ```
-    (OktaUser)-[OWNS]->(OktaDevice)
-    ```
 
 ### OktaDevice
 

--- a/tests/data/okta/devices.py
+++ b/tests/data/okta/devices.py
@@ -1,0 +1,41 @@
+def create_test_device():
+    return {
+        "id": "device-001",
+        "status": "ACTIVE",
+        "created": "2023-01-15T10:30:00.000Z",
+        "lastUpdated": "2023-12-01T14:22:00.000Z",
+        "profile": {
+            "displayName": "iPhone 14 Pro",
+            "platform": "IOS",
+            "manufacturer": "Apple",
+            "model": "iPhone",
+            "serialNumber": "ABC123XYZ",
+            "osVersion": "17.1.0",
+            "userAgent": "Mozilla/5.0...",
+            "deviceId": "device-id-123",
+        },
+        "_embedded": {
+            "user": {
+                "id": "user-001",
+            },
+        },
+        "_links": {
+            "self": {
+                "href": "https://test.okta.com/api/v1/devices/device-001",
+            },
+            "user": {
+                "href": "https://test.okta.com/api/v1/users/user-001",
+            },
+        },
+    }
+
+
+def create_test_device_no_user():
+    """
+    test device without user association
+    """
+    device = create_test_device()
+    device["id"] = "device-no-user"
+    device["_embedded"] = {}
+    device["_links"].pop("user", None)
+    return device

--- a/tests/integration/cartography/intel/okta/test_devices.py
+++ b/tests/integration/cartography/intel/okta/test_devices.py
@@ -1,0 +1,162 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.okta.devices
+from cartography.intel.okta.sync_state import OktaSyncState
+from tests.data.okta.devices import create_test_device
+from tests.data.okta.devices import create_test_device_no_user
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_ORG_ID = "test-okta-org-id"
+TEST_UPDATE_TAG = 123456789
+TEST_API_KEY = "test-api-key"
+
+
+@patch.object(cartography.intel.okta.devices, "create_api_client")
+@patch.object(cartography.intel.okta.devices, "_get_okta_devices")
+def test_sync_okta_devices(mock_get_devices, mock_api_client, neo4j_session):
+    """
+    Test that Okta devices are synced correctly to the graph.
+    """
+    # Arrange - Create test devices
+    test_device_1 = create_test_device()
+    test_device_2 = create_test_device()
+    test_device_2["id"] = "device-002"
+    test_device_2["profile"]["displayName"] = "MacBook Pro"
+    test_device_2["_embedded"]["user"]["id"] = "user-002"
+
+    # Mock the API calls
+    mock_get_devices.return_value = [test_device_1, test_device_2]
+    mock_api_client.return_value = MagicMock()
+
+    # Create the OktaOrganization node first
+    neo4j_session.run(
+        """
+        MERGE (o:OktaOrganization{id: $ORG_ID})
+        ON CREATE SET o.firstseen = timestamp()
+        SET o.lastupdated = $UPDATE_TAG
+        """,
+        ORG_ID=TEST_ORG_ID,
+        UPDATE_TAG=TEST_UPDATE_TAG,
+    )
+
+    # Create test users that devices will link to
+    neo4j_session.run(
+        """
+        MERGE (u1:OktaUser{id: 'user-001'})
+        SET u1.lastupdated = $UPDATE_TAG
+        MERGE (u2:OktaUser{id: 'user-002'})
+        SET u2.lastupdated = $UPDATE_TAG
+        """,
+        UPDATE_TAG=TEST_UPDATE_TAG,
+    )
+
+    sync_state = OktaSyncState()
+
+    # Act - Call the main sync function
+    cartography.intel.okta.devices.sync_okta_devices(
+        neo4j_session,
+        TEST_ORG_ID,
+        TEST_UPDATE_TAG,
+        TEST_API_KEY,
+        sync_state,
+    )
+
+    # Assert - Verify devices were created with correct properties
+    expected_devices = {
+        ("device-001", "ACTIVE", "iPhone 14 Pro"),
+        ("device-002", "ACTIVE", "MacBook Pro"),
+    }
+    actual_devices = check_nodes(
+        neo4j_session, "OktaDevice", ["id", "status", "display_name"]
+    )
+    assert actual_devices == expected_devices
+
+    # Assert - Verify devices are connected to organization
+    expected_org_rels = {
+        (TEST_ORG_ID, "device-001"),
+        (TEST_ORG_ID, "device-002"),
+    }
+    actual_org_rels = check_rels(
+        neo4j_session,
+        "OktaOrganization",
+        "id",
+        "OktaDevice",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    )
+    assert actual_org_rels == expected_org_rels
+
+    # Assert - Verify devices are connected to users via OWNS relationship
+    expected_owns_rels = {
+        ("user-001", "device-001"),
+        ("user-002", "device-002"),
+    }
+    actual_owns_rels = check_rels(
+        neo4j_session,
+        "OktaUser",
+        "id",
+        "OktaDevice",
+        "id",
+        "OWNS",
+        rel_direction_right=True,
+    )
+    assert actual_owns_rels == expected_owns_rels
+
+
+@patch.object(cartography.intel.okta.devices, "create_api_client")
+@patch.object(cartography.intel.okta.devices, "_get_okta_devices")
+def test_sync_okta_devices_no_user(
+    mock_get_devices, mock_api_client, neo4j_session
+):
+    """
+    Test that devices without user associations are handled correctly.
+    """
+    # Arrange
+    test_device = create_test_device_no_user()
+
+    mock_get_devices.return_value = [test_device]
+    mock_api_client.return_value = MagicMock()
+
+    neo4j_session.run(
+        """
+        MERGE (o:OktaOrganization{id: $ORG_ID})
+        SET o.lastupdated = $UPDATE_TAG
+        """,
+        ORG_ID=TEST_ORG_ID,
+        UPDATE_TAG=TEST_UPDATE_TAG,
+    )
+
+    sync_state = OktaSyncState()
+
+    # Act
+    cartography.intel.okta.devices.sync_okta_devices(
+        neo4j_session,
+        TEST_ORG_ID,
+        TEST_UPDATE_TAG,
+        TEST_API_KEY,
+        sync_state,
+    )
+
+    # Assert - Device should be created but no OWNS relationship
+    result = neo4j_session.run(
+        """
+        MATCH (d:OktaDevice{id: 'device-no-user'})
+        RETURN d.id as id, d.user_id as user_id
+        """,
+    )
+    devices = [dict(r) for r in result]
+    assert len(devices) == 1
+    assert devices[0]["id"] == "device-no-user"
+
+    # Assert - No OWNS relationship should exist for device-no-user
+    result = neo4j_session.run(
+        """
+        MATCH (u:OktaUser)-[r:OWNS]->(d:OktaDevice{id: 'device-no-user'})
+        RETURN u.id as user_id, d.id as device_id
+        """,
+    )
+    relationships = [dict(r) for r in result]
+    assert len(relationships) == 0, f"Found unexpected relationships: {relationships}"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,9 @@ logging.getLogger("neo4j").setLevel(logging.WARNING)
 @pytest.fixture(scope="module")
 def neo4j_session():
     driver = neo4j.GraphDatabase.driver(settings.get("NEO4J_URL"))
-    with driver.session() as session:
-        yield session
-        session.run("MATCH (n) DETACH DELETE n;")
+    try:
+        with driver.session() as session:
+            yield session
+            session.run("MATCH (n) DETACH DELETE n;")
+    finally:
+        driver.close()

--- a/uv.lock
+++ b/uv.lock
@@ -1377,7 +1377,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -1377,7 +1377,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
### Summary
> This PR implements support for ingesting Okta Devices from the Okta Management API, addressing issue #2086. The implementation adds a new `OktaDevice` node type to the graph, enabling tracking of enrolled, managed, and registered devices associated with Okta users and organizations.


### Related issues or links
- https://github.com/cartography-cncf/cartography/issues/2086


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [X] Update/add unit or integration tests.
        Added comprehensive integration tests in `tests/integration/cartography/intel/okta/test_devices.py`:
        - `test_sync_okta_devices`: Tests successful device sync with user associations
        - `test_sync_okta_devices_no_user`: Tests handling of devices without user associations
  - Tests verify:
        - Device nodes are created with correct properties
        - Devices are connected to OktaOrganization via RESOURCE relationship
        - Devices are connected to OktaUser via OWNS relationship (when user exists)
        - Devices without user associations are handled gracefully
- [X] Include a screenshot showing what the graph looked like before and after your changes.

<img width="1017" height="626" alt="Screenshot 2025-12-19 at 3 31 10 PM" src="https://github.com/user-attachments/assets/21beb266-74de-4f06-8363-1468acd761ef" />

<img width="1273" height="348" alt="Screenshot 2025-12-19 at 3 31 55 PM" src="https://github.com/user-attachments/assets/6d0b106c-9131-4774-9f44-ec17fed0f13c" />

<img width="1262" height="350" alt="Screenshot 2025-12-19 at 3 32 23 PM" src="https://github.com/user-attachments/assets/e59067b4-60e9-4171-9a20-219e72252ebd" />

- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [X] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
- [X] Confirm that the linter actually passes (submitting a PR where the linter fails shows reviewers that you did not test your code and will delay your review).
