### PR TITLE
perf(gcp): batch permission relationship sync

### DIFF
--- a/cartography/intel/gcp/permission_relationships.py
+++ b/cartography/intel/gcp/permission_relationships.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+from collections.abc import Iterator
 from string import Template
 from typing import Any
 
@@ -15,6 +16,8 @@ from cartography.models.gcp.permission_relationships import GCPPermissionMatchLi
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
+
+GCP_PERMISSION_RELATIONSHIP_BATCH_SIZE = 500
 
 
 def resolve_gcp_scope(scope: str, project_id: str) -> str:
@@ -128,19 +131,60 @@ def calculate_permission_relationships(
     resource_dict: dict[str, str],
     permissions: list[str],
 ) -> list[dict[str, Any]]:
+    return [
+        mapping
+        for batch in iter_permission_relationship_batches(
+            principals,
+            resource_dict,
+            permissions,
+        )
+        for mapping in batch
+    ]
+
+
+def calculate_permission_relationships_for_resource(
+    principals: dict[str, Any],
+    resource_id: str,
+    resource_scope: str,
+    permissions: list[str],
+) -> list[dict[str, Any]]:
     allowed_mappings: list[dict[str, Any]] = []
-    for resource_id, resource_scope in resource_dict.items():
-        for principal_email, policy_bindings in principals.items():
-            if principal_allowed_on_resource(
-                policy_bindings, resource_scope, permissions
-            ):
-                allowed_mappings.append(
-                    {
-                        "principal_email": principal_email,
-                        "resource_id": resource_id,
-                    }
-                )
+    for principal_email, policy_bindings in principals.items():
+        if principal_allowed_on_resource(policy_bindings, resource_scope, permissions):
+            allowed_mappings.append(
+                {
+                    "principal_email": principal_email,
+                    "resource_id": resource_id,
+                }
+            )
     return allowed_mappings
+
+
+def iter_permission_relationship_batches(
+    principals: dict[str, Any],
+    resource_dict: dict[str, str],
+    permissions: list[str],
+    batch_size: int = GCP_PERMISSION_RELATIONSHIP_BATCH_SIZE,
+) -> Iterator[list[dict[str, Any]]]:
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be greater than 0, got {batch_size}")
+
+    batch: list[dict[str, Any]] = []
+    for resource_id, resource_scope in resource_dict.items():
+        batch.extend(
+            calculate_permission_relationships_for_resource(
+                principals,
+                resource_id,
+                resource_scope,
+                permissions,
+            )
+        )
+        while len(batch) >= batch_size:
+            yield batch[:batch_size]
+            batch = batch[batch_size:]
+
+    if batch:
+        yield batch
 
 
 @timeit
