### PR TITLE
fix(aws): reduce SageMaker regional retry tail

### DIFF
--- a/cartography/intel/aws/sagemaker/__init__.py
+++ b/cartography/intel/aws/sagemaker/__init__.py
@@ -89,6 +89,6 @@ def sync(
             current_aws_account_id,
             update_tag,
             common_job_parameters,
-            skip_regions.copy(),
+            skip_regions,
         )
         skip_regions.update(newly_failed_regions)

--- a/cartography/intel/aws/sagemaker/__init__.py
+++ b/cartography/intel/aws/sagemaker/__init__.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Dict
 from typing import List
+from typing import Set
 
 import boto3
 import neo4j
@@ -17,6 +18,7 @@ from cartography.intel.aws.sagemaker.notebook_instances import sync_notebook_ins
 from cartography.intel.aws.sagemaker.training_jobs import sync_training_jobs
 from cartography.intel.aws.sagemaker.transform_jobs import sync_transform_jobs
 from cartography.intel.aws.sagemaker.user_profiles import sync_user_profiles
+from cartography.intel.aws.sagemaker.util import get_available_sagemaker_regions
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -46,102 +48,47 @@ def sync(
         current_aws_account_id,
     )
 
-    # Sync Notebook Instances
-    sync_notebook_instances(
-        neo4j_session,
-        boto3_session,
-        regions,
-        current_aws_account_id,
-        update_tag,
-        common_job_parameters,
-    )
+    available_regions = get_available_sagemaker_regions(boto3_session, regions)
+    if not available_regions:
+        logger.warning(
+            "Could not determine available SageMaker regions for account '%s'. Continuing with requested regions.",
+            current_aws_account_id,
+        )
+        sagemaker_regions = regions
+    else:
+        sagemaker_regions = [
+            region for region in regions if region in available_regions
+        ]
+        unsupported_regions = sorted(set(regions) - set(sagemaker_regions))
+        if unsupported_regions:
+            logger.info(
+                "Skipping SageMaker sync for account '%s' in unsupported regions: %s",
+                current_aws_account_id,
+                ", ".join(unsupported_regions),
+            )
 
-    # Sync Domains
-    sync_domains(
-        neo4j_session,
-        boto3_session,
-        regions,
-        current_aws_account_id,
-        update_tag,
-        common_job_parameters,
-    )
+    skip_regions: Set[str] = set()
+    submodule_syncs = [
+        sync_notebook_instances,
+        sync_domains,
+        sync_user_profiles,
+        sync_training_jobs,
+        sync_models,
+        sync_endpoint_configs,
+        sync_endpoints,
+        sync_transform_jobs,
+        sync_model_package_groups,
+        sync_model_packages,
+    ]
 
-    # Sync User Profiles
-    sync_user_profiles(
-        neo4j_session,
-        boto3_session,
-        regions,
-        current_aws_account_id,
-        update_tag,
-        common_job_parameters,
-    )
-
-    # Sync Training Jobs
-    sync_training_jobs(
-        neo4j_session,
-        boto3_session,
-        regions,
-        current_aws_account_id,
-        update_tag,
-        common_job_parameters,
-    )
-
-    # Sync Models
-    sync_models(
-        neo4j_session,
-        boto3_session,
-        regions,
-        current_aws_account_id,
-        update_tag,
-        common_job_parameters,
-    )
-
-    # Sync Endpoint Configs
-    sync_endpoint_configs(
-        neo4j_session,
-        boto3_session,
-        regions,
-        current_aws_account_id,
-        update_tag,
-        common_job_parameters,
-    )
-
-    # Sync Endpoints
-    sync_endpoints(
-        neo4j_session,
-        boto3_session,
-        regions,
-        current_aws_account_id,
-        update_tag,
-        common_job_parameters,
-    )
-
-    # Sync Transform Jobs
-    sync_transform_jobs(
-        neo4j_session,
-        boto3_session,
-        regions,
-        current_aws_account_id,
-        update_tag,
-        common_job_parameters,
-    )
-
-    # Sync Model Package Groups
-    sync_model_package_groups(
-        neo4j_session,
-        boto3_session,
-        regions,
-        current_aws_account_id,
-        update_tag,
-        common_job_parameters,
-    )
-
-    # Sync Model Packages
-    sync_model_packages(
-        neo4j_session,
-        boto3_session,
-        regions,
-        current_aws_account_id,
-        update_tag,
-        common_job_parameters,
-    )
+    for sync_submodule in submodule_syncs:
+        newly_failed_regions = sync_submodule(
+            neo4j_session,
+            boto3_session,
+            sagemaker_regions,
+            current_aws_account_id,
+            update_tag,
+            common_job_parameters,
+            skip_regions.copy(),
+        )
+        skip_regions.update(newly_failed_regions)

--- a/cartography/intel/aws/sagemaker/domains.py
+++ b/cartography/intel/aws/sagemaker/domains.py
@@ -6,16 +6,17 @@ import neo4j
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.aws.sagemaker.util import sagemaker_handle_regions
+from cartography.intel.aws.sagemaker.util import sync_sagemaker_resource
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.models.aws.sagemaker.domain import AWSSageMakerDomainSchema
-from cartography.util import aws_handle_regions
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
 @timeit
-@aws_handle_regions
+@sagemaker_handle_regions
 def get_domains(
     boto3_session: boto3.session.Session,
     region: str,
@@ -111,30 +112,22 @@ def sync_domains(
     current_aws_account_id: str,
     aws_update_tag: int,
     common_job_parameters: dict[str, Any],
-) -> None:
+    skip_regions: set[str],
+) -> set[str]:
     """
     Sync SageMaker Domains for all specified regions.
     """
-    for region in regions:
-        logger.info(
-            "Syncing SageMaker Domains for region '%s' in account '%s'.",
-            region,
-            current_aws_account_id,
-        )
-        # Get domains from AWS
-        domains = get_domains(boto3_session, region)
-
-        # Transform the data
-        transformed_domains = transform_domains(domains, region)
-
-        # Load into Neo4j
-        load_domains(
-            neo4j_session,
-            transformed_domains,
-            region,
-            current_aws_account_id,
-            aws_update_tag,
-        )
-
-    # Cleanup old domains
-    cleanup_domains(neo4j_session, common_job_parameters)
+    return sync_sagemaker_resource(
+        neo4j_session=neo4j_session,
+        boto3_session=boto3_session,
+        regions=regions,
+        current_aws_account_id=current_aws_account_id,
+        aws_update_tag=aws_update_tag,
+        common_job_parameters=common_job_parameters,
+        skip_regions=skip_regions,
+        submodule_name="domains",
+        get_resources=get_domains,
+        transform_resources=transform_domains,
+        load_resources=load_domains,
+        cleanup_resources=cleanup_domains,
+    )

