### PR TITLE
Link Kandji, CrowdStrike, and SnipeIT devices by serial/hostname and add integration test

### DIFF
--- a/cartography/models/ontology/mapping/data/devices.py
+++ b/cartography/models/ontology/mapping/data/devices.py
@@ -102,6 +102,80 @@ kandji_mapping = OntologyMapping(
             ],
         ),
     ],
+    rels=[
+        OntologyRelMapping(
+            __comment__=(
+                "Link KandjiDevice to CrowdstrikeHost when serial numbers match, "
+                "or when both serial numbers are missing and hostnames match."
+            ),
+            query=(
+                "MATCH (k:KandjiDevice), (c:CrowdstrikeHost) "
+                "WHERE "
+                "((k.serial_number IS NOT NULL AND k.serial_number <> '' "
+                "AND c.serial_number IS NOT NULL AND c.serial_number <> '' "
+                "AND k.serial_number = c.serial_number) "
+                "OR ((k.serial_number IS NULL OR k.serial_number = '') "
+                "AND (c.serial_number IS NULL OR c.serial_number = '') "
+                "AND k.device_name = c.hostname)) "
+                "MERGE (k)-[r:POTENTIALLY_SAME_DEVICE]->(c) "
+                "ON CREATE SET r.firstseen = timestamp() "
+                "SET r.lastupdated = $UPDATE_TAG, "
+                "r.match_method = CASE "
+                "WHEN k.serial_number IS NOT NULL AND k.serial_number <> '' "
+                "AND c.serial_number IS NOT NULL AND c.serial_number <> '' "
+                "THEN 'serial_number' ELSE 'hostname' END"
+            ),
+            iterative=False,
+        ),
+        OntologyRelMapping(
+            __comment__=(
+                "Link KandjiDevice to SnipeitAsset when serial numbers match, "
+                "or when both serial numbers are missing and hostnames match."
+            ),
+            query=(
+                "MATCH (k:KandjiDevice), (s:SnipeitAsset) "
+                "WHERE "
+                "((k.serial_number IS NOT NULL AND k.serial_number <> '' "
+                "AND s.serial IS NOT NULL AND s.serial <> '' "
+                "AND k.serial_number = s.serial) "
+                "OR ((k.serial_number IS NULL OR k.serial_number = '') "
+                "AND (s.serial IS NULL OR s.serial = '') "
+                "AND k.device_name = s.name)) "
+                "MERGE (k)-[r:POTENTIALLY_SAME_DEVICE]->(s) "
+                "ON CREATE SET r.firstseen = timestamp() "
+                "SET r.lastupdated = $UPDATE_TAG, "
+                "r.match_method = CASE "
+                "WHEN k.serial_number IS NOT NULL AND k.serial_number <> '' "
+                "AND s.serial IS NOT NULL AND s.serial <> '' "
+                "THEN 'serial_number' ELSE 'hostname' END"
+            ),
+            iterative=False,
+        ),
+        OntologyRelMapping(
+            __comment__=(
+                "Link CrowdstrikeHost to SnipeitAsset when serial numbers match, "
+                "or when both serial numbers are missing and hostnames match."
+            ),
+            query=(
+                "MATCH (c:CrowdstrikeHost), (s:SnipeitAsset) "
+                "WHERE "
+                "((c.serial_number IS NOT NULL AND c.serial_number <> '' "
+                "AND s.serial IS NOT NULL AND s.serial <> '' "
+                "AND c.serial_number = s.serial) "
+                "OR ((c.serial_number IS NULL OR c.serial_number = '') "
+                "AND (s.serial IS NULL OR s.serial = '') "
+                "AND c.hostname = s.name)) "
+                "MERGE (c)-[r:POTENTIALLY_SAME_DEVICE]->(s) "
+                "ON CREATE SET r.firstseen = timestamp() "
+                "SET r.lastupdated = $UPDATE_TAG, "
+                "r.match_method = CASE "
+                "WHEN c.serial_number IS NOT NULL AND c.serial_number <> '' "
+                "AND s.serial IS NOT NULL AND s.serial <> '' "
+                "THEN 'serial_number' ELSE 'hostname' END"
+            ),
+            iterative=False,
+        ),
+    ],
 )
 snipeit_mapping = OntologyMapping(
     module_name="snipeit",

--- a/tests/integration/cartography/intel/ontology/test_devices.py
+++ b/tests/integration/cartography/intel/ontology/test_devices.py
@@ -197,3 +197,55 @@ def test_load_ontology_devices_relationships(neo4j_session):
         )
         == expected_rels
     )
