### PR TITLE
fix(aws): Sync Failure in AWS Bedrock

### DIFF
--- a/cartography/intel/aws/bedrock/custom_models.py
+++ b/cartography/intel/aws/bedrock/custom_models.py
@@ -39,7 +39,7 @@ def get_custom_models(
     to retrieve full details (jobArn, jobName, trainingDataConfig, outputDataConfig).
     """
     if region not in CUSTOM_MODELS_SUPPORTED_REGIONS:
-        logger.info(
+        logger.debug(
             "Bedrock custom models not supported in region %s. Skipping.",
             region,
         )


### PR DESCRIPTION
### Summary

**Bug:** The AWS bedrock sync for custom models fails loudly in regions where custom models are not supported (anywhere not us-east-1 or us-west-2). ListCustomModels API returns a Validation Exception: Unknown Operation causing the entire sync to fail. See below for full error. 

**Fix:** The get_custom_models function now catches this specific error and gracefully skipping and logging unsupported regions allowing the sync to continue. 