### PR TITLE
fix(gcp): pass explicit creds to cloud run location discovery

### DIFF
--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -546,6 +546,7 @@ def _sync_project_resources(
                 project_id,
                 gcp_update_tag,
                 common_job_parameters,
+                credentials=credentials,
             )
             cloudrun_execution.sync_executions(
                 neo4j_session,
@@ -553,6 +554,7 @@ def _sync_project_resources(
                 project_id,
                 gcp_update_tag,
                 common_job_parameters,
+                credentials=credentials,
             )
 
         # Build the BigQuery v2 client once — used for datasets/tables/routines

--- a/cartography/intel/gcp/cloudrun/execution.py
+++ b/cartography/intel/gcp/cloudrun/execution.py
@@ -1,8 +1,10 @@
 import logging
 import re
+from typing import Optional
 
 import neo4j
 from google.api_core.exceptions import PermissionDenied
+from google.auth.credentials import Credentials as GoogleCredentials
 from google.auth.exceptions import DefaultCredentialsError
 from google.auth.exceptions import RefreshError
 from googleapiclient.discovery import Resource
@@ -19,7 +21,10 @@ logger = logging.getLogger(__name__)
 
 @timeit
 def get_executions(
-    client: Resource, project_id: str, location: str = "-"
+    client: Resource,
+    project_id: str,
+    location: str = "-",
+    credentials: Optional[GoogleCredentials] = None,
 ) -> list[dict]:
     """
     Gets GCP Cloud Run Executions for a project and location.
@@ -34,7 +39,11 @@ def get_executions(
         # Determine which locations to query
         if location == "-":
             # Discover all Cloud Run locations for this project
-            locations = discover_cloud_run_locations(client, project_id)
+            locations = discover_cloud_run_locations(
+                client,
+                project_id,
+                credentials=credentials,
+            )
         else:
             # Query specific location
             locations = {f"projects/{project_id}/locations/{location}"}
@@ -185,12 +194,13 @@ def sync_executions(
     project_id: str,
     update_tag: int,
     common_job_parameters: dict,
+    credentials: Optional[GoogleCredentials] = None,
 ) -> None:
     """
     Syncs GCP Cloud Run Executions for a project.
     """
     logger.info(f"Syncing Cloud Run Executions for project {project_id}.")
-    executions_raw = get_executions(client, project_id)
+    executions_raw = get_executions(client, project_id, credentials=credentials)
     if not executions_raw:
         logger.info(f"No Cloud Run executions found for project {project_id}.")
 

--- a/cartography/intel/gcp/cloudrun/job.py
+++ b/cartography/intel/gcp/cloudrun/job.py
@@ -1,8 +1,10 @@
 import logging
 import re
+from typing import Optional
 
 import neo4j
 from google.api_core.exceptions import PermissionDenied
+from google.auth.credentials import Credentials as GoogleCredentials
 from google.auth.exceptions import DefaultCredentialsError
 from google.auth.exceptions import RefreshError
 from googleapiclient.discovery import Resource
@@ -18,7 +20,12 @@ logger = logging.getLogger(__name__)
 
 
 @timeit
-def get_jobs(client: Resource, project_id: str, location: str = "-") -> list[dict]:
+def get_jobs(
+    client: Resource,
+    project_id: str,
+    location: str = "-",
+    credentials: Optional[GoogleCredentials] = None,
+) -> list[dict]:
     """
     Gets GCP Cloud Run Jobs for a project and location.
     """
@@ -27,7 +34,11 @@ def get_jobs(client: Resource, project_id: str, location: str = "-") -> list[dic
         # Determine which locations to query
         if location == "-":
             # Discover all Cloud Run locations for this project
-            locations = discover_cloud_run_locations(client, project_id)
+            locations = discover_cloud_run_locations(
+                client,
+                project_id,
+                credentials=credentials,
+            )
         else:
             # Query specific location
             locations = {f"projects/{project_id}/locations/{location}"}
@@ -146,12 +157,13 @@ def sync_jobs(
     project_id: str,
     update_tag: int,
     common_job_parameters: dict,
+    credentials: Optional[GoogleCredentials] = None,
 ) -> None:
     """
     Syncs GCP Cloud Run Jobs for a project.
     """
     logger.info(f"Syncing Cloud Run Jobs for project {project_id}.")
-    jobs_raw = get_jobs(client, project_id)
+    jobs_raw = get_jobs(client, project_id, credentials=credentials)
     if not jobs_raw:
         logger.info(f"No Cloud Run jobs found for project {project_id}.")
 

--- a/cartography/intel/gcp/cloudrun/util.py
+++ b/cartography/intel/gcp/cloudrun/util.py
@@ -3,14 +3,23 @@ Utility functions for GCP Cloud Run intel module.
 """
 
 import logging
+from typing import Optional
 
+from google.auth.credentials import Credentials as GoogleCredentials
 from googleapiclient.discovery import Resource
 from googleapiclient.errors import HttpError
+
+from cartography.intel.gcp.clients import build_client
+from cartography.intel.gcp.clients import get_gcp_credentials
 
 logger = logging.getLogger(__name__)
 
 
-def discover_cloud_run_locations(client: Resource, project_id: str) -> set[str]:
+def discover_cloud_run_locations(
+    client: Resource,
+    project_id: str,
+    credentials: Optional[GoogleCredentials] = None,
+) -> set[str]:
     """
     Discovers GCP locations with Cloud Run resources.
 
@@ -19,12 +28,10 @@ def discover_cloud_run_locations(client: Resource, project_id: str) -> set[str]:
     Falls back to discovering via services list if the v1 API call fails.
     """
     try:
-        # Use v1 API's locations.list() to get all Cloud Run regions
-        from cartography.intel.gcp.clients import build_client
-        from cartography.intel.gcp.clients import get_gcp_credentials
-
-        credentials = get_gcp_credentials()
-        v1_client = build_client("run", "v1", credentials=credentials)
+        # Use v1 API's locations.list() to get all Cloud Run regions.
+        # Prefer caller-provided credentials to avoid accidental fallback to ADC.
+        resolved_credentials = credentials or get_gcp_credentials()
+        v1_client = build_client("run", "v1", credentials=resolved_credentials)
 
         parent = f"projects/{project_id}"
         request = v1_client.projects().locations().list(name=parent)
@@ -61,10 +68,9 @@ def discover_cloud_run_locations(client: Resource, project_id: str) -> set[str]:
                 "v1 API returned no locations, falling back to service-based discovery"
             )
 
