### PR TITLE
fix(googleworkspace): Handle Google Workspace memberships missing type

### DIFF
--- a/cartography/intel/googleworkspace/groups.py
+++ b/cartography/intel/googleworkspace/groups.py
@@ -282,10 +282,9 @@ def transform_groups(
                 member_type = "GROUP" if member_key_id in group_emails else "USER"
                 logger.warning(
                     "Google Workspace membership %s is missing type; inferred %s "
-                    "from preferredMemberKey.id=%s",
+                    "from known group keys",
                     member.get("name", "<unknown>"),
                     member_type,
-                    member_key_id,
                 )
 
             for role_obj in member.get("roles", []):

--- a/cartography/intel/googleworkspace/groups.py
+++ b/cartography/intel/googleworkspace/groups.py
@@ -244,6 +244,11 @@ def transform_groups(
     transformed_groups: list[dict] = []
     group_member_relationships: list[dict] = []
     group_owner_relationships: list[dict] = []
+    group_emails = {
+        group.get("groupKey", {}).get("id")
+        for group in groups
+        if group.get("groupKey", {}).get("id")
+    }
 
     for group in groups:
         transformed_group = group.copy()
@@ -272,12 +277,23 @@ def transform_groups(
             if member_key_id is None:
                 continue
 
+            member_type = member.get("type")
+            if member_type is None:
+                member_type = "GROUP" if member_key_id in group_emails else "USER"
+                logger.warning(
+                    "Google Workspace membership %s is missing type; inferred %s "
+                    "from preferredMemberKey.id=%s",
+                    member.get("name", "<unknown>"),
+                    member_type,
+                    member_key_id,
+                )
+
             for role_obj in member.get("roles", []):
                 if role_obj.get("name") == "OWNER":
                     is_owner = True
                     break
 
-            if member["type"] == "GROUP":
+            if member_type == "GROUP":
                 # Create group-to-group relationships
                 relationship_data = {
                     "parent_group_id": group["name"],

--- a/tests/integration/cartography/intel/googleworkspace/test_groups.py
+++ b/tests/integration/cartography/intel/googleworkspace/test_groups.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from unittest.mock import patch
 
 import cartography.intel.googleworkspace.groups
@@ -49,6 +50,31 @@ def _ensure_local_neo4j_has_test_groups(neo4j_session):
         TEST_CUSTOMER_ID,
         TEST_UPDATE_TAG,
     )
+
+
+def test_transform_groups_infers_group_membership_when_type_missing():
+    groups = deepcopy(MOCK_GOOGLEWORKSPACE_GROUPS_RESPONSE)
+    group_memberships = deepcopy(MOCK_GOOGLEWORKSPACE_MEMBERS_BY_GROUP_EMAIL)
+    del group_memberships["groups/group-engineering"][2]["type"]
+
+    transformed_groups, group_member_relationships, group_owner_relationships = (
+        cartography.intel.googleworkspace.groups.transform_groups(
+            groups,
+            group_memberships,
+        )
+    )
+
+    assert {group["name"] for group in transformed_groups} == {
+        "groups/group-engineering",
+        "groups/group-operations",
+    }
+    assert group_owner_relationships == []
+    assert group_member_relationships == [
+        {
+            "parent_group_id": "groups/group-engineering",
+            "subgroup_email": "operations@simpson.corp",
+        },
+    ]
 
 
 @patch.object(


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

Google Workspace group ingestion assumed every membership payload included a `type` field.
When that field is absent, sync raised a `KeyError` and aborted group processing.

This change falls back to inferring group-vs-user memberships from the known group email set, logs the incomplete payload, and adds a regression test covering the missing-`type` case.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- N/A


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- `make test_lint`
- `uv run --frozen pytest -vvv tests/integration/cartography/intel/googleworkspace/test_groups.py`


### Checklist

#### General
- [ ] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

- This PR intentionally omits tenant-specific logs and incident references because the fix came from a production report outside this public repo.
- No schema changes are included; this only hardens existing Google Workspace membership handling.
