### PR TITLE
feat(jfrog): add Artifactory repositories intel module

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -65,6 +65,7 @@ PANEL_SENTRY = "Sentry Options"
 PANEL_SUBIMAGE = "SubImage Options"
 PANEL_SPACELIFT = "Spacelift Options"
 PANEL_JUMPCLOUD = "JumpCloud Options"
+PANEL_JFROG = "JFrog Options"
 PANEL_STATSD = "StatsD Metrics"
 PANEL_ANALYSIS = "Analysis Options"
 
@@ -88,6 +89,7 @@ MODULE_PANELS = {
     "cve": PANEL_CVE,
     "pagerduty": PANEL_PAGERDUTY,
     "jumpcloud": PANEL_JUMPCLOUD,
+    "jfrog": PANEL_JFROG,
     "lastpass": PANEL_LASTPASS,
     "bigfix": PANEL_BIGFIX,
     "duo": PANEL_DUO,
@@ -995,6 +997,36 @@ class CLI:
                     help="JumpCloud organization ID used as the tenant identifier.",
                     rich_help_panel=PANEL_JUMPCLOUD,
                     hidden=PANEL_JUMPCLOUD not in visible_panels,
+                ),
+            ] = None,
+            # =================================================================
+            # JFrog Options
+            # =================================================================
+            jfrog_artifactory_base_url: Annotated[
+                str | None,
+                typer.Option(
+                    "--jfrog-artifactory-base-url",
+                    help="JFrog Artifactory base URL (e.g. https://example.jfrog.io).",
+                    rich_help_panel=PANEL_JFROG,
+                    hidden=PANEL_JFROG not in visible_panels,
+                ),
+            ] = None,
+            jfrog_artifactory_token_env_var: Annotated[
+                str | None,
+                typer.Option(
+                    "--jfrog-artifactory-token-env-var",
+                    help="Environment variable name containing JFrog Artifactory access token.",
+                    rich_help_panel=PANEL_JFROG,
+                    hidden=PANEL_JFROG not in visible_panels,
+                ),
+            ] = None,
+            jfrog_artifactory_tenant_id: Annotated[
+                str | None,
+                typer.Option(
+                    "--jfrog-artifactory-tenant-id",
+                    help="Tenant ID for JFrog Artifactory (defaults to base URL).",
+                    rich_help_panel=PANEL_JFROG,
+                    hidden=PANEL_JFROG not in visible_panels,
                 ),
             ] = None,
             # =================================================================
@@ -1933,6 +1965,17 @@ class CLI:
                     jumpcloud_api_key_env_var,
                 )
                 jumpcloud_api_key = os.environ.get(jumpcloud_api_key_env_var)
+
+            # Read JFrog Artifactory token
+            jfrog_artifactory_token = None
+            if jfrog_artifactory_token_env_var:
+                logger.debug(
+                    "Reading token for JFrog Artifactory from environment variable %s",
+                    jfrog_artifactory_token_env_var,
+                )
+                jfrog_artifactory_token = os.environ.get(
+                    jfrog_artifactory_token_env_var
+                )
             # Read LastPass credentials
             lastpass_cid = None
             if lastpass_cid_env_var:
@@ -2294,6 +2337,9 @@ class CLI:
                 googleworkspace_config=googleworkspace_config,
                 jumpcloud_api_key=jumpcloud_api_key,
                 jumpcloud_org_id=jumpcloud_org_id,
+                jfrog_artifactory_base_url=jfrog_artifactory_base_url,
+                jfrog_artifactory_token=jfrog_artifactory_token,
+                jfrog_artifactory_tenant_id=jfrog_artifactory_tenant_id,
                 lastpass_cid=lastpass_cid,
                 lastpass_provhash=lastpass_provhash,
                 bigfix_username=bigfix_username,

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -283,6 +283,12 @@ class Config:
     :param jumpcloud_api_key: JumpCloud API key for authentication. Optional.
     :type jumpcloud_org_id: str
     :param jumpcloud_org_id: JumpCloud organization ID used as the tenant identifier. Optional.
