### PR TITLE
fix(gcp): Handle CAI policy binding rate limits in GCP sync

### DIFF
--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -507,11 +507,8 @@ def _sync_project_resources(
                 and policy_bindings_status
                 != policy_bindings.PolicyBindingsSyncStatus.SUCCESS
             ):
-                status_label = (
-                    policy_bindings_status.value.replace("_", " ")
-                    if policy_bindings_status is not None
-                    else "not_run"
-                )
+                assert policy_bindings_status is not None
+                status_label = policy_bindings_status.value.replace("_", " ")
                 logger.warning(
                     "Skipping GCP permission relationships for project %s because policy bindings sync was %s. "
                     "Preserving existing permission relationships for this project.",

--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -172,6 +172,7 @@ def _sync_project_resources(
     for project in projects:
         project_id = project["projectId"]
         common_job_parameters["PROJECT_ID"] = project_id
+        policy_bindings_status: policy_bindings.PolicyBindingsSyncStatus | None = None
         enabled_services = _services_enabled_on_project(
             build_client("serviceusage", "v1", credentials=credentials),
             project_id,
@@ -441,11 +442,15 @@ def _sync_project_resources(
         # Policy bindings sync uses CAI gRPC client.
         # We attempt policy bindings for all projects unless we've already encountered a permission error.
         # CAI uses the service account's host project for quota by default.
-        if policy_bindings_permission_ok is not False and (
+        policy_bindings_requested = (
             requested_syncs is None or "policy_bindings" in requested_syncs
-        ):
-            # Check if CAI is enabled (cached after first check on first project)
-            if cai_enabled_on_first_project is None:
+        )
+        if policy_bindings_requested:
+            if policy_bindings_permission_ok is False:
+                policy_bindings_status = (
+                    policy_bindings.PolicyBindingsSyncStatus.SKIPPED_PERMISSION_DENIED
+                )
+            elif cai_enabled_on_first_project is None:
                 first_project_services = _services_enabled_on_project(
                     build_client("serviceusage", "v1", credentials=credentials),
                     project_id,
@@ -463,8 +468,15 @@ def _sync_project_resources(
                         "Enable the Cloud Asset Inventory API to sync IAM policy bindings.",
                         project_id,
                     )
+                    policy_bindings_status = (
+                        policy_bindings.PolicyBindingsSyncStatus.SKIPPED_API_DISABLED
+                    )
+            elif cai_enabled_on_first_project is False:
+                policy_bindings_status = (
+                    policy_bindings.PolicyBindingsSyncStatus.SKIPPED_API_DISABLED
+                )
 
-            if cai_enabled_on_first_project:
+            if cai_enabled_on_first_project and policy_bindings_status is None:
                 # Lazily initialize CAI gRPC client for policy bindings.
                 if cai_grpc_client is None:
                     cai_grpc_client = build_asset_client(
@@ -474,7 +486,7 @@ def _sync_project_resources(
                     "Syncing IAM policies for GCP project %s.",
                     project_id,
                 )
-                success = policy_bindings.sync(
+                policy_bindings_status = policy_bindings.sync(
                     neo4j_session,
                     project_id,
                     gcp_update_tag,
@@ -483,16 +495,36 @@ def _sync_project_resources(
                 )
                 # Track if we have permission. Once set to False (permission denied),
                 # the outer condition will skip policy_bindings for remaining projects.
-                if not success:
+                if (
+                    policy_bindings_status
+                    == policy_bindings.PolicyBindingsSyncStatus.SKIPPED_PERMISSION_DENIED
+                ):
                     policy_bindings_permission_ok = False
 
         if requested_syncs is None or "permission_relationships" in requested_syncs:
-            permission_relationships.sync(
-                neo4j_session,
-                project_id,
-                gcp_update_tag,
-                common_job_parameters,
-            )
+            if (
+                policy_bindings_requested
+                and policy_bindings_status
+                != policy_bindings.PolicyBindingsSyncStatus.SUCCESS
+            ):
+                status_label = (
+                    policy_bindings_status.value.replace("_", " ")
+                    if policy_bindings_status is not None
+                    else "not_run"
+                )
+                logger.warning(
+                    "Skipping GCP permission relationships for project %s because policy bindings sync was %s. "
+                    "Preserving existing permission relationships for this project.",
+                    project_id,
+                    status_label,
+                )
+            else:
+                permission_relationships.sync(
+                    neo4j_session,
+                    project_id,
+                    gcp_update_tag,
+                    common_job_parameters,
+                )
 
         if service_names.cloud_sql in enabled_services:
             logger.info("Syncing GCP project %s for Cloud SQL.", project_id)

--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -113,8 +113,6 @@ def build_cai_policy_bindings_retry(project_id: str, operation: str) -> Retry:
 
 
 def _is_rate_limit_retry_error(exc: Exception) -> bool:
-    if isinstance(exc, ResourceExhausted):
-        return True
     return isinstance(exc, RetryError) and isinstance(exc.cause, ResourceExhausted)
 
 

--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -1,9 +1,18 @@
 import hashlib
 import logging
+import time
+from enum import Enum
+from threading import Lock
 from typing import Any
 
 import neo4j
+from google.api_core.exceptions import DeadlineExceeded
 from google.api_core.exceptions import PermissionDenied
+from google.api_core.exceptions import ResourceExhausted
+from google.api_core.exceptions import RetryError
+from google.api_core.exceptions import ServiceUnavailable
+from google.api_core.retry import if_exception_type
+from google.api_core.retry import Retry
 from google.cloud.asset_v1 import AssetServiceClient
 from google.cloud.asset_v1.types import BatchGetEffectiveIamPoliciesRequest
 from google.cloud.asset_v1.types import SearchAllIamPoliciesRequest
@@ -15,6 +24,91 @@ from cartography.models.gcp.policy_bindings import GCPPolicyBindingSchema
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
+
+
+class PolicyBindingsSyncStatus(str, Enum):
+    SUCCESS = "success"
+    SKIPPED_API_DISABLED = "skipped_api_disabled"
+    SKIPPED_PERMISSION_DENIED = "skipped_permission_denied"
+    SKIPPED_RATE_LIMIT = "skipped_rate_limit"
+    SKIPPED_RETRY_EXHAUSTED = "skipped_retry_exhausted"
+
+
+CAI_POLICY_BINDINGS_RETRY_INITIAL = 1.0
+CAI_POLICY_BINDINGS_RETRY_MAX = 32.0
+CAI_POLICY_BINDINGS_RETRY_MULTIPLIER = 2.0
+CAI_POLICY_BINDINGS_RETRY_TIMEOUT = 300.0
+CAI_POLICY_BINDINGS_BATCH_TIMEOUT = 300.0
+CAI_POLICY_BINDINGS_SEARCH_TIMEOUT = 30.0
+CAI_POLICY_BINDINGS_MIN_INTERVAL_SECONDS = {
+    # Cloud Asset default quotas:
+    # BatchGetEffectiveIamPolicies: 100/min/project ~= 0.6s between calls
+    # SearchAllIamPolicies: 400/min/project ~= 0.15s between calls
+    "batch_get_effective_iam_policies": 0.75,
+    "search_all_iam_policies": 0.20,
+}
+_CAI_POLICY_BINDINGS_THROTTLE_LOCK = Lock()
+_CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION: dict[str, float] = {}
+
+
+def _wait_for_cai_policy_bindings_slot(operation: str) -> None:
+    min_interval = CAI_POLICY_BINDINGS_MIN_INTERVAL_SECONDS[operation]
+    with _CAI_POLICY_BINDINGS_THROTTLE_LOCK:
+        now = time.monotonic()
+        last_call = _CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION.get(operation)
+        if last_call is not None:
+            sleep_for = max(0.0, min_interval - (now - last_call))
+            if sleep_for > 0:
+                logger.debug(
+                    "Throttling Cloud Asset policy bindings %s for %.2f seconds.",
+                    operation,
+                    sleep_for,
+                )
+                time.sleep(sleep_for)
+        _CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION[operation] = time.monotonic()
+
+
+def _log_cai_policy_bindings_retry(
+    project_id: str,
+    operation: str,
+    exc: Exception,
+) -> None:
+    if isinstance(exc, ResourceExhausted):
+        error_kind = "quota/rate-limit error"
+    else:
+        error_kind = "transient gRPC error"
+    logger.warning(
+        "Retrying Cloud Asset policy bindings %s for project %s after %s: %s",
+        operation,
+        project_id,
+        error_kind,
+        exc,
+    )
+
+
+def build_cai_policy_bindings_retry(project_id: str, operation: str) -> Retry:
+    return Retry(
+        predicate=if_exception_type(
+            DeadlineExceeded,
+            ResourceExhausted,
+            ServiceUnavailable,
+        ),
+        initial=CAI_POLICY_BINDINGS_RETRY_INITIAL,
+        maximum=CAI_POLICY_BINDINGS_RETRY_MAX,
+        multiplier=CAI_POLICY_BINDINGS_RETRY_MULTIPLIER,
+        timeout=CAI_POLICY_BINDINGS_RETRY_TIMEOUT,
+        on_error=lambda exc: _log_cai_policy_bindings_retry(
+            project_id,
+            operation,
+            exc,
+        ),
+    )
+
+
+def _is_rate_limit_retry_error(exc: Exception) -> bool:
+    if isinstance(exc, ResourceExhausted):
+        return True
+    return isinstance(exc, RetryError) and isinstance(exc.cause, ResourceExhausted)
 
 
 @timeit
@@ -32,10 +126,16 @@ def get_policy_bindings(
 
     # Fetch effective policies for project resource (using org scope for inheritance)
     effective_scope = org_id
+    _wait_for_cai_policy_bindings_slot("batch_get_effective_iam_policies")
     response = client.batch_get_effective_iam_policies(
         request=BatchGetEffectiveIamPoliciesRequest(
             scope=effective_scope, names=[project_resource_name]
-        )
+        ),
+        retry=build_cai_policy_bindings_retry(
+            project_id,
+            "batch_get_effective_iam_policies",
+        ),
+        timeout=CAI_POLICY_BINDINGS_BATCH_TIMEOUT,
     )
     effective_dict = MessageToDict(response._pb, preserving_proto_field_name=True)
 
@@ -48,25 +148,38 @@ def get_policy_bindings(
         scope=f"projects/{project_id}",
         asset_types=[],
     )
-    for policy in client.search_all_iam_policies(request=search_request):
-        policy_dict = MessageToDict(policy._pb, preserving_proto_field_name=True)
-        # Filter out project resource itself (we already have effective policies for it)
-        resource = policy_dict.get("resource", "")
-        if resource != project_resource_name:
-            policy_data = policy_dict.get("policy", {})
-            bindings = policy_data.get("bindings", [])
+    search_retry = build_cai_policy_bindings_retry(
+        project_id,
+        "search_all_iam_policies",
+    )
+    _wait_for_cai_policy_bindings_slot("search_all_iam_policies")
+    search_pager = client.search_all_iam_policies(
+        request=search_request,
+        retry=search_retry,
+        timeout=CAI_POLICY_BINDINGS_SEARCH_TIMEOUT,
+    )
+    for page in search_pager.pages:
+        for policy in page.results:
+            policy_dict = MessageToDict(policy._pb, preserving_proto_field_name=True)
+            # Filter out project resource itself (we already have effective policies for it)
+            resource = policy_dict.get("resource", "")
+            if resource != project_resource_name:
+                policy_data = policy_dict.get("policy", {})
+                bindings = policy_data.get("bindings", [])
 
-            policies.append(
-                {
-                    "full_resource_name": resource,
-                    "policies": [
-                        {
-                            "attached_resource": resource,
-                            "policy": {"bindings": bindings},
-                        }
-                    ],
-                }
-            )
+                policies.append(
+                    {
+                        "full_resource_name": resource,
+                        "policies": [
+                            {
+                                "attached_resource": resource,
+                                "policy": {"bindings": bindings},
+                            }
+                        ],
+                    }
+                )
+        if page.next_page_token:
+            _wait_for_cai_policy_bindings_slot("search_all_iam_policies")
 
     return {
         "project_id": project_id,
@@ -198,11 +311,11 @@ def sync(
     update_tag: int,
     common_job_parameters: dict[str, Any],
     client: AssetServiceClient,
-) -> bool:
+) -> PolicyBindingsSyncStatus:
     """
     Sync GCP IAM policy bindings for a project.
 
-    Returns True if sync was successful, False if skipped due to permissions.
+    Returns a status describing whether policy bindings were refreshed.
     """
     try:
         bindings_data = get_policy_bindings(
@@ -216,10 +329,42 @@ def sync(
             project_id,
             e,
         )
-        return False
+        return PolicyBindingsSyncStatus.SKIPPED_PERMISSION_DENIED
+    except RetryError as e:
+        if _is_rate_limit_retry_error(e):
+            logger.warning(
+                "Cloud Asset policy bindings retries exhausted for project %s after quota/rate-limit errors. "
+                "Preserving existing policy-binding and permission-relationship data. Error: %s",
+                project_id,
+                e,
+            )
+            return PolicyBindingsSyncStatus.SKIPPED_RATE_LIMIT
+        logger.warning(
+            "Cloud Asset policy bindings retries exhausted for project %s after transient gRPC errors. "
+            "Preserving existing policy-binding and permission-relationship data. Error: %s",
+            project_id,
+            e,
+        )
+        return PolicyBindingsSyncStatus.SKIPPED_RETRY_EXHAUSTED
+    except (DeadlineExceeded, ResourceExhausted, ServiceUnavailable) as e:
+        if isinstance(e, ResourceExhausted):
+            logger.warning(
+                "Cloud Asset policy bindings rate-limited for project %s. "
+                "Preserving existing policy-binding and permission-relationship data. Error: %s",
+                project_id,
+                e,
+            )
+            return PolicyBindingsSyncStatus.SKIPPED_RATE_LIMIT
+        logger.warning(
+            "Cloud Asset policy bindings failed for project %s with a transient gRPC error. "
+            "Preserving existing policy-binding and permission-relationship data. Error: %s",
+            project_id,
+            e,
+        )
+        return PolicyBindingsSyncStatus.SKIPPED_RETRY_EXHAUSTED
 
     transformed_bindings_data = transform_bindings(bindings_data)
 
     load_bindings(neo4j_session, transformed_bindings_data, project_id, update_tag)
     cleanup(neo4j_session, common_job_parameters)
-    return True
+    return PolicyBindingsSyncStatus.SUCCESS

--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -53,19 +53,26 @@ _CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION: dict[str, float] = {}
 
 def _wait_for_cai_policy_bindings_slot(operation: str) -> None:
     min_interval = CAI_POLICY_BINDINGS_MIN_INTERVAL_SECONDS[operation]
+    sleep_for = 0.0
     with _CAI_POLICY_BINDINGS_THROTTLE_LOCK:
         now = time.monotonic()
-        last_call = _CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION.get(operation)
-        if last_call is not None:
-            sleep_for = max(0.0, min_interval - (now - last_call))
-            if sleep_for > 0:
-                logger.debug(
-                    "Throttling Cloud Asset policy bindings %s for %.2f seconds.",
-                    operation,
-                    sleep_for,
-                )
-                time.sleep(sleep_for)
-        _CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION[operation] = time.monotonic()
+        next_allowed_time = _CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION.get(
+            operation,
+            now,
+        )
+        scheduled_time = max(now, next_allowed_time)
+        sleep_for = max(0.0, scheduled_time - now)
+        _CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION[operation] = (
+            scheduled_time + min_interval
+        )
+
+    if sleep_for > 0:
+        logger.debug(
+            "Throttling Cloud Asset policy bindings %s for %.2f seconds.",
+            operation,
+            sleep_for,
+        )
+        time.sleep(sleep_for)
 
 
 def _log_cai_policy_bindings_retry(

--- a/tests/integration/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/integration/cartography/intel/gcp/test_policy_bindings.py
@@ -284,8 +284,8 @@ def test_sync_gcp_policy_bindings_permission_denied(
 ):
     """
     Test that policy bindings sync handles PermissionDenied gracefully.
-    When the user lacks org-level cloudasset.viewer role, sync should return False
-    and not raise an exception.
+    When the user lacks org-level cloudasset.viewer role, sync should return a
+    skipped status and not raise an exception.
     """
     # ARRANGE
     _create_test_project(neo4j_session)

--- a/tests/integration/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/integration/cartography/intel/gcp/test_policy_bindings.py
@@ -300,6 +300,9 @@ def test_sync_gcp_policy_bindings_permission_denied(
         mock_asset_client,
     )
 
-    # ASSERT - sync should return False and not raise an exception
-    assert result is False
+    # ASSERT - sync should return a skipped status and not raise an exception
+    assert (
+        result
+        == cartography.intel.gcp.policy_bindings.PolicyBindingsSyncStatus.SKIPPED_PERMISSION_DENIED
+    )
     mock_get_policy_bindings.assert_called_once()

--- a/tests/unit/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/unit/cartography/intel/gcp/test_policy_bindings.py
@@ -2,6 +2,7 @@ import logging
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import pytest
 from google.api_core.exceptions import PermissionDenied
 from google.api_core.exceptions import ResourceExhausted
 from google.api_core.exceptions import RetryError
@@ -16,6 +17,39 @@ COMMON_JOB_PARAMS = {
     "ORG_RESOURCE_NAME": "organizations/1337",
     "PROJECT_ID": TEST_PROJECT_ID,
 }
+
+
+def test_wait_for_cai_policy_bindings_slot_reserves_per_operation_slots():
+    original_state = policy_bindings._CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION.copy()
+    policy_bindings._CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION.clear()
+    try:
+        with (
+            patch.object(policy_bindings.time, "monotonic", return_value=100.0),
+            patch.object(policy_bindings.time, "sleep") as mock_sleep,
+        ):
+            policy_bindings._wait_for_cai_policy_bindings_slot(
+                "search_all_iam_policies"
+            )
+            policy_bindings._wait_for_cai_policy_bindings_slot(
+                "search_all_iam_policies"
+            )
+            policy_bindings._wait_for_cai_policy_bindings_slot(
+                "batch_get_effective_iam_policies"
+            )
+
+        assert mock_sleep.call_count == 1
+        assert mock_sleep.call_args.args[0] == pytest.approx(0.2)
+        assert policy_bindings._CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION[
+            "search_all_iam_policies"
+        ] == pytest.approx(100.4)
+        assert policy_bindings._CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION[
+            "batch_get_effective_iam_policies"
+        ] == pytest.approx(100.75)
+    finally:
+        policy_bindings._CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION.clear()
+        policy_bindings._CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION.update(
+            original_state
+        )
 
 
 @patch.object(policy_bindings, "_wait_for_cai_policy_bindings_slot")

--- a/tests/unit/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/unit/cartography/intel/gcp/test_policy_bindings.py
@@ -1,0 +1,178 @@
+import logging
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from google.api_core.exceptions import PermissionDenied
+from google.api_core.exceptions import ResourceExhausted
+from google.api_core.exceptions import RetryError
+
+import cartography.intel.gcp
+import cartography.intel.gcp.policy_bindings as policy_bindings
+
+TEST_PROJECT_ID = "project-abc"
+TEST_UPDATE_TAG = 123456789
+COMMON_JOB_PARAMS = {
+    "UPDATE_TAG": TEST_UPDATE_TAG,
+    "ORG_RESOURCE_NAME": "organizations/1337",
+    "PROJECT_ID": TEST_PROJECT_ID,
+}
+
+
+@patch.object(policy_bindings, "_wait_for_cai_policy_bindings_slot")
+@patch.object(policy_bindings, "MessageToDict")
+def test_get_policy_bindings_passes_custom_retry_to_cai_rpcs(
+    mock_message_to_dict,
+    mock_wait_for_slot,
+):
+    client = MagicMock()
+    client.batch_get_effective_iam_policies.return_value = MagicMock(_pb=object())
+
+    search_page = MagicMock()
+    search_page.results = [MagicMock(_pb=object())]
+    search_page.next_page_token = ""
+    search_pager = MagicMock()
+    search_pager.pages = [search_page]
+    client.search_all_iam_policies.return_value = search_pager
+
+    mock_message_to_dict.side_effect = [
+        {
+            "policy_results": [
+                {
+                    "full_resource_name": f"//cloudresourcemanager.googleapis.com/projects/{TEST_PROJECT_ID}",
+                    "policies": [],
+                },
+            ],
+        },
+        {
+            "resource": "//storage.googleapis.com/buckets/test-bucket",
+            "policy": {"bindings": [{"role": "roles/storage.objectViewer"}]},
+        },
+    ]
+
+    result = policy_bindings.get_policy_bindings(
+        TEST_PROJECT_ID,
+        COMMON_JOB_PARAMS,
+        client,
+    )
+
+    assert len(result["policy_results"]) == 2
+    batch_retry = client.batch_get_effective_iam_policies.call_args.kwargs["retry"]
+    search_retry = client.search_all_iam_policies.call_args.kwargs["retry"]
+
+    assert batch_retry._predicate(ResourceExhausted("quota exceeded")) is True
+    assert search_retry._predicate(ResourceExhausted("quota exceeded")) is True
+    assert batch_retry._predicate(PermissionDenied("forbidden")) is False
+    assert search_retry._predicate(PermissionDenied("forbidden")) is False
+
+    assert (
+        client.batch_get_effective_iam_policies.call_args.kwargs["timeout"]
+        == policy_bindings.CAI_POLICY_BINDINGS_BATCH_TIMEOUT
+    )
+    assert (
+        client.search_all_iam_policies.call_args.kwargs["timeout"]
+        == policy_bindings.CAI_POLICY_BINDINGS_SEARCH_TIMEOUT
+    )
+    assert mock_wait_for_slot.call_count == 2
+
+
+@patch.object(policy_bindings, "cleanup")
+@patch.object(policy_bindings, "load_bindings")
+@patch.object(
+    policy_bindings,
+    "get_policy_bindings",
+    side_effect=RetryError(
+        "Cloud Asset policy bindings retry budget exhausted",
+        ResourceExhausted("429 quota exceeded"),
+    ),
+)
+def test_sync_skips_load_and_cleanup_on_rate_limit_retry_exhaustion(
+    mock_get_policy_bindings,
+    mock_load_bindings,
+    mock_cleanup,
+    caplog,
+):
+    with caplog.at_level(logging.WARNING):
+        result = policy_bindings.sync(
+            MagicMock(),
+            TEST_PROJECT_ID,
+            TEST_UPDATE_TAG,
+            COMMON_JOB_PARAMS,
+            MagicMock(),
+        )
+
+    assert result == policy_bindings.PolicyBindingsSyncStatus.SKIPPED_RATE_LIMIT
+    mock_get_policy_bindings.assert_called_once()
+    mock_load_bindings.assert_not_called()
+    mock_cleanup.assert_not_called()
+    assert any("retries exhausted" in record.message for record in caplog.records)
+    assert any(
+        "Preserving existing policy-binding" in record.message
+        for record in caplog.records
+    )
+
+
+@patch("cartography.intel.gcp.build_asset_client")
+@patch("cartography.intel.gcp.build_client")
+@patch("cartography.intel.gcp.permission_relationships.sync")
+@patch(
+    "cartography.intel.gcp.policy_bindings.sync",
+    return_value=policy_bindings.PolicyBindingsSyncStatus.SKIPPED_RATE_LIMIT,
+)
+@patch(
+    "cartography.intel.gcp._services_enabled_on_project",
+    side_effect=[set(), {cartography.intel.gcp.service_names.cai}],
+)
+def test_sync_project_resources_skips_permission_relationships_after_policy_binding_rate_limit(
+    mock_services_enabled,
+    mock_policy_bindings_sync,
+    mock_permission_relationships_sync,
+    mock_build_client,
+    mock_build_asset_client,
+):
+    mock_build_client.return_value = MagicMock()
+    mock_build_asset_client.return_value = MagicMock()
+
+    cartography.intel.gcp._sync_project_resources(
+        neo4j_session=MagicMock(),
+        projects=[{"projectId": TEST_PROJECT_ID}],
+        gcp_update_tag=TEST_UPDATE_TAG,
+        common_job_parameters=COMMON_JOB_PARAMS.copy(),
+        credentials=MagicMock(),
+        requested_syncs={"policy_bindings", "permission_relationships"},
+    )
+
+    assert mock_services_enabled.call_count == 2
+    mock_policy_bindings_sync.assert_called_once()
+    mock_permission_relationships_sync.assert_not_called()
+
+
+@patch("cartography.intel.gcp.build_asset_client")
+@patch("cartography.intel.gcp.build_client")
+@patch("cartography.intel.gcp.permission_relationships.sync")
+@patch("cartography.intel.gcp.policy_bindings.sync")
+@patch(
+    "cartography.intel.gcp._services_enabled_on_project",
+    side_effect=[set(), set()],
+)
+def test_sync_project_resources_skips_permission_relationships_when_cai_api_disabled(
+    mock_services_enabled,
+    mock_policy_bindings_sync,
+    mock_permission_relationships_sync,
+    mock_build_client,
+    mock_build_asset_client,
+):
+    mock_build_client.return_value = MagicMock()
+    mock_build_asset_client.return_value = MagicMock()
+
+    cartography.intel.gcp._sync_project_resources(
+        neo4j_session=MagicMock(),
+        projects=[{"projectId": TEST_PROJECT_ID}],
+        gcp_update_tag=TEST_UPDATE_TAG,
+        common_job_parameters=COMMON_JOB_PARAMS.copy(),
+        credentials=MagicMock(),
+        requested_syncs={"policy_bindings", "permission_relationships"},
+    )
+
+    assert mock_services_enabled.call_count == 2
+    mock_policy_bindings_sync.assert_not_called()
+    mock_permission_relationships_sync.assert_not_called()


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->
Handle Cloud Asset Inventory policy-binding quota exhaustion in the GCP sync path by adding targeted CAI gRPC retry/backoff for rate-limit and transient failures, adding light CAI-specific throttling for the two policy-binding RPCs, and preserving existing policy-binding and derived permission-relationship data when a project cannot be refreshed completely.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- None


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

None.


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- `uv run pytest tests/unit/cartography/intel/gcp/test_policy_bindings.py tests/unit/cartography/intel/gcp/test_selective_sync.py tests/integration/cartography/intel/gcp/test_policy_bindings.py -q`


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

The main behavior change is that incomplete Cloud Asset policy-binding refreshes no longer clean up or recompute derived permission relationships for the affected project.
