### PR TITLE
feat(crowdstrike): enrich device ontology ownership

### DIFF
--- a/cartography/models/crowdstrike/hosts.py
+++ b/cartography/models/crowdstrike/hosts.py
@@ -9,6 +9,7 @@ from cartography.models.core.nodes import CartographyNodeSchema
 class CrowdstrikeHostNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef("device_id")
     cid: PropertyRef = PropertyRef("cid")
+    email: PropertyRef = PropertyRef("email", extra_index=True)
     instance_id: PropertyRef = PropertyRef("instance_id", extra_index=True)
     serial_number: PropertyRef = PropertyRef("serial_number", extra_index=True)
     status: PropertyRef = PropertyRef("status")

--- a/cartography/models/ontology/mapping/data/devices.py
+++ b/cartography/models/ontology/mapping/data/devices.py
@@ -49,7 +49,7 @@ crowdstrike_mapping = OntologyMapping(
     rels=[
         OntologyRelMapping(
             __comment__="Link Device to User based on CrowdstrikeHost email matching canonical User email",
-            query="MATCH (u:User), (host:CrowdstrikeHost)<-[obs:OBSERVED_AS]-(d:Device) WHERE u.email IS NOT NULL AND host.email IS NOT NULL AND toLower(u.email) = toLower(host.email) AND obs.lastupdated = $UPDATE_TAG AND d.lastupdated = $UPDATE_TAG MERGE (u)-[r:OWNS]->(d) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+            query="MATCH (host:CrowdstrikeHost)<-[obs:OBSERVED_AS]-(d:Device) WHERE host.email IS NOT NULL AND obs.lastupdated = $UPDATE_TAG AND d.lastupdated = $UPDATE_TAG WITH d, toLower(host.email) AS host_email MATCH (u:User) WHERE u.email IS NOT NULL AND toLower(u.email) = host_email MERGE (u)-[r:OWNS]->(d) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
             iterative=False,
         ),
     ],

--- a/cartography/models/ontology/mapping/data/devices.py
+++ b/cartography/models/ontology/mapping/data/devices.py
@@ -25,8 +25,12 @@ crowdstrike_mapping = OntologyMapping(
             node_label="CrowdstrikeHost",
             fields=[
                 OntologyFieldMapping(ontology_field="hostname", node_field="hostname"),
+                OntologyFieldMapping(ontology_field="os", node_field="platform_name"),
                 OntologyFieldMapping(
                     ontology_field="os_version", node_field="os_version"
+                ),
+                OntologyFieldMapping(
+                    ontology_field="model", node_field="system_product_name"
                 ),
                 OntologyFieldMapping(
                     ontology_field="platform", node_field="platform_name"
@@ -40,6 +44,13 @@ crowdstrike_mapping = OntologyMapping(
                     ontology_field="instance_id", node_field="instance_id"
                 ),
             ],
+        ),
+    ],
+    rels=[
+        OntologyRelMapping(
+            __comment__="Link Device to User based on CrowdstrikeHost email matching canonical User email",
+            query="MATCH (u:User), (host:CrowdstrikeHost)<-[obs:OBSERVED_AS]-(d:Device) WHERE u.email IS NOT NULL AND host.email IS NOT NULL AND toLower(u.email) = toLower(host.email) AND obs.lastupdated = $UPDATE_TAG AND d.lastupdated = $UPDATE_TAG MERGE (u)-[r:OWNS]->(d) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+            iterative=False,
         ),
     ],
 )

--- a/docs/root/modules/crowdstrike/schema.md
+++ b/docs/root/modules/crowdstrike/schema.md
@@ -4,7 +4,7 @@
 
 Representation of a Crowdstrike Host
 
