### PR TITLE
fix: Use GitHubOrganization as sub_resource_relationship for GitHubBranchProtectionRule

### DIFF
--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -1269,24 +1269,23 @@ def load_branch_protection_rules(
     neo4j_session: neo4j.Session,
     update_tag: int,
     branch_protection_rules: List[Dict],
+    org_url: str,
 ) -> None:
     """
     Ingest GitHub branch protection rules into Neo4j
     :param neo4j_session: Neo4J session object for server communication
     :param update_tag: Timestamp used to determine data freshness
     :param branch_protection_rules: List of branch protection rule objects from GitHub's branchProtectionRules API
+    :param org_url: The URL of the GitHub organization
     :return: Nothing
     """
-    # Group branch protection rules by repo_url for schema-based loading
     rules_by_repo = defaultdict(list)
 
     for rule in branch_protection_rules:
         repo_url = rule["repo_url"]
-        # Remove repo_url from the rule object since we'll pass it as kwargs
         rule_without_kwargs = {k: v for k, v in rule.items() if k != "repo_url"}
         rules_by_repo[repo_url].append(rule_without_kwargs)
 
-    # Load branch protection rules for each repository separately
     for repo_url, repo_rules in rules_by_repo.items():
         load_data(
             neo4j_session,
@@ -1294,6 +1293,7 @@ def load_branch_protection_rules(
             repo_rules,
             lastupdated=update_tag,
             repo_url=repo_url,
+            org_url=org_url,
         )
 
 
@@ -1301,20 +1301,18 @@ def load_branch_protection_rules(
 def cleanup_branch_protection_rules(
     neo4j_session: neo4j.Session,
     common_job_parameters: Dict[str, Any],
-    repo_urls: List[str],
+    org_url: str,
 ) -> None:
     """
     Delete GitHub branch protection rules from the graph if they were not updated in the last sync.
     :param neo4j_session: Neo4j session
     :param common_job_parameters: Common job parameters containing UPDATE_TAG
-    :param repo_urls: List of repository URLs to clean up branch protection rules for
+    :param org_url: The URL of the GitHub organization
     """
-    # Run cleanup for each repository separately
-    for repo_url in repo_urls:
-        cleanup_params = {**common_job_parameters, "repo_url": repo_url}
-        GraphJob.from_node_schema(
-            GitHubBranchProtectionRuleSchema(), cleanup_params
-        ).run(neo4j_session)
+    cleanup_params = {**common_job_parameters, "org_url": org_url}
+    GraphJob.from_node_schema(GitHubBranchProtectionRuleSchema(), cleanup_params).run(
+        neo4j_session
+    )
 
 
 @timeit
@@ -1322,6 +1320,7 @@ def load(
     neo4j_session: neo4j.Session,
     common_job_parameters: Dict,
     repo_data: Dict,
+    org_url: str,
 ) -> None:
     load_github_repos(
         neo4j_session,
@@ -1369,6 +1368,7 @@ def load(
         neo4j_session,
         common_job_parameters["UPDATE_TAG"],
         repo_data["branch_protection_rules"],
+        org_url,
     )
 
 
@@ -1414,7 +1414,8 @@ def sync(
             exc_info=True,
         )
     repo_data = transform(repos_json, direct_collabs, outside_collabs)
-    load(neo4j_session, common_job_parameters, repo_data)
+    org_url = f"https://github.com/{organization}"
+    load(neo4j_session, common_job_parameters, repo_data, org_url)
 
     # Collect repository URLs that have dependencies for cleanup
     repo_urls_with_dependencies = list(
@@ -1432,12 +1433,6 @@ def sync(
         neo4j_session, common_job_parameters, repo_urls_with_manifests
     )
 
-    # Collect repository URLs that have branch protection rules for cleanup
-    repo_urls_with_branch_protection_rules = list(
-        {rule["repo_url"] for rule in repo_data["branch_protection_rules"]}
-    )
-    cleanup_branch_protection_rules(
-        neo4j_session, common_job_parameters, repo_urls_with_branch_protection_rules
-    )
+    cleanup_branch_protection_rules(neo4j_session, common_job_parameters, org_url)
 
     run_cleanup_job("github_repos_cleanup.json", neo4j_session, common_job_parameters)

--- a/cartography/models/github/branch_protection_rules.py
+++ b/cartography/models/github/branch_protection_rules.py
@@ -14,6 +14,7 @@ from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -78,11 +79,32 @@ class GitHubBranchProtectionRuleToRepositoryRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class GitHubBranchProtectionRuleToOrganizationRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitHubBranchProtectionRuleToOrganizationRel(CartographyRelSchema):
+    target_node_label: str = "GitHubOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("org_url", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GitHubBranchProtectionRuleToOrganizationRelProperties = (
+        GitHubBranchProtectionRuleToOrganizationRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class GitHubBranchProtectionRuleSchema(CartographyNodeSchema):
     label: str = "GitHubBranchProtectionRule"
     properties: GitHubBranchProtectionRuleNodeProperties = (
         GitHubBranchProtectionRuleNodeProperties()
     )
-    sub_resource_relationship: GitHubBranchProtectionRuleToRepositoryRel = (
-        GitHubBranchProtectionRuleToRepositoryRel()
+    sub_resource_relationship: GitHubBranchProtectionRuleToOrganizationRel = (
+        GitHubBranchProtectionRuleToOrganizationRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [GitHubBranchProtectionRuleToRepositoryRel()]
     )

--- a/docs/root/modules/github/schema.md
+++ b/docs/root/modules/github/schema.md
@@ -15,6 +15,7 @@ U -- COMMITTED_TO --> R
 R -- LANGUAGE --> L(ProgrammingLanguage)
 R -- BRANCH --> B(GitHubBranch)
 R -- HAS_RULE --> BPR(GitHubBranchProtectionRule)
+O -- RESOURCE --> BPR
 R -- REQUIRES --> D(Dependency)
 R -- HAS_MANIFEST --> M(DependencyGraphManifest)
 M -- HAS_DEP --> D
@@ -329,6 +330,12 @@ Representation of a single GitHubBranchProtectionRule [BranchProtectionRule obje
 
     ```
     (GitHubRepository)-[:HAS_RULE]->(GitHubBranchProtectionRule)
+    ```
+
+- GitHubOrganizations own GitHubBranchProtectionRules as a sub-resource (for cleanup).
+
+    ```
+    (GitHubOrganization)-[:RESOURCE]->(GitHubBranchProtectionRule)
     ```
 
 ### ProgrammingLanguage

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -13,6 +13,7 @@ from tests.integration.util import check_rels
 TEST_UPDATE_TAG = 123456789
 TEST_JOB_PARAMS = {"UPDATE_TAG": TEST_UPDATE_TAG}
 TEST_GITHUB_URL = "https://fake.github.net/graphql/"
+TEST_ORG_URL = "https://github.com/example_org"
 
 
 def _ensure_local_neo4j_has_test_data(neo4j_session):
@@ -25,6 +26,7 @@ def _ensure_local_neo4j_has_test_data(neo4j_session):
         neo4j_session,
         TEST_JOB_PARAMS,
         repo_data,
+        TEST_ORG_URL,
     )
 
 


### PR DESCRIPTION
## Summary
- Change `GitHubBranchProtectionRule` to use `GitHubOrganization` as its `sub_resource_relationship` for proper cleanup

## Changes
- Add `GitHubBranchProtectionRuleToOrganizationRel` with `RESOURCE` label pointing to `GitHubOrganization`
- Move `GitHubBranchProtectionRuleToRepositoryRel` to `other_relationships`
- Update `load_branch_protection_rules()` to accept `org_url` parameter
- Simplify `cleanup_branch_protection_rules()` to use `org_url` instead of iterating through `repo_urls`
- Update schema documentation in `docs/root/modules/github/schema.md`
- Update tests to pass `org_url`

## Test plan
<img width="1036" height="358" alt="Screenshot 2026-01-27 at 1 25 14 AM" src="https://github.com/user-attachments/assets/c25620f4-860c-47d7-8401-e782058f9100" />
<img width="1036" height="428" alt="Screenshot 2026-01-27 at 1 25 41 AM" src="https://github.com/user-attachments/assets/743d0d34-5240-42e8-a3e6-6999746cc0b1" />
