### PR TITLE
refactor(aws): split ECR provenance into its own sync phase

### DIFF
--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -137,7 +137,13 @@ def _sync_one_account(
         if func_name not in requested_syncs_set:
             continue
         # Skip permission relationships and tags for now because they rely on data already being in the graph
-        if func_name == "ecr:image_layers":
+        if func_name == "ecr:provenance":
+            # ecr:provenance uses the standard AWS sync args plus aioboto3_session
+            RESOURCE_FUNCTIONS[func_name](
+                **sync_args,
+                aioboto3_session=aioboto3_session,
+            )
+        elif func_name == "ecr:image_layers":
             # has a different signature than the other functions (aioboto3_session replaces boto3_session)
             RESOURCE_FUNCTIONS[func_name](
                 neo4j_session,

--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -12,6 +12,7 @@ from cartography.graph.job import GraphJob
 from cartography.intel.aws.ecr_shared import INDEX_MEDIA_TYPES
 from cartography.intel.container_arch import normalize_architecture
 from cartography.models.aws.ecr.image import ECRImageBaseSchema
+from cartography.models.aws.ecr.image import ECRImageSchema
 from cartography.models.aws.ecr.repository import ECRRepositorySchema
 from cartography.models.aws.ecr.repository_image import ECRRepositoryImageSchema
 from cartography.util import aws_handle_regions
@@ -362,7 +363,9 @@ def cleanup(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:
     GraphJob.from_node_schema(ECRRepositoryImageSchema(), common_job_parameters).run(
         neo4j_session
     )
-    GraphJob.from_node_schema(ECRImageBaseSchema(), common_job_parameters).run(
+    # Use ECRImageSchema (not ECRImageBaseSchema) for cleanup so that
+    # stale HAS_LAYER relationships are also removed when images change.
+    GraphJob.from_node_schema(ECRImageSchema(), common_job_parameters).run(
         neo4j_session
     )
 

--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -9,9 +9,9 @@ import neo4j
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.aws.ecr_shared import INDEX_MEDIA_TYPES
 from cartography.intel.container_arch import normalize_architecture
 from cartography.models.aws.ecr.image import ECRImageBaseSchema
-from cartography.models.aws.ecr.image import ECRImageSchema
 from cartography.models.aws.ecr.repository import ECRRepositorySchema
 from cartography.models.aws.ecr.repository_image import ECRRepositoryImageSchema
 from cartography.util import aws_handle_regions
@@ -22,10 +22,7 @@ from cartography.util import to_synchronous
 logger = logging.getLogger(__name__)
 
 # Manifest list media types
-MANIFEST_LIST_MEDIA_TYPES = {
-    "application/vnd.docker.distribution.manifest.list.v2+json",
-    "application/vnd.oci.image.index.v1+json",
-}
+MANIFEST_LIST_MEDIA_TYPES = INDEX_MEDIA_TYPES
 
 
 REPO_BATCH_SIZE = 100
@@ -219,7 +216,9 @@ def load_ecr_repositories(
 
 
 @timeit
-def transform_ecr_repository_images(repo_data: Dict) -> tuple[List[Dict], List[Dict]]:
+def transform_ecr_repository_images(
+    repo_data: Dict,
+) -> tuple[List[Dict], List[Dict]]:
     """
     Transform ECR repository images into repo image list and ECR image list.
     For manifest lists, creates ECR images for manifest list, platform-specific images, and attestations.
@@ -363,12 +362,12 @@ def cleanup(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:
     GraphJob.from_node_schema(ECRRepositoryImageSchema(), common_job_parameters).run(
         neo4j_session
     )
-    GraphJob.from_node_schema(ECRImageSchema(), common_job_parameters).run(
+    GraphJob.from_node_schema(ECRImageBaseSchema(), common_job_parameters).run(
         neo4j_session
     )
 
 
-def _get_image_data(
+def get_repository_image_data(
     boto3_session: boto3.session.Session,
     region: str,
     repositories: List[Dict[str, Any]],
@@ -412,10 +411,8 @@ def sync(
             region,
             current_aws_account_id,
         )
-        image_data = {}
         repositories = get_ecr_repositories(boto3_session, region)
-        image_data = _get_image_data(boto3_session, region, repositories)
-        # len here should be 1!
+        image_data = get_repository_image_data(boto3_session, region, repositories)
         load_ecr_repositories(
             neo4j_session,
             repositories,

--- a/cartography/intel/aws/ecr_image_layers.py
+++ b/cartography/intel/aws/ecr_image_layers.py
@@ -6,7 +6,6 @@ fetching can be significantly slower than basic ECR repository/image syncing.
 """
 
 import asyncio
-import json
 import logging
 from typing import Any
 from typing import Optional
@@ -14,14 +13,22 @@ from typing import Optional
 import aioboto3
 import httpx
 import neo4j
-from botocore.exceptions import ClientError
 from types_aiobotocore_ecr import ECRClient
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.aws.ecr_shared import ALL_ACCEPTED
+from cartography.intel.aws.ecr_shared import (
+    batch_get_manifest as shared_batch_get_manifest,
+)
+from cartography.intel.aws.ecr_shared import ECR_DOCKER_MANIFEST_MT
+from cartography.intel.aws.ecr_shared import ECR_OCI_MANIFEST_MT
+from cartography.intel.aws.ecr_shared import ECRFetchTransientError
+from cartography.intel.aws.ecr_shared import (
+    get_blob_json_via_presigned as shared_get_blob_json_via_presigned,
+)
+from cartography.intel.aws.ecr_shared import INDEX_MEDIA_TYPES_LOWER
 from cartography.intel.container_arch import normalize_architecture
-from cartography.intel.supply_chain import extract_workflow_path_from_ref
-from cartography.intel.supply_chain import normalize_vcs_url
 from cartography.models.aws.ecr.image import ECRImageSchema
 from cartography.models.aws.ecr.image_layer import ECRImageLayerSchema
 from cartography.util import timeit
@@ -29,8 +36,7 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 
 
-class ECRLayerFetchTransientError(Exception):
-    """Raised when a transient ECR/image-blob fetch failure should skip one image."""
+ECRLayerFetchTransientError = ECRFetchTransientError
 
 
 EMPTY_LAYER_DIFF_ID = (
@@ -40,90 +46,8 @@ EMPTY_LAYER_DIFF_ID = (
 # Keep per-transaction memory low; each record fan-outs to many relationships.
 ECR_LAYER_BATCH_SIZE = 200
 
-# ECR manifest media types
-ECR_DOCKER_INDEX_MT = "application/vnd.docker.distribution.manifest.list.v2+json"
-ECR_DOCKER_MANIFEST_MT = "application/vnd.docker.distribution.manifest.v2+json"
-ECR_OCI_INDEX_MT = "application/vnd.oci.image.index.v1+json"
-ECR_OCI_MANIFEST_MT = "application/vnd.oci.image.manifest.v1+json"
-
-ALL_ACCEPTED = [
-    ECR_OCI_INDEX_MT,
-    ECR_DOCKER_INDEX_MT,
-    ECR_OCI_MANIFEST_MT,
-    ECR_DOCKER_MANIFEST_MT,
-]
-
-INDEX_MEDIA_TYPES = {ECR_OCI_INDEX_MT, ECR_DOCKER_INDEX_MT}
-INDEX_MEDIA_TYPES_LOWER = {mt.lower() for mt in INDEX_MEDIA_TYPES}
-
 # Media types that should be skipped when processing manifests
 SKIP_CONFIG_MEDIA_TYPE_FRAGMENTS = {"buildkit", "attestation", "in-toto"}
-RETRYABLE_HTTP_STATUS_CODES = {429, 500, 502, 503, 504}
-RETRYABLE_ECR_ERROR_CODES = {
-    "InternalFailure",
-    "InternalServerException",
-    "RequestLimitExceeded",
-    "RequestThrottled",
-    "RequestTimeout",
-    "RequestTimeoutException",
-    "ServerException",
-    "ServiceUnavailable",
-    "ServiceUnavailableException",
-    "Throttling",
-    "ThrottlingException",
-    "TooManyRequestsException",
-}
-RETRYABLE_HTTPX_EXCEPTIONS = (
-    httpx.ConnectError,
-    httpx.PoolTimeout,
-    httpx.ReadError,
-    httpx.ReadTimeout,
-    httpx.RemoteProtocolError,
-    httpx.TimeoutException,
-    httpx.WriteError,
-    httpx.WriteTimeout,
-)
-MAX_BLOB_DOWNLOAD_ATTEMPTS = 3
-
-
-def _is_retryable_aws_client_error(error: ClientError) -> bool:
-    error_code = error.response.get("Error", {}).get("Code", "")
-    status_code = error.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
-    return (
-        error_code in RETRYABLE_ECR_ERROR_CODES
-        or status_code in RETRYABLE_HTTP_STATUS_CODES
-    )
-
-
-def _is_retryable_http_error(error: httpx.HTTPError) -> bool:
-    if isinstance(error, RETRYABLE_HTTPX_EXCEPTIONS):
-        return True
-    if isinstance(error, httpx.HTTPStatusError) and error.response is not None:
-        return error.response.status_code in RETRYABLE_HTTP_STATUS_CODES
-    return False
-
-
-def _safe_http_error_for_log(error: httpx.HTTPError) -> str:
-    if isinstance(error, httpx.HTTPStatusError) and error.response is not None:
-        return f"{error.__class__.__name__}(status_code={error.response.status_code})"
-    return f"{error.__class__.__name__}: {error}"
-
-
-def extract_repo_uri_from_image_uri(image_uri: str) -> str:
-    """
-    Extract repository URI from image URI by removing tag or digest.
-
-    Examples:
-        "repo@sha256:digest" -> "repo"
-        "repo:tag" -> "repo"
-        "repo" -> "repo"
-    """
-    if "@sha256:" in image_uri:
-        return image_uri.split("@", 1)[0]
-    elif ":" in image_uri:
-        return image_uri.rsplit(":", 1)[0]
-    else:
-        return image_uri
 
 
 def extract_platform_from_manifest(manifest_ref: dict) -> str:
@@ -150,63 +74,12 @@ def _format_platform(
 async def batch_get_manifest(
     ecr_client: ECRClient, repo: str, image_ref: str, accepted_media_types: list[str]
 ) -> tuple[dict, str]:
-    """Get image manifest using batch_get_image API."""
-    try:
-        resp = await ecr_client.batch_get_image(
-            repositoryName=repo,
-            imageIds=(
-                [{"imageDigest": image_ref}]
-                if image_ref.startswith("sha256:")
-                else [{"imageTag": image_ref}]
-            ),
-            acceptedMediaTypes=accepted_media_types,
-        )
-    except ClientError as error:
-        error_code = error.response.get("Error", {}).get("Code", "")
-        if error_code == "ImageNotFoundException":
-            logger.warning(
-                "Image %s:%s not found while fetching manifest", repo, image_ref
-            )
-            return {}, ""
-        if error_code in {"AccessDenied", "AccessDeniedException"}:
-            logger.warning(
-                "Skipping manifest fetch for %s:%s due to %s (missing ecr:BatchGetImage permission)",
-                repo,
-                image_ref,
-                error_code,
-            )
-            return {}, ""
-        if _is_retryable_aws_client_error(error):
-            logger.warning(
-                "Transient AWS error fetching manifest for %s:%s: %s",
-                repo,
-                image_ref,
-                error_code or error,
-            )
-            raise ECRLayerFetchTransientError(
-                f"Transient manifest fetch failure for {repo}:{image_ref}"
-            ) from error
-        # Fail loudly on unexpected, non-retryable AWS errors
-        logger.error(
-            "Failed to get manifest for %s:%s due to AWS error %s",
-            repo,
-            image_ref,
-            error_code,
-        )
-        raise
-    except Exception:
-        logger.exception(
-            "Unexpected error fetching manifest for %s:%s", repo, image_ref
-        )
-        raise
-
-    if not resp.get("images"):
-        logger.warning(f"No image found for {repo}:{image_ref}")
-        return {}, ""
-
-    manifest_json = json.loads(resp["images"][0]["imageManifest"])
-    media_type = resp["images"][0].get("imageManifestMediaType", "")
-    return manifest_json, media_type
+    return await shared_batch_get_manifest(
+        ecr_client,
+        repo,
+        image_ref,
+        accepted_media_types,
+    )
 
 
 async def get_blob_json_via_presigned(
@@ -215,216 +88,12 @@ async def get_blob_json_via_presigned(
     digest: str,
     http_client: httpx.AsyncClient,
 ) -> dict:
-    """Download and parse JSON blob using presigned URL."""
-    try:
-        url_response = await ecr_client.get_download_url_for_layer(
-            repositoryName=repo,
-            layerDigest=digest,
-        )
-    except ClientError as error:
-        if _is_retryable_aws_client_error(error):
-            logger.warning(
-                "Transient AWS error requesting blob download URL for layer %s in repo %s: %s",
-                digest,
-                repo,
-                error.response.get("Error", {}).get("Code", "unknown"),
-            )
-            raise ECRLayerFetchTransientError(
-                f"Transient download URL failure for {repo}@{digest}"
-            ) from error
-        logger.error(
-            "Failed to request download URL for layer %s in repo %s: %s",
-            digest,
-            repo,
-            error.response.get("Error", {}).get("Code", "unknown"),
-        )
-        raise
-
-    url = url_response["downloadUrl"]
-    last_error: httpx.HTTPError | None = None
-    for attempt in range(1, MAX_BLOB_DOWNLOAD_ATTEMPTS + 1):
-        try:
-            response = await http_client.get(url, timeout=30.0)
-            response.raise_for_status()
-            return response.json()
-        except httpx.HTTPError as error:
-            last_error = error
-            if attempt < MAX_BLOB_DOWNLOAD_ATTEMPTS and _is_retryable_http_error(error):
-                logger.warning(
-                    "Retrying blob download for %s in repo %s after transient HTTP error on attempt %d/%d: %s",
-                    digest,
-                    repo,
-                    attempt,
-                    MAX_BLOB_DOWNLOAD_ATTEMPTS,
-                    _safe_http_error_for_log(error),
-                )
-                await asyncio.sleep(2 ** (attempt - 1))
-                continue
-            if _is_retryable_http_error(error):
-                logger.warning(
-                    "Exhausted blob download retries for %s in repo %s after transient HTTP error: %s",
-                    digest,
-                    repo,
-                    _safe_http_error_for_log(error),
-                )
-                raise ECRLayerFetchTransientError(
-                    f"Transient blob download failure for {repo}@{digest}"
-                ) from error
-            logger.error(
-                "HTTP error downloading blob %s for repo %s: %s",
-                digest,
-                repo,
-                _safe_http_error_for_log(error),
-            )
-            raise
-
-    raise ECRLayerFetchTransientError(
-        f"Transient blob download failure for {repo}@{digest}"
-    ) from last_error
-
-
-async def _extract_provenance_from_attestation(
-    ecr_client: ECRClient,
-    repo_name: str,
-    attestation_manifest_digest: str,
-    http_client: httpx.AsyncClient,
-) -> Optional[dict[str, Any]]:
-    """
-    Extract provenance information from an in-toto SLSA attestation.
-
-    This function fetches an attestation manifest, downloads its in-toto layer,
-    and extracts:
-    - Parent image reference from materials
-    - Source repository info from VCS metadata
-    - Build invocation info from environment
-
-    :param ecr_client: ECR client for fetching manifests and layers
-    :param repo_name: ECR repository name
-    :param attestation_manifest_digest: Digest of the attestation manifest
-    :param http_client: HTTP client for downloading blobs
-    :return: Dict with provenance data, or None if no provenance found
-
-    Raises:
-        Exception: If there's an error fetching or parsing the attestation
-    """
-    attestation_manifest, _ = await batch_get_manifest(
+    return await shared_get_blob_json_via_presigned(
         ecr_client,
-        repo_name,
-        attestation_manifest_digest,
-        [ECR_OCI_MANIFEST_MT, ECR_DOCKER_MANIFEST_MT],
-    )
-
-    if not attestation_manifest:
-        logger.debug(
-            "No attestation manifest found for digest %s in repo %s",
-            attestation_manifest_digest,
-            repo_name,
-        )
-        return None
-
-    # Get the in-toto layer from the attestation manifest
-    layers = attestation_manifest.get("layers", [])
-    intoto_layer = next(
-        (layer for layer in layers if "in-toto" in layer.get("mediaType", "").lower()),
-        None,
-    )
-
-    if not intoto_layer:
-        logger.debug(
-            "No in-toto layer found in attestation manifest %s",
-            attestation_manifest_digest,
-        )
-        return None
-
-    # Download the in-toto attestation blob
-    intoto_digest = intoto_layer.get("digest")
-    if not intoto_digest:
-        logger.debug("No digest found for in-toto layer")
-        return None
-
-    attestation_blob = await get_blob_json_via_presigned(
-        ecr_client,
-        repo_name,
-        intoto_digest,
+        repo,
+        digest,
         http_client,
     )
-
-    if not attestation_blob:
-        logger.debug("Failed to download attestation blob")
-        return None
-
-    predicate = attestation_blob.get("predicate", {})
-    result: dict[str, Any] = {}
-
-    # Extract parent image from SLSA provenance materials
-    materials = predicate.get("materials", [])
-    for material in materials:
-        uri = material.get("uri", "")
-        uri_l = uri.lower()
-        # Look for container image URIs that are NOT the dockerfile itself
-        is_container_ref = (
-            uri_l.startswith("pkg:docker/")
-            or uri_l.startswith("pkg:oci/")
-            or uri_l.startswith("oci://")
-        )
-        if is_container_ref and "dockerfile" not in uri_l:
-            digest_obj = material.get("digest", {})
-            sha256_digest = digest_obj.get("sha256")
-            if sha256_digest:
-                result["parent_image_uri"] = uri
-                result["parent_image_digest"] = f"sha256:{sha256_digest}"
-                break
-
-    # Extract source info from BuildKit metadata VCS section
-    # Path: metadata["https://mobyproject.org/buildkit@v1#metadata"].vcs
-    metadata = predicate.get("metadata", {})
-    buildkit_metadata = metadata.get("https://mobyproject.org/buildkit@v1#metadata", {})
-    vcs = buildkit_metadata.get("vcs", {})
-
-    if vcs.get("source"):
-        result["source_uri"] = normalize_vcs_url(vcs["source"])
-    if vcs.get("revision"):
-        result["source_revision"] = vcs["revision"]
-
-    # Extract invocation info from environment
-    # Path: invocation.environment
-    invocation = predicate.get("invocation", {})
-    environment = invocation.get("environment", {})
-
-    if environment.get("github_repository"):
-        server_url = environment.get("github_server_url", "https://github.com").rstrip(
-            "/"
-        )
-        result["invocation_uri"] = f"{server_url}/{environment['github_repository']}"
-    if environment.get("github_workflow_ref"):
-        workflow_path = extract_workflow_path_from_ref(
-            environment["github_workflow_ref"]
-        )
-        if workflow_path:
-            result["invocation_workflow"] = workflow_path
-    if environment.get("github_run_number"):
-        result["invocation_run_number"] = environment["github_run_number"]
-
-    # Extract source file (Dockerfile path) from invocation configSource
-    # Only meaningful when we also have source repository info
-    if "source_uri" in result:
-        config_source = invocation.get("configSource", {})
-        entry_point = config_source.get("entryPoint", "Dockerfile")
-        dockerfile_dir = (
-            (vcs.get("localdir:dockerfile") or "").removeprefix("./").rstrip("/")
-        )
-        result["source_file"] = (
-            f"{dockerfile_dir}/{entry_point}" if dockerfile_dir else entry_point
-        )
-
-    if not result:
-        logger.debug(
-            "No provenance data found in attestation %s",
-            attestation_manifest_digest,
-        )
-        return None
-
-    return result
 
 
 async def _diff_ids_for_manifest(
@@ -507,7 +176,6 @@ def transform_ecr_image_layers(
     image_layers_data: dict[str, dict[str, list[str]]],
     image_digest_map: dict[str, str],
     history_by_diff_id: Optional[dict[str, str]] = None,
-    image_attestation_map: Optional[dict[str, dict[str, str]]] = None,
     existing_properties_map: Optional[dict[str, dict[str, Any]]] = None,
 ) -> tuple[list[dict], list[dict]]:
     """
@@ -517,14 +185,11 @@ def transform_ecr_image_layers(
     :param image_layers_data: Map of image URI to platform to diff_ids
     :param image_digest_map: Map of image URI to image digest
     :param history_by_diff_id: Map of diff_id to history command (created_by)
-    :param image_attestation_map: Map of image URI to attestation data (parent_image_uri, parent_image_digest)
     :param existing_properties_map: Map of image digest to existing ECRImage properties (type, architecture, etc.)
     :return: List of layer objects ready for ingestion
     """
     if history_by_diff_id is None:
         history_by_diff_id = {}
-    if image_attestation_map is None:
-        image_attestation_map = {}
     if existing_properties_map is None:
         existing_properties_map = {}
     layers_by_diff_id: dict[str, dict[str, Any]] = {}
@@ -604,38 +269,6 @@ def transform_ecr_image_layers(
                             image_digest,
                             platform_values,
                         )
-
-            # Add provenance data if available for this image
-            if image_uri in image_attestation_map:
-                provenance = image_attestation_map[image_uri]
-                # Parent image info
-                if provenance.get("parent_image_uri"):
-                    membership["parent_image_uri"] = provenance["parent_image_uri"]
-                if provenance.get("parent_image_digest"):
-                    membership["parent_image_digest"] = provenance[
-                        "parent_image_digest"
-                    ]
-                # Source repository info from VCS metadata
-                if provenance.get("source_uri"):
-                    membership["source_uri"] = provenance["source_uri"]
-                if provenance.get("source_revision"):
-                    membership["source_revision"] = provenance["source_revision"]
-                # Build invocation info from GitHub Actions
-                if provenance.get("invocation_uri"):
-                    membership["invocation_uri"] = provenance["invocation_uri"]
-                if provenance.get("invocation_workflow"):
-                    membership["invocation_workflow"] = provenance[
-                        "invocation_workflow"
-                    ]
-                if provenance.get("invocation_run_number"):
-                    membership["invocation_run_number"] = provenance[
-                        "invocation_run_number"
-                    ]
-                # Source file (Dockerfile path) from configSource
-                if provenance.get("source_file"):
-                    membership["source_file"] = provenance["source_file"]
-                membership["from_attestation"] = True
-                membership["confidence"] = "explicit"
 
             memberships_by_digest[image_digest] = membership
 
@@ -730,7 +363,6 @@ async def fetch_image_layers_async(
     dict[str, dict[str, list[str]]],
     dict[str, str],
     dict[str, str],
-    dict[str, dict[str, str]],
 ]:
     """
     Fetch image layers for ECR images in parallel with caching and non-blocking I/O.
@@ -739,12 +371,10 @@ async def fetch_image_layers_async(
         - image_layers_data: Map of image URI to platform to diff_ids
         - image_digest_map: Map of image URI to image digest
         - history_by_diff_id: Map of diff_id to history command (created_by)
-        - image_attestation_map: Map of image URI to attestation data (parent_image_uri, parent_image_digest)
     """
     image_layers_data: dict[str, dict[str, list[str]]] = {}
     image_digest_map: dict[str, str] = {}
     all_history_by_diff_id: dict[str, str] = {}
-    image_attestation_map: dict[str, dict[str, str]] = {}
     semaphore = asyncio.Semaphore(max_concurrent)
 
     # Cache for manifest fetches keyed by (repo_name, imageDigest)
@@ -791,24 +421,11 @@ async def fetch_image_layers_async(
     async def fetch_single_image_layers(
         repo_image: dict,
         http_client: httpx.AsyncClient,
-    ) -> Optional[
-        tuple[
-            str,
-            str,
-            dict[str, list[str]],
-            dict[str, str],
-            Optional[dict[str, dict[str, str]]],
-        ]
-    ]:
+    ) -> Optional[tuple[str, str, dict[str, list[str]], dict[str, str]]]:
         """
-        Fetch layers for a single image and extract attestation if present.
+        Fetch layers for a single image.
 
-        Returns tuple of (uri, digest, platform_layers, history_by_diff_id, attestations_by_child_digest) where:
-        - uri: The image URI
-        - digest: The image digest
-        - platform_layers: Map of platform to list of layer diff_ids
-        - history_by_diff_id: Map of diff_id to history command (created_by)
-        - attestations_by_child_digest: Maps child image digest to parent image info
+        Returns tuple of (uri, digest, platform_layers, history_by_diff_id) or None.
         """
         async with semaphore:
             # Caller guarantees these fields exist in every repo_image
@@ -833,50 +450,24 @@ async def fetch_image_layers_async(
             manifest_media_type = (media_type or doc.get("mediaType", "")).lower()
             platform_layers: dict[str, list[str]] = {}
             history_by_diff_id: dict[str, str] = {}
-            attestation_data: Optional[dict[str, dict[str, str]]] = None
 
             if doc.get("manifests") and manifest_media_type in INDEX_MEDIA_TYPES_LOWER:
 
                 async def _process_child_manifest(
                     manifest_ref: dict,
-                ) -> tuple[
-                    dict[str, list[str]],
-                    dict[str, str],
-                    Optional[tuple[str, dict[str, str]]],
-                ]:
-                    # Check if this is an attestation manifest
+                ) -> tuple[dict[str, list[str]], dict[str, str]]:
+                    # Skip attestation manifests — provenance is handled by ecr:provenance
                     if (
                         manifest_ref.get("annotations", {}).get(
                             "vnd.docker.reference.type"
                         )
                         == "attestation-manifest"
                     ):
-                        # Extract which child image this attestation is for
-                        attests_child_digest = manifest_ref.get("annotations", {}).get(
-                            "vnd.docker.reference.digest"
-                        )
-                        if not attests_child_digest:
-                            return {}, {}, None
-
-                        # Extract provenance from attestation (includes parent image and source info)
-                        attestation_digest = manifest_ref.get("digest")
-                        if attestation_digest:
-                            provenance_info = (
-                                await _extract_provenance_from_attestation(
-                                    ecr_client,
-                                    repo_name,
-                                    attestation_digest,
-                                    http_client,
-                                )
-                            )
-                            if provenance_info:
-                                # Return (attests_child_digest, provenance_info) tuple
-                                return {}, {}, (attests_child_digest, provenance_info)
-                        return {}, {}, None
+                        return {}, {}
 
                     child_digest = manifest_ref.get("digest")
                     if not child_digest:
-                        return {}, {}, None
+                        return {}, {}
 
                     # Use optimized caching for child manifest
                     child_doc, _ = await _fetch_and_cache_manifest(
@@ -885,7 +476,7 @@ async def fetch_image_layers_async(
                         [ECR_OCI_MANIFEST_MT, ECR_DOCKER_MANIFEST_MT],
                     )
                     if not child_doc:
-                        return {}, {}, None
+                        return {}, {}
 
                     platform_hint = extract_platform_from_manifest(manifest_ref)
                     diff_map, history_map = await _diff_ids_for_manifest(
@@ -895,33 +486,33 @@ async def fetch_image_layers_async(
                         http_client,
                         platform_hint,
                     )
-                    return diff_map, history_map, None
+                    return diff_map, history_map
 
                 # Process all child manifests in parallel
                 child_tasks = [
                     _process_child_manifest(manifest_ref)
                     for manifest_ref in doc.get("manifests", [])
                 ]
-                child_results = await asyncio.gather(*child_tasks)
+                child_results = await asyncio.gather(
+                    *child_tasks,
+                    return_exceptions=True,
+                )
 
                 # Merge results from successful child manifest processing
-                # Track attestation data by child digest for proper mapping
-                attestations_by_child_digest: dict[str, dict[str, str]] = {}
-
                 for result in child_results:
-                    layer_data, hist_data, attest_data = result
+                    if isinstance(result, ECRLayerFetchTransientError):
+                        logger.warning(
+                            "Skipping child manifest after transient error: %s",
+                            result,
+                        )
+                        continue
+                    if isinstance(result, BaseException):
+                        raise result
+                    layer_data, hist_data = result
                     if layer_data:
                         platform_layers.update(layer_data)
                     if hist_data:
                         history_by_diff_id.update(hist_data)
-                    if attest_data:
-                        # attest_data is (child_digest, parent_info) tuple
-                        child_digest, parent_info = attest_data
-                        attestations_by_child_digest[child_digest] = parent_info
-
-                # Build attestation_data with child digest mapping
-                if attestations_by_child_digest:
-                    attestation_data = attestations_by_child_digest
             else:
                 diff_map, hist_map = await _diff_ids_for_manifest(
                     ecr_client,
@@ -933,15 +524,12 @@ async def fetch_image_layers_async(
                 platform_layers.update(diff_map)
                 history_by_diff_id.update(hist_map)
 
-            # Return if we found layers or attestation data
-            # Manifest lists may have attestation_data without platform_layers
-            if platform_layers or attestation_data:
+            if platform_layers:
                 return (
                     uri,
                     digest,
                     platform_layers,
                     history_by_diff_id,
-                    attestation_data,
                 )
 
             return None
@@ -952,15 +540,7 @@ async def fetch_image_layers_async(
             repo_image: dict,
         ) -> tuple[
             str,
-            Optional[
-                tuple[
-                    str,
-                    str,
-                    dict[str, list[str]],
-                    dict[str, str],
-                    Optional[dict[str, dict[str, str]]],
-                ]
-            ],
+            Optional[tuple[str, str, dict[str, list[str]], dict[str, str]]],
         ]:
             try:
                 return repo_image["uri"], await fetch_single_image_layers(
@@ -991,7 +571,6 @@ async def fetch_image_layers_async(
                 image_layers_data,
                 image_digest_map,
                 all_history_by_diff_id,
-                image_attestation_map,
             )
 
         progress_interval = max(1, min(100, total // 10 or 1))
@@ -1028,26 +607,13 @@ async def fetch_image_layers_async(
                 )
 
             if result:
-                uri, digest, layer_data, history_data, attestations_by_child_digest = (
-                    result
-                )
+                uri, digest, layer_data, history_data = result
                 if not digest:
                     raise ValueError(f"Empty digest returned for image {uri}")
                 image_layers_data[uri] = layer_data
                 image_digest_map[uri] = digest
                 if history_data:
                     all_history_by_diff_id.update(history_data)
-                if attestations_by_child_digest:
-                    # Map attestation data by child digest URIs
-                    repo_uri = extract_repo_uri_from_image_uri(uri)
-                    for (
-                        child_digest,
-                        parent_info,
-                    ) in attestations_by_child_digest.items():
-                        child_uri = f"{repo_uri}@{child_digest}"
-                        image_attestation_map[child_uri] = parent_info
-                        # Also add to digest map so transform can look up the child digest
-                        image_digest_map[child_uri] = child_digest
 
     logger.info(
         f"Successfully fetched layers for {len(image_layers_data)}/{len(repo_images_list)} images"
@@ -1056,15 +622,10 @@ async def fetch_image_layers_async(
         logger.info(
             f"Extracted history commands for {len(all_history_by_diff_id)} layers"
         )
-    if image_attestation_map:
-        logger.info(
-            f"Found attestations with base image info for {len(image_attestation_map)} images"
-        )
     return (
         image_layers_data,
         image_digest_map,
         all_history_by_diff_id,
-        image_attestation_map,
     )
 
 
@@ -1154,11 +715,10 @@ def sync(
                 repo_uri = img_data["repo_uri"]
                 digest_uri = f"{repo_uri}@{digest}"
 
-                # Fetch manifests for:
-                # - Platform-specific images (type="image") - to get their layers
-                # - Manifest lists (type="manifest_list") - to extract attestation parent image data
-                # Skip only attestations since they don't have useful layer or parent data
-                if image_type != "attestation":
+                # Only fetch manifests for platform-specific images (layers).
+                # Provenance is handled by ecr:provenance; attestations and manifest
+                # lists have no useful layer data.
+                if image_type == "image":
                     repo_images_list.append(
                         {
                             "imageDigest": digest,
@@ -1188,7 +748,6 @@ def sync(
                 dict[str, dict[str, list[str]]],
                 dict[str, str],
                 dict[str, str],
-                dict[str, dict[str, str]],
             ]:
                 async with aioboto3_session.client(
                     "ecr", region_name=region
@@ -1207,7 +766,6 @@ def sync(
                 image_layers_data,
                 image_digest_map,
                 history_by_diff_id,
-                image_attestation_map,
             ) = loop.run_until_complete(_fetch_with_async_client())
 
             logger.info(
@@ -1217,7 +775,6 @@ def sync(
                 image_layers_data,
                 image_digest_map,
                 history_by_diff_id,
-                image_attestation_map,
                 existing_properties,
             )
             load_ecr_image_layers(

--- a/cartography/intel/aws/ecr_provenance.py
+++ b/cartography/intel/aws/ecr_provenance.py
@@ -1,0 +1,424 @@
+import asyncio
+import logging
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+import aioboto3
+import boto3
+import httpx
+import neo4j
+
+from cartography.client.core.tx import load_graph_data
+from cartography.client.core.tx import run_write_query
+from cartography.intel.aws import ecr
+from cartography.intel.aws.ecr_shared import batch_get_manifest
+from cartography.intel.aws.ecr_shared import ECR_DOCKER_MANIFEST_MT
+from cartography.intel.aws.ecr_shared import ECR_OCI_MANIFEST_MT
+from cartography.intel.aws.ecr_shared import ECRFetchTransientError
+from cartography.intel.aws.ecr_shared import get_blob_json_via_presigned
+from cartography.intel.supply_chain import extract_workflow_path_from_ref
+from cartography.intel.supply_chain import normalize_vcs_url
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+ECR_IMAGE_PROVENANCE_QUERY = """
+UNWIND $DictList AS item
+MATCH (:AWSAccount {id: $AWS_ID})-[:RESOURCE]->(img:ECRImage)
+WHERE img.region = $Region
+  AND img.id = item["imageDigest"]
+SET
+    img.source_uri = item["source_uri"],
+    img.source_revision = item["source_revision"],
+    img.invocation_uri = item["invocation_uri"],
+    img.invocation_workflow = item["invocation_workflow"],
+    img.invocation_run_number = item["invocation_run_number"],
+    img.source_file = item["source_file"],
+    img.provenance_lastupdated = $update_tag
+"""
+
+
+ECR_IMAGE_BUILT_FROM_QUERY = """
+UNWIND $DictList AS item
+MATCH (:AWSAccount {id: $AWS_ID})-[:RESOURCE]->(child:ECRImage)
+WHERE child.region = $Region
+  AND child.id = item["imageDigest"]
+MATCH (:AWSAccount {id: $AWS_ID})-[:RESOURCE]->(parent:ECRImage)
+WHERE parent.region = $Region
+  AND parent.id = item["parent_image_digest"]
+MERGE (child)-[r:BUILT_FROM]->(parent)
+ON CREATE SET r.firstseen = timestamp()
+SET
+    r.lastupdated = $update_tag,
+    r.from_attestation = item["from_attestation"],
+    r.parent_image_uri = item["parent_image_uri"],
+    r.confidence = item["confidence"]
+"""
+
+
+STALE_ECR_IMAGE_PROVENANCE_QUERY = """
+MATCH (:AWSAccount {id: $AWS_ID})-[:RESOURCE]->(img:ECRImage)
+WHERE img.region = $Region
+  AND img.provenance_lastupdated IS NOT NULL
+  AND img.provenance_lastupdated <> $update_tag
+SET
+    img.source_uri = NULL,
+    img.source_revision = NULL,
+    img.invocation_uri = NULL,
+    img.invocation_workflow = NULL,
+    img.invocation_run_number = NULL,
+    img.source_file = NULL,
+    img.provenance_lastupdated = NULL
+"""
+
+
+STALE_BUILT_FROM_QUERY = """
+MATCH (:AWSAccount {id: $AWS_ID})-[:RESOURCE]->(img:ECRImage)-[r:BUILT_FROM]->(:ECRImage)
+WHERE img.region = $Region
+  AND coalesce(r.from_attestation, false) = true
+  AND r.lastupdated <> $update_tag
+DELETE r
+"""
+
+
+def _collect_attestations(
+    repo_data: Dict[str, Any],
+) -> list[dict[str, str]]:
+    """Extract attestation metadata from ECR image inventory."""
+    attestations = []
+    for repo_uri, images in repo_data.items():
+        repo_name = repo_uri.split("/", 1)[1] if "/" in repo_uri else repo_uri
+        for img in images:
+            for manifest_img in img.get("_manifest_images", []):
+                if manifest_img.get("type") == "attestation" and manifest_img.get(
+                    "attests_digest"
+                ):
+                    attestations.append(
+                        {
+                            "repo_name": repo_name,
+                            "digest": manifest_img["digest"],
+                            "attests_digest": manifest_img["attests_digest"],
+                        }
+                    )
+    return attestations
+
+
+async def _extract_provenance_from_attestation(
+    ecr_client: Any,
+    repo_name: str,
+    attestation_manifest_digest: str,
+    http_client: httpx.AsyncClient,
+) -> Optional[dict[str, Any]]:
+    """Extract provenance from an in-toto SLSA attestation manifest."""
+    attestation_manifest, _ = await batch_get_manifest(
+        ecr_client,
+        repo_name,
+        attestation_manifest_digest,
+        [ECR_OCI_MANIFEST_MT, ECR_DOCKER_MANIFEST_MT],
+    )
+    if not attestation_manifest:
+        return None
+
+    layers = attestation_manifest.get("layers", [])
+    intoto_layer = next(
+        (layer for layer in layers if "in-toto" in layer.get("mediaType", "").lower()),
+        None,
+    )
+    if not intoto_layer:
+        return None
+
+    intoto_digest = intoto_layer.get("digest")
+    if not intoto_digest:
+        return None
+
+    attestation_blob = await get_blob_json_via_presigned(
+        ecr_client,
+        repo_name,
+        intoto_digest,
+        http_client,
+    )
+    if not attestation_blob:
+        return None
+
+    predicate = attestation_blob.get("predicate", {})
+    result: dict[str, Any] = {}
+
+    dependency_list: list[dict[str, Any]] = predicate.get("materials", [])
+    if not dependency_list:
+        build_def = predicate.get("buildDefinition", {})
+        dependency_list = build_def.get("resolvedDependencies", [])
+
+    for dep in dependency_list:
+        uri = dep.get("uri", "")
+        uri_l = uri.lower()
+        is_container_ref = (
+            uri_l.startswith("pkg:docker/")
+            or uri_l.startswith("pkg:oci/")
+            or uri_l.startswith("oci://")
+        )
+        if is_container_ref and "dockerfile" not in uri_l:
+            sha = dep.get("digest", {}).get("sha256")
+            if sha:
+                result["parent_image_uri"] = uri
+                result["parent_image_digest"] = f"sha256:{sha}"
+                break
+
+    metadata = predicate.get("metadata", {})
+    vcs = metadata.get("https://mobyproject.org/buildkit@v1#metadata", {}).get(
+        "vcs", {}
+    )
+    if not vcs:
+        rd = predicate.get("runDetails", {}).get("metadata", {})
+        vcs = rd.get("buildkit_metadata", {}).get("vcs", {})
+
+    if vcs.get("source"):
+        result["source_uri"] = normalize_vcs_url(vcs["source"])
+    if vcs.get("revision"):
+        result["source_revision"] = vcs["revision"]
+
+    invocation = predicate.get("invocation", {})
+    env = invocation.get("environment", {})
+    if env.get("github_repository"):
+        server = env.get("github_server_url", "https://github.com").rstrip("/")
+        result["invocation_uri"] = f"{server}/{env['github_repository']}"
+    if env.get("github_workflow_ref"):
+        workflow = extract_workflow_path_from_ref(env["github_workflow_ref"])
+        if workflow:
+            result["invocation_workflow"] = workflow
+    if env.get("github_run_number"):
+        result["invocation_run_number"] = env["github_run_number"]
+
+    if "invocation_uri" not in result:
+        builder_id = predicate.get("runDetails", {}).get("builder", {}).get("id", "")
+        if "github.com" in builder_id and "/actions/runs/" in builder_id:
+            parts = builder_id.split("/actions/runs/")
+            if len(parts) == 2:
+                result["invocation_uri"] = parts[0]
+
+    if "source_uri" in result:
+        entry_point = invocation.get("configSource", {}).get("entryPoint", "")
+        if not entry_point:
+            build_def = predicate.get("buildDefinition", {})
+            entry_point = (
+                build_def.get("externalParameters", {})
+                .get("configSource", {})
+                .get("path", "Dockerfile")
+            )
+        if not entry_point:
+            entry_point = "Dockerfile"
+        dockerfile_dir = (
+            (vcs.get("localdir:dockerfile") or "").removeprefix("./").rstrip("/")
+        )
+        result["source_file"] = (
+            f"{dockerfile_dir}/{entry_point}" if dockerfile_dir else entry_point
+        )
+
+    return result or None
+
+
+async def _fetch_provenance_for_attestations(
+    aioboto3_session: aioboto3.Session,
+    region: str,
+    attestations: list[dict[str, str]],
+) -> dict[str, dict[str, Any]]:
+    """Fetch provenance from attestation blobs concurrently."""
+    provenance_map: dict[str, dict[str, Any]] = {}
+    semaphore = asyncio.Semaphore(200)
+
+    async with aioboto3_session.client("ecr", region_name=region) as ecr_client:
+        async with httpx.AsyncClient() as http_client:
+
+            async def _process(att: dict[str, str]) -> None:
+                async with semaphore:
+                    try:
+                        provenance = await _extract_provenance_from_attestation(
+                            ecr_client,
+                            att["repo_name"],
+                            att["digest"],
+                            http_client,
+                        )
+                    except ECRFetchTransientError:
+                        logger.warning(
+                            "Skipping provenance for attestation %s after transient error.",
+                            att["digest"],
+                        )
+                        return
+
+                    if provenance:
+                        provenance_map[att["attests_digest"]] = provenance
+
+            tasks = [asyncio.create_task(_process(att)) for att in attestations]
+            if tasks:
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+                for result in results:
+                    if isinstance(result, ECRFetchTransientError):
+                        continue
+                    if isinstance(result, Exception):
+                        logger.warning(
+                            "Unexpected error extracting provenance: %s: %s",
+                            type(result).__name__,
+                            result,
+                        )
+
+    return provenance_map
+
+
+def _fetch_provenance(
+    aioboto3_session: aioboto3.Session,
+    region: str,
+    repo_data: Dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    attestations = _collect_attestations(repo_data)
+    if not attestations:
+        return {}
+
+    logger.info("Fetching provenance from %d attestation images.", len(attestations))
+
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    provenance_map = loop.run_until_complete(
+        _fetch_provenance_for_attestations(aioboto3_session, region, attestations)
+    )
+    logger.info("Extracted provenance for %d images.", len(provenance_map))
+    return provenance_map
+
+
+def transform_ecr_image_provenance(
+    provenance_map: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    provenance_items = []
+    for image_digest in sorted(provenance_map):
+        provenance_items.append(
+            {
+                "imageDigest": image_digest,
+                "from_attestation": True,
+                "confidence": "explicit",
+                **provenance_map[image_digest],
+            }
+        )
+    return provenance_items
+
+
+@timeit
+def load_ecr_image_provenance(
+    neo4j_session: neo4j.Session,
+    provenance_items: list[dict[str, Any]],
+    region: str,
+    current_aws_account_id: str,
+    update_tag: int,
+) -> None:
+    if not provenance_items:
+        return
+
+    logger.info(
+        "Loading provenance properties for %d ECR images in region %s.",
+        len(provenance_items),
+        region,
+    )
+    load_graph_data(
+        neo4j_session,
+        ECR_IMAGE_PROVENANCE_QUERY,
+        provenance_items,
+        AWS_ID=current_aws_account_id,
+        Region=region,
+        update_tag=update_tag,
+    )
+
+
+@timeit
+def load_ecr_image_parent_relationships(
+    neo4j_session: neo4j.Session,
+    provenance_items: list[dict[str, Any]],
+    region: str,
+    current_aws_account_id: str,
+    update_tag: int,
+) -> None:
+    built_from_items = [
+        item for item in provenance_items if item.get("parent_image_digest")
+    ]
+    if not built_from_items:
+        return
+
+    logger.info(
+        "Loading BUILT_FROM relationships for %d ECR images in region %s.",
+        len(built_from_items),
+        region,
+    )
+    load_graph_data(
+        neo4j_session,
+        ECR_IMAGE_BUILT_FROM_QUERY,
+        built_from_items,
+        AWS_ID=current_aws_account_id,
+        Region=region,
+        update_tag=update_tag,
+    )
+
+
+def cleanup(
+    neo4j_session: neo4j.Session,
+    region: str,
+    current_aws_account_id: str,
+    update_tag: int,
+) -> None:
+    run_write_query(
+        neo4j_session,
+        STALE_BUILT_FROM_QUERY,
+        AWS_ID=current_aws_account_id,
+        Region=region,
+        update_tag=update_tag,
+    )
+    run_write_query(
+        neo4j_session,
+        STALE_ECR_IMAGE_PROVENANCE_QUERY,
+        AWS_ID=current_aws_account_id,
+        Region=region,
+        update_tag=update_tag,
+    )
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    boto3_session: boto3.session.Session,
+    regions: list[str],
+    current_aws_account_id: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+    aioboto3_session: aioboto3.Session | None = None,
+) -> None:
+    del common_job_parameters
+
+    if aioboto3_session is None:
+        raise ValueError("ecr:provenance requires an aioboto3_session")
+
+    for region in regions:
+        logger.info(
+            "Syncing ECR provenance for region '%s' in account '%s'.",
+            region,
+            current_aws_account_id,
+        )
+        repositories = ecr.get_ecr_repositories(boto3_session, region)
+        image_data = ecr.get_repository_image_data(boto3_session, region, repositories)
+        provenance_map = _fetch_provenance(aioboto3_session, region, image_data)
+        provenance_items = transform_ecr_image_provenance(provenance_map)
+        load_ecr_image_provenance(
+            neo4j_session,
+            provenance_items,
+            region,
+            current_aws_account_id,
+            update_tag,
+        )
+        load_ecr_image_parent_relationships(
+            neo4j_session,
+            provenance_items,
+            region,
+            current_aws_account_id,
+            update_tag,
+        )
+        cleanup(neo4j_session, region, current_aws_account_id, update_tag)

--- a/cartography/intel/aws/ecr_provenance.py
+++ b/cartography/intel/aws/ecr_provenance.py
@@ -61,8 +61,8 @@ SET
 STALE_ECR_IMAGE_PROVENANCE_QUERY = """
 MATCH (:AWSAccount {id: $AWS_ID})-[:RESOURCE]->(img:ECRImage)
 WHERE img.region = $Region
-  AND img.provenance_lastupdated IS NOT NULL
-  AND img.provenance_lastupdated <> $update_tag
+  AND img.source_uri IS NOT NULL
+  AND (img.provenance_lastupdated IS NULL OR img.provenance_lastupdated <> $update_tag)
 SET
     img.source_uri = NULL,
     img.source_revision = NULL,

--- a/cartography/intel/aws/ecr_shared.py
+++ b/cartography/intel/aws/ecr_shared.py
@@ -1,0 +1,217 @@
+import asyncio
+import json
+import logging
+
+import httpx
+from botocore.exceptions import ClientError
+from types_aiobotocore_ecr import ECRClient
+
+logger = logging.getLogger(__name__)
+
+
+class ECRFetchTransientError(Exception):
+    """Raised when a transient ECR/blob fetch failure should skip one artifact."""
+
+
+ECR_DOCKER_INDEX_MT = "application/vnd.docker.distribution.manifest.list.v2+json"
+ECR_DOCKER_MANIFEST_MT = "application/vnd.docker.distribution.manifest.v2+json"
+ECR_OCI_INDEX_MT = "application/vnd.oci.image.index.v1+json"
+ECR_OCI_MANIFEST_MT = "application/vnd.oci.image.manifest.v1+json"
+
+ALL_ACCEPTED = [
+    ECR_OCI_INDEX_MT,
+    ECR_DOCKER_INDEX_MT,
+    ECR_OCI_MANIFEST_MT,
+    ECR_DOCKER_MANIFEST_MT,
+]
+
+INDEX_MEDIA_TYPES = {ECR_OCI_INDEX_MT, ECR_DOCKER_INDEX_MT}
+INDEX_MEDIA_TYPES_LOWER = {mt.lower() for mt in INDEX_MEDIA_TYPES}
+
+RETRYABLE_HTTP_STATUS_CODES = {429, 500, 502, 503, 504}
+RETRYABLE_ECR_ERROR_CODES = {
+    "InternalFailure",
+    "InternalServerException",
+    "RequestLimitExceeded",
+    "RequestThrottled",
+    "RequestTimeout",
+    "RequestTimeoutException",
+    "ServerException",
+    "ServiceUnavailable",
+    "ServiceUnavailableException",
+    "Throttling",
+    "ThrottlingException",
+    "TooManyRequestsException",
+}
+RETRYABLE_HTTPX_EXCEPTIONS = (
+    httpx.ConnectError,
+    httpx.PoolTimeout,
+    httpx.ReadError,
+    httpx.ReadTimeout,
+    httpx.RemoteProtocolError,
+    httpx.TimeoutException,
+    httpx.WriteError,
+    httpx.WriteTimeout,
+)
+MAX_BLOB_DOWNLOAD_ATTEMPTS = 3
+
+
+def is_retryable_aws_client_error(error: ClientError) -> bool:
+    error_code = error.response.get("Error", {}).get("Code", "")
+    status_code = error.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+    return (
+        error_code in RETRYABLE_ECR_ERROR_CODES
+        or status_code in RETRYABLE_HTTP_STATUS_CODES
+    )
+
+
+def is_retryable_http_error(error: httpx.HTTPError) -> bool:
+    if isinstance(error, RETRYABLE_HTTPX_EXCEPTIONS):
+        return True
+    if isinstance(error, httpx.HTTPStatusError) and error.response is not None:
+        return error.response.status_code in RETRYABLE_HTTP_STATUS_CODES
+    return False
+
+
+def safe_http_error_for_log(error: httpx.HTTPError) -> str:
+    if isinstance(error, httpx.HTTPStatusError) and error.response is not None:
+        return f"{error.__class__.__name__}(status_code={error.response.status_code})"
+    return f"{error.__class__.__name__}: {error}"
+
+
+async def batch_get_manifest(
+    ecr_client: ECRClient,
+    repo: str,
+    image_ref: str,
+    accepted_media_types: list[str],
+) -> tuple[dict, str]:
+    """Get an image manifest using the ECR BatchGetImage API."""
+    try:
+        resp = await ecr_client.batch_get_image(
+            repositoryName=repo,
+            imageIds=(
+                [{"imageDigest": image_ref}]
+                if image_ref.startswith("sha256:")
+                else [{"imageTag": image_ref}]
+            ),
+            acceptedMediaTypes=accepted_media_types,
+        )
+    except ClientError as error:
+        error_code = error.response.get("Error", {}).get("Code", "")
+        if error_code == "ImageNotFoundException":
+            logger.warning(
+                "Image %s:%s not found while fetching manifest", repo, image_ref
+            )
+            return {}, ""
+        if error_code in {"AccessDenied", "AccessDeniedException"}:
+            logger.warning(
+                "Skipping manifest fetch for %s:%s due to %s (missing ecr:BatchGetImage permission)",
+                repo,
+                image_ref,
+                error_code,
+            )
+            return {}, ""
+        if is_retryable_aws_client_error(error):
+            logger.warning(
+                "Transient AWS error fetching manifest for %s:%s: %s",
+                repo,
+                image_ref,
+                error_code or error,
+            )
+            raise ECRFetchTransientError(
+                f"Transient manifest fetch failure for {repo}:{image_ref}"
+            ) from error
+        logger.error(
+            "Failed to get manifest for %s:%s due to AWS error %s",
+            repo,
+            image_ref,
+            error_code,
+        )
+        raise
+    except Exception:
+        logger.exception(
+            "Unexpected error fetching manifest for %s:%s", repo, image_ref
+        )
+        raise
+
+    if not resp.get("images"):
+        logger.warning("No image found for %s:%s", repo, image_ref)
+        return {}, ""
+
+    manifest_json = json.loads(resp["images"][0]["imageManifest"])
+    media_type = resp["images"][0].get("imageManifestMediaType", "")
+    return manifest_json, media_type
+
+
+async def get_blob_json_via_presigned(
+    ecr_client: ECRClient,
+    repo: str,
+    digest: str,
+    http_client: httpx.AsyncClient,
+) -> dict:
+    """Download and parse a JSON blob using a presigned layer URL."""
+    try:
+        url_response = await ecr_client.get_download_url_for_layer(
+            repositoryName=repo,
+            layerDigest=digest,
+        )
+    except ClientError as error:
+        if is_retryable_aws_client_error(error):
+            logger.warning(
+                "Transient AWS error requesting blob download URL for layer %s in repo %s: %s",
+                digest,
+                repo,
+                error.response.get("Error", {}).get("Code", "unknown"),
+            )
+            raise ECRFetchTransientError(
+                f"Transient download URL failure for {repo}@{digest}"
+            ) from error
+        logger.error(
+            "Failed to request download URL for layer %s in repo %s: %s",
+            digest,
+            repo,
+            error.response.get("Error", {}).get("Code", "unknown"),
+        )
+        raise
+
+    url = url_response["downloadUrl"]
+    last_error: httpx.HTTPError | None = None
+    for attempt in range(1, MAX_BLOB_DOWNLOAD_ATTEMPTS + 1):
+        try:
+            response = await http_client.get(url, timeout=30.0)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPError as error:
+            last_error = error
+            if attempt < MAX_BLOB_DOWNLOAD_ATTEMPTS and is_retryable_http_error(error):
+                logger.warning(
+                    "Retrying blob download for %s in repo %s after transient HTTP error on attempt %d/%d: %s",
+                    digest,
+                    repo,
+                    attempt,
+                    MAX_BLOB_DOWNLOAD_ATTEMPTS,
+                    safe_http_error_for_log(error),
+                )
+                await asyncio.sleep(2 ** (attempt - 1))
+                continue
+            if is_retryable_http_error(error):
+                logger.warning(
+                    "Exhausted blob download retries for %s in repo %s after transient HTTP error: %s",
+                    digest,
+                    repo,
+                    safe_http_error_for_log(error),
+                )
+                raise ECRFetchTransientError(
+                    f"Transient blob download failure for {repo}@{digest}"
+                ) from error
+            logger.error(
+                "HTTP error downloading blob %s for repo %s: %s",
+                digest,
+                repo,
+                safe_http_error_for_log(error),
+            )
+            raise
+
+    raise ECRFetchTransientError(
+        f"Transient blob download failure for {repo}@{digest}"
+    ) from last_error

--- a/cartography/intel/aws/resources.py
+++ b/cartography/intel/aws/resources.py
@@ -17,6 +17,7 @@ from . import config
 from . import dynamodb
 from . import ecr
 from . import ecr_image_layers
+from . import ecr_provenance
 from . import ecs
 from . import efs
 from . import eks
@@ -112,6 +113,7 @@ RESOURCE_FUNCTIONS: OrderedDict[str, Callable[..., None]] = OrderedDict(
         "ec2:volumes": sync_ebs_volumes,
         "ec2:snapshots": sync_ebs_snapshots,
         "ecr": ecr.sync,
+        "ecr:provenance": ecr_provenance.sync,
         "ecr:image_layers": ecr_image_layers.sync,
         # `ec2:instance` must be synced before `ecs` so that EC2Instance nodes exist
         # when ECSContainerInstance creates IS_INSTANCE relationships.

--- a/cartography/models/aws/ecr/image.py
+++ b/cartography/models/aws/ecr/image.py
@@ -15,7 +15,7 @@ from cartography.models.core.relationships import TargetNodeMatcher
 
 @dataclass(frozen=True)
 class ECRImageBaseNodeProperties(CartographyNodeProperties):
-    """Properties managed by the basic ECR module (ecr.py) from DescribeImages API."""
+    """Properties managed by the basic ECR module (ecr.py)."""
 
     id: PropertyRef = PropertyRef("imageDigest")
     digest: PropertyRef = PropertyRef("imageDigest", extra_index=True)
@@ -34,7 +34,7 @@ class ECRImageBaseNodeProperties(CartographyNodeProperties):
 
 @dataclass(frozen=True)
 class ECRImageNodeProperties(CartographyNodeProperties):
-    """All ECRImage properties including layer/provenance fields managed by ecr_image_layers."""
+    """ECRImage properties managed by ecr_image_layers."""
 
     id: PropertyRef = PropertyRef("imageDigest")
     digest: PropertyRef = PropertyRef("imageDigest", extra_index=True)
@@ -50,17 +50,6 @@ class ECRImageNodeProperties(CartographyNodeProperties):
     media_type: PropertyRef = PropertyRef("media_type")
     artifact_media_type: PropertyRef = PropertyRef("artifact_media_type")
     child_image_digests: PropertyRef = PropertyRef("child_image_digests")
-    # SLSA Provenance: Source repository info from VCS metadata
-    source_uri: PropertyRef = PropertyRef("source_uri", extra_index=True)
-    source_revision: PropertyRef = PropertyRef("source_revision")
-    # SLSA Provenance: Build invocation info from CI
-    invocation_uri: PropertyRef = PropertyRef("invocation_uri", extra_index=True)
-    invocation_workflow: PropertyRef = PropertyRef(
-        "invocation_workflow", extra_index=True
-    )
-    invocation_run_number: PropertyRef = PropertyRef("invocation_run_number")
-    # SLSA Provenance: Dockerfile path from configSource.entryPoint + vcs localdir
-    source_file: PropertyRef = PropertyRef("source_file")
 
 
 @dataclass(frozen=True)
@@ -167,12 +156,7 @@ class ECRImageAttestsRel(CartographyRelSchema):
 
 @dataclass(frozen=True)
 class ECRImageBaseSchema(CartographyNodeSchema):
-    """Schema used by the basic ECR module (ecr.py) to load image metadata from DescribeImages.
-
-    Only includes properties from the ECR API — does NOT include layer or provenance
-    fields (layer_diff_ids, source_uri, invocation_uri, etc.) so that loading from
-    DescribeImages doesn't clear values set by ecr_image_layers.
-    """
+    """Schema used by ecr.py to load repositories, images, and manifest relationships."""
 
     label: str = "ECRImage"
     properties: ECRImageBaseNodeProperties = ECRImageBaseNodeProperties()
@@ -203,10 +187,7 @@ class ECRImageBaseSchema(CartographyNodeSchema):
 
 @dataclass(frozen=True)
 class ECRImageSchema(CartographyNodeSchema):
-    """Full schema used by ecr_image_layers to enrich ECRImage nodes with layer and provenance data.
-
-    Also used for cleanup in ecr.py to handle all relationship types (HAS_LAYER, BUILT_FROM, etc.).
-    """
+    """Schema used by ecr_image_layers to enrich ECRImage nodes with layer data."""
 
     label: str = "ECRImage"
     properties: ECRImageNodeProperties = ECRImageNodeProperties()
@@ -214,9 +195,6 @@ class ECRImageSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             ECRImageHasLayerRel(),
-            ECRImageToParentImageRel(),
-            ECRImageContainsImageRel(),
-            ECRImageAttestsRel(),
         ],
     )
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(

--- a/cartography/models/aws/ecr/image.py
+++ b/cartography/models/aws/ecr/image.py
@@ -187,7 +187,11 @@ class ECRImageBaseSchema(CartographyNodeSchema):
 
 @dataclass(frozen=True)
 class ECRImageSchema(CartographyNodeSchema):
-    """Schema used by ecr_image_layers to enrich ECRImage nodes with layer data."""
+    """Schema used by ecr_image_layers for layer sync and by ecr.py for cleanup.
+
+    Must include ALL ECRImage relationship types so the cleanup job properly
+    detaches stale HAS_LAYER, BUILT_FROM, CONTAINS_IMAGE, and ATTESTS edges.
+    """
 
     label: str = "ECRImage"
     properties: ECRImageNodeProperties = ECRImageNodeProperties()
@@ -195,6 +199,9 @@ class ECRImageSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             ECRImageHasLayerRel(),
+            ECRImageToParentImageRel(),
+            ECRImageContainsImageRel(),
+            ECRImageAttestsRel(),
         ],
     )
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(

--- a/tests/integration/cartography/intel/aws/test_ecr_layers.py
+++ b/tests/integration/cartography/intel/aws/test_ecr_layers.py
@@ -339,301 +339,6 @@ def test_transform_marks_empty_layer():
     assert non_empty_layer["is_empty"] is False
 
 
-@patch.object(
-    cartography.intel.aws.ecr,
-    "get_ecr_repositories",
-    return_value=test_data.DESCRIBE_REPOSITORIES["repositories"][:1],
-)
-@patch.object(
-    cartography.intel.aws.ecr,
-    "get_ecr_repository_images",
-    return_value=test_data.LIST_REPOSITORY_IMAGES[
-        "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository"
-    ][:2],
-)
-@patch("cartography.intel.aws.ecr_image_layers.fetch_image_layers_async")
-@patch("cartography.client.aws.ecr.get_ecr_images")
-def test_sync_built_from_relationship(
-    mock_get_ecr_images,
-    mock_fetch_layers,
-    mock_get_repo_images,
-    mock_get_repos,
-    neo4j_session,
-):
-    """Test that BUILT_FROM relationship is created between ECRImage nodes."""
-    parent_digest = (
-        "sha256:0000000000000000000000000000000000000000000000000000000000000000"
-    )
-    child_digest = (
-        "sha256:0000000000000000000000000000000000000000000000000000000000000001"
-    )
-
-    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
-    cartography.intel.aws.ecr.sync(
-        neo4j_session,
-        MagicMock(),
-        [TEST_REGION],
-        TEST_ACCOUNT_ID,
-        TEST_UPDATE_TAG,
-        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
-    )
-
-    mock_get_ecr_images.return_value = {
-        (
-            "us-east-1",
-            "1",
-            "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository:1",
-            "example-repository",
-            parent_digest,
-        ),
-        (
-            "us-east-1",
-            "2",
-            "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository:latest",
-            "example-repository",
-            child_digest,
-        ),
-    }
-
-    mock_fetch_layers.return_value = (
-        {
-            "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository:1": {
-                "linux/amd64": test_data.SAMPLE_CONFIG_BLOB["rootfs"]["diff_ids"]
-            },
-            "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository:latest": {
-                "linux/amd64": test_data.SAMPLE_CONFIG_BLOB["rootfs"]["diff_ids"]
-            },
-        },
-        {
-            "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository:1": parent_digest,
-            "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository:latest": child_digest,
-        },
-        {},  # history_by_diff_id
-        {
-            "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository:latest": {
-                "parent_image_uri": "pkg:docker/000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository@1",
-                "parent_image_digest": parent_digest,
-            }
-        },
-    )
-
-    sync_ecr_layers(
-        neo4j_session,
-        MagicMock(),
-        [TEST_REGION],
-        TEST_ACCOUNT_ID,
-        TEST_UPDATE_TAG,
-        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
-    )
-
-    assert check_rels(
-        neo4j_session,
-        "ECRImage",
-        "id",
-        "ECRImage",
-        "id",
-        "BUILT_FROM",
-        rel_direction_right=True,
-    ) >= {(child_digest, parent_digest)}
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "parent_uri,parent_digest",
-    [
-        (
-            "pkg:docker/123456789012.dkr.ecr.us-east-1.amazonaws.com/base-image@v1.0",
-            "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
-        ),
-        (
-            "pkg:oci/myregistry.azurecr.io/base-image@v1.0",
-            "sha256:abc123def456",
-        ),
-        (
-            "oci://harbor.example.com/library/alpine@sha256:xyz789",
-            "sha256:xyz789abc",
-        ),
-    ],
-)
-async def test_extract_provenance_from_attestation_uri_schemes(
-    parent_uri, parent_digest
-):
-    """Test extracting provenance from attestation with various URI schemes."""
-    # Arrange
-    mock_ecr_client = MagicMock()
-    mock_http_client = AsyncMock()
-
-    attestation_manifest = (
-        {
-            "layers": [
-                {"mediaType": "application/vnd.in-toto+json", "digest": "sha256:def456"}
-            ]
-        },
-        "application/vnd.oci.image.manifest.v1+json",
-    )
-
-    attestation_blob = {
-        "predicate": {
-            "materials": [
-                {
-                    "uri": parent_uri,
-                    "digest": {"sha256": parent_digest.removeprefix("sha256:")},
-                },
-            ]
-        }
-    }
-
-    original_batch_get_manifest = ecr_layers.batch_get_manifest
-    original_get_blob = ecr_layers.get_blob_json_via_presigned
-
-    ecr_layers.batch_get_manifest = AsyncMock(return_value=attestation_manifest)
-    ecr_layers.get_blob_json_via_presigned = AsyncMock(return_value=attestation_blob)
-
-    try:
-        # Act
-        result = await ecr_layers._extract_provenance_from_attestation(
-            mock_ecr_client, "test-repo", "sha256:attestation", mock_http_client
-        )
-
-        # Assert
-        assert result is not None
-        assert result["parent_image_uri"] == parent_uri
-        assert result["parent_image_digest"] == parent_digest
-    finally:
-        ecr_layers.batch_get_manifest = original_batch_get_manifest
-        ecr_layers.get_blob_json_via_presigned = original_get_blob
-
-
-@pytest.mark.asyncio
-async def test_extract_provenance_from_attestation_with_source_info():
-    """Test extracting full provenance including source repo and invocation info."""
-    # Arrange
-    mock_ecr_client = MagicMock()
-    mock_http_client = AsyncMock()
-
-    attestation_manifest = (
-        {
-            "layers": [
-                {"mediaType": "application/vnd.in-toto+json", "digest": "sha256:def456"}
-            ]
-        },
-        "application/vnd.oci.image.manifest.v1+json",
-    )
-
-    # Full SLSA provenance attestation blob with VCS and invocation info
-    attestation_blob = {
-        "predicate": {
-            "materials": [
-                {
-                    "uri": "pkg:docker/base-image@v1.0",
-                    "digest": {"sha256": "parentdigest123"},
-                },
-            ],
-            "invocation": {
-                "environment": {
-                    "github_repository": "subimagesec/subimage",
-                    "github_workflow_ref": "subimagesec/subimage/.github/workflows/build.yaml@refs/heads/main",
-                    "github_run_number": "1470",
-                }
-            },
-            "metadata": {
-                "https://mobyproject.org/buildkit@v1#metadata": {
-                    "vcs": {
-                        "source": "https://github.com/subimagesec/subimage",
-                        "revision": "abc123def456",
-                    }
-                }
-            },
-        }
-    }
-
-    original_batch_get_manifest = ecr_layers.batch_get_manifest
-    original_get_blob = ecr_layers.get_blob_json_via_presigned
-
-    ecr_layers.batch_get_manifest = AsyncMock(return_value=attestation_manifest)
-    ecr_layers.get_blob_json_via_presigned = AsyncMock(return_value=attestation_blob)
-
-    try:
-        # Act
-        result = await ecr_layers._extract_provenance_from_attestation(
-            mock_ecr_client, "test-repo", "sha256:attestation", mock_http_client
-        )
-
-        # Assert
-        assert result is not None
-        # Parent image info
-        assert result["parent_image_uri"] == "pkg:docker/base-image@v1.0"
-        assert result["parent_image_digest"] == "sha256:parentdigest123"
-        # Source repository info
-        assert result["source_uri"] == "https://github.com/subimagesec/subimage"
-        assert result["source_revision"] == "abc123def456"
-        # Build invocation info
-        assert result["invocation_uri"] == "https://github.com/subimagesec/subimage"
-        assert result["invocation_workflow"] == ".github/workflows/build.yaml"
-        assert result["invocation_run_number"] == "1470"
-        # Source file defaults to "Dockerfile" when no configSource.entryPoint
-        assert result["source_file"] == "Dockerfile"
-    finally:
-        ecr_layers.batch_get_manifest = original_batch_get_manifest
-        ecr_layers.get_blob_json_via_presigned = original_get_blob
-
-
-@pytest.mark.asyncio
-async def test_extract_provenance_source_file_with_config_source():
-    """Test source_file extraction with configSource.entryPoint and vcs localdir:dockerfile."""
-    mock_ecr_client = MagicMock()
-    mock_http_client = AsyncMock()
-
-    attestation_manifest = (
-        {
-            "layers": [
-                {"mediaType": "application/vnd.in-toto+json", "digest": "sha256:def456"}
-            ]
-        },
-        "application/vnd.oci.image.manifest.v1+json",
-    )
-
-    attestation_blob = {
-        "predicate": {
-            "invocation": {
-                "configSource": {
-                    "entryPoint": "Dockerfile.prod",
-                },
-                "environment": {
-                    "github_repository": "myorg/myrepo",
-                    "github_workflow_ref": "myorg/myrepo/.github/workflows/build.yaml@refs/heads/main",
-                },
-            },
-            "metadata": {
-                "https://mobyproject.org/buildkit@v1#metadata": {
-                    "vcs": {
-                        "source": "https://github.com/myorg/myrepo",
-                        "localdir:dockerfile": "./deploy",
-                    }
-                }
-            },
-        }
-    }
-
-    original_batch_get_manifest = ecr_layers.batch_get_manifest
-    original_get_blob = ecr_layers.get_blob_json_via_presigned
-
-    ecr_layers.batch_get_manifest = AsyncMock(return_value=attestation_manifest)
-    ecr_layers.get_blob_json_via_presigned = AsyncMock(return_value=attestation_blob)
-
-    try:
-        result = await ecr_layers._extract_provenance_from_attestation(
-            mock_ecr_client, "test-repo", "sha256:attestation", mock_http_client
-        )
-
-        assert result is not None
-        assert result["source_uri"] == "https://github.com/myorg/myrepo"
-        assert result["source_file"] == "deploy/Dockerfile.prod"
-    finally:
-        ecr_layers.batch_get_manifest = original_batch_get_manifest
-        ecr_layers.get_blob_json_via_presigned = original_get_blob
-
-
 @pytest.mark.asyncio
 @patch(
     "cartography.intel.aws.ecr_image_layers.get_blob_json_via_presigned",
@@ -645,15 +350,15 @@ async def test_fetch_image_layers_async_handles_manifest_list(
     mock_get_blob_json,
 ):
     repo_image = {
-        "uri": "000000000000.dkr.ecr.us-east-1.amazonaws.com/subimage-shared:multi",
+        "uri": "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-shared:multi",
         "imageDigest": "sha256:indexdigest000000000000000000000000000000000000000000000000000000000000",
-        "repo_uri": "000000000000.dkr.ecr.us-east-1.amazonaws.com/subimage-shared",
+        "repo_uri": "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-shared",
     }
 
     manifest_lookup = {
         repo_image["imageDigest"]: (
             test_data.MULTI_ARCH_INDEX,
-            ecr_layers.ECR_OCI_INDEX_MT,
+            "application/vnd.oci.image.index.v1+json",
         ),
         "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": (
             test_data.MULTI_ARCH_AMD64_MANIFEST,
@@ -689,7 +394,7 @@ async def test_fetch_image_layers_async_handles_manifest_list(
 
     mock_get_blob_json.side_effect = fake_get_blob_json
 
-    image_layers_data, digest_map, history_map, attestation_map = (
+    image_layers_data, digest_map, history_map = (
         await ecr_layers.fetch_image_layers_async(
             MagicMock(),
             [repo_image],
@@ -712,19 +417,6 @@ async def test_fetch_image_layers_async_handles_manifest_list(
     # Verify history_map is populated (may be empty if test data doesn't include history)
     assert isinstance(history_map, dict)
 
-    # Verify attestation data is extracted and mapped to child AMD64 image
-    # The attestation in MULTI_ARCH_INDEX attests to the AMD64 image (line 108 of test_data)
-    expected_child_uri = f"000000000000.dkr.ecr.us-east-1.amazonaws.com/subimage-shared@{test_data.MANIFEST_LIST_AMD64_DIGEST}"
-    assert (
-        expected_child_uri in attestation_map
-    ), "Attestation data should be mapped to child image!"
-    assert (
-        attestation_map[expected_child_uri]["parent_image_digest"]
-        == "sha256:parent1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
-    )
-    # Verify child digest is in digest_map too
-    assert digest_map[expected_child_uri] == test_data.MANIFEST_LIST_AMD64_DIGEST
-
 
 @pytest.mark.asyncio
 @patch(
@@ -737,9 +429,9 @@ async def test_fetch_image_layers_async_skips_attestation_only(
     mock_get_blob_json,
 ):
     repo_image = {
-        "uri": "000000000000.dkr.ecr.us-east-1.amazonaws.com/subimage-shared:attestation",
+        "uri": "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-shared:attestation",
         "imageDigest": "sha256:attestationindex0000000000000000000000000000000000000000000000000000",
-        "repo_uri": "000000000000.dkr.ecr.us-east-1.amazonaws.com/subimage-shared",
+        "repo_uri": "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-shared",
     }
 
     mock_batch_get_manifest.return_value = (
@@ -747,7 +439,7 @@ async def test_fetch_image_layers_async_skips_attestation_only(
         ecr_layers.ECR_OCI_MANIFEST_MT,
     )
 
-    image_layers_data, digest_map, history_map, attestation_map = (
+    image_layers_data, digest_map, history_map = (
         await ecr_layers.fetch_image_layers_async(
             MagicMock(),
             [repo_image],
@@ -904,8 +596,6 @@ def test_sync_layers_preserves_multi_arch_image_properties(
             f"000000000000.dkr.ecr.us-east-1.amazonaws.com/multi-arch-repository@{test_data.MANIFEST_LIST_ARM64_DIGEST}": test_data.MANIFEST_LIST_ARM64_DIGEST,
         },
         # history_by_diff_id (empty)
-        {},
-        # image_attestation_map (empty)
         {},
     )
 

--- a/tests/integration/cartography/intel/aws/test_ecr_provenance.py
+++ b/tests/integration/cartography/intel/aws/test_ecr_provenance.py
@@ -1,0 +1,500 @@
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+import cartography.intel.aws.ecr
+import cartography.intel.aws.ecr_provenance
+import tests.data.aws.ecr as test_data
+from tests.integration.cartography.intel.aws.common import create_test_account
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_ACCOUNT_ID = "000000000000"
+TEST_REGION = "us-east-1"
+TEST_UPDATE_TAG = 123456789
+
+
+def _load_example_ecr_images(neo4j_session):
+    repository = test_data.DESCRIBE_REPOSITORIES["repositories"][0]
+    repo_uri = repository["repositoryUri"]
+    parent_digest = (
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    )
+    child_digest = (
+        "sha256:0000000000000000000000000000000000000000000000000000000000000001"
+    )
+    repo_data = {
+        repo_uri: [
+            {
+                "imageDigest": parent_digest,
+                "imageTag": "1",
+            },
+            {
+                "imageDigest": child_digest,
+                "imageTag": "2",
+            },
+        ],
+    }
+
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    cartography.intel.aws.ecr.load_ecr_repositories(
+        neo4j_session,
+        [repository],
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+    repo_images, ecr_images = cartography.intel.aws.ecr.transform_ecr_repository_images(
+        repo_data
+    )
+    cartography.intel.aws.ecr.load_ecr_repository_images(
+        neo4j_session,
+        repo_images,
+        ecr_images,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+    return parent_digest, child_digest
+
+
+def test_loads_ecr_image_provenance_and_built_from_relationship(neo4j_session):
+    parent_digest, child_digest = _load_example_ecr_images(neo4j_session)
+
+    provenance_items = [
+        {
+            "imageDigest": child_digest,
+            "parent_image_uri": "pkg:docker/000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository@1",
+            "parent_image_digest": parent_digest,
+            "source_uri": "https://github.com/example/repo",
+            "source_revision": "abc123",
+            "invocation_uri": "https://github.com/example/repo",
+            "invocation_workflow": ".github/workflows/build.yaml",
+            "invocation_run_number": "1001",
+            "source_file": "Dockerfile",
+            "from_attestation": True,
+            "confidence": "explicit",
+        },
+    ]
+
+    cartography.intel.aws.ecr_provenance.load_ecr_image_provenance(
+        neo4j_session,
+        provenance_items,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+    cartography.intel.aws.ecr_provenance.load_ecr_image_parent_relationships(
+        neo4j_session,
+        provenance_items,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "ECRImage",
+        ["digest", "source_uri", "invocation_workflow"],
+    ) >= {
+        (
+            child_digest,
+            "https://github.com/example/repo",
+            ".github/workflows/build.yaml",
+        ),
+    }
+    assert check_rels(
+        neo4j_session,
+        "ECRImage",
+        "id",
+        "ECRImage",
+        "id",
+        "BUILT_FROM",
+        rel_direction_right=True,
+    ) >= {(child_digest, parent_digest)}
+
+
+def test_cleanup_removes_stale_ecr_image_provenance(neo4j_session):
+    parent_digest, child_digest = _load_example_ecr_images(neo4j_session)
+
+    provenance_items = [
+        {
+            "imageDigest": child_digest,
+            "parent_image_uri": "pkg:docker/000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository@1",
+            "parent_image_digest": parent_digest,
+            "source_uri": "https://github.com/example/repo",
+            "source_revision": "abc123",
+            "invocation_uri": "https://github.com/example/repo",
+            "invocation_workflow": ".github/workflows/build.yaml",
+            "invocation_run_number": "1001",
+            "source_file": "Dockerfile",
+            "from_attestation": True,
+            "confidence": "explicit",
+        },
+    ]
+
+    cartography.intel.aws.ecr_provenance.load_ecr_image_provenance(
+        neo4j_session,
+        provenance_items,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+    cartography.intel.aws.ecr_provenance.load_ecr_image_parent_relationships(
+        neo4j_session,
+        provenance_items,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+    cartography.intel.aws.ecr_provenance.cleanup(
+        neo4j_session,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG + 1,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "ECRImage",
+        ["digest", "source_uri"],
+    ) >= {
+        (child_digest, None),
+    }
+    assert (
+        child_digest,
+        parent_digest,
+    ) not in check_rels(
+        neo4j_session,
+        "ECRImage",
+        "id",
+        "ECRImage",
+        "id",
+        "BUILT_FROM",
+        rel_direction_right=True,
+    )
+
+
+def test_transform_ecr_image_provenance_sorts_output():
+    transformed = cartography.intel.aws.ecr_provenance.transform_ecr_image_provenance(
+        {
+            "sha256:b": {"source_uri": "https://github.com/example/b"},
+            "sha256:a": {"source_uri": "https://github.com/example/a"},
+        }
+    )
+
+    assert [item["imageDigest"] for item in transformed] == ["sha256:a", "sha256:b"]
+    assert all(item["from_attestation"] is True for item in transformed)
+    assert all(item["confidence"] == "explicit" for item in transformed)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "parent_uri,parent_digest",
+    [
+        (
+            "pkg:docker/123456789012.dkr.ecr.us-east-1.amazonaws.com/base-image@v1.0",
+            "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        ),
+        (
+            "pkg:oci/myregistry.azurecr.io/base-image@v1.0",
+            "sha256:abc123def456",
+        ),
+        (
+            "oci://harbor.example.com/library/alpine@sha256:xyz789",
+            "sha256:xyz789abc",
+        ),
+    ],
+)
+async def test_extract_provenance_from_attestation_uri_schemes(
+    parent_uri, parent_digest
+):
+    mock_ecr_client = MagicMock()
+    mock_http_client = AsyncMock()
+
+    attestation_manifest = (
+        {
+            "layers": [
+                {"mediaType": "application/vnd.in-toto+json", "digest": "sha256:def456"}
+            ]
+        },
+        "application/vnd.oci.image.manifest.v1+json",
+    )
+    attestation_blob = {
+        "predicate": {
+            "materials": [
+                {
+                    "uri": parent_uri,
+                    "digest": {"sha256": parent_digest.removeprefix("sha256:")},
+                },
+            ]
+        }
+    }
+
+    original_batch_get_manifest = (
+        cartography.intel.aws.ecr_provenance.batch_get_manifest
+    )
+    original_get_blob = cartography.intel.aws.ecr_provenance.get_blob_json_via_presigned
+    cartography.intel.aws.ecr_provenance.batch_get_manifest = AsyncMock(
+        return_value=attestation_manifest
+    )
+    cartography.intel.aws.ecr_provenance.get_blob_json_via_presigned = AsyncMock(
+        return_value=attestation_blob
+    )
+
+    try:
+        result = await cartography.intel.aws.ecr_provenance._extract_provenance_from_attestation(
+            mock_ecr_client,
+            "test-repo",
+            "sha256:attestation",
+            mock_http_client,
+        )
+    finally:
+        cartography.intel.aws.ecr_provenance.batch_get_manifest = (
+            original_batch_get_manifest
+        )
+        cartography.intel.aws.ecr_provenance.get_blob_json_via_presigned = (
+            original_get_blob
+        )
+
+    assert result is not None
+    assert result["parent_image_uri"] == parent_uri
+    assert result["parent_image_digest"] == parent_digest
+
+
+@pytest.mark.asyncio
+async def test_extract_provenance_from_attestation_with_source_info():
+    mock_ecr_client = MagicMock()
+    mock_http_client = AsyncMock()
+
+    attestation_manifest = (
+        {
+            "layers": [
+                {"mediaType": "application/vnd.in-toto+json", "digest": "sha256:def456"}
+            ]
+        },
+        "application/vnd.oci.image.manifest.v1+json",
+    )
+    attestation_blob = {
+        "predicate": {
+            "materials": [
+                {
+                    "uri": "pkg:docker/base-image@v1.0",
+                    "digest": {"sha256": "parentdigest123"},
+                },
+            ],
+            "invocation": {
+                "environment": {
+                    "github_repository": "exampleco/example-repo",
+                    "github_workflow_ref": "exampleco/example-repo/.github/workflows/build.yaml@refs/heads/main",
+                    "github_run_number": "1001",
+                }
+            },
+            "metadata": {
+                "https://mobyproject.org/buildkit@v1#metadata": {
+                    "vcs": {
+                        "source": "https://github.com/exampleco/example-repo",
+                        "revision": "abc123def456",
+                    }
+                }
+            },
+        }
+    }
+
+    original_batch_get_manifest = (
+        cartography.intel.aws.ecr_provenance.batch_get_manifest
+    )
+    original_get_blob = cartography.intel.aws.ecr_provenance.get_blob_json_via_presigned
+    cartography.intel.aws.ecr_provenance.batch_get_manifest = AsyncMock(
+        return_value=attestation_manifest
+    )
+    cartography.intel.aws.ecr_provenance.get_blob_json_via_presigned = AsyncMock(
+        return_value=attestation_blob
+    )
+
+    try:
+        result = await cartography.intel.aws.ecr_provenance._extract_provenance_from_attestation(
+            mock_ecr_client,
+            "test-repo",
+            "sha256:attestation",
+            mock_http_client,
+        )
+    finally:
+        cartography.intel.aws.ecr_provenance.batch_get_manifest = (
+            original_batch_get_manifest
+        )
+        cartography.intel.aws.ecr_provenance.get_blob_json_via_presigned = (
+            original_get_blob
+        )
+
+    assert result is not None
+    assert result["parent_image_uri"] == "pkg:docker/base-image@v1.0"
+    assert result["parent_image_digest"] == "sha256:parentdigest123"
+    assert result["source_uri"] == "https://github.com/exampleco/example-repo"
+    assert result["source_revision"] == "abc123def456"
+    assert result["invocation_uri"] == "https://github.com/exampleco/example-repo"
+    assert result["invocation_workflow"] == ".github/workflows/build.yaml"
+    assert result["invocation_run_number"] == "1001"
+    assert result["source_file"] == "Dockerfile"
+
+
+@pytest.mark.asyncio
+async def test_extract_provenance_source_file_with_config_source():
+    mock_ecr_client = MagicMock()
+    mock_http_client = AsyncMock()
+
+    attestation_manifest = (
+        {
+            "layers": [
+                {"mediaType": "application/vnd.in-toto+json", "digest": "sha256:def456"}
+            ]
+        },
+        "application/vnd.oci.image.manifest.v1+json",
+    )
+    attestation_blob = {
+        "predicate": {
+            "invocation": {
+                "configSource": {
+                    "entryPoint": "Dockerfile.prod",
+                },
+                "environment": {
+                    "github_repository": "myorg/myrepo",
+                    "github_workflow_ref": "myorg/myrepo/.github/workflows/build.yaml@refs/heads/main",
+                },
+            },
+            "metadata": {
+                "https://mobyproject.org/buildkit@v1#metadata": {
+                    "vcs": {
+                        "source": "https://github.com/myorg/myrepo",
+                        "localdir:dockerfile": "./deploy",
+                    }
+                }
+            },
+        }
+    }
+
+    original_batch_get_manifest = (
+        cartography.intel.aws.ecr_provenance.batch_get_manifest
+    )
+    original_get_blob = cartography.intel.aws.ecr_provenance.get_blob_json_via_presigned
+    cartography.intel.aws.ecr_provenance.batch_get_manifest = AsyncMock(
+        return_value=attestation_manifest
+    )
+    cartography.intel.aws.ecr_provenance.get_blob_json_via_presigned = AsyncMock(
+        return_value=attestation_blob
+    )
+
+    try:
+        result = await cartography.intel.aws.ecr_provenance._extract_provenance_from_attestation(
+            mock_ecr_client,
+            "test-repo",
+            "sha256:attestation",
+            mock_http_client,
+        )
+    finally:
+        cartography.intel.aws.ecr_provenance.batch_get_manifest = (
+            original_batch_get_manifest
+        )
+        cartography.intel.aws.ecr_provenance.get_blob_json_via_presigned = (
+            original_get_blob
+        )
+
+    assert result is not None
+    assert result["source_uri"] == "https://github.com/myorg/myrepo"
+    assert result["source_file"] == "deploy/Dockerfile.prod"
+
+
+@pytest.mark.asyncio
+async def test_extract_provenance_slsa_v1_format():
+    mock_ecr_client = MagicMock()
+    mock_http_client = AsyncMock()
+
+    attestation_manifest = (
+        {
+            "layers": [
+                {"mediaType": "application/vnd.in-toto+json", "digest": "sha256:def456"}
+            ]
+        },
+        "application/vnd.oci.image.manifest.v1+json",
+    )
+    attestation_blob = {
+        "predicateType": "https://slsa.dev/provenance/v1",
+        "predicate": {
+            "buildDefinition": {
+                "resolvedDependencies": [
+                    {
+                        "uri": "pkg:docker/111111111111.dkr.ecr.us-east-1.amazonaws.com/base-images@examplebase?platform=linux%2Famd64",
+                        "digest": {
+                            "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                    },
+                    {
+                        "uri": "pkg:docker/docker/dockerfile@1.7",
+                        "digest": {
+                            "sha256": "a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e"
+                        },
+                    },
+                ],
+                "externalParameters": {
+                    "configSource": {"path": "Dockerfile"},
+                },
+            },
+            "runDetails": {
+                "builder": {
+                    "id": "https://github.com/exampleco/example-repo/actions/runs/123456789/attempts/1",
+                },
+                "metadata": {
+                    "buildkit_metadata": {
+                        "vcs": {
+                            "source": "https://github.com/exampleco/example-repo",
+                            "revision": "abcdef0123456789abcdef0123456789abcdef01",
+                            "localdir:context": "example-service",
+                            "localdir:dockerfile": "example-service",
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+    original_batch_get_manifest = (
+        cartography.intel.aws.ecr_provenance.batch_get_manifest
+    )
+    original_get_blob = cartography.intel.aws.ecr_provenance.get_blob_json_via_presigned
+    cartography.intel.aws.ecr_provenance.batch_get_manifest = AsyncMock(
+        return_value=attestation_manifest
+    )
+    cartography.intel.aws.ecr_provenance.get_blob_json_via_presigned = AsyncMock(
+        return_value=attestation_blob
+    )
+
+    try:
+        result = await cartography.intel.aws.ecr_provenance._extract_provenance_from_attestation(
+            mock_ecr_client,
+            "example-service",
+            "sha256:attestation",
+            mock_http_client,
+        )
+    finally:
+        cartography.intel.aws.ecr_provenance.batch_get_manifest = (
+            original_batch_get_manifest
+        )
+        cartography.intel.aws.ecr_provenance.get_blob_json_via_presigned = (
+            original_get_blob
+        )
+
+    assert result is not None
+    assert (
+        result["parent_image_uri"]
+        == "pkg:docker/111111111111.dkr.ecr.us-east-1.amazonaws.com/base-images@examplebase?platform=linux%2Famd64"
+    )
+    assert (
+        result["parent_image_digest"]
+        == "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    )
+    assert result["source_uri"] == "https://github.com/exampleco/example-repo"
+    assert result["source_revision"] == "abcdef0123456789abcdef0123456789abcdef01"
+    assert result["invocation_uri"] == "https://github.com/exampleco/example-repo"
+    assert result["source_file"] == "example-service/Dockerfile"

--- a/tests/integration/cartography/intel/aws/test_init.py
+++ b/tests/integration/cartography/intel/aws/test_init.py
@@ -39,8 +39,8 @@ def make_aws_sync_test_kwargs(
     Returns a dummy dict of kwargs to use for AWS sync functions.
     The keys of this dict are also used to ensure that parameter names for all sync functions are standardized; see
     `test_standardize_aws_sync_kwargs`.
-    Note: aioboto3_session is NOT included here because it's only used by ecr:image_layers, which has a different
-    signature from the standard AWS sync functions.
+    Note: aioboto3_session is not included here because modules that use it expose it as
+    an extra/defaulted argument or use a non-standard signature handled separately.
     """
     return {
         "neo4j_session": neo4j_session,
@@ -309,6 +309,12 @@ def test_sync_one_account_all_sync_functions(
 
     # Test that ALL syncs got called.
     for sync_name in cartography.intel.aws.resources.RESOURCE_FUNCTIONS.keys():
+        if sync_name == "ecr:provenance":
+            AWS_RESOURCE_FUNCTIONS_STUB[sync_name].assert_called_with(
+                **aws_sync_test_kwargs,
+                aioboto3_session=mock_aioboto3_session(),
+            )
+            continue
         # ecr:image_layers has a different signature (uses aioboto3_session instead of boto3_session)
         # and is called with positional args in _sync_one_account
         if sync_name == "ecr:image_layers":
@@ -403,7 +409,7 @@ def test_standardize_aws_sync_kwargs():
     called with positional args in _sync_one_account, so it's excluded from this validation.
     """
     aws_sync_test_kwargs = make_aws_sync_test_kwargs(mock.MagicMock, mock.MagicMock)
-    # aioboto3_session is used only by ecr:image_layers
+    # aioboto3_session is used by ECR deep-inspection modules
     ecr_image_layers_kwargs = [
         "neo4j_session",
         "aioboto3_session",

--- a/tests/unit/cartography/intel/aws/test_ecr_image_layers.py
+++ b/tests/unit/cartography/intel/aws/test_ecr_image_layers.py
@@ -10,63 +10,10 @@ from botocore.exceptions import ClientError
 import tests.data.aws.ecr as test_data
 from cartography.intel.aws.ecr_image_layers import batch_get_manifest
 from cartography.intel.aws.ecr_image_layers import ECRLayerFetchTransientError
-from cartography.intel.aws.ecr_image_layers import extract_repo_uri_from_image_uri
 from cartography.intel.aws.ecr_image_layers import fetch_image_layers_async
 from cartography.intel.aws.ecr_image_layers import get_blob_json_via_presigned
 from cartography.intel.aws.ecr_image_layers import transform_ecr_image_layers
 from cartography.intel.supply_chain import extract_workflow_path_from_ref
-
-
-@pytest.mark.parametrize(
-    "input_uri,expected_repo_uri",
-    [
-        # Digest-based URI
-        (
-            "123456789.dkr.ecr.us-east-1.amazonaws.com/my-repo@sha256:abcdef123456789",
-            "123456789.dkr.ecr.us-east-1.amazonaws.com/my-repo",
-        ),
-        # Tag-based URI
-        (
-            "123456789.dkr.ecr.us-east-1.amazonaws.com/my-repo:v1.0.0",
-            "123456789.dkr.ecr.us-east-1.amazonaws.com/my-repo",
-        ),
-        # No tag or digest
-        (
-            "123456789.dkr.ecr.us-east-1.amazonaws.com/my-repo",
-            "123456789.dkr.ecr.us-east-1.amazonaws.com/my-repo",
-        ),
-        # Complex repository name with slashes
-        (
-            "123456789.dkr.ecr.us-west-2.amazonaws.com/team/service/component:latest",
-            "123456789.dkr.ecr.us-west-2.amazonaws.com/team/service/component",
-        ),
-        # Tag with multiple colons in name
-        (
-            "123456789.dkr.ecr.us-east-1.amazonaws.com/namespace/my-repo:v1.0.0",
-            "123456789.dkr.ecr.us-east-1.amazonaws.com/namespace/my-repo",
-        ),
-        # Port in tag (edge case)
-        (
-            "123456789.dkr.ecr.eu-west-1.amazonaws.com/app:build-123",
-            "123456789.dkr.ecr.eu-west-1.amazonaws.com/app",
-        ),
-        # Edge cases
-        # Empty string
-        ("", ""),
-        # Only digest marker (malformed)
-        ("@sha256:", ""),
-        # Only colon (malformed)
-        (":", ""),
-        # Multiple @ symbols (should split on first)
-        ("repo@sha256:abc@def", "repo"),
-        # Mixed digest and tag markers (digest takes precedence)
-        ("repo@sha256:abc:tag", "repo"),
-    ],
-)
-def test_extract_repo_uri_from_image_uri(input_uri, expected_repo_uri):
-    """Test the extract_repo_uri_from_image_uri helper function."""
-    actual_repo_uri = extract_repo_uri_from_image_uri(input_uri)
-    assert actual_repo_uri == expected_repo_uri
 
 
 def test_transform_ecr_image_layers_missing_digest_fails():
@@ -272,13 +219,11 @@ def test_fetch_image_layers_async_skips_only_transient_image_failure(mocker):
         new=AsyncMock(return_value=test_data.SAMPLE_CONFIG_BLOB),
     )
 
-    image_layers_data, image_digest_map, history_by_diff_id, image_attestation_map = (
-        asyncio.run(
-            fetch_image_layers_async(
-                AsyncMock(),
-                repo_images_list,
-                max_concurrent=2,
-            )
+    image_layers_data, image_digest_map, history_by_diff_id = asyncio.run(
+        fetch_image_layers_async(
+            AsyncMock(),
+            repo_images_list,
+            max_concurrent=2,
         )
     )
 
@@ -286,12 +231,16 @@ def test_fetch_image_layers_async_skips_only_transient_image_failure(mocker):
     assert f"{repo_uri}:good" in image_layers_data
     assert image_digest_map == {f"{repo_uri}:good": "sha256:good"}
     assert isinstance(history_by_diff_id, dict)
-    assert image_attestation_map == {}
 
 
-def test_fetch_image_layers_async_skips_manifest_list_image_when_child_fetch_fails(
+def test_fetch_image_layers_async_still_processes_successful_children_when_one_child_fails_transiently(
     mocker,
 ):
+    """When one child manifest in a manifest list fails transiently, the other
+    children should still be processed.  Before the fix, removing
+    ``return_exceptions=True`` from the child ``asyncio.gather`` caused the
+    entire manifest list to be skipped when *any* child (e.g. the attestation
+    manifest) hit a transient error."""
     repo_uri = "000000000000.dkr.ecr.us-east-1.amazonaws.com/example-repository"
     repo_images_list = [
         {
@@ -326,20 +275,18 @@ def test_fetch_image_layers_async_skips_manifest_list_image_when_child_fetch_fai
         new=AsyncMock(return_value=test_data.SAMPLE_CONFIG_BLOB),
     )
 
-    image_layers_data, image_digest_map, history_by_diff_id, image_attestation_map = (
-        asyncio.run(
-            fetch_image_layers_async(
-                AsyncMock(),
-                repo_images_list,
-                max_concurrent=4,
-            )
+    image_layers_data, image_digest_map, history_by_diff_id = asyncio.run(
+        fetch_image_layers_async(
+            AsyncMock(),
+            repo_images_list,
+            max_concurrent=4,
         )
     )
 
-    assert image_layers_data == {}
-    assert image_digest_map == {}
-    assert history_by_diff_id == {}
-    assert image_attestation_map == {}
+    # The amd64 child succeeded so layers should still be present
+    assert f"{repo_uri}:manifest-list" in image_layers_data
+    assert image_digest_map == {f"{repo_uri}:manifest-list": "sha256:manifest-list"}
+    assert isinstance(history_by_diff_id, dict)
 
 
 def test_transform_layers_creates_graph_structure():
@@ -456,87 +403,6 @@ def test_transform_layers_creates_graph_structure():
         (m["imageDigest"], tuple(m["layer_diff_ids"])) for m in memberships
     }
     assert observed_memberships == expected_memberships
-
-
-def test_transform_ecr_image_layers_with_attestation_data():
-    """Test that attestation data is correctly added to memberships."""
-    image_layers_data = {
-        "123456789012.dkr.ecr.us-east-1.amazonaws.com/backend:latest": {
-            "linux/amd64": [
-                "sha256:1111111111111111111111111111111111111111111111111111111111111111",
-                "sha256:2222222222222222222222222222222222222222222222222222222222222222",
-            ]
-        }
-    }
-
-    image_digest_map = {
-        "123456789012.dkr.ecr.us-east-1.amazonaws.com/backend:latest": "sha256:aaaa000000000000000000000000000000000000000000000000000000000001"
-    }
-
-    image_attestation_map = {
-        "123456789012.dkr.ecr.us-east-1.amazonaws.com/backend:latest": {
-            "parent_image_uri": "pkg:docker/123456789012.dkr.ecr.us-east-1.amazonaws.com/base-images@abc123",
-            "parent_image_digest": "sha256:bbbb000000000000000000000000000000000000000000000000000000000001",
-        }
-    }
-
-    layers, memberships = transform_ecr_image_layers(
-        image_layers_data,
-        image_digest_map,
-        None,  # history_by_diff_id
-        image_attestation_map,
-    )
-
-    # Should have 2 layers
-    assert len(layers) == 2
-
-    # Should have 1 membership with attestation data
-    assert len(memberships) == 1
-    membership = memberships[0]
-
-    assert (
-        membership["imageDigest"]
-        == "sha256:aaaa000000000000000000000000000000000000000000000000000000000001"
-    )
-    assert len(membership["layer_diff_ids"]) == 2
-    assert (
-        membership["parent_image_uri"]
-        == "pkg:docker/123456789012.dkr.ecr.us-east-1.amazonaws.com/base-images@abc123"
-    )
-    assert (
-        membership["parent_image_digest"]
-        == "sha256:bbbb000000000000000000000000000000000000000000000000000000000001"
-    )
-
-
-def test_transform_ecr_image_layers_without_attestation_data():
-    """Test that transform works without attestation data (backward compatibility)."""
-    image_layers_data = {
-        "123456789012.dkr.ecr.us-east-1.amazonaws.com/backend:latest": {
-            "linux/amd64": [
-                "sha256:1111111111111111111111111111111111111111111111111111111111111111",
-            ]
-        }
-    }
-
-    image_digest_map = {
-        "123456789012.dkr.ecr.us-east-1.amazonaws.com/backend:latest": "sha256:aaaa000000000000000000000000000000000000000000000000000000000001"
-    }
-
-    # No attestation map provided
-    layers, memberships = transform_ecr_image_layers(
-        image_layers_data,
-        image_digest_map,
-    )
-
-    # Should work without errors
-    assert len(layers) == 1
-    assert len(memberships) == 1
-
-    membership = memberships[0]
-    # Should NOT have parent_image_uri or parent_image_digest
-    assert "parent_image_uri" not in membership
-    assert "parent_image_digest" not in membership
 
 
 def test_transform_ecr_image_layers_with_history():


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional changes)

### Summary
This follow-up PR separates ECR inventory, provenance, and layer enrichment into distinct sync phases.

It keeps `ecr` focused on repository/image inventory and manifest relationships, moves attestation parsing and `BUILT_FROM` creation into a new `ecr:provenance` phase, and keeps `ecr:image_layers` focused on layer enrichment only. It also extracts shared ECR manifest/blob fetch helpers into `ecr_shared.py` so the two deep-inspection phases do not depend on each other.

The branch also includes follow-up cleanup fixes for the split:
- preserve stale `HAS_LAYER` cleanup
- clear legacy provenance properties left behind on upgraded graphs

### Related issues or links
- Follow-up to #2525

### How was this tested?
- `uv run pytest tests/integration/cartography/intel/aws/test_ecr.py tests/integration/cartography/intel/aws/test_ecr_provenance.py`
- `uv run pytest tests/integration/cartography/intel/aws/test_ecr_layers.py tests/integration/cartography/intel/aws/test_init.py`

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

### Notes for reviewers
This is intentionally separate from #2525. The smaller PR keeps the production fix narrowly scoped, while this branch carries the larger module-boundary change so it can be reviewed on its own terms.
