### PR TITLE
feat(santa): add Zentral-backed Santa module and ontology mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ You can learn more about the story behind Cartography in our [presentation at BS
 - [Oracle Cloud Infrastructure](https://cartography-cncf.github.io/cartography/modules/oci/index.html) - IAM
 - [PagerDuty](https://cartography-cncf.github.io/cartography/modules/pagerduty/index.html) - Users, teams, services, schedules, escalation policies, integrations, vendors
 - [Scaleway](https://cartography-cncf.github.io/cartography/modules/scaleway/index.html) - Projects, IAM, Local Storage, Instances
+- [Santa](https://cartography-cncf.github.io/cartography/modules/santa/index.html) - Machines, Users, Observed Applications, Observed Application Versions
 - [SentinelOne](https://cartography-cncf.github.io/cartography/modules/sentinelone/index.html) - Accounts, Agents, Applications, Application Versions, CVEs
 - [Slack](https://cartography-cncf.github.io/cartography/modules/slack/index.html) - Teams, Users, UserGroups, Channels
 - [SnipeIT](https://cartography-cncf.github.io/cartography/modules/snipeit/index.html) - Users, Assets

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -50,6 +50,7 @@ PANEL_TRIVY = "Trivy Options"
 PANEL_ONTOLOGY = "Ontology Options"
 PANEL_SCALEWAY = "Scaleway Options"
 PANEL_SENTINELONE = "SentinelOne Options"
+PANEL_SANTA = "Santa Options"
 PANEL_KEYCLOAK = "Keycloak Options"
 PANEL_SLACK = "Slack Options"
 PANEL_SPACELIFT = "Spacelift Options"
@@ -90,6 +91,7 @@ MODULE_PANELS = {
     "ontology": PANEL_ONTOLOGY,
     "scaleway": PANEL_SCALEWAY,
     "sentinelone": PANEL_SENTINELONE,
+    "santa": PANEL_SANTA,
     "keycloak": PANEL_KEYCLOAK,
     "slack": PANEL_SLACK,
     "spacelift": PANEL_SPACELIFT,
@@ -1235,6 +1237,54 @@ class CLI:
                 ),
             ] = "SENTINELONE_API_TOKEN",
             # =================================================================
+            # Santa Options
+            # =================================================================
+            santa_base_url: Annotated[
+                str | None,
+                typer.Option(
+                    "--santa-base-url",
+                    help="Zentral API base URL used for Santa exports.",
+                    rich_help_panel=PANEL_SANTA,
+                    hidden=PANEL_SANTA not in visible_panels,
+                ),
+            ] = None,
+            santa_token_env_var: Annotated[
+                str,
+                typer.Option(
+                    "--santa-token-env-var",
+                    help="Environment variable name containing Zentral API token for Santa exports.",
+                    rich_help_panel=PANEL_SANTA,
+                    hidden=PANEL_SANTA not in visible_panels,
+                ),
+            ] = "SANTA_TOKEN",
+            santa_source_name: Annotated[
+                str,
+                typer.Option(
+                    "--santa-source-name",
+                    help="Inventory source name used to filter Santa exports.",
+                    rich_help_panel=PANEL_SANTA,
+                    hidden=PANEL_SANTA not in visible_panels,
+                ),
+            ] = "Santa",
+            santa_event_lookback_days: Annotated[
+                int,
+                typer.Option(
+                    "--santa-event-lookback-days",
+                    help="Number of days of Santa execution events to process.",
+                    rich_help_panel=PANEL_SANTA,
+                    hidden=PANEL_SANTA not in visible_panels,
+                ),
+            ] = 30,
+            santa_request_timeout: Annotated[
+                int,
+                typer.Option(
+                    "--santa-request-timeout",
+                    help="Request timeout in seconds for Zentral Santa API calls.",
+                    rich_help_panel=PANEL_SANTA,
+                    hidden=PANEL_SANTA not in visible_panels,
+                ),
+            ] = 60,
+            # =================================================================
             # Keycloak Options
             # =================================================================
             keycloak_client_id: Annotated[
@@ -1774,6 +1824,15 @@ class CLI:
                 )
                 sentinelone_api_token = os.environ.get(sentinelone_api_token_env_var)
 
+            # Read Santa API token
+            santa_token = None
+            if santa_base_url and santa_token_env_var:
+                logger.debug(
+                    "Reading Santa API token from environment variable %s",
+                    santa_token_env_var,
+                )
+                santa_token = os.environ.get(santa_token_env_var)
+
             # Read Keycloak client secret
             keycloak_client_secret = None
             if keycloak_client_secret_env_var:
@@ -1928,6 +1987,11 @@ class CLI:
                 sentinelone_api_url=sentinelone_api_url,
                 sentinelone_api_token=sentinelone_api_token,
                 sentinelone_account_ids=sentinelone_account_ids_list,
+                santa_base_url=santa_base_url,
+                santa_token=santa_token,
+                santa_source_name=santa_source_name,
+                santa_event_lookback_days=santa_event_lookback_days,
+                santa_request_timeout=santa_request_timeout,
                 spacelift_api_endpoint=spacelift_api_endpoint_resolved,
                 spacelift_api_token=spacelift_api_token,
                 spacelift_api_key_id=spacelift_api_key_id,

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -202,6 +202,16 @@ class Config:
     :param sentinelone_api_token: SentinelOne API token for authentication. Optional.
     :type sentinelone_account_ids: list[str]
     :param sentinelone_account_ids: List of SentinelOne account IDs to sync. Optional.
+    :type santa_base_url: string
+    :param santa_base_url: Zentral API base URL for Santa data export. Optional.
+    :type santa_token: string
+    :param santa_token: Zentral API token used for Santa export endpoints. Optional.
+    :type santa_source_name: string
+    :param santa_source_name: Inventory source name to filter Santa exports. Defaults to "Santa".
+    :type santa_event_lookback_days: int
+    :param santa_event_lookback_days: Number of days of Santa execution events to process. Defaults to 30.
+    :type santa_request_timeout: int
+    :param santa_request_timeout: Request timeout (seconds) used for Zentral Santa API calls. Defaults to 60.
     :type spacelift_api_endpoint: string
     :param spacelift_api_endpoint: Spacelift GraphQL API endpoint. Optional.
     :type spacelift_api_token: string
@@ -333,6 +343,11 @@ class Config:
         sentinelone_api_url=None,
         sentinelone_api_token=None,
         sentinelone_account_ids=None,
+        santa_base_url=None,
+        santa_token=None,
+        santa_source_name="Santa",
+        santa_event_lookback_days=30,
+        santa_request_timeout=60,
         spacelift_api_endpoint=None,
         spacelift_api_token=None,
         spacelift_api_key_id=None,
@@ -449,6 +464,11 @@ class Config:
         self.sentinelone_api_url = sentinelone_api_url
         self.sentinelone_api_token = sentinelone_api_token
         self.sentinelone_account_ids = sentinelone_account_ids
+        self.santa_base_url = santa_base_url
+        self.santa_token = santa_token
+        self.santa_source_name = santa_source_name
+        self.santa_event_lookback_days = santa_event_lookback_days
+        self.santa_request_timeout = santa_request_timeout
         self.spacelift_api_endpoint = spacelift_api_endpoint
         self.spacelift_api_token = spacelift_api_token
         self.spacelift_api_key_id = spacelift_api_key_id

--- a/cartography/intel/santa/__init__.py
+++ b/cartography/intel/santa/__init__.py
@@ -1,0 +1,61 @@
+import logging
+
+import neo4j
+
+import cartography.intel.santa.events
+import cartography.intel.santa.machines
+from cartography.config import Config
+from cartography.intel.santa.client import ZentralSantaClient
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def start_santa_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
+    """
+    If this module is configured, perform ingestion of Santa machine and event data from Zentral.
+
+    :param neo4j_session: Neo4j session for database interface.
+    :param config: A cartography.config object.
+
+    :return: None
+    """
+    if not config.santa_base_url or not config.santa_token:
+        logger.info(
+            "Santa import is not configured - skipping this module. See docs to configure.",
+        )
+        return
+
+    if config.santa_event_lookback_days < 0:
+        raise ValueError("santa_event_lookback_days must be greater than or equal to 0")
+
+    if config.santa_request_timeout <= 0:
+        raise ValueError("santa_request_timeout must be greater than 0")
+
+    source_name = config.santa_source_name or "Santa"
+
+    common_job_parameters = {
+        "UPDATE_TAG": config.update_tag,
+    }
+
+    client = ZentralSantaClient(
+        base_url=config.santa_base_url,
+        token=config.santa_token,
+        request_timeout=config.santa_request_timeout,
+    )
+
+    cartography.intel.santa.machines.sync(
+        neo4j_session,
+        client,
+        source_name,
+        common_job_parameters,
+    )
+
+    cartography.intel.santa.events.sync(
+        neo4j_session,
+        client,
+        source_name,
+        config.santa_event_lookback_days,
+        common_job_parameters,
+    )

--- a/cartography/intel/santa/client.py
+++ b/cartography/intel/santa/client.py
@@ -1,0 +1,202 @@
+import csv
+import io
+import json
+import logging
+import time
+import zipfile
+from typing import Any
+from typing import IO
+from typing import Iterator
+from urllib.parse import urljoin
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class SantaEventExportEndpointUnavailable(RuntimeError):
+    """Raised when Zentral does not expose the Santa events export endpoint."""
+
+
+class ZentralSantaClient:
+    """Client for Zentral machine snapshot and Santa event export APIs."""
+
+    MACHINE_SNAPSHOTS_EXPORT_ENDPOINT = "/api/inventory/machines/export_snapshots/"
+    SANTA_EVENTS_EXPORT_ENDPOINT = "/api/santa/events/export/"
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str,
+        request_timeout: int = 60,
+        poll_interval_seconds: float = 1.0,
+        max_poll_seconds: int = 600,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._timeout = (request_timeout, request_timeout)
+        self._poll_interval_seconds = poll_interval_seconds
+        self._max_poll_seconds = max_poll_seconds
+
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "Accept": "application/json",
+                "Authorization": f"Token {token}",
+            },
+        )
+
+    def export_machine_snapshots(self, source_name: str) -> Iterator[dict[str, Any]]:
+        params: dict[str, str] = {}
+        if source_name:
+            params["source_name"] = source_name
+        task_result_url = self._start_export(
+            self.MACHINE_SNAPSHOTS_EXPORT_ENDPOINT,
+            params=params or None,
+        )
+        yield from self._iter_task_records(task_result_url)
+
+    def export_santa_events(self, source_name: str) -> Iterator[dict[str, Any]]:
+        params: dict[str, str] = {"export_format": "zip"}
+        if source_name:
+            params["source_name"] = source_name
+        task_result_url = self._start_export(
+            self.SANTA_EVENTS_EXPORT_ENDPOINT,
+            params=params,
+        )
+        yield from self._iter_task_records(task_result_url)
+
+    def _start_export(
+        self,
+        endpoint: str,
+        params: dict[str, str] | None = None,
+    ) -> str:
+        response = self._session.post(
+            self._absolute_url(endpoint),
+            params=params,
+            timeout=self._timeout,
+        )
+
+        if endpoint == self.SANTA_EVENTS_EXPORT_ENDPOINT and response.status_code in {
+            404,
+            405,
+        }:
+            raise SantaEventExportEndpointUnavailable(
+                "Zentral Santa event export endpoint is unavailable (404/405). "
+                "Santa app-on-machine mapping requires /api/santa/events/export/."
+            )
+
+        response.raise_for_status()
+        payload = response.json()
+        task_result_url = payload.get("task_result_url")
+        if not task_result_url:
+            raise RuntimeError(
+                f"Zentral export endpoint {endpoint} did not return task_result_url",
+            )
+        return str(task_result_url)
+
+    def _iter_task_records(self, task_result_url: str) -> Iterator[dict[str, Any]]:
+        download_url = self._wait_for_task(task_result_url)
+        response = self._session.get(download_url, timeout=self._timeout)
+        response.raise_for_status()
+        yield from self._iter_records_from_blob(response.content)
+
+    def _wait_for_task(self, task_result_url: str) -> str:
+        started = time.monotonic()
+        url = self._absolute_url(task_result_url)
+
+        while True:
+            response = self._session.get(url, timeout=self._timeout)
+            response.raise_for_status()
+            payload = response.json()
+
+            if payload.get("unready"):
+                if time.monotonic() - started > self._max_poll_seconds:
+                    raise TimeoutError(
+                        f"Timed out waiting for Zentral task result at {task_result_url}",
+                    )
+                time.sleep(self._poll_interval_seconds)
+                continue
+
+            status = payload.get("status")
+            if status != "SUCCESS":
+                raise RuntimeError(
+                    f"Zentral task {payload.get('id')} completed with status '{status}'",
+                )
+
+            download_url = payload.get("download_url")
+            if not download_url:
+                raise RuntimeError(
+                    f"Zentral task {payload.get('id')} did not include download_url",
+                )
+            return self._absolute_url(str(download_url))
+
+    def _iter_records_from_blob(self, blob: bytes) -> Iterator[dict[str, Any]]:
+        if self._is_zip_blob(blob):
+            yield from self._iter_records_from_zip(blob)
+            return
+
+        yield from self._iter_records_from_text_blob(blob)
+
+    def _iter_records_from_zip(self, blob: bytes) -> Iterator[dict[str, Any]]:
+        with zipfile.ZipFile(io.BytesIO(blob), mode="r") as archive:
+            for info in archive.infolist():
+                if info.is_dir():
+                    continue
+                filename = info.filename.lower()
+                with archive.open(info, mode="r") as data:
+                    if filename.endswith(".jsonl"):
+                        yield from self._iter_jsonl_records(data)
+                    elif filename.endswith(".csv"):
+                        yield from self._iter_csv_records(data)
+
+    def _iter_records_from_text_blob(self, blob: bytes) -> Iterator[dict[str, Any]]:
+        payload = blob.lstrip()
+        if not payload:
+            return
+
+        if payload.startswith(b"["):
+            parsed = json.loads(payload.decode("utf-8"))
+            if isinstance(parsed, list):
+                for row in parsed:
+                    if isinstance(row, dict):
+                        yield row
+            return
+
+        if payload.startswith(b"{"):
+            yield from self._iter_jsonl_records(io.BytesIO(blob))
+            return
+
+        yield from self._iter_csv_records(io.BytesIO(blob))
+
+    @staticmethod
+    def _iter_jsonl_records(stream: IO[bytes]) -> Iterator[dict[str, Any]]:
+        text = stream.read().decode("utf-8")
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            parsed = json.loads(line)
+            if isinstance(parsed, dict):
+                yield parsed
+
+    @staticmethod
+    def _iter_csv_records(stream: IO[bytes]) -> Iterator[dict[str, Any]]:
+        text = stream.read().decode("utf-8")
+        sample = text[:2048]
+        try:
+            dialect = csv.Sniffer().sniff(sample, delimiters=",;\t|")
+        except csv.Error:
+            dialect = csv.excel
+
+        for row in csv.DictReader(io.StringIO(text), dialect=dialect):
+            if any(value not in (None, "") for value in row.values()):
+                yield row
+
+    @staticmethod
+    def _is_zip_blob(blob: bytes) -> bool:
+        if not blob:
+            return False
+        return zipfile.is_zipfile(io.BytesIO(blob))
+
+    def _absolute_url(self, path: str) -> str:
+        return urljoin(f"{self._base_url}/", path.lstrip("/"))

--- a/cartography/intel/santa/events.py
+++ b/cartography/intel/santa/events.py
@@ -1,0 +1,363 @@
+import logging
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.santa.client import ZentralSantaClient
+from cartography.models.santa.application import SantaObservedApplicationSchema
+from cartography.models.santa.application_version import (
+    SantaObservedApplicationVersionSchema,
+)
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+def _first_value(data: dict[str, Any], field_paths: list[str]) -> str | None:
+    for field_path in field_paths:
+        current: Any = data
+        for part in field_path.split("."):
+            if not isinstance(current, dict):
+                current = None
+                break
+            current = current.get(part)
+
+        if isinstance(current, str):
+            current = current.strip()
+        if current not in (None, ""):
+            return str(current)
+    return None
+
+
+def _normalize_identifier(value: str) -> str:
+    normalized = value.strip().lower()
+    cleaned = []
+    for character in normalized:
+        if character.isalnum() or character in {":", ".", "-", "_"}:
+            cleaned.append(character)
+        elif character in {"/", " ", "\\"}:
+            cleaned.append("_")
+    result = "".join(cleaned).strip("_")
+    return result or "unknown"
+
+
+def _looks_like_email(value: str | None) -> bool:
+    return bool(value and "@" in value and "." in value.rsplit("@", maxsplit=1)[-1])
+
+
+def _extract_machine_id(event: dict[str, Any]) -> str | None:
+    return _first_value(
+        event,
+        [
+            "machine.serial_number",
+            "machine.serial",
+            "machine_serial_number",
+            "machine_serial",
+            "serial_number",
+            "serial",
+            "machine_id",
+        ],
+    )
+
+
+def _extract_application_identifier(event: dict[str, Any]) -> str | None:
+    return _first_value(
+        event,
+        [
+            "target.bundle_identifier",
+            "bundle_identifier",
+            "bundle_id",
+            "file.bundle_identifier",
+            "file_bundle_identifier",
+            "file.bundle_id",
+            "file_bundle_id",
+            "file.sha256",
+            "file_sha256",
+            "sha256",
+            "file.path",
+            "file_path",
+            "path",
+            "file_name",
+            "filename",
+        ],
+    )
+
+
+def _extract_application_name(event: dict[str, Any]) -> str | None:
+    path_value = _first_value(event, ["file.path", "file_path", "path"])
+    if path_value and "/" in path_value:
+        path_value = path_value.rsplit("/", maxsplit=1)[-1]
+
+    return (
+        _first_value(
+            event,
+            [
+                "target.display_name",
+                "display_name",
+                "bundle_name",
+                "file.bundle_name",
+                "file_name",
+                "filename",
+            ],
+        )
+        or path_value
+    )
+
+
+def _extract_application_version(event: dict[str, Any]) -> str:
+    return (
+        _first_value(
+            event,
+            [
+                "target.version",
+                "version",
+                "bundle_version",
+                "file.bundle_version",
+                "app_version",
+            ],
+        )
+        or "unknown"
+    )
+
+
+def _extract_user_id(event: dict[str, Any]) -> str | None:
+    user_id = _first_value(
+        event,
+        [
+            "user.id",
+            "user.unique_id",
+            "principal_user.unique_id",
+            "executing_user.id",
+            "user_id",
+            "principal_user_id",
+        ],
+    )
+    if user_id:
+        return user_id
+
+    principal_name = _first_value(
+        event,
+        [
+            "user.principal_name",
+            "principal_user.principal_name",
+            "executing_user.principal_name",
+            "username",
+            "user",
+        ],
+    )
+    if principal_name:
+        return (
+            principal_name.lower()
+            if _looks_like_email(principal_name)
+            else principal_name
+        )
+
+    return None
+
+
+def _parse_event_timestamp(value: Any) -> datetime | None:
+    if value in (None, ""):
+        return None
+
+    if isinstance(value, (int, float)):
+        timestamp = float(value)
+        if timestamp > 10_000_000_000:
+            timestamp = timestamp / 1000.0
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+
+        if raw.isdigit():
+            return _parse_event_timestamp(int(raw))
+
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        try:
+            parsed = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    return None
+
+
+def _event_is_within_lookback(event: dict[str, Any], cutoff: datetime | None) -> bool:
+    if cutoff is None:
+        return True
+
+    timestamp_value = _first_value(
+        event,
+        [
+            "event_time",
+            "timestamp",
+            "created_at",
+            "recorded_at",
+            "decision_time",
+            "time",
+        ],
+    )
+    event_timestamp = _parse_event_timestamp(timestamp_value)
+    if event_timestamp is None:
+        return True
+    return event_timestamp >= cutoff
+
+
+@timeit
+def get(client: ZentralSantaClient, source_name: str) -> list[dict[str, Any]]:
+    events = list(client.export_santa_events(source_name))
+    logger.info("Retrieved %d Santa execution events from Zentral", len(events))
+    return events
+
+
+@timeit
+def transform_events(
+    event_rows: list[dict[str, Any]],
+    source_name: str,
+    lookback_days: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    cutoff: datetime | None = None
+    if lookback_days > 0:
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=lookback_days)
+
+    applications_by_id: dict[str, dict[str, Any]] = {}
+    versions: list[dict[str, Any]] = []
+    seen_version_rows: set[tuple[str, str | None, str | None]] = set()
+
+    for event in event_rows:
+        if not _event_is_within_lookback(event, cutoff):
+            continue
+
+        application_identifier = _extract_application_identifier(event)
+        if not application_identifier:
+            logger.debug("Skipping Santa event without application identifier")
+            continue
+
+        application_name = _extract_application_name(event) or application_identifier
+        application_id = _normalize_identifier(application_identifier)
+        app_version = _extract_application_version(event)
+        app_version_id = (
+            f"{application_id}:{_normalize_identifier(app_version)}"
+            if app_version
+            else f"{application_id}:unknown"
+        )
+
+        applications_by_id[application_id] = {
+            "id": application_id,
+            "name": application_name,
+            "identifier": application_identifier,
+            "source_name": source_name,
+        }
+
+        machine_id = _extract_machine_id(event)
+        executed_by_user_id = _extract_user_id(event)
+        dedupe_key = (app_version_id, machine_id, executed_by_user_id)
+        if dedupe_key in seen_version_rows:
+            continue
+        seen_version_rows.add(dedupe_key)
+
+        version_row: dict[str, Any] = {
+            "id": app_version_id,
+            "version": app_version,
+            "application_id": application_id,
+            "source_name": source_name,
+        }
+
+        event_time = _first_value(
+            event,
+            [
+                "event_time",
+                "timestamp",
+                "created_at",
+                "recorded_at",
+                "decision_time",
+                "time",
+            ],
+        )
+        if event_time:
+            version_row["last_seen"] = event_time
+
+        if machine_id:
+            version_row["machine_id"] = machine_id
+        if executed_by_user_id:
+            version_row["executed_by_user_id"] = executed_by_user_id
+
+        versions.append(version_row)
+
+    return list(applications_by_id.values()), versions
+
+
+@timeit
+def load_applications(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    update_tag: int,
+) -> None:
+    logger.info("Loading %d Santa observed applications into Neo4j", len(data))
+    load(
+        neo4j_session,
+        SantaObservedApplicationSchema(),
+        data,
+        lastupdated=update_tag,
+    )
+
+
+@timeit
+def load_application_versions(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    update_tag: int,
+) -> None:
+    logger.info("Loading %d Santa observed application versions into Neo4j", len(data))
+    load(
+        neo4j_session,
+        SantaObservedApplicationVersionSchema(),
+        data,
+        lastupdated=update_tag,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    logger.debug("Running SantaObservedApplication cleanup")
+    GraphJob.from_node_schema(
+        SantaObservedApplicationSchema(), common_job_parameters
+    ).run(
+        neo4j_session,
+    )
+    logger.debug("Running SantaObservedApplicationVersion cleanup")
+    GraphJob.from_node_schema(
+        SantaObservedApplicationVersionSchema(),
+        common_job_parameters,
+    ).run(
+        neo4j_session,
+    )
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: ZentralSantaClient,
+    source_name: str,
+    lookback_days: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    event_rows = get(client, source_name)
+    applications, versions = transform_events(event_rows, source_name, lookback_days)
+
+    update_tag = int(common_job_parameters["UPDATE_TAG"])
+    load_applications(neo4j_session, applications, update_tag)
+    load_application_versions(neo4j_session, versions, update_tag)
+    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/santa/machines.py
+++ b/cartography/intel/santa/machines.py
@@ -1,0 +1,239 @@
+import logging
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.santa.client import ZentralSantaClient
+from cartography.models.santa.machine import SantaMachineSchema
+from cartography.models.santa.user import SantaUserSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+def _first_value(data: dict[str, Any], field_paths: list[str]) -> str | None:
+    for field_path in field_paths:
+        current: Any = data
+        for part in field_path.split("."):
+            if not isinstance(current, dict):
+                current = None
+                break
+            current = current.get(part)
+
+        if isinstance(current, str):
+            current = current.strip()
+        if current not in (None, ""):
+            return str(current)
+    return None
+
+
+def _extract_machine_id(snapshot: dict[str, Any]) -> str | None:
+    return _first_value(
+        snapshot,
+        [
+            "serial_number",
+            "system_info.hardware_serial",
+            "imei",
+            "meid",
+        ],
+    )
+
+
+def _extract_email(principal_name: str | None) -> str | None:
+    if not principal_name:
+        return None
+    if "@" not in principal_name:
+        return None
+    return principal_name.lower()
+
+
+def _extract_user(principal_user: dict[str, Any]) -> tuple[str | None, dict[str, Any]]:
+    principal_name = _first_value(principal_user, ["principal_name"])
+    user_id = _first_value(principal_user, ["principal_name", "unique_id"])
+    if not user_id:
+        return None, {}
+
+    display_name = _first_value(principal_user, ["display_name"]) or principal_name
+
+    user_row: dict[str, Any] = {
+        "id": user_id,
+        "principal_name": principal_name,
+        "display_name": display_name,
+    }
+    email = _extract_email(principal_name)
+    if email:
+        user_row["email"] = email
+
+    return user_id, user_row
+
+
+def _merge_non_empty(existing: dict[str, Any], updates: dict[str, Any]) -> None:
+    for key, value in updates.items():
+        if value not in (None, ""):
+            existing[key] = value
+
+
+def _format_os_version(snapshot: dict[str, Any]) -> str | None:
+    os_version = snapshot.get("os_version")
+    if not isinstance(os_version, dict):
+        return None
+
+    name = _first_value(os_version, ["name"])
+    version_parts = [
+        _first_value(os_version, ["major"]),
+        _first_value(os_version, ["minor"]),
+        _first_value(os_version, ["patch"]),
+        _first_value(os_version, ["build"]),
+    ]
+    compact_version = ".".join(p for p in version_parts if p)
+
+    if name and compact_version:
+        return f"{name} {compact_version}"
+    return name or compact_version or None
+
+
+@timeit
+def get(client: ZentralSantaClient, source_name: str) -> list[dict[str, Any]]:
+    snapshots = list(client.export_machine_snapshots(source_name))
+    logger.info("Retrieved %d machine snapshots from Zentral", len(snapshots))
+    return snapshots
+
+
+@timeit
+def transform_machine_snapshots(
+    machine_snapshots: list[dict[str, Any]],
+    source_name: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    machine_map: dict[str, dict[str, Any]] = {}
+    user_map: dict[str, dict[str, Any]] = {}
+
+    for snapshot in machine_snapshots:
+        machine_id = _extract_machine_id(snapshot)
+        if not machine_id:
+            logger.debug("Skipping machine snapshot without stable identifier")
+            continue
+
+        machine_source_name = (
+            _first_value(snapshot, ["source.name"]) or source_name or "Santa"
+        )
+
+        machine_row: dict[str, Any] = {
+            "id": machine_id,
+            "hostname": _first_value(
+                snapshot,
+                [
+                    "system_info.hostname",
+                    "system_info.computer_name",
+                    "serial_number",
+                ],
+            )
+            or machine_id,
+            "serial_number": _first_value(
+                snapshot,
+                ["serial_number", "system_info.hardware_serial"],
+            )
+            or machine_id,
+            "platform": _first_value(snapshot, ["platform"]),
+            "model": _first_value(snapshot, ["system_info.hardware_model"]),
+            "os_version": _format_os_version(snapshot),
+            "source_name": machine_source_name,
+            "last_seen": _first_value(snapshot, ["last_seen"]),
+        }
+
+        principal_user = snapshot.get("principal_user")
+        if isinstance(principal_user, dict):
+            user_id, user_row = _extract_user(principal_user)
+            if user_id and user_row:
+                user_row["source_name"] = machine_source_name
+                existing_user_row = user_map.get(user_id)
+                if existing_user_row:
+                    _merge_non_empty(existing_user_row, user_row)
+                else:
+                    user_map[user_id] = user_row
+                machine_row["primary_user_id"] = user_id
+
+        existing_machine_row = machine_map.get(machine_id)
+        if existing_machine_row:
+            _merge_non_empty(existing_machine_row, machine_row)
+        else:
+            machine_map[machine_id] = machine_row
+
+    return list(machine_map.values()), list(user_map.values())
+
+
+@timeit
+def load_machines(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    update_tag: int,
+) -> None:
+    logger.info("Loading %d Santa machines into Neo4j", len(data))
+    load(
+        neo4j_session,
+        SantaMachineSchema(),
+        data,
+        lastupdated=update_tag,
+    )
+
+
+@timeit
+def load_users(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    update_tag: int,
+) -> None:
+    logger.info("Loading %d Santa users into Neo4j", len(data))
+    load(
+        neo4j_session,
+        SantaUserSchema(),
+        data,
+        lastupdated=update_tag,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    logger.debug("Running SantaMachine cleanup")
+    GraphJob.from_node_schema(SantaMachineSchema(), common_job_parameters).run(
+        neo4j_session,
+    )
+    logger.debug("Running SantaUser cleanup")
+    GraphJob.from_node_schema(SantaUserSchema(), common_job_parameters).run(
+        neo4j_session,
+    )
+    # SantaUser currently has no schema-owned relationships, so GraphJob cleanup is a no-op.
+    # Explicitly remove stale SantaUser nodes to keep user attribution current between sync runs.
+    while True:
+        result = neo4j_session.run(
+            """
+            MATCH (n:SantaUser)
+            WHERE n.lastupdated <> $UPDATE_TAG
+            WITH n LIMIT $LIMIT_SIZE
+            DETACH DELETE n
+            """,
+            UPDATE_TAG=common_job_parameters["UPDATE_TAG"],
+            LIMIT_SIZE=100,
+        )
+        if result.consume().counters.nodes_deleted == 0:
+            break
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: ZentralSantaClient,
+    source_name: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    machine_snapshots = get(client, source_name)
+    machines, users = transform_machine_snapshots(machine_snapshots, source_name)
+
+    update_tag = int(common_job_parameters["UPDATE_TAG"])
+    load_users(neo4j_session, users, update_tag)
+    load_machines(neo4j_session, machines, update_tag)
+    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/models/ontology/device.py
+++ b/cartography/models/ontology/device.py
@@ -117,6 +117,17 @@ class DeviceToGoogleWorkspaceDeviceRel(CartographyRelSchema):
     properties: DeviceToNodeRelProperties = DeviceToNodeRelProperties()
 
 
+# (:Device)-[:OBSERVED_AS]->(:SantaMachine)
+class DeviceToSantaMachineRel(CartographyRelSchema):
+    target_node_label: str = "SantaMachine"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"hostname": PropertyRef("hostname")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "OBSERVED_AS"
+    properties: DeviceToNodeRelProperties = DeviceToNodeRelProperties()
+
+
 @dataclass(frozen=True)
 class DeviceSchema(CartographyNodeSchema):
     label: str = "Device"
@@ -133,5 +144,6 @@ class DeviceSchema(CartographyNodeSchema):
             DeviceToCrowdstrikeHostRel(),
             DeviceToBigfixComputerRel(),
             DeviceToGoogleWorkspaceDeviceRel(),
+            DeviceToSantaMachineRel(),
         ],
     )

--- a/cartography/models/ontology/mapping/data/devices.py
+++ b/cartography/models/ontology/mapping/data/devices.py
@@ -148,6 +148,34 @@ tailscale_mapping = OntologyMapping(
         )
     ],
 )
+santa_mapping = OntologyMapping(
+    module_name="santa",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="SantaMachine",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="hostname", node_field="hostname", required=True
+                ),
+                OntologyFieldMapping(
+                    ontology_field="serial_number", node_field="serial_number"
+                ),
+                OntologyFieldMapping(
+                    ontology_field="os_version", node_field="os_version"
+                ),
+                OntologyFieldMapping(ontology_field="model", node_field="model"),
+                OntologyFieldMapping(ontology_field="platform", node_field="platform"),
+            ],
+        ),
+    ],
+    rels=[
+        OntologyRelMapping(
+            __comment__="Link Device to User based on SantaUser-SantaMachine relationship",
+            query="MATCH (u:User)-[:HAS_ACCOUNT]->(:SantaUser)<-[:PRIMARY_USER]-(:SantaMachine)<-[:OBSERVED_AS]-(d:Device) MERGE (u)-[r:OWNS]->(d) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+            iterative=False,
+        ),
+    ],
+)
 
 googleworkspace_mapping = OntologyMapping(
     module_name="googleworkspace",
@@ -189,6 +217,7 @@ DEVICES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "duo": duo_mapping,
     "googleworkspace": googleworkspace_mapping,
     "kandji": kandji_mapping,
+    "santa": santa_mapping,
     "snipeit": snipeit_mapping,
     "tailscale": tailscale_mapping,
 }

