### PR TITLE
feat(openai): add Container, Skill, and VectorStore ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can learn more about the story behind Cartography in our [presentation at BS
 - [Microsoft Entra ID](https://cartography-cncf.github.io/cartography/modules/entra/index.html) -  Users, Groups, Applications, OUs, App Roles, federation to AWS Identity Center
 - [NIST CVE](https://cartography-cncf.github.io/cartography/modules/cve/index.html) - Common Vulnerabilities and Exposures (CVE) data from NIST database
 - [Okta](https://cartography-cncf.github.io/cartography/modules/okta/index.html) - users, groups, organizations, roles, applications, factors, trusted origins, reply URIs, federation to AWS roles, federation to AWS Identity Center
-- [OpenAI](https://cartography-cncf.github.io/cartography/modules/openai/index.html) - Organization, AdminApiKey, User, Project, ServiceAccount, ApiKey
+- [OpenAI](https://cartography-cncf.github.io/cartography/modules/openai/index.html) - Organization, AdminApiKey, User, Project, ServiceAccount, ApiKey, Container, Skill, VectorStore
 - [Oracle Cloud Infrastructure](https://cartography-cncf.github.io/cartography/modules/oci/index.html) - IAM
 - [PagerDuty](https://cartography-cncf.github.io/cartography/modules/pagerduty/index.html) - Users, teams, services, schedules, escalation policies, integrations, vendors
 - [Scaleway](https://cartography-cncf.github.io/cartography/modules/scaleway/index.html) - Projects, IAM, Local Storage, Instances

--- a/cartography/intel/openai/__init__.py
+++ b/cartography/intel/openai/__init__.py
@@ -5,9 +5,12 @@ import requests
 
 import cartography.intel.openai.adminapikeys
 import cartography.intel.openai.apikeys
+import cartography.intel.openai.containers
 import cartography.intel.openai.projects
 import cartography.intel.openai.serviceaccounts
+import cartography.intel.openai.skills
 import cartography.intel.openai.users
+import cartography.intel.openai.vectorstores
 from cartography.config import Config
 from cartography.util import timeit
 
@@ -77,6 +80,28 @@ def start_openai_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
             project_job_parameters,
             project_id=project["id"],
         )
+
+        # Data-plane APIs scoped by OpenAI-Project header
+        api_session.headers["OpenAI-Project"] = project["id"]
+        cartography.intel.openai.containers.sync(
+            neo4j_session,
+            api_session,
+            project_job_parameters,
+            project_id=project["id"],
+        )
+        cartography.intel.openai.skills.sync(
+            neo4j_session,
+            api_session,
+            project_job_parameters,
+            project_id=project["id"],
+        )
+        cartography.intel.openai.vectorstores.sync(
+            neo4j_session,
+            api_session,
+            project_job_parameters,
+            project_id=project["id"],
+        )
+        api_session.headers.pop("OpenAI-Project", None)
 
     cartography.intel.openai.adminapikeys.sync(
         neo4j_session,

--- a/cartography/intel/openai/containers.py
+++ b/cartography/intel/openai/containers.py
@@ -1,0 +1,77 @@
+import logging
+from typing import Any
+from typing import Dict
+from typing import List
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.openai.util import paginated_get
+from cartography.models.openai.container import OpenAIContainerSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+# Connect and read timeouts of 60 seconds each; see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
+_TIMEOUT = (60, 60)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: Dict[str, Any],
+    project_id: str,
+) -> None:
+    containers = get(
+        api_session,
+        common_job_parameters["BASE_URL"],
+    )
+    load_containers(
+        neo4j_session,
+        containers,
+        project_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+) -> List[Dict[str, Any]]:
+    return list(
+        paginated_get(
+            api_session,
+            f"{base_url}/containers",
+            timeout=_TIMEOUT,
+        )
+    )
+
+
+@timeit
+def load_containers(
+    neo4j_session: neo4j.Session,
+    data: List[Dict[str, Any]],
+    project_id: str,
+    update_tag: int,
+) -> None:
+    logger.info("Loading %d OpenAI Container into Neo4j.", len(data))
+    load(
+        neo4j_session,
+        OpenAIContainerSchema(),
+        data,
+        lastupdated=update_tag,
+        project_id=project_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: Dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(OpenAIContainerSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/openai/containers.py
+++ b/cartography/intel/openai/containers.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import logging
 from typing import Any
-from typing import Dict
-from typing import List
 
 import neo4j
 import requests
@@ -21,7 +21,7 @@ _TIMEOUT = (60, 60)
 def sync(
     neo4j_session: neo4j.Session,
     api_session: requests.Session,
-    common_job_parameters: Dict[str, Any],
+    common_job_parameters: dict[str, Any],
     project_id: str,
 ) -> None:
     containers = get(
@@ -41,7 +41,7 @@ def sync(
 def get(
     api_session: requests.Session,
     base_url: str,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     return list(
         paginated_get(
             api_session,
@@ -54,7 +54,7 @@ def get(
 @timeit
 def load_containers(
     neo4j_session: neo4j.Session,
-    data: List[Dict[str, Any]],
+    data: list[dict[str, Any]],
     project_id: str,
     update_tag: int,
 ) -> None:
@@ -70,7 +70,7 @@ def load_containers(
 
 @timeit
 def cleanup(
-    neo4j_session: neo4j.Session, common_job_parameters: Dict[str, Any]
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
 ) -> None:
     GraphJob.from_node_schema(OpenAIContainerSchema(), common_job_parameters).run(
         neo4j_session

--- a/cartography/intel/openai/skills.py
+++ b/cartography/intel/openai/skills.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import logging
 from typing import Any
-from typing import Dict
-from typing import List
 
 import neo4j
 import requests
@@ -21,7 +21,7 @@ _TIMEOUT = (60, 60)
 def sync(
     neo4j_session: neo4j.Session,
     api_session: requests.Session,
-    common_job_parameters: Dict[str, Any],
+    common_job_parameters: dict[str, Any],
     project_id: str,
 ) -> None:
     skills = get(
@@ -41,7 +41,7 @@ def sync(
 def get(
     api_session: requests.Session,
     base_url: str,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     return list(
         paginated_get(
             api_session,
@@ -54,7 +54,7 @@ def get(
 @timeit
 def load_skills(
     neo4j_session: neo4j.Session,
-    data: List[Dict[str, Any]],
+    data: list[dict[str, Any]],
     project_id: str,
     update_tag: int,
 ) -> None:
@@ -70,7 +70,7 @@ def load_skills(
 
 @timeit
 def cleanup(
-    neo4j_session: neo4j.Session, common_job_parameters: Dict[str, Any]
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
 ) -> None:
     GraphJob.from_node_schema(OpenAISkillSchema(), common_job_parameters).run(
         neo4j_session

--- a/cartography/intel/openai/skills.py
+++ b/cartography/intel/openai/skills.py
@@ -1,0 +1,77 @@
+import logging
+from typing import Any
+from typing import Dict
+from typing import List
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.openai.util import paginated_get
+from cartography.models.openai.skill import OpenAISkillSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+# Connect and read timeouts of 60 seconds each; see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
+_TIMEOUT = (60, 60)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: Dict[str, Any],
+    project_id: str,
+) -> None:
+    skills = get(
+        api_session,
+        common_job_parameters["BASE_URL"],
+    )
+    load_skills(
+        neo4j_session,
+        skills,
+        project_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+) -> List[Dict[str, Any]]:
+    return list(
+        paginated_get(
+            api_session,
+            f"{base_url}/skills",
+            timeout=_TIMEOUT,
+        )
+    )
+
+
+@timeit
+def load_skills(
+    neo4j_session: neo4j.Session,
+    data: List[Dict[str, Any]],
+    project_id: str,
+    update_tag: int,
+) -> None:
+    logger.info("Loading %d OpenAI Skill into Neo4j.", len(data))
+    load(
+        neo4j_session,
+        OpenAISkillSchema(),
+        data,
+        lastupdated=update_tag,
+        project_id=project_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: Dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(OpenAISkillSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/openai/vectorstores.py
+++ b/cartography/intel/openai/vectorstores.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import logging
 from typing import Any
-from typing import Dict
-from typing import List
 
 import neo4j
 import requests
@@ -21,7 +21,7 @@ _TIMEOUT = (60, 60)
 def sync(
     neo4j_session: neo4j.Session,
     api_session: requests.Session,
-    common_job_parameters: Dict[str, Any],
+    common_job_parameters: dict[str, Any],
     project_id: str,
 ) -> None:
     vectorstores = get(
@@ -41,7 +41,7 @@ def sync(
 def get(
     api_session: requests.Session,
     base_url: str,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     return list(
         paginated_get(
             api_session,
@@ -54,7 +54,7 @@ def get(
 @timeit
 def load_vectorstores(
     neo4j_session: neo4j.Session,
-    data: List[Dict[str, Any]],
+    data: list[dict[str, Any]],
     project_id: str,
     update_tag: int,
 ) -> None:
@@ -70,7 +70,7 @@ def load_vectorstores(
 
 @timeit
 def cleanup(
-    neo4j_session: neo4j.Session, common_job_parameters: Dict[str, Any]
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
 ) -> None:
     GraphJob.from_node_schema(OpenAIVectorStoreSchema(), common_job_parameters).run(
         neo4j_session

--- a/cartography/intel/openai/vectorstores.py
+++ b/cartography/intel/openai/vectorstores.py
@@ -1,0 +1,77 @@
+import logging
+from typing import Any
+from typing import Dict
+from typing import List
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.openai.util import paginated_get
+from cartography.models.openai.vectorstore import OpenAIVectorStoreSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+# Connect and read timeouts of 60 seconds each; see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
+_TIMEOUT = (60, 60)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: Dict[str, Any],
+    project_id: str,
+) -> None:
+    vectorstores = get(
+        api_session,
+        common_job_parameters["BASE_URL"],
+    )
+    load_vectorstores(
+        neo4j_session,
+        vectorstores,
+        project_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+) -> List[Dict[str, Any]]:
+    return list(
+        paginated_get(
+            api_session,
+            f"{base_url}/vector_stores",
+            timeout=_TIMEOUT,
+        )
+    )
+
+
+@timeit
+def load_vectorstores(
+    neo4j_session: neo4j.Session,
+    data: List[Dict[str, Any]],
+    project_id: str,
+    update_tag: int,
+) -> None:
+    logger.info("Loading %d OpenAI VectorStore into Neo4j.", len(data))
+    load(
+        neo4j_session,
+        OpenAIVectorStoreSchema(),
+        data,
+        lastupdated=update_tag,
+        project_id=project_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: Dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(OpenAIVectorStoreSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/models/openai/container.py
+++ b/cartography/models/openai/container.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class OpenAIContainerNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    object: PropertyRef = PropertyRef("object")
+    name: PropertyRef = PropertyRef("name")
+    status: PropertyRef = PropertyRef("status")
+    created_at: PropertyRef = PropertyRef("created_at")
+    last_active_at: PropertyRef = PropertyRef("last_active_at")
+    memory_limit: PropertyRef = PropertyRef("memory_limit")
+
+
+@dataclass(frozen=True)
+class OpenAIContainerToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:OpenAIContainer)<-[:RESOURCE]-(:OpenAIProject)
+class OpenAIContainerToProjectRel(CartographyRelSchema):
+    target_node_label: str = "OpenAIProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("project_id", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: OpenAIContainerToProjectRelProperties = (
+        OpenAIContainerToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class OpenAIContainerSchema(CartographyNodeSchema):
+    label: str = "OpenAIContainer"
+    properties: OpenAIContainerNodeProperties = OpenAIContainerNodeProperties()
+    sub_resource_relationship: OpenAIContainerToProjectRel = (
+        OpenAIContainerToProjectRel()
+    )

--- a/cartography/models/openai/container.py
+++ b/cartography/models/openai/container.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -44,6 +45,7 @@ class OpenAIContainerToProjectRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class OpenAIContainerSchema(CartographyNodeSchema):
     label: str = "OpenAIContainer"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeInstance"])
     properties: OpenAIContainerNodeProperties = OpenAIContainerNodeProperties()
     sub_resource_relationship: OpenAIContainerToProjectRel = (
         OpenAIContainerToProjectRel()

--- a/cartography/models/openai/skill.py
+++ b/cartography/models/openai/skill.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class OpenAISkillNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    object: PropertyRef = PropertyRef("object")
+    name: PropertyRef = PropertyRef("name")
+    description: PropertyRef = PropertyRef("description")
+    created_at: PropertyRef = PropertyRef("created_at")
+    default_version: PropertyRef = PropertyRef("default_version")
+    latest_version: PropertyRef = PropertyRef("latest_version")
+
+
+@dataclass(frozen=True)
+class OpenAISkillToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:OpenAISkill)<-[:RESOURCE]-(:OpenAIProject)
+class OpenAISkillToProjectRel(CartographyRelSchema):
+    target_node_label: str = "OpenAIProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("project_id", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: OpenAISkillToProjectRelProperties = (
+        OpenAISkillToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class OpenAISkillSchema(CartographyNodeSchema):
+    label: str = "OpenAISkill"
+    properties: OpenAISkillNodeProperties = OpenAISkillNodeProperties()
+    sub_resource_relationship: OpenAISkillToProjectRel = (
+        OpenAISkillToProjectRel()
+    )

--- a/cartography/models/openai/skill.py
+++ b/cartography/models/openai/skill.py
@@ -36,15 +36,11 @@ class OpenAISkillToProjectRel(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: OpenAISkillToProjectRelProperties = (
-        OpenAISkillToProjectRelProperties()
-    )
+    properties: OpenAISkillToProjectRelProperties = OpenAISkillToProjectRelProperties()
 
 
 @dataclass(frozen=True)
 class OpenAISkillSchema(CartographyNodeSchema):
     label: str = "OpenAISkill"
     properties: OpenAISkillNodeProperties = OpenAISkillNodeProperties()
-    sub_resource_relationship: OpenAISkillToProjectRel = (
-        OpenAISkillToProjectRel()
-    )
+    sub_resource_relationship: OpenAISkillToProjectRel = OpenAISkillToProjectRel()

--- a/cartography/models/openai/vectorstore.py
+++ b/cartography/models/openai/vectorstore.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class OpenAIVectorStoreNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    object: PropertyRef = PropertyRef("object")
+    name: PropertyRef = PropertyRef("name")
+    status: PropertyRef = PropertyRef("status")
+    created_at: PropertyRef = PropertyRef("created_at")
+    last_active_at: PropertyRef = PropertyRef("last_active_at")
+    usage_bytes: PropertyRef = PropertyRef("usage_bytes")
+    expires_at: PropertyRef = PropertyRef("expires_at")
+
+
+@dataclass(frozen=True)
+class OpenAIVectorStoreToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:OpenAIVectorStore)<-[:RESOURCE]-(:OpenAIProject)
+class OpenAIVectorStoreToProjectRel(CartographyRelSchema):
+    target_node_label: str = "OpenAIProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("project_id", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: OpenAIVectorStoreToProjectRelProperties = (
+        OpenAIVectorStoreToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class OpenAIVectorStoreSchema(CartographyNodeSchema):
+    label: str = "OpenAIVectorStore"
+    properties: OpenAIVectorStoreNodeProperties = OpenAIVectorStoreNodeProperties()
+    sub_resource_relationship: OpenAIVectorStoreToProjectRel = (
+        OpenAIVectorStoreToProjectRel()
+    )

--- a/cartography/models/openai/vectorstore.py
+++ b/cartography/models/openai/vectorstore.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -45,6 +46,7 @@ class OpenAIVectorStoreToProjectRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class OpenAIVectorStoreSchema(CartographyNodeSchema):
     label: str = "OpenAIVectorStore"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Database"])
     properties: OpenAIVectorStoreNodeProperties = OpenAIVectorStoreNodeProperties()
     sub_resource_relationship: OpenAIVectorStoreToProjectRel = (
         OpenAIVectorStoreToProjectRel()

--- a/docs/root/modules/openai/schema.md
+++ b/docs/root/modules/openai/schema.md
@@ -27,7 +27,7 @@ Represents an OpenAI Organization.
 
 | Field | Description |
 |-------|-------------|
-| id | The identifier, which can be referenced in API endpoints |
+| **id** | The identifier, which can be referenced in API endpoints |
 | firstseen| Timestamp of when a sync job first created this node  |
 | lastupdated |  Timestamp of the last time the node was updated |
 
@@ -49,7 +49,7 @@ Represents an individual Admin API key in an org.
 
 | Field | Description |
 |-------|-------------|
-| id | The identifier, which can be referenced in API endpoints |
+| **id** | The identifier, which can be referenced in API endpoints |
 | firstseen| Timestamp of when a sync job first created this node  |
 | lastupdated |  Timestamp of the last time the node was updated |
 | object | The object type, which is always `organization.admin_api_key` |
@@ -77,12 +77,12 @@ Represents an individual `user` within an organization.
 
 | Field | Description |
 |-------|-------------|
-| id | The identifier, which can be referenced in API endpoints |
+| **id** | The identifier, which can be referenced in API endpoints |
 | firstseen| Timestamp of when a sync job first created this node  |
 | lastupdated |  Timestamp of the last time the node was updated |
 | object | The object type, which is always `organization.user` |
 | name | The name of the user |
-| email | The email address of the user |
+| **email** | The email address of the user |
 | role | `owner` or `reader` |
 | added_at | The Unix timestamp (in seconds) of when the user was added. |
 
@@ -116,7 +116,7 @@ Represents an individual project.
 
 | Field | Description |
 |-------|-------------|
-| id | The identifier, which can be referenced in API endpoints |
+| **id** | The identifier, which can be referenced in API endpoints |
 | firstseen| Timestamp of when a sync job first created this node  |
 | lastupdated |  Timestamp of the last time the node was updated |
 | object | The object type, which is always `organization.project` |
@@ -155,7 +155,7 @@ Represents an individual service account in a project.
 
 | Field | Description |
 |-------|-------------|
-| id | The identifier, which can be referenced in API endpoints |
+| **id** | The identifier, which can be referenced in API endpoints |
 | firstseen| Timestamp of when a sync job first created this node  |
 | lastupdated |  Timestamp of the last time the node was updated |
 | object | The object type, which is always `organization.project.service_account` |
@@ -186,7 +186,7 @@ Represents an individual API key in a project.
 
 | Field | Description |
 |-------|-------------|
-| id | The identifier, which can be referenced in API endpoints |
+| **id** | The identifier, which can be referenced in API endpoints |
 | firstseen| Timestamp of when a sync job first created this node  |
 | lastupdated |  Timestamp of the last time the node was updated |
 | object | The object type, which is always `organization.project.api_key` |
@@ -214,7 +214,7 @@ Represents a compute container in a project.
 
 | Field | Description |
 |-------|-------------|
-| id | The identifier, which can be referenced in API endpoints |
+| **id** | The identifier, which can be referenced in API endpoints |
 | firstseen| Timestamp of when a sync job first created this node  |
 | lastupdated |  Timestamp of the last time the node was updated |
 | object | The object type, which is always `container` |
@@ -227,7 +227,7 @@ Represents a compute container in a project.
 #### Relationships
 - `Container` belongs to a `Project`
     ```
-    (:OpenAIProject)-[:RESOURCE]->(:OpenAIContainer)
+    (:OpenAIContainer)<-[:RESOURCE]-(:OpenAIProject)
     ```
 
 ### OpenAISkill
@@ -236,7 +236,7 @@ Represents a custom skill in a project.
 
 | Field | Description |
 |-------|-------------|
-| id | The identifier, which can be referenced in API endpoints |
+| **id** | The identifier, which can be referenced in API endpoints |
 | firstseen| Timestamp of when a sync job first created this node  |
 | lastupdated |  Timestamp of the last time the node was updated |
 | object | The object type, which is always `skill` |
@@ -249,7 +249,7 @@ Represents a custom skill in a project.
 #### Relationships
 - `Skill` belongs to a `Project`
     ```
-    (:OpenAIProject)-[:RESOURCE]->(:OpenAISkill)
+    (:OpenAISkill)<-[:RESOURCE]-(:OpenAIProject)
     ```
 
 ### OpenAIVectorStore
@@ -260,7 +260,7 @@ Represents a vector store in a project.
 
 | Field | Description |
 |-------|-------------|
-| id | The identifier, which can be referenced in API endpoints |
+| **id** | The identifier, which can be referenced in API endpoints |
 | firstseen| Timestamp of when a sync job first created this node  |
 | lastupdated |  Timestamp of the last time the node was updated |
 | object | The object type, which is always `vector_store` |
@@ -274,5 +274,5 @@ Represents a vector store in a project.
 #### Relationships
 - `VectorStore` belongs to a `Project`
     ```
-    (:OpenAIProject)-[:RESOURCE]->(:OpenAIVectorStore)
+    (:OpenAIVectorStore)<-[:RESOURCE]-(:OpenAIProject)
     ```

--- a/docs/root/modules/openai/schema.md
+++ b/docs/root/modules/openai/schema.md
@@ -6,6 +6,9 @@ O(Organization) -- RESOURCE --> P(Project)
 O -- RESOURCE --> U(User)
 P -- RESOURCE --> K(ApiKey)
 P -- RESOURCE --> SA(ServiceAccount)
+P -- RESOURCE --> C(Container)
+P -- RESOURCE --> S(Skill)
+P -- RESOURCE --> VS(VectorStore)
 U -- OWNS --> AK
 U -- OWNS --> K
 SA -- OWNS --> AK
@@ -123,11 +126,14 @@ Represents an individual project.
 | status | `active` or `archived` |
 
 #### Relationships
--  `ServiceAccount` and `APIKey` belong to an `OpenAIProject`.
+-  `ServiceAccount`, `APIKey`, `Container`, `Skill`, and `VectorStore` belong to an `OpenAIProject`.
     ```
     (:OpenAIProject)<-[:RESOURCE]-(
         :OpenAIServiceAccount,
         :OpenAIApiKey,
+        :OpenAIContainer,
+        :OpenAISkill,
+        :OpenAIVectorStore,
     )
     ```
 - `Project` belongs to an `Organization`
@@ -198,4 +204,75 @@ Represents an individual API key in a project.
     ```
     (:OpenAIUser)-[:OWNS]->(:OpenAIApiKey)
     (:OpenAIServiceAccount)-[:OWNS]->(:OpenAIApiKey)
+    ```
+
+### OpenAIContainer
+
+Represents a compute container in a project.
+
+> **Ontology Mapping**: This node has the extra label `ComputeInstance` to enable cross-platform queries for compute resources across different systems (e.g., EC2Instance, GCPInstance).
+
+| Field | Description |
+|-------|-------------|
+| id | The identifier, which can be referenced in API endpoints |
+| firstseen| Timestamp of when a sync job first created this node  |
+| lastupdated |  Timestamp of the last time the node was updated |
+| object | The object type, which is always `container` |
+| name | The name of the container |
+| status | Status of the container (e.g., active, deleted) |
+| created_at | The Unix timestamp (in seconds) of when the container was created |
+| last_active_at | The Unix timestamp (in seconds) of when the container was last active |
+| memory_limit | The memory limit configured for the container |
+
+#### Relationships
+- `Container` belongs to a `Project`
+    ```
+    (:OpenAIProject)-[:RESOURCE]->(:OpenAIContainer)
+    ```
+
+### OpenAISkill
+
+Represents a custom skill in a project.
+
+| Field | Description |
+|-------|-------------|
+| id | The identifier, which can be referenced in API endpoints |
+| firstseen| Timestamp of when a sync job first created this node  |
+| lastupdated |  Timestamp of the last time the node was updated |
+| object | The object type, which is always `skill` |
+| name | The name of the skill |
+| description | Description of the skill |
+| created_at | The Unix timestamp (in seconds) of when the skill was created |
+| default_version | The default version for the skill |
+| latest_version | The latest version for the skill |
+
+#### Relationships
+- `Skill` belongs to a `Project`
+    ```
+    (:OpenAIProject)-[:RESOURCE]->(:OpenAISkill)
+    ```
+
+### OpenAIVectorStore
+
+Represents a vector store in a project.
+
+> **Ontology Mapping**: This node has the extra label `Database` to enable cross-platform queries for data stores across different systems (e.g., AzureSQLDatabase, GCPBigtableInstance).
+
+| Field | Description |
+|-------|-------------|
+| id | The identifier, which can be referenced in API endpoints |
+| firstseen| Timestamp of when a sync job first created this node  |
+| lastupdated |  Timestamp of the last time the node was updated |
+| object | The object type, which is always `vector_store` |
+| name | The name of the vector store |
+| status | The status of the vector store (`expired`, `in_progress`, or `completed`) |
+| created_at | The Unix timestamp (in seconds) of when the vector store was created |
+| last_active_at | The Unix timestamp (in seconds) of when the vector store was last active |
+| usage_bytes | The total number of bytes used by the files in the vector store |
+| expires_at | The Unix timestamp (in seconds) of when the vector store will expire |
+
+#### Relationships
+- `VectorStore` belongs to a `Project`
+    ```
+    (:OpenAIProject)-[:RESOURCE]->(:OpenAIVectorStore)
     ```

--- a/tests/data/openai/containers.py
+++ b/tests/data/openai/containers.py
@@ -1,0 +1,20 @@
+OPENAI_CONTAINERS = [
+    {
+        "object": "container",
+        "id": "cntr-abc123def456",
+        "name": "data-processing",
+        "status": "active",
+        "created_at": 1743941099,
+        "last_active_at": 1743945000,
+        "memory_limit": "4g",
+    },
+    {
+        "object": "container",
+        "id": "cntr-ghi789jkl012",
+        "name": "model-serving",
+        "status": "active",
+        "created_at": 1743942000,
+        "last_active_at": 1743946000,
+        "memory_limit": "16g",
+    },
+]

--- a/tests/data/openai/skills.py
+++ b/tests/data/openai/skills.py
@@ -1,0 +1,20 @@
+OPENAI_SKILLS = [
+    {
+        "object": "skill",
+        "id": "skill-abc123def456",
+        "name": "code-reviewer",
+        "description": "Reviews code for best practices",
+        "created_at": 1743941099,
+        "default_version": "v1",
+        "latest_version": "v2",
+    },
+    {
+        "object": "skill",
+        "id": "skill-ghi789jkl012",
+        "name": "data-analyzer",
+        "description": "Analyzes structured data",
+        "created_at": 1743942000,
+        "default_version": "v1",
+        "latest_version": "v1",
+    },
+]

--- a/tests/data/openai/vectorstores.py
+++ b/tests/data/openai/vectorstores.py
@@ -1,0 +1,22 @@
+OPENAI_VECTORSTORES = [
+    {
+        "object": "vector_store",
+        "id": "vs_abc123def456",
+        "name": "knowledge-base",
+        "status": "completed",
+        "created_at": 1743941099,
+        "last_active_at": 1743945000,
+        "usage_bytes": 104857600,
+        "expires_at": None,
+    },
+    {
+        "object": "vector_store",
+        "id": "vs_ghi789jkl012",
+        "name": "document-index",
+        "status": "completed",
+        "created_at": 1743942000,
+        "last_active_at": 1743946000,
+        "usage_bytes": 52428800,
+        "expires_at": 1751717099,
+    },
+]

--- a/tests/integration/cartography/intel/openai/test_containers.py
+++ b/tests/integration/cartography/intel/openai/test_containers.py
@@ -1,0 +1,80 @@
+from unittest.mock import patch
+
+import requests
+
+import cartography.intel.openai.containers
+import tests.data.openai.containers
+import tests.data.openai.projects
+from tests.integration.cartography.intel.openai.test_projects import (
+    _ensure_local_neo4j_has_test_projects,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_PROJECT_ID = tests.data.openai.projects.OPENAI_PROJECTS[0]["id"]
+
+
+def _ensure_local_neo4j_has_test_containers(neo4j_session):
+    cartography.intel.openai.containers.load_containers(
+        neo4j_session,
+        tests.data.openai.containers.OPENAI_CONTAINERS,
+        TEST_PROJECT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.openai.containers,
+    "get",
+    return_value=tests.data.openai.containers.OPENAI_CONTAINERS,
+)
+def test_load_openai_containers(mock_api, neo4j_session):
+    """
+    Ensure that containers actually get loaded
+    """
+
+    # Arrange
+    api_session = requests.Session()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "BASE_URL": "https://api.openai.com/v1",
+        "project_id": TEST_PROJECT_ID,
+    }
+    _ensure_local_neo4j_has_test_projects(neo4j_session)
+
+    # Act
+    cartography.intel.openai.containers.sync(
+        neo4j_session,
+        api_session,
+        common_job_parameters,
+        TEST_PROJECT_ID,
+    )
+
+    # Assert Containers exist
+    expected_nodes = {
+        ("cntr-abc123def456", "data-processing"),
+        ("cntr-ghi789jkl012", "model-serving"),
+    }
+    assert (
+        check_nodes(neo4j_session, "OpenAIContainer", ["id", "name"])
+        == expected_nodes
+    )
+
+    # Assert Containers are connected with Project
+    expected_rels = {
+        ("cntr-abc123def456", TEST_PROJECT_ID),
+        ("cntr-ghi789jkl012", TEST_PROJECT_ID),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "OpenAIContainer",
+            "id",
+            "OpenAIProject",
+            "id",
+            "RESOURCE",
+            rel_direction_right=False,
+        )
+        == expected_rels
+    )

--- a/tests/integration/cartography/intel/openai/test_containers.py
+++ b/tests/integration/cartography/intel/openai/test_containers.py
@@ -57,8 +57,7 @@ def test_load_openai_containers(mock_api, neo4j_session):
         ("cntr-ghi789jkl012", "model-serving"),
     }
     assert (
-        check_nodes(neo4j_session, "OpenAIContainer", ["id", "name"])
-        == expected_nodes
+        check_nodes(neo4j_session, "OpenAIContainer", ["id", "name"]) == expected_nodes
     )
 
     # Assert Containers are connected with Project

--- a/tests/integration/cartography/intel/openai/test_skills.py
+++ b/tests/integration/cartography/intel/openai/test_skills.py
@@ -1,0 +1,80 @@
+from unittest.mock import patch
+
+import requests
+
+import cartography.intel.openai.skills
+import tests.data.openai.projects
+import tests.data.openai.skills
+from tests.integration.cartography.intel.openai.test_projects import (
+    _ensure_local_neo4j_has_test_projects,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_PROJECT_ID = tests.data.openai.projects.OPENAI_PROJECTS[0]["id"]
+
+
+def _ensure_local_neo4j_has_test_skills(neo4j_session):
+    cartography.intel.openai.skills.load_skills(
+        neo4j_session,
+        tests.data.openai.skills.OPENAI_SKILLS,
+        TEST_PROJECT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.openai.skills,
+    "get",
+    return_value=tests.data.openai.skills.OPENAI_SKILLS,
+)
+def test_load_openai_skills(mock_api, neo4j_session):
+    """
+    Ensure that skills actually get loaded
+    """
+
+    # Arrange
+    api_session = requests.Session()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "BASE_URL": "https://api.openai.com/v1",
+        "project_id": TEST_PROJECT_ID,
+    }
+    _ensure_local_neo4j_has_test_projects(neo4j_session)
+
+    # Act
+    cartography.intel.openai.skills.sync(
+        neo4j_session,
+        api_session,
+        common_job_parameters,
+        TEST_PROJECT_ID,
+    )
+
+    # Assert Skills exist
+    expected_nodes = {
+        ("skill-abc123def456", "code-reviewer"),
+        ("skill-ghi789jkl012", "data-analyzer"),
+    }
+    assert (
+        check_nodes(neo4j_session, "OpenAISkill", ["id", "name"])
+        == expected_nodes
+    )
+
+    # Assert Skills are connected with Project
+    expected_rels = {
+        ("skill-abc123def456", TEST_PROJECT_ID),
+        ("skill-ghi789jkl012", TEST_PROJECT_ID),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "OpenAISkill",
+            "id",
+            "OpenAIProject",
+            "id",
+            "RESOURCE",
+            rel_direction_right=False,
+        )
+        == expected_rels
+    )

--- a/tests/integration/cartography/intel/openai/test_skills.py
+++ b/tests/integration/cartography/intel/openai/test_skills.py
@@ -56,10 +56,7 @@ def test_load_openai_skills(mock_api, neo4j_session):
         ("skill-abc123def456", "code-reviewer"),
         ("skill-ghi789jkl012", "data-analyzer"),
     }
-    assert (
-        check_nodes(neo4j_session, "OpenAISkill", ["id", "name"])
-        == expected_nodes
-    )
+    assert check_nodes(neo4j_session, "OpenAISkill", ["id", "name"]) == expected_nodes
 
     # Assert Skills are connected with Project
     expected_rels = {

--- a/tests/integration/cartography/intel/openai/test_vectorstores.py
+++ b/tests/integration/cartography/intel/openai/test_vectorstores.py
@@ -1,0 +1,80 @@
+from unittest.mock import patch
+
+import requests
+
+import cartography.intel.openai.vectorstores
+import tests.data.openai.projects
+import tests.data.openai.vectorstores
+from tests.integration.cartography.intel.openai.test_projects import (
+    _ensure_local_neo4j_has_test_projects,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_PROJECT_ID = tests.data.openai.projects.OPENAI_PROJECTS[0]["id"]
+
+
+def _ensure_local_neo4j_has_test_vectorstores(neo4j_session):
+    cartography.intel.openai.vectorstores.load_vectorstores(
+        neo4j_session,
+        tests.data.openai.vectorstores.OPENAI_VECTORSTORES,
+        TEST_PROJECT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.openai.vectorstores,
+    "get",
+    return_value=tests.data.openai.vectorstores.OPENAI_VECTORSTORES,
+)
+def test_load_openai_vectorstores(mock_api, neo4j_session):
+    """
+    Ensure that vector stores actually get loaded
+    """
+
+    # Arrange
+    api_session = requests.Session()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "BASE_URL": "https://api.openai.com/v1",
+        "project_id": TEST_PROJECT_ID,
+    }
+    _ensure_local_neo4j_has_test_projects(neo4j_session)
+
+    # Act
+    cartography.intel.openai.vectorstores.sync(
+        neo4j_session,
+        api_session,
+        common_job_parameters,
+        TEST_PROJECT_ID,
+    )
+
+    # Assert VectorStores exist
+    expected_nodes = {
+        ("vs_abc123def456", "knowledge-base"),
+        ("vs_ghi789jkl012", "document-index"),
+    }
+    assert (
+        check_nodes(neo4j_session, "OpenAIVectorStore", ["id", "name"])
+        == expected_nodes
+    )
+
+    # Assert VectorStores are connected with Project
+    expected_rels = {
+        ("vs_abc123def456", TEST_PROJECT_ID),
+        ("vs_ghi789jkl012", TEST_PROJECT_ID),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "OpenAIVectorStore",
+            "id",
+            "OpenAIProject",
+            "id",
+            "RESOURCE",
+            rel_direction_right=False,
+        )
+        == expected_rels
+    )


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)


### Summary

Add three new data-plane resources to the OpenAI intel module:

- **OpenAIContainer** (`ComputeInstance`): Compute containers scoped to a project. Properties include status, memory_limit, last_active_at.
- **OpenAISkill** : Custom skills scoped to a project. Properties include description, default_version, latest_version.
- **OpenAIVectorStore** (`Database`): Vector stores scoped to a project. Properties include status, usage_bytes, expires_at.

These resources use the `OpenAI-Project` header for project scoping (data-plane API at `/v1/containers`, `/v1/skills`, `/v1/vector_stores`), unlike existing admin API endpoints that use URL-based scoping (`/organization/projects/{id}/...`).

All three are wired into the existing per-project sync loop in `start_openai_ingestion()`.


### Related issues or links

- Increases OpenAI module coverage with data-plane resources


### How was this tested?

- Integration tests added for all 3 resources (test node creation and project relationships)
- All lints pass (`make test_lint`): isort, black, flake8, pyupgrade, mypy
- All modules import successfully


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [x] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [x] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

- The 3 new resources are data-plane APIs that require the `OpenAI-Project` header (set per project iteration), unlike existing admin endpoints that embed the project ID in the URL path.
- Ontology mappings: `OpenAIContainer` → `ComputeInstance`, `OpenAIVectorStore` → `Database`.
- Pagination uses the same `paginated_get()` helper as existing modules.