@@ -285,6 +329,7 @@ def load_principal_mappings(
     matchlink_schema: GCPPermissionMatchLink,
     update_tag: int,
     project_id: str,
+    batch_size: int = GCP_PERMISSION_RELATIONSHIP_BATCH_SIZE,
 ) -> None:
     """
     Load principal mappings into Neo4j using MatchLinks.
@@ -301,10 +346,100 @@ def load_principal_mappings(
         neo4j_session,
         matchlink_schema,
         principal_mappings,
+        batch_size=batch_size,
         lastupdated=update_tag,
         _sub_resource_label="GCPProject",
         _sub_resource_id=project_id,
     )
+
+
+@timeit
+def evaluate_and_load_permission_relationships(
+    neo4j_session: neo4j.Session,
+    principals: dict[str, Any],
+    resource_dict: dict[str, str],
+    permissions: list[str],
+    matchlink_schema: GCPPermissionMatchLink,
+    update_tag: int,
+    project_id: str,
+    batch_size: int = GCP_PERMISSION_RELATIONSHIP_BATCH_SIZE,
+) -> int:
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be greater than 0, got {batch_size}")
+
+    total_resources = len(resource_dict)
+    if total_resources == 0:
+        logger.info(
+            "No %s resources found for relationship '%s' in project '%s'.",
+            matchlink_schema.target_node_label,
+            matchlink_schema.rel_label,
+            project_id,
+        )
+        return 0
+
+    relationships_loaded = 0
+    resources_processed = 0
+    progress_interval = max(1, min(100, total_resources // 10 or 1))
+    batch: list[dict[str, Any]] = []
+
+    for resource_id, resource_scope in resource_dict.items():
+        batch.extend(
+            calculate_permission_relationships_for_resource(
+                principals,
+                resource_id,
+                resource_scope,
+                permissions,
+            )
+        )
+        resources_processed += 1
+
+        while len(batch) >= batch_size:
+            batch_to_load = batch[:batch_size]
+            load_principal_mappings(
+                neo4j_session,
+                batch_to_load,
+                matchlink_schema,
+                update_tag,
+                project_id,
+                batch_size=batch_size,
+            )
+            relationships_loaded += len(batch_to_load)
+            batch = batch[batch_size:]
+
+        if (
+            resources_processed % progress_interval == 0
+            or resources_processed == total_resources
+        ):
+            percent = (resources_processed / total_resources) * 100
+            logger.info(
+                "Relationship '%s' for '%s': processed %d/%d resources (%.1f%%), loaded %d relationships so far",
+                matchlink_schema.rel_label,
+                matchlink_schema.target_node_label,
+                resources_processed,
+                total_resources,
+                percent,
+                relationships_loaded,
+            )
+
+    if batch:
+        load_principal_mappings(
+            neo4j_session,
+            batch,
+            matchlink_schema,
+            update_tag,
+            project_id,
+            batch_size=batch_size,
+        )
+        relationships_loaded += len(batch)
+
+    logger.info(
+        "Completed relationship '%s' for '%s': processed %d resources and loaded %d relationships",
+        matchlink_schema.rel_label,
+        matchlink_schema.target_node_label,
+        total_resources,
+        relationships_loaded,
+    )
+    return relationships_loaded
 
 
 @timeit
@@ -362,12 +497,17 @@ def sync(
         permissions = rpr["permissions"]
 
         resource_dict = get_resource_ids(neo4j_session, project_id, target_label)
+        principal_count = len(principals)
+        resource_count = len(resource_dict)
 
         logger.info(
-            f"Evaluating relationship '{relationship_name}' for resource type '{target_label}'"
-        )
-        matches = calculate_permission_relationships(
-            principals, resource_dict, permissions
+            "Starting relationship '%s' for resource type '%s' in project '%s' with %d permissions, %d principals, and %d resources",
+            relationship_name,
+            target_label,
+            project_id,
+            len(permissions),
+            principal_count,
+            resource_count,
         )
 
         # Create MatchLink schema with dynamic attributes
@@ -377,12 +517,22 @@ def sync(
             rel_label=relationship_name,
         )
 
-        load_principal_mappings(
+        loaded_relationship_count = evaluate_and_load_permission_relationships(
             neo4j_session,
-            matches,
+            principals,
+            resource_dict,
+            permissions,
             matchlink_schema,
             update_tag,
             project_id,
+            batch_size=GCP_PERMISSION_RELATIONSHIP_BATCH_SIZE,
+        )
+        logger.info(
+            "Finished loading relationship '%s' for resource type '%s' in project '%s' with %d total relationships before cleanup",
+            relationship_name,
+            target_label,
+            project_id,
+            loaded_relationship_count,
         )
         cleanup_rpr(
             neo4j_session,

--- a/cartography/intel/gcp/permission_relationships.py
+++ b/cartography/intel/gcp/permission_relationships.py
@@ -4,6 +4,7 @@ import re
 from collections.abc import Iterator
 from string import Template
 from typing import Any
+from typing import Callable
 
 import neo4j
 import yaml
@@ -126,22 +127,6 @@ def principal_allowed_on_resource(
     return False
 
 
-def calculate_permission_relationships(
-    principals: dict[str, Any],
-    resource_dict: dict[str, str],
-    permissions: list[str],
-) -> list[dict[str, Any]]:
-    return [
-        mapping
-        for batch in iter_permission_relationship_batches(
-            principals,
-            resource_dict,
-            permissions,
-        )
-        for mapping in batch
-    ]
-
-
 def calculate_permission_relationships_for_resource(
     principals: dict[str, Any],
     resource_id: str,
@@ -165,12 +150,17 @@ def iter_permission_relationship_batches(
     resource_dict: dict[str, str],
     permissions: list[str],
     batch_size: int = GCP_PERMISSION_RELATIONSHIP_BATCH_SIZE,
+    progress_callback: Callable[[int, int], None] | None = None,
 ) -> Iterator[list[dict[str, Any]]]:
     if batch_size <= 0:
         raise ValueError(f"batch_size must be greater than 0, got {batch_size}")
 
     batch: list[dict[str, Any]] = []
-    for resource_id, resource_scope in resource_dict.items():
+    total_resources = len(resource_dict)
+    for resources_processed, (resource_id, resource_scope) in enumerate(
+        resource_dict.items(),
+        start=1,
+    ):
         batch.extend(
             calculate_permission_relationships_for_resource(
                 principals,
@@ -179,6 +169,8 @@ def iter_permission_relationship_batches(
                 permissions,
             )
         )
+        if progress_callback is not None:
+            progress_callback(resources_processed, total_resources)
         while len(batch) >= batch_size:
             yield batch[:batch_size]
             batch = batch[batch_size:]
@@ -378,34 +370,9 @@ def evaluate_and_load_permission_relationships(
         return 0
 
     relationships_loaded = 0
-    resources_processed = 0
     progress_interval = max(1, min(100, total_resources // 10 or 1))
-    batch: list[dict[str, Any]] = []
 
-    for resource_id, resource_scope in resource_dict.items():
-        batch.extend(
-            calculate_permission_relationships_for_resource(
-                principals,
-                resource_id,
-                resource_scope,
-                permissions,
-            )
-        )
-        resources_processed += 1
-
-        while len(batch) >= batch_size:
-            batch_to_load = batch[:batch_size]
-            load_principal_mappings(
-                neo4j_session,
-                batch_to_load,
-                matchlink_schema,
-                update_tag,
-                project_id,
-                batch_size=batch_size,
-            )
-            relationships_loaded += len(batch_to_load)
-            batch = batch[batch_size:]
-
+    def _log_progress(resources_processed: int, total_resources: int) -> None:
         if (
             resources_processed % progress_interval == 0
             or resources_processed == total_resources
@@ -421,7 +388,13 @@ def evaluate_and_load_permission_relationships(
                 relationships_loaded,
             )
 
-    if batch:
+    for batch in iter_permission_relationship_batches(
+        principals,
+        resource_dict,
+        permissions,
+        batch_size=batch_size,
+        progress_callback=_log_progress,
+    ):
         load_principal_mappings(
             neo4j_session,
             batch,

--- a/docs/root/modules/gcp/config.md
+++ b/docs/root/modules/gcp/config.md
@@ -17,7 +17,7 @@ Grant the following roles to the identity at the **organization level**. This en
 | `roles/resourcemanager.folderViewer` | List/get GCP Folders | Yes |
 | `roles/bigquery.dataViewer` | List/get BigQuery datasets, tables, and routines | Optional |
 | `roles/bigquery.connectionUser` | List BigQuery connections | Optional |
-| `roles/cloudasset.viewer` | Sync IAM policy bindings (effective policies across org hierarchy) | Optional |
+| `roles/cloudasset.viewer` | Sync IAM policy bindings (effective policies across org hierarchy) and enable permission relationship syncs that depend on those bindings | Optional |
 | `roles/artifactregistry.reader` | List/get Artifact Registry repositories and artifacts | Optional |
 | `roles/run.viewer` | List/get Cloud Run services, jobs, and executions | Optional |
 | `roles/notebooks.viewer` | List/get Vertex AI Workbench (Notebooks API) resources | Optional |
@@ -91,6 +91,8 @@ Cartography uses the [Cloud Asset Inventory API](https://cloud.google.com/asset-
 1. **IAM Fallback**: When the IAM API is disabled on a target project, Cartography falls back to CAI to retrieve service accounts and custom roles.
 2. **Policy Bindings**: Sync effective IAM policies (including inherited policies from parent orgs/folders) for all resources.
 
+GCP permission relationship syncs depend on policy bindings being present in the graph. In practice, that means permission relationship syncs require the CAI-backed policy bindings sync to succeed.
+
 #### Setup
 
 When using a service account, CAI API calls are automatically billed against the service account's **host project**. No additional configuration is required.
@@ -112,3 +114,4 @@ When using a service account, CAI API calls are automatically billed against the
 
 - **IAM Fallback**: Requires the Cloud Asset Inventory API to be enabled on the service account's host project. If the API is not enabled or the identity lacks permissions, Cartography will log a warning and skip the CAI fallback (other sync operations will continue normally). Note: The CAI fallback only syncs service accounts and project-level custom roles. Predefined roles and organization-level custom roles are synced separately at the organization level via the IAM API.
 - **Policy Bindings**: Requires organization-level `roles/cloudasset.viewer`. If this role is missing, Cartography will log a warning and skip policy bindings sync (other sync operations will continue normally).
+- **Permission Relationships**: Depend on policy bindings being present in the graph. If CAI is unavailable or `roles/cloudasset.viewer` is missing, permission relationships will not have the policy binding data they need and may produce no results.

--- a/docs/root/modules/gcp/permission-mapping.md
+++ b/docs/root/modules/gcp/permission-mapping.md
@@ -7,6 +7,8 @@ As mapping all permissions is infeasible both to calculate and store, Cartograph
 
 You can specify your own permission mapping file using the `--gcp-permission-relationships-file` command line parameter
 
+Permission relationship syncs depend on GCP policy bindings already being present in the graph. In the normal GCP sync flow, those policy bindings come from the CAI-backed policy bindings sync.
+
 #### Permission Mapping File
 The [permission relationship file](https://github.com/cartography-cncf/cartography/blob/master/cartography/data/gcp_permission_relationships.yaml) is a yaml file that specifies what permission relationships should be created in the graph. It consists of RPR (Resource Permission Relationship) sections that are going to map specific permissions between GCP principals and resources
 ```yaml

--- a/tests/unit/cartography/intel/gcp/test_permission_relationships.py
+++ b/tests/unit/cartography/intel/gcp/test_permission_relationships.py
@@ -67,11 +67,6 @@ def test_iter_permission_relationship_batches_preserves_matches():
         (("principal_email", "alice@example.com"), ("resource_id", "bucket-3")),
         (("principal_email", "bob@example.com"), ("resource_id", "bucket-2")),
     }
-    assert flattened == permission_relationships.calculate_permission_relationships(
-        principals,
-        resource_dict,
-        permissions,
-    )
 
 
 def test_sync_loads_permission_relationships_in_multiple_batches(monkeypatch):

--- a/tests/unit/cartography/intel/gcp/test_permission_relationships.py
+++ b/tests/unit/cartography/intel/gcp/test_permission_relationships.py
@@ -1,0 +1,206 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from cartography.intel.gcp import permission_relationships
+
+TEST_PROJECT_ID = "project-abc"
+TEST_UPDATE_TAG = 123456789
+COMMON_JOB_PARAMS = {
+    "UPDATE_TAG": TEST_UPDATE_TAG,
+    "ORG_RESOURCE_NAME": "organizations/1337",
+    "PROJECT_ID": TEST_PROJECT_ID,
+    "gcp_permission_relationships_file": "dummy_path",
+}
+
+
+def _build_policy_bindings(
+    permissions: list[str],
+    scope: str,
+) -> dict[str, dict[str, object]]:
+    return {
+        "binding-1": {
+            "permissions": permission_relationships.compile_permissions(
+                {
+                    "permissions": permissions,
+                    "denied_permissions": [],
+                }
+            ),
+            "scope": permission_relationships.compile_gcp_regex(scope),
+        }
+    }
+
+
+def test_iter_permission_relationship_batches_preserves_matches():
+    principals = {
+        "alice@example.com": _build_policy_bindings(
+            ["storage.objects.get"],
+            "project/project-abc/resource/*",
+        ),
+        "bob@example.com": _build_policy_bindings(
+            ["storage.objects.get"],
+            "project/project-abc/resource/bucket-2",
+        ),
+    }
+    resource_dict = {
+        "bucket-1": "project/project-abc/resource/bucket-1",
+        "bucket-2": "project/project-abc/resource/bucket-2",
+        "bucket-3": "project/project-abc/resource/bucket-3",
+    }
+    permissions = ["storage.objects.get"]
+
+    batches = list(
+        permission_relationships.iter_permission_relationship_batches(
+            principals,
+            resource_dict,
+            permissions,
+            batch_size=2,
+        )
+    )
+    flattened = [mapping for batch in batches for mapping in batch]
+
+    assert all(len(batch) <= 2 for batch in batches)
+    assert {tuple(sorted(mapping.items())) for mapping in flattened} == {
+        (("principal_email", "alice@example.com"), ("resource_id", "bucket-1")),
+        (("principal_email", "alice@example.com"), ("resource_id", "bucket-2")),
+        (("principal_email", "alice@example.com"), ("resource_id", "bucket-3")),
+        (("principal_email", "bob@example.com"), ("resource_id", "bucket-2")),
+    }
+    assert flattened == permission_relationships.calculate_permission_relationships(
+        principals,
+        resource_dict,
+        permissions,
+    )
+
+
+def test_sync_loads_permission_relationships_in_multiple_batches(monkeypatch):
+    principals = {
+        "alice@example.com": _build_policy_bindings(
+            ["storage.objects.get"],
+            "project/project-abc/resource/*",
+        ),
+    }
+    resource_dict = {
+        "bucket-1": "project/project-abc/resource/bucket-1",
+        "bucket-2": "project/project-abc/resource/bucket-2",
+        "bucket-3": "project/project-abc/resource/bucket-3",
+    }
+    relationship_mapping = [
+        {
+            "permissions": ["storage.objects.get"],
+            "relationship_name": "CAN_READ",
+            "target_label": "GCPBucket",
+        }
+    ]
+    neo4j_session = MagicMock()
+
+    monkeypatch.setattr(
+        permission_relationships,
+        "GCP_PERMISSION_RELATIONSHIP_BATCH_SIZE",
+        2,
+    )
+
+    with (
+        patch.object(
+            permission_relationships,
+            "get_principals_for_project",
+            return_value=principals,
+        ),
+        patch.object(
+            permission_relationships,
+            "parse_permission_relationships_file",
+            return_value=relationship_mapping,
+        ),
+        patch.object(
+            permission_relationships,
+            "get_resource_ids",
+            return_value=resource_dict,
+        ),
+        patch.object(
+            permission_relationships,
+            "load_principal_mappings",
+        ) as mock_load_principal_mappings,
+        patch.object(
+            permission_relationships,
+            "cleanup_rpr",
+        ) as mock_cleanup_rpr,
+    ):
+        permission_relationships.sync(
+            neo4j_session,
+            TEST_PROJECT_ID,
+            TEST_UPDATE_TAG,
+            COMMON_JOB_PARAMS,
+        )
+
+    assert mock_load_principal_mappings.call_count == 2
+    assert [
+        len(call.args[1]) for call in mock_load_principal_mappings.call_args_list
+    ] == [
+        2,
+        1,
+    ]
+    mock_cleanup_rpr.assert_called_once()
+
+
+def test_sync_skips_cleanup_when_batch_load_fails(monkeypatch):
+    principals = {
+        "alice@example.com": _build_policy_bindings(
+            ["storage.objects.get"],
+            "project/project-abc/resource/*",
+        ),
+    }
+    resource_dict = {
+        "bucket-1": "project/project-abc/resource/bucket-1",
+        "bucket-2": "project/project-abc/resource/bucket-2",
+    }
+    relationship_mapping = [
+        {
+            "permissions": ["storage.objects.get"],
+            "relationship_name": "CAN_READ",
+            "target_label": "GCPBucket",
+        }
+    ]
+    neo4j_session = MagicMock()
+
+    monkeypatch.setattr(
+        permission_relationships,
+        "GCP_PERMISSION_RELATIONSHIP_BATCH_SIZE",
+        2,
+    )
+
+    with (
+        patch.object(
+            permission_relationships,
+            "get_principals_for_project",
+            return_value=principals,
+        ),
+        patch.object(
+            permission_relationships,
+            "parse_permission_relationships_file",
+            return_value=relationship_mapping,
+        ),
+        patch.object(
+            permission_relationships,
+            "get_resource_ids",
+            return_value=resource_dict,
+        ),
+        patch.object(
+            permission_relationships,
+            "load_principal_mappings",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch.object(
+            permission_relationships,
+            "cleanup_rpr",
+        ) as mock_cleanup_rpr,
+    ):
+        with pytest.raises(RuntimeError, match="boom"):
+            permission_relationships.sync(
+                neo4j_session,
+                TEST_PROJECT_ID,
+                TEST_UPDATE_TAG,
+                COMMON_JOB_PARAMS,
+            )
+
+    mock_cleanup_rpr.assert_not_called()


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

This changes the GCP permission relationship sync path to avoid materializing one large relationship list per mapping before writing to Neo4j.

The sync now evaluates resources incrementally, flushes relationship matchlinks in bounded batches, and emits clearer progress logging around evaluation, write progress, and cleanup. The permission semantics and cleanup contract remain unchanged.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- Internal tracking only.


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

None.


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- Updated tests
- live validation locally
```
INFO:cartography.intel.gcp.iam:Syncing organization-level IAM for organizations/<redacted-org-id>
INFO:cartography.intel.gcp.iam:Found 2297 predefined roles
INFO:cartography.intel.gcp.iam:Found 1 custom organization roles in organizations/<redacted-org-id>
INFO:cartography.client.core.tx:Loaded 2298 GCPRole nodes
INFO:live_validation:running manual service account load from live IAM data
INFO:cartography.client.core.tx:Loaded 1 GCPServiceAccount nodes
INFO:live_validation:running manual role load from live IAM role data
INFO:cartography.client.core.tx:Loaded 18 GCPRole nodes
INFO:live_validation:running manual policy binding load from live project IAM policy
INFO:cartography.client.core.tx:Loaded 18 GCPPolicyBinding nodes
INFO:live_validation:running storage.sync_gcp_buckets
INFO:cartography.intel.gcp.storage:Syncing Storage objects for project <redacted-project-id>.
INFO:cartography.client.core.tx:Loaded 2 GCPBucket nodes
INFO:cartography.client.core.tx:Loaded 1 GCPBucketLabel nodes
INFO:cartography.client.core.tx:Loaded 1 GCPLabel nodes
INFO:cartography.graph.statement:Completed GCPBucketLabel statement #1
INFO:cartography.graph.statement:Completed GCPBucketLabel statement #2
INFO:cartography.graph.statement:Completed GCPBucketLabel statement #3
INFO:cartography.graph.job:Finished job GCPBucketLabel
INFO:cartography.graph.statement:Completed GCPBucket statement #1
INFO:cartography.graph.statement:Completed GCPBucket statement #2
INFO:cartography.graph.job:Finished job GCPBucket
INFO:live_validation:running permission_relationships.sync
INFO:cartography.intel.gcp.permission_relationships:Syncing GCP Permission Relationships for project '<redacted-project-id>'.
INFO:cartography.intel.gcp.permission_relationships:Starting relationship 'CAN_READ' for resource type 'GCPBucket' in project '<redacted-project-id>' with 1 permissions, 1 principals, and 2 resources
INFO:cartography.intel.gcp.permission_relationships:Relationship 'CAN_READ' for 'GCPBucket': processed 1/2 resources (50.0%), loaded 0 relationships so far
INFO:cartography.intel.gcp.permission_relationships:Relationship 'CAN_READ' for 'GCPBucket': processed 2/2 resources (100.0%), loaded 0 relationships so far
INFO:cartography.intel.gcp.permission_relationships:Loading 2 CAN_READ relationships for GCPPrincipal -> GCPBucket
INFO:cartography.client.core.tx:Loaded 2 (GCPPrincipal)-[CAN_READ]->(GCPBucket) relationships
INFO:cartography.intel.gcp.permission_relationships:Completed relationship 'CAN_READ' for 'GCPBucket': processed 2 resources and loaded 2 relationships
INFO:cartography.intel.gcp.permission_relationships:Finished loading relationship 'CAN_READ' for resource type 'GCPBucket' in project '<redacted-project-id>' with 2 total relationships before cleanup
INFO:cartography.intel.gcp.permission_relationships:Cleaning up relationship 'CAN_READ' for node label 'GCPBucket'
INFO:cartography.graph.statement:Completed CAN_READ statement #1
INFO:cartography.graph.job:Finished job CAN_READ
INFO:cartography.intel.gcp.permission_relationships:Starting relationship 'CAN_WRITE' for resource type 'GCPBucket' in project '<redacted-project-id>' with 2 permissions, 1 principals, and 2 resources
INFO:cartography.intel.gcp.permission_relationships:Relationship 'CAN_WRITE' for 'GCPBucket': processed 1/2 resources (50.0%), loaded 0 relationships so far
INFO:cartography.intel.gcp.permission_relationships:Relationship 'CAN_WRITE' for 'GCPBucket': processed 2/2 resources (100.0%), loaded 0 relationships so far
INFO:cartography.intel.gcp.permission_relationships:Loading 2 CAN_WRITE relationships for GCPPrincipal -> GCPBucket
INFO:cartography.client.core.tx:Loaded 2 (GCPPrincipal)-[CAN_WRITE]->(GCPBucket) relationships
INFO:cartography.intel.gcp.permission_relationships:Completed relationship 'CAN_WRITE' for 'GCPBucket': processed 2 resources and loaded 2 relationships
INFO:cartography.intel.gcp.permission_relationships:Finished loading relationship 'CAN_WRITE' for resource type 'GCPBucket' in project '<redacted-project-id>' with 2 total relationships before cleanup
INFO:cartography.intel.gcp.permission_relationships:Cleaning up relationship 'CAN_WRITE' for node label 'GCPBucket'
INFO:cartography.graph.statement:Completed CAN_WRITE statement #1
INFO:cartography.graph.job:Finished job CAN_WRITE
INFO:cartography.intel.gcp.permission_relationships:Starting relationship 'CAN_DELETE' for resource type 'GCPBucket' in project '<redacted-project-id>' with 1 permissions, 1 principals, and 2 resources
INFO:cartography.intel.gcp.permission_relationships:Relationship 'CAN_DELETE' for 'GCPBucket': processed 1/2 resources (50.0%), loaded 0 relationships so far
INFO:cartography.intel.gcp.permission_relationships:Relationship 'CAN_DELETE' for 'GCPBucket': processed 2/2 resources (100.0%), loaded 0 relationships so far
INFO:cartography.intel.gcp.permission_relationships:Loading 2 CAN_DELETE relationships for GCPPrincipal -> GCPBucket
INFO:cartography.client.core.tx:Loaded 2 (GCPPrincipal)-[CAN_DELETE]->(GCPBucket) relationships
INFO:cartography.intel.gcp.permission_relationships:Completed relationship 'CAN_DELETE' for 'GCPBucket': processed 2 resources and loaded 2 relationships
INFO:cartography.intel.gcp.permission_relationships:Finished loading relationship 'CAN_DELETE' for resource type 'GCPBucket' in project '<redacted-project-id>' with 2 total relationships before cleanup
INFO:cartography.intel.gcp.permission_relationships:Cleaning up relationship 'CAN_DELETE' for node label 'GCPBucket'
INFO:cartography.graph.statement:Completed CAN_DELETE statement #1
INFO:cartography.graph.job:Finished job CAN_DELETE
WARNING:neo4j.notifications:Received notification from DBMS server: <GqlStatusObject gql_status='01N50', status_description='warn: label does not exist. The label `GCPSecretManagerSecret` does not exist in database `tmp-cartography-gcp-pr-<redacted-run-id>`. Verify that the spelling is correct.', position=<SummaryInputPosition line=2, column=71, offset=71>, raw_classification='UNRECOGNIZED', classification=<NotificationClassification.UNRECOGNIZED: 'UNRECOGNIZED'>, raw_severity='WARNING', severity=<NotificationSeverity.WARNING: 'WARNING'>, diagnostic_record={'_classification': 'UNRECOGNIZED', '_severity': 'WARNING', '_position': {'offset': 71, 'line': 2, 'column': 71}, 'OPERATION': '', 'OPERATION_CODE': '0', 'CURRENT_SCHEMA': '/'}> for query: '
    MATCH (project:GCPProject{id: $ProjectId})-[:RESOURCE]->(resource:GCPSecretManagerSecret)
    RETURN resource.id as resource_id
    '
INFO:cartography.intel.gcp.permission_relationships:Starting relationship 'CAN_READ' for resource type 'GCPSecretManagerSecret' in project '<redacted-project-id>' with 1 permissions, 1 principals, and 0 resources
INFO:cartography.intel.gcp.permission_relationships:No GCPSecretManagerSecret resources found for relationship 'CAN_READ' in project '<redacted-project-id>'.
INFO:cartography.intel.gcp.permission_relationships:Finished loading relationship 'CAN_READ' for resource type 'GCPSecretManagerSecret' in project '<redacted-project-id>' with 0 total relationships before cleanup
INFO:cartography.intel.gcp.permission_relationships:Cleaning up relationship 'CAN_READ' for node label 'GCPSecretManagerSecret'
INFO:cartography.graph.statement:Completed CAN_READ statement #1
INFO:cartography.graph.job:Finished job CAN_READ
INFO:cartography.intel.gcp.permission_relationships:Completed GCP Permission Relationships sync for project <redacted-project-id>
```

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

This PR intentionally stays narrow to the GCP permission relationship hot path. It does not change relationship meaning, add concurrency, or change schema documentation because the graph model is unchanged.
