### PR TITLE
fix(aws): handle account-instance IAM Identity Center permission set errors

### DIFF
--- a/cartography/intel/aws/identitycenter.py
+++ b/cartography/intel/aws/identitycenter.py
@@ -42,7 +42,10 @@ def _is_permission_set_sync_unsupported_error(
         return False
 
     message = error_info.get("Message", "").lower()
-    return "not supported for this identity center instance" in message
+    return (
+        "not supported for this identity center instance" in message
+        or "not supported for account instances of iam identity center" in message
+    )
 
 
 @timeit

--- a/tests/unit/cartography/intel/aws/test_identitycenter.py
+++ b/tests/unit/cartography/intel/aws/test_identitycenter.py
@@ -101,6 +101,21 @@ def test_is_permission_set_sync_unsupported_error():
     assert _is_permission_set_sync_unsupported_error(error)
 
 
+def test_is_permission_set_sync_unsupported_error_for_account_instance_message():
+    """Test support for AWS account-instance specific unsupported error wording."""
+    error = botocore.exceptions.ClientError(
+        error_response={
+            "Error": {
+                "Code": "ValidationException",
+                "Message": "This operation is not supported for account instances of IAM Identity Center.",
+            },
+        },
+        operation_name="ListPermissionSets",
+    )
+
+    assert _is_permission_set_sync_unsupported_error(error)
+
+
 def test_is_permission_set_sync_unsupported_error_returns_false_for_other_errors():
     """Test that other ValidationExceptions are not treated as unsupported instance errors."""
     error = botocore.exceptions.ClientError(


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)



### Summary
Some AWS accounts return a different `ValidationException` message for `ListPermissionSets` when IAM Identity Center is account-scoped. This caused the sync to raise instead of skipping permission-set sync for unsupported instances.

This change extends `_is_permission_set_sync_unsupported_error` to also detect the `"not supported for account instances of IAM Identity Center"` message variant and adds a unit test covering that case.


### Related issues or links
- None.


### How was this tested?
- Added `test_is_permission_set_sync_unsupported_error_for_account_instance_message`.



### Checklist

#### General
- [ ] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
The only functional change is the broader handling of unsupported account-scoped IAM Identity Center permission-set errors plus the matching unit test.