--- a/cartography/intel/aws/sagemaker/endpoint_configs.py
+++ b/cartography/intel/aws/sagemaker/endpoint_configs.py
@@ -6,18 +6,19 @@ import neo4j
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.aws.sagemaker.util import sagemaker_handle_regions
+from cartography.intel.aws.sagemaker.util import sync_sagemaker_resource
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.models.aws.sagemaker.endpoint_config import (
     AWSSageMakerEndpointConfigSchema,
 )
-from cartography.util import aws_handle_regions
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
 @timeit
-@aws_handle_regions
+@sagemaker_handle_regions
 def get_endpoint_configs(
     boto3_session: boto3.session.Session,
     region: str,
@@ -114,30 +115,22 @@ def sync_endpoint_configs(
     current_aws_account_id: str,
     aws_update_tag: int,
     common_job_parameters: dict[str, Any],
-) -> None:
+    skip_regions: set[str],
+) -> set[str]:
     """
     Sync SageMaker Endpoint Configs for all specified regions.
     """
-    for region in regions:
-        logger.info(
-            "Syncing SageMaker Endpoint Configs for region '%s' in account '%s'.",
-            region,
-            current_aws_account_id,
-        )
-        # Get endpoint configs from AWS
-        endpoint_configs = get_endpoint_configs(boto3_session, region)
-
-        # Transform the data
-        transformed_configs = transform_endpoint_configs(endpoint_configs, region)
-
-        # Load into Neo4j
-        load_endpoint_configs(
-            neo4j_session,
-            transformed_configs,
-            region,
-            current_aws_account_id,
-            aws_update_tag,
-        )
-
-    # Cleanup old endpoint configs
-    cleanup_endpoint_configs(neo4j_session, common_job_parameters)
+    return sync_sagemaker_resource(
+        neo4j_session=neo4j_session,
+        boto3_session=boto3_session,
+        regions=regions,
+        current_aws_account_id=current_aws_account_id,
+        aws_update_tag=aws_update_tag,
+        common_job_parameters=common_job_parameters,
+        skip_regions=skip_regions,
+        submodule_name="endpoint_configs",
+        get_resources=get_endpoint_configs,
+        transform_resources=transform_endpoint_configs,
+        load_resources=load_endpoint_configs,
+        cleanup_resources=cleanup_endpoint_configs,
+    )

--- a/cartography/intel/aws/sagemaker/endpoints.py
+++ b/cartography/intel/aws/sagemaker/endpoints.py
@@ -6,16 +6,17 @@ import neo4j
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.aws.sagemaker.util import sagemaker_handle_regions
+from cartography.intel.aws.sagemaker.util import sync_sagemaker_resource
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.models.aws.sagemaker.endpoint import AWSSageMakerEndpointSchema
-from cartography.util import aws_handle_regions
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
 @timeit
-@aws_handle_regions
+@sagemaker_handle_regions
 def get_endpoints(
     boto3_session: boto3.session.Session,
     region: str,
@@ -108,30 +109,22 @@ def sync_endpoints(
     current_aws_account_id: str,
     aws_update_tag: int,
     common_job_parameters: dict[str, Any],
-) -> None:
+    skip_regions: set[str],
+) -> set[str]:
     """
     Sync SageMaker Endpoints for all specified regions.
     """
-    for region in regions:
-        logger.info(
-            "Syncing SageMaker Endpoints for region '%s' in account '%s'.",
-            region,
-            current_aws_account_id,
-        )
-        # Get endpoints from AWS
-        endpoints = get_endpoints(boto3_session, region)
-
-        # Transform the data
-        transformed_endpoints = transform_endpoints(endpoints, region)
-
-        # Load into Neo4j
-        load_endpoints(
-            neo4j_session,
-            transformed_endpoints,
-            region,
-            current_aws_account_id,
-            aws_update_tag,
-        )
-
-    # Cleanup old endpoints
-    cleanup_endpoints(neo4j_session, common_job_parameters)
+    return sync_sagemaker_resource(
+        neo4j_session=neo4j_session,
+        boto3_session=boto3_session,
+        regions=regions,
+        current_aws_account_id=current_aws_account_id,
+        aws_update_tag=aws_update_tag,
+        common_job_parameters=common_job_parameters,
+        skip_regions=skip_regions,
+        submodule_name="endpoints",
+        get_resources=get_endpoints,
+        transform_resources=transform_endpoints,
+        load_resources=load_endpoints,
+        cleanup_resources=cleanup_endpoints,
+    )

--- a/cartography/intel/aws/sagemaker/model_package_groups.py
+++ b/cartography/intel/aws/sagemaker/model_package_groups.py
@@ -6,18 +6,19 @@ import neo4j
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.aws.sagemaker.util import sagemaker_handle_regions
+from cartography.intel.aws.sagemaker.util import sync_sagemaker_resource
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.models.aws.sagemaker.model_package_group import (
     AWSSageMakerModelPackageGroupSchema,
 )
-from cartography.util import aws_handle_regions
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
 @timeit
-@aws_handle_regions
+@sagemaker_handle_regions
 def get_model_package_groups(
     boto3_session: boto3.session.Session,
     region: str,
@@ -109,32 +110,22 @@ def sync_model_package_groups(
     current_aws_account_id: str,
     aws_update_tag: int,
     common_job_parameters: dict[str, Any],
-) -> None:
+    skip_regions: set[str],
+) -> set[str]:
     """
     Sync SageMaker Model Package Groups for all specified regions.
     """
-    for region in regions:
-        logger.info(
-            "Syncing SageMaker Model Package Groups for region '%s' in account '%s'.",
-            region,
-            current_aws_account_id,
-        )
-        # Get model package groups from AWS
-        model_package_groups = get_model_package_groups(boto3_session, region)
-
-        # Transform the data
-        transformed_groups = transform_model_package_groups(
-            model_package_groups, region
-        )
-
-        # Load into Neo4j
-        load_model_package_groups(
-            neo4j_session,
-            transformed_groups,
-            region,
-            current_aws_account_id,
-            aws_update_tag,
-        )
-
-    # Cleanup old model package groups
-    cleanup_model_package_groups(neo4j_session, common_job_parameters)
+    return sync_sagemaker_resource(
+        neo4j_session=neo4j_session,
+        boto3_session=boto3_session,
+        regions=regions,
+        current_aws_account_id=current_aws_account_id,
+        aws_update_tag=aws_update_tag,
+        common_job_parameters=common_job_parameters,
+        skip_regions=skip_regions,
+        submodule_name="model_package_groups",
+        get_resources=get_model_package_groups,
+        transform_resources=transform_model_package_groups,
+        load_resources=load_model_package_groups,
+        cleanup_resources=cleanup_model_package_groups,
+    )

--- a/cartography/intel/aws/sagemaker/model_packages.py
+++ b/cartography/intel/aws/sagemaker/model_packages.py
@@ -7,18 +7,19 @@ import neo4j
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.sagemaker.util import extract_bucket_name_from_s3_uri
+from cartography.intel.aws.sagemaker.util import sagemaker_handle_regions
+from cartography.intel.aws.sagemaker.util import sync_sagemaker_resource
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.models.aws.sagemaker.model_package import (
     AWSSageMakerModelPackageSchema,
 )
