### PR TITLE
fix(ubuntu): add HTTP retry policy to avoid transient 503 failures

### DIFF
--- a/cartography/intel/ubuntu/cves.py
+++ b/cartography/intel/ubuntu/cves.py
@@ -7,8 +7,8 @@ import neo4j
 from cartography.client.core.tx import load
 from cartography.client.core.tx import read_single_value_tx
 from cartography.client.core.tx import run_write_query
-from cartography.intel.ubuntu.util import retryable_session
 from cartography.intel.ubuntu.feed import FEED_ID
+from cartography.intel.ubuntu.util import retryable_session
 from cartography.models.ubuntu.cves import UbuntuCVESchema
 from cartography.util import timeit
 

--- a/cartography/intel/ubuntu/cves.py
+++ b/cartography/intel/ubuntu/cves.py
@@ -3,11 +3,11 @@ from collections.abc import Iterator
 from typing import Any
 
 import neo4j
-from requests import Session
 
 from cartography.client.core.tx import load
 from cartography.client.core.tx import read_single_value_tx
 from cartography.client.core.tx import run_write_query
+from cartography.intel.ubuntu.util import retryable_session
 from cartography.intel.ubuntu.feed import FEED_ID
 from cartography.models.ubuntu.cves import UbuntuCVESchema
 from cartography.util import timeit
