### PR TITLE
feat: Add support for Okta device ingestion

### DIFF
--- a/cartography/data/indexes.cypher
+++ b/cartography/data/indexes.cypher
@@ -130,6 +130,8 @@ CREATE INDEX IF NOT EXISTS FOR (n:OktaTrustedOrigin) ON (n.id);
 CREATE INDEX IF NOT EXISTS FOR (n:OktaTrustedOrigin) ON (n.lastupdated);
 CREATE INDEX IF NOT EXISTS FOR (n:OktaAdministrationRole) ON (n.id);
 CREATE INDEX IF NOT EXISTS FOR (n:OktaAdministrationRole) ON (n.lastupdated);
+CREATE INDEX IF NOT EXISTS FOR (n:OktaDevice) ON (n.id);
+CREATE INDEX IF NOT EXISTS FOR (n:OktaDevice) ON (n.lastupdated);
 CREATE INDEX IF NOT EXISTS FOR (n:OCICompartment) ON (n.ocid);
 CREATE INDEX IF NOT EXISTS FOR (n:OCICompartment) ON (n.name);
 CREATE INDEX IF NOT EXISTS FOR (n:OCICompartment) ON (n.lastupdated);

--- a/cartography/data/jobs/cleanup/okta_import_cleanup.json
+++ b/cartography/data/jobs/cleanup/okta_import_cleanup.json
@@ -55,6 +55,18 @@
       "__comment__": "Delete stale OktaAdministrationRole relationships"
     },
     {
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaUser)-[r:HAS_DEVICE]->(:OktaDevice) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "iterative": true,
+      "iterationsize": 100,
+      "__comment__": "Delete stale OktaUser to OktaDevice HAS_DEVICE relationships"
+    },
+    {
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(n:OktaDevice) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "iterative": true,
+      "iterationsize": 100,
+      "__comment__": "Delete stale OktaDevice"
+    },
+    {
       "query": "MATCH (n:OktaOrganization{id: $OKTA_ORG_ID}) WHERE n.lastupdated <> $UPDATE_TAG DELETE (n)",
       "iterative": false,
       "__comment__": "Delete stale OktaOrganization"

--- a/cartography/intel/okta/__init__.py
+++ b/cartography/intel/okta/__init__.py
@@ -7,6 +7,7 @@ from okta.framework.OktaError import OktaError
 from cartography.config import Config
 from cartography.intel.okta import applications
 from cartography.intel.okta import awssaml
+from cartography.intel.okta import devices
 from cartography.intel.okta import factors
 from cartography.intel.okta import groups
 from cartography.intel.okta import organization
@@ -101,6 +102,12 @@ def start_okta_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
         state,
     )
     origins.sync_trusted_origins(
+        neo4j_session,
+        config.okta_org_id,
+        config.update_tag,
+        config.okta_api_key,
+    )
+    devices.sync_okta_devices(
         neo4j_session,
         config.okta_org_id,
         config.update_tag,

--- a/cartography/intel/okta/devices.py
+++ b/cartography/intel/okta/devices.py
@@ -1,0 +1,271 @@
+import json
+import logging
+from typing import Dict
+from typing import List
+
+import neo4j
+from okta.framework.ApiClient import ApiClient
+from okta.framework.OktaError import OktaError
+
+from cartography.client.core.tx import run_write_query
+from cartography.intel.okta.utils import check_rate_limit
+from cartography.intel.okta.utils import create_api_client
+from cartography.intel.okta.utils import is_last_page
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+def _create_device_client(okta_org: str, okta_api_key: str) -> ApiClient:
+    """
+    Create Okta Device API client
+    :param okta_org: Okta organization name
+    :param okta_api_key: Okta API key
+    :return: Instance of ApiClient for /api/v1/devices endpoint
+    """
+    return create_api_client(
+        okta_org,
+        "/api/v1/devices",
+        okta_api_key,
+    )
+
+
+@timeit
+def _get_okta_devices(api_client: ApiClient) -> List[Dict]:
+    """
+    Get Okta devices from Okta server with pagination
+    Uses expand=userSummary to get device-user associations in a single call
+    :param api_client: Okta API client
+    :return: Array of device data
+    """
+    device_list: List[Dict] = []
+    next_url = None
+
+    while True:
+        try:
+            if next_url:
+                response = api_client.get(next_url)
+            else:
+                # Use expand=userSummary to get user associations
+                params = {"limit": 200, "expand": "userSummary"}
+                response = api_client.get_path("/", params)
+        except OktaError:
+            logger.error("OktaError while listing devices")
+            raise
+
+        device_list.extend(json.loads(response.text))
+
+        check_rate_limit(response)
+
+        if not is_last_page(response):
+            next_url = response.links.get("next").get("url")
+        else:
+            break
+
+    return device_list
+
+
+@timeit
+def transform_okta_device(device_data: Dict) -> Dict:
+    """
+    Transform okta device data
+    :param device_data: raw device data from Okta API
+    :return: Dictionary containing device properties for ingestion
+    """
+    device_props = {}
+
+    # Required fields
+    device_props["id"] = device_data["id"]
+    device_props["status"] = device_data.get("status")
+    device_props["created"] = device_data.get("created")
+    device_props["last_updated"] = device_data.get("lastUpdated")
+
+    # Profile fields (all optional depending on platform)
+    profile = device_data.get("profile", {})
+    device_props["display_name"] = profile.get("displayName")
+    device_props["platform"] = profile.get("platform")
+    device_props["serial_number"] = profile.get("serialNumber")
+    device_props["sid"] = profile.get("sid")
+    device_props["manufacturer"] = profile.get("manufacturer")
+    device_props["model"] = profile.get("model")
+    device_props["os_version"] = profile.get("osVersion")
+    device_props["registered"] = profile.get("registered")
+    device_props["secure_hardware_present"] = profile.get("secureHardwarePresent")
+    device_props["disk_encryption_type"] = profile.get("diskEncryptionType")
+    device_props["imei"] = profile.get("imei")
+    device_props["meid"] = profile.get("meid")
+    device_props["udid"] = profile.get("udid")
+
+    # Resource metadata
+    device_props["resource_type"] = device_data.get("resourceType")
+    resource_display_name = device_data.get("resourceDisplayName", {})
+    if resource_display_name:
+        device_props["resource_display_name"] = resource_display_name.get("value")
+        device_props["resource_display_name_sensitive"] = resource_display_name.get(
+            "sensitive"
+        )
+    else:
+        device_props["resource_display_name"] = None
+        device_props["resource_display_name_sensitive"] = None
+
+    device_props["resource_alternate_id"] = device_data.get("resourceAlternateId")
+
+    return device_props
+
+
+@timeit
+def transform_okta_device_users(device_data: Dict) -> List[Dict]:
+    """
+    Extract user-device relationships from device data
+    :param device_data: raw device data from Okta API (with expand=userSummary)
+    :return: List of user-device relationship data
+    """
+    relationships = []
+    device_id = device_data["id"]
+    embedded_users = device_data.get("_embedded", {}).get("users", [])
+
+    for user_data in embedded_users:
+        user_info = user_data.get("user", {})
+        user_id = user_info.get("id")
+
+        if user_id:
+            relationships.append(
+                {
+                    "device_id": device_id,
+                    "user_id": user_id,
+                    "management_status": user_data.get("managementStatus"),
+                    "screen_lock_type": user_data.get("screenLockType"),
+                    "enrolled_at": user_data.get("created"),
+                }
+            )
+
+    return relationships
+
+
+@timeit
+def _load_okta_devices(
+    neo4j_session: neo4j.Session,
+    okta_org_id: str,
+    device_list: List[Dict],
+    okta_update_tag: int,
+) -> None:
+    """
+    Load Okta device information into the graph
+    :param neo4j_session: session with neo4j server
+    :param okta_org_id: okta organization id
+    :param device_list: list of devices
+    :param okta_update_tag: The timestamp value to set our new Neo4j resources with
+    :return: Nothing
+    """
+    ingest_statement = """
+    MATCH (org:OktaOrganization{id: $ORG_ID})
+    WITH org
+    UNWIND $DEVICE_LIST as device_data
+    MERGE (device:OktaDevice{id: device_data.id})
+    ON CREATE SET device.firstseen = timestamp()
+    SET device.status = device_data.status,
+    device.created = device_data.created,
+    device.last_updated = device_data.last_updated,
+    device.display_name = device_data.display_name,
+    device.platform = device_data.platform,
+    device.serial_number = device_data.serial_number,
+    device.sid = device_data.sid,
+    device.manufacturer = device_data.manufacturer,
+    device.model = device_data.model,
+    device.os_version = device_data.os_version,
+    device.registered = device_data.registered,
+    device.secure_hardware_present = device_data.secure_hardware_present,
+    device.disk_encryption_type = device_data.disk_encryption_type,
+    device.imei = device_data.imei,
+    device.meid = device_data.meid,
+    device.udid = device_data.udid,
+    device.resource_type = device_data.resource_type,
+    device.resource_display_name = device_data.resource_display_name,
+    device.resource_display_name_sensitive = device_data.resource_display_name_sensitive,
+    device.resource_alternate_id = device_data.resource_alternate_id,
+    device.lastupdated = $okta_update_tag
+    WITH device, org
+    MERGE (org)-[r:RESOURCE]->(device)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.lastupdated = $okta_update_tag
+    """
+
+    run_write_query(
+        neo4j_session,
+        ingest_statement,
+        ORG_ID=okta_org_id,
+        DEVICE_LIST=device_list,
+        okta_update_tag=okta_update_tag,
+    )
+
+
+@timeit
+def _load_okta_device_users(
+    neo4j_session: neo4j.Session,
+    device_user_relationships: List[Dict],
+    okta_update_tag: int,
+) -> None:
+    """
+    Load user-device relationships into the graph
+    :param neo4j_session: session with neo4j server
+    :param device_user_relationships: list of user-device relationship data
+    :param okta_update_tag: The timestamp value to set our new Neo4j resources with
+    :return: Nothing
+    """
+    ingest_statement = """
+    UNWIND $RELATIONSHIPS as rel_data
+    MATCH (user:OktaUser{id: rel_data.user_id})
+    MATCH (device:OktaDevice{id: rel_data.device_id})
+    MERGE (user)-[r:HAS_DEVICE]->(device)
+    ON CREATE SET r.firstseen = timestamp()
+    SET r.management_status = rel_data.management_status,
+    r.screen_lock_type = rel_data.screen_lock_type,
+    r.enrolled_at = rel_data.enrolled_at,
+    r.lastupdated = $okta_update_tag
+    """
+
+    run_write_query(
+        neo4j_session,
+        ingest_statement,
+        RELATIONSHIPS=device_user_relationships,
+        okta_update_tag=okta_update_tag,
+    )
+
+
+@timeit
+def sync_okta_devices(
+    neo4j_session: neo4j.Session,
+    okta_org_id: str,
+    okta_update_tag: int,
+    okta_api_key: str,
+) -> None:
+    """
+    Sync Okta devices and device-user relationships
+    Requires okta.devices.read scope
+    :param neo4j_session: Session with Neo4j server
+    :param okta_org_id: Okta organization id to sync
+    :param okta_update_tag: The timestamp value to set our new Neo4j resources with
+    :param okta_api_key: Okta API key
+    :return: Nothing
+    """
+    logger.info("Syncing Okta Devices")
+
+    # Fetch devices with user associations (expand=userSummary)
+    device_client = _create_device_client(okta_org_id, okta_api_key)
+    raw_devices = _get_okta_devices(device_client)
+
+    # Transform and load devices
+    device_list = [transform_okta_device(d) for d in raw_devices]
+    _load_okta_devices(neo4j_session, okta_org_id, device_list, okta_update_tag)
+
+    # Extract and load user-device relationships
+    all_relationships = []
+    for device_data in raw_devices:
+        relationships = transform_okta_device_users(device_data)
+        all_relationships.extend(relationships)
+
+    if all_relationships:
+        _load_okta_device_users(neo4j_session, all_relationships, okta_update_tag)
+        logger.info(f"Synced {len(all_relationships)} device-user relationships")
+
+    logger.info(f"Synced {len(device_list)} Okta devices")

--- a/docs/root/modules/okta/schema.md
+++ b/docs/root/modules/okta/schema.md
@@ -40,6 +40,11 @@ Representation of an [Okta Organization](https://developer.okta.com/docs/concept
     ```
     (OktaOrganization)-[RESOURCE]->(OktaAdministrationRole)
     ```
+- An OktaOrganization contains OktaDevices
+
+    ```
+    (OktaOrganization)-[RESOURCE]->(OktaDevice)
+    ```
 
 ### OktaUser :: UserAccount
 
@@ -89,6 +94,10 @@ Representation of an [Okta User](https://developer.okta.com/docs/reference/api/u
     (:OktaUser)-[:MEMBER_OF_OKTA_ROLE]->(:OktaAdministrationRole)
     ```
  - OktaUsers can have authentication factors
+ - OktaUsers can have enrolled devices
+    ```
+    (:OktaUser)-[:HAS_DEVICE]->(:OktaDevice)
+    ```
     ```
     (:OktaUser)-[:FACTOR]->(:OktaUserFactor)
     ```
@@ -275,3 +284,48 @@ Representation of [Okta Application ReplyUri](https://developer.okta.com/docs/re
     ```
     (ReplyUri)-[REPLYURI]->(OktaApplication)
     ```
+
+### OktaDevice
+
+Representation of an [Okta Device](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Device/#tag/Device/operation/listDevices) enrolled or managed by Okta.
+
+| Field | Description |
+|-------|--------------|
+| id | device id |
+| status | device status (CREATED, ACTIVE, DEACTIVATED, SUSPENDED) |
+| created | device creation date and time |
+| last_updated | date and time of last device property changes |
+| display_name | user-defined display name for the device |
+| platform | device platform (WINDOWS, MACOS, ANDROID, IOS, etc.) |
+| manufacturer | device manufacturer (e.g., "Apple", "Google") |
+| model | device model (e.g., "MacBook Pro", "Pixel 6") |
+| os_version | operating system version |
+| serial_number | hardware serial number |
+| sid | Windows Security Identifier (for Windows devices) |
+| imei | International Mobile Equipment Identity (for mobile devices) |
+| meid | Mobile Equipment Identifier (for mobile devices) |
+| udid | Unique Device Identifier (for iOS devices) |
+| registered | whether the device is registered |
+| secure_hardware_present | whether device has secure hardware (TPM, Secure Enclave) |
+| disk_encryption_type | type of disk encryption (ALL_INTERNAL_VOLUMES, USER, NONE) |
+| resource_type | Okta resource type (UDDevice) |
+| resource_display_name | resource display name |
+| resource_display_name_sensitive | whether display name is sensitive |
+| resource_alternate_id | alternate resource identifier |
+| firstseen| Timestamp of when a sync job first discovered this node |
+| lastupdated |  Timestamp of the last time the node was updated |
+
+#### Relationships
+
+ - OktaOrganizations contain OktaDevices
+    ```
+    (OktaOrganization)-[RESOURCE]->(OktaDevice)
+    ```
+ - OktaUsers can have enrolled devices
+    ```
+    (OktaUser)-[HAS_DEVICE]->(OktaDevice)
+    ```
+    The HAS_DEVICE relationship includes these properties:
+    - `management_status`: Device management status (MANAGED, NOT_MANAGED)
+    - `screen_lock_type`: Type of screen lock (BIOMETRIC, PASSCODE)
+    - `enrolled_at`: Date and time when user enrolled the device

--- a/tests/data/okta/devices.py
+++ b/tests/data/okta/devices.py
@@ -1,0 +1,134 @@
+# Test data for Okta Devices API
+# Based on: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Device/#tag/Device/operation/listDevices
+
+# Sample response from GET /api/v1/devices?expand=userSummary
+SAMPLE_DEVICES = [
+    {
+        "id": "guo4a5u7YAHhjXrMK0g4",
+        "status": "CREATED",
+        "created": "2019-10-02T18:03:07.000Z",
+        "lastUpdated": "2019-10-02T18:03:07.000Z",
+        "profile": {
+            "displayName": "Example device name 1",
+            "platform": "WINDOWS",
+            "serialNumber": "XXDDRFCFRGF3M8MD6D",
+            "sid": "S-1-11-111",
+            "registered": True,
+            "secureHardwarePresent": False,
+            "diskEncryptionType": "ALL_INTERNAL_VOLUMES",
+        },
+        "resourceType": "UDDevice",
+        "resourceDisplayName": {
+            "value": "Example device name 1",
+            "sensitive": False,
+        },
+        "resourceAlternateId": None,
+        "resourceId": "guo4a5u7YAHhjXrMK0g4",
+        "_links": {
+            "activate": {
+                "href": "https://test.okta.com/api/v1/devices/guo4a5u7YAHhjXrMK0g4/lifecycle/activate",
+                "hints": {
+                    "allow": [
+                        "POST",
+                    ],
+                },
+            },
+            "self": {
+                "href": "https://test.okta.com/api/v1/devices/guo4a5u7YAHhjXrMK0g4",
+                "hints": {
+                    "allow": [
+                        "GET",
+                        "PATCH",
+                        "PUT",
+                    ],
+                },
+            },
+            "users": {
+                "href": "https://test.okta.com/api/v1/devices/guo4a5u7YAHhjXrMK0g4/users",
+                "hints": {
+                    "allow": [
+                        "GET",
+                    ],
+                },
+            },
+        },
+        "_embedded": {
+            "users": [],
+        },
+    },
+    {
+        "id": "guo4a5u7YAHhjXrMK0g5",
+        "status": "ACTIVE",
+        "created": "2023-06-21T23:24:02.000Z",
+        "lastUpdated": "2023-06-21T23:24:02.000Z",
+        "profile": {
+            "displayName": "Example device name 2",
+            "platform": "ANDROID",
+            "manufacturer": "Google",
+            "model": "Pixel 6",
+            "osVersion": "13:2023-05-05",
+            "registered": True,
+            "secureHardwarePresent": True,
+            "diskEncryptionType": "USER",
+        },
+        "resourceType": "UDDevice",
+        "resourceDisplayName": {
+            "value": "Example device name 2",
+            "sensitive": False,
+        },
+        "resourceAlternateId": None,
+        "resourceId": "guo4a5u7YAHhjXrMK0g5",
+        "_links": {
+            "activate": {
+                "href": "https://test.okta.com/api/v1/devices/guo4a5u7YAHhjXrMK0g5/lifecycle/activate",
+                "hints": {
+                    "allow": [
+                        "POST",
+                    ],
+                },
+            },
+            "self": {
+                "href": "https://test.okta.com/api/v1/devices/guo4a5u7YAHhjXrMK0g5",
+                "hints": {
+                    "allow": [
+                        "GET",
+                        "PATCH",
+                        "PUT",
+                    ],
+                },
+            },
+            "users": {
+                "href": "https://test.okta.com/api/v1/devices/guo4a5u7YAHhjXrMK0g5/users",
+                "hints": {
+                    "allow": [
+                        "GET",
+                    ],
+                },
+            },
+        },
+        "_embedded": {
+            "users": [
+                {
+                    "managementStatus": "MANAGED",
+                    "created": "2021-10-01T16:52:41.000Z",
+                    "screenLockType": "BIOMETRIC",
+                    "user": {
+                        "id": "00u17vh0q8ov8IU881d7",
+                        "realmId": "00u17vh0q8ov8IU8T0g5",
+                        "profile": {
+                            "firstName": "fname",
+                            "lastName": "lname",
+                            "login": "email@email.com",
+                            "email": "email@email.com",
+                        },
+                        "_links": {
+                            "self": {
+                                "href": "https://test.okta.com/api/v1/users/00u17vh0q8ov8IU881d7",
+                            },
+                        },
+                    },
+                },
+            ],
+        },
+    },
+]

--- a/tests/integration/cartography/intel/okta/test_devices.py
+++ b/tests/integration/cartography/intel/okta/test_devices.py
@@ -1,0 +1,334 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.okta.devices
+from tests.data.okta.devices import SAMPLE_DEVICES
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_ORG_ID = "test-okta-org-id"
+TEST_UPDATE_TAG = 123456789
+TEST_API_KEY = "test-api-key"
+
+
+@patch.object(cartography.intel.okta.devices, "_create_device_client")
+@patch.object(cartography.intel.okta.devices, "_get_okta_devices")
+def test_sync_okta_devices(mock_get_devices, mock_device_client, neo4j_session):
+    """
+    Test that Okta devices are synced correctly to the graph.
+    This follows the recommended pattern: mock get() functions, call sync(), verify outcomes.
+    """
+    # Arrange - Use sample devices from test data
+    mock_get_devices.return_value = SAMPLE_DEVICES
+    mock_device_client.return_value = MagicMock()
+
+    # Create the OktaOrganization node first
+    neo4j_session.run(
+        """
+        MERGE (o:OktaOrganization{id: $ORG_ID})
+        ON CREATE SET o.firstseen = timestamp()
+        SET o.lastupdated = $UPDATE_TAG
+        """,
+        ORG_ID=TEST_ORG_ID,
+        UPDATE_TAG=TEST_UPDATE_TAG,
+    )
+
+    # Act - Call the main sync function
+    cartography.intel.okta.devices.sync_okta_devices(
+        neo4j_session,
+        TEST_ORG_ID,
+        TEST_UPDATE_TAG,
+        TEST_API_KEY,
+    )
+
+    # Assert - Verify devices were created with correct properties
+    expected_devices = {
+        ("guo4a5u7YAHhjXrMK0g4", "Example device name 1", "WINDOWS", "CREATED"),
+        ("guo4a5u7YAHhjXrMK0g5", "Example device name 2", "ANDROID", "ACTIVE"),
+    }
+    actual_devices = check_nodes(
+        neo4j_session, "OktaDevice", ["id", "display_name", "platform", "status"]
+    )
+    assert actual_devices == expected_devices
+
+    # Assert - Verify devices are connected to organization
+    expected_org_rels = {
+        (TEST_ORG_ID, "guo4a5u7YAHhjXrMK0g4"),
+        (TEST_ORG_ID, "guo4a5u7YAHhjXrMK0g5"),
+    }
+    actual_org_rels = check_rels(
+        neo4j_session,
+        "OktaOrganization",
+        "id",
+        "OktaDevice",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    )
+    assert actual_org_rels == expected_org_rels
+
+
+@patch.object(cartography.intel.okta.devices, "_create_device_client")
+@patch.object(cartography.intel.okta.devices, "_get_okta_devices")
+def test_sync_okta_devices_with_user_relationships(
+    mock_get_devices, mock_device_client, neo4j_session
+):
+    """
+    Test that user-device relationships are created correctly.
+    """
+    # Arrange
+    mock_get_devices.return_value = SAMPLE_DEVICES
+    mock_device_client.return_value = MagicMock()
+
+    # Create OktaOrganization
+    neo4j_session.run(
+        """
+        MERGE (o:OktaOrganization{id: $ORG_ID})
+        SET o.lastupdated = $UPDATE_TAG
+        """,
+        ORG_ID=TEST_ORG_ID,
+        UPDATE_TAG=TEST_UPDATE_TAG,
+    )
+
+    # Create OktaUser that exists in the _embedded.users data
+    neo4j_session.run(
+        """
+        MERGE (u:OktaUser{id: '00u17vh0q8ov8IU881d7'})
+        SET u.email = 'email@email.com',
+            u.lastupdated = $UPDATE_TAG
+        """,
+        UPDATE_TAG=TEST_UPDATE_TAG,
+    )
+
+    # Act
+    cartography.intel.okta.devices.sync_okta_devices(
+        neo4j_session,
+        TEST_ORG_ID,
+        TEST_UPDATE_TAG,
+        TEST_API_KEY,
+    )
+
+    # Assert - Verify user-device relationship exists
+    expected_user_device_rels = {
+        ("00u17vh0q8ov8IU881d7", "guo4a5u7YAHhjXrMK0g5"),
+    }
+    actual_user_device_rels = check_rels(
+        neo4j_session,
+        "OktaUser",
+        "id",
+        "OktaDevice",
+        "id",
+        "HAS_DEVICE",
+        rel_direction_right=True,
+    )
+    assert actual_user_device_rels == expected_user_device_rels
+
+    # Assert - Verify relationship properties are stored
+    result = neo4j_session.run(
+        """
+        MATCH (:OktaUser{id: '00u17vh0q8ov8IU881d7'})-[r:HAS_DEVICE]->(:OktaDevice{id: 'guo4a5u7YAHhjXrMK0g5'})
+        RETURN r.management_status as mgmt_status, r.screen_lock_type as lock_type
+        """,
+    )
+    rel_data = [dict(r) for r in result][0]
+    assert rel_data["mgmt_status"] == "MANAGED"
+    assert rel_data["lock_type"] == "BIOMETRIC"
+
+
+@patch.object(cartography.intel.okta.devices, "_create_device_client")
+@patch.object(cartography.intel.okta.devices, "_get_okta_devices")
+def test_sync_okta_devices_device_properties(
+    mock_get_devices, mock_device_client, neo4j_session
+):
+    """
+    Test that device properties are stored correctly.
+    """
+    # Arrange
+    mock_get_devices.return_value = SAMPLE_DEVICES
+    mock_device_client.return_value = MagicMock()
+
+    neo4j_session.run(
+        """
+        MERGE (o:OktaOrganization{id: $ORG_ID})
+        SET o.lastupdated = $UPDATE_TAG
+        """,
+        ORG_ID=TEST_ORG_ID,
+        UPDATE_TAG=TEST_UPDATE_TAG,
+    )
+
+    # Act
+    cartography.intel.okta.devices.sync_okta_devices(
+        neo4j_session,
+        TEST_ORG_ID,
+        TEST_UPDATE_TAG,
+        TEST_API_KEY,
+    )
+
+    # Assert - Check Windows device properties
+    result = neo4j_session.run(
+        """
+        MATCH (d:OktaDevice{id: 'guo4a5u7YAHhjXrMK0g4'})
+        RETURN d.display_name as name,
+               d.platform as platform,
+               d.serial_number as serial,
+               d.sid as sid,
+               d.registered as registered,
+               d.secure_hardware_present as secure_hw,
+               d.disk_encryption_type as encryption
+        """,
+    )
+    device_data = [dict(r) for r in result][0]
+    assert device_data["name"] == "Example device name 1"
+    assert device_data["platform"] == "WINDOWS"
+    assert device_data["serial"] == "XXDDRFCFRGF3M8MD6D"
+    assert device_data["sid"] == "S-1-11-111"
+    assert device_data["registered"] is True
+    assert device_data["secure_hw"] is False
+    assert device_data["encryption"] == "ALL_INTERNAL_VOLUMES"
+
+    # Assert - Check Android device properties
+    result = neo4j_session.run(
+        """
+        MATCH (d:OktaDevice{id: 'guo4a5u7YAHhjXrMK0g5'})
+        RETURN d.display_name as name,
+               d.platform as platform,
+               d.manufacturer as manufacturer,
+               d.model as model,
+               d.os_version as os_version,
+               d.secure_hardware_present as secure_hw,
+               d.disk_encryption_type as encryption
+        """,
+    )
+    device_data = [dict(r) for r in result][0]
+    assert device_data["name"] == "Example device name 2"
+    assert device_data["platform"] == "ANDROID"
+    assert device_data["manufacturer"] == "Google"
+    assert device_data["model"] == "Pixel 6"
+    assert device_data["os_version"] == "13:2023-05-05"
+    assert device_data["secure_hw"] is True
+    assert device_data["encryption"] == "USER"
+
+
+@patch.object(cartography.intel.okta.devices, "_create_device_client")
+@patch.object(cartography.intel.okta.devices, "_get_okta_devices")
+def test_sync_okta_devices_updates_existing(
+    mock_get_devices, mock_device_client, neo4j_session
+):
+    """
+    Test that syncing updates existing devices rather than creating duplicates.
+    """
+    # Arrange - Create an existing device in the graph
+    neo4j_session.run(
+        """
+        MERGE (o:OktaOrganization{id: $ORG_ID})
+        SET o.lastupdated = $UPDATE_TAG
+        MERGE (o)-[:RESOURCE]->(d:OktaDevice{id: 'guo4a5u7YAHhjXrMK0g4'})
+        SET d.display_name = 'Old Device Name',
+            d.status = 'DEACTIVATED',
+            d.lastupdated = 111111
+        """,
+        ORG_ID=TEST_ORG_ID,
+        UPDATE_TAG=TEST_UPDATE_TAG,
+    )
+
+    # Create updated device data
+    mock_get_devices.return_value = SAMPLE_DEVICES
+    mock_device_client.return_value = MagicMock()
+
+    # Act
+    cartography.intel.okta.devices.sync_okta_devices(
+        neo4j_session,
+        TEST_ORG_ID,
+        TEST_UPDATE_TAG,
+        TEST_API_KEY,
+    )
+
+    # Assert - Device should be updated, not duplicated
+    result = neo4j_session.run(
+        """
+        MATCH (d:OktaDevice{id: 'guo4a5u7YAHhjXrMK0g4'})
+        RETURN d.display_name as name,
+               d.status as status,
+               d.lastupdated as lastupdated
+        """,
+    )
+    devices = [dict(r) for r in result]
+    assert len(devices) == 1  # Should be only one device, not a duplicate
+    device_data = devices[0]
+    assert device_data["name"] == "Example device name 1"
+    assert device_data["status"] == "CREATED"
+    assert device_data["lastupdated"] == TEST_UPDATE_TAG
+
+
+@patch.object(cartography.intel.okta.devices, "_create_device_client")
+@patch.object(cartography.intel.okta.devices, "_get_okta_devices")
+def test_sync_okta_devices_optional_fields(
+    mock_get_devices, mock_device_client, neo4j_session
+):
+    """
+    Test that devices with missing optional fields are handled correctly.
+    """
+    # Arrange - Create a device with minimal fields
+    minimal_device = {
+        "id": "dev-minimal-001",
+        "status": "CREATED",
+        "created": "2024-12-19T00:00:00.000Z",
+        "lastUpdated": "2024-12-19T00:00:00.000Z",
+        "profile": {
+            "displayName": "Minimal Device",
+            "platform": "WINDOWS",
+            "registered": False,
+            # No manufacturer, model, serialNumber, etc.
+        },
+        "resourceType": "UDDevice",
+        "resourceDisplayName": {
+            "value": "Minimal Device",
+            "sensitive": False,
+        },
+        "resourceAlternateId": None,
+        "resourceId": "dev-minimal-001",
+        "_links": {},
+        "_embedded": {
+            "users": [],
+        },
+    }
+
+    mock_get_devices.return_value = [minimal_device]
+    mock_device_client.return_value = MagicMock()
+
+    neo4j_session.run(
+        """
+        MERGE (o:OktaOrganization{id: $ORG_ID})
+        SET o.lastupdated = $UPDATE_TAG
+        """,
+        ORG_ID=TEST_ORG_ID,
+        UPDATE_TAG=TEST_UPDATE_TAG,
+    )
+
+    # Act
+    cartography.intel.okta.devices.sync_okta_devices(
+        neo4j_session,
+        TEST_ORG_ID,
+        TEST_UPDATE_TAG,
+        TEST_API_KEY,
+    )
+
+    # Assert - Device should be created with null optional fields
+    result = neo4j_session.run(
+        """
+        MATCH (d:OktaDevice{id: 'dev-minimal-001'})
+        RETURN d.display_name as name,
+               d.platform as platform,
+               d.manufacturer as manufacturer,
+               d.model as model,
+               d.serial_number as serial,
+               d.sid as sid
+        """,
+    )
+    device_data = [dict(r) for r in result][0]
+    assert device_data["name"] == "Minimal Device"
+    assert device_data["platform"] == "WINDOWS"
+    assert device_data["manufacturer"] is None
+    assert device_data["model"] is None
+    assert device_data["serial"] is None
+    assert device_data["sid"] is None

--- a/tests/unit/cartography/intel/okta/test_device.py
+++ b/tests/unit/cartography/intel/okta/test_device.py
@@ -1,0 +1,127 @@
+from cartography.intel.okta.devices import transform_okta_device
+from cartography.intel.okta.devices import transform_okta_device_users
+from tests.data.okta.devices import SAMPLE_DEVICES
+
+
+def test_transform_okta_device_windows():
+    """Test transformation of a Windows device."""
+    device_data = SAMPLE_DEVICES[0]  # Windows device
+
+    result = transform_okta_device(device_data)
+
+    assert result["id"] == "guo4a5u7YAHhjXrMK0g4"
+    assert result["status"] == "CREATED"
+    assert result["created"] == "2019-10-02T18:03:07.000Z"
+    assert result["last_updated"] == "2019-10-02T18:03:07.000Z"
+    assert result["display_name"] == "Example device name 1"
+    assert result["platform"] == "WINDOWS"
+    assert result["serial_number"] == "XXDDRFCFRGF3M8MD6D"
+    assert result["sid"] == "S-1-11-111"
+    assert result["registered"] is True
+    assert result["secure_hardware_present"] is False
+    assert result["disk_encryption_type"] == "ALL_INTERNAL_VOLUMES"
+    assert result["resource_type"] == "UDDevice"
+    assert result["resource_display_name"] == "Example device name 1"
+    assert result["resource_display_name_sensitive"] is False
+
+
+def test_transform_okta_device_android():
+    """Test transformation of an Android device."""
+    device_data = SAMPLE_DEVICES[1]  # Android device
+
+    result = transform_okta_device(device_data)
+
+    assert result["id"] == "guo4a5u7YAHhjXrMK0g5"
+    assert result["status"] == "ACTIVE"
+    assert result["created"] == "2023-06-21T23:24:02.000Z"
+    assert result["last_updated"] == "2023-06-21T23:24:02.000Z"
+    assert result["display_name"] == "Example device name 2"
+    assert result["platform"] == "ANDROID"
+    assert result["manufacturer"] == "Google"
+    assert result["model"] == "Pixel 6"
+    assert result["os_version"] == "13:2023-05-05"
+    assert result["registered"] is True
+    assert result["secure_hardware_present"] is True
+    assert result["disk_encryption_type"] == "USER"
+
+
+def test_transform_okta_device_with_minimal_values():
+    """Test transformation of a device with only required fields."""
+    device_data = {
+        "id": "device123",
+        "status": "CREATED",
+        "profile": {
+            "platform": "IOS",
+        },
+    }
+
+    result = transform_okta_device(device_data)
+
+    assert result["id"] == "device123"
+    assert result["status"] == "CREATED"
+    assert result["platform"] == "IOS"
+    assert result["created"] is None
+    assert result["last_updated"] is None
+    assert result["display_name"] is None
+    assert result["manufacturer"] is None
+    assert result["model"] is None
+
+
+def test_transform_okta_device_users_with_users():
+    """Test extraction of user-device relationships."""
+    device_data = SAMPLE_DEVICES[1]  # Android device with user
+
+    result = transform_okta_device_users(device_data)
+
+    assert len(result) == 1
+    assert result[0]["device_id"] == "guo4a5u7YAHhjXrMK0g5"
+    assert result[0]["user_id"] == "00u17vh0q8ov8IU881d7"
+    assert result[0]["management_status"] == "MANAGED"
+    assert result[0]["screen_lock_type"] == "BIOMETRIC"
+    assert result[0]["enrolled_at"] == "2021-10-01T16:52:41.000Z"
+
+
+def test_transform_okta_device_users_with_no_users():
+    """Test extraction when device has no users."""
+    device_data = SAMPLE_DEVICES[0]  # Windows device with no users
+
+    result = transform_okta_device_users(device_data)
+
+    assert result == []
+
+
+def test_transform_okta_device_users_with_no_embedded():
+    """Test extraction when _embedded field is missing."""
+    device_data = {
+        "id": "device789",
+    }
+
+    result = transform_okta_device_users(device_data)
+
+    assert result == []
+
+
+def test_transform_okta_device_users_with_partial_data():
+    """Test extraction when user data has missing optional fields."""
+    device_data = {
+        "id": "device999",
+        "_embedded": {
+            "users": [
+                {
+                    "user": {
+                        "id": "user999",
+                    },
+                    # Missing managementStatus, screenLockType, created
+                },
+            ],
+        },
+    }
+
+    result = transform_okta_device_users(device_data)
+
+    assert len(result) == 1
+    assert result[0]["device_id"] == "device999"
+    assert result[0]["user_id"] == "user999"
+    assert result[0]["management_status"] is None
+    assert result[0]["screen_lock_type"] is None
+    assert result[0]["enrolled_at"] is None


### PR DESCRIPTION
## Description
Implements support for tracking Okta devices in Neo4j

## Changes
- **Data Model**: Created `OktaDevice` node schema
- **API Integration**: Added `/api/v1/devices` endpoint support using `expand=userSummary`
- **Transformation**: Added `transform_okta_device()` and `transform_okta_device_users()` to convert Okta API format (camelCase) to Python/Neo4j format (snake_case)
- **Loading**: Added `_load_okta_devices()` and `_load_okta_device_users()` to create nodes and `(OktaUser)-[:HAS_DEVICE]->(OktaDevice)` relationships with management metadata
- **Cleanup**: Added cleanup queries to remove stale devices and relationships
- **Tests**: Added unit tests and integration tests 
- **Documentation**: Updated Okta schema documentation with complete `OktaDevice` specification

## Files Changed
- `cartography/intel/okta/devices.py` - New module for device sync, transformation, and loading
- `cartography/intel/okta/__init__.py` - Integrated device sync into main Okta module
- `cartography/data/indexes.cypher` - Added indexes for `OktaDevice` nodes
- `cartography/data/jobs/cleanup/okta_import_cleanup.json` - Added cleanup for stale devices and relationships
- `docs/root/modules/okta/schema.md` - Added `OktaDevice` documentation
- `tests/data/okta/devices.py` - New test fixtures with sample device data
- `tests/integration/cartography/intel/okta/test_devices.py` - New integration tests
- `tests/unit/cartography/intel/okta/test_device.py` - New unit tests

## Notes
- Close #2086 
- Documentation: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Device/#tag/Device/operation/listDevices

## Test Plan

### Unit 
<img width="1144" height="441" alt="Screenshot 2025-12-19 at 6 14 37 PM" src="https://github.com/user-attachments/assets/1b383829-6eb5-4b8b-a0f3-4dd96d927d5f" />

### Integration
<img width="1144" height="564" alt="Screenshot 2025-12-19 at 6 14 06 PM" src="https://github.com/user-attachments/assets/b430a0de-ef2f-4ed1-a0fb-e41d17485171" />

### Query (on dummy data)
<img width="1608" height="512" alt="Screenshot 2025-12-19 at 6 15 07 PM" src="https://github.com/user-attachments/assets/9e597aa0-2823-4aa7-8bfa-18adcbc9d7c8" />
<img width="1608" height="506" alt="Screenshot 2025-12-19 at 6 14 56 PM" src="https://github.com/user-attachments/assets/1d781b50-f867-43b0-88fc-af8ef2827f1c" />