-    except HttpError as e:
-        # Only fall back for HTTP/API errors (e.g., API not enabled, 404, etc.)
-        # Auth errors (DefaultCredentialsError, RefreshError) will propagate
-        # since the fallback would also fail with the same auth issue
+    except (HttpError, RuntimeError) as e:
+        # Fall back to service-based discovery for HTTP/API failures and when
+        # the v1 helper cannot initialize credentials in non-ADC environments.
         logger.warning(
             f"Could not discover locations via v1 API: {e}. "
             f"Falling back to discovery via services list.",

--- a/tests/unit/cartography/intel/gcp/test_cloudrun_util.py
+++ b/tests/unit/cartography/intel/gcp/test_cloudrun_util.py
@@ -1,0 +1,76 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from cartography.intel.gcp.cloudrun.util import discover_cloud_run_locations
+
+
+def test_discover_cloud_run_locations_prefers_provided_credentials():
+    mock_v1_client = MagicMock()
+    mock_request = MagicMock()
+    mock_request.execute.return_value = {
+        "locations": [{"name": "projects/test-project/locations/us-central1"}],
+    }
+    mock_v1_client.projects.return_value.locations.return_value.list.return_value = (
+        mock_request
+    )
+    mock_v1_client.projects.return_value.locations.return_value.list_next.return_value = (
+        None
+    )
+
+    mock_credentials = MagicMock()
+    with (
+        patch(
+            "cartography.intel.gcp.cloudrun.util.build_client",
+            return_value=mock_v1_client,
+        ) as mock_build_client,
+        patch(
+            "cartography.intel.gcp.cloudrun.util.get_gcp_credentials",
+        ) as mock_get_gcp_credentials,
+    ):
+        result = discover_cloud_run_locations(
+            client=MagicMock(),
+            project_id="test-project",
+            credentials=mock_credentials,
+        )
+
+    assert result == {"projects/test-project/locations/us-central1"}
+    mock_build_client.assert_called_once_with(
+        "run",
+        "v1",
+        credentials=mock_credentials,
+    )
+    mock_get_gcp_credentials.assert_not_called()
+
+
+def test_discover_cloud_run_locations_falls_back_when_v1_discovery_unavailable():
+    mock_client = MagicMock()
+
+    mock_services_request = MagicMock()
+    mock_services_request.execute.return_value = {
+        "services": [
+            {"name": "projects/test-project/locations/us-west1/services/svc-1"},
+            {"name": "projects/test-project/locations/europe-west1/services/svc-2"},
+        ],
+    }
+
+    services = (
+        mock_client.projects.return_value.locations.return_value.services.return_value
+    )
+    services.list.return_value = mock_services_request
+    services.list_next.return_value = None
+
+    with patch(
+        "cartography.intel.gcp.cloudrun.util.build_client",
+        side_effect=RuntimeError(
+            "GCP credentials are not available; cannot build client."
+        ),
+    ):
+        result = discover_cloud_run_locations(
+            client=mock_client,
+            project_id="test-project",
+        )
+
+    assert result == {
+        "projects/test-project/locations/europe-west1",
+        "projects/test-project/locations/us-west1",
+    }


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
Fix Cloud Run Jobs/Executions sync in non-ADC environments (for example, AWS->GCP WIF) by propagating caller-provided GCP credentials into Cloud Run location discovery.

Before this change, `discover_cloud_run_locations()` rebuilt a v1 client with `get_gcp_credentials()` (ADC) and could fail even when the caller already had valid credentials. In WIF batch runs this raised `RuntimeError("GCP credentials are not available; cannot build client.")` and failed project sync.

### Breaking changes
None.

### How was this tested?
- added a test
- tested locally

Staging failure evidence that motivated this fix:
```text
INFO:sync.<redacted>:Creating Google WIF credentials using boto3 session credentials
INFO:sync.<redacted>:Using AWS region for WIF: us-east-1
INFO:sync.<redacted>:Created WIF credentials for project <redacted>, pool <redacted>, provider <redacted>
...
INFO:cartography.intel.gcp:Syncing GCP project <redacted> for Cloud Run.
INFO:cartography.intel.gcp.cloudrun.job:Syncing Cloud Run Jobs for project <redacted>.
```

Failure signature:
```text
RuntimeError: GCP credentials are not available; cannot build client.
  File ".../cartography/intel/gcp/cloudrun/job.py", line <redacted>, in get_jobs
    locations = discover_cloud_run_locations(client, project_id)
  File ".../cartography/intel/gcp/cloudrun/util.py", line <redacted>, in discover_cloud_run_locations
    v1_client = build_client("run", "v1", credentials=...)
```

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [x] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```
