### PR TITLE
perf(aws): Add index on EC2Instance metadatahttptokens

### DIFF
--- a/cartography/models/aws/ec2/instances.py
+++ b/cartography/models/aws/ec2/instances.py
@@ -38,7 +38,7 @@ class EC2InstanceNodeProperties(CartographyNodeProperties):
     bootmode: PropertyRef = PropertyRef("BootMode")
     instancelifecycle: PropertyRef = PropertyRef("InstanceLifecycle")
     hibernationoptions: PropertyRef = PropertyRef("HibernationOption")
-    metadatahttptokens: PropertyRef = PropertyRef("MetadataHttpTokens")
+    metadatahttptokens: PropertyRef = PropertyRef("MetadataHttpTokens", extra_index=True)
     metadatahttpputresponsehoplimit: PropertyRef = PropertyRef(
         "MetadataHttpPutResponseHopLimit"
     )

--- a/cartography/models/aws/ec2/instances.py
+++ b/cartography/models/aws/ec2/instances.py
@@ -38,7 +38,9 @@ class EC2InstanceNodeProperties(CartographyNodeProperties):
     bootmode: PropertyRef = PropertyRef("BootMode")
     instancelifecycle: PropertyRef = PropertyRef("InstanceLifecycle")
     hibernationoptions: PropertyRef = PropertyRef("HibernationOption")
-    metadatahttptokens: PropertyRef = PropertyRef("MetadataHttpTokens", extra_index=True)
+    metadatahttptokens: PropertyRef = PropertyRef(
+        "MetadataHttpTokens", extra_index=True
+    )
     metadatahttpputresponsehoplimit: PropertyRef = PropertyRef(
         "MetadataHttpPutResponseHopLimit"
     )


### PR DESCRIPTION
## Summary
- Adds `extra_index=True` to the `metadatahttptokens` property on the `EC2InstanceNodeProperties` model
- This creates a Neo4j index on the property, improving query performance for IMDSv2 enforcement checks and security posture assessments that filter EC2 instances by their metadata HTTP tokens setting

## Test plan
- [x] Unit tests pass (`test_instances_transform.py`)
- [x] Index creation tests pass (`test_querybuilder_indexcreation.py`)
- [x] `cubic review` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)