### PR TITLE
fix(aws): honor configured profile even when only one is discovered

### DIFF
--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -266,14 +266,13 @@ def _sync_multiple_accounts(
     aws_best_effort_mode: bool,
     aws_requested_syncs: List[str] = [],
     regions: list[str] | None = None,
+    use_profile_for_session: bool = False,
 ) -> bool:
     logger.info("Syncing AWS accounts: %s", ", ".join(accounts.values()))
     organizations.sync(neo4j_session, accounts, sync_tag, common_job_parameters)
 
     failed_account_ids = []
     exception_tracebacks = []
-
-    num_accounts = len(accounts)
 
     for profile_name, account_id in accounts.items():
         logger.info(
@@ -282,13 +281,14 @@ def _sync_multiple_accounts(
             profile_name,
         )
         common_job_parameters["AWS_ID"] = account_id
-        if num_accounts == 1:
-            # Use the default boto3 session because boto3 gets confused if you give it a profile name with 1 account
-            boto3_session = boto3.Session()
-            aioboto3_session = aioboto3.Session()
-        else:
+        if use_profile_for_session:
+            # Honor explicit profiles even for single-profile setups, so hub/spoke STS assume-role configs sync the spoke.
             boto3_session = boto3.Session(profile_name=profile_name)
             aioboto3_session = aioboto3.Session(profile_name=profile_name)
+        else:
+            # Default session keeps env-var-only credentials working when ~/.aws/config is absent (see #1042).
+            boto3_session = boto3.Session()
+            aioboto3_session = aioboto3.Session()
 
         _autodiscover_accounts(
             neo4j_session,
@@ -477,6 +477,7 @@ def start_aws_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
         config.aws_best_effort_mode,
         requested_syncs,
         regions=regions,
+        use_profile_for_session=config.aws_sync_all_profiles,
     )
 
     if sync_successful:

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -266,7 +266,7 @@ def _sync_multiple_accounts(
     aws_best_effort_mode: bool,
     aws_requested_syncs: List[str] = [],
     regions: list[str] | None = None,
-    use_profile_for_session: bool = False,
+    use_explicit_profile: bool = False,
 ) -> bool:
     logger.info("Syncing AWS accounts: %s", ", ".join(accounts.values()))
     organizations.sync(neo4j_session, accounts, sync_tag, common_job_parameters)
@@ -281,14 +281,11 @@ def _sync_multiple_accounts(
             profile_name,
         )
         common_job_parameters["AWS_ID"] = account_id
-        if use_profile_for_session:
-            # Honor explicit profiles even for single-profile setups, so hub/spoke STS assume-role configs sync the spoke.
-            boto3_session = boto3.Session(profile_name=profile_name)
-            aioboto3_session = aioboto3.Session(profile_name=profile_name)
-        else:
-            # Default session keeps env-var-only credentials working when ~/.aws/config is absent (see #1042).
-            boto3_session = boto3.Session()
-            aioboto3_session = aioboto3.Session()
+        # When use_explicit_profile is set, honor configured profiles (hub/spoke STS assume-role configs, #1142/#1185).
+        # Otherwise fall back to the default session so env-var-only credentials keep working when ~/.aws/config is absent (#1042).
+        session_kwargs = {"profile_name": profile_name} if use_explicit_profile else {}
+        boto3_session = boto3.Session(**session_kwargs)
+        aioboto3_session = aioboto3.Session(**session_kwargs)
 
         _autodiscover_accounts(
             neo4j_session,
@@ -477,7 +474,9 @@ def start_aws_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
         config.aws_best_effort_mode,
         requested_syncs,
         regions=regions,
-        use_profile_for_session=config.aws_sync_all_profiles,
+        # Today this flag mirrors aws_sync_all_profiles 1:1; it's named separately so _sync_multiple_accounts
+        # stays decoupled from the CLI option should the two ever diverge.
+        use_explicit_profile=config.aws_sync_all_profiles,
     )
 
     if sync_successful:

--- a/tests/integration/cartography/intel/aws/test_init.py
+++ b/tests/integration/cartography/intel/aws/test_init.py
@@ -67,47 +67,45 @@ def test_sync_multiple_accounts(
     mock_sync_orgs,
     neo4j_session,
 ):
-    test_config = cartography.config.Config(
-        neo4j_uri="bolt://localhost:7687",
-    )
     cartography.intel.aws._sync_multiple_accounts(
         neo4j_session,
         TEST_ACCOUNTS,
         TEST_UPDATE_TAG,
         GRAPH_JOB_PARAMETERS,
-        test_config,
+        aws_best_effort_mode=False,
+        use_profile_for_session=True,
     )
 
     # Ensure we call _sync_one_account on all accounts in our list.
     mock_sync_one.assert_any_call(
         neo4j_session,
-        mock_boto3_session(),
+        mock_boto3_session(profile_name="profile1"),
         "000000000000",
         TEST_UPDATE_TAG,
         GRAPH_JOB_PARAMETERS,
         regions=None,
         aws_requested_syncs=[],
-        aioboto3_session=mock_aioboto3_session(),
+        aioboto3_session=mock_aioboto3_session(profile_name="profile1"),
     )
     mock_sync_one.assert_any_call(
         neo4j_session,
-        mock_boto3_session(),
+        mock_boto3_session(profile_name="profile2"),
         "000000000001",
         TEST_UPDATE_TAG,
         GRAPH_JOB_PARAMETERS,
         regions=None,
         aws_requested_syncs=[],
-        aioboto3_session=mock_aioboto3_session(),
+        aioboto3_session=mock_aioboto3_session(profile_name="profile2"),
     )
     mock_sync_one.assert_any_call(
         neo4j_session,
-        mock_boto3_session(),
+        mock_boto3_session(profile_name="profile3"),
         "000000000002",
         TEST_UPDATE_TAG,
         GRAPH_JOB_PARAMETERS,
         regions=None,
         aws_requested_syncs=[],
-        aioboto3_session=mock_aioboto3_session(),
+        aioboto3_session=mock_aioboto3_session(profile_name="profile3"),
     )
 
     # Ensure _sync_one_account and _autodiscover is called once for each account
@@ -116,6 +114,81 @@ def test_sync_multiple_accounts(
 
     # This is a brittle test, but it is here to ensure that the mock_cleanup path is correct.
     assert mock_cleanup.call_count == 1
+
+
+@mock.patch.object(cartography.intel.aws.organizations, "sync", return_value=None)
+@mock.patch("cartography.intel.aws.aioboto3.Session")
+@mock.patch("cartography.intel.aws.boto3.Session")
+@mock.patch.object(cartography.intel.aws, "_sync_one_account", return_value=None)
+@mock.patch.object(cartography.intel.aws, "_autodiscover_accounts", return_value=None)
+@mock.patch.object(cartography.intel.aws, "run_cleanup_job", return_value=None)
+def test_sync_multiple_accounts_single_profile_uses_profile_name(
+    mock_cleanup,
+    mock_autodiscover,
+    mock_sync_one,
+    mock_boto3_session,
+    mock_aioboto3_session,
+    mock_sync_orgs,
+    neo4j_session,
+):
+    # Regression for #1142 and #1185: single explicit profile must not fall back to the default session.
+    single_account = {"spoke1": "000000000099"}
+
+    cartography.intel.aws._sync_multiple_accounts(
+        neo4j_session,
+        single_account,
+        TEST_UPDATE_TAG,
+        GRAPH_JOB_PARAMETERS,
+        aws_best_effort_mode=False,
+        use_profile_for_session=True,
+    )
+
+    mock_boto3_session.assert_any_call(profile_name="spoke1")
+    mock_aioboto3_session.assert_any_call(profile_name="spoke1")
+    mock_sync_one.assert_called_once_with(
+        neo4j_session,
+        mock_boto3_session(profile_name="spoke1"),
+        "000000000099",
+        TEST_UPDATE_TAG,
+        GRAPH_JOB_PARAMETERS,
+        regions=None,
+        aws_requested_syncs=[],
+        aioboto3_session=mock_aioboto3_session(profile_name="spoke1"),
+    )
+
+
+@mock.patch.object(cartography.intel.aws.organizations, "sync", return_value=None)
+@mock.patch("cartography.intel.aws.aioboto3.Session")
+@mock.patch("cartography.intel.aws.boto3.Session")
+@mock.patch.object(cartography.intel.aws, "_sync_one_account", return_value=None)
+@mock.patch.object(cartography.intel.aws, "_autodiscover_accounts", return_value=None)
+@mock.patch.object(cartography.intel.aws, "run_cleanup_job", return_value=None)
+def test_sync_multiple_accounts_default_path_uses_default_session(
+    mock_cleanup,
+    mock_autodiscover,
+    mock_sync_one,
+    mock_boto3_session,
+    mock_aioboto3_session,
+    mock_sync_orgs,
+    neo4j_session,
+):
+    # Without --aws-sync-all-profiles the default session must be used (preserves #1042 fix for env-var-only creds).
+    default_account = {"default": "000000000000"}
+
+    cartography.intel.aws._sync_multiple_accounts(
+        neo4j_session,
+        default_account,
+        TEST_UPDATE_TAG,
+        GRAPH_JOB_PARAMETERS,
+        aws_best_effort_mode=False,
+        use_profile_for_session=False,
+    )
+
+    for call in mock_boto3_session.call_args_list:
+        assert "profile_name" not in call.kwargs
+    for call in mock_aioboto3_session.call_args_list:
+        assert "profile_name" not in call.kwargs
+    assert mock_sync_one.call_count == 1
 
 
 @mock.patch("cartography.intel.aws.aioboto3.Session")

--- a/tests/integration/cartography/intel/aws/test_init.py
+++ b/tests/integration/cartography/intel/aws/test_init.py
@@ -6,6 +6,7 @@ from typing import List
 from unittest import mock
 
 import neo4j
+from moto import mock_aws
 from pytest import raises
 
 import cartography.config
@@ -73,7 +74,7 @@ def test_sync_multiple_accounts(
         TEST_UPDATE_TAG,
         GRAPH_JOB_PARAMETERS,
         aws_best_effort_mode=False,
-        use_profile_for_session=True,
+        use_explicit_profile=True,
     )
 
     # Ensure we call _sync_one_account on all accounts in our list.
@@ -140,7 +141,7 @@ def test_sync_multiple_accounts_single_profile_uses_profile_name(
         TEST_UPDATE_TAG,
         GRAPH_JOB_PARAMETERS,
         aws_best_effort_mode=False,
-        use_profile_for_session=True,
+        use_explicit_profile=True,
     )
 
     mock_boto3_session.assert_any_call(profile_name="spoke1")
@@ -181,7 +182,7 @@ def test_sync_multiple_accounts_default_path_uses_default_session(
         TEST_UPDATE_TAG,
         GRAPH_JOB_PARAMETERS,
         aws_best_effort_mode=False,
-        use_profile_for_session=False,
+        use_explicit_profile=False,
     )
 
     for call in mock_boto3_session.call_args_list:
@@ -189,6 +190,59 @@ def test_sync_multiple_accounts_default_path_uses_default_session(
     for call in mock_aioboto3_session.call_args_list:
         assert "profile_name" not in call.kwargs
     assert mock_sync_one.call_count == 1
+
+
+@mock_aws
+@mock.patch.object(cartography.intel.aws.organizations, "sync", return_value=None)
+@mock.patch.object(cartography.intel.aws, "_autodiscover_accounts", return_value=None)
+@mock.patch.object(cartography.intel.aws, "run_cleanup_job", return_value=None)
+def test_sync_multiple_accounts_profile_session_is_usable(
+    mock_cleanup,
+    mock_autodiscover,
+    mock_sync_orgs,
+    neo4j_session,
+    monkeypatch,
+    tmp_path,
+):
+    # Smoke test for #1042/#1142/#1185: the real boto3 Session built for each profile
+    # must resolve credentials from the configured profile and support live AWS calls.
+    # Unlike the mocked plumbing tests above, nothing patches boto3.Session here.
+    creds_file = tmp_path / "credentials"
+    creds_file.write_text(
+        "[spoke1]\n"
+        "aws_access_key_id = spoke-access\n"
+        "aws_secret_access_key = spoke-secret\n",
+    )
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(creds_file))
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+
+    captured_sessions = []
+
+    def capture(neo4j_session, boto3_session, *args, **kwargs):
+        captured_sessions.append(boto3_session)
+
+    with mock.patch.object(
+        cartography.intel.aws, "_sync_one_account", side_effect=capture
+    ):
+        cartography.intel.aws._sync_multiple_accounts(
+            neo4j_session,
+            {"spoke1": "000000000099"},
+            TEST_UPDATE_TAG,
+            GRAPH_JOB_PARAMETERS,
+            aws_best_effort_mode=False,
+            use_explicit_profile=True,
+        )
+
+    assert len(captured_sessions) == 1
+    session = captured_sessions[0]
+    assert session.profile_name == "spoke1"
+    creds = session.get_credentials()
+    assert creds is not None
+    assert creds.access_key == "spoke-access"
+    # The session is good enough to call STS through moto — if profile_name weren't
+    # honored, this would fail with NoCredentialsError (empty creds file).
+    identity = session.client("sts", region_name="us-east-1").get_caller_identity()
+    assert "Account" in identity
 
 
 @mock.patch("cartography.intel.aws.aioboto3.Session")


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

`_sync_multiple_accounts` used to fall back to the default boto3 session whenever exactly one account was being synced, which broke two documented flows:

- **#1142**: `--aws-sync-all-profiles` with a single configured profile silently reverted to the default profile (raising `AccessDenied` because the default creds had no IAM permissions on the target account).
- **#1185**: Hub/spoke STS assume-role setups logged the spoke account ID but actually ingested the hub's data because the spoke profile was dropped in favor of the default session.

Both had the same root cause: the `num_accounts == 1` discriminator was introduced in #1043 to dodge `ProfileNotFound` when env-var-only credentials are used without `~/.aws/config`, but it was too aggressive — it also dropped legitimately configured profiles whenever only one was discovered.

This PR replaces the discriminator with an explicit `use_explicit_profile` flag plumbed from `config.aws_sync_all_profiles` through `start_aws_ingestion` → `_sync_multiple_accounts`:

- If the user passed `--aws-sync-all-profiles`, honor each discovered profile by name (fixes #1142 and #1185).
- Otherwise, keep using the default session (preserves the #1042 fix for env-var-only credentials).


### Release note

Users running `--aws-sync-all-profiles` against a single configured profile may observe a change in auth behavior after upgrading: cartography now correctly uses the named profile instead of silently falling back to the default session. If you were unintentionally relying on that fallback (e.g., the default session happened to have the right credentials), you'll need to either drop `--aws-sync-all-profiles` or make sure the named profile resolves to credentials with `SecurityAudit` on the target account.


### Related issues or links

- Fixes #1142
- Fixes #1185
- Preserves behavior from #1043 / #1042


### Breaking changes

None at the API level. See the release note above for a behavioral change that may affect misconfigured single-profile setups.


### How was this tested?

- `uv run --frozen pytest tests/integration/cartography/intel/aws/test_init.py` → 11 passed.
- `uv run --frozen pre-commit run --files cartography/intel/aws/__init__.py tests/integration/cartography/intel/aws/test_init.py` → all hooks passed.
- Added three regression tests:
  - `test_sync_multiple_accounts_single_profile_uses_profile_name` — asserts that with `use_explicit_profile=True` and a single-entry accounts dict, `boto3.Session` / `aioboto3.Session` are called with `profile_name=\"spoke1\"`.
  - `test_sync_multiple_accounts_default_path_uses_default_session` — asserts that with `use_explicit_profile=False` no `profile_name` kwarg is passed (preserves the #1042 env-var-only path).
  - `test_sync_multiple_accounts_profile_session_is_usable` — moto-backed smoke test that exercises a real `boto3.Session` (no mocks on `boto3.Session`). It writes a shared credentials file with a distinctive `[spoke1]` profile, captures the session built by `_sync_multiple_accounts`, and verifies (a) `session.profile_name == \"spoke1\"`, (b) `get_credentials()` returns the profile's creds (not moto's default \`testing\` creds), and (c) an STS call succeeds through moto. This catches the class of bug that #1042/#1142/#1185 belong to — verifying the session is actually usable end-to-end, not just that `profile_name` was forwarded.
- Updated the existing `test_sync_multiple_accounts` to assert per-iteration `profile_name` kwargs and to fix a pre-existing signature mismatch (it was passing a `Config` object where `aws_best_effort_mode: bool` is expected; it only passed because `Config` was truthy).


### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.


### Notes for reviewers

- The single-line comments on the two branches of the session-kwargs construction document *why* each path exists — happy to expand or trim if you prefer.
- The `use_explicit_profile` parameter defaults to `False` so other callers (if any emerge) keep the safer default-session behavior.
- The `\"default\"` profile is still skipped in `get_aws_accounts_from_botocore_config`, unchanged here.
- Today `use_explicit_profile` mirrors `aws_sync_all_profiles` 1:1; it's named separately (with an inline comment at the call site) so `_sync_multiple_accounts` stays decoupled from the CLI option should the two ever diverge.