### PR TITLE
fix(gcp): migrate artifact registry sync client

### DIFF
--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -39,6 +39,7 @@ from cartography.intel.gcp import permission_relationships
 from cartography.intel.gcp import policy_bindings
 from cartography.intel.gcp import secretsmanager
 from cartography.intel.gcp import storage
+from cartography.intel.gcp.clients import build_artifact_registry_client
 from cartography.intel.gcp.clients import build_asset_client
 from cartography.intel.gcp.clients import build_client
 from cartography.intel.gcp.clients import get_gcp_credentials
@@ -529,8 +530,8 @@ def _sync_project_resources(
 
         if service_names.artifact_registry in enabled_services:
             logger.info("Syncing GCP project %s for Artifact Registry.", project_id)
-            artifact_registry_client = build_client(
-                "artifactregistry", "v1", credentials=credentials
+            artifact_registry_client = build_artifact_registry_client(
+                credentials=credentials
             )
             artifact_registry.sync(
                 neo4j_session,

--- a/cartography/intel/gcp/artifact_registry/__init__.py
+++ b/cartography/intel/gcp/artifact_registry/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 import neo4j
 from google.auth.credentials import Credentials as GoogleCredentials
-from googleapiclient.discovery import Resource
+from google.cloud.artifactregistry_v1 import ArtifactRegistryClient
 
 from cartography.intel.gcp.artifact_registry.artifact import (
     sync_artifact_registry_artifacts,
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 @timeit
 def sync(
     neo4j_session: neo4j.Session,
-    client: Resource,
+    client: ArtifactRegistryClient,
     credentials: GoogleCredentials,
     project_id: str,
     update_tag: int,
@@ -36,7 +36,7 @@ def sync(
 
     :param neo4j_session: The Neo4j session.
     :param client: The Artifact Registry API client.
-    :param credentials: GCP credentials (unused but kept for API compatibility).
+    :param credentials: GCP credentials used for the Go module compatibility path.
     :param project_id: The GCP project ID.
     :param update_tag: The update tag for this sync.
     :param common_job_parameters: Common job parameters for cleanup.
@@ -61,6 +61,7 @@ def sync(
         project_id,
         update_tag,
         common_job_parameters,
+        credentials,
     )
 
     # Load platform images (manifests) - no HTTP calls needed, data comes from dockerImages API

--- a/cartography/intel/gcp/artifact_registry/artifact.py
+++ b/cartography/intel/gcp/artifact_registry/artifact.py
@@ -1,16 +1,27 @@
 import logging
 
 import neo4j
-from google.api_core.exceptions import PermissionDenied
+from google.api_core.exceptions import GoogleAPICallError
+from google.auth.credentials import Credentials as GoogleCredentials
 from google.auth.exceptions import DefaultCredentialsError
 from google.auth.exceptions import RefreshError
+from google.cloud.artifactregistry_v1 import ArtifactRegistryClient
 from googleapiclient.discovery import Resource
 from googleapiclient.errors import HttpError
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.gcp.artifact_registry.util import (
+    artifact_registry_message_to_dict,
+)
+from cartography.intel.gcp.artifact_registry.util import (
+    classify_artifact_registry_error,
+)
+from cartography.intel.gcp.clients import build_client
 from cartography.intel.gcp.util import gcp_api_execute_with_retry
+from cartography.intel.gcp.util import get_error_reason
 from cartography.intel.gcp.util import is_api_disabled_error
+from cartography.intel.gcp.util import is_billing_disabled_error
 from cartography.models.gcp.artifact_registry.artifact import (
     GCPArtifactRegistryGenericArtifactSchema,
 )
@@ -28,8 +39,42 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 
 
+def _log_skipped_artifact_kind(repository_name: str, artifact_kind: str) -> None:
+    logger.warning(
+        "Skipping %s enumeration for Artifact Registry repository %s due to access or service state.",
+        artifact_kind,
+        repository_name,
+    )
+
+
+def _handle_artifact_registry_list_error(
+    exc: Exception, repository_name: str, artifact_kind: str
+) -> list[dict] | None:
+    classification = classify_artifact_registry_error(exc)
+    if classification is None:
+        raise exc
+
+    _log_skipped_artifact_kind(repository_name, artifact_kind)
+    return None
+
+
+def _list_generated_resources(
+    client: ArtifactRegistryClient,
+    repository_name: str,
+    list_method_name: str,
+    artifact_kind: str,
+) -> list[dict] | None:
+    try:
+        pager = getattr(client, list_method_name)(parent=repository_name)
+        return [artifact_registry_message_to_dict(item) for item in pager]
+    except (GoogleAPICallError, DefaultCredentialsError, RefreshError) as exc:
+        return _handle_artifact_registry_list_error(exc, repository_name, artifact_kind)
+
+
 @timeit
-def get_docker_images(client: Resource, repository_name: str) -> list[dict] | None:
+def get_docker_images(
+    client: ArtifactRegistryClient, repository_name: str
+) -> list[dict] | None:
     """
     Gets Docker images for a repository.
 
@@ -39,42 +84,18 @@ def get_docker_images(client: Resource, repository_name: str) -> list[dict] | No
              is not enabled or access is denied.
     :raises HttpError: For errors other than API disabled or permission denied.
     """
-    try:
-        images: list[dict] = []
-        request = (
-            client.projects()
-            .locations()
-            .repositories()
-            .dockerImages()
-            .list(parent=repository_name)
-        )
-        while request is not None:
-            response = gcp_api_execute_with_retry(request)
-            images.extend(response.get("dockerImages", []))
-            request = (
-                client.projects()
-                .locations()
-                .repositories()
-                .dockerImages()
-                .list_next(
-                    previous_request=request,
-                    previous_response=response,
-                )
-            )
-        return images
-    except HttpError as e:
-        if is_api_disabled_error(e):
-            logger.warning(
-                "Could not retrieve Docker images for repository %s due to permissions "
-                "issues or API not enabled. Skipping.",
-                repository_name,
-            )
-            return None
-        raise
+    return _list_generated_resources(
+        client,
+        repository_name,
+        "list_docker_images",
+        "Docker images",
+    )
 
 
 @timeit
-def get_maven_artifacts(client: Resource, repository_name: str) -> list[dict] | None:
+def get_maven_artifacts(
+    client: ArtifactRegistryClient, repository_name: str
+) -> list[dict] | None:
     """
     Gets Maven artifacts for a repository.
 
@@ -84,42 +105,18 @@ def get_maven_artifacts(client: Resource, repository_name: str) -> list[dict] | 
              is not enabled or access is denied.
     :raises HttpError: For errors other than API disabled or permission denied.
     """
-    try:
-        artifacts: list[dict] = []
-        request = (
-            client.projects()
-            .locations()
-            .repositories()
-            .mavenArtifacts()
-            .list(parent=repository_name)
-        )
-        while request is not None:
-            response = gcp_api_execute_with_retry(request)
-            artifacts.extend(response.get("mavenArtifacts", []))
-            request = (
-                client.projects()
-                .locations()
-                .repositories()
-                .mavenArtifacts()
-                .list_next(
-                    previous_request=request,
-                    previous_response=response,
-                )
-            )
-        return artifacts
-    except HttpError as e:
-        if is_api_disabled_error(e):
-            logger.warning(
-                "Could not retrieve Maven artifacts for repository %s due to permissions "
-                "issues or API not enabled. Skipping.",
-                repository_name,
-            )
-            return None
-        raise
+    return _list_generated_resources(
+        client,
+        repository_name,
+        "list_maven_artifacts",
+        "Maven artifacts",
+    )
 
 
 @timeit
-def get_npm_packages(client: Resource, repository_name: str) -> list[dict] | None:
+def get_npm_packages(
+    client: ArtifactRegistryClient, repository_name: str
+) -> list[dict] | None:
     """
     Gets npm packages for a repository.
 
@@ -129,42 +126,18 @@ def get_npm_packages(client: Resource, repository_name: str) -> list[dict] | Non
              is not enabled or access is denied.
     :raises HttpError: For errors other than API disabled or permission denied.
     """
-    try:
-        packages: list[dict] = []
-        request = (
-            client.projects()
-            .locations()
-            .repositories()
-            .npmPackages()
-            .list(parent=repository_name)
-        )
-        while request is not None:
-            response = gcp_api_execute_with_retry(request)
-            packages.extend(response.get("npmPackages", []))
-            request = (
-                client.projects()
-                .locations()
-                .repositories()
-                .npmPackages()
-                .list_next(
-                    previous_request=request,
-                    previous_response=response,
-                )
-            )
-        return packages
-    except HttpError as e:
-        if is_api_disabled_error(e):
-            logger.warning(
-                "Could not retrieve npm packages for repository %s due to permissions "
-                "issues or API not enabled. Skipping.",
-                repository_name,
-            )
-            return None
-        raise
+    return _list_generated_resources(
+        client,
+        repository_name,
+        "list_npm_packages",
+        "npm packages",
+    )
 
 
 @timeit
-def get_python_packages(client: Resource, repository_name: str) -> list[dict] | None:
+def get_python_packages(
+    client: ArtifactRegistryClient, repository_name: str
+) -> list[dict] | None:
     """
     Gets Python packages for a repository.
 
@@ -173,42 +146,16 @@ def get_python_packages(client: Resource, repository_name: str) -> list[dict] | 
     :return: List of Python package dicts from the API, or None if API is not enabled.
     :raises HttpError: For errors other than API disabled or permission denied.
     """
-    try:
-        packages: list[dict] = []
-        request = (
-            client.projects()
-            .locations()
-            .repositories()
-            .pythonPackages()
-            .list(parent=repository_name)
-        )
-        while request is not None:
-            response = gcp_api_execute_with_retry(request)
-            packages.extend(response.get("pythonPackages", []))
-            request = (
-                client.projects()
-                .locations()
-                .repositories()
-                .pythonPackages()
-                .list_next(
-                    previous_request=request,
-                    previous_response=response,
-                )
-            )
-        return packages
-    except HttpError as e:
-        if is_api_disabled_error(e):
-            logger.warning(
-                "Could not retrieve Python packages for repository %s due to permissions "
-                "issues or API not enabled. Skipping.",
-                repository_name,
-            )
-            return None
-        raise
+    return _list_generated_resources(
+        client,
+        repository_name,
+        "list_python_packages",
+        "Python packages",
+    )
 
 
 @timeit
-def get_go_modules(client: Resource, repository_name: str) -> list[dict]:
+def get_go_modules(client: Resource, repository_name: str) -> list[dict] | None:
     """
     Gets Go modules for a repository.
 
@@ -226,7 +173,7 @@ def get_go_modules(client: Resource, repository_name: str) -> list[dict]:
             .list(parent=repository_name)
         )
         while request is not None:
-            response = request.execute()
+            response = gcp_api_execute_with_retry(request)
             modules.extend(response.get("goModules", []))
             request = (
                 client.projects()
@@ -239,92 +186,80 @@ def get_go_modules(client: Resource, repository_name: str) -> list[dict]:
                 )
             )
         return modules
-    except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
-        logger.warning(
-            f"Failed to get Go modules for repository {repository_name} "
-            f"due to permissions or auth error: {e}",
-        )
-        return []
+    except HttpError as exc:
+        if is_api_disabled_error(exc) or is_billing_disabled_error(exc):
+            _log_skipped_artifact_kind(repository_name, "Go modules")
+            return None
+        if get_error_reason(exc) in {
+            "forbidden",
+            "insufficientPermissions",
+            "IAM_PERMISSION_DENIED",
+        }:
+            _log_skipped_artifact_kind(repository_name, "Go modules")
+            return None
+        raise
+    except (GoogleAPICallError, DefaultCredentialsError, RefreshError) as exc:
+        return _handle_artifact_registry_list_error(exc, repository_name, "Go modules")
 
 
 @timeit
-def get_apt_artifacts(client: Resource, repository_name: str) -> list[dict]:
+def get_apt_artifacts(
+    client: ArtifactRegistryClient, repository_name: str
+) -> list[dict] | None:
     """
-    Gets APT artifacts for a repository.
+    Gets APT package versions for a repository.
 
     :param client: The Artifact Registry API client.
     :param repository_name: The full repository resource name.
-    :return: List of APT artifact dicts from the API.
+    :return: List of APT package-version dicts from the API.
     """
-    artifacts: list[dict] = []
     try:
-        request = (
-            client.projects()
-            .locations()
-            .repositories()
-            .aptArtifacts()
-            .list(parent=repository_name)
-        )
-        while request is not None:
-            response = request.execute()
-            artifacts.extend(response.get("aptArtifacts", []))
-            request = (
-                client.projects()
-                .locations()
-                .repositories()
-                .aptArtifacts()
-                .list_next(
-                    previous_request=request,
-                    previous_response=response,
-                )
+        artifacts: list[dict] = []
+        for package in client.list_packages(parent=repository_name):
+            package_dict = artifact_registry_message_to_dict(package)
+            package_name = (
+                package_dict.get("displayName")
+                or package_dict.get("name", "").split("/packages/")[-1]
             )
+            for version in client.list_versions(parent=package_dict.get("name")):
+                version_dict = artifact_registry_message_to_dict(version)
+                version_dict["packageName"] = package_name
+                artifacts.append(version_dict)
         return artifacts
-    except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
-        logger.warning(
-            f"Failed to get APT artifacts for repository {repository_name} "
-            f"due to permissions or auth error: {e}",
+    except (GoogleAPICallError, DefaultCredentialsError, RefreshError) as exc:
+        return _handle_artifact_registry_list_error(
+            exc, repository_name, "APT package versions"
         )
-        return []
 
 
 @timeit
-def get_yum_artifacts(client: Resource, repository_name: str) -> list[dict]:
+def get_yum_artifacts(
+    client: ArtifactRegistryClient, repository_name: str
+) -> list[dict] | None:
     """
-    Gets YUM artifacts for a repository.
+    Gets YUM package versions for a repository.
 
     :param client: The Artifact Registry API client.
     :param repository_name: The full repository resource name.
-    :return: List of YUM artifact dicts from the API.
+    :return: List of YUM package-version dicts from the API.
     """
-    artifacts: list[dict] = []
     try:
-        request = (
-            client.projects()
-            .locations()
-            .repositories()
-            .yumArtifacts()
-            .list(parent=repository_name)
-        )
-        while request is not None:
-            response = request.execute()
-            artifacts.extend(response.get("yumArtifacts", []))
-            request = (
-                client.projects()
-                .locations()
-                .repositories()
-                .yumArtifacts()
-                .list_next(
-                    previous_request=request,
-                    previous_response=response,
-                )
+        artifacts: list[dict] = []
+        for package in client.list_packages(parent=repository_name):
+            package_dict = artifact_registry_message_to_dict(package)
+            package_name = (
+                package_dict.get("displayName")
+                or package_dict.get("name", "").split("/packages/")[-1]
             )
+            for version in client.list_versions(parent=package_dict.get("name")):
+                version_dict = artifact_registry_message_to_dict(version)
+                version_dict["packageName"] = package_name
+                artifacts.append(version_dict)
         return artifacts
-    except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
-        logger.warning(
-            f"Failed to get YUM artifacts for repository {repository_name} "
-            f"due to permissions or auth error: {e}",
+    except (GoogleAPICallError, DefaultCredentialsError, RefreshError) as exc:
+        return _handle_artifact_registry_list_error(
+            exc, repository_name, "YUM package versions"
         )
-        return []
 
 
 def transform_docker_images(
@@ -588,7 +523,7 @@ FORMAT_HANDLERS = {
     "MAVEN": (get_maven_artifacts, transform_maven_artifacts),
     "NPM": (get_npm_packages, transform_npm_packages),
     "PYTHON": (get_python_packages, transform_python_packages),
-    "GO": (get_go_modules, transform_go_modules),
+    "GO": (None, transform_go_modules),
     "APT": (get_apt_artifacts, transform_apt_artifacts),
     "YUM": (get_yum_artifacts, transform_yum_artifacts),
 }
@@ -756,11 +691,12 @@ def transform_image_manifests(
 @timeit
 def sync_artifact_registry_artifacts(
     neo4j_session: neo4j.Session,
-    client: Resource,
+    client: ArtifactRegistryClient,
     repositories: list[dict],
     project_id: str,
     update_tag: int,
     common_job_parameters: dict,
+    credentials: GoogleCredentials,
 ) -> list[dict]:
     """
     Syncs GCP Artifact Registry artifacts for all repositories.
@@ -781,6 +717,7 @@ def sync_artifact_registry_artifacts(
     helm_charts_transformed: list[dict] = []
     language_packages_transformed: list[dict] = []
     other_artifacts_transformed: list[dict] = []
+    legacy_go_client: Resource | None = None
 
     for repo in repositories:
         repo_name = repo.get("name")
@@ -796,9 +733,17 @@ def sync_artifact_registry_artifacts(
             )
             continue
 
-        get_func, _ = handlers
-
-        artifacts_raw = get_func(client, repo_name)
+        if repo_format == "GO":
+            if legacy_go_client is None:
+                legacy_go_client = build_client(
+                    "artifactregistry",
+                    "v1",
+                    credentials=credentials,
+                )
+            artifacts_raw = get_go_modules(legacy_go_client, repo_name)
+        else:
+            get_func, _ = handlers
+            artifacts_raw = get_func(client, repo_name) if get_func else None
         if artifacts_raw is None:
             # Skip this repository if API is not enabled or access denied
             continue

--- a/cartography/intel/gcp/artifact_registry/repository.py
+++ b/cartography/intel/gcp/artifact_registry/repository.py
@@ -1,14 +1,19 @@
 import logging
 
 import neo4j
-from google.api_core.exceptions import PermissionDenied
+from google.api_core.exceptions import GoogleAPICallError
 from google.auth.exceptions import DefaultCredentialsError
 from google.auth.exceptions import RefreshError
-from googleapiclient.discovery import Resource
-from googleapiclient.errors import HttpError
+from google.cloud.artifactregistry_v1 import ArtifactRegistryClient
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.gcp.artifact_registry.util import (
+    artifact_registry_message_to_dict,
+)
+from cartography.intel.gcp.artifact_registry.util import (
+    classify_artifact_registry_error,
+)
 from cartography.intel.gcp.artifact_registry.util import get_artifact_registry_locations
 from cartography.models.gcp.artifact_registry.repository import (
     GCPArtifactRegistryRepositorySchema,
@@ -19,7 +24,9 @@ logger = logging.getLogger(__name__)
 
 
 @timeit
-def get_artifact_registry_repositories(client: Resource, project_id: str) -> list[dict]:
+def get_artifact_registry_repositories(
+    client: ArtifactRegistryClient, project_id: str
+) -> list[dict]:
     """
     Gets GCP Artifact Registry repositories for a project across all locations.
     """
@@ -32,29 +39,18 @@ def get_artifact_registry_repositories(client: Resource, project_id: str) -> lis
     for location in locations:
         try:
             parent = f"projects/{project_id}/locations/{location}"
-            request = client.projects().locations().repositories().list(parent=parent)
-            while request is not None:
-                response = request.execute()
-                repositories.extend(response.get("repositories", []))
-                request = (
-                    client.projects()
-                    .locations()
-                    .repositories()
-                    .list_next(
-                        previous_request=request,
-                        previous_response=response,
-                    )
-                )
-        except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
-            logger.warning(
-                f"Failed to get Artifact Registry repositories for project {project_id} "
-                f"in location {location} due to permissions or auth error: {e}",
+            repositories.extend(
+                artifact_registry_message_to_dict(repository)
+                for repository in client.list_repositories(parent=parent)
             )
-            continue
-        except HttpError as e:
-            logger.debug(
-                f"Failed to get Artifact Registry repositories for project {project_id} "
-                f"in location {location}: {e}",
+        except (GoogleAPICallError, DefaultCredentialsError, RefreshError) as e:
+            classification = classify_artifact_registry_error(e)
+            if classification is None:
+                raise
+            logger.warning(
+                "Skipping Artifact Registry repositories for project %s in location %s due to access or service state.",
+                project_id,
+                location,
             )
             continue
 
@@ -144,7 +140,7 @@ def cleanup_repositories(
 @timeit
 def sync_artifact_registry_repositories(
     neo4j_session: neo4j.Session,
-    client: Resource,
+    client: ArtifactRegistryClient,
     project_id: str,
     update_tag: int,
     common_job_parameters: dict,

--- a/cartography/intel/gcp/artifact_registry/util.py
+++ b/cartography/intel/gcp/artifact_registry/util.py
@@ -1,30 +1,75 @@
 import logging
+from typing import Any
 
-from googleapiclient.discovery import Resource
-from googleapiclient.errors import HttpError
+from google.api_core.exceptions import GoogleAPICallError
+from google.api_core.exceptions import PermissionDenied
+from google.auth.exceptions import DefaultCredentialsError
+from google.auth.exceptions import RefreshError
+from google.cloud.artifactregistry_v1 import ArtifactRegistryClient
+from google.protobuf.json_format import MessageToDict
 
-from cartography.intel.gcp.util import gcp_api_execute_with_retry
-from cartography.intel.gcp.util import get_error_reason
-from cartography.intel.gcp.util import is_api_disabled_error
-from cartography.intel.gcp.util import is_billing_disabled_error
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
+def artifact_registry_message_to_dict(message: Any) -> dict[str, Any]:
+    """
+    Convert a protobuf or proto-plus message to the lowerCamelCase dict shape
+    used by the existing Artifact Registry transforms.
+    """
+    if isinstance(message, dict):
+        return message
+
+    protobuf_message = getattr(message, "_pb", message)
+    return MessageToDict(
+        protobuf_message,
+        preserving_proto_field_name=False,
+    )
+
+
+def classify_artifact_registry_error(exc: Exception) -> str | None:
+    """
+    Return a coarse error class for Artifact Registry calls that should be skipped.
+    """
+    if isinstance(exc, (DefaultCredentialsError, RefreshError, PermissionDenied)):
+        return "permission_denied"
+
+    if not isinstance(exc, GoogleAPICallError):
+        return None
+
+    lowered = str(exc).lower()
+    if "billing_disabled" in lowered or "requires billing to be enabled" in lowered:
+        return "billing_disabled"
+    if (
+        "accessnotconfigured" in lowered
+        or "service_disabled" in lowered
+        or "api has not been used" in lowered
+        or "is not enabled" in lowered
+        or "it is disabled" in lowered
+    ):
+        return "api_disabled"
+    if (
+        "permission denied" in lowered
+        or "insufficientpermissions" in lowered
+        or "iam_permission_denied" in lowered
+        or "forbidden" in lowered
+    ):
+        return "permission_denied"
+    return None
+
+
 @timeit
-def get_artifact_registry_locations(client: Resource, project_id: str) -> list[str]:
+def get_artifact_registry_locations(
+    client: ArtifactRegistryClient, project_id: str
+) -> list[str]:
     """
     Gets all available Artifact Registry locations for a project.
     """
     try:
-        req = client.projects().locations().list(name=f"projects/{project_id}")
-        res = gcp_api_execute_with_retry(req)
-
+        res = client.list_locations(request={"name": f"projects/{project_id}"})
         locations = [
-            location.get("locationId")
-            for location in res.get("locations", [])
-            if location.get("locationId")
+            location.location_id for location in res.locations if location.location_id
         ]
 
         logger.info(
@@ -32,27 +77,24 @@ def get_artifact_registry_locations(client: Resource, project_id: str) -> list[s
         )
         return locations
 
-    except HttpError as e:
-        if is_billing_disabled_error(e):
+    except (GoogleAPICallError, DefaultCredentialsError, RefreshError) as e:
+        classification = classify_artifact_registry_error(e)
+        if classification == "billing_disabled":
             logger.warning(
-                "Artifact Registry billing is disabled for project %s. Skipping Artifact Registry sync for this project. Full details: %s",
+                "Artifact Registry billing is disabled for project %s. Skipping Artifact Registry sync for this project.",
                 project_id,
-                e,
             )
             return []
-        if is_api_disabled_error(e):
+        if classification == "api_disabled":
             logger.info(
-                "Artifact Registry API appears disabled for project %s. Skipping Artifact Registry sync for this project. Full details: %s",
+                "Artifact Registry API appears disabled for project %s. Skipping Artifact Registry sync for this project.",
                 project_id,
-                e,
             )
             return []
-        reason = get_error_reason(e)
-        if reason in {"forbidden", "insufficientPermissions", "IAM_PERMISSION_DENIED"}:
+        if classification == "permission_denied":
             logger.warning(
-                "Missing permissions for Artifact Registry in project %s. Skipping Artifact Registry sync for this project. Full details: %s",
+                "Missing permissions for Artifact Registry in project %s. Skipping Artifact Registry sync for this project.",
                 project_id,
-                e,
             )
             return []
         logger.error(

--- a/cartography/intel/gcp/clients.py
+++ b/cartography/intel/gcp/clients.py
@@ -6,6 +6,7 @@ import httplib2
 from google.auth import default
 from google.auth.credentials import Credentials as GoogleCredentials
 from google.auth.exceptions import DefaultCredentialsError
+from google.cloud.artifactregistry_v1 import ArtifactRegistryClient
 from google.cloud.asset_v1 import AssetServiceClient
 from google_auth_httplib2 import AuthorizedHttp
 from googleapiclient.discovery import Resource
@@ -65,6 +66,27 @@ def build_asset_client(
             "GCP credentials are not available; cannot build asset client."
         )
     return AssetServiceClient(credentials=resolved_credentials)
+
+
+def build_artifact_registry_client(
+    credentials: Optional[GoogleCredentials] = None,
+    quota_project_id: Optional[str] = None,
+) -> ArtifactRegistryClient:
+    """
+    Build an ArtifactRegistryClient.
+
+    :param credentials: Optional credentials to use. If not provided, ADC will be used.
+    :param quota_project_id: Optional quota project ID for billing. If not provided,
+        the ADC default project will be used.
+    """
+    resolved_credentials = credentials or get_gcp_credentials(
+        quota_project_id=quota_project_id,
+    )
+    if resolved_credentials is None:
+        raise RuntimeError(
+            "GCP credentials are not available; cannot build Artifact Registry client."
+        )
+    return ArtifactRegistryClient(credentials=resolved_credentials)
 
 
 def get_gcp_credentials(

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -1665,7 +1665,7 @@ Representation of a language package in a GCP Artifact Registry repository. This
 
 #### GCPArtifactRegistryGenericArtifact
 
-Representation of a generic artifact in a GCP Artifact Registry repository. This node type covers [APT Artifacts](https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.aptArtifacts) and [YUM Artifacts](https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.yumArtifacts).
+Representation of a generic artifact in a GCP Artifact Registry repository. This node type covers APT and YUM package versions discovered from Artifact Registry package inventories.
 
 | Field | Description |
 |-------|-------------|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ dependencies = [
     "scaleway>=2.10.0",
     "google-cloud-resource-manager>=1.14.2",
     "google-cloud-asset>=1.0.0",
+    "google-cloud-artifact-registry>=1.20.0",
     "types-aiobotocore-ecr",
     "typer>=0.9.0",
     "azure-mgmt-synapse>=2.0.0",

--- a/tests/data/gcp/artifact_registry.py
+++ b/tests/data/gcp/artifact_registry.py
@@ -21,6 +21,24 @@ MOCK_REPOSITORIES = [
         "createTime": "2024-01-02T00:00:00Z",
         "updateTime": "2024-01-16T00:00:00Z",
     },
+    {
+        "name": "projects/test-project/locations/us-east1/repositories/apt-repo",
+        "format": "APT",
+        "mode": "STANDARD_REPOSITORY",
+        "description": "APT packages repository",
+        "sizeBytes": "256000",
+        "createTime": "2024-01-03T00:00:00Z",
+        "updateTime": "2024-01-17T00:00:00Z",
+    },
+    {
+        "name": "projects/test-project/locations/us-east1/repositories/yum-repo",
+        "format": "YUM",
+        "mode": "STANDARD_REPOSITORY",
+        "description": "YUM packages repository",
+        "sizeBytes": "384000",
+        "createTime": "2024-01-04T00:00:00Z",
+        "updateTime": "2024-01-18T00:00:00Z",
+    },
 ]
 
 # Manifest list data for multi-arch images (returned in imageManifests field)
@@ -80,6 +98,24 @@ MOCK_MAVEN_ARTIFACTS = [
         "version": "1.0.0",
         "createTime": "2024-01-05T00:00:00Z",
         "updateTime": "2024-01-05T00:00:00Z",
+    },
+]
+
+MOCK_APT_ARTIFACTS = [
+    {
+        "name": "projects/test-project/locations/us-east1/repositories/apt-repo/packages/curl/versions/7.88.1",
+        "packageName": "curl",
+        "createTime": "2024-01-06T00:00:00Z",
+        "updateTime": "2024-01-06T00:00:00Z",
+    },
+]
+
+MOCK_YUM_ARTIFACTS = [
+    {
+        "name": "projects/test-project/locations/us-east1/repositories/yum-repo/packages/bash/versions/5.2.26",
+        "packageName": "bash",
+        "createTime": "2024-01-07T00:00:00Z",
+        "updateTime": "2024-01-07T00:00:00Z",
     },
 ]
 

--- a/tests/integration/cartography/intel/gcp/test_artifact_registry.py
+++ b/tests/integration/cartography/intel/gcp/test_artifact_registry.py
@@ -2,12 +2,16 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from cartography.intel.gcp.artifact_registry import sync
+from cartography.intel.gcp.artifact_registry.artifact import transform_apt_artifacts
 from cartography.intel.gcp.artifact_registry.artifact import transform_docker_images
 from cartography.intel.gcp.artifact_registry.artifact import transform_maven_artifacts
+from cartography.intel.gcp.artifact_registry.artifact import transform_yum_artifacts
+from tests.data.gcp.artifact_registry import MOCK_APT_ARTIFACTS
 from tests.data.gcp.artifact_registry import MOCK_DOCKER_IMAGES
 from tests.data.gcp.artifact_registry import MOCK_HELM_CHARTS
 from tests.data.gcp.artifact_registry import MOCK_MAVEN_ARTIFACTS
 from tests.data.gcp.artifact_registry import MOCK_REPOSITORIES
+from tests.data.gcp.artifact_registry import MOCK_YUM_ARTIFACTS
 from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
 
@@ -19,9 +23,13 @@ TEST_DOCKER_REPO_ID = (
 TEST_MAVEN_REPO_ID = (
     "projects/test-project/locations/us-central1/repositories/maven-repo"
 )
+TEST_APT_REPO_ID = "projects/test-project/locations/us-east1/repositories/apt-repo"
+TEST_YUM_REPO_ID = "projects/test-project/locations/us-east1/repositories/yum-repo"
 TEST_DOCKER_IMAGE_ID = "projects/test-project/locations/us-central1/repositories/docker-repo/dockerImages/my-app@sha256:abc123"
 TEST_HELM_CHART_ID = "projects/test-project/locations/us-central1/repositories/docker-repo/dockerImages/my-chart@sha256:xyz789"
 TEST_MAVEN_ARTIFACT_ID = "projects/test-project/locations/us-central1/repositories/maven-repo/mavenArtifacts/com.example:my-lib:1.0.0"
+TEST_APT_ARTIFACT_ID = "projects/test-project/locations/us-east1/repositories/apt-repo/packages/curl/versions/7.88.1"
+TEST_YUM_ARTIFACT_ID = "projects/test-project/locations/us-east1/repositories/yum-repo/packages/bash/versions/5.2.26"
 TEST_PLATFORM_IMAGE_AMD64_ID = f"{TEST_DOCKER_IMAGE_ID}@sha256:def456"
 TEST_PLATFORM_IMAGE_ARM64_ID = f"{TEST_DOCKER_IMAGE_ID}@sha256:ghi789"
 
@@ -42,11 +50,21 @@ def _mock_get_maven_artifacts(client, repo_name):
     return MOCK_MAVEN_ARTIFACTS
 
 
+def _mock_get_apt_artifacts(client, repo_name):
+    return MOCK_APT_ARTIFACTS
+
+
+def _mock_get_yum_artifacts(client, repo_name):
+    return MOCK_YUM_ARTIFACTS
+
+
 @patch(
     "cartography.intel.gcp.artifact_registry.artifact.FORMAT_HANDLERS",
     {
         "DOCKER": (_mock_get_docker_images, transform_docker_images),
         "MAVEN": (_mock_get_maven_artifacts, transform_maven_artifacts),
+        "APT": (_mock_get_apt_artifacts, transform_apt_artifacts),
+        "YUM": (_mock_get_yum_artifacts, transform_yum_artifacts),
     },
 )
 @patch(
@@ -79,6 +97,8 @@ def test_sync_artifact_registry(
     assert check_nodes(neo4j_session, "GCPArtifactRegistryRepository", ["id"]) == {
         (TEST_DOCKER_REPO_ID,),
         (TEST_MAVEN_REPO_ID,),
+        (TEST_APT_REPO_ID,),
+        (TEST_YUM_REPO_ID,),
     }
 
     # Assert: Check container image nodes
@@ -94,6 +114,12 @@ def test_sync_artifact_registry(
     # Assert: Check language package nodes (Maven artifact)
     assert check_nodes(neo4j_session, "GCPArtifactRegistryLanguagePackage", ["id"]) == {
         (TEST_MAVEN_ARTIFACT_ID,),
+    }
+
+    # Assert: Check generic artifact nodes (APT and YUM artifacts)
+    assert check_nodes(neo4j_session, "GCPArtifactRegistryGenericArtifact", ["id"]) == {
+        (TEST_APT_ARTIFACT_ID,),
+        (TEST_YUM_ARTIFACT_ID,),
     }
 
     # Assert: Check platform image nodes
@@ -113,6 +139,8 @@ def test_sync_artifact_registry(
     ) == {
         (TEST_PROJECT_ID, TEST_DOCKER_REPO_ID),
         (TEST_PROJECT_ID, TEST_MAVEN_REPO_ID),
+        (TEST_PROJECT_ID, TEST_APT_REPO_ID),
+        (TEST_PROJECT_ID, TEST_YUM_REPO_ID),
     }
 
     # Assert: Check GCPProject -> GCPArtifactRegistryContainerImage relationships
@@ -164,6 +192,32 @@ def test_sync_artifact_registry(
         "id",
         "CONTAINS",
     ) == {(TEST_MAVEN_REPO_ID, TEST_MAVEN_ARTIFACT_ID)}
+
+    # Assert: Check GCPProject -> GCPArtifactRegistryGenericArtifact relationships
+    assert check_rels(
+        neo4j_session,
+        "GCPProject",
+        "id",
+        "GCPArtifactRegistryGenericArtifact",
+        "id",
+        "RESOURCE",
+    ) == {
+        (TEST_PROJECT_ID, TEST_APT_ARTIFACT_ID),
+        (TEST_PROJECT_ID, TEST_YUM_ARTIFACT_ID),
+    }
+
+    # Assert: Check GCPArtifactRegistryRepository -> GCPArtifactRegistryGenericArtifact relationships
+    assert check_rels(
+        neo4j_session,
+        "GCPArtifactRegistryRepository",
+        "id",
+        "GCPArtifactRegistryGenericArtifact",
+        "id",
+        "CONTAINS",
+    ) == {
+        (TEST_APT_REPO_ID, TEST_APT_ARTIFACT_ID),
+        (TEST_YUM_REPO_ID, TEST_YUM_ARTIFACT_ID),
+    }
 
     # Assert: Check GCPArtifactRegistryContainerImage -> GCPArtifactRegistryPlatformImage relationships
     assert check_rels(

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_artifact.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_artifact.py
@@ -1,0 +1,100 @@
+from unittest.mock import ANY
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from google.api_core.exceptions import GoogleAPICallError
+
+from cartography.intel.gcp.artifact_registry.artifact import get_apt_artifacts
+from cartography.intel.gcp.artifact_registry.artifact import get_yum_artifacts
+
+
+def test_get_apt_artifacts_flattens_package_versions():
+    client = MagicMock()
+    client.list_packages.return_value = [
+        {
+            "name": "projects/test-project/locations/us-east1/repositories/apt-repo/packages/curl",
+            "displayName": "curl",
+        }
+    ]
+    client.list_versions.return_value = [
+        {
+            "name": "projects/test-project/locations/us-east1/repositories/apt-repo/packages/curl/versions/7.88.1",
+            "createTime": "2024-01-06T00:00:00Z",
+            "updateTime": "2024-01-06T00:00:00Z",
+        }
+    ]
+
+    artifacts = get_apt_artifacts(
+        client,
+        "projects/test-project/locations/us-east1/repositories/apt-repo",
+    )
+
+    assert artifacts == [
+        {
+            "name": "projects/test-project/locations/us-east1/repositories/apt-repo/packages/curl/versions/7.88.1",
+            "createTime": "2024-01-06T00:00:00Z",
+            "updateTime": "2024-01-06T00:00:00Z",
+            "packageName": "curl",
+        }
+    ]
+    client.list_versions.assert_called_once_with(
+        parent="projects/test-project/locations/us-east1/repositories/apt-repo/packages/curl"
+    )
+
+
+def test_get_yum_artifacts_returns_none_on_permission_issue():
+    client = MagicMock()
+    client.list_packages.side_effect = GoogleAPICallError("permission denied")
+
+    artifacts = get_yum_artifacts(
+        client,
+        "projects/test-project/locations/us-east1/repositories/yum-repo",
+    )
+
+    assert artifacts is None
+
+
+def test_go_modules_compatibility_client_is_built_once():
+    mock_generated_client = MagicMock()
+    repositories = [
+        {
+            "name": "projects/test-project/locations/us-central1/repositories/go-repo",
+            "format": "GO",
+        },
+        {
+            "name": "projects/test-project/locations/us-central1/repositories/second-go-repo",
+            "format": "GO",
+        },
+    ]
+
+    with (
+        patch(
+            "cartography.intel.gcp.artifact_registry.artifact.build_client",
+            return_value=MagicMock(),
+        ) as mock_build_client,
+        patch(
+            "cartography.intel.gcp.artifact_registry.artifact.get_go_modules",
+            return_value=[],
+        ) as mock_get_go_modules,
+    ):
+        from cartography.intel.gcp.artifact_registry.artifact import (
+            sync_artifact_registry_artifacts,
+        )
+
+        result = sync_artifact_registry_artifacts(
+            neo4j_session=MagicMock(),
+            client=mock_generated_client,
+            repositories=repositories,
+            project_id="test-project",
+            update_tag=123,
+            common_job_parameters={"UPDATE_TAG": 123, "PROJECT_ID": "test-project"},
+            credentials=MagicMock(),
+        )
+
+    assert result == []
+    mock_build_client.assert_called_once_with(
+        "artifactregistry",
+        "v1",
+        credentials=ANY,
+    )
+    assert mock_get_go_modules.call_count == 2

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_repository.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_repository.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock
+
+from cartography.intel.gcp.artifact_registry.repository import (
+    get_artifact_registry_repositories,
+)
+
+
+def test_get_artifact_registry_repositories_lists_all_locations(monkeypatch):
+    client = MagicMock()
+    monkeypatch.setattr(
+        "cartography.intel.gcp.artifact_registry.repository.get_artifact_registry_locations",
+        lambda _client, _project_id: ["us-central1", "us-east1"],
+    )
+
+    client.list_repositories.side_effect = [
+        [
+            {
+                "name": "projects/test-project/locations/us-central1/repositories/docker-repo",
+                "format": "DOCKER",
+            }
+        ],
+        [
+            {
+                "name": "projects/test-project/locations/us-east1/repositories/apt-repo",
+                "format": "APT",
+            }
+        ],
+    ]
+
+    repositories = get_artifact_registry_repositories(client, "test-project")
+
+    assert repositories == [
+        {
+            "name": "projects/test-project/locations/us-central1/repositories/docker-repo",
+            "format": "DOCKER",
+        },
+        {
+            "name": "projects/test-project/locations/us-east1/repositories/apt-repo",
+            "format": "APT",
+        },
+    ]
+    assert client.list_repositories.call_count == 2

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_util.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_util.py
@@ -1,98 +1,50 @@
-import json
 from unittest.mock import MagicMock
 
 import pytest
-from googleapiclient.errors import HttpError
+from google.api_core.exceptions import GoogleAPICallError
+from google.api_core.exceptions import PermissionDenied
 
 from cartography.intel.gcp.artifact_registry.util import get_artifact_registry_locations
 
 
-def _make_http_error(status: int, payload: dict) -> HttpError:
-    resp = MagicMock()
-    resp.status = status
-    return HttpError(resp=resp, content=json.dumps(payload).encode("utf-8"))
-
-
-def _make_client() -> tuple[MagicMock, MagicMock]:
+def test_get_artifact_registry_locations_success():
     client = MagicMock()
-    request = MagicMock()
-    client.projects.return_value.locations.return_value.list.return_value = request
-    return client, request
-
-
-def test_get_artifact_registry_locations_success(monkeypatch):
-    client, _request = _make_client()
-    monkeypatch.setattr(
-        "cartography.intel.gcp.artifact_registry.util.gcp_api_execute_with_retry",
-        lambda _req: {
-            "locations": [{"locationId": "us-central1"}, {"locationId": "europe-west1"}]
-        },
-    )
+    client.list_locations.return_value.locations = [
+        MagicMock(location_id="us-central1"),
+        MagicMock(location_id="europe-west1"),
+    ]
 
     locations = get_artifact_registry_locations(client, "test-project")
+
     assert locations == ["us-central1", "europe-west1"]
+    client.list_locations.assert_called_once_with(
+        request={"name": "projects/test-project"}
+    )
 
 
-def test_get_artifact_registry_locations_billing_disabled_returns_empty(monkeypatch):
-    client, _request = _make_client()
-    billing_error = _make_http_error(
-        403,
-        {
-            "error": {
-                "message": "This API method requires billing to be enabled.",
-                "details": [
-                    {
-                        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
-                        "reason": "BILLING_DISABLED",
-                    }
-                ],
-            }
-        },
-    )
-    monkeypatch.setattr(
-        "cartography.intel.gcp.artifact_registry.util.gcp_api_execute_with_retry",
-        lambda _req: (_ for _ in ()).throw(billing_error),
-    )
+def test_get_artifact_registry_locations_permission_denied_returns_empty():
+    client = MagicMock()
+    client.list_locations.side_effect = PermissionDenied("Permission denied")
 
     locations = get_artifact_registry_locations(client, "test-project")
+
     assert locations == []
 
 
-def test_get_artifact_registry_locations_forbidden_returns_empty(monkeypatch):
-    client, _request = _make_client()
-    forbidden_error = _make_http_error(
-        403,
-        {
-            "error": {
-                "message": "Permission denied",
-                "errors": [{"reason": "forbidden"}],
-            }
-        },
-    )
-    monkeypatch.setattr(
-        "cartography.intel.gcp.artifact_registry.util.gcp_api_execute_with_retry",
-        lambda _req: (_ for _ in ()).throw(forbidden_error),
+def test_get_artifact_registry_locations_billing_disabled_returns_empty():
+    client = MagicMock()
+    client.list_locations.side_effect = GoogleAPICallError(
+        "This API method requires billing to be enabled. BILLING_DISABLED"
     )
 
     locations = get_artifact_registry_locations(client, "test-project")
+
     assert locations == []
 
 
-def test_get_artifact_registry_locations_unknown_error_raises(monkeypatch):
-    client, _request = _make_client()
-    server_error = _make_http_error(
-        500,
-        {
-            "error": {
-                "message": "internal error",
-                "errors": [{"reason": "backendError"}],
-            }
-        },
-    )
-    monkeypatch.setattr(
-        "cartography.intel.gcp.artifact_registry.util.gcp_api_execute_with_retry",
-        lambda _req: (_ for _ in ()).throw(server_error),
-    )
+def test_get_artifact_registry_locations_unknown_error_raises():
+    client = MagicMock()
+    client.list_locations.side_effect = GoogleAPICallError("backend failure")
 
-    with pytest.raises(HttpError):
+    with pytest.raises(GoogleAPICallError):
         get_artifact_registry_locations(client, "test-project")

--- a/tests/unit/cartography/intel/gcp/test_clients.py
+++ b/tests/unit/cartography/intel/gcp/test_clients.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from cartography.intel.gcp.clients import build_artifact_registry_client
+
+
+def test_build_artifact_registry_client_uses_resolved_credentials():
+    credentials = MagicMock()
+
+    with (
+        patch(
+            "cartography.intel.gcp.clients.get_gcp_credentials",
+            return_value=credentials,
+        ),
+        patch(
+            "cartography.intel.gcp.clients.ArtifactRegistryClient",
+        ) as mock_client,
+    ):
+        build_artifact_registry_client()
+
+    mock_client.assert_called_once_with(credentials=credentials)

--- a/uv.lock
+++ b/uv.lock
@@ -881,6 +881,7 @@ dependencies = [
     { name = "duo-client" },
     { name = "google-api-python-client" },
     { name = "google-auth" },
+    { name = "google-cloud-artifact-registry" },
     { name = "google-cloud-asset" },
     { name = "google-cloud-resource-manager" },
     { name = "httpx" },
@@ -988,6 +989,7 @@ requires-dist = [
     { name = "duo-client" },
     { name = "google-api-python-client", specifier = ">=1.7.8" },
     { name = "google-auth", specifier = ">=2.37.0" },
+    { name = "google-cloud-artifact-registry", specifier = ">=1.20.0" },
     { name = "google-cloud-asset", specifier = ">=1.0.0" },
     { name = "google-cloud-resource-manager", specifier = ">=1.14.2" },
     { name = "httpx", specifier = ">=0.24.0" },
@@ -1757,6 +1759,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/eb/f8dcd4e3c596733f872732b43836df6486fa09966ce5586443d4e9e288fb/google_cloud_access_context_manager-0.3.0.tar.gz", hash = "sha256:f3aa35c9225b7aaef85ecdacedcc1577789be8d458b7a41b6ad23b504786e5f9", size = 46643, upload-time = "2025-10-17T02:33:32.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/94/24b010493660dd55e2d9769ae7ef44164aebd7e1f4a9266cf9459affd687/google_cloud_access_context_manager-0.3.0-py3-none-any.whl", hash = "sha256:5d15ad51547f06c281e35f16b4ffcb3e98bb2d898b01470f88b94edfb2eeb0a3", size = 58852, upload-time = "2025-10-17T02:30:33.768Z" },
+]
+
+[[package]]
+name = "google-cloud-artifact-registry"
+version = "1.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/63/5f4bc66db0c95f456d7f6394f98b132f5dbdbbaac9942472ab8382037a0b/google_cloud_artifact_registry-1.20.0.tar.gz", hash = "sha256:88161c9b8ad467915f9ee1f3fa923554431f91aa15aeb87e4fdbb99affb3235b", size = 314342, upload-time = "2026-02-12T14:50:18.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/42/46feb7393c7f7962a40f7db679af22fa83bd9b17ba28f5a801babdd5d1ad/google_cloud_artifact_registry-1.20.0-py3-none-any.whl", hash = "sha256:a0a4ba0a6f6421260e5b6063681089e1da2a27e0598829a70d6426f623b1c4d2", size = 249267, upload-time = "2026-02-12T14:49:49.256Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

### Summary
Migrate GCP Artifact Registry sync from the discovery client to the generated Artifact Registry client and restore OS-package repository sync by enumerating package versions through the supported package APIs. The graph schema and loaded node types remain unchanged.

### Related issues or links
- N/A (tracked outside this public repository)

### How was this tested?
- `python3 -m compileall cartography/intel/gcp cartography/models/gcp tests/unit/cartography/intel/gcp tests/integration/cartography/intel/gcp`
- Git commit hooks: `uv-lock`, `isort`, `black`, `flake8`, `pyupgrade`, `mypy`
- Added/updated unit and integration tests for Artifact Registry repository listing and APT/YUM package-version handling

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

### Notes for reviewers
- The upstream Artifact Registry inventory shape changed only at the client/API layer. The transformed payloads still populate the existing Cartography models and relationships.
- APT and YUM fixtures changed because the raw upstream enumeration now comes from `packages` and `versions` rather than the unsupported direct artifact listing path.
