### PR TITLE
feat(permissions): Add DynamoDB write and Secrets Manager permission mappings

### DIFF
--- a/cartography/data/permission_relationships.yaml
+++ b/cartography/data/permission_relationships.yaml
@@ -18,7 +18,21 @@
   - dynamodb:GetItem
   - dynamodb:GetRecords
   - dynamodb:Query
+  - dynamodb:Scan
   relationship_name: CAN_QUERY
+# Map principals that can write data to DynamoDB.
+- target_label: DynamoDBTable
+  permissions:
+  - dynamodb:PutItem
+  - dynamodb:UpdateItem
+  - dynamodb:DeleteItem
+  - dynamodb:BatchWriteItem
+  relationship_name: CAN_WRITE
+# Map principals that can retrieve secrets from Secrets Manager.
+- target_label: SecretsManagerSecret
+  permissions:
+  - secretsmanager:GetSecretValue
+  relationship_name: GET_SECRET
 # Map principals that can administer RedshiftClusters.
 - target_label: RedshiftCluster
   permissions:


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Add missing high-impact IAM permission-to-resource relationship mappings to `cartography/data/permission_relationships.yaml`:

1. **`dynamodb:Scan`** added to existing `DynamoDBTable / CAN_QUERY` — highest-risk read operation, commonly used by cross-account roles
2. **New `DynamoDBTable / CAN_WRITE`** mapping for `PutItem`, `UpdateItem`, `DeleteItem`, `BatchWriteItem`
3. **New `SecretsManagerSecret / GET_SECRET`** mapping for `secretsmanager:GetSecretValue` — common exfiltration target

All changes are additive — no existing relationships removed or renamed.


### Related issues or links

- N/A


### How was this tested?

- All 24 existing unit tests in `tests/unit/cartography/intel/aws/test_permission_relationships.py` pass, including `test_permission_file_load` which validates YAML parsing.
- No new sync entities or schema changes — only data additions to the permission relationships YAML.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.


### Notes for reviewers

This is a data-only change to `permission_relationships.yaml`. The permission evaluation engine (`permission_relationships.py`) is unchanged. Both `DynamoDBTable` and `SecretsManagerSecret` are existing node labels in the cartography schema.