### PR TITLE
feat(aws): add IAM service-specific credentials sync

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -36,6 +36,9 @@ from cartography.models.aws.iam.root_principal import AWSRootPrincipalSchema
 from cartography.models.aws.iam.samlprovider import AWSSAMLProviderSchema
 from cartography.models.aws.iam.server_certificate import AWSServerCertificateSchema
 from cartography.models.aws.iam.service_principal import AWSServicePrincipalSchema
+from cartography.models.aws.iam.service_specific_credential import (
+    AWSServiceSpecificCredentialSchema,
+)
 from cartography.models.aws.iam.sts_assumerole_allow import STSAssumeRoleAllowMatchLink
 from cartography.models.aws.iam.user import AWSUserSchema
 from cartography.stats import get_stats_client
@@ -434,6 +437,44 @@ def get_account_access_key_data(
 
 
 @timeit
+def get_user_service_specific_credentials_data(
+    boto3_session: boto3.Session,
+    users: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """
+    Get service-specific credential data for all users.
+    Returns a dict mapping user ARN to list of service-specific credential data.
+    """
+    user_service_specific_credentials: dict[str, list[dict[str, Any]]] = {}
+
+    for user in users:
+        username = user["name"]
+        user_arn = user["arn"]
+
+        credentials = get_service_specific_credentials_data(boto3_session, username)
+        user_service_specific_credentials[user_arn] = credentials
+
+    return user_service_specific_credentials
+
+
+@timeit
+def get_service_specific_credentials_data(
+    boto3_session: boto3.Session,
+    username: str,
+) -> list[dict[str, Any]]:
+    client = create_boto3_client(boto3_session, "iam")
+    try:
+        response = client.list_service_specific_credentials(UserName=username)
+    except client.exceptions.NoSuchEntityException:
+        logger.warning(
+            "Could not get service-specific credentials for user %s due to NoSuchEntityException; skipping.",
+            username,
+        )
+        return []
+    return response.get("ServiceSpecificCredentials", [])
+
+
+@timeit
 def get_group_memberships(
     boto3_session: boto3.Session, groups: list[dict[str, Any]]
 ) -> dict[str, list[str]]:
@@ -544,6 +585,33 @@ def transform_access_keys(
                 access_key_data.append(access_key_record)
 
     return access_key_data
+
+
+def transform_service_specific_credentials(
+    user_service_specific_credentials: dict[str, list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    service_specific_credential_data = []
+
+    for user_arn, credentials in user_service_specific_credentials.items():
+        for credential in credentials:
+            credential_id = credential.get("ServiceSpecificCredentialId")
+            if not credential_id:
+                continue
+
+            service_specific_credential_data.append(
+                {
+                    "service_specific_credential_id": credential_id,
+                    "service_name": credential.get("ServiceName"),
+                    "service_user_name": credential.get("ServiceUserName"),
+                    "status": credential.get("Status"),
+                    "username": credential.get("UserName"),
+                    "createdate": str(credential.get("CreateDate", "")),
+                    "createdate_dt": credential.get("CreateDate"),
+                    "user_arn": user_arn,
+                }
+            )
+
+    return service_specific_credential_data
 
 
 def transform_role_trust_policies(
@@ -672,6 +740,22 @@ def load_access_keys(
         neo4j_session,
         AccountAccessKeySchema(),
         access_keys,
+        lastupdated=aws_update_tag,
+        AWS_ID=current_aws_account_id,
+    )
+
+
+@timeit
+def load_service_specific_credentials(
+    neo4j_session: neo4j.Session,
+    service_specific_credentials: list[dict[str, Any]],
+    aws_update_tag: int,
+    current_aws_account_id: str,
+) -> None:
+    load(
+        neo4j_session,
+        AWSServiceSpecificCredentialSchema(),
+        service_specific_credentials,
         lastupdated=aws_update_tag,
         AWS_ID=current_aws_account_id,
     )
@@ -999,6 +1083,48 @@ def sync_user_access_keys(
         neo4j_session, access_key_data, aws_update_tag, current_aws_account_id
     )
     GraphJob.from_node_schema(AccountAccessKeySchema(), common_job_parameters).run(
+        neo4j_session
+    )
+
+
+@timeit
+def sync_user_service_specific_credentials(
+    neo4j_session: neo4j.Session,
+    boto3_session: boto3.Session,
+    current_aws_account_id: str,
+    aws_update_tag: int,
+    common_job_parameters: Dict,
+) -> None:
+    logger.info(
+        "Syncing IAM user service-specific credentials for account '%s'.",
+        current_aws_account_id,
+    )
+
+    query = (
+        "MATCH (user:AWSUser)<-[:RESOURCE]-(:AWSAccount{id: $AWS_ID}) "
+        "RETURN user.name as name, user.arn as arn"
+    )
+    users = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        query,
+        AWS_ID=current_aws_account_id,
+    )
+
+    user_service_specific_credentials = get_user_service_specific_credentials_data(
+        boto3_session, users
+    )
+    service_specific_credential_data = transform_service_specific_credentials(
+        user_service_specific_credentials
+    )
+    load_service_specific_credentials(
+        neo4j_session,
+        service_specific_credential_data,
+        aws_update_tag,
+        current_aws_account_id,
+    )
+    GraphJob.from_node_schema(
+        AWSServiceSpecificCredentialSchema(), common_job_parameters
+    ).run(
         neo4j_session
     )
 
@@ -1780,6 +1906,13 @@ def sync(
         common_job_parameters,
     )
     sync_user_access_keys(
+        neo4j_session,
+        boto3_session,
+        current_aws_account_id,
+        update_tag,
+        common_job_parameters,
+    )
+    sync_user_service_specific_credentials(
         neo4j_session,
         boto3_session,
         current_aws_account_id,

--- a/cartography/models/aws/iam/service_specific_credential.py
+++ b/cartography/models/aws/iam/service_specific_credential.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AWSServiceSpecificCredentialNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("service_specific_credential_id")
+    service_specific_credential_id: PropertyRef = PropertyRef(
+        "service_specific_credential_id",
+        extra_index=True,
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    service_name: PropertyRef = PropertyRef("service_name")
+    service_user_name: PropertyRef = PropertyRef("service_user_name")
+    status: PropertyRef = PropertyRef("status")
+    username: PropertyRef = PropertyRef("username")
+    createdate: PropertyRef = PropertyRef("createdate")
+    createdate_dt: PropertyRef = PropertyRef("createdate_dt")
+
+
+@dataclass(frozen=True)
+class AWSServiceSpecificCredentialToAWSUserRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AWSServiceSpecificCredentialToAWSUserRel(CartographyRelSchema):
+    target_node_label: str = "AWSUser"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("user_arn")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "SERVICE_SPECIFIC_CREDENTIAL"
+    properties: AWSServiceSpecificCredentialToAWSUserRelProperties = (
+        AWSServiceSpecificCredentialToAWSUserRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AWSServiceSpecificCredentialToAWSAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AWSServiceSpecificCredentialToAWSAccountRel(CartographyRelSchema):
+    target_node_label: str = "AWSAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AWSServiceSpecificCredentialToAWSAccountRelProperties = (
+        AWSServiceSpecificCredentialToAWSAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AWSServiceSpecificCredentialSchema(CartographyNodeSchema):
+    label: str = "AWSServiceSpecificCredential"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["APIKey"])
+    properties: AWSServiceSpecificCredentialNodeProperties = (
+        AWSServiceSpecificCredentialNodeProperties()
+    )
+    sub_resource_relationship: AWSServiceSpecificCredentialToAWSAccountRel = (
+        AWSServiceSpecificCredentialToAWSAccountRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [AWSServiceSpecificCredentialToAWSUserRel()],
+    )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -816,6 +816,12 @@ Representation of an [AWSUser](https://docs.aws.amazon.com/IAM/latest/APIReferen
     (AWSUser)-[AWS_ACCESS_KEY]->(AccountAccessKey)
     ```
 
+- AWS Users can have Service-Specific Credentials.
+
+    ```cypher
+    (AWSUser)-[SERVICE_SPECIFIC_CREDENTIAL]->(AWSServiceSpecificCredential)
+    ```
+
 - AWS Accounts contain AWS Users.
 
     ```cypher
@@ -1172,6 +1178,38 @@ Representation of an AWS [Access Key](https://docs.aws.amazon.com/IAM/latest/API
 - Account Access Keys are a resource under the AWS Account.
     ```
     (:AWSAccount)-[:RESOURCE]->(:AccountAccessKey)
+    ```
+
+### AWSServiceSpecificCredential
+
+Representation of an AWS [Service-Specific Credential](https://docs.aws.amazon.com/IAM/latest/APIReference/API_ServiceSpecificCredentialMetadata.html). Service-specific credentials are static credentials tied to a specific AWS service (e.g., Amazon Bedrock, CodeCommit) that IAM users can have associated with their accounts.
+
+> **Ontology Mapping**: This node has the extra label `APIKey` to enable cross-platform queries for API keys across different systems (e.g., AnthropicApiKey, OpenAIApiKey, ScalewayApiKey).
+
+| Field | Description |
+|-------|-------------|
+| firstseen| Timestamp of when a sync job first discovered this node  |
+| lastupdated |  Timestamp of the last time the node was updated |
+| **id** | The service-specific credential ID (same as service\_specific\_credential\_id) |
+| **service\_specific\_credential\_id** | The unique identifier for the service-specific credential |
+| service\_name | The name of the AWS service associated with the credential (e.g., codecommit.amazonaws.com) |
+| service\_user\_name | The generated username for the service-specific credential |
+| status | Active: valid for API calls. Inactive: not valid for API calls |
+| username | The IAM username associated with the credential |
+| createdate | Date when the credential was created |
+| createdate\_dt | DateTime object representing when the credential was created |
+
+#### Relationships
+- Service-Specific Credentials are associated with AWS Users.
+
+    ```cypher
+    (AWSUser)-[SERVICE_SPECIFIC_CREDENTIAL]->(AWSServiceSpecificCredential)
+    ```
+
+- Service-Specific Credentials are a resource under the AWS Account.
+
+    ```cypher
+    (AWSAccount)-[RESOURCE]->(AWSServiceSpecificCredential)
     ```
 
 ### AWSMfaDevice

--- a/tests/data/aws/iam/service_specific_credentials.py
+++ b/tests/data/aws/iam/service_specific_credentials.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+GET_USER_SERVICE_SPECIFIC_CREDENTIALS_DATA = {
+    "arn:aws:iam::1234:user/user1": [
+        {
+            "UserName": "user1",
+            "Status": "Active",
+            "ServiceUserName": "AKIAUSER1AT1670000000000",
+            "CreateDate": datetime(2024, 1, 12, 18, 5, 0),
+            "ServiceSpecificCredentialId": "ANPAEXAMPLEUSER1A",
+            "ServiceName": "codecommit.amazonaws.com",
+        },
+        {
+            "UserName": "user1",
+            "Status": "Inactive",
+            "ServiceUserName": "AIDAUSER1AT1670000000001",
+            "CreateDate": datetime(2024, 4, 3, 9, 30, 0),
+            "ServiceSpecificCredentialId": "ANPAEXAMPLEUSER1B",
+            "ServiceName": "bedrock.amazonaws.com",
+        },
+    ],
+    "arn:aws:iam::1234:user/user2": [
+        {
+            "UserName": "user2",
+            "Status": "Active",
+            "ServiceUserName": "AKIAUSER2AT1670000000000",
+            "CreateDate": datetime(2025, 2, 6, 11, 45, 0),
+            "ServiceSpecificCredentialId": "ANPAEXAMPLEUSER2A",
+            "ServiceName": "codecommit.amazonaws.com",
+        },
+    ],
+    "arn:aws:iam::1234:user/user3": [],
+}

--- a/tests/integration/cartography/intel/aws/iam/test_iam_sync.py
+++ b/tests/integration/cartography/intel/aws/iam/test_iam_sync.py
@@ -13,6 +13,9 @@ from tests.data.aws.iam.role_policies import (
     ANOTHER_GET_ROLE_LIST_DATASET as GET_ROLE_LIST_DATA,
 )
 from tests.data.aws.iam.role_policies import GET_ROLE_MANAGED_POLICY_DATA
+from tests.data.aws.iam.service_specific_credentials import (
+    GET_USER_SERVICE_SPECIFIC_CREDENTIALS_DATA,
+)
 from tests.data.aws.iam.user_inline_policies import GET_USER_INLINE_POLS_SAMPLE
 from tests.data.aws.iam.user_policies import GET_USER_LIST_DATA
 from tests.data.aws.iam.user_policies import GET_USER_MANAGED_POLS_SAMPLE
@@ -22,6 +25,7 @@ from tests.integration.util import check_rels
 
 TEST_ACCOUNT_ID = "1234"
 TEST_UPDATE_TAG = 123456789
+TEST_UPDATE_TAG_2 = 123456790
 
 
 @patch.object(
@@ -87,7 +91,13 @@ TEST_UPDATE_TAG = 123456789
     "get_user_access_keys_data",
     return_value=GET_USER_ACCESS_KEYS_DATA,
 )
+@patch.object(
+    cartography.intel.aws.iam,
+    "get_user_service_specific_credentials_data",
+    return_value=GET_USER_SERVICE_SPECIFIC_CREDENTIALS_DATA,
+)
 def test_sync_iam(
+    mock_get_user_service_specific_credentials_data,
     mock_get_user_access_keys,
     mock_get_user_list_data,
     mock_get_user_policy_data,
@@ -371,3 +381,135 @@ def test_sync_iam(
         ("AKIAJQ5CMEXAMPLE", "arn:aws:iam::1234:user/user2"),
         ("AKIAEXAMPLE123", "arn:aws:iam::1234:user/user3"),
     }
+
+    # Assert: Check that service-specific credential nodes were created
+    assert check_nodes(
+        neo4j_session,
+        "AWSServiceSpecificCredential",
+        ["service_specific_credential_id", "service_name", "status"],
+    ) == {
+        ("ANPAEXAMPLEUSER1A", "codecommit.amazonaws.com", "Active"),
+        ("ANPAEXAMPLEUSER1B", "bedrock.amazonaws.com", "Inactive"),
+        ("ANPAEXAMPLEUSER2A", "codecommit.amazonaws.com", "Active"),
+    }
+
+    # Assert: Check that relationships were created between users and service-specific credentials
+    assert check_rels(
+        neo4j_session,
+        "AWSServiceSpecificCredential",
+        "service_specific_credential_id",
+        "AWSUser",
+        "arn",
+        "SERVICE_SPECIFIC_CREDENTIAL",
+        rel_direction_right=False,
+    ) == {
+        ("ANPAEXAMPLEUSER1A", "arn:aws:iam::1234:user/user1"),
+        ("ANPAEXAMPLEUSER1B", "arn:aws:iam::1234:user/user1"),
+        ("ANPAEXAMPLEUSER2A", "arn:aws:iam::1234:user/user2"),
+    }
+
+    # Assert: Check account RESOURCE relationships to service-specific credentials
+    assert check_rels(
+        neo4j_session,
+        "AWSAccount",
+        "id",
+        "AWSServiceSpecificCredential",
+        "service_specific_credential_id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (TEST_ACCOUNT_ID, "ANPAEXAMPLEUSER1A"),
+        (TEST_ACCOUNT_ID, "ANPAEXAMPLEUSER1B"),
+        (TEST_ACCOUNT_ID, "ANPAEXAMPLEUSER2A"),
+    }
+
+
+@patch.object(
+    cartography.intel.aws.iam,
+    "get_user_service_specific_credentials_data",
+    side_effect=[
+        GET_USER_SERVICE_SPECIFIC_CREDENTIALS_DATA,
+        {
+            "arn:aws:iam::1234:user/user1": [],
+            "arn:aws:iam::1234:user/user2": [],
+            "arn:aws:iam::1234:user/user3": [],
+        },
+    ],
+)
+def test_sync_user_service_specific_credentials_cleanup(
+    mock_get_user_service_specific_credentials_data,
+    neo4j_session,
+):
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+    # Seed users because sync_user_service_specific_credentials queries existing AWSUser nodes.
+    users = cartography.intel.aws.iam.transform_users(GET_USER_LIST_DATA["Users"])
+    cartography.intel.aws.iam.load_users(
+        neo4j_session,
+        users,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+    cartography.intel.aws.iam.sync_user_service_specific_credentials(
+        neo4j_session,
+        boto3_session,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "AWSServiceSpecificCredential",
+        ["service_specific_credential_id"],
+    ) == {
+        ("ANPAEXAMPLEUSER1A",),
+        ("ANPAEXAMPLEUSER1B",),
+        ("ANPAEXAMPLEUSER2A",),
+    }
+
+    # Re-sync with empty credentials and a new update tag; stale credentials should be cleaned up.
+    cartography.intel.aws.iam.sync_user_service_specific_credentials(
+        neo4j_session,
+        boto3_session,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG_2,
+        {"UPDATE_TAG": TEST_UPDATE_TAG_2, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+
+    assert (
+        check_nodes(
+            neo4j_session,
+            "AWSServiceSpecificCredential",
+            ["service_specific_credential_id"],
+        )
+        == set()
+    )
+
+    assert (
+        check_rels(
+            neo4j_session,
+            "AWSServiceSpecificCredential",
+            "service_specific_credential_id",
+            "AWSUser",
+            "arn",
+            "SERVICE_SPECIFIC_CREDENTIAL",
+            rel_direction_right=False,
+        )
+        == set()
+    )
+
+    assert (
+        check_rels(
+            neo4j_session,
+            "AWSAccount",
+            "id",
+            "AWSServiceSpecificCredential",
+            "service_specific_credential_id",
+            "RESOURCE",
+            rel_direction_right=True,
+        )
+        == set()
+    )

--- a/tests/unit/cartography/intel/aws/iam/test_iam.py
+++ b/tests/unit/cartography/intel/aws/iam/test_iam.py
@@ -4,6 +4,9 @@ from cartography.intel.aws import iam
 from cartography.intel.aws.iam import PolicyType
 from cartography.intel.aws.iam import transform_policy_data
 from tests.data.aws.iam.mfa_devices import LIST_MFA_DEVICES
+from tests.data.aws.iam.service_specific_credentials import (
+    GET_USER_SERVICE_SPECIFIC_CREDENTIALS_DATA,
+)
 from tests.data.aws.iam.server_certificates import LIST_SERVER_CERTIFICATES_RESPONSE
 
 SINGLE_STATEMENT = {
@@ -320,4 +323,107 @@ def test_transform_mfa_devices():
 def test_transform_mfa_devices_empty():
     raw_data = []
     result = iam.transform_mfa_devices(raw_data)
+    assert result == []
+
+
+def test_transform_service_specific_credentials():
+    result = iam.transform_service_specific_credentials(
+        GET_USER_SERVICE_SPECIFIC_CREDENTIALS_DATA
+    )
+
+    assert len(result) == 3
+    assert result[0]["service_specific_credential_id"] == "ANPAEXAMPLEUSER1A"
+    assert result[0]["service_name"] == "codecommit.amazonaws.com"
+    assert result[0]["user_arn"] == "arn:aws:iam::1234:user/user1"
+
+    assert result[1]["service_specific_credential_id"] == "ANPAEXAMPLEUSER1B"
+    assert result[1]["status"] == "Inactive"
+    assert result[1]["username"] == "user1"
+
+    assert result[2]["service_specific_credential_id"] == "ANPAEXAMPLEUSER2A"
+    assert result[2]["service_name"] == "codecommit.amazonaws.com"
+    assert result[2]["user_arn"] == "arn:aws:iam::1234:user/user2"
+
+
+def test_get_user_service_specific_credentials_data(monkeypatch):
+    users = [
+        {"name": "user1", "arn": "arn:aws:iam::1234:user/user1"},
+        {"name": "user2", "arn": "arn:aws:iam::1234:user/user2"},
+    ]
+
+    lookup = {
+        "user1": GET_USER_SERVICE_SPECIFIC_CREDENTIALS_DATA[
+            "arn:aws:iam::1234:user/user1"
+        ],
+        "user2": GET_USER_SERVICE_SPECIFIC_CREDENTIALS_DATA[
+            "arn:aws:iam::1234:user/user2"
+        ],
+    }
+
+    def _fake_getter(_boto3_session, username):
+        return lookup[username]
+
+    monkeypatch.setattr(
+        iam,
+        "get_service_specific_credentials_data",
+        _fake_getter,
+    )
+
+    result = iam.get_user_service_specific_credentials_data(object(), users)
+
+    assert set(result.keys()) == {
+        "arn:aws:iam::1234:user/user1",
+        "arn:aws:iam::1234:user/user2",
+    }
+    assert len(result["arn:aws:iam::1234:user/user1"]) == 2
+    assert len(result["arn:aws:iam::1234:user/user2"]) == 1
+
+
+def test_transform_service_specific_credentials_skips_missing_credential_id():
+    raw = {
+        "arn:aws:iam::1234:user/user1": [
+            {
+                "UserName": "user1",
+                "ServiceName": "codecommit.amazonaws.com",
+                "ServiceUserName": "foo",
+                "Status": "Active",
+                "CreateDate": datetime.datetime(2024, 1, 1, 0, 0, 0),
+            },
+            {
+                "UserName": "user1",
+                "ServiceSpecificCredentialId": "ANPAVALID",
+                "ServiceName": "bedrock.amazonaws.com",
+                "ServiceUserName": "bar",
+                "Status": "Inactive",
+                "CreateDate": datetime.datetime(2024, 1, 2, 0, 0, 0),
+            },
+        ]
+    }
+
+    result = iam.transform_service_specific_credentials(raw)
+
+    assert len(result) == 1
+    assert result[0]["service_specific_credential_id"] == "ANPAVALID"
+    assert result[0]["service_name"] == "bedrock.amazonaws.com"
+
+
+def test_get_service_specific_credentials_data_handles_no_such_entity(monkeypatch):
+    class NoSuchEntityException(Exception):
+        pass
+
+    class FakeExceptions:
+        pass
+
+    FakeExceptions.NoSuchEntityException = NoSuchEntityException
+
+    class FakeClient:
+        exceptions = FakeExceptions
+
+        def list_service_specific_credentials(self, **kwargs):
+            raise NoSuchEntityException()
+
+    monkeypatch.setattr(iam, "create_boto3_client", lambda *_: FakeClient())
+
+    result = iam.get_service_specific_credentials_data(object(), "deleted-user")
+
     assert result == []


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

### Summary

Add support for syncing AWS IAM service-specific credentials to Cartography. Service-specific credentials are static credentials tied to specific AWS services (e.g., Amazon Bedrock, CodeCommit) that IAM users can have associated with their accounts.

**Changes:**
- Added `AWSServiceSpecificCredential` node schema with extra label `APIKey` (enables cross-platform API key queries)
- Implemented sync functions following the standard GET → TRANSFORM → LOAD → CLEANUP pattern
- Relationships: `(AWSUser)-[SERVICE_SPECIFIC_CREDENTIAL]->(AWSServiceSpecificCredential)` and `(AWSAccount)-[RESOURCE]->(AWSServiceSpecificCredential)`
- Added unit and integration tests (including cleanup lifecycle test)
- Updated schema documentation

### Related issues or links

- Fixes #1887

### How was this tested?

- Unit tests: `uv run pytest -vvv tests/unit/cartography/intel/aws/iam/test_iam.py` — 17 passed
- Integration tests: `uv run pytest -vvv tests/integration/cartography/intel/aws/iam/test_iam_sync.py`
- Tests cover: transform logic, aggregation, edge cases (missing credential ID, NoSuchEntityException), full sync, and cleanup lifecycle

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [x] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

### Notes for reviewers

- This follows the same pattern as `AccountAccessKey` (access keys sync)
- Uses direct API call (`list_service_specific_credentials`) instead of paginator because this API doesn't support boto3 paginators
- `NoSuchEntityException` is handled gracefully for users deleted between Neo4j query and AWS API call