### PR TITLE
fix(gcp): list Go modules via packages API in Artifact Registry

### DIFF
--- a/cartography/intel/gcp/artifact_registry/artifact.py
+++ b/cartography/intel/gcp/artifact_registry/artifact.py
@@ -212,33 +212,40 @@ def get_go_modules(client: Resource, repository_name: str) -> list[dict]:
     """
     Gets Go modules for a repository.
 
+    The Artifact Registry v1 API does not expose a ``goModules.list`` method;
+    Go modules are enumerated via the generic ``packages``/``versions`` endpoints.
+
     :param client: The Artifact Registry API client.
     :param repository_name: The full repository resource name.
-    :return: List of Go module dicts from the API.
+    :return: List of Go module version dicts, each enriched with ``packageName``.
     """
-    modules: list[dict] = []
+    artifacts: list[dict] = []
     try:
-        request = (
-            client.projects()
-            .locations()
-            .repositories()
-            .goModules()
-            .list(parent=repository_name)
-        )
-        while request is not None:
-            response = gcp_api_execute_with_retry(request)
-            modules.extend(response.get("goModules", []))
-            request = (
-                client.projects()
-                .locations()
-                .repositories()
-                .goModules()
-                .list_next(
-                    previous_request=request,
-                    previous_response=response,
+        packages_resource = client.projects().locations().repositories().packages()
+        packages_request = packages_resource.list(parent=repository_name)
+        while packages_request is not None:
+            packages_response = gcp_api_execute_with_retry(packages_request)
+            for package in packages_response.get("packages", []):
+                package_name = (
+                    package.get("displayName")
+                    or package.get("name", "").split("/packages/")[-1]
                 )
+                versions_resource = packages_resource.versions()
+                versions_request = versions_resource.list(parent=package.get("name"))
+                while versions_request is not None:
+                    versions_response = gcp_api_execute_with_retry(versions_request)
+                    for version in versions_response.get("versions", []):
+                        version["packageName"] = package_name
+                        artifacts.append(version)
+                    versions_request = versions_resource.list_next(
+                        previous_request=versions_request,
+                        previous_response=versions_response,
+                    )
+            packages_request = packages_resource.list_next(
+                previous_request=packages_request,
+                previous_response=packages_response,
             )
-        return modules
+        return artifacts
     except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
         logger.warning(
             f"Failed to get Go modules for repository {repository_name} "
@@ -512,11 +519,15 @@ def transform_go_modules(
     project_id: str,
 ) -> list[dict]:
     """
-    Transforms Go modules to the GCPArtifactRegistryLanguagePackage node format.
+    Transforms Go module versions to the GCPArtifactRegistryLanguagePackage node format.
+
+    Each input entry is a version resource (from ``packages.versions.list``)
+    enriched with a ``packageName`` field identifying the parent module.
     """
     transformed: list[dict] = []
     for module in modules_data:
         name = module.get("name", "")
+        version = name.split("/versions/")[-1] if "/versions/" in name else None
 
         transformed.append(
             {
@@ -524,8 +535,8 @@ def transform_go_modules(
                 "name": name.split("/")[-1] if name else None,
                 "format": "GO",
                 "uri": None,
-                "version": module.get("version"),
-                "package_name": None,
+                "version": version,
+                "package_name": module.get("packageName"),
                 "create_time": module.get("createTime"),
                 "update_time": module.get("updateTime"),
                 "repository_id": repository_id,

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_os_packages.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_os_packages.py
@@ -103,23 +103,32 @@ def test_get_yum_artifacts_uses_packages_and_versions():
     )
 
 
-def test_get_go_modules_uses_retry_helper():
-    client = MagicMock()
+def test_get_go_modules_uses_packages_and_versions():
+    client = _make_os_package_client("example.com/foo", "v1.2.3")
     repositories = (
         client.projects.return_value.locations.return_value.repositories.return_value
     )
-    request = MagicMock()
-    next_request = MagicMock()
-    repositories.goModules.return_value.list.return_value = request
-    repositories.goModules.return_value.list_next.side_effect = [next_request, None]
-    request.execute.return_value = {"goModules": [{"name": "module-1"}]}
-    next_request.execute.return_value = {"goModules": [{"name": "module-2"}]}
+    packages = repositories.packages.return_value
+    versions = packages.versions.return_value
+    packages_request = packages.list.return_value
+    versions_request = versions.list.return_value
 
     modules = get_go_modules(
         client,
         "projects/test-project/locations/us-east1/repositories/repo",
     )
 
-    assert modules == [{"name": "module-1"}, {"name": "module-2"}]
-    request.execute.assert_called_once_with(num_retries=GCP_API_NUM_RETRIES)
-    next_request.execute.assert_called_once_with(num_retries=GCP_API_NUM_RETRIES)
+    assert modules == [
+        {
+            "name": "projects/test-project/locations/us-east1/repositories/repo/packages/example.com/foo/versions/v1.2.3",
+            "createTime": "2024-01-06T00:00:00Z",
+            "updateTime": "2024-01-06T00:00:00Z",
+            "packageName": "example.com/foo",
+        }
+    ]
+    packages_request.execute.assert_called_once_with(
+        num_retries=GCP_API_NUM_RETRIES,
+    )
+    versions_request.execute.assert_called_once_with(
+        num_retries=GCP_API_NUM_RETRIES,
+    )


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
`get_go_modules` in `cartography/intel/gcp/artifact_registry/artifact.py` called `client.projects().locations().repositories().goModules().list(...)`, but the Artifact Registry v1 discovery document only exposes `upload` on the `goModules` resource — there is no `list` method. Every Go-format repository therefore raised `AttributeError: 'Resource' object has no attribute 'list'` during sync.

This PR reworks `get_go_modules` to enumerate Go modules via the generic `packages.list` + `packages.versions.list` pagination already used by `get_apt_artifacts` / `get_yum_artifacts`, and aligns `transform_go_modules` with the new version-shaped payload (extracting `version` from the resource name and carrying the enriched `packageName`).


### Related issues or links

- Fixes #


### How was this tested?
- `.venv/bin/python -m pytest tests/unit/cartography/intel/gcp/test_artifact_registry_os_packages.py -v` — 3 passed, including the rewritten `test_get_go_modules_uses_packages_and_versions`.
- `.venv/bin/python -m pytest tests/unit/cartography/intel/gcp/ -v` — full GCP unit suite, 116 passed.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).


### Notes for reviewers
The node schema (`GCPArtifactRegistryLanguagePackage`) is unchanged — only the GCP-side ingestion shape shifts to consume `packages.versions` entries. The `id` of Go module nodes will move from the legacy `goModules/...` resource name to the `packages/.../versions/...` resource name, which is the canonical identifier returned by the API that actually works; since the previous path never returned any data, this is effectively a first-time ingestion of Go modules rather than a migration.