### PR TITLE
fix(trivy): handle missing Results key for images with no vulnerabilities

### DIFF
--- a/cartography/intel/trivy/scanner.py
+++ b/cartography/intel/trivy/scanner.py
@@ -174,13 +174,7 @@ def _parse_trivy_data(
     # Extract artifact name if present (only for file-based)
     artifact_name = trivy_data.get("ArtifactName")
 
-    if "Results" not in trivy_data:
-        logger.error(
-            f"Scan data did not contain a `Results` key for {source}. This indicates a malformed scan result."
-        )
-        raise ValueError(f"Missing 'Results' key in scan data for {source}")
-
-    results = trivy_data["Results"]
+    results = trivy_data.get("Results", [])
     if not results:
         stat_handler.incr("image_scan_no_results_count")
         logger.info(f"No vulnerabilities found for {source}")


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary

Trivy scans for container images with **zero vulnerabilities** may omit the `Results` key entirely instead of returning an empty array. This is documented, expected Trivy behavior (see [aquasecurity/trivy#2787](https://github.com/aquasecurity/trivy/issues/2787) - closed as "not planned", confirming this is intentional).

Currently, a missing `Results` key is treated as malformed data and raises:
```
ValueError: Missing 'Results' key in scan data for <image>
```

This causes sync failures for clean images that have no vulnerabilities.

**This fix treats a missing `Results` key as equivalent to an empty results array** (no vulnerabilities found), allowing clean images to sync successfully.

### Related issues or links

- Related upstream issue: [aquasecurity/trivy#2787](https://github.com/aquasecurity/trivy/issues/2787) - documents that Trivy intentionally omits `Results` when empty

### How was this tested?

- Updated unit test `test_sync_single_image_from_s3_handles_missing_results_key` to verify missing `Results` key is handled gracefully (sync succeeds instead of raising ValueError)
- Ran `make lint` - all checks pass
- Ran `pytest tests/unit/cartography/intel/trivy/test_scanner.py -v` - all 12 tests pass

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.