+    :type jfrog_artifactory_base_url: str
+    :param jfrog_artifactory_base_url: JFrog Artifactory base URL. Optional.
+    :type jfrog_artifactory_token: str
+    :param jfrog_artifactory_token: JFrog Artifactory access token. Optional.
+    :type jfrog_artifactory_tenant_id: str
+    :param jfrog_artifactory_tenant_id: JFrog Artifactory tenant identifier. Optional.
     """
 
     def __init__(
@@ -425,6 +431,9 @@ class Config:
         ubuntu_security_api_url=None,
         jumpcloud_api_key=None,
         jumpcloud_org_id=None,
+        jfrog_artifactory_base_url=None,
+        jfrog_artifactory_token=None,
+        jfrog_artifactory_tenant_id=None,
         neo4j_connection_timeout=None,
         neo4j_keep_alive=None,
         neo4j_max_transaction_retry_time=None,
@@ -576,3 +585,6 @@ class Config:
         self.ubuntu_security_api_url = ubuntu_security_api_url
         self.jumpcloud_api_key = jumpcloud_api_key
         self.jumpcloud_org_id = jumpcloud_org_id
+        self.jfrog_artifactory_base_url = jfrog_artifactory_base_url
+        self.jfrog_artifactory_token = jfrog_artifactory_token
+        self.jfrog_artifactory_tenant_id = jfrog_artifactory_tenant_id

--- a/cartography/intel/jfrog/__init__.py
+++ b/cartography/intel/jfrog/__init__.py
@@ -1,0 +1,43 @@
+import logging
+
+import neo4j
+import requests
+
+from cartography.config import Config
+from cartography.intel.jfrog import repositories
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def start_jfrog_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
+    if not config.jfrog_artifactory_base_url or not config.jfrog_artifactory_token:
+        logger.info(
+            "JFrog Artifactory import is not configured - skipping this module. "
+            "Set --jfrog-artifactory-base-url and --jfrog-artifactory-token-env-var.",
+        )
+        return
+
+    tenant_id = config.jfrog_artifactory_tenant_id or config.jfrog_artifactory_base_url
+    common_job_parameters = {
+        "UPDATE_TAG": config.update_tag,
+        "TENANT_ID": tenant_id,
+    }
+
+    api_session = requests.Session()
+    api_session.headers.update(
+        {
+            "Authorization": f"Bearer {config.jfrog_artifactory_token}",
+            "Accept": "application/json",
+        }
+    )
+
+    repositories.sync(
+        neo4j_session,
+        api_session,
+        config.jfrog_artifactory_base_url,
+        tenant_id,
+        config.update_tag,
+        common_job_parameters,
+    )

--- a/cartography/intel/jfrog/repositories.py
+++ b/cartography/intel/jfrog/repositories.py
@@ -1,0 +1,153 @@
+import logging
+from typing import Any
+from urllib.parse import urlparse
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.models.jfrog.repository import JFrogArtifactoryRepositorySchema
+from cartography.models.jfrog.tenant import JFrogArtifactoryTenantSchema
+from cartography.util import backoff_handler
+from cartography.util import retries_with_backoff
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+_TIMEOUT = (60, 60)
+
+
+def _call_api(
+    api_session: requests.Session,
+    method: str,
+    url: str,
+) -> Any:
+    wrapped = retries_with_backoff(
+        func=_call_api_base,
+        exception_type=requests.exceptions.RequestException,
+        max_tries=5,
+        on_backoff=backoff_handler,
+    )
+    return wrapped(api_session, method, url)
+
+
+def _call_api_base(
+    api_session: requests.Session,
+    method: str,
+    url: str,
+) -> Any:
+    response = api_session.request(method=method, url=url, timeout=_TIMEOUT)
+    response.raise_for_status()
+    return response.json()
+
+
+@timeit
+def get_repositories(
+    api_session: requests.Session,
+    artifactory_base_url: str,
+) -> list[dict[str, Any]]:
+    list_url = f"{artifactory_base_url.rstrip('/')}/artifactory/api/repositories"
+    repositories: list[dict[str, Any]] = _call_api(api_session, "GET", list_url)
+
+    enriched: list[dict[str, Any]] = []
+    for repo in repositories:
+        key = repo.get("key")
+        if not key:
+            continue
+        details_url = (
+            f"{artifactory_base_url.rstrip('/')}/artifactory/api/repositories/{key}"
+        )
+        try:
+            details = _call_api(api_session, "GET", details_url)
+        except requests.exceptions.RequestException as e:
+            logger.warning("Failed to fetch details for repository %s: %s", key, e)
+            details = {}
+
+        enriched.append({**repo, **details})
+
+    return enriched
+
+
+def transform_repositories(
+    repositories: list[dict[str, Any]], tenant_id: str
+) -> list[dict[str, Any]]:
+    transformed: list[dict[str, Any]] = []
+    for repo in repositories:
+        key = repo.get("key")
+        if not key:
+            continue
+        transformed.append(
+            {
+                "id": f"{tenant_id}:{key}",
+                "key": key,
+                "description": repo.get("description"),
+                "package_type": repo.get("packageType") or repo.get("package_type"),
+                "repo_type": repo.get("type") or repo.get("repo_type"),
+                "url": repo.get("url"),
+                "project_key": repo.get("projectKey"),
+                "rclass": repo.get("rclass"),
+            }
+        )
+    return transformed
+
+
+@timeit
+def load_tenant(
+    neo4j_session: neo4j.Session,
+    tenant_id: str,
+    artifactory_base_url: str,
+    update_tag: int,
+) -> None:
+    parsed = urlparse(artifactory_base_url)
+    tenant_name = parsed.netloc or tenant_id
+    load(
+        neo4j_session,
+        JFrogArtifactoryTenantSchema(),
+        [{"id": tenant_id, "name": tenant_name, "base_url": artifactory_base_url}],
+        lastupdated=update_tag,
+    )
+
+
+@timeit
+def load_repositories(
+    neo4j_session: neo4j.Session,
+    repositories: list[dict[str, Any]],
+    tenant_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        JFrogArtifactoryRepositorySchema(),
+        repositories,
+        lastupdated=update_tag,
+        TENANT_ID=tenant_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(
+        JFrogArtifactoryRepositorySchema(), common_job_parameters
+    ).run(neo4j_session)
+    GraphJob.from_node_schema(JFrogArtifactoryTenantSchema(), common_job_parameters).run(
+        neo4j_session
+    )
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    artifactory_base_url: str,
+    tenant_id: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    repositories = get_repositories(api_session, artifactory_base_url)
+    transformed = transform_repositories(repositories, tenant_id)
+    load_tenant(neo4j_session, tenant_id, artifactory_base_url, update_tag)
+    load_repositories(neo4j_session, transformed, tenant_id, update_tag)
+    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/models/jfrog/__init__.py
+++ b/cartography/models/jfrog/__init__.py
@@ -1,0 +1,7 @@
+from cartography.models.jfrog.repository import JFrogArtifactoryRepositorySchema
+from cartography.models.jfrog.tenant import JFrogArtifactoryTenantSchema
+
+__all__ = [
+    "JFrogArtifactoryRepositorySchema",
+    "JFrogArtifactoryTenantSchema",
+]

--- a/cartography/models/jfrog/repository.py
+++ b/cartography/models/jfrog/repository.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.core.relationships import make_target_node_matcher
+
+
+@dataclass(frozen=True)
+class JFrogArtifactoryRepositoryNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", extra_index=True)
+    key: PropertyRef = PropertyRef("key")
+    description: PropertyRef = PropertyRef("description")
+    package_type: PropertyRef = PropertyRef("package_type")
+    repo_type: PropertyRef = PropertyRef("repo_type")
+    url: PropertyRef = PropertyRef("url")
+    project_key: PropertyRef = PropertyRef("project_key")
+    rclass: PropertyRef = PropertyRef("rclass")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class JFrogArtifactoryRepositoryToTenantRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:JFrogArtifactoryTenant)-[:RESOURCE]->(:JFrogArtifactoryRepository)
+class JFrogArtifactoryRepositoryToTenantRel(CartographyRelSchema):
+    target_node_label: str = "JFrogArtifactoryTenant"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("TENANT_ID", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: JFrogArtifactoryRepositoryToTenantRelProperties = (
+        JFrogArtifactoryRepositoryToTenantRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class JFrogArtifactoryRepositorySchema(CartographyNodeSchema):
+    label: str = "JFrogArtifactoryRepository"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ContainerRegistry"])
+    properties: JFrogArtifactoryRepositoryNodeProperties = (
+        JFrogArtifactoryRepositoryNodeProperties()
+    )
+    sub_resource_relationship: JFrogArtifactoryRepositoryToTenantRel = (
+        JFrogArtifactoryRepositoryToTenantRel()
+    )

--- a/cartography/models/jfrog/tenant.py
+++ b/cartography/models/jfrog/tenant.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+
+
+@dataclass(frozen=True)
+class JFrogArtifactoryTenantNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", extra_index=True)
+    name: PropertyRef = PropertyRef("name")
+    base_url: PropertyRef = PropertyRef("base_url")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class JFrogArtifactoryTenantSchema(CartographyNodeSchema):
+    label: str = "JFrogArtifactoryTenant"
+    properties: JFrogArtifactoryTenantNodeProperties = (
+        JFrogArtifactoryTenantNodeProperties()
+    )

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -31,6 +31,7 @@ import cartography.intel.googleworkspace
 import cartography.intel.gsuite
 import cartography.intel.jamf
 import cartography.intel.jumpcloud
+import cartography.intel.jfrog
 import cartography.intel.kandji
 import cartography.intel.keycloak
 import cartography.intel.kubernetes
@@ -85,6 +86,7 @@ TOP_LEVEL_MODULES: OrderedDict[str, Callable[..., None]] = OrderedDict(
         "keycloak": cartography.intel.keycloak.start_keycloak_ingestion,
         "kubernetes": cartography.intel.kubernetes.start_k8s_ingestion,
         "jumpcloud": cartography.intel.jumpcloud.start_jumpcloud_ingestion,
+        "jfrog": cartography.intel.jfrog.start_jfrog_ingestion,
         "lastpass": cartography.intel.lastpass.start_lastpass_ingestion,
         "bigfix": cartography.intel.bigfix.start_bigfix_ingestion,
         "duo": cartography.intel.duo.start_duo_ingestion,

--- a/tests/data/jfrog/repositories.py
+++ b/tests/data/jfrog/repositories.py
@@ -1,0 +1,20 @@
+JFROG_REPOSITORIES = [
+    {
+        "key": "docker-prod",
+        "type": "LOCAL",
+        "url": "https://example.jfrog.io/artifactory/docker-prod",
+        "packageType": "Docker",
+        "description": "Production docker images",
+        "projectKey": "PRJ",
+        "rclass": "local",
+    },
+    {
+        "key": "maven-remote",
+        "type": "REMOTE",
+        "url": "https://example.jfrog.io/artifactory/maven-remote",
+        "packageType": "Maven",
+        "description": "Remote Maven cache",
+        "projectKey": "PRJ",
+        "rclass": "remote",
+    },
+]

--- a/tests/integration/cartography/intel/jfrog/test_repositories.py
+++ b/tests/integration/cartography/intel/jfrog/test_repositories.py
@@ -1,0 +1,106 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.jfrog.repositories
+import tests.data.jfrog.repositories
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_TENANT_ID = "example-tenant"
+TEST_BASE_URL = "https://example.jfrog.io"
+
+
+def _ensure_local_neo4j_has_test_repositories(neo4j_session):
+    transformed = cartography.intel.jfrog.repositories.transform_repositories(
+        tests.data.jfrog.repositories.JFROG_REPOSITORIES,
+        TEST_TENANT_ID,
+    )
+    cartography.intel.jfrog.repositories.load_tenant(
+        neo4j_session,
+        TEST_TENANT_ID,
+        TEST_BASE_URL,
+        TEST_UPDATE_TAG,
+    )
+    cartography.intel.jfrog.repositories.load_repositories(
+        neo4j_session,
+        transformed,
+        TEST_TENANT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.jfrog.repositories,
+    "get_repositories",
+    return_value=tests.data.jfrog.repositories.JFROG_REPOSITORIES,
+)
+def test_load_jfrog_repositories(mock_api, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "TENANT_ID": TEST_TENANT_ID,
+    }
+
+    cartography.intel.jfrog.repositories.sync(
+        neo4j_session,
+        api_session,
+        TEST_BASE_URL,
+        TEST_TENANT_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    expected_tenant_nodes = {
+        (TEST_TENANT_ID, "example.jfrog.io", TEST_BASE_URL),
+    }
+    assert (
+        check_nodes(
+            neo4j_session,
+            "JFrogArtifactoryTenant",
+            ["id", "name", "base_url"],
+        )
+        == expected_tenant_nodes
+    )
+
+    expected_repo_nodes = {
+        (
+            f"{TEST_TENANT_ID}:docker-prod",
+            "docker-prod",
+            "Docker",
+            "LOCAL",
+            "PRJ",
+        ),
+        (
+            f"{TEST_TENANT_ID}:maven-remote",
+            "maven-remote",
+            "Maven",
+            "REMOTE",
+            "PRJ",
+        ),
+    }
+    assert (
+        check_nodes(
+            neo4j_session,
+            "JFrogArtifactoryRepository",
+            ["id", "key", "package_type", "repo_type", "project_key"],
+        )
+        == expected_repo_nodes
+    )
+
+    expected_rels = {
+        (TEST_TENANT_ID, f"{TEST_TENANT_ID}:docker-prod"),
+        (TEST_TENANT_ID, f"{TEST_TENANT_ID}:maven-remote"),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "JFrogArtifactoryTenant",
+            "id",
+            "JFrogArtifactoryRepository",
+            "id",
+            "RESOURCE",
+            rel_direction_right=True,
+        )
+        == expected_rels
+    )


### PR DESCRIPTION
### Motivation

- Provide a Cartography intel module to discover JFrog Artifactory repository metadata and surface repositories as ContainerRegistry nodes in the graph.
- Model the implementation after existing artifact registry modules (GCP/ECR) and use Artifactory REST endpoints (`/artifactory/api/repositories` and `/artifactory/api/repositories/{key}`) to collect repository and configuration details.

### Description

- Add new data models `JFrogArtifactoryTenant` and `JFrogArtifactoryRepository` and a `(:JFrogArtifactoryTenant)-[:RESOURCE]->(:JFrogArtifactoryRepository)` sub-resource relationship in `cartography/models/jfrog/`.
- Implement a new intel module under `cartography/intel/jfrog/` that performs `get -> transform -> load -> cleanup` for Artifactory repositories and tenant nodes, including resilient HTTP calls with `retries_with_backoff`.
- Wire the module into the top-level sync registry as the `jfrog` stage and add CLI and `Config` options for `--jfrog-artifactory-base-url`, `--jfrog-artifactory-token-env-var`, and `--jfrog-artifactory-tenant-id` so the module can be configured at runtime.
- Add integration-style test data and a test `tests/integration/cartography/intel/jfrog/test_repositories.py` that validates node properties and `RESOURCE` relationships produced by the loader.

### Testing

- Ran `python -m compileall cartography/intel/jfrog cartography/models/jfrog tests/integration/cartography/intel/jfrog tests/data/jfrog` which succeeded and compiled the new modules without syntax errors.
- Ran `pytest -q tests/integration/cartography/intel/jfrog/test_repositories.py` which could not complete in this environment due to a missing `neo4j` test dependency (`ModuleNotFoundError: No module named 'neo4j'`).
- Added integration test files and test data for reviewer verification: `tests/integration/cartography/intel/jfrog/test_repositories.py` and `tests/data/jfrog/repositories.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c2aa3978708323a88111413c080fe9)