### PR TITLE
fix(gcp): Handle HttpError per location in CloudRun job and execution sync

### DIFF
--- a/cartography/intel/gcp/cloudrun/job.py
+++ b/cartography/intel/gcp/cloudrun/job.py
@@ -49,10 +49,14 @@ def get_jobs(client: Resource, project_id: str, location: str = "-") -> list[dic
                         )
                     )
             except HttpError as e:
-                logger.warning(
-                    f"Failed to list Cloud Run jobs in {loc_name}: {e}. Skipping location.",
-                )
-                continue
+                # Only skip 403 permission errors (e.g., restricted regions)
+                # Re-raise other errors (429, 500, etc.) to surface systemic failures
+                if e.resp.status == 403:
+                    logger.warning(
+                        f"Permission denied listing Cloud Run jobs in {loc_name}. Skipping location.",
+                    )
+                    continue
+                raise
 
         return jobs
     except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

When Cloud Run location discovery returns restricted/inaccessible regions (e.g., `me-central2`), the API returns 403 errors when trying to list jobs or executions in those locations. Without error handling, this crashes the entire Cartography sync.

**Root cause:**
1. `discover_cloud_run_locations()` queries the v1 API for all available Cloud Run regions
2. It returns **all** regions including restricted ones like `me-central2` (Middle East region)
3. When `job.py` and `execution.py` iterate over these locations and try to list jobs/executions, the API returns 403 for restricted regions
4. The unhandled `HttpError` crashes the entire GCP sync


### Related issues or links

- https://github.com/cartography-cncf/cartography/pull/2282
- https://github.com/cartography-cncf/cartography/pull/2209


### How was this tested?

Tested manually by running Cartography against a GCP organization where some Cloud Run regions are restricted.

**Execution logs (redacted):**
```
INFO:cartography.intel.gcp:Syncing GCP project <REDACTED_PROJECT_ID> for Cloud Run.
INFO:cartography.intel.gcp.cloudrun.service:Syncing Cloud Run Services for project <REDACTED_PROJECT_ID>.
INFO:cartography.intel.gcp.cloudrun.revision:Syncing Cloud Run Revisions for project <REDACTED_PROJECT_ID>.
INFO:cartography.intel.gcp.cloudrun.job:Syncing Cloud Run Jobs for project <REDACTED_PROJECT_ID>.
WARNING:cartography.intel.gcp.cloudrun.job:Permission denied listing Cloud Run jobs in projects/<REDACTED_PROJECT_ID>/locations/me-central2. Skipping location.
INFO:cartography.intel.gcp.cloudrun.execution:Syncing Cloud Run Executions for project <REDACTED_PROJECT_ID>.
WARNING:cartography.intel.gcp.cloudrun.execution:Permission denied listing Cloud Run jobs/executions in projects/<REDACTED_PROJECT_ID>/locations/me-central2. Skipping location.
```

Before this fix, the sync would crash with an unhandled `HttpError`. After the fix:
- 403 permission errors on restricted locations are skipped gracefully with a warning
- Other HTTP errors (429, 500, etc.) are re-raised to fail fast on systemic issues
- The sync continues for accessible locations


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

Logs shown above demonstrate the fix working - warnings are logged for 403 errors and sync continues.


### Notes for reviewers

Updated based on feedback to narrow the error handling:
- Only 403 permission errors are skipped (restricted/inaccessible regions)
- Other HTTP errors (429 rate limiting, 500 server errors, etc.) are re-raised to fail fast and surface systemic failures
- This avoids partial syncs followed by cleanup for transient issues