### PR TITLE
feat(trivy): load all packages, not just vulnerable ones

### DIFF
--- a/tests/data/trivy/trivy_gcp_sample.py
+++ b/tests/data/trivy/trivy_gcp_sample.py
@@ -106,6 +106,32 @@ TRIVY_GCP_SAMPLE = {
                     "LastModifiedDate": "2024-03-15T00:00:00Z",
                 },
             ],
+            "Packages": [
+                {
+                    "ID": "openssl@3.0.15-1~deb12u1",
+                    "Name": "openssl",
+                    "Version": "3.0.15-1~deb12u1",
+                    "Identifier": {
+                        "PURL": "pkg:deb/debian/openssl@3.0.15-1~deb12u1?arch=amd64&distro=debian-12.8",
+                    },
+                },
+                {
+                    "ID": "curl@7.88.1-10+deb12u5",
+                    "Name": "curl",
+                    "Version": "7.88.1-10+deb12u5",
+                    "Identifier": {
+                        "PURL": "pkg:deb/debian/curl@7.88.1-10+deb12u5?arch=amd64&distro=debian-12.8",
+                    },
+                },
+                {
+                    "ID": "libc6@2.36-9+deb12u4",
+                    "Name": "libc6",
+                    "Version": "2.36-9+deb12u4",
+                    "Identifier": {
+                        "PURL": "pkg:deb/debian/libc6@2.36-9+deb12u4?arch=amd64&distro=debian-12.8",
+                    },
+                },
+            ],
         },
     ],
 }

--- a/tests/data/trivy/trivy_gitlab_sample.py
+++ b/tests/data/trivy/trivy_gitlab_sample.py
@@ -117,6 +117,32 @@ TRIVY_GITLAB_SAMPLE = {
                     "LastModifiedDate": "2024-02-10T00:00:00Z",
                 },
             ],
+            "Packages": [
+                {
+                    "ID": "openssl@3.0.15-1~deb12u1",
+                    "Name": "openssl",
+                    "Version": "3.0.15-1~deb12u1",
+                    "Identifier": {
+                        "PURL": "pkg:deb/debian/openssl@3.0.15-1~deb12u1?arch=amd64&distro=debian-12.8",
+                    },
+                },
+                {
+                    "ID": "curl@7.88.1-10+deb12u5",
+                    "Name": "curl",
+                    "Version": "7.88.1-10+deb12u5",
+                    "Identifier": {
+                        "PURL": "pkg:deb/debian/curl@7.88.1-10+deb12u5?arch=amd64&distro=debian-12.8",
+                    },
+                },
+                {
+                    "ID": "coreutils@9.1-1",
+                    "Name": "coreutils",
+                    "Version": "9.1-1",
+                    "Identifier": {
+                        "PURL": "pkg:deb/debian/coreutils@9.1-1?arch=amd64&distro=debian-12.8",
+                    },
+                },
+            ],
         },
     ],
 }

--- a/tests/data/trivy/trivy_sample.py
+++ b/tests/data/trivy/trivy_sample.py
@@ -1370,6 +1370,44 @@ TRIVY_SAMPLE = {
                     "LastModifiedDate": "2025-04-30T15:21:11.547Z",
                 },
             ],
