### PR TITLE
Feature/O365 Integration Fixing Issue#1489

### DIFF
--- a/cartography/intel/entra/users.py
+++ b/cartography/intel/entra/users.py
@@ -60,6 +60,7 @@ USER_SELECT_FIELDS = [
     "employeeType",
     "accountEnabled",
     "ageGroup",
+    "assignedPlans",
 ]
 
 
@@ -142,6 +143,14 @@ def transform_users(users: list[User]) -> Generator[dict[str, Any], None, None]:
             "account_enabled": user.account_enabled,
             "age_group": user.age_group,
             "manager_id": manager_id,
+            "assigned_plans": [
+                {
+                    "service_plan_id": str(plan.service_plan_id),
+                    "service": plan.service,
+                    "capability_status": plan.capability_status,
+                }
+                for plan in getattr(user, "assigned_plans", []) or []
+            ],
         }
 
 

--- a/cartography/intel/entra/users.py
+++ b/cartography/intel/entra/users.py
@@ -145,7 +145,9 @@ def transform_users(users: list[User]) -> Generator[dict[str, Any], None, None]:
             "manager_id": manager_id,
             "assigned_plans": [
                 {
-                    "service_plan_id": str(plan.service_plan_id),
+                    "service_plan_id": (
+                        str(plan.service_plan_id) if plan.service_plan_id else None
+                    ),
                     "service": plan.service,
                     "capability_status": plan.capability_status,
                 }

--- a/cartography/models/entra/user.py
+++ b/cartography/models/entra/user.py
@@ -40,6 +40,7 @@ class EntraUserNodeProperties(CartographyNodeProperties):
     account_enabled: PropertyRef = PropertyRef("account_enabled")
     age_group: PropertyRef = PropertyRef("age_group")
     manager_id: PropertyRef = PropertyRef("manager_id")
+    assigned_plans: PropertyRef = PropertyRef("assigned_plans")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 

--- a/docs/root/modules/entra/index.md
+++ b/docs/root/modules/entra/index.md
@@ -8,3 +8,5 @@ schema
 
 
 Microsoft Entra (formerly Azure Active Directory) is Microsoft's cloud-based identity and access management service. Cartography can ingest data from Entra to provide visibility into users and tenants in your organization.
+
+This module also supports syncing **Office 365** users and groups, as they are backed by Entra ID.

--- a/tests/unit/cartography/intel/entra/test_users.py
+++ b/tests/unit/cartography/intel/entra/test_users.py
@@ -1,0 +1,100 @@
+from unittest.mock import MagicMock
+
+from cartography.intel.entra.users import transform_users
+
+
+def test_transform_users_with_assigned_plans():
+    # Arrange
+    mock_user = MagicMock()
+    mock_user.id = "test-user-id"
+    mock_user.user_principal_name = "test@example.com"
+    mock_user.display_name = "Test User"
+    mock_user.given_name = "Test"
+    mock_user.surname = "User"
+    mock_user.mail = "test@example.com"
+    mock_user.mobile_phone = None
+    mock_user.business_phones = []
+    mock_user.job_title = None
+    mock_user.department = None
+    mock_user.office_location = None
+    mock_user.city = None
+    mock_user.state = None
+    mock_user.country = None
+    mock_user.company_name = None
+    mock_user.preferred_language = None
+    mock_user.employee_id = None
+    mock_user.employee_type = None
+    mock_user.account_enabled = True
+    mock_user.age_group = None
+    mock_user.manager = None
+
+    # Mock assigned plans
+    mock_plan1 = MagicMock()
+    mock_plan1.service_plan_id = "plan-id-1"
+    mock_plan1.service = "Exchange"
+    mock_plan1.capability_status = "Enabled"
+
+    mock_plan2 = MagicMock()
+    mock_plan2.service_plan_id = "plan-id-2"
+    mock_plan2.service = "SharePoint"
+    mock_plan2.capability_status = "Suspended"
+
+    mock_user.assigned_plans = [mock_plan1, mock_plan2]
+
+    users = [mock_user]
+
+    # Act
+    result = list(transform_users(users))
+
+    # Assert
+    assert len(result) == 1
+    transformed_user = result[0]
+    assert transformed_user["id"] == "test-user-id"
+    assert "assigned_plans" in transformed_user
+    assert len(transformed_user["assigned_plans"]) == 2
+
+    assert transformed_user["assigned_plans"][0]["service_plan_id"] == "plan-id-1"
+    assert transformed_user["assigned_plans"][0]["service"] == "Exchange"
+    assert transformed_user["assigned_plans"][0]["capability_status"] == "Enabled"
+
+    assert transformed_user["assigned_plans"][1]["service_plan_id"] == "plan-id-2"
+    assert transformed_user["assigned_plans"][1]["service"] == "SharePoint"
+    assert transformed_user["assigned_plans"][1]["capability_status"] == "Suspended"
+
+
+def test_transform_users_with_no_assigned_plans():
+    # Arrange
+    mock_user = MagicMock()
+    mock_user.id = "test-user-id"
+    mock_user.assigned_plans = None
+
+    # Fill required fields with dummies
+    mock_user.user_principal_name = None
+    mock_user.display_name = None
+    mock_user.given_name = None
+    mock_user.surname = None
+    mock_user.mail = None
+    mock_user.mobile_phone = None
+    mock_user.business_phones = []
+    mock_user.job_title = None
+    mock_user.department = None
+    mock_user.office_location = None
+    mock_user.city = None
+    mock_user.state = None
+    mock_user.country = None
+    mock_user.company_name = None
+    mock_user.preferred_language = None
+    mock_user.employee_id = None
+    mock_user.employee_type = None
+    mock_user.account_enabled = None
+    mock_user.age_group = None
+    mock_user.manager = None
+
+    users = [mock_user]
+
+    # Act
+    result = list(transform_users(users))
+
+    # Assert
+    assert len(result) == 1
+    assert result[0]["assigned_plans"] == []


### PR DESCRIPTION
### Summary
This PR implements support for Office 365 integration by extending the existing Microsoft Entra ID module. Since Office 365 identities are backed by Entra ID, this change enhances the [EntraUser](cci:2://file:///home/ilyaas/workspace/github.com/IlyaasK/cartography/cartography/models/entra/user.py:75:0-90:5) node to include license and service plan information (`assignedPlans`), which is the key differentiator for O365 user management. This allows users to query for O365-specific license assignments and capabilities directly on [EntraUser](cci:2://file:///home/ilyaas/workspace/github.com/IlyaasK/cartography/cartography/models/entra/user.py:75:0-90:5) nodes.

### Related issues or links
- https://github.com/cartography-cncf/cartography/issues/1489

### Detailed Changes
*   **[cartography/models/entra/user.py](cci:7://file:///home/ilyaas/workspace/github.com/IlyaasK/cartography/cartography/models/entra/user.py:0:0-0:0)**:
    *   **Change**: Added [assigned_plans](cci:1://file:///home/ilyaas/workspace/github.com/IlyaasK/cartography/tests/unit/cartography/intel/entra/test_users.py:5:0-61:84) property to the [EntraUserSchema](cci:2://file:///home/ilyaas/workspace/github.com/IlyaasK/cartography/cartography/models/entra/user.py:75:0-90:5).
    *   **Reason**: To store the license/service plan details (e.g., "Exchange", "SharePoint") associated with a user, which allows mapping users to specific O365 services.

*   **[cartography/intel/entra/users.py](cci:7://file:///home/ilyaas/workspace/github.com/IlyaasK/cartography/cartography/intel/entra/users.py:0:0-0:0)**:
    *   **Change**: Added `assignedPlans` to the `USER_SELECT_FIELDS` list in the MS Graph API query.
    *   **Reason**: To request this specific attribute from the Graph API, as it is not fetched by default.
    *   **Change**: Updated [transform_users()](cci:1://file:///home/ilyaas/workspace/github.com/IlyaasK/cartography/cartography/intel/entra/users.py:111:0-153:9) to extract and structure the `assignedPlans` data (Service Plan ID, Service Name, Capability Status) into the new schema property.
    *   **Reason**: To convert the raw API response into a structured format suitable for Neo4j storage.

*   **[docs/root/modules/entra/index.md](cci:7://file:///home/ilyaas/workspace/github.com/IlyaasK/cartography/docs/root/modules/entra/index.md:0:0-0:0)**:
    *   **Change**: Updated the module documentation.
    *   **Reason**: To explicitly inform users that the Entra ID module now supports syncing Office 365 Users and Groups.

*   **[tests/unit/cartography/intel/entra/test_users.py](cci:7://file:///home/ilyaas/workspace/github.com/IlyaasK/cartography/tests/unit/cartography/intel/entra/test_users.py:0:0-0:0)**:
    *   **Change**: Added a new unit test suite.
    *   **Reason**: To verify that the transformation logic correctly handles users with and without assigned plans, ensuring reliability and preventing regression.

### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [x] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [x] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [x] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
- [x] Confirm that the linter actually passes (submitting a PR where the linter fails shows reviewers that you did not test your code and will delay your review).