### PR TITLE
feat(microsoft): add GCC High / DoD / China sovereign cloud support

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -606,6 +606,19 @@ class CLI:
                     hidden=PANEL_ENTRA not in visible_panels,
                 ),
             ] = None,
+            entra_cloud: Annotated[
+                str | None,
+                typer.Option(
+                    "--entra-cloud",
+                    help=(
+                        "Microsoft sovereign cloud for Entra/Intune Graph API calls. "
+                        "One of: commercial (default), usgov (GCC High / L4), "
+                        "usgov-dod (DoD / L5), china."
+                    ),
+                    rich_help_panel=PANEL_ENTRA,
+                    hidden=PANEL_ENTRA not in visible_panels,
+                ),
+            ] = None,
             # =================================================================
             # GCP Options
             # =================================================================
@@ -2286,6 +2299,7 @@ class CLI:
                 entra_tenant_id=entra_tenant_id,
                 entra_client_id=entra_client_id,
                 entra_client_secret=entra_client_secret,
+                entra_cloud=entra_cloud,
                 aws_requested_syncs=aws_requested_syncs,
                 aws_guardduty_severity_threshold=aws_guardduty_severity_threshold,
                 analysis_job_directory=analysis_job_directory,

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -71,6 +71,9 @@ class Config:
     :param entra_client_id: Client Id for connecting in a Service Principal Authentication approach. Optional.
     :type entra_client_secret: str
     :param entra_client_secret: Client Secret for connecting in a Service Principal Authentication approach. Optional.
+    :type entra_cloud: str
+    :param entra_cloud: Microsoft sovereign cloud for Entra/Intune Graph API calls.
+        One of: commercial, usgov (GCC High / L4), usgov-dod (DoD / L5), china. Defaults to commercial.
     :type aws_requested_syncs: str
     :param aws_requested_syncs: Comma-separated list of AWS resources to sync. Optional.
     :type aws_guardduty_severity_threshold: str
@@ -314,6 +317,7 @@ class Config:
         entra_tenant_id=None,
         entra_client_id=None,
         entra_client_secret=None,
+        entra_cloud=None,
         aws_requested_syncs=None,
         aws_guardduty_severity_threshold=None,
         analysis_job_directory=None,
@@ -467,6 +471,7 @@ class Config:
         self.entra_tenant_id = entra_tenant_id
         self.entra_client_id = entra_client_id
         self.entra_client_secret = entra_client_secret
+        self.entra_cloud = entra_cloud
         self.aws_requested_syncs = aws_requested_syncs
         self.aws_guardduty_severity_threshold = aws_guardduty_severity_threshold
         self.analysis_job_directory = analysis_job_directory

--- a/cartography/intel/microsoft/clouds.py
+++ b/cartography/intel/microsoft/clouds.py
@@ -1,0 +1,66 @@
+"""Sovereign-cloud endpoint definitions for Microsoft Graph.
+
+Supports the commercial cloud plus the GCC High / DoD US Government and
+China national clouds. Each cloud exposes a distinct Graph endpoint and
+AAD authority host — see
+https://learn.microsoft.com/en-us/graph/deployments for the authoritative
+list.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MicrosoftCloud:
+    name: str
+    graph_base_url: str
+    graph_scope: str
+    authority: str
+
+
+COMMERCIAL = MicrosoftCloud(
+    name="commercial",
+    graph_base_url="https://graph.microsoft.com/v1.0/",
+    graph_scope="https://graph.microsoft.com/.default",
+    authority="https://login.microsoftonline.com",
+)
+
+USGOV = MicrosoftCloud(
+    name="usgov",
+    graph_base_url="https://graph.microsoft.us/v1.0/",
+    graph_scope="https://graph.microsoft.us/.default",
+    authority="https://login.microsoftonline.us",
+)
+
+USGOV_DOD = MicrosoftCloud(
+    name="usgov-dod",
+    graph_base_url="https://dod-graph.microsoft.us/v1.0/",
+    graph_scope="https://dod-graph.microsoft.us/.default",
+    authority="https://login.microsoftonline.us",
+)
+
+CHINA = MicrosoftCloud(
+    name="china",
+    graph_base_url="https://microsoftgraph.chinacloudapi.cn/v1.0/",
+    graph_scope="https://microsoftgraph.chinacloudapi.cn/.default",
+    authority="https://login.chinacloudapi.cn",
+)
+
+CLOUDS: dict[str, MicrosoftCloud] = {
+    c.name: c for c in (COMMERCIAL, USGOV, USGOV_DOD, CHINA)
+}
+
+DEFAULT_CLOUD_NAME = COMMERCIAL.name
+
+
+def get_cloud(name: str | None) -> MicrosoftCloud:
+    """Resolve a cloud name to its :class:`MicrosoftCloud` definition.
+
+    :raises ValueError: if the name is not a known cloud.
+    """
+    key = (name or DEFAULT_CLOUD_NAME).lower()
+    try:
+        return CLOUDS[key]
+    except KeyError:
+        valid = ", ".join(sorted(CLOUDS))
+        raise ValueError(f"Unknown Microsoft cloud {name!r}. Valid values: {valid}.")

--- a/cartography/intel/microsoft/entra/__init__.py
+++ b/cartography/intel/microsoft/entra/__init__.py
@@ -2,10 +2,11 @@ import asyncio
 import logging
 
 import neo4j
-from azure.identity import ClientSecretCredential
-from msgraph import GraphServiceClient
 
 from cartography.config import Config
+from cartography.intel.microsoft.clouds import COMMERCIAL
+from cartography.intel.microsoft.clouds import get_cloud
+from cartography.intel.microsoft.clouds import MicrosoftCloud
 from cartography.intel.microsoft.entra.app_role_assignments import (
     sync_app_role_assignments,
 )
@@ -20,6 +21,7 @@ from cartography.intel.microsoft.entra.users import get_tenant
 from cartography.intel.microsoft.entra.users import load_tenant
 from cartography.intel.microsoft.entra.users import sync_entra_users
 from cartography.intel.microsoft.entra.users import transform_tenant
+from cartography.intel.microsoft.entra.utils import build_graph_client
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -32,6 +34,7 @@ async def sync_tenant(
     client_id: str,
     client_secret: str,
     update_tag: int,
+    cloud: MicrosoftCloud = COMMERCIAL,
 ) -> None:
     """
     Sync tenant information as a prerequisite for all other Entra resource syncs.
