### PR TITLE
feat(gcp): Update CloudRunJob and CloudRunRevision to have container ontology label

### DIFF
--- a/cartography/models/gcp/cloudrun/job.py
+++ b/cartography/models/gcp/cloudrun/job.py
@@ -123,7 +123,7 @@ class CloudRunJobToArtifactRegistryContainerImageRel(CartographyRelSchema):
 class GCPCloudRunJobSchema(CartographyNodeSchema):
     label: str = "GCPCloudRunJob"
     properties: GCPCloudRunJobProperties = GCPCloudRunJobProperties()
-    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Function"])
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Function", "Container"])
     sub_resource_relationship: ProjectToCloudRunJobRel = ProjectToCloudRunJobRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [

--- a/cartography/models/gcp/cloudrun/revision.py
+++ b/cartography/models/gcp/cloudrun/revision.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -143,6 +144,7 @@ class CloudRunRevisionToArtifactRegistryContainerImageRel(CartographyRelSchema):
 class GCPCloudRunRevisionSchema(CartographyNodeSchema):
     label: str = "GCPCloudRunRevision"
     properties: GCPCloudRunRevisionProperties = GCPCloudRunRevisionProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Container"])
     sub_resource_relationship: ProjectToCloudRunRevisionRel = (
         ProjectToCloudRunRevisionRel()
     )

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -1862,6 +1862,10 @@ Representation of a GCP [Cloud Run Revision](https://cloud.google.com/run/docs/r
     (GCPCloudRunRevision)-[:HAS_IMAGE]->(GitLabContainerImage)
     (GCPCloudRunRevision)-[:HAS_IMAGE]->(GCPArtifactRegistryContainerImage)
     ```
+  - GCPCloudRunRevisions are connected to the concrete single platform `Image` they actually ran via `RESOLVED_IMAGE`. This edge is produced by the `resolved_image_analysis.json` analysis job when the target can be deterministically identified. See [Container](../../ontology/schema.md#container) for the full semantics.
+    ```
+    (GCPCloudRunRevision)-[:RESOLVED_IMAGE]->(Image)
+    ```
 
 ### GCPCloudRunJob
 
@@ -1905,6 +1909,10 @@ Representation of a GCP [Cloud Run Job](https://cloud.google.com/run/docs/refere
     (GCPCloudRunJob)-[:HAS_IMAGE]->(ECRImage)
     (GCPCloudRunJob)-[:HAS_IMAGE]->(GitLabContainerImage)
     (GCPCloudRunJob)-[:HAS_IMAGE]->(GCPArtifactRegistryContainerImage)
+    ```
+  - GCPCloudRunJobs are connected to the concrete single platform `Image` they actually ran via `RESOLVED_IMAGE`. This edge is produced by the `resolved_image_analysis.json` analysis job when the target can be deterministically identified. See [Container](../../ontology/schema.md#container) for the full semantics.
+    ```
+    (GCPCloudRunJob)-[:RESOLVED_IMAGE]->(Image)
     ```
 
 ### GCPCloudRunExecution

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -1822,6 +1822,8 @@ Cloud Run services can split traffic across multiple revisions, so exact runtime
 
 Representation of a GCP [Cloud Run Revision](https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.services.revisions).
 
+> **Ontology Mapping**: This node has the extra label `Container` to enable cross-platform queries for container workloads (alongside `KubernetesContainer`, `ECSContainer`, `AzureGroupContainer`, etc.). Cloud Run revisions participate in the `RESOLVED_IMAGE` analysis job.
+
 | Field | Description |
 |---|---|
 | firstseen | Timestamp of when a sync job first discovered this node |
@@ -1865,7 +1867,7 @@ Representation of a GCP [Cloud Run Revision](https://cloud.google.com/run/docs/r
 
 Representation of a GCP [Cloud Run Job](https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.jobs).
 
-> **Ontology Mapping**: This node has the extra label `Function` to enable cross-platform queries for serverless functions across different systems (e.g., AWSLambda, AzureFunctionApp, GCPCloudFunction).
+> **Ontology Mapping**: This node has the extra labels `Function` and `Container`. `Function` enables cross-platform queries for serverless functions across different systems (e.g., AWSLambda, AzureFunctionApp, GCPCloudFunction). `Container` enables cross-platform container-workload queries (alongside `KubernetesContainer`, `ECSContainer`, etc.) and makes Cloud Run jobs participate in the `RESOLVED_IMAGE` analysis job. Cloud Run jobs legitimately inhabit both categories — they are container images run as on-demand functions.
 
 | Field | Description |
 |---|---|

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -288,7 +288,7 @@ Container is a semantic label.
 ```
 
 A container represents a lightweight, standalone executable package that includes everything needed to run an application.
-It generalizes concepts like ECS Containers, Kubernetes Containers, and Azure Container Instances.
+It generalizes concepts like ECS Containers, Kubernetes Containers, Azure Container Instances, and GCP Cloud Run Revisions / Jobs.
 
 | Field | Description |
 |-------|-------------|

--- a/tests/integration/cartography/intel/ontology/test_resolved_images.py
+++ b/tests/integration/cartography/intel/ontology/test_resolved_images.py
@@ -2,10 +2,22 @@
 Integration test for the Container -> Image RESOLVED_IMAGE analysis job.
 """
 
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.gcp.cloudrun.job as cloudrun_job
+import cartography.intel.gcp.cloudrun.revision as cloudrun_revision
 from cartography.util import run_analysis_job
+from tests.data.gcp.cloudrun import MOCK_JOB_WITH_DIGEST
+from tests.data.gcp.cloudrun import MOCK_REVISION_WITH_DIGEST
+from tests.data.gcp.cloudrun import TEST_JOB_PRIMARY_DIGEST
+from tests.data.gcp.cloudrun import TEST_REVISION_PRIMARY_DIGEST
 from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
+TEST_PROJECT_ID = "test-project"
+TEST_REVISION_ID = "projects/test-project/locations/us-central1/services/test-service/revisions/test-service-00001-abc"
+TEST_JOB_ID = "projects/test-project/locations/us-west1/jobs/test-job"
 
 
 def test_resolved_image_analysis_creates_rel_via_has_image(neo4j_session):
@@ -43,31 +55,86 @@ def test_resolved_image_analysis_creates_rel_via_has_image(neo4j_session):
     ) == {("container-1", "sha256:deadbeef")}
 
 
-def test_resolved_image_analysis_creates_rel_for_gcp_cloud_run_revision(neo4j_session):
-    """GCPCloudRunRevision carries the :Container label and should participate in RESOLVED_IMAGE."""
+@patch("cartography.intel.gcp.cloudrun.revision.get_revisions")
+@patch("cartography.intel.gcp.cloudrun.job.get_jobs")
+def test_resolved_image_analysis_creates_rel_for_cloud_run(
+    mock_get_jobs,
+    mock_get_revisions,
+    neo4j_session,
+):
+    """Run Cloud Run revision and job through the real load path, then verify RESOLVED_IMAGE is created.
+
+    This proves the schema's :Container label assignment and the analysis job work end-to-end.
+    """
     neo4j_session.run("MATCH (n) DETACH DELETE n")
+
+    # Arrange: prerequisite nodes
     neo4j_session.run(
-        """
-        MERGE (c:Container:GCPCloudRunRevision {id: 'revision-1'})
-        SET c._ont_image_digest = 'sha256:cloudrundigest',
-            c.lastupdated = $update_tag
-
-        MERGE (i:Image:GCPArtifactRegistryContainerImage {id: 'sha256:cloudrundigest'})
-        SET i._ont_digest = 'sha256:cloudrundigest',
-            i.lastupdated = $update_tag
-
-        MERGE (c)-[r:HAS_IMAGE]->(i)
-        SET r.lastupdated = $update_tag
-        """,
-        update_tag=TEST_UPDATE_TAG,
+        "MERGE (p:GCPProject {id: $pid}) SET p.lastupdated = $tag",
+        pid=TEST_PROJECT_ID,
+        tag=TEST_UPDATE_TAG,
+    )
+    neo4j_session.run(
+        "MERGE (sa:GCPServiceAccount {email: $e}) SET sa.lastupdated = $tag",
+        e="test-sa@test-project.iam.gserviceaccount.com",
+        tag=TEST_UPDATE_TAG,
+    )
+    neo4j_session.run(
+        "MERGE (sa:GCPServiceAccount {email: $e}) SET sa.lastupdated = $tag",
+        e="batch-sa@test-project.iam.gserviceaccount.com",
+        tag=TEST_UPDATE_TAG,
     )
 
+    # Arrange: image nodes that HAS_IMAGE will match (need :Image label for the analysis job)
+    neo4j_session.run(
+        """
+        MERGE (i:Image:ECRImage {id: $digest})
+        SET i.digest = $digest, i.lastupdated = $tag
+        """,
+        digest=TEST_REVISION_PRIMARY_DIGEST,
+        tag=TEST_UPDATE_TAG,
+    )
+    neo4j_session.run(
+        """
+        MERGE (i:Image:ECRImage {id: $digest})
+        SET i.digest = $digest, i.lastupdated = $tag
+        """,
+        digest=TEST_JOB_PRIMARY_DIGEST,
+        tag=TEST_UPDATE_TAG,
+    )
+
+    # Act: sync Cloud Run through the real load path
+    mock_get_revisions.return_value = MOCK_REVISION_WITH_DIGEST
+    mock_get_jobs.return_value = MOCK_JOB_WITH_DIGEST
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "PROJECT_ID": TEST_PROJECT_ID,
+    }
+    mock_client = MagicMock()
+
+    cloudrun_revision.sync_revisions(
+        neo4j_session,
+        mock_client,
+        TEST_PROJECT_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+    cloudrun_job.sync_jobs(
+        neo4j_session,
+        mock_client,
+        TEST_PROJECT_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    # Act: run the RESOLVED_IMAGE analysis job
     run_analysis_job(
         "resolved_image_analysis.json",
         neo4j_session,
         {"UPDATE_TAG": TEST_UPDATE_TAG},
     )
 
+    # Assert: RESOLVED_IMAGE edges exist for both revision and job
     assert check_rels(
         neo4j_session,
         "Container",
@@ -75,42 +142,10 @@ def test_resolved_image_analysis_creates_rel_for_gcp_cloud_run_revision(neo4j_se
         "Image",
         "id",
         "RESOLVED_IMAGE",
-    ) == {("revision-1", "sha256:cloudrundigest")}
-
-
-def test_resolved_image_analysis_creates_rel_for_gcp_cloud_run_job(neo4j_session):
-    """GCPCloudRunJob carries both :Function and :Container labels and should participate in RESOLVED_IMAGE."""
-    neo4j_session.run("MATCH (n) DETACH DELETE n")
-    neo4j_session.run(
-        """
-        MERGE (c:Container:Function:GCPCloudRunJob {id: 'job-1'})
-        SET c._ont_image_digest = 'sha256:jobdigest',
-            c.lastupdated = $update_tag
-
-        MERGE (i:Image:ECRImage {id: 'sha256:jobdigest'})
-        SET i._ont_digest = 'sha256:jobdigest',
-            i.lastupdated = $update_tag
-
-        MERGE (c)-[r:HAS_IMAGE]->(i)
-        SET r.lastupdated = $update_tag
-        """,
-        update_tag=TEST_UPDATE_TAG,
-    )
-
-    run_analysis_job(
-        "resolved_image_analysis.json",
-        neo4j_session,
-        {"UPDATE_TAG": TEST_UPDATE_TAG},
-    )
-
-    assert check_rels(
-        neo4j_session,
-        "Container",
-        "id",
-        "Image",
-        "id",
-        "RESOLVED_IMAGE",
-    ) == {("job-1", "sha256:jobdigest")}
+    ) == {
+        (TEST_REVISION_ID, TEST_REVISION_PRIMARY_DIGEST),
+        (TEST_JOB_ID, TEST_JOB_PRIMARY_DIGEST),
+    }
 
 
 def test_resolved_image_analysis_creates_rel_via_manifest_list(neo4j_session):

--- a/tests/integration/cartography/intel/ontology/test_resolved_images.py
+++ b/tests/integration/cartography/intel/ontology/test_resolved_images.py
@@ -43,6 +43,76 @@ def test_resolved_image_analysis_creates_rel_via_has_image(neo4j_session):
     ) == {("container-1", "sha256:deadbeef")}
 
 
+def test_resolved_image_analysis_creates_rel_for_gcp_cloud_run_revision(neo4j_session):
+    """GCPCloudRunRevision carries the :Container label and should participate in RESOLVED_IMAGE."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (c:Container:GCPCloudRunRevision {id: 'revision-1'})
+        SET c._ont_image_digest = 'sha256:cloudrundigest',
+            c.lastupdated = $update_tag
+
+        MERGE (i:Image:GCPArtifactRegistryContainerImage {id: 'sha256:cloudrundigest'})
+        SET i._ont_digest = 'sha256:cloudrundigest',
+            i.lastupdated = $update_tag
+
+        MERGE (c)-[r:HAS_IMAGE]->(i)
+        SET r.lastupdated = $update_tag
+        """,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    run_analysis_job(
+        "resolved_image_analysis.json",
+        neo4j_session,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "Container",
+        "id",
+        "Image",
+        "id",
+        "RESOLVED_IMAGE",
+    ) == {("revision-1", "sha256:cloudrundigest")}
+
+
+def test_resolved_image_analysis_creates_rel_for_gcp_cloud_run_job(neo4j_session):
+    """GCPCloudRunJob carries both :Function and :Container labels and should participate in RESOLVED_IMAGE."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (c:Container:Function:GCPCloudRunJob {id: 'job-1'})
+        SET c._ont_image_digest = 'sha256:jobdigest',
+            c.lastupdated = $update_tag
+
+        MERGE (i:Image:ECRImage {id: 'sha256:jobdigest'})
+        SET i._ont_digest = 'sha256:jobdigest',
+            i.lastupdated = $update_tag
+
+        MERGE (c)-[r:HAS_IMAGE]->(i)
+        SET r.lastupdated = $update_tag
+        """,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    run_analysis_job(
+        "resolved_image_analysis.json",
+        neo4j_session,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "Container",
+        "id",
+        "Image",
+        "id",
+        "RESOLVED_IMAGE",
+    ) == {("job-1", "sha256:jobdigest")}
+
+
 def test_resolved_image_analysis_creates_rel_via_manifest_list(neo4j_session):
     """The analysis job should resolve a Container pointed at an ImageManifestList to the architecture-matching child Image."""
     neo4j_session.run("MATCH (n) DETACH DELETE n")


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->
- This PR gives both GCPCloudRunJob and GCPCloudRunRevision the :Container Ontology label 

- The reason that both these nodes need to have the label is because in GCP world both these node types have container-image workloads. Since the analysis job that computes RESOLVED_IMAGE relises on the container label if either of these node types don't have the label it will ignore the HAS_IMAGE rels that originate from a GCPCloudRunJob/GCPCloudRunRevision and will will make those Container-Image workloads invisible. This double label situation gives us parity with how K8s, ECS, and AzureGroupContainers handle the RESOLVED_IMAGE rel. It just has 2 types of "containers" instead of one. 

### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- Closes gap in coverage mentioned in https://github.com/cartography-cncf/cartography/pull/2617


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->



### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- Integration Tests updated


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [x] New or updated unit/integration tests.


#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [x] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).
