### PR TITLE
feat(ontology): Add Analysis Job to compute RESOLVED_IMAGE rel between Container and Images

### DIFF
--- a/cartography/data/jobs/analysis/resolved_image_analysis.json
+++ b/cartography/data/jobs/analysis/resolved_image_analysis.json
@@ -1,0 +1,21 @@
+{
+  "name": "Container RESOLVED_IMAGE analysis",
+  "statements": [
+    {
+      "__comment": "Cleanup: remove stale RESOLVED_IMAGE edges from previous runs.",
+      "query": "MATCH (:Container)-[r:RESOLVED_IMAGE]->(:Image) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r RETURN COUNT(*) AS TotalCompleted",
+      "iterative": true,
+      "iterationsize": 1000
+    },
+    {
+      "__comment": "Create RESOLVED_IMAGE by traversing the existing HAS_IMAGE edge from Container to Image. Excludes :ImageManifestList to guarantee the target is a deterministic single-platform image. HAS_IMAGE is created at ingest time by matching container runtime digest to image digest, so its existence is already a deterministic digest-level identification.",
+      "query": "MATCH (c:Container)-[:HAS_IMAGE]->(i:Image) WHERE NOT i:ImageManifestList MERGE (c)-[r:RESOLVED_IMAGE]->(i) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "iterative": false
+    },
+    {
+      "__comment": "Create RESOLVED_IMAGE for containers whose HAS_IMAGE points at an ImageManifestList. Traverses CONTAINS_IMAGE to the platform child :Image whose architecture matches the container's architecture_normalized, and only creates the edge when exactly one child matches (determinism guard).",
+      "query": "MATCH (c:Container)-[:HAS_IMAGE]->(:ImageManifestList)-[:CONTAINS_IMAGE]->(i:Image) WHERE c.architecture_normalized IS NOT NULL AND i._ont_architecture = c.architecture_normalized WITH c, collect(DISTINCT i) AS candidates WHERE size(candidates) = 1 WITH c, candidates[0] AS img MERGE (c)-[r:RESOLVED_IMAGE]->(img) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "iterative": false
+    }
+  ]
+}

--- a/cartography/intel/ontology/__init__.py
+++ b/cartography/intel/ontology/__init__.py
@@ -8,6 +8,7 @@ import cartography.intel.ontology.packages
 import cartography.intel.ontology.publicips
 import cartography.intel.ontology.users
 from cartography.config import Config
+from cartography.util import run_analysis_job
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -58,5 +59,12 @@ def run(neo4j_session: neo4j.Session, config: Config) -> None:
     cartography.intel.ontology.publicips.sync(
         neo4j_session,
         config.update_tag,
+        common_job_parameters,
+    )
+    # Create RESOLVED_IMAGE edges from :Container to the concrete single-platform :Image they are running.
+    # Runs last so the :Container / :Image semantic labels and HAS_IMAGE edges from every provider are in place.
+    run_analysis_job(
+        "resolved_image_analysis.json",
+        neo4j_session,
         common_job_parameters,
     )

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -36,6 +36,9 @@ IT -- IMAGE --> IM
 IML{{ImageManifestList}} -- CONTAINS_IMAGE --> IM
 IA{{ImageAttestation}} -- ATTESTS --> IM
 IM -- HAS_LAYER --> IL{{ImageLayer}}
