### PR TITLE
docs: fix markdown formatting issues in schema docs

### DIFF
--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -187,11 +187,11 @@ Representation of a GCP [DNS Zone](https://cloud.google.com/dns/docs/reference/v
 | ---------- | ------------------------------------------------------- |
 | created_at | The date and time the zone was created                  |
 | description              | An optional description of the zone|
-| dns_name | The DNS name of this managed zone, for instance "example.com.".
+| dns_name | The DNS name of this managed zone, for instance "example.com.". |
 | firstseen  | Timestamp of when a sync job first discovered this node |
 | **id**                   |Unique identifier|
 | name       | The name of the zone                                    |
-| nameservers |Virtual name servers the zone is delegated to
+| nameservers |Virtual name servers the zone is delegated to |
 | visibility | The zone's visibility: `public` zones are exposed to the Internet, while `private` zones are visible only to Virtual Private Cloud resources.|
 
 

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -58,7 +58,7 @@ A user often has one or many user accounts.
 
 ```{important}
 If field `active` is null, it should not be considered as `true` or `false`, only as unknown.
-```{note}
+```
 
 | Field | Description |
 |-------|-------------|


### PR DESCRIPTION
## Summary

Fix two markdown formatting issues in the documentation:
- **GCPDNSZone table**: Added missing trailing pipes on `dns_name` and `nameservers` rows
- **Ontology schema**: Closed unclosed `{important}` directive that was breaking rendering

## Checklist

- [x] Verified docs render correctly locally via `uv run ./docs/build.sh`

DNSZone still looks fine
<img width="726" height="622" alt="Screenshot 2026-01-21 at 10 07 41 PM" src="https://github.com/user-attachments/assets/031f5af4-deed-4511-a005-a26a7adcae1e" />

Ontology User looks good now
<img width="738" height="930" alt="Screenshot 2026-01-21 at 10 07 06 PM" src="https://github.com/user-attachments/assets/64c69d5c-fe84-458d-add7-a2e891c6a7a3" />

Old Ontology user
<img width="748" height="887" alt="Screenshot 2026-01-21 at 10 06 50 PM" src="https://github.com/user-attachments/assets/5a1bdc58-a89e-451b-abff-5807d6f81ecb" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)