### PR TITLE
feat(gitlab): align code-to-cloud graph modeling

### DIFF
--- a/cartography/intel/aws/ecr_image_layers.py
+++ b/cartography/intel/aws/ecr_image_layers.py
@@ -21,10 +21,9 @@ from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.util.botocore_config import create_aioboto3_client
 from cartography.intel.container_arch import normalize_architecture
-from cartography.intel.supply_chain import extract_workflow_path_from_ref
 from cartography.intel.supply_chain import extract_container_parent_image
 from cartography.intel.supply_chain import extract_image_source_provenance
-from cartography.intel.supply_chain import get_slsa_dependency_list
+from cartography.intel.supply_chain import extract_workflow_path_from_ref
 from cartography.models.aws.ecr.image import ECRImageSchema
 from cartography.models.aws.ecr.image_layer import ECRImageLayerSchema
 from cartography.util import timeit

--- a/cartography/intel/aws/ecr_image_layers.py
+++ b/cartography/intel/aws/ecr_image_layers.py
@@ -22,7 +22,9 @@ from cartography.graph.job import GraphJob
 from cartography.intel.aws.util.botocore_config import create_aioboto3_client
 from cartography.intel.container_arch import normalize_architecture
 from cartography.intel.supply_chain import extract_workflow_path_from_ref
-from cartography.intel.supply_chain import normalize_vcs_url
+from cartography.intel.supply_chain import extract_container_parent_image
+from cartography.intel.supply_chain import extract_image_source_provenance
+from cartography.intel.supply_chain import get_slsa_dependency_list
 from cartography.models.aws.ecr.image import ECRImageSchema
 from cartography.models.aws.ecr.image_layer import ECRImageLayerSchema
 from cartography.util import timeit