-from cartography.util import aws_handle_regions
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
 @timeit
-@aws_handle_regions
+@sagemaker_handle_regions
 def get_model_packages(
     boto3_session: boto3.session.Session,
     region: str,
@@ -126,30 +127,22 @@ def sync_model_packages(
     current_aws_account_id: str,
     aws_update_tag: int,
     common_job_parameters: dict[str, Any],
-) -> None:
+    skip_regions: set[str],
+) -> set[str]:
     """
     Sync SageMaker Model Packages for all specified regions.
     """
-    for region in regions:
-        logger.info(
-            "Syncing SageMaker Model Packages for region '%s' in account '%s'.",
-            region,
-            current_aws_account_id,
-        )
-        # Get model packages from AWS
-        model_packages = get_model_packages(boto3_session, region)
-
-        # Transform the data
-        transformed_packages = transform_model_packages(model_packages, region)
-
-        # Load into Neo4j
-        load_model_packages(
-            neo4j_session,
-            transformed_packages,
-            region,
-            current_aws_account_id,
-            aws_update_tag,
-        )
-
-    # Cleanup old model packages
-    cleanup_model_packages(neo4j_session, common_job_parameters)
+    return sync_sagemaker_resource(
+        neo4j_session=neo4j_session,
+        boto3_session=boto3_session,
+        regions=regions,
+        current_aws_account_id=current_aws_account_id,
+        aws_update_tag=aws_update_tag,
+        common_job_parameters=common_job_parameters,
+        skip_regions=skip_regions,
+        submodule_name="model_packages",
+        get_resources=get_model_packages,
+        transform_resources=transform_model_packages,
+        load_resources=load_model_packages,
+        cleanup_resources=cleanup_model_packages,
+    )

--- a/cartography/intel/aws/sagemaker/models.py
+++ b/cartography/intel/aws/sagemaker/models.py
@@ -7,16 +7,17 @@ import neo4j
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.sagemaker.util import extract_bucket_name_from_s3_uri
+from cartography.intel.aws.sagemaker.util import sagemaker_handle_regions
+from cartography.intel.aws.sagemaker.util import sync_sagemaker_resource
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.models.aws.sagemaker.model import AWSSageMakerModelSchema
-from cartography.util import aws_handle_regions
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
 @timeit
-@aws_handle_regions
+@sagemaker_handle_regions
 def get_models(
     boto3_session: boto3.session.Session,
     region: str,
@@ -139,30 +140,22 @@ def sync_models(
     current_aws_account_id: str,
     aws_update_tag: int,
     common_job_parameters: dict[str, Any],
-) -> None:
+    skip_regions: set[str],
+) -> set[str]:
     """
     Sync SageMaker Models for all specified regions.
     """
-    for region in regions:
-        logger.info(
-            "Syncing SageMaker Models for region '%s' in account '%s'.",
-            region,
-            current_aws_account_id,
-        )
-        # Get models from AWS
-        models = get_models(boto3_session, region)
-
-        # Transform the data
-        transformed_models = transform_models(models, region)
-
-        # Load into Neo4j
-        load_models(
-            neo4j_session,
-            transformed_models,
-            region,
-            current_aws_account_id,
-            aws_update_tag,
-        )
-
-    # Cleanup old models
-    cleanup_models(neo4j_session, common_job_parameters)
+    return sync_sagemaker_resource(
+        neo4j_session=neo4j_session,
+        boto3_session=boto3_session,
+        regions=regions,
+        current_aws_account_id=current_aws_account_id,
+        aws_update_tag=aws_update_tag,
+        common_job_parameters=common_job_parameters,
+        skip_regions=skip_regions,
+        submodule_name="models",
+        get_resources=get_models,
+        transform_resources=transform_models,
+        load_resources=load_models,
+        cleanup_resources=cleanup_models,
+    )

--- a/cartography/intel/aws/sagemaker/notebook_instances.py
+++ b/cartography/intel/aws/sagemaker/notebook_instances.py
@@ -6,18 +6,19 @@ import neo4j
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.aws.sagemaker.util import sagemaker_handle_regions
+from cartography.intel.aws.sagemaker.util import sync_sagemaker_resource
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.models.aws.sagemaker.notebook_instance import (
     AWSSageMakerNotebookInstanceSchema,
 )
-from cartography.util import aws_handle_regions
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
 @timeit
-@aws_handle_regions
+@sagemaker_handle_regions
 def get_notebook_instances(
     boto3_session: boto3.session.Session,
     region: str,
@@ -122,33 +123,22 @@ def sync_notebook_instances(
     current_aws_account_id: str,
     aws_update_tag: int,
     common_job_parameters: dict[str, Any],
-) -> None:
+    skip_regions: set[str],
+) -> set[str]:
     """
     Sync SageMaker Notebook Instances for all specified regions.
     """
-    for region in regions:
-        logger.info(
-            "Syncing SageMaker Notebook Instances for region '%s' in account '%s'.",
-            region,
-            current_aws_account_id,
-        )
-        # Get notebook instances from AWS
-        notebook_instances = get_notebook_instances(boto3_session, region)
-
-        # Transform the data
-        transformed_instances = transform_notebook_instances(
-            notebook_instances,
-            region,
-        )
-
-        # Load into Neo4j
-        load_notebook_instances(
-            neo4j_session,
-            transformed_instances,
-            region,
-            current_aws_account_id,
-            aws_update_tag,
-        )
-
-    # Cleanup old notebook instances
-    cleanup_notebook_instances(neo4j_session, common_job_parameters)
+    return sync_sagemaker_resource(
+        neo4j_session=neo4j_session,
+        boto3_session=boto3_session,
+        regions=regions,
+        current_aws_account_id=current_aws_account_id,
+        aws_update_tag=aws_update_tag,
+        common_job_parameters=common_job_parameters,
+        skip_regions=skip_regions,
+        submodule_name="notebook_instances",
+        get_resources=get_notebook_instances,
+        transform_resources=transform_notebook_instances,
+        load_resources=load_notebook_instances,
+        cleanup_resources=cleanup_notebook_instances,
+    )

--- a/cartography/intel/aws/sagemaker/training_jobs.py
+++ b/cartography/intel/aws/sagemaker/training_jobs.py
@@ -7,16 +7,17 @@ import neo4j
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.sagemaker.util import extract_bucket_name_from_s3_uri
+from cartography.intel.aws.sagemaker.util import sagemaker_handle_regions
+from cartography.intel.aws.sagemaker.util import sync_sagemaker_resource
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.models.aws.sagemaker.training_job import AWSSageMakerTrainingJobSchema
-from cartography.util import aws_handle_regions
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
 @timeit
-@aws_handle_regions
+@sagemaker_handle_regions
 def get_training_jobs(
     boto3_session: boto3.session.Session,
     region: str,
@@ -148,30 +149,22 @@ def sync_training_jobs(
     current_aws_account_id: str,
     aws_update_tag: int,
     common_job_parameters: dict[str, Any],
-) -> None:
+    skip_regions: set[str],
+) -> set[str]:
     """
     Sync SageMaker Training Jobs for all specified regions.
     """
