### PR TITLE
fix(graph): order matchlink cleanup index by scope first

### DIFF
--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -1458,7 +1458,7 @@ def build_create_index_queries_for_matchlink(
         >>> # Returns:
         >>> # - CREATE INDEX FOR (n:User) ON (n.id)
         >>> # - CREATE INDEX FOR (n:Role) ON (n.name)
-        >>> # - CREATE INDEX FOR ()-[r:HAS_ROLE]->() ON (r.lastupdated, r._sub_resource_label, r._sub_resource_id)
+        >>> # - CREATE INDEX FOR ()-[r:HAS_ROLE]->() ON (r._sub_resource_label, r._sub_resource_id, r.lastupdated)
 
         >>> # Missing source node matcher
         >>> incomplete_rel = CartographyRelSchema(target_node_label='Role', ...)
@@ -1499,11 +1499,12 @@ def build_create_index_queries_for_matchlink(
             ),
         )
 
-    # Create a composite index for the relationship between the source and target nodes.
-    # https://neo4j.com/docs/cypher-manual/4.3/indexes-for-search-performance/#administration-indexes-create-a-composite-index-for-relationships
+    # Create a composite relationship index that matches the cleanup predicate shape.
+    # Matchlink cleanup filters by sub-resource equality first and then uses lastupdated
+    # as a trailing inequality, so that order avoids broad scans under parallel sync load.
     rel_index_template = Template(
         "CREATE INDEX IF NOT EXISTS FOR ()$rel_direction[r:$RelLabel]$rel_direction_end() "
-        "ON (r.lastupdated, r._sub_resource_label, r._sub_resource_id);",
+        "ON (r._sub_resource_label, r._sub_resource_id, r.lastupdated);",
     )
     if rel_schema.direction == LinkDirection.INWARD:
         result.append(

--- a/tests/unit/cartography/graph/test_matchlink.py
+++ b/tests/unit/cartography/graph/test_matchlink.py
@@ -76,7 +76,7 @@ def test_build_create_index_queries_for_matchlink():
     expected_queries = {
         "CREATE INDEX IF NOT EXISTS FOR (n:AWSPrincipal) ON (n.principal_arn);",
         "CREATE INDEX IF NOT EXISTS FOR (n:S3Bucket) ON (n.name);",
-        "CREATE INDEX IF NOT EXISTS FOR ()-[r:CAN_ACCESS]->() ON (r.lastupdated, r._sub_resource_label, r._sub_resource_id);",
+        "CREATE INDEX IF NOT EXISTS FOR ()-[r:CAN_ACCESS]->() ON (r._sub_resource_label, r._sub_resource_id, r.lastupdated);",
     }
 
     # Assert: compare the list of index queries


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
This fixes a query-planning problem in matchlink cleanup that becomes visible during parallel sync workloads, especially in the GCP permission-relationship path.

The cleanup query for matchlinks scopes by `_sub_resource_label` and `_sub_resource_id` first, and then applies `lastupdated <> $UPDATE_TAG` to remove stale edges. Cartography was generating the relationship composite index in the opposite order, with `lastupdated` first. Neo4j's index documentation explicitly calls out that equality predicates should precede the range predicate in a composite index, and that predicates after the range predicate may fall back to filtering instead of indexed lookup.

In practice, that means cleanup can degrade from a scoped seek into a much broader relationship scan. Under parallel project syncs, those longer cleanup transactions hold locks longer, increase write pressure, and make commit-time connection loss more likely. That lines up with the Python driver's definition of `IncompleteCommit`: the client lost the connection while waiting for the commit response, leaving transaction outcome unknown.

This PR is intentionally small and only changes the generated relationship index order for matchlinks so the existing cleanup predicate shape can use the index the way Neo4j expects.


### Related issues or links
- N/A
- Neo4j Cypher Manual: composite indexes and range predicates: https://neo4j.com/docs/cypher-manual/4.3/query-tuning/indexes/
- Neo4j Python driver docs for `IncompleteCommit`: https://neo4j.com/docs/api/python-driver/current/api.html#neo4j.exceptions.IncompleteCommit
- Neo4j community guidance on heavy concurrent writes and lock contention: https://community.neo4j.com/t/neo4j-3-5-17-unstable-waiting-forever-for-a-lock/17523


### Breaking changes
None.


### How was this tested?
- `uv run --frozen pytest tests/unit/cartography/graph/test_matchlink.py`


### Checklist

#### General
- [ ] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.
- [ ] Screenshot showing the graph before and after changes.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
This description intentionally omits any tenant-specific sync identifiers or raw logs because the repro came from a private environment and Cartography is public.
