### PR TITLE
feat(ontology): Jamf device emails should derive canonical ownership edges

### DIFF
--- a/cartography/models/ontology/mapping/data/devices.py
+++ b/cartography/models/ontology/mapping/data/devices.py
@@ -272,6 +272,13 @@ jamf_mapping = OntologyMapping(
             ],
         ),
     ],
+    rels=[
+        OntologyRelMapping(
+            __comment__="Link Device to User based on Jamf device email matching canonical User email",
+            query="MATCH (j)<-[obs:OBSERVED_AS]-(d:Device) WHERE (j:JamfComputer OR j:JamfMobileDevice) AND j.email IS NOT NULL AND trim(j.email) <> '' AND obs.lastupdated = $UPDATE_TAG AND d.lastupdated = $UPDATE_TAG WITH d, toLower(trim(j.email)) AS jamf_email MATCH (u:User) WHERE u.email IS NOT NULL AND trim(u.email) <> '' AND toLower(trim(u.email)) = jamf_email MERGE (u)-[r:OWNS]->(d) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+            iterative=False,
+        ),
+    ],
 )
 
 jumpcloud_mapping = OntologyMapping(

--- a/docs/root/modules/jamf/schema.md
+++ b/docs/root/modules/jamf/schema.md
@@ -6,6 +6,7 @@ T(JamfTenant) -- RESOURCE --> CG(JamfComputerGroup)
 T -- RESOURCE --> MG(JamfMobileDeviceGroup)
 T -- RESOURCE --> C(JamfComputer)
 T -- RESOURCE --> M(JamfMobileDevice)
+U(User) -- OWNS --> D(Device)
 C -- MEMBER_OF --> CG
 M -- MEMBER_OF --> MG
 D(Device) -- OBSERVED_AS --> C
@@ -100,7 +101,7 @@ Representation of a Jamf mobile device group.
 
 Representation of a Jamf-managed macOS computer inventory record.
 
-> **Ontology Mapping**: `JamfComputer` contributes to the `Device` ontology using serial number as the primary key and hostname as a supplemental match strategy.
+> **Ontology Mapping**: `JamfComputer` contributes to the `Device` ontology using serial number as the primary key and hostname as a supplemental match strategy. When Jamf provides a device email, the ontology also uses that email as a correlation signal to derive canonical `(:User)-[:OWNS]->(:Device)` relationships.
 
 | Field | Description |
 |-------|-------------|
@@ -150,13 +151,17 @@ Representation of a Jamf-managed macOS computer inventory record.
   ```
   (:Device)-[:OBSERVED_AS]->(:JamfComputer)
   ```
+- `User` can own a canonical `Device` observed through Jamf when the Jamf device email matches the canonical user email.
+  ```
+  (:User)-[:OWNS]->(:Device)-[:OBSERVED_AS]->(:JamfComputer)
+  ```
 
 
 ### JamfMobileDevice
 
 Representation of a Jamf-managed iPhone or iPad inventory record.
 
-> **Ontology Mapping**: `JamfMobileDevice` contributes to the `Device` ontology using serial number as the primary key while promoting Jamf `display_name` and a normalized Jamf mobile OS value into the canonical `Device` hostname and OS fields.
+> **Ontology Mapping**: `JamfMobileDevice` contributes to the `Device` ontology using serial number as the primary key while promoting Jamf `display_name` and a normalized Jamf mobile OS value into the canonical `Device` hostname and OS fields. When Jamf provides a device email, the ontology also uses that email as a correlation signal to derive canonical `(:User)-[:OWNS]->(:Device)` relationships.
 
 | Field | Description |
 |-------|-------------|
@@ -200,4 +205,8 @@ Representation of a Jamf-managed iPhone or iPad inventory record.
 - `Device` can observe the same endpoint as a `JamfMobileDevice`.
   ```
   (:Device)-[:OBSERVED_AS]->(:JamfMobileDevice)
+  ```
+- `User` can own a canonical `Device` observed through Jamf when the Jamf device email matches the canonical user email.
+  ```
+  (:User)-[:OWNS]->(:Device)-[:OBSERVED_AS]->(:JamfMobileDevice)
   ```

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -116,6 +116,7 @@ If field `active` is null, it should not be considered as `true` or `false`, onl
     ```
     (:User)-[:OWNS]->(:Device)
     ```
+  Jamf device emails, CrowdStrike host emails, and provider-native ownership edges are examples of signals Cartography can use to derive this relationship.
 - `User` can own one or many `APIKey` (semantic label):
     ```
     (:User)-[:OWNS]->(:APIKey)
@@ -199,6 +200,7 @@ A client computer is a host that accesses a service made available by a server o
     ```
     (:User)-[:OWNS]->(:Device)
     ```
+  This relationship may be derived from provider signals such as Jamf device emails, CrowdStrike host emails, or native provider ownership edges.
 
 
 ### APIKey

--- a/tests/integration/cartography/intel/ontology/test_devices.py
+++ b/tests/integration/cartography/intel/ontology/test_devices.py
@@ -691,3 +691,137 @@ def test_load_ontology_devices_from_jamf_mobile_devices(neo4j_session):
         ("IPHONESPRING001", "IPHONESPRING001"),
         ("IPADSPRING001", "IPADSPRING001"),
     }
+
+
+def test_link_ontology_devices_from_jamf_computer_email(neo4j_session):
+    """Jamf computer email should derive canonical User-OWNS-Device relationships."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (u:User {id: 'hjsimpson@simpson.corp'})
+        SET u.email = 'HJSimpson@simpson.corp',
+            u.lastupdated = $update_tag
+
+        CREATE (:JamfComputer {
+            id: 'jamf-computer-1',
+            name: 'springfield-mac-01',
+            os_name: 'macOS',
+            os_version: '14.5',
+            model: 'MacBook Pro',
+            platform: 'macOS',
+            serial_number: 'SN-JAMF-COMP-001',
+            email: 'hjsimpson@simpson.corp',
+            lastupdated: $update_tag
+        })
+        """,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    cartography.intel.ontology.devices.sync(
+        neo4j_session,
+        ["jamf"],
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "User",
+        "id",
+        "Device",
+        "hostname",
+        "OWNS",
+        rel_direction_right=True,
+    ) == {("hjsimpson@simpson.corp", "springfield-mac-01")}
+
+
+def test_link_ontology_devices_from_jamf_mobile_device_email(neo4j_session):
+    """Jamf mobile device email should derive canonical User-OWNS-Device relationships."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (u:User {id: 'mbsimpson@simpson.corp'})
+        SET u.email = 'mbsimpson@simpson.corp',
+            u.lastupdated = $update_tag
+
+        CREATE (:JamfMobileDevice {
+            id: 'jamf-mobile-ownership-1',
+            display_name: 'marges-iphone',
+            os: 'iOS',
+            os_version: '17.5',
+            model: 'iPhone 15',
+            platform: 'iPhone',
+            serial_number: 'SN-JAMF-MOBILE-001',
+            email: 'MBSimpson@simpson.corp',
+            lastupdated: $update_tag
+        })
+        """,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    cartography.intel.ontology.devices.sync(
+        neo4j_session,
+        ["jamf"],
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "User",
+        "id",
+        "Device",
+        "hostname",
+        "OWNS",
+        rel_direction_right=True,
+    ) == {("mbsimpson@simpson.corp", "marges-iphone")}
+
+
+def test_link_ontology_devices_from_jamf_email_skips_empty_and_non_matching(
+    neo4j_session,
+):
+    """Jamf email-based ownership should ignore empty and non-matching emails."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (u:User {id: 'lisasimpson@simpson.corp'})
+        SET u.email = 'lisasimpson@simpson.corp',
+            u.lastupdated = $update_tag
+
+        CREATE (:JamfComputer {
+            id: 'jamf-computer-empty-email',
+            name: 'empty-email-mac',
+            serial_number: 'SN-JAMF-COMP-EMPTY',
+            os_name: 'macOS',
+            email: '',
+            lastupdated: $update_tag
+        })
+
+        CREATE (:JamfMobileDevice {
+            id: 'jamf-mobile-non-match',
+            display_name: 'non-match-phone',
+            serial_number: 'SN-JAMF-MOBILE-NOMATCH',
+            os: 'iOS',
+            email: 'bartsimpson@simpson.corp',
+            lastupdated: $update_tag
+        })
+        """,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    cartography.intel.ontology.devices.sync(
+        neo4j_session,
+        ["jamf"],
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert (
+        neo4j_session.run(
+            """
+            MATCH (:User {id: 'lisasimpson@simpson.corp'})-[r:OWNS]->(:Device)
+            RETURN count(r) AS count
+            """
+        ).single()["count"]
+        == 0
+    )


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

Jamf already contributes device observations and device-associated email addresses, but those signals were not being used to derive canonical `(:User)-[:OWNS]->(:Device)` relationships.

This change closes that gap by letting Jamf device emails participate in the same ontology ownership model that other device sources already use. That makes the canonical graph more useful for cross-provider identity and device questions without changing Jamf ingestion or introducing new provider-specific relationship shapes.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- N/A


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- `uv run --frozen pytest -vvv tests/integration/cartography/intel/ontology/test_devices.py`
- Added integration coverage for Jamf computer email ownership derivation
- Added integration coverage for Jamf mobile device email ownership derivation
- Added a negative Jamf case to confirm empty and non-matching emails do not create ownership edges


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

The main behavior change is limited to ontology ownership derivation. Jamf ingestion remains unchanged; the graph now uses the already-ingested Jamf device email as a correlation signal when building canonical `User -> Device` ownership edges.
