### PR TITLE
chore(graph): bump default cleanup iterationsize to 10000

### DIFF
--- a/cartography/graph/job.py
+++ b/cartography/graph/job.py
@@ -330,7 +330,7 @@ class GraphJob:
         cls,
         node_schema: CartographyNodeSchema,
         parameters: Dict[str, Any],
-        iterationsize: int = 100,
+        iterationsize: int = 10000,
         cascade_delete: bool = False,
     ) -> "GraphJob":
         """
@@ -352,7 +352,7 @@ class GraphJob:
                 Must include all parameters required by the generated queries.
                 Common parameters include UPDATE_TAG and sub-resource identifiers.
             iterationsize (int, optional): The number of items to process in each iteration.
-                Defaults to 100.
+                Defaults to 10000, matching Neo4j's recommendation for large deletes.
             cascade_delete (bool): If True, also delete all child nodes that have a
                 relationship to stale nodes matching node_schema.sub_resource_relationship.rel_label.
                 Defaults to False to preserve existing behavior.
@@ -404,7 +404,7 @@ class GraphJob:
         sub_resource_label: str,
         sub_resource_id: str,
         update_tag: int,
-        iterationsize: int = 100,
+        iterationsize: int = 10000,
     ) -> "GraphJob":
         """
         Create a cleanup job for matchlink relationships.
@@ -421,7 +421,7 @@ class GraphJob:
             sub_resource_id (str): The ID of the sub-resource to scope cleanup to.
             update_tag (int): The update tag to identify stale relationships.
             iterationsize (int, optional): The number of items to process in each iteration.
-                Defaults to 100.
+                Defaults to 10000, matching Neo4j's recommendation for large deletes.
 
         Returns:
             GraphJob: A new GraphJob instance configured for matchlink cleanup.
@@ -433,7 +433,6 @@ class GraphJob:
             - For a given rel_schema, the fields used in the rel_schema.properties._sub_resource_label.name and
             rel_schema.properties._sub_resource_id.name must be provided as keys and values in the params dict.
             - The rel_schema must have a source_node_matcher and target_node_matcher.
-            - The number of items to process in each iteration. Defaults to 100.
         """
         cleanup_link_query = build_cleanup_query_for_matchlink(rel_schema)
         logger.debug("Cleanup query: %s", cleanup_link_query)


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Neo4j recommends a batch size of 10,000 for large delete operations. The default `iterationsize` in `GraphJob.from_node_schema()` and `GraphJob.from_matchlink()` was 100, which causes excessive Python↔Neo4j round-trips during cleanup of large datasets.

This PR bumps both defaults from `100` → `10000`. Callers that explicitly pass `iterationsize` (e.g. `cartography/intel/aws/inspector.py` which uses its own `BATCH_SIZE = 1000`) are unaffected. Legacy JSON cleanup jobs under `cartography/data/jobs/cleanup/*.json` carry their own explicit `iterationsize: 100` and are intentionally left untouched — the issue targets the Python default, and updating every JSON file expands scope beyond what's asked.

Docstrings are updated to reflect the new default and cite the Neo4j recommendation.


### Related issues or links

- Fixes #2195
- [Neo4j large-delete best practices](https://neo4j.com/developer/kb/large-delete-transaction-best-practices-in-neo4j/)


### How was this tested?

- `uv run --frozen pre-commit run --files cartography/graph/job.py` — passes (black, isort, flake8, mypy, pyupgrade)
- `uv run --frozen pytest tests/unit/cartography/graph/ tests/unit/cartography/data/jobs/` — 80 passed


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works. — N/A, default-value change with existing coverage.