### PR TITLE
feat(ontology): add CodeRepository semantic label for source code repositories

### DIFF
--- a/cartography/models/ontology/mapping/__init__.py
+++ b/cartography/models/ontology/mapping/__init__.py
@@ -3,6 +3,9 @@ import logging
 from cartography.models.core.nodes import CartographyNodeSchema
 from cartography.models.ontology.device import DeviceSchema
 from cartography.models.ontology.mapping.data.apikeys import APIKEYS_ONTOLOGY_MAPPING
+from cartography.models.ontology.mapping.data.coderepositories import (
+    CODEREPOSITORIES_ONTOLOGY_MAPPING,
+)
 from cartography.models.ontology.mapping.data.computeinstance import (
     COMPUTE_INSTANCE_ONTOLOGY_MAPPING,
 )
@@ -55,6 +58,7 @@ ONTOLOGY_NODES_MAPPING: dict[str, dict[str, OntologyMapping]] = {
 SEMANTIC_LABELS_MAPPING: dict[str, dict[str, OntologyMapping]] = {
     "useraccounts": USERACCOUNTS_ONTOLOGY_MAPPING,
     "apikeys": APIKEYS_ONTOLOGY_MAPPING,
+    "coderepositories": CODEREPOSITORIES_ONTOLOGY_MAPPING,
     "computeinstance": COMPUTE_INSTANCE_ONTOLOGY_MAPPING,
     "containers": CONTAINER_ONTOLOGY_MAPPING,
     "containerregistries": CONTAINERREGISTRIES_ONTOLOGY_MAPPING,

--- a/cartography/models/ontology/mapping/data/coderepositories.py
+++ b/cartography/models/ontology/mapping/data/coderepositories.py
@@ -1,0 +1,81 @@
+from cartography.models.ontology.mapping.specs import OntologyFieldMapping
+from cartography.models.ontology.mapping.specs import OntologyMapping
+from cartography.models.ontology.mapping.specs import OntologyNodeMapping
+
+# CodeRepository ontology fields:
+# - id: Unique identifier (URL or URI)
+# - name: Repository name
+# - fullname: Full path including namespace (e.g., "org/repo")
+# - description: Repository description
+# - url: Web URL to access the repository
+# - default_branch: Default branch name
+# - public: Whether the repository is publicly accessible
+# - archived: Whether the repository is archived
+
+github_mapping = OntologyMapping(
+    module_name="github",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="GitHubRepository",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="id", node_field="id", required=True
+                ),
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(ontology_field="fullname", node_field="fullname"),
+                OntologyFieldMapping(
+                    ontology_field="description", node_field="description"
+                ),
+                OntologyFieldMapping(ontology_field="url", node_field="url"),
+                OntologyFieldMapping(
+                    ontology_field="default_branch", node_field="defaultbranch"
+                ),
+                OntologyFieldMapping(
+                    ontology_field="public",
+                    node_field="private",
+                    special_handling="invert_boolean",
+                ),
+                OntologyFieldMapping(ontology_field="archived", node_field="archived"),
+            ],
+        ),
+    ],
+)
+
+gitlab_mapping = OntologyMapping(
+    module_name="gitlab",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="GitLabProject",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="id", node_field="id", required=True
+                ),
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(
+                    ontology_field="fullname", node_field="path_with_namespace"
+                ),
+                OntologyFieldMapping(
+                    ontology_field="description", node_field="description"
+                ),
+                # GitLabProject uses 'id' as web_url, so we use the same field for url
+                OntologyFieldMapping(ontology_field="url", node_field="id"),
+                OntologyFieldMapping(
+                    ontology_field="default_branch", node_field="default_branch"
+                ),
+                # GitLab uses 'visibility' (private, internal, public) - only "public" maps to public=true
+                OntologyFieldMapping(
+                    ontology_field="public",
+                    node_field="visibility",
+                    special_handling="equal_boolean",
+                    extra={"values": ["public"]},
+                ),
+                OntologyFieldMapping(ontology_field="archived", node_field="archived"),
+            ],
+        ),
+    ],
+)
+
+CODEREPOSITORIES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
+    "github": github_mapping,
+    "gitlab": gitlab_mapping,
+}