-> **Ontology Mapping**: This node has the extra label `Device` to enable cross-platform queries for devices across different systems (e.g., BigfixComputer, KandjiDevice, TailscaleDevice).
+> **Ontology Mapping**: This node participates in the canonical `Device` ontology, enabling cross-platform device correlation via `(:Device)-[:OBSERVED_AS]->(:CrowdstrikeHost)` relationships.
 
 | Field | Description |
 |-------|-------------|
@@ -12,6 +12,7 @@ Representation of a Crowdstrike Host
 | lastupdated | Timestamp of the last time the node was updated |
 | id | The device ID for this host |
 | cid | The customer ID |
+| email | Email address associated with the host record in CrowdStrike. |
 | instance\_id | The AWS instance ID associated with this host |
 | status | Containment Status of the machine. "Normal" denotes good operations; other values might mean reduced functionality or support. |
 | hostname | The name of the machine. |

--- a/tests/data/crowdstrike/endpoints.py
+++ b/tests/data/crowdstrike/endpoints.py
@@ -2,6 +2,7 @@ GET_HOSTS = [
     {
         "device_id": "00000000000000000000000000000000",
         "cid": "11111111111111111111111111111111",
+        "email": "alice@example.com",
         "agent_load_flags": "0",
         "agent_local_time": "2021-12-08T15:16:24.360Z",
         "agent_version": "6.30.14406.0",

--- a/tests/integration/cartography/intel/crowdstrike/test_endpoints.py
+++ b/tests/integration/cartography/intel/crowdstrike/test_endpoints.py
@@ -24,3 +24,12 @@ def test_load_host_data(neo4j_session, *args):
     )
     actual_nodes = {(n["n.id"]) for n in nodes}
     assert actual_nodes == expected_nodes
+
+    nodes = neo4j_session.run(
+        """
+        MATCH (n:CrowdstrikeHost)
+        RETURN n.email
+        """,
+    )
+    actual_emails = {n["n.email"] for n in nodes}
+    assert actual_emails == {"alice@example.com"}

--- a/tests/integration/cartography/intel/crowdstrike/test_endpoints.py
+++ b/tests/integration/cartography/intel/crowdstrike/test_endpoints.py
@@ -1,5 +1,6 @@
 import cartography.intel.crowdstrike.endpoints
 import tests.data.crowdstrike.endpoints
+from tests.integration.util import check_nodes
 
 TEST_UPDATE_TAG = 123456789
 
@@ -12,24 +13,8 @@ def test_load_host_data(neo4j_session, *args):
         TEST_UPDATE_TAG,
     )
 
-    expected_nodes = {
-        ("00000000000000000000000000000000"),
-    }
-
-    nodes = neo4j_session.run(
-        """
-        MATCH (n:CrowdstrikeHost)
-        RETURN n.id
-        """,
-    )
-    actual_nodes = {(n["n.id"]) for n in nodes}
-    assert actual_nodes == expected_nodes
-
-    nodes = neo4j_session.run(
-        """
-        MATCH (n:CrowdstrikeHost)
-        RETURN n.email
-        """,
-    )
-    actual_emails = {n["n.email"] for n in nodes}
-    assert actual_emails == {"alice@example.com"}
+    assert check_nodes(
+        neo4j_session,
+        "CrowdstrikeHost",
+        ["id", "email"],
+    ) == {("00000000000000000000000000000000", "alice@example.com")}

--- a/tests/integration/cartography/intel/ontology/test_devices.py
+++ b/tests/integration/cartography/intel/ontology/test_devices.py
@@ -442,6 +442,10 @@ def test_link_ontology_devices_from_crowdstrike_email(neo4j_session):
         SET u.email = 'hjsimpson@simpson.corp',
             u.lastupdated = $update_tag
 
