### PR TITLE
feat(kubernetes): map KubernetesCluster to its EKSCluster

### DIFF
--- a/cartography/models/kubernetes/clusters.py
+++ b/cartography/models/kubernetes/clusters.py
@@ -4,6 +4,12 @@ from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
 from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
 
 
 @dataclass(frozen=True)
@@ -40,7 +46,29 @@ class KubernetesClusterNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
+class KubernetesClusterToEKSClusterRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:EKSCluster)-[:MAPS_TO]->(:KubernetesCluster)
+class KubernetesClusterToEKSClusterRel(CartographyRelSchema):
+    target_node_label: str = "EKSCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("external_id")}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "MAPS_TO"
+    properties: KubernetesClusterToEKSClusterRelProperties = (
+        KubernetesClusterToEKSClusterRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class KubernetesClusterSchema(CartographyNodeSchema):
     label: str = "KubernetesCluster"
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeCluster"])
     properties: KubernetesClusterNodeProperties = KubernetesClusterNodeProperties()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [KubernetesClusterToEKSClusterRel()]
+    )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -2796,6 +2796,11 @@ Representation of an AWS [EKS Cluster](https://docs.aws.amazon.com/eks/latest/AP
     (AWSAccount)-[RESOURCE]->(EKSCluster)
     ```
 
+- An EKS Cluster maps to the `KubernetesCluster` synced from the same control plane.
+    ```
+    (:EKSCluster)-[:MAPS_TO]->(:KubernetesCluster)
+    ```
+
 #### Example queries
 
 - Compare EKS API server certificate authority metadata across clusters:

--- a/docs/root/modules/kubernetes/schema.md
+++ b/docs/root/modules/kubernetes/schema.md
@@ -54,6 +54,11 @@ Representation of a [Kubernetes Cluster.](https://kubernetes.io/docs/concepts/ov
     (:KubernetesCluster)-[:RESOURCE]->(:KubernetesPod)
     ```
 
+- A `KubernetesCluster` maps to the `EKSCluster` that hosts it when its `external_id` is an EKS cluster ARN.
+    ```
+    (:EKSCluster)-[:MAPS_TO]->(:KubernetesCluster)
+    ```
+
 ### KubernetesNode
 Representation of a [Kubernetes Node.](https://kubernetes.io/docs/concepts/architecture/nodes/)
 

--- a/tests/integration/cartography/intel/kubernetes/test_clusters.py
+++ b/tests/integration/cartography/intel/kubernetes/test_clusters.py
@@ -3,6 +3,7 @@ from cartography.intel.kubernetes.clusters import load_kubernetes_cluster
 from tests.data.kubernetes.clusters import KUBERNETES_CLUSTER_DATA
 from tests.data.kubernetes.clusters import KUBERNETES_CLUSTER_IDS
 from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
 
@@ -59,6 +60,30 @@ def test_load_clusters(neo4j_session):
             False,
         ),
     }
+
+
+def test_kubernetes_cluster_maps_to_eks_cluster(neo4j_session):
+    # Arrange: seed an EKSCluster whose arn matches cluster 1's external_id.
+    # Cluster 2's external_id intentionally has no matching EKSCluster.
+    cluster_1_arn = KUBERNETES_CLUSTER_DATA[0]["external_id"]
+    neo4j_session.run(
+        "MERGE (:EKSCluster {id: $arn, arn: $arn, lastupdated: $update_tag})",
+        arn=cluster_1_arn,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # Act
+    load_kubernetes_cluster(neo4j_session, KUBERNETES_CLUSTER_DATA, TEST_UPDATE_TAG)
+
+    # Assert: MAPS_TO edge only for the cluster whose external_id matches.
+    assert check_rels(
+        neo4j_session,
+        "EKSCluster",
+        "arn",
+        "KubernetesCluster",
+        "id",
+        "MAPS_TO",
+    ) == {(cluster_1_arn, KUBERNETES_CLUSTER_IDS[0])}
 
 
 # cleaning up the kubernetes cluster node is currently not supported


### PR DESCRIPTION
### Type of change

- [x] New feature (non-breaking change that adds functionality)

### Summary

Adds a direct `(:EKSCluster)-[:MAPS_TO]->(:KubernetesCluster)` relationship so analysts and rules can traverse from the AWS-side view of a managed cluster to the Kubernetes-side view (and vice versa) without going through intermediate nodes.

The relationship is resolved on the `KubernetesCluster` ingestion path by matching the existing `external_id` property (already populated with the EKS cluster ARN for EKS clusters) against `EKSCluster.arn`. No orchestration changes are required: when both modules have synced, the edge materializes automatically; for non-EKS clusters the matcher finds nothing and no edge is created.

This mirrors the existing cross-provider identity convention used for `(:AWSRole)-[:MAPS_TO]->(:KubernetesUser)` and `(:AWSRole)-[:MAPS_TO]->(:KubernetesGroup)`.

### Related issues or links

- Fixes SUB-940

### How was this tested?

- New integration test `test_kubernetes_cluster_maps_to_eks_cluster` in `tests/integration/cartography/intel/kubernetes/test_clusters.py` seeds an `EKSCluster` matching one of the fixture K8s clusters' `external_id` and asserts:
  - the `MAPS_TO` edge is created for the matching cluster, and
  - the non-matching cluster gets no edge.
- Full kubernetes integration test file passes:
  ```
  $ uv run --frozen pytest tests/integration/cartography/intel/kubernetes/test_clusters.py tests/integration/cartography/intel/kubernetes/test_namespaces.py
  ===== 5 passed in 7.45s =====
  ```
- `make lint` (pre-commit) passes.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) (both Kubernetes and AWS schema docs).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md). — not applicable; no entry list changes.

### Notes for reviewers

- Chose \`MAPS_TO\` (rather than \`RESOURCE\` or \`RUNS_ON\`) to match the existing cross-provider identity convention already used for \`KubernetesUser\`/\`KubernetesGroup\` ↔ \`AWSRole\`/\`AWSUser\`.
- Direction is \`INWARD\` on \`KubernetesClusterSchema\` so the edge points \`EKSCluster → KubernetesCluster\`, consistent with the existing MAPS_TO conventions.
- Matcher uses the per-record \`external_id\` (not a kwarg) — keeps the ingestion call sites unchanged and naturally no-ops for non-EKS clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)