### PR TITLE
fix(ontology): enable PublicIP sync in ontology orchestrator

### DIFF
--- a/cartography/intel/ontology/__init__.py
+++ b/cartography/intel/ontology/__init__.py
@@ -4,6 +4,7 @@ import neo4j
 
 import cartography.intel.ontology.devices
 import cartography.intel.ontology.loadbalancers
+import cartography.intel.ontology.publicips
 import cartography.intel.ontology.users
 from cartography.config import Config
 from cartography.util import timeit
@@ -44,6 +45,11 @@ def run(neo4j_session: neo4j.Session, config: Config) -> None:
         common_job_parameters,
     )
     cartography.intel.ontology.loadbalancers.sync(
+        neo4j_session,
+        config.update_tag,
+        common_job_parameters,
+    )
+    cartography.intel.ontology.publicips.sync(
         neo4j_session,
         config.update_tag,
         common_job_parameters,


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary

The `PublicIP` ontology module was added in #2285 but was never called from the ontology orchestrator (`cartography/intel/ontology/__init__.py`). This resulted in no `PublicIP` nodes being created during sync, even when source nodes (e.g., `ElasticIPAddress`, `AzurePublicIPAddress`) existed in the graph.

This PR adds the missing import and sync call for `publicips`.


### Related issues or links

- Fixes the missing activation from #2285

### Notes for reviewers

This is a straightforward fix - the module was complete but simply not wired up in the orchestrator. The sync function signature matches `loadbalancers.sync()` exactly (no source of truth parameter needed).