### PR TITLE
hotfix: fix tests broken by recenet AI slop PR

### DIFF
--- a/tests/integration/cartography/intel/aws/iam/test_iam.py
+++ b/tests/integration/cartography/intel/aws/iam/test_iam.py
@@ -216,18 +216,14 @@ def test_load_roles_creates_trust_relationships(neo4j_session):
     assert actual == expected
 
 
-@mock.patch.object(cartography.intel.aws.iam, "get_saml_providers")
-def test_sync_saml_providers(mock_get_saml, neo4j_session):
+def test_sync_saml_providers(neo4j_session):
     _create_base_account(neo4j_session)
-    mock_get_saml.return_value = tests.data.aws.iam.LIST_SAML_PROVIDERS
 
-    cartography.intel.aws.iam.sync(
+    cartography.intel.aws.iam.load_saml_providers(
         neo4j_session,
-        mock.MagicMock(),
-        [TEST_REGION],
+        tests.data.aws.iam.LIST_SAML_PROVIDERS["SAMLProviderList"],
         TEST_ACCOUNT_ID,
         TEST_UPDATE_TAG,
-        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
     )
 
     nodes = check_nodes(neo4j_session, "AWSSAMLProvider", ["arn"])

--- a/tests/integration/cartography/intel/aws/iam/test_iam_sync.py
+++ b/tests/integration/cartography/intel/aws/iam/test_iam_sync.py
@@ -26,6 +26,20 @@ TEST_UPDATE_TAG = 123456789
 
 @patch.object(
     cartography.intel.aws.iam,
+    "get_server_certificates",
+    return_value=[],
+)
+@patch.object(
+    cartography.intel.aws.iam,
+    "get_saml_providers",
+    return_value={"SAMLProviderList": []},
+)
+@patch.object(
+    cartography.intel.aws.iam,
+    "sync_service_last_accessed_details",
+)
+@patch.object(
+    cartography.intel.aws.iam,
     "get_group_memberships",
     return_value=GET_GROUP_MEMBERSHIPS_DATA,
 )
@@ -85,6 +99,9 @@ def test_sync_iam(
     mock_get_role_policy_data,
     mock_get_role_managed_policy_data,
     mock_get_group_memberships,
+    mock_sync_service_last_accessed_details,
+    mock_get_saml_providers,
+    mock_get_server_certificates,
     neo4j_session,
 ):
     """Test IAM sync end-to-end"""


### PR DESCRIPTION
### Type of change

Fix integration tests broken by AI slop PR I recently merged :(
Integration tests was silently failing, causing integration tests during ~20minutes