### PR TITLE
fix(gcp): serialize Vertex AI endpoint labels to JSON

### DIFF
--- a/cartography/intel/gcp/vertex/endpoints.py
+++ b/cartography/intel/gcp/vertex/endpoints.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Dict
 from typing import List
@@ -57,6 +58,10 @@ def transform_vertex_ai_endpoints(endpoints: List[Dict]) -> List[Dict]:
     transformed_endpoints = []
 
     for endpoint in endpoints:
+        # Neo4j properties cannot store maps; serialize map-like fields to JSON.
+        labels = endpoint.get("labels")
+        labels_json = json.dumps(labels) if labels else None
+
         transformed_endpoint = {
             "id": endpoint.get("name"),  # Full resource name
             "name": endpoint.get("name"),
@@ -65,7 +70,7 @@ def transform_vertex_ai_endpoints(endpoints: List[Dict]) -> List[Dict]:
             "create_time": endpoint.get("createTime"),
             "update_time": endpoint.get("updateTime"),
             "etag": endpoint.get("etag"),
-            "labels": endpoint.get("labels"),
+            "labels": labels_json,
             "network": endpoint.get("network"),
         }
 

--- a/tests/data/gcp/vertex.py
+++ b/tests/data/gcp/vertex.py
@@ -38,6 +38,7 @@ VERTEX_ENDPOINTS_RESPONSE = [
         "createTime": "2024-01-01T00:00:00Z",
         "updateTime": "2024-01-02T00:00:00Z",
         "etag": "test-etag-456",
+        "labels": {"env": "test", "team": "ml"},
         "network": "projects/test-project/global/networks/default",
         "deployedModels": [
             {


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

Closes https://github.com/cartography-cncf/cartography/issues/2481

### Summary

`transform_vertex_ai_endpoints()` passes GCP resource labels as a raw Python dict to Neo4j, causing a `CypherTypeError` when a Vertex AI endpoint has labels. All other Vertex AI modules (`models.py`, `datasets.py`, `feature_groups.py`) correctly serialize labels with `json.dumps()` — only `endpoints.py` was missing this.

This fix serializes the labels dict to a JSON string before setting it as a Neo4j property, matching the pattern used in sibling modules.

### How was this tested?

- Added labels to endpoint test fixture data
- Integration tests pass: `uv run pytest tests/integration/cartography/intel/gcp/test_vertex.py`
- Linters pass: `uv run pre-commit run --files cartography/intel/gcp/vertex/endpoints.py tests/data/gcp/vertex.py`

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)