### PR TITLE
fix(ec2): Use execute_read for AWS EC2 image/snapshot reads

### DIFF
--- a/cartography/intel/aws/ec2/images.py
+++ b/cartography/intel/aws/ec2/images.py
@@ -40,8 +40,8 @@ def get_images_in_use(
     }
     RETURN DISTINCT image;
     """
-    result = read_list_of_values_tx(
-        neo4j_session,
+    result = neo4j_session.execute_read(
+        read_list_of_values_tx,
         get_images_query,
         AWS_ACCOUNT_ID=current_aws_account_id,
         Region=region,

--- a/cartography/intel/aws/ec2/snapshots.py
+++ b/cartography/intel/aws/ec2/snapshots.py
@@ -28,8 +28,8 @@ def get_snapshots_in_use(
     WHERE v.region = $Region
     RETURN v.snapshotid as snapshot
     """
-    results = read_list_of_values_tx(
-        neo4j_session,
+    results = neo4j_session.execute_read(
+        read_list_of_values_tx,
         query,
         AWS_ACCOUNT_ID=current_aws_account_id,
         Region=region,


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
Use `session.execute_read(...)` for AWS EC2 images/snapshots read helpers so reads go through managed transactions and Cartography's existing retry logic. This avoids transient `SessionExpired` failures during long Aura syncs and aligns with the driver API migration in PR #2340.

Redacted error observed:
```
SessionExpired: Failed to read from defunct connection <aura-host>:7687
Connection reset by peer
```

Relevant docs:
- https://neo4j.com/docs/python-manual/current/transactions/ (managed transactions retry transient errors)
- https://neo4j.com/docs/python-manual/current/query-advanced/ (implicit transactions do not retry)
- https://graphacademy.neo4j.com/courses/drivers-python/3-in-production/1-transaction-management/ (managed transaction semantics)


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- https://github.com/cartography-cncf/cartography/pull/2340


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

None.


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- Standard integration tests

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
This completes the managed-transaction API migration for two AWS EC2 read helpers that still invoked `read_list_of_values_tx` directly with a `Session`, which bypassed the retry path. PR #2340 updated the driver APIs overall but did not touch these call sites.
