### PR TITLE
Support benchmark families in framework filters

### DIFF
--- a/cartography/rules/cli.py
+++ b/cartography/rules/cli.py
@@ -15,6 +15,7 @@ from typing_extensions import Annotated
 
 from cartography.rules.data.rules import RULES
 from cartography.rules.runners import get_all_frameworks
+from cartography.rules.runners import parse_framework_filter
 from cartography.rules.runners import run_rules
 
 app = typer.Typer(
@@ -91,7 +92,12 @@ def complete_frameworks(incomplete: str) -> Generator[str, None, None]:
     """
     Autocomplete framework filters for CLI tab completion.
 
-    Supports formats: "CIS", "CIS:aws", "CIS:aws:5.0"
+    Supports formats:
+    - "CIS"
+    - "CIS:aws"
+    - "CIS:aws:5.0"
+    - "CIS:aws:foundations"
+    - "CIS:aws:foundations:6.0"
 
     Args:
         incomplete (str): The partial framework filter typed by the user.
@@ -115,18 +121,42 @@ def complete_frameworks(incomplete: str) -> Generator[str, None, None]:
             if option.startswith(incomplete_lower):
                 yield option
 
-            # Short name + scope + revision (e.g., "cis:aws:5.0")
-            revisions = sorted(
+            # Short name + scope + revision (e.g., "cis:aws:5.0") for frameworks without family
+            plain_revisions = sorted(
                 {
                     fw.revision
                     for fw in fws
-                    if fw.scope == scope and fw.revision is not None
+                    if fw.scope == scope
+                    and fw.family is None
+                    and fw.revision is not None
                 }
             )
-            for revision in revisions:
+            for revision in plain_revisions:
                 full_option = f"{short_name}:{scope}:{revision}"
                 if full_option.startswith(incomplete_lower):
                     yield full_option
+
+            families = sorted(
+                {fw.family for fw in fws if fw.scope == scope and fw.family is not None}
+            )
+            for family in families:
+                family_option = f"{short_name}:{scope}:{family}"
+                if family_option.startswith(incomplete_lower):
+                    yield family_option
+
+                family_revisions = sorted(
+                    {
+                        fw.revision
+                        for fw in fws
+                        if fw.scope == scope
+                        and fw.family == family
+                        and fw.revision is not None
+                    }
+                )
+                for revision in family_revisions:
+                    full_option = f"{short_name}:{scope}:{family}:{revision}"
+                    if full_option.startswith(incomplete_lower):
+                        yield full_option
 
 
 # ----------------------------
@@ -152,27 +182,33 @@ def frameworks_cmd() -> None:
     typer.secho("\nCompliance Frameworks\n", bold=True)
 
     for short_name, fws in frameworks.items():
-        # Get unique scopes and their revisions
-        scopes: dict[str | None, set[str | None]] = {}
+        # Get unique scopes, families, and revisions
+        scopes: dict[str | None, dict[str | None, set[str | None]]] = {}
         for fw in fws:
             if fw.scope not in scopes:
-                scopes[fw.scope] = set()
-            scopes[fw.scope].add(fw.revision)
+                scopes[fw.scope] = {}
+            if fw.family not in scopes[fw.scope]:
+                scopes[fw.scope][fw.family] = set()
+            scopes[fw.scope][fw.family].add(fw.revision)
 
         typer.secho(f"{short_name.upper()}", fg=typer.colors.CYAN)
-        if fws:
-            typer.echo(f"  Name: {fws[0].name}")
-        for scope, revisions in sorted(scopes.items(), key=lambda x: x[0] or ""):
-            rev_list = [r for r in revisions if r is not None]
+        for name in sorted({fw.name for fw in fws}):
+            typer.echo(f"  Name: {name}")
+        for scope, families in sorted(scopes.items(), key=lambda x: x[0] or ""):
             if scope is not None:
-                if rev_list:
+                typer.echo(f"  Scope: {scope}")
+            for family, revisions in sorted(families.items(), key=lambda x: x[0] or ""):
+                rev_list = [r for r in revisions if r is not None]
+                prefix = "    " if scope is not None else "  "
+                if family is not None:
+                    if rev_list:
+                        rev_str = ", ".join(sorted(rev_list))
+                        typer.echo(f"{prefix}Family: {family} (revisions: {rev_str})")
+                    else:
+                        typer.echo(f"{prefix}Family: {family}")
+                elif rev_list:
                     rev_str = ", ".join(sorted(rev_list))
-                    typer.echo(f"  Scope: {scope} (revisions: {rev_str})")
-                else:
-                    typer.echo(f"  Scope: {scope}")
-            elif rev_list:
-                rev_str = ", ".join(sorted(rev_list))
-                typer.echo(f"  Revisions: {rev_str}")
+                    typer.echo(f"{prefix}Revisions: {rev_str}")
 
         # Count rules using this framework
         rule_count = sum(1 for rule in RULES.values() if rule.has_framework(short_name))
@@ -194,7 +230,7 @@ def list_cmd(
         typer.Option(
             "--framework",
             "-f",
-            help="Filter by framework (e.g., CIS, CIS:aws, CIS:aws:5.0)",
+            help="Filter by framework (e.g., CIS, CIS:aws, CIS:aws:5.0, CIS:aws:foundations:6.0)",
             autocompletion=complete_frameworks,
         ),
     ] = None,
@@ -207,6 +243,7 @@ def list_cmd(
         cartography-rules list
         cartography-rules list --framework CIS
         cartography-rules list --framework CIS:aws
+        cartography-rules list --framework CIS:aws:foundations
         cartography-rules list mfa-missing
     """
     # List all rules (optionally filtered by framework)
@@ -216,10 +253,11 @@ def list_cmd(
         fw_scope = None
         fw_revision = None
         if framework:
-            parts = framework.split(":")
-            fw_short_name = parts[0] if len(parts) >= 1 else None
-            fw_scope = parts[1] if len(parts) >= 2 else None
-            fw_revision = parts[2] if len(parts) >= 3 else None
+            fw_short_name, fw_scope, fw_revision, fw_family = parse_framework_filter(
+                framework
+            )
+        else:
+            fw_family = None
 
         if framework:
             typer.secho(f"\nRules matching framework: {framework}\n", bold=True)
@@ -230,7 +268,7 @@ def list_cmd(
         for rule_name, rule_obj in RULES.items():
             # Apply framework filter
             if framework and not rule_obj.has_framework(
-                fw_short_name, fw_scope, fw_revision
+                fw_short_name, fw_scope, fw_revision, fw_family
             ):
                 continue
 
@@ -246,6 +284,8 @@ def list_cmd(
                     fw_parts = [fw.short_name]
                     if fw.scope:
                         fw_parts.append(fw.scope)
+                    if fw.family:
+                        fw_parts.append(fw.family)
                     if fw.revision:
                         fw_parts.append(fw.revision)
                     fw_str = ":".join(fw_parts)
@@ -331,7 +371,7 @@ def run_cmd(
         typer.Option(
             "--framework",
             "-f",
-            help="Filter by framework (e.g., CIS, CIS:aws, CIS:aws:5.0)",
+            help="Filter by framework (e.g., CIS, CIS:aws, CIS:aws:5.0, CIS:aws:foundations:6.0)",
             autocompletion=complete_frameworks,
         ),
     ] = None,
@@ -344,6 +384,7 @@ def run_cmd(
         cartography-rules run all
         cartography-rules run all --framework CIS
         cartography-rules run all --framework CIS:aws:5.0
+        cartography-rules run all --framework CIS:aws:foundations:6.0
         cartography-rules run mfa-missing
         cartography-rules run mfa-missing missing-mfa-cloudflare
     """

--- a/cartography/rules/runners.py
+++ b/cartography/rules/runners.py
@@ -18,6 +18,41 @@ from cartography.rules.spec.result import FactResult
 from cartography.rules.spec.result import RuleResult
 
 
+def parse_framework_filter(
+    framework_filter: str,
+) -> tuple[str | None, str | None, str | None, str | None]:
+    """
+    Parse a framework filter string.
+
+    Supports the following formats (case-insensitive):
+    - "CIS"
+    - "CIS:aws"
+    - "CIS:aws:5.0"
+    - "CIS:aws:foundations"
+    - "CIS:aws:foundations:6.0"
+
+    Returns:
+        Tuple of (short_name, scope, revision, family).
+    """
+    parts = framework_filter.split(":")
+    short_name = parts[0] if len(parts) >= 1 else None
+    scope = parts[1] if len(parts) >= 2 else None
+    revision = None
+    family = None
+
+    if len(parts) >= 3:
+        third = parts[2]
+        if len(parts) >= 4:
+            family = third
+            revision = parts[3]
+        elif any(char.isalpha() for char in third):
+            family = third
+        else:
+            revision = third
+
+    return short_name, scope, revision, family
+
+
 def get_all_frameworks() -> dict[str, list[Framework]]:
     """
     Get all unique frameworks from all rules, grouped by short_name.
@@ -34,7 +69,15 @@ def get_all_frameworks() -> dict[str, list[Framework]]:
 
     # Convert sets to sorted lists
     return {
-        name: sorted(fws, key=lambda f: (f.scope, f.revision, f.requirement))
+        name: sorted(
+            fws,
+            key=lambda f: (
+                f.scope or "",
+                f.family or "",
+                f.revision or "",
+                f.requirement,
+            ),
+        )
         for name, fws in sorted(frameworks_by_name.items())
     }
 
@@ -234,6 +277,8 @@ def filter_rules_by_framework(
     - "CIS" - Match any rule with a CIS framework
     - "CIS:aws" - Match CIS frameworks with scope "aws"
     - "CIS:aws:5.0" - Match CIS frameworks with scope "aws" and revision "5.0"
+    - "CIS:aws:foundations" - Match CIS frameworks with scope "aws" and family "foundations"
+    - "CIS:aws:foundations:6.0" - Match CIS frameworks with scope "aws", family "foundations", and revision "6.0"
 
     Args:
         rule_names: List of rule names to filter.
@@ -242,17 +287,14 @@ def filter_rules_by_framework(
     Returns:
         List of rule names that match the framework filter.
     """
-    parts = framework_filter.split(":")
-    short_name = parts[0] if len(parts) >= 1 else None
-    scope = parts[1] if len(parts) >= 2 else None
-    revision = parts[2] if len(parts) >= 3 else None
+    short_name, scope, revision, family = parse_framework_filter(framework_filter)
 
     filtered = []
     for rule_name in rule_names:
         if rule_name not in RULES:
             continue
         rule = RULES[rule_name]
-        if rule.has_framework(short_name, scope, revision):
+        if rule.has_framework(short_name, scope, revision, family):
             filtered.append(rule_name)
     return filtered
 
@@ -281,7 +323,7 @@ def run_rules(
         output_format (str): Either "text" or "json". Defaults to "text".
         fact_filter (str | None): Optional fact ID to filter execution (case-insensitive).
         exclude_experimental (bool): Whether to exclude experimental facts from execution.
-        framework_filter (str | None): Optional framework filter (e.g., "CIS", "CIS:aws", "CIS:aws:5.0").
+        framework_filter (str | None): Optional framework filter (e.g., "CIS", "CIS:aws", "CIS:aws:5.0", "CIS:aws:foundations:6.0").
 
     Returns:
         int: The exit code (0 for success, 1 for failure).

--- a/cartography/rules/spec/model.py
+++ b/cartography/rules/spec/model.py
@@ -170,6 +170,7 @@ class Framework:
         short_name: Abbreviated name for filtering (e.g., "cis").
         requirement: The specific requirement identifier (e.g., "1.14").
         scope: Optional platform or domain the framework applies to (e.g., "aws", "gcp").
+        family: Optional benchmark family within the platform (e.g., "foundations", "compute").
         revision: Optional version/revision of the framework (e.g., "5.0").
     """
 
@@ -177,6 +178,7 @@ class Framework:
     short_name: str
     requirement: str
     scope: str | None = None
+    family: str | None = None
     revision: str | None = None
 
     def __post_init__(self) -> None:
@@ -186,6 +188,8 @@ class Framework:
         object.__setattr__(self, "requirement", self.requirement.lower())
         if self.scope is not None:
             object.__setattr__(self, "scope", self.scope.lower())
+        if self.family is not None:
+            object.__setattr__(self, "family", self.family.lower())
         if self.revision is not None:
             object.__setattr__(self, "revision", self.revision.lower())
 
@@ -194,6 +198,7 @@ class Framework:
         short_name: str | None = None,
         scope: str | None = None,
         revision: str | None = None,
+        family: str | None = None,
     ) -> bool:
         """
         Check if this framework matches the given filter criteria.
@@ -202,6 +207,7 @@ class Framework:
             short_name: Filter by short name (case-insensitive).
             scope: Filter by scope (case-insensitive).
             revision: Filter by revision (case-insensitive).
+            family: Filter by benchmark family (case-insensitive).
 
         Returns:
             True if all provided criteria match, False otherwise.
@@ -210,6 +216,9 @@ class Framework:
             return False
         if scope:
             if self.scope is None or self.scope != scope.lower():
+                return False
+        if family:
+            if self.family is None or self.family != family.lower():
                 return False
         if revision:
             if self.revision is None or self.revision != revision.lower():
@@ -329,6 +338,7 @@ class Rule:
         short_name: str | None = None,
         scope: str | None = None,
         revision: str | None = None,
+        family: str | None = None,
     ) -> bool:
         """
         Check if this rule has a framework matching the given criteria.
@@ -337,11 +347,14 @@ class Rule:
             short_name: Filter by framework short name (case-insensitive).
             scope: Filter by framework scope (case-insensitive).
             revision: Filter by framework revision (case-insensitive).
+            family: Filter by framework family (case-insensitive).
 
         Returns:
             True if any framework matches all provided criteria.
         """
-        return any(fw.matches(short_name, scope, revision) for fw in self.frameworks)
+        return any(
+            fw.matches(short_name, scope, revision, family) for fw in self.frameworks
+        )
 
     def get_fact_by_id(self, fact_id: str) -> Fact | None:
         """

--- a/tests/unit/rules/test_cli.py
+++ b/tests/unit/rules/test_cli.py
@@ -1,10 +1,14 @@
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from typer.testing import CliRunner
 
 from cartography.rules.cli import app
 from cartography.rules.cli import complete_facts
+from cartography.rules.cli import complete_frameworks
 from cartography.rules.cli import complete_rules
+from cartography.rules.spec.model import Framework
+from cartography.rules.spec.model import Rule
 
 runner = CliRunner()
 
@@ -37,6 +41,38 @@ def test_list_command_invalid_rule_exits():
     assert "Unknown rule" in result.stdout or "Unknown rule" in result.stderr
 
 
+@patch("cartography.rules.cli.get_all_frameworks")
+def test_complete_frameworks_supports_family_filters(mock_get_all_frameworks):
+    mock_get_all_frameworks.return_value = {
+        "cis": [
+            Framework(
+                name="CIS AWS Foundations Benchmark",
+                short_name="CIS",
+                scope="aws",
+                family="foundations",
+                revision="6.0",
+                requirement="2.11",
+            ),
+            Framework(
+                name="CIS AWS Compute Services Benchmark",
+                short_name="CIS",
+                scope="aws",
+                family="compute",
+                revision="1.1",
+                requirement="3.1",
+            ),
+        ],
+    }
+
+    results = list(complete_frameworks("cis:aws"))
+
+    assert "cis:aws" in results
+    assert "cis:aws:foundations" in results
+    assert "cis:aws:foundations:6.0" in results
+    assert "cis:aws:compute" in results
+    assert "cis:aws:compute:1.1" in results
+
+
 def test_run_command_all_with_filters_fails():
     """Test that 'all' rule cannot be used with fact filters."""
     # Act
@@ -66,3 +102,57 @@ def test_complete_facts_needs_valid_rule():
     # Assert
     # Should return empty list when rule is invalid
     assert len(results) == 0
+
+
+@patch.dict("cartography.rules.cli.RULES", clear=True)
+def test_list_command_filters_by_family():
+    rule_foundations = Rule(
+        id="rule-foundations",
+        name="Foundations Rule",
+        description="Foundations",
+        version="1.0.0",
+        tags=("test",),
+        facts=(),
+        output_model=MagicMock(),
+        frameworks=(
+            Framework(
+                name="CIS AWS Foundations Benchmark",
+                short_name="CIS",
+                scope="aws",
+                family="foundations",
+                revision="6.0",
+                requirement="2.11",
+            ),
+        ),
+    )
+    rule_compute = Rule(
+        id="rule-compute",
+        name="Compute Rule",
+        description="Compute",
+        version="1.0.0",
+        tags=("test",),
+        facts=(),
+        output_model=MagicMock(),
+        frameworks=(
+            Framework(
+                name="CIS AWS Compute Services Benchmark",
+                short_name="CIS",
+                scope="aws",
+                family="compute",
+                revision="1.1",
+                requirement="3.1",
+            ),
+        ),
+    )
+
+    from cartography.rules.cli import RULES
+
+    RULES[rule_foundations.id] = rule_foundations
+    RULES[rule_compute.id] = rule_compute
+
+    result = runner.invoke(app, ["list", "--framework", "CIS:aws:foundations"])
+
+    assert result.exit_code == 0
+    assert "rule-foundations" in result.stdout
+    assert "cis:aws:foundations:6.0" in result.stdout
+    assert "rule-compute" not in result.stdout

--- a/tests/unit/rules/test_model.py
+++ b/tests/unit/rules/test_model.py
@@ -11,11 +11,13 @@ def test_framework_normalizes_to_lowercase():
         short_name="CIS",
         requirement="1.14",
         scope="AWS",
+        family="Foundations",
         revision="5.0",
     )
     assert fw.name == "cis aws foundations benchmark"
     assert fw.short_name == "cis"
     assert fw.scope == "aws"
+    assert fw.family == "foundations"
     assert fw.revision == "5.0"
     assert fw.requirement == "1.14"
 
@@ -29,6 +31,7 @@ def test_framework_optional_fields():
         requirement="AC-1",
     )
     assert fw_minimal.scope is None
+    assert fw_minimal.family is None
     assert fw_minimal.revision is None
     assert fw_minimal.requirement == "ac-1"
 
@@ -40,7 +43,20 @@ def test_framework_optional_fields():
         scope="aws",
     )
     assert fw_with_scope.scope == "aws"
+    assert fw_with_scope.family is None
     assert fw_with_scope.revision is None
+
+    # With family only
+    fw_with_family = Framework(
+        name="CIS AWS Compute Services Benchmark",
+        short_name="CIS",
+        requirement="3.1",
+        scope="aws",
+        family="compute",
+    )
+    assert fw_with_family.scope == "aws"
+    assert fw_with_family.family == "compute"
+    assert fw_with_family.revision is None
 
     # With revision only
     fw_with_revision = Framework(
@@ -60,6 +76,7 @@ def test_framework_matches_case_insensitive():
         short_name="CIS",
         requirement="1.14",
         scope="aws",
+        family="foundations",
         revision="5.0",
     )
     # All match variations should work
@@ -67,6 +84,10 @@ def test_framework_matches_case_insensitive():
     assert fw.matches("cis")
     assert fw.matches("CIS", "AWS")
     assert fw.matches("cis", "aws", "5.0")
+    assert fw.matches(short_name="CIS", scope="AWS", family="Foundations")
+    assert fw.matches(
+        short_name="cis", scope="aws", revision="5.0", family="foundations"
+    )
     assert fw.matches(short_name="CIS", scope="AWS", revision="5.0")
 
 
@@ -77,18 +98,21 @@ def test_framework_matches_partial_filter():
         short_name="CIS",
         requirement="1.14",
         scope="aws",
+        family="foundations",
         revision="5.0",
     )
     # Partial matches
     assert fw.matches("cis")
     assert fw.matches("cis", "aws")
     assert fw.matches(scope="aws")
+    assert fw.matches(family="foundations")
     assert fw.matches(revision="5.0")
 
     # Non-matches
     assert not fw.matches("nist")
     assert not fw.matches("cis", "gcp")
     assert not fw.matches("cis", "aws", "4.0")
+    assert not fw.matches(short_name="cis", scope="aws", family="compute")
 
 
 def test_framework_matches_with_optional_fields():
@@ -114,6 +138,7 @@ def test_framework_matches_with_optional_fields():
     assert not fw_no_revision.matches(
         "cis", "aws", "5.0"
     )  # Can't match revision if None
+    assert not fw_no_revision.matches(short_name="cis", scope="aws", family="compute")
 
 
 def test_all_module_keys_in_mapping_except_cross_cloud():

--- a/tests/unit/rules/test_runners.py
+++ b/tests/unit/rules/test_runners.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from cartography.rules.runners import _run_single_rule
+from cartography.rules.runners import filter_rules_by_framework
+from cartography.rules.runners import parse_framework_filter
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Framework
 from cartography.rules.spec.model import Maturity
@@ -266,3 +268,89 @@ def test_run_single_rule_propagates_frameworks(mock_run_fact):
     assert rule_result.rule_frameworks[0].scope == "aws"
     assert rule_result.rule_frameworks[0].revision == "5.0"
     assert rule_result.rule_frameworks[0].requirement == "1.14"
+
+
+def test_parse_framework_filter_backward_compatible_formats():
+    assert parse_framework_filter("CIS") == ("CIS", None, None, None)
+    assert parse_framework_filter("CIS:aws") == ("CIS", "aws", None, None)
+    assert parse_framework_filter("CIS:aws:5.0") == ("CIS", "aws", "5.0", None)
+
+
+def test_parse_framework_filter_with_family():
+    assert parse_framework_filter("CIS:aws:foundations") == (
+        "CIS",
+        "aws",
+        None,
+        "foundations",
+    )
+    assert parse_framework_filter("CIS:aws:foundations:6.0") == (
+        "CIS",
+        "aws",
+        "6.0",
+        "foundations",
+    )
+
+
+@patch.dict("cartography.rules.runners.RULES", clear=True)
+def test_filter_rules_by_framework_supports_family():
+    foundations_rule = Rule(
+        id="rule-foundations",
+        name="Foundations Rule",
+        description="Foundations",
+        version="1.0.0",
+        tags=("test",),
+        facts=(),
+        output_model=MagicMock(),
+        frameworks=(
+            Framework(
+                name="CIS AWS Foundations Benchmark",
+                short_name="CIS",
+                scope="aws",
+                family="foundations",
+                revision="6.0",
+                requirement="2.11",
+            ),
+        ),
+    )
+    compute_rule = Rule(
+        id="rule-compute",
+        name="Compute Rule",
+        description="Compute",
+        version="1.0.0",
+        tags=("test",),
+        facts=(),
+        output_model=MagicMock(),
+        frameworks=(
+            Framework(
+                name="CIS AWS Compute Services Benchmark",
+                short_name="CIS",
+                scope="aws",
+                family="compute",
+                revision="1.1",
+                requirement="3.1",
+            ),
+        ),
+    )
+
+    from cartography.rules.runners import RULES
+
+    RULES[foundations_rule.id] = foundations_rule
+    RULES[compute_rule.id] = compute_rule
+
+    all_rule_names = list(RULES.keys())
+
+    assert sorted(filter_rules_by_framework(all_rule_names, "CIS")) == sorted(
+        all_rule_names
+    )
+    assert sorted(filter_rules_by_framework(all_rule_names, "CIS:aws")) == sorted(
+        all_rule_names
+    )
+    assert filter_rules_by_framework(all_rule_names, "CIS:aws:foundations") == [
+        foundations_rule.id
+    ]
+    assert filter_rules_by_framework(all_rule_names, "CIS:aws:foundations:6.0") == [
+        foundations_rule.id
+    ]
+    assert filter_rules_by_framework(all_rule_names, "CIS:aws:compute:1.1") == [
+        compute_rule.id
+    ]


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
This PR adds benchmark-family awareness to Cartography's framework metadata and selector plumbing so that multiple AWS CIS benchmark families can coexist without filter collisions.

Today, framework selection only distinguishes `short_name`, `scope`, and `revision`, which is enough for a single AWS CIS family but not for a world where AWS Foundations, Compute Services, Database Services, Storage Services, and End User Compute Services all need to be represented side by side. This change preserves existing filter behavior while adding the minimum new taxonomy needed for the upcoming AWS benchmark-family PRs.


### Related issues or links
- None.


### How was this tested?
- `/opt/homebrew/bin/uv run --frozen pytest -q tests/unit/rules/test_model.py tests/unit/rules/test_runners.py tests/unit/rules/test_cli.py`
- Pre-commit hooks during commit, including `isort`, `black`, `flake8`, `pyupgrade`, and `mypy`


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.
- [ ] Screenshot showing the graph before and after changes.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
The main review focus is whether the family-aware filter behavior stays backward compatible for existing selectors like `CIS`, `CIS:aws`, and `CIS:aws:5.0` while correctly distinguishing benchmark families such as `CIS:aws:foundations:6.0` and `CIS:aws:compute:1.1`.
