### PR TITLE
feat(gcp): Add workload_identity_enabled property to GKECluster

### DIFF
--- a/cartography/intel/gcp/gke.py
+++ b/cartography/intel/gcp/gke.py
@@ -186,6 +186,9 @@ def transform_gke_clusters(api_result: Dict[str, Any]) -> List[Dict[str, Any]]:
             ).get("enabled"),
             "legacy_abac": (c.get("legacyAbac", {}) or {}).get("enabled"),
             "shielded_nodes": (c.get("shieldedNodes", {}) or {}).get("enabled"),
+            "workload_identity_enabled": bool(
+                (c.get("workloadIdentityConfig", {}) or {}).get("workloadPool"),
+            ),
             "private_nodes": (c.get("privateClusterConfig", {}) or {}).get(
                 "enablePrivateNodes"
             ),

--- a/cartography/models/gcp/gke.py
+++ b/cartography/models/gcp/gke.py
@@ -35,6 +35,7 @@ class GCPGKEClusterNodeProperties(CartographyNodeProperties):
     master_authorized_networks: PropertyRef = PropertyRef("master_authorized_networks")
     legacy_abac: PropertyRef = PropertyRef("legacy_abac")
     shielded_nodes: PropertyRef = PropertyRef("shielded_nodes")
+    workload_identity_enabled: PropertyRef = PropertyRef("workload_identity_enabled")
     private_nodes: PropertyRef = PropertyRef("private_nodes")
     private_endpoint_enabled: PropertyRef = PropertyRef("private_endpoint_enabled")
     private_endpoint: PropertyRef = PropertyRef("private_endpoint")

--- a/tests/data/gcp/gke.py
+++ b/tests/data/gcp/gke.py
@@ -63,6 +63,9 @@ GKE_RESPONSE = {
             },
             "legacyAbac": {},
             "shieldedNodes": {},
+            "workloadIdentityConfig": {
+                "workloadPool": "test-cluster.svc.id.goog",
+            },
             "ipAllocationPolicy": {
                 "useIpAliases": True,
                 "clusterIpv4Cidr": "0.0.0.0/14",


### PR DESCRIPTION
## Summary
- Add `workload_identity_enabled` boolean property to `GKECluster` nodes, derived from the GCP API's `workloadIdentityConfig.workloadPool` field
- Enables downstream consumers to determine whether GKE Workload Identity is active on a cluster (i.e., whether pods can reach the node metadata server)
- Follows existing patterns for boolean security properties on GKECluster

## Test plan
- [x] Existing GKE unit tests pass (3/3)
- [x] Existing GKE integration tests pass (3/3)
- [x] Test data updated with `workloadIdentityConfig` fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)