### PR TITLE
fix(aws): skip permission relationships without resource arns

### DIFF
--- a/cartography/intel/aws/permission_relationships.py
+++ b/cartography/intel/aws/permission_relationships.py
@@ -34,7 +34,7 @@ def evaluate_clause(clause: str, match: str) -> bool:
         [bool] -- True if the clause matched, False otherwise
     """
     if match is None:
-        return False
+        raise ValueError("match must not be None")
     result = compile_regex(clause).fullmatch(match)
     return result is not None
 

--- a/cartography/intel/aws/permission_relationships.py
+++ b/cartography/intel/aws/permission_relationships.py
@@ -33,6 +33,8 @@ def evaluate_clause(clause: str, match: str) -> bool:
     Returns:
         [bool] -- True if the clause matched, False otherwise
     """
+    if match is None:
+        return False
     result = compile_regex(clause).fullmatch(match)
     return result is not None
 
@@ -173,7 +175,6 @@ def principal_allowed_on_resource(
         )
 
         if explicit_deny:
-
             return False
         if not granted and allowed:
             granted = True
@@ -295,6 +296,7 @@ def get_resource_arns(
     get_resource_query = Template(
         """
     MATCH (acc:AWSAccount{id:$AccountId})-[:RESOURCE]->(resource:$node_label)
+    WHERE resource.arn IS NOT NULL
     return resource.arn as arn
     """,
     )

--- a/tests/integration/cartography/intel/aws/test_permission_relationships.py
+++ b/tests/integration/cartography/intel/aws/test_permission_relationships.py
@@ -46,6 +46,18 @@ ROLE_POLICY_DATA = {
     }
 }
 
+SSM_ROLE_POLICY_DATA = {
+    "arn:aws:iam::000000000000:role/TestReadRole": {
+        "SSMSessionPolicy": [
+            {
+                "Effect": "Allow",
+                "Action": ["ssm:StartSession"],
+                "Resource": ["*"],
+            }
+        ]
+    }
+}
+
 
 def test_permission_relationships_with_iam_integration(neo4j_session):
     """
@@ -80,7 +92,6 @@ def test_permission_relationships_with_iam_integration(neo4j_session):
             "cartography.intel.aws.iam.get_role_managed_policy_data", return_value={}
         ),
     ):
-
         # Call sync_roles to create the complete IAM structure
         common_job_parameters = {"AWS_ID": TEST_ACCOUNT_ID}
         cartography.intel.aws.iam.sync_roles(
@@ -129,3 +140,71 @@ def test_permission_relationships_with_iam_integration(neo4j_session):
     assert (
         actual_rels == expected_rels
     ), f"Expected CAN_READ relationship not found. Got: {actual_rels}"
+
+
+def test_permission_relationships_skips_resources_without_arn(neo4j_session):
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+    neo4j_session.run(
+        """
+        MATCH (aws:AWSAccount{id: $AccountId})
+        MERGE (ec2:EC2Instance{id: 'i-1234567890abcdef0'})<-[:RESOURCE]-(aws)
+        SET ec2.lastupdated = $UpdateTag
+        """,
+        AccountId=TEST_ACCOUNT_ID,
+        UpdateTag=TEST_UPDATE_TAG,
+    )
+
+    with (
+        patch(
+            "cartography.intel.aws.iam.get_role_list_data",
+            return_value=SIMPLE_ROLE_DATA,
+        ),
+        patch(
+            "cartography.intel.aws.iam.get_role_policy_data",
+            return_value=SSM_ROLE_POLICY_DATA,
+        ),
+        patch(
+            "cartography.intel.aws.iam.get_role_managed_policy_data", return_value={}
+        ),
+        patch(
+            "cartography.intel.aws.permission_relationships.parse_permission_relationships_file",
+            return_value=[
+                {
+                    "target_label": "EC2Instance",
+                    "permissions": ["ssm:StartSession"],
+                    "relationship_name": "SSM_FULL_ACCESS",
+                },
+            ],
+        ),
+    ):
+        common_job_parameters = {"AWS_ID": TEST_ACCOUNT_ID}
+        cartography.intel.aws.iam.sync_roles(
+            neo4j_session,
+            MagicMock(),
+            TEST_ACCOUNT_ID,
+            TEST_UPDATE_TAG,
+            common_job_parameters,
+        )
+
+        cartography.intel.aws.permission_relationships.sync(
+            neo4j_session,
+            None,
+            [TEST_REGION],
+            TEST_ACCOUNT_ID,
+            TEST_UPDATE_TAG,
+            {
+                "permission_relationships_file": "dummy-path.yaml",
+            },
+        )
+
+    actual_rels = check_rels(
+        neo4j_session,
+        "AWSRole",
+        "arn",
+        "EC2Instance",
+        "id",
+        "SSM_FULL_ACCESS",
+    )
+
+    assert actual_rels == set()

--- a/tests/unit/cartography/intel/aws/test_permission_relationships.py
+++ b/tests/unit/cartography/intel/aws/test_permission_relationships.py
@@ -1,3 +1,5 @@
+import pytest
+
 from cartography.intel.aws import permission_relationships
 
 GET_OBJECT_LOWERCASE_RESOURCE_WILDCARD = [
@@ -502,7 +504,8 @@ def test_multiple_comma():
 
 
 def test_evaluate_clause_with_none_match():
-    assert not permission_relationships.evaluate_clause("*", None)
+    with pytest.raises(ValueError, match="match must not be None"):
+        permission_relationships.evaluate_clause("*", None)
 
 
 def test_permission_file_load():

--- a/tests/unit/cartography/intel/aws/test_permission_relationships.py
+++ b/tests/unit/cartography/intel/aws/test_permission_relationships.py
@@ -380,7 +380,7 @@ def test_full_policy_explicit_allow():
         "ListAllow": [
             {
                 "action": [
-                    "s3:listobject" "dynamodb:query",
+                    "s3:listobjectdynamodb:query",
                 ],
                 "resource": [
                     "*",
@@ -413,7 +413,7 @@ def test_full_multiple_principal():
             "ListAllow": [
                 {
                     "action": [
-                        "s3:listobject" "dynamodb:query",
+                        "s3:listobjectdynamodb:query",
                     ],
                     "resource": [
                         "*",
@@ -499,6 +499,10 @@ def test_multiple_comma():
         ["S3:GetObject"],
         "arn:aws:s3:::testbucket",
     )
+
+
+def test_evaluate_clause_with_none_match():
+    assert not permission_relationships.evaluate_clause("*", None)
 
 
 def test_permission_file_load():


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

### Summary
- Prevent AWS permission relationship evaluation from crashing when a matched resource node does not have an `arn` property.
- Filter non-ARN resources out of `get_resource_arns()` and add regression coverage for both the low-level matcher and the EC2/SSM sync scenario from the bug report.

### Related issues or links
- Fixes #1792

### How was this tested?
- `uv run --frozen pre-commit run --files "cartography/intel/aws/permission_relationships.py" "tests/unit/cartography/intel/aws/test_permission_relationships.py" "tests/integration/cartography/intel/aws/test_permission_relationships.py"`
- `uv run --frozen pytest -vvv tests/unit/cartography/intel/aws/test_permission_relationships.py`
- `uv run --frozen pytest -vvv tests/integration/cartography/intel/aws/test_permission_relationships.py`

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

### Notes for reviewers
- This change does not alter schema shape; it only avoids evaluating permission relationships for resources that cannot participate because they have no ARN.