-    for region in regions:
-        logger.info(
-            "Syncing SageMaker Training Jobs for region '%s' in account '%s'.",
-            region,
-            current_aws_account_id,
-        )
-        # Get training jobs from AWS
-        training_jobs = get_training_jobs(boto3_session, region)
-
-        # Transform the data
-        transformed_jobs = transform_training_jobs(training_jobs, region)
-
-        # Load into Neo4j
-        load_training_jobs(
-            neo4j_session,
-            transformed_jobs,
-            region,
-            current_aws_account_id,
-            aws_update_tag,
-        )
-
-    # Cleanup old training jobs
-    cleanup_training_jobs(neo4j_session, common_job_parameters)
+    return sync_sagemaker_resource(
+        neo4j_session=neo4j_session,
+        boto3_session=boto3_session,
+        regions=regions,
+        current_aws_account_id=current_aws_account_id,
+        aws_update_tag=aws_update_tag,
+        common_job_parameters=common_job_parameters,
+        skip_regions=skip_regions,
+        submodule_name="training_jobs",
+        get_resources=get_training_jobs,
+        transform_resources=transform_training_jobs,
+        load_resources=load_training_jobs,
+        cleanup_resources=cleanup_training_jobs,
+    )

--- a/cartography/intel/aws/sagemaker/transform_jobs.py
+++ b/cartography/intel/aws/sagemaker/transform_jobs.py
@@ -7,18 +7,19 @@ import neo4j
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.sagemaker.util import extract_bucket_name_from_s3_uri
+from cartography.intel.aws.sagemaker.util import sagemaker_handle_regions
+from cartography.intel.aws.sagemaker.util import sync_sagemaker_resource
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.models.aws.sagemaker.transform_job import (
     AWSSageMakerTransformJobSchema,
 )
-from cartography.util import aws_handle_regions
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
 @timeit
-@aws_handle_regions
+@sagemaker_handle_regions
 def get_transform_jobs(
     boto3_session: boto3.session.Session,
     region: str,
@@ -123,30 +124,22 @@ def sync_transform_jobs(
     current_aws_account_id: str,
     aws_update_tag: int,
     common_job_parameters: dict[str, Any],
-) -> None:
+    skip_regions: set[str],
+) -> set[str]:
     """
     Sync SageMaker Transform Jobs for all specified regions.
     """
-    for region in regions:
-        logger.info(
-            "Syncing SageMaker Transform Jobs for region '%s' in account '%s'.",
-            region,
-            current_aws_account_id,
-        )
-        # Get transform jobs from AWS
-        transform_jobs = get_transform_jobs(boto3_session, region)
-
-        # Transform the data
-        transformed_jobs = transform_transform_jobs(transform_jobs, region)
-
-        # Load into Neo4j
-        load_transform_jobs(
-            neo4j_session,
-            transformed_jobs,
-            region,
-            current_aws_account_id,
-            aws_update_tag,
-        )
-
-    # Cleanup old transform jobs
-    cleanup_transform_jobs(neo4j_session, common_job_parameters)
+    return sync_sagemaker_resource(
+        neo4j_session=neo4j_session,
+        boto3_session=boto3_session,
+        regions=regions,
+        current_aws_account_id=current_aws_account_id,
+        aws_update_tag=aws_update_tag,
+        common_job_parameters=common_job_parameters,
+        skip_regions=skip_regions,
+        submodule_name="transform_jobs",
+        get_resources=get_transform_jobs,
+        transform_resources=transform_transform_jobs,
+        load_resources=load_transform_jobs,
+        cleanup_resources=cleanup_transform_jobs,
+    )

--- a/cartography/intel/aws/sagemaker/user_profiles.py
+++ b/cartography/intel/aws/sagemaker/user_profiles.py
@@ -6,16 +6,17 @@ import neo4j
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.aws.sagemaker.util import sagemaker_handle_regions
+from cartography.intel.aws.sagemaker.util import sync_sagemaker_resource
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.models.aws.sagemaker.user_profile import AWSSageMakerUserProfileSchema
-from cartography.util import aws_handle_regions
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
 @timeit
-@aws_handle_regions
+@sagemaker_handle_regions
 def get_user_profiles(
     boto3_session: boto3.session.Session,
     region: str,
@@ -122,30 +123,22 @@ def sync_user_profiles(
     current_aws_account_id: str,
     aws_update_tag: int,
     common_job_parameters: dict[str, Any],
-) -> None:
+    skip_regions: set[str],
+) -> set[str]:
     """
     Sync SageMaker User Profiles for all specified regions.
     """
-    for region in regions:
-        logger.info(
-            "Syncing SageMaker User Profiles for region '%s' in account '%s'.",
-            region,
-            current_aws_account_id,
-        )
-        # Get user profiles from AWS
-        user_profiles = get_user_profiles(boto3_session, region)
-
-        # Transform the data
-        transformed_profiles = transform_user_profiles(user_profiles, region)
-
-        # Load into Neo4j
-        load_user_profiles(
-            neo4j_session,
-            transformed_profiles,
-            region,
-            current_aws_account_id,
-            aws_update_tag,
-        )
-
-    # Cleanup old user profiles
-    cleanup_user_profiles(neo4j_session, common_job_parameters)
+    return sync_sagemaker_resource(
+        neo4j_session=neo4j_session,
+        boto3_session=boto3_session,
+        regions=regions,
+        current_aws_account_id=current_aws_account_id,
+        aws_update_tag=aws_update_tag,
+        common_job_parameters=common_job_parameters,
+        skip_regions=skip_regions,
+        submodule_name="user_profiles",
+        get_resources=get_user_profiles,
+        transform_resources=transform_user_profiles,
+        load_resources=load_user_profiles,
+        cleanup_resources=cleanup_user_profiles,
+    )

--- a/cartography/intel/aws/sagemaker/util.py
+++ b/cartography/intel/aws/sagemaker/util.py
@@ -15,6 +15,7 @@ from botocore.exceptions import ConnectionClosedError
 from botocore.exceptions import ConnectTimeoutError
 from botocore.exceptions import EndpointConnectionError
 from botocore.exceptions import ReadTimeoutError
+from botocore.exceptions import UnknownRegionError
 from botocore.parsers import ResponseParserError
 
 from cartography.util import AWS_REGION_ACCESS_DENIED_ERROR_CODES
