### PR TITLE
feat(gcp): map CAN_READ from principals to GCPSecretManagerSecret

### DIFF
--- a/cartography/data/gcp_permission_relationships.yaml
+++ b/cartography/data/gcp_permission_relationships.yaml
@@ -19,3 +19,9 @@
   permissions:
   - storage.objects.delete
   relationship_name: CAN_DELETE
+
+# Map principals that can access GCP Secret Manager secret versions.
+- target_label: GCPSecretManagerSecret
+  permissions:
+  - secretmanager.versions.access
+  relationship_name: CAN_READ

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -1459,6 +1459,12 @@ Representation of a GCP [Secret Manager Secret](https://cloud.google.com/secret-
     (GCPProject)-[:RESOURCE]->(GCPSecretManagerSecret)
     ```
 
+- GCPPrincipals with appropriate permissions can read GCP Secret Manager secrets. Created from [gcp_permission_relationships.yaml](https://github.com/cartography-cncf/cartography/blob/master/cartography/data/gcp_permission_relationships.yaml).
+
+    ```
+    (GCPPrincipal)-[CAN_READ]->(GCPSecretManagerSecret)
+    ```
+
 ### GCPSecretManagerSecretVersion
 
 Representation of a GCP [Secret Manager Secret Version](https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets.versions). A SecretVersion stores a specific version of secret data within a Secret.

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -1462,7 +1462,7 @@ Representation of a GCP [Secret Manager Secret](https://cloud.google.com/secret-
 - GCPPrincipals with appropriate permissions can read GCP Secret Manager secrets. Created from [gcp_permission_relationships.yaml](https://github.com/cartography-cncf/cartography/blob/master/cartography/data/gcp_permission_relationships.yaml).
 
     ```
-    (GCPPrincipal)-[CAN_READ]->(GCPSecretManagerSecret)
+    (GCPPrincipal)-[:CAN_READ]->(GCPSecretManagerSecret)
     ```
 
 ### GCPSecretManagerSecretVersion


### PR DESCRIPTION
## Summary
- Extend `cartography/data/gcp_permission_relationships.yaml` with a `CAN_READ` mapping for `GCPSecretManagerSecret` keyed on `secretmanager.versions.access`.
- Document the new inbound `(:GCPPrincipal)-[:CAN_READ]->(:GCPSecretManagerSecret)` relationship in the GCP schema doc, matching the existing `GCPBucket` style.

## Why
Secret Manager secrets are already ingested by `cartography/intel/gcp/secretsmanager.py`, but no permission edges were created so downstream consumers could not traverse from a service account to the secrets it can read. `secretmanager.versions.access` is the IAM permission that actually gates access to a secret version's payload (granted by `roles/secretmanager.secretAccessor` and `roles/secretmanager.admin` — see the [GCP IAM permissions reference](https://cloud.google.com/secret-manager/docs/access-control)).

CAN_WRITE / CAN_DELETE mappings are noted as natural follow-ups but left out of this minimum fix.

## Test plan
- [ ] Run a GCP sync against a project where a service account is bound to `roles/secretmanager.secretAccessor`, then verify `MATCH (p:GCPPrincipal)-[:CAN_READ]->(s:GCPSecretManagerSecret) RETURN p, s` returns the expected edges.
- [ ] Confirm principals bound via a role that does not include `secretmanager.versions.access` do not get the edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)