### PR TITLE
fix(github): defer global cleanup and exclude inactive unmanaged accounts

### DIFF
--- a/cartography/intel/github/__init__.py
+++ b/cartography/intel/github/__init__.py
@@ -62,6 +62,8 @@ def start_github_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     common_job_parameters = {
         "UPDATE_TAG": config.update_tag,
     }
+    processed_any_org = False
+
     # run sync for the provided github organizations
     for auth_data in auth_tokens["organization"]:
         credential = make_credential(auth_data)
@@ -135,15 +137,18 @@ def start_github_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
                 workflows=all_workflows,
             )
 
-    # Clean up unscoped GitHub nodes once after all orgs have been refreshed.
-    cartography.intel.github.users.cleanup(neo4j_session, common_job_parameters)
-    cartography.intel.github.repos.cleanup_global_resources(
-        neo4j_session,
-        common_job_parameters,
-    )
+        processed_any_org = True
 
-    # DEPRECATED: one-time migration, run once per sync cycle (not per org)
-    cartography.intel.github.repos.cleanup_orphaned_github_branches(
-        neo4j_session,
-        common_job_parameters,
-    )
+    if processed_any_org:
+        # Clean up unscoped GitHub nodes once after all orgs have been refreshed.
+        cartography.intel.github.users.cleanup(neo4j_session, common_job_parameters)
+        cartography.intel.github.repos.cleanup_global_resources(
+            neo4j_session,
+            common_job_parameters,
+        )
+
+        # DEPRECATED: one-time migration, run once per sync cycle (not per org)
+        cartography.intel.github.repos.cleanup_orphaned_github_branches(
+            neo4j_session,
+            common_job_parameters,
+        )

--- a/cartography/intel/github/__init__.py
+++ b/cartography/intel/github/__init__.py
@@ -135,6 +135,13 @@ def start_github_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
                 workflows=all_workflows,
             )
 