@@ -357,43 +359,9 @@ async def _extract_provenance_from_attestation(
     predicate = attestation_blob.get("predicate", {})
     result: dict[str, Any] = {}
 
-    # Supports SLSA v0.2 materials and SLSA v1 resolvedDependencies.
-    dependency_list: list[dict[str, Any]] = predicate.get("materials", [])
-    if not dependency_list:
-        build_def = predicate.get("buildDefinition", {})
-        dependency_list = build_def.get("resolvedDependencies", [])
+    result.update(extract_container_parent_image(predicate))
 
-    for dep in dependency_list:
-        uri = dep.get("uri", "")
-        uri_l = uri.lower()
-        # Look for container image URIs that are NOT the dockerfile itself
-        is_container_ref = (
-            uri_l.startswith("pkg:docker/")
-            or uri_l.startswith("pkg:oci/")
-            or uri_l.startswith("oci://")
-        )
-        if is_container_ref and "dockerfile" not in uri_l:
-            digest_obj = dep.get("digest", {})
-            sha256_digest = digest_obj.get("sha256")
-            if sha256_digest:
-                result["parent_image_uri"] = uri
-                result["parent_image_digest"] = f"sha256:{sha256_digest}"
-                break
-
-    # SLSA v0.2 stores VCS in predicate.metadata, while SLSA v1 uses
-    # runDetails.metadata.buildkit_metadata.vcs.
-    metadata = predicate.get("metadata", {})
-    buildkit_metadata = metadata.get("https://mobyproject.org/buildkit@v1#metadata", {})
-    vcs = buildkit_metadata.get("vcs", {})
-    if not vcs:
-        run_details = predicate.get("runDetails", {})
-        run_metadata = run_details.get("metadata", {})
-        vcs = run_metadata.get("buildkit_metadata", {}).get("vcs", {})
-
-    if vcs.get("source"):
-        result["source_uri"] = normalize_vcs_url(vcs["source"])
-    if vcs.get("revision"):
-        result["source_revision"] = vcs["revision"]
+    result.update(extract_image_source_provenance(predicate))
 
     # Prefer GitHub Actions env vars when present, otherwise fall back to the
     # SLSA v1 builder URL.
@@ -421,27 +389,6 @@ async def _extract_provenance_from_attestation(
             parts = builder_id.split("/actions/runs/")
             if len(parts) == 2:
                 result["invocation_uri"] = parts[0]
-
-    # SLSA v1 can move the Dockerfile path into
-    # buildDefinition.externalParameters.configSource.path.
-    if "source_uri" in result:
-        config_source = invocation.get("configSource", {})
-        entry_point = config_source.get("entryPoint", "")
-        if not entry_point:
-            build_def = predicate.get("buildDefinition", {})
-            entry_point = (
-                build_def.get("externalParameters", {})
-                .get("configSource", {})
-                .get("path", "Dockerfile")
-            )
-        if not entry_point:
-            entry_point = "Dockerfile"
-        dockerfile_dir = (
-            (vcs.get("localdir:dockerfile") or "").removeprefix("./").rstrip("/")
-        )
-        result["source_file"] = (
-            f"{dockerfile_dir}/{entry_point}" if dockerfile_dir else entry_point
-        )
 
     if not result:
         logger.debug(

--- a/cartography/intel/aws/util/botocore_config.py
+++ b/cartography/intel/aws/util/botocore_config.py
@@ -37,11 +37,7 @@ def _get_botocore_config(
     }
     if max_pool_connections is not None:
         kwargs["max_pool_connections"] = max_pool_connections
-    return _normalize_retries(
-        botocore.config.Config(**kwargs),
-        max_attempts=max_attempts,
-        retry_mode=retry_mode,
-    )
+    return botocore.config.Config(**kwargs)
 
 
 def get_botocore_config(

--- a/cartography/intel/aws/util/botocore_config.py
+++ b/cartography/intel/aws/util/botocore_config.py
@@ -4,8 +4,24 @@ from typing import Any
 import botocore.config
 
 
+def _normalize_retries(
+    config: botocore.config.Config,
+    *,
+    max_attempts: int,
+    retry_mode: str,
+) -> botocore.config.Config:
+    # Botocore mutates Config.retries during client creation by replacing
+    # max_attempts with total_max_attempts. Reset the shared config object so
+    # callers always see the contract Cartography expects.
+    config.retries = {
+        "max_attempts": max_attempts,
+        "mode": retry_mode,
+    }
+    return config
+
+
 @lru_cache(maxsize=None)
-def get_botocore_config(
+def _get_botocore_config(
     *,
     read_timeout: int = 120,
     max_attempts: int = 10,
@@ -21,7 +37,30 @@ def get_botocore_config(
     }
     if max_pool_connections is not None:
         kwargs["max_pool_connections"] = max_pool_connections
-    return botocore.config.Config(**kwargs)
+    return _normalize_retries(
+        botocore.config.Config(**kwargs),
+        max_attempts=max_attempts,
+        retry_mode=retry_mode,
+    )
+
+
+def get_botocore_config(
+    *,
+    read_timeout: int = 120,
+    max_attempts: int = 10,
+    retry_mode: str = "adaptive",
+    max_pool_connections: int | None = None,
+) -> botocore.config.Config:
+    return _normalize_retries(
+        _get_botocore_config(
+            read_timeout=read_timeout,
+            max_attempts=max_attempts,
+            retry_mode=retry_mode,
+            max_pool_connections=max_pool_connections,
+        ),
+        max_attempts=max_attempts,
+        retry_mode=retry_mode,
+    )
 
 
 def _create_client(

--- a/cartography/intel/gitlab/__init__.py
+++ b/cartography/intel/gitlab/__init__.py
@@ -54,7 +54,7 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
 
     # Sync the specified organization (top-level group)
     try:
-        organization = cartography.intel.gitlab.organizations.sync_gitlab_organizations(
+        cartography.intel.gitlab.organizations.sync_gitlab_organizations(
             neo4j_session,
             gitlab_url,
             token,
@@ -78,7 +78,6 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
             )
         raise
 
-    org_url: str = organization["web_url"]
     common_job_parameters["gitlab_url"] = gitlab_url
 
     # Sync groups (nested subgroups within this organization)
@@ -216,36 +215,36 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
 
     # Cleanup leaf nodes (dependencies, dependency_files, branches) for each project
     for project in all_projects:
-        project_url: str = project["web_url"]
+        project_id: int = project["id"]
 
         # Cleanup dependencies
         cartography.intel.gitlab.dependencies.cleanup_dependencies(
-            neo4j_session, common_job_parameters, project_url
+            neo4j_session, common_job_parameters, project_id, gitlab_url
         )
 
         # Cleanup dependency files
         cartography.intel.gitlab.dependency_files.cleanup_dependency_files(
-            neo4j_session, common_job_parameters, project_url
+            neo4j_session, common_job_parameters, project_id, gitlab_url
         )
 
         # Cleanup branches
         cartography.intel.gitlab.branches.cleanup_branches(
-            neo4j_session, common_job_parameters, project_url
+            neo4j_session, common_job_parameters, project_id, gitlab_url
         )
 
     # Cleanup projects with cascade delete
     cartography.intel.gitlab.projects.cleanup_projects(
-        neo4j_session, common_job_parameters, org_url
+        neo4j_session, common_job_parameters, organization_id, gitlab_url
     )
 
     # Cleanup users
     cartography.intel.gitlab.users.cleanup_users(
-        neo4j_session, common_job_parameters, org_url
+        neo4j_session, common_job_parameters, organization_id, gitlab_url
     )
 
     # Cleanup groups with cascade delete
     cartography.intel.gitlab.groups.cleanup_groups(
-        neo4j_session, common_job_parameters, org_url
+        neo4j_session, common_job_parameters, organization_id, gitlab_url
     )
 
     # Cleanup organizations

--- a/cartography/intel/gitlab/__init__.py
+++ b/cartography/intel/gitlab/__init__.py
@@ -45,6 +45,7 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     common_job_parameters: dict[str, Any] = {
         "UPDATE_TAG": config.update_tag,
         "ORGANIZATION_ID": organization_id,
+        "org_id": organization_id,
     }
 
     logger.info(
@@ -78,9 +79,7 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         raise
 
     org_url: str = organization["web_url"]
-
-    # Add org_url to common_job_parameters for cleanup jobs
-    common_job_parameters["org_url"] = org_url
+    common_job_parameters["gitlab_url"] = gitlab_url
 
     # Sync groups (nested subgroups within this organization)
     # Returns the groups list to avoid redundant API calls
@@ -121,7 +120,7 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
             neo4j_session,
             gitlab_url,
             token,
-            org_url,
+            organization_id,
             organization_id,
             config.update_tag,
             common_job_parameters,
@@ -135,7 +134,7 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
             neo4j_session,
             gitlab_url,
             token,
-            org_url,
+            organization_id,
             all_container_repositories,
             config.update_tag,
             common_job_parameters,
@@ -147,7 +146,7 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         neo4j_session,
         gitlab_url,
         token,
-        org_url,
+        organization_id,
         all_container_repositories,
         config.update_tag,
         common_job_parameters,
@@ -158,7 +157,7 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         neo4j_session,
         gitlab_url,
         token,
-        org_url,
+        organization_id,
         all_image_manifests,
         manifest_lists,
         config.update_tag,
@@ -171,7 +170,7 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         neo4j_session,
         gitlab_url,
         token,
-        org_url,
+        organization_id,
         config.update_tag,
         common_job_parameters,
         all_projects,

--- a/cartography/intel/gitlab/branches.py
+++ b/cartography/intel/gitlab/branches.py
@@ -29,7 +29,10 @@ def get_branches(gitlab_url: str, token: str, project_id: int) -> list[dict[str,
 
 
 def transform_branches(
-    raw_branches: list[dict[str, Any]], project_url: str
+    raw_branches: list[dict[str, Any]],
+    project_id: int,
+    project_url: str,
+    gitlab_url: str,
 ) -> list[dict[str, Any]]:
     """
     Transform raw GitLab branch data to match our schema.
@@ -50,8 +53,9 @@ def transform_branches(
             "protected": branch.get("protected", False),
             "default": branch.get("default", False),
             "web_url": branch.get("web_url"),
-            # Relationship fields
-            "project_url": project_url,  # For RESOURCE relationship to GitLabProject
+            "project_id": project_id,
+            "project_url": project_url,
+            "gitlab_url": gitlab_url,
         }
         transformed.append(transformed_branch)
 
@@ -63,7 +67,8 @@ def transform_branches(
 def load_branches(
     neo4j_session: neo4j.Session,
     branches: list[dict[str, Any]],
-    project_url: str,
+    project_id: int,
+    gitlab_url: str,
     update_tag: int,
 ) -> None:
     """
@@ -74,7 +79,8 @@ def load_branches(
         GitLabBranchSchema(),
         branches,
         lastupdated=update_tag,
-        project_url=project_url,
+        project_id=project_id,
+        gitlab_url=gitlab_url,
     )
 
 
@@ -82,13 +88,18 @@ def load_branches(
 def cleanup_branches(
     neo4j_session: neo4j.Session,
     common_job_parameters: dict[str, Any],
-    project_url: str,
+    project_id: int,
+    gitlab_url: str,
 ) -> None:
     """
     Remove stale GitLab branches from the graph for a specific project.
     """
-    logger.info(f"Running GitLab branches cleanup for project {project_url}")
-    cleanup_params = {**common_job_parameters, "project_url": project_url}
+    logger.info(f"Running GitLab branches cleanup for project {project_id}")
+    cleanup_params = {
+        **common_job_parameters,
+        "project_id": project_id,
+        "gitlab_url": gitlab_url,
+    }
     GraphJob.from_node_schema(GitLabBranchSchema(), cleanup_params).run(neo4j_session)
 
 
@@ -122,13 +133,21 @@ def sync_gitlab_branches(
             continue
 
         # Transform to match our schema
-        transformed_branches = transform_branches(raw_branches, project_url)
+        transformed_branches = transform_branches(
+            raw_branches, project_id, project_url, gitlab_url
+        )
 
         logger.info(
             f"Found {len(transformed_branches)} branches in project {project_name}"
         )
 
         # Load branches for this project
-        load_branches(neo4j_session, transformed_branches, project_url, update_tag)
+        load_branches(
+            neo4j_session,
+            transformed_branches,
+            project_id,
+            gitlab_url,
+            update_tag,
+        )
 
     logger.info("GitLab branches sync completed")

--- a/cartography/intel/gitlab/container_image_attestations.py
+++ b/cartography/intel/gitlab/container_image_attestations.py
@@ -354,8 +354,9 @@ def transform_image_provenance_records(
         parent_image_digest = attestation.get("parent_image_digest")
         if not attests_digest or (not source_uri and not parent_image_digest):
             continue
-        provenance_by_digest[str(attests_digest)] = {
-            "digest": attests_digest,
+        digest = str(attests_digest)
+        existing = provenance_by_digest.get(digest, {"digest": attests_digest})
+        candidate = {
             "source_uri": source_uri,
             "source_revision": attestation.get("source_revision"),
             "source_file": attestation.get("source_file"),
@@ -364,6 +365,8 @@ def transform_image_provenance_records(
             "from_attestation": True,
             "confidence": 1.0,
         }
+        existing.update({k: v for k, v in candidate.items() if v is not None})
+        provenance_by_digest[digest] = existing
 
     records = list(provenance_by_digest.values())
     logger.info("Transformed %d image provenance record(s)", len(records))

--- a/cartography/intel/gitlab/container_image_attestations.py
+++ b/cartography/intel/gitlab/container_image_attestations.py
@@ -237,7 +237,11 @@ def _extract_predicate_from_attestation(
     token: str,
 ) -> dict[str, Any] | None:
     """
-    Decode a DSSE attestation blob and return the embedded predicate when present.
+    Decode an attestation blob and return the embedded predicate when present.
+
+    Supports both:
+    - DSSE/cosign envelopes where the blob contains a base64 `payload`
+    - raw in-toto statements where the blob is already JSON with `predicate`
     """
     registry_url = attestation.get("_registry_url")
     repository_name = attestation.get("_repository_name")
@@ -266,22 +270,26 @@ def _extract_predicate_from_attestation(
         return None
 
     payload_b64 = blob.get("payload")
-    if not payload_b64:
+    if payload_b64:
+        try:
+            payload = json.loads(b64decode(str(payload_b64)).decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            logger.debug(
+                "Failed to decode attestation payload for %s",
+                attestation.get("_digest"),
+                exc_info=True,
+            )
+            return None
+
+        if isinstance(payload, dict) and "predicate" in payload:
+            predicate = payload.get("predicate")
+            return unwrap_attestation_predicate(predicate)
         return None
 
-    try:
-        payload = json.loads(b64decode(str(payload_b64)).decode("utf-8"))
-    except (ValueError, UnicodeDecodeError):
-        logger.debug(
-            "Failed to decode attestation payload for %s",
-            attestation.get("_digest"),
-            exc_info=True,
-        )
-        return None
-
-    if isinstance(payload, dict) and "predicate" in payload:
-        predicate = payload.get("predicate")
+    if "predicate" in blob:
+        predicate = blob.get("predicate")
         return unwrap_attestation_predicate(predicate)
+
     return None
 
 
@@ -343,7 +351,8 @@ def transform_image_provenance_records(
     for attestation in transformed_attestations:
         attests_digest = attestation.get("attests_digest")
         source_uri = attestation.get("source_uri")
-        if not attests_digest or not source_uri:
+        parent_image_digest = attestation.get("parent_image_digest")
+        if not attests_digest or (not source_uri and not parent_image_digest):
             continue
         provenance_by_digest[str(attests_digest)] = {
             "digest": attests_digest,

--- a/cartography/intel/gitlab/container_image_attestations.py
+++ b/cartography/intel/gitlab/container_image_attestations.py
@@ -7,7 +7,9 @@ Attestations are discovered via cosign's tag-based scheme:
 - Attestations: sha256-{digest}.att
 """
 
+import json
 import logging
+from base64 import b64decode
 from dataclasses import dataclass
 from typing import Any
 
@@ -16,9 +18,14 @@ import requests
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.gitlab.util import fetch_registry_blob
 from cartography.intel.gitlab.util import fetch_registry_manifest
+from cartography.intel.supply_chain import normalize_vcs_url
 from cartography.models.gitlab.container_image_attestations import (
     GitLabContainerImageAttestationSchema,
+)
+from cartography.models.gitlab.container_images import (
+    GitLabContainerImageProvenanceSchema,
 )
 from cartography.util import timeit
 
@@ -222,8 +229,113 @@ def get_container_image_attestations(
     return all_attestations, summary
 
 
+def _extract_predicate_from_attestation(
+    attestation: dict[str, Any],
+    gitlab_url: str,
+    token: str,
+) -> dict[str, Any] | None:
+    """
+    Decode a DSSE attestation blob and return the embedded predicate when present.
+    """
+    registry_url = attestation.get("_registry_url")
+    repository_name = attestation.get("_repository_name")
+    layers = attestation.get("layers", [])
+    if not registry_url or not repository_name or not layers:
+        return None
+
+    layer_digest = layers[0].get("digest")
+    if not layer_digest:
+        return None
+
+    try:
+        blob = fetch_registry_blob(
+            gitlab_url,
+            str(registry_url),
+            str(repository_name),
+            str(layer_digest),
+            token,
+        )
+    except requests.exceptions.RequestException:
+        logger.warning(
+            "Failed to fetch attestation blob for %s",
+            attestation.get("_digest"),
+            exc_info=True,
+        )
+        return None
+
+    payload_b64 = blob.get("payload")
+    if not payload_b64:
+        return None
+
+    try:
+        payload = json.loads(b64decode(str(payload_b64)).decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        logger.debug(
+            "Failed to decode attestation payload for %s",
+            attestation.get("_digest"),
+            exc_info=True,
+        )
+        return None
+
+    if isinstance(payload, dict) and "predicate" in payload:
+        predicate = payload.get("predicate")
+        return predicate if isinstance(predicate, dict) else None
+    return None
+
+
+def _extract_image_provenance(
+    attestation: dict[str, Any],
+    predicate: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Extract the subset of SLSA provenance fields used by supply-chain matching.
+    """
+    result: dict[str, Any] = {}
+
+    metadata = predicate.get("metadata", {})
+    buildkit_metadata = metadata.get("https://mobyproject.org/buildkit@v1#metadata", {})
+    vcs = buildkit_metadata.get("vcs", {})
+    if not vcs:
+        run_details = predicate.get("runDetails", {})
+        run_metadata = run_details.get("metadata", {})
+        vcs = run_metadata.get("buildkit_metadata", {}).get("vcs", {})
+
+    if vcs.get("source"):
+        result["source_uri"] = normalize_vcs_url(str(vcs["source"]))
+    if vcs.get("revision"):
+        result["source_revision"] = vcs["revision"]
+
+    invocation = predicate.get("invocation", {})
+    config_source = invocation.get("configSource", {})
+    entry_point = config_source.get("entryPoint", "")
+    if not entry_point:
+        build_def = predicate.get("buildDefinition", {})
+        entry_point = (
+            build_def.get("externalParameters", {})
+            .get("configSource", {})
+            .get("path", "Dockerfile")
+        )
+    if not entry_point:
+        entry_point = "Dockerfile"
+
+    if result.get("source_uri"):
+        dockerfile_dir = (
+            str(vcs.get("localdir:dockerfile") or "")
+            .removeprefix("./")
+            .rstrip("/")
+        )
+        result["source_file"] = (
+            f"{dockerfile_dir}/{entry_point}" if dockerfile_dir else entry_point
+        )
+
+    result["attests_digest"] = attestation.get("_attests_digest")
+    return result
+
+
 def transform_container_image_attestations(
     raw_attestations: list[dict[str, Any]],
+    gitlab_url: str,
+    token: str,
 ) -> list[dict[str, Any]]:
     """
     Transform raw attestation data into the format expected by the schema.
@@ -231,39 +343,73 @@ def transform_container_image_attestations(
     transformed = []
 
     for attestation in raw_attestations:
-        transformed.append(
-            {
-                "digest": attestation.get("_digest"),
-                "media_type": attestation.get("mediaType"),
-                "attestation_type": attestation.get("_attestation_type"),
-                "predicate_type": attestation.get("predicateType"),
-                "attests_digest": attestation.get("_attests_digest"),
-            }
-        )
+        record = {
+            "digest": attestation.get("_digest"),
+            "media_type": attestation.get("mediaType"),
+            "attestation_type": attestation.get("_attestation_type"),
+            "predicate_type": attestation.get("predicateType"),
+            "attests_digest": attestation.get("_attests_digest"),
+        }
+        if attestation.get("_attestation_type") in {"att", "buildx"}:
+            predicate = _extract_predicate_from_attestation(
+                attestation,
+                gitlab_url,
+                token,
+            )
+            if predicate:
+                record.update(_extract_image_provenance(attestation, predicate))
+        transformed.append(record)
 
     logger.info(f"Transformed {len(transformed)} container image attestations")
     return transformed
+
+
+def transform_image_provenance_records(
+    transformed_attestations: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Build provenance-only records to merge onto GitLabContainerImage nodes by digest.
+    """
+    provenance_by_digest: dict[str, dict[str, Any]] = {}
+
+    for attestation in transformed_attestations:
+        attests_digest = attestation.get("attests_digest")
+        source_uri = attestation.get("source_uri")
+        if not attests_digest or not source_uri:
+            continue
+        provenance_by_digest[str(attests_digest)] = {
+            "digest": attests_digest,
+            "source_uri": source_uri,
+            "source_revision": attestation.get("source_revision"),
+            "source_file": attestation.get("source_file"),
+        }
+
+    records = list(provenance_by_digest.values())
+    logger.info("Transformed %d image provenance record(s)", len(records))
+    return records
 
 
 @timeit
 def load_container_image_attestations(
     neo4j_session: neo4j.Session,
     attestations: list[dict[str, Any]],
-    org_url: str,
+    org_id: int,
+    gitlab_url: str,
     update_tag: int,
 ) -> None:
     """
     Load GitLab container image attestations into the graph.
     """
     logger.info(
-        f"Loading {len(attestations)} container image attestations for {org_url}"
+        f"Loading {len(attestations)} container image attestations for {org_id}"
     )
     load(
         neo4j_session,
         GitLabContainerImageAttestationSchema(),
         attestations,
         lastupdated=update_tag,
-        org_url=org_url,
+        org_id=org_id,
+        gitlab_url=gitlab_url,
     )
 
 
@@ -283,11 +429,31 @@ def cleanup_container_image_attestations(
 
 
 @timeit
+def load_image_provenance(
+    neo4j_session: neo4j.Session,
+    provenance_records: list[dict[str, Any]],
+    update_tag: int,
+) -> None:
+    """
+    Load provenance fields directly onto GitLabContainerImage nodes.
+    """
+    if not provenance_records:
+        return
+
+    load(
+        neo4j_session,
+        GitLabContainerImageProvenanceSchema(),
+        provenance_records,
+        lastupdated=update_tag,
+    )
+
+
+@timeit
 def sync_container_image_attestations(
     neo4j_session: neo4j.Session,
     gitlab_url: str,
     token: str,
-    org_url: str,
+    org_id: int,
     manifests: list[dict[str, Any]],
     manifest_lists: list[dict[str, Any]],
     update_tag: int,
@@ -296,18 +462,34 @@ def sync_container_image_attestations(
     """
     Sync GitLab container image attestations for an organization.
     """
-    logger.info(f"Syncing container image attestations for organization {org_url}")
+    logger.info(f"Syncing container image attestations for organization {org_id}")
 
     raw_attestations, summary = get_container_image_attestations(
         gitlab_url, token, manifests, manifest_lists
     )
 
-    transformed = transform_container_image_attestations(raw_attestations)
-    load_container_image_attestations(neo4j_session, transformed, org_url, update_tag)
+    transformed = transform_container_image_attestations(
+        raw_attestations,
+        gitlab_url,
+        token,
+    )
+    provenance_records = transform_image_provenance_records(transformed)
+    load_container_image_attestations(
+        neo4j_session,
+        transformed,
+        org_id,
+        gitlab_url,
+        update_tag,
+    )
+    load_image_provenance(
+        neo4j_session,
+        provenance_records,
+        update_tag,
+    )
     if summary.failed:
         logger.warning(
             "Skipping GitLab container image attestations cleanup for %s because %d of %d registry probe(s) failed. Existing attestation data was preserved.",
-            org_url,
+            org_id,
             summary.failed,
             summary.attempted,
         )

--- a/cartography/intel/gitlab/container_image_attestations.py
+++ b/cartography/intel/gitlab/container_image_attestations.py
@@ -20,8 +20,8 @@ from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.gitlab.util import fetch_registry_blob
 from cartography.intel.gitlab.util import fetch_registry_manifest
-from cartography.intel.supply_chain import extract_image_source_provenance
 from cartography.intel.supply_chain import extract_container_parent_image
+from cartography.intel.supply_chain import extract_image_source_provenance
 from cartography.intel.supply_chain import unwrap_attestation_predicate
 from cartography.models.gitlab.container_image_attestations import (
     GitLabContainerImageAttestationSchema,
@@ -294,7 +294,9 @@ def _extract_image_provenance(
     """
     result = extract_image_source_provenance(predicate)
     result.update(extract_container_parent_image(predicate))
-    result["attests_digest"] = attestation.get("_attests_digest")
+    attests_digest = attestation.get("_attests_digest")
+    if attests_digest is not None:
+        result["attests_digest"] = str(attests_digest)
     return result
 
 

--- a/cartography/intel/gitlab/container_image_attestations.py
+++ b/cartography/intel/gitlab/container_image_attestations.py
@@ -320,9 +320,7 @@ def _extract_image_provenance(
 
     if result.get("source_uri"):
         dockerfile_dir = (
-            str(vcs.get("localdir:dockerfile") or "")
-            .removeprefix("./")
-            .rstrip("/")
+            str(vcs.get("localdir:dockerfile") or "").removeprefix("./").rstrip("/")
         )
         result["source_file"] = (
             f"{dockerfile_dir}/{entry_point}" if dockerfile_dir else entry_point

--- a/cartography/intel/gitlab/container_image_attestations.py
+++ b/cartography/intel/gitlab/container_image_attestations.py
@@ -20,7 +20,9 @@ from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.gitlab.util import fetch_registry_blob
 from cartography.intel.gitlab.util import fetch_registry_manifest
-from cartography.intel.supply_chain import normalize_vcs_url
+from cartography.intel.supply_chain import extract_image_source_provenance
+from cartography.intel.supply_chain import extract_container_parent_image
+from cartography.intel.supply_chain import unwrap_attestation_predicate
 from cartography.models.gitlab.container_image_attestations import (
     GitLabContainerImageAttestationSchema,
 )
@@ -279,7 +281,7 @@ def _extract_predicate_from_attestation(
 
     if isinstance(payload, dict) and "predicate" in payload:
         predicate = payload.get("predicate")
-        return predicate if isinstance(predicate, dict) else None
+        return unwrap_attestation_predicate(predicate)
     return None
 
 
@@ -290,42 +292,8 @@ def _extract_image_provenance(
     """
     Extract the subset of SLSA provenance fields used by supply-chain matching.
     """
-    result: dict[str, Any] = {}
-
-    metadata = predicate.get("metadata", {})
-    buildkit_metadata = metadata.get("https://mobyproject.org/buildkit@v1#metadata", {})
-    vcs = buildkit_metadata.get("vcs", {})
-    if not vcs:
-        run_details = predicate.get("runDetails", {})
-        run_metadata = run_details.get("metadata", {})
-        vcs = run_metadata.get("buildkit_metadata", {}).get("vcs", {})
-
-    if vcs.get("source"):
-        result["source_uri"] = normalize_vcs_url(str(vcs["source"]))
-    if vcs.get("revision"):
-        result["source_revision"] = vcs["revision"]
-
-    invocation = predicate.get("invocation", {})
-    config_source = invocation.get("configSource", {})
-    entry_point = config_source.get("entryPoint", "")
-    if not entry_point:
-        build_def = predicate.get("buildDefinition", {})
-        entry_point = (
-            build_def.get("externalParameters", {})
-            .get("configSource", {})
-            .get("path", "Dockerfile")
-        )
-    if not entry_point:
-        entry_point = "Dockerfile"
-
-    if result.get("source_uri"):
-        dockerfile_dir = (
-            str(vcs.get("localdir:dockerfile") or "").removeprefix("./").rstrip("/")
-        )
-        result["source_file"] = (
-            f"{dockerfile_dir}/{entry_point}" if dockerfile_dir else entry_point
-        )
-
+    result = extract_image_source_provenance(predicate)
+    result.update(extract_container_parent_image(predicate))
     result["attests_digest"] = attestation.get("_attests_digest")
     return result
 
@@ -380,6 +348,10 @@ def transform_image_provenance_records(
             "source_uri": source_uri,
             "source_revision": attestation.get("source_revision"),
             "source_file": attestation.get("source_file"),
+            "parent_image_uri": attestation.get("parent_image_uri"),
+            "parent_image_digest": attestation.get("parent_image_digest"),
+            "from_attestation": True,
+            "confidence": 1.0,
         }
 
     records = list(provenance_by_digest.values())

--- a/cartography/intel/gitlab/container_images.py
+++ b/cartography/intel/gitlab/container_images.py
@@ -364,9 +364,29 @@ def transform_container_image_layers(
         layers = manifest.get("layers", [])
         config = manifest.get("_config", {})
         diff_ids_raw = config.get("rootfs", {}).get("diff_ids", [])
+        history_raw = config.get("history", [])
 
         # Ensure diff_ids is a list for type checking
         diff_ids: list[Any] = diff_ids_raw if isinstance(diff_ids_raw, list) else []
+        history_entries: list[Any] = (
+            history_raw if isinstance(history_raw, list) else []
+        )
+
+        # Align history entries to diff_ids using the OCI config convention where
+        # empty layers do not consume diff_ids.
+        history_by_diff_id: dict[str, str] = {}
+        diff_id_index = 0
+        for history_entry_raw in history_entries:
+            if not isinstance(history_entry_raw, dict):
+                continue
+            if history_entry_raw.get("empty_layer", False):
+                continue
+            if diff_id_index >= len(diff_ids):
+                break
+            created_by = history_entry_raw.get("created_by")
+            if created_by:
+                history_by_diff_id[str(diff_ids[diff_id_index])] = str(created_by)
+            diff_id_index += 1
 
         # Process each layer in the chain
         for i, layer in enumerate(layers):
@@ -399,6 +419,8 @@ def transform_container_image_layers(
                     "digest": layer_digest,
                     "media_type": layer.get("mediaType"),
                     "size": layer.get("size"),
+                    "is_empty": False,
+                    "history": history_by_diff_id.get(str(diff_id)),
                     "next_diff_ids": set(),
                 }
 
@@ -418,7 +440,10 @@ def transform_container_image_layers(
             "digest": layer["digest"],
             "media_type": layer["media_type"],
             "size": layer["size"],
+            "is_empty": layer["is_empty"],
         }
+        if layer["history"]:
+            layer_dict["history"] = layer["history"]
         if layer["next_diff_ids"]:
             layer_dict["next_diff_ids"] = list(layer["next_diff_ids"])
         all_layers.append(layer_dict)

--- a/cartography/intel/gitlab/container_images.py
+++ b/cartography/intel/gitlab/container_images.py
@@ -440,7 +440,8 @@ def transform_container_image_layers(
 def load_container_images(
     neo4j_session: neo4j.Session,
     images: list[dict[str, Any]],
-    org_url: str,
+    org_id: int,
+    gitlab_url: str,
     update_tag: int,
 ) -> None:
     """
@@ -452,7 +453,8 @@ def load_container_images(
         images,
         batch_size=GITLAB_CONTAINER_IMAGE_BATCH_SIZE,
         lastupdated=update_tag,
-        org_url=org_url,
+        org_id=org_id,
+        gitlab_url=gitlab_url,
     )
 
 
@@ -473,7 +475,8 @@ def cleanup_container_images(
 def load_container_image_layers(
     neo4j_session: neo4j.Session,
     layers: list[dict[str, Any]],
-    org_url: str,
+    org_id: int,
+    gitlab_url: str,
     update_tag: int,
 ) -> None:
     """
@@ -485,7 +488,8 @@ def load_container_image_layers(
         layers,
         batch_size=GITLAB_CONTAINER_IMAGE_LAYER_BATCH_SIZE,
         lastupdated=update_tag,
-        org_url=org_url,
+        org_id=org_id,
+        gitlab_url=gitlab_url,
     )
 
 
@@ -507,7 +511,7 @@ def sync_container_images(
     neo4j_session: neo4j.Session,
     gitlab_url: str,
     token: str,
-    org_url: str,
+    org_id: int,
     repositories: list[dict[str, Any]],
     update_tag: int,
     common_job_parameters: dict[str, Any],
@@ -548,11 +552,23 @@ def sync_container_images(
         layers = transform_container_image_layers(raw_manifests)
 
         # Load layers FIRST so they exist when image relationships are created.
-        load_container_image_layers(neo4j_session, layers, org_url, update_tag)
-        load_container_images(neo4j_session, images, org_url, update_tag)
+        load_container_image_layers(
+            neo4j_session,
+            layers,
+            org_id,
+            gitlab_url,
+            update_tag,
+        )
+        load_container_images(
+            neo4j_session,
+            images,
+            org_id,
+            gitlab_url,
+            update_tag,
+        )
 
     if total_repositories == 0:
-        logger.info("No GitLab container repositories found for %s", org_url)
+        logger.info("No GitLab container repositories found for %s", org_id)
 
     cleanup_container_image_layers(neo4j_session, common_job_parameters)
     cleanup_container_images(neo4j_session, common_job_parameters)

--- a/cartography/intel/gitlab/container_repositories.py
+++ b/cartography/intel/gitlab/container_repositories.py
@@ -73,7 +73,8 @@ def transform_container_repositories(
 def load_container_repositories(
     neo4j_session: neo4j.Session,
     repositories: list[dict[str, Any]],
-    org_url: str,
+    org_id: int,
+    gitlab_url: str,
     update_tag: int,
 ) -> None:
     """
@@ -84,7 +85,8 @@ def load_container_repositories(
         GitLabContainerRepositorySchema(),
         repositories,
         lastupdated=update_tag,
-        org_url=org_url,
+        org_id=org_id,
+        gitlab_url=gitlab_url,
     )
 
 
@@ -108,7 +110,7 @@ def sync_container_repositories(
     neo4j_session: neo4j.Session,
     gitlab_url: str,
     token: str,
-    org_url: str,
+    org_id: int,
     group_id: int,
     update_tag: int,
     common_job_parameters: dict[str, Any],
@@ -116,12 +118,18 @@ def sync_container_repositories(
     """
     Sync GitLab container repositories for an organization.
     """
-    logger.info(f"Syncing container repositories for organization {org_url}")
+    logger.info(f"Syncing container repositories for organization {org_id}")
 
     raw_repositories = get_container_repositories(gitlab_url, token, group_id)
 
     transformed = transform_container_repositories(raw_repositories)
-    load_container_repositories(neo4j_session, transformed, org_url, update_tag)
+    load_container_repositories(
+        neo4j_session,
+        transformed,
+        org_id,
+        gitlab_url,
+        update_tag,
+    )
     cleanup_container_repositories(neo4j_session, common_job_parameters)
 
     return raw_repositories

--- a/cartography/intel/gitlab/container_repository_tags.py
+++ b/cartography/intel/gitlab/container_repository_tags.py
@@ -126,7 +126,8 @@ def transform_container_repository_tags(
 def load_container_repository_tags(
     neo4j_session: neo4j.Session,
     tags: list[dict[str, Any]],
-    org_url: str,
+    org_id: int,
+    gitlab_url: str,
     update_tag: int,
 ) -> None:
     """
@@ -137,7 +138,8 @@ def load_container_repository_tags(
         GitLabContainerRepositoryTagSchema(),
         tags,
         lastupdated=update_tag,
-        org_url=org_url,
+        org_id=org_id,
+        gitlab_url=gitlab_url,
     )
 
 
@@ -161,7 +163,7 @@ def sync_container_repository_tags(
     neo4j_session: neo4j.Session,
     gitlab_url: str,
     token: str,
-    org_url: str,
+    org_id: int,
     repositories: list[dict[str, Any]],
     update_tag: int,
     common_job_parameters: dict[str, Any],
@@ -169,12 +171,18 @@ def sync_container_repository_tags(
     """
     Sync GitLab container repository tags for an organization.
     """
-    logger.info(f"Syncing container repository tags for organization {org_url}")
+    logger.info(f"Syncing container repository tags for organization {org_id}")
 
     raw_tags = get_all_container_repository_tags(gitlab_url, token, repositories)
 
     transformed = transform_container_repository_tags(raw_tags)
-    load_container_repository_tags(neo4j_session, transformed, org_url, update_tag)
+    load_container_repository_tags(
+        neo4j_session,
+        transformed,
+        org_id,
+        gitlab_url,
+        update_tag,
+    )
     cleanup_container_repository_tags(neo4j_session, common_job_parameters)
 
     return raw_tags

--- a/cartography/intel/gitlab/dependencies.py
+++ b/cartography/intel/gitlab/dependencies.py
@@ -301,7 +301,9 @@ def _parse_cyclonedx_sbom(
 
 def transform_dependencies(
     raw_dependencies: list[dict[str, Any]],
+    project_id: int,
     project_url: str,
+    gitlab_url: str,
 ) -> list[dict[str, Any]]:
     """
     Transform raw dependency data to match our schema.
@@ -323,7 +325,9 @@ def transform_dependencies(
             "name": name,
             "version": version,
             "package_manager": package_manager,
+            "project_id": project_id,
             "project_url": project_url,
+            "gitlab_url": gitlab_url,
         }
 
         if manifest_id:
@@ -339,7 +343,8 @@ def transform_dependencies(
 def load_dependencies(
     neo4j_session: neo4j.Session,
     dependencies: list[dict[str, Any]],
-    project_url: str,
+    project_id: int,
+    gitlab_url: str,
     update_tag: int,
 ) -> None:
     """
@@ -350,7 +355,8 @@ def load_dependencies(
         GitLabDependencySchema(),
         dependencies,
         lastupdated=update_tag,
-        project_url=project_url,
+        project_id=project_id,
+        gitlab_url=gitlab_url,
     )
 
 
@@ -358,13 +364,18 @@ def load_dependencies(
 def cleanup_dependencies(
     neo4j_session: neo4j.Session,
     common_job_parameters: dict[str, Any],
-    project_url: str,
+    project_id: int,
+    gitlab_url: str,
 ) -> None:
     """
     Remove stale GitLab dependencies from the graph for a specific project.
     """
-    logger.info(f"Running GitLab dependencies cleanup for project {project_url}")
-    cleanup_params = {**common_job_parameters, "project_url": project_url}
+    logger.info(f"Running GitLab dependencies cleanup for project {project_id}")
+    cleanup_params = {
+        **common_job_parameters,
+        "project_id": project_id,
+        "gitlab_url": gitlab_url,
+    }
     GraphJob.from_node_schema(GitLabDependencySchema(), cleanup_params).run(
         neo4j_session
     )
@@ -418,7 +429,7 @@ def sync_gitlab_dependencies(
                 logger.debug(f"No dependency files found for project {project_name}")
                 continue
             transformed_files = transform_dependency_files(
-                raw_dependency_files, project_url
+                raw_dependency_files, project_id, project_url, gitlab_url
             )
 
         if not transformed_files:
@@ -437,14 +448,23 @@ def sync_gitlab_dependencies(
             logger.debug(f"No dependencies found for project {project_name}")
             continue
 
-        transformed_dependencies = transform_dependencies(raw_dependencies, project_url)
+        transformed_dependencies = transform_dependencies(
+            raw_dependencies,
+            project_id,
+            project_url,
+            gitlab_url,
+        )
 
         logger.debug(
             f"Found {len(transformed_dependencies)} dependencies in project {project_name}"
         )
 
         load_dependencies(
-            neo4j_session, transformed_dependencies, project_url, update_tag
+            neo4j_session,
+            transformed_dependencies,
+            project_id,
+            gitlab_url,
+            update_tag,
         )
 
     logger.info("GitLab dependencies sync completed")

--- a/cartography/intel/gitlab/dependency_files.py
+++ b/cartography/intel/gitlab/dependency_files.py
@@ -121,7 +121,9 @@ def get_dependency_files(
 
 def transform_dependency_files(
     raw_dependency_files: list[dict[str, Any]],
+    project_id: int,
     project_url: str,
+    gitlab_url: str,
 ) -> list[dict[str, Any]]:
     """
     Transform raw GitLab dependency file data to match our schema.
@@ -138,7 +140,9 @@ def transform_dependency_files(
             "id": dep_file_id,
             "path": file_path,
             "filename": filename,
+            "project_id": project_id,
             "project_url": project_url,
+            "gitlab_url": gitlab_url,
         }
         transformed.append(transformed_file)
 
@@ -150,21 +154,23 @@ def transform_dependency_files(
 def load_dependency_files(
     neo4j_session: neo4j.Session,
     dependency_files: list[dict[str, Any]],
-    project_url: str,
+    project_id: int,
+    gitlab_url: str,
     update_tag: int,
 ) -> None:
     """
     Load GitLab dependency files into the graph for a specific project.
     """
     logger.info(
-        f"Loading {len(dependency_files)} dependency files for project {project_url}"
+        f"Loading {len(dependency_files)} dependency files for project {project_id}"
     )
     load(
         neo4j_session,
         GitLabDependencyFileSchema(),
         dependency_files,
         lastupdated=update_tag,
-        project_url=project_url,
+        project_id=project_id,
+        gitlab_url=gitlab_url,
     )
 
 
@@ -172,13 +178,18 @@ def load_dependency_files(
 def cleanup_dependency_files(
     neo4j_session: neo4j.Session,
     common_job_parameters: dict[str, Any],
-    project_url: str,
+    project_id: int,
+    gitlab_url: str,
 ) -> None:
     """
     Remove stale GitLab dependency files from the graph for a specific project.
     """
-    logger.info(f"Running GitLab dependency files cleanup for project {project_url}")
-    cleanup_params = {**common_job_parameters, "project_url": project_url}
+    logger.info(f"Running GitLab dependency files cleanup for project {project_id}")
+    cleanup_params = {
+        **common_job_parameters,
+        "project_id": project_id,
+        "gitlab_url": gitlab_url,
+    }
     GraphJob.from_node_schema(GitLabDependencyFileSchema(), cleanup_params).run(
         neo4j_session
     )
@@ -228,7 +239,7 @@ def sync_gitlab_dependency_files(
             continue
 
         transformed_files = transform_dependency_files(
-            raw_dependency_files, project_url
+            raw_dependency_files, project_id, project_url, gitlab_url
         )
 
         # Store for downstream use
@@ -238,7 +249,13 @@ def sync_gitlab_dependency_files(
             f"Found {len(transformed_files)} dependency files in project {project_name}"
         )
 
-        load_dependency_files(neo4j_session, transformed_files, project_url, update_tag)
+        load_dependency_files(
+            neo4j_session,
+            transformed_files,
+            project_id,
+            gitlab_url,
+            update_tag,
+        )
 
     logger.info("GitLab dependency files sync completed")
     return dependency_files_by_project

--- a/cartography/intel/gitlab/groups.py
+++ b/cartography/intel/gitlab/groups.py
@@ -33,34 +33,25 @@ def get_groups(gitlab_url: str, token: str, org_id: int) -> list[dict[str, Any]]
 
 
 def transform_groups(
-    raw_groups: list[dict[str, Any]], org_url: str
+    raw_groups: list[dict[str, Any]], org_id: int, gitlab_url: str
 ) -> list[dict[str, Any]]:
     """
     Transform raw GitLab group data to match our schema.
     """
     transformed = []
 
-    # Build lookup map for parent URL resolution
-    id_to_web_url = {group.get("id"): group.get("web_url") for group in raw_groups}
-
     for group in raw_groups:
-        parent_id = group.get("parent_id")
-        web_url = group.get("web_url")
-
-        # Get parent group URL if this is a nested group
-        parent_group_url = id_to_web_url.get(parent_id) if parent_id else None
-
         transformed_group = {
-            "web_url": web_url,
+            "id": group.get("id"),
+            "web_url": group.get("web_url"),
             "name": group.get("name"),
             "path": group.get("path"),
             "full_path": group.get("full_path"),
             "description": group.get("description"),
             "visibility": group.get("visibility"),
-            "parent_id": parent_id,
+            "parent_id": group.get("parent_id"),
             "created_at": group.get("created_at"),
-            "org_url": org_url,
-            "parent_group_url": parent_group_url,
+            "gitlab_url": gitlab_url,
         }
         transformed.append(transformed_group)
 
@@ -72,7 +63,8 @@ def transform_groups(
 def load_groups(
     neo4j_session: neo4j.Session,
     groups: list[dict[str, Any]],
-    org_url: str,
+    org_id: int,
+    gitlab_url: str,
     update_tag: int,
 ) -> None:
     """
@@ -83,7 +75,8 @@ def load_groups(
         GitLabGroupSchema(),
         groups,
         lastupdated=update_tag,
-        org_url=org_url,
+        org_id=org_id,
+        gitlab_url=gitlab_url,
     )
 
 
@@ -91,14 +84,19 @@ def load_groups(
 def cleanup_groups(
     neo4j_session: neo4j.Session,
     common_job_parameters: dict[str, Any],
-    org_url: str,
+    org_id: int,
+    gitlab_url: str,
 ) -> None:
     """
     Remove stale GitLab groups from the graph for a specific organization.
     Uses cascade delete to also remove child projects and nested groups.
     """
-    logger.info(f"Running GitLab groups cleanup for organization {org_url}")
-    cleanup_params = {**common_job_parameters, "org_url": org_url}
+    logger.info(f"Running GitLab groups cleanup for organization {org_id}")
+    cleanup_params = {
+        **common_job_parameters,
+        "org_id": org_id,
+        "gitlab_url": gitlab_url,
+    }
     GraphJob.from_node_schema(
         GitLabGroupSchema(), cleanup_params, cascade_delete=True
     ).run(neo4j_session)
@@ -139,10 +137,16 @@ def sync_gitlab_groups(
         return []
 
     # Transform to match our schema
-    transformed_groups = transform_groups(raw_groups, org_url)
+    transformed_groups = transform_groups(raw_groups, organization_id, gitlab_url)
 
     # Load into Neo4j
-    load_groups(neo4j_session, transformed_groups, org_url, update_tag)
+    load_groups(
+        neo4j_session,
+        transformed_groups,
+        organization_id,
+        gitlab_url,
+        update_tag,
+    )
 
     logger.info("GitLab groups sync completed")
     return raw_groups

--- a/cartography/intel/gitlab/organizations.py
+++ b/cartography/intel/gitlab/organizations.py
@@ -34,6 +34,7 @@ def transform_organizations(
 
     for org in raw_orgs:
         transformed_org = {
+            "id": org.get("id"),
             "web_url": org.get("web_url"),
             "name": org.get("name"),
             "path": org.get("path"),

--- a/cartography/intel/gitlab/projects.py
+++ b/cartography/intel/gitlab/projects.py
@@ -152,8 +152,8 @@ def transform_projects(
             # Group-level project - has relationship to nested group
             group_id = namespace_id
 
-        # Get languages for this project (stored as JSON string for Neo4j)
-        project_id: int = project.get("id", 0)
+        # GitLab project IDs are canonical and required for identity/matching.
+        project_id = project["id"]
         project_languages = languages_by_project.get(project_id, {})
         # Convert to JSON string for storage in Neo4j
         languages_json = json.dumps(project_languages) if project_languages else None

--- a/cartography/intel/gitlab/projects.py
+++ b/cartography/intel/gitlab/projects.py
@@ -115,7 +115,9 @@ def get_projects(gitlab_url: str, token: str, group_id: int) -> list[dict[str, A
 
 def transform_projects(
     raw_projects: list[dict[str, Any]],
+    org_id: int,
     org_url: str,
+    gitlab_url: str,
     languages_by_project: dict[int, dict[str, float]] | None = None,
 ) -> list[dict[str, Any]]:
     """
@@ -140,14 +142,15 @@ def transform_projects(
             continue
 
         namespace_url = namespace.get("web_url")
+        namespace_id = namespace.get("id")
 
         # Determine if this project is in the org directly or in a nested group
         if namespace_url == org_url:
             # Org-level project - no group relationship
-            group_url = None
+            group_id = None
         else:
             # Group-level project - has relationship to nested group
-            group_url = namespace_url
+            group_id = namespace_id
 
         # Get languages for this project (stored as JSON string for Neo4j)
         project_id: int = project.get("id", 0)
@@ -156,6 +159,7 @@ def transform_projects(
         languages_json = json.dumps(project_languages) if project_languages else None
 
         transformed_project = {
+            "id": project_id,
             "web_url": project.get("web_url"),
             "name": project.get("name"),
             "path": project.get("path"),
@@ -166,8 +170,9 @@ def transform_projects(
             "archived": project.get("archived", False),
             "created_at": project.get("created_at"),
             "last_activity_at": project.get("last_activity_at"),
-            "org_url": org_url,
-            "group_url": group_url,
+            "org_id": org_id,
+            "group_id": group_id,
+            "gitlab_url": gitlab_url,
             "languages": languages_json,
         }
         transformed.append(transformed_project)
@@ -180,7 +185,8 @@ def transform_projects(
 def load_projects(
     neo4j_session: neo4j.Session,
     projects: list[dict[str, Any]],
-    org_url: str,
+    org_id: int,
+    gitlab_url: str,
     update_tag: int,
 ) -> None:
     """
@@ -191,7 +197,8 @@ def load_projects(
         GitLabProjectSchema(),
         projects,
         lastupdated=update_tag,
-        org_url=org_url,
+        org_id=org_id,
+        gitlab_url=gitlab_url,
     )
 
 
@@ -199,14 +206,19 @@ def load_projects(
 def cleanup_projects(
     neo4j_session: neo4j.Session,
     common_job_parameters: dict[str, Any],
-    org_url: str,
+    org_id: int,
+    gitlab_url: str,
 ) -> None:
     """
     Remove stale GitLab projects from the graph for a specific organization.
     Uses cascade delete to also remove child branches, dependency files, and dependencies.
     """
-    logger.info(f"Running GitLab projects cleanup for organization {org_url}")
-    cleanup_params = {**common_job_parameters, "org_url": org_url}
+    logger.info(f"Running GitLab projects cleanup for organization {org_id}")
+    cleanup_params = {
+        **common_job_parameters,
+        "org_id": org_id,
+        "gitlab_url": gitlab_url,
+    }
     GraphJob.from_node_schema(
         GitLabProjectSchema(), cleanup_params, cascade_delete=True
     ).run(neo4j_session)
@@ -257,7 +269,7 @@ def sync_gitlab_projects(
     logger.info(f"Found languages for {projects_with_languages} projects")
 
     transformed_projects = transform_projects(
-        raw_projects, org_url, languages_by_project
+        raw_projects, organization_id, org_url, gitlab_url, languages_by_project
     )
 
     if not transformed_projects:
@@ -268,7 +280,13 @@ def sync_gitlab_projects(
         f"Found {len(transformed_projects)} projects in organization {org_name}"
     )
 
-    load_projects(neo4j_session, transformed_projects, org_url, update_tag)
+    load_projects(
+        neo4j_session,
+        transformed_projects,
+        organization_id,
+        gitlab_url,
+        update_tag,
+    )
 
     logger.info("GitLab projects sync completed")
     return raw_projects

--- a/cartography/intel/gitlab/supply_chain.py
+++ b/cartography/intel/gitlab/supply_chain.py
@@ -82,7 +82,7 @@ def get_unmatched_gitlab_container_images_with_history(
             repo_img.created_at DESC
         WITH repo, collect({
             digest: img.digest,
-            uri: repo_img.location,
+            uri: repo_img.id,
             repository_location: coalesce(repo.uri, repo.id),
             project_id: repo.project_id,
             tag: repo_img.name,

--- a/cartography/intel/gitlab/supply_chain.py
+++ b/cartography/intel/gitlab/supply_chain.py
@@ -25,6 +25,8 @@ from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
+GITLAB_SINGLETON_DOCKERFILE_FALLBACK_CONFIDENCE = 0.2
+
 
 @timeit
 def get_unmatched_gitlab_container_images_with_history(
@@ -295,6 +297,60 @@ def get_dockerfiles_for_projects(
     return all_dockerfiles
 
 
+def build_singleton_dockerfile_fallback_matchlinks(
+    images: list[ContainerImage],
+    dockerfiles: list[dict[str, Any]],
+    matched_image_digests: set[str],
+) -> list[dict[str, Any]]:
+    """
+    Build low-confidence fallback matchlinks when a scoped project has exactly one Dockerfile.
+
+    This is GitLab-specific: container repositories map back to a GitLab project, so if a
+    project's registry image has no provenance match and command matching fails, a lone
+    Dockerfile in that same project is still a strong enough heuristic to preserve as a
+    fallback signal.
+    """
+    fallback_records: list[dict[str, Any]] = []
+
+    for image in images:
+        if image.digest in matched_image_digests:
+            continue
+        if not image.scope_keys:
+            continue
+
+        candidate_dockerfiles = [
+            df_info
+            for df_info in dockerfiles
+            if all(
+                df_info.get("scope_keys", {}).get(scope_name) == scope_value
+                for scope_name, scope_value in image.scope_keys.items()
+            )
+        ]
+
+        if len(candidate_dockerfiles) != 1:
+            continue
+
+        dockerfile = candidate_dockerfiles[0]
+        project_url = dockerfile.get("project_url")
+        if not project_url:
+            continue
+
+        fallback_records.append(
+            {
+                "image_digest": image.digest,
+                "project_url": project_url,
+                "match_method": "dockerfile_singleton_fallback",
+                "dockerfile_path": dockerfile.get("path"),
+                "confidence": GITLAB_SINGLETON_DOCKERFILE_FALLBACK_CONFIDENCE,
+                "matched_commands": 0,
+                "total_commands": 0,
+                "command_similarity": 0.0,
+            }
+        )
+
+    return fallback_records
+
+
 @timeit
 def sync(
     neo4j_session: neo4j.Session,
@@ -375,24 +431,34 @@ def sync(
                 dockerfiles,
                 min_confidence=min_match_confidence,
             )
-            if matches:
-                matchlink_data = transform_matches_for_matchlink(
-                    matches,
-                    "project_url",
-                )
-                if matchlink_data:
+            matchlink_data = transform_matches_for_matchlink(
+                matches,
+                "project_url",
+            )
+            fallback_matchlink_data = build_singleton_dockerfile_fallback_matchlinks(
+                unmatched,
+                dockerfiles,
+                {match.image_digest for match in matches},
+            )
+            all_dockerfile_matchlink_data = matchlink_data + fallback_matchlink_data
+            if all_dockerfile_matchlink_data:
+                if fallback_matchlink_data:
                     logger.info(
-                        "Loading %d dockerfile-based PACKAGED_FROM relationships",
-                        len(matchlink_data),
+                        "Adding %d singleton Dockerfile fallback PACKAGED_FROM relationship(s)",
+                        len(fallback_matchlink_data),
                     )
-                    load_matchlinks(
-                        neo4j_session,
-                        GitLabProjectDockerfilePackagedFromMatchLink(),
-                        matchlink_data,
-                        lastupdated=update_tag,
-                        _sub_resource_label="GitLabOrganization",
-                        _sub_resource_id=organization_id,
-                    )
+                logger.info(
+                    "Loading %d dockerfile-based PACKAGED_FROM relationships",
+                    len(all_dockerfile_matchlink_data),
+                )
+                load_matchlinks(
+                    neo4j_session,
+                    GitLabProjectDockerfilePackagedFromMatchLink(),
+                    all_dockerfile_matchlink_data,
+                    lastupdated=update_tag,
+                    _sub_resource_label="GitLabOrganization",
+                    _sub_resource_id=organization_id,
+                )
 
     # 4. Cleanup stale relationships
     GraphJob.from_matchlink(

--- a/cartography/intel/gitlab/supply_chain.py
+++ b/cartography/intel/gitlab/supply_chain.py
@@ -78,14 +78,14 @@ def get_unmatched_gitlab_container_images_with_history(
           )
         WITH repo, img, repo_img
         ORDER BY
-            CASE WHEN repo_img.tag = 'latest' THEN 0 ELSE 1 END,
-            repo_img.image_pushed_at DESC
+            CASE WHEN repo_img.name = 'latest' THEN 0 ELSE 1 END,
+            repo_img.created_at DESC
         WITH repo, collect({
             digest: img.digest,
-            uri: repo_img.uri,
+            uri: repo_img.location,
             repository_location: coalesce(repo.uri, repo.id),
             project_id: repo.project_id,
-            tag: repo_img.tag,
+            tag: repo_img.name,
             layer_diff_ids: img.layer_diff_ids,
             type: img.type,
             architecture: img.architecture,

--- a/cartography/intel/gitlab/supply_chain.py
+++ b/cartography/intel/gitlab/supply_chain.py
@@ -29,15 +29,15 @@ logger = logging.getLogger(__name__)
 @timeit
 def get_unmatched_gitlab_container_images_with_history(
     neo4j_session: neo4j.Session,
-    org_url: str,
+    organization_id: int,
     update_tag: int,
     limit: int | None = None,
 ) -> list[ContainerImage]:
     """
-    Query GitLab container images not yet matched by provenance in this sync iteration.
+    Query container images not yet matched by provenance in this sync iteration.
 
-    Scoped to the current GitLab organization via the graph path:
-    GitLabOrganization → RESOURCE → GitLabContainerRepository → HAS_TAG → Tag → REFERENCES → Image.
+    Uses the generic ontology labels and relationship labels so the same query works
+    for ECR and GitLab Container Registry.
 
     Returns one image per container repository (preferring 'latest' tag, then most recent).
     Excludes images that already have a PACKAGED_FROM relationship created in the current
@@ -45,27 +45,29 @@ def get_unmatched_gitlab_container_images_with_history(
     previous iterations are included so they can be re-matched before cleanup removes them.
 
     :param neo4j_session: Neo4j session
-    :param org_url: The GitLab organization URL to scope the query
+    :param organization_id: The GitLab organization numeric ID used for scoping
     :param update_tag: The current sync update tag
     :param limit: Optional limit on number of images to return
     :return: List of ContainerImage objects with layer history populated
     """
     query = """
-        MATCH (org:GitLabOrganization {id: $org_url})-[:RESOURCE]->(repo:GitLabContainerRepository)
-              -[:HAS_TAG]->(tag:GitLabContainerRepositoryTag)
-              -[:REFERENCES]->(img:GitLabContainerImage)
+        MATCH (img:Image)<-[:IMAGE]-(repo_img:ImageTag)<-[:REPO_IMAGE]-(repo:ContainerRegistry)
         WHERE img.layer_diff_ids IS NOT NULL
           AND size(img.layer_diff_ids) > 0
           AND NOT exists((img)-[:PACKAGED_FROM {lastupdated: $update_tag}]->())
-        WITH repo, img, tag
+          AND (
+              NOT exists((img)-[:PACKAGED_FROM {_sub_resource_label: 'GitLabOrganization'}]->())
+              OR exists((img)-[:PACKAGED_FROM {_sub_resource_id: $organization_id}]->())
+          )
+        WITH repo, img, repo_img
         ORDER BY
-            CASE WHEN tag.name = 'latest' THEN 0 ELSE 1 END,
-            tag.created_at DESC
+            CASE WHEN repo_img.tag = 'latest' THEN 0 ELSE 1 END,
+            repo_img.image_pushed_at DESC
         WITH repo, collect({
             digest: img.digest,
-            uri: img.uri,
-            repository_location: repo.id,
-            tag: tag.name,
+            uri: repo_img.uri,
+            repository_location: coalesce(repo.uri, repo.id),
+            tag: repo_img.tag,
             layer_diff_ids: img.layer_diff_ids,
             type: img.type,
             architecture: img.architecture,
@@ -98,7 +100,11 @@ def get_unmatched_gitlab_container_images_with_history(
     if limit:
         query += f" LIMIT {limit}"
 
-    result = neo4j_session.run(query, update_tag=update_tag, org_url=org_url)
+    result = neo4j_session.run(
+        query,
+        update_tag=update_tag,
+        organization_id=organization_id,
+    )
     images = []
 
     for record in result:
@@ -120,7 +126,7 @@ def get_unmatched_gitlab_container_images_with_history(
         )
 
     logger.info(
-        f"Found {len(images)} GitLab container images with layer history (one per repository)"
+        f"Found {len(images)} unmatched container images with layer history"
     )
     return images
 
@@ -277,7 +283,7 @@ def sync(
     neo4j_session: neo4j.Session,
     gitlab_url: str,
     token: str,
-    org_url: str,
+    organization_id: int,
     update_tag: int,
     common_job_parameters: dict[str, Any],
     projects: list[dict[str, Any]],
@@ -297,14 +303,14 @@ def sync(
     :param neo4j_session: Neo4j session for querying container images
     :param gitlab_url: The GitLab instance URL
     :param token: GitLab API token
-    :param org_url: The GitLab organization URL
+    :param organization_id: The GitLab organization numeric ID
     :param update_tag: The update timestamp tag
     :param common_job_parameters: Common job parameters
     :param projects: List of project dictionaries to search for Dockerfiles
     :param image_limit: Optional limit on number of images to process
     :param min_match_confidence: Minimum confidence threshold for matches
     """
-    logger.info("Starting supply chain sync for GitLab org %s", org_url)
+    logger.info("Starting supply chain sync for GitLab org %s", organization_id)
 
     # 1. PACKAGED_FROM matchlinks (SLSA provenance — no pre-query needed)
     provenance_data = [
@@ -331,13 +337,13 @@ def sync(
             provenance_data,
             lastupdated=update_tag,
             _sub_resource_label="GitLabOrganization",
-            _sub_resource_id=org_url,
+            _sub_resource_id=organization_id,
         )
 
     # 2. Get images WITHOUT existing PACKAGED_FROM for dockerfile analysis
     unmatched = get_unmatched_gitlab_container_images_with_history(
         neo4j_session,
-        org_url,
+        organization_id,
         update_tag,
         limit=image_limit,
     )
@@ -367,21 +373,21 @@ def sync(
                         matchlink_data,
                         lastupdated=update_tag,
                         _sub_resource_label="GitLabOrganization",
-                        _sub_resource_id=org_url,
+                        _sub_resource_id=organization_id,
                     )
 
     # 4. Cleanup stale relationships
     GraphJob.from_matchlink(
         GitLabProjectProvenancePackagedFromMatchLink(),
         "GitLabOrganization",
-        org_url,
+        organization_id,
         update_tag,
     ).run(neo4j_session)
 
     GraphJob.from_matchlink(
         GitLabProjectDockerfilePackagedFromMatchLink(),
         "GitLabOrganization",
-        org_url,
+        organization_id,
         update_tag,
     ).run(neo4j_session)
 
@@ -392,4 +398,4 @@ def sync(
         common_job_parameters,
     )
 
-    logger.info("Completed supply chain sync for GitLab org %s", org_url)
+    logger.info("Completed supply chain sync for GitLab org %s", organization_id)

--- a/cartography/intel/gitlab/supply_chain.py
+++ b/cartography/intel/gitlab/supply_chain.py
@@ -1,6 +1,7 @@
 import base64
 import logging
 from typing import Any
+from typing import cast
 
 import neo4j
 import requests
@@ -68,7 +69,12 @@ def get_unmatched_gitlab_container_images_with_history(
           AND NOT exists((img)-[:PACKAGED_FROM {lastupdated: $update_tag}]->())
           AND (
               NOT exists((img)-[:PACKAGED_FROM {_sub_resource_label: 'GitLabOrganization'}]->())
-              OR exists((img)-[:PACKAGED_FROM {_sub_resource_id: $organization_id}]->())
+              OR exists((
+                  img
+              )-[:PACKAGED_FROM {
+                  _sub_resource_label: 'GitLabOrganization',
+                  _sub_resource_id: $organization_id
+              }]->())
           )
         WITH repo, img, repo_img
         ORDER BY
@@ -464,14 +470,14 @@ def sync(
     GraphJob.from_matchlink(
         GitLabProjectProvenancePackagedFromMatchLink(),
         "GitLabOrganization",
-        str(organization_id),
+        cast(Any, organization_id),
         update_tag,
     ).run(neo4j_session)
 
     GraphJob.from_matchlink(
         GitLabProjectDockerfilePackagedFromMatchLink(),
         "GitLabOrganization",
-        str(organization_id),
+        cast(Any, organization_id),
         update_tag,
     ).run(neo4j_session)
 

--- a/cartography/intel/gitlab/supply_chain.py
+++ b/cartography/intel/gitlab/supply_chain.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 def get_unmatched_gitlab_container_images_with_history(
     neo4j_session: neo4j.Session,
     organization_id: int,
+    gitlab_url: str,
     update_tag: int,
     limit: int | None = None,
 ) -> list[ContainerImage]:
@@ -46,6 +47,7 @@ def get_unmatched_gitlab_container_images_with_history(
 
     :param neo4j_session: Neo4j session
     :param organization_id: The GitLab organization numeric ID used for scoping
+    :param gitlab_url: The GitLab instance URL used to scope GitLab registry images
     :param update_tag: The current sync update tag
     :param limit: Optional limit on number of images to return
     :return: List of ContainerImage objects with layer history populated
@@ -54,6 +56,13 @@ def get_unmatched_gitlab_container_images_with_history(
         MATCH (img:Image)<-[:IMAGE]-(repo_img:ImageTag)<-[:REPO_IMAGE]-(repo:ContainerRegistry)
         WHERE img.layer_diff_ids IS NOT NULL
           AND size(img.layer_diff_ids) > 0
+          AND (
+              NOT repo:GitLabContainerRepository
+              OR exists(
+                  (:GitLabOrganization {id: $organization_id, gitlab_url: $gitlab_url})
+                  -[:RESOURCE]->(repo)
+              )
+          )
           AND NOT exists((img)-[:PACKAGED_FROM {lastupdated: $update_tag}]->())
           AND (
               NOT exists((img)-[:PACKAGED_FROM {_sub_resource_label: 'GitLabOrganization'}]->())
@@ -104,6 +113,7 @@ def get_unmatched_gitlab_container_images_with_history(
         query,
         update_tag=update_tag,
         organization_id=organization_id,
+        gitlab_url=gitlab_url,
     )
     images = []
 
@@ -125,9 +135,7 @@ def get_unmatched_gitlab_container_images_with_history(
             )
         )
 
-    logger.info(
-        f"Found {len(images)} unmatched container images with layer history"
-    )
+    logger.info(f"Found {len(images)} unmatched container images with layer history")
     return images
 
 
@@ -344,6 +352,7 @@ def sync(
     unmatched = get_unmatched_gitlab_container_images_with_history(
         neo4j_session,
         organization_id,
+        gitlab_url,
         update_tag,
         limit=image_limit,
     )
@@ -380,14 +389,14 @@ def sync(
     GraphJob.from_matchlink(
         GitLabProjectProvenancePackagedFromMatchLink(),
         "GitLabOrganization",
-        organization_id,
+        str(organization_id),
         update_tag,
     ).run(neo4j_session)
 
     GraphJob.from_matchlink(
         GitLabProjectDockerfilePackagedFromMatchLink(),
         "GitLabOrganization",
-        organization_id,
+        str(organization_id),
         update_tag,
     ).run(neo4j_session)
 

--- a/cartography/intel/gitlab/supply_chain.py
+++ b/cartography/intel/gitlab/supply_chain.py
@@ -76,6 +76,7 @@ def get_unmatched_gitlab_container_images_with_history(
             digest: img.digest,
             uri: repo_img.uri,
             repository_location: coalesce(repo.uri, repo.id),
+            project_id: repo.project_id,
             tag: repo_img.tag,
             layer_diff_ids: img.layer_diff_ids,
             type: img.type,
@@ -98,6 +99,7 @@ def get_unmatched_gitlab_container_images_with_history(
             best.digest AS digest,
             best.uri AS uri,
             best.repository_location AS repository_location,
+            best.project_id AS project_id,
             best.tag AS tag,
             best.layer_diff_ids AS layer_diff_ids,
             best.type AS type,
@@ -132,6 +134,11 @@ def get_unmatched_gitlab_container_images_with_history(
                 architecture=record["architecture"],
                 os=record["os"],
                 layer_history=layer_history,
+                scope_keys=(
+                    {"gitlab_project_id": str(record["project_id"])}
+                    if record["project_id"] is not None
+                    else None
+                ),
             )
         )
 
@@ -236,6 +243,8 @@ def _build_dockerfile_info(
         return None
     info["project_url"] = project_url
     info["project_name"] = project_name
+    if project.get("id") is not None:
+        info["scope_keys"] = {"gitlab_project_id": str(project["id"])}
     # Used by the shared matching algorithm
     info["source_repo_id"] = project_url
     return info

--- a/cartography/intel/gitlab/users.py
+++ b/cartography/intel/gitlab/users.py
@@ -90,6 +90,7 @@ def get_commits(
 def transform_commit_activity(
     commits_by_project: dict[int, list[dict[str, Any]]],
     users_by_email: dict[str, int],
+    users_by_name: dict[str, int],
     user_records: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """
@@ -99,10 +100,13 @@ def transform_commit_activity(
     Takes existing user records and creates new records with commit properties added.
 
     Matching strategy:
-    1. Match by author_email only.
+    1. Match by author_email first.
+    2. Fall back to author_name when email is unavailable or not exposed by the
+       GitLab members API for the current token/instance.
 
     :param commits_by_project: Dict mapping project_id to list of commits
     :param users_by_email: Dict mapping user email to user ID
+    :param users_by_name: Dict mapping user display name to user ID
     :param user_records: Existing user records with all user properties
     :return: List of commit activity records (user data + commit properties)
     """
@@ -114,18 +118,23 @@ def transform_commit_activity(
 
     # Track matching stats for logging
     email_matches = 0
+    name_matches = 0
     no_matches = 0
 
     for project_id, commits in commits_by_project.items():
         for commit in commits:
             committed_date = commit.get("committed_date")
             author_email = commit.get("author_email")
+            author_name = commit.get("author_name")
             if not committed_date:
                 continue
 
             if author_email and author_email in users_by_email:
                 user_id = users_by_email[author_email]
                 email_matches += 1
+            elif author_name and author_name in users_by_name:
+                user_id = users_by_name[author_name]
+                name_matches += 1
             else:
                 no_matches += 1
                 continue
@@ -137,7 +146,8 @@ def transform_commit_activity(
             activity[key].append(committed_date)
 
     logger.info(
-        f"Commit author matching: {email_matches} by email, {no_matches} unmatched"
+        f"Commit author matching: {email_matches} by email, "
+        f"{name_matches} by name, {no_matches} unmatched"
     )
 
     # Build records by taking existing user data and adding commit properties
@@ -436,8 +446,9 @@ def sync_gitlab_users(
     # Load users and their group memberships into Neo4j
     load_users(neo4j_session, user_records, organization_id, gitlab_url, update_tag)
 
-    # Build email mapping for commit author matching.
+    # Build email/name mappings for commit author matching.
     users_by_email: dict[str, int] = {}
+    users_by_name: dict[str, int] = {}
 
     # Collect all members (org + groups) to process
     all_members = list(org_members)
@@ -456,8 +467,15 @@ def sync_gitlab_users(
         # Build email mapping (if email is available)
         if email and user_id:
             users_by_email[email] = user_id
+        name = member.get("name")
+        if name and user_id:
+            users_by_name[name] = user_id
 
-    logger.info(f"Built commit author mappings: {len(users_by_email)} by email")
+    logger.info(
+        "Built commit author mappings: %d by email, %d by name",
+        len(users_by_email),
+        len(users_by_name),
+    )
 
     # Fetch commits for all projects to build commit activity
     commits_by_project: dict[int, list[dict[str, Any]]] = {}
@@ -482,7 +500,7 @@ def sync_gitlab_users(
     # Transform and load commit activity
     if commits_by_project:
         activity_records = transform_commit_activity(
-            commits_by_project, users_by_email, user_records
+            commits_by_project, users_by_email, users_by_name, user_records
         )
         if activity_records:
             load_commit_activity(

--- a/cartography/intel/gitlab/users.py
+++ b/cartography/intel/gitlab/users.py
@@ -88,9 +88,9 @@ def get_commits(
 
 
 def transform_commit_activity(
-    commits_by_project: dict[str, list[dict[str, Any]]],
-    users_by_email: dict[str, str],
-    users_by_name: dict[str, str],
+    commits_by_project: dict[int, list[dict[str, Any]]],
+    users_by_email: dict[str, int],
+    users_by_name: dict[str, int],
     user_records: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """
@@ -103,24 +103,24 @@ def transform_commit_activity(
     1. Try to match by author_email first (more accurate)
     2. Fall back to author_name if email not available or not found
 
-    :param commits_by_project: Dict mapping project_url to list of commits
-    :param users_by_email: Dict mapping user email to user web_url
-    :param users_by_name: Dict mapping user display name to user web_url
+    :param commits_by_project: Dict mapping project_id to list of commits
+    :param users_by_email: Dict mapping user email to user ID
+    :param users_by_name: Dict mapping user display name to user ID
     :param user_records: Existing user records with all user properties
     :return: List of commit activity records (user data + commit properties)
     """
     # Build a lookup from web_url to user record for quick access
-    users_by_url = {record["web_url"]: record for record in user_records}
+    users_by_id = {record["id"]: record for record in user_records}
 
-    # Aggregate: (user_url, project_url) -> list of commit dates
-    activity: dict[tuple[str, str], list[str]] = {}
+    # Aggregate: (user_id, project_id) -> list of commit dates
+    activity: dict[tuple[int, int], list[str]] = {}
 
     # Track matching stats for logging
     email_matches = 0
     name_matches = 0
     no_matches = 0
 
-    for project_url, commits in commits_by_project.items():
+    for project_id, commits in commits_by_project.items():
         for commit in commits:
             committed_date = commit.get("committed_date")
             author_email = commit.get("author_email")
@@ -130,18 +130,18 @@ def transform_commit_activity(
                 continue
 
             # Try to match user by email first, then fall back to name
-            user_url = None
+            user_id = None
             if author_email and author_email in users_by_email:
-                user_url = users_by_email[author_email]
+                user_id = users_by_email[author_email]
                 email_matches += 1
             elif author_name and author_name in users_by_name:
-                user_url = users_by_name[author_name]
+                user_id = users_by_name[author_name]
                 name_matches += 1
             else:
                 no_matches += 1
                 continue
 
-            key = (user_url, project_url)
+            key = (user_id, project_id)
 
             if key not in activity:
                 activity[key] = []
@@ -154,7 +154,7 @@ def transform_commit_activity(
 
     # Build records by taking existing user data and adding commit properties
     records = []
-    for (user_url, project_url), dates in activity.items():
+    for (user_id, project_id), dates in activity.items():
         # Parse ISO dates to datetime objects for proper timezone-aware comparison
         commit_dates = [
             datetime.fromisoformat(date.replace("Z", "+00:00")) for date in dates
@@ -162,10 +162,10 @@ def transform_commit_activity(
 
         # Find the user record (may have multiple if they have group memberships)
         # Just take the first one since we only need the user properties
-        base_user_data = users_by_url.get(user_url)
+        base_user_data = users_by_id.get(user_id)
         if not base_user_data:
             logger.warning(
-                f"User {user_url} not found in user records, skipping commit activity"
+                f"User {user_id} not found in user records, skipping commit activity"
             )
             continue
 
@@ -176,7 +176,7 @@ def transform_commit_activity(
         # Create new record with user properties + commit properties
         record = {
             **base_user_data,  # Copy all user properties
-            "project_url": project_url,
+            "project_id": project_id,
             "commit_count": len(dates),
             "first_commit_date": first_date,
             "last_commit_date": last_date,
@@ -194,7 +194,8 @@ def transform_commit_activity(
 
 def transform_users_and_memberships(
     org_members: list[dict[str, Any]],
-    group_members_by_group: dict[str, list[dict[str, Any]]],
+    group_members_by_group: dict[int, list[dict[str, Any]]],
+    gitlab_url: str,
 ) -> list[dict[str, Any]]:
     """
     Transform raw GitLab user and membership data into the format expected by the schema.
@@ -207,14 +208,14 @@ def transform_users_and_memberships(
     user data but no group relationship fields.
     """
     # Track which users we've seen and their group memberships
-    user_memberships: dict[str, list[dict[str, Any]]] = {}
+    user_memberships: dict[int, list[dict[str, Any]]] = {}
 
     # Process organization members (these may or may not have group memberships)
     for member in org_members:
-        user_url = member.get("web_url")
+        user_id = member.get("id")
         username = member.get("username", "")
 
-        if not user_url:
+        if not user_id:
             continue
 
         # Skip bot users (group/project access tokens)
@@ -224,16 +225,16 @@ def transform_users_and_memberships(
             continue
 
         # Initialize user if not seen before
-        if user_url not in user_memberships:
-            user_memberships[user_url] = []
+        if user_id not in user_memberships:
+            user_memberships[user_id] = []
 
     # Process group memberships
-    for group_url, members in group_members_by_group.items():
+    for group_id, members in group_members_by_group.items():
         for member in members:
-            user_url = member.get("web_url")
+            user_id = member.get("id")
             username = member.get("username", "")
 
-            if not user_url:
+            if not user_id:
                 continue
 
             # Skip bot users (group/project access tokens)
@@ -242,8 +243,8 @@ def transform_users_and_memberships(
                 continue
 
             # Initialize user if not seen before
-            if user_url not in user_memberships:
-                user_memberships[user_url] = []
+            if user_id not in user_memberships:
+                user_memberships[user_id] = []
 
             # Add group membership
             access_level = member.get("access_level")
@@ -254,23 +255,25 @@ def transform_users_and_memberships(
             )
 
             membership = {
-                "web_url": user_url,  # User node id
+                "id": user_id,
+                "web_url": member.get("web_url"),
                 "username": member.get("username"),
                 "name": member.get("name"),
                 "state": member.get("state"),
                 "email": member.get("email"),
                 "is_admin": member.get("is_admin", False),
-                "group_url": group_url,  # Target for MEMBER_OF relationship
+                "group_id": group_id,
+                "gitlab_url": gitlab_url,
                 "role": role,
                 "access_level": access_level,
             }
-            user_memberships[user_url].append(membership)
+            user_memberships[user_id].append(membership)
 
     # Build final records: one record per user-group membership
     records: list[dict[str, Any]] = []
     users_without_groups = 0
 
-    for user_url, memberships in user_memberships.items():
+    for user_id, memberships in user_memberships.items():
         if memberships:
             # User has group memberships - add one record per membership
             records.extend(memberships)
@@ -278,18 +281,20 @@ def transform_users_and_memberships(
             # User has no group memberships - add single record with just user data
             # Find user data from org_members
             user_data = next(
-                (m for m in org_members if m.get("web_url") == user_url), None
+                (m for m in org_members if m.get("id") == user_id), None
             )
             if user_data:
                 records.append(
                     {
-                        "web_url": user_url,  # User node id
+                        "id": user_id,
+                        "web_url": user_data.get("web_url"),
                         "username": user_data.get("username"),
                         "name": user_data.get("name"),
                         "state": user_data.get("state"),
                         "email": user_data.get("email"),
                         "is_admin": user_data.get("is_admin", False),
-                        # No group_url = no MEMBER_OF relationship created
+                        "gitlab_url": gitlab_url,
+                        # No group_id = no MEMBER_OF relationship created
                     }
                 )
                 users_without_groups += 1
@@ -306,7 +311,8 @@ def transform_users_and_memberships(
 def load_users(
     neo4j_session: neo4j.Session,
     user_records: list[dict[str, Any]],
-    org_url: str,
+    org_id: int,
+    gitlab_url: str,
     update_tag: int,
 ) -> None:
     """
@@ -322,7 +328,8 @@ def load_users(
         GitLabUserSchema(),
         user_records,
         lastupdated=update_tag,
-        org_url=org_url,
+        org_id=org_id,
+        gitlab_url=gitlab_url,
     )
 
 
@@ -330,7 +337,8 @@ def load_users(
 def load_commit_activity(
     neo4j_session: neo4j.Session,
     activity_records: list[dict[str, Any]],
-    org_url: str,
+    org_id: int,
+    gitlab_url: str,
     update_tag: int,
 ) -> None:
     """
@@ -345,7 +353,8 @@ def load_commit_activity(
         GitLabUserSchema(),
         activity_records,
         lastupdated=update_tag,
-        org_url=org_url,
+        org_id=org_id,
+        gitlab_url=gitlab_url,
     )
 
 
@@ -353,13 +362,18 @@ def load_commit_activity(
 def cleanup_users(
     neo4j_session: neo4j.Session,
     common_job_parameters: dict[str, Any],
-    org_url: str,
+    org_id: int,
+    gitlab_url: str,
 ) -> None:
     """
     Remove stale GitLab users from the graph for a specific organization.
     """
-    logger.info(f"Running GitLab users cleanup for organization {org_url}")
-    cleanup_params = {**common_job_parameters, "org_url": org_url}
+    logger.info(f"Running GitLab users cleanup for organization {org_id}")
+    cleanup_params = {
+        **common_job_parameters,
+        "org_id": org_id,
+        "gitlab_url": gitlab_url,
+    }
     GraphJob.from_node_schema(GitLabUserSchema(), cleanup_params).run(neo4j_session)
 
 
@@ -403,21 +417,20 @@ def sync_gitlab_users(
         org_members = []
 
     # Fetch members for all descendant groups
-    group_members_by_group: dict[str, list[dict[str, Any]]] = {}
+    group_members_by_group: dict[int, list[dict[str, Any]]] = {}
     for group in groups:
         group_id = group.get("id")
-        group_url = group.get("web_url")
-        if not group_id or not group_url:
+        if not group_id:
             continue
 
         try:
             members = get_group_members(gitlab_url, token, group_id)
             if members:
-                group_members_by_group[group_url] = members
-                logger.debug(f"Fetched {len(members)} members for group {group_url}")
+                group_members_by_group[group_id] = members
+                logger.debug(f"Fetched {len(members)} members for group {group_id}")
         except Exception:
             logger.warning(
-                f"Failed to fetch members for group {group_url}", exc_info=True
+                f"Failed to fetch members for group {group_id}", exc_info=True
             )
             continue
 
@@ -426,19 +439,21 @@ def sync_gitlab_users(
     )
 
     # Transform users and memberships into records
-    user_records = transform_users_and_memberships(org_members, group_members_by_group)
+    user_records = transform_users_and_memberships(
+        org_members, group_members_by_group, gitlab_url
+    )
 
     if not user_records:
         logger.info(f"No users found for organization {org_name}")
         return
 
     # Load users and their group memberships into Neo4j
-    load_users(neo4j_session, user_records, org_url, update_tag)
+    load_users(neo4j_session, user_records, organization_id, gitlab_url, update_tag)
 
     # Build email and name mappings for commit author matching
     # Try email first (more accurate), fall back to name
-    users_by_email: dict[str, str] = {}
-    users_by_name: dict[str, str] = {}
+    users_by_email: dict[str, int] = {}
+    users_by_name: dict[str, int] = {}
 
     # Track duplicate names for warning
     duplicate_names: set[str] = set()
@@ -451,7 +466,7 @@ def sync_gitlab_users(
     for member in all_members:
         name = member.get("name")
         email = member.get("email")
-        web_url = member.get("web_url")
+        user_id = member.get("id")
         username = member.get("username", "")
 
         # Skip bot users
@@ -459,15 +474,15 @@ def sync_gitlab_users(
             continue
 
         # Build email mapping (if email is available)
-        if email and web_url:
-            users_by_email[email] = web_url
+        if email and user_id:
+            users_by_email[email] = user_id
 
         # Build name mapping (always available as fallback)
-        if name and web_url:
+        if name and user_id:
             # Check for duplicate names
-            if name in users_by_name and users_by_name[name] != web_url:
+            if name in users_by_name and users_by_name[name] != user_id:
                 duplicate_names.add(name)
-            users_by_name[name] = web_url
+            users_by_name[name] = user_id
 
     # Warn about duplicate names (silent data loss risk)
     if duplicate_names:
@@ -483,23 +498,20 @@ def sync_gitlab_users(
     )
 
     # Fetch commits for all projects to build commit activity
-    commits_by_project: dict[str, list[dict[str, Any]]] = {}
+    commits_by_project: dict[int, list[dict[str, Any]]] = {}
     for project in projects:
         project_id = project.get("id")
-        project_url = project.get("web_url")
-        if not project_id or not project_url:
+        if not project_id:
             continue
 
         try:
             commits = get_commits(gitlab_url, token, project_id, commits_since_days)
             if commits:
-                commits_by_project[project_url] = commits
-                logger.debug(
-                    f"Fetched {len(commits)} commits for project {project_url}"
-                )
+                commits_by_project[project_id] = commits
+                logger.debug(f"Fetched {len(commits)} commits for project {project_id}")
         except Exception:
             logger.warning(
-                f"Failed to fetch commits for project {project_url}", exc_info=True
+                f"Failed to fetch commits for project {project_id}", exc_info=True
             )
             continue
 
@@ -511,6 +523,12 @@ def sync_gitlab_users(
             commits_by_project, users_by_email, users_by_name, user_records
         )
         if activity_records:
-            load_commit_activity(neo4j_session, activity_records, org_url, update_tag)
+            load_commit_activity(
+                neo4j_session,
+                activity_records,
+                organization_id,
+                gitlab_url,
+                update_tag,
+            )
 
     logger.info("GitLab users sync completed")

--- a/cartography/intel/gitlab/users.py
+++ b/cartography/intel/gitlab/users.py
@@ -90,7 +90,6 @@ def get_commits(
 def transform_commit_activity(
     commits_by_project: dict[int, list[dict[str, Any]]],
     users_by_email: dict[str, int],
-    users_by_name: dict[str, int],
     user_records: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """
@@ -100,12 +99,10 @@ def transform_commit_activity(
     Takes existing user records and creates new records with commit properties added.
 
     Matching strategy:
-    1. Try to match by author_email first (more accurate)
-    2. Fall back to author_name if email not available or not found
+    1. Match by author_email only.
 
     :param commits_by_project: Dict mapping project_id to list of commits
     :param users_by_email: Dict mapping user email to user ID
-    :param users_by_name: Dict mapping user display name to user ID
     :param user_records: Existing user records with all user properties
     :return: List of commit activity records (user data + commit properties)
     """
@@ -117,26 +114,18 @@ def transform_commit_activity(
 
     # Track matching stats for logging
     email_matches = 0
-    name_matches = 0
     no_matches = 0
 
     for project_id, commits in commits_by_project.items():
         for commit in commits:
             committed_date = commit.get("committed_date")
             author_email = commit.get("author_email")
-            author_name = commit.get("author_name")
-
             if not committed_date:
                 continue
 
-            # Try to match user by email first, then fall back to name
-            user_id = None
             if author_email and author_email in users_by_email:
                 user_id = users_by_email[author_email]
                 email_matches += 1
-            elif author_name and author_name in users_by_name:
-                user_id = users_by_name[author_name]
-                name_matches += 1
             else:
                 no_matches += 1
                 continue
@@ -148,8 +137,7 @@ def transform_commit_activity(
             activity[key].append(committed_date)
 
     logger.info(
-        f"Commit author matching: {email_matches} by email, "
-        f"{name_matches} by name, {no_matches} unmatched"
+        f"Commit author matching: {email_matches} by email, {no_matches} unmatched"
     )
 
     # Build records by taking existing user data and adding commit properties
@@ -280,9 +268,7 @@ def transform_users_and_memberships(
         else:
             # User has no group memberships - add single record with just user data
             # Find user data from org_members
-            user_data = next(
-                (m for m in org_members if m.get("id") == user_id), None
-            )
+            user_data = next((m for m in org_members if m.get("id") == user_id), None)
             if user_data:
                 records.append(
                     {
@@ -450,13 +436,8 @@ def sync_gitlab_users(
     # Load users and their group memberships into Neo4j
     load_users(neo4j_session, user_records, organization_id, gitlab_url, update_tag)
 
-    # Build email and name mappings for commit author matching
-    # Try email first (more accurate), fall back to name
+    # Build email mapping for commit author matching.
     users_by_email: dict[str, int] = {}
-    users_by_name: dict[str, int] = {}
-
-    # Track duplicate names for warning
-    duplicate_names: set[str] = set()
 
     # Collect all members (org + groups) to process
     all_members = list(org_members)
@@ -464,7 +445,6 @@ def sync_gitlab_users(
         all_members.extend(members)
 
     for member in all_members:
-        name = member.get("name")
         email = member.get("email")
         user_id = member.get("id")
         username = member.get("username", "")
@@ -477,25 +457,7 @@ def sync_gitlab_users(
         if email and user_id:
             users_by_email[email] = user_id
 
-        # Build name mapping (always available as fallback)
-        if name and user_id:
-            # Check for duplicate names
-            if name in users_by_name and users_by_name[name] != user_id:
-                duplicate_names.add(name)
-            users_by_name[name] = user_id
-
-    # Warn about duplicate names (silent data loss risk)
-    if duplicate_names:
-        logger.warning(
-            f"Found {len(duplicate_names)} users with duplicate display names. "
-            "Commit matching by name may be inaccurate for these users. "
-            "Email matching will be attempted first."
-        )
-
-    logger.info(
-        f"Built commit author mappings: {len(users_by_email)} by email, "
-        f"{len(users_by_name)} by name"
-    )
+    logger.info(f"Built commit author mappings: {len(users_by_email)} by email")
 
     # Fetch commits for all projects to build commit activity
     commits_by_project: dict[int, list[dict[str, Any]]] = {}
@@ -520,7 +482,7 @@ def sync_gitlab_users(
     # Transform and load commit activity
     if commits_by_project:
         activity_records = transform_commit_activity(
-            commits_by_project, users_by_email, users_by_name, user_records
+            commits_by_project, users_by_email, user_records
         )
         if activity_records:
             load_commit_activity(

--- a/cartography/intel/supply_chain.py
+++ b/cartography/intel/supply_chain.py
@@ -626,14 +626,6 @@ def match_images_to_dockerfiles(
                     image.display_name,
                     image.tag,
                 )
-                print(
-                    "\n=== SUPPLY_CHAIN DEBUG: NO SCOPED DOCKERFILES ===\n"
-                    f"image={image.display_name}:{image.tag}\n"
-                    f"digest={image.digest}\n"
-                    f"scope_keys={image.scope_keys}\n"
-                    f"image_commands={image_commands}\n"
-                    f"available_dockerfile_scopes={[df_info.get('scope_keys') for _, df_info in parsed_dockerfiles]}\n"
-                )
                 continue
 
         df_matches = find_best_dockerfile_matches(
@@ -672,48 +664,6 @@ def match_images_to_dockerfiles(
                 best_match.confidence,
             )
         else:
-            debug_matches = find_best_dockerfile_matches(
-                image_commands,
-                [parsed for parsed, _ in candidate_dockerfiles],
-                min_confidence=0.0,
-            )
-            debug_top_matches: list[dict[str, Any]] = []
-            for debug_match in debug_matches[:5]:
-                matching_df_info = next(
-                    (
-                        candidate_info
-                        for parsed, candidate_info in candidate_dockerfiles
-                        if parsed is debug_match.dockerfile
-                    ),
-                    {},
-                )
-                debug_top_matches.append(
-                    {
-                        "path": matching_df_info.get("path"),
-                        "source_repo_id": matching_df_info.get("source_repo_id"),
-                        "scope_keys": matching_df_info.get("scope_keys"),
-                        "confidence": round(debug_match.confidence, 4),
-                        "command_similarity": round(
-                            debug_match.command_similarity,
-                            4,
-                        ),
-                        "matched_commands": debug_match.matched_commands,
-                        "total_commands": debug_match.total_commands,
-                        "dockerfile_commands": [
-                            normalize_command(f"{instr.cmd} {instr.value}")
-                            for instr in debug_match.dockerfile.get_final_stage_layer_instructions()
-                        ],
-                    }
-                )
-            print(
-                "\n=== SUPPLY_CHAIN DEBUG: NO MATCH ===\n"
-                f"image={image.display_name}:{image.tag}\n"
-                f"digest={image.digest}\n"
-                f"scope_keys={image.scope_keys}\n"
-                f"image_commands={image_commands}\n"
-                f"candidate_dockerfile_count={len(candidate_dockerfiles)}\n"
-                f"top_matches={json.dumps(debug_top_matches, indent=2, sort_keys=True)}\n"
-            )
             logger.debug(
                 "No match found for image %s:%s", image.display_name, image.tag
             )

--- a/cartography/intel/supply_chain.py
+++ b/cartography/intel/supply_chain.py
@@ -171,9 +171,6 @@ def normalize_command(cmd: str | None) -> str:
     # Lowercase first for consistent matching
     cmd = cmd.lower()
 
-    # Remove Dockerfile instruction prefixes
-    cmd = re.sub(r"^(run|copy|add)\s+", "", cmd)
-
     # Remove shell prefix added by Docker
     cmd = re.sub(r"^/bin/sh -c\s+", "", cmd)
     cmd = re.sub(r"^#\(nop\)\s+", "", cmd)  # BuildKit nop marker
@@ -188,8 +185,33 @@ def normalize_command(cmd: str | None) -> str:
     cmd = re.sub(r"\s*#.*$", "", cmd)
 
     # Normalize whitespace
-    cmd = " ".join(cmd.split())
+    cmd = " ".join(cmd.split()).strip()
+    if not cmd:
+        return ""
 
+    copy_add_match = re.match(r"^(copy|add)\s+(.+)$", cmd)
+    if copy_add_match:
+        instruction = copy_add_match.group(1)
+        remainder = copy_add_match.group(2)
+
+        # OCI history often looks like:
+        #   copy file:<hash> in /dest/
+        #   add dir:<hash> in /dest/
+        oci_copy_add = re.match(r"^(?:file|dir):\S+\s+in\s+(.+)$", remainder)
+        if oci_copy_add:
+            destination = oci_copy_add.group(1).strip()
+            return f"{instruction}_in {destination}"
+
+        # Dockerfile shell form: COPY src dest
+        # Keep only the destination so it becomes comparable to OCI history.
+        parts = remainder.split()
+        if parts:
+            destination = parts[-1]
+            return f"{instruction}_in {destination}"
+
+    # Remove Dockerfile RUN prefix after shell/buildkit cleanup so shell-wrapped
+    # history and raw Dockerfile instructions normalize the same way.
+    cmd = re.sub(r"^run\s+", "", cmd)
     return cmd.strip()
 
 
@@ -466,7 +488,9 @@ def _match_commands_to_dockerfile(
             command_similarity=0.0,
         )
 
-    df_commands = [instr.normalized_value for instr in df_instructions]
+    df_commands = [
+        normalize_command(f"{instr.cmd} {instr.value}") for instr in df_instructions
+    ]
 
     n_df_commands = len(df_commands)
     if len(image_commands) > n_df_commands:
@@ -602,6 +626,14 @@ def match_images_to_dockerfiles(
                     image.display_name,
                     image.tag,
                 )
+                print(
+                    "\n=== SUPPLY_CHAIN DEBUG: NO SCOPED DOCKERFILES ===\n"
+                    f"image={image.display_name}:{image.tag}\n"
+                    f"digest={image.digest}\n"
+                    f"scope_keys={image.scope_keys}\n"
+                    f"image_commands={image_commands}\n"
+                    f"available_dockerfile_scopes={[df_info.get('scope_keys') for _, df_info in parsed_dockerfiles]}\n"
+                )
                 continue
 
         df_matches = find_best_dockerfile_matches(
@@ -640,6 +672,48 @@ def match_images_to_dockerfiles(
                 best_match.confidence,
             )
         else:
+            debug_matches = find_best_dockerfile_matches(
+                image_commands,
+                [parsed for parsed, _ in candidate_dockerfiles],
+                min_confidence=0.0,
+            )
+            debug_top_matches: list[dict[str, Any]] = []
+            for debug_match in debug_matches[:5]:
+                matching_df_info = next(
+                    (
+                        candidate_info
+                        for parsed, candidate_info in candidate_dockerfiles
+                        if parsed is debug_match.dockerfile
+                    ),
+                    {},
+                )
+                debug_top_matches.append(
+                    {
+                        "path": matching_df_info.get("path"),
+                        "source_repo_id": matching_df_info.get("source_repo_id"),
+                        "scope_keys": matching_df_info.get("scope_keys"),
+                        "confidence": round(debug_match.confidence, 4),
+                        "command_similarity": round(
+                            debug_match.command_similarity,
+                            4,
+                        ),
+                        "matched_commands": debug_match.matched_commands,
+                        "total_commands": debug_match.total_commands,
+                        "dockerfile_commands": [
+                            normalize_command(f"{instr.cmd} {instr.value}")
+                            for instr in debug_match.dockerfile.get_final_stage_layer_instructions()
+                        ],
+                    }
+                )
+            print(
+                "\n=== SUPPLY_CHAIN DEBUG: NO MATCH ===\n"
+                f"image={image.display_name}:{image.tag}\n"
+                f"digest={image.digest}\n"
+                f"scope_keys={image.scope_keys}\n"
+                f"image_commands={image_commands}\n"
+                f"candidate_dockerfile_count={len(candidate_dockerfiles)}\n"
+                f"top_matches={json.dumps(debug_top_matches, indent=2, sort_keys=True)}\n"
+            )
             logger.debug(
                 "No match found for image %s:%s", image.display_name, image.tag
             )

--- a/cartography/intel/supply_chain.py
+++ b/cartography/intel/supply_chain.py
@@ -518,6 +518,7 @@ class ContainerImage:
     architecture: str | None
     os: str | None
     layer_history: list[dict[str, Any]]
+    scope_keys: dict[str, str] | None = None
 
 
 @dataclass
@@ -546,14 +547,12 @@ def match_images_to_dockerfiles(
     :param min_confidence: Minimum confidence threshold for matches
     :return: List of ImageDockerfileMatch objects
     """
-    parsed_dockerfiles: list[ParsedDockerfile] = []
-    dockerfile_info_map: dict[str, dict[str, Any]] = {}
+    parsed_dockerfiles: list[tuple[ParsedDockerfile, dict[str, Any]]] = []
 
     for df_info in dockerfiles:
         try:
             parsed = parse(df_info["content"])
-            dockerfile_info_map[parsed.content_hash] = df_info
-            parsed_dockerfiles.append(parsed)
+            parsed_dockerfiles.append((parsed, df_info))
         except Exception as e:
             logger.warning("Failed to parse dockerfile %s: %s", df_info.get("path"), e)
 
@@ -586,13 +585,41 @@ def match_images_to_dockerfiles(
             )
             continue
 
+        candidate_dockerfiles = parsed_dockerfiles
+        if image.scope_keys:
+            candidate_dockerfiles = [
+                (parsed, df_info)
+                for parsed, df_info in parsed_dockerfiles
+                if all(
+                    df_info.get("scope_keys", {}).get(scope_name) == scope_value
+                    for scope_name, scope_value in image.scope_keys.items()
+                )
+            ]
+            if not candidate_dockerfiles:
+                logger.debug(
+                    "No Dockerfiles scoped to %s for image %s:%s",
+                    image.scope_keys,
+                    image.display_name,
+                    image.tag,
+                )
+                continue
+
         df_matches = find_best_dockerfile_matches(
-            image_commands, parsed_dockerfiles, min_confidence
+            image_commands,
+            [parsed for parsed, _ in candidate_dockerfiles],
+            min_confidence,
         )
 
         if df_matches:
             best_match = df_matches[0]
-            df_info = dockerfile_info_map.get(best_match.dockerfile.content_hash, {})
+            df_info = next(
+                (
+                    candidate_info
+                    for parsed, candidate_info in candidate_dockerfiles
+                    if parsed is best_match.dockerfile
+                ),
+                {},
+            )
 
             matches.append(
                 ImageDockerfileMatch(

--- a/cartography/intel/supply_chain.py
+++ b/cartography/intel/supply_chain.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import re
 from dataclasses import dataclass
@@ -739,6 +740,146 @@ def normalize_vcs_url(url: str) -> str:
         normalized = normalized[:-4]
 
     return normalized
+
+
+def unwrap_attestation_predicate(predicate: Any) -> dict[str, Any] | None:
+    """
+    Normalize a predicate payload into the actual SLSA predicate object.
+
+    Attestation blobs can contain:
+    - an in-toto statement where `predicate` is already the predicate dict
+    - a DSSE/cosign envelope where `predicate.Data` contains a serialized statement
+    """
+    if not isinstance(predicate, dict):
+        return None
+
+    dsse_data = predicate.get("Data")
+    if isinstance(dsse_data, str):
+        try:
+            decoded = json.loads(dsse_data)
+        except ValueError:
+            logger.debug("Failed to decode nested attestation predicate Data")
+            return None
+
+        if isinstance(decoded, dict):
+            nested_predicate = decoded.get("predicate")
+            return nested_predicate if isinstance(nested_predicate, dict) else None
+
+    return predicate
+
+
+def get_slsa_dependency_list(predicate: dict[str, Any]) -> list[dict[str, Any]]:
+    """
+    Return the dependency list across supported SLSA predicate shapes.
+
+    Supports:
+    - SLSA v0.2: predicate.materials
+    - SLSA v1: predicate.buildDefinition.resolvedDependencies
+    """
+    dependency_list = predicate.get("materials", [])
+    if dependency_list:
+        return dependency_list
+
+    build_def = predicate.get("buildDefinition", {})
+    return build_def.get("resolvedDependencies", [])
+
+
+def extract_container_parent_image(predicate: dict[str, Any]) -> dict[str, str]:
+    """
+    Extract the parent/base container image reference from SLSA dependencies.
+
+    Supports both SLSA v0.2 `materials` and SLSA v1 `resolvedDependencies`.
+    Returns the first container image dependency that is not the Dockerfile frontend.
+    """
+    for dependency in get_slsa_dependency_list(predicate):
+        if not isinstance(dependency, dict):
+            continue
+
+        uri = str(dependency.get("uri", ""))
+        uri_l = uri.lower()
+        is_container_ref = (
+            uri_l.startswith("pkg:docker/")
+            or uri_l.startswith("pkg:oci/")
+            or uri_l.startswith("oci://")
+        )
+        if not is_container_ref or "dockerfile" in uri_l:
+            continue
+
+        digest = dependency.get("digest", {})
+        if not isinstance(digest, dict):
+            continue
+
+        sha256_digest = digest.get("sha256")
+        if sha256_digest:
+            return {
+                "parent_image_uri": uri,
+                "parent_image_digest": f"sha256:{sha256_digest}",
+            }
+
+    return {}
+
+
+def extract_image_source_provenance(predicate: dict[str, Any]) -> dict[str, str]:
+    """
+    Extract provider-agnostic image provenance source fields from a SLSA predicate.
+
+    Returns any of:
+    - source_uri
+    - source_revision
+    - source_file
+    """
+    result: dict[str, str] = {}
+
+    metadata = predicate.get("metadata", {})
+    buildkit_metadata = metadata.get("https://mobyproject.org/buildkit@v1#metadata", {})
+    vcs = buildkit_metadata.get("vcs", {})
+    if not vcs:
+        run_details = predicate.get("runDetails", {})
+        run_metadata = run_details.get("metadata", {})
+        vcs = run_metadata.get("buildkit_metadata", {}).get("vcs", {})
+
+    build_def = predicate.get("buildDefinition", {})
+    external_parameters = build_def.get("externalParameters", {})
+    resolved_dependencies = get_slsa_dependency_list(predicate)
+
+    source_uri = vcs.get("source") or external_parameters.get("source")
+    if source_uri:
+        result["source_uri"] = normalize_vcs_url(str(source_uri))
+
+    source_revision = vcs.get("revision")
+    if not source_revision:
+        for dependency in resolved_dependencies:
+            if not isinstance(dependency, dict):
+                continue
+            digest = dependency.get("digest", {})
+            if not isinstance(digest, dict):
+                continue
+            git_commit = digest.get("gitCommit")
+            if git_commit:
+                source_revision = git_commit
+                break
+    if source_revision:
+        result["source_revision"] = str(source_revision)
+
+    invocation = predicate.get("invocation", {})
+    config_source = invocation.get("configSource", {})
+    entry_point = config_source.get("entryPoint", "")
+    if not entry_point:
+        entry_point = external_parameters.get("entryPoint", "")
+    if not entry_point:
+        entry_point = external_parameters.get("configSource", {}).get("path", "")
+    if not entry_point:
+        entry_point = "Dockerfile"
+
+    if "source_uri" in result:
+        dockerfile_dir = (
+            str(vcs.get("localdir:dockerfile") or "").removeprefix("./").rstrip("/")
+        )
+        result["source_file"] = (
+            f"{dockerfile_dir}/{entry_point}" if dockerfile_dir else str(entry_point)
+        )
+
+    return result
 
 
 def extract_workflow_path_from_ref(workflow_ref: str | None) -> str | None:

--- a/cartography/models/gitlab/branches.py
+++ b/cartography/models/gitlab/branches.py
@@ -51,7 +51,10 @@ class GitLabProjectHasBranchRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabProject"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("project_url")},
+        {
+            "id": PropertyRef("project_id"),
+            "gitlab_url": PropertyRef("gitlab_url"),
+        },
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS_BRANCH"
@@ -77,7 +80,10 @@ class GitLabBranchToProjectRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabProject"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("project_url", set_in_kwargs=True)},
+        {
+            "id": PropertyRef("project_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"

--- a/cartography/models/gitlab/container_image_attestations.py
+++ b/cartography/models/gitlab/container_image_attestations.py
@@ -30,6 +30,9 @@ class GitLabContainerImageAttestationNodeProperties(CartographyNodeProperties):
     attestation_type: PropertyRef = PropertyRef("attestation_type", extra_index=True)
     predicate_type: PropertyRef = PropertyRef("predicate_type")
     attests_digest: PropertyRef = PropertyRef("attests_digest", extra_index=True)
+    source_uri: PropertyRef = PropertyRef("source_uri")
+    source_revision: PropertyRef = PropertyRef("source_revision")
+    source_file: PropertyRef = PropertyRef("source_file")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -46,7 +49,10 @@ class GitLabContainerImageAttestationToOrgRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabOrganization"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("org_url", set_in_kwargs=True)},
+        {
+            "id": PropertyRef("org_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"

--- a/cartography/models/gitlab/container_image_layers.py
+++ b/cartography/models/gitlab/container_image_layers.py
@@ -32,6 +32,8 @@ class GitLabContainerImageLayerNodeProperties(CartographyNodeProperties):
     digest: PropertyRef = PropertyRef("digest", extra_index=True)
     media_type: PropertyRef = PropertyRef("media_type")
     size: PropertyRef = PropertyRef("size")
+    is_empty: PropertyRef = PropertyRef("is_empty")
+    history: PropertyRef = PropertyRef("history")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 

--- a/cartography/models/gitlab/container_image_layers.py
+++ b/cartography/models/gitlab/container_image_layers.py
@@ -49,7 +49,10 @@ class GitLabContainerImageLayerToOrgRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabOrganization"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("org_url", set_in_kwargs=True)},
+        {
+            "id": PropertyRef("org_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"

--- a/cartography/models/gitlab/container_images.py
+++ b/cartography/models/gitlab/container_images.py
@@ -34,6 +34,9 @@ class GitLabContainerImageNodeProperties(CartographyNodeProperties):
     architecture: PropertyRef = PropertyRef("architecture")
     os: PropertyRef = PropertyRef("os")
     variant: PropertyRef = PropertyRef("variant")
+    source_uri: PropertyRef = PropertyRef("source_uri", extra_index=True)
+    source_revision: PropertyRef = PropertyRef("source_revision")
+    source_file: PropertyRef = PropertyRef("source_file")
     child_image_digests: PropertyRef = PropertyRef("child_image_digests")
     # Layer diff IDs from the image config (used for Dockerfile matching and layer relationships)
     layer_diff_ids: PropertyRef = PropertyRef("layer_diff_ids")
@@ -56,7 +59,10 @@ class GitLabContainerImageToOrgRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabOrganization"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("org_url", set_in_kwargs=True)},
+        {
+            "id": PropertyRef("org_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
@@ -200,4 +206,29 @@ class GitLabContainerImageSchema(CartographyNodeSchema):
                 conditions={"type": "manifest_list"},
             ),
         ],
+    )
+
+
+@dataclass(frozen=True)
+class GitLabContainerImageProvenanceNodeProperties(CartographyNodeProperties):
+    """
+    Minimal property set for provenance-only updates on existing GitLabContainerImage nodes.
+    """
+
+    id: PropertyRef = PropertyRef("digest")
+    source_uri: PropertyRef = PropertyRef("source_uri", extra_index=True)
+    source_revision: PropertyRef = PropertyRef("source_revision")
+    source_file: PropertyRef = PropertyRef("source_file")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabContainerImageProvenanceSchema(CartographyNodeSchema):
+    """
+    Schema for provenance-only enrichment of GitLabContainerImage nodes.
+    """
+
+    label: str = "GitLabContainerImage"
+    properties: GitLabContainerImageProvenanceNodeProperties = (
+        GitLabContainerImageProvenanceNodeProperties()
     )

--- a/cartography/models/gitlab/container_images.py
+++ b/cartography/models/gitlab/container_images.py
@@ -37,6 +37,8 @@ class GitLabContainerImageNodeProperties(CartographyNodeProperties):
     source_uri: PropertyRef = PropertyRef("source_uri", extra_index=True)
     source_revision: PropertyRef = PropertyRef("source_revision")
     source_file: PropertyRef = PropertyRef("source_file")
+    parent_image_uri: PropertyRef = PropertyRef("parent_image_uri")
+    parent_image_digest: PropertyRef = PropertyRef("parent_image_digest")
     child_image_digests: PropertyRef = PropertyRef("child_image_digests")
     # Layer diff IDs from the image config (used for Dockerfile matching and layer relationships)
     layer_diff_ids: PropertyRef = PropertyRef("layer_diff_ids")
@@ -165,6 +167,31 @@ class GitLabContainerImageToTailLayerRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class GitLabContainerImageToParentImageRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    from_attestation: PropertyRef = PropertyRef("from_attestation")
+    parent_image_uri: PropertyRef = PropertyRef("parent_image_uri")
+    confidence: PropertyRef = PropertyRef("confidence")
+
+
+@dataclass(frozen=True)
+class GitLabContainerImageToParentImageRel(CartographyRelSchema):
+    """
+    Relationship from a GitLabContainerImage to its parent/base image.
+    """
+
+    target_node_label: str = "GitLabContainerImage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"digest": PropertyRef("parent_image_digest")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "BUILT_FROM"
+    properties: GitLabContainerImageToParentImageRelProperties = (
+        GitLabContainerImageToParentImageRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class GitLabContainerImageSchema(CartographyNodeSchema):
     """
     Schema for GitLab Container Image nodes.
@@ -192,6 +219,7 @@ class GitLabContainerImageSchema(CartographyNodeSchema):
             GitLabContainerImageToLayerRel(),
             GitLabContainerImageToHeadLayerRel(),
             GitLabContainerImageToTailLayerRel(),
+            GitLabContainerImageToParentImageRel(),
         ],
     )
     # Add generic ontology labels for cross-registry querying
@@ -219,6 +247,8 @@ class GitLabContainerImageProvenanceNodeProperties(CartographyNodeProperties):
     source_uri: PropertyRef = PropertyRef("source_uri", extra_index=True)
     source_revision: PropertyRef = PropertyRef("source_revision")
     source_file: PropertyRef = PropertyRef("source_file")
+    parent_image_uri: PropertyRef = PropertyRef("parent_image_uri")
+    parent_image_digest: PropertyRef = PropertyRef("parent_image_digest")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -231,4 +261,9 @@ class GitLabContainerImageProvenanceSchema(CartographyNodeSchema):
     label: str = "GitLabContainerImage"
     properties: GitLabContainerImageProvenanceNodeProperties = (
         GitLabContainerImageProvenanceNodeProperties()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            GitLabContainerImageToParentImageRel(),
+        ],
     )

--- a/cartography/models/gitlab/container_repositories.py
+++ b/cartography/models/gitlab/container_repositories.py
@@ -57,7 +57,10 @@ class GitLabContainerRepositoryToOrgRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabOrganization"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("org_url", set_in_kwargs=True)},
+        {
+            "id": PropertyRef("org_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"

--- a/cartography/models/gitlab/container_repository_tags.py
+++ b/cartography/models/gitlab/container_repository_tags.py
@@ -50,7 +50,10 @@ class GitLabContainerRepositoryTagToOrgRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabOrganization"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("org_url", set_in_kwargs=True)},
+        {
+            "id": PropertyRef("org_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
@@ -83,6 +86,28 @@ class GitLabContainerRepositoryTagToImageRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class GitLabContainerRepositoryTagToGenericImageRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabContainerRepositoryTagToGenericImageRel(CartographyRelSchema):
+    """
+    Generic cross-registry edge from ImageTag to Image.
+    """
+
+    target_node_label: str = "GitLabContainerImage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("digest")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "IMAGE"
+    properties: GitLabContainerRepositoryTagToGenericImageRelProperties = (
+        GitLabContainerRepositoryTagToGenericImageRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class GitLabContainerRepositoryTagToRepoRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
@@ -101,6 +126,28 @@ class GitLabContainerRepositoryTagToRepoRel(CartographyRelSchema):
     rel_label: str = "HAS_TAG"
     properties: GitLabContainerRepositoryTagToRepoRelProperties = (
         GitLabContainerRepositoryTagToRepoRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitLabContainerRepositoryTagToGenericRepoRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabContainerRepositoryTagToGenericRepoRel(CartographyRelSchema):
+    """
+    Generic cross-registry edge from ContainerRegistry to ImageTag.
+    """
+
+    target_node_label: str = "GitLabContainerRepository"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("repository_location")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "REPO_IMAGE"
+    properties: GitLabContainerRepositoryTagToGenericRepoRelProperties = (
+        GitLabContainerRepositoryTagToGenericRepoRelProperties()
     )
 
 
@@ -127,7 +174,11 @@ class GitLabContainerRepositoryTagSchema(CartographyNodeSchema):
     )
     other_relationships: OtherRelationships = OtherRelationships(
         [
+            GitLabContainerRepositoryTagToGenericRepoRel(),
+            GitLabContainerRepositoryTagToGenericImageRel(),
+            # DEPRECATED: For backward compatibility, will be removed in v1.0.0.
             GitLabContainerRepositoryTagToRepoRel(),
+            # DEPRECATED: For backward compatibility, will be removed in v1.0.0.
             GitLabContainerRepositoryTagToImageRel(),
         ],
     )

--- a/cartography/models/gitlab/dependencies.py
+++ b/cartography/models/gitlab/dependencies.py
@@ -30,6 +30,8 @@ class GitLabDependencyNodeProperties(CartographyNodeProperties):
     package_manager: PropertyRef = PropertyRef(
         "package_manager"
     )  # npm, pip, bundler, maven, etc.
+    project_id: PropertyRef = PropertyRef("project_id")
+    gitlab_url: PropertyRef = PropertyRef("gitlab_url", extra_index=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -50,7 +52,10 @@ class GitLabDependencyToProjectRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabProject"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("project_url", set_in_kwargs=True)}
+        {
+            "id": PropertyRef("project_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        }
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
@@ -76,7 +81,10 @@ class GitLabProjectRequiresDependencyRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabProject"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("project_url", set_in_kwargs=True)}
+        {
+            "id": PropertyRef("project_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        }
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "REQUIRES"

--- a/cartography/models/gitlab/groups.py
+++ b/cartography/models/gitlab/groups.py
@@ -27,12 +27,14 @@ class GitLabGroupNodeProperties(CartographyNodeProperties):
     Groups are nested within a GitLab organization and can contain other groups and projects.
     """
 
-    id: PropertyRef = PropertyRef("web_url")  # Unique identifier
+    id: PropertyRef = PropertyRef("id")  # Stable numeric GitLab group ID
     name: PropertyRef = PropertyRef("name", extra_index=True)  # Display name
     path: PropertyRef = PropertyRef("path", extra_index=True)  # URL path slug
     full_path: PropertyRef = PropertyRef(
         "full_path", extra_index=True
     )  # Full hierarchy path
+    web_url: PropertyRef = PropertyRef("web_url", extra_index=True)
+    gitlab_url: PropertyRef = PropertyRef("gitlab_url", extra_index=True)
     description: PropertyRef = PropertyRef("description")
     visibility: PropertyRef = PropertyRef("visibility")  # private, internal, public
     parent_id: PropertyRef = PropertyRef(
@@ -60,7 +62,10 @@ class GitLabGroupToParentGroupRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabGroup"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("parent_group_url")},
+        {
+            "id": PropertyRef("parent_id"),
+            "gitlab_url": PropertyRef("gitlab_url"),
+        },
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "MEMBER_OF"
@@ -87,7 +92,10 @@ class GitLabGroupToOrganizationRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabOrganization"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("org_url", set_in_kwargs=True)},
+        {
+            "id": PropertyRef("org_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"

--- a/cartography/models/gitlab/manifests.py
+++ b/cartography/models/gitlab/manifests.py
@@ -33,7 +33,9 @@ class GitLabDependencyFileNodeProperties(CartographyNodeProperties):
     filename: PropertyRef = PropertyRef(
         "filename", extra_index=True
     )  # File name (e.g., "package.json")
+    project_id: PropertyRef = PropertyRef("project_id")
     project_url: PropertyRef = PropertyRef("project_url")  # Parent project URL
+    gitlab_url: PropertyRef = PropertyRef("gitlab_url", extra_index=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -55,7 +57,10 @@ class GitLabProjectHasDependencyFileRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabProject"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("project_url")},
+        {
+            "id": PropertyRef("project_id"),
+            "gitlab_url": PropertyRef("gitlab_url"),
+        },
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS_DEPENDENCY_FILE"
@@ -81,7 +86,10 @@ class GitLabDependencyFileToProjectRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabProject"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("project_url", set_in_kwargs=True)}
+        {
+            "id": PropertyRef("project_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        }
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"

--- a/cartography/models/gitlab/organizations.py
+++ b/cartography/models/gitlab/organizations.py
@@ -20,17 +20,18 @@ class GitLabOrganizationNodeProperties(CartographyNodeProperties):
     Organizations are top-level groups in GitLab's hierarchy.
     """
 
-    id: PropertyRef = PropertyRef("web_url")  # Unique identifier
+    id: PropertyRef = PropertyRef("id")  # Stable numeric GitLab group ID
     name: PropertyRef = PropertyRef("name", extra_index=True)  # Display name
     path: PropertyRef = PropertyRef("path", extra_index=True)  # URL path slug
     full_path: PropertyRef = PropertyRef(
         "full_path", extra_index=True
     )  # Full hierarchy path
+    web_url: PropertyRef = PropertyRef("web_url", extra_index=True)
     description: PropertyRef = PropertyRef("description")
     visibility: PropertyRef = PropertyRef("visibility")  # private, internal, public
     created_at: PropertyRef = PropertyRef("created_at")
     gitlab_url: PropertyRef = PropertyRef(
-        "gitlab_url"
+        "gitlab_url", extra_index=True
     )  # GitLab instance URL for scoped cleanup
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 

--- a/cartography/models/gitlab/packaged_matchlink.py
+++ b/cartography/models/gitlab/packaged_matchlink.py
@@ -39,14 +39,14 @@ class GitLabProjectProvenancePackagedFromMatchLink(CartographyRelSchema):
     """
     MatchLink for SLSA provenance: (Image)-[:PACKAGED_FROM]->(GitLabProject).
 
-    Matches Image.source_uri to GitLabProject.id using the same project URL value.
+    Matches Image.source_uri to GitLabProject.web_url using the same project URL value.
     No pre-query needed: just pass the project URLs from the projects list.
     """
 
     target_node_label: str = "GitLabProject"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {
-            "id": PropertyRef("project_url"),
+            "web_url": PropertyRef("project_url"),
         }
     )
     source_node_label: str = "Image"
@@ -73,7 +73,7 @@ class GitLabProjectDockerfilePackagedFromMatchLink(CartographyRelSchema):
     target_node_label: str = "GitLabProject"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {
-            "id": PropertyRef("project_url"),
+            "web_url": PropertyRef("project_url"),
         }
     )
     source_node_label: str = "Image"

--- a/cartography/models/gitlab/projects.py
+++ b/cartography/models/gitlab/projects.py
@@ -26,12 +26,14 @@ class GitLabProjectNodeProperties(CartographyNodeProperties):
     Projects are GitLab's equivalent of repositories.
     """
 
-    id: PropertyRef = PropertyRef("web_url")  # Unique identifier
+    id: PropertyRef = PropertyRef("id")  # Stable numeric GitLab project ID
     name: PropertyRef = PropertyRef("name", extra_index=True)  # Project name
     path: PropertyRef = PropertyRef("path", extra_index=True)  # URL path slug
     path_with_namespace: PropertyRef = PropertyRef(
         "path_with_namespace", extra_index=True
     )  # Full path
+    web_url: PropertyRef = PropertyRef("web_url", extra_index=True)
+    gitlab_url: PropertyRef = PropertyRef("gitlab_url", extra_index=True)
     description: PropertyRef = PropertyRef("description")
     visibility: PropertyRef = PropertyRef("visibility")  # private, internal, public
     default_branch: PropertyRef = PropertyRef("default_branch")  # Default branch name
@@ -64,7 +66,10 @@ class GitLabGroupCanAccessProjectRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabGroup"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("group_url")},
+        {
+            "id": PropertyRef("group_id"),
+            "gitlab_url": PropertyRef("gitlab_url"),
+        },
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "CAN_ACCESS"
@@ -92,7 +97,10 @@ class GitLabProjectToGroupRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabGroup"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("group_url")},
+        {
+            "id": PropertyRef("group_id"),
+            "gitlab_url": PropertyRef("gitlab_url"),
+        },
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "MEMBER_OF"
@@ -119,7 +127,10 @@ class GitLabProjectToOrganizationRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabOrganization"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("org_url", set_in_kwargs=True)},
+        {
+            "id": PropertyRef("org_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
@@ -149,5 +160,7 @@ class GitLabProjectSchema(CartographyNodeSchema):
     sub_resource_relationship: GitLabProjectToOrganizationRel = (
         GitLabProjectToOrganizationRel()
     )
-    # Add GitLabRepository label for backwards compatibility
-    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["GitLabRepository"])
+    # Add GitLabRepository for compatibility and CodeRepository for ontology queries.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        ["GitLabRepository", "CodeRepository"]
+    )

--- a/cartography/models/gitlab/users.py
+++ b/cartography/models/gitlab/users.py
@@ -27,12 +27,14 @@ class GitLabUserNodeProperties(CartographyNodeProperties):
     Users can be members of groups and commit to projects.
     """
 
-    id: PropertyRef = PropertyRef("web_url")  # Unique identifier (user profile URL)
+    id: PropertyRef = PropertyRef("id")  # Stable numeric GitLab user ID
     username: PropertyRef = PropertyRef("username", extra_index=True)  # GitLab username
     name: PropertyRef = PropertyRef("name")  # Full name
     state: PropertyRef = PropertyRef("state")  # User state (active, blocked, etc.)
     email: PropertyRef = PropertyRef("email")  # Email address (if public)
     is_admin: PropertyRef = PropertyRef("is_admin")  # Whether user is an admin
+    web_url: PropertyRef = PropertyRef("web_url", extra_index=True)
+    gitlab_url: PropertyRef = PropertyRef("gitlab_url", extra_index=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -54,7 +56,10 @@ class GitLabUserToOrganizationRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabOrganization"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("org_url", set_in_kwargs=True)},
+        {
+            "id": PropertyRef("org_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
@@ -85,7 +90,10 @@ class GitLabUserMemberOfGroupRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabGroup"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("group_url")},
+        {
+            "id": PropertyRef("group_id"),
+            "gitlab_url": PropertyRef("gitlab_url"),
+        },
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "MEMBER_OF"
@@ -118,7 +126,10 @@ class GitLabUserCommittedToProjectRel(CartographyRelSchema):
 
     target_node_label: str = "GitLabProject"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("project_url")},
+        {
+            "id": PropertyRef("project_id"),
+            "gitlab_url": PropertyRef("gitlab_url"),
+        },
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "COMMITTED_TO"

--- a/cartography/models/ontology/mapping/data/coderepositories.py
+++ b/cartography/models/ontology/mapping/data/coderepositories.py
@@ -51,8 +51,7 @@ gitlab_mapping = OntologyMapping(
                 OntologyFieldMapping(
                     ontology_field="description", node_field="description"
                 ),
-                # GitLabProject uses 'id' as web_url, so we use the same field for url
-                OntologyFieldMapping(ontology_field="url", node_field="id"),
+                OntologyFieldMapping(ontology_field="url", node_field="web_url"),
                 OntologyFieldMapping(
                     ontology_field="default_branch", node_field="default_branch"
                 ),

--- a/docs/root/modules/gitlab/schema.md
+++ b/docs/root/modules/gitlab/schema.md
@@ -22,7 +22,9 @@ O -- RESOURCE --> CIL(GitLabContainerImageLayer)
 O -- RESOURCE --> CT(GitLabContainerRepositoryTag)
 O -- RESOURCE --> CA(GitLabContainerImageAttestation)
 CR -- REPO_IMAGE --> CT
+CR -. HAS_TAG .-> CT
 CT -- IMAGE --> CI
+CT -. REFERENCES .-> CI
 CI -- CONTAINS_IMAGE --> CI
 CI -- HAS_LAYER --> CIL
 CA -- ATTESTS --> CI
@@ -44,11 +46,12 @@ Representation of a GitLab top-level group (organization). In GitLab, organizati
 | **name** | Name of the organization |
 | **path** | URL path slug |
 | **full_path** | Full path including all parent groups |
-| web_url | Web URL of the organization |
+| **web_url** | Web URL of the organization |
 | description | Description of the organization |
 | visibility | Visibility level (private, internal, public) |
 | parent_id | Parent group ID (null for top-level organizations) |
 | created_at | GitLab timestamp from when the organization was created |
+| **gitlab_url** | GitLab instance URL |
 
 #### Relationships
 
@@ -84,7 +87,8 @@ Representation of a GitLab nested subgroup. Groups can contain other groups (cre
 | **name** | Name of the group |
 | **path** | URL path slug |
 | **full_path** | Full path including all parent groups |
-| web_url | Web URL of the group |
+| **web_url** | Web URL of the group |
+| **gitlab_url** | GitLab instance URL |
 | description | Description of the group |
 | visibility | Visibility level (private, internal, public) |
 | parent_id | Parent group ID |
@@ -130,7 +134,8 @@ Representation of a GitLab project (repository). Projects are GitLab's equivalen
 | **name** | Name of the project |
 | **path** | URL path slug |
 | **path_with_namespace** | Full path including namespace |
-| web_url | Web URL of the project |
+| **web_url** | Web URL of the project |
+| **gitlab_url** | GitLab instance URL |
 | description | Description of the project |
 | visibility | Visibility level (private, internal, public) |
 | default_branch | Default branch name (e.g., main, master) |
@@ -233,7 +238,8 @@ Representation of a GitLab user. Users belong to an organization and can be memb
 | lastupdated | Timestamp of the last time the node was updated |
 | **id** | The numeric GitLab user ID |
 | **username** | Username of the user |
-| web_url | Web URL of the user |
+| **web_url** | Web URL of the user |
+| **gitlab_url** | GitLab instance URL |
 | name | Full name of the user |
 | state | State of the user (active, blocked, etc.) |
 | email | Email address of the user (if public) |
@@ -374,6 +380,12 @@ Representation of a GitLab container registry repository. Each project can have 
     (GitLabContainerRepository)-[REPO_IMAGE]->(GitLabContainerRepositoryTag)
     ```
 
+    Legacy compatibility edge still emitted by the current implementation:
+
+    ```
+    (GitLabContainerRepository)-[HAS_TAG]->(GitLabContainerRepositoryTag)
+    ```
+
 ### GitLabContainerRepositoryTag
 
 Representation of a tag within a GitLab container repository. Tags are human-readable pointers to container images.
@@ -414,6 +426,12 @@ Representation of a tag within a GitLab container repository. Tags are human-rea
     (GitLabContainerRepositoryTag)-[IMAGE]->(GitLabContainerImage)
     ```
 
+    Legacy compatibility edge still emitted by the current implementation:
+
+    ```
+    (GitLabContainerRepositoryTag)-[REFERENCES]->(GitLabContainerImage)
+    ```
+
 ### GitLabContainerImage
 
 Representation of a container image identified by its digest. Images are content-addressable and can be referenced by multiple tags. Manifest lists (multi-architecture images) contain references to platform-specific child images.
@@ -425,11 +443,11 @@ Representation of a container image identified by its digest. Images are content
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
 | **id** | The image digest (e.g., `sha256:abc123...`) |
-| digest | Same as id, the image digest |
-| uri | The base repository URI (e.g., `registry.gitlab.com/group/project`) |
+| **digest** | Same as id, the image digest |
+| **uri** | The base repository URI (e.g., `registry.gitlab.com/group/project`) |
 | media_type | OCI/Docker media type of the manifest |
 | schema_version | Manifest schema version |
-| type | Either `image` (single platform) or `manifest_list` (multi-arch) |
+| **type** | Either `image` (single platform) or `manifest_list` (multi-arch) |
 | architecture | CPU architecture (e.g., `amd64`, `arm64`) - null for manifest lists |
 | os | Operating system (e.g., `linux`) - null for manifest lists |
 | variant | Architecture variant (e.g., `v8`) - null for manifest lists |
@@ -437,7 +455,7 @@ Representation of a container image identified by its digest. Images are content
 | layer_diff_ids | List of uncompressed layer diff_ids that compose this image (only for single-platform images) |
 | head_layer_diff_id | Diff_id of the first (base) layer in this image |
 | tail_layer_diff_id | Diff_id of the last (topmost) layer in this image |
-| source_uri | Normalized VCS URL extracted from image provenance |
+| **source_uri** | Normalized VCS URL extracted from image provenance |
 | source_revision | Commit SHA extracted from image provenance |
 | source_file | Source definition file extracted from image provenance (for example `Dockerfile`) |
 

--- a/docs/root/modules/gitlab/schema.md
+++ b/docs/root/modules/gitlab/schema.md
@@ -21,8 +21,8 @@ O -- RESOURCE --> CI(GitLabContainerImage)
 O -- RESOURCE --> CIL(GitLabContainerImageLayer)
 O -- RESOURCE --> CT(GitLabContainerRepositoryTag)
 O -- RESOURCE --> CA(GitLabContainerImageAttestation)
-CR -- HAS_TAG --> CT
-CT -- REFERENCES --> CI
+CR -- REPO_IMAGE --> CT
+CT -- IMAGE --> CI
 CI -- CONTAINS_IMAGE --> CI
 CI -- HAS_LAYER --> CIL
 CA -- ATTESTS --> CI
@@ -40,10 +40,11 @@ Representation of a GitLab top-level group (organization). In GitLab, organizati
 |-------|--------------|
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
-| **id** | The web URL of the GitLab organization/group |
+| **id** | The numeric GitLab organization ID |
 | **name** | Name of the organization |
 | **path** | URL path slug |
 | **full_path** | Full path including all parent groups |
+| web_url | Web URL of the organization |
 | description | Description of the organization |
 | visibility | Visibility level (private, internal, public) |
 | parent_id | Parent group ID (null for top-level organizations) |
@@ -79,10 +80,11 @@ Representation of a GitLab nested subgroup. Groups can contain other groups (cre
 |-------|--------------|
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
-| **id** | The web URL of the GitLab group |
+| **id** | The numeric GitLab group ID |
 | **name** | Name of the group |
 | **path** | URL path slug |
 | **full_path** | Full path including all parent groups |
+| web_url | Web URL of the group |
 | description | Description of the group |
 | visibility | Visibility level (private, internal, public) |
 | parent_id | Parent group ID |
@@ -124,10 +126,11 @@ Representation of a GitLab project (repository). Projects are GitLab's equivalen
 |-------|--------------|
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
-| **id** | The web URL of the GitLab project |
+| **id** | The numeric GitLab project ID |
 | **name** | Name of the project |
 | **path** | URL path slug |
 | **path_with_namespace** | Full path including namespace |
+| web_url | Web URL of the project |
 | description | Description of the project |
 | visibility | Visibility level (private, internal, public) |
 | default_branch | Default branch name (e.g., main, master) |
@@ -196,7 +199,7 @@ ORDER BY project_count DESC
     - **last_commit_date**: Timestamp of the user's most recent commit to the project
     - **first_commit_date**: Timestamp of the user's oldest commit to the project
 
-    Commit authors are matched to GitLab users by display name. Only commits from current members are tracked.
+    Commit authors are matched to GitLab users by email address. Only commits from current members are tracked.
 
 - GitLabProjects have GitLabBranches.
 
@@ -228,8 +231,9 @@ Representation of a GitLab user. Users belong to an organization and can be memb
 |-------|--------------|
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
-| **id** | The web URL of the GitLab user |
+| **id** | The numeric GitLab user ID |
 | **username** | Username of the user |
+| web_url | Web URL of the user |
 | name | Full name of the user |
 | state | State of the user (active, blocked, etc.) |
 | email | Email address of the user (if public) |
@@ -367,7 +371,7 @@ Representation of a GitLab container registry repository. Each project can have 
 - GitLabContainerRepositories have GitLabContainerRepositoryTags.
 
     ```
-    (GitLabContainerRepository)-[HAS_TAG]->(GitLabContainerRepositoryTag)
+    (GitLabContainerRepository)-[REPO_IMAGE]->(GitLabContainerRepositoryTag)
     ```
 
 ### GitLabContainerRepositoryTag
@@ -401,13 +405,13 @@ Representation of a tag within a GitLab container repository. Tags are human-rea
 - GitLabContainerRepositoryTags belong to GitLabContainerRepositories.
 
     ```
-    (GitLabContainerRepository)-[HAS_TAG]->(GitLabContainerRepositoryTag)
+    (GitLabContainerRepository)-[REPO_IMAGE]->(GitLabContainerRepositoryTag)
     ```
 
 - GitLabContainerRepositoryTags reference GitLabContainerImages.
 
     ```
-    (GitLabContainerRepositoryTag)-[REFERENCES]->(GitLabContainerImage)
+    (GitLabContainerRepositoryTag)-[IMAGE]->(GitLabContainerImage)
     ```
 
 ### GitLabContainerImage
@@ -433,6 +437,9 @@ Representation of a container image identified by its digest. Images are content
 | layer_diff_ids | List of uncompressed layer diff_ids that compose this image (only for single-platform images) |
 | head_layer_diff_id | Diff_id of the first (base) layer in this image |
 | tail_layer_diff_id | Diff_id of the last (topmost) layer in this image |
+| source_uri | Normalized VCS URL extracted from image provenance |
+| source_revision | Commit SHA extracted from image provenance |
+| source_file | Source definition file extracted from image provenance (for example `Dockerfile`) |
 
 #### Relationships
 
@@ -451,7 +458,7 @@ Representation of a container image identified by its digest. Images are content
 - GitLabContainerRepositoryTags reference GitLabContainerImages.
 
     ```
-    (GitLabContainerRepositoryTag)-[REFERENCES]->(GitLabContainerImage)
+    (GitLabContainerRepositoryTag)-[IMAGE]->(GitLabContainerImage)
     ```
 
 - GitLabContainerImageAttestations attest to GitLabContainerImages.
@@ -570,7 +577,7 @@ Representation of a container image attestation (signature or provenance). Attes
 Get all container images with their tags:
 
 ```cypher
-MATCH (repo:GitLabContainerRepository)-[:HAS_TAG]->(tag:GitLabContainerRepositoryTag)-[:REFERENCES]->(img:GitLabContainerImage)
+MATCH (repo:GitLabContainerRepository)-[:REPO_IMAGE]->(tag:GitLabContainerRepositoryTag)-[:IMAGE]->(img:GitLabContainerImage)
 RETURN repo.name, tag.name, img.digest, img.architecture, img.os
 ```
 
@@ -592,8 +599,8 @@ Get the full container registry hierarchy:
 
 ```cypher
 MATCH (org:GitLabOrganization)-[:RESOURCE]->(repo:GitLabContainerRepository)
-OPTIONAL MATCH (repo)-[:HAS_TAG]->(tag:GitLabContainerRepositoryTag)
-OPTIONAL MATCH (tag)-[:REFERENCES]->(img:GitLabContainerImage)
+OPTIONAL MATCH (repo)-[:REPO_IMAGE]->(tag:GitLabContainerRepositoryTag)
+OPTIONAL MATCH (tag)-[:IMAGE]->(img:GitLabContainerImage)
 RETURN org.name, repo.name, tag.name, img.digest
 ```
 

--- a/docs/root/modules/gitlab/schema.md
+++ b/docs/root/modules/gitlab/schema.md
@@ -268,7 +268,7 @@ Representation of a GitLab user. Users belong to an organization and can be memb
     (GitLabUser)-[COMMITTED_TO{commit_count, last_commit_date, first_commit_date}]->(GitLabProject)
     ```
 
-    This relationship is created by analyzing git commits and matching commit authors (by name) to current GitLab members.
+    This relationship is created by analyzing git commits and matching commit authors to current GitLab members by email address when available, with a display-name fallback.
 
 ### GitLabBranch
 

--- a/docs/root/modules/gitlab/schema.md
+++ b/docs/root/modules/gitlab/schema.md
@@ -204,7 +204,7 @@ ORDER BY project_count DESC
     - **last_commit_date**: Timestamp of the user's most recent commit to the project
     - **first_commit_date**: Timestamp of the user's oldest commit to the project
 
-    Commit authors are matched to GitLab users by email address. Only commits from current members are tracked.
+    Commit authors are matched to GitLab users by email address when available, with a display-name fallback for current members. Only commits from current members are tracked.
 
 - GitLabProjects have GitLabBranches.
 

--- a/tests/data/gitlab/branches.py
+++ b/tests/data/gitlab/branches.py
@@ -35,6 +35,8 @@ GET_GITLAB_BRANCHES_RESPONSE = [
 ]
 
 TEST_PROJECT_URL = "https://gitlab.example.com/myorg/awesome-project"
+TEST_PROJECT_ID = 123
+TEST_GITLAB_URL = "https://gitlab.example.com"
 
 # Expected transformed branches output
 TRANSFORMED_BRANCHES = [
@@ -44,7 +46,9 @@ TRANSFORMED_BRANCHES = [
         "protected": True,
         "default": True,
         "web_url": "https://gitlab.example.com/myorg/awesome-project/-/tree/main",
+        "project_id": TEST_PROJECT_ID,
         "project_url": TEST_PROJECT_URL,
+        "gitlab_url": TEST_GITLAB_URL,
     },
     {
         "id": "https://gitlab.example.com/myorg/awesome-project/tree/develop",
@@ -52,7 +56,9 @@ TRANSFORMED_BRANCHES = [
         "protected": True,
         "default": False,
         "web_url": "https://gitlab.example.com/myorg/awesome-project/-/tree/develop",
+        "project_id": TEST_PROJECT_ID,
         "project_url": TEST_PROJECT_URL,
+        "gitlab_url": TEST_GITLAB_URL,
     },
     {
         "id": "https://gitlab.example.com/myorg/awesome-project/tree/feature/new-api",
@@ -60,6 +66,8 @@ TRANSFORMED_BRANCHES = [
         "protected": False,
         "default": False,
         "web_url": "https://gitlab.example.com/myorg/awesome-project/-/tree/feature/new-api",
+        "project_id": TEST_PROJECT_ID,
         "project_url": TEST_PROJECT_URL,
+        "gitlab_url": TEST_GITLAB_URL,
     },
 ]

--- a/tests/data/gitlab/dependencies.py
+++ b/tests/data/gitlab/dependencies.py
@@ -31,6 +31,8 @@ GET_GITLAB_DEPENDENCIES_RESPONSE = [
 ]
 
 TEST_PROJECT_URL = "https://gitlab.example.com/myorg/awesome-project"
+TEST_PROJECT_ID = 123
+TEST_GITLAB_URL = "https://gitlab.example.com"
 
 # Expected transformed dependencies output
 TRANSFORMED_DEPENDENCIES = [
@@ -39,7 +41,8 @@ TRANSFORMED_DEPENDENCIES = [
         "name": "express",
         "version": "4.18.2",
         "package_manager": "npm",
-        "project_url": TEST_PROJECT_URL,
+        "project_id": TEST_PROJECT_ID,
+        "gitlab_url": TEST_GITLAB_URL,
         "manifest_id": "https://gitlab.example.com/myorg/awesome-project/blob/package.json",
     },
     {
@@ -47,7 +50,8 @@ TRANSFORMED_DEPENDENCIES = [
         "name": "lodash",
         "version": "4.17.21",
         "package_manager": "npm",
-        "project_url": TEST_PROJECT_URL,
+        "project_id": TEST_PROJECT_ID,
+        "gitlab_url": TEST_GITLAB_URL,
         "manifest_id": "https://gitlab.example.com/myorg/awesome-project/blob/package.json",
     },
     {
@@ -55,13 +59,15 @@ TRANSFORMED_DEPENDENCIES = [
         "name": "requests",
         "version": "2.31.0",
         "package_manager": "pypi",
-        "project_url": TEST_PROJECT_URL,
+        "project_id": TEST_PROJECT_ID,
+        "gitlab_url": TEST_GITLAB_URL,
     },
     {
         "id": "https://gitlab.example.com/myorg/awesome-project:golang:gin@1.9.1",
         "name": "gin",
         "version": "1.9.1",
         "package_manager": "golang",
-        "project_url": TEST_PROJECT_URL,
+        "project_id": TEST_PROJECT_ID,
+        "gitlab_url": TEST_GITLAB_URL,
     },
 ]

--- a/tests/data/gitlab/dependency_files.py
+++ b/tests/data/gitlab/dependency_files.py
@@ -23,6 +23,8 @@ GET_GITLAB_DEPENDENCY_FILES_RESPONSE = [
 ]
 
 TEST_PROJECT_URL = "https://gitlab.example.com/myorg/awesome-project"
+TEST_PROJECT_ID = 123
+TEST_GITLAB_URL = "https://gitlab.example.com"
 
 # Expected transformed dependency files output
 TRANSFORMED_DEPENDENCY_FILES = [
@@ -30,18 +32,21 @@ TRANSFORMED_DEPENDENCY_FILES = [
         "id": "https://gitlab.example.com/myorg/awesome-project/blob/package.json",
         "path": "package.json",
         "filename": "package.json",
-        "project_url": TEST_PROJECT_URL,
+        "project_id": TEST_PROJECT_ID,
+        "gitlab_url": TEST_GITLAB_URL,
     },
     {
         "id": "https://gitlab.example.com/myorg/awesome-project/blob/backend/requirements.txt",
         "path": "backend/requirements.txt",
         "filename": "requirements.txt",
-        "project_url": TEST_PROJECT_URL,
+        "project_id": TEST_PROJECT_ID,
+        "gitlab_url": TEST_GITLAB_URL,
     },
     {
         "id": "https://gitlab.example.com/myorg/awesome-project/blob/services/api/go.mod",
         "path": "services/api/go.mod",
         "filename": "go.mod",
-        "project_url": TEST_PROJECT_URL,
+        "project_id": TEST_PROJECT_ID,
+        "gitlab_url": TEST_GITLAB_URL,
     },
 ]

--- a/tests/data/gitlab/groups.py
+++ b/tests/data/gitlab/groups.py
@@ -38,10 +38,13 @@ GET_GITLAB_GROUPS_RESPONSE = [
 ]
 
 TEST_ORG_URL = "https://gitlab.example.com/myorg"
+TEST_ORG_ID = 100
+TEST_GITLAB_URL = "https://gitlab.example.com"
 
 # Expected transformed groups output
 TRANSFORMED_GROUPS = [
     {
+        "id": 20,
         "web_url": "https://gitlab.example.com/myorg/platform",
         "name": "Platform",
         "path": "platform",
@@ -50,10 +53,11 @@ TRANSFORMED_GROUPS = [
         "visibility": "private",
         "parent_id": 100,
         "created_at": "2023-06-15T09:00:00Z",
-        "org_url": TEST_ORG_URL,
-        "parent_group_url": None,  # Parent is org, not in group list
+        "org_id": TEST_ORG_ID,
+        "gitlab_url": TEST_GITLAB_URL,
     },
     {
+        "id": 30,
         "web_url": "https://gitlab.example.com/myorg/apps",
         "name": "Apps",
         "path": "apps",
@@ -62,10 +66,11 @@ TRANSFORMED_GROUPS = [
         "visibility": "internal",
         "parent_id": 100,
         "created_at": "2023-07-20T14:30:00Z",
-        "org_url": TEST_ORG_URL,
-        "parent_group_url": None,  # Parent is org, not in group list
+        "org_id": TEST_ORG_ID,
+        "gitlab_url": TEST_GITLAB_URL,
     },
     {
+        "id": 40,
         "web_url": "https://gitlab.example.com/myorg/platform/infrastructure",
         "name": "Infrastructure",
         "path": "infrastructure",
@@ -74,7 +79,7 @@ TRANSFORMED_GROUPS = [
         "visibility": "private",
         "parent_id": 20,
         "created_at": "2024-01-10T11:00:00Z",
-        "org_url": TEST_ORG_URL,
-        "parent_group_url": "https://gitlab.example.com/myorg/platform",  # Nested under Platform
+        "org_id": TEST_ORG_ID,
+        "gitlab_url": TEST_GITLAB_URL,
     },
 ]

--- a/tests/data/gitlab/organizations.py
+++ b/tests/data/gitlab/organizations.py
@@ -15,6 +15,7 @@ GET_GITLAB_ORGANIZATION_RESPONSE = {
 
 # Expected transformed organization output
 TRANSFORMED_ORGANIZATION = {
+    "id": 100,
     "web_url": "https://gitlab.example.com/myorg",
     "name": "MyOrg",
     "path": "myorg",

--- a/tests/data/gitlab/projects.py
+++ b/tests/data/gitlab/projects.py
@@ -76,9 +76,13 @@ LANGUAGES_BY_PROJECT = {
     789: {"TypeScript": 70.0, "CSS": 25.0, "HTML": 5.0},
 }
 
+TEST_ORG_ID = 10
+TEST_GITLAB_URL = "https://gitlab.example.com"
+
 # Expected transformed projects output (with languages as JSON strings)
 TRANSFORMED_PROJECTS = [
     {
+        "id": 123,
         "web_url": "https://gitlab.example.com/myorg/awesome-project",
         "name": "awesome-project",
         "path": "awesome-project",
@@ -89,11 +93,13 @@ TRANSFORMED_PROJECTS = [
         "archived": False,
         "created_at": "2024-01-15T10:30:00Z",
         "last_activity_at": "2024-12-15T14:45:00Z",
-        "org_url": "https://gitlab.example.com/myorg",
-        "group_url": None,  # Org-level project
+        "org_id": TEST_ORG_ID,
+        "group_id": 10,
+        "gitlab_url": TEST_GITLAB_URL,
         "languages": json.dumps({"Python": 65.5, "JavaScript": 34.5}),
     },
     {
+        "id": 456,
         "web_url": "https://gitlab.example.com/myorg/platform/backend-service",
         "name": "backend-service",
         "path": "backend-service",
@@ -104,11 +110,13 @@ TRANSFORMED_PROJECTS = [
         "archived": False,
         "created_at": "2024-03-20T08:15:00Z",
         "last_activity_at": "2024-12-18T16:20:00Z",
-        "org_url": "https://gitlab.example.com/myorg",
-        "group_url": "https://gitlab.example.com/myorg/platform",  # Nested group
+        "org_id": TEST_ORG_ID,
+        "group_id": 20,
+        "gitlab_url": TEST_GITLAB_URL,
         "languages": json.dumps({"Go": 85.0, "Shell": 15.0}),
     },
     {
+        "id": 789,
         "web_url": "https://gitlab.example.com/myorg/apps/frontend-app",
         "name": "frontend-app",
         "path": "frontend-app",
@@ -119,8 +127,9 @@ TRANSFORMED_PROJECTS = [
         "archived": False,
         "created_at": "2024-05-10T12:00:00Z",
         "last_activity_at": "2024-12-19T09:30:00Z",
-        "org_url": "https://gitlab.example.com/myorg",
-        "group_url": "https://gitlab.example.com/myorg/apps",  # Nested group
+        "org_id": TEST_ORG_ID,
+        "group_id": 30,
+        "gitlab_url": TEST_GITLAB_URL,
         "languages": json.dumps({"TypeScript": 70.0, "CSS": 25.0, "HTML": 5.0}),
     },
 ]

--- a/tests/data/gitlab/users.py
+++ b/tests/data/gitlab/users.py
@@ -3,7 +3,7 @@
 TEST_ORG_URL = "https://gitlab.example.com/myorg"
 
 # Organization members: Alice and Bob are org-level members
-# Alice has email available (will match by email), Bob doesn't (will match by name)
+# Alice and Bob both have email available so commit attribution uses stable identity.
 GET_GITLAB_ORG_MEMBERS = [
     {
         "id": 1,
@@ -20,7 +20,7 @@ GET_GITLAB_ORG_MEMBERS = [
         "username": "bob",
         "name": "Bob Jones",
         "state": "active",
-        "email": None,  # Email not available - will match by name fallback
+        "email": "bob@example.com",
         "web_url": "https://gitlab.example.com/bob",
         "is_admin": False,
         "access_level": 10,  # Guest at org level

--- a/tests/integration/cartography/intel/aws/test_resourcegroupstaggingapi.py
+++ b/tests/integration/cartography/intel/aws/test_resourcegroupstaggingapi.py
@@ -1,3 +1,4 @@
+import copy
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -24,7 +25,7 @@ TEST_UPDATE_TAG = 123456789
 @patch.object(
     rgta,
     "get_tags",
-    return_value=GET_RESOURCES_RESPONSE,
+    return_value=copy.deepcopy(GET_RESOURCES_RESPONSE),
 )
 def test_sync_tags(mock_get_tags, mock_get_instances, neo4j_session):
     """

--- a/tests/integration/cartography/intel/gitlab/test_branches.py
+++ b/tests/integration/cartography/intel/gitlab/test_branches.py
@@ -1,6 +1,8 @@
 """Integration tests for GitLab branches module."""
 
 from cartography.intel.gitlab.branches import load_branches
+from tests.data.gitlab.branches import TEST_GITLAB_URL
+from tests.data.gitlab.branches import TEST_PROJECT_ID
 from tests.data.gitlab.branches import TEST_PROJECT_URL
 from tests.data.gitlab.branches import TRANSFORMED_BRANCHES
 from tests.integration.util import check_nodes
@@ -13,12 +15,16 @@ def _create_test_project(neo4j_session):
     """Create test GitLabProject node."""
     neo4j_session.run(
         """
-        MERGE (p:GitLabProject{id: $project_url})
+        MERGE (p:GitLabProject{id: $project_id})
         ON CREATE SET p.firstseen = timestamp()
         SET p.lastupdated = $update_tag,
-            p.name = 'awesome-project'
+            p.name = 'awesome-project',
+            p.web_url = $project_url,
+            p.gitlab_url = $gitlab_url
         """,
+        project_id=TEST_PROJECT_ID,
         project_url=TEST_PROJECT_URL,
+        gitlab_url=TEST_GITLAB_URL,
         update_tag=TEST_UPDATE_TAG,
     )
 
@@ -32,7 +38,8 @@ def test_load_gitlab_branches_nodes(neo4j_session):
     load_branches(
         neo4j_session,
         TRANSFORMED_BRANCHES,
-        TEST_PROJECT_URL,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
@@ -57,22 +64,23 @@ def test_load_gitlab_branches_resource_relationships(neo4j_session):
     load_branches(
         neo4j_session,
         TRANSFORMED_BRANCHES,
-        TEST_PROJECT_URL,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
     # Assert - Check RESOURCE relationships from Project to Branch
     expected = {
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project/tree/main",
         ),
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project/tree/develop",
         ),
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project/tree/feature/new-api",
         ),
     }
@@ -98,22 +106,23 @@ def test_load_gitlab_branches_has_branch_relationships(neo4j_session):
     load_branches(
         neo4j_session,
         TRANSFORMED_BRANCHES,
-        TEST_PROJECT_URL,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
     # Assert - Check HAS_BRANCH relationships
     expected = {
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project/tree/main",
         ),
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project/tree/develop",
         ),
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project/tree/feature/new-api",
         ),
     }
@@ -139,7 +148,8 @@ def test_load_gitlab_branches_properties(neo4j_session):
     load_branches(
         neo4j_session,
         TRANSFORMED_BRANCHES,
-        TEST_PROJECT_URL,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 

--- a/tests/integration/cartography/intel/gitlab/test_cascade_delete.py
+++ b/tests/integration/cartography/intel/gitlab/test_cascade_delete.py
@@ -15,7 +15,10 @@ from tests.integration.util import check_nodes
 
 TEST_UPDATE_TAG = 123456789
 TEST_UPDATE_TAG_V2 = 123456790
+TEST_GITLAB_URL = "https://gitlab.example.com"
+TEST_ORG_ID = 100
 TEST_ORG_URL = "https://gitlab.example.com/myorg"
+TEST_PROJECT_ID = 123
 TEST_PROJECT_URL = "https://gitlab.example.com/myorg/test-project"
 
 
@@ -34,24 +37,28 @@ class TestProjectCascadeDelete:
         # Create organization
         neo4j_session.run(
             """
-            MERGE (o:GitLabOrganization {id: $org_url})
-            SET o.lastupdated = $tag
+            MERGE (o:GitLabOrganization {id: $org_id})
+            SET o.lastupdated = $tag, o.web_url = $org_url, o.gitlab_url = $gitlab_url
             """,
+            org_id=TEST_ORG_ID,
             org_url=TEST_ORG_URL,
+            gitlab_url=TEST_GITLAB_URL,
             tag=TEST_UPDATE_TAG_V2,  # Current tag - org is fresh
         )
 
         # Create stale project (old update tag)
         neo4j_session.run(
             """
-            MERGE (p:GitLabProject {id: $project_url})
-            SET p.lastupdated = $old_tag
+            MERGE (p:GitLabProject {id: $project_id})
+            SET p.lastupdated = $old_tag, p.web_url = $project_url, p.gitlab_url = $gitlab_url
             WITH p
-            MATCH (o:GitLabOrganization {id: $org_url})
+            MATCH (o:GitLabOrganization {id: $org_id})
             MERGE (o)-[:RESOURCE]->(p)
             """,
+            project_id=TEST_PROJECT_ID,
             project_url=TEST_PROJECT_URL,
-            org_url=TEST_ORG_URL,
+            org_id=TEST_ORG_ID,
+            gitlab_url=TEST_GITLAB_URL,
             old_tag=TEST_UPDATE_TAG,  # Old tag - project is stale
         )
 
@@ -59,24 +66,24 @@ class TestProjectCascadeDelete:
         # These simulate branches that weren't synced because the project was deleted
         neo4j_session.run(
             """
-            MATCH (p:GitLabProject {id: $project_url})
+            MATCH (p:GitLabProject {id: $project_id})
             MERGE (b:GitLabBranch {id: $branch_id})
             SET b.lastupdated = $old_tag, b.name = 'main'
             MERGE (p)-[:RESOURCE]->(b)
             """,
-            project_url=TEST_PROJECT_URL,
+            project_id=TEST_PROJECT_ID,
             branch_id=f"{TEST_PROJECT_URL}/tree/main",
             old_tag=TEST_UPDATE_TAG,
         )
 
         neo4j_session.run(
             """
-            MATCH (p:GitLabProject {id: $project_url})
+            MATCH (p:GitLabProject {id: $project_id})
             MERGE (b:GitLabBranch {id: $branch_id})
             SET b.lastupdated = $old_tag, b.name = 'develop'
             MERGE (p)-[:RESOURCE]->(b)
             """,
-            project_url=TEST_PROJECT_URL,
+            project_id=TEST_PROJECT_ID,
             branch_id=f"{TEST_PROJECT_URL}/tree/develop",
             old_tag=TEST_UPDATE_TAG,
         )
@@ -88,7 +95,8 @@ class TestProjectCascadeDelete:
         # Run cleanup with cascade_delete=True
         common_job_params = {
             "UPDATE_TAG": TEST_UPDATE_TAG_V2,
-            "org_url": TEST_ORG_URL,
+            "org_id": TEST_ORG_ID,
+            "gitlab_url": TEST_GITLAB_URL,
         }
         GraphJob.from_node_schema(
             GitLabProjectSchema(), common_job_params, cascade_delete=True
@@ -112,36 +120,40 @@ class TestProjectCascadeDelete:
         # Create organization
         neo4j_session.run(
             """
-            MERGE (o:GitLabOrganization {id: $org_url})
-            SET o.lastupdated = $tag
+            MERGE (o:GitLabOrganization {id: $org_id})
+            SET o.lastupdated = $tag, o.web_url = $org_url, o.gitlab_url = $gitlab_url
             """,
+            org_id=TEST_ORG_ID,
             org_url=TEST_ORG_URL,
+            gitlab_url=TEST_GITLAB_URL,
             tag=TEST_UPDATE_TAG_V2,
         )
 
         # Create stale project
         neo4j_session.run(
             """
-            MERGE (p:GitLabProject {id: $project_url})
-            SET p.lastupdated = $old_tag
+            MERGE (p:GitLabProject {id: $project_id})
+            SET p.lastupdated = $old_tag, p.web_url = $project_url, p.gitlab_url = $gitlab_url
             WITH p
-            MATCH (o:GitLabOrganization {id: $org_url})
+            MATCH (o:GitLabOrganization {id: $org_id})
             MERGE (o)-[:RESOURCE]->(p)
             """,
+            project_id=TEST_PROJECT_ID,
             project_url=TEST_PROJECT_URL,
-            org_url=TEST_ORG_URL,
+            org_id=TEST_ORG_ID,
+            gitlab_url=TEST_GITLAB_URL,
             old_tag=TEST_UPDATE_TAG,  # Stale
         )
 
         # Create a stale branch (should be deleted)
         neo4j_session.run(
             """
-            MATCH (p:GitLabProject {id: $project_url})
+            MATCH (p:GitLabProject {id: $project_id})
             MERGE (b:GitLabBranch {id: $branch_id})
             SET b.lastupdated = $old_tag, b.name = 'stale-branch'
             MERGE (p)-[:RESOURCE]->(b)
             """,
-            project_url=TEST_PROJECT_URL,
+            project_id=TEST_PROJECT_ID,
             branch_id="stale-branch-id",
             old_tag=TEST_UPDATE_TAG,  # Stale
         )
@@ -149,12 +161,12 @@ class TestProjectCascadeDelete:
         # Create a fresh branch (should be preserved - maybe re-parented)
         neo4j_session.run(
             """
-            MATCH (p:GitLabProject {id: $project_url})
+            MATCH (p:GitLabProject {id: $project_id})
             MERGE (b:GitLabBranch {id: $branch_id})
             SET b.lastupdated = $current_tag, b.name = 'fresh-branch'
             MERGE (p)-[:RESOURCE]->(b)
             """,
-            project_url=TEST_PROJECT_URL,
+            project_id=TEST_PROJECT_ID,
             branch_id="fresh-branch-id",
             current_tag=TEST_UPDATE_TAG_V2,  # Current - should be preserved
         )
@@ -165,7 +177,8 @@ class TestProjectCascadeDelete:
         # Run cleanup with cascade_delete
         common_job_params = {
             "UPDATE_TAG": TEST_UPDATE_TAG_V2,
-            "org_url": TEST_ORG_URL,
+            "org_id": TEST_ORG_ID,
+            "gitlab_url": TEST_GITLAB_URL,
         }
         GraphJob.from_node_schema(
             GitLabProjectSchema(), common_job_params, cascade_delete=True
@@ -188,36 +201,40 @@ class TestProjectCascadeDelete:
         # Create organization
         neo4j_session.run(
             """
-            MERGE (o:GitLabOrganization {id: $org_url})
-            SET o.lastupdated = $tag
+            MERGE (o:GitLabOrganization {id: $org_id})
+            SET o.lastupdated = $tag, o.web_url = $org_url, o.gitlab_url = $gitlab_url
             """,
+            org_id=TEST_ORG_ID,
             org_url=TEST_ORG_URL,
+            gitlab_url=TEST_GITLAB_URL,
             tag=TEST_UPDATE_TAG_V2,
         )
 
         # Create stale project
         neo4j_session.run(
             """
-            MERGE (p:GitLabProject {id: $project_url})
-            SET p.lastupdated = $old_tag
+            MERGE (p:GitLabProject {id: $project_id})
+            SET p.lastupdated = $old_tag, p.web_url = $project_url, p.gitlab_url = $gitlab_url
             WITH p
-            MATCH (o:GitLabOrganization {id: $org_url})
+            MATCH (o:GitLabOrganization {id: $org_id})
             MERGE (o)-[:RESOURCE]->(p)
             """,
+            project_id=TEST_PROJECT_ID,
             project_url=TEST_PROJECT_URL,
-            org_url=TEST_ORG_URL,
+            org_id=TEST_ORG_ID,
+            gitlab_url=TEST_GITLAB_URL,
             old_tag=TEST_UPDATE_TAG,
         )
 
         # Create child dependency file
         neo4j_session.run(
             """
-            MATCH (p:GitLabProject {id: $project_url})
+            MATCH (p:GitLabProject {id: $project_id})
             MERGE (df:GitLabDependencyFile {id: $dep_file_id})
             SET df.lastupdated = $old_tag, df.path = 'requirements.txt'
             MERGE (p)-[:RESOURCE]->(df)
             """,
-            project_url=TEST_PROJECT_URL,
+            project_id=TEST_PROJECT_ID,
             dep_file_id=f"{TEST_PROJECT_URL}/requirements.txt",
             old_tag=TEST_UPDATE_TAG,
         )
@@ -229,7 +246,8 @@ class TestProjectCascadeDelete:
         # Run cleanup with cascade_delete=True
         common_job_params = {
             "UPDATE_TAG": TEST_UPDATE_TAG_V2,
-            "org_url": TEST_ORG_URL,
+            "org_id": TEST_ORG_ID,
+            "gitlab_url": TEST_GITLAB_URL,
         }
         GraphJob.from_node_schema(
             GitLabProjectSchema(), common_job_params, cascade_delete=True
@@ -251,36 +269,40 @@ class TestProjectCascadeDelete:
         # Create organization
         neo4j_session.run(
             """
-            MERGE (o:GitLabOrganization {id: $org_url})
-            SET o.lastupdated = $tag
+            MERGE (o:GitLabOrganization {id: $org_id})
+            SET o.lastupdated = $tag, o.web_url = $org_url, o.gitlab_url = $gitlab_url
             """,
+            org_id=TEST_ORG_ID,
             org_url=TEST_ORG_URL,
+            gitlab_url=TEST_GITLAB_URL,
             tag=TEST_UPDATE_TAG_V2,
         )
 
         # Create stale project
         neo4j_session.run(
             """
-            MERGE (p:GitLabProject {id: $project_url})
-            SET p.lastupdated = $old_tag
+            MERGE (p:GitLabProject {id: $project_id})
+            SET p.lastupdated = $old_tag, p.web_url = $project_url, p.gitlab_url = $gitlab_url
             WITH p
-            MATCH (o:GitLabOrganization {id: $org_url})
+            MATCH (o:GitLabOrganization {id: $org_id})
             MERGE (o)-[:RESOURCE]->(p)
             """,
+            project_id=TEST_PROJECT_ID,
             project_url=TEST_PROJECT_URL,
-            org_url=TEST_ORG_URL,
+            org_id=TEST_ORG_ID,
+            gitlab_url=TEST_GITLAB_URL,
             old_tag=TEST_UPDATE_TAG,
         )
 
         # Create child branch
         neo4j_session.run(
             """
-            MATCH (p:GitLabProject {id: $project_url})
+            MATCH (p:GitLabProject {id: $project_id})
             MERGE (b:GitLabBranch {id: $branch_id})
             SET b.lastupdated = $old_tag, b.name = 'main'
             MERGE (p)-[:RESOURCE]->(b)
             """,
-            project_url=TEST_PROJECT_URL,
+            project_id=TEST_PROJECT_ID,
             branch_id=f"{TEST_PROJECT_URL}/tree/main",
             old_tag=TEST_UPDATE_TAG,
         )
@@ -292,7 +314,8 @@ class TestProjectCascadeDelete:
         # Run cleanup WITHOUT cascade_delete (default behavior)
         common_job_params = {
             "UPDATE_TAG": TEST_UPDATE_TAG_V2,
-            "org_url": TEST_ORG_URL,
+            "org_id": TEST_ORG_ID,
+            "gitlab_url": TEST_GITLAB_URL,
         }
         GraphJob.from_node_schema(
             GitLabProjectSchema(),

--- a/tests/integration/cartography/intel/gitlab/test_container_registry.py
+++ b/tests/integration/cartography/intel/gitlab/test_container_registry.py
@@ -34,6 +34,14 @@ TEST_ATTESTATION_BLOB = {
         json.dumps(
             {
                 "predicate": {
+                    "materials": [
+                        {
+                            "uri": "pkg:docker/registry.gitlab.example.com/base-images/python@3.12",
+                            "digest": {
+                                "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                            },
+                        },
+                    ],
                     "metadata": {
                         "https://mobyproject.org/buildkit@v1#metadata": {
                             "vcs": {
@@ -71,6 +79,21 @@ def _create_test_org(neo4j_session):
         org_id=TEST_ORG_ID,
         org_url=TEST_ORG_URL,
         gitlab_url=TEST_GITLAB_URL,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+
+def _create_test_parent_image(neo4j_session):
+    """Create a base image node so BUILT_FROM can resolve."""
+    neo4j_session.run(
+        """
+        MERGE (img:GitLabContainerImage {id: $digest})
+        ON CREATE SET img.firstseen = timestamp()
+        SET img.digest = $digest,
+            img.type = 'image',
+            img.lastupdated = $update_tag
+        """,
+        digest="sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
         update_tag=TEST_UPDATE_TAG,
     )
 
@@ -116,6 +139,7 @@ def test_sync_container_registry(
 
     # Create test organization
     _create_test_org(neo4j_session)
+    _create_test_parent_image(neo4j_session)
 
     common_job_parameters = {
         "UPDATE_TAG": TEST_UPDATE_TAG,
@@ -219,7 +243,7 @@ def test_sync_container_registry(
     }
     assert (
         check_nodes(neo4j_session, "GitLabContainerImage", ["id", "type"])
-        == expected_images
+        >= expected_images
     )
 
     # Verify container image RESOURCE relationships
@@ -590,13 +614,32 @@ def test_sync_container_registry(
             "sha256:aaa111222333444555666777888999000aaabbbcccdddeeefff000111222333",
             "https://gitlab.example.com/myorg/awesome-project",
             "docker/Dockerfile",
+            "pkg:docker/registry.gitlab.example.com/base-images/python@3.12",
         ),
     }
     assert (
         check_nodes(
             neo4j_session,
             "GitLabContainerImage",
-            ["id", "source_uri", "source_file"],
+            ["id", "source_uri", "source_file", "parent_image_uri"],
         )
         >= expected_provenance
+    )
+
+    expected_built_from_rels = {
+        (
+            "sha256:aaa111222333444555666777888999000aaabbbcccdddeeefff000111222333",
+            "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        ),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "GitLabContainerImage",
+            "id",
+            "GitLabContainerImage",
+            "id",
+            "BUILT_FROM",
+        )
+        >= expected_built_from_rels
     )

--- a/tests/integration/cartography/intel/gitlab/test_container_registry.py
+++ b/tests/integration/cartography/intel/gitlab/test_container_registry.py
@@ -1,5 +1,7 @@
 """Integration tests for GitLab container registry module."""
 
+import base64
+import json
 from unittest.mock import patch
 
 from cartography.intel.gitlab.container_image_attestations import (
@@ -27,18 +29,48 @@ from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
 TEST_ORG_ID = 12345
+TEST_ATTESTATION_BLOB = {
+    "payload": base64.b64encode(
+        json.dumps(
+            {
+                "predicate": {
+                    "metadata": {
+                        "https://mobyproject.org/buildkit@v1#metadata": {
+                            "vcs": {
+                                "source": "https://gitlab.example.com/myorg/awesome-project.git",
+                                "revision": "deadbeefcafebabe",
+                                "localdir:dockerfile": "docker",
+                            },
+                        },
+                    },
+                    "buildDefinition": {
+                        "externalParameters": {
+                            "configSource": {
+                                "path": "Dockerfile",
+                            },
+                        },
+                    },
+                },
+            }
+        ).encode("utf-8")
+    ).decode("utf-8"),
+}
 
 
 def _create_test_org(neo4j_session):
     """Create test GitLabOrganization node."""
     neo4j_session.run(
         """
-        MERGE (o:GitLabOrganization{id: $org_url})
+        MERGE (o:GitLabOrganization{id: $org_id})
         ON CREATE SET o.firstseen = timestamp()
         SET o.lastupdated = $update_tag,
-            o.name = 'myorg'
+            o.name = 'myorg',
+            o.web_url = $org_url,
+            o.gitlab_url = $gitlab_url
         """,
+        org_id=TEST_ORG_ID,
         org_url=TEST_ORG_URL,
+        gitlab_url=TEST_GITLAB_URL,
         update_tag=TEST_UPDATE_TAG,
     )
 
@@ -59,6 +91,10 @@ def _create_test_org(neo4j_session):
     return_value=(GET_CONTAINER_IMAGES_RESPONSE, GET_CONTAINER_MANIFEST_LISTS_RESPONSE),
 )
 @patch(
+    "cartography.intel.gitlab.container_image_attestations.fetch_registry_blob",
+    return_value=TEST_ATTESTATION_BLOB,
+)
+@patch(
     "cartography.intel.gitlab.container_repository_tags.get_all_container_repository_tags",
     return_value=GET_CONTAINER_REPOSITORY_TAGS_RESPONSE,
 )
@@ -69,6 +105,7 @@ def _create_test_org(neo4j_session):
 def test_sync_container_registry(
     mock_get_repos,
     mock_get_tags,
+    mock_fetch_registry_blob,
     mock_get_images,
     mock_get_attestations,
     neo4j_session,
@@ -83,7 +120,8 @@ def test_sync_container_registry(
     common_job_parameters = {
         "UPDATE_TAG": TEST_UPDATE_TAG,
         "ORGANIZATION_ID": TEST_ORG_ID,
-        "org_url": TEST_ORG_URL,
+        "org_id": TEST_ORG_ID,
+        "gitlab_url": TEST_GITLAB_URL,
     }
 
     # Run all sync functions in correct order
@@ -92,7 +130,7 @@ def test_sync_container_registry(
         neo4j_session,
         TEST_GITLAB_URL,
         "fake-token",
-        TEST_ORG_URL,
+        TEST_ORG_ID,
         TEST_ORG_ID,
         TEST_UPDATE_TAG,
         common_job_parameters,
@@ -102,7 +140,7 @@ def test_sync_container_registry(
         neo4j_session,
         TEST_GITLAB_URL,
         "fake-token",
-        TEST_ORG_URL,
+        TEST_ORG_ID,
         raw_repositories,
         TEST_UPDATE_TAG,
         common_job_parameters,
@@ -112,7 +150,7 @@ def test_sync_container_registry(
         neo4j_session,
         TEST_GITLAB_URL,
         "fake-token",
-        TEST_ORG_URL,
+        TEST_ORG_ID,
         raw_repositories,
         TEST_UPDATE_TAG,
         common_job_parameters,
@@ -122,7 +160,7 @@ def test_sync_container_registry(
         neo4j_session,
         TEST_GITLAB_URL,
         "fake-token",
-        TEST_ORG_URL,
+        TEST_ORG_ID,
         raw_manifests,
         manifest_lists,
         TEST_UPDATE_TAG,
@@ -141,8 +179,8 @@ def test_sync_container_registry(
 
     # Verify container repository RESOURCE relationships
     expected_repo_rels = {
-        (TEST_ORG_URL, "registry.gitlab.example.com/myorg/awesome-project/app"),
-        (TEST_ORG_URL, "registry.gitlab.example.com/myorg/awesome-project/worker"),
+        (TEST_ORG_ID, "registry.gitlab.example.com/myorg/awesome-project/app"),
+        (TEST_ORG_ID, "registry.gitlab.example.com/myorg/awesome-project/worker"),
     }
     assert (
         check_rels(
@@ -187,23 +225,23 @@ def test_sync_container_registry(
     # Verify container image RESOURCE relationships
     expected_image_rels = {
         (
-            TEST_ORG_URL,
+            TEST_ORG_ID,
             "sha256:aaa111222333444555666777888999000aaabbbcccdddeeefff000111222333",
         ),
         (
-            TEST_ORG_URL,
+            TEST_ORG_ID,
             "sha256:bbb222333444555666777888999000aaabbbcccdddeeefff000111222333444",
         ),
         (
-            TEST_ORG_URL,
+            TEST_ORG_ID,
             "sha256:child1amd64555666777888999000aaabbbcccdddeeefff000111222333444",
         ),
         (
-            TEST_ORG_URL,
+            TEST_ORG_ID,
             "sha256:child2arm64555666777888999000aaabbbcccdddeeefff000111222333444",
         ),
         (
-            TEST_ORG_URL,
+            TEST_ORG_ID,
             "sha256:ccc333444555666777888999000aaabbbcccdddeeefff000111222333444555",
         ),
     }
@@ -255,10 +293,10 @@ def test_sync_container_registry(
 
     # Verify tag RESOURCE relationships
     expected_tag_rels = {
-        (TEST_ORG_URL, "registry.gitlab.example.com/myorg/awesome-project/app:latest"),
-        (TEST_ORG_URL, "registry.gitlab.example.com/myorg/awesome-project/app:v1.0.0"),
+        (TEST_ORG_ID, "registry.gitlab.example.com/myorg/awesome-project/app:latest"),
+        (TEST_ORG_ID, "registry.gitlab.example.com/myorg/awesome-project/app:v1.0.0"),
         (
-            TEST_ORG_URL,
+            TEST_ORG_ID,
             "registry.gitlab.example.com/myorg/awesome-project/worker:v0.9.0",
         ),
     }
@@ -301,6 +339,19 @@ def test_sync_container_registry(
         == expected_has_tag_rels
     )
 
+    # Verify generic REPO_IMAGE relationships (repository -> tag)
+    assert (
+        check_rels(
+            neo4j_session,
+            "GitLabContainerRepository",
+            "id",
+            "GitLabContainerRepositoryTag",
+            "id",
+            "REPO_IMAGE",
+        )
+        == expected_has_tag_rels
+    )
+
     # Verify tag REFERENCES relationships (tag -> image)
     expected_references_rels = {
         (
@@ -328,6 +379,19 @@ def test_sync_container_registry(
         == expected_references_rels
     )
 
+    # Verify generic IMAGE relationships (tag -> image)
+    assert (
+        check_rels(
+            neo4j_session,
+            "GitLabContainerRepositoryTag",
+            "id",
+            "GitLabContainerImage",
+            "id",
+            "IMAGE",
+        )
+        == expected_references_rels
+    )
+
     # Verify attestation nodes
     expected_attestations = {
         (
@@ -349,11 +413,11 @@ def test_sync_container_registry(
     # Verify attestation RESOURCE relationships
     expected_attestation_rels = {
         (
-            TEST_ORG_URL,
+            TEST_ORG_ID,
             "sha256:sig111222333444555666777888999000aaabbbcccdddeeefff000111222333",
         ),
         (
-            TEST_ORG_URL,
+            TEST_ORG_ID,
             "sha256:att111222333444555666777888999000aaabbbcccdddeeefff000111222333",
         ),
     }
@@ -407,15 +471,15 @@ def test_sync_container_registry(
     # Verify layer RESOURCE relationships
     expected_layer_rels = {
         (
-            TEST_ORG_URL,
+            TEST_ORG_ID,
             "sha256:diff1111222333444555666777888999000aaabbbcccdddeeefff000111222",
         ),
         (
-            TEST_ORG_URL,
+            TEST_ORG_ID,
             "sha256:diff2222333444555666777888999000aaabbbcccdddeeefff000111222333",
         ),
         (
-            TEST_ORG_URL,
+            TEST_ORG_ID,
             "sha256:diff3333444555666777888999000aaabbbcccdddeeefff000111222333444",
         ),
     }
@@ -518,4 +582,21 @@ def test_sync_container_registry(
             "TAIL",
         )
         == expected_tail_rels
+    )
+
+    # Verify provenance was loaded onto the image node
+    expected_provenance = {
+        (
+            "sha256:aaa111222333444555666777888999000aaabbbcccdddeeefff000111222333",
+            "https://gitlab.example.com/myorg/awesome-project",
+            "docker/Dockerfile",
+        ),
+    }
+    assert (
+        check_nodes(
+            neo4j_session,
+            "GitLabContainerImage",
+            ["id", "source_uri", "source_file"],
+        )
+        >= expected_provenance
     )

--- a/tests/integration/cartography/intel/gitlab/test_dependencies.py
+++ b/tests/integration/cartography/intel/gitlab/test_dependencies.py
@@ -1,6 +1,8 @@
 """Integration tests for GitLab dependencies module."""
 
 from cartography.intel.gitlab.dependencies import load_dependencies
+from tests.data.gitlab.dependencies import TEST_GITLAB_URL
+from tests.data.gitlab.dependencies import TEST_PROJECT_ID
 from tests.data.gitlab.dependencies import TEST_PROJECT_URL
 from tests.data.gitlab.dependencies import TRANSFORMED_DEPENDENCIES
 from tests.integration.util import check_nodes
@@ -13,12 +15,16 @@ def _create_test_project(neo4j_session):
     """Create test GitLabProject node."""
     neo4j_session.run(
         """
-        MERGE (p:GitLabProject{id: $project_url})
+        MERGE (p:GitLabProject{id: $project_id})
         ON CREATE SET p.firstseen = timestamp()
         SET p.lastupdated = $update_tag,
-            p.name = 'awesome-project'
+            p.name = 'awesome-project',
+            p.web_url = $project_url,
+            p.gitlab_url = $gitlab_url
         """,
+        project_id=TEST_PROJECT_ID,
         project_url=TEST_PROJECT_URL,
+        gitlab_url=TEST_GITLAB_URL,
         update_tag=TEST_UPDATE_TAG,
     )
 
@@ -48,7 +54,8 @@ def test_load_gitlab_dependencies_nodes(neo4j_session):
     load_dependencies(
         neo4j_session,
         TRANSFORMED_DEPENDENCIES,
-        TEST_PROJECT_URL,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
@@ -85,26 +92,27 @@ def test_load_gitlab_dependencies_resource_relationships(neo4j_session):
     load_dependencies(
         neo4j_session,
         TRANSFORMED_DEPENDENCIES,
-        TEST_PROJECT_URL,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
     # Assert - Check RESOURCE relationships from Project to Dependency
     expected = {
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project:npm:express@4.18.2",
         ),
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project:npm:lodash@4.17.21",
         ),
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project:pypi:requests@2.31.0",
         ),
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project:golang:gin@1.9.1",
         ),
     }
@@ -130,26 +138,27 @@ def test_load_gitlab_dependencies_requires_relationships(neo4j_session):
     load_dependencies(
         neo4j_session,
         TRANSFORMED_DEPENDENCIES,
-        TEST_PROJECT_URL,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
     # Assert - Check REQUIRES relationships
     expected = {
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project:npm:express@4.18.2",
         ),
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project:npm:lodash@4.17.21",
         ),
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project:pypi:requests@2.31.0",
         ),
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project:golang:gin@1.9.1",
         ),
     }
@@ -178,7 +187,8 @@ def test_load_gitlab_dependencies_has_dep_relationships(neo4j_session):
     load_dependencies(
         neo4j_session,
         TRANSFORMED_DEPENDENCIES,
-        TEST_PROJECT_URL,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
@@ -216,7 +226,8 @@ def test_load_gitlab_dependencies_properties(neo4j_session):
     load_dependencies(
         neo4j_session,
         TRANSFORMED_DEPENDENCIES,
-        TEST_PROJECT_URL,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 

--- a/tests/integration/cartography/intel/gitlab/test_dependency_files.py
+++ b/tests/integration/cartography/intel/gitlab/test_dependency_files.py
@@ -1,6 +1,8 @@
 """Integration tests for GitLab dependency files module."""
 
 from cartography.intel.gitlab.dependency_files import load_dependency_files
+from tests.data.gitlab.dependency_files import TEST_GITLAB_URL
+from tests.data.gitlab.dependency_files import TEST_PROJECT_ID
 from tests.data.gitlab.dependency_files import TEST_PROJECT_URL
 from tests.data.gitlab.dependency_files import TRANSFORMED_DEPENDENCY_FILES
 from tests.integration.util import check_nodes
@@ -13,12 +15,16 @@ def _create_test_project(neo4j_session):
     """Create test GitLabProject node."""
     neo4j_session.run(
         """
-        MERGE (p:GitLabProject{id: $project_url})
+        MERGE (p:GitLabProject{id: $project_id})
         ON CREATE SET p.firstseen = timestamp()
         SET p.lastupdated = $update_tag,
-            p.name = 'awesome-project'
+            p.name = 'awesome-project',
+            p.web_url = $project_url,
+            p.gitlab_url = $gitlab_url
         """,
+        project_id=TEST_PROJECT_ID,
         project_url=TEST_PROJECT_URL,
+        gitlab_url=TEST_GITLAB_URL,
         update_tag=TEST_UPDATE_TAG,
     )
 
@@ -32,7 +38,8 @@ def test_load_gitlab_dependency_files_nodes(neo4j_session):
     load_dependency_files(
         neo4j_session,
         TRANSFORMED_DEPENDENCY_FILES,
-        TEST_PROJECT_URL,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
@@ -66,22 +73,23 @@ def test_load_gitlab_dependency_files_resource_relationships(neo4j_session):
     load_dependency_files(
         neo4j_session,
         TRANSFORMED_DEPENDENCY_FILES,
-        TEST_PROJECT_URL,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
     # Assert - Check RESOURCE relationships from Project to DependencyFile
     expected = {
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project/blob/package.json",
         ),
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project/blob/backend/requirements.txt",
         ),
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project/blob/services/api/go.mod",
         ),
     }
@@ -107,22 +115,23 @@ def test_load_gitlab_dependency_files_has_dependency_file_relationships(neo4j_se
     load_dependency_files(
         neo4j_session,
         TRANSFORMED_DEPENDENCY_FILES,
-        TEST_PROJECT_URL,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
     # Assert - Check HAS_DEPENDENCY_FILE relationships
     expected = {
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project/blob/package.json",
         ),
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project/blob/backend/requirements.txt",
         ),
         (
-            TEST_PROJECT_URL,
+            TEST_PROJECT_ID,
             "https://gitlab.example.com/myorg/awesome-project/blob/services/api/go.mod",
         ),
     }
@@ -148,7 +157,8 @@ def test_load_gitlab_dependency_files_properties(neo4j_session):
     load_dependency_files(
         neo4j_session,
         TRANSFORMED_DEPENDENCY_FILES,
-        TEST_PROJECT_URL,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 

--- a/tests/integration/cartography/intel/gitlab/test_groups.py
+++ b/tests/integration/cartography/intel/gitlab/test_groups.py
@@ -1,6 +1,8 @@
 """Integration tests for GitLab groups module."""
 
 from cartography.intel.gitlab.groups import load_groups
+from tests.data.gitlab.groups import TEST_GITLAB_URL
+from tests.data.gitlab.groups import TEST_ORG_ID
 from tests.data.gitlab.groups import TEST_ORG_URL
 from tests.data.gitlab.groups import TRANSFORMED_GROUPS
 from tests.integration.util import check_nodes
@@ -13,12 +15,16 @@ def _create_test_organization(neo4j_session):
     """Create test GitLabOrganization node."""
     neo4j_session.run(
         """
-        MERGE (org:GitLabOrganization{id: $org_url})
+        MERGE (org:GitLabOrganization{id: $org_id})
         ON CREATE SET org.firstseen = timestamp()
         SET org.lastupdated = $update_tag,
-            org.name = 'myorg'
+            org.name = 'myorg',
+            org.web_url = $org_url,
+            org.gitlab_url = $gitlab_url
         """,
+        org_id=TEST_ORG_ID,
         org_url=TEST_ORG_URL,
+        gitlab_url=TEST_GITLAB_URL,
         update_tag=TEST_UPDATE_TAG,
     )
 
@@ -32,15 +38,16 @@ def test_load_gitlab_groups_nodes(neo4j_session):
     load_groups(
         neo4j_session,
         TRANSFORMED_GROUPS,
-        TEST_ORG_URL,
+        TEST_ORG_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
     # Assert - Check that group nodes exist
     expected_nodes = {
-        ("https://gitlab.example.com/myorg/platform", "Platform"),
-        ("https://gitlab.example.com/myorg/apps", "Apps"),
-        ("https://gitlab.example.com/myorg/platform/infrastructure", "Infrastructure"),
+        (20, "Platform"),
+        (30, "Apps"),
+        (40, "Infrastructure"),
     }
     assert check_nodes(neo4j_session, "GitLabGroup", ["id", "name"]) == expected_nodes
 
@@ -54,15 +61,16 @@ def test_load_gitlab_groups_to_organization_relationships(neo4j_session):
     load_groups(
         neo4j_session,
         TRANSFORMED_GROUPS,
-        TEST_ORG_URL,
+        TEST_ORG_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
     # Assert - Check RESOURCE relationships from Organization to Group
     expected = {
-        (TEST_ORG_URL, "https://gitlab.example.com/myorg/platform"),
-        (TEST_ORG_URL, "https://gitlab.example.com/myorg/apps"),
-        (TEST_ORG_URL, "https://gitlab.example.com/myorg/platform/infrastructure"),
+        (TEST_ORG_ID, 20),
+        (TEST_ORG_ID, 30),
+        (TEST_ORG_ID, 40),
     }
     assert (
         check_rels(
@@ -86,17 +94,15 @@ def test_load_gitlab_groups_nested_relationships(neo4j_session):
     load_groups(
         neo4j_session,
         TRANSFORMED_GROUPS,
-        TEST_ORG_URL,
+        TEST_ORG_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
     # Assert - Check MEMBER_OF relationships for nested groups
     # Infrastructure is nested under Platform
     expected = {
-        (
-            "https://gitlab.example.com/myorg/platform/infrastructure",
-            "https://gitlab.example.com/myorg/platform",
-        ),
+        (40, 20),
     }
     assert (
         check_rels(
@@ -120,28 +126,29 @@ def test_load_gitlab_groups_properties(neo4j_session):
     load_groups(
         neo4j_session,
         TRANSFORMED_GROUPS,
-        TEST_ORG_URL,
+        TEST_ORG_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
     # Assert - Check all properties
     expected_nodes = {
         (
-            "https://gitlab.example.com/myorg/platform",
+            20,
             "Platform",
             "platform",
             "myorg/platform",
             "private",
         ),
         (
-            "https://gitlab.example.com/myorg/apps",
+            30,
             "Apps",
             "apps",
             "myorg/apps",
             "internal",
         ),
         (
-            "https://gitlab.example.com/myorg/platform/infrastructure",
+            40,
             "Infrastructure",
             "infrastructure",
             "myorg/platform/infrastructure",

--- a/tests/integration/cartography/intel/gitlab/test_organizations.py
+++ b/tests/integration/cartography/intel/gitlab/test_organizations.py
@@ -7,6 +7,7 @@ from tests.integration.util import check_nodes
 
 TEST_UPDATE_TAG = 123456789
 TEST_GITLAB_URL = "https://gitlab.example.com"
+TEST_ORG_ID = 100
 
 
 def test_load_gitlab_organization_nodes(neo4j_session):
@@ -20,7 +21,7 @@ def test_load_gitlab_organization_nodes(neo4j_session):
 
     # Assert - Check that organization node exists
     expected_nodes = {
-        ("https://gitlab.example.com/myorg", "MyOrg"),
+        (TEST_ORG_ID, "MyOrg"),
     }
     assert (
         check_nodes(neo4j_session, "GitLabOrganization", ["id", "name"])
@@ -40,7 +41,7 @@ def test_load_gitlab_organization_properties(neo4j_session):
     # Assert - Check all properties
     expected_nodes = {
         (
-            "https://gitlab.example.com/myorg",
+            TEST_ORG_ID,
             "MyOrg",
             "myorg",
             "myorg",
@@ -75,7 +76,7 @@ def test_cleanup_gitlab_organizations(neo4j_session):
 
     # Verify organization exists
     assert check_nodes(neo4j_session, "GitLabOrganization", ["id"]) == {
-        ("https://gitlab.example.com/myorg",),
+        (TEST_ORG_ID,),
     }
 
     # Act - Run cleanup with a different UPDATE_TAG (simulating stale data)
@@ -86,5 +87,5 @@ def test_cleanup_gitlab_organizations(neo4j_session):
     # This documents current behavior: orgs are not auto-cleaned as they have
     # no sub_resource_relationship to scope cleanup
     assert check_nodes(neo4j_session, "GitLabOrganization", ["id"]) == {
-        ("https://gitlab.example.com/myorg",),
+        (TEST_ORG_ID,),
     }

--- a/tests/integration/cartography/intel/gitlab/test_projects.py
+++ b/tests/integration/cartography/intel/gitlab/test_projects.py
@@ -3,6 +3,8 @@
 import json
 
 from cartography.intel.gitlab.projects import load_projects
+from tests.data.gitlab.projects import TEST_GITLAB_URL
+from tests.data.gitlab.projects import TEST_ORG_ID
 from tests.data.gitlab.projects import TRANSFORMED_PROJECTS
 from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
@@ -15,12 +17,16 @@ def _create_test_organization(neo4j_session):
     """Create test GitLabOrganization node."""
     neo4j_session.run(
         """
-        MERGE (org:GitLabOrganization{id: $org_url})
+        MERGE (org:GitLabOrganization{id: $org_id})
         ON CREATE SET org.firstseen = timestamp()
         SET org.lastupdated = $update_tag,
-            org.name = 'myorg'
+            org.name = 'myorg',
+            org.web_url = $org_url,
+            org.gitlab_url = $gitlab_url
         """,
+        org_id=TEST_ORG_ID,
         org_url=TEST_ORG_URL,
+        gitlab_url=TEST_GITLAB_URL,
         update_tag=TEST_UPDATE_TAG,
     )
 
@@ -29,11 +35,11 @@ def _create_test_groups(neo4j_session):
     """Create test GitLabGroup nodes for nested groups."""
     groups = [
         {
-            "id": "https://gitlab.example.com/myorg/platform",
+            "id": 20,
             "name": "Platform",
         },
         {
-            "id": "https://gitlab.example.com/myorg/apps",
+            "id": 30,
             "name": "Apps",
         },
     ]
@@ -43,10 +49,12 @@ def _create_test_groups(neo4j_session):
             MERGE (g:GitLabGroup{id: $id})
             ON CREATE SET g.firstseen = timestamp()
             SET g.lastupdated = $update_tag,
-                g.name = $name
+                g.name = $name,
+                g.gitlab_url = $gitlab_url
             """,
             id=group["id"],
             name=group["name"],
+            gitlab_url=TEST_GITLAB_URL,
             update_tag=TEST_UPDATE_TAG,
         )
 
@@ -60,18 +68,16 @@ def test_load_gitlab_projects_nodes(neo4j_session):
     load_projects(
         neo4j_session,
         TRANSFORMED_PROJECTS,
-        TEST_ORG_URL,
+        TEST_ORG_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
     # Assert - Check that project nodes exist
     expected_nodes = {
-        ("https://gitlab.example.com/myorg/awesome-project", "awesome-project"),
-        (
-            "https://gitlab.example.com/myorg/platform/backend-service",
-            "backend-service",
-        ),
-        ("https://gitlab.example.com/myorg/apps/frontend-app", "frontend-app"),
+        (123, "awesome-project"),
+        (456, "backend-service"),
+        (789, "frontend-app"),
     }
     assert check_nodes(neo4j_session, "GitLabProject", ["id", "name"]) == expected_nodes
 
@@ -85,15 +91,16 @@ def test_load_gitlab_projects_to_organization_relationships(neo4j_session):
     load_projects(
         neo4j_session,
         TRANSFORMED_PROJECTS,
-        TEST_ORG_URL,
+        TEST_ORG_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
     # Assert - Check RESOURCE relationships from Organization to Project
     expected = {
-        (TEST_ORG_URL, "https://gitlab.example.com/myorg/awesome-project"),
-        (TEST_ORG_URL, "https://gitlab.example.com/myorg/platform/backend-service"),
-        (TEST_ORG_URL, "https://gitlab.example.com/myorg/apps/frontend-app"),
+        (TEST_ORG_ID, 123),
+        (TEST_ORG_ID, 456),
+        (TEST_ORG_ID, 789),
     }
     assert (
         check_rels(
@@ -118,21 +125,16 @@ def test_load_gitlab_projects_to_group_relationships(neo4j_session):
     load_projects(
         neo4j_session,
         TRANSFORMED_PROJECTS,
-        TEST_ORG_URL,
+        TEST_ORG_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
     # Assert - Check CAN_ACCESS relationships from Group to Project
     # Only projects in nested groups should have this relationship
     expected = {
-        (
-            "https://gitlab.example.com/myorg/platform",
-            "https://gitlab.example.com/myorg/platform/backend-service",
-        ),
-        (
-            "https://gitlab.example.com/myorg/apps",
-            "https://gitlab.example.com/myorg/apps/frontend-app",
-        ),
+        (20, 456),
+        (30, 789),
     }
     assert (
         check_rels(
@@ -156,28 +158,29 @@ def test_load_gitlab_projects_properties(neo4j_session):
     load_projects(
         neo4j_session,
         TRANSFORMED_PROJECTS,
-        TEST_ORG_URL,
+        TEST_ORG_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
     # Assert - Check that all project properties are loaded correctly
     expected_nodes = {
         (
-            "https://gitlab.example.com/myorg/awesome-project",
+            123,
             "awesome-project",
             "private",
             "main",
             False,
         ),
         (
-            "https://gitlab.example.com/myorg/platform/backend-service",
+            456,
             "backend-service",
             "internal",
             "master",
             False,
         ),
         (
-            "https://gitlab.example.com/myorg/apps/frontend-app",
+            789,
             "frontend-app",
             "public",
             "main",
@@ -203,7 +206,8 @@ def test_load_gitlab_projects_languages_property(neo4j_session):
     load_projects(
         neo4j_session,
         TRANSFORMED_PROJECTS,
-        TEST_ORG_URL,
+        TEST_ORG_ID,
+        TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
 
@@ -211,7 +215,7 @@ def test_load_gitlab_projects_languages_property(neo4j_session):
     result = neo4j_session.run(
         """
         MATCH (p:GitLabProject)
-        WHERE p.id = 'https://gitlab.example.com/myorg/awesome-project'
+        WHERE p.id = 123
         RETURN p.languages as languages
         """,
     )
@@ -223,7 +227,7 @@ def test_load_gitlab_projects_languages_property(neo4j_session):
     result = neo4j_session.run(
         """
         MATCH (p:GitLabProject)
-        WHERE p.id = 'https://gitlab.example.com/myorg/platform/backend-service'
+        WHERE p.id = 456
         RETURN p.languages as languages
         """,
     )

--- a/tests/integration/cartography/intel/gitlab/test_users.py
+++ b/tests/integration/cartography/intel/gitlab/test_users.py
@@ -120,7 +120,11 @@ def test_sync_gitlab_users(
         "https://gitlab.example.com",
         "fake-token",
         TEST_UPDATE_TAG,
-        {"ORGANIZATION_ID": TEST_ORG_ID, "org_id": TEST_ORG_ID, "gitlab_url": TEST_GITLAB_URL},
+        {
+            "ORGANIZATION_ID": TEST_ORG_ID,
+            "org_id": TEST_ORG_ID,
+            "gitlab_url": TEST_GITLAB_URL,
+        },
         test_groups,
         test_projects,
         commits_since_days=90,

--- a/tests/integration/cartography/intel/gitlab/test_users.py
+++ b/tests/integration/cartography/intel/gitlab/test_users.py
@@ -14,18 +14,23 @@ TEST_UPDATE_TAG = 123456789
 TEST_ORG_ID = 100
 TEST_GROUP_ID = 20
 TEST_PROJECT_ID = 123
+TEST_GITLAB_URL = "https://gitlab.example.com"
 
 
 def _create_test_organization(neo4j_session):
     """Create test GitLabOrganization node."""
     neo4j_session.run(
         """
-        MERGE (org:GitLabOrganization{id: $org_url})
+        MERGE (org:GitLabOrganization{id: $org_id})
         ON CREATE SET org.firstseen = timestamp()
         SET org.lastupdated = $update_tag,
-            org.name = 'myorg'
+            org.name = 'myorg',
+            org.web_url = $org_url,
+            org.gitlab_url = $gitlab_url
         """,
+        org_id=TEST_ORG_ID,
         org_url=TEST_ORG_URL,
+        gitlab_url=TEST_GITLAB_URL,
         update_tag=TEST_UPDATE_TAG,
     )
 
@@ -34,12 +39,16 @@ def _create_test_group(neo4j_session):
     """Create test GitLabGroup node."""
     neo4j_session.run(
         """
-        MERGE (g:GitLabGroup{id: $group_url})
+        MERGE (g:GitLabGroup{id: $group_id})
         ON CREATE SET g.firstseen = timestamp()
         SET g.lastupdated = $update_tag,
-            g.name = 'Platform'
+            g.name = 'Platform',
+            g.web_url = $group_url,
+            g.gitlab_url = $gitlab_url
         """,
+        group_id=TEST_GROUP_ID,
         group_url="https://gitlab.example.com/myorg/platform",
+        gitlab_url=TEST_GITLAB_URL,
         update_tag=TEST_UPDATE_TAG,
     )
 
@@ -48,12 +57,16 @@ def _create_test_project(neo4j_session):
     """Create test GitLabProject node."""
     neo4j_session.run(
         """
-        MERGE (p:GitLabProject{id: $project_url})
+        MERGE (p:GitLabProject{id: $project_id})
         ON CREATE SET p.firstseen = timestamp()
         SET p.lastupdated = $update_tag,
-            p.name = 'awesome-project'
+            p.name = 'awesome-project',
+            p.web_url = $project_url,
+            p.gitlab_url = $gitlab_url
         """,
+        project_id=TEST_PROJECT_ID,
         project_url="https://gitlab.example.com/myorg/awesome-project",
+        gitlab_url=TEST_GITLAB_URL,
         update_tag=TEST_UPDATE_TAG,
     )
 
@@ -107,7 +120,7 @@ def test_sync_gitlab_users(
         "https://gitlab.example.com",
         "fake-token",
         TEST_UPDATE_TAG,
-        {"ORGANIZATION_ID": TEST_ORG_ID},
+        {"ORGANIZATION_ID": TEST_ORG_ID, "org_id": TEST_ORG_ID, "gitlab_url": TEST_GITLAB_URL},
         test_groups,
         test_projects,
         commits_since_days=90,
@@ -115,8 +128,8 @@ def test_sync_gitlab_users(
 
     # Assert - Check both user nodes exist
     expected_users = {
-        ("https://gitlab.example.com/alice", "alice", "Alice Smith"),
-        ("https://gitlab.example.com/bob", "bob", "Bob Jones"),
+        (1, "alice", "Alice Smith"),
+        (2, "bob", "Bob Jones"),
     }
     assert (
         check_nodes(neo4j_session, "GitLabUser", ["id", "username", "name"])
@@ -127,8 +140,8 @@ def test_sync_gitlab_users(
     # Only Alice is in the Platform group, Bob is org-only
     expected_memberships = {
         (
-            "https://gitlab.example.com/alice",
-            "https://gitlab.example.com/myorg/platform",
+            1,
+            TEST_GROUP_ID,
         ),
     }
     assert (
@@ -147,12 +160,12 @@ def test_sync_gitlab_users(
     # Both Alice and Bob have commits
     expected_commits = {
         (
-            "https://gitlab.example.com/alice",
-            "https://gitlab.example.com/myorg/awesome-project",
+            1,
+            TEST_PROJECT_ID,
         ),
         (
-            "https://gitlab.example.com/bob",
-            "https://gitlab.example.com/myorg/awesome-project",
+            2,
+            TEST_PROJECT_ID,
         ),
     }
     assert (
@@ -176,8 +189,8 @@ def test_sync_gitlab_users(
                r.first_commit_date AS first_commit_date,
                r.last_commit_date AS last_commit_date
         """,
-        user_id="https://gitlab.example.com/alice",
-        project_id="https://gitlab.example.com/myorg/awesome-project",
+        user_id=1,
+        project_id=TEST_PROJECT_ID,
     ).single()
 
     assert alice_result is not None, "Alice's COMMITTED_TO relationship should exist"
@@ -198,8 +211,8 @@ def test_sync_gitlab_users(
                r.first_commit_date AS first_commit_date,
                r.last_commit_date AS last_commit_date
         """,
-        user_id="https://gitlab.example.com/bob",
-        project_id="https://gitlab.example.com/myorg/awesome-project",
+        user_id=2,
+        project_id=TEST_PROJECT_ID,
     ).single()
 
     assert bob_result is not None, "Bob's COMMITTED_TO relationship should exist"

--- a/tests/integration/cartography/intel/trivy/test_trivy_gitlab_disk.py
+++ b/tests/integration/cartography/intel/trivy/test_trivy_gitlab_disk.py
@@ -26,6 +26,8 @@ from tests.integration.cartography.intel.trivy.test_helpers import (
 )
 
 TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = 12345
+TEST_GITLAB_URL = "https://gitlab.example.com"
 TEST_REPOSITORIES = [
     {"id": 1, "project_id": 1, "location": "registry.gitlab.com/myorg/app"}
 ]
@@ -42,12 +44,16 @@ def _create_test_org(neo4j_session):
     """Create test GitLabOrganization node."""
     neo4j_session.run(
         """
-        MERGE (o:GitLabOrganization{id: $org_url})
+        MERGE (o:GitLabOrganization{id: $org_id})
         ON CREATE SET o.firstseen = timestamp()
         SET o.lastupdated = $update_tag,
-            o.name = 'myorg'
+            o.name = 'myorg',
+            o.web_url = $org_url,
+            o.gitlab_url = $gitlab_url
         """,
+        org_id=TEST_ORG_ID,
         org_url=TEST_ORG_URL,
+        gitlab_url=TEST_GITLAB_URL,
         update_tag=TEST_UPDATE_TAG,
     )
 
@@ -89,7 +95,8 @@ def test_sync_trivy_gitlab(
 
     common_job_parameters = {
         "UPDATE_TAG": TEST_UPDATE_TAG,
-        "org_url": TEST_ORG_URL,
+        "org_id": TEST_ORG_ID,
+        "gitlab_url": TEST_GITLAB_URL,
     }
 
     # First sync GitLab container images
@@ -97,7 +104,7 @@ def test_sync_trivy_gitlab(
         neo4j_session,
         "https://gitlab.example.com",
         "fake-token",
-        TEST_ORG_URL,
+        TEST_ORG_ID,
         TEST_REPOSITORIES,
         TEST_UPDATE_TAG,
         common_job_parameters,
@@ -108,7 +115,7 @@ def test_sync_trivy_gitlab(
         neo4j_session,
         "https://gitlab.example.com",
         "fake-token",
-        TEST_ORG_URL,
+        TEST_ORG_ID,
         [],  # repositories - not used since we're mocking get_all_container_repository_tags
         TEST_UPDATE_TAG,
         common_job_parameters,
@@ -167,7 +174,8 @@ def _sync_gitlab_data(neo4j_session, update_tag=TEST_UPDATE_TAG):
 
     common_job_parameters = {
         "UPDATE_TAG": update_tag,
-        "org_url": TEST_ORG_URL,
+        "org_id": TEST_ORG_ID,
+        "gitlab_url": TEST_GITLAB_URL,
     }
 
     # Sync GitLab container images
@@ -183,7 +191,7 @@ def _sync_gitlab_data(neo4j_session, update_tag=TEST_UPDATE_TAG):
             neo4j_session,
             "https://gitlab.example.com",
             "fake-token",
-            TEST_ORG_URL,
+            TEST_ORG_ID,
             TEST_REPOSITORIES,
             TEST_UPDATE_TAG,
             common_job_parameters,
@@ -199,7 +207,7 @@ def _sync_gitlab_data(neo4j_session, update_tag=TEST_UPDATE_TAG):
             neo4j_session,
             "https://gitlab.example.com",
             "fake-token",
-            TEST_ORG_URL,
+            TEST_ORG_ID,
             [],
             TEST_UPDATE_TAG,
             common_job_parameters,

--- a/tests/unit/cartography/intel/gitlab/test_container_image_attestations.py
+++ b/tests/unit/cartography/intel/gitlab/test_container_image_attestations.py
@@ -3,13 +3,13 @@ from unittest.mock import Mock
 import requests
 
 from cartography.intel.gitlab.container_image_attestations import (
-    AttestationDiscoverySummary,
-)
-from cartography.intel.gitlab.container_image_attestations import (
     _extract_image_provenance,
 )
 from cartography.intel.gitlab.container_image_attestations import (
     _extract_predicate_from_attestation,
+)
+from cartography.intel.gitlab.container_image_attestations import (
+    AttestationDiscoverySummary,
 )
 from cartography.intel.gitlab.container_image_attestations import (
     get_container_image_attestations,

--- a/tests/unit/cartography/intel/gitlab/test_container_image_attestations.py
+++ b/tests/unit/cartography/intel/gitlab/test_container_image_attestations.py
@@ -6,10 +6,19 @@ from cartography.intel.gitlab.container_image_attestations import (
     AttestationDiscoverySummary,
 )
 from cartography.intel.gitlab.container_image_attestations import (
+    _extract_image_provenance,
+)
+from cartography.intel.gitlab.container_image_attestations import (
+    _extract_predicate_from_attestation,
+)
+from cartography.intel.gitlab.container_image_attestations import (
     get_container_image_attestations,
 )
 from cartography.intel.gitlab.container_image_attestations import (
     sync_container_image_attestations,
+)
+from cartography.intel.gitlab.container_image_attestations import (
+    transform_image_provenance_records,
 )
 
 
@@ -178,3 +187,139 @@ def test_sync_container_image_attestations_runs_cleanup_when_complete(monkeypatc
 
     load_mock.assert_called_once()
     cleanup_mock.assert_called_once()
+
+
+def test_extract_predicate_from_attestation_unwraps_dsse_payload(monkeypatch):
+    predicate_blob = {
+        "payload": "eyJwcmVkaWNhdGUiOiB7IkJ1aWxkRGVmaW5pdGlvbiI6IG51bGx9fQ==",
+    }
+    attestation = {
+        "_digest": "sha256:attestation123",
+        "_registry_url": "https://registry.example.com",
+        "_repository_name": "group/project",
+        "layers": [{"digest": "sha256:layer"}],
+    }
+
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_image_attestations.fetch_registry_blob",
+        lambda *args, **kwargs: predicate_blob,
+    )
+
+    predicate = _extract_predicate_from_attestation(
+        attestation,
+        "https://gitlab.example.com",
+        "pat",
+    )
+
+    assert predicate == {"BuildDefinition": None}
+
+
+def test_extract_image_provenance_supports_buildkit_shape():
+    attestation = {"_attests_digest": "sha256:image123"}
+    predicate = {
+        "materials": [
+            {
+                "uri": "pkg:docker/registry.gitlab.com/base-images/python@3.12",
+                "digest": {
+                    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                },
+            },
+        ],
+        "metadata": {
+            "https://mobyproject.org/buildkit@v1#metadata": {
+                "vcs": {
+                    "source": "https://gitlab.example.com/myorg/awesome-project.git",
+                    "revision": "deadbeefcafebabe",
+                    "localdir:dockerfile": "docker",
+                },
+            },
+        },
+        "buildDefinition": {
+            "externalParameters": {
+                "configSource": {
+                    "path": "Dockerfile",
+                },
+            },
+        },
+    }
+
+    result = _extract_image_provenance(attestation, predicate)
+
+    assert result == {
+        "source_uri": "https://gitlab.example.com/myorg/awesome-project",
+        "source_revision": "deadbeefcafebabe",
+        "source_file": "docker/Dockerfile",
+        "parent_image_uri": "pkg:docker/registry.gitlab.com/base-images/python@3.12",
+        "parent_image_digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "attests_digest": "sha256:image123",
+    }
+
+
+def test_extract_image_provenance_supports_gitlab_slsa_v1_shape():
+    attestation = {"_attests_digest": "sha256:image123"}
+    predicate = {
+        "buildDefinition": {
+            "externalParameters": {
+                "source": "https://gitlab.example.com/myorg/awesome-project.git",
+                "entryPoint": "docker/Dockerfile",
+            },
+            "resolvedDependencies": [
+                {
+                    "uri": "pkg:docker/registry.gitlab.com/base-images/python@3.12",
+                    "digest": {
+                        "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                    },
+                },
+                {
+                    "uri": "https://gitlab.example.com/myorg/awesome-project",
+                    "digest": {
+                        "gitCommit": "a288201509dd9a85da4141e07522bad412938dbe",
+                    },
+                },
+            ],
+        },
+        "runDetails": {
+            "metadata": {
+                "invocationId": 412,
+            },
+        },
+    }
+
+    result = _extract_image_provenance(attestation, predicate)
+
+    assert result == {
+        "source_uri": "https://gitlab.example.com/myorg/awesome-project",
+        "source_revision": "a288201509dd9a85da4141e07522bad412938dbe",
+        "source_file": "docker/Dockerfile",
+        "parent_image_uri": "pkg:docker/registry.gitlab.com/base-images/python@3.12",
+        "parent_image_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "attests_digest": "sha256:image123",
+    }
+
+
+def test_transform_image_provenance_records_keeps_gitlab_slsa_fields():
+    records = transform_image_provenance_records(
+        [
+            {
+                "attests_digest": "sha256:image123",
+                "source_uri": "https://gitlab.example.com/myorg/awesome-project",
+                "source_revision": "a288201509dd9a85da4141e07522bad412938dbe",
+                "source_file": "docker/Dockerfile",
+                "parent_image_uri": "pkg:docker/registry.gitlab.com/base-images/python@3.12",
+                "parent_image_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            },
+        ],
+    )
+
+    assert records == [
+        {
+            "digest": "sha256:image123",
+            "source_uri": "https://gitlab.example.com/myorg/awesome-project",
+            "source_revision": "a288201509dd9a85da4141e07522bad412938dbe",
+            "source_file": "docker/Dockerfile",
+            "parent_image_uri": "pkg:docker/registry.gitlab.com/base-images/python@3.12",
+            "parent_image_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "from_attestation": True,
+            "confidence": 1.0,
+        },
+    ]

--- a/tests/unit/cartography/intel/gitlab/test_container_image_attestations.py
+++ b/tests/unit/cartography/intel/gitlab/test_container_image_attestations.py
@@ -214,6 +214,39 @@ def test_extract_predicate_from_attestation_unwraps_dsse_payload(monkeypatch):
     assert predicate == {"BuildDefinition": None}
 
 
+def test_extract_predicate_from_attestation_accepts_raw_in_toto_statement(monkeypatch):
+    attestation = {
+        "_digest": "sha256:attestation123",
+        "_registry_url": "https://registry.example.com",
+        "_repository_name": "group/project",
+        "layers": [{"digest": "sha256:layer"}],
+    }
+    raw_statement = {
+        "_type": "https://in-toto.io/Statement/v0.1",
+        "predicateType": "https://slsa.dev/provenance/v1",
+        "predicate": {
+            "buildDefinition": {
+                "externalParameters": {
+                    "source": "https://gitlab.example.com/myorg/project.git",
+                },
+            },
+        },
+    }
+
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_image_attestations.fetch_registry_blob",
+        lambda *args, **kwargs: raw_statement,
+    )
+
+    predicate = _extract_predicate_from_attestation(
+        attestation,
+        "https://gitlab.example.com",
+        "pat",
+    )
+
+    assert predicate == raw_statement["predicate"]
+
+
 def test_extract_image_provenance_supports_buildkit_shape():
     attestation = {"_attests_digest": "sha256:image123"}
     predicate = {
@@ -317,6 +350,31 @@ def test_transform_image_provenance_records_keeps_gitlab_slsa_fields():
             "source_uri": "https://gitlab.example.com/myorg/awesome-project",
             "source_revision": "a288201509dd9a85da4141e07522bad412938dbe",
             "source_file": "docker/Dockerfile",
+            "parent_image_uri": "pkg:docker/registry.gitlab.com/base-images/python@3.12",
+            "parent_image_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "from_attestation": True,
+            "confidence": 1.0,
+        },
+    ]
+
+
+def test_transform_image_provenance_records_keeps_parent_only_records():
+    records = transform_image_provenance_records(
+        [
+            {
+                "attests_digest": "sha256:image123",
+                "parent_image_uri": "pkg:docker/registry.gitlab.com/base-images/python@3.12",
+                "parent_image_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            },
+        ],
+    )
+
+    assert records == [
+        {
+            "digest": "sha256:image123",
+            "source_uri": None,
+            "source_revision": None,
+            "source_file": None,
             "parent_image_uri": "pkg:docker/registry.gitlab.com/base-images/python@3.12",
             "parent_image_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
             "from_attestation": True,

--- a/tests/unit/cartography/intel/gitlab/test_container_image_attestations.py
+++ b/tests/unit/cartography/intel/gitlab/test_container_image_attestations.py
@@ -119,6 +119,10 @@ def test_sync_container_image_attestations_skips_cleanup_after_partial_failure(
         load_mock,
     )
     monkeypatch.setattr(
+        "cartography.intel.gitlab.container_image_attestations.load_image_provenance",
+        Mock(),
+    )
+    monkeypatch.setattr(
         "cartography.intel.gitlab.container_image_attestations.cleanup_container_image_attestations",
         cleanup_mock,
     )
@@ -127,7 +131,7 @@ def test_sync_container_image_attestations_skips_cleanup_after_partial_failure(
         neo4j_session=Mock(),
         gitlab_url="https://gitlab.example.com",
         token="pat",
-        org_url="https://gitlab.example.com/groups/core",
+        org_id=123,
         manifests=[],
         manifest_lists=[],
         update_tag=123,
@@ -153,6 +157,10 @@ def test_sync_container_image_attestations_runs_cleanup_when_complete(monkeypatc
         load_mock,
     )
     monkeypatch.setattr(
+        "cartography.intel.gitlab.container_image_attestations.load_image_provenance",
+        Mock(),
+    )
+    monkeypatch.setattr(
         "cartography.intel.gitlab.container_image_attestations.cleanup_container_image_attestations",
         cleanup_mock,
     )
@@ -161,7 +169,7 @@ def test_sync_container_image_attestations_runs_cleanup_when_complete(monkeypatc
         neo4j_session=Mock(),
         gitlab_url="https://gitlab.example.com",
         token="pat",
-        org_url="https://gitlab.example.com/groups/core",
+        org_id=123,
         manifests=[],
         manifest_lists=[],
         update_tag=123,

--- a/tests/unit/cartography/intel/gitlab/test_container_image_attestations.py
+++ b/tests/unit/cartography/intel/gitlab/test_container_image_attestations.py
@@ -372,9 +372,37 @@ def test_transform_image_provenance_records_keeps_parent_only_records():
     assert records == [
         {
             "digest": "sha256:image123",
-            "source_uri": None,
-            "source_revision": None,
-            "source_file": None,
+            "parent_image_uri": "pkg:docker/registry.gitlab.com/base-images/python@3.12",
+            "parent_image_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "from_attestation": True,
+            "confidence": 1.0,
+        },
+    ]
+
+
+def test_transform_image_provenance_records_merges_parent_only_without_overwriting_source():
+    records = transform_image_provenance_records(
+        [
+            {
+                "attests_digest": "sha256:image123",
+                "source_uri": "https://gitlab.example.com/myorg/awesome-project",
+                "source_revision": "a288201509dd9a85da4141e07522bad412938dbe",
+                "source_file": "docker/Dockerfile",
+            },
+            {
+                "attests_digest": "sha256:image123",
+                "parent_image_uri": "pkg:docker/registry.gitlab.com/base-images/python@3.12",
+                "parent_image_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            },
+        ],
+    )
+
+    assert records == [
+        {
+            "digest": "sha256:image123",
+            "source_uri": "https://gitlab.example.com/myorg/awesome-project",
+            "source_revision": "a288201509dd9a85da4141e07522bad412938dbe",
+            "source_file": "docker/Dockerfile",
             "parent_image_uri": "pkg:docker/registry.gitlab.com/base-images/python@3.12",
             "parent_image_digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
             "from_attestation": True,

--- a/tests/unit/cartography/intel/gitlab/test_container_images.py
+++ b/tests/unit/cartography/intel/gitlab/test_container_images.py
@@ -139,7 +139,11 @@ def test_sync_container_images_processes_repositories_in_batches(monkeypatch):
         org_id=123,
         repositories=repositories,
         update_tag=123,
-        common_job_parameters={"UPDATE_TAG": 123, "org_id": 123, "gitlab_url": "https://gitlab.example.com"},
+        common_job_parameters={
+            "UPDATE_TAG": 123,
+            "org_id": 123,
+            "gitlab_url": "https://gitlab.example.com",
+        },
     )
 
     assert mocks["get_images"].call_count == 3
@@ -168,7 +172,11 @@ def test_sync_container_images_cleans_up_when_repositories_empty(monkeypatch):
         org_id=123,
         repositories=[],
         update_tag=123,
-        common_job_parameters={"UPDATE_TAG": 123, "org_id": 123, "gitlab_url": "https://gitlab.example.com"},
+        common_job_parameters={
+            "UPDATE_TAG": 123,
+            "org_id": 123,
+            "gitlab_url": "https://gitlab.example.com",
+        },
     )
 
     mocks["get_images"].assert_not_called()

--- a/tests/unit/cartography/intel/gitlab/test_container_images.py
+++ b/tests/unit/cartography/intel/gitlab/test_container_images.py
@@ -72,7 +72,8 @@ def test_load_container_images_uses_conservative_batch_size(monkeypatch):
     load_container_images(
         neo4j_session=Mock(),
         images=[{"digest": "sha256:image"}],
-        org_url="https://gitlab.example.com/groups/core",
+        org_id=123,
+        gitlab_url="https://gitlab.example.com",
         update_tag=123,
     )
 
@@ -89,7 +90,8 @@ def test_load_container_image_layers_uses_conservative_batch_size(monkeypatch):
     load_container_image_layers(
         neo4j_session=Mock(),
         layers=[{"diff_id": "sha256:layer"}],
-        org_url="https://gitlab.example.com/groups/core",
+        org_id=123,
+        gitlab_url="https://gitlab.example.com",
         update_tag=123,
     )
 
@@ -134,10 +136,10 @@ def test_sync_container_images_processes_repositories_in_batches(monkeypatch):
         neo4j_session=Mock(),
         gitlab_url="https://gitlab.example.com",
         token="pat",
-        org_url="https://gitlab.example.com/groups/core",
+        org_id=123,
         repositories=repositories,
         update_tag=123,
-        common_job_parameters={"UPDATE_TAG": 123},
+        common_job_parameters={"UPDATE_TAG": 123, "org_id": 123, "gitlab_url": "https://gitlab.example.com"},
     )
 
     assert mocks["get_images"].call_count == 3
@@ -163,10 +165,10 @@ def test_sync_container_images_cleans_up_when_repositories_empty(monkeypatch):
         neo4j_session=Mock(),
         gitlab_url="https://gitlab.example.com",
         token="pat",
-        org_url="https://gitlab.example.com/groups/core",
+        org_id=123,
         repositories=[],
         update_tag=123,
-        common_job_parameters={"UPDATE_TAG": 123},
+        common_job_parameters={"UPDATE_TAG": 123, "org_id": 123, "gitlab_url": "https://gitlab.example.com"},
     )
 
     mocks["get_images"].assert_not_called()

--- a/tests/unit/cartography/intel/gitlab/test_container_images.py
+++ b/tests/unit/cartography/intel/gitlab/test_container_images.py
@@ -7,6 +7,7 @@ from cartography.intel.gitlab.container_images import (
 from cartography.intel.gitlab.container_images import load_container_image_layers
 from cartography.intel.gitlab.container_images import load_container_images
 from cartography.intel.gitlab.container_images import sync_container_images
+from cartography.intel.gitlab.container_images import transform_container_image_layers
 
 
 def _patch_sync_container_images_dependencies(
@@ -188,3 +189,62 @@ def test_sync_container_images_cleans_up_when_repositories_empty(monkeypatch):
     mocks["cleanup_images"].assert_called_once()
     assert manifests == []
     assert manifest_lists == []
+
+
+def test_transform_container_image_layers_persists_history_and_is_empty():
+    raw_manifests = [
+        {
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "_digest": "sha256:image",
+            "layers": [
+                {
+                    "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                    "size": 10,
+                    "digest": "sha256:layer1",
+                },
+                {
+                    "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+                    "size": 20,
+                    "digest": "sha256:layer2",
+                },
+            ],
+            "_config": {
+                "rootfs": {
+                    "diff_ids": [
+                        "sha256:diff1",
+                        "sha256:diff2",
+                    ],
+                },
+                "history": [
+                    {
+                        "created_by": "/bin/sh -c #(nop) LABEL maintainer=test",
+                        "empty_layer": True,
+                    },
+                    {"created_by": "/bin/sh -c apk add curl"},
+                    {"created_by": "/bin/sh -c mkdir /app"},
+                ],
+            },
+        },
+    ]
+
+    layers = transform_container_image_layers(raw_manifests)
+
+    assert layers == [
+        {
+            "diff_id": "sha256:diff1",
+            "digest": "sha256:layer1",
+            "media_type": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "size": 10,
+            "is_empty": False,
+            "history": "/bin/sh -c apk add curl",
+            "next_diff_ids": ["sha256:diff2"],
+        },
+        {
+            "diff_id": "sha256:diff2",
+            "digest": "sha256:layer2",
+            "media_type": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "size": 20,
+            "is_empty": False,
+            "history": "/bin/sh -c mkdir /app",
+        },
+    ]

--- a/tests/unit/cartography/intel/gitlab/test_supply_chain.py
+++ b/tests/unit/cartography/intel/gitlab/test_supply_chain.py
@@ -1,0 +1,110 @@
+from cartography.intel.gitlab.supply_chain import (
+    build_singleton_dockerfile_fallback_matchlinks,
+)
+from cartography.intel.gitlab.supply_chain import (
+    GITLAB_SINGLETON_DOCKERFILE_FALLBACK_CONFIDENCE,
+)
+from cartography.intel.supply_chain import ContainerImage
+
+
+def test_build_singleton_dockerfile_fallback_matchlinks_uses_scoped_singleton():
+    image = ContainerImage(
+        digest="sha256:image1",
+        uri="registry.gitlab.com/acme/service:latest",
+        registry_id="registry.gitlab.com/acme/service",
+        display_name="registry.gitlab.com/acme/service",
+        tag="latest",
+        layer_diff_ids=["sha256:layer1"],
+        image_type="image",
+        architecture="amd64",
+        os="linux",
+        layer_history=[],
+        scope_keys={"gitlab_project_id": "100"},
+    )
+
+    dockerfiles = [
+        {
+            "path": "Dockerfile",
+            "project_url": "https://gitlab.example.com/acme/service",
+            "scope_keys": {"gitlab_project_id": "100"},
+        },
+        {
+            "path": "Dockerfile",
+            "project_url": "https://gitlab.example.com/acme/other",
+            "scope_keys": {"gitlab_project_id": "200"},
+        },
+    ]
+
+    fallback = build_singleton_dockerfile_fallback_matchlinks(
+        [image],
+        dockerfiles,
+        set(),
+    )
+
+    assert fallback == [
+        {
+            "image_digest": "sha256:image1",
+            "project_url": "https://gitlab.example.com/acme/service",
+            "match_method": "dockerfile_singleton_fallback",
+            "dockerfile_path": "Dockerfile",
+            "confidence": GITLAB_SINGLETON_DOCKERFILE_FALLBACK_CONFIDENCE,
+            "matched_commands": 0,
+            "total_commands": 0,
+            "command_similarity": 0.0,
+        },
+    ]
+
+
+def test_build_singleton_dockerfile_fallback_matchlinks_skips_already_matched_and_ambiguous():
+    image_already_matched = ContainerImage(
+        digest="sha256:image1",
+        uri="registry.gitlab.com/acme/service:latest",
+        registry_id="registry.gitlab.com/acme/service",
+        display_name="registry.gitlab.com/acme/service",
+        tag="latest",
+        layer_diff_ids=["sha256:layer1"],
+        image_type="image",
+        architecture="amd64",
+        os="linux",
+        layer_history=[],
+        scope_keys={"gitlab_project_id": "100"},
+    )
+    image_ambiguous = ContainerImage(
+        digest="sha256:image2",
+        uri="registry.gitlab.com/acme/ambiguous:latest",
+        registry_id="registry.gitlab.com/acme/ambiguous",
+        display_name="registry.gitlab.com/acme/ambiguous",
+        tag="latest",
+        layer_diff_ids=["sha256:layer2"],
+        image_type="image",
+        architecture="amd64",
+        os="linux",
+        layer_history=[],
+        scope_keys={"gitlab_project_id": "200"},
+    )
+
+    dockerfiles = [
+        {
+            "path": "Dockerfile",
+            "project_url": "https://gitlab.example.com/acme/service",
+            "scope_keys": {"gitlab_project_id": "100"},
+        },
+        {
+            "path": "Dockerfile",
+            "project_url": "https://gitlab.example.com/acme/ambiguous",
+            "scope_keys": {"gitlab_project_id": "200"},
+        },
+        {
+            "path": "docker/Dockerfile",
+            "project_url": "https://gitlab.example.com/acme/ambiguous",
+            "scope_keys": {"gitlab_project_id": "200"},
+        },
+    ]
+
+    fallback = build_singleton_dockerfile_fallback_matchlinks(
+        [image_already_matched, image_ambiguous],
+        dockerfiles,
+        {"sha256:image1"},
+    )
+
+    assert fallback == []

--- a/tests/unit/cartography/intel/gitlab/test_users.py
+++ b/tests/unit/cartography/intel/gitlab/test_users.py
@@ -1,0 +1,36 @@
+from cartography.intel.gitlab.users import transform_commit_activity
+
+
+def test_transform_commit_activity_falls_back_to_author_name():
+    commits_by_project = {
+        123: [
+            {
+                "author_name": "Alice Smith",
+                "author_email": None,
+                "committed_date": "2024-12-01T10:00:00Z",
+            },
+        ],
+    }
+    users_by_email = {}
+    users_by_name = {"Alice Smith": 1}
+    user_records = [
+        {
+            "id": 1,
+            "username": "alice",
+            "name": "Alice Smith",
+            "web_url": "https://gitlab.example.com/alice",
+            "gitlab_url": "https://gitlab.example.com",
+        },
+    ]
+
+    records = transform_commit_activity(
+        commits_by_project,
+        users_by_email,
+        users_by_name,
+        user_records,
+    )
+
+    assert len(records) == 1
+    assert records[0]["id"] == 1
+    assert records[0]["project_id"] == 123
+    assert records[0]["commit_count"] == 1

--- a/tests/unit/cartography/intel/test_dockerfile_parser.py
+++ b/tests/unit/cartography/intel/test_dockerfile_parser.py
@@ -29,8 +29,8 @@ def test_normalize_removes_shell_prefix():
 
 def test_normalize_removes_instruction_prefix():
     assert normalize_command("RUN pip install flask") == "pip install flask"
-    assert normalize_command("COPY . /app") == ". /app"
-    assert normalize_command("ADD file.tar /opt") == "file.tar /opt"
+    assert normalize_command("COPY . /app") == "copy_in /app"
+    assert normalize_command("ADD file.tar /opt") == "add_in /opt"
 
 
 def test_normalize_removes_buildkit_prefix():
@@ -46,6 +46,16 @@ def test_normalize_removes_buildkit_mount():
 def test_normalize_removes_nop_marker():
     cmd = "#(nop) WORKDIR /app"
     assert normalize_command(cmd) == "workdir /app"
+
+
+def test_normalize_oci_copy_history_to_destination():
+    cmd = "/bin/sh -c #(nop) COPY file:abc123 in /usr/local/bin/ "
+    assert normalize_command(cmd) == "copy_in /usr/local/bin/"
+
+
+def test_normalize_oci_add_history_to_destination():
+    cmd = "/bin/sh -c #(nop) ADD dir:abc123 in /scripts/ "
+    assert normalize_command(cmd) == "add_in /scripts/"
 
 
 def test_normalize_removes_inline_comments():

--- a/tests/unit/cartography/intel/test_supply_chain.py
+++ b/tests/unit/cartography/intel/test_supply_chain.py
@@ -143,3 +143,36 @@ def test_match_images_to_dockerfiles_scopes_by_scope_keys():
 
     assert len(matches) == 1
     assert matches[0].source_repo_id == "https://gitlab.example.com/acme/service"
+
+
+def test_match_images_to_dockerfiles_matches_copy_destination_patterns():
+    image = ContainerImage(
+        digest="sha256:test-copy",
+        uri="registry.gitlab.com/acme/service:latest",
+        registry_id="registry.gitlab.com/acme/service",
+        display_name="registry.gitlab.com/acme/service",
+        tag="latest",
+        layer_diff_ids=["sha256:layer1"],
+        image_type="image",
+        architecture="amd64",
+        os="linux",
+        layer_history=[
+            {
+                "created_by": "/bin/sh -c #(nop) COPY file:abcd1234 in /usr/local/bin/",
+                "empty_layer": False,
+            },
+        ],
+    )
+
+    dockerfiles = [
+        {
+            "path": "Dockerfile",
+            "content": "FROM alpine\nCOPY ./bin/service /usr/local/bin/\n",
+            "source_repo_id": "https://gitlab.example.com/acme/service",
+        },
+    ]
+
+    matches = match_images_to_dockerfiles([image], dockerfiles, min_confidence=0.5)
+
+    assert len(matches) == 1
+    assert matches[0].source_repo_id == "https://gitlab.example.com/acme/service"

--- a/tests/unit/cartography/intel/test_supply_chain.py
+++ b/tests/unit/cartography/intel/test_supply_chain.py
@@ -1,0 +1,102 @@
+from cartography.intel.supply_chain import extract_image_source_provenance
+from cartography.intel.supply_chain import extract_container_parent_image
+from cartography.intel.supply_chain import get_slsa_dependency_list
+from cartography.intel.supply_chain import unwrap_attestation_predicate
+
+
+def test_unwrap_attestation_predicate_supports_dsse_data():
+    predicate = {
+        "Data": '{"predicate": {"buildDefinition": {"externalParameters": {"entryPoint": "Dockerfile"}}}}'
+    }
+
+    assert unwrap_attestation_predicate(predicate) == {
+        "buildDefinition": {
+            "externalParameters": {
+                "entryPoint": "Dockerfile",
+            },
+        },
+    }
+
+
+def test_get_slsa_dependency_list_supports_v02_and_v1():
+    v02 = {"materials": [{"uri": "oci://example/base"}]}
+    v1 = {"buildDefinition": {"resolvedDependencies": [{"uri": "oci://example/base"}]}}
+
+    assert get_slsa_dependency_list(v02) == [{"uri": "oci://example/base"}]
+    assert get_slsa_dependency_list(v1) == [{"uri": "oci://example/base"}]
+
+
+def test_extract_image_source_provenance_supports_buildkit_shape():
+    predicate = {
+        "metadata": {
+            "https://mobyproject.org/buildkit@v1#metadata": {
+                "vcs": {
+                    "source": "https://gitlab.example.com/myorg/awesome-project.git",
+                    "revision": "deadbeefcafebabe",
+                    "localdir:dockerfile": "docker",
+                },
+            },
+        },
+        "buildDefinition": {
+            "externalParameters": {
+                "configSource": {
+                    "path": "Dockerfile",
+                },
+            },
+        },
+    }
+
+    assert extract_image_source_provenance(predicate) == {
+        "source_uri": "https://gitlab.example.com/myorg/awesome-project",
+        "source_revision": "deadbeefcafebabe",
+        "source_file": "docker/Dockerfile",
+    }
+
+
+def test_extract_image_source_provenance_supports_gitlab_slsa_v1_shape():
+    predicate = {
+        "buildDefinition": {
+            "externalParameters": {
+                "source": "https://gitlab.example.com/myorg/awesome-project.git",
+                "entryPoint": "docker/Dockerfile",
+            },
+            "resolvedDependencies": [
+                {
+                    "uri": "https://gitlab.example.com/myorg/awesome-project",
+                    "digest": {
+                        "gitCommit": "a288201509dd9a85da4141e07522bad412938dbe",
+                    },
+                },
+            ],
+        },
+    }
+
+    assert extract_image_source_provenance(predicate) == {
+        "source_uri": "https://gitlab.example.com/myorg/awesome-project",
+        "source_revision": "a288201509dd9a85da4141e07522bad412938dbe",
+        "source_file": "docker/Dockerfile",
+    }
+
+
+def test_extract_container_parent_image_supports_slsa_v1_dependencies():
+    predicate = {
+        "buildDefinition": {
+            "resolvedDependencies": [
+                {
+                    "uri": "pkg:docker/docker/dockerfile@1.9",
+                    "digest": {"sha256": "ignored"},
+                },
+                {
+                    "uri": "pkg:docker/registry.gitlab.com/base-images/python@3.12",
+                    "digest": {
+                        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    },
+                },
+            ],
+        },
+    }
+
+    assert extract_container_parent_image(predicate) == {
+        "parent_image_uri": "pkg:docker/registry.gitlab.com/base-images/python@3.12",
+        "parent_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    }

--- a/tests/unit/cartography/intel/test_supply_chain.py
+++ b/tests/unit/cartography/intel/test_supply_chain.py
@@ -1,5 +1,5 @@
-from cartography.intel.supply_chain import extract_image_source_provenance
 from cartography.intel.supply_chain import extract_container_parent_image
+from cartography.intel.supply_chain import extract_image_source_provenance
 from cartography.intel.supply_chain import get_slsa_dependency_list
 from cartography.intel.supply_chain import unwrap_attestation_predicate
 

--- a/tests/unit/cartography/intel/test_supply_chain.py
+++ b/tests/unit/cartography/intel/test_supply_chain.py
@@ -1,6 +1,8 @@
+from cartography.intel.supply_chain import ContainerImage
 from cartography.intel.supply_chain import extract_container_parent_image
 from cartography.intel.supply_chain import extract_image_source_provenance
 from cartography.intel.supply_chain import get_slsa_dependency_list
+from cartography.intel.supply_chain import match_images_to_dockerfiles
 from cartography.intel.supply_chain import unwrap_attestation_predicate
 
 
@@ -100,3 +102,44 @@ def test_extract_container_parent_image_supports_slsa_v1_dependencies():
         "parent_image_uri": "pkg:docker/registry.gitlab.com/base-images/python@3.12",
         "parent_image_digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     }
+
+
+def test_match_images_to_dockerfiles_scopes_by_scope_keys():
+    image = ContainerImage(
+        digest="sha256:test",
+        uri="registry.gitlab.com/acme/service:latest",
+        registry_id="registry.gitlab.com/acme/service",
+        display_name="registry.gitlab.com/acme/service",
+        tag="latest",
+        layer_diff_ids=["sha256:layer1"],
+        image_type="image",
+        architecture="amd64",
+        os="linux",
+        layer_history=[
+            {
+                "created_by": "RUN apk add curl",
+                "empty_layer": False,
+            },
+        ],
+        scope_keys={"gitlab_project_id": "100"},
+    )
+
+    dockerfiles = [
+        {
+            "path": "Dockerfile",
+            "content": "FROM alpine\nRUN apk add curl\n",
+            "scope_keys": {"gitlab_project_id": "100"},
+            "source_repo_id": "https://gitlab.example.com/acme/service",
+        },
+        {
+            "path": "Dockerfile",
+            "content": "FROM alpine\nRUN apk add curl\n",
+            "scope_keys": {"gitlab_project_id": "200"},
+            "source_repo_id": "https://gitlab.example.com/acme/other-service",
+        },
+    ]
+
+    matches = match_images_to_dockerfiles([image], dockerfiles, min_confidence=0.5)
+
+    assert len(matches) == 1
+    assert matches[0].source_repo_id == "https://gitlab.example.com/acme/service"


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

This PR aligns the GitLab module with Cartography's generic code-to-cloud model so GitLab repositories can map cleanly to both GitLab Container Registry images and external registries such as ECR.

It switches GitLab core entities to numeric GitLab IDs, adds `CodeRepository` to `GitLabProject`, adds generic registry relationships (`REPO_IMAGE` and `IMAGE`) alongside deprecated legacy GitLab-specific edges, and ingests provenance directly onto `GitLabContainerImage` so `PACKAGED_FROM` matching can use the same graph pattern as the GitHub/ECR flow.

It also updates the GitLab schema docs, ontology URL mapping, and the affected integration/unit tests. A small AWS test stability fix is included so the full suite remains deterministic.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- Fixes #


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

- `GitLabOrganization`, `GitLabGroup`, `GitLabProject`, and `GitLabUser` now use numeric GitLab IDs as their primary `id` instead of `web_url`.
- Queries or downstream logic that treated `GitLabProject.id` (or the other GitLab node IDs) as a web URL must switch to the new `web_url` property.
- GitLab container registry ingestion now emits the generic `REPO_IMAGE` and `IMAGE` relationships. The legacy `HAS_TAG` and `REFERENCES` relationships are still emitted for backward compatibility and are marked deprecated for removal in `v1.0.0`.
- Commit attribution now matches GitLab users by email instead of display name to avoid false-positive author matches.

Migration path:
- Use `web_url` when you need the browser URL for GitLab entities.
- Prefer the generic graph pattern `(:ContainerRegistry)-[:REPO_IMAGE]->(:ImageTag)-[:IMAGE]->(:Image)` for code-to-cloud queries.


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- `uv run pytest -q tests/integration/cartography/intel/gitlab tests/unit/cartography/intel/gitlab tests/integration/cartography/intel/trivy/test_trivy_gitlab_disk.py`
- `uv run pytest -q`


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

Review the GitLab supply-chain path as two separate concerns:
1. identity/model changes (`id`, `web_url`, ontology mapping, `CodeRepository`)
2. registry/provenance alignment (`REPO_IMAGE`, `IMAGE`, provenance on `GitLabContainerImage`)

The AWS diff is limited to test determinism and does not change Cartography's AWS ingestion behavior.