+CT -- HAS_IMAGE --> IM
+CT -- HAS_IMAGE --> IML
+CT -- RESOLVED_IMAGE --> IM
 ```
 
 :::{note}
@@ -298,6 +301,20 @@ It generalizes concepts like ECS Containers, Kubernetes Containers, and Azure Co
 | _ont_region | The region or zone where the container is running. |
 | _ont_namespace | Namespace for logical isolation (e.g., Kubernetes namespace). |
 | _ont_health_status | The health status of the container. |
+
+#### Relationships
+
+- `Container` references the image it was asked to run via `HAS_IMAGE` (created at ingest time by matching container runtime digest to image digest). The target may be either a single-platform `Image` or an `ImageManifestList`:
+    ```
+    (:Container)-[:HAS_IMAGE]->(:Image)
+    (:Container)-[:HAS_IMAGE]->(:ImageManifestList)
+    ```
+- `Container` is connected to a concrete single platform `Image` that actually ran via `RESOLVED_IMAGE`. This edge is produced by the `resolved_image_analysis.json` analysis job, which runs after the ontology stage. It is only created when the target can be deterministically identified:
+    - When `HAS_IMAGE` already points at an `:Image` (not `:ImageManifestList`), `RESOLVED_IMAGE` is created directly.
+    - When `HAS_IMAGE` points at an `:ImageManifestList`, `RESOLVED_IMAGE` is created to the child `:Image` reached via `CONTAINS_IMAGE` whose architecture matches the container's `architecture_normalized`. If zero or more than one child match, no edge is created (determinism guard).
+    ```
+    (:Container)-[:RESOLVED_IMAGE]->(:Image)
+    ```
 
 
 ### ComputeCluster

--- a/tests/integration/cartography/intel/ontology/test_resolved_images.py
+++ b/tests/integration/cartography/intel/ontology/test_resolved_images.py
@@ -1,0 +1,91 @@
+"""
+Integration test for the Container -> Image RESOLVED_IMAGE analysis job.
+"""
+
+from cartography.util import run_analysis_job
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+def test_resolved_image_analysis_creates_rel_via_has_image(neo4j_session):
+    """The analysis job should create RESOLVED_IMAGE from :Container to :Image over an existing HAS_IMAGE edge."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (c:Container:KubernetesContainer {id: 'container-1'})
+        SET c._ont_image_digest = 'sha256:deadbeef',
+            c.lastupdated = $update_tag
+
+        MERGE (i:Image:ECRImage {id: 'sha256:deadbeef'})
+        SET i._ont_digest = 'sha256:deadbeef',
+            i.lastupdated = $update_tag
+
+        MERGE (c)-[r:HAS_IMAGE]->(i)
+        SET r.lastupdated = $update_tag
+        """,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    run_analysis_job(
+        "resolved_image_analysis.json",
+        neo4j_session,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "Container",
+        "id",
+        "Image",
+        "id",
+        "RESOLVED_IMAGE",
+    ) == {("container-1", "sha256:deadbeef")}
+
+
+def test_resolved_image_analysis_creates_rel_via_manifest_list(neo4j_session):
+    """The analysis job should resolve a Container pointed at an ImageManifestList to the architecture-matching child Image."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (c:Container:ECSContainer {id: 'container-ml-1'})
+        SET c.architecture_normalized = 'amd64',
+            c.lastupdated = $update_tag
+
+        MERGE (ml:ECRImage:ImageManifestList {id: 'sha256:manifestlist'})
+        SET ml.lastupdated = $update_tag
+
+        MERGE (child_amd64:Image:ECRImage {id: 'sha256:childamd64'})
+        SET child_amd64._ont_architecture = 'amd64',
+            child_amd64.lastupdated = $update_tag
+
+        MERGE (child_arm64:Image:ECRImage {id: 'sha256:childarm64'})
+        SET child_arm64._ont_architecture = 'arm64',
+            child_arm64.lastupdated = $update_tag
+
+        MERGE (c)-[r:HAS_IMAGE]->(ml)
+        SET r.lastupdated = $update_tag
+
+        MERGE (ml)-[r1:CONTAINS_IMAGE]->(child_amd64)
+        SET r1.lastupdated = $update_tag
+
+        MERGE (ml)-[r2:CONTAINS_IMAGE]->(child_arm64)
+        SET r2.lastupdated = $update_tag
+        """,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    run_analysis_job(
+        "resolved_image_analysis.json",
+        neo4j_session,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "Container",
+        "id",
+        "Image",
+        "id",
+        "RESOLVED_IMAGE",
+    ) == {("container-ml-1", "sha256:childamd64")}


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

- This PR adds an analysis job that traverses the HAS_IMAGE edge from Container to Image to create the RESOLVED_IMAGE relationship for both single platform images and those in a manifest list. 

### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- Integration test verifying creation of RESOLVED_IMAGE rels for both single platform images and those that are in manifest lists. 

<img width="1496" height="550" alt="image" src="https://github.com/user-attachments/assets/6fcf8fb1-766c-44b8-90ce-edf020cc1aed" />


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [x] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [x] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).



### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

- ECSContainers currently only have HAS_IMAGE with an ECRImage, adding the rest of the relevant registries in a follow up PR
- GCPCloudRunService and GCPCloudRunRevision do not have the necessary Container label to let this work for ontology. 