+    # Clean up unscoped GitHub nodes once after all orgs have been refreshed.
+    cartography.intel.github.users.cleanup(neo4j_session, common_job_parameters)
+    cartography.intel.github.repos.cleanup_global_resources(
+        neo4j_session,
+        common_job_parameters,
+    )
+
     # DEPRECATED: one-time migration, run once per sync cycle (not per org)
     cartography.intel.github.repos.cleanup_orphaned_github_branches(
         neo4j_session,

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -1745,6 +1745,24 @@ def cleanup_python_requirements(
 
 
 @timeit
+def cleanup_global_resources(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: Dict[str, Any],
+) -> None:
+    """
+    Clean up stale GitHub resources that are not scoped to a single organization.
+
+    These schemas use global cleanup semantics, so running them after each org sync can
+    delete data for orgs that have not been processed yet in the current sync cycle.
+    """
+    cleanup_github_repos(neo4j_session, common_job_parameters)
+    cleanup_github_languages(neo4j_session, common_job_parameters)
+    cleanup_github_owners(neo4j_session, common_job_parameters)
+    cleanup_github_collaborators(neo4j_session, common_job_parameters)
+    cleanup_python_requirements(neo4j_session, common_job_parameters)
+
+
+@timeit
 def load(
     neo4j_session: neo4j.Session,
     common_job_parameters: Dict,
@@ -1889,7 +1907,6 @@ def sync(
 
     repo_data = transform(repos_json, direct_collabs, outside_collabs)
     load(neo4j_session, common_job_parameters, repo_data)
-    cleanup_github_repos(neo4j_session, common_job_parameters)
     owner_org_id = next(
         (
             repo["owner_org_id"]
@@ -1899,10 +1916,6 @@ def sync(
         f"https://github.com/{organization}",
     )
     cleanup_github_branches(neo4j_session, common_job_parameters, owner_org_id)
-    cleanup_github_languages(neo4j_session, common_job_parameters)
-    cleanup_github_owners(neo4j_session, common_job_parameters)
-    cleanup_github_collaborators(neo4j_session, common_job_parameters)
-    cleanup_python_requirements(neo4j_session, common_job_parameters)
 
     # Collect repository URLs that have dependencies for cleanup
     repo_urls_with_dependencies = list(

--- a/cartography/intel/github/users.py
+++ b/cartography/intel/github/users.py
@@ -277,7 +277,6 @@ def sync(
         org_data,
         common_job_parameters["UPDATE_TAG"],
     )
-    cleanup(neo4j_session, common_job_parameters)
 
     merge_module_sync_metadata(
         neo4j_session,

--- a/cartography/rules/data/rules/unmanaged_accounts.py
+++ b/cartography/rules/data/rules/unmanaged_accounts.py
@@ -12,18 +12,24 @@ _unmanaged_accounts_ontology = Fact(
     cypher_query="""
     MATCH (a:UserAccount)
     WHERE NOT (a)<-[:HAS_ACCOUNT]-(:User)
-    AND (a.active = true OR a.active IS NULL)
+    AND COALESCE(a._ont_active, true)
+    AND NOT COALESCE(a._ont_inactive, false)
+    AND COALESCE(a.active, true)
     return a.id as id, a._ont_email AS email, a._ont_source AS source
     """,
     cypher_visual_query="""
     MATCH (a:UserAccount)
     WHERE NOT (a)<-[:HAS_ACCOUNT]-(:User)
-    AND (a.active = true OR a.active IS NULL)
+    AND COALESCE(a._ont_active, true)
+    AND NOT COALESCE(a._ont_inactive, false)
+    AND COALESCE(a.active, true)
     return a
     """,
     cypher_count_query="""
     MATCH (a:UserAccount)
-    WHERE a.active = true OR a.active IS NULL
+    WHERE COALESCE(a._ont_active, true)
+    AND NOT COALESCE(a._ont_inactive, false)
+    AND COALESCE(a.active, true)
     RETURN COUNT(a) AS count
     """,
     module=Module.CROSS_CLOUD,

--- a/tests/integration/cartography/intel/github/test_users.py
+++ b/tests/integration/cartography/intel/github/test_users.py
@@ -181,6 +181,8 @@ def test_sync_with_cleanups(mock_owners, mock_users, neo4j_session):
         TEST_GITHUB_URL,
         TEST_GITHUB_ORG,
     )
+    cartography.intel.github.users.cleanup(neo4j_session, {"UPDATE_TAG": 200})
+
     # Assert that Marge is no longer an ADMIN of the GitHub org and the admin is now Homer
     assert check_rels(
         neo4j_session,

--- a/tests/unit/cartography/intel/github/test_github.py
+++ b/tests/unit/cartography/intel/github/test_github.py
@@ -87,7 +87,7 @@ def test_start_github_ingestion_skips_global_cleanup_when_no_orgs_configured(
     mock_cleanup_global_resources: Mock,
     mock_cleanup_orphaned_branches: Mock,
 ) -> None:
-    github_config = {"organization": []}
+    github_config: dict[str, list[dict[str, str]]] = {"organization": []}
     config = Mock(
         github_config=b64encode(json.dumps(github_config).encode()).decode(),
         update_tag=123,

--- a/tests/unit/cartography/intel/github/test_github.py
+++ b/tests/unit/cartography/intel/github/test_github.py
@@ -1,8 +1,10 @@
 import typing
+from base64 import b64encode
 from copy import deepcopy
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone as tz
+import json
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -16,6 +18,63 @@ from cartography.intel.github.util import fetch_all
 from cartography.intel.github.util import fetch_all_rest_api_pages
 from cartography.intel.github.util import handle_rate_limit_sleep
 from tests.data.github.rate_limit import RATE_LIMIT_RESPONSE_JSON
+
+
+@patch("cartography.intel.github.repos.cleanup_orphaned_github_branches")
+@patch("cartography.intel.github.repos.cleanup_global_resources")
+@patch("cartography.intel.github.users.cleanup")
+@patch("cartography.intel.github.supply_chain.sync")
+@patch("cartography.intel.github.repos.get", return_value=[])
+@patch("cartography.intel.github.commits.sync_github_commits")
+@patch("cartography.intel.github._get_repos_from_graph", return_value=[])
+@patch("cartography.intel.github.actions.sync", return_value=[])
+@patch("cartography.intel.github.teams.sync_github_teams")
+@patch("cartography.intel.github.repos.sync")
+@patch("cartography.intel.github.users.sync")
+@patch("cartography.intel.github.make_credential", side_effect=["token-1", "token-2"])
+def test_start_github_ingestion_defers_global_cleanup_until_after_all_orgs(
+    mock_make_credential: Mock,
+    mock_users_sync: Mock,
+    mock_repos_sync: Mock,
+    mock_teams_sync: Mock,
+    mock_actions_sync: Mock,
+    mock_get_repos_from_graph: Mock,
+    mock_sync_github_commits: Mock,
+    mock_get_repos: Mock,
+    mock_supply_chain_sync: Mock,
+    mock_users_cleanup: Mock,
+    mock_cleanup_global_resources: Mock,
+    mock_cleanup_orphaned_branches: Mock,
+) -> None:
+    github_config = {
+        "organization": [
+            {"name": "org-1", "url": "https://api.github.com/graphql"},
+            {"name": "org-2", "url": "https://api.github.com/graphql"},
+        ],
+    }
+    config = Mock(
+        github_config=b64encode(json.dumps(github_config).encode()).decode(),
+        update_tag=123,
+        github_commit_lookback_days=7,
+    )
+
+    from cartography.intel.github import start_github_ingestion
+
+    neo4j_session = Mock()
+    start_github_ingestion(neo4j_session, config)
+
+    assert mock_users_sync.call_count == 2
+    assert mock_repos_sync.call_count == 2
+    mock_users_cleanup.assert_called_once_with(neo4j_session, {"UPDATE_TAG": 123})
+    mock_cleanup_global_resources.assert_called_once_with(
+        neo4j_session,
+        {"UPDATE_TAG": 123},
+    )
+    mock_cleanup_orphaned_branches.assert_called_once_with(
+        neo4j_session,
+        {"UPDATE_TAG": 123},
+    )
+    assert mock_supply_chain_sync.call_count == 0
 
 
 @patch("cartography.intel.github.util.time.sleep")

--- a/tests/unit/cartography/intel/github/test_github.py
+++ b/tests/unit/cartography/intel/github/test_github.py
@@ -1,10 +1,10 @@
+import json
 import typing
 from base64 import b64encode
 from copy import deepcopy
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone as tz
-import json
 from unittest.mock import Mock
 from unittest.mock import patch
 
@@ -75,6 +75,34 @@ def test_start_github_ingestion_defers_global_cleanup_until_after_all_orgs(
         {"UPDATE_TAG": 123},
     )
     assert mock_supply_chain_sync.call_count == 0
+
+
+@patch("cartography.intel.github.repos.cleanup_orphaned_github_branches")
+@patch("cartography.intel.github.repos.cleanup_global_resources")
+@patch("cartography.intel.github.users.cleanup")
+@patch("cartography.intel.github.make_credential")
+def test_start_github_ingestion_skips_global_cleanup_when_no_orgs_configured(
+    mock_make_credential: Mock,
+    mock_users_cleanup: Mock,
+    mock_cleanup_global_resources: Mock,
+    mock_cleanup_orphaned_branches: Mock,
+) -> None:
+    github_config = {"organization": []}
+    config = Mock(
+        github_config=b64encode(json.dumps(github_config).encode()).decode(),
+        update_tag=123,
+        github_commit_lookback_days=7,
+    )
+
+    from cartography.intel.github import start_github_ingestion
+
+    neo4j_session = Mock()
+    start_github_ingestion(neo4j_session, config)
+
+    mock_make_credential.assert_not_called()
+    mock_users_cleanup.assert_not_called()
+    mock_cleanup_global_resources.assert_not_called()
+    mock_cleanup_orphaned_branches.assert_not_called()
 
 
 @patch("cartography.intel.github.util.time.sleep")

--- a/tests/unit/cartography/intel/github/test_repos.py
+++ b/tests/unit/cartography/intel/github/test_repos.py
@@ -361,10 +361,30 @@ def test_sync_cleans_up_branches_when_org_has_no_repos(
         "example-org",
     )
 
+    mock_cleanup_github_repos.assert_not_called()
     mock_cleanup_github_branches.assert_called_once_with(
         None,
         {"UPDATE_TAG": TEST_UPDATE_TAG},
         "https://github.com/example-org",
+    )
+    mock_cleanup_github_languages.assert_not_called()
+    mock_cleanup_github_owners.assert_not_called()
+    mock_cleanup_github_collaborators.assert_not_called()
+    mock_cleanup_python_requirements.assert_not_called()
+    mock_cleanup_github_dependencies.assert_called_once_with(
+        None,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+        [],
+    )
+    mock_cleanup_github_manifests.assert_called_once_with(
+        None,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+        [],
+    )
+    mock_cleanup_branch_protection_rules.assert_called_once_with(
+        None,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+        [],
     )
 
 
@@ -425,12 +445,12 @@ def test_sync_continues_when_privileged_fetch_fails(
     )
     assert mock_get_repo_collaborators.call_count == 2
     mock_load.assert_called_once()
-    mock_cleanup_github_repos.assert_called_once()
+    mock_cleanup_github_repos.assert_not_called()
     mock_cleanup_github_branches.assert_called_once()
-    mock_cleanup_github_languages.assert_called_once()
-    mock_cleanup_github_owners.assert_called_once()
-    mock_cleanup_github_collaborators.assert_called_once()
-    mock_cleanup_python_requirements.assert_called_once()
+    mock_cleanup_github_languages.assert_not_called()
+    mock_cleanup_github_owners.assert_not_called()
+    mock_cleanup_github_collaborators.assert_not_called()
+    mock_cleanup_python_requirements.assert_not_called()
     mock_cleanup_github_dependencies.assert_called_once()
     mock_cleanup_github_manifests.assert_called_once()
     mock_cleanup_branch_protection_rules.assert_called_once()

--- a/tests/unit/rules/test_unmanaged_accounts.py
+++ b/tests/unit/rules/test_unmanaged_accounts.py
@@ -1,0 +1,16 @@
+from cartography.rules.data.rules.unmanaged_accounts import unmanaged_accounts
+
+
+def test_unmanaged_account_rule_uses_normalized_activity_fields() -> None:
+    fact = unmanaged_accounts.facts[0]
+
+    assert "COALESCE(a._ont_active, true)" in fact.cypher_query
+    assert "NOT COALESCE(a._ont_inactive, false)" in fact.cypher_query
+    assert "COALESCE(a.active, true)" in fact.cypher_query
+
+
+def test_unmanaged_account_count_query_excludes_normalized_inactive_accounts() -> None:
+    fact = unmanaged_accounts.facts[0]
+
+    assert "COALESCE(a._ont_active, true)" in fact.cypher_count_query
+    assert "NOT COALESCE(a._ont_inactive, false)" in fact.cypher_count_query


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

### Summary
Defers GitHub global cleanup until all configured organizations have been processed so multi-org syncs do not delete data for orgs later in the same run.
Updates the `unmanaged-account` rule to exclude normalized inactive accounts, including deactivated Slack users that were being flagged because the rule only checked `a.active`.

### Related issues or links
- Fixes #

### How was this tested?
- `uv run --frozen pre-commit run --files cartography/rules/data/rules/unmanaged_accounts.py tests/unit/rules/test_unmanaged_accounts.py`
- `uv run --frozen pytest tests/unit/rules/test_unmanaged_accounts.py`

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.
- [ ] Screenshot showing the graph before and after changes.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

### Notes for reviewers
This branch already included the GitHub cleanup fix commits. The final commit on top narrows the unmanaged account rule so normalized inactive accounts are excluded.