### PR TITLE
fix(aws): skip CodeBuild unsupported/timeout regions

### DIFF
--- a/cartography/util.py
+++ b/cartography/util.py
@@ -27,7 +27,9 @@ import backoff
 import boto3
 import botocore
 import neo4j
+from botocore.exceptions import ConnectTimeoutError
 from botocore.exceptions import EndpointConnectionError
+from botocore.exceptions import ReadTimeoutError
 from botocore.parsers import ResponseParserError
 
 from cartography.graph.job import GraphJob
@@ -716,6 +718,12 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
             logger.warning(
                 "Encountered an EndpointConnectionError. This means that the AWS "
                 "resource is not available in this region. Skipping.",
+            )
+            return []
+        except (ConnectTimeoutError, ReadTimeoutError):
+            logger.warning(
+                "Encountered a timeout while calling a regional AWS endpoint. "
+                "Skipping this region.",
             )
             return []
 

--- a/tests/unit/cartography/intel/aws/test_codebuild.py
+++ b/tests/unit/cartography/intel/aws/test_codebuild.py
@@ -1,8 +1,13 @@
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
+import pytest
+from botocore.exceptions import ClientError
+from botocore.exceptions import ConnectTimeoutError
 from botocore.exceptions import EndpointConnectionError
 
 from cartography.intel.aws import codebuild
+from tests.data.aws.codebuild import GET_PROJECTS
 
 
 def test_get_all_codebuild_projects_endpoint_connection_error():
@@ -21,3 +26,60 @@ def test_get_all_codebuild_projects_endpoint_connection_error():
     # failures are often about service availability in that region, not client/server
     # network issues
     assert result == []
+
+
+def test_get_all_codebuild_projects_connect_timeout_error():
+    """Ensure ConnectTimeoutError is handled gracefully."""
+    boto3_session = MagicMock()
+    paginator = boto3_session.client.return_value.get_paginator.return_value
+    paginator.paginate.side_effect = ConnectTimeoutError(
+        endpoint_url="https://codebuild.ca-west-1.amazonaws.com"
+    )
+
+    result = codebuild.get_all_codebuild_projects(boto3_session, "ca-west-1")
+
+    assert result == []
+
+
+def test_get_all_codebuild_projects_invalid_token_error_raises():
+    """Ensure non-skippable auth/config errors still surface."""
+    boto3_session = MagicMock()
+    paginator = boto3_session.client.return_value.get_paginator.return_value
+    paginator.paginate.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "InvalidToken",
+                "Message": "token invalid",
+            },
+        },
+        "ListProjects",
+    )
+
+    with pytest.raises(RuntimeError):
+        codebuild.get_all_codebuild_projects(boto3_session, "us-east-1")
+
+
+@patch.object(codebuild, "cleanup")
+@patch.object(codebuild, "load_codebuild_projects")
+@patch.object(codebuild, "get_all_codebuild_projects", return_value=GET_PROJECTS)
+def test_sync_skips_unsupported_region(
+    mock_get_all_codebuild_projects,
+    mock_load_codebuild_projects,
+    mock_cleanup,
+):
+    boto3_session = MagicMock()
+    boto3_session.get_available_partitions.return_value = ["aws"]
+    boto3_session.get_available_regions.return_value = ["us-east-1"]
+
+    codebuild.sync(
+        neo4j_session=MagicMock(),
+        boto3_session=boto3_session,
+        regions=["us-east-1", "ca-west-1"],
+        current_aws_account_id="123456789012",
+        update_tag=123,
+        common_job_parameters={"UPDATE_TAG": 123, "AWS_ID": "123456789012"},
+    )
+
+    mock_get_all_codebuild_projects.assert_called_once_with(boto3_session, "us-east-1")
+    mock_load_codebuild_projects.assert_called_once()
+    mock_cleanup.assert_called_once()

--- a/tests/unit/cartography/test_util.py
+++ b/tests/unit/cartography/test_util.py
@@ -136,6 +136,15 @@ def test_aws_handle_regions(mocker):
     with pytest.raises(ZeroDivisionError):
         raises_unsupported_error(1, 2)
 
+    # regional connectivity timeouts should be skipped
+    @aws_handle_regions
+    def raises_connect_timeout_error(a, b):
+        raise botocore.exceptions.ConnectTimeoutError(
+            endpoint_url="https://codebuild.ca-west-1.amazonaws.com",
+        )
+
+    assert raises_connect_timeout_error(1, 2) == []
+
 
 def test_is_service_control_policy_explicit_deny():
     scp_error = botocore.exceptions.ClientError(


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
This PR hardens AWS CodeBuild sync so a single problematic region does not fail the entire AWS sync run.

Changes:
- Pre-filters CodeBuild regions by intersecting requested regions with `boto3` available CodeBuild regions across partitions.
- Skips unsupported regions with an explicit log message.
- Extends `aws_handle_regions` to treat regional endpoint timeout connectivity errors (`ConnectTimeoutError`, `ReadTimeoutError`) as skippable regional failures, similar to existing `EndpointConnectionError` behavior.
- Adds/updates unit tests for unsupported-region skip, timeout skip behavior, and non-skippable error propagation.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- Fixes #N/A


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

None.


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->



### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

Root cause:
- CodeBuild regional iteration could hit per-region endpoint/connectivity failures and fail the whole sync path.

Why this is safe:
- Scope is limited to region filtering and regional connectivity exceptions.
- Non-skippable auth/config errors are still raised.

Errors now skipped:
- Unsupported CodeBuild regions (pre-filtered in CodeBuild sync).
- `EndpointConnectionError` (existing behavior).
- `ConnectTimeoutError` and `ReadTimeoutError` (new handling in regional wrapper).

Errors still raised:
- Non-skippable auth/config errors, e.g. `InvalidToken` and other unhandled `ClientError`s.

Redacted incident logs (as observed):

```text
botocore.exceptions.ConnectTimeoutError: Connect timeout on endpoint URL: "https://codebuild.ca-west-1.amazonaws.com/"
urllib3.exceptions.ConnectTimeoutError: (<AWSHTTPSConnection(host='codebuild.ca-west-1.amazonaws.com', port=443)>, 'Connection to codebuild.ca-west-1.amazonaws.com timed out. (connect timeout=60)')
```

```text
botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the AssumeRole operation:
User: arn:aws:sts::<redacted>:assumed-role/<redacted>/<session-id>
is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::<redacted>:role/SubImageScanRole
```
