### PR TITLE
Fix Neo4j error in Semgrep SCA findings with unknown vulnerability identifiers

### DIFF
--- a/cartography/intel/semgrep/findings.py
+++ b/cartography/intel/semgrep/findings.py
@@ -167,7 +167,9 @@ def transform_sca_vulns(
         if vuln.get("vulnerability_identifier"):
             vuln_id = vuln["vulnerability_identifier"].upper()
             sca_vuln["cveId"] = vuln_id
-            sca_vuln["ref_urls"] = [_build_vuln_url(vuln_id)]
+            # Filter out None values to prevent Neo4j collection error
+            ref_url = _build_vuln_url(vuln_id)
+            sca_vuln["ref_urls"] = [ref_url] if ref_url is not None else []
         if vuln.get("fix_recommendations") and len(vuln["fix_recommendations"]) > 0:
             fix = vuln["fix_recommendations"][0]
             dep_fix = f"{fix['package']}|{fix['version']}"

--- a/tests/data/semgrep/sca.py
+++ b/tests/data/semgrep/sca.py
@@ -76,7 +76,73 @@ SCA_RESPONSE = {
     ],
 }
 
+# Test data for vulnerability with unknown identifier format (should result in empty ref_urls)
+VULN_ID_UNKNOWN = 73537137
+SCA_RESPONSE_UNKNOWN_VULN = {
+    "findings": [
+        {
+            "id": VULN_ID_UNKNOWN,
+            "ref": "main",
+            "syntactic_id": "91f6bebf5c374b3db9ae6b0afeb8ba4f",
+            "match_based_id": "cf89274a455b0f7dae15d218af143cf317fb9886d12f3dcbe0e37cad02d0d29411cecb9a2c3fedc9e973de",
+            "repository": {
+                "name": "simpsoncorp/sample_repo",
+                "url": "https://github.com/simpsoncorp/sample_repo",
+            },
+            "line_of_code_url": "https://github.com/simpsoncorp/sample_repo/blob/71bbed12f950de8335006d7f91112263d8504f1b/src/packages/components/AccountsTable/constants.tsx#L274",  # noqa E501
+            "first_seen_scan_id": 30469982,
+            "state": "unresolved",
+            "triage_state": "untriaged",
+            "status": "open",
+            "confidence": "high",
+            "created_at": "2024-07-11T20:46:25.269650Z",
+            "relevant_since": "2024-07-11T20:46:25.268845Z",
+            "rule_name": "ssc-1e99e462-0fc5-4109-ad52-d2b5a7048232",
+            "rule_message": "description",
+            "location": {
+                "file_path": "src/packages/linked-accounts/components/LinkedAccountsTable/constants.tsx",
+                "line": 274,
+                "column": 37,
+                "end_line": 274,
+                "end_column": 62,
+            },
+            "triaged_at": None,
+            "triage_comment": None,
+            "triage_reason": None,
+            "state_updated_at": None,
+            "categories": ["security"],
+            "rule": {
+                "name": "ssc-1e99e462-0fc5-4109-ad52-d2b5a7048232",
+                "message": "description",
+                "confidence": "high",
+                "category": "security",
+                "subcategories": [],
+                "vulnerability_classes": ["Denial-of-Service (DoS)"],
+                "cwe_names": [
+                    "CWE-1333: Inefficient Regular Expression Complexity",
+                    "CWE-400: Uncontrolled Resource Consumption",
+                ],
+                "owasp_names": ["A06: 2021 - Vulnerable and Outdated Components"],
+            },
+            "severity": "high",
+            "vulnerability_identifier": "UNKNOWN-2022-31129",  # This will cause _build_vuln_url to return None
+            "reachability": "reachable",
+            "reachable_condition": None,
+            "found_dependency": {
+                "package": "moment",
+                "version": "2.29.2",
+                "ecosystem": "npm",
+                "transitivity": "direct",
+                "lockfile_line_url": "https: //github.com/simpsoncorp/sample_repo/blob/commit_id/package-lock.json#L14373",
+            },
+            "fix_recommendations": [{"package": "moment", "version": "2.29.4"}],
+            "usage": None,  # No usage data for this test case
+        },
+    ],
+}
+
 RAW_VULNS = SCA_RESPONSE["findings"]
+RAW_VULNS_WITH_UNKNOWN = SCA_RESPONSE_UNKNOWN_VULN["findings"]
 
 USAGES = [
     {


### PR DESCRIPTION
### Summary
Fixes Neo4j `CypherTypeError` when Semgrep returns vulnerability identifiers that don't match CVE or GHSA patterns.

**Problem:** 
- `_build_vuln_url()` returns `None` for unknown vulnerability formats
- Creates `ref_urls = [None]` which Neo4j rejects

**Solution:**
- Filter out `None` values: `ref_urls = [url] if url else []`
- Unknown vulnerabilities now get empty `ref_urls` instead of `[None]`

**Testing:** 
- Added test case for unknown vulnerability identifier format.


### Related issues or links
> Include links to relevant issues or other pages.

- https://github.com/cartography-cncf/cartography/issues/...


### Checklist

Provide proof that this works (this makes reviews move faster). Please perform one or more of the following:
- [ ] Update/add unit or integration tests.
- [ ] Include a screenshot showing what the graph looked like before and after your changes.
- [ ] Include console log trace showing what happened before and after your changes.

If you are changing a node or relationship:
- [ ] Update the [schema](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) and [readme](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

If you are implementing a new intel module:
- [ ] Use the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
- [ ] Confirm that the linter actually passes (submitting a PR where the linter fails shows reviewers that you did not test your code and will delay your review).
