### PR TITLE
fix(gcp): speed up artifact registry sync

### DIFF
--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -550,12 +550,8 @@ def _sync_project_resources(
 
         if service_names.artifact_registry in enabled_services:
             logger.info("Syncing GCP project %s for Artifact Registry.", project_id)
-            artifact_registry_client = build_client(
-                "artifactregistry", "v1", credentials=credentials
-            )
             artifact_registry.sync(
                 neo4j_session,
-                artifact_registry_client,
                 credentials,
                 project_id,
                 gcp_update_tag,

--- a/cartography/intel/gcp/artifact_registry/__init__.py
+++ b/cartography/intel/gcp/artifact_registry/__init__.py
@@ -2,7 +2,6 @@ import logging
 
 import neo4j
 from google.auth.credentials import Credentials as GoogleCredentials
-from googleapiclient.discovery import Resource
 
 from cartography.intel.gcp.artifact_registry.artifact import (
     sync_artifact_registry_artifacts,
@@ -21,7 +20,6 @@ logger = logging.getLogger(__name__)
 @timeit
 def sync(
     neo4j_session: neo4j.Session,
-    client: Resource,
     credentials: GoogleCredentials,
     project_id: str,
     update_tag: int,
@@ -36,7 +34,6 @@ def sync(
     3. Image manifests (for multi-architecture Docker images, extracted from imageManifests field)
 
     :param neo4j_session: The Neo4j session.
-    :param client: Legacy Artifact Registry discovery client kept for API compatibility.
     :param credentials: GCP credentials used to build the GAPIC Artifact Registry client.
     :param project_id: The GCP project ID.
     :param update_tag: The update tag for this sync.

--- a/cartography/intel/gcp/artifact_registry/__init__.py
+++ b/cartography/intel/gcp/artifact_registry/__init__.py
@@ -12,6 +12,7 @@ from cartography.intel.gcp.artifact_registry.manifest import load_manifests
 from cartography.intel.gcp.artifact_registry.repository import (
     sync_artifact_registry_repositories,
 )
+from cartography.intel.gcp.clients import build_artifact_registry_client
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -35,18 +36,19 @@ def sync(
     3. Image manifests (for multi-architecture Docker images, extracted from imageManifests field)
 
     :param neo4j_session: The Neo4j session.
-    :param client: The Artifact Registry API client.
-    :param credentials: GCP credentials (unused but kept for API compatibility).
+    :param client: Legacy Artifact Registry discovery client kept for API compatibility.
+    :param credentials: GCP credentials used to build the GAPIC Artifact Registry client.
     :param project_id: The GCP project ID.
     :param update_tag: The update tag for this sync.
     :param common_job_parameters: Common job parameters for cleanup.
     """
     logger.info(f"Syncing Artifact Registry for project {project_id}.")
+    artifact_registry_client = build_artifact_registry_client(credentials=credentials)
 
     # Sync repositories
-    repositories_raw = sync_artifact_registry_repositories(
+    repository_result = sync_artifact_registry_repositories(
         neo4j_session,
-        client,
+        artifact_registry_client,
         project_id,
         update_tag,
         common_job_parameters,
@@ -54,19 +56,31 @@ def sync(
 
     # Sync artifacts for all repositories
     # This now returns transformed platform images from the imageManifests field
-    platform_images = sync_artifact_registry_artifacts(
+    artifact_result = sync_artifact_registry_artifacts(
         neo4j_session,
-        client,
-        repositories_raw,
+        artifact_registry_client,
+        repository_result.repositories,
         project_id,
         update_tag,
         common_job_parameters,
+        cleanup_safe=repository_result.cleanup_safe,
     )
 
     # Load platform images (manifests) - no HTTP calls needed, data comes from dockerImages API
-    if platform_images:
-        load_manifests(neo4j_session, platform_images, project_id, update_tag)
+    if artifact_result.platform_images:
+        load_manifests(
+            neo4j_session,
+            artifact_result.platform_images,
+            project_id,
+            update_tag,
+        )
 
-    cleanup_job_params = common_job_parameters.copy()
-    cleanup_job_params["PROJECT_ID"] = project_id
-    cleanup_manifests(neo4j_session, cleanup_job_params)
+    if artifact_result.cleanup_safe:
+        cleanup_job_params = common_job_parameters.copy()
+        cleanup_job_params["PROJECT_ID"] = project_id
+        cleanup_manifests(neo4j_session, cleanup_job_params)
+    else:
+        logger.warning(
+            "Skipping Artifact Registry manifest cleanup for project %s because artifact discovery was incomplete.",
+            project_id,
+        )

--- a/cartography/intel/gcp/artifact_registry/artifact.py
+++ b/cartography/intel/gcp/artifact_registry/artifact.py
@@ -1,16 +1,28 @@
 import logging
+from collections import Counter
+from dataclasses import dataclass
+from functools import partial
+from urllib.parse import unquote
 
 import neo4j
 from google.api_core.exceptions import PermissionDenied
 from google.auth.exceptions import DefaultCredentialsError
 from google.auth.exceptions import RefreshError
-from googleapiclient.discovery import Resource
-from googleapiclient.errors import HttpError
+from google.cloud.artifactregistry_v1 import ArtifactRegistryClient
+from google.cloud.artifactregistry_v1.types import Package
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
-from cartography.intel.gcp.util import gcp_api_execute_with_retry
-from cartography.intel.gcp.util import is_api_disabled_error
+from cartography.intel.gcp.artifact_registry.util import (
+    ARTIFACT_REGISTRY_LOAD_BATCH_SIZE,
+)
+from cartography.intel.gcp.artifact_registry.util import (
+    DEFAULT_ARTIFACT_REGISTRY_WORKERS,
+)
+from cartography.intel.gcp.artifact_registry.util import (
+    fetch_artifact_registry_resources,
+)
+from cartography.intel.gcp.util import proto_message_to_dict
 from cartography.models.gcp.artifact_registry.artifact import (
     GCPArtifactRegistryGenericArtifactSchema,
 )
@@ -28,8 +40,45 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class RepositoryArtifactFetchResult:
+    repository_name: str
+    repository_format: str
+    artifacts: list[dict]
+    cleanup_safe: bool
+
+
+@dataclass(frozen=True)
+class ArtifactRegistryArtifactSyncResult:
+    platform_images: list[dict]
+    cleanup_safe: bool
+
+
+def _extract_package_name(package: Package) -> str:
+    package_data = proto_message_to_dict(package)
+    raw_name = package_data.get("displayName") or package_data.get("name", "")
+    return unquote(raw_name.split("/packages/")[-1]) if raw_name else ""
+
+
+def _list_package_versions(
+    client: ArtifactRegistryClient,
+    repository_name: str,
+) -> list[dict]:
+    artifacts: list[dict] = []
+    for package in client.list_packages(parent=repository_name):
+        package_name = _extract_package_name(package)
+        for version in client.list_versions(parent=package.name):
+            version_data = proto_message_to_dict(version)
+            version_data["packageName"] = package_name
+            artifacts.append(version_data)
+    return artifacts
+
+
 @timeit
-def get_docker_images(client: Resource, repository_name: str) -> list[dict] | None:
+def get_docker_images(
+    client: ArtifactRegistryClient,
+    repository_name: str,
+) -> list[dict] | None:
     """
     Gets Docker images for a repository.
 
@@ -37,44 +86,27 @@ def get_docker_images(client: Resource, repository_name: str) -> list[dict] | No
     :param repository_name: The full repository resource name.
     :return: List of Docker image dicts from the API, or None if the Artifact Registry API
              is not enabled or access is denied.
-    :raises HttpError: For errors other than API disabled or permission denied.
+    :raises GoogleAPICallError: For errors other than permission denied.
     """
     try:
-        images: list[dict] = []
-        request = (
-            client.projects()
-            .locations()
-            .repositories()
-            .dockerImages()
-            .list(parent=repository_name)
+        return [
+            proto_message_to_dict(image)
+            for image in client.list_docker_images(parent=repository_name)
+        ]
+    except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
+        logger.warning(
+            "Could not retrieve Docker images for repository %s due to permissions or auth error. Skipping. %s",
+            repository_name,
+            e,
         )
-        while request is not None:
-            response = gcp_api_execute_with_retry(request)
-            images.extend(response.get("dockerImages", []))
-            request = (
-                client.projects()
-                .locations()
-                .repositories()
-                .dockerImages()
-                .list_next(
-                    previous_request=request,
-                    previous_response=response,
-                )
-            )
-        return images
-    except HttpError as e:
-        if is_api_disabled_error(e):
-            logger.warning(
-                "Could not retrieve Docker images for repository %s due to permissions "
-                "issues or API not enabled. Skipping.",
-                repository_name,
-            )
-            return None
-        raise
+        return None
 
 
 @timeit
-def get_maven_artifacts(client: Resource, repository_name: str) -> list[dict] | None:
+def get_maven_artifacts(
+    client: ArtifactRegistryClient,
+    repository_name: str,
+) -> list[dict] | None:
     """
     Gets Maven artifacts for a repository.
 
@@ -82,44 +114,27 @@ def get_maven_artifacts(client: Resource, repository_name: str) -> list[dict] | 
     :param repository_name: The full repository resource name.
     :return: List of Maven artifact dicts from the API, or None if the Artifact Registry API
              is not enabled or access is denied.
-    :raises HttpError: For errors other than API disabled or permission denied.
+    :raises GoogleAPICallError: For errors other than permission denied.
     """
     try:
-        artifacts: list[dict] = []
-        request = (
-            client.projects()
-            .locations()
-            .repositories()
-            .mavenArtifacts()
-            .list(parent=repository_name)
+        return [
+            proto_message_to_dict(artifact)
+            for artifact in client.list_maven_artifacts(parent=repository_name)
+        ]
+    except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
+        logger.warning(
+            "Could not retrieve Maven artifacts for repository %s due to permissions or auth error. Skipping. %s",
+            repository_name,
+            e,
         )
-        while request is not None:
-            response = gcp_api_execute_with_retry(request)
-            artifacts.extend(response.get("mavenArtifacts", []))
-            request = (
-                client.projects()
-                .locations()
-                .repositories()
-                .mavenArtifacts()
-                .list_next(
-                    previous_request=request,
-                    previous_response=response,
-                )
-            )
-        return artifacts
-    except HttpError as e:
-        if is_api_disabled_error(e):
-            logger.warning(
-                "Could not retrieve Maven artifacts for repository %s due to permissions "
-                "issues or API not enabled. Skipping.",
-                repository_name,
-            )
-            return None
-        raise
+        return None
 
 
 @timeit
-def get_npm_packages(client: Resource, repository_name: str) -> list[dict] | None:
+def get_npm_packages(
+    client: ArtifactRegistryClient,
+    repository_name: str,
+) -> list[dict] | None:
     """
     Gets npm packages for a repository.
 
@@ -127,88 +142,54 @@ def get_npm_packages(client: Resource, repository_name: str) -> list[dict] | Non
     :param repository_name: The full repository resource name.
     :return: List of npm package dicts from the API, or None if the Artifact Registry API
              is not enabled or access is denied.
-    :raises HttpError: For errors other than API disabled or permission denied.
+    :raises GoogleAPICallError: For errors other than permission denied.
     """
     try:
-        packages: list[dict] = []
-        request = (
-            client.projects()
-            .locations()
-            .repositories()
-            .npmPackages()
-            .list(parent=repository_name)
+        return [
+            proto_message_to_dict(package)
+            for package in client.list_npm_packages(parent=repository_name)
+        ]
+    except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
+        logger.warning(
+            "Could not retrieve npm packages for repository %s due to permissions or auth error. Skipping. %s",
+            repository_name,
+            e,
         )
-        while request is not None:
-            response = gcp_api_execute_with_retry(request)
-            packages.extend(response.get("npmPackages", []))
-            request = (
-                client.projects()
-                .locations()
-                .repositories()
-                .npmPackages()
-                .list_next(
-                    previous_request=request,
-                    previous_response=response,
-                )
-            )
-        return packages
-    except HttpError as e:
-        if is_api_disabled_error(e):
-            logger.warning(
-                "Could not retrieve npm packages for repository %s due to permissions "
-                "issues or API not enabled. Skipping.",
-                repository_name,
-            )
-            return None
-        raise
+        return None
 
 
 @timeit
-def get_python_packages(client: Resource, repository_name: str) -> list[dict] | None:
+def get_python_packages(
+    client: ArtifactRegistryClient,
+    repository_name: str,
+) -> list[dict] | None:
     """
     Gets Python packages for a repository.
 
     :param client: The Artifact Registry API client.
     :param repository_name: The full repository resource name.
     :return: List of Python package dicts from the API, or None if API is not enabled.
-    :raises HttpError: For errors other than API disabled or permission denied.
+    :raises GoogleAPICallError: For errors other than permission denied.
     """
     try:
-        packages: list[dict] = []
-        request = (
-            client.projects()
-            .locations()
-            .repositories()
-            .pythonPackages()
-            .list(parent=repository_name)
+        return [
+            proto_message_to_dict(package)
+            for package in client.list_python_packages(parent=repository_name)
+        ]
+    except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
+        logger.warning(
+            "Could not retrieve Python packages for repository %s due to permissions or auth error. Skipping. %s",
+            repository_name,
+            e,
         )
-        while request is not None:
-            response = gcp_api_execute_with_retry(request)
-            packages.extend(response.get("pythonPackages", []))
-            request = (
-                client.projects()
-                .locations()
-                .repositories()
-                .pythonPackages()
-                .list_next(
-                    previous_request=request,
-                    previous_response=response,
-                )
-            )
-        return packages
-    except HttpError as e:
-        if is_api_disabled_error(e):
-            logger.warning(
-                "Could not retrieve Python packages for repository %s due to permissions "
-                "issues or API not enabled. Skipping.",
-                repository_name,
-            )
-            return None
-        raise
+        return None
 
 
 @timeit
-def get_go_modules(client: Resource, repository_name: str) -> list[dict]:
+def get_go_modules(
+    client: ArtifactRegistryClient,
+    repository_name: str,
+) -> list[dict] | None:
     """
     Gets Go modules for a repository.
 
@@ -219,43 +200,21 @@ def get_go_modules(client: Resource, repository_name: str) -> list[dict]:
     :param repository_name: The full repository resource name.
     :return: List of Go module version dicts, each enriched with ``packageName``.
     """
-    artifacts: list[dict] = []
     try:
-        packages_resource = client.projects().locations().repositories().packages()
-        packages_request = packages_resource.list(parent=repository_name)
-        while packages_request is not None:
-            packages_response = gcp_api_execute_with_retry(packages_request)
-            for package in packages_response.get("packages", []):
-                package_name = (
-                    package.get("displayName")
-                    or package.get("name", "").split("/packages/")[-1]
-                )
-                versions_resource = packages_resource.versions()
-                versions_request = versions_resource.list(parent=package.get("name"))
-                while versions_request is not None:
-                    versions_response = gcp_api_execute_with_retry(versions_request)
-                    for version in versions_response.get("versions", []):
-                        version["packageName"] = package_name
-                        artifacts.append(version)
-                    versions_request = versions_resource.list_next(
-                        previous_request=versions_request,
-                        previous_response=versions_response,
-                    )
-            packages_request = packages_resource.list_next(
-                previous_request=packages_request,
-                previous_response=packages_response,
-            )
-        return artifacts
+        return _list_package_versions(client, repository_name)
     except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
         logger.warning(
             f"Failed to get Go modules for repository {repository_name} "
             f"due to permissions or auth error: {e}",
         )
-        return []
+        return None
 
 
 @timeit
-def get_apt_artifacts(client: Resource, repository_name: str) -> list[dict]:
+def get_apt_artifacts(
+    client: ArtifactRegistryClient,
+    repository_name: str,
+) -> list[dict] | None:
     """
     Gets APT package versions for a repository.
 
@@ -263,43 +222,21 @@ def get_apt_artifacts(client: Resource, repository_name: str) -> list[dict]:
     :param repository_name: The full repository resource name.
     :return: List of APT package-version dicts from the API.
     """
-    artifacts: list[dict] = []
     try:
-        packages_resource = client.projects().locations().repositories().packages()
-        packages_request = packages_resource.list(parent=repository_name)
-        while packages_request is not None:
-            packages_response = gcp_api_execute_with_retry(packages_request)
-            for package in packages_response.get("packages", []):
-                package_name = (
-                    package.get("displayName")
-                    or package.get("name", "").split("/packages/")[-1]
-                )
-                versions_resource = packages_resource.versions()
-                versions_request = versions_resource.list(parent=package.get("name"))
-                while versions_request is not None:
-                    versions_response = gcp_api_execute_with_retry(versions_request)
-                    for version in versions_response.get("versions", []):
-                        version["packageName"] = package_name
-                        artifacts.append(version)
-                    versions_request = versions_resource.list_next(
-                        previous_request=versions_request,
-                        previous_response=versions_response,
-                    )
-            packages_request = packages_resource.list_next(
-                previous_request=packages_request,
-                previous_response=packages_response,
-            )
-        return artifacts
+        return _list_package_versions(client, repository_name)
     except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
         logger.warning(
             f"Failed to get APT package versions for repository {repository_name} "
             f"due to permissions or auth error: {e}",
         )
-        return []
+        return None
 
 
 @timeit
-def get_yum_artifacts(client: Resource, repository_name: str) -> list[dict]:
+def get_yum_artifacts(
+    client: ArtifactRegistryClient,
+    repository_name: str,
+) -> list[dict] | None:
     """
     Gets YUM package versions for a repository.
 
@@ -307,39 +244,14 @@ def get_yum_artifacts(client: Resource, repository_name: str) -> list[dict]:
     :param repository_name: The full repository resource name.
     :return: List of YUM package-version dicts from the API.
     """
-    artifacts: list[dict] = []
     try:
-        packages_resource = client.projects().locations().repositories().packages()
-        packages_request = packages_resource.list(parent=repository_name)
-        while packages_request is not None:
-            packages_response = gcp_api_execute_with_retry(packages_request)
-            for package in packages_response.get("packages", []):
-                package_name = (
-                    package.get("displayName")
-                    or package.get("name", "").split("/packages/")[-1]
-                )
-                versions_resource = packages_resource.versions()
-                versions_request = versions_resource.list(parent=package.get("name"))
-                while versions_request is not None:
-                    versions_response = gcp_api_execute_with_retry(versions_request)
-                    for version in versions_response.get("versions", []):
-                        version["packageName"] = package_name
-                        artifacts.append(version)
-                    versions_request = versions_resource.list_next(
-                        previous_request=versions_request,
-                        previous_response=versions_response,
-                    )
-            packages_request = packages_resource.list_next(
-                previous_request=packages_request,
-                previous_response=packages_response,
-            )
-        return artifacts
+        return _list_package_versions(client, repository_name)
     except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
         logger.warning(
             f"Failed to get YUM package versions for repository {repository_name} "
             f"due to permissions or auth error: {e}",
         )
-        return []
+        return None
 
 
 def transform_docker_images(
@@ -627,6 +539,7 @@ def load_generic_artifacts(
         neo4j_session,
         GCPArtifactRegistryGenericArtifactSchema(),
         data,
+        batch_size=ARTIFACT_REGISTRY_LOAD_BATCH_SIZE,
         lastupdated=update_tag,
         PROJECT_ID=project_id,
     )
@@ -658,6 +571,7 @@ def load_docker_images(
         neo4j_session,
         GCPArtifactRegistryContainerImageSchema(),
         data,
+        batch_size=ARTIFACT_REGISTRY_LOAD_BATCH_SIZE,
         lastupdated=update_tag,
         PROJECT_ID=project_id,
     )
@@ -689,6 +603,7 @@ def load_language_packages(
         neo4j_session,
         GCPArtifactRegistryLanguagePackageSchema(),
         data,
+        batch_size=ARTIFACT_REGISTRY_LOAD_BATCH_SIZE,
         lastupdated=update_tag,
         PROJECT_ID=project_id,
     )
@@ -720,6 +635,7 @@ def load_helm_charts(
         neo4j_session,
         GCPArtifactRegistryHelmChartSchema(),
         data,
+        batch_size=ARTIFACT_REGISTRY_LOAD_BATCH_SIZE,
         lastupdated=update_tag,
         PROJECT_ID=project_id,
     )
@@ -772,15 +688,38 @@ def transform_image_manifests(
     return all_manifests
 
 
+def _get_repository_artifacts(
+    client: ArtifactRegistryClient,
+    repository: tuple[str, str],
+) -> RepositoryArtifactFetchResult:
+    repo_name, repo_format = repository
+    handlers = FORMAT_HANDLERS.get(repo_format)
+    if handlers is None:
+        logger.debug(
+            "No artifact handler for format %s in repository %s",
+            repo_format,
+            repo_name,
+        )
+        return RepositoryArtifactFetchResult(repo_name, repo_format, [], True)
+
+    get_func, _ = handlers
+    artifacts = get_func(client, repo_name)
+    if artifacts is None:
+        return RepositoryArtifactFetchResult(repo_name, repo_format, [], False)
+    return RepositoryArtifactFetchResult(repo_name, repo_format, artifacts, True)
+
+
 @timeit
 def sync_artifact_registry_artifacts(
     neo4j_session: neo4j.Session,
-    client: Resource,
+    client: ArtifactRegistryClient,
     repositories: list[dict],
     project_id: str,
     update_tag: int,
     common_job_parameters: dict,
-) -> list[dict]:
+    cleanup_safe: bool = True,
+    max_workers: int = DEFAULT_ARTIFACT_REGISTRY_WORKERS,
+) -> ArtifactRegistryArtifactSyncResult:
     """
     Syncs GCP Artifact Registry artifacts for all repositories.
 
@@ -794,40 +733,51 @@ def sync_artifact_registry_artifacts(
     """
     logger.info(f"Syncing Artifact Registry artifacts for project {project_id}.")
 
-    # Separate collections for different artifact types
     docker_images_raw: list[dict] = []
     docker_images_transformed: list[dict] = []
     helm_charts_transformed: list[dict] = []
     language_packages_transformed: list[dict] = []
     other_artifacts_transformed: list[dict] = []
+    candidate_repositories: list[tuple[str, str]] = []
 
     for repo in repositories:
         repo_name = repo.get("name")
         repo_format = repo.get("format")
 
-        if not repo_name or not repo_format:
+        if not isinstance(repo_name, str) or not isinstance(repo_format, str):
+            continue
+        candidate_repositories.append((repo_name, repo_format))
+
+    format_counts = Counter(repo_format for _, repo_format in candidate_repositories)
+    logger.info(
+        "Artifact Registry project %s has %d candidate repositories by format: %s",
+        project_id,
+        len(candidate_repositories),
+        dict(sorted(format_counts.items())),
+    )
+
+    fetch_repository_artifacts = partial(_get_repository_artifacts, client)
+    repository_results = fetch_artifact_registry_resources(
+        items=candidate_repositories,
+        fetch_for_item=fetch_repository_artifacts,
+        resource_type="artifacts by repository",
+        project_id=project_id,
+        max_workers=max_workers,
+    )
+
+    artifact_cleanup_safe = cleanup_safe
+    nonempty_repositories = 0
+    for result in repository_results:
+        artifact_cleanup_safe = artifact_cleanup_safe and result.cleanup_safe
+        if not result.artifacts:
             continue
 
-        handlers = FORMAT_HANDLERS.get(repo_format)
-        if handlers is None:
-            logger.debug(
-                f"No artifact handler for format {repo_format} in repository {repo_name}"
-            )
-            continue
+        nonempty_repositories += 1
+        repo_name = result.repository_name
+        repo_format = result.repository_format
+        artifacts_raw = result.artifacts
 
-        get_func, _ = handlers
-
-        artifacts_raw = get_func(client, repo_name)
-        if artifacts_raw is None:
-            # Skip this repository if API is not enabled or access denied
-            continue
-        if not artifacts_raw:
-            continue
-
-        # Route to appropriate collection based on format
         if repo_format == "DOCKER":
-            # Split Docker format artifacts by artifact type
-            # Helm charts are stored as OCI artifacts and identified via artifactType or mediaType
             for artifact in artifacts_raw:
                 artifact_type = artifact.get("artifactType", "")
                 media_type = artifact.get("mediaType", "")
@@ -839,23 +789,32 @@ def sync_artifact_registry_artifacts(
                         transform_helm_charts([artifact], repo_name, project_id)
                     )
                 else:
-                    # Actual Docker images - collect raw for manifest extraction
                     docker_images_raw.append(artifact)
                     docker_images_transformed.extend(
                         transform_docker_images([artifact], repo_name, project_id)
                     )
         elif repo_format in LANGUAGE_PACKAGE_FORMATS:
-            # Use the format-specific transformer from FORMAT_HANDLERS
-            _, transform_func = handlers
+            _, transform_func = FORMAT_HANDLERS[repo_format]
             language_packages_transformed.extend(
                 transform_func(artifacts_raw, repo_name, project_id)
             )
         else:
-            # APT, YUM, and any other formats use the unified schema
-            _, transform_func = handlers
+            _, transform_func = FORMAT_HANDLERS[repo_format]
             other_artifacts_transformed.extend(
                 transform_func(artifacts_raw, repo_name, project_id)
             )
+
+    logger.info(
+        "Collected Artifact Registry artifacts for project %s from %d/%d non-empty repositories: "
+        "docker_images=%d, helm_charts=%d, language_packages=%d, generic_artifacts=%d.",
+        project_id,
+        nonempty_repositories,
+        len(candidate_repositories),
+        len(docker_images_transformed),
+        len(helm_charts_transformed),
+        len(language_packages_transformed),
+        len(other_artifacts_transformed),
+    )
 
     # Load Docker images with the dedicated schema
     if docker_images_transformed:
@@ -879,14 +838,18 @@ def sync_artifact_registry_artifacts(
             neo4j_session, other_artifacts_transformed, project_id, update_tag
         )
 
-    # Cleanup all node types
-    cleanup_job_params = common_job_parameters.copy()
-    cleanup_job_params["PROJECT_ID"] = project_id
-    cleanup_docker_images(neo4j_session, cleanup_job_params)
-    cleanup_helm_charts(neo4j_session, cleanup_job_params)
-    cleanup_language_packages(neo4j_session, cleanup_job_params)
-    cleanup_generic_artifacts(neo4j_session, cleanup_job_params)
+    if artifact_cleanup_safe:
+        cleanup_job_params = common_job_parameters.copy()
+        cleanup_job_params["PROJECT_ID"] = project_id
+        cleanup_docker_images(neo4j_session, cleanup_job_params)
+        cleanup_helm_charts(neo4j_session, cleanup_job_params)
+        cleanup_language_packages(neo4j_session, cleanup_job_params)
+        cleanup_generic_artifacts(neo4j_session, cleanup_job_params)
+    else:
+        logger.warning(
+            "Skipping Artifact Registry artifact cleanup for project %s because artifact discovery was incomplete.",
+            project_id,
+        )
 
-    # Extract and transform platform images from imageManifests field (no HTTP calls needed)
     platform_images = transform_image_manifests(docker_images_raw, project_id)
-    return platform_images
+    return ArtifactRegistryArtifactSyncResult(platform_images, artifact_cleanup_safe)

--- a/cartography/intel/gcp/artifact_registry/artifact.py
+++ b/cartography/intel/gcp/artifact_registry/artifact.py
@@ -5,6 +5,7 @@ from functools import partial
 from urllib.parse import unquote
 
 import neo4j
+from google.api_core.exceptions import NotFound
 from google.api_core.exceptions import PermissionDenied
 from google.auth.exceptions import DefaultCredentialsError
 from google.auth.exceptions import RefreshError
@@ -93,11 +94,17 @@ def get_docker_images(
             proto_message_to_dict(image)
             for image in client.list_docker_images(parent=repository_name)
         ]
+    except NotFound:
+        logger.debug(
+            "Docker images not found for repository %s. The repository may have been deleted during sync.",
+            repository_name,
+        )
+        return []
     except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
         logger.warning(
-            "Could not retrieve Docker images for repository %s due to permissions or auth error. Skipping. %s",
+            "Could not retrieve Docker images for repository %s due to permissions or auth error. Skipping. (%s)",
             repository_name,
-            e,
+            type(e).__name__,
         )
         return None
 
@@ -121,11 +128,17 @@ def get_maven_artifacts(
             proto_message_to_dict(artifact)
             for artifact in client.list_maven_artifacts(parent=repository_name)
         ]
+    except NotFound:
+        logger.debug(
+            "Maven artifacts not found for repository %s. The repository may have been deleted during sync.",
+            repository_name,
+        )
+        return []
     except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
         logger.warning(
-            "Could not retrieve Maven artifacts for repository %s due to permissions or auth error. Skipping. %s",
+            "Could not retrieve Maven artifacts for repository %s due to permissions or auth error. Skipping. (%s)",
             repository_name,
-            e,
+            type(e).__name__,
         )
         return None
 
@@ -149,11 +162,17 @@ def get_npm_packages(
             proto_message_to_dict(package)
             for package in client.list_npm_packages(parent=repository_name)
         ]
+    except NotFound:
+        logger.debug(
+            "npm packages not found for repository %s. The repository may have been deleted during sync.",
+            repository_name,
+        )
+        return []
     except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
         logger.warning(
-            "Could not retrieve npm packages for repository %s due to permissions or auth error. Skipping. %s",
+            "Could not retrieve npm packages for repository %s due to permissions or auth error. Skipping. (%s)",
             repository_name,
-            e,
+            type(e).__name__,
         )
         return None
 
@@ -176,11 +195,17 @@ def get_python_packages(
             proto_message_to_dict(package)
             for package in client.list_python_packages(parent=repository_name)
         ]
+    except NotFound:
+        logger.debug(
+            "Python packages not found for repository %s. The repository may have been deleted during sync.",
+            repository_name,
+        )
+        return []
     except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
         logger.warning(
-            "Could not retrieve Python packages for repository %s due to permissions or auth error. Skipping. %s",
+            "Could not retrieve Python packages for repository %s due to permissions or auth error. Skipping. (%s)",
             repository_name,
-            e,
+            type(e).__name__,
         )
         return None
 
@@ -202,10 +227,17 @@ def get_go_modules(
     """
     try:
         return _list_package_versions(client, repository_name)
+    except NotFound:
+        logger.debug(
+            "Go modules not found for repository %s. The repository may have been deleted during sync.",
+            repository_name,
+        )
+        return []
     except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
         logger.warning(
-            f"Failed to get Go modules for repository {repository_name} "
-            f"due to permissions or auth error: {e}",
+            "Failed to get Go modules for repository %s due to permissions or auth error. (%s)",
+            repository_name,
+            type(e).__name__,
         )
         return None
 
@@ -224,10 +256,17 @@ def get_apt_artifacts(
     """
     try:
         return _list_package_versions(client, repository_name)
+    except NotFound:
+        logger.debug(
+            "APT package versions not found for repository %s. The repository may have been deleted during sync.",
+            repository_name,
+        )
+        return []
     except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
         logger.warning(
-            f"Failed to get APT package versions for repository {repository_name} "
-            f"due to permissions or auth error: {e}",
+            "Failed to get APT package versions for repository %s due to permissions or auth error. (%s)",
+            repository_name,
+            type(e).__name__,
         )
         return None
 
@@ -246,10 +285,17 @@ def get_yum_artifacts(
     """
     try:
         return _list_package_versions(client, repository_name)
+    except NotFound:
+        logger.debug(
+            "YUM package versions not found for repository %s. The repository may have been deleted during sync.",
+            repository_name,
+        )
+        return []
     except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
         logger.warning(
-            f"Failed to get YUM package versions for repository {repository_name} "
-            f"due to permissions or auth error: {e}",
+            "Failed to get YUM package versions for repository %s due to permissions or auth error. (%s)",
+            repository_name,
+            type(e).__name__,
         )
         return None
 
@@ -703,7 +749,14 @@ def _get_repository_artifacts(
         return RepositoryArtifactFetchResult(repo_name, repo_format, [], True)
 
     get_func, _ = handlers
-    artifacts = get_func(client, repo_name)
+    try:
+        artifacts = get_func(client, repo_name)
+    except NotFound:
+        logger.debug(
+            "Artifacts not found for repository %s. The repository may have been deleted during sync.",
+            repo_name,
+        )
+        return RepositoryArtifactFetchResult(repo_name, repo_format, [], True)
     if artifacts is None:
         return RepositoryArtifactFetchResult(repo_name, repo_format, [], False)
     return RepositoryArtifactFetchResult(repo_name, repo_format, artifacts, True)

--- a/cartography/intel/gcp/artifact_registry/artifact.py
+++ b/cartography/intel/gcp/artifact_registry/artifact.py
@@ -68,7 +68,15 @@ def _list_package_versions(
     artifacts: list[dict] = []
     for package in client.list_packages(parent=repository_name):
         package_name = _extract_package_name(package)
-        for version in client.list_versions(parent=package.name):
+        try:
+            versions = client.list_versions(parent=package.name)
+        except NotFound:
+            logger.debug(
+                "Package versions not found for package %s. The package may have been deleted during sync.",
+                package.name,
+            )
+            continue
+        for version in versions:
             version_data = proto_message_to_dict(version)
             version_data["packageName"] = package_name
             artifacts.append(version_data)
@@ -749,14 +757,7 @@ def _get_repository_artifacts(
         return RepositoryArtifactFetchResult(repo_name, repo_format, [], True)
 
     get_func, _ = handlers
-    try:
-        artifacts = get_func(client, repo_name)
-    except NotFound:
-        logger.debug(
-            "Artifacts not found for repository %s. The repository may have been deleted during sync.",
-            repo_name,
-        )
-        return RepositoryArtifactFetchResult(repo_name, repo_format, [], True)
+    artifacts = get_func(client, repo_name)
     if artifacts is None:
         return RepositoryArtifactFetchResult(repo_name, repo_format, [], False)
     return RepositoryArtifactFetchResult(repo_name, repo_format, artifacts, True)
@@ -782,7 +783,7 @@ def sync_artifact_registry_artifacts(
     :param project_id: The GCP project ID.
     :param update_tag: The update tag for this sync.
     :param common_job_parameters: Common job parameters for cleanup.
-    :return: List of transformed platform image data (from imageManifests field).
+    :return: Artifact sync result containing platform images and cleanup-safety state.
     """
     logger.info(f"Syncing Artifact Registry artifacts for project {project_id}.")
 

--- a/cartography/intel/gcp/artifact_registry/manifest.py
+++ b/cartography/intel/gcp/artifact_registry/manifest.py
@@ -9,6 +9,9 @@ from google.auth.transport.requests import Request
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.gcp.artifact_registry.util import (
+    ARTIFACT_REGISTRY_LOAD_BATCH_SIZE,
+)
 from cartography.models.gcp.artifact_registry.platform_image import (
     GCPArtifactRegistryPlatformImageSchema,
 )
@@ -243,6 +246,7 @@ def load_manifests(
         neo4j_session,
         GCPArtifactRegistryPlatformImageSchema(),
         data,
+        batch_size=ARTIFACT_REGISTRY_LOAD_BATCH_SIZE,
         lastupdated=update_tag,
         PROJECT_ID=project_id,
     )

--- a/cartography/intel/gcp/artifact_registry/repository.py
+++ b/cartography/intel/gcp/artifact_registry/repository.py
@@ -222,9 +222,15 @@ def sync_artifact_registry_repositories(
     result = get_artifact_registry_repositories(client, project_id)
     repositories_raw = result.repositories
     if not repositories_raw:
-        logger.info(
-            f"No Artifact Registry repositories found for project {project_id}."
-        )
+        if result.cleanup_safe:
+            logger.info(
+                f"No Artifact Registry repositories found for project {project_id}."
+            )
+        else:
+            logger.warning(
+                "Artifact Registry repository discovery incomplete for project %s; no repositories will be loaded and cleanup will be skipped.",
+                project_id,
+            )
 
     repositories = transform_repositories(repositories_raw, project_id)
     load_repositories(neo4j_session, repositories, project_id, update_tag)

--- a/cartography/intel/gcp/artifact_registry/repository.py
+++ b/cartography/intel/gcp/artifact_registry/repository.py
@@ -224,7 +224,8 @@ def sync_artifact_registry_repositories(
     if not repositories_raw:
         if result.cleanup_safe:
             logger.info(
-                f"No Artifact Registry repositories found for project {project_id}."
+                "No Artifact Registry repositories found for project %s.",
+                project_id,
             )
         else:
             logger.warning(

--- a/cartography/intel/gcp/artifact_registry/repository.py
+++ b/cartography/intel/gcp/artifact_registry/repository.py
@@ -58,19 +58,19 @@ def _list_repositories_for_location(
     except PermissionDenied as e:
         logger.warning(
             "Failed to get Artifact Registry repositories for project %s in location %s "
-            "due to permissions. Skipping Artifact Registry cleanup for this project. %s",
+            "due to permissions. Skipping Artifact Registry cleanup for this project. (%s)",
             project_id,
             location,
-            e,
+            type(e).__name__,
         )
         return LocationRepositoryFetchResult(location, [], False)
     except (DefaultCredentialsError, RefreshError) as e:
         logger.warning(
             "Failed to get Artifact Registry repositories for project %s in location %s "
-            "due to auth error. Skipping Artifact Registry cleanup for this project. %s",
+            "due to auth error. Skipping Artifact Registry cleanup for this project. (%s)",
             project_id,
             location,
-            e,
+            type(e).__name__,
         )
         return LocationRepositoryFetchResult(location, [], False)
     except GoogleAPICallError:

--- a/cartography/intel/gcp/artifact_registry/repository.py
+++ b/cartography/intel/gcp/artifact_registry/repository.py
@@ -1,16 +1,27 @@
 import logging
+from dataclasses import dataclass
+from functools import partial
 
 import neo4j
+from google.api_core.exceptions import GoogleAPICallError
 from google.api_core.exceptions import PermissionDenied
 from google.auth.exceptions import DefaultCredentialsError
 from google.auth.exceptions import RefreshError
-from googleapiclient.discovery import Resource
-from googleapiclient.errors import HttpError
+from google.cloud.artifactregistry_v1 import ArtifactRegistryClient
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.gcp.artifact_registry.util import (
+    ARTIFACT_REGISTRY_LOAD_BATCH_SIZE,
+)
+from cartography.intel.gcp.artifact_registry.util import (
+    DEFAULT_ARTIFACT_REGISTRY_WORKERS,
+)
+from cartography.intel.gcp.artifact_registry.util import (
+    fetch_artifact_registry_resources,
+)
 from cartography.intel.gcp.artifact_registry.util import get_artifact_registry_locations
-from cartography.intel.gcp.util import gcp_api_execute_with_retry
+from cartography.intel.gcp.util import proto_message_to_dict
 from cartography.models.gcp.artifact_registry.repository import (
     GCPArtifactRegistryRepositorySchema,
 )
@@ -19,47 +30,100 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class ArtifactRegistryRepositorySyncResult:
+    repositories: list[dict]
+    cleanup_safe: bool
+
+
+@dataclass(frozen=True)
+class LocationRepositoryFetchResult:
+    location: str
+    repositories: list[dict]
+    cleanup_safe: bool
+
+
+def _list_repositories_for_location(
+    client: ArtifactRegistryClient,
+    project_id: str,
+    location: str,
+) -> LocationRepositoryFetchResult:
+    try:
+        parent = f"projects/{project_id}/locations/{location}"
+        repositories = [
+            proto_message_to_dict(repository)
+            for repository in client.list_repositories(parent=parent)
+        ]
+        return LocationRepositoryFetchResult(location, repositories, True)
+    except PermissionDenied as e:
+        logger.warning(
+            "Failed to get Artifact Registry repositories for project %s in location %s "
+            "due to permissions. Skipping Artifact Registry cleanup for this project. %s",
+            project_id,
+            location,
+            e,
+        )
+        return LocationRepositoryFetchResult(location, [], False)
+    except (DefaultCredentialsError, RefreshError) as e:
+        logger.warning(
+            "Failed to get Artifact Registry repositories for project %s in location %s "
+            "due to auth error. Skipping Artifact Registry cleanup for this project. %s",
+            project_id,
+            location,
+            e,
+        )
+        return LocationRepositoryFetchResult(location, [], False)
+    except GoogleAPICallError:
+        logger.error(
+            "Unexpected error getting Artifact Registry repositories for project %s in location %s.",
+            project_id,
+            location,
+            exc_info=True,
+        )
+        raise
+
+
 @timeit
-def get_artifact_registry_repositories(client: Resource, project_id: str) -> list[dict]:
+def get_artifact_registry_repositories(
+    client: ArtifactRegistryClient,
+    project_id: str,
+    max_workers: int = DEFAULT_ARTIFACT_REGISTRY_WORKERS,
+) -> ArtifactRegistryRepositorySyncResult:
     """
     Gets GCP Artifact Registry repositories for a project across all locations.
     """
-    repositories: list[dict] = []
-
     locations = get_artifact_registry_locations(client, project_id)
+    if locations is None:
+        return ArtifactRegistryRepositorySyncResult([], False)
     if not locations:
-        return []
+        return ArtifactRegistryRepositorySyncResult([], True)
 
-    for location in locations:
-        try:
-            parent = f"projects/{project_id}/locations/{location}"
-            request = client.projects().locations().repositories().list(parent=parent)
-            while request is not None:
-                response = gcp_api_execute_with_retry(request)
-                repositories.extend(response.get("repositories", []))
-                request = (
-                    client.projects()
-                    .locations()
-                    .repositories()
-                    .list_next(
-                        previous_request=request,
-                        previous_response=response,
-                    )
-                )
-        except (PermissionDenied, DefaultCredentialsError, RefreshError) as e:
-            logger.warning(
-                f"Failed to get Artifact Registry repositories for project {project_id} "
-                f"in location {location} due to permissions or auth error: {e}",
-            )
-            continue
-        except HttpError as e:
-            logger.debug(
-                f"Failed to get Artifact Registry repositories for project {project_id} "
-                f"in location {location}: {e}",
-            )
-            continue
+    fetch_for_location = partial(_list_repositories_for_location, client, project_id)
+    location_results = fetch_artifact_registry_resources(
+        items=locations,
+        fetch_for_item=fetch_for_location,
+        resource_type="repositories by location",
+        project_id=project_id,
+        max_workers=max_workers,
+    )
 
-    return repositories
+    repositories: list[dict] = []
+    nonempty_locations = 0
+    cleanup_safe = True
+    for result in location_results:
+        cleanup_safe = cleanup_safe and result.cleanup_safe
+        if result.repositories:
+            nonempty_locations += 1
+            repositories.extend(result.repositories)
+
+    logger.info(
+        "Collected %d Artifact Registry repositories across %d/%d queried locations for project %s.",
+        len(repositories),
+        nonempty_locations,
+        len(locations),
+        project_id,
+    )
+    return ArtifactRegistryRepositorySyncResult(repositories, cleanup_safe)
 
 
 def transform_repositories(
@@ -125,6 +189,7 @@ def load_repositories(
         neo4j_session,
         GCPArtifactRegistryRepositorySchema(),
         data,
+        batch_size=ARTIFACT_REGISTRY_LOAD_BATCH_SIZE,
         lastupdated=update_tag,
         PROJECT_ID=project_id,
     )
@@ -145,16 +210,17 @@ def cleanup_repositories(
 @timeit
 def sync_artifact_registry_repositories(
     neo4j_session: neo4j.Session,
-    client: Resource,
+    client: ArtifactRegistryClient,
     project_id: str,
     update_tag: int,
     common_job_parameters: dict,
-) -> list[dict]:
+) -> ArtifactRegistryRepositorySyncResult:
     """
     Syncs GCP Artifact Registry repositories and returns the raw repository data.
     """
     logger.info(f"Syncing Artifact Registry repositories for project {project_id}.")
-    repositories_raw = get_artifact_registry_repositories(client, project_id)
+    result = get_artifact_registry_repositories(client, project_id)
+    repositories_raw = result.repositories
     if not repositories_raw:
         logger.info(
             f"No Artifact Registry repositories found for project {project_id}."
@@ -163,8 +229,14 @@ def sync_artifact_registry_repositories(
     repositories = transform_repositories(repositories_raw, project_id)
     load_repositories(neo4j_session, repositories, project_id, update_tag)
 
-    cleanup_job_params = common_job_parameters.copy()
-    cleanup_job_params["PROJECT_ID"] = project_id
-    cleanup_repositories(neo4j_session, cleanup_job_params)
+    if result.cleanup_safe:
+        cleanup_job_params = common_job_parameters.copy()
+        cleanup_job_params["PROJECT_ID"] = project_id
+        cleanup_repositories(neo4j_session, cleanup_job_params)
+    else:
+        logger.warning(
+            "Skipping Artifact Registry repository cleanup for project %s because repository discovery was incomplete.",
+            project_id,
+        )
 
-    return repositories_raw
+    return result

--- a/cartography/intel/gcp/artifact_registry/util.py
+++ b/cartography/intel/gcp/artifact_registry/util.py
@@ -83,25 +83,23 @@ def get_artifact_registry_locations(
     except PermissionDenied as e:
         logger.warning(
             "Missing permissions for Artifact Registry locations in project %s. "
-            "Skipping Artifact Registry cleanup for this project. %s",
+            "Skipping Artifact Registry cleanup for this project. (%s)",
             project_id,
-            e,
+            type(e).__name__,
         )
         return None
     except (DefaultCredentialsError, RefreshError) as e:
         logger.warning(
             "Failed to get Artifact Registry locations for project %s due to auth error. "
-            "Skipping Artifact Registry cleanup for this project. %s",
+            "Skipping Artifact Registry cleanup for this project. (%s)",
             project_id,
-            e,
+            type(e).__name__,
         )
         return None
-    except GoogleAPICallError as e:
-        logger.warning(
-            "Failed to get Artifact Registry locations for project %s. "
-            "Skipping Artifact Registry cleanup for this project. %s",
+    except GoogleAPICallError:
+        logger.error(
+            "Unexpected error getting Artifact Registry locations for project %s.",
             project_id,
-            e,
             exc_info=True,
         )
-        return None
+        raise

--- a/cartography/intel/gcp/artifact_registry/util.py
+++ b/cartography/intel/gcp/artifact_registry/util.py
@@ -1,64 +1,107 @@
 import logging
+from collections.abc import Callable
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
+from typing import TypeVar
 
-from googleapiclient.discovery import Resource
-from googleapiclient.errors import HttpError
+from google.api_core.exceptions import GoogleAPICallError
+from google.api_core.exceptions import PermissionDenied
+from google.auth.exceptions import DefaultCredentialsError
+from google.auth.exceptions import RefreshError
+from google.cloud.artifactregistry_v1 import ArtifactRegistryClient
 
-from cartography.intel.gcp.util import gcp_api_execute_with_retry
-from cartography.intel.gcp.util import get_error_reason
-from cartography.intel.gcp.util import is_api_disabled_error
-from cartography.intel.gcp.util import is_billing_disabled_error
-from cartography.intel.gcp.util import summarize_gcp_http_error
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
+ARTIFACT_REGISTRY_LOAD_BATCH_SIZE = 1000
+DEFAULT_ARTIFACT_REGISTRY_WORKERS = 8
+
+ItemT = TypeVar("ItemT")
+ResultT = TypeVar("ResultT")
+
+
+def fetch_artifact_registry_resources(
+    *,
+    items: list[ItemT],
+    fetch_for_item: Callable[[ItemT], ResultT],
+    resource_type: str,
+    project_id: str,
+    max_workers: int = DEFAULT_ARTIFACT_REGISTRY_WORKERS,
+) -> list[ResultT]:
+    if not items:
+        return []
+
+    worker_count = max(1, min(max_workers, len(items)))
+    logger.info(
+        "Fetching Artifact Registry %s for project %s across %d item(s) with max_workers=%d.",
+        resource_type,
+        project_id,
+        len(items),
+        worker_count,
+    )
+
+    if worker_count <= 1:
+        return [fetch_for_item(item) for item in items]
+
+    results_by_index: dict[int, ResultT] = {}
+    with ThreadPoolExecutor(max_workers=worker_count) as executor:
+        futures = {
+            executor.submit(fetch_for_item, item): index
+            for index, item in enumerate(items)
+        }
+        for future in as_completed(futures):
+            results_by_index[futures[future]] = future.result()
+
+    return [results_by_index[index] for index in range(len(items))]
+
 
 @timeit
-def get_artifact_registry_locations(client: Resource, project_id: str) -> list[str]:
+def get_artifact_registry_locations(
+    client: ArtifactRegistryClient,
+    project_id: str,
+) -> list[str] | None:
     """
     Gets all available Artifact Registry locations for a project.
     """
     try:
-        req = client.projects().locations().list(name=f"projects/{project_id}")
-        res = gcp_api_execute_with_retry(req)
-
         locations = [
-            location.get("locationId")
-            for location in res.get("locations", [])
-            if location.get("locationId")
+            location.location_id
+            for location in client.list_locations(
+                request={"name": f"projects/{project_id}"}
+            ).locations
+            if location.location_id
         ]
 
         logger.info(
-            f"Found {len(locations)} Artifact Registry locations for project {project_id}"
+            "Found %d Artifact Registry locations for project %s.",
+            len(locations),
+            project_id,
         )
         return locations
 
-    except HttpError as e:
-        if is_billing_disabled_error(e):
-            logger.warning(
-                "Artifact Registry billing is disabled for project %s. Skipping Artifact Registry sync for this project. %s",
-                project_id,
-                summarize_gcp_http_error(e),
-            )
-            return []
-        if is_api_disabled_error(e):
-            logger.info(
-                "Artifact Registry API appears disabled for project %s. Skipping Artifact Registry sync for this project. %s",
-                project_id,
-                summarize_gcp_http_error(e),
-            )
-            return []
-        reason = get_error_reason(e)
-        if reason in {"forbidden", "insufficientPermissions", "IAM_PERMISSION_DENIED"}:
-            logger.warning(
-                "Missing permissions for Artifact Registry in project %s. Skipping Artifact Registry sync for this project. %s",
-                project_id,
-                summarize_gcp_http_error(e),
-            )
-            return []
-        logger.error(
-            "Failed to get Artifact Registry locations for project %s: %s",
+    except PermissionDenied as e:
+        logger.warning(
+            "Missing permissions for Artifact Registry locations in project %s. "
+            "Skipping Artifact Registry cleanup for this project. %s",
             project_id,
-            summarize_gcp_http_error(e),
+            e,
         )
-        raise
+        return None
+    except (DefaultCredentialsError, RefreshError) as e:
+        logger.warning(
+            "Failed to get Artifact Registry locations for project %s due to auth error. "
+            "Skipping Artifact Registry cleanup for this project. %s",
+            project_id,
+            e,
+        )
+        return None
+    except GoogleAPICallError as e:
+        logger.warning(
+            "Failed to get Artifact Registry locations for project %s. "
+            "Skipping Artifact Registry cleanup for this project. %s",
+            project_id,
+            e,
+            exc_info=True,
+        )
+        return None

--- a/cartography/intel/gcp/clients.py
+++ b/cartography/intel/gcp/clients.py
@@ -14,6 +14,7 @@ from google.cloud.aiplatform_v1.services.feature_registry_service import (
 )
 from google.cloud.aiplatform_v1.services.model_service import ModelServiceClient
 from google.cloud.aiplatform_v1.services.pipeline_service import PipelineServiceClient
+from google.cloud.artifactregistry_v1 import ArtifactRegistryClient
 from google.cloud.asset_v1 import AssetServiceClient
 from google_auth_httplib2 import AuthorizedHttp
 from googleapiclient.discovery import Resource
@@ -85,6 +86,18 @@ def build_asset_client(
         quota_project_id=quota_project_id,
     )
     return AssetServiceClient(credentials=resolved_credentials)
+
+
+def build_artifact_registry_client(
+    credentials: Optional[GoogleCredentials] = None,
+    quota_project_id: Optional[str] = None,
+) -> ArtifactRegistryClient:
+    return ArtifactRegistryClient(
+        credentials=_resolve_credentials(
+            credentials=credentials,
+            quota_project_id=quota_project_id,
+        ),
+    )
 
 
 def build_vertex_ai_model_client(

--- a/cartography/intel/gcp/clients.py
+++ b/cartography/intel/gcp/clients.py
@@ -92,8 +92,8 @@ def build_asset_client(
 
 
 def build_artifact_registry_client(
-    credentials: Optional[GoogleCredentials] = None,
-    quota_project_id: Optional[str] = None,
+    credentials: GoogleCredentials | None = None,
+    quota_project_id: str | None = None,
 ) -> ArtifactRegistryClient:
     return ArtifactRegistryClient(
         credentials=_resolve_credentials(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ dependencies = [
     "scaleway>=2.10.0",
     "google-cloud-resource-manager>=1.14.2",
     "google-cloud-asset>=1.0.0",
+    "google-cloud-artifact-registry>=1.21.0",
     "google-cloud-aiplatform>=1.127.0",
     "types-aiobotocore-ecr>=3.1.0",
     "typer>=0.9.0",

--- a/tests/integration/cartography/intel/gcp/test_artifact_registry.py
+++ b/tests/integration/cartography/intel/gcp/test_artifact_registry.py
@@ -94,12 +94,10 @@ def test_sync_artifact_registry(
         "UPDATE_TAG": TEST_UPDATE_TAG,
         "PROJECT_ID": TEST_PROJECT_ID,
     }
-    mock_client = MagicMock()
     mock_credentials = MagicMock()
 
     sync(
         neo4j_session,
-        mock_client,
         mock_credentials,
         TEST_PROJECT_ID,
         TEST_UPDATE_TAG,

--- a/tests/integration/cartography/intel/gcp/test_artifact_registry.py
+++ b/tests/integration/cartography/intel/gcp/test_artifact_registry.py
@@ -1,3 +1,5 @@
+from typing import Any
+from typing import cast
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -6,6 +8,9 @@ from cartography.intel.gcp.artifact_registry.artifact import transform_apt_artif
 from cartography.intel.gcp.artifact_registry.artifact import transform_docker_images
 from cartography.intel.gcp.artifact_registry.artifact import transform_maven_artifacts
 from cartography.intel.gcp.artifact_registry.artifact import transform_yum_artifacts
+from cartography.intel.gcp.artifact_registry.repository import (
+    ArtifactRegistryRepositorySyncResult,
+)
 from tests.data.gcp.artifact_registry import MOCK_APT_ARTIFACTS
 from tests.data.gcp.artifact_registry import MOCK_DOCKER_IMAGES
 from tests.data.gcp.artifact_registry import MOCK_HELM_CHARTS
@@ -69,9 +74,17 @@ def _mock_get_yum_artifacts(client, repo_name):
 )
 @patch(
     "cartography.intel.gcp.artifact_registry.repository.get_artifact_registry_repositories",
-    return_value=MOCK_REPOSITORIES,
+    return_value=ArtifactRegistryRepositorySyncResult(
+        cast(list[dict[str, Any]], MOCK_REPOSITORIES),
+        True,
+    ),
+)
+@patch(
+    "cartography.intel.gcp.artifact_registry.build_artifact_registry_client",
+    return_value=MagicMock(name="artifact-registry-client"),
 )
 def test_sync_artifact_registry(
+    mock_build_artifact_registry_client,
     mock_get_repositories,
     neo4j_session,
 ):
@@ -91,6 +104,9 @@ def test_sync_artifact_registry(
         TEST_PROJECT_ID,
         TEST_UPDATE_TAG,
         common_job_parameters,
+    )
+    mock_build_artifact_registry_client.assert_called_once_with(
+        credentials=mock_credentials,
     )
 
     # Assert: Check repository nodes

--- a/tests/integration/cartography/intel/trivy/test_trivy_gcp_disk.py
+++ b/tests/integration/cartography/intel/trivy/test_trivy_gcp_disk.py
@@ -1,10 +1,15 @@
 import json
+from typing import Any
+from typing import cast
 from unittest.mock import MagicMock
 from unittest.mock import mock_open
 from unittest.mock import patch
 
 from cartography.intel.gcp.artifact_registry import sync
 from cartography.intel.gcp.artifact_registry.artifact import transform_docker_images
+from cartography.intel.gcp.artifact_registry.repository import (
+    ArtifactRegistryRepositorySyncResult,
+)
 from cartography.intel.trivy import sync_trivy_from_dir
 from tests.data.gcp.artifact_registry import MOCK_DOCKER_IMAGES
 from tests.data.gcp.artifact_registry import MOCK_PLATFORM_IMAGES
@@ -63,9 +68,17 @@ async def _mock_get_all_manifests_async(
 )
 @patch(
     "cartography.intel.gcp.artifact_registry.repository.get_artifact_registry_repositories",
-    return_value=MOCK_REPOSITORIES,
+    return_value=ArtifactRegistryRepositorySyncResult(
+        cast(list[dict[str, Any]], MOCK_REPOSITORIES),
+        True,
+    ),
+)
+@patch(
+    "cartography.intel.gcp.artifact_registry.build_artifact_registry_client",
+    return_value=MagicMock(name="artifact-registry-client"),
 )
 def test_sync_trivy_gcp(
+    mock_build_artifact_registry_client,
     mock_get_repositories,
     mock_get_manifests,
     mock_list_dir_scan_results,
@@ -99,6 +112,9 @@ def test_sync_trivy_gcp(
         TEST_PROJECT_ID,
         TEST_UPDATE_TAG,
         common_job_parameters,
+    )
+    mock_build_artifact_registry_client.assert_called_once_with(
+        credentials=mock_credentials,
     )
 
     # Act - sync Trivy results

--- a/tests/integration/cartography/intel/trivy/test_trivy_gcp_disk.py
+++ b/tests/integration/cartography/intel/trivy/test_trivy_gcp_disk.py
@@ -102,12 +102,10 @@ def test_sync_trivy_gcp(
     }
 
     # First sync GCP Artifact Registry container images and platform images
-    mock_client = MagicMock()
     mock_credentials = MagicMock()
 
     sync(
         neo4j_session,
-        mock_client,
         mock_credentials,
         TEST_PROJECT_ID,
         TEST_UPDATE_TAG,

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_artifact.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_artifact.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from google.api_core.exceptions import GoogleAPICallError
+from google.api_core.exceptions import NotFound
 
 from cartography.intel.gcp.artifact_registry.artifact import (
     sync_artifact_registry_artifacts,
@@ -19,6 +20,10 @@ def _permission_denied_getter(client, repository_name):
 
 def _unexpected_error_getter(client, repository_name):
     raise GoogleAPICallError("boom")
+
+
+def _not_found_getter(client, repository_name):
+    raise NotFound("not found")
 
 
 def test_sync_artifact_registry_artifacts_skips_cleanup_when_repository_incomplete(
@@ -79,6 +84,46 @@ def test_sync_artifact_registry_artifacts_propagates_unexpected_gapic_errors(
             {"UPDATE_TAG": 123},
             max_workers=1,
         )
+
+
+def test_sync_artifact_registry_artifacts_treats_not_found_as_empty_repo(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "cartography.intel.gcp.artifact_registry.artifact.FORMAT_HANDLERS",
+        {"DOCKER": (_not_found_getter, transform_docker_images)},
+    )
+
+    with (
+        patch(
+            "cartography.intel.gcp.artifact_registry.artifact.cleanup_docker_images"
+        ) as cleanup_docker_images,
+        patch(
+            "cartography.intel.gcp.artifact_registry.artifact.cleanup_helm_charts"
+        ) as cleanup_helm_charts,
+        patch(
+            "cartography.intel.gcp.artifact_registry.artifact.cleanup_language_packages"
+        ) as cleanup_language_packages,
+        patch(
+            "cartography.intel.gcp.artifact_registry.artifact.cleanup_generic_artifacts"
+        ) as cleanup_generic_artifacts,
+    ):
+        result = sync_artifact_registry_artifacts(
+            MagicMock(),
+            MagicMock(),
+            [{"name": "repo", "format": "DOCKER"}],
+            "test-project",
+            123,
+            {"UPDATE_TAG": 123},
+            max_workers=1,
+        )
+
+    assert result.cleanup_safe is True
+    assert result.platform_images == []
+    cleanup_docker_images.assert_called_once()
+    cleanup_helm_charts.assert_called_once()
+    cleanup_language_packages.assert_called_once()
+    cleanup_generic_artifacts.assert_called_once()
 
 
 def test_load_docker_images_uses_artifact_registry_batch_size():

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_artifact.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_artifact.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 
 import pytest
 from google.api_core.exceptions import GoogleAPICallError
-from google.api_core.exceptions import NotFound
 
 from cartography.intel.gcp.artifact_registry.artifact import (
     sync_artifact_registry_artifacts,
@@ -20,10 +19,6 @@ def _permission_denied_getter(client, repository_name):
 
 def _unexpected_error_getter(client, repository_name):
     raise GoogleAPICallError("boom")
-
-
-def _not_found_getter(client, repository_name):
-    raise NotFound("not found")
 
 
 def _run_sync_with_cleanup_mocks(monkeypatch, getter):
@@ -102,25 +97,6 @@ def test_sync_artifact_registry_artifacts_propagates_unexpected_gapic_errors(
             {"UPDATE_TAG": 123},
             max_workers=1,
         )
-
-
-def test_sync_artifact_registry_artifacts_treats_not_found_as_empty_repo(
-    monkeypatch,
-):
-    (
-        result,
-        cleanup_docker_images,
-        cleanup_helm_charts,
-        cleanup_language_packages,
-        cleanup_generic_artifacts,
-    ) = _run_sync_with_cleanup_mocks(monkeypatch, _not_found_getter)
-
-    assert result.cleanup_safe is True
-    assert result.platform_images == []
-    cleanup_docker_images.assert_called_once()
-    cleanup_helm_charts.assert_called_once()
-    cleanup_language_packages.assert_called_once()
-    cleanup_generic_artifacts.assert_called_once()
 
 
 def test_load_docker_images_uses_artifact_registry_batch_size():

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_artifact.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_artifact.py
@@ -26,12 +26,10 @@ def _not_found_getter(client, repository_name):
     raise NotFound("not found")
 
 
-def test_sync_artifact_registry_artifacts_skips_cleanup_when_repository_incomplete(
-    monkeypatch,
-):
+def _run_sync_with_cleanup_mocks(monkeypatch, getter):
     monkeypatch.setattr(
         "cartography.intel.gcp.artifact_registry.artifact.FORMAT_HANDLERS",
-        {"DOCKER": (_permission_denied_getter, transform_docker_images)},
+        {"DOCKER": (getter, transform_docker_images)},
     )
 
     with (
@@ -57,6 +55,26 @@ def test_sync_artifact_registry_artifacts_skips_cleanup_when_repository_incomple
             {"UPDATE_TAG": 123},
             max_workers=1,
         )
+
+    return (
+        result,
+        cleanup_docker_images,
+        cleanup_helm_charts,
+        cleanup_language_packages,
+        cleanup_generic_artifacts,
+    )
+
+
+def test_sync_artifact_registry_artifacts_skips_cleanup_when_repository_incomplete(
+    monkeypatch,
+):
+    (
+        result,
+        cleanup_docker_images,
+        cleanup_helm_charts,
+        cleanup_language_packages,
+        cleanup_generic_artifacts,
+    ) = _run_sync_with_cleanup_mocks(monkeypatch, _permission_denied_getter)
 
     assert result.cleanup_safe is False
     assert result.platform_images == []
@@ -89,34 +107,13 @@ def test_sync_artifact_registry_artifacts_propagates_unexpected_gapic_errors(
 def test_sync_artifact_registry_artifacts_treats_not_found_as_empty_repo(
     monkeypatch,
 ):
-    monkeypatch.setattr(
-        "cartography.intel.gcp.artifact_registry.artifact.FORMAT_HANDLERS",
-        {"DOCKER": (_not_found_getter, transform_docker_images)},
-    )
-
-    with (
-        patch(
-            "cartography.intel.gcp.artifact_registry.artifact.cleanup_docker_images"
-        ) as cleanup_docker_images,
-        patch(
-            "cartography.intel.gcp.artifact_registry.artifact.cleanup_helm_charts"
-        ) as cleanup_helm_charts,
-        patch(
-            "cartography.intel.gcp.artifact_registry.artifact.cleanup_language_packages"
-        ) as cleanup_language_packages,
-        patch(
-            "cartography.intel.gcp.artifact_registry.artifact.cleanup_generic_artifacts"
-        ) as cleanup_generic_artifacts,
-    ):
-        result = sync_artifact_registry_artifacts(
-            MagicMock(),
-            MagicMock(),
-            [{"name": "repo", "format": "DOCKER"}],
-            "test-project",
-            123,
-            {"UPDATE_TAG": 123},
-            max_workers=1,
-        )
+    (
+        result,
+        cleanup_docker_images,
+        cleanup_helm_charts,
+        cleanup_language_packages,
+        cleanup_generic_artifacts,
+    ) = _run_sync_with_cleanup_mocks(monkeypatch, _not_found_getter)
 
     assert result.cleanup_safe is True
     assert result.platform_images == []

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_artifact.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_artifact.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from google.api_core.exceptions import GoogleAPICallError
+
+from cartography.intel.gcp.artifact_registry.artifact import (
+    sync_artifact_registry_artifacts,
+)
+from cartography.intel.gcp.artifact_registry.artifact import transform_docker_images
+from cartography.intel.gcp.artifact_registry.util import (
+    ARTIFACT_REGISTRY_LOAD_BATCH_SIZE,
+)
+
+
+def _permission_denied_getter(client, repository_name):
+    return None
+
+
+def _unexpected_error_getter(client, repository_name):
+    raise GoogleAPICallError("boom")
+
+
+def test_sync_artifact_registry_artifacts_skips_cleanup_when_repository_incomplete(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "cartography.intel.gcp.artifact_registry.artifact.FORMAT_HANDLERS",
+        {"DOCKER": (_permission_denied_getter, transform_docker_images)},
+    )
+
+    with (
+        patch(
+            "cartography.intel.gcp.artifact_registry.artifact.cleanup_docker_images"
+        ) as cleanup_docker_images,
+        patch(
+            "cartography.intel.gcp.artifact_registry.artifact.cleanup_helm_charts"
+        ) as cleanup_helm_charts,
+        patch(
+            "cartography.intel.gcp.artifact_registry.artifact.cleanup_language_packages"
+        ) as cleanup_language_packages,
+        patch(
+            "cartography.intel.gcp.artifact_registry.artifact.cleanup_generic_artifacts"
+        ) as cleanup_generic_artifacts,
+    ):
+        result = sync_artifact_registry_artifacts(
+            MagicMock(),
+            MagicMock(),
+            [{"name": "repo", "format": "DOCKER"}],
+            "test-project",
+            123,
+            {"UPDATE_TAG": 123},
+            max_workers=1,
+        )
+
+    assert result.cleanup_safe is False
+    assert result.platform_images == []
+    cleanup_docker_images.assert_not_called()
+    cleanup_helm_charts.assert_not_called()
+    cleanup_language_packages.assert_not_called()
+    cleanup_generic_artifacts.assert_not_called()
+
+
+def test_sync_artifact_registry_artifacts_propagates_unexpected_gapic_errors(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "cartography.intel.gcp.artifact_registry.artifact.FORMAT_HANDLERS",
+        {"DOCKER": (_unexpected_error_getter, transform_docker_images)},
+    )
+
+    with pytest.raises(GoogleAPICallError):
+        sync_artifact_registry_artifacts(
+            MagicMock(),
+            MagicMock(),
+            [{"name": "repo", "format": "DOCKER"}],
+            "test-project",
+            123,
+            {"UPDATE_TAG": 123},
+            max_workers=1,
+        )
+
+
+def test_load_docker_images_uses_artifact_registry_batch_size():
+    from cartography.intel.gcp.artifact_registry.artifact import load_docker_images
+
+    with patch("cartography.intel.gcp.artifact_registry.artifact.load") as load:
+        load_docker_images(MagicMock(), [{"id": "image"}], "test-project", 123)
+
+    assert load.call_args.kwargs["batch_size"] == ARTIFACT_REGISTRY_LOAD_BATCH_SIZE

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_os_packages.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_os_packages.py
@@ -1,55 +1,46 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from cartography.intel.gcp.artifact_registry.artifact import get_apt_artifacts
 from cartography.intel.gcp.artifact_registry.artifact import get_go_modules
 from cartography.intel.gcp.artifact_registry.artifact import get_yum_artifacts
-from cartography.intel.gcp.util import GCP_API_NUM_RETRIES
 
 
 def _make_os_package_client(package_name: str, version_name: str) -> MagicMock:
     client = MagicMock()
-    repositories = (
-        client.projects.return_value.locations.return_value.repositories.return_value
-    )
-    packages = repositories.packages.return_value
-    versions = packages.versions.return_value
-
-    packages_request = MagicMock()
-    packages_request.execute.return_value = {
-        "packages": [
-            {
-                "name": f"projects/test-project/locations/us-east1/repositories/repo/packages/{package_name}",
+    package_resource_name = f"projects/test-project/locations/us-east1/repositories/repo/packages/{package_name}"
+    client.list_packages.return_value = [
+        SimpleNamespace(
+            name=package_resource_name,
+            data={
+                "name": package_resource_name,
                 "displayName": package_name,
-            }
-        ]
-    }
-    packages.list.return_value = packages_request
-    packages.list_next.return_value = None
-
-    versions_request = MagicMock()
-    versions_request.execute.return_value = {
-        "versions": [
-            {
-                "name": f"projects/test-project/locations/us-east1/repositories/repo/packages/{package_name}/versions/{version_name}",
+            },
+        )
+    ]
+    client.list_versions.return_value = [
+        SimpleNamespace(
+            name=f"{package_resource_name}/versions/{version_name}",
+            data={
+                "name": f"{package_resource_name}/versions/{version_name}",
                 "createTime": "2024-01-06T00:00:00Z",
                 "updateTime": "2024-01-06T00:00:00Z",
-            }
-        ]
-    }
-    versions.list.return_value = versions_request
-    versions.list_next.return_value = None
+            },
+        )
+    ]
     return client
 
 
-def test_get_apt_artifacts_uses_packages_and_versions():
+def _proto_message_to_dict(message):
+    return message.data
+
+
+def test_get_apt_artifacts_uses_packages_and_versions(monkeypatch):
     client = _make_os_package_client("curl", "7.88.1")
-    repositories = (
-        client.projects.return_value.locations.return_value.repositories.return_value
+    monkeypatch.setattr(
+        "cartography.intel.gcp.artifact_registry.artifact.proto_message_to_dict",
+        _proto_message_to_dict,
     )
-    packages = repositories.packages.return_value
-    versions = packages.versions.return_value
-    packages_request = packages.list.return_value
-    versions_request = versions.list.return_value
 
     artifacts = get_apt_artifacts(
         client,
@@ -64,23 +55,20 @@ def test_get_apt_artifacts_uses_packages_and_versions():
             "packageName": "curl",
         }
     ]
-    packages_request.execute.assert_called_once_with(
-        num_retries=GCP_API_NUM_RETRIES,
+    client.list_packages.assert_called_once_with(
+        parent="projects/test-project/locations/us-east1/repositories/repo",
     )
-    versions_request.execute.assert_called_once_with(
-        num_retries=GCP_API_NUM_RETRIES,
+    client.list_versions.assert_called_once_with(
+        parent="projects/test-project/locations/us-east1/repositories/repo/packages/curl",
     )
 
 
-def test_get_yum_artifacts_uses_packages_and_versions():
+def test_get_yum_artifacts_uses_packages_and_versions(monkeypatch):
     client = _make_os_package_client("bash", "5.2.26")
-    repositories = (
-        client.projects.return_value.locations.return_value.repositories.return_value
+    monkeypatch.setattr(
+        "cartography.intel.gcp.artifact_registry.artifact.proto_message_to_dict",
+        _proto_message_to_dict,
     )
-    packages = repositories.packages.return_value
-    versions = packages.versions.return_value
-    packages_request = packages.list.return_value
-    versions_request = versions.list.return_value
 
     artifacts = get_yum_artifacts(
         client,
@@ -95,23 +83,20 @@ def test_get_yum_artifacts_uses_packages_and_versions():
             "packageName": "bash",
         }
     ]
-    packages_request.execute.assert_called_once_with(
-        num_retries=GCP_API_NUM_RETRIES,
+    client.list_packages.assert_called_once_with(
+        parent="projects/test-project/locations/us-east1/repositories/repo",
     )
-    versions_request.execute.assert_called_once_with(
-        num_retries=GCP_API_NUM_RETRIES,
+    client.list_versions.assert_called_once_with(
+        parent="projects/test-project/locations/us-east1/repositories/repo/packages/bash",
     )
 
 
-def test_get_go_modules_uses_packages_and_versions():
+def test_get_go_modules_uses_packages_and_versions(monkeypatch):
     client = _make_os_package_client("example.com/foo", "v1.2.3")
-    repositories = (
-        client.projects.return_value.locations.return_value.repositories.return_value
+    monkeypatch.setattr(
+        "cartography.intel.gcp.artifact_registry.artifact.proto_message_to_dict",
+        _proto_message_to_dict,
     )
-    packages = repositories.packages.return_value
-    versions = packages.versions.return_value
-    packages_request = packages.list.return_value
-    versions_request = versions.list.return_value
 
     modules = get_go_modules(
         client,
@@ -126,9 +111,9 @@ def test_get_go_modules_uses_packages_and_versions():
             "packageName": "example.com/foo",
         }
     ]
-    packages_request.execute.assert_called_once_with(
-        num_retries=GCP_API_NUM_RETRIES,
+    client.list_packages.assert_called_once_with(
+        parent="projects/test-project/locations/us-east1/repositories/repo",
     )
-    versions_request.execute.assert_called_once_with(
-        num_retries=GCP_API_NUM_RETRIES,
+    client.list_versions.assert_called_once_with(
+        parent="projects/test-project/locations/us-east1/repositories/repo/packages/example.com/foo",
     )

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_os_packages.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_os_packages.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from google.api_core.exceptions import NotFound
+
 from cartography.intel.gcp.artifact_registry.artifact import get_apt_artifacts
 from cartography.intel.gcp.artifact_registry.artifact import get_go_modules
 from cartography.intel.gcp.artifact_registry.artifact import get_yum_artifacts
@@ -117,3 +119,49 @@ def test_get_go_modules_uses_packages_and_versions(monkeypatch):
     client.list_versions.assert_called_once_with(
         parent="projects/test-project/locations/us-east1/repositories/repo/packages/example.com/foo",
     )
+
+
+def test_get_go_modules_skips_package_deleted_before_versions_list(monkeypatch):
+    client = MagicMock()
+    deleted_package = SimpleNamespace(
+        name="projects/test-project/locations/us-east1/repositories/repo/packages/deleted",
+        data={
+            "name": "projects/test-project/locations/us-east1/repositories/repo/packages/deleted",
+            "displayName": "deleted",
+        },
+    )
+    kept_package = SimpleNamespace(
+        name="projects/test-project/locations/us-east1/repositories/repo/packages/kept",
+        data={
+            "name": "projects/test-project/locations/us-east1/repositories/repo/packages/kept",
+            "displayName": "kept",
+        },
+    )
+    kept_version = SimpleNamespace(
+        name="projects/test-project/locations/us-east1/repositories/repo/packages/kept/versions/v1.0.0",
+        data={
+            "name": "projects/test-project/locations/us-east1/repositories/repo/packages/kept/versions/v1.0.0",
+            "createTime": "2024-01-06T00:00:00Z",
+            "updateTime": "2024-01-06T00:00:00Z",
+        },
+    )
+    client.list_packages.return_value = [deleted_package, kept_package]
+    client.list_versions.side_effect = [NotFound("deleted"), [kept_version]]
+    monkeypatch.setattr(
+        "cartography.intel.gcp.artifact_registry.artifact.proto_message_to_dict",
+        _proto_message_to_dict,
+    )
+
+    modules = get_go_modules(
+        client,
+        "projects/test-project/locations/us-east1/repositories/repo",
+    )
+
+    assert modules == [
+        {
+            "name": "projects/test-project/locations/us-east1/repositories/repo/packages/kept/versions/v1.0.0",
+            "createTime": "2024-01-06T00:00:00Z",
+            "updateTime": "2024-01-06T00:00:00Z",
+            "packageName": "kept",
+        }
+    ]

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_os_packages.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_os_packages.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 from google.api_core.exceptions import NotFound
 
 from cartography.intel.gcp.artifact_registry.artifact import get_apt_artifacts
@@ -37,12 +38,16 @@ def _proto_message_to_dict(message):
     return message.data
 
 
-def test_get_apt_artifacts_uses_packages_and_versions(monkeypatch):
-    client = _make_os_package_client("curl", "7.88.1")
+@pytest.fixture(autouse=True)
+def proto_message_to_dict(monkeypatch):
     monkeypatch.setattr(
         "cartography.intel.gcp.artifact_registry.artifact.proto_message_to_dict",
         _proto_message_to_dict,
     )
+
+
+def test_get_apt_artifacts_uses_packages_and_versions():
+    client = _make_os_package_client("curl", "7.88.1")
 
     artifacts = get_apt_artifacts(
         client,
@@ -65,13 +70,8 @@ def test_get_apt_artifacts_uses_packages_and_versions(monkeypatch):
     )
 
 
-def test_get_yum_artifacts_uses_packages_and_versions(monkeypatch):
+def test_get_yum_artifacts_uses_packages_and_versions():
     client = _make_os_package_client("bash", "5.2.26")
-    monkeypatch.setattr(
-        "cartography.intel.gcp.artifact_registry.artifact.proto_message_to_dict",
-        _proto_message_to_dict,
-    )
-
     artifacts = get_yum_artifacts(
         client,
         "projects/test-project/locations/us-east1/repositories/repo",
@@ -93,13 +93,8 @@ def test_get_yum_artifacts_uses_packages_and_versions(monkeypatch):
     )
 
 
-def test_get_go_modules_uses_packages_and_versions(monkeypatch):
+def test_get_go_modules_uses_packages_and_versions():
     client = _make_os_package_client("example.com/foo", "v1.2.3")
-    monkeypatch.setattr(
-        "cartography.intel.gcp.artifact_registry.artifact.proto_message_to_dict",
-        _proto_message_to_dict,
-    )
-
     modules = get_go_modules(
         client,
         "projects/test-project/locations/us-east1/repositories/repo",
@@ -121,7 +116,7 @@ def test_get_go_modules_uses_packages_and_versions(monkeypatch):
     )
 
 
-def test_get_go_modules_skips_package_deleted_before_versions_list(monkeypatch):
+def test_get_go_modules_skips_package_deleted_before_versions_list():
     client = MagicMock()
     deleted_package = SimpleNamespace(
         name="projects/test-project/locations/us-east1/repositories/repo/packages/deleted",
@@ -147,10 +142,6 @@ def test_get_go_modules_skips_package_deleted_before_versions_list(monkeypatch):
     )
     client.list_packages.return_value = [deleted_package, kept_package]
     client.list_versions.side_effect = [NotFound("deleted"), [kept_version]]
-    monkeypatch.setattr(
-        "cartography.intel.gcp.artifact_registry.artifact.proto_message_to_dict",
-        _proto_message_to_dict,
-    )
 
     modules = get_go_modules(
         client,

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_repository.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_repository.py
@@ -1,39 +1,75 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+from google.api_core.exceptions import PermissionDenied
 
 from cartography.intel.gcp.artifact_registry.repository import (
     get_artifact_registry_repositories,
 )
-from cartography.intel.gcp.util import GCP_API_NUM_RETRIES
 
 
-def test_get_artifact_registry_repositories_uses_retry_helper():
+def test_get_artifact_registry_repositories_uses_gapic_client(monkeypatch):
     client = MagicMock()
-    location_request = MagicMock()
-    repository_request = MagicMock()
-    next_repository_request = MagicMock()
-    locations = client.projects.return_value.locations.return_value
-    locations.list.return_value = location_request
-    locations.list_next.return_value = None
-    repositories = (
-        client.projects.return_value.locations.return_value.repositories.return_value
+    client.list_repositories.side_effect = [
+        [SimpleNamespace(name="repo-1")],
+        [SimpleNamespace(name="repo-2")],
+    ]
+    monkeypatch.setattr(
+        "cartography.intel.gcp.artifact_registry.repository.get_artifact_registry_locations",
+        lambda _client, _project_id: ["us-central1", "us-east1"],
     )
-    repositories.list.return_value = repository_request
-    repositories.list_next.side_effect = [next_repository_request, None]
+    monkeypatch.setattr(
+        "cartography.intel.gcp.artifact_registry.repository.proto_message_to_dict",
+        lambda repo: {"name": repo.name},
+    )
 
-    location_request.execute.return_value = {
-        "locations": [{"locationId": "us-central1"}]
-    }
-    repository_request.execute.return_value = {"repositories": [{"name": "repo-1"}]}
-    next_repository_request.execute.return_value = {
-        "repositories": [{"name": "repo-2"}]
-    }
+    result = get_artifact_registry_repositories(
+        client,
+        "test-project",
+        max_workers=1,
+    )
+
+    assert result.repositories == [{"name": "repo-1"}, {"name": "repo-2"}]
+    assert result.cleanup_safe is True
+    client.list_repositories.assert_any_call(
+        parent="projects/test-project/locations/us-central1"
+    )
+    client.list_repositories.assert_any_call(
+        parent="projects/test-project/locations/us-east1"
+    )
+
+
+def test_get_artifact_registry_repositories_location_failure_is_not_cleanup_safe(
+    monkeypatch,
+):
+    client = MagicMock()
+    monkeypatch.setattr(
+        "cartography.intel.gcp.artifact_registry.repository.get_artifact_registry_locations",
+        lambda _client, _project_id: None,
+    )
 
     result = get_artifact_registry_repositories(client, "test-project")
 
-    assert result == [{"name": "repo-1"}, {"name": "repo-2"}]
-    repository_request.execute.assert_called_once_with(
-        num_retries=GCP_API_NUM_RETRIES,
+    assert result.repositories == []
+    assert result.cleanup_safe is False
+    client.list_repositories.assert_not_called()
+
+
+def test_get_artifact_registry_repositories_permission_denied_skips_cleanup(
+    monkeypatch,
+):
+    client = MagicMock()
+    client.list_repositories.side_effect = PermissionDenied("denied")
+    monkeypatch.setattr(
+        "cartography.intel.gcp.artifact_registry.repository.get_artifact_registry_locations",
+        lambda _client, _project_id: ["us-central1"],
     )
-    next_repository_request.execute.assert_called_once_with(
-        num_retries=GCP_API_NUM_RETRIES,
+
+    result = get_artifact_registry_repositories(
+        client,
+        "test-project",
+        max_workers=1,
     )
+
+    assert result.repositories == []
+    assert result.cleanup_safe is False

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_util.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_util.py
@@ -36,16 +36,14 @@ def test_get_artifact_registry_locations_forbidden_returns_none(caplog):
     assert "Skipping Artifact Registry cleanup" in caplog.text
 
 
-def test_get_artifact_registry_locations_unknown_error_returns_none(caplog):
+def test_get_artifact_registry_locations_unknown_error_raises(caplog):
     def _raise_api_error(request):
         raise GoogleAPICallError("backend error")
 
     client = SimpleNamespace(list_locations=_raise_api_error)
 
-    locations = get_artifact_registry_locations(client, "test-project")
-
-    assert locations is None
-    assert "Failed to get Artifact Registry locations" in caplog.text
+    with pytest.raises(GoogleAPICallError):
+        get_artifact_registry_locations(client, "test-project")
 
 
 def test_fetch_artifact_registry_resources_preserves_input_order():

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_util.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_util.py
@@ -1,105 +1,73 @@
-import json
-import logging
-from unittest.mock import MagicMock
+from types import SimpleNamespace
 
 import pytest
-from googleapiclient.errors import HttpError
+from google.api_core.exceptions import GoogleAPICallError
+from google.api_core.exceptions import PermissionDenied
 
+from cartography.intel.gcp.artifact_registry.util import (
+    fetch_artifact_registry_resources,
+)
 from cartography.intel.gcp.artifact_registry.util import get_artifact_registry_locations
 
 
-def _make_http_error(status: int, payload: dict) -> HttpError:
-    resp = MagicMock()
-    resp.status = status
-    return HttpError(resp=resp, content=json.dumps(payload).encode("utf-8"))
-
-
-def _make_client() -> tuple[MagicMock, MagicMock]:
-    client = MagicMock()
-    request = MagicMock()
-    client.projects.return_value.locations.return_value.list.return_value = request
-    return client, request
-
-
-def test_get_artifact_registry_locations_success(monkeypatch):
-    client, _request = _make_client()
-    monkeypatch.setattr(
-        "cartography.intel.gcp.artifact_registry.util.gcp_api_execute_with_retry",
-        lambda _req: {
-            "locations": [{"locationId": "us-central1"}, {"locationId": "europe-west1"}]
-        },
+def test_get_artifact_registry_locations_success():
+    client = SimpleNamespace(
+        list_locations=lambda request: SimpleNamespace(
+            locations=[
+                SimpleNamespace(location_id="us-central1"),
+                SimpleNamespace(location_id="europe-west1"),
+            ]
+        )
     )
 
     locations = get_artifact_registry_locations(client, "test-project")
     assert locations == ["us-central1", "europe-west1"]
 
 
-def test_get_artifact_registry_locations_billing_disabled_returns_empty(
-    monkeypatch, caplog
-):
-    client, _request = _make_client()
-    billing_error = _make_http_error(
-        403,
-        {
-            "error": {
-                "message": "This API method requires billing to be enabled.",
-                "details": [
-                    {
-                        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
-                        "reason": "BILLING_DISABLED",
-                    }
-                ],
-            }
-        },
-    )
-    monkeypatch.setattr(
-        "cartography.intel.gcp.artifact_registry.util.gcp_api_execute_with_retry",
-        lambda _req: (_ for _ in ()).throw(billing_error),
-    )
+def test_get_artifact_registry_locations_forbidden_returns_none(caplog):
+    def _raise_permission_denied(request):
+        raise PermissionDenied("permission denied")
 
-    with caplog.at_level(logging.WARNING):
-        locations = get_artifact_registry_locations(client, "test-project")
-
-    assert locations == []
-    assert "HTTP 403 BILLING_DISABLED" in caplog.text
-    assert "googleapiclient.errors.HttpError" not in caplog.text
-
-
-def test_get_artifact_registry_locations_forbidden_returns_empty(monkeypatch):
-    client, _request = _make_client()
-    forbidden_error = _make_http_error(
-        403,
-        {
-            "error": {
-                "message": "Permission denied",
-                "errors": [{"reason": "forbidden"}],
-            }
-        },
-    )
-    monkeypatch.setattr(
-        "cartography.intel.gcp.artifact_registry.util.gcp_api_execute_with_retry",
-        lambda _req: (_ for _ in ()).throw(forbidden_error),
-    )
+    client = SimpleNamespace(list_locations=_raise_permission_denied)
 
     locations = get_artifact_registry_locations(client, "test-project")
-    assert locations == []
+
+    assert locations is None
+    assert "Skipping Artifact Registry cleanup" in caplog.text
 
 
-def test_get_artifact_registry_locations_unknown_error_raises(monkeypatch):
-    client, _request = _make_client()
-    server_error = _make_http_error(
-        500,
-        {
-            "error": {
-                "message": "internal error",
-                "errors": [{"reason": "backendError"}],
-            }
-        },
+def test_get_artifact_registry_locations_unknown_error_returns_none(caplog):
+    def _raise_api_error(request):
+        raise GoogleAPICallError("backend error")
+
+    client = SimpleNamespace(list_locations=_raise_api_error)
+
+    locations = get_artifact_registry_locations(client, "test-project")
+
+    assert locations is None
+    assert "Failed to get Artifact Registry locations" in caplog.text
+
+
+def test_fetch_artifact_registry_resources_preserves_input_order():
+    result = fetch_artifact_registry_resources(
+        items=[3, 1, 2],
+        fetch_for_item=lambda item: item * 10,
+        resource_type="test resources",
+        project_id="test-project",
+        max_workers=3,
     )
-    monkeypatch.setattr(
-        "cartography.intel.gcp.artifact_registry.util.gcp_api_execute_with_retry",
-        lambda _req: (_ for _ in ()).throw(server_error),
-    )
 
-    with pytest.raises(HttpError):
-        get_artifact_registry_locations(client, "test-project")
+    assert result == [30, 10, 20]
+
+
+def test_fetch_artifact_registry_resources_propagates_unexpected_errors():
+    def _raise(item):
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError):
+        fetch_artifact_registry_resources(
+            items=[1],
+            fetch_for_item=_raise,
+            resource_type="test resources",
+            project_id="test-project",
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -884,6 +884,7 @@ dependencies = [
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "google-cloud-aiplatform" },
+    { name = "google-cloud-artifact-registry" },
     { name = "google-cloud-asset" },
     { name = "google-cloud-resource-manager" },
     { name = "httpx" },
@@ -978,6 +979,7 @@ requires-dist = [
     { name = "google-api-python-client", specifier = ">=2.0.0" },
     { name = "google-auth", specifier = ">=2.37.0" },
     { name = "google-cloud-aiplatform", specifier = ">=1.127.0" },
+    { name = "google-cloud-artifact-registry", specifier = ">=1.21.0" },
     { name = "google-cloud-asset", specifier = ">=1.0.0" },
     { name = "google-cloud-resource-manager", specifier = ">=1.14.2" },
     { name = "httpx", specifier = ">=0.24.0" },
@@ -1790,6 +1792,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/f3/b2a9417014c93858a2e3266134f931eefd972c2d410b25d7b8782fc6f143/google_cloud_aiplatform-1.148.1.tar.gz", hash = "sha256:75d605fba34e68714bd08e1e482755d0a6e3ae972805f809d088e686c30879e7", size = 10278758, upload-time = "2026-04-17T23:45:26.738Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/5b/e3515d7bbba602c2b0f6a0da5431785e897252443682e4735d0e6873dc8f/google_cloud_aiplatform-1.148.1-py2.py3-none-any.whl", hash = "sha256:035101e2d8e65c6a706cc3930b2452de7ddcbde50dd130320fcea0d8b03b0c5a", size = 8434481, upload-time = "2026-04-17T23:45:22.919Z" },
+]
+
+[[package]]
+name = "google-cloud-artifact-registry"
+version = "1.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpc-google-iam-v1" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/2b/24e6956789bc1244efb18143aa4f124e03d870228e5bfd065c04d38a4d6b/google_cloud_artifact_registry-1.21.0.tar.gz", hash = "sha256:546e51eb5d463a6e5c668be6727d14f8ec82bc798031398006b2213d703e184c", size = 315219, upload-time = "2026-03-30T22:50:38.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/8c/a5c68031728f38d3306bad5ac10c0ca670cbdf414db308ddefa2c47f2b34/google_cloud_artifact_registry-1.21.0-py3-none-any.whl", hash = "sha256:a07079035438fd0f2e7264d4318b388650495f011db575405c18c9881449025c", size = 250544, upload-time = "2026-03-30T22:48:49.345Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

This moves the GCP Artifact Registry sync path from discovery-based artifact enumeration to the official `google-cloud-artifact-registry` GAPIC client.

The graph model is unchanged. The change focuses on making larger Artifact Registry syncs faster and safer by:

- using a gRPC-backed Artifact Registry client for repository and artifact listing
- querying locations and repositories with bounded intra-project concurrency
- querying per-repository artifacts with the same bounded concurrency helper
- preserving existing transforms by converting GAPIC protobuf messages to the same dict shape as before
- skipping cleanup when discovery is incomplete, so permission/auth failures do not manufacture deletions from partial data
- using an explicit smaller Artifact Registry load batch size for node writes
- adding higher-signal logs for location, repository, worker, and artifact counts


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- Related: #2640


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

None.


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`
- `uv run pytest tests/unit/cartography/intel/gcp/test_artifact_registry_*.py tests/integration/cartography/intel/gcp/test_artifact_registry.py tests/integration/cartography/intel/trivy/test_trivy_gcp_disk.py -q`
- Live read-only GCP API validation plus local Neo4j graph parity against a representative project with Artifact Registry repositories. Project identifier redacted below.

```text
INFO:cartography.intel.gcp.artifact_registry.util:Found 46 Artifact Registry locations for project <project_id>.
INFO:cartography.intel.gcp.artifact_registry.util:Fetching Artifact Registry repositories by location for project <project_id> across 46 item(s) with max_workers=8.
INFO:cartography.intel.gcp.artifact_registry.repository:Collected 4 Artifact Registry repositories across 2/46 queried locations for project <project_id>.
INFO:cartography.client.core.tx:Loaded 4 GCPArtifactRegistryRepository nodes
INFO:cartography.intel.gcp.artifact_registry.artifact:Artifact Registry project <project_id> has 4 candidate repositories by format: {'APT': 1, 'DOCKER': 1, 'GO': 1, 'YUM': 1}
INFO:cartography.intel.gcp.artifact_registry.util:Fetching Artifact Registry artifacts by repository for project <project_id> across 4 item(s) with max_workers=4.
INFO:cartography.intel.gcp.artifact_registry.artifact:Collected Artifact Registry artifacts for project <project_id> from 4/4 non-empty repositories: docker_images=6, helm_charts=0, language_packages=1, generic_artifacts=2.
INFO:cartography.client.core.tx:Loaded 6 GCPArtifactRegistryContainerImage nodes
INFO:cartography.client.core.tx:Loaded 1 GCPArtifactRegistryLanguagePackage nodes
INFO:cartography.client.core.tx:Loaded 2 GCPArtifactRegistryGenericArtifact nodes
INFO:cartography.client.core.tx:Loaded 4 GCPArtifactRegistryPlatformImage nodes
expected_counts {'repos': 4, 'docker': 6, 'generic': 2, 'language': 1} cleanup_safe True
graph_counts {'repos': 4, 'docker': 6, 'generic': 2, 'language': 1}
```


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [x] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

Artifact Registry supports regional and multi-regional repositories, so this intentionally uses the global GAPIC client rather than constructing per-region endpoints. Cleanup is intentionally skipped when the project view is incomplete due to permission/auth failures; unexpected GAPIC errors still fail the resource family instead of loading partial data and cleaning up from an incomplete snapshot.