+            "Packages": [
+                {
+                    "ID": "apt@2.6.1",
+                    "Name": "apt",
+                    "Version": "2.6.1",
+                    "Identifier": {
+                        "PURL": "pkg:deb/debian/apt@2.6.1?arch=amd64&distro=debian-12.8",
+                    },
+                    "Layer": {
+                        "Digest": "sha256:8cf9fb7a0b56cf93bf2502aff8087344f2dd06e29fb027b0c06aa2726ab3eda8",
+                        "DiffID": "sha256:c0f1022b22a9b36851b358f44e5475e39d166e71a8073cf53c894a299239b1c5",
+                    },
+                },
+                {
+                    "ID": "bash@5.2.15-2+b2",
+                    "Name": "bash",
+                    "Version": "5.2.15-2+b2",
+                    "Identifier": {
+                        "PURL": "pkg:deb/debian/bash@5.2.15-2+b2?arch=amd64&distro=debian-12.8",
+                    },
+                    "Layer": {
+                        "Digest": "sha256:8cf9fb7a0b56cf93bf2502aff8087344f2dd06e29fb027b0c06aa2726ab3eda8",
+                        "DiffID": "sha256:c0f1022b22a9b36851b358f44e5475e39d166e71a8073cf53c894a299239b1c5",
+                    },
+                },
+                {
+                    "ID": "gcc-12-base@12.2.0-14",
+                    "Name": "gcc-12-base",
+                    "Version": "12.2.0-14",
+                    "Identifier": {
+                        "PURL": "pkg:deb/debian/gcc-12-base@12.2.0-14?arch=amd64&distro=debian-12.8",
+                    },
+                    "Layer": {
+                        "Digest": "sha256:8cf9fb7a0b56cf93bf2502aff8087344f2dd06e29fb027b0c06aa2726ab3eda8",
+                        "DiffID": "sha256:c0f1022b22a9b36851b358f44e5475e39d166e71a8073cf53c894a299239b1c5",
+                    },
+                },
+            ],
         },
         {
             "Target": "Python",
@@ -1425,6 +1463,32 @@ TRIVY_SAMPLE = {
                     "PublishedDate": "2025-04-24T19:15:47.06Z",
                     "LastModifiedDate": "2025-04-29T13:52:28.49Z",
                 }
+            ],
+            "Packages": [
+                {
+                    "ID": "h11@0.14.0",
+                    "Name": "h11",
+                    "Version": "0.14.0",
+                    "Identifier": {
+                        "PURL": "pkg:pypi/h11@0.14.0",
+                    },
+                },
+                {
+                    "ID": "requests@2.31.0",
+                    "Name": "requests",
+                    "Version": "2.31.0",
+                    "Identifier": {
+                        "PURL": "pkg:pypi/requests@2.31.0",
+                    },
+                },
+                {
+                    "ID": "urllib3@2.0.7",
+                    "Name": "urllib3",
+                    "Version": "2.0.7",
+                    "Identifier": {
+                        "PURL": "pkg:pypi/urllib3@2.0.7",
+                    },
+                },
             ],
         },
     ],

--- a/tests/integration/cartography/intel/trivy/test_helpers.py
+++ b/tests/integration/cartography/intel/trivy/test_helpers.py
@@ -23,8 +23,9 @@ def assert_trivy_findings(neo4j_session: Session) -> None:
 
 
 def assert_trivy_packages(neo4j_session: Session) -> None:
-    """Assert Package nodes exist with expected values."""
+    """Assert Package nodes exist with expected values (vulnerable + non-vulnerable)."""
     assert check_nodes(neo4j_session, "Package", ["id", "name", "version"]) == {
+        # Vulnerable packages (from Vulnerabilities array)
         ("0.14.0|h11", "h11", "0.14.0"),
         ("1.20.1-2+deb12u2|krb5-locales", "krb5-locales", "1.20.1-2+deb12u2"),
         ("1.20.1-2+deb12u2|libk5crypto3", "libk5crypto3", "1.20.1-2+deb12u2"),
@@ -39,6 +40,11 @@ def assert_trivy_packages(neo4j_session: Session) -> None:
         ("4.19.0-2|libtasn1-6", "libtasn1-6", "4.19.0-2"),
         ("5.36.0-7+deb12u1|perl-base", "perl-base", "5.36.0-7+deb12u1"),
         ("5.4.1-0.2|liblzma5", "liblzma5", "5.4.1-0.2"),
+        # Non-vulnerable packages (from Packages array only)
+        ("2.6.1|apt", "apt", "2.6.1"),
+        ("5.2.15-2+b2|bash", "bash", "5.2.15-2+b2"),
+        ("2.31.0|requests", "requests", "2.31.0"),
+        ("2.0.7|urllib3", "urllib3", "2.0.7"),
     }
 
 
