### PR TITLE
fix(jamf): normalize mobile os before ontology mapping

### DIFF
--- a/cartography/intel/jamf/mobile_devices.py
+++ b/cartography/intel/jamf/mobile_devices.py
@@ -26,6 +26,33 @@ _SECTION_PARAMS = {
 }
 
 
+def _normalize_mobile_os(device_type: str | None) -> str | None:
+    """Normalize Jamf mobile device family values into OS-family values.
+
+    Jamf's v2 mobile inventory uses ``deviceType`` for mobile family/platform
+    values. In practice this may already be an OS-family value such as ``iOS``,
+    but some tenants and fixtures return hardware-family values such as
+    ``iPhone`` or ``iPad``. Normalize the known values here so the provider node
+    can expose a consistent OS-family field to the ontology.
+    """
+    if not device_type:
+        return None
+
+    normalized = device_type.strip().lower()
+    os_by_device_type = {
+        "ios": "iOS",
+        "iphone": "iOS",
+        "ipod": "iOS",
+        "ipados": "iPadOS",
+        "ipad": "iPadOS",
+        "tvos": "tvOS",
+        "apple tv": "tvOS",
+        "appletv": "tvOS",
+        "android": "Android",
+    }
+    return os_by_device_type.get(normalized)
+
+
 @timeit
 def get(
     api_session: requests.Session,
@@ -64,6 +91,7 @@ def transform(api_result: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "last_inventory_update_date": general.get("lastInventoryUpdateDate"),
                 "last_enrolled_date": general.get("lastEnrolledDate"),
                 "platform": device.get("deviceType"),
+                "os": _normalize_mobile_os(device.get("deviceType")),
                 "os_version": general.get("osVersion"),
                 "os_build": general.get("osBuild"),
                 "serial_number": hardware.get("serialNumber"),

--- a/cartography/models/jamf/mobiledevice.py
+++ b/cartography/models/jamf/mobiledevice.py
@@ -21,6 +21,7 @@ class JamfMobileDeviceNodeProperties(CartographyNodeProperties):
     last_inventory_update_date: PropertyRef = PropertyRef("last_inventory_update_date")
     last_enrolled_date: PropertyRef = PropertyRef("last_enrolled_date")
     platform: PropertyRef = PropertyRef("platform")
+    os: PropertyRef = PropertyRef("os")
     os_version: PropertyRef = PropertyRef("os_version")
     os_build: PropertyRef = PropertyRef("os_build")
     serial_number: PropertyRef = PropertyRef("serial_number", extra_index=True)

--- a/cartography/models/ontology/mapping/data/devices.py
+++ b/cartography/models/ontology/mapping/data/devices.py
@@ -256,7 +256,7 @@ jamf_mapping = OntologyMapping(
                 ),
                 OntologyFieldMapping(
                     ontology_field="os",
-                    node_field="platform",
+                    node_field="os",
                 ),
                 OntologyFieldMapping(
                     ontology_field="os_version",

--- a/docs/root/modules/jamf/schema.md
+++ b/docs/root/modules/jamf/schema.md
@@ -156,7 +156,7 @@ Representation of a Jamf-managed macOS computer inventory record.
 
 Representation of a Jamf-managed iPhone or iPad inventory record.
 
-> **Ontology Mapping**: `JamfMobileDevice` contributes to the `Device` ontology using serial number as the primary key while promoting Jamf `display_name` and `platform` into the canonical `Device` hostname and OS fields.
+> **Ontology Mapping**: `JamfMobileDevice` contributes to the `Device` ontology using serial number as the primary key while promoting Jamf `display_name` and a normalized Jamf mobile OS value into the canonical `Device` hostname and OS fields.
 
 | Field | Description |
 |-------|-------------|
@@ -169,6 +169,7 @@ Representation of a Jamf-managed iPhone or iPad inventory record.
 | last_inventory_update_date | Last inventory update timestamp |
 | last_enrolled_date | Enrollment timestamp |
 | platform | Jamf device type |
+| os | Normalized OS family derived from the Jamf device type when available |
 | os_version | OS version |
 | os_build | OS build |
 | **serial_number** | Device serial number |

--- a/tests/integration/cartography/intel/jamf/test_jamf.py
+++ b/tests/integration/cartography/intel/jamf/test_jamf.py
@@ -205,13 +205,30 @@ def test_sync_mobile_devices(mock_get, mock_groups_get, neo4j_session):
             "id",
             "display_name",
             "serial_number",
+            "os",
             "platform",
             "passcode_compliant",
             "username",
         ],
     ) == {
-        (9001, "Bart-iPhone-01", "IPHONESPRING001", "iPhone", True, "b.simpson"),
-        (9002, "Lisa-iPad-01", "IPADSPRING001", "iPad", False, "l.simpson"),
+        (
+            9001,
+            "Bart-iPhone-01",
+            "IPHONESPRING001",
+            "iOS",
+            "iPhone",
+            True,
+            "b.simpson",
+        ),
+        (
+            9002,
+            "Lisa-iPad-01",
+            "IPADSPRING001",
+            "iPadOS",
+            "iPad",
+            False,
+            "l.simpson",
+        ),
     }
 
     assert check_rels(

--- a/tests/integration/cartography/intel/ontology/test_devices.py
+++ b/tests/integration/cartography/intel/ontology/test_devices.py
@@ -628,6 +628,7 @@ def test_load_ontology_devices_from_jamf_mobile_devices(neo4j_session):
         CREATE (:JamfMobileDevice {
             id: 'jamf-mobile-1',
             display_name: 'Bart-iPhone-01',
+            os: 'iOS',
             platform: 'iPhone',
             os_version: '17.4.1',
             model: 'iPhone 15',
@@ -637,6 +638,7 @@ def test_load_ontology_devices_from_jamf_mobile_devices(neo4j_session):
         CREATE (:JamfMobileDevice {
             id: 'jamf-mobile-2',
             display_name: 'Lisa-iPad-01',
+            os: 'iPadOS',
             platform: 'iPad',
             os_version: '17.3',
             model: 'iPad Pro',
@@ -661,7 +663,7 @@ def test_load_ontology_devices_from_jamf_mobile_devices(neo4j_session):
     ) == {
         (
             "Bart-iPhone-01",
-            "iPhone",
+            "iOS",
             "17.4.1",
             "iPhone 15",
             "iPhone",
@@ -669,7 +671,7 @@ def test_load_ontology_devices_from_jamf_mobile_devices(neo4j_session):
         ),
         (
             "Lisa-iPad-01",
-            "iPad",
+            "iPadOS",
             "17.3",
             "iPad Pro",
             "iPad",

--- a/tests/unit/cartography/intel/jamf/test_mobile_devices.py
+++ b/tests/unit/cartography/intel/jamf/test_mobile_devices.py
@@ -1,10 +1,14 @@
+from typing import Any
+from typing import cast
 from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
 
+from cartography.intel.jamf.mobile_devices import _normalize_mobile_os
 from cartography.intel.jamf.mobile_devices import get
 from cartography.intel.jamf.mobile_devices import transform
+from tests.data.jamf.mobile_devices import MOBILE_DEVICES
 
 
 @patch("cartography.intel.jamf.mobile_devices.get_paginated_jamf_results")
@@ -29,3 +33,79 @@ def test_get_requests_groups_section(
 def test_transform_requires_mobile_device_id() -> None:
     with pytest.raises(KeyError, match="mobileDeviceId"):
         transform([{"deviceType": "iPhone"}])
+
+
+def test_normalize_mobile_os() -> None:
+    cases = [
+        ("iPhone", "iOS"),
+        ("iPad", "iPadOS"),
+        ("iOS", "iOS"),
+        ("tvOS", "tvOS"),
+        ("Android", "Android"),
+        ("unknown", None),
+        (None, None),
+    ]
+
+    for device_type, expected_os in cases:
+        assert _normalize_mobile_os(device_type) == expected_os
+
+
+def test_transform_normalizes_mobile_os_family() -> None:
+    transformed = transform(cast(list[dict[str, Any]], MOBILE_DEVICES))
+
+    assert transformed == [
+        {
+            "id": 9001,
+            "display_name": "Bart-iPhone-01",
+            "managed": True,
+            "supervised": True,
+            "last_inventory_update_date": "2026-04-16T15:20:00Z",
+            "last_enrolled_date": "2025-09-01T08:00:00Z",
+            "platform": "iPhone",
+            "os": "iOS",
+            "os_version": "17.4.1",
+            "os_build": "21E236",
+            "serial_number": "IPHONESPRING001",
+            "model": "iPhone 15",
+            "model_identifier": "iPhone15,4",
+            "activation_lock_enabled": True,
+            "bootstrap_token_escrowed": True,
+            "data_protected": True,
+            "hardware_encryption": True,
+            "jailbreak_detected": False,
+            "lost_mode_enabled": False,
+            "passcode_compliant": True,
+            "passcode_present": True,
+            "username": "b.simpson",
+            "user_real_name": "Bart Simpson",
+            "email": "b.simpson@springfield.example",
+            "group_ids": [201],
+        },
+        {
+            "id": 9002,
+            "display_name": "Lisa-iPad-01",
+            "managed": True,
+            "supervised": False,
+            "last_inventory_update_date": "2026-04-16T12:20:00Z",
+            "last_enrolled_date": "2025-03-15T08:00:00Z",
+            "platform": "iPad",
+            "os": "iPadOS",
+            "os_version": "17.3",
+            "os_build": "21D50",
+            "serial_number": "IPADSPRING001",
+            "model": "iPad Pro",
+            "model_identifier": "iPad14,3",
+            "activation_lock_enabled": False,
+            "bootstrap_token_escrowed": False,
+            "data_protected": True,
+            "hardware_encryption": True,
+            "jailbreak_detected": False,
+            "lost_mode_enabled": True,
+            "passcode_compliant": False,
+            "passcode_present": True,
+            "username": "l.simpson",
+            "user_real_name": "Lisa Simpson",
+            "email": "l.simpson@springfield.example",
+            "group_ids": [],
+        },
+    ]


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

### Summary
Follow-up to #2636.

`JamfMobileDevice` now contributes `display_name -> Device.hostname`, which improves the canonical `Device` rows for Jamf mobile inventory. But the current `Device.os <- JamfMobileDevice.platform` mapping still relies on Jamf's raw `deviceType` field, and that field is not consistently an OS-family value across environments and fixtures.

In the live tenant we validated, `deviceType` comes through as `iOS`, so the existing mapping happens to work. In Cartography's sanitized integration fixtures, the same field is `iPhone` / `iPad`, which means the canonical ontology can end up with semantically incorrect `Device.os` values even though the data is otherwise valid.

This follow-up fixes that at the Jamf provider layer by:
- normalizing known Jamf mobile `deviceType` values into an explicit `JamfMobileDevice.os` field
- mapping `Device.os` from that normalized provider field instead of from `platform`
- keeping `platform` unchanged so the raw Jamf device family is still preserved separately

Why this belongs here:
- it keeps the `Device` ontology aligned with its own `os` vs `platform` semantics
- it avoids hardcoded canonical assumptions in the ontology layer itself
- it keeps downstream consumers from having to special-case Jamf mobile device-family strings

### Related issues or links
- Follow-up to #2636

### How was this tested?
- tested locally on Jamf tenant

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).
