### PR TITLE
feat(kubernetes): make list secrets and aws-auth configmap permissions optional

### DIFF
--- a/cartography/intel/kubernetes/eks.py
+++ b/cartography/intel/kubernetes/eks.py
@@ -5,6 +5,7 @@ import boto3
 import neo4j
 import yaml
 from botocore.exceptions import ClientError
+from kubernetes.client.exceptions import ApiException
 from kubernetes.client.models import V1ConfigMap
 
 from cartography.client.core.tx import load
@@ -453,26 +454,49 @@ def sync(
 
     # 1. Sync AWS IAM mappings (aws-auth ConfigMap)
     logger.info("Syncing AWS IAM mappings from aws-auth ConfigMap")
-    configmap = get_aws_auth_configmap(k8s_client)
-    auth_mappings = parse_aws_auth_map(configmap)
+    configmap: V1ConfigMap | None
+    try:
+        configmap = get_aws_auth_configmap(k8s_client)
+    except ApiException as e:
+        if e.status in (401, 403):
+            logger.warning(
+                "Cartography lacks permission to read the aws-auth ConfigMap on cluster %s "
+                "(status %s). Skipping legacy IAM mappings; continuing with Access Entries "
+                "and OIDC providers.",
+                cluster_name,
+                e.status,
+            )
+            configmap = None
+        elif e.status == 404:
+            logger.info(
+                "No aws-auth ConfigMap on cluster %s — normal for clusters using EKS "
+                "Access Entries exclusively.",
+                cluster_name,
+            )
+            configmap = None
+        else:
+            raise
 
-    # Transform and load both role and user mappings
-    if auth_mappings.get("roles") or auth_mappings.get("users"):
-        transformed_data = transform_aws_auth_mappings(auth_mappings, cluster_name)
-        load_aws_auth_mappings(
-            neo4j_session,
-            transformed_data["users"],
-            transformed_data["groups"],
-            update_tag,
-            cluster_id,
-            cluster_name,
-        )
-        logger.info(
-            f"Successfully synced {len(auth_mappings.get('roles', []))} AWS IAM role mappings "
-            f"and {len(auth_mappings.get('users', []))} AWS IAM user mappings"
-        )
-    else:
-        logger.info("No role or user mappings found in aws-auth ConfigMap")
+    if configmap is not None:
+        auth_mappings = parse_aws_auth_map(configmap)
+
+        # Transform and load both role and user mappings
+        if auth_mappings.get("roles") or auth_mappings.get("users"):
+            transformed_data = transform_aws_auth_mappings(auth_mappings, cluster_name)
+            load_aws_auth_mappings(
+                neo4j_session,
+                transformed_data["users"],
+                transformed_data["groups"],
+                update_tag,
+                cluster_id,
+                cluster_name,
+            )
+            logger.info(
+                f"Successfully synced {len(auth_mappings.get('roles', []))} AWS IAM role mappings "
+                f"and {len(auth_mappings.get('users', []))} AWS IAM user mappings"
+            )
+        else:
+            logger.info("No role or user mappings found in aws-auth ConfigMap")
 
     # 2. Sync EKS Access Entries (EKS API)
     logger.info("Syncing EKS Access Entries from EKS API")

--- a/cartography/intel/kubernetes/secrets.py
+++ b/cartography/intel/kubernetes/secrets.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any
 
 import neo4j
+from kubernetes.client.exceptions import ApiException
 from kubernetes.client.models import V1OwnerReference
 from kubernetes.client.models import V1Secret
 
@@ -19,7 +20,10 @@ logger = logging.getLogger(__name__)
 
 @timeit
 def get_secrets(client: K8sClient) -> list[V1Secret]:
-    items = k8s_paginate(client.core.list_secret_for_all_namespaces)
+    items = k8s_paginate(
+        client.core.list_secret_for_all_namespaces,
+        raise_on_forbidden=True,
+    )
     return items
 
 
@@ -100,7 +104,23 @@ def sync_secrets(
     update_tag: int,
     common_job_parameters: dict[str, Any],
 ) -> None:
-    secrets = get_secrets(client)
+    try:
+        secrets = get_secrets(client)
+    except ApiException as e:
+        if e.status in (401, 403):
+            # Skipping load + cleanup is intentional: if the operator previously granted
+            # `list secrets` and later revoked it, running cleanup would wipe the existing
+            # KubernetesSecret subgraph for this cluster.
+            logger.warning(
+                "Cartography lacks permission to list secrets on cluster %s (status %s). "
+                "Skipping secret sync and preserving previously synced secrets. "
+                "If this is intentional (granting `list secrets` also exposes the base64 "
+                "`data` field and you prefer not to grant it), you can ignore this warning.",
+                client.name,
+                e.status,
+            )
+            return
+        raise
     transformed_secrets = transform_secrets(secrets, client.name)
     load_secrets(
         session=session,

--- a/cartography/intel/kubernetes/util.py
+++ b/cartography/intel/kubernetes/util.py
@@ -201,12 +201,16 @@ def get_epoch(date: datetime | None) -> int | None:
 
 def k8s_paginate(
     list_func: Callable,
+    raise_on_forbidden: bool = False,
     **kwargs: Any,
 ) -> list[dict[str, Any]]:
     """
     Handles pagination for a Kubernetes API call.
 
     :param list_func: The list function to call (e.g. client.core.list_pod_for_all_namespaces)
+    :param raise_on_forbidden: When True, re-raise ApiException with status 401/403 so the caller
+        can handle missing permissions (used for optional RBAC verbs). Other ApiExceptions are still
+        logged and swallowed.
     :param kwargs: Keyword arguments to pass to the list function (e.g. limit=100)
     :return: A list of all resources returned by the list function
     """
@@ -249,6 +253,8 @@ def k8s_paginate(
                 break
 
         except ApiException as e:
+            if raise_on_forbidden and e.status in (401, 403):
+                raise
             logger.error(
                 f"Kubernetes API error retrieving {function_name} resources. {e}: {e.status} - {e.reason}"
             )

--- a/docs/root/modules/kubernetes/config.md
+++ b/docs/root/modules/kubernetes/config.md
@@ -12,16 +12,26 @@ Cartography's Kubernetes module requires read-only access to the following Kuber
 
 - `get namespaces` for reading `kube-system` cluster metadata
 - `list namespaces`
+- `list nodes` for reading node architecture (used to resolve container images)
 - `list pods`
 - `list services`
 - `list serviceaccounts`
-- `list secrets`
 - `list roles`
 - `list rolebindings`
 - `list clusterroles`
 - `list clusterrolebindings`
 - `list ingresses`
-- `get configmaps` for reading the `aws-auth` ConfigMap in `kube-system` (`EKS` only)
+
+### Optional Permissions
+
+These permissions are recommended but Cartography degrades gracefully if they are withheld: it logs a warning, skips the corresponding step, and preserves any data previously synced for that resource.
+
+- `list secrets` — enables ingestion of `KubernetesSecret` metadata (name, namespace, type, owner references). Kubernetes RBAC has no verb that exposes secret metadata without also exposing the content: granting `list secrets` also authorizes reading the base64-encoded `data` field of every secret in scope. Cartography never reads or stores secret content, but any identity with this permission can. Operators who prefer not to grant cluster-wide read access to secret content can omit this verb; Cartography will skip `sync_secrets` and will not delete previously synced secrets.
+- `get configmaps` (EKS only) — enables ingestion of legacy IAM identity mappings from the `aws-auth` ConfigMap in `kube-system`. This is optional because:
+  - Clusters that use [EKS Access Entries](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html) exclusively may not have an `aws-auth` ConfigMap at all.
+  - Some operators prefer not to grant `get` on all ConfigMaps just to read `aws-auth`.
+
+  When omitted or when the ConfigMap does not exist, Cartography still ingests identity mappings from EKS Access Entries and external OIDC providers.
 
 Create a ClusterRole and bind it to the identity used by Cartography:
 
@@ -39,11 +49,16 @@ rules:
 # Core resources - list only
 - apiGroups: [""]
   resources:
+    - nodes
     - pods
     - services
     - serviceaccounts
   verbs: ["list"]
-# Secrets - Cartography stores metadata only
+# Secrets (optional) — omit if you don't want to grant cluster-wide read access
+# to secret contents. Kubernetes RBAC has no metadata-only verb: `list secrets`
+# also exposes the base64 `data` field. Cartography ingests metadata only, but any
+# identity with this permission can read the content. See the Optional Permissions
+# section above for the behavior when this verb is omitted.
 - apiGroups: [""]
   resources:
     - secrets
@@ -61,7 +76,9 @@ rules:
   resources:
     - ingresses
   verbs: ["list"]
-# ConfigMaps (EKS only) - read aws-auth identity mapping
+# ConfigMaps (EKS only, optional) — only used to read the aws-auth ConfigMap for
+# legacy IAM identity mappings. Omit if your cluster uses EKS Access Entries
+# exclusively or if you don't want to grant `get` on all ConfigMaps.
 - apiGroups: [""]
   resources:
     - configmaps

--- a/docs/root/modules/kubernetes/config.md
+++ b/docs/root/modules/kubernetes/config.md
@@ -24,14 +24,14 @@ Cartography's Kubernetes module requires read-only access to the following Kuber
 
 ### Optional Permissions
 
-These permissions are recommended but Cartography degrades gracefully if they are withheld: it logs a warning, skips the corresponding step, and preserves any data previously synced for that resource.
+These permissions are recommended but Cartography degrades gracefully if they are withheld: it logs a warning and skips the corresponding step. See each bullet for the precise behavior, since the trade-off differs per resource.
 
-- `list secrets` — enables ingestion of `KubernetesSecret` metadata (name, namespace, type, owner references). Kubernetes RBAC has no verb that exposes secret metadata without also exposing the content: granting `list secrets` also authorizes reading the base64-encoded `data` field of every secret in scope. Cartography never reads or stores secret content, but any identity with this permission can. Operators who prefer not to grant cluster-wide read access to secret content can omit this verb; Cartography will skip `sync_secrets` and will not delete previously synced secrets.
+- `list secrets` — enables ingestion of `KubernetesSecret` metadata (name, namespace, type, owner references). Kubernetes RBAC has no verb that exposes secret metadata without also exposing the content: granting `list secrets` also authorizes reading the base64-encoded `data` field of every secret in scope. Cartography never reads or stores secret content, but any identity with this permission can. Operators who prefer not to grant cluster-wide read access to secret content can omit this verb. When omitted, Cartography skips `sync_secrets` entirely — including the cleanup step — so previously synced `KubernetesSecret` nodes are preserved.
 - `get configmaps` (EKS only) — enables ingestion of legacy IAM identity mappings from the `aws-auth` ConfigMap in `kube-system`. This is optional because:
   - Clusters that use [EKS Access Entries](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html) exclusively may not have an `aws-auth` ConfigMap at all.
   - Some operators prefer not to grant `get` on all ConfigMaps just to read `aws-auth`.
 
-  When omitted or when the ConfigMap does not exist, Cartography still ingests identity mappings from EKS Access Entries and external OIDC providers.
+  When omitted or when the ConfigMap does not exist, Cartography still ingests identity mappings from EKS Access Entries and external OIDC providers. Note that the EKS identity sync still runs its cleanup step over `KubernetesUser` and `KubernetesGroup`: mappings that previously came only from `aws-auth` (i.e. not also re-asserted by Access Entries in the current run) will be removed from the graph. If you want to preserve legacy `aws-auth` mappings across syncs, grant this verb.
 
 Create a ClusterRole and bind it to the identity used by Cartography:
 

--- a/tests/integration/cartography/intel/kubernetes/test_eks.py
+++ b/tests/integration/cartography/intel/kubernetes/test_eks.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+from kubernetes.client.exceptions import ApiException
 from kubernetes.client.models import V1ConfigMap
 
 from cartography.intel.aws.iam import load_role_data
@@ -333,3 +334,85 @@ def test_eks_sync_creates_aws_role_relationships_and_oidc_providers(
     # Note: OIDC Provider nodes only contain infrastructure metadata.
     # Identity relationships (OktaUser/Group -> KubernetesUser/Group) are handled
     # by the respective data models and Okta module, not by the EKS module.
+
+
+def _run_eks_sync_with_configmap_error(
+    neo4j_session, status: int, caplog_level: str | None = None, caplog=None
+) -> None:
+    """Helper: set up AWS prereqs, mock aws-auth read to raise ApiException, run sync_eks."""
+    neo4j_session.run(
+        """
+        MERGE (aa:AWSAccount{id: $account_id})
+        ON CREATE SET aa.firstseen = timestamp()
+        SET aa.lastupdated = $update_tag, aa :Tenant
+        """,
+        account_id=TEST_ACCOUNT_ID,
+        update_tag=TEST_UPDATE_TAG,
+    )
+    load_kubernetes_cluster(neo4j_session, MOCK_CLUSTER_DATA, TEST_UPDATE_TAG)
+
+    mock_k8s_client = MagicMock()
+    mock_k8s_client.name = TEST_CLUSTER_NAME
+    mock_k8s_client.core.read_namespaced_config_map.side_effect = ApiException(
+        status=status, reason="Forbidden" if status == 403 else "Not Found"
+    )
+
+    with (
+        patch(
+            "cartography.intel.kubernetes.eks.get_access_entries",
+            return_value=MOCK_ACCESS_ENTRIES,
+        ),
+        patch(
+            "cartography.intel.kubernetes.eks.get_oidc_provider",
+            return_value=MOCK_OIDC_PROVIDER,
+        ),
+    ):
+        sync_eks(
+            neo4j_session,
+            mock_k8s_client,
+            MagicMock(),
+            TEST_REGION,
+            TEST_UPDATE_TAG,
+            TEST_CLUSTER_ID,
+            TEST_CLUSTER_NAME,
+        )
+
+
+def test_eks_sync_skips_aws_auth_on_forbidden(neo4j_session, caplog):
+    """
+    When Cartography lacks `get` on the aws-auth ConfigMap, sync_eks logs a warning,
+    skips legacy IAM mappings, but still ingests Access Entries and OIDC providers.
+    """
+    with caplog.at_level("WARNING"):
+        _run_eks_sync_with_configmap_error(neo4j_session, status=403)
+
+    assert any(
+        "lacks permission to read the aws-auth ConfigMap" in record.message
+        for record in caplog.records
+    )
+
+    # Access Entries users still created
+    actual_users = check_nodes(neo4j_session, "KubernetesUser", ["id"])
+    assert ("test-cluster/alice-access-entry",) in actual_users
+
+    # OIDC Provider still created
+    actual_oidc = check_nodes(neo4j_session, "KubernetesOIDCProvider", ["id"])
+    assert (f"{TEST_CLUSTER_NAME}/oidc/okta-provider",) in actual_oidc
+
+
+def test_eks_sync_skips_aws_auth_on_not_found(neo4j_session, caplog):
+    """
+    When the aws-auth ConfigMap does not exist (404, typical for Access Entries-only
+    clusters), sync_eks logs an info message and continues with the remaining steps.
+    """
+    with caplog.at_level("INFO"):
+        _run_eks_sync_with_configmap_error(neo4j_session, status=404)
+
+    assert any(
+        "No aws-auth ConfigMap on cluster" in record.message
+        for record in caplog.records
+    )
+
+    # Access Entries still ingested
+    actual_users = check_nodes(neo4j_session, "KubernetesUser", ["id"])
+    assert ("test-cluster/alice-access-entry",) in actual_users

--- a/tests/unit/cartography/intel/kubernetes/test_secrets.py
+++ b/tests/unit/cartography/intel/kubernetes/test_secrets.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from kubernetes.client.exceptions import ApiException
+
+from cartography.intel.kubernetes.secrets import sync_secrets
+
+
+def _make_api_exception(status: int) -> ApiException:
+    return ApiException(status=status, reason="Forbidden")
+
+
+@patch("cartography.intel.kubernetes.secrets.cleanup")
+@patch("cartography.intel.kubernetes.secrets.load_secrets")
+def test_sync_secrets_skips_load_and_cleanup_on_forbidden(
+    mock_load_secrets, mock_cleanup, caplog
+):
+    mock_client = MagicMock()
+    mock_client.name = "my-cluster"
+    mock_client.core.list_secret_for_all_namespaces.__name__ = (
+        "list_secret_for_all_namespaces"
+    )
+    mock_client.core.list_secret_for_all_namespaces.side_effect = _make_api_exception(
+        403
+    )
+
+    with caplog.at_level("WARNING"):
+        sync_secrets(
+            session=MagicMock(),
+            client=mock_client,
+            update_tag=1,
+            common_job_parameters={"CLUSTER_ID": "cluster-id"},
+        )
+
+    mock_load_secrets.assert_not_called()
+    mock_cleanup.assert_not_called()
+    assert any(
+        "lacks permission to list secrets" in record.message
+        for record in caplog.records
+    )
+
+
+@patch("cartography.intel.kubernetes.secrets.cleanup")
+@patch("cartography.intel.kubernetes.secrets.load_secrets")
+def test_sync_secrets_skips_load_and_cleanup_on_unauthorized(
+    mock_load_secrets, mock_cleanup
+):
+    mock_client = MagicMock()
+    mock_client.name = "my-cluster"
+    mock_client.core.list_secret_for_all_namespaces.__name__ = (
+        "list_secret_for_all_namespaces"
+    )
+    mock_client.core.list_secret_for_all_namespaces.side_effect = _make_api_exception(
+        401
+    )
+
+    sync_secrets(
+        session=MagicMock(),
+        client=mock_client,
+        update_tag=1,
+        common_job_parameters={"CLUSTER_ID": "cluster-id"},
+    )
+
+    mock_load_secrets.assert_not_called()
+    mock_cleanup.assert_not_called()


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary

Makes two sensitive Kubernetes RBAC verbs optional for Cartography and documents the trade-off so operators can make an informed choice:

1. **`list secrets`** — Kubernetes RBAC does not expose a verb that returns only Secret metadata; granting `list secrets` also authorizes reading the base64 `data` field of every secret in scope. Cartography only ingests metadata (name, namespace, type, owner references) and never stores content, but some operators legitimately choose not to grant this permission.
2. **`get configmaps` on `kube-system/aws-auth`** (EKS only) — Clusters using EKS Access Entries exclusively may not have an `aws-auth` ConfigMap at all, and some operators prefer not to grant `get` on all ConfigMaps just to read one.

Previously:
- A 403 on `list secrets` was silently swallowed by `k8s_paginate`, producing an empty list. `cleanup` then wiped any previously synced `KubernetesSecret` nodes for that cluster.
- A 403 on reading `aws-auth` crashed `sync_eks`, which raised out of `start_k8s_ingestion` and aborted the entire cluster sync (including subsequent clusters in the kubeconfig).

Now:
- `k8s_paginate` accepts an opt-in `raise_on_forbidden` kwarg that re-raises `ApiException` with status 401/403 so callers can handle optional permissions explicitly. Default behavior is unchanged for all other callers.
- `sync_secrets` catches 401/403, logs a clear warning explaining the trade-off, and skips `load` + `cleanup` so previously synced secrets are preserved.
- `sync_eks` catches 401/403 (permission denied) and 404 (ConfigMap absent — normal for Access Entries-only clusters) around the `aws-auth` read, logs an appropriate message, and continues with Access Entries + OIDC + cleanup.
- Docs split Kubernetes permissions into **Required** and **Optional**, with rationale for each optional verb and commented YAML blocks in the `ClusterRole` example.


### Related issues or links

- Fixes #


### How was this tested?

- New unit tests in `tests/unit/cartography/intel/kubernetes/test_secrets.py`:
  - `sync_secrets` on `ApiException(403)` → `load`/`cleanup` not called, warning logged.
  - `sync_secrets` on `ApiException(401)` → `load`/`cleanup` not called.
- New integration tests in `tests/integration/cartography/intel/kubernetes/test_eks.py`:
  - `sync_eks` on `ApiException(403)` reading aws-auth → warning logged, Access Entries and OIDC providers still ingested.
  - `sync_eks` on `ApiException(404)` reading aws-auth → info logged, Access Entries and OIDC providers still ingested.
- Full kubernetes suite: `56 passed` (unit + integration).
- `make test_lint` passes (isort, black, flake8, pyupgrade, mypy).


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- N/A — no schema changes.

#### If you are changing a node or relationship
- N/A — no schema changes.


### Notes for reviewers

- Behavior change is opt-in at the helper layer: `k8s_paginate` keeps its existing "log and swallow" default for every other caller, so `pods`, `services`, `ingress`, `rbac`, `nodes` are untouched.
- `sync_eks` still runs `cleanup` after skipping aws-auth. This means a cluster that previously only had aws-auth mappings (no Access Entries) will see those `KubernetesUser`/`KubernetesGroup` nodes cleaned up if the permission is later revoked. This is consistent with the rest of the module and documented implicitly by the fact that aws-auth is now optional.