### PR TITLE
fix(okta): use next link presence for users pagination

### DIFF
--- a/cartography/intel/okta/users.py
+++ b/cartography/intel/okta/users.py
@@ -45,13 +45,12 @@ def _get_okta_users(user_client: UsersClient) -> List[Dict]:
     user_list: List[Dict] = []
     paged_users = user_client.get_paged_users()
 
-    # TODO: Fix bug, we miss last page :(
     while True:
         user_list.extend(paged_users.result)
         check_rate_limit(paged_users.response)
-        if not paged_users.is_last_page():
-            # Keep on fetching pages of users until the last page
-            paged_users = user_client.get_paged_users(url=paged_users.next_url)
+        next_link = paged_users.response.links.get("next")
+        if next_link:
+            paged_users = user_client.get_paged_users(url=next_link["url"])
         else:
             break
 

--- a/tests/unit/cartography/intel/okta/test_user.py
+++ b/tests/unit/cartography/intel/okta/test_user.py
@@ -1,3 +1,7 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from cartography.intel.okta.users import _get_okta_users
 from cartography.intel.okta.users import transform_okta_user
 from tests.data.okta.users import create_test_user
 
@@ -167,3 +171,58 @@ def test_userprofile_transform_with_no_transition_status():
     }
 
     assert result == expected
+
+
+def _make_paged_result(users, has_next=False, next_url=None):
+    """Helper to create a mock PagedResults object."""
+    mock = MagicMock()
+    mock.result = users
+    mock.response.links = {}
+    if has_next and next_url:
+        mock.response.links["next"] = {"url": next_url}
+    mock.response.headers = {
+        "x-rate-limit-remaining": "100",
+        "x-rate-limit-limit": "100",
+        "x-rate-limit-reset": "0",
+    }
+    return mock
+
+
+@patch("cartography.intel.okta.users.check_rate_limit")
+def test_get_okta_users_fetches_all_pages(mock_rate_limit):
+    """Verify that _get_okta_users fetches every page including the last one."""
+    user_page_1 = [create_test_user()]
+    user_page_2 = [create_test_user()]
+    user_page_3 = [create_test_user()]
+
+    page_3 = _make_paged_result(user_page_3, has_next=False)
+    page_2 = _make_paged_result(
+        user_page_2, has_next=True, next_url="https://okta.example.com/page3"
+    )
+    page_1 = _make_paged_result(
+        user_page_1, has_next=True, next_url="https://okta.example.com/page2"
+    )
+
+    mock_client = MagicMock()
+    mock_client.get_paged_users.side_effect = [page_1, page_2, page_3]
+
+    result = _get_okta_users(mock_client)
+
+    assert len(result) == 3
+    assert result == user_page_1 + user_page_2 + user_page_3
+    assert mock_client.get_paged_users.call_count == 3
+
+
+@patch("cartography.intel.okta.users.check_rate_limit")
+def test_get_okta_users_single_page(mock_rate_limit):
+    """Verify single-page results are returned correctly."""
+    users = [create_test_user()]
+    page = _make_paged_result(users, has_next=False)
+
+    mock_client = MagicMock()
+    mock_client.get_paged_users.return_value = page
+
+    result = _get_okta_users(mock_client)
+
+    assert len(result) == 1
+    assert mock_client.get_paged_users.call_count == 1


### PR DESCRIPTION
## Summary
- Fix pagination in Okta users module that skips the final page of results (#1195)
- Replace `is_last_page()` SDK method with direct Link header check, matching the approach used by groups and applications modules
- Add unit tests for multi-page and single-page pagination

## Context
PR #1243 (Okta module refactor) was expected to address this but is blocked on an upstream SDK issue (okta/okta-sdk-python#481). This targeted fix resolves the pagination bug independently.

The old code called `paged_users.is_last_page()` from the Okta SDK, which had issues with the last page. The new approach checks `response.links.get("next")` directly, which is safe because `requests.Response.links` always returns an empty dict (never None) when no Link headers are present.

Note: groups.py and applications.py use a slightly different pattern (the `is_last_page()` utility from `utils.py` + chained `.get("next").get("url")`). The approach here avoids the chained `.get()` call that would raise AttributeError without the guard. A follow-up PR could unify all three modules.

## Test plan
- [x] Unit test: multi-page pagination (3 pages, all collected)
- [x] Unit test: single-page results
- [x] Existing transform tests pass (7 tests)
- [x] black, isort, flake8 clean

Fixes #1195