--- a/cartography/models/ontology/mapping/data/useraccounts.py
+++ b/cartography/models/ontology/mapping/data/useraccounts.py
@@ -433,6 +433,25 @@ slack_mapping = OntologyMapping(
         ),
     ],
 )
+santa_mapping = OntologyMapping(
+    module_name="santa",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="SantaUser",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="email", node_field="email", required=True
+                ),
+                OntologyFieldMapping(
+                    ontology_field="username", node_field="principal_name"
+                ),
+                OntologyFieldMapping(
+                    ontology_field="fullname", node_field="display_name"
+                ),
+            ],
+        ),
+    ],
+)
 spacelift_mapping = OntologyMapping(
     module_name="spacelift",
     nodes=[
@@ -493,6 +512,7 @@ USERACCOUNTS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws": aws_mapping,
     "googleworkspace": googleworkspace_mapping,
     "slack": slack_mapping,
+    "santa": santa_mapping,
     "spacelift": spacelift_mapping,
     "pagerduty": pagerduty_mapping,
 }

--- a/cartography/models/santa/__init__.py
+++ b/cartography/models/santa/__init__.py
@@ -1,0 +1,15 @@
+# Santa data models
+
+from cartography.models.santa.application import SantaObservedApplicationSchema
+from cartography.models.santa.application_version import (
+    SantaObservedApplicationVersionSchema,
+)
+from cartography.models.santa.machine import SantaMachineSchema
+from cartography.models.santa.user import SantaUserSchema
+
+__all__ = [
+    "SantaMachineSchema",
+    "SantaUserSchema",
+    "SantaObservedApplicationSchema",
+    "SantaObservedApplicationVersionSchema",
+]

--- a/cartography/models/santa/application.py
+++ b/cartography/models/santa/application.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+
+
+@dataclass(frozen=True)
+class SantaObservedApplicationNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    name: PropertyRef = PropertyRef("name")
+    identifier: PropertyRef = PropertyRef("identifier", extra_index=True)
+    source_name: PropertyRef = PropertyRef("source_name")
+
+
+@dataclass(frozen=True)
+class SantaObservedApplicationSchema(CartographyNodeSchema):
+    label: str = "SantaObservedApplication"
+    scoped_cleanup: bool = False
+    properties: SantaObservedApplicationNodeProperties = (
+        SantaObservedApplicationNodeProperties()
+    )

--- a/cartography/models/santa/application_version.py
+++ b/cartography/models/santa/application_version.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class SantaObservedApplicationVersionNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", extra_index=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    version: PropertyRef = PropertyRef("version")
+    source_name: PropertyRef = PropertyRef("source_name")
+    last_seen: PropertyRef = PropertyRef("last_seen")
+
+
+@dataclass(frozen=True)
+class SantaObservedApplicationVersionRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:SantaObservedApplication)-[:VERSION]->(:SantaObservedApplicationVersion)
+class SantaObservedApplicationToVersionRel(CartographyRelSchema):
+    target_node_label: str = "SantaObservedApplication"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("application_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "VERSION"
+    properties: SantaObservedApplicationVersionRelProperties = (
+        SantaObservedApplicationVersionRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+# (:SantaMachine)-[:OBSERVED_EXECUTION]->(:SantaObservedApplicationVersion)
+class SantaMachineObservedExecutionRel(CartographyRelSchema):
+    target_node_label: str = "SantaMachine"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("machine_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "OBSERVED_EXECUTION"
+    properties: SantaObservedApplicationVersionRelProperties = (
+        SantaObservedApplicationVersionRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+# (:SantaUser)-[:EXECUTED]->(:SantaObservedApplicationVersion)
+class SantaUserExecutedRel(CartographyRelSchema):
+    target_node_label: str = "SantaUser"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("executed_by_user_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "EXECUTED"
+    properties: SantaObservedApplicationVersionRelProperties = (
+        SantaObservedApplicationVersionRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class SantaObservedApplicationVersionSchema(CartographyNodeSchema):
+    label: str = "SantaObservedApplicationVersion"
+    scoped_cleanup: bool = False
+    properties: SantaObservedApplicationVersionNodeProperties = (
+        SantaObservedApplicationVersionNodeProperties()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        rels=[
+            SantaObservedApplicationToVersionRel(),
+            SantaMachineObservedExecutionRel(),
+            SantaUserExecutedRel(),
+        ],
+    )

--- a/cartography/models/santa/machine.py
+++ b/cartography/models/santa/machine.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class SantaMachineNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    hostname: PropertyRef = PropertyRef("hostname", extra_index=True)
+    serial_number: PropertyRef = PropertyRef("serial_number", extra_index=True)
+    platform: PropertyRef = PropertyRef("platform")
+    model: PropertyRef = PropertyRef("model")
+    os_version: PropertyRef = PropertyRef("os_version")
+    source_name: PropertyRef = PropertyRef("source_name")
+    last_seen: PropertyRef = PropertyRef("last_seen")
+
+
+@dataclass(frozen=True)
+class SantaMachineToSantaUserRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:SantaMachine)-[:PRIMARY_USER]->(:SantaUser)
+class SantaMachineToSantaUserRel(CartographyRelSchema):
+    target_node_label: str = "SantaUser"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("primary_user_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "PRIMARY_USER"
+    properties: SantaMachineToSantaUserRelProperties = (
+        SantaMachineToSantaUserRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class SantaMachineSchema(CartographyNodeSchema):
+    label: str = "SantaMachine"
+    scoped_cleanup: bool = False
+    properties: SantaMachineNodeProperties = SantaMachineNodeProperties()
+    other_relationships: OtherRelationships = OtherRelationships(
+        rels=[SantaMachineToSantaUserRel()],
+    )

--- a/cartography/models/santa/user.py
+++ b/cartography/models/santa/user.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+
+
+@dataclass(frozen=True)
+class SantaUserNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    email: PropertyRef = PropertyRef("email", extra_index=True)
+    principal_name: PropertyRef = PropertyRef("principal_name", extra_index=True)
+    display_name: PropertyRef = PropertyRef("display_name")
+    source_name: PropertyRef = PropertyRef("source_name")
+
+
+@dataclass(frozen=True)
+class SantaUserSchema(CartographyNodeSchema):
+    label: str = "SantaUser"
+    scoped_cleanup: bool = False
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        ["UserAccount"]
+    )  # UserAccount label is used for ontology mapping.
+    properties: SantaUserNodeProperties = SantaUserNodeProperties()

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -37,6 +37,7 @@ import cartography.intel.okta
 import cartography.intel.ontology
 import cartography.intel.openai
 import cartography.intel.pagerduty
+import cartography.intel.santa
 import cartography.intel.scaleway
 import cartography.intel.semgrep
 import cartography.intel.sentinelone
@@ -82,6 +83,7 @@ TOP_LEVEL_MODULES: OrderedDict[str, Callable[..., None]] = OrderedDict(
         "duo": cartography.intel.duo.start_duo_ingestion,
         "workday": cartography.intel.workday.start_workday_ingestion,
         "scaleway": cartography.intel.scaleway.start_scaleway_ingestion,
+        "santa": cartography.intel.santa.start_santa_ingestion,
         "semgrep": cartography.intel.semgrep.start_semgrep_ingestion,
         "snipeit": cartography.intel.snipeit.start_snipeit_ingestion,
         "tailscale": cartography.intel.tailscale.start_tailscale_ingestion,

--- a/docs/root/modules/santa/config.md
+++ b/docs/root/modules/santa/config.md
@@ -1,0 +1,36 @@
+## Santa Configuration
+
+Follow these steps to analyze Santa machine and execution data from Zentral with Cartography.
+
+1. Generate a Zentral API token with permissions required by the inventory and Santa export endpoints.
+1. Set `SANTA_TOKEN` in your environment (or pass a different variable name with `--santa-token-env-var`).
+1. Pass Zentral base URL with `--santa-base-url`.
+1. Optionally set the inventory source name with `--santa-source-name` (defaults to `Santa`).
+1. Optionally tune lookback and request timeout with `--santa-event-lookback-days` and `--santa-request-timeout`.
+
+### CLI Example
+
+```bash
+export SANTA_TOKEN='<zentral-api-token>'
+
+cartography \
+  --neo4j-uri bolt://localhost:7687 \
+  --selected-modules santa \
+  --santa-base-url https://zentral.example.com \
+  --santa-token-env-var SANTA_TOKEN \
+  --santa-source-name Santa \
+  --santa-event-lookback-days 30 \
+  --santa-request-timeout 60
+```
+
+## Required Zentral Permissions
+
+- `inventory.view_machinesnapshot` for `/api/inventory/machines/export_snapshots/`
+- Permission for the Santa events export endpoint (`/api/santa/events/export/`) when available
+
+## Endpoint Dependency
+
+Cartography Santa ingestion is intentionally fail-fast for app-on-machine data:
+
+- If Zentral does not expose `/api/santa/events/export/` (for example 404/405), Santa ingestion raises an explicit error.
+- Machine snapshot ingestion depends on Zentral inventory export tasks (`task_result_url` + `download_url`) and does not require local CSV exports.

--- a/docs/root/modules/santa/index.md
+++ b/docs/root/modules/santa/index.md
@@ -1,0 +1,6 @@
+# Santa
+
+```{toctree}
+config
+schema
+```

--- a/docs/root/modules/santa/schema.md
+++ b/docs/root/modules/santa/schema.md
@@ -1,0 +1,114 @@
+## Santa Schema
+
+### SantaMachine
+
+Represents a machine observed by Zentral inventory snapshots for a Santa source.
+
+> **Ontology Mapping**: This node maps into the ontology `Device` model via hostname.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Stable machine identifier (usually serial number) |
+| **hostname** | Machine hostname |
+| **serial_number** | Hardware serial number |
+| platform | Platform from inventory snapshot |
+| model | Hardware model |
+| os_version | Formatted OS version |
+| source_name | Zentral inventory source used for export |
+| last_seen | Last seen timestamp from inventory export |
+
+#### Relationships
+
+- Machine primary user attribution:
+
+  ```
+  (SantaMachine)-[:PRIMARY_USER]->(SantaUser)
+  ```
+
+- Observed executions on machine:
+
+  ```
+  (SantaMachine)-[:OBSERVED_EXECUTION]->(SantaObservedApplicationVersion)
+  ```
+
+### SantaUser
+
+Represents the principal user observed from Zentral machine snapshots.
+
+> **Ontology Mapping**: This node has the extra label `UserAccount` to enable ontology `User` joins.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Stable principal identifier (unique_id or principal_name) |
+| **email** | Principal email when available |
+| principal_name | Principal account name |
+| display_name | Principal display name |
+| source_name | Zentral inventory source used for export |
+
+#### Relationships
+
+- User observed as machine primary user:
+
+  ```
+  (SantaMachine)-[:PRIMARY_USER]->(SantaUser)
+  ```
+
+- User executed observed app versions:
+
+  ```
+  (SantaUser)-[:EXECUTED]->(SantaObservedApplicationVersion)
+  ```
+
+### SantaObservedApplication
+
+Represents a normalized application identifier observed in Santa events.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Normalized application identifier |
+| name | Display name of the application |
+| identifier | Original identifier value from Santa event payload |
+| source_name | Zentral source used for export |
+
+#### Relationships
+
+- Application to version:
+
+  ```
+  (SantaObservedApplication)-[:VERSION]->(SantaObservedApplicationVersion)
+  ```
+
+### SantaObservedApplicationVersion
+
+Represents a version of an observed application from Santa execution events.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Normalized application-version identifier |
+| version | Version string from Santa event payload |
+| source_name | Zentral source used for export |
+| last_seen | Event timestamp used to represent last observation |
+
+#### Relationships
+
+- Version belongs to an application:
+
+  ```
+  (SantaObservedApplication)-[:VERSION]->(SantaObservedApplicationVersion)
+  ```
+
+- Version observed on machine execution:
+
+  ```
+  (SantaMachine)-[:OBSERVED_EXECUTION]->(SantaObservedApplicationVersion)
+  ```
+
+- Version executed by user:
+
+  ```
+  (SantaUser)-[:EXECUTED]->(SantaObservedApplicationVersion)
+  ```
+
+## Observed Execution Semantics
+
+`OBSERVED_EXECUTION` captures that at least one Santa event associated a machine with an application version. It is not a process timeline and does not preserve every individual execution event.

--- a/docs/root/usage/schema.md
+++ b/docs/root/usage/schema.md
@@ -105,6 +105,9 @@
 ```{include} ../modules/pagerduty/schema.md
 ```
 
+```{include} ../modules/santa/schema.md
+```
+
 ```{include} ../modules/scaleway/schema.md
 ```
 

--- a/tests/data/santa/__init__.py
+++ b/tests/data/santa/__init__.py
@@ -1,0 +1,1 @@
+# Santa test data

--- a/tests/data/santa/events.py
+++ b/tests/data/santa/events.py
@@ -1,0 +1,37 @@
+EVENT_ROWS = [
+    {
+        "machine_serial_number": "C02ABC123",
+        "bundle_id": "com.apple.Terminal",
+        "bundle_name": "Terminal",
+        "bundle_version": "2.14",
+        "principal_user": {"principal_name": "homer@simpson.corp"},
+        "event_time": "2099-02-01T10:00:00Z",
+    },
+    {
+        "machine_serial_number": "C02DEF456",
+        "bundle_id": "com.google.Chrome",
+        "bundle_name": "Google Chrome",
+        "bundle_version": "124.0",
+        "principal_user": {"principal_name": "lisa@simpson.corp"},
+        "event_time": "2099-02-01T10:00:00Z",
+    },
+    {
+        "machine_serial_number": "C02DEF456",
+        "bundle_id": "com.google.Chrome",
+        "bundle_name": "Google Chrome",
+        "bundle_version": "124.0",
+        "principal_user": {"principal_name": "lisa@simpson.corp"},
+        "event_time": "2099-02-01T10:05:00Z",
+    },
+]
+
+EVENT_ROWS_SECOND_RUN = [
+    {
+        "machine_serial_number": "C02DEF456",
+        "bundle_id": "com.google.Chrome",
+        "bundle_name": "Google Chrome",
+        "bundle_version": "125.1",
+        "principal_user": {"principal_name": "lisa@simpson.corp"},
+        "event_time": "2099-02-02T10:00:00Z",
+    },
+]

--- a/tests/data/santa/events.py
+++ b/tests/data/santa/events.py
@@ -4,7 +4,10 @@ EVENT_ROWS = [
         "bundle_id": "com.apple.Terminal",
         "bundle_name": "Terminal",
         "bundle_version": "2.14",
-        "principal_user": {"principal_name": "homer@simpson.corp"},
+        "principal_user": {
+            "unique_id": "uid-homer",
+            "principal_name": "homer@simpson.corp",
+        },
         "event_time": "2099-02-01T10:00:00Z",
     },
     {
@@ -12,7 +15,10 @@ EVENT_ROWS = [
         "bundle_id": "com.google.Chrome",
         "bundle_name": "Google Chrome",
         "bundle_version": "124.0",
-        "principal_user": {"principal_name": "lisa@simpson.corp"},
+        "principal_user": {
+            "unique_id": "uid-lisa",
+            "principal_name": "lisa@simpson.corp",
+        },
         "event_time": "2099-02-01T10:00:00Z",
     },
     {
@@ -20,7 +26,10 @@ EVENT_ROWS = [
         "bundle_id": "com.google.Chrome",
         "bundle_name": "Google Chrome",
         "bundle_version": "124.0",
-        "principal_user": {"principal_name": "lisa@simpson.corp"},
+        "principal_user": {
+            "unique_id": "uid-lisa",
+            "principal_name": "lisa@simpson.corp",
+        },
         "event_time": "2099-02-01T10:05:00Z",
     },
 ]
@@ -31,7 +40,10 @@ EVENT_ROWS_SECOND_RUN = [
         "bundle_id": "com.google.Chrome",
         "bundle_name": "Google Chrome",
         "bundle_version": "125.1",
-        "principal_user": {"principal_name": "lisa@simpson.corp"},
+        "principal_user": {
+            "unique_id": "uid-lisa",
+            "principal_name": "lisa@simpson.corp",
+        },
         "event_time": "2099-02-02T10:00:00Z",
     },
 ]

--- a/tests/data/santa/machines.py
+++ b/tests/data/santa/machines.py
@@ -1,0 +1,77 @@
+MACHINE_SNAPSHOTS = [
+    {
+        "serial_number": "C02ABC123",
+        "platform": "macOS",
+        "source": {"module": "santa", "name": "Santa"},
+        "system_info": {
+            "hostname": "donut-mac",
+            "computer_name": "donut-mac",
+            "hardware_model": "MacBook Pro",
+            "hardware_serial": "C02ABC123",
+        },
+        "os_version": {
+            "name": "macOS",
+            "major": "14",
+            "minor": "5",
+            "patch": "0",
+            "build": "23F79",
+        },
+        "principal_user": {
+            "unique_id": "uid-homer",
+            "principal_name": "homer@simpson.corp",
+            "display_name": "Homer Simpson",
+        },
+        "last_seen": "2026-02-01T10:00:00Z",
+    },
+    {
+        "serial_number": "C02DEF456",
+        "platform": "macOS",
+        "source": {"module": "santa", "name": "Santa"},
+        "system_info": {
+            "hostname": "lisa-mac",
+            "computer_name": "lisa-mac",
+            "hardware_model": "MacBook Air",
+            "hardware_serial": "C02DEF456",
+        },
+        "os_version": {
+            "name": "macOS",
+            "major": "14",
+            "minor": "4",
+            "patch": "1",
+            "build": "23E224",
+        },
+        "principal_user": {
+            "unique_id": "uid-lisa",
+            "principal_name": "lisa@simpson.corp",
+            "display_name": "Lisa Simpson",
+        },
+        "last_seen": "2026-02-01T10:00:00Z",
+    },
+]
+
+MACHINE_SNAPSHOTS_SECOND_RUN = [
+    {
+        "serial_number": "C02DEF456",
+        "platform": "macOS",
+        "source": {"module": "santa", "name": "Santa"},
+        "system_info": {
+            "hostname": "lisa-mac",
+            "computer_name": "lisa-mac",
+            "hardware_model": "MacBook Air",
+            "hardware_serial": "C02DEF456",
+        },
+        "os_version": {
+            "name": "macOS",
+            "major": "14",
+            "minor": "5",
+            "patch": "0",
+            "build": "23F79",
+        },
+        "principal_user": {
+            "unique_id": "uid-lisa",
+            "principal_name": "lisa@simpson.corp",
+            "display_name": "Lisa Simpson",
+        },
+        "last_seen": "2026-02-02T12:00:00Z",
+    },
+]

--- a/tests/integration/cartography/intel/santa/__init__.py
+++ b/tests/integration/cartography/intel/santa/__init__.py
@@ -1,0 +1,1 @@
+# Santa integration tests

--- a/tests/integration/cartography/intel/santa/test_santa.py
+++ b/tests/integration/cartography/intel/santa/test_santa.py
@@ -158,6 +158,9 @@ def test_santa_sync_cleanup_removes_stale_records(neo4j_session) -> None:
 
     assert check_nodes(neo4j_session, "SantaMachine", ["id"]) == {("C02DEF456",)}
     assert check_nodes(neo4j_session, "SantaUser", ["id"]) == {("lisa@simpson.corp",)}
+    assert check_nodes(neo4j_session, "SantaObservedApplication", ["id"]) == {
+        ("com.google.chrome",)
+    }
     assert check_nodes(
         neo4j_session,
         "SantaObservedApplicationVersion",

--- a/tests/integration/cartography/intel/santa/test_santa.py
+++ b/tests/integration/cartography/intel/santa/test_santa.py
@@ -1,0 +1,216 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.ontology.devices
+import cartography.intel.ontology.users
+import cartography.intel.santa
+from cartography.config import Config
+from tests.data.santa.events import EVENT_ROWS
+from tests.data.santa.events import EVENT_ROWS_SECOND_RUN
+from tests.data.santa.machines import MACHINE_SNAPSHOTS
+from tests.data.santa.machines import MACHINE_SNAPSHOTS_SECOND_RUN
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+def _build_config(update_tag: int) -> Config:
+    return Config(
+        neo4j_uri="bolt://localhost:7687",
+        update_tag=update_tag,
+        santa_base_url="https://zentral.example.com",
+        santa_token="test-token",
+        santa_source_name="Santa",
+        santa_event_lookback_days=3650,
+        santa_request_timeout=30,
+    )
+
+
+def _run_santa_sync(
+    neo4j_session,
+    machine_snapshots: list[dict],
+    event_rows: list[dict],
+    update_tag: int,
+) -> None:
+    client = Mock()
+    client.export_machine_snapshots.return_value = machine_snapshots
+    client.export_santa_events.return_value = event_rows
+
+    with patch.object(
+        cartography.intel.santa, "ZentralSantaClient", return_value=client
+    ):
+        cartography.intel.santa.start_santa_ingestion(
+            neo4j_session,
+            _build_config(update_tag),
+        )
+
+
+def test_santa_sync_loads_nodes_and_relationships(neo4j_session) -> None:
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _run_santa_sync(neo4j_session, MACHINE_SNAPSHOTS, EVENT_ROWS, TEST_UPDATE_TAG)
+
+    assert check_nodes(neo4j_session, "SantaMachine", ["id", "hostname"]) == {
+        ("C02ABC123", "donut-mac"),
+        ("C02DEF456", "lisa-mac"),
+    }
+
+    assert check_nodes(neo4j_session, "SantaUser", ["id", "email"]) == {
+        ("homer@simpson.corp", "homer@simpson.corp"),
+        ("lisa@simpson.corp", "lisa@simpson.corp"),
+    }
+
+    assert check_nodes(
+        neo4j_session,
+        "SantaObservedApplication",
+        ["id", "name"],
+    ) == {
+        ("com.apple.terminal", "Terminal"),
+        ("com.google.chrome", "Google Chrome"),
+    }
+
+    assert check_nodes(
+        neo4j_session,
+        "SantaObservedApplicationVersion",
+        ["id", "version"],
+    ) == {
+        ("com.apple.terminal:2.14", "2.14"),
+        ("com.google.chrome:124.0", "124.0"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "SantaMachine",
+        "id",
+        "SantaUser",
+        "id",
+        "PRIMARY_USER",
+        rel_direction_right=True,
+    ) == {
+        ("C02ABC123", "homer@simpson.corp"),
+        ("C02DEF456", "lisa@simpson.corp"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "SantaMachine",
+        "id",
+        "SantaObservedApplicationVersion",
+        "id",
+        "OBSERVED_EXECUTION",
+        rel_direction_right=True,
+    ) == {
+        ("C02ABC123", "com.apple.terminal:2.14"),
+        ("C02DEF456", "com.google.chrome:124.0"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "SantaObservedApplication",
+        "id",
+        "SantaObservedApplicationVersion",
+        "id",
+        "VERSION",
+        rel_direction_right=True,
+    ) == {
+        ("com.apple.terminal", "com.apple.terminal:2.14"),
+        ("com.google.chrome", "com.google.chrome:124.0"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "SantaUser",
+        "id",
+        "SantaObservedApplicationVersion",
+        "id",
+        "EXECUTED",
+        rel_direction_right=True,
+    ) == {
+        ("homer@simpson.corp", "com.apple.terminal:2.14"),
+        ("lisa@simpson.corp", "com.google.chrome:124.0"),
+    }
+
+
+def test_santa_sync_cleanup_removes_stale_records(neo4j_session) -> None:
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+
+    client = Mock()
+    client.export_machine_snapshots.side_effect = [
+        MACHINE_SNAPSHOTS,
+        MACHINE_SNAPSHOTS_SECOND_RUN,
+    ]
+    client.export_santa_events.side_effect = [
+        EVENT_ROWS,
+        EVENT_ROWS_SECOND_RUN,
+    ]
+
+    with patch.object(
+        cartography.intel.santa, "ZentralSantaClient", return_value=client
+    ):
+        cartography.intel.santa.start_santa_ingestion(
+            neo4j_session,
+            _build_config(TEST_UPDATE_TAG),
+        )
+        cartography.intel.santa.start_santa_ingestion(
+            neo4j_session,
+            _build_config(TEST_UPDATE_TAG + 1),
+        )
+
+    assert check_nodes(neo4j_session, "SantaMachine", ["id"]) == {("C02DEF456",)}
+    assert check_nodes(neo4j_session, "SantaUser", ["id"]) == {("lisa@simpson.corp",)}
+    assert check_nodes(
+        neo4j_session,
+        "SantaObservedApplicationVersion",
+        ["id"],
+    ) == {("com.google.chrome:125.1",)}
+
+
+def test_santa_ontology_links_users_and_devices(neo4j_session) -> None:
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _run_santa_sync(neo4j_session, MACHINE_SNAPSHOTS, EVENT_ROWS, TEST_UPDATE_TAG)
+
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG}
+
+    cartography.intel.ontology.users.sync(
+        neo4j_session,
+        ["santa"],
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+    cartography.intel.ontology.devices.sync(
+        neo4j_session,
+        ["santa"],
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    assert check_nodes(neo4j_session, "Device", ["hostname"]) == {
+        ("donut-mac",),
+        ("lisa-mac",),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "Device",
+        "hostname",
+        "SantaMachine",
+        "hostname",
+        "OBSERVED_AS",
+        rel_direction_right=True,
+    ) == {
+        ("donut-mac", "donut-mac"),
+        ("lisa-mac", "lisa-mac"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "User",
+        "email",
+        "Device",
+        "hostname",
+        "OWNS",
+        rel_direction_right=True,
+    ) == {
+        ("homer@simpson.corp", "donut-mac"),
+        ("lisa@simpson.corp", "lisa-mac"),
+    }

--- a/tests/unit/cartography/intel/santa/__init__.py
+++ b/tests/unit/cartography/intel/santa/__init__.py
@@ -1,0 +1,1 @@
+# Santa unit tests

--- a/tests/unit/cartography/intel/santa/test_client.py
+++ b/tests/unit/cartography/intel/santa/test_client.py
@@ -1,0 +1,172 @@
+import io
+import zipfile
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from cartography.intel.santa.client import SantaEventExportEndpointUnavailable
+from cartography.intel.santa.client import ZentralSantaClient
+
+
+def _build_zip_blob(files: dict[str, str]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for filename, content in files.items():
+            archive.writestr(filename, content)
+    return buffer.getvalue()
+
+
+def _response(
+    status_code: int,
+    json_data: dict | None = None,
+    content: bytes | None = None,
+) -> Mock:
+    response = Mock()
+    response.status_code = status_code
+    response.json.return_value = json_data or {}
+    response.content = content or b""
+
+    if status_code >= 400:
+        response.raise_for_status.side_effect = requests.HTTPError(
+            f"HTTP {status_code}"
+        )
+    else:
+        response.raise_for_status.return_value = None
+    return response
+
+
+@patch("cartography.intel.santa.client.requests.Session")
+def test_export_machine_snapshots_poll_and_parse_jsonl(mock_session: Mock) -> None:
+    session = Mock()
+    mock_session.return_value = session
+
+    zip_blob = _build_zip_blob(
+        {
+            "santa.jsonl": (
+                '{"serial_number": "C02ABC123", "system_info": {"hostname": "donut-mac"}}\n'
+                '{"serial_number": "C02DEF456", "system_info": {"hostname": "lisa-mac"}}\n'
+            )
+        }
+    )
+
+    session.post.return_value = _response(
+        201,
+        {"task_result_url": "/api/task_result/11111111-1111-1111-1111-111111111111/"},
+    )
+    session.get.side_effect = [
+        _response(
+            200,
+            {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "status": "PENDING",
+                "unready": True,
+            },
+        ),
+        _response(
+            200,
+            {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "status": "SUCCESS",
+                "unready": False,
+                "download_url": "/api/task_result/11111111-1111-1111-1111-111111111111/download/",
+            },
+        ),
+        _response(200, content=zip_blob),
+    ]
+
+    client = ZentralSantaClient(
+        base_url="https://zentral.example.com",
+        token="test-token",
+        request_timeout=5,
+        poll_interval_seconds=0,
+    )
+
+    rows = list(client.export_machine_snapshots("Santa"))
+
+    assert rows == [
+        {"serial_number": "C02ABC123", "system_info": {"hostname": "donut-mac"}},
+        {"serial_number": "C02DEF456", "system_info": {"hostname": "lisa-mac"}},
+    ]
+
+    session.post.assert_called_once_with(
+        "https://zentral.example.com/api/inventory/machines/export_snapshots/",
+        params={"source_name": "Santa"},
+        timeout=(5, 5),
+    )
+    assert session.get.call_count == 3
+
+
+@patch("cartography.intel.santa.client.requests.Session")
+def test_export_santa_events_poll_and_parse_csv(mock_session: Mock) -> None:
+    session = Mock()
+    mock_session.return_value = session
+
+    zip_blob = _build_zip_blob(
+        {
+            "events.csv": (
+                "machine_serial_number;bundle_id;bundle_version\n"
+                "C02ABC123;com.apple.Terminal;2.14\n"
+            )
+        }
+    )
+
+    session.post.return_value = _response(
+        201,
+        {"task_result_url": "/api/task_result/22222222-2222-2222-2222-222222222222/"},
+    )
+    session.get.side_effect = [
+        _response(
+            200,
+            {
+                "id": "22222222-2222-2222-2222-222222222222",
+                "status": "SUCCESS",
+                "unready": False,
+                "download_url": "/api/task_result/22222222-2222-2222-2222-222222222222/download/",
+            },
+        ),
+        _response(200, content=zip_blob),
+    ]
+
+    client = ZentralSantaClient(
+        base_url="https://zentral.example.com",
+        token="test-token",
+        request_timeout=5,
+        poll_interval_seconds=0,
+    )
+
+    rows = list(client.export_santa_events("Santa"))
+
+    assert rows == [
+        {
+            "machine_serial_number": "C02ABC123",
+            "bundle_id": "com.apple.Terminal",
+            "bundle_version": "2.14",
+        }
+    ]
+
+    session.post.assert_called_once_with(
+        "https://zentral.example.com/api/santa/events/export/",
+        params={"export_format": "zip", "source_name": "Santa"},
+        timeout=(5, 5),
+    )
+
+
+@patch("cartography.intel.santa.client.requests.Session")
+def test_export_santa_events_fail_fast_when_endpoint_is_missing(
+    mock_session: Mock,
+) -> None:
+    session = Mock()
+    mock_session.return_value = session
+    session.post.return_value = _response(404)
+
+    client = ZentralSantaClient(
+        base_url="https://zentral.example.com",
+        token="test-token",
+        request_timeout=5,
+        poll_interval_seconds=0,
+    )
+
+    with pytest.raises(SantaEventExportEndpointUnavailable):
+        list(client.export_santa_events("Santa"))

--- a/tests/unit/cartography/intel/santa/test_transform_events.py
+++ b/tests/unit/cartography/intel/santa/test_transform_events.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+from cartography.intel.santa.events import transform_events
+from tests.data.santa.events import EVENT_ROWS
+
+
+def test_transform_events_builds_app_and_version_records() -> None:
+    applications, versions = transform_events(
+        EVENT_ROWS,
+        source_name="Santa",
+        lookback_days=3650,
+    )
+
+    assert {app["id"] for app in applications} == {
+        "com.apple.terminal",
+        "com.google.chrome",
+    }
+
+    assert {version["id"] for version in versions} == {
+        "com.apple.terminal:2.14",
+        "com.google.chrome:124.0",
+    }
+
+    terminal_version = next(
+        version for version in versions if version["id"] == "com.apple.terminal:2.14"
+    )
+    assert terminal_version["application_id"] == "com.apple.terminal"
+    assert terminal_version["machine_id"] == "C02ABC123"
+    assert terminal_version["executed_by_user_id"] == "homer@simpson.corp"
+
+
+def test_transform_events_respects_lookback_window() -> None:
+    now = datetime.now(tz=timezone.utc)
+    events = [
+        {
+            "machine_serial_number": "C02ABC123",
+            "bundle_id": "com.apple.Terminal",
+            "bundle_name": "Terminal",
+            "bundle_version": "2.14",
+            "principal_user": {"principal_name": "homer@simpson.corp"},
+            "event_time": (now - timedelta(days=1)).isoformat(),
+        },
+        {
+            "machine_serial_number": "C02ABC123",
+            "bundle_id": "com.apple.TextEdit",
+            "bundle_name": "TextEdit",
+            "bundle_version": "1.0",
+            "principal_user": {"principal_name": "homer@simpson.corp"},
+            "event_time": (now - timedelta(days=30)).isoformat(),
+        },
+    ]
+
+    applications, versions = transform_events(
+        events,
+        source_name="Santa",
+        lookback_days=7,
+    )
+
+    assert applications == [
+        {
+            "id": "com.apple.terminal",
+            "name": "Terminal",
+            "identifier": "com.apple.Terminal",
+            "source_name": "Santa",
+        }
+    ]
+    assert versions == [
+        {
+            "id": "com.apple.terminal:2.14",
+            "version": "2.14",
+            "application_id": "com.apple.terminal",
+            "source_name": "Santa",
+            "last_seen": events[0]["event_time"],
+            "machine_id": "C02ABC123",
+            "executed_by_user_id": "homer@simpson.corp",
+        }
+    ]

--- a/tests/unit/cartography/intel/santa/test_transform_machines.py
+++ b/tests/unit/cartography/intel/santa/test_transform_machines.py
@@ -1,0 +1,56 @@
+from cartography.intel.santa.machines import transform_machine_snapshots
+from tests.data.santa.machines import MACHINE_SNAPSHOTS
+
+
+def test_transform_machine_snapshots_extracts_machines_and_users() -> None:
+    machines, users = transform_machine_snapshots(MACHINE_SNAPSHOTS, "Santa")
+
+    assert {machine["id"] for machine in machines} == {"C02ABC123", "C02DEF456"}
+    assert {machine["hostname"] for machine in machines} == {"donut-mac", "lisa-mac"}
+
+    donut_machine = next(
+        machine for machine in machines if machine["id"] == "C02ABC123"
+    )
+    assert donut_machine["primary_user_id"] == "homer@simpson.corp"
+    assert donut_machine["source_name"] == "Santa"
+
+    assert {user["id"] for user in users} == {
+        "homer@simpson.corp",
+        "lisa@simpson.corp",
+    }
+    assert {user["email"] for user in users} == {
+        "homer@simpson.corp",
+        "lisa@simpson.corp",
+    }
+
+
+def test_transform_machine_snapshots_handles_missing_user_and_identifier() -> None:
+    snapshots = [
+        {
+            "platform": "macOS",
+            "source": {"name": "Santa"},
+            "system_info": {"hostname": "no-id-mac"},
+        },
+        {
+            "serial_number": "C02XYZ999",
+            "platform": "macOS",
+            "source": {"name": "Santa"},
+            "system_info": {"hostname": "anonymous-mac"},
+        },
+    ]
+
+    machines, users = transform_machine_snapshots(snapshots, "Santa")
+
+    assert machines == [
+        {
+            "id": "C02XYZ999",
+            "hostname": "anonymous-mac",
+            "serial_number": "C02XYZ999",
+            "platform": "macOS",
+            "model": None,
+            "os_version": None,
+            "source_name": "Santa",
+            "last_seen": None,
+        }
+    ]
+    assert users == []


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

Adds a new `santa` intel module that ingests Santa machine snapshots and execution events from Zentral export APIs, maps machines/users/apps into the graph, and links Santa data into ontology `Device` and `User` entities. This addresses Santa visibility for machine inventory and observed app execution while keeping behavior fail-fast when the Santa events export endpoint is unavailable.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- [Santa](https://santa.dev)


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

None.


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- unit and integration tests


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [x] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

- This module is Zentral-backed only; no local CSV export flow is required.
- `SantaUser` cleanup includes explicit stale-node deletion because schema-owned cleanup is relationship-oriented when no sub-resource is present.
- `SantaMachine -> Device` and `SantaUser -> User` ontology mappings are included, plus derived `User OWNS Device` relationship from `PRIMARY_USER`.
- The module intentionally raises a dedicated error if `/api/santa/events/export/` is missing (404/405).