@@ -205,7 +205,7 @@ def _fetch_cves(
     """
     offset = start_offset
     total_fetched = 0
-    session = Session()
+    session = retryable_session()
 
     if since is None:
         params_base: dict[str, str] = {"limit": str(_PAGE_SIZE), "order": "ascending"}

--- a/cartography/intel/ubuntu/notices.py
+++ b/cartography/intel/ubuntu/notices.py
@@ -3,11 +3,11 @@ from collections.abc import Iterator
 from typing import Any
 
 import neo4j
-from requests import Session
 
 from cartography.client.core.tx import load
 from cartography.client.core.tx import read_single_value_tx
 from cartography.client.core.tx import run_write_query
+from cartography.intel.ubuntu.util import retryable_session
 from cartography.intel.ubuntu.feed import FEED_ID
 from cartography.models.ubuntu.notices import UbuntuSecurityNoticeSchema
 from cartography.util import timeit
@@ -207,7 +207,7 @@ def _fetch_notices(
     """
     offset = start_offset
     total_fetched = 0
-    session = Session()
+    session = retryable_session()
 
     if since is None:
         params_base: dict[str, str] = {"limit": str(_PAGE_SIZE), "order": "oldest"}

--- a/cartography/intel/ubuntu/notices.py
+++ b/cartography/intel/ubuntu/notices.py
@@ -7,8 +7,8 @@ import neo4j
 from cartography.client.core.tx import load
 from cartography.client.core.tx import read_single_value_tx
 from cartography.client.core.tx import run_write_query
-from cartography.intel.ubuntu.util import retryable_session
 from cartography.intel.ubuntu.feed import FEED_ID
+from cartography.intel.ubuntu.util import retryable_session
 from cartography.models.ubuntu.notices import UbuntuSecurityNoticeSchema
 from cartography.util import timeit
 

--- a/cartography/intel/ubuntu/util.py
+++ b/cartography/intel/ubuntu/util.py
@@ -10,9 +10,24 @@ from urllib3.exceptions import MaxRetryError
 
 logger = logging.getLogger(__name__)
 
+_UBUNTU_API_RETRY_TOTAL = 5
+_UBUNTU_API_RETRY_CONNECT = 1
+_UBUNTU_API_RETRY_BACKOFF_FACTOR = 1.0
+_UBUNTU_API_STATUS_FORCELIST: tuple[int, ...] = (429, 500, 502, 503, 504)
+_UBUNTU_API_ALLOWED_METHODS: frozenset[str] = frozenset({"GET"})
+
 
 class LoggingRetry(Retry):
     """Retry subclass that logs each retry attempt for production observability."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        # urllib3 reconstructs via type(self)(**params); accept full Retry kwargs.
+        kwargs.setdefault("total", _UBUNTU_API_RETRY_TOTAL)
+        kwargs.setdefault("connect", _UBUNTU_API_RETRY_CONNECT)
+        kwargs.setdefault("backoff_factor", _UBUNTU_API_RETRY_BACKOFF_FACTOR)
+        kwargs.setdefault("status_forcelist", _UBUNTU_API_STATUS_FORCELIST)
+        kwargs.setdefault("allowed_methods", _UBUNTU_API_ALLOWED_METHODS)
+        super().__init__(**kwargs)
 
     def increment(
         self,
@@ -24,15 +39,18 @@ class LoggingRetry(Retry):
         _stacktrace: Any = None,
     ) -> LoggingRetry:
         status = response.status if response else None
-        remaining = self.total
-        if isinstance(remaining, int):
-            remaining -= 1
+        retries_left: int | bool | None
+        match self.total:
+            case int(total_int):
+                retries_left = total_int - 1
+            case _:
+                retries_left = self.total
         logger.warning(
             "Ubuntu API retry: method=%s url=%s status=%s retries_left=%s error=%s",
             method,
             url,
             status,
-            remaining,
+            retries_left,
             error,
         )
         try:
@@ -61,12 +79,6 @@ def retryable_session() -> Session:
     returns intermittently.  Uses exponential backoff via urllib3.
     """
     session = Session()
-    retry_policy = LoggingRetry(
-        total=5,
-        connect=1,
-        backoff_factor=1,
-        status_forcelist=[429, 500, 502, 503, 504],
-        allowed_methods=["GET"],
-    )
+    retry_policy = LoggingRetry()
     session.mount("https://", HTTPAdapter(max_retries=retry_policy))
     return session

--- a/cartography/intel/ubuntu/util.py
+++ b/cartography/intel/ubuntu/util.py
@@ -1,10 +1,57 @@
+from __future__ import annotations
+
 import logging
+from typing import Any
 
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
+from urllib3.exceptions import MaxRetryError
 
 logger = logging.getLogger(__name__)
+
+
+class LoggingRetry(Retry):
+    """Retry subclass that logs each retry attempt for production observability."""
+
+    def increment(
+        self,
+        method: str | None = None,
+        url: str | None = None,
+        response: Any | None = None,
+        error: Exception | None = None,
+        _pool: Any | None = None,
+        _stacktrace: Any = None,
+    ) -> LoggingRetry:
+        status = response.status if response else None
+        remaining = self.total
+        if isinstance(remaining, int):
+            remaining -= 1
+        logger.warning(
+            "Ubuntu API retry: method=%s url=%s status=%s retries_left=%s error=%s",
+            method,
+            url,
+            status,
+            remaining,
+            error,
+        )
+        try:
+            return super().increment(
+                method=method,
+                url=url,
+                response=response,
+                error=error,
+                _pool=_pool,
+                _stacktrace=_stacktrace,
+            )
+        except MaxRetryError:
+            logger.error(
+                "Ubuntu API retries exhausted: method=%s url=%s last_status=%s",
+                method,
+                url,
+                status,
+            )
+            raise
 
 
 def retryable_session() -> Session:
@@ -14,7 +61,7 @@ def retryable_session() -> Session:
     returns intermittently.  Uses exponential backoff via urllib3.
     """
     session = Session()
-    retry_policy = Retry(
+    retry_policy = LoggingRetry(
         total=5,
         connect=1,
         backoff_factor=1,

--- a/cartography/intel/ubuntu/util.py
+++ b/cartography/intel/ubuntu/util.py
@@ -1,0 +1,25 @@
+import logging
+
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
+
+logger = logging.getLogger(__name__)
+
+
+def retryable_session() -> Session:
+    """Build a requests Session with automatic retries on transient HTTP errors.
+
+    Covers 429 (rate-limit) and 5xx status codes that the Ubuntu Security API
+    returns intermittently.  Uses exponential backoff via urllib3.
+    """
+    session = Session()
+    retry_policy = Retry(
+        total=5,
+        connect=1,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
+    session.mount("https://", HTTPAdapter(max_retries=retry_policy))
+    return session

--- a/tests/unit/cartography/intel/ubuntu/test_retry.py
+++ b/tests/unit/cartography/intel/ubuntu/test_retry.py
@@ -1,10 +1,12 @@
-from unittest.mock import MagicMock
-from unittest.mock import patch
+import logging
+from unittest.mock import Mock
 
+import pytest
 from requests import Session
 from requests.adapters import HTTPAdapter
-from urllib3 import Retry
+from urllib3.exceptions import MaxRetryError
 
+from cartography.intel.ubuntu.util import LoggingRetry
 from cartography.intel.ubuntu.util import retryable_session
 
 
@@ -17,17 +19,16 @@ class TestRetryableSession:
         session = retryable_session()
         adapter = session.get_adapter("https://ubuntu.com")
         assert isinstance(adapter, HTTPAdapter)
-        retry: Retry = adapter.max_retries
-        assert isinstance(retry, Retry)
+        assert isinstance(adapter.max_retries, LoggingRetry)
 
     def test_retry_policy_covers_503(self):
         session = retryable_session()
-        retry: Retry = session.get_adapter("https://example.com").max_retries
+        retry = session.get_adapter("https://example.com").max_retries
         assert 503 in retry.status_forcelist
 
     def test_retry_policy_parameters(self):
         session = retryable_session()
-        retry: Retry = session.get_adapter("https://example.com").max_retries
+        retry = session.get_adapter("https://example.com").max_retries
         assert retry.total == 5
         assert retry.connect == 1
         assert retry.backoff_factor == 1
@@ -35,31 +36,34 @@ class TestRetryableSession:
         assert set(retry.allowed_methods) == {"GET"}
 
 
-class TestFetchUsesRetrySession:
-    @patch("cartography.intel.ubuntu.cves.retryable_session")
-    def test_fetch_cves_creates_retryable_session(self, mock_factory):
-        mock_session = MagicMock(spec=Session)
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"cves": [], "total_results": 0}
-        mock_session.get.return_value = mock_response
-        mock_factory.return_value = mock_session
+class TestLoggingRetry:
+    def test_logs_warning_on_retry(self, caplog):
+        retry = LoggingRetry(total=3, status_forcelist=[503], allowed_methods=["GET"])
+        mock_response = Mock(status=503)
 
-        from cartography.intel.ubuntu.cves import _fetch_cves
+        with caplog.at_level(logging.WARNING, logger="cartography.intel.ubuntu.util"):
+            retry.increment(
+                method="GET",
+                url="/security/cves.json",
+                response=mock_response,
+            )
 
-        list(_fetch_cves("https://ubuntu.com"))
-        mock_factory.assert_called_once()
+        assert len(caplog.records) == 1
+        assert "Ubuntu API retry" in caplog.records[0].message
+        assert "503" in caplog.records[0].message
 
-    @patch("cartography.intel.ubuntu.notices.retryable_session")
-    def test_fetch_notices_creates_retryable_session(self, mock_factory):
-        mock_session = MagicMock(spec=Session)
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"notices": [], "total_results": 0}
-        mock_session.get.return_value = mock_response
-        mock_factory.return_value = mock_session
+    def test_logs_error_when_retries_exhausted(self, caplog):
+        retry = LoggingRetry(total=0, status_forcelist=[503], allowed_methods=["GET"])
+        mock_response = Mock(status=503)
 
-        from cartography.intel.ubuntu.notices import _fetch_notices
+        with caplog.at_level(logging.WARNING, logger="cartography.intel.ubuntu.util"):
+            with pytest.raises(MaxRetryError):
+                retry.increment(
+                    method="GET",
+                    url="/security/cves.json",
+                    response=mock_response,
+                )
 
-        list(_fetch_notices("https://ubuntu.com"))
-        mock_factory.assert_called_once()
+        error_records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(error_records) == 1
+        assert "retries exhausted" in error_records[0].message

--- a/tests/unit/cartography/intel/ubuntu/test_retry.py
+++ b/tests/unit/cartography/intel/ubuntu/test_retry.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from requests import Session
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
+
+from cartography.intel.ubuntu.util import retryable_session
+
+
+class TestRetryableSession:
+    def test_returns_session_instance(self):
+        session = retryable_session()
+        assert isinstance(session, Session)
+
+    def test_mounts_https_adapter_with_retry(self):
+        session = retryable_session()
+        adapter = session.get_adapter("https://ubuntu.com")
+        assert isinstance(adapter, HTTPAdapter)
+        retry: Retry = adapter.max_retries
+        assert isinstance(retry, Retry)
+
+    def test_retry_policy_covers_503(self):
+        session = retryable_session()
+        retry: Retry = session.get_adapter("https://example.com").max_retries
+        assert 503 in retry.status_forcelist
+
+    def test_retry_policy_parameters(self):
+        session = retryable_session()
+        retry: Retry = session.get_adapter("https://example.com").max_retries
+        assert retry.total == 5
+        assert retry.connect == 1
+        assert retry.backoff_factor == 1
+        assert set(retry.status_forcelist) == {429, 500, 502, 503, 504}
+        assert set(retry.allowed_methods) == {"GET"}
+
+
+class TestFetchUsesRetrySession:
+    @patch("cartography.intel.ubuntu.cves.retryable_session")
+    def test_fetch_cves_creates_retryable_session(self, mock_factory):
+        mock_session = MagicMock(spec=Session)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"cves": [], "total_results": 0}
+        mock_session.get.return_value = mock_response
+        mock_factory.return_value = mock_session
+
+        from cartography.intel.ubuntu.cves import _fetch_cves
+
+        list(_fetch_cves("https://ubuntu.com"))
+        mock_factory.assert_called_once()
+
+    @patch("cartography.intel.ubuntu.notices.retryable_session")
+    def test_fetch_notices_creates_retryable_session(self, mock_factory):
+        mock_session = MagicMock(spec=Session)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"notices": [], "total_results": 0}
+        mock_session.get.return_value = mock_response
+        mock_factory.return_value = mock_session
+
+        from cartography.intel.ubuntu.notices import _fetch_notices
+
+        list(_fetch_notices("https://ubuntu.com"))
+        mock_factory.assert_called_once()


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
The Ubuntu Security API returns intermittent 503 errors that crash the full sync.  Add a retryable_session() helper using urllib3. Retry with exponential backoff (5 retries, backoff_factor=1) for transient HTTP status codes (429, 500, 502, 503, 504).  Both _fetch_cves and _fetch_notices now use the retryable session instead of a bare requests.Session().

### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- Fixes #


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

### How was this tested?

Ran in our cartography deployment environment. Successful run and was able to see the retry kicked in a couple of times.  

<img width="1360" height="158" alt="Screenshot 2026-04-14 at 18 07 24" src="https://github.com/user-attachments/assets/4afc0317-d799-4557-a862-684af68f443a" />

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->
