### PR TITLE
feat(gcp): Link GCP Artifact Registry platform images for ontology resolution

### DIFF
--- a/cartography/models/gcp/artifact_registry/platform_image.py
+++ b/cartography/models/gcp/artifact_registry/platform_image.py
@@ -66,6 +66,20 @@ class GCPArtifactRegistryPlatformImageToDockerImageRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+# (:GCPArtifactRegistryContainerImage)-[:CONTAINS_IMAGE]->(:GCPArtifactRegistryPlatformImage)
+class GCPArtifactRegistryPlatformImageToParentImageRel(CartographyRelSchema):
+    target_node_label: str = "GCPArtifactRegistryContainerImage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("parent_artifact_id")}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "CONTAINS_IMAGE"
+    properties: GCPArtifactRegistryPlatformImageToArtifactRelProperties = (
+        GCPArtifactRegistryPlatformImageToArtifactRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class GCPArtifactRegistryPlatformImageSchema(CartographyNodeSchema):
     label: str = "GCPArtifactRegistryPlatformImage"
     properties: GCPArtifactRegistryPlatformImageNodeProperties = (
@@ -77,6 +91,7 @@ class GCPArtifactRegistryPlatformImageSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             GCPArtifactRegistryPlatformImageToDockerImageRel(),
+            GCPArtifactRegistryPlatformImageToParentImageRel(),
         ]
     )
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Image"])

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -1522,6 +1522,7 @@ graph LR
     Repository -->|CONTAINS| LanguagePackage
     Repository -->|CONTAINS| GenericArtifact
     ContainerImage -->|HAS_MANIFEST| PlatformImage
+    ContainerImage -->|CONTAINS_IMAGE| PlatformImage
     TrivyFinding -->|AFFECTS| ContainerImage
     Package -->|DEPLOYED| ContainerImage
 ```
@@ -1604,6 +1605,7 @@ Representation of a [Docker Image](https://cloud.google.com/artifact-registry/do
 - GCPArtifactRegistryContainerImages have GCPArtifactRegistryPlatformImages (for multi-architecture images).
     ```
     (GCPArtifactRegistryContainerImage)-[:HAS_MANIFEST]->(GCPArtifactRegistryPlatformImage)
+    (GCPArtifactRegistryContainerImage)-[:CONTAINS_IMAGE]->(GCPArtifactRegistryPlatformImage)
     ```
 
 - TrivyImageFindings affect GCPArtifactRegistryContainerImages.
@@ -1735,6 +1737,7 @@ Representation of a platform-specific manifest within a multi-architecture Docke
 - GCPArtifactRegistryContainerImages have GCPArtifactRegistryPlatformImages.
     ```
     (GCPArtifactRegistryContainerImage)-[:HAS_MANIFEST]->(GCPArtifactRegistryPlatformImage)
+    (GCPArtifactRegistryContainerImage)-[:CONTAINS_IMAGE]->(GCPArtifactRegistryPlatformImage)
     ```
 
 #### Trivy Integration Queries

--- a/tests/integration/cartography/intel/gcp/test_artifact_registry.py
+++ b/tests/integration/cartography/intel/gcp/test_artifact_registry.py
@@ -245,3 +245,16 @@ def test_sync_artifact_registry(
         (TEST_DOCKER_IMAGE_ID, TEST_PLATFORM_IMAGE_AMD64_ID),
         (TEST_DOCKER_IMAGE_ID, TEST_PLATFORM_IMAGE_ARM64_ID),
     }
+
+    # Assert: Check ontology-standard manifest-list -> platform-image relationships
+    assert check_rels(
+        neo4j_session,
+        "GCPArtifactRegistryContainerImage",
+        "id",
+        "GCPArtifactRegistryPlatformImage",
+        "id",
+        "CONTAINS_IMAGE",
+    ) == {
+        (TEST_DOCKER_IMAGE_ID, TEST_PLATFORM_IMAGE_AMD64_ID),
+        (TEST_DOCKER_IMAGE_ID, TEST_PLATFORM_IMAGE_ARM64_ID),
+    }

--- a/tests/integration/cartography/intel/ontology/test_resolved_images.py
+++ b/tests/integration/cartography/intel/ontology/test_resolved_images.py
@@ -270,3 +270,56 @@ def test_resolved_image_analysis_creates_rel_via_manifest_list(neo4j_session):
         "id",
         "RESOLVED_IMAGE",
     ) == {("container-ml-1", "sha256:childamd64")}
+
+
+def test_resolved_image_analysis_creates_rel_for_gcp_artifact_registry_manifest_list(
+    neo4j_session,
+):
+    """GAR manifest lists should resolve through CONTAINS_IMAGE to the matching platform image."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (c:Container:GCPCloudRunServiceContainer {id: 'cloud-run-container-1'})
+        SET c.architecture_normalized = 'amd64',
+            c.lastupdated = $update_tag
+
+        MERGE (ml:GCPArtifactRegistryContainerImage:ImageManifestList {id: 'gar-manifest-list'})
+        SET ml.digest = 'sha256:manifestlist',
+            ml.lastupdated = $update_tag
+
+        MERGE (child_amd64:GCPArtifactRegistryPlatformImage:Image {id: 'gar-child-amd64'})
+        SET child_amd64.digest = 'sha256:childamd64',
+            child_amd64._ont_architecture = 'amd64',
+            child_amd64.lastupdated = $update_tag
+
+        MERGE (child_arm64:GCPArtifactRegistryPlatformImage:Image {id: 'gar-child-arm64'})
+        SET child_arm64.digest = 'sha256:childarm64',
+            child_arm64._ont_architecture = 'arm64',
+            child_arm64.lastupdated = $update_tag
+
+        MERGE (c)-[r:HAS_IMAGE]->(ml)
+        SET r.lastupdated = $update_tag
+
+        MERGE (ml)-[r1:CONTAINS_IMAGE]->(child_amd64)
+        SET r1.lastupdated = $update_tag
+
+        MERGE (ml)-[r2:CONTAINS_IMAGE]->(child_arm64)
+        SET r2.lastupdated = $update_tag
+        """,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    run_analysis_job(
+        "resolved_image_analysis.json",
+        neo4j_session,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "Container",
+        "id",
+        "Image",
+        "id",
+        "RESOLVED_IMAGE",
+    ) == {("cloud-run-container-1", "gar-child-amd64")}


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

This adds the ontology-standard `CONTAINS_IMAGE` relationship from GCP Artifact Registry manifest-list images to their platform-specific images, while preserving the existing `HAS_MANIFEST` relationship.

The generic `RESOLVED_IMAGE` analysis already resolves `ImageManifestList` nodes through `CONTAINS_IMAGE` to the architecture-matching child `Image`. Adding this relationship lets GCP Artifact Registry platform images participate in that shared image-resolution path.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

N/A


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

None.


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- Added integration tests


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

`HAS_MANIFEST` remains unchanged for compatibility. `CONTAINS_IMAGE` is added as the generic ontology edge used by resolved-image analysis.

The schema README checklist item is unchecked because `docs/schema/README.md` does not exist in this checkout.
