### PR TITLE
fix(gcp): handle KMS API disabled error to prevent project sync crash

### DIFF
--- a/cartography/intel/gcp/kms.py
+++ b/cartography/intel/gcp/kms.py
@@ -3,10 +3,12 @@ from typing import Any
 
 import neo4j
 from googleapiclient.discovery import Resource
+from googleapiclient.errors import HttpError
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.gcp.util import gcp_api_execute_with_retry
+from cartography.intel.gcp.util import is_api_disabled_error
 from cartography.models.gcp.kms.cryptokey import GCPCryptoKeySchema
 from cartography.models.gcp.kms.keyring import GCPKeyRingSchema
 from cartography.util import timeit
@@ -15,30 +17,39 @@ logger = logging.getLogger(__name__)
 
 
 @timeit
-def get_kms_locations(client: Resource, project_id: str) -> list[dict]:
+def get_kms_locations(client: Resource, project_id: str) -> list[dict] | None:
     """
     Retrieve KMS locations for a given project.
 
     :param client: The KMS resource object created by googleapiclient.discovery.build().
     :param project_id: The GCP Project ID to retrieve locations from.
-    :return: A list of dictionaries representing KMS locations.
+    :return: A list of dictionaries representing KMS locations, or None if API is disabled.
     """
     parent = f"projects/{project_id}"
-    request = client.projects().locations().list(name=parent)
-
     locations = []
-    while request is not None:
-        response = gcp_api_execute_with_retry(request)
-        locations.extend(response.get("locations", []))
-        request = (
-            client.projects()
-            .locations()
-            .list_next(
-                previous_request=request,
-                previous_response=response,
+    try:
+        request = client.projects().locations().list(name=parent)
+        while request is not None:
+            response = gcp_api_execute_with_retry(request)
+            locations.extend(response.get("locations", []))
+            request = (
+                client.projects()
+                .locations()
+                .list_next(
+                    previous_request=request,
+                    previous_response=response,
+                )
             )
-        )
-    return locations
+        return locations
+    except HttpError as e:
+        if is_api_disabled_error(e):
+            logger.warning(
+                "Could not retrieve KMS locations on project %s due to permissions "
+                "issues or API not enabled. Skipping sync to preserve existing data.",
+                project_id,
+            )
+            return None
+        raise
 
 
 @timeit
@@ -205,6 +216,8 @@ def sync(
     logger.info("Syncing GCP KMS for project %s.", project_id)
 
     locations = get_kms_locations(kms_client, project_id)
+    if locations is None:
+        return
     if not locations:
         logger.info("No KMS locations found for project %s.", project_id)
 


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

When GCP's Service Usage API reports KMS as "enabled" but the actual KMS endpoint returns `403 SERVICE_DISABLED` (a known GCP inconsistency), the unhandled `HttpError` crashes the entire project sync — not just KMS.

This adds `is_api_disabled_error()` handling to `get_kms_locations()`, matching the pattern already used by 12+ other GCP modules (Cloud SQL, Bigtable, Cloud Run, Cloud Functions, Artifact Registry, etc.). When the error is detected, the KMS sync is gracefully skipped with a warning log, preserving existing data.


### Related issues or links

- Fixes #


### How was this tested?

- Verified the change follows the exact same pattern used in `cloud_sql_instance.py`, `bigtable_instance.py`, `gcf.py`, `cloudrun/service.py`, and other GCP modules.
- Code review of the diff to ensure correct early return in `sync()` when `get_kms_locations()` returns `None`.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.


### Notes for reviewers

This is a surgical fix scoped to `get_kms_locations()` only. The downstream functions (`get_key_rings`, `get_crypto_keys`) are not reached when the API is disabled since `sync()` returns early. The pattern is identical to `cloud_sql_instance.py:get_sql_instances()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)