+
+
+def test_link_cross_tool_devices_by_serial_or_hostname(neo4j_session):
+    """Test POTENTIALLY_SAME_DEVICE links across Kandji, CrowdStrike, and SnipeIT."""
+    neo4j_session.run(
+        """
+        CREATE (:KandjiDevice {id: 'k-serial', device_name: 'k-serial-host', serial_number: 'SER-001'})
+        CREATE (:CrowdstrikeHost {id: 'c-serial', hostname: 'c-serial-host', serial_number: 'SER-001'})
+        CREATE (:SnipeitAsset {id: 's-serial', name: 's-serial-host', serial: 'SER-001'})
+        CREATE (:KandjiDevice {id: 'k-hostname', device_name: 'shared-host'})
+        CREATE (:CrowdstrikeHost {id: 'c-hostname', hostname: 'shared-host'})
+        CREATE (:SnipeitAsset {id: 's-hostname', name: 'shared-host'})
+        """
+    )
+
+    cartography.intel.ontology.devices.link_ontology_nodes(
+        neo4j_session,
+        "devices",
+        TEST_UPDATE_TAG,
+    )
+
+    rels = neo4j_session.run(
+        """
+        MATCH (src)-[r:POTENTIALLY_SAME_DEVICE]->(dst)
+        RETURN labels(src)[0] AS src_label,
+               coalesce(src.id, src.hostname, src.device_id) AS src_id,
+               labels(dst)[0] AS dst_label,
+               coalesce(dst.id, dst.hostname, dst.device_id) AS dst_id,
+               r.match_method AS match_method
+        """
+    )
+    actual = {
+        (
+            row["src_label"],
+            row["src_id"],
+            row["dst_label"],
+            row["dst_id"],
+            row["match_method"],
+        )
+        for row in rels
+    }
+
+    expected = {
+        ("KandjiDevice", "k-serial", "CrowdstrikeHost", "c-serial", "serial_number"),
+        ("KandjiDevice", "k-serial", "SnipeitAsset", "s-serial", "serial_number"),
+        ("CrowdstrikeHost", "c-serial", "SnipeitAsset", "s-serial", "serial_number"),
+        ("KandjiDevice", "k-hostname", "CrowdstrikeHost", "c-hostname", "hostname"),
+        ("KandjiDevice", "k-hostname", "SnipeitAsset", "s-hostname", "hostname"),
+        ("CrowdstrikeHost", "c-hostname", "SnipeitAsset", "s-hostname", "hostname"),
+    }
+
+    assert actual == expected


### PR DESCRIPTION
### Motivation
- Ensure device records from Kandji, CrowdStrike, and SnipeIT are correlated when they represent the same physical device. 
- Prefer matching by `serial_number` when present and fall back to `hostname` when serials are absent. 
- Provide automated coverage to prevent regressions in cross-tool device linking logic.

### Description
- Added three `OntologyRelMapping` entries to `kandji_mapping` creating `POTENTIALLY_SAME_DEVICE` relationships between `KandjiDevice`↔`CrowdstrikeHost`, `KandjiDevice`↔`SnipeitAsset`, and `CrowdstrikeHost`↔`SnipeitAsset` with Cypher that matches on non-empty `serial_number` equality or, if both serials are missing/empty, on hostname equality. 
- Each mapping sets relationship properties `firstseen`, `lastupdated`, and `match_method` (`'serial_number'` or `'hostname'`) depending on which criterion matched. 
- Added an integration test `test_link_cross_tool_devices_by_serial_or_hostname` in `tests/integration/cartography/intel/ontology/test_devices.py` that creates example nodes, runs `link_ontology_nodes` for the `devices` ontology, and asserts the expected cross-tool links and `match_method` values.

### Testing
- Ran `pytest tests/integration/cartography/intel/ontology/test_devices.py::test_link_cross_tool_devices_by_serial_or_hostname` which created sample nodes, invoked `link_ontology_nodes`, and validated the created `POTENTIALLY_SAME_DEVICE` relationships; the test passed. 
- Existing device ontology integration checks in `test_load_ontology_devices_relationships` were left intact and continue to pass in the integration suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af0b46755083238f8674dd43aa8c9c)