+        MERGE (u2:User {id: 'marge@simpson.corp'})
+        SET u2.email = 'marge@simpson.corp',
+            u2.lastupdated = $update_tag
+
         CREATE (:CrowdstrikeHost {
             id: 'crowdstrike-host-2',
             device_id: 'crowdstrike-host-2',

--- a/tests/integration/cartography/intel/ontology/test_devices.py
+++ b/tests/integration/cartography/intel/ontology/test_devices.py
@@ -382,6 +382,99 @@ def test_load_ontology_devices_from_sentinelone(neo4j_session):
     ) == {("SN-S1-001", "SN-S1-001")}
 
 
+def test_load_ontology_devices_from_crowdstrike(neo4j_session):
+    """CrowdStrike hosts should produce ontology devices and OBSERVED_AS links."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        CREATE (:CrowdstrikeHost {
+            id: 'crowdstrike-host-1',
+            device_id: 'crowdstrike-host-1',
+            hostname: 'falcon-host-01',
+            platform_name: 'Windows',
+            os_version: '11.0.22631',
+            system_product_name: 'Latitude 7440',
+            serial_number: 'SN-CROWDSTRIKE-001',
+            lastupdated: $update_tag
+        })
+        """,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    cartography.intel.ontology.devices.sync(
+        neo4j_session,
+        ["crowdstrike"],
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "Device",
+        ["hostname", "os", "os_version", "model", "serial_number"],
+    ) == {
+        (
+            "falcon-host-01",
+            "Windows",
+            "11.0.22631",
+            "Latitude 7440",
+            "SN-CROWDSTRIKE-001",
+        )
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "Device",
+        "serial_number",
+        "CrowdstrikeHost",
+        "serial_number",
+        "OBSERVED_AS",
+        rel_direction_right=True,
+    ) == {("SN-CROWDSTRIKE-001", "SN-CROWDSTRIKE-001")}
+
+
+def test_link_ontology_devices_from_crowdstrike_email(neo4j_session):
+    """CrowdStrike host email should derive canonical User-OWNS-Device relationships."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (u:User {id: 'hjsimpson@simpson.corp'})
+        SET u.email = 'hjsimpson@simpson.corp',
+            u.lastupdated = $update_tag
+
+        CREATE (:CrowdstrikeHost {
+            id: 'crowdstrike-host-2',
+            device_id: 'crowdstrike-host-2',
+            hostname: 'falcon-host-02',
+            platform_name: 'macOS',
+            os_version: '14.4',
+            system_product_name: 'MacBook Pro',
+            serial_number: 'SN-CROWDSTRIKE-002',
+            email: 'hjsimpson@simpson.corp',
+            lastupdated: $update_tag
+        })
+        """,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    cartography.intel.ontology.devices.sync(
+        neo4j_session,
+        ["crowdstrike"],
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "User",
+        "email",
+        "Device",
+        "hostname",
+        "OWNS",
+        rel_direction_right=True,
+    ) == {("hjsimpson@simpson.corp", "falcon-host-02")}
+
+
 @pytest.mark.parametrize("source_of_truth", [["microsoft"], ["entra"]])
 def test_load_ontology_devices_from_entra_intune(neo4j_session, source_of_truth):
     """Intune managed devices should produce ontology devices and OBSERVED_AS links."""


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

This change improves CrowdStrike device support in Cartography's ontology flow.

It adds `email` ingestion to `CrowdstrikeHost`, enriches the canonical device mapping with additional CrowdStrike fields, and derives canonical `(:User)-[:OWNS]->(:Device)` relationships when a canonical user email matches a CrowdStrike host email. The ownership derivation is intentionally scoped from fresh `(:Device)-[:OBSERVED_AS]->(:CrowdstrikeHost)` rows before matching users. It also clarifies the CrowdStrike schema docs to describe canonical `Device` ontology participation correctly.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- None.


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

None.


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->


### Checklist

#### General
- [ ] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

- The new `User-OWNS-Device` edge is intentionally derived from CrowdStrike host `email` as a correlation signal, not a stronger device-assignment authority.
- Test coverage includes both the positive matching-email case and a negative non-matching-email case.
- The template references `docs/schema/README.md`, but that path is not present in this repository checkout.
