### PR TITLE
fix(aws): preserve S3 buckets on head_bucket timeouts

### DIFF
--- a/cartography/intel/aws/s3.py
+++ b/cartography/intel/aws/s3.py
@@ -14,7 +14,9 @@ import boto3
 import botocore
 import neo4j
 from botocore.exceptions import ClientError
+from botocore.exceptions import ConnectTimeoutError
 from botocore.exceptions import EndpointConnectionError
+from botocore.exceptions import ReadTimeoutError
 from policyuniverse.policy import Policy
 
 from cartography.client.core.tx import load
@@ -101,6 +103,12 @@ def get_s3_bucket_list(boto3_session: boto3.session.Session) -> List[Dict]:
                 continue
             else:
                 raise
+        except (ConnectTimeoutError, EndpointConnectionError, ReadTimeoutError):
+            bucket["Region"] = None
+            logger.warning(
+                "skipping bucket='%s' region discovery due to transport timeout/connection error.",
+                bucket["Name"],
+            )
     return buckets
 
 

--- a/tests/unit/cartography/intel/aws/test_s3.py
+++ b/tests/unit/cartography/intel/aws/test_s3.py
@@ -87,18 +87,36 @@ def test_get_s3_bucket_list_common_exception_sets_region_none(mock_is_common):
     assert result["Buckets"][0]["Region"] is None
 
 
-def test_get_s3_bucket_list_connect_timeout_sets_region_none():
-    """Transport timeouts during region discovery should preserve the bucket."""
+def test_get_s3_bucket_list_connect_timeout_preserves_other_buckets():
+    """A timeout on one bucket should not stop region discovery for surrounding buckets."""
     mock_session = MagicMock()
     mock_client = mock_session.client.return_value
 
     mock_client.list_buckets.return_value = {
-        "Buckets": [{"Name": "slow-bucket"}],
+        "Buckets": [
+            {"Name": "first-bucket"},
+            {"Name": "slow-bucket"},
+            {"Name": "last-bucket"},
+        ],
     }
-    mock_client.head_bucket.side_effect = ConnectTimeoutError(
-        endpoint_url="https://slow-bucket.s3.me-south-1.amazonaws.com/",
-        error="timed out",
-    )
+    mock_client.head_bucket.side_effect = [
+        {
+            "BucketRegion": "us-east-1",
+            "ResponseMetadata": {"HTTPHeaders": {}},
+        },
+        ConnectTimeoutError(
+            endpoint_url="https://slow-bucket.s3.me-south-1.amazonaws.com/",
+            error="timed out",
+        ),
+        {
+            "BucketRegion": "eu-west-1",
+            "ResponseMetadata": {"HTTPHeaders": {}},
+        },
+    ]
 
     result = get_s3_bucket_list(mock_session)
-    assert result["Buckets"][0]["Region"] is None
+    assert result["Buckets"] == [
+        {"Name": "first-bucket", "Region": "us-east-1"},
+        {"Name": "slow-bucket", "Region": None},
+        {"Name": "last-bucket", "Region": "eu-west-1"},
+    ]

--- a/tests/unit/cartography/intel/aws/test_s3.py
+++ b/tests/unit/cartography/intel/aws/test_s3.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from botocore.exceptions import ClientError
+from botocore.exceptions import ConnectTimeoutError
 
 from cartography.intel.aws.s3 import get_s3_bucket_list
 
@@ -81,6 +82,23 @@ def test_get_s3_bucket_list_common_exception_sets_region_none(mock_is_common):
         "Buckets": [{"Name": "bad-bucket"}],
     }
     mock_client.head_bucket.side_effect = _make_client_error(403)
+
+    result = get_s3_bucket_list(mock_session)
+    assert result["Buckets"][0]["Region"] is None
+
+
+def test_get_s3_bucket_list_connect_timeout_sets_region_none():
+    """Transport timeouts during region discovery should preserve the bucket."""
+    mock_session = MagicMock()
+    mock_client = mock_session.client.return_value
+
+    mock_client.list_buckets.return_value = {
+        "Buckets": [{"Name": "slow-bucket"}],
+    }
+    mock_client.head_bucket.side_effect = ConnectTimeoutError(
+        endpoint_url="https://slow-bucket.s3.me-south-1.amazonaws.com/",
+        error="timed out",
+    )
 
     result = get_s3_bucket_list(mock_session)
     assert result["Buckets"][0]["Region"] is None


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
Preserve S3 buckets when `head_bucket()` region discovery hits a transport timeout or connection error.

This keeps the sync on the per-bucket failure path used elsewhere in the module instead of aborting the entire account sync because one bucket endpoint is slow or unreachable.


### Related issues or links
- N/A


### Breaking changes
None.


### How was this tested?
- `uv run pytest tests/unit/cartography/intel/aws/test_s3.py -q`
- `uv run pytest tests/integration/cartography/intel/aws/test_s3.py -q`
- Commit hooks passed during `git commit`, including `isort`, `black`, `flake8`, and `mypy`.


### Checklist

#### General
- [ ] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
- I kept this out of `aws_handle_regions()` because this code path is global and bucket-by-bucket rather than region-scoped.
- Returning `[]` for the whole call on one timeout would make cleanup semantics worse than preserving the bucket with `Region=None` and continuing.