@@ -108,6 +114,23 @@ def assert_all_trivy_relationships(neo4j_session: Session) -> None:
         ),
         (
             "5.4.1-0.2|liblzma5",
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        ),
+        # Non-vulnerable packages from Packages array
+        (
+            "2.6.1|apt",
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        ),
+        (
+            "5.2.15-2+b2|bash",
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        ),
+        (
+            "2.31.0|requests",
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        ),
+        (
+            "2.0.7|urllib3",
             "sha256:0000000000000000000000000000000000000000000000000000000000000000",
         ),
     }

--- a/tests/integration/cartography/intel/trivy/test_trivy_gcp_disk.py
+++ b/tests/integration/cartography/intel/trivy/test_trivy_gcp_disk.py
@@ -120,6 +120,10 @@ def test_sync_trivy_gcp(
             "7.88.1-10+deb12u5|curl",
             "sha256:def456",  # Platform-specific digest
         ),
+        (
+            "2.36-9+deb12u4|libc6",
+            "sha256:def456",  # Non-vulnerable package from Packages array
+        ),
     }
 
     expected_finding_rels = {

--- a/tests/integration/cartography/intel/trivy/test_trivy_gitlab_disk.py
+++ b/tests/integration/cartography/intel/trivy/test_trivy_gitlab_disk.py
@@ -129,6 +129,10 @@ def test_sync_trivy_gitlab(
             "7.88.1-10+deb12u5|curl",
             "sha256:aaa111222333444555666777888999000aaabbbcccdddeeefff000111222333",
         ),
+        (
+            "9.1-1|coreutils",
+            "sha256:aaa111222333444555666777888999000aaabbbcccdddeeefff000111222333",
+        ),
     }
 
     expected_finding_rels = {


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)


### Summary

With `--list-all-pkgs`, Trivy's JSON includes a `Packages` array per result class containing ALL installed packages. Previously, `transform_scan_results()` only iterated the `Vulnerabilities` array, creating `TrivyPackage` nodes only for packages with CVEs. This meant we were loading ~81 packages instead of ~1,804.

This PR adds `transform_all_packages()` which processes the `Packages` arrays, deduplicating against already-loaded vulnerable packages to avoid overwriting their `FindingId` (which would break the AFFECTS relationship). Non-vulnerable packages get `FindingId=None` so no AFFECTS rel is created, but they still get DEPLOYED relationships to their image.

This is a prerequisite for Syft DEPENDS_ON enrichment — without target package nodes existing, most dependency edges can't match.


### Related issues or links

- Part of Syft dependency enrichment work


### How was this tested?

- Added `Packages` arrays to test data for all three registry types (AWS ECR, GCP Artifact Registry, GitLab)
- Updated integration test assertions to verify non-vulnerable packages are loaded as `TrivyPackage` nodes with correct DEPLOYED relationships
- All 8 Trivy integration tests pass
- All 75 trivy/syft tests pass


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.
Logs: 
```
  INFO:cartography.intel.trivy.scanner:Found 4 json files in /tmp/e2e-test/trivy
  INFO:cartography.intel.trivy.scanner:Loading 525 additional non-vulnerable packages for <account_id>.dkr.ecr.us-east-1.amazonaws.com/subimage-scanner:<tag>
  INFO:cartography.intel.trivy.scanner:Loading 463 additional non-vulnerable packages for <account_id>.dkr.ecr.us-east-1.amazonaws.com/subimage-backend:<tag>
  INFO:cartography.intel.trivy.scanner:Loading 253 additional non-vulnerable packages for <account_id>.dkr.ecr.us-east-1.amazonaws.com/subimage-frontend:<tag>
  INFO:cartography.intel.trivy.scanner:Loading 487 additional non-vulnerable packages for <account_id>.dkr.ecr.us-east-1.amazonaws.com/subimage-frontend-svelte:<tag>
  INFO:cartography.intel.trivy.scanner:Running Trivy cleanup
```

### Notes for reviewers

- The deduplication strategy (Python-side `seen_ids` set) is intentional — Neo4j MERGE + SET would overwrite `FindingId` to `None` on vulnerable packages if we loaded them again without it.
- This is backward-compatible: if `--list-all-pkgs` isn't used, the `Packages` array simply won't exist and `transform_all_packages()` returns an empty list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)