### PR TITLE
feat(gcp): add GCPCloudRunService USES_SERVICE_ACCOUNT relationship

### DIFF
--- a/cartography/intel/gcp/cloudrun/service.py
+++ b/cartography/intel/gcp/cloudrun/service.py
@@ -78,6 +78,9 @@ def transform_services(services_data: list[dict], project_id: str) -> list[dict]
         # Get latest ready revision - the v2 API returns the full resource name
         latest_ready_revision = service.get("latestReadyRevision")
 
+        # Get service account email from template.serviceAccount (v2 API)
+        service_account_email = service.get("template", {}).get("serviceAccount")
+
         transformed.append(
             {
                 "id": full_name,
@@ -86,6 +89,7 @@ def transform_services(services_data: list[dict], project_id: str) -> list[dict]
                 "location": location,
                 "uri": service.get("uri"),
                 "latest_ready_revision": latest_ready_revision,
+                "service_account_email": service_account_email,
                 "ingress": service.get("ingress"),
                 "project_id": project_id,
                 "labels": service.get("labels", {}),

--- a/cartography/models/gcp/cloudrun/service.py
+++ b/cartography/models/gcp/cloudrun/service.py
@@ -8,6 +8,7 @@ from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -19,6 +20,7 @@ class GCPCloudRunServiceProperties(CartographyNodeProperties):
     location: PropertyRef = PropertyRef("location")
     uri: PropertyRef = PropertyRef("uri")
     latest_ready_revision: PropertyRef = PropertyRef("latest_ready_revision")
+    service_account_email: PropertyRef = PropertyRef("service_account_email")
     project_id: PropertyRef = PropertyRef("project_id")
     ingress: PropertyRef = PropertyRef("ingress")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
@@ -43,10 +45,33 @@ class ProjectToCloudRunServiceRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class CloudRunServiceToServiceAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class CloudRunServiceToServiceAccountRel(CartographyRelSchema):
+    target_node_label: str = "GCPServiceAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"email": PropertyRef("service_account_email")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_SERVICE_ACCOUNT"
+    properties: CloudRunServiceToServiceAccountRelProperties = (
+        CloudRunServiceToServiceAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class GCPCloudRunServiceSchema(CartographyNodeSchema):
     label: str = "GCPCloudRunService"
     properties: GCPCloudRunServiceProperties = GCPCloudRunServiceProperties()
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Function"])
     sub_resource_relationship: ProjectToCloudRunServiceRel = (
         ProjectToCloudRunServiceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            CloudRunServiceToServiceAccountRel(),
+        ],
     )

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -1781,6 +1781,7 @@ graph LR
     Service -->|HAS_REVISION| Revision
     Job -->|HAS_EXECUTION| Execution
 
+    Service -->|USES_SERVICE_ACCOUNT| ServiceAccount
     Revision -->|USES_SERVICE_ACCOUNT| ServiceAccount
     Job -->|USES_SERVICE_ACCOUNT| ServiceAccount
 ```
@@ -1801,6 +1802,7 @@ Representation of a GCP [Cloud Run Service](https://cloud.google.com/run/docs/re
 | description | User-provided description of the service |
 | uri | Default URL serving the service |
 | latest_ready_revision | Full resource name of the latest ready revision for this service |
+| service_account_email | The email of the service account configured on the service template (used by new revisions created from this service) |
 | ingress | The ingress setting for the service. Values: `INGRESS_TRAFFIC_ALL`, `INGRESS_TRAFFIC_INTERNAL_ONLY`, `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER`, `INGRESS_TRAFFIC_NONE`. |
 | exposed_internet | Set to `true` if `ingress` is `INGRESS_TRAFFIC_ALL`. Set to `false` if `ingress` is `INGRESS_TRAFFIC_INTERNAL_ONLY` or `INGRESS_TRAFFIC_NONE`. Other values are currently left unset because they may still be internet-reachable via load balancers. |
 | exposed_internet_type | Set to `'direct'` when the service allows all ingress traffic. |
@@ -1816,6 +1818,10 @@ Cloud Run services can split traffic across multiple revisions, so exact runtime
   - GCPCloudRunServices have GCPCloudRunRevisions.
     ```
     (GCPCloudRunService)-[:HAS_REVISION]->(GCPCloudRunRevision)
+    ```
+  - GCPCloudRunServices use GCPServiceAccounts.
+    ```
+    (GCPCloudRunService)-[:USES_SERVICE_ACCOUNT]->(GCPServiceAccount)
     ```
 
 ### GCPCloudRunRevision

--- a/tests/data/gcp/cloudrun.py
+++ b/tests/data/gcp/cloudrun.py
@@ -10,6 +10,9 @@ MOCK_SERVICES = {
             "uri": "https://test-service-abc123-uc.a.run.app",
             "ingress": "INGRESS_TRAFFIC_ALL",
             "latestReadyRevision": "projects/test-project/locations/us-central1/services/test-service/revisions/test-service-00001-abc",
+            "template": {
+                "serviceAccount": "test-sa@test-project.iam.gserviceaccount.com",
+            },
         },
     ],
 }

--- a/tests/integration/cartography/intel/gcp/test_cloudrun.py
+++ b/tests/integration/cartography/intel/gcp/test_cloudrun.py
@@ -364,6 +364,15 @@ def test_sync_cloudrun(
     # Assert: Check service account relationships
     assert check_rels(
         neo4j_session,
+        "GCPCloudRunService",
+        "id",
+        "GCPServiceAccount",
+        "email",
+        "USES_SERVICE_ACCOUNT",
+    ) == {(TEST_SERVICE_ID, TEST_SA_EMAIL_1)}
+
+    assert check_rels(
+        neo4j_session,
         "GCPCloudRunRevision",
         "id",
         "GCPServiceAccount",


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Cloud Run services carry a service account on their template (`template.serviceAccount` in the v2 API) that governs the identity of revisions created from them. Today we only model `USES_SERVICE_ACCOUNT` from `GCPCloudRunRevision` and `GCPCloudRunJob`, so principal-to-workload queries have to traverse `(Service)-[:HAS_REVISION]->(Revision)-[:USES_SERVICE_ACCOUNT]->(SA)` and miss services that have no ready revision yet.

This PR:

- Extracts `template.serviceAccount` in `transform_services` (one level shallower than the job payload, where it's at `template.template.serviceAccount`).
- Adds `service_account_email` to `GCPCloudRunServiceProperties`.
- Adds `CloudRunServiceToServiceAccountRel` (`USES_SERVICE_ACCOUNT`, OUTWARD, matched by `email`) to `GCPCloudRunServiceSchema.other_relationships`, mirroring the revision/job modeling.
- Updates the GCP schema docs (mermaid overview, property table, relationship bullet).


### Related issues or links

<!-- none -->


### How was this tested?

- Extended `MOCK_SERVICES` with a `template.serviceAccount` and added a `check_rels` assertion on `(GCPCloudRunService)-[:USES_SERVICE_ACCOUNT]->(GCPServiceAccount)` in the existing `test_sync_cloudrun` integration test.
- `uv run --frozen pytest tests/integration/cartography/intel/gcp/test_cloudrun.py` — 2 passed.
- `uv run --frozen pytest tests/unit/cartography/intel/gcp/` — 116 passed.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).


### Notes for reviewers

- Safe to land independently of the revision/job edges: the new relationship uses the same `email`-based matcher, so it shares the existing `GCPServiceAccount` node ingested by the IAM module.
- The service template lives at `template.serviceAccount`, not `template.template.serviceAccount` — I intentionally did not refactor job/revision extraction into a shared helper since the payload shapes differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)