### PR TITLE
fix(slack): remove archived channel and reduce log verbosity

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -1517,6 +1517,7 @@ def main(argv=None):
     logging.getLogger("neo4j").setLevel(logging.WARNING)
     logging.getLogger("azure.identity").setLevel(logging.WARNING)
     logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("slack_sdk").setLevel(logging.WARNING)
     logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(
         logging.WARNING
     )

--- a/cartography/intel/slack/channels.py
+++ b/cartography/intel/slack/channels.py
@@ -36,10 +36,9 @@ def get(
         "conversations_list",
         "channels",
         team_id=team_id,
+        exclude_archived=True,
     ):
-        if channel["is_archived"]:
-            channels.append(channel)
-        elif get_memberships:
+        if get_memberships:
             for member in slack_paginate(
                 slack_client,
                 "conversations_members",


### PR DESCRIPTION
This PR closes https://github.com/cartography-cncf/cartography/issues/2226 by:
- removing archived channel from the sync
- reducing slack sdk log verbosity