--- a/docs/root/modules/github/schema.md
+++ b/docs/root/modules/github/schema.md
@@ -36,6 +36,7 @@ U -- MAINTAINER --> T
 
 Representation of a single GitHubRepository (repo) [repository object](https://developer.github.com/v4/object/repository/). This node contains all data unique to the repo.
 
+> **Ontology Mapping**: This node has the extra label `CodeRepository` to enable cross-platform queries for source code repositories across different systems (e.g., GitLabProject).
 
 | Field | Description |
 |-------|--------------|

--- a/docs/root/modules/gitlab/schema.md
+++ b/docs/root/modules/gitlab/schema.md
@@ -114,6 +114,8 @@ Representation of a GitLab nested subgroup. Groups can contain other groups (cre
 
 Representation of a GitLab project (repository). Projects are GitLab's equivalent of repositories and can belong to organizations or groups. The `GitLabRepository` label is included for backwards compatibility with existing queries.
 
+> **Ontology Mapping**: This node has the extra label `CodeRepository` to enable cross-platform queries for source code repositories across different systems (e.g., GitHubRepository).
+
 | Field | Description |
 |-------|--------------|
 | firstseen | Timestamp of when a sync job first created this node |

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -11,10 +11,11 @@ U -- OWNS --> CC(Device)
 U -- OWNS --> AK{{APIKey}}
 U -- AUTHORIZED --> OA{{ThirdPartyApp}}
 LB{{LoadBalancer}} -- EXPOSE --> CI{{ComputeInstance}}
-LB -- EXPOSE --> CT{{Container}}
+LB{{LoadBalancer}} -- EXPOSE --> CT{{Container}}
 DB{{Database}}
 TN{{Tenant}}
 FN{{Function}}
+REPO{{CodeRepository}}
 PIP(PublicIP) -- POINTS_TO --> LB
 PIP -- POINTS_TO --> CI
 CR{{ContainerRegistry}} -- REPO_IMAGE --> IT{{ImageTag}}
@@ -310,6 +311,27 @@ It generalizes concepts like AWS Lambda functions, GCP Cloud Functions, GCP Clou
 | _ont_memory | Memory allocated to the function (in MB). |
 | _ont_timeout | Timeout for function execution (in seconds). |
 | _ont_deployment_type | The deployment type: `code` for source code functions (Lambda, Cloud Functions, Azure Functions), `container` for container-based functions (Cloud Run). |
+
+
+### CodeRepository
+
+```{note}
+CodeRepository is a semantic label.
+```
+
+A code repository represents a source code repository containing software projects and their version history.
+Code repositories are critical assets for supply chain security as they contain intellectual property and often secrets.
+It generalizes concepts like GitHub Repositories and GitLab Projects.
+
+| Field | Description |
+|-------|-------------|
+| _ont_name | The name of the repository (REQUIRED). |
+| _ont_fullname | The full path including namespace (e.g., "org/repo", "group/subgroup/project"). |
+| _ont_description | Description of the repository. |
+| _ont_url | Web URL to access the repository. |
+| _ont_default_branch | The default branch name (e.g., "main", "master"). |
+| _ont_public | Whether the repository is publicly accessible. |
+| _ont_archived | Whether the repository is archived (read-only). |
 
 
 ### LoadBalancer

--- a/tests/unit/cartography/intel/ontology/test_ontology_mapping.py
+++ b/tests/unit/cartography/intel/ontology/test_ontology_mapping.py
@@ -24,6 +24,7 @@ OLD_FORMAT_NODES = [
     "OktaOrganization",
     "AWSAccount",
     "EntraTenant",  # main label is AzureTenant
+    "GitHubRepository",
 ]
 
 


### PR DESCRIPTION
## Summary

- Adds a new `CodeRepository` semantic label to the ontology for source code repositories
- Maps `GitHubRepository` and `GitLabProject` nodes to enable cross-platform queries
- Essential for supply chain security analysis across different code hosting platforms

**Ontology fields:**
| Field | Description |
|-------|-------------|
| `_ont_name` | Repository name |
| `_ont_fullname` | Full path including namespace |
| `_ont_description` | Repository description |
| `_ont_url` | Web URL to access the repository |
| `_ont_default_branch` | Default branch name |
| `_ont_public` | Whether the repository is publicly accessible |
| `_ont_archived` | Whether the repository is archived |

## Test plan

- [x] Unit tests for ontology mapping pass
- [x] Linting passes