@@ -41,15 +44,9 @@ async def sync_tenant(
     :param client_id: Azure application client ID
     :param client_secret: Azure application client secret
     :param update_tag: Update tag for tracking data freshness
+    :param cloud: Microsoft sovereign cloud (commercial, usgov, etc.)
     """
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id,
-        client_id=client_id,
-        client_secret=client_secret,
-    )
-    client = GraphServiceClient(
-        credential, scopes=["https://graph.microsoft.com/.default"]
-    )
+    client = build_graph_client(tenant_id, client_id, client_secret, cloud)
 
     # Fetch tenant and load it
     tenant = await get_tenant(client)
@@ -81,6 +78,9 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
         )
         return
 
+    cloud = get_cloud(config.entra_cloud)
+    logger.info("Using Microsoft cloud %r for Entra sync", cloud.name)
+
     common_job_parameters = {
         "UPDATE_TAG": config.update_tag,
         "TENANT_ID": config.entra_tenant_id,
@@ -94,6 +94,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             config.entra_client_id,
             config.entra_client_secret,
             config.update_tag,
+            cloud,
         )
 
         # Run user sync
@@ -104,6 +105,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             config.entra_client_secret,
             config.update_tag,
             common_job_parameters,
+            cloud,
         )
 
         # Run group sync
@@ -114,6 +116,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             config.entra_client_secret,
             config.update_tag,
             common_job_parameters,
+            cloud,
         )
 
         # Run OU sync
@@ -124,6 +127,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             config.entra_client_secret,
             config.update_tag,
             common_job_parameters,
+            cloud,
         )
 
         # Run application sync
@@ -134,6 +138,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             config.entra_client_secret,
             config.update_tag,
             common_job_parameters,
+            cloud,
         )
 
         # Run service principals sync
@@ -144,6 +149,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             config.entra_client_secret,
             config.update_tag,
             common_job_parameters,
+            cloud,
         )
 
         # Run app role assignments sync
@@ -154,6 +160,7 @@ def start_entra_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             config.entra_client_secret,
             config.update_tag,
             common_job_parameters,
+            cloud,
         )
 
         # Run federation sync (after all resources are synced)

--- a/cartography/intel/microsoft/entra/app_role_assignments.py
+++ b/cartography/intel/microsoft/entra/app_role_assignments.py
@@ -3,7 +3,6 @@ from typing import Any
 from typing import AsyncGenerator
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from msgraph import GraphServiceClient
 from msgraph.generated.models.app_role_assignment_collection_response import (
     AppRoleAssignmentCollectionResponse,
@@ -13,10 +12,13 @@ from cartography.client.core.tx import load
 from cartography.client.core.tx import read_list_of_values_tx
 from cartography.client.core.tx import read_single_value_tx
 from cartography.graph.job import GraphJob
+from cartography.intel.microsoft.clouds import COMMERCIAL
+from cartography.intel.microsoft.clouds import MicrosoftCloud
 from cartography.intel.microsoft.entra.applications import (
     APP_ROLE_ASSIGNMENTS_PAGE_SIZE,
 )
 from cartography.intel.microsoft.entra.applications import logger
+from cartography.intel.microsoft.entra.utils import build_graph_client
 from cartography.intel.microsoft.entra.utils import call_with_retries
 from cartography.models.microsoft.entra.app_role_assignment import (
     EntraAppRoleAssignmentSchema,
@@ -239,6 +241,7 @@ async def sync_app_role_assignments(
     client_secret: str,
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    cloud: MicrosoftCloud = COMMERCIAL,
 ) -> None:
     """
     Sync Entra app role assignments to the graph.
@@ -249,18 +252,9 @@ async def sync_app_role_assignments(
     :param client_secret: Azure application client secret
     :param update_tag: Update tag for tracking data freshness
     :param common_job_parameters: Common job parameters for cleanup
+    :param cloud: Microsoft sovereign cloud (commercial, usgov, etc.)
     """
-    # Create credentials and client
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id,
-        client_id=client_id,
-        client_secret=client_secret,
-    )
-
-    client = GraphServiceClient(
-        credential,
-        scopes=["https://graph.microsoft.com/.default"],
-    )
+    client = build_graph_client(tenant_id, client_id, client_secret, cloud)
     assignment_batch_size = 200  # Batch size for assignments
     assignments_batch = []
     total_assignment_count = 0

--- a/cartography/intel/microsoft/entra/applications.py
+++ b/cartography/intel/microsoft/entra/applications.py
@@ -5,12 +5,14 @@ from typing import AsyncGenerator
 from typing import Generator
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from msgraph.generated.models.application import Application
 from msgraph.graph_service_client import GraphServiceClient
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.microsoft.clouds import COMMERCIAL
+from cartography.intel.microsoft.clouds import MicrosoftCloud
+from cartography.intel.microsoft.entra.utils import build_graph_client
 from cartography.intel.microsoft.entra.utils import call_with_retries
 from cartography.models.microsoft.entra.application import EntraApplicationSchema
 from cartography.util import timeit
@@ -143,6 +145,7 @@ async def sync_entra_applications(
     client_secret: str,
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    cloud: MicrosoftCloud = COMMERCIAL,
 ) -> None:
     """
     Sync Entra applications and their app role assignments to the graph.
@@ -153,18 +156,9 @@ async def sync_entra_applications(
     :param client_secret: Azure application client secret
     :param update_tag: Update tag for tracking data freshness
     :param common_job_parameters: Common job parameters containing UPDATE_TAG and TENANT_ID
+    :param cloud: Microsoft sovereign cloud (commercial, usgov, etc.)
     """
-    # Create credentials and client
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id,
-        client_id=client_id,
-        client_secret=client_secret,
-    )
-
-    client = GraphServiceClient(
-        credential,
-        scopes=["https://graph.microsoft.com/.default"],
-    )
+    client = build_graph_client(tenant_id, client_id, client_secret, cloud)
 
     # Step 1: Sync applications
     app_batch_size = 10  # Batch size for applications

--- a/cartography/intel/microsoft/entra/groups.py
+++ b/cartography/intel/microsoft/entra/groups.py
@@ -3,13 +3,15 @@ from typing import AsyncGenerator
 from typing import Generator
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from msgraph import GraphServiceClient
 from msgraph.generated.models.directory_object import DirectoryObject
 from msgraph.generated.models.group import Group
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.microsoft.clouds import COMMERCIAL
+from cartography.intel.microsoft.clouds import MicrosoftCloud
+from cartography.intel.microsoft.entra.utils import build_graph_client
 from cartography.intel.microsoft.entra.utils import call_with_retries
 from cartography.models.microsoft.entra.group import EntraGroupSchema
 from cartography.util import timeit
@@ -133,14 +135,10 @@ async def sync_entra_groups(
     client_secret: str,
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    cloud: MicrosoftCloud = COMMERCIAL,
 ) -> None:
     """Sync Entra groups."""
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id, client_id=client_id, client_secret=client_secret
-    )
-    client = GraphServiceClient(
-        credential, scopes=["https://graph.microsoft.com/.default"]
-    )
+    client = build_graph_client(tenant_id, client_id, client_secret, cloud)
 
     # Collect groups in batches to avoid loading all at once
     groups_batch = []

--- a/cartography/intel/microsoft/entra/ou.py
+++ b/cartography/intel/microsoft/entra/ou.py
@@ -5,12 +5,14 @@ from typing import AsyncGenerator
 from typing import Generator
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from msgraph import GraphServiceClient
 from msgraph.generated.models.administrative_unit import AdministrativeUnit
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.microsoft.clouds import COMMERCIAL
+from cartography.intel.microsoft.clouds import MicrosoftCloud
+from cartography.intel.microsoft.entra.utils import build_graph_client
 from cartography.intel.microsoft.entra.utils import call_with_retries
 from cartography.models.microsoft.entra.ou import EntraOUSchema
 from cartography.util import timeit
@@ -99,19 +101,12 @@ async def sync_entra_ous(
     client_secret: str,
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    cloud: MicrosoftCloud = COMMERCIAL,
 ) -> None:
     """
     Sync Entra OUs
     """
-    # Initialize Graph client
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id,
-        client_id=client_id,
-        client_secret=client_secret,
-    )
-    client = GraphServiceClient(
-        credential, scopes=["https://graph.microsoft.com/.default"]
-    )
+    client = build_graph_client(tenant_id, client_id, client_secret, cloud)
 
     # Process OUs in batches
     batch_size = 100  # OUs are typically fewer than users/groups

--- a/cartography/intel/microsoft/entra/service_principals.py
+++ b/cartography/intel/microsoft/entra/service_principals.py
@@ -4,12 +4,14 @@ from typing import Any
 from typing import AsyncGenerator
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from msgraph import GraphServiceClient
 from msgraph.generated.models.service_principal import ServicePrincipal
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.microsoft.clouds import COMMERCIAL
+from cartography.intel.microsoft.clouds import MicrosoftCloud
+from cartography.intel.microsoft.entra.utils import build_graph_client
 from cartography.intel.microsoft.entra.utils import call_with_retries
 from cartography.models.microsoft.entra.service_principal import (
     EntraServicePrincipalSchema,
@@ -176,6 +178,7 @@ async def sync_service_principals(
     client_secret: str,
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    cloud: MicrosoftCloud = COMMERCIAL,
 ) -> None:
     """
     Sync Entra service principals to the graph.
@@ -186,18 +189,9 @@ async def sync_service_principals(
     :param client_secret: Azure application client secret
     :param update_tag: Update tag for tracking data freshness
     :param common_job_parameters: Common job parameters for cleanup
+    :param cloud: Microsoft sovereign cloud (commercial, usgov, etc.)
     """
-    # Create credentials and client
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id,
-        client_id=client_id,
-        client_secret=client_secret,
-    )
-
-    client = GraphServiceClient(
-        credential,
-        scopes=["https://graph.microsoft.com/.default"],
-    )
+    client = build_graph_client(tenant_id, client_id, client_secret, cloud)
     service_principals_batch = []
     batch_size = 50  # Batch size for service principals
     total_count = 0

--- a/cartography/intel/microsoft/entra/users.py
+++ b/cartography/intel/microsoft/entra/users.py
@@ -4,13 +4,15 @@ from typing import AsyncGenerator
 from typing import Generator
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from msgraph import GraphServiceClient
 from msgraph.generated.models.organization import Organization
 from msgraph.generated.models.user import User
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.microsoft.clouds import COMMERCIAL
+from cartography.intel.microsoft.clouds import MicrosoftCloud
+from cartography.intel.microsoft.entra.utils import build_graph_client
 from cartography.intel.microsoft.entra.utils import call_with_retries
 from cartography.models.microsoft.entra.tenant import EntraTenantSchema
 from cartography.models.microsoft.entra.user import EntraUserSchema
@@ -225,6 +227,7 @@ async def sync_entra_users(
     client_secret: str,
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    cloud: MicrosoftCloud = COMMERCIAL,
 ) -> None:
     """
     Sync Entra users and tenant information
@@ -234,17 +237,10 @@ async def sync_entra_users(
     :param client_secret: Entra application client secret
     :param update_tag: Timestamp used to determine data freshness
     :param common_job_parameters: dict of other job parameters to carry to sub-jobs
+    :param cloud: Microsoft sovereign cloud (commercial, usgov, etc.)
     :return: None
     """
-    # Initialize Graph client
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id,
-        client_id=client_id,
-        client_secret=client_secret,
-    )
-    client = GraphServiceClient(
-        credential, scopes=["https://graph.microsoft.com/.default"]
-    )
+    client = build_graph_client(tenant_id, client_id, client_secret, cloud)
 
     # Process users in batches to reduce memory consumption
     batch_size = (

--- a/cartography/intel/microsoft/entra/utils.py
+++ b/cartography/intel/microsoft/entra/utils.py
@@ -4,14 +4,42 @@ from typing import Callable
 
 import backoff
 import httpx
+from azure.identity import ClientSecretCredential
+from msgraph import GraphServiceClient
 
 from cartography.helpers import backoff_handler
+from cartography.intel.microsoft.clouds import MicrosoftCloud
 
 logger = logging.getLogger(__name__)
 
 # Transient transport errors that are safe to retry (HTTP/2 resets, connection drops, etc.)
 TRANSIENT_EXCEPTIONS = (httpx.ReadError, httpx.ConnectError, httpx.RemoteProtocolError)
 MAX_RETRIES = 3
+
+
+def build_graph_client(
+    tenant_id: str,
+    client_id: str,
+    client_secret: str,
+    cloud: MicrosoftCloud,
+) -> GraphServiceClient:
+    """Construct a Graph client wired to the given sovereign cloud.
+
+    The msgraph SDK defaults to the commercial `graph.microsoft.com`
+    endpoint; to target GCC High / DoD / China we must override both the
+    AAD authority (for token acquisition) and the request adapter's
+    `base_url` (for all Graph calls). See
+    https://github.com/microsoftgraph/msgraph-sdk-python/blob/main/docs/national-clouds.md.
+    """
+    credential = ClientSecretCredential(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        client_secret=client_secret,
+        authority=cloud.authority,
+    )
+    client = GraphServiceClient(credential, scopes=[cloud.graph_scope])
+    client.request_adapter.base_url = cloud.graph_base_url
+    return client
 
 
 async def call_with_retries(

--- a/cartography/intel/microsoft/intune/__init__.py
+++ b/cartography/intel/microsoft/intune/__init__.py
@@ -2,11 +2,11 @@ import asyncio
 import logging
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from kiota_abstractions.api_error import APIError
-from msgraph import GraphServiceClient
 
 from cartography.config import Config
+from cartography.intel.microsoft.clouds import get_cloud
+from cartography.intel.microsoft.entra.utils import build_graph_client
 from cartography.intel.microsoft.intune.compliance_policies import (
     sync_compliance_policies,
 )
@@ -43,20 +43,20 @@ def start_intune_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         )
         return
 
+    cloud = get_cloud(config.entra_cloud)
+    logger.info("Using Microsoft cloud %r for Intune sync", cloud.name)
+
     common_job_parameters = {
         "UPDATE_TAG": config.update_tag,
         "TENANT_ID": config.entra_tenant_id,
     }
 
     async def main() -> None:
-        credential = ClientSecretCredential(
-            tenant_id=config.entra_tenant_id,
-            client_id=config.entra_client_id,
-            client_secret=config.entra_client_secret,
-        )
-        intune_client = GraphServiceClient(
-            credential,
-            scopes=["https://graph.microsoft.com/.default"],
+        intune_client = build_graph_client(
+            config.entra_tenant_id,
+            config.entra_client_id,
+            config.entra_client_secret,
+            cloud,
         )
 
         managed_devices_synced = False

--- a/docs/root/modules/microsoft/config.md
+++ b/docs/root/modules/microsoft/config.md
@@ -1,0 +1,29 @@
+## Microsoft Configuration
+
+The `microsoft` module ingests both Entra ID and Intune data through Microsoft Graph using a single Service Principal. Configure it with the following CLI settings:
+
+- `--entra-tenant-id`: Your Entra tenant ID
+- `--entra-client-id`: The client ID of your Entra application
+- `--entra-client-secret-env-var`: The name of an environment variable that contains the client secret of your Entra application.
+- `--entra-cloud`: (optional) Microsoft sovereign cloud to target. One of:
+    - `commercial` (default) — `graph.microsoft.com` / `login.microsoftonline.com`
+    - `usgov` — GCC High / L4 (`graph.microsoft.us` / `login.microsoftonline.us`)
+    - `usgov-dod` — DoD / L5 (`dod-graph.microsoft.us` / `login.microsoftonline.us`)
+    - `china` — 21Vianet (`microsoftgraph.chinacloudapi.cn` / `login.chinacloudapi.cn`)
+
+Endpoints are those published in the Microsoft Graph [deployments reference](https://learn.microsoft.com/en-us/graph/deployments). The CLI flags are named `--entra-*` for backwards compatibility — they apply to both the Entra and Intune submodules.
+
+To set up the Service Principal:
+
+1. Go to [App Registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade) in the Azure portal (or the equivalent portal for your sovereign cloud).
+1. Create a new app registration.
+1. Grant it the following Microsoft Graph application permissions:
+    - `AdministrativeUnit.Read.All` — Read all administrative units
+    - `AppRoleAssignment.ReadWrite.All` — Manage app permission grants and app role assignments
+    - `Application.Read.All` — Read all applications
+    - `Directory.Read.All` — Read directory data
+    - `Group.Read.All` — Read all groups
+    - `GroupMember.Read.All` — Read all group memberships
+    - `User.Read.All` — Read all users' full profiles
+    - `DeviceManagementManagedDevices.Read.All` — Required for Intune managed devices and detected apps
+    - `DeviceManagementConfiguration.Read.All` — Required for Intune compliance policies

--- a/docs/root/modules/microsoft/index.md
+++ b/docs/root/modules/microsoft/index.md
@@ -2,6 +2,7 @@
 
 
 ```{toctree}
+config
 schema
 ```
 
@@ -13,4 +14,4 @@ The `microsoft` module is the top-level umbrella for Microsoft tenant, SaaS, and
 
 `microsoft` is the canonical top-level module name. `entra` remains accepted as a backward-compatible alias for module selection and ontology source configuration during the migration.
 
-See the [configuration docs](../../modules/entra/config) and [schema](schema) for details.
+Supports commercial, GCC High / DoD (US Government), and China sovereign clouds — see [config](config) for details.

--- a/tests/unit/cartography/intel/microsoft/entra/test_utils.py
+++ b/tests/unit/cartography/intel/microsoft/entra/test_utils.py
@@ -1,0 +1,43 @@
+import pytest
+
+from cartography.intel.microsoft.clouds import CHINA
+from cartography.intel.microsoft.clouds import COMMERCIAL
+from cartography.intel.microsoft.clouds import USGOV
+from cartography.intel.microsoft.clouds import USGOV_DOD
+from cartography.intel.microsoft.entra.utils import build_graph_client
+
+
+@pytest.mark.parametrize(
+    "cloud",
+    [COMMERCIAL, USGOV, USGOV_DOD, CHINA],
+)
+def test_build_graph_client_wires_cloud_endpoints(cloud):
+    """The Graph client's adapter base_url and the credential's authority
+    must be driven by the supplied cloud; no commercial-cloud defaults
+    should leak through when a non-commercial cloud is requested.
+    """
+    client = build_graph_client(
+        tenant_id="00000000-0000-0000-0000-000000000000",
+        client_id="cid",
+        client_secret="sec",
+        cloud=cloud,
+    )
+    assert client.request_adapter.base_url == cloud.graph_base_url
+
+
+def test_build_graph_client_default_matches_sdk_default():
+    """Zero-change guarantee for commercial-cloud callers: the base_url
+    we set must match what the msgraph SDK would pick on its own.
+    """
+    from azure.identity import ClientSecretCredential
+    from msgraph import GraphServiceClient
+
+    default_client = GraphServiceClient(
+        ClientSecretCredential(tenant_id="t", client_id="c", client_secret="s"),
+        scopes=["https://graph.microsoft.com/.default"],
+    )
+    commercial_client = build_graph_client("t", "c", "s", COMMERCIAL)
+    assert (
+        commercial_client.request_adapter.base_url
+        == default_client.request_adapter.base_url
+    )

--- a/tests/unit/cartography/intel/microsoft/test_clouds.py
+++ b/tests/unit/cartography/intel/microsoft/test_clouds.py
@@ -1,0 +1,49 @@
+import pytest
+
+from cartography.intel.microsoft.clouds import CHINA
+from cartography.intel.microsoft.clouds import COMMERCIAL
+from cartography.intel.microsoft.clouds import DEFAULT_CLOUD_NAME
+from cartography.intel.microsoft.clouds import get_cloud
+from cartography.intel.microsoft.clouds import USGOV
+from cartography.intel.microsoft.clouds import USGOV_DOD
+
+
+def test_default_cloud_is_commercial():
+    assert DEFAULT_CLOUD_NAME == "commercial"
+    assert get_cloud(None) is COMMERCIAL
+    assert get_cloud("") is COMMERCIAL
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("commercial", COMMERCIAL),
+        ("COMMERCIAL", COMMERCIAL),
+        ("usgov", USGOV),
+        ("usgov-dod", USGOV_DOD),
+        ("china", CHINA),
+    ],
+)
+def test_get_cloud_resolves_known_names(name, expected):
+    assert get_cloud(name) is expected
+
+
+def test_get_cloud_rejects_unknown():
+    with pytest.raises(ValueError, match="Unknown Microsoft cloud"):
+        get_cloud("azurestack")
+
+
+@pytest.mark.parametrize(
+    "cloud,graph_host,authority",
+    [
+        (COMMERCIAL, "graph.microsoft.com", "login.microsoftonline.com"),
+        (USGOV, "graph.microsoft.us", "login.microsoftonline.us"),
+        (USGOV_DOD, "dod-graph.microsoft.us", "login.microsoftonline.us"),
+        (CHINA, "microsoftgraph.chinacloudapi.cn", "login.chinacloudapi.cn"),
+    ],
+)
+def test_cloud_endpoints_match_microsoft_docs(cloud, graph_host, authority):
+    """Pin the endpoints to https://learn.microsoft.com/en-us/graph/deployments."""
+    assert cloud.graph_base_url == f"https://{graph_host}/v1.0/"
+    assert cloud.graph_scope == f"https://{graph_host}/.default"
+    assert cloud.authority == f"https://{authority}"

--- a/tests/unit/cartography/intel/microsoft/test_start_ingestion_cloud_wiring.py
+++ b/tests/unit/cartography/intel/microsoft/test_start_ingestion_cloud_wiring.py
@@ -1,0 +1,110 @@
+"""Verify that ``config.entra_cloud`` flows end-to-end from the ingestion
+entry points (``start_entra_ingestion`` / ``start_intune_ingestion``) down
+to every ``sync_*`` call and ultimately to ``build_graph_client``.
+
+Regression guard: if a future change adds a new Entra/Intune sync step
+without threading the cloud parameter, these tests fail.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+import cartography.intel.microsoft.entra as entra_pkg
+import cartography.intel.microsoft.intune as intune_pkg
+from cartography.config import Config
+from cartography.intel.microsoft.clouds import COMMERCIAL
+from cartography.intel.microsoft.clouds import USGOV
+
+ENTRA_SYNC_FUNCS = [
+    "sync_tenant",
+    "sync_entra_users",
+    "sync_entra_groups",
+    "sync_entra_ous",
+    "sync_entra_applications",
+    "sync_service_principals",
+    "sync_app_role_assignments",
+]
+
+
+def _make_config(cloud_name: str | None) -> Config:
+    return Config(
+        neo4j_uri="bolt://localhost:7687",
+        update_tag=1,
+        entra_tenant_id="tid",
+        entra_client_id="cid",
+        entra_client_secret="sec",
+        entra_cloud=cloud_name,
+    )
+
+
+@pytest.mark.parametrize(
+    "cloud_name,expected",
+    [(None, COMMERCIAL), ("commercial", COMMERCIAL), ("usgov", USGOV)],
+)
+def test_start_entra_ingestion_threads_cloud(cloud_name, expected):
+    """Every Entra sync_* is called with the resolved cloud."""
+    config = _make_config(cloud_name)
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    with (
+        patch.object(entra_pkg, "sync_tenant", side_effect=_noop) as m_tenant,
+        patch.object(entra_pkg, "sync_entra_users", side_effect=_noop) as m_users,
+        patch.object(entra_pkg, "sync_entra_groups", side_effect=_noop) as m_groups,
+        patch.object(entra_pkg, "sync_entra_ous", side_effect=_noop) as m_ous,
+        patch.object(entra_pkg, "sync_entra_applications", side_effect=_noop) as m_apps,
+        patch.object(entra_pkg, "sync_service_principals", side_effect=_noop) as m_sp,
+        patch.object(
+            entra_pkg, "sync_app_role_assignments", side_effect=_noop
+        ) as m_ara,
+        patch.object(entra_pkg, "sync_entra_federation", side_effect=_noop),
+    ):
+        entra_pkg.start_entra_ingestion(MagicMock(), config)
+
+    for mock in (m_tenant, m_users, m_groups, m_ous, m_apps, m_sp, m_ara):
+        assert mock.call_args is not None, f"{mock} was not called"
+        assert (
+            mock.call_args.args[-1] is expected
+        ), f"{mock} got cloud={mock.call_args.args[-1]!r}, expected {expected!r}"
+
+
+@pytest.mark.parametrize(
+    "cloud_name,expected_base_url",
+    [
+        (None, COMMERCIAL.graph_base_url),
+        ("commercial", COMMERCIAL.graph_base_url),
+        ("usgov", USGOV.graph_base_url),
+    ],
+)
+def test_start_intune_ingestion_builds_client_for_cloud(cloud_name, expected_base_url):
+    """The Graph client constructed by the Intune entry point must use
+    the base_url for the cloud named in ``config.entra_cloud``.
+    """
+    config = _make_config(cloud_name)
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    with (
+        patch.object(intune_pkg, "sync_managed_devices", side_effect=_noop) as m_md,
+        patch.object(intune_pkg, "sync_detected_apps", side_effect=_noop),
+        patch.object(intune_pkg, "sync_compliance_policies", side_effect=_noop),
+        patch.object(intune_pkg, "run_scoped_analysis_job"),
+    ):
+        intune_pkg.start_intune_ingestion(MagicMock(), config)
+
+    built_client = m_md.call_args.args[1]
+    assert built_client.request_adapter.base_url == expected_base_url
+
+
+def test_start_entra_ingestion_skips_when_unconfigured():
+    """Zero-change guarantee: missing credentials still short-circuits."""
+    config = Config(neo4j_uri="bolt://localhost:7687", update_tag=1)
+
+    with patch.object(entra_pkg, "sync_tenant") as m_tenant:
+        entra_pkg.start_entra_ingestion(MagicMock(), config)
+
+    m_tenant.assert_not_called()


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary

Entra and Intune ingestion hardcoded the commercial `graph.microsoft.com` endpoint, which prevented cartography from running against GCC High, DoD (L5), or the China national cloud. Each sovereign cloud exposes a distinct Graph endpoint and AAD authority host per the [Microsoft Graph deployments reference](https://learn.microsoft.com/en-us/graph/deployments).

This PR:
- Introduces a `MicrosoftCloud` mapping (`cartography/intel/microsoft/clouds.py`) for commercial / usgov / usgov-dod / china.
- Adds a shared `build_graph_client()` helper that wires the AAD authority, scope, and Graph `base_url` for the selected cloud per the [msgraph national clouds guide](https://github.com/microsoftgraph/msgraph-sdk-python/blob/main/docs/national-clouds.md).
- Routes the 8 previously-duplicated `ClientSecretCredential` / `GraphServiceClient` instantiations in the `microsoft/` module through the helper.
- Adds a `--entra-cloud` CLI flag (default: `commercial`). The flag retains the `--entra-*` prefix because it applies to both the Entra and Intune submodules.

Scope is limited to the `microsoft` intel module (Graph API). Sovereign-cloud support for the Azure ARM module is a separate follow-up.

### Related issues or links

- Fixes #2332

### Breaking changes

None. Every `sync_*` signature takes `cloud: MicrosoftCloud = COMMERCIAL` as a default argument, so existing callers — integration tests, `demo/seeds/entra.py`, and the deprecated `cartography.intel.entra` shim — continue to work without changes. A unit test verifies that the commercial `base_url` and AAD authority we set are byte-identical to what the msgraph SDK and `azure-identity` pick on their own.

### How was this tested?

- `make lint` — all pre-commit hooks pass.
- `pytest tests/unit/cartography/intel/microsoft/ tests/integration/cartography/intel/microsoft/` — 31 tests pass (8 previously existed, 23 new in this PR).
- `pytest tests/integration/cartography/intel/azure/test_rbac.py tests/integration/cartography/intel/azure/test_permission_relationships.py` — both still pass (they import from `cartography.intel.microsoft.entra`).
- Full unit suite (`pytest tests/unit`) — 1355 tests pass, zero regressions.

New tests:

- `tests/unit/cartography/intel/microsoft/test_clouds.py` — pins the cloud endpoint/authority values against the Microsoft Graph deployments reference, covers default resolution and invalid names.
- `tests/unit/cartography/intel/microsoft/entra/test_utils.py` — verifies `build_graph_client` sets the correct `base_url` for each cloud and that the commercial build matches the msgraph SDK default byte-for-byte.
- `tests/unit/cartography/intel/microsoft/test_start_ingestion_cloud_wiring.py` — end-to-end wiring guard that asserts `config.entra_cloud` flows through every `sync_*` of `start_entra_ingestion` and through to the Graph client built by `start_intune_ingestion`. Catches regressions where a future sync step forgets to thread the cloud parameter.

I don't have access to a GCC High / DoD / China tenant, so I can't attach sync logs from a real non-commercial environment. Reviewers from orgs with sovereign-cloud tenants are very welcome to validate.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- N/A — no entity changes.

#### If you are changing a node or relationship
- N/A — no schema changes.

#### If you are implementing a new intel module
- N/A — extends existing modules.

### Notes for reviewers

- Doc updates live in `docs/root/modules/microsoft/config.md` (new) and `docs/root/modules/microsoft/index.md`. The legacy `docs/root/modules/entra/` path is untouched.
- The new CLI flag is named `--entra-cloud` rather than `--microsoft-cloud` to match the existing `--entra-*` naming convention; happy to rename if you prefer.
- Azure ARM sovereign-cloud support is intentionally out of scope — the issue specifically targets Entra, and ARM would require touching ~20 management-client call sites. I'll open a follow-up PR if there's appetite.