### PR TITLE
feat(jamf): sync device inventory and memberships

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -791,7 +791,7 @@ class CLI:
                 str | None,
                 typer.Option(
                     "--jamf-base-uri",
-                    help="Jamf base URI, e.g. https://hostname.com/JSSResource.",
+                    help="Jamf base URI, e.g. https://hostname.jamfcloud.com.",
                     rich_help_panel=PANEL_JAMF,
                     hidden=PANEL_JAMF not in visible_panels,
                 ),

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -107,7 +107,7 @@ class Config:
     :type gcp_permission_relationships_file: str
     :param gcp_permission_relationships_file: File path for the GCP resource permission relationships file. Optional.
     :type jamf_base_uri: string
-    :param jamf_base_uri: Jamf data provider base URI, e.g. https://example.com/JSSResource. Optional.
+    :param jamf_base_uri: Jamf data provider base URI, e.g. https://example.jamfcloud.com. Optional.
     :type jamf_user: string
     :param jamf_user: User name used to authenticate to the Jamf data provider. Optional.
     :type jamf_password: string

--- a/cartography/intel/jamf/__init__.py
+++ b/cartography/intel/jamf/__init__.py
@@ -4,6 +4,7 @@ import neo4j
 
 from cartography.config import Config
 from cartography.intel.jamf import computers
+from cartography.intel.jamf.util import create_jamf_api_session
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -22,11 +23,18 @@ def start_jamf_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
         "UPDATE_TAG": config.update_tag,
         "TENANT_ID": config.jamf_base_uri,
     }
-    computers.sync(
-        neo4j_session,
+    api_session = create_jamf_api_session(
         config.jamf_base_uri,
         config.jamf_user,
         config.jamf_password,
-        config.update_tag,
-        common_job_parameters,
     )
+    try:
+        computers.sync(
+            neo4j_session,
+            api_session,
+            config.jamf_base_uri,
+            config.update_tag,
+            common_job_parameters,
+        )
+    finally:
+        api_session.close()

--- a/cartography/intel/jamf/__init__.py
+++ b/cartography/intel/jamf/__init__.py
@@ -4,6 +4,8 @@ import neo4j
 
 from cartography.config import Config
 from cartography.intel.jamf import computers
+from cartography.intel.jamf import groups
+from cartography.intel.jamf import mobile_devices
 from cartography.intel.jamf.util import create_jamf_api_session
 from cartography.util import timeit
 
@@ -29,7 +31,21 @@ def start_jamf_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
         config.jamf_password,
     )
     try:
