### PR TITLE
fix(tailscale): request all fields from devices API to collect serial numbers

### DIFF
--- a/cartography/intel/tailscale/devices.py
+++ b/cartography/intel/tailscale/devices.py
@@ -56,6 +56,7 @@ def get(
     req = api_session.get(
         f"{base_url}/tailnet/{org}/devices",
         timeout=_TIMEOUT,
+        params={"fields": "all"},
     )
     req.raise_for_status()
     results = req.json()["devices"]


### PR DESCRIPTION
## Summary
- The Tailscale `GET /tailnet/{org}/devices` API defaults to returning only core fields, which **excludes `postureIdentity`** (the field containing `serialNumbers`).
- Added `params={"fields": "all"}` to the API request so that posture identity data is returned and serial numbers are correctly ingested.

## Test plan
- [x] Existing integration test `test_load_tailscale_devices` passes and validates serial number ingestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)