### PR TITLE
fix(rules): exclude inactive unmanaged accounts

### DIFF
--- a/cartography/rules/data/rules/unmanaged_accounts.py
+++ b/cartography/rules/data/rules/unmanaged_accounts.py
@@ -12,18 +12,24 @@ _unmanaged_accounts_ontology = Fact(
     cypher_query="""
     MATCH (a:UserAccount)
     WHERE NOT (a)<-[:HAS_ACCOUNT]-(:User)
-    AND (a.active = true OR a.active IS NULL)
+    AND COALESCE(a._ont_active, true)
+    AND NOT COALESCE(a._ont_inactive, false)
+    AND COALESCE(a.active, true)
     return a.id as id, a._ont_email AS email, a._ont_source AS source
     """,
     cypher_visual_query="""
     MATCH (a:UserAccount)
     WHERE NOT (a)<-[:HAS_ACCOUNT]-(:User)
-    AND (a.active = true OR a.active IS NULL)
+    AND COALESCE(a._ont_active, true)
+    AND NOT COALESCE(a._ont_inactive, false)
+    AND COALESCE(a.active, true)
     return a
     """,
     cypher_count_query="""
     MATCH (a:UserAccount)
-    WHERE a.active = true OR a.active IS NULL
+    WHERE COALESCE(a._ont_active, true)
+    AND NOT COALESCE(a._ont_inactive, false)
+    AND COALESCE(a.active, true)
     RETURN COUNT(a) AS count
     """,
     module=Module.CROSS_CLOUD,

--- a/tests/unit/rules/test_unmanaged_accounts.py
+++ b/tests/unit/rules/test_unmanaged_accounts.py
@@ -1,0 +1,16 @@
+from cartography.rules.data.rules.unmanaged_accounts import unmanaged_accounts
+
+
+def test_unmanaged_account_rule_uses_normalized_activity_fields() -> None:
+    fact = unmanaged_accounts.facts[0]
+
+    assert "COALESCE(a._ont_active, true)" in fact.cypher_query
+    assert "NOT COALESCE(a._ont_inactive, false)" in fact.cypher_query
+    assert "COALESCE(a.active, true)" in fact.cypher_query
+
+
+def test_unmanaged_account_count_query_excludes_normalized_inactive_accounts() -> None:
+    fact = unmanaged_accounts.facts[0]
+
+    assert "COALESCE(a._ont_active, true)" in fact.cypher_count_query
+    assert "NOT COALESCE(a._ont_inactive, false)" in fact.cypher_count_query


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

### Summary
Updates the `unmanaged-account` rule to exclude normalized inactive accounts.
This prevents deactivated Slack users from being flagged when their inactivity is only represented through ontology-normalized fields like `_ont_inactive`.

### Related issues or links
- Fixes #

### How was this tested?
- `uv run --frozen pre-commit run --files cartography/rules/data/rules/unmanaged_accounts.py tests/unit/rules/test_unmanaged_accounts.py`
- `uv run --frozen pytest tests/unit/rules/test_unmanaged_accounts.py`

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.
- [ ] Screenshot showing the graph before and after changes.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

### Notes for reviewers
This PR only contains the rule fix and its focused unit test, separated from the existing GitHub cleanup PR.