@@ -115,7 +116,7 @@ def get_available_sagemaker_regions(
         for region in regions:
             try:
                 partitions.add(get_partition_for_region(region))
-            except Exception:
+            except UnknownRegionError:
                 logger.debug(
                     "Could not determine AWS partition for region '%s' while filtering SageMaker regions.",
                     region,

--- a/cartography/intel/aws/sagemaker/util.py
+++ b/cartography/intel/aws/sagemaker/util.py
@@ -1,4 +1,209 @@
+import logging
+from functools import wraps
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import Iterable
 from typing import Optional
+from typing import Set
+from typing import TypeVar
+
+import boto3
+import neo4j
+from botocore.exceptions import ClientError
+from botocore.exceptions import ConnectionClosedError
+from botocore.exceptions import ConnectTimeoutError
+from botocore.exceptions import EndpointConnectionError
+from botocore.exceptions import ReadTimeoutError
+from botocore.parsers import ResponseParserError
+
+from cartography.util import AWS_REGION_ACCESS_DENIED_ERROR_CODES
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+_RETRYABLE_HTTP_STATUS_CODES = {429, 500, 502, 503, 504}
+_REGION_UNSUPPORTED_SNIPPETS = (
+    "not supported in the called region",
+    "not supported in this region",
+    "unsupported in this region",
+)
+
+AWSGetFunc = TypeVar("AWSGetFunc", bound=Callable[..., Iterable[Any]])
+
+
+class SageMakerTransientRegionFailure(Exception):
+    pass
+
+
+def _is_retryable_sagemaker_error(error: ClientError) -> bool:
+    error_code = error.response.get("Error", {}).get("Code", "")
+    status_code = error.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+    return (
+        error_code
+        in {
+            "RequestLimitExceeded",
+            "RequestThrottled",
+            "RequestTimeout",
+            "RequestTimeoutException",
+            "ServiceUnavailable",
+            "ServiceUnavailableException",
+            "Throttling",
+            "ThrottlingException",
+            "TooManyRequestsException",
+        }
+        or status_code in _RETRYABLE_HTTP_STATUS_CODES
+    )
+
+
+def _is_region_unsupported_error(
+    error_code: Optional[str],
+    error_message: Optional[str],
+) -> bool:
+    if error_code != "UnknownOperationException" or not error_message:
+        return False
+    lowered = error_message.lower()
+    return any(snippet in lowered for snippet in _REGION_UNSUPPORTED_SNIPPETS)
+
+
+def sagemaker_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
+    @wraps(func)
+    def inner_function(*args, **kwargs):  # type: ignore
+        try:
+            return func(*args, **kwargs)
+        except ClientError as error:
+            error_code = error.response.get("Error", {}).get("Code")
+            error_message = error.response.get("Error", {}).get("Message")
+            if error_code == "InvalidToken":
+                raise RuntimeError(
+                    "AWS returned an InvalidToken error. Configure regional STS endpoints by "
+                    "setting environment variable AWS_STS_REGIONAL_ENDPOINTS=regional or adding "
+                    "'sts_regional_endpoints = regional' to your AWS config file."
+                ) from error
+            if _is_retryable_sagemaker_error(error):
+                raise SageMakerTransientRegionFailure(
+                    f"AWS SDK retries were exhausted for transient SageMaker failure in {func.__name__}"
+                ) from error
+            if _is_region_unsupported_error(error_code, error_message):
+                logger.warning("%s in this region. Skipping...", error_message)
+                return []
+            if error_code in AWS_REGION_ACCESS_DENIED_ERROR_CODES:
+                logger.warning("%s in this region. Skipping...", error_message)
+                return []
+            raise
+        except (
+            ConnectionClosedError,
+            ConnectTimeoutError,
+            EndpointConnectionError,
+            ReadTimeoutError,
+            ResponseParserError,
+        ) as error:
+            raise SageMakerTransientRegionFailure(
+                f"Encountered a transient regional SageMaker endpoint failure in {func.__name__}"
+            ) from error
+
+    return cast(AWSGetFunc, inner_function)
+
+
+def get_available_sagemaker_regions(
+    boto3_session: boto3.session.Session,
+    regions: list[str],
+) -> Set[str]:
+    partitions: Set[str] = set()
+    get_partition_for_region = getattr(boto3_session, "get_partition_for_region", None)
+    if callable(get_partition_for_region):
+        for region in regions:
+            try:
+                partitions.add(get_partition_for_region(region))
+            except Exception:
+                logger.debug(
+                    "Could not determine AWS partition for region '%s' while filtering SageMaker regions.",
+                    region,
+                )
+    if not partitions:
+        partitions.update(boto3_session.get_available_partitions())
+
+    available_regions: Set[str] = set()
+    for partition_name in partitions:
+        available_regions.update(
+            boto3_session.get_available_regions(
+                "sagemaker",
+                partition_name=partition_name,
+            ),
+        )
+    return available_regions
+
+
+@timeit
+def sync_sagemaker_resource(
+    neo4j_session: neo4j.Session,
+    boto3_session: boto3.session.Session,
+    regions: list[str],
+    current_aws_account_id: str,
+    aws_update_tag: int,
+    common_job_parameters: dict[str, Any],
+    skip_regions: set[str],
+    submodule_name: str,
+    get_resources: Callable[[boto3.session.Session, str], list[dict[str, Any]]],
+    transform_resources: Callable[[list[dict[str, Any]], str], list[dict[str, Any]]],
+    load_resources: Callable[
+        [neo4j.Session, list[dict[str, Any]], str, str, int],
+        None,
+    ],
+    cleanup_resources: Callable[[neo4j.Session, dict[str, Any]], None],
+) -> set[str]:
+    cleanup_safe = not skip_regions
+    newly_failed_regions: set[str] = set()
+
+    for region in regions:
+        if region in skip_regions:
+            logger.info(
+                "Skipping SageMaker submodule '%s' for account '%s' in region '%s' because the region was previously marked as transiently failed.",
+                submodule_name,
+                current_aws_account_id,
+                region,
+            )
+            continue
+
+        logger.info(
+            "Syncing SageMaker submodule '%s' for region '%s' in account '%s'.",
+            submodule_name,
+            region,
+            current_aws_account_id,
+        )
+        try:
+            resources = get_resources(boto3_session, region)
+        except SageMakerTransientRegionFailure as error:
+            newly_failed_regions.add(region)
+            cleanup_safe = False
+            logger.warning(
+                "Marking SageMaker region '%s' as transiently failed for account '%s' in submodule '%s': %s",
+                region,
+                current_aws_account_id,
+                submodule_name,
+                error,
+            )
+            continue
+
+        transformed_resources = transform_resources(resources, region)
+        load_resources(
+            neo4j_session,
+            transformed_resources,
+            region,
+            current_aws_account_id,
+            aws_update_tag,
+        )
+
+    if cleanup_safe:
+        cleanup_resources(neo4j_session, common_job_parameters)
+    else:
+        logger.warning(
+            "Skipping SageMaker cleanup for account '%s' in submodule '%s' because one or more regions were transiently skipped. Preserving last-known-good data.",
+            current_aws_account_id,
+            submodule_name,
+        )
+
+    return newly_failed_regions
 
 
 def extract_bucket_name_from_s3_uri(s3_uri: str) -> Optional[str]:

--- a/cartography/intel/aws/sagemaker/util.py
+++ b/cartography/intel/aws/sagemaker/util.py
@@ -18,18 +18,12 @@ from botocore.exceptions import ReadTimeoutError
 from botocore.exceptions import UnknownRegionError
 from botocore.parsers import ResponseParserError
 
-from cartography.util import AWS_REGION_ACCESS_DENIED_ERROR_CODES
+from cartography.util import is_aws_region_skippable_client_error
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 _RETRYABLE_HTTP_STATUS_CODES = {429, 500, 502, 503, 504}
-_REGION_UNSUPPORTED_SNIPPETS = (
-    "not supported in the called region",
-    "not supported in this region",
-    "unsupported in this region",
-)
-
 AWSGetFunc = TypeVar("AWSGetFunc", bound=Callable[..., Iterable[Any]])
 
 
@@ -57,16 +51,6 @@ def _is_retryable_sagemaker_error(error: ClientError) -> bool:
     )
 
 
-def _is_region_unsupported_error(
-    error_code: Optional[str],
-    error_message: Optional[str],
-) -> bool:
-    if error_code != "UnknownOperationException" or not error_message:
-        return False
-    lowered = error_message.lower()
-    return any(snippet in lowered for snippet in _REGION_UNSUPPORTED_SNIPPETS)
-
-
 def sagemaker_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
     @wraps(func)
     def inner_function(*args, **kwargs):  # type: ignore
@@ -85,10 +69,7 @@ def sagemaker_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
                 raise SageMakerTransientRegionFailure(
                     f"AWS SDK retries were exhausted for transient SageMaker failure in {func.__name__}"
                 ) from error
-            if _is_region_unsupported_error(error_code, error_message):
-                logger.warning("%s in this region. Skipping...", error_message)
-                return []
-            if error_code in AWS_REGION_ACCESS_DENIED_ERROR_CODES:
+            if is_aws_region_skippable_client_error(error):
                 logger.warning("%s in this region. Skipping...", error_message)
                 return []
             raise

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -594,6 +594,27 @@ def _is_region_unsupported_unknown_operation(
     )
 
 
+def is_aws_region_skippable_client_error(
+    error: botocore.exceptions.ClientError,
+) -> bool:
+    """
+    Return True when a ClientError indicates regional unavailability or regional access denial.
+
+    This is the shared classification used by AWS sync code that needs to decide
+    whether a regional failure should degrade to a regional skip instead of
+    failing the account-level sync.
+    """
+    error_code = error.response.get("Error", {}).get("Code")
+    error_message = error.response.get("Error", {}).get("Message")
+    return (
+        _is_region_unsupported_unknown_operation(
+            error_code,
+            error_message,
+        )
+        or error_code in AWS_REGION_ACCESS_DENIED_ERROR_CODES
+    )
+
+
 # TODO Move this to cartography.intel.aws.util.common
 def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
     """
@@ -671,16 +692,10 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
                     "setting environment variable AWS_STS_REGIONAL_ENDPOINTS=regional or adding "
                     "'sts_regional_endpoints = regional' to your AWS config file."
                 ) from e
-            if _is_region_unsupported_unknown_operation(error_code, error_message):
-                logger.warning(
-                    "{} in this region. Skipping...".format(
-                        error_message,
-                    ),
-                )
-                return []
             # The account is not authorized to use this service in this region
-            # so we can continue without raising an exception
-            if error_code in AWS_REGION_ACCESS_DENIED_ERROR_CODES:
+            # or the service is unavailable in the region, so we can continue
+            # without raising an exception.
+            if is_aws_region_skippable_client_error(e):
                 if is_service_control_policy_explicit_deny(e):
                     logger.warning(
                         "Service control policy denied access while calling %s: %s",

--- a/tests/unit/cartography/intel/aws/test_sagemaker.py
+++ b/tests/unit/cartography/intel/aws/test_sagemaker.py
@@ -3,9 +3,11 @@ from unittest.mock import MagicMock
 import pytest
 from botocore.exceptions import ClientError
 from botocore.exceptions import ConnectTimeoutError
+from botocore.exceptions import UnknownRegionError
 
 from cartography.intel.aws import sagemaker
 from cartography.intel.aws.sagemaker import notebook_instances
+from cartography.intel.aws.sagemaker.util import get_available_sagemaker_regions
 from cartography.intel.aws.sagemaker.util import SageMakerTransientRegionFailure
 
 
@@ -269,3 +271,31 @@ def test_sagemaker_sync_filters_supported_regions_and_carries_skip_regions_forwa
             {"UPDATE_TAG": 1, "AWS_ID": "123456789012"},
             {"me-south-1"},
         )
+
+
+def test_get_available_sagemaker_regions_skips_unknown_regions_and_uses_known_partition(
+    mocker,
+):
+    boto3_session = MagicMock()
+
+    def _get_partition_for_region(region):
+        if region == "not-a-region":
+            raise UnknownRegionError(
+                region_name=region,
+                error_msg="No partition found for provided region_name.",
+            )
+        return "aws"
+
+    boto3_session.get_partition_for_region.side_effect = _get_partition_for_region
+    boto3_session.get_available_regions.return_value = ["us-east-1", "me-south-1"]
+
+    available_regions = get_available_sagemaker_regions(
+        boto3_session,
+        ["us-east-1", "not-a-region"],
+    )
+
+    assert available_regions == {"us-east-1", "me-south-1"}
+    boto3_session.get_available_regions.assert_called_once_with(
+        "sagemaker",
+        partition_name="aws",
+    )

--- a/tests/unit/cartography/intel/aws/test_sagemaker.py
+++ b/tests/unit/cartography/intel/aws/test_sagemaker.py
@@ -182,46 +182,57 @@ def test_sagemaker_sync_filters_supported_regions_and_carries_skip_regions_forwa
     boto3_session = MagicMock()
     boto3_session.get_partition_for_region.side_effect = lambda region: "aws"
     boto3_session.get_available_regions.return_value = ["us-east-1", "me-south-1"]
+    captured_skip_regions = {}
+
+    def _capture_skip_regions(name, return_value):
+        def _side_effect(*args):
+            captured_skip_regions.setdefault(name, []).append(args[6].copy())
+            return return_value
+
+        return _side_effect
 
     sync_notebook_instances = mocker.patch(
         "cartography.intel.aws.sagemaker.sync_notebook_instances",
-        return_value={"me-south-1"},
+        side_effect=_capture_skip_regions(
+            "notebook_instances",
+            {"me-south-1"},
+        ),
     )
     sync_domains = mocker.patch(
         "cartography.intel.aws.sagemaker.sync_domains",
-        return_value=set(),
+        side_effect=_capture_skip_regions("domains", set()),
     )
     sync_user_profiles = mocker.patch(
         "cartography.intel.aws.sagemaker.sync_user_profiles",
-        return_value=set(),
+        side_effect=_capture_skip_regions("user_profiles", set()),
     )
     sync_training_jobs = mocker.patch(
         "cartography.intel.aws.sagemaker.sync_training_jobs",
-        return_value=set(),
+        side_effect=_capture_skip_regions("training_jobs", set()),
     )
     sync_models = mocker.patch(
         "cartography.intel.aws.sagemaker.sync_models",
-        return_value=set(),
+        side_effect=_capture_skip_regions("models", set()),
     )
     sync_endpoint_configs = mocker.patch(
         "cartography.intel.aws.sagemaker.sync_endpoint_configs",
-        return_value=set(),
+        side_effect=_capture_skip_regions("endpoint_configs", set()),
     )
     sync_endpoints = mocker.patch(
         "cartography.intel.aws.sagemaker.sync_endpoints",
-        return_value=set(),
+        side_effect=_capture_skip_regions("endpoints", set()),
     )
     sync_transform_jobs = mocker.patch(
         "cartography.intel.aws.sagemaker.sync_transform_jobs",
-        return_value=set(),
+        side_effect=_capture_skip_regions("transform_jobs", set()),
     )
     sync_model_package_groups = mocker.patch(
         "cartography.intel.aws.sagemaker.sync_model_package_groups",
-        return_value=set(),
+        side_effect=_capture_skip_regions("model_package_groups", set()),
     )
     sync_model_packages = mocker.patch(
         "cartography.intel.aws.sagemaker.sync_model_packages",
-        return_value=set(),
+        side_effect=_capture_skip_regions("model_packages", set()),
     )
 
     sagemaker.sync(
@@ -234,25 +245,17 @@ def test_sagemaker_sync_filters_supported_regions_and_carries_skip_regions_forwa
     )
 
     expected_regions = ["us-east-1", "me-south-1"]
-    sync_notebook_instances.assert_called_once_with(
+    assert sync_notebook_instances.call_count == 1
+    assert sync_notebook_instances.call_args.args[:6] == (
         mocker.ANY,
         boto3_session,
         expected_regions,
         "123456789012",
         1,
         {"UPDATE_TAG": 1, "AWS_ID": "123456789012"},
-        set(),
-    )
-    sync_domains.assert_called_once_with(
-        mocker.ANY,
-        boto3_session,
-        expected_regions,
-        "123456789012",
-        1,
-        {"UPDATE_TAG": 1, "AWS_ID": "123456789012"},
-        {"me-south-1"},
     )
     for patched_sync in (
+        sync_domains,
         sync_user_profiles,
         sync_training_jobs,
         sync_models,
@@ -262,15 +265,29 @@ def test_sagemaker_sync_filters_supported_regions_and_carries_skip_regions_forwa
         sync_model_package_groups,
         sync_model_packages,
     ):
-        patched_sync.assert_called_once_with(
+        assert patched_sync.call_count == 1
+        assert patched_sync.call_args.args[:6] == (
             mocker.ANY,
             boto3_session,
             expected_regions,
             "123456789012",
             1,
             {"UPDATE_TAG": 1, "AWS_ID": "123456789012"},
-            {"me-south-1"},
         )
+
+    assert captured_skip_regions["notebook_instances"] == [set()]
+    for name in (
+        "domains",
+        "user_profiles",
+        "training_jobs",
+        "models",
+        "endpoint_configs",
+        "endpoints",
+        "transform_jobs",
+        "model_package_groups",
+        "model_packages",
+    ):
+        assert captured_skip_regions[name] == [{"me-south-1"}]
 
 
 def test_get_available_sagemaker_regions_skips_unknown_regions_and_uses_known_partition(

--- a/tests/unit/cartography/intel/aws/test_sagemaker.py
+++ b/tests/unit/cartography/intel/aws/test_sagemaker.py
@@ -1,0 +1,271 @@
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+from botocore.exceptions import ConnectTimeoutError
+
+from cartography.intel.aws import sagemaker
+from cartography.intel.aws.sagemaker import notebook_instances
+from cartography.intel.aws.sagemaker.util import SageMakerTransientRegionFailure
+
+
+def _client_error(code: str, message: str, status_code: int) -> ClientError:
+    return ClientError(
+        {
+            "Error": {"Code": code, "Message": message},
+            "ResponseMetadata": {"HTTPStatusCode": status_code},
+        },
+        "ListNotebookInstances",
+    )
+
+
+def test_get_notebook_instances_raises_transient_region_failure_on_timeout(mocker):
+    boto3_session = MagicMock()
+    client = MagicMock()
+    client.get_paginator.return_value.paginate.side_effect = ConnectTimeoutError(
+        endpoint_url="https://api.sagemaker.me-south-1.amazonaws.com",
+    )
+    mocker.patch(
+        "cartography.intel.aws.sagemaker.notebook_instances.create_boto3_client",
+        return_value=client,
+    )
+
+    with pytest.raises(SageMakerTransientRegionFailure):
+        notebook_instances.get_notebook_instances(boto3_session, "me-south-1")
+
+
+def test_get_notebook_instances_raises_transient_region_failure_on_retryable_client_error(
+    mocker,
+):
+    boto3_session = MagicMock()
+    client = MagicMock()
+    client.get_paginator.return_value.paginate.side_effect = _client_error(
+        "ServiceUnavailable",
+        "Service unavailable",
+        503,
+    )
+    mocker.patch(
+        "cartography.intel.aws.sagemaker.notebook_instances.create_boto3_client",
+        return_value=client,
+    )
+
+    with pytest.raises(SageMakerTransientRegionFailure):
+        notebook_instances.get_notebook_instances(boto3_session, "me-south-1")
+
+
+def test_get_notebook_instances_returns_empty_list_on_access_denied(mocker):
+    boto3_session = MagicMock()
+    client = MagicMock()
+    client.get_paginator.return_value.paginate.side_effect = _client_error(
+        "AccessDeniedException",
+        "Access denied",
+        403,
+    )
+    mocker.patch(
+        "cartography.intel.aws.sagemaker.notebook_instances.create_boto3_client",
+        return_value=client,
+    )
+
+    result = notebook_instances.get_notebook_instances(boto3_session, "me-south-1")
+
+    assert result == []
+
+
+def test_get_notebook_instances_returns_empty_list_on_unsupported_region_error(
+    mocker,
+):
+    boto3_session = MagicMock()
+    client = MagicMock()
+    client.get_paginator.return_value.paginate.side_effect = _client_error(
+        "UnknownOperationException",
+        "This operation is not supported in this region.",
+        400,
+    )
+    mocker.patch(
+        "cartography.intel.aws.sagemaker.notebook_instances.create_boto3_client",
+        return_value=client,
+    )
+
+    result = notebook_instances.get_notebook_instances(boto3_session, "me-south-1")
+
+    assert result == []
+
+
+def test_sync_notebook_instances_loads_healthy_regions_and_skips_cleanup_after_transient_failure(
+    mocker,
+):
+    def _get_notebook_instances_side_effect(_, region):
+        if region == "us-east-1":
+            return [{"NotebookInstanceName": "nb-1"}]
+        raise SageMakerTransientRegionFailure("temporary failure")
+
+    get_notebook_instances = mocker.patch(
+        "cartography.intel.aws.sagemaker.notebook_instances.get_notebook_instances",
+        side_effect=_get_notebook_instances_side_effect,
+    )
+    transform_notebook_instances = mocker.patch(
+        "cartography.intel.aws.sagemaker.notebook_instances.transform_notebook_instances",
+        side_effect=lambda data, region: [{"Region": region, **item} for item in data],
+    )
+    load_notebook_instances = mocker.patch(
+        "cartography.intel.aws.sagemaker.notebook_instances.load_notebook_instances",
+    )
+    cleanup_notebook_instances = mocker.patch(
+        "cartography.intel.aws.sagemaker.notebook_instances.cleanup_notebook_instances",
+    )
+
+    failed_regions = notebook_instances.sync_notebook_instances(
+        neo4j_session=MagicMock(),
+        boto3_session=MagicMock(),
+        regions=["us-east-1", "me-south-1"],
+        current_aws_account_id="123456789012",
+        aws_update_tag=1,
+        common_job_parameters={"UPDATE_TAG": 1, "AWS_ID": "123456789012"},
+        skip_regions=set(),
+    )
+
+    assert failed_regions == {"me-south-1"}
+    assert get_notebook_instances.call_count == 2
+    transform_notebook_instances.assert_called_once_with(
+        [{"NotebookInstanceName": "nb-1"}],
+        "us-east-1",
+    )
+    load_notebook_instances.assert_called_once_with(
+        mocker.ANY,
+        [{"NotebookInstanceName": "nb-1", "Region": "us-east-1"}],
+        "us-east-1",
+        "123456789012",
+        1,
+    )
+    cleanup_notebook_instances.assert_not_called()
+
+
+def test_sync_notebook_instances_skips_cleanup_when_regions_are_already_marked_failed(
+    mocker,
+):
+    get_notebook_instances = mocker.patch(
+        "cartography.intel.aws.sagemaker.notebook_instances.get_notebook_instances",
+        return_value=[{"NotebookInstanceName": "nb-1"}],
+    )
+    mocker.patch(
+        "cartography.intel.aws.sagemaker.notebook_instances.transform_notebook_instances",
+        side_effect=lambda data, region: data,
+    )
+    load_notebook_instances = mocker.patch(
+        "cartography.intel.aws.sagemaker.notebook_instances.load_notebook_instances",
+    )
+    cleanup_notebook_instances = mocker.patch(
+        "cartography.intel.aws.sagemaker.notebook_instances.cleanup_notebook_instances",
+    )
+
+    failed_regions = notebook_instances.sync_notebook_instances(
+        neo4j_session=MagicMock(),
+        boto3_session=MagicMock(),
+        regions=["us-east-1", "me-south-1"],
+        current_aws_account_id="123456789012",
+        aws_update_tag=1,
+        common_job_parameters={"UPDATE_TAG": 1, "AWS_ID": "123456789012"},
+        skip_regions={"me-south-1"},
+    )
+
+    assert failed_regions == set()
+    get_notebook_instances.assert_called_once_with(mocker.ANY, "us-east-1")
+    load_notebook_instances.assert_called_once()
+    cleanup_notebook_instances.assert_not_called()
+
+
+def test_sagemaker_sync_filters_supported_regions_and_carries_skip_regions_forward(
+    mocker,
+):
+    boto3_session = MagicMock()
+    boto3_session.get_partition_for_region.side_effect = lambda region: "aws"
+    boto3_session.get_available_regions.return_value = ["us-east-1", "me-south-1"]
+
+    sync_notebook_instances = mocker.patch(
+        "cartography.intel.aws.sagemaker.sync_notebook_instances",
+        return_value={"me-south-1"},
+    )
+    sync_domains = mocker.patch(
+        "cartography.intel.aws.sagemaker.sync_domains",
+        return_value=set(),
+    )
+    sync_user_profiles = mocker.patch(
+        "cartography.intel.aws.sagemaker.sync_user_profiles",
+        return_value=set(),
+    )
+    sync_training_jobs = mocker.patch(
+        "cartography.intel.aws.sagemaker.sync_training_jobs",
+        return_value=set(),
+    )
+    sync_models = mocker.patch(
+        "cartography.intel.aws.sagemaker.sync_models",
+        return_value=set(),
+    )
+    sync_endpoint_configs = mocker.patch(
+        "cartography.intel.aws.sagemaker.sync_endpoint_configs",
+        return_value=set(),
+    )
+    sync_endpoints = mocker.patch(
+        "cartography.intel.aws.sagemaker.sync_endpoints",
+        return_value=set(),
+    )
+    sync_transform_jobs = mocker.patch(
+        "cartography.intel.aws.sagemaker.sync_transform_jobs",
+        return_value=set(),
+    )
+    sync_model_package_groups = mocker.patch(
+        "cartography.intel.aws.sagemaker.sync_model_package_groups",
+        return_value=set(),
+    )
+    sync_model_packages = mocker.patch(
+        "cartography.intel.aws.sagemaker.sync_model_packages",
+        return_value=set(),
+    )
+
+    sagemaker.sync(
+        neo4j_session=MagicMock(),
+        boto3_session=boto3_session,
+        regions=["us-east-1", "me-south-1", "eu-west-3"],
+        current_aws_account_id="123456789012",
+        update_tag=1,
+        common_job_parameters={"UPDATE_TAG": 1, "AWS_ID": "123456789012"},
+    )
+
+    expected_regions = ["us-east-1", "me-south-1"]
+    sync_notebook_instances.assert_called_once_with(
+        mocker.ANY,
+        boto3_session,
+        expected_regions,
+        "123456789012",
+        1,
+        {"UPDATE_TAG": 1, "AWS_ID": "123456789012"},
+        set(),
+    )
+    sync_domains.assert_called_once_with(
+        mocker.ANY,
+        boto3_session,
+        expected_regions,
+        "123456789012",
+        1,
+        {"UPDATE_TAG": 1, "AWS_ID": "123456789012"},
+        {"me-south-1"},
+    )
+    for patched_sync in (
+        sync_user_profiles,
+        sync_training_jobs,
+        sync_models,
+        sync_endpoint_configs,
+        sync_endpoints,
+        sync_transform_jobs,
+        sync_model_package_groups,
+        sync_model_packages,
+    ):
+        patched_sync.assert_called_once_with(
+            mocker.ANY,
+            boto3_session,
+            expected_regions,
+            "123456789012",
+            1,
+            {"UPDATE_TAG": 1, "AWS_ID": "123456789012"},
+            {"me-south-1"},
+        )


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

This change reduces repeated SageMaker regional retries during AWS syncs.

It filters requested regions to SageMaker-supported regions, treats transient regional SageMaker failures as first-class skip signals, carries failed-region state forward across SageMaker submodules for the same account, and suppresses cleanup when any SageMaker region was transiently skipped so last-known-good data is preserved.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- Fixes #


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

None.


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- Added new unit tests


### Checklist

#### General
- [ ] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