+        groups.sync(
+            neo4j_session,
+            api_session,
+            config.jamf_base_uri,
+            config.update_tag,
+            common_job_parameters,
+        )
         computers.sync(
+            neo4j_session,
+            api_session,
+            config.jamf_base_uri,
+            config.update_tag,
+            common_job_parameters,
+        )
+        mobile_devices.sync(
             neo4j_session,
             api_session,
             config.jamf_base_uri,

--- a/cartography/intel/jamf/computers.py
+++ b/cartography/intel/jamf/computers.py
@@ -70,7 +70,7 @@ def transform(api_result: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
         result.append(
             {
-                "id": device.get("id"),
+                "id": device["id"],
                 "udid": device.get("udid"),
                 "name": general.get("name"),
                 "platform": general.get("platform"),

--- a/cartography/intel/jamf/computers.py
+++ b/cartography/intel/jamf/computers.py
@@ -9,6 +9,7 @@ from cartography.graph.job import GraphJob
 from cartography.intel.jamf.tenant import load_tenant
 from cartography.intel.jamf.util import get_http_status_code
 from cartography.intel.jamf.util import get_paginated_jamf_results
+from cartography.intel.jamf.util import normalize_group_id
 from cartography.models.jamf.computer import JamfComputerSchema
 from cartography.util import timeit
 
@@ -34,16 +35,6 @@ def _get_nested(data: dict[str, Any], *keys: str) -> Any:
             return None
         current = current.get(key)
     return current
-
-
-def _normalize_group_id(value: Any) -> int | str | None:
-    if value is None:
-        return None
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str) and value.isdigit():
-        return int(value)
-    return value
 
 
 @timeit
@@ -121,7 +112,7 @@ def transform(api_result: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "group_ids": [
                     group_id
                     for group_id in (
-                        _normalize_group_id(group.get("groupId"))
+                        normalize_group_id(group.get("groupId"))
                         for group in (device.get("groupMemberships") or [])
                     )
                     if group_id is not None

--- a/cartography/intel/jamf/computers.py
+++ b/cartography/intel/jamf/computers.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 import neo4j
+import requests
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
@@ -15,11 +16,10 @@ logger = logging.getLogger(__name__)
 
 @timeit
 def get(
+    api_session: requests.Session,
     jamf_base_uri: str,
-    jamf_user: str,
-    jamf_password: str,
 ) -> dict[str, Any]:
-    return call_jamf_api("/computergroups", jamf_base_uri, jamf_user, jamf_password)
+    return call_jamf_api("/computergroups", jamf_base_uri, api_session)
 
 
 def transform(api_result: dict[str, Any]) -> list[dict[str, Any]]:
@@ -78,14 +78,13 @@ def cleanup(
 @timeit
 def sync(
     neo4j_session: neo4j.Session,
+    api_session: requests.Session,
     jamf_base_uri: str,
-    jamf_user: str,
-    jamf_password: str,
     update_tag: int,
     common_job_parameters: dict[str, Any],
 ) -> None:
     # 1. GET
-    raw_data = get(jamf_base_uri, jamf_user, jamf_password)
+    raw_data = get(api_session, jamf_base_uri)
     # 2. TRANSFORM
     computer_groups = transform(raw_data)
     # 3. LOAD

--- a/cartography/intel/jamf/groups.py
+++ b/cartography/intel/jamf/groups.py
@@ -1,0 +1,155 @@
+import logging
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.jamf.tenant import load_tenant
+from cartography.intel.jamf.util import call_jamf_api
+from cartography.intel.jamf.util import get_http_status_code
+from cartography.intel.jamf.util import get_paginated_jamf_results
+from cartography.models.jamf.computergroup import JamfComputerGroupSchema
+from cartography.models.jamf.mobiledevicegroup import JamfMobileDeviceGroupSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_group_id(value: Any) -> int | str | None:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return value
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    jamf_base_uri: str,
+) -> list[dict[str, Any]]:
+    try:
+        return get_paginated_jamf_results(
+            "/api/v1/groups",
+            jamf_base_uri,
+            api_session,
+        )
+    except requests.HTTPError as err:
+        if get_http_status_code(err) not in {404, 405}:
+            raise
+
+        logger.info(
+            "Jamf: /api/v1/groups unavailable; falling back to legacy Classic API computer groups.",
+        )
+        classic_groups = call_jamf_api(
+            "/computergroups",
+            jamf_base_uri,
+            api_session,
+        ).get("computer_groups", [])
+        return [
+            {
+                "groupDescription": None,
+                "groupJamfProId": group.get("id"),
+                "groupName": group.get("name"),
+                "groupType": "COMPUTER",
+                "membershipCount": None,
+                "smart": group.get("is_smart"),
+            }
+            for group in classic_groups
+        ]
+
+
+def transform(
+    api_result: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    computer_groups: list[dict[str, Any]] = []
+    mobile_device_groups: list[dict[str, Any]] = []
+    for group in api_result:
+        transformed_group = {
+            "id": _normalize_group_id(group.get("groupJamfProId")),
+            "name": group.get("groupName"),
+            "description": group.get("groupDescription"),
+            "membership_count": group.get("membershipCount"),
+            "is_smart": group.get("smart"),
+        }
+        if group.get("groupType") == "MOBILE":
+            mobile_device_groups.append(transformed_group)
+        else:
+            computer_groups.append(transformed_group)
+    return computer_groups, mobile_device_groups
+
+
+def load_groups(
+    neo4j_session: neo4j.Session,
+    computer_groups: list[dict[str, Any]],
+    mobile_device_groups: list[dict[str, Any]],
+    tenant_id: str,
+    update_tag: int,
+) -> None:
+    load_tenant(neo4j_session, tenant_id, update_tag)
+    if computer_groups:
+        load(
+            neo4j_session,
+            JamfComputerGroupSchema(),
+            computer_groups,
+            lastupdated=update_tag,
+            TENANT_ID=tenant_id,
+        )
+    if mobile_device_groups:
+        load(
+            neo4j_session,
+            JamfMobileDeviceGroupSchema(),
+            mobile_device_groups,
+            lastupdated=update_tag,
+            TENANT_ID=tenant_id,
+        )
+
+
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(JamfComputerGroupSchema(), common_job_parameters).run(
+        neo4j_session,
+    )
+    GraphJob.from_node_schema(
+        JamfMobileDeviceGroupSchema(),
+        common_job_parameters,
+    ).run(neo4j_session)
+
+    # DEPRECATED: remove orphaned pre-migration computer groups without RESOURCE rel.
+    neo4j_session.run(
+        """
+        MATCH (n:JamfComputerGroup)
+        WHERE n.lastupdated <> $UPDATE_TAG
+          AND NOT (n)<-[:RESOURCE]-(:JamfTenant)
+        WITH n LIMIT $LIMIT_SIZE
+        DETACH DELETE n
+        """,
+        UPDATE_TAG=common_job_parameters["UPDATE_TAG"],
+        LIMIT_SIZE=100,
+    )
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    jamf_base_uri: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    raw_data = get(api_session, jamf_base_uri)
+    computer_groups, mobile_device_groups = transform(raw_data)
+    load_groups(
+        neo4j_session,
+        computer_groups,
+        mobile_device_groups,
+        jamf_base_uri,
+        update_tag,
+    )
+    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/jamf/groups.py
+++ b/cartography/intel/jamf/groups.py
@@ -58,8 +58,8 @@ def get(
         return [
             {
                 "groupDescription": None,
-                "groupJamfProId": group.get("id"),
-                "groupName": group.get("name"),
+                "groupJamfProId": group["id"],
+                "groupName": group["name"],
                 "groupType": "COMPUTER",
                 "membershipCount": None,
                 "smart": group.get("is_smart"),
@@ -68,8 +68,8 @@ def get(
         ] + [
             {
                 "groupDescription": None,
-                "groupJamfProId": group.get("id"),
-                "groupName": group.get("name"),
+                "groupJamfProId": group["id"],
+                "groupName": group["name"],
                 "groupType": "MOBILE",
                 "membershipCount": None,
                 "smart": group.get("is_smart"),
@@ -85,7 +85,7 @@ def transform(
     mobile_device_groups: list[dict[str, Any]] = []
     for group in api_result:
         transformed_group = {
-            "id": normalize_group_id(group.get("groupJamfProId")),
+            "id": normalize_group_id(group["groupJamfProId"]),
             "name": group.get("groupName"),
             "description": group.get("groupDescription"),
             "membership_count": group.get("membershipCount"),

--- a/cartography/intel/jamf/groups.py
+++ b/cartography/intel/jamf/groups.py
@@ -5,26 +5,18 @@ import neo4j
 import requests
 
 from cartography.client.core.tx import load
+from cartography.client.core.tx import run_write_query
 from cartography.graph.job import GraphJob
 from cartography.intel.jamf.tenant import load_tenant
 from cartography.intel.jamf.util import call_jamf_api
 from cartography.intel.jamf.util import get_http_status_code
 from cartography.intel.jamf.util import get_paginated_jamf_results
+from cartography.intel.jamf.util import normalize_group_id
 from cartography.models.jamf.computergroup import JamfComputerGroupSchema
 from cartography.models.jamf.mobiledevicegroup import JamfMobileDeviceGroupSchema
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
-
-
-def _normalize_group_id(value: Any) -> int | str | None:
-    if value is None:
-        return None
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str) and value.isdigit():
-        return int(value)
-    return value
 
 
 @timeit
@@ -43,13 +35,26 @@ def get(
             raise
 
         logger.info(
-            "Jamf: /api/v1/groups unavailable; falling back to legacy Classic API computer groups.",
+            "Jamf: /api/v1/groups unavailable; falling back to legacy Classic API group endpoints.",
         )
         classic_groups = call_jamf_api(
             "/computergroups",
             jamf_base_uri,
             api_session,
         ).get("computer_groups", [])
+        try:
+            classic_mobile_groups = call_jamf_api(
+                "/mobiledevicegroups",
+                jamf_base_uri,
+                api_session,
+            ).get("mobile_device_groups", [])
+        except requests.HTTPError as mobile_err:
+            if get_http_status_code(mobile_err) not in {404, 405}:
+                raise
+            logger.info(
+                "Jamf: Classic mobile device groups endpoint unavailable; skipping mobile groups in legacy fallback.",
+            )
+            classic_mobile_groups = []
         return [
             {
                 "groupDescription": None,
@@ -60,6 +65,16 @@ def get(
                 "smart": group.get("is_smart"),
             }
             for group in classic_groups
+        ] + [
+            {
+                "groupDescription": None,
+                "groupJamfProId": group.get("id"),
+                "groupName": group.get("name"),
+                "groupType": "MOBILE",
+                "membershipCount": None,
+                "smart": group.get("is_smart"),
+            }
+            for group in classic_mobile_groups
         ]
 
 
@@ -70,7 +85,7 @@ def transform(
     mobile_device_groups: list[dict[str, Any]] = []
     for group in api_result:
         transformed_group = {
-            "id": _normalize_group_id(group.get("groupJamfProId")),
+            "id": normalize_group_id(group.get("groupJamfProId")),
             "name": group.get("groupName"),
             "description": group.get("groupDescription"),
             "membership_count": group.get("membershipCount"),
@@ -122,7 +137,8 @@ def cleanup(
     ).run(neo4j_session)
 
     # DEPRECATED: remove orphaned pre-migration computer groups without RESOURCE rel.
-    neo4j_session.run(
+    run_write_query(
+        neo4j_session,
         """
         MATCH (n:JamfComputerGroup)
         WHERE n.lastupdated <> $UPDATE_TAG

--- a/cartography/intel/jamf/mobile_devices.py
+++ b/cartography/intel/jamf/mobile_devices.py
@@ -9,7 +9,7 @@ from cartography.graph.job import GraphJob
 from cartography.intel.jamf.tenant import load_tenant
 from cartography.intel.jamf.util import get_http_status_code
 from cartography.intel.jamf.util import get_paginated_jamf_results
-from cartography.models.jamf.computer import JamfComputerSchema
+from cartography.models.jamf.mobiledevice import JamfMobileDeviceSchema
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -18,22 +18,10 @@ _SECTION_PARAMS = {
     "section": [
         "GENERAL",
         "HARDWARE",
-        "OPERATING_SYSTEM",
         "SECURITY",
-        "DISK_ENCRYPTION",
-        "GROUP_MEMBERSHIPS",
         "USER_AND_LOCATION",
     ],
 }
-
-
-def _get_nested(data: dict[str, Any], *keys: str) -> Any:
-    current: Any = data
-    for key in keys:
-        if not isinstance(current, dict):
-            return None
-        current = current.get(key)
-    return current
 
 
 def _normalize_group_id(value: Any) -> int | str | None:
@@ -53,7 +41,7 @@ def get(
 ) -> list[dict[str, Any]]:
     try:
         return get_paginated_jamf_results(
-            "/api/v1/computers-inventory",
+            "/api/v2/mobile-devices/detail",
             jamf_base_uri,
             api_session,
             params=_SECTION_PARAMS,
@@ -62,7 +50,7 @@ def get(
         if get_http_status_code(err) not in {404, 405}:
             raise
         logger.info(
-            "Jamf: /api/v1/computers-inventory unavailable; skipping computer inventory sync.",
+            "Jamf: /api/v2/mobile-devices/detail unavailable; skipping mobile device sync.",
         )
         return []
 
@@ -72,57 +60,39 @@ def transform(api_result: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for device in api_result:
         general = device.get("general") or {}
         hardware = device.get("hardware") or {}
-        operating_system = device.get("operatingSystem") or {}
         security = device.get("security") or {}
-        disk_encryption = device.get("diskEncryption") or {}
         user_and_location = device.get("userAndLocation") or {}
 
         result.append(
             {
-                "id": device.get("id"),
-                "udid": device.get("udid"),
-                "name": general.get("name"),
-                "platform": general.get("platform"),
-                "report_date": general.get("reportDate"),
-                "last_contact_time": general.get("lastContactTime"),
-                "site_name": _get_nested(general, "site", "name"),
+                "id": device.get("mobileDeviceId"),
+                "display_name": general.get("displayName"),
+                "managed": general.get("managed"),
                 "supervised": general.get("supervised"),
-                "user_approved_mdm": general.get("userApprovedMdm"),
-                "declarative_device_management_enabled": general.get(
-                    "declarativeDeviceManagementEnabled"
-                ),
-                "enrolled_via_automated_device_enrollment": general.get(
-                    "enrolledViaAutomatedDeviceEnrollment"
-                ),
-                "remote_management_managed": _get_nested(
-                    general,
-                    "remoteManagement",
-                    "managed",
-                ),
+                "last_inventory_update_date": general.get("lastInventoryUpdateDate"),
+                "last_enrolled_date": general.get("lastEnrolledDate"),
+                "platform": device.get("deviceType"),
+                "os_version": general.get("osVersion"),
+                "os_build": general.get("osBuild"),
                 "serial_number": hardware.get("serialNumber"),
                 "model": hardware.get("model"),
                 "model_identifier": hardware.get("modelIdentifier"),
-                "os_name": operating_system.get("name"),
-                "os_version": operating_system.get("version"),
-                "os_build": operating_system.get("build"),
-                "filevault_enabled": disk_encryption.get("fileVault2Enabled"),
-                "firewall_enabled": security.get("firewallEnabled"),
-                "gatekeeper_status": security.get("gatekeeperStatus"),
-                "sip_status": security.get("sipStatus"),
-                "secure_boot_level": security.get("secureBootLevel"),
                 "activation_lock_enabled": security.get("activationLockEnabled"),
-                "recovery_lock_enabled": security.get("recoveryLockEnabled"),
-                "bootstrap_token_escrowed_status": security.get(
-                    "bootstrapTokenEscrowedStatus"
-                ),
+                "bootstrap_token_escrowed": security.get("bootstrapTokenEscrowed"),
+                "data_protected": security.get("dataProtected"),
+                "hardware_encryption": security.get("hardwareEncryption"),
+                "jailbreak_detected": security.get("jailBreakDetected"),
+                "lost_mode_enabled": security.get("lostModeEnabled"),
+                "passcode_compliant": security.get("passcodeCompliant"),
+                "passcode_present": security.get("passcodePresent"),
                 "username": user_and_location.get("username"),
-                "user_real_name": user_and_location.get("realname"),
-                "email": user_and_location.get("email"),
+                "user_real_name": user_and_location.get("realName"),
+                "email": user_and_location.get("emailAddress"),
                 "group_ids": [
                     group_id
                     for group_id in (
                         _normalize_group_id(group.get("groupId"))
-                        for group in (device.get("groupMemberships") or [])
+                        for group in (device.get("groups") or [])
                     )
                     if group_id is not None
                 ],
@@ -131,7 +101,7 @@ def transform(api_result: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return result
 
 
-def load_computers(
+def load_mobile_devices(
     neo4j_session: neo4j.Session,
     data: list[dict[str, Any]],
     tenant_id: str,
@@ -142,7 +112,7 @@ def load_computers(
         return
     load(
         neo4j_session,
-        JamfComputerSchema(),
+        JamfMobileDeviceSchema(),
         data,
         lastupdated=update_tag,
         TENANT_ID=tenant_id,
@@ -150,9 +120,10 @@ def load_computers(
 
 
 def cleanup(
-    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
 ) -> None:
-    GraphJob.from_node_schema(JamfComputerSchema(), common_job_parameters).run(
+    GraphJob.from_node_schema(JamfMobileDeviceSchema(), common_job_parameters).run(
         neo4j_session,
     )
 
@@ -166,6 +137,6 @@ def sync(
     common_job_parameters: dict[str, Any],
 ) -> None:
     raw_data = get(api_session, jamf_base_uri)
-    computers = transform(raw_data)
-    load_computers(neo4j_session, computers, jamf_base_uri, update_tag)
+    mobile_devices = transform(raw_data)
+    load_mobile_devices(neo4j_session, mobile_devices, jamf_base_uri, update_tag)
     cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/jamf/mobile_devices.py
+++ b/cartography/intel/jamf/mobile_devices.py
@@ -57,7 +57,7 @@ def transform(api_result: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
         result.append(
             {
-                "id": device.get("mobileDeviceId"),
+                "id": device["mobileDeviceId"],
                 "display_name": general.get("displayName"),
                 "managed": general.get("managed"),
                 "supervised": general.get("supervised"),

--- a/cartography/intel/jamf/mobile_devices.py
+++ b/cartography/intel/jamf/mobile_devices.py
@@ -9,6 +9,7 @@ from cartography.graph.job import GraphJob
 from cartography.intel.jamf.tenant import load_tenant
 from cartography.intel.jamf.util import get_http_status_code
 from cartography.intel.jamf.util import get_paginated_jamf_results
+from cartography.intel.jamf.util import normalize_group_id
 from cartography.models.jamf.mobiledevice import JamfMobileDeviceSchema
 from cartography.util import timeit
 
@@ -19,19 +20,10 @@ _SECTION_PARAMS = {
         "GENERAL",
         "HARDWARE",
         "SECURITY",
+        "GROUPS",
         "USER_AND_LOCATION",
     ],
 }
-
-
-def _normalize_group_id(value: Any) -> int | str | None:
-    if value is None:
-        return None
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str) and value.isdigit():
-        return int(value)
-    return value
 
 
 @timeit
@@ -91,7 +83,7 @@ def transform(api_result: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "group_ids": [
                     group_id
                     for group_id in (
-                        _normalize_group_id(group.get("groupId"))
+                        normalize_group_id(group.get("groupId"))
                         for group in (device.get("groups") or [])
                     )
                     if group_id is not None

--- a/cartography/intel/jamf/tenant.py
+++ b/cartography/intel/jamf/tenant.py
@@ -1,0 +1,17 @@
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.models.jamf.tenant import JamfTenantSchema
+
+
+def load_tenant(
+    neo4j_session: neo4j.Session,
+    tenant_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        JamfTenantSchema(),
+        [{"id": tenant_id}],
+        lastupdated=update_tag,
+    )

--- a/cartography/intel/jamf/util.py
+++ b/cartography/intel/jamf/util.py
@@ -42,6 +42,7 @@ def create_jamf_api_session(
         )
     except requests.exceptions.Timeout:
         logger.warning("Jamf: requests.post('%s') timed out.", token_uri)
+        session.close()
         raise
 
     if response.ok:
@@ -59,8 +60,13 @@ def create_jamf_api_session(
         )
         return session
 
-    response.raise_for_status()
-    return session
+    try:
+        response.raise_for_status()
+    except requests.HTTPError:
+        session.close()
+        raise
+
+    raise AssertionError("unreachable")
 
 
 @timeit

--- a/cartography/intel/jamf/util.py
+++ b/cartography/intel/jamf/util.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 _TIMEOUT = (60, 60)
 _CLASSIC_API_PATH = "/JSSResource"
 _AUTH_TOKEN_PATH = "/api/v1/auth/token"
+_DEFAULT_PAGE_SIZE = 100
 
 
 def _normalize_jamf_base_uri(jamf_base_uri: str) -> str:
@@ -22,6 +23,18 @@ def _get_jamf_instance_uri(jamf_base_uri: str) -> str:
     if normalized_uri.endswith(_CLASSIC_API_PATH):
         return normalized_uri[: -len(_CLASSIC_API_PATH)]
     return normalized_uri
+
+
+def _get_request_base_uri(jamf_base_uri: str, api_path: str) -> str:
+    if api_path.startswith("/api/"):
+        return _get_jamf_instance_uri(jamf_base_uri)
+    return _normalize_jamf_base_uri(jamf_base_uri)
+
+
+def get_http_status_code(err: requests.HTTPError) -> int | None:
+    if err.response is None:
+        return None
+    return err.response.status_code
 
 
 @timeit
@@ -74,12 +87,14 @@ def call_jamf_api(
     api_and_parameters: str,
     jamf_base_uri: str,
     api_session: requests.Session,
+    params: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    uri = _normalize_jamf_base_uri(jamf_base_uri) + api_and_parameters
+    uri = _get_request_base_uri(jamf_base_uri, api_and_parameters) + api_and_parameters
     try:
         response = api_session.get(
             uri,
             timeout=_TIMEOUT,
+            params=params,
         )
     except requests.exceptions.Timeout:
         # Add context and re-raise for callers to handle
@@ -88,3 +103,34 @@ def call_jamf_api(
     # if call failed, use requests library to raise an exception
     response.raise_for_status()
     return response.json()
+
+
+@timeit
+def get_paginated_jamf_results(
+    api_path: str,
+    jamf_base_uri: str,
+    api_session: requests.Session,
+    params: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    page = 0
+    results: list[dict[str, Any]] = []
+
+    while True:
+        page_params = {"page": page, "page-size": _DEFAULT_PAGE_SIZE}
+        if params:
+            page_params.update(params)
+
+        response = call_jamf_api(
+            api_path,
+            jamf_base_uri,
+            api_session,
+            params=page_params,
+        )
+        page_results = response.get("results", [])
+        results.extend(page_results)
+
+        total_count = response.get("totalCount")
+        if total_count is None or len(results) >= total_count or not page_results:
+            return results
+
+        page += 1

--- a/cartography/intel/jamf/util.py
+++ b/cartography/intel/jamf/util.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Any
+from typing import NoReturn
 
 import requests
 import requests.auth
@@ -26,9 +27,12 @@ def _get_jamf_instance_uri(jamf_base_uri: str) -> str:
 
 
 def _get_request_base_uri(jamf_base_uri: str, api_path: str) -> str:
+    normalized_uri = _normalize_jamf_base_uri(jamf_base_uri)
     if api_path.startswith("/api/"):
-        return _get_jamf_instance_uri(jamf_base_uri)
-    return _normalize_jamf_base_uri(jamf_base_uri)
+        return _get_jamf_instance_uri(normalized_uri)
+    if normalized_uri.endswith(_CLASSIC_API_PATH):
+        return normalized_uri
+    return f"{normalized_uri}{_CLASSIC_API_PATH}"
 
 
 def get_http_status_code(err: requests.HTTPError) -> int | None:
@@ -47,6 +51,11 @@ def normalize_group_id(value: Any) -> int | str | None:
     if isinstance(value, str) and value.isdigit():
         return int(value)
     return value
+
+
+def _raise_http_status(response: requests.Response) -> NoReturn:
+    response.raise_for_status()
+    raise RuntimeError("requests.Response.raise_for_status() unexpectedly returned")
 
 
 @timeit
@@ -88,14 +97,10 @@ def create_jamf_api_session(
         return session
 
     try:
-        response.raise_for_status()
+        _raise_http_status(response)
     except requests.HTTPError:
         session.close()
         raise
-
-    raise RuntimeError(
-        "Jamf auth token request failed without returning a handled status"
-    )
 
 
 @timeit

--- a/cartography/intel/jamf/util.py
+++ b/cartography/intel/jamf/util.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+import requests
 import requests.auth
 
 from cartography.util import timeit
@@ -8,27 +9,75 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 # Connect and read timeouts of 60 seconds each; see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
 _TIMEOUT = (60, 60)
+_CLASSIC_API_PATH = "/JSSResource"
+_AUTH_TOKEN_PATH = "/api/v1/auth/token"
+
+
+def _normalize_jamf_base_uri(jamf_base_uri: str) -> str:
+    return jamf_base_uri.rstrip("/")
+
+
+def _get_jamf_instance_uri(jamf_base_uri: str) -> str:
+    normalized_uri = _normalize_jamf_base_uri(jamf_base_uri)
+    if normalized_uri.endswith(_CLASSIC_API_PATH):
+        return normalized_uri[: -len(_CLASSIC_API_PATH)]
+    return normalized_uri
+
+
+@timeit
+def create_jamf_api_session(
+    jamf_base_uri: str,
+    jamf_user: str,
+    jamf_password: str,
+) -> requests.Session:
+    session = requests.Session()
+    session.headers.update({"Accept": "application/json"})
+    jamf_auth = requests.auth.HTTPBasicAuth(jamf_user, jamf_password)
+    token_uri = f"{_get_jamf_instance_uri(jamf_base_uri)}{_AUTH_TOKEN_PATH}"
+    try:
+        response = session.post(
+            token_uri,
+            auth=jamf_auth,
+            timeout=_TIMEOUT,
+        )
+    except requests.exceptions.Timeout:
+        logger.warning("Jamf: requests.post('%s') timed out.", token_uri)
+        raise
+
+    if response.ok:
+        session.headers.update(
+            {"Authorization": f"Bearer {response.json()['token']}"},
+        )
+        logger.info("Jamf: authenticated to the Classic API using bearer token auth.")
+        return session
+
+    if response.status_code in {404, 405}:
+        session.auth = jamf_auth
+        logger.info(
+            "Jamf: auth token endpoint unavailable at '%s'; falling back to legacy Basic auth.",
+            token_uri,
+        )
+        return session
+
+    response.raise_for_status()
+    return session
 
 
 @timeit
 def call_jamf_api(
     api_and_parameters: str,
     jamf_base_uri: str,
-    jamf_user: str,
-    jamf_password: str,
+    api_session: requests.Session,
 ) -> dict[str, Any]:
-    uri = jamf_base_uri + api_and_parameters
-    jamf_auth = requests.auth.HTTPBasicAuth(jamf_user, jamf_password)
+    uri = _normalize_jamf_base_uri(jamf_base_uri) + api_and_parameters
     try:
-        response = requests.get(
+        response = api_session.get(
             uri,
-            auth=jamf_auth,
-            headers={"Accept": "application/json"},
             timeout=_TIMEOUT,
         )
     except requests.exceptions.Timeout:
         # Add context and re-raise for callers to handle
-        logger.warning(f"Jamf: requests.get('{uri}') timed out.")
+        logger.warning("Jamf: requests.get('%s') timed out.", uri)
         raise
     # if call failed, use requests library to raise an exception
     response.raise_for_status()

--- a/cartography/intel/jamf/util.py
+++ b/cartography/intel/jamf/util.py
@@ -71,6 +71,8 @@ def create_jamf_api_session(
         raise
 
     if response.ok:
+        # TODO: Jamf bearer tokens expire after a short TTL. Refresh or keep alive the
+        # token if this sync grows enough for long-running sessions to matter.
         session.headers.update(
             {"Authorization": f"Bearer {response.json()['token']}"},
         )
@@ -91,7 +93,9 @@ def create_jamf_api_session(
         session.close()
         raise
 
-    raise AssertionError("unreachable")
+    raise RuntimeError(
+        "Jamf auth token request failed without returning a handled status"
+    )
 
 
 @timeit

--- a/cartography/intel/jamf/util.py
+++ b/cartography/intel/jamf/util.py
@@ -37,6 +37,18 @@ def get_http_status_code(err: requests.HTTPError) -> int | None:
     return err.response.status_code
 
 
+def normalize_group_id(value: Any) -> int | str | None:
+    # Jamf's modern APIs return numeric group IDs as strings, while the Classic API
+    # fallback returns ints. Normalize both to ints for stable node matching.
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return value
+
+
 @timeit
 def create_jamf_api_session(
     jamf_base_uri: str,

--- a/cartography/models/jamf/computer.py
+++ b/cartography/models/jamf/computer.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class JamfComputerNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    udid: PropertyRef = PropertyRef("udid")
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    serial_number: PropertyRef = PropertyRef("serial_number", extra_index=True)
+    model: PropertyRef = PropertyRef("model")
+    model_identifier: PropertyRef = PropertyRef("model_identifier")
+    platform: PropertyRef = PropertyRef("platform")
+    os_name: PropertyRef = PropertyRef("os_name")
+    os_version: PropertyRef = PropertyRef("os_version")
+    os_build: PropertyRef = PropertyRef("os_build")
+    report_date: PropertyRef = PropertyRef("report_date")
+    last_contact_time: PropertyRef = PropertyRef("last_contact_time")
+    site_name: PropertyRef = PropertyRef("site_name")
+    supervised: PropertyRef = PropertyRef("supervised")
+    user_approved_mdm: PropertyRef = PropertyRef("user_approved_mdm")
+    declarative_device_management_enabled: PropertyRef = PropertyRef(
+        "declarative_device_management_enabled"
+    )
+    enrolled_via_automated_device_enrollment: PropertyRef = PropertyRef(
+        "enrolled_via_automated_device_enrollment"
+    )
+    remote_management_managed: PropertyRef = PropertyRef("remote_management_managed")
+    filevault_enabled: PropertyRef = PropertyRef("filevault_enabled")
+    firewall_enabled: PropertyRef = PropertyRef("firewall_enabled")
+    gatekeeper_status: PropertyRef = PropertyRef("gatekeeper_status")
+    sip_status: PropertyRef = PropertyRef("sip_status")
+    secure_boot_level: PropertyRef = PropertyRef("secure_boot_level")
+    activation_lock_enabled: PropertyRef = PropertyRef("activation_lock_enabled")
+    recovery_lock_enabled: PropertyRef = PropertyRef("recovery_lock_enabled")
+    bootstrap_token_escrowed_status: PropertyRef = PropertyRef(
+        "bootstrap_token_escrowed_status"
+    )
+    username: PropertyRef = PropertyRef("username")
+    user_real_name: PropertyRef = PropertyRef("user_real_name")
+    email: PropertyRef = PropertyRef("email")
+
+
+@dataclass(frozen=True)
+class JamfComputerToTenantRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class JamfComputerToTenantRel(CartographyRelSchema):
+    target_node_label: str = "JamfTenant"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("TENANT_ID", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: JamfComputerToTenantRelProperties = JamfComputerToTenantRelProperties()
+
+
+@dataclass(frozen=True)
+class JamfComputerToGroupRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class JamfComputerToGroupRel(CartographyRelSchema):
+    target_node_label: str = "JamfComputerGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("group_ids", one_to_many=True)}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MEMBER_OF"
+    properties: JamfComputerToGroupRelProperties = JamfComputerToGroupRelProperties()
+
+
+@dataclass(frozen=True)
+class JamfComputerSchema(CartographyNodeSchema):
+    label: str = "JamfComputer"
+    properties: JamfComputerNodeProperties = JamfComputerNodeProperties()
+    sub_resource_relationship: JamfComputerToTenantRel = JamfComputerToTenantRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [JamfComputerToGroupRel()]
+    )

--- a/cartography/models/jamf/mobiledevice.py
+++ b/cartography/models/jamf/mobiledevice.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class JamfMobileDeviceNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    display_name: PropertyRef = PropertyRef("display_name", extra_index=True)
+    managed: PropertyRef = PropertyRef("managed")
+    supervised: PropertyRef = PropertyRef("supervised")
+    last_inventory_update_date: PropertyRef = PropertyRef("last_inventory_update_date")
+    last_enrolled_date: PropertyRef = PropertyRef("last_enrolled_date")
+    platform: PropertyRef = PropertyRef("platform")
+    os_version: PropertyRef = PropertyRef("os_version")
+    os_build: PropertyRef = PropertyRef("os_build")
+    serial_number: PropertyRef = PropertyRef("serial_number", extra_index=True)
+    model: PropertyRef = PropertyRef("model")
+    model_identifier: PropertyRef = PropertyRef("model_identifier")
+    activation_lock_enabled: PropertyRef = PropertyRef("activation_lock_enabled")
+    bootstrap_token_escrowed: PropertyRef = PropertyRef("bootstrap_token_escrowed")
+    data_protected: PropertyRef = PropertyRef("data_protected")
+    hardware_encryption: PropertyRef = PropertyRef("hardware_encryption")
+    jailbreak_detected: PropertyRef = PropertyRef("jailbreak_detected")
+    lost_mode_enabled: PropertyRef = PropertyRef("lost_mode_enabled")
+    passcode_compliant: PropertyRef = PropertyRef("passcode_compliant")
+    passcode_present: PropertyRef = PropertyRef("passcode_present")
+    username: PropertyRef = PropertyRef("username")
+    user_real_name: PropertyRef = PropertyRef("user_real_name")
+    email: PropertyRef = PropertyRef("email")
+
+
+@dataclass(frozen=True)
+class JamfMobileDeviceToTenantRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class JamfMobileDeviceToTenantRel(CartographyRelSchema):
+    target_node_label: str = "JamfTenant"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("TENANT_ID", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: JamfMobileDeviceToTenantRelProperties = (
+        JamfMobileDeviceToTenantRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class JamfMobileDeviceToGroupRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class JamfMobileDeviceToGroupRel(CartographyRelSchema):
+    target_node_label: str = "JamfMobileDeviceGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("group_ids", one_to_many=True)}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MEMBER_OF"
+    properties: JamfMobileDeviceToGroupRelProperties = (
+        JamfMobileDeviceToGroupRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class JamfMobileDeviceSchema(CartographyNodeSchema):
+    label: str = "JamfMobileDevice"
+    properties: JamfMobileDeviceNodeProperties = JamfMobileDeviceNodeProperties()
+    sub_resource_relationship: JamfMobileDeviceToTenantRel = (
+        JamfMobileDeviceToTenantRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [JamfMobileDeviceToGroupRel()]
+    )

--- a/cartography/models/jamf/mobiledevicegroup.py
+++ b/cartography/models/jamf/mobiledevicegroup.py
@@ -11,7 +11,7 @@ from cartography.models.core.relationships import TargetNodeMatcher
 
 
 @dataclass(frozen=True)
-class JamfComputerGroupNodeProperties(CartographyNodeProperties):
+class JamfMobileDeviceGroupNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef("id")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
     name: PropertyRef = PropertyRef("name")
@@ -21,31 +21,29 @@ class JamfComputerGroupNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class JamfTenantToComputerGroupRelProperties(CartographyRelProperties):
+class JamfTenantToMobileDeviceGroupRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class JamfTenantToComputerGroupRel(CartographyRelSchema):
-    """
-    (:JamfTenant)-[:RESOURCE]->(:JamfComputerGroup)
-    """
-
+class JamfTenantToMobileDeviceGroupRel(CartographyRelSchema):
     target_node_label: str = "JamfTenant"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("TENANT_ID", set_in_kwargs=True)},
+        {"id": PropertyRef("TENANT_ID", set_in_kwargs=True)}
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: JamfTenantToComputerGroupRelProperties = (
-        JamfTenantToComputerGroupRelProperties()
+    properties: JamfTenantToMobileDeviceGroupRelProperties = (
+        JamfTenantToMobileDeviceGroupRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class JamfComputerGroupSchema(CartographyNodeSchema):
-    label: str = "JamfComputerGroup"
-    properties: JamfComputerGroupNodeProperties = JamfComputerGroupNodeProperties()
-    sub_resource_relationship: JamfTenantToComputerGroupRel = (
-        JamfTenantToComputerGroupRel()
+class JamfMobileDeviceGroupSchema(CartographyNodeSchema):
+    label: str = "JamfMobileDeviceGroup"
+    properties: JamfMobileDeviceGroupNodeProperties = (
+        JamfMobileDeviceGroupNodeProperties()
+    )
+    sub_resource_relationship: JamfTenantToMobileDeviceGroupRel = (
+        JamfTenantToMobileDeviceGroupRel()
     )

--- a/cartography/models/ontology/device.py
+++ b/cartography/models/ontology/device.py
@@ -390,21 +390,6 @@ class DeviceToJamfComputerHostnameMatchLink(CartographyRelSchema):
     properties: DeviceHostnameMatchLinkProperties = DeviceHostnameMatchLinkProperties()
 
 
-@dataclass(frozen=True)
-class DeviceToJamfMobileDeviceHostnameMatchLink(CartographyRelSchema):
-    target_node_label: str = "JamfMobileDevice"
-    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"display_name": PropertyRef("hostname")},
-    )
-    source_node_label: str = "Device"
-    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
-        {"hostname": PropertyRef("hostname")},
-    )
-    direction: LinkDirection = LinkDirection.OUTWARD
-    rel_label: str = "OBSERVED_AS"
-    properties: DeviceHostnameMatchLinkProperties = DeviceHostnameMatchLinkProperties()
-
-
 # Configuration for hostname matchlinks used by the intel module.
 # Each tuple: (target_label, target_hostname_field, matchlink_schema)
 HOSTNAME_MATCHLINKS: list[tuple[str, str, CartographyRelSchema]] = [
@@ -431,9 +416,4 @@ HOSTNAME_MATCHLINKS: list[tuple[str, str, CartographyRelSchema]] = [
         DeviceToIntuneManagedDeviceHostnameMatchLink(),
     ),
     ("JamfComputer", "name", DeviceToJamfComputerHostnameMatchLink()),
-    (
-        "JamfMobileDevice",
-        "display_name",
-        DeviceToJamfMobileDeviceHostnameMatchLink(),
-    ),
 ]

--- a/cartography/models/ontology/device.py
+++ b/cartography/models/ontology/device.py
@@ -149,6 +149,28 @@ class DeviceToIntuneManagedDeviceBySerialRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class DeviceToJamfComputerBySerialRel(CartographyRelSchema):
+    target_node_label: str = "JamfComputer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"serial_number": PropertyRef("serial_number")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "OBSERVED_AS"
+    properties: DeviceToNodeRelProperties = DeviceToNodeRelProperties()
+
+
+@dataclass(frozen=True)
+class DeviceToJamfMobileDeviceBySerialRel(CartographyRelSchema):
+    target_node_label: str = "JamfMobileDevice"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"serial_number": PropertyRef("serial_number")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "OBSERVED_AS"
+    properties: DeviceToNodeRelProperties = DeviceToNodeRelProperties()
+
+
+@dataclass(frozen=True)
 class DeviceSchema(CartographyNodeSchema):
     label: str = "Device"
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Ontology"])
@@ -166,6 +188,8 @@ class DeviceSchema(CartographyNodeSchema):
             DeviceToGoogleWorkspaceDeviceBySerialRel(),
             DeviceToS1AgentBySerialRel(),
             DeviceToIntuneManagedDeviceBySerialRel(),
+            DeviceToJamfComputerBySerialRel(),
+            DeviceToJamfMobileDeviceBySerialRel(),
         ],
     )
 
@@ -351,6 +375,36 @@ class DeviceToIntuneManagedDeviceHostnameMatchLink(CartographyRelSchema):
     properties: DeviceHostnameMatchLinkProperties = DeviceHostnameMatchLinkProperties()
 
 
+@dataclass(frozen=True)
+class DeviceToJamfComputerHostnameMatchLink(CartographyRelSchema):
+    target_node_label: str = "JamfComputer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"name": PropertyRef("hostname")},
+    )
+    source_node_label: str = "Device"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"hostname": PropertyRef("hostname")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "OBSERVED_AS"
+    properties: DeviceHostnameMatchLinkProperties = DeviceHostnameMatchLinkProperties()
+
+
+@dataclass(frozen=True)
+class DeviceToJamfMobileDeviceHostnameMatchLink(CartographyRelSchema):
+    target_node_label: str = "JamfMobileDevice"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"display_name": PropertyRef("hostname")},
+    )
+    source_node_label: str = "Device"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"hostname": PropertyRef("hostname")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "OBSERVED_AS"
+    properties: DeviceHostnameMatchLinkProperties = DeviceHostnameMatchLinkProperties()
+
+
 # Configuration for hostname matchlinks used by the intel module.
 # Each tuple: (target_label, target_hostname_field, matchlink_schema)
 HOSTNAME_MATCHLINKS: list[tuple[str, str, CartographyRelSchema]] = [
@@ -375,5 +429,11 @@ HOSTNAME_MATCHLINKS: list[tuple[str, str, CartographyRelSchema]] = [
         "IntuneManagedDevice",
         "device_name",
         DeviceToIntuneManagedDeviceHostnameMatchLink(),
+    ),
+    ("JamfComputer", "name", DeviceToJamfComputerHostnameMatchLink()),
+    (
+        "JamfMobileDevice",
+        "display_name",
+        DeviceToJamfMobileDeviceHostnameMatchLink(),
     ),
 ]

--- a/cartography/models/ontology/mapping/data/devices.py
+++ b/cartography/models/ontology/mapping/data/devices.py
@@ -251,10 +251,6 @@ jamf_mapping = OntologyMapping(
             node_label="JamfMobileDevice",
             fields=[
                 OntologyFieldMapping(
-                    ontology_field="hostname",
-                    node_field="display_name",
-                ),
-                OntologyFieldMapping(
                     ontology_field="os_version",
                     node_field="os_version",
                 ),

--- a/cartography/models/ontology/mapping/data/devices.py
+++ b/cartography/models/ontology/mapping/data/devices.py
@@ -226,6 +226,50 @@ sentinelone_mapping = OntologyMapping(
     ],
 )
 
+jamf_mapping = OntologyMapping(
+    module_name="jamf",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="JamfComputer",
+            fields=[
+                OntologyFieldMapping(ontology_field="hostname", node_field="name"),
+                OntologyFieldMapping(ontology_field="os", node_field="os_name"),
+                OntologyFieldMapping(
+                    ontology_field="os_version",
+                    node_field="os_version",
+                ),
+                OntologyFieldMapping(ontology_field="model", node_field="model"),
+                OntologyFieldMapping(ontology_field="platform", node_field="platform"),
+                OntologyFieldMapping(
+                    ontology_field="serial_number",
+                    node_field="serial_number",
+                    required=True,
+                ),
+            ],
+        ),
+        OntologyNodeMapping(
+            node_label="JamfMobileDevice",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="hostname",
+                    node_field="display_name",
+                ),
+                OntologyFieldMapping(
+                    ontology_field="os_version",
+                    node_field="os_version",
+                ),
+                OntologyFieldMapping(ontology_field="model", node_field="model"),
+                OntologyFieldMapping(ontology_field="platform", node_field="platform"),
+                OntologyFieldMapping(
+                    ontology_field="serial_number",
+                    node_field="serial_number",
+                    required=True,
+                ),
+            ],
+        ),
+    ],
+)
+
 jumpcloud_mapping = OntologyMapping(
     module_name="jumpcloud",
     nodes=[
@@ -293,6 +337,7 @@ DEVICES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "microsoft": entra_mapping,
     "googleworkspace": googleworkspace_mapping,
     "jumpcloud": jumpcloud_mapping,
+    "jamf": jamf_mapping,
     "kandji": kandji_mapping,
     "sentinelone": sentinelone_mapping,
     "snipeit": snipeit_mapping,

--- a/docs/root/modules/jamf/schema.md
+++ b/docs/root/modules/jamf/schema.md
@@ -2,27 +2,46 @@
 
 ```mermaid
 graph LR
-T(JamfTenant) -- RESOURCE --> G(JamfComputerGroup)
+T(JamfTenant) -- RESOURCE --> CG(JamfComputerGroup)
+T -- RESOURCE --> MG(JamfMobileDeviceGroup)
+T -- RESOURCE --> C(JamfComputer)
+T -- RESOURCE --> M(JamfMobileDevice)
+C -- MEMBER_OF --> CG
+M -- MEMBER_OF --> MG
+D(Device) -- OBSERVED_AS --> C
+D -- OBSERVED_AS --> M
 ```
 
 ### JamfTenant
 
-Representation of a Jamf Tenant (identified by the Jamf base URI).
+Representation of a Jamf tenant, identified by the configured Jamf base URI.
 
-> **Ontology Mapping**: This node has the extra label `Tenant` to enable cross-platform queries for organizational tenants across different systems (e.g., OktaOrganization, AWSAccount).
+> **Ontology Mapping**: This node has the extra label `Tenant` to enable cross-platform queries for organizational tenants across different systems.
 
 | Field | Description |
 |-------|-------------|
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
-| id | Jamf Tenant ID (the base URI) |
+| id | Jamf tenant ID (the base URI) |
 
 #### Relationships
 
 - `JamfComputerGroup` belongs to a `JamfTenant`.
-    ```
-    (:JamfTenant)-[:RESOURCE]->(:JamfComputerGroup)
-    ```
+  ```
+  (:JamfTenant)-[:RESOURCE]->(:JamfComputerGroup)
+  ```
+- `JamfMobileDeviceGroup` belongs to a `JamfTenant`.
+  ```
+  (:JamfTenant)-[:RESOURCE]->(:JamfMobileDeviceGroup)
+  ```
+- `JamfComputer` belongs to a `JamfTenant`.
+  ```
+  (:JamfTenant)-[:RESOURCE]->(:JamfComputer)
+  ```
+- `JamfMobileDevice` belongs to a `JamfTenant`.
+  ```
+  (:JamfTenant)-[:RESOURCE]->(:JamfMobileDevice)
+  ```
 
 
 ### JamfComputerGroup
@@ -34,12 +53,150 @@ Representation of a Jamf computer group.
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
 | id | The group id |
-| name | The friendly name of the group |
-| is_smart | Whether the group is [smart](https://docs.jamf.com/10.4.0/jamf-pro/administrator-guide/Smart_Computer_Groups.html) |
+| name | Friendly name of the group |
+| description | Group description |
+| membership_count | Number of members reported by Jamf |
+| is_smart | Whether the group is a smart group |
 
 #### Relationships
 
 - `JamfComputerGroup` belongs to a `JamfTenant`.
-    ```
-    (:JamfTenant)-[:RESOURCE]->(:JamfComputerGroup)
-    ```
+  ```
+  (:JamfTenant)-[:RESOURCE]->(:JamfComputerGroup)
+  ```
+- `JamfComputer` can be a member of a `JamfComputerGroup`.
+  ```
+  (:JamfComputer)-[:MEMBER_OF]->(:JamfComputerGroup)
+  ```
+
+
+### JamfMobileDeviceGroup
+
+Representation of a Jamf mobile device group.
+
+| Field | Description |
+|-------|-------------|
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| id | The group id |
+| name | Friendly name of the group |
+| description | Group description |
+| membership_count | Number of members reported by Jamf |
+| is_smart | Whether the group is a smart group |
+
+#### Relationships
+
+- `JamfMobileDeviceGroup` belongs to a `JamfTenant`.
+  ```
+  (:JamfTenant)-[:RESOURCE]->(:JamfMobileDeviceGroup)
+  ```
+- `JamfMobileDevice` can be a member of a `JamfMobileDeviceGroup`.
+  ```
+  (:JamfMobileDevice)-[:MEMBER_OF]->(:JamfMobileDeviceGroup)
+  ```
+
+
+### JamfComputer
+
+Representation of a Jamf-managed macOS computer inventory record.
+
+> **Ontology Mapping**: `JamfComputer` contributes to the `Device` ontology using serial number as the primary key and hostname as a supplemental match strategy.
+
+| Field | Description |
+|-------|-------------|
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| id | Jamf computer inventory id |
+| udid | Device UDID |
+| name | Device hostname |
+| serial_number | Device serial number |
+| model | Device model |
+| model_identifier | Model identifier |
+| platform | Platform reported by Jamf |
+| os_name | OS family |
+| os_version | OS version |
+| os_build | OS build |
+| report_date | Last inventory report timestamp |
+| last_contact_time | Last Jamf contact timestamp |
+| site_name | Jamf site name |
+| supervised | Whether the device is supervised |
+| user_approved_mdm | Whether MDM is user approved |
+| declarative_device_management_enabled | Whether DDM is enabled |
+| enrolled_via_automated_device_enrollment | Whether ADE was used |
+| remote_management_managed | Whether remote management is enabled |
+| filevault_enabled | Whether FileVault is enabled |
+| firewall_enabled | Whether the firewall is enabled |
+| gatekeeper_status | Gatekeeper status |
+| sip_status | SIP status |
+| secure_boot_level | Secure boot level |
+| activation_lock_enabled | Whether Activation Lock is enabled |
+| recovery_lock_enabled | Whether Recovery Lock is enabled |
+| bootstrap_token_escrowed_status | Bootstrap token escrow state |
+| username | Associated username |
+| user_real_name | Associated real name |
+| email | Associated email address |
+
+#### Relationships
+
+- `JamfComputer` belongs to a `JamfTenant`.
+  ```
+  (:JamfTenant)-[:RESOURCE]->(:JamfComputer)
+  ```
+- `JamfComputer` can be a member of a `JamfComputerGroup`.
+  ```
+  (:JamfComputer)-[:MEMBER_OF]->(:JamfComputerGroup)
+  ```
+- `Device` can observe the same endpoint as a `JamfComputer`.
+  ```
+  (:Device)-[:OBSERVED_AS]->(:JamfComputer)
+  ```
+
+
+### JamfMobileDevice
+
+Representation of a Jamf-managed iPhone or iPad inventory record.
+
+> **Ontology Mapping**: `JamfMobileDevice` contributes to the `Device` ontology using serial number as the primary key and display name as a supplemental match strategy.
+
+| Field | Description |
+|-------|-------------|
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| id | Jamf mobile device inventory id |
+| display_name | Device display name |
+| managed | Whether the device is managed |
+| supervised | Whether the device is supervised |
+| last_inventory_update_date | Last inventory update timestamp |
+| last_enrolled_date | Enrollment timestamp |
+| platform | Jamf device type |
+| os_version | OS version |
+| os_build | OS build |
+| serial_number | Device serial number |
+| model | Device model |
+| model_identifier | Model identifier |
+| activation_lock_enabled | Whether Activation Lock is enabled |
+| bootstrap_token_escrowed | Whether bootstrap token is escrowed |
+| data_protected | Whether data protection is enabled |
+| hardware_encryption | Whether hardware encryption is enabled |
+| jailbreak_detected | Whether jailbreak/rooting was detected |
+| lost_mode_enabled | Whether lost mode is enabled |
+| passcode_compliant | Whether the passcode meets policy |
+| passcode_present | Whether a passcode is present |
+| username | Associated username |
+| user_real_name | Associated real name |
+| email | Associated email address |
+
+#### Relationships
+
+- `JamfMobileDevice` belongs to a `JamfTenant`.
+  ```
+  (:JamfTenant)-[:RESOURCE]->(:JamfMobileDevice)
+  ```
+- `JamfMobileDevice` can be a member of a `JamfMobileDeviceGroup`.
+  ```
+  (:JamfMobileDevice)-[:MEMBER_OF]->(:JamfMobileDeviceGroup)
+  ```
+- `Device` can observe the same endpoint as a `JamfMobileDevice`.
+  ```
+  (:Device)-[:OBSERVED_AS]->(:JamfMobileDevice)
+  ```

--- a/docs/root/modules/jamf/schema.md
+++ b/docs/root/modules/jamf/schema.md
@@ -22,7 +22,7 @@ Representation of a Jamf tenant, identified by the configured Jamf base URI.
 |-------|-------------|
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
-| id | Jamf tenant ID (the base URI) |
+| **id** | Jamf tenant ID (the base URI) |
 
 #### Relationships
 
@@ -52,7 +52,7 @@ Representation of a Jamf computer group.
 |-------|-------------|
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
-| id | The group id |
+| **id** | The group id |
 | name | Friendly name of the group |
 | description | Group description |
 | membership_count | Number of members reported by Jamf |
@@ -78,7 +78,7 @@ Representation of a Jamf mobile device group.
 |-------|-------------|
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
-| id | The group id |
+| **id** | The group id |
 | name | Friendly name of the group |
 | description | Group description |
 | membership_count | Number of members reported by Jamf |
@@ -106,10 +106,10 @@ Representation of a Jamf-managed macOS computer inventory record.
 |-------|-------------|
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
-| id | Jamf computer inventory id |
+| **id** | Jamf computer inventory id |
 | udid | Device UDID |
-| name | Device hostname |
-| serial_number | Device serial number |
+| **name** | Device hostname |
+| **serial_number** | Device serial number |
 | model | Device model |
 | model_identifier | Model identifier |
 | platform | Platform reported by Jamf |
@@ -162,8 +162,8 @@ Representation of a Jamf-managed iPhone or iPad inventory record.
 |-------|-------------|
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
-| id | Jamf mobile device inventory id |
-| display_name | Device display name |
+| **id** | Jamf mobile device inventory id |
+| **display_name** | Device display name |
 | managed | Whether the device is managed |
 | supervised | Whether the device is supervised |
 | last_inventory_update_date | Last inventory update timestamp |
@@ -171,7 +171,7 @@ Representation of a Jamf-managed iPhone or iPad inventory record.
 | platform | Jamf device type |
 | os_version | OS version |
 | os_build | OS build |
-| serial_number | Device serial number |
+| **serial_number** | Device serial number |
 | model | Device model |
 | model_identifier | Model identifier |
 | activation_lock_enabled | Whether Activation Lock is enabled |

--- a/tests/data/jamf/computers.py
+++ b/tests/data/jamf/computers.py
@@ -1,7 +1,111 @@
-GROUPS = {
-    "computer_groups": [
-        {"id": 123, "is_smart": True, "name": "10.13.6"},
-        {"id": 234, "is_smart": True, "name": "10.14 and Above"},
-        {"id": 345, "is_smart": True, "name": "10.14.6"},
+COMPUTERS_RESPONSE = {
+    "results": [
+        {
+            "id": 7001,
+            "udid": "simpsons-mac-udid-7001",
+            "general": {
+                "name": "Springfield-Admin-Mac-01",
+                "platform": "macOS",
+                "reportDate": "2026-04-16T16:00:00Z",
+                "lastContactTime": "2026-04-16T15:55:00Z",
+                "site": {"name": "Springfield HQ"},
+                "supervised": True,
+                "userApprovedMdm": True,
+                "declarativeDeviceManagementEnabled": True,
+                "enrolledViaAutomatedDeviceEnrollment": True,
+                "remoteManagement": {"managed": True},
+            },
+            "hardware": {
+                "serialNumber": "C02SPRING001",
+                "model": "MacBook Pro",
+                "modelIdentifier": "Mac15,9",
+            },
+            "operatingSystem": {
+                "name": "macOS",
+                "version": "14.5",
+                "build": "23F79",
+            },
+            "security": {
+                "activationLockEnabled": True,
+                "recoveryLockEnabled": True,
+                "bootstrapTokenEscrowedStatus": "ESCROWED",
+                "firewallEnabled": True,
+                "gatekeeperStatus": "APP_STORE_AND_IDENTIFIED_DEVELOPERS",
+                "secureBootLevel": "FULL_SECURITY",
+                "sipStatus": "ENABLED",
+            },
+            "diskEncryption": {"fileVault2Enabled": True},
+            "userAndLocation": {
+                "username": "h.simpson",
+                "realname": "Homer Simpson",
+                "email": "h.simpson@springfield.example",
+            },
+            "groupMemberships": [
+                {
+                    "groupId": 101,
+                    "groupName": "Springfield Managed Macs",
+                    "groupDescription": "All managed macOS endpoints",
+                    "smartGroup": True,
+                },
+                {
+                    "groupId": 102,
+                    "groupName": "Sector 7G Workstations",
+                    "groupDescription": "Power plant engineering fleet",
+                    "smartGroup": False,
+                },
+            ],
+        },
+        {
+            "id": 7002,
+            "udid": "simpsons-mac-udid-7002",
+            "general": {
+                "name": "Springfield-Design-Mac-02",
+                "platform": "macOS",
+                "reportDate": "2026-04-16T14:00:00Z",
+                "lastContactTime": "2026-04-16T13:52:00Z",
+                "site": {"name": "Springfield Annex"},
+                "supervised": False,
+                "userApprovedMdm": False,
+                "declarativeDeviceManagementEnabled": False,
+                "enrolledViaAutomatedDeviceEnrollment": False,
+                "remoteManagement": {"managed": False},
+            },
+            "hardware": {
+                "serialNumber": "C02SPRING002",
+                "model": "MacBook Air",
+                "modelIdentifier": "Mac14,2",
+            },
+            "operatingSystem": {
+                "name": "macOS",
+                "version": "13.6.7",
+                "build": "22G720",
+            },
+            "security": {
+                "activationLockEnabled": False,
+                "recoveryLockEnabled": False,
+                "bootstrapTokenEscrowedStatus": "NOT_ESCROWED",
+                "firewallEnabled": False,
+                "gatekeeperStatus": "APP_STORE_ONLY",
+                "secureBootLevel": "MEDIUM_SECURITY",
+                "sipStatus": "DISABLED",
+            },
+            "diskEncryption": {"fileVault2Enabled": False},
+            "userAndLocation": {
+                "username": "l.simpson",
+                "realname": "Lisa Simpson",
+                "email": "l.simpson@springfield.example",
+            },
+            "groupMemberships": [
+                {
+                    "groupId": 101,
+                    "groupName": "Springfield Managed Macs",
+                    "groupDescription": "All managed macOS endpoints",
+                    "smartGroup": True,
+                }
+            ],
+        },
     ],
+    "totalCount": 2,
 }
+
+COMPUTERS = COMPUTERS_RESPONSE["results"]

--- a/tests/data/jamf/groups.py
+++ b/tests/data/jamf/groups.py
@@ -1,0 +1,43 @@
+GROUPS_RESPONSE = {
+    "results": [
+        {
+            "groupDescription": "All managed macOS endpoints",
+            "groupJamfProId": "101",
+            "groupName": "Springfield Managed Macs",
+            "groupPlatformId": "platform-computer-101",
+            "groupType": "COMPUTER",
+            "membershipCount": 42,
+            "smart": True,
+        },
+        {
+            "groupDescription": "Power plant engineering fleet",
+            "groupJamfProId": "102",
+            "groupName": "Sector 7G Workstations",
+            "groupPlatformId": "platform-computer-102",
+            "groupType": "COMPUTER",
+            "membershipCount": 12,
+            "smart": False,
+        },
+        {
+            "groupDescription": "Managed iPhone fleet",
+            "groupJamfProId": "201",
+            "groupName": "Springfield iPhones",
+            "groupPlatformId": "platform-mobile-201",
+            "groupType": "MOBILE",
+            "membershipCount": 85,
+            "smart": True,
+        },
+        {
+            "groupDescription": "Managed iPad fleet",
+            "groupJamfProId": "202",
+            "groupName": "Springfield iPads",
+            "groupPlatformId": "platform-mobile-202",
+            "groupType": "MOBILE",
+            "membershipCount": 19,
+            "smart": True,
+        },
+    ],
+    "totalCount": 4,
+}
+
+GROUPS = GROUPS_RESPONSE["results"]

--- a/tests/data/jamf/mobile_devices.py
+++ b/tests/data/jamf/mobile_devices.py
@@ -1,0 +1,82 @@
+MOBILE_DEVICES_RESPONSE = {
+    "results": [
+        {
+            "mobileDeviceId": 9001,
+            "deviceType": "iPhone",
+            "general": {
+                "displayName": "Bart-iPhone-01",
+                "managed": True,
+                "supervised": True,
+                "lastInventoryUpdateDate": "2026-04-16T15:20:00Z",
+                "lastEnrolledDate": "2025-09-01T08:00:00Z",
+                "osVersion": "17.4.1",
+                "osBuild": "21E236",
+            },
+            "hardware": {
+                "serialNumber": "IPHONESPRING001",
+                "model": "iPhone 15",
+                "modelIdentifier": "iPhone15,4",
+            },
+            "security": {
+                "activationLockEnabled": True,
+                "bootstrapTokenEscrowed": True,
+                "dataProtected": True,
+                "hardwareEncryption": True,
+                "jailBreakDetected": False,
+                "lostModeEnabled": False,
+                "passcodeCompliant": True,
+                "passcodePresent": True,
+            },
+            "userAndLocation": {
+                "username": "b.simpson",
+                "realName": "Bart Simpson",
+                "emailAddress": "b.simpson@springfield.example",
+            },
+            "groups": [
+                {
+                    "groupId": 201,
+                    "groupName": "Springfield iPhones",
+                    "groupDescription": "Managed iPhone fleet",
+                    "smart": True,
+                }
+            ],
+        },
+        {
+            "mobileDeviceId": 9002,
+            "deviceType": "iPad",
+            "general": {
+                "displayName": "Lisa-iPad-01",
+                "managed": True,
+                "supervised": False,
+                "lastInventoryUpdateDate": "2026-04-16T12:20:00Z",
+                "lastEnrolledDate": "2025-03-15T08:00:00Z",
+                "osVersion": "17.3",
+                "osBuild": "21D50",
+            },
+            "hardware": {
+                "serialNumber": "IPADSPRING001",
+                "model": "iPad Pro",
+                "modelIdentifier": "iPad14,3",
+            },
+            "security": {
+                "activationLockEnabled": False,
+                "bootstrapTokenEscrowed": False,
+                "dataProtected": True,
+                "hardwareEncryption": True,
+                "jailBreakDetected": False,
+                "lostModeEnabled": True,
+                "passcodeCompliant": False,
+                "passcodePresent": True,
+            },
+            "userAndLocation": {
+                "username": "l.simpson",
+                "realName": "Lisa Simpson",
+                "emailAddress": "l.simpson@springfield.example",
+            },
+            "groups": None,
+        },
+    ],
+    "totalCount": 2,
+}
+
+MOBILE_DEVICES = MOBILE_DEVICES_RESPONSE["results"]

--- a/tests/integration/cartography/intel/jamf/test_jamf.py
+++ b/tests/integration/cartography/intel/jamf/test_jamf.py
@@ -2,34 +2,29 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import cartography.intel.jamf.computers
-from cartography.intel.jamf.computers import sync
-from tests.data.jamf.computers import GROUPS
+import cartography.intel.jamf.groups
+import cartography.intel.jamf.mobile_devices
+from cartography.intel.jamf.computers import sync as sync_computers
+from cartography.intel.jamf.groups import sync as sync_groups
+from cartography.intel.jamf.mobile_devices import sync as sync_mobile_devices
+from tests.data.jamf.computers import COMPUTERS
+from tests.data.jamf.groups import GROUPS
+from tests.data.jamf.mobile_devices import MOBILE_DEVICES
 from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
 TEST_JAMF_URI = "https://test.jamfcloud.com"
-TEST_JAMF_USER = "test_user"
-TEST_JAMF_PASSWORD = "test_password"
 
 
-@patch.object(
-    cartography.intel.jamf.computers,
-    "get",
-    return_value=GROUPS,
-)
-def test_sync(mock_get, neo4j_session):
-    """
-    Ensure that the main sync function orchestrates the Jamf sync correctly.
-    """
-    # Arrange
+@patch.object(cartography.intel.jamf.groups, "get", return_value=GROUPS)
+def test_sync_groups(mock_get, neo4j_session):
     common_job_parameters = {
         "UPDATE_TAG": TEST_UPDATE_TAG,
         "TENANT_ID": TEST_JAMF_URI,
     }
 
-    # Act
-    sync(
+    sync_groups(
         neo4j_session,
         MagicMock(),
         TEST_JAMF_URI,
@@ -37,27 +32,28 @@ def test_sync(mock_get, neo4j_session):
         common_job_parameters,
     )
 
-    # Assert - JamfTenant node exists
-    assert check_nodes(
-        neo4j_session,
-        "JamfTenant",
-        ["id"],
-    ) == {
+    assert check_nodes(neo4j_session, "JamfTenant", ["id"]) == {
         (TEST_JAMF_URI,),
     }
 
-    # Assert - JamfComputerGroup nodes exist with expected properties
     assert check_nodes(
         neo4j_session,
         "JamfComputerGroup",
-        ["id", "name", "is_smart"],
+        ["id", "name", "description", "membership_count", "is_smart"],
     ) == {
-        (123, "10.13.6", True),
-        (234, "10.14 and Above", True),
-        (345, "10.14.6", True),
+        (101, "Springfield Managed Macs", "All managed macOS endpoints", 42, True),
+        (102, "Sector 7G Workstations", "Power plant engineering fleet", 12, False),
     }
 
-    # Assert - Relationships exist between tenant and computer groups
+    assert check_nodes(
+        neo4j_session,
+        "JamfMobileDeviceGroup",
+        ["id", "name", "description", "membership_count", "is_smart"],
+    ) == {
+        (201, "Springfield iPhones", "Managed iPhone fleet", 85, True),
+        (202, "Springfield iPads", "Managed iPad fleet", 19, True),
+    }
+
     assert check_rels(
         neo4j_session,
         "JamfTenant",
@@ -67,7 +63,178 @@ def test_sync(mock_get, neo4j_session):
         "RESOURCE",
         rel_direction_right=True,
     ) == {
-        (TEST_JAMF_URI, 123),
-        (TEST_JAMF_URI, 234),
-        (TEST_JAMF_URI, 345),
+        (TEST_JAMF_URI, 101),
+        (TEST_JAMF_URI, 102),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "JamfTenant",
+        "id",
+        "JamfMobileDeviceGroup",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (TEST_JAMF_URI, 201),
+        (TEST_JAMF_URI, 202),
+    }
+
+
+@patch.object(cartography.intel.jamf.groups, "get", return_value=GROUPS)
+@patch.object(cartography.intel.jamf.computers, "get", return_value=COMPUTERS)
+def test_sync_computers(mock_get, mock_groups_get, neo4j_session):
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "TENANT_ID": TEST_JAMF_URI,
+    }
+
+    sync_groups(
+        neo4j_session,
+        MagicMock(),
+        TEST_JAMF_URI,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    sync_computers(
+        neo4j_session,
+        MagicMock(),
+        TEST_JAMF_URI,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "JamfComputer",
+        [
+            "id",
+            "name",
+            "serial_number",
+            "os_version",
+            "firewall_enabled",
+            "filevault_enabled",
+            "username",
+        ],
+    ) == {
+        (
+            7001,
+            "Springfield-Admin-Mac-01",
+            "C02SPRING001",
+            "14.5",
+            True,
+            True,
+            "h.simpson",
+        ),
+        (
+            7002,
+            "Springfield-Design-Mac-02",
+            "C02SPRING002",
+            "13.6.7",
+            False,
+            False,
+            "l.simpson",
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "JamfTenant",
+        "id",
+        "JamfComputer",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (TEST_JAMF_URI, 7001),
+        (TEST_JAMF_URI, 7002),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "JamfComputer",
+        "id",
+        "JamfComputerGroup",
+        "id",
+        "MEMBER_OF",
+        rel_direction_right=True,
+    ) == {
+        (7001, 101),
+        (7001, 102),
+        (7002, 101),
+    }
+
+
+@patch.object(
+    cartography.intel.jamf.groups,
+    "get",
+    return_value=GROUPS,
+)
+@patch.object(
+    cartography.intel.jamf.mobile_devices,
+    "get",
+    return_value=MOBILE_DEVICES,
+)
+def test_sync_mobile_devices(mock_get, mock_groups_get, neo4j_session):
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "TENANT_ID": TEST_JAMF_URI,
+    }
+
+    sync_groups(
+        neo4j_session,
+        MagicMock(),
+        TEST_JAMF_URI,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    sync_mobile_devices(
+        neo4j_session,
+        MagicMock(),
+        TEST_JAMF_URI,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "JamfMobileDevice",
+        [
+            "id",
+            "display_name",
+            "serial_number",
+            "platform",
+            "passcode_compliant",
+            "username",
+        ],
+    ) == {
+        (9001, "Bart-iPhone-01", "IPHONESPRING001", "iPhone", True, "b.simpson"),
+        (9002, "Lisa-iPad-01", "IPADSPRING001", "iPad", False, "l.simpson"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "JamfTenant",
+        "id",
+        "JamfMobileDevice",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (TEST_JAMF_URI, 9001),
+        (TEST_JAMF_URI, 9002),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "JamfMobileDevice",
+        "id",
+        "JamfMobileDeviceGroup",
+        "id",
+        "MEMBER_OF",
+        rel_direction_right=True,
+    ) == {
+        (9001, 201),
     }

--- a/tests/integration/cartography/intel/jamf/test_jamf.py
+++ b/tests/integration/cartography/intel/jamf/test_jamf.py
@@ -1,3 +1,4 @@
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import cartography.intel.jamf.computers
@@ -30,9 +31,8 @@ def test_sync(mock_get, neo4j_session):
     # Act
     sync(
         neo4j_session,
+        MagicMock(),
         TEST_JAMF_URI,
-        TEST_JAMF_USER,
-        TEST_JAMF_PASSWORD,
         TEST_UPDATE_TAG,
         common_job_parameters,
     )

--- a/tests/unit/cartography/intel/jamf/test_computers.py
+++ b/tests/unit/cartography/intel/jamf/test_computers.py
@@ -1,0 +1,8 @@
+import pytest
+
+from cartography.intel.jamf.computers import transform
+
+
+def test_transform_requires_computer_id() -> None:
+    with pytest.raises(KeyError, match="id"):
+        transform([{"general": {"name": "Springfield-MacBook"}}])

--- a/tests/unit/cartography/intel/jamf/test_groups.py
+++ b/tests/unit/cartography/intel/jamf/test_groups.py
@@ -1,0 +1,98 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import requests
+
+from cartography.intel.jamf.groups import get
+
+
+@patch("cartography.intel.jamf.groups.get_paginated_jamf_results")
+def test_get_falls_back_to_classic_computer_and_mobile_groups(
+    mock_get_paginated_jamf_results: Mock,
+) -> None:
+    response = requests.Response()
+    response.status_code = 404
+    err = requests.HTTPError(response=response)
+    mock_get_paginated_jamf_results.side_effect = err
+
+    mock_session = Mock()
+
+    with patch(
+        "cartography.intel.jamf.groups.call_jamf_api",
+        side_effect=[
+            {
+                "computer_groups": [
+                    {"id": 101, "name": "Springfield Managed Macs", "is_smart": True},
+                ],
+            },
+            {
+                "mobile_device_groups": [
+                    {"id": 201, "name": "Springfield iPhones", "is_smart": False},
+                ],
+            },
+        ],
+    ) as mock_call_jamf_api:
+        results = get(mock_session, "https://test.jamfcloud.com/JSSResource")
+
+    assert results == [
+        {
+            "groupDescription": None,
+            "groupJamfProId": 101,
+            "groupName": "Springfield Managed Macs",
+            "groupType": "COMPUTER",
+            "membershipCount": None,
+            "smart": True,
+        },
+        {
+            "groupDescription": None,
+            "groupJamfProId": 201,
+            "groupName": "Springfield iPhones",
+            "groupType": "MOBILE",
+            "membershipCount": None,
+            "smart": False,
+        },
+    ]
+    assert [call.args[0] for call in mock_call_jamf_api.call_args_list] == [
+        "/computergroups",
+        "/mobiledevicegroups",
+    ]
+
+
+@patch("cartography.intel.jamf.groups.get_paginated_jamf_results")
+def test_get_legacy_fallback_skips_mobile_groups_when_classic_endpoint_missing(
+    mock_get_paginated_jamf_results: Mock,
+) -> None:
+    response = requests.Response()
+    response.status_code = 404
+    err = requests.HTTPError(response=response)
+    mock_get_paginated_jamf_results.side_effect = err
+
+    mobile_response = requests.Response()
+    mobile_response.status_code = 404
+    mobile_err = requests.HTTPError(response=mobile_response)
+
+    mock_session = Mock()
+
+    with patch(
+        "cartography.intel.jamf.groups.call_jamf_api",
+        side_effect=[
+            {
+                "computer_groups": [
+                    {"id": 101, "name": "Springfield Managed Macs", "is_smart": True},
+                ],
+            },
+            mobile_err,
+        ],
+    ):
+        results = get(mock_session, "https://test.jamfcloud.com/JSSResource")
+
+    assert results == [
+        {
+            "groupDescription": None,
+            "groupJamfProId": 101,
+            "groupName": "Springfield Managed Macs",
+            "groupType": "COMPUTER",
+            "membershipCount": None,
+            "smart": True,
+        },
+    ]

--- a/tests/unit/cartography/intel/jamf/test_groups.py
+++ b/tests/unit/cartography/intel/jamf/test_groups.py
@@ -1,9 +1,11 @@
 from unittest.mock import Mock
 from unittest.mock import patch
 
+import pytest
 import requests
 
 from cartography.intel.jamf.groups import get
+from cartography.intel.jamf.groups import transform
 
 
 @patch("cartography.intel.jamf.groups.get_paginated_jamf_results")
@@ -96,3 +98,15 @@ def test_get_legacy_fallback_skips_mobile_groups_when_classic_endpoint_missing(
             "smart": True,
         },
     ]
+
+
+def test_transform_requires_group_id() -> None:
+    with pytest.raises(KeyError, match="groupJamfProId"):
+        transform(
+            [
+                {
+                    "groupName": "Springfield Managed Macs",
+                    "groupType": "COMPUTER",
+                },
+            ],
+        )

--- a/tests/unit/cartography/intel/jamf/test_init.py
+++ b/tests/unit/cartography/intel/jamf/test_init.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from cartography.config import Config
+from cartography.intel.jamf import start_jamf_ingestion
+
+
+@patch("cartography.intel.jamf.computers.sync")
+@patch("cartography.intel.jamf.create_jamf_api_session")
+def test_start_jamf_ingestion_uses_shared_api_session(
+    mock_create_jamf_api_session: Mock,
+    mock_sync: Mock,
+) -> None:
+    mock_api_session = MagicMock()
+    mock_create_jamf_api_session.return_value = mock_api_session
+    config = cast(
+        Config,
+        SimpleNamespace(
+            jamf_base_uri="https://test.jamfcloud.com/JSSResource",
+            jamf_user="test-user",
+            jamf_password="test-password",
+            update_tag=123456789,
+        ),
+    )
+
+    start_jamf_ingestion(MagicMock(), config)
+
+    mock_create_jamf_api_session.assert_called_once_with(
+        "https://test.jamfcloud.com/JSSResource",
+        "test-user",
+        "test-password",
+    )
+    mock_sync.assert_called_once()
+    assert mock_sync.call_args.args[1] is mock_api_session
+    mock_api_session.close.assert_called_once_with()

--- a/tests/unit/cartography/intel/jamf/test_init.py
+++ b/tests/unit/cartography/intel/jamf/test_init.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
+import pytest
+
 from cartography.config import Config
 from cartography.intel.jamf import start_jamf_ingestion
 
@@ -35,4 +37,29 @@ def test_start_jamf_ingestion_uses_shared_api_session(
     )
     mock_sync.assert_called_once()
     assert mock_sync.call_args.args[1] is mock_api_session
+    mock_api_session.close.assert_called_once_with()
+
+
+@patch("cartography.intel.jamf.computers.sync")
+@patch("cartography.intel.jamf.create_jamf_api_session")
+def test_start_jamf_ingestion_closes_session_on_sync_error(
+    mock_create_jamf_api_session: Mock,
+    mock_sync: Mock,
+) -> None:
+    mock_api_session = MagicMock()
+    mock_create_jamf_api_session.return_value = mock_api_session
+    mock_sync.side_effect = RuntimeError("boom")
+    config = cast(
+        Config,
+        SimpleNamespace(
+            jamf_base_uri="https://test.jamfcloud.com/JSSResource",
+            jamf_user="test-user",
+            jamf_password="test-password",
+            update_tag=123456789,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        start_jamf_ingestion(MagicMock(), config)
+
     mock_api_session.close.assert_called_once_with()

--- a/tests/unit/cartography/intel/jamf/test_init.py
+++ b/tests/unit/cartography/intel/jamf/test_init.py
@@ -10,18 +10,22 @@ from cartography.config import Config
 from cartography.intel.jamf import start_jamf_ingestion
 
 
+@patch("cartography.intel.jamf.mobile_devices.sync")
 @patch("cartography.intel.jamf.computers.sync")
+@patch("cartography.intel.jamf.groups.sync")
 @patch("cartography.intel.jamf.create_jamf_api_session")
 def test_start_jamf_ingestion_uses_shared_api_session(
     mock_create_jamf_api_session: Mock,
-    mock_sync: Mock,
+    mock_group_sync: Mock,
+    mock_computer_sync: Mock,
+    mock_mobile_sync: Mock,
 ) -> None:
     mock_api_session = MagicMock()
     mock_create_jamf_api_session.return_value = mock_api_session
     config = cast(
         Config,
         SimpleNamespace(
-            jamf_base_uri="https://test.jamfcloud.com/JSSResource",
+            jamf_base_uri="https://test.jamfcloud.com",
             jamf_user="test-user",
             jamf_password="test-password",
             update_tag=123456789,
@@ -31,28 +35,36 @@ def test_start_jamf_ingestion_uses_shared_api_session(
     start_jamf_ingestion(MagicMock(), config)
 
     mock_create_jamf_api_session.assert_called_once_with(
-        "https://test.jamfcloud.com/JSSResource",
+        "https://test.jamfcloud.com",
         "test-user",
         "test-password",
     )
-    mock_sync.assert_called_once()
-    assert mock_sync.call_args.args[1] is mock_api_session
+    mock_group_sync.assert_called_once()
+    mock_computer_sync.assert_called_once()
+    mock_mobile_sync.assert_called_once()
+    assert mock_group_sync.call_args.args[1] is mock_api_session
+    assert mock_computer_sync.call_args.args[1] is mock_api_session
+    assert mock_mobile_sync.call_args.args[1] is mock_api_session
     mock_api_session.close.assert_called_once_with()
 
 
+@patch("cartography.intel.jamf.mobile_devices.sync")
 @patch("cartography.intel.jamf.computers.sync")
+@patch("cartography.intel.jamf.groups.sync")
 @patch("cartography.intel.jamf.create_jamf_api_session")
 def test_start_jamf_ingestion_closes_session_on_sync_error(
     mock_create_jamf_api_session: Mock,
-    mock_sync: Mock,
+    mock_group_sync: Mock,
+    mock_computer_sync: Mock,
+    mock_mobile_sync: Mock,
 ) -> None:
     mock_api_session = MagicMock()
     mock_create_jamf_api_session.return_value = mock_api_session
-    mock_sync.side_effect = RuntimeError("boom")
+    mock_computer_sync.side_effect = RuntimeError("boom")
     config = cast(
         Config,
         SimpleNamespace(
-            jamf_base_uri="https://test.jamfcloud.com/JSSResource",
+            jamf_base_uri="https://test.jamfcloud.com",
             jamf_user="test-user",
             jamf_password="test-password",
             update_tag=123456789,
@@ -62,4 +74,6 @@ def test_start_jamf_ingestion_closes_session_on_sync_error(
     with pytest.raises(RuntimeError, match="boom"):
         start_jamf_ingestion(MagicMock(), config)
 
+    mock_group_sync.assert_called_once()
+    mock_mobile_sync.assert_not_called()
     mock_api_session.close.assert_called_once_with()

--- a/tests/unit/cartography/intel/jamf/test_mobile_devices.py
+++ b/tests/unit/cartography/intel/jamf/test_mobile_devices.py
@@ -1,0 +1,23 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from cartography.intel.jamf.mobile_devices import get
+
+
+@patch("cartography.intel.jamf.mobile_devices.get_paginated_jamf_results")
+def test_get_requests_groups_section(
+    mock_get_paginated_jamf_results: Mock,
+) -> None:
+    mock_get_paginated_jamf_results.return_value = []
+
+    get(Mock(), "https://test.jamfcloud.com")
+
+    assert mock_get_paginated_jamf_results.call_args.kwargs["params"] == {
+        "section": [
+            "GENERAL",
+            "HARDWARE",
+            "SECURITY",
+            "GROUPS",
+            "USER_AND_LOCATION",
+        ],
+    }

--- a/tests/unit/cartography/intel/jamf/test_mobile_devices.py
+++ b/tests/unit/cartography/intel/jamf/test_mobile_devices.py
@@ -1,7 +1,10 @@
 from unittest.mock import Mock
 from unittest.mock import patch
 
+import pytest
+
 from cartography.intel.jamf.mobile_devices import get
+from cartography.intel.jamf.mobile_devices import transform
 
 
 @patch("cartography.intel.jamf.mobile_devices.get_paginated_jamf_results")
@@ -21,3 +24,8 @@ def test_get_requests_groups_section(
             "USER_AND_LOCATION",
         ],
     }
+
+
+def test_transform_requires_mobile_device_id() -> None:
+    with pytest.raises(KeyError, match="mobileDeviceId"):
+        transform([{"deviceType": "iPhone"}])

--- a/tests/unit/cartography/intel/jamf/test_util.py
+++ b/tests/unit/cartography/intel/jamf/test_util.py
@@ -139,6 +139,25 @@ def test_call_jamf_api_normalizes_trailing_slashes() -> None:
     )
 
 
+def test_call_jamf_api_appends_classic_api_path_for_plain_host() -> None:
+    mock_session = Mock()
+    mock_response = Mock()
+    mock_response.json.return_value = {"computer_groups": []}
+    mock_session.get.return_value = mock_response
+
+    call_jamf_api(
+        "/computergroups",
+        "https://test.jamfcloud.com",
+        mock_session,
+    )
+
+    mock_session.get.assert_called_once_with(
+        "https://test.jamfcloud.com/JSSResource/computergroups",
+        timeout=(60, 60),
+        params=None,
+    )
+
+
 def test_call_jamf_api_uses_instance_uri_for_modern_api_paths() -> None:
     mock_session = Mock()
     mock_response = Mock()

--- a/tests/unit/cartography/intel/jamf/test_util.py
+++ b/tests/unit/cartography/intel/jamf/test_util.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 from unittest.mock import patch
 
+import pytest
 import requests
 
 from cartography.intel.jamf.util import call_jamf_api
@@ -56,6 +57,66 @@ def test_create_jamf_api_session_falls_back_to_basic_auth(
     assert session is mock_session
     assert mock_session.headers == {"Accept": "application/json"}
     assert isinstance(mock_session.auth, requests.auth.HTTPBasicAuth)
+
+
+@patch("cartography.intel.jamf.util.requests.Session")
+def test_create_jamf_api_session_falls_back_to_basic_auth_on_405(
+    mock_session_class: Mock,
+) -> None:
+    mock_session = Mock()
+    mock_session.headers = {}
+    token_response = Mock(ok=False, status_code=405)
+    mock_session.post.return_value = token_response
+    mock_session_class.return_value = mock_session
+
+    session = create_jamf_api_session(
+        "https://test.jamfcloud.com/JSSResource",
+        "test-user",
+        "test-password",
+    )
+
+    assert session is mock_session
+    assert isinstance(mock_session.auth, requests.auth.HTTPBasicAuth)
+
+
+@patch("cartography.intel.jamf.util.requests.Session")
+def test_create_jamf_api_session_closes_session_on_timeout(
+    mock_session_class: Mock,
+) -> None:
+    mock_session = Mock()
+    mock_session.headers = {}
+    mock_session.post.side_effect = requests.exceptions.Timeout()
+    mock_session_class.return_value = mock_session
+
+    with pytest.raises(requests.exceptions.Timeout):
+        create_jamf_api_session(
+            "https://test.jamfcloud.com/JSSResource",
+            "test-user",
+            "test-password",
+        )
+
+    mock_session.close.assert_called_once_with()
+
+
+@patch("cartography.intel.jamf.util.requests.Session")
+def test_create_jamf_api_session_closes_session_on_http_error(
+    mock_session_class: Mock,
+) -> None:
+    mock_session = Mock()
+    mock_session.headers = {}
+    token_response = Mock(ok=False, status_code=401)
+    token_response.raise_for_status.side_effect = requests.HTTPError("unauthorized")
+    mock_session.post.return_value = token_response
+    mock_session_class.return_value = mock_session
+
+    with pytest.raises(requests.HTTPError, match="unauthorized"):
+        create_jamf_api_session(
+            "https://test.jamfcloud.com/JSSResource",
+            "test-user",
+            "test-password",
+        )
+
+    mock_session.close.assert_called_once_with()
 
 
 def test_call_jamf_api_normalizes_trailing_slashes() -> None:

--- a/tests/unit/cartography/intel/jamf/test_util.py
+++ b/tests/unit/cartography/intel/jamf/test_util.py
@@ -6,6 +6,7 @@ import requests
 
 from cartography.intel.jamf.util import call_jamf_api
 from cartography.intel.jamf.util import create_jamf_api_session
+from cartography.intel.jamf.util import get_paginated_jamf_results
 
 
 @patch("cartography.intel.jamf.util.requests.Session")
@@ -134,4 +135,56 @@ def test_call_jamf_api_normalizes_trailing_slashes() -> None:
     mock_session.get.assert_called_once_with(
         "https://test.jamfcloud.com/JSSResource/computergroups",
         timeout=(60, 60),
+        params=None,
     )
+
+
+def test_call_jamf_api_uses_instance_uri_for_modern_api_paths() -> None:
+    mock_session = Mock()
+    mock_response = Mock()
+    mock_response.json.return_value = {"results": [], "totalCount": 0}
+    mock_session.get.return_value = mock_response
+
+    call_jamf_api(
+        "/api/v1/groups",
+        "https://test.jamfcloud.com/JSSResource/",
+        mock_session,
+    )
+
+    mock_session.get.assert_called_once_with(
+        "https://test.jamfcloud.com/api/v1/groups",
+        timeout=(60, 60),
+        params=None,
+    )
+
+
+def test_get_paginated_jamf_results_collects_all_pages() -> None:
+    mock_session = Mock()
+    first_page_response = Mock()
+    first_page_response.json.return_value = {
+        "results": [{"id": 1}, {"id": 2}],
+        "totalCount": 3,
+    }
+    second_page_response = Mock()
+    second_page_response.json.return_value = {
+        "results": [{"id": 3}],
+        "totalCount": 3,
+    }
+    mock_session.get.side_effect = [first_page_response, second_page_response]
+
+    results = get_paginated_jamf_results(
+        "/api/v1/groups",
+        "https://test.jamfcloud.com",
+        mock_session,
+    )
+
+    assert results == [{"id": 1}, {"id": 2}, {"id": 3}]
+    assert mock_session.get.call_count == 2
+    assert mock_session.get.call_args_list[0].kwargs["params"] == {
+        "page": 0,
+        "page-size": 100,
+    }
+    assert mock_session.get.call_args_list[1].kwargs["params"] == {
+        "page": 1,
+        "page-size": 100,
+    }

--- a/tests/unit/cartography/intel/jamf/test_util.py
+++ b/tests/unit/cartography/intel/jamf/test_util.py
@@ -1,0 +1,76 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import requests
+
+from cartography.intel.jamf.util import call_jamf_api
+from cartography.intel.jamf.util import create_jamf_api_session
+
+
+@patch("cartography.intel.jamf.util.requests.Session")
+def test_create_jamf_api_session_prefers_bearer_token(mock_session_class: Mock) -> None:
+    mock_session = Mock()
+    mock_session.headers = {}
+    token_response = Mock(ok=True, status_code=200)
+    token_response.json.return_value = {"token": "test-token"}
+    mock_session.post.return_value = token_response
+    mock_session_class.return_value = mock_session
+
+    session = create_jamf_api_session(
+        "https://test.jamfcloud.com/JSSResource",
+        "test-user",
+        "test-password",
+    )
+
+    assert session is mock_session
+    assert mock_session.headers["Accept"] == "application/json"
+    assert mock_session.headers["Authorization"] == "Bearer test-token"
+    mock_session.post.assert_called_once()
+    assert (
+        mock_session.post.call_args.args[0]
+        == "https://test.jamfcloud.com/api/v1/auth/token"
+    )
+    assert isinstance(
+        mock_session.post.call_args.kwargs["auth"],
+        requests.auth.HTTPBasicAuth,
+    )
+    assert "auth" not in mock_session.__dict__
+
+
+@patch("cartography.intel.jamf.util.requests.Session")
+def test_create_jamf_api_session_falls_back_to_basic_auth(
+    mock_session_class: Mock,
+) -> None:
+    mock_session = Mock()
+    mock_session.headers = {}
+    token_response = Mock(ok=False, status_code=404)
+    mock_session.post.return_value = token_response
+    mock_session_class.return_value = mock_session
+
+    session = create_jamf_api_session(
+        "https://test.jamfcloud.com/JSSResource",
+        "test-user",
+        "test-password",
+    )
+
+    assert session is mock_session
+    assert mock_session.headers == {"Accept": "application/json"}
+    assert isinstance(mock_session.auth, requests.auth.HTTPBasicAuth)
+
+
+def test_call_jamf_api_normalizes_trailing_slashes() -> None:
+    mock_session = Mock()
+    mock_response = Mock()
+    mock_response.json.return_value = {"computer_groups": []}
+    mock_session.get.return_value = mock_response
+
+    call_jamf_api(
+        "/computergroups",
+        "https://test.jamfcloud.com/JSSResource/",
+        mock_session,
+    )
+
+    mock_session.get.assert_called_once_with(
+        "https://test.jamfcloud.com/JSSResource/computergroups",
+        timeout=(60, 60),
+    )


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):

### Summary
This expands the Jamf module beyond Classic API computer groups so Cartography can ingest Jamf computer inventory, mobile device inventory, and group membership relationships.

It also keeps the earlier Jamf auth modernization in place by reusing a single API session, preferring bearer token auth, and handling both Classic and modern Jamf API base paths from the same configured base URI.

To keep the change safe for older tenants, the module now uses progressive capability fallback:
- `POST /api/v1/auth/token` with fallback to legacy Basic auth on `404/405`
- `/api/v1/groups` with fallback to Classic group endpoints on `404/405`
- computer and mobile inventory endpoints are treated as optional and skipped when the tenant does not support them

The new test fixtures preserve the real Jamf response shape while using fully sanitized dummy data.

### Related issues or links
- [PR #2625](https://github.com/cartography-cncf/cartography/pull/2625)

### How was this tested?
- `make test_lint`
- ran locally
```
INFO:cartography.intel.jamf.util:Jamf: authenticated to the Classic API using bearer token auth.
INFO:cartography.client.core.tx:Loaded <> JamfTenant nodes
INFO:cartography.client.core.tx:Loaded <> JamfComputerGroup nodes
INFO:cartography.client.core.tx:Loaded <> JamfMobileDeviceGroup nodes
INFO:cartography.graph.statement:Completed JamfComputerGroup statement #1
INFO:cartography.graph.statement:Completed JamfComputerGroup statement #2
INFO:cartography.graph.job:Finished job JamfComputerGroup
INFO:cartography.graph.statement:Completed JamfMobileDeviceGroup statement #1
INFO:cartography.graph.statement:Completed JamfMobileDeviceGroup statement #2
INFO:cartography.graph.job:Finished job JamfMobileDeviceGroup
INFO:cartography.client.core.tx:Loaded <> JamfTenant nodes
INFO:cartography.client.core.tx:Loaded <> JamfComputer nodes
INFO:cartography.graph.statement:Completed JamfComputer statement #1
INFO:cartography.graph.statement:Completed JamfComputer statement #2
INFO:cartography.graph.statement:Completed JamfComputer statement #3
INFO:cartography.graph.job:Finished job JamfComputer
INFO:cartography.client.core.tx:Loaded <> JamfTenant nodes
INFO:cartography.client.core.tx:Loaded <> JamfMobileDevice nodes
INFO:cartography.graph.statement:Completed JamfMobileDevice statement #1
INFO:cartography.graph.statement:Completed JamfMobileDevice statement #2
INFO:cartography.graph.statement:Completed JamfMobileDevice statement #3
INFO:cartography.graph.job:Finished job JamfMobileDevice

```

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [x] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the schema README.

### Notes for reviewers
- The sanitized Jamf fixtures are intentionally shaped after real API payloads, but all names, serials, emails, and identifiers are dummy values.
- `JamfComputer` and `JamfMobileDevice` now contribute to the `Device` ontology via serial number and hostname/display-name matching.
- The live validation rerun after the mobile `GROUPS` fix showed full parity for `JamfMobileDevice -> JamfMobileDeviceGroup` memberships as well.
