### PR TITLE
feat(ontology): Add RESOLVED_IMAGE relationship for containers

### DIFF
--- a/cartography/intel/ontology/__init__.py
+++ b/cartography/intel/ontology/__init__.py
@@ -2,6 +2,7 @@ import logging
 
 import neo4j
 
+import cartography.intel.ontology.containers
 import cartography.intel.ontology.devices
 import cartography.intel.ontology.loadbalancers
 import cartography.intel.ontology.publicips
@@ -41,6 +42,11 @@ def run(neo4j_session: neo4j.Session, config: Config) -> None:
     cartography.intel.ontology.devices.sync(
         neo4j_session,
         computers_source_of_truth,
+        config.update_tag,
+        common_job_parameters,
+    )
+    cartography.intel.ontology.containers.sync(
+        neo4j_session,
         config.update_tag,
         common_job_parameters,
     )

--- a/cartography/intel/ontology/containers.py
+++ b/cartography/intel/ontology/containers.py
@@ -1,0 +1,18 @@
+import logging
+from typing import Any
+
+import neo4j
+
+from cartography.intel.ontology.utils import link_semantic_labels
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    link_semantic_labels(neo4j_session, "containers", update_tag)

--- a/cartography/models/ontology/mapping/data/containers.py
+++ b/cartography/models/ontology/mapping/data/containers.py
@@ -1,6 +1,7 @@
 from cartography.models.ontology.mapping.specs import OntologyFieldMapping
 from cartography.models.ontology.mapping.specs import OntologyMapping
 from cartography.models.ontology.mapping.specs import OntologyNodeMapping
+from cartography.models.ontology.mapping.specs import OntologyRelMapping
 
 aws_ecs_container_mapping = OntologyMapping(
     module_name="aws",
@@ -25,6 +26,29 @@ aws_ecs_container_mapping = OntologyMapping(
                     ontology_field="health_status", node_field="health_status"
                 ),
             ],
+        ),
+    ],
+    rels=[
+        OntologyRelMapping(
+            __comment__="Link ECSContainer to Image directly via HAS_IMAGE",
+            query=(
+                "MATCH (c:ECSContainer {lastupdated: $UPDATE_TAG})-[:HAS_IMAGE]->(img:Image) "
+                "MERGE (c)-[r:RESOLVED_IMAGE]->(img) "
+                "ON CREATE SET r.firstseen = timestamp() "
+                "SET r.lastupdated = $UPDATE_TAG"
+            ),
+            iterative=False,
+        ),
+        OntologyRelMapping(
+            __comment__="Link ECSContainer to Image via ImageManifestList",
+            query=(
+                "MATCH (c:ECSContainer {lastupdated: $UPDATE_TAG})-[:HAS_IMAGE]->"
+                "(:ImageManifestList)-[:CONTAINS_IMAGE]->(img:Image) "
+                "MERGE (c)-[r:RESOLVED_IMAGE]->(img) "
+                "ON CREATE SET r.firstseen = timestamp() "
+                "SET r.lastupdated = $UPDATE_TAG"
+            ),
+            iterative=False,
         ),
     ],
 )
@@ -52,6 +76,29 @@ kubernetes_mapping = OntologyMapping(
                 ),
                 # health_status: Kubernetes uses status_ready and status_started separately, not a unified health_status field
             ],
+        ),
+    ],
+    rels=[
+        OntologyRelMapping(
+            __comment__="Link KubernetesContainer to Image directly via HAS_IMAGE",
+            query=(
+                "MATCH (c:KubernetesContainer {lastupdated: $UPDATE_TAG})-[:HAS_IMAGE]->(img:Image) "
+                "MERGE (c)-[r:RESOLVED_IMAGE]->(img) "
+                "ON CREATE SET r.firstseen = timestamp() "
+                "SET r.lastupdated = $UPDATE_TAG"
+            ),
+            iterative=False,
+        ),
+        OntologyRelMapping(
+            __comment__="Link KubernetesContainer to Image via ImageManifestList",
+            query=(
+                "MATCH (c:KubernetesContainer {lastupdated: $UPDATE_TAG})-[:HAS_IMAGE]->"
+                "(:ImageManifestList)-[:CONTAINS_IMAGE]->(img:Image) "
+                "MERGE (c)-[r:RESOLVED_IMAGE]->(img) "
+                "ON CREATE SET r.firstseen = timestamp() "
+                "SET r.lastupdated = $UPDATE_TAG"
+            ),
+            iterative=False,
         ),
     ],
 )

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -12,6 +12,7 @@ U -- OWNS --> AK{{APIKey}}
 U -- AUTHORIZED --> OA{{ThirdPartyApp}}
 LB{{LoadBalancer}} -- EXPOSE --> CI{{ComputeInstance}}
 LB{{LoadBalancer}} -- EXPOSE --> CT{{Container}}
+CT -- RESOLVED_IMAGE --> IM
 DB{{Database}}
 OS{{ObjectStorage}}
 TN{{Tenant}}
@@ -242,6 +243,15 @@ It generalizes concepts like ECS Containers, Kubernetes Containers, and Azure Co
 | _ont_region | The region or zone where the container is running. |
 | _ont_namespace | Namespace for logical isolation (e.g., Kubernetes namespace). |
 | _ont_health_status | The health status of the container. |
+
+#### Relationships
+
+- `Container` resolves to one or many `Image` (semantic label). This relationship is derived from two graph patterns:
+    - Direct: `(:Container)-[:HAS_IMAGE]->(:Image)`
+    - Via manifest list: `(:Container)-[:HAS_IMAGE]->(:ImageManifestList)-[:CONTAINS_IMAGE]->(:Image)`
+    ```
+    (:Container)-[:RESOLVED_IMAGE]->(:Image)
+    ```
 
 
 ### ThirdPartyApp


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Add ontology relationship mappings that create `(Container)-[:RESOLVED_IMAGE]->(Image)` relationships by resolving two graph patterns:

- **Direct**: `(Container)-[:HAS_IMAGE]->(Image)`
- **Via manifest list**: `(Container)-[:HAS_IMAGE]->(ImageManifestList)-[:CONTAINS_IMAGE]->(Image)`

This enables querying which actual platform-specific images a container is running, regardless of whether the container references an image directly or through a manifest list.

**Changes:**
- `cartography/models/ontology/mapping/data/containers.py` — Added `OntologyRelMapping` entries for AWS ECS and Kubernetes providers
- `cartography/intel/ontology/containers.py` — New ontology sync module for containers
- `cartography/intel/ontology/__init__.py` — Registered the containers sync in the ontology run pipeline
- `docs/root/modules/ontology/schema.md` — Updated mermaid diagram and Container section with RESOLVED_IMAGE relationship


### Related issues or links

### Breaking changes

None. This is a purely additive change.

### How was this tested?

- Pre-commit hooks pass (isort, black, flake8, mypy)
- Module imports verified successfully

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

### Notes for reviewers

Azure is excluded from the relationship mappings because `AzureContainerInstance` does not have a `HAS_IMAGE` relationship in its model.