### PR TITLE
fix(anthropic,openai): add HTTP retry with backoff for transient errors

### DIFF
--- a/cartography/intel/anthropic/__init__.py
+++ b/cartography/intel/anthropic/__init__.py
@@ -2,6 +2,8 @@ import logging
 
 import neo4j
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
 
 import cartography.intel.anthropic.apikeys
 import cartography.intel.anthropic.users
@@ -30,6 +32,13 @@ def start_anthropic_ingestion(neo4j_session: neo4j.Session, config: Config) -> N
 
     # Create requests sessions
     api_session = requests.session()
+    retry_policy = Retry(
+        total=5,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
+    api_session.mount("https://", HTTPAdapter(max_retries=retry_policy))
     api_session.headers.update(
         {
             "X-Api-Key": config.anthropic_apikey,

--- a/cartography/intel/openai/__init__.py
+++ b/cartography/intel/openai/__init__.py
@@ -2,6 +2,8 @@ import logging
 
 import neo4j
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
 
 import cartography.intel.openai.adminapikeys
 import cartography.intel.openai.apikeys
@@ -32,6 +34,13 @@ def start_openai_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
 
     # Create requests sessions
     api_session = requests.session()
+    retry_policy = Retry(
+        total=5,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
+    api_session.mount("https://", HTTPAdapter(max_retries=retry_policy))
     api_session.headers.update(
         {
             "Authorization": f"Bearer {config.openai_apikey}",


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

The Anthropic and OpenAI intel modules lacked retry logic for transient HTTP errors (429, 5xx), causing syncs to fail immediately on temporary API issues.

This adds a `urllib3.Retry` policy with exponential backoff on both modules' `requests.Session`, retrying up to 5 times on status codes `429, 500, 502, 503, 504`. This is consistent with the existing pattern used in the CVE module (`cartography/intel/cve/__init__.py`).


### Related issues or links

- N/A


### How was this tested?

Code review of the existing CVE module pattern. The retry policy is handled transparently by urllib3/requests at the transport layer — no functional changes to the sync logic.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.


### Notes for reviewers

Both modules create a bare `requests.session()` and call `.raise_for_status()` in their `paginated_get()` utilities, meaning any transient 5xx or rate-limit response would immediately abort the entire sync. Other modules (CVE, GCP, AWS, GitHub) already have retry mechanisms. This PR brings Anthropic and OpenAI in line with that practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)