### PR TITLE
feat(aws): add ECS ExecuteCommand permission relationship

### DIFF
--- a/cartography/data/permission_relationships.yaml
+++ b/cartography/data/permission_relationships.yaml
@@ -56,3 +56,8 @@
   - rds:StopDBInstance
   - rds:StartDBInstance
   relationship_name: CAN_ADMINISTER
+# Map principals that can execute commands in ECS tasks.
+- target_label: ECSTask
+  permissions:
+  - ecs:ExecuteCommand
+  relationship_name: CAN_EXECUTE_COMMAND


### PR DESCRIPTION
## Summary
- Adds `ecs:ExecuteCommand` to `permission_relationships.yaml` so the permission resolution engine creates `(AWSPrincipal)-[:CAN_EXECUTE_COMMAND]->(ECSTask)` relationships in the graph
- Enables visibility into which IAM principals can exec into ECS tasks, useful for security auditing

## Test plan
- [ ] Existing unit and integration tests for permission_relationships pass (no code changes, only YAML data)
- [ ] Verify `ECSTask` nodes with matching ARNs get `CAN_EXECUTE_COMMAND` relationships created when principals have `ecs:ExecuteCommand` in their policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)