### PR TITLE
fix(gcp): cleanup legacy project->role resource edges

### DIFF
--- a/cartography/data/jobs/analysis/gcp_role_resource_edge_migration.json
+++ b/cartography/data/jobs/analysis/gcp_role_resource_edge_migration.json
@@ -1,0 +1,10 @@
+{
+  "name": "GCP role resource edge migration",
+  "statements": [
+    {
+      "__comment__": "DEPRECATED: temporary backward-compatibility cleanup; remove in v1.0.0 once legacy project->role edges are no longer expected.",
+      "query": "MATCH (:GCPProject)-[r:RESOURCE]->(role:GCPRole) WHERE role.scope IN ['GLOBAL', 'ORGANIZATION'] OR (role.name IS NOT NULL AND (role.name STARTS WITH 'roles/' OR role.name STARTS WITH 'organizations/')) DELETE r",
+      "iterative": false
+    }
+  ]
+}

--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -785,6 +785,12 @@ def start_gcp_ingestion(
         neo4j_session,
         common_job_parameters,
     )
+    # DEPRECATED: compatibility migration for legacy role edges. Remove in v1.0.0.
+    run_analysis_job(
+        "gcp_role_resource_edge_migration.json",
+        neo4j_session,
+        common_job_parameters,
+    )
 
     run_analysis_job(
         "gcp_gke_asset_exposure.json",

--- a/tests/integration/cartography/intel/gcp/test_iam.py
+++ b/tests/integration/cartography/intel/gcp/test_iam.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import cartography.intel.gcp.iam
 import tests.data.gcp.iam
+from cartography.graph.job import GraphJob
 from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
 
@@ -383,3 +384,69 @@ def test_sync_project_role_scope_property(
     # Custom project roles should have PROJECT scope and CUSTOM type
     assert roles["projects/project-abc/roles/customRole1"] == ("PROJECT", "CUSTOM")
     assert roles["projects/project-abc/roles/customRole2"] == ("PROJECT", "CUSTOM")
+
+
+def test_gcp_role_resource_edge_migration_cleans_legacy_project_role_links(
+    neo4j_session,
+):
+    """
+    Ensure migration removes legacy project->role links for global/org roles
+    while preserving legitimate project custom role relationships.
+    """
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _create_test_project(neo4j_session, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+    _create_test_organization(neo4j_session, TEST_ORG_ID, TEST_UPDATE_TAG)
+
+    neo4j_session.run(
+        """
+        CREATE (global_role:GCPRole {
+            id: 'roles/compute.admin',
+            name: 'roles/compute.admin',
+            scope: 'GLOBAL',
+            lastupdated: $update_tag
+        })
+        CREATE (org_role:GCPRole {
+            id: 'organizations/123456789012/roles/customOrgRole1',
+            name: 'organizations/123456789012/roles/customOrgRole1',
+            scope: 'ORGANIZATION',
+            lastupdated: $update_tag
+        })
+        CREATE (legacy_role:GCPRole {
+            id: 'roles/storage.objectViewer',
+            name: 'roles/storage.objectViewer',
+            lastupdated: $update_tag
+        })
+        CREATE (project_role:GCPRole {
+            id: 'projects/project-abc/roles/customRole1',
+            name: 'projects/project-abc/roles/customRole1',
+            scope: 'PROJECT',
+            lastupdated: $update_tag
+        })
+        WITH global_role, org_role, legacy_role, project_role
+        MATCH (p:GCPProject {id: $project_id})
+        CREATE (p)-[:RESOURCE {lastupdated: $update_tag}]->(global_role)
+        CREATE (p)-[:RESOURCE {lastupdated: $update_tag}]->(org_role)
+        CREATE (p)-[:RESOURCE {lastupdated: $update_tag}]->(legacy_role)
+        CREATE (p)-[:RESOURCE {lastupdated: $update_tag}]->(project_role)
+        """,
+        project_id=TEST_PROJECT_ID,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    GraphJob.run_from_json_file(
+        "cartography/data/jobs/analysis/gcp_role_resource_edge_migration.json",
+        neo4j_session,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "GCPProject",
+        "id",
+        "GCPRole",
+        "name",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (TEST_PROJECT_ID, "projects/project-abc/roles/customRole1"),
+    }


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
This PR adds a temporary GCP migration cleanup that removes legacy `(:GCPProject)-[:RESOURCE]->(:GCPRole)` edges for non-project roles.

Why:
- Older graph shapes can retain project-scoped `RESOURCE` links to global/org roles (`roles/*`, `organizations/*/roles/*`), which conflicts with the current model where those roles are org-scoped.
- This can distort role topology and downstream reasoning.

What changed:
- Added analysis job `cartography/data/jobs/analysis/gcp_role_resource_edge_migration.json`.
- Invoked the migration in `start_gcp_ingestion()` after IP migration.
- Added explicit deprecation note to remove this compatibility migration in `v1.0.0`.
- Added integration test to assert legacy links are removed while project custom role links are preserved.

### Related
https://github.com/cartography-cncf/cartography/pull/1469

### Breaking changes
None.


### How was this tested?
- added integration tests


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
- This intentionally targets only non-project role names/scopes to avoid touching legitimate project custom role links.
- The migration is temporary by design and marked `DEPRECATED` for removal in `v1.0.0`.
