### PR TITLE
feat(rules): add rule to detect unpinned GitHub Actions

### DIFF
--- a/cartography/rules/data/rules/__init__.py
+++ b/cartography/rules/data/rules/__init__.py
@@ -129,6 +129,7 @@ from cartography.rules.data.rules.subimage_coverage import (
     subimage_module_not_configured,
 )
 from cartography.rules.data.rules.unmanaged_accounts import unmanaged_accounts
+from cartography.rules.data.rules.unpinned_github_actions import unpinned_github_actions
 from cartography.rules.data.rules.workload_identity_admin_capabilities import (
     workload_identity_admin_capabilities,
 )
@@ -178,6 +179,7 @@ RULES = {
     workload_identity_admin_capabilities.id: workload_identity_admin_capabilities,
     cloud_security_product_deactivated.id: cloud_security_product_deactivated,
     malicious_npm_dependencies_shai_hulud.id: malicious_npm_dependencies_shai_hulud,
+    unpinned_github_actions.id: unpinned_github_actions,
     # NIST AI RMF Rules
     nist_ai_third_party_app_inventory.id: nist_ai_third_party_app_inventory,
     nist_ai_third_party_app_sensitive_scopes.id: nist_ai_third_party_app_sensitive_scopes,

--- a/cartography/rules/data/rules/unpinned_github_actions.py
+++ b/cartography/rules/data/rules/unpinned_github_actions.py
@@ -1,0 +1,100 @@
+from cartography.rules.spec.model import Fact
+from cartography.rules.spec.model import Finding
+from cartography.rules.spec.model import Maturity
+from cartography.rules.spec.model import Module
+from cartography.rules.spec.model import Rule
+from cartography.rules.spec.model import RuleReference
+
+# Filter applied consistently across query, visual query, and count query:
+# - is_pinned: false          -> action not pinned to a full commit SHA
+# - is_local: false           -> exclude in-repo actions (./.github/actions/...)
+# - owner <> 'docker'         -> exclude docker:// references (different pinning model)
+_UNPINNED_ACTION_MATCH = """
+MATCH (repo:GitHubRepository)-[:HAS_WORKFLOW]->(wf:GitHubWorkflow)-[:USES_ACTION]->(a:GitHubAction)
+WHERE a.is_pinned = false
+  AND a.is_local = false
+  AND a.owner <> 'docker'
+"""
+
+_TOTAL_ACTIONS_MATCH = """
+MATCH (a:GitHubAction)
+WHERE a.is_local = false
+  AND a.owner <> 'docker'
+"""
+
+
+_unpinned_github_actions_fact = Fact(
+    id="unpinned-github-actions",
+    name="GitHub workflows using unpinned third-party Actions",
+    description=(
+        "Finds GitHub Actions referenced by workflows that are not pinned to a full "
+        "commit SHA. Mutable references (branches, tags, major-version tags) let a "
+        "compromised upstream maintainer swap in malicious code on the next workflow "
+        "run. Local actions (./.github/actions/...) and docker:// references are "
+        "excluded."
+    ),
+    cypher_query=_UNPINNED_ACTION_MATCH
+    + """
+    RETURN
+        a.full_name AS action,
+        a.version AS version,
+        wf.path AS workflow_path,
+        repo.fullname AS repo,
+        a.id AS action_id
+    ORDER BY repo, workflow_path, action
+    """,
+    cypher_visual_query=_UNPINNED_ACTION_MATCH
+    + """
+    RETURN *
+    """,
+    cypher_count_query=_TOTAL_ACTIONS_MATCH
+    + """
+    RETURN COUNT(a) AS count
+    """,
+    asset_id_field="action_id",
+    module=Module.GITHUB,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+class UnpinnedGitHubActionOutput(Finding):
+    action: str | None = None
+    version: str | None = None
+    workflow_path: str | None = None
+    repo: str | None = None
+    action_id: str | None = None
+
+
+unpinned_github_actions = Rule(
+    id="unpinned-github-actions",
+    name="Unpinned GitHub Actions",
+    description=(
+        "Detects GitHub workflows that reference third-party GitHub Actions using a "
+        "mutable reference (branch or tag) rather than a full commit SHA. A "
+        "compromise of the upstream action repository — as happened with "
+        "tj-actions/changed-files in March 2025 — lets attackers retarget an "
+        "existing tag at malicious code, which then executes with the workflow's "
+        "permissions and access to its secrets on the next run. Pinning every "
+        "third-party action to a full 40-character commit SHA, combined with "
+        "Dependabot to keep those pins current, is the mitigation recommended by "
+        "GitHub's security hardening guide."
+    ),
+    output_model=UnpinnedGitHubActionOutput,
+    tags=("supply_chain", "github", "stride:tampering"),
+    facts=(_unpinned_github_actions_fact,),
+    version="0.1.0",
+    references=[
+        RuleReference(
+            text="GitHub - Security hardening for GitHub Actions (pin to full-length commit SHA)",
+            url="https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions",
+        ),
+        RuleReference(
+            text="CISA - Supply Chain Compromise of Third-Party tj-actions/changed-files (CVE-2025-30066)",
+            url="https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066",
+        ),
+        RuleReference(
+            text="StepSecurity - Harden-Runner detection of tj-actions/changed-files compromise",
+            url="https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised",
+        ),
+    ],
+)

--- a/cartography/rules/data/rules/unpinned_github_actions.py
+++ b/cartography/rules/data/rules/unpinned_github_actions.py
@@ -5,36 +5,18 @@ from cartography.rules.spec.model import Module
 from cartography.rules.spec.model import Rule
 from cartography.rules.spec.model import RuleReference
 
-# Filter applied consistently across query, visual query, and count query:
-# - is_pinned: false          -> action not pinned to a full commit SHA
-# - is_local: false           -> exclude in-repo actions (./.github/actions/...)
-# - owner <> 'docker'         -> exclude docker:// references (different pinning model)
-_UNPINNED_ACTION_MATCH = """
-MATCH (repo:GitHubRepository)-[:HAS_WORKFLOW]->(wf:GitHubWorkflow)-[:USES_ACTION]->(a:GitHubAction)
-WHERE a.is_pinned = false
-  AND a.is_local = false
-  AND a.owner <> 'docker'
-"""
-
-_TOTAL_ACTIONS_MATCH = """
-MATCH (a:GitHubAction)
-WHERE a.is_local = false
-  AND a.owner <> 'docker'
-"""
-
-
 _unpinned_github_actions_fact = Fact(
     id="unpinned-github-actions",
     name="GitHub workflows using unpinned third-party Actions",
     description=(
         "Finds GitHub Actions referenced by workflows that are not pinned to a full "
-        "commit SHA. Mutable references (branches, tags, major-version tags) let a "
-        "compromised upstream maintainer swap in malicious code on the next workflow "
-        "run. Local actions (./.github/actions/...) and docker:// references are "
-        "excluded."
+        "commit SHA. Local (./.github/actions/...) and docker:// references are excluded."
     ),
-    cypher_query=_UNPINNED_ACTION_MATCH
-    + """
+    cypher_query="""
+    MATCH (repo:GitHubRepository)-[:HAS_WORKFLOW]->(wf:GitHubWorkflow)-[:USES_ACTION]->(a:GitHubAction)
+    WHERE a.is_pinned = false
+      AND a.is_local = false
+      AND a.owner <> 'docker'
     RETURN
         a.full_name AS action,
         a.version AS version,
@@ -43,12 +25,17 @@ _unpinned_github_actions_fact = Fact(
         a.id AS action_id
     ORDER BY repo, workflow_path, action
     """,
-    cypher_visual_query=_UNPINNED_ACTION_MATCH
-    + """
+    cypher_visual_query="""
+    MATCH (repo:GitHubRepository)-[:HAS_WORKFLOW]->(wf:GitHubWorkflow)-[:USES_ACTION]->(a:GitHubAction)
+    WHERE a.is_pinned = false
+      AND a.is_local = false
+      AND a.owner <> 'docker'
     RETURN *
     """,
-    cypher_count_query=_TOTAL_ACTIONS_MATCH
-    + """
+    cypher_count_query="""
+    MATCH (a:GitHubAction)
+    WHERE a.is_local = false
+      AND a.owner <> 'docker'
     RETURN COUNT(a) AS count
     """,
     asset_id_field="action_id",
@@ -69,15 +56,11 @@ unpinned_github_actions = Rule(
     id="unpinned-github-actions",
     name="Unpinned GitHub Actions",
     description=(
-        "Detects GitHub workflows that reference third-party GitHub Actions using a "
-        "mutable reference (branch or tag) rather than a full commit SHA. A "
-        "compromise of the upstream action repository — as happened with "
-        "tj-actions/changed-files in March 2025 — lets attackers retarget an "
-        "existing tag at malicious code, which then executes with the workflow's "
-        "permissions and access to its secrets on the next run. Pinning every "
-        "third-party action to a full 40-character commit SHA, combined with "
-        "Dependabot to keep those pins current, is the mitigation recommended by "
-        "GitHub's security hardening guide."
+        "Detects workflows referencing third-party GitHub Actions by a mutable ref "
+        "(branch or tag) instead of a full commit SHA. If the upstream action is "
+        "compromised — as with tj-actions/changed-files in March 2025 — attackers "
+        "can retarget a tag at malicious code that then runs with the workflow's "
+        "secrets. Pin to a full SHA and let Dependabot keep the pin current."
     ),
     output_model=UnpinnedGitHubActionOutput,
     tags=("supply_chain", "github", "stride:tampering"),


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Adds a new rule, `unpinned-github-actions`, that flags third-party GitHub Actions referenced by a mutable ref (branch or tag) instead of a full commit SHA. If the upstream action is compromised — as with `tj-actions/changed-files` (CVE-2025-30066) in March 2025 — attackers can retarget a tag at malicious code that then runs with the workflow's secrets.

All the signal is already on the graph: `GitHubAction.is_pinned` is set by `workflow_parser.py` based on a 40-hex-char SHA match. The rule's Cypher joins `GitHubRepository -> GitHubWorkflow -> GitHubAction` with `is_pinned = false`, excluding in-repo (`./.github/actions/...`) and `docker://` references. `asset_id_field = "action_id"` dedupes the failing count when the same action is referenced from many workflows.


### Related issues or links

- [GitHub — Security hardening for GitHub Actions (pin to full-length commit SHA)](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [CISA — Supply Chain Compromise of Third-Party tj-actions/changed-files (CVE-2025-30066)](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066)


### How was this tested?

- `uv run --frozen pytest tests/unit/rules/` → 470 passed. The generic rule-registry tests exercise every rule's shape and now cover this one.
- `uv run --frozen pre-commit run --all-files` → clean.
- Smoke-loaded the rule from `RULES['unpinned-github-actions']` and inspected the rendered Cypher for each of `cypher_query`, `cypher_visual_query`, `cypher_count_query`.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works. <!-- Covered by the generic rule-registry unit tests. -->

#### Proof of functionality
- [x] New or updated unit/integration tests.


### Notes for reviewers

- No new intel module, schema, or sync changes — the existing GitHub intel already populates `GitHubAction.is_pinned`.
- `docker://` references are excluded (different pinning model — digests). A dedicated rule would fit better if we want that signal.
- Reusable-workflow calls (`owner/repo/.github/workflows/x.yml@v1`) are *included* — GitHub's hardening guidance applies to them too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)