### PR TITLE
refactor(aws-iam): drop dead AccountAccessKey rel definitions

### DIFF
--- a/cartography/models/aws/iam/access_key.py
+++ b/cartography/models/aws/iam/access_key.py
@@ -32,26 +32,6 @@ class AccountAccessKeyNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class AWSUserToAccountAccessKeyRelProperties(CartographyRelProperties):
-    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
-
-
-@dataclass(frozen=True)
-class AWSUserToAccountAccessKeyRel(CartographyRelSchema):
-    target_node_label: str = "AccountAccessKey"
-    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {
-            "accesskeyid": PropertyRef("accesskeyid"),
-        }
-    )
-    direction: LinkDirection = LinkDirection.OUTWARD
-    rel_label: str = "AWS_ACCESS_KEY"
-    properties: AWSUserToAccountAccessKeyRelProperties = (
-        AWSUserToAccountAccessKeyRelProperties()
-    )
-
-
-@dataclass(frozen=True)
 class AccountAccessKeyToAWSUserRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
@@ -102,6 +82,5 @@ class AccountAccessKeySchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             AccountAccessKeyToAWSUserRel(),
-            AccountAccessKeyToAWSAccountRel(),
         ]
     )


### PR DESCRIPTION
## Summary

- Remove `AWSUserToAccountAccessKeyRel` and its properties class — defined but never wired into any schema. The active `(AWSUser)-[:AWS_ACCESS_KEY]->(AccountAccessKey)` edge is created by the INWARD `AccountAccessKeyToAWSUserRel`.
- Stop listing `AccountAccessKeyToAWSAccountRel` in `other_relationships`; it's already the `sub_resource_relationship`, so the querybuilder was emitting a redundant MERGE for the same `(AWSAccount)-[:RESOURCE]->(AccountAccessKey)` edge.

No behavior change — both edits are dead/redundant code removal.

## Test plan

- [x] \`uv run pytest tests/integration/cartography/intel/aws/iam/test_iam_sync.py\` — passes (covers \`id == accesskeyid\` and the \`AWS_ACCESS_KEY\` edge back to \`AWSUser\`)
- [x] \`uv run pytest tests/unit/cartography/intel/aws/\` — 176 passed
- [x] \`cubic review\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)