### PR TITLE
feat(sysdig): Add Sysdig intel module

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -55,6 +55,7 @@ PANEL_AIRBYTE = "Airbyte Options"
 PANEL_DOCKER_SCOUT = "Docker Scout Options"
 PANEL_TRIVY = "Trivy Options"
 PANEL_SYFT = "Syft Options"
+PANEL_SYSDIG = "Sysdig Options"
 PANEL_AIBOM = "AIBOM Options"
 PANEL_UBUNTU = "Ubuntu Security Options"
 PANEL_ONTOLOGY = "Ontology Options"
@@ -109,6 +110,7 @@ MODULE_PANELS = {
     "docker_scout": PANEL_DOCKER_SCOUT,
     "trivy": PANEL_TRIVY,
     "syft": PANEL_SYFT,
+    "sysdig": PANEL_SYSDIG,
     "aibom": PANEL_AIBOM,
     "ubuntu": PANEL_UBUNTU,
     "ontology": PANEL_ONTOLOGY,
@@ -1448,6 +1450,54 @@ class CLI:
                     hidden=PANEL_SYFT not in visible_panels,
                 ),
             ] = None,
+            # =================================================================
+            # Sysdig Options
+            # =================================================================
+            sysdig_api_token_env_var: Annotated[
+                str | None,
+                typer.Option(
+                    "--sysdig-api-token-env-var",
+                    help="Environment variable name containing Sysdig API token.",
+                    rich_help_panel=PANEL_SYSDIG,
+                    hidden=PANEL_SYSDIG not in visible_panels,
+                ),
+            ] = None,
+            sysdig_api_url: Annotated[
+                str,
+                typer.Option(
+                    "--sysdig-api-url",
+                    help="Sysdig API base URL.",
+                    rich_help_panel=PANEL_SYSDIG,
+                    hidden=PANEL_SYSDIG not in visible_panels,
+                ),
+            ] = "https://api.us1.sysdig.com",
+            sysdig_tenant_id: Annotated[
+                str | None,
+                typer.Option(
+                    "--sysdig-tenant-id",
+                    help="Stable tenant id for Sysdig data. Defaults to the API hostname.",
+                    rich_help_panel=PANEL_SYSDIG,
+                    hidden=PANEL_SYSDIG not in visible_panels,
+                ),
+            ] = None,
+            sysdig_runtime_event_lookback_hours: Annotated[
+                int,
+                typer.Option(
+                    "--sysdig-runtime-event-lookback-hours",
+                    help="Runtime event lookback window in hours.",
+                    rich_help_panel=PANEL_SYSDIG,
+                    hidden=PANEL_SYSDIG not in visible_panels,
+                ),
+            ] = 24,
+            sysdig_page_size: Annotated[
+                int,
+                typer.Option(
+                    "--sysdig-page-size",
+                    help="SysQL query page size.",
+                    rich_help_panel=PANEL_SYSDIG,
+                    hidden=PANEL_SYSDIG not in visible_panels,
+                ),
+            ] = 1000,
             # AIBOM Options
             # =================================================================
             aibom_s3_bucket: Annotated[
@@ -2255,6 +2305,21 @@ class CLI:
             if syft_results_dir:
                 logger.debug("Syft results dir: %s", syft_results_dir)
 
+            # Read Sysdig API token
+            sysdig_api_token = None
+            if sysdig_api_token_env_var:
+                logger.debug(
+                    "Reading Sysdig API token from environment variable %s",
+                    sysdig_api_token_env_var,
+                )
+                sysdig_api_token = os.environ.get(sysdig_api_token_env_var)
+            if sysdig_runtime_event_lookback_hours < 1:
+                raise typer.BadParameter(
+                    "--sysdig-runtime-event-lookback-hours must be at least 1"
+                )
+            if sysdig_page_size < 1:
+                raise typer.BadParameter("--sysdig-page-size must be at least 1")
+
             # Log AIBOM config
             if aibom_s3_bucket:
                 logger.debug("AIBOM S3 bucket: %s", aibom_s3_bucket)
@@ -2481,6 +2546,11 @@ class CLI:
                 syft_s3_bucket=syft_s3_bucket,
                 syft_s3_prefix=syft_s3_prefix,
                 syft_results_dir=syft_results_dir,
+                sysdig_api_token=sysdig_api_token,
+                sysdig_api_url=sysdig_api_url,
+                sysdig_tenant_id=sysdig_tenant_id,
+                sysdig_runtime_event_lookback_hours=sysdig_runtime_event_lookback_hours,
+                sysdig_page_size=sysdig_page_size,
                 aibom_s3_bucket=aibom_s3_bucket,
                 aibom_s3_prefix=aibom_s3_prefix,
                 aibom_results_dir=aibom_results_dir,

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -275,6 +275,16 @@ class Config:
     :param syft_s3_bucket: S3 bucket containing Syft scan results. Optional.
     :type syft_s3_prefix: str
     :param syft_s3_prefix: S3 prefix path containing Syft scan results. Optional.
+    :type sysdig_api_token: str
+    :param sysdig_api_token: Sysdig API token. Optional.
+    :type sysdig_api_url: str
+    :param sysdig_api_url: Sysdig API base URL. Optional.
+    :type sysdig_tenant_id: str
+    :param sysdig_tenant_id: Stable tenant id for Sysdig data. Optional.
+    :type sysdig_runtime_event_lookback_hours: int
+    :param sysdig_runtime_event_lookback_hours: Runtime event lookback window in hours. Optional.
+    :type sysdig_page_size: int
+    :param sysdig_page_size: SysQL query page size. Optional.
     :type workos_api_key: str
     :param workos_api_key: WorkOS API key. Optional.
     :type workos_client_id: str
@@ -432,6 +442,11 @@ class Config:
         syft_results_dir=None,
         syft_s3_bucket=None,
         syft_s3_prefix=None,
+        sysdig_api_token=None,
+        sysdig_api_url="https://api.us1.sysdig.com",
+        sysdig_tenant_id=None,
+        sysdig_runtime_event_lookback_hours=24,
+        sysdig_page_size=1000,
         workos_api_key=None,
         workos_client_id=None,
         sentry_token=None,
@@ -591,6 +606,11 @@ class Config:
         self.syft_results_dir = syft_results_dir
         self.syft_s3_bucket = syft_s3_bucket
         self.syft_s3_prefix = syft_s3_prefix
+        self.sysdig_api_token = sysdig_api_token
+        self.sysdig_api_url = sysdig_api_url
+        self.sysdig_tenant_id = sysdig_tenant_id
+        self.sysdig_runtime_event_lookback_hours = sysdig_runtime_event_lookback_hours
+        self.sysdig_page_size = sysdig_page_size
         self.workos_api_key = workos_api_key
         self.workos_client_id = workos_client_id
         self.sentry_token = sentry_token

--- a/cartography/data/jobs/analysis/ontology_packages_linking.json
+++ b/cartography/data/jobs/analysis/ontology_packages_linking.json
@@ -12,8 +12,18 @@
       "iterative": false
     },
     {
+      "__comment": "Link Package to ontology Image via SysdigPackage DEPLOYED",
+      "query": "MATCH (p:Package)-[:DETECTED_AS]->(sp:SysdigPackage)-[:DEPLOYED]->(img:Image) MERGE (p)-[r:DEPLOYED]->(img) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "iterative": false
+    },
+    {
       "__comment": "Link TrivyImageFinding AFFECTS to canonical Package via TrivyPackage",
       "query": "MATCH (f:TrivyImageFinding)-[:AFFECTS]->(tp:TrivyPackage)<-[:DETECTED_AS]-(p:Package) MERGE (f)-[r:AFFECTS]->(p) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "iterative": false
+    },
+    {
+      "__comment": "Link SysdigVulnerabilityFinding AFFECTS to canonical Package via SysdigPackage",
+      "query": "MATCH (f:SysdigVulnerabilityFinding)-[:AFFECTS]->(sp:SysdigPackage)<-[:DETECTED_AS]-(p:Package) MERGE (f)-[r:AFFECTS]->(p) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {

--- a/cartography/intel/sysdig/__init__.py
+++ b/cartography/intel/sysdig/__init__.py
@@ -1,0 +1,277 @@
+import logging
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.config import Config
+from cartography.graph.job import GraphJob
+from cartography.intel.sysdig.client import schema_has_entity
+from cartography.intel.sysdig.client import SysdigClient
+from cartography.intel.sysdig.transform import normalize_tenant_id
+from cartography.intel.sysdig.transform import transform_risk_findings
+from cartography.intel.sysdig.transform import transform_runtime_event_summaries
+from cartography.intel.sysdig.transform import transform_security_findings
+from cartography.intel.sysdig.transform import transform_tenant
+from cartography.intel.sysdig.transform import transform_vulnerabilities
+from cartography.models.sysdig import SysdigImageSchema
+from cartography.models.sysdig import SysdigPackageSchema
+from cartography.models.sysdig import SysdigResourceSchema
+from cartography.models.sysdig import SysdigRiskFindingSchema
+from cartography.models.sysdig import SysdigRuntimeEventSummarySchema
+from cartography.models.sysdig import SysdigSecurityFindingSchema
+from cartography.models.sysdig import SysdigTenantSchema
+from cartography.models.sysdig import SysdigVulnerabilityFindingSchema
+from cartography.stats import get_stats_client
+from cartography.util import merge_module_sync_metadata
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+stat_handler = get_stats_client(__name__)
+
+VULNERABILITY_QUERY = """
+MATCH {root} AS resource AFFECTED_BY Vulnerability AS vulnerability
+OPTIONAL MATCH Vulnerability AS vulnerability AFFECTS Package AS package
+RETURN resource, vulnerability, package
+"""
+
+RISK_QUERY = """
+MATCH {root} AS resource AFFECTED_BY RiskFinding AS finding
+RETURN resource, finding
+"""
+
+SECURITY_FINDING_QUERY = """
+MATCH {root} AS resource AFFECTED_BY {entity} AS finding
+RETURN resource, finding
+"""
+
+RUNTIME_EVENT_QUERY = """
+MATCH {root} AS resource
+OPTIONAL MATCH RuntimeEvent AS event GENERATED_BY resource
+WHERE event.timestamp >= '{cutoff}'
+RETURN event, resource
+"""
+
+RESOURCE_ROOT_ENTITIES = (
+    "KubeWorkload",
+    "KubePod",
+    "KubeNode",
+    "KubeCluster",
+    "KubeNamespace",
+    "KubeDeployment",
+    "KubeDaemonSet",
+    "KubeStatefulSet",
+    "ContainerImage",
+    "CloudResource",
+    "AWSResource",
+    "AWSAccount",
+    "GCPResource",
+    "GCPProject",
+    "AzureResource",
+    "AzureSubscription",
+    "EC2Instance",
+)
+
+SECURITY_FINDING_ENTITIES = (
+    "PostureFinding",
+    "ComplianceFinding",
+    "SecurityFinding",
+)
+
+
+@timeit
+def start_sysdig_ingestion(
+    neo4j_session: neo4j.Session,
+    config: Config,
+) -> None:
+    if not config.sysdig_api_token:
+        logger.info("Sysdig API token not configured; skipping Sysdig sync")
+        return
+
+    tenant_id = config.sysdig_tenant_id or normalize_tenant_id(config.sysdig_api_url)
+    common_job_parameters = {
+        "UPDATE_TAG": config.update_tag,
+        "TENANT_ID": tenant_id,
+    }
+
+    client = SysdigClient(
+        config.sysdig_api_url,
+        config.sysdig_api_token,
+        page_size=config.sysdig_page_size,
+    )
+    sync(
+        neo4j_session,
+        client,
+        config.sysdig_api_url,
+        tenant_id,
+        config.update_tag,
+        config.sysdig_runtime_event_lookback_hours,
+        common_job_parameters,
+    )
+
+    merge_module_sync_metadata(
+        neo4j_session,
+        group_type="sysdig",
+        group_id=tenant_id,
+        synced_type="sysdig",
+        update_tag=config.update_tag,
+        stat_handler=stat_handler,
+    )
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: SysdigClient,
+    api_url: str,
+    tenant_id: str,
+    update_tag: int,
+    runtime_event_lookback_hours: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    schema = client.get_schema()
+    common_job_parameters["TENANT_ID"] = tenant_id
+    load_sysdig_data(
+        neo4j_session,
+        SysdigTenantSchema(),
+        transform_tenant(api_url, tenant_id),
+        update_tag,
+    )
+
+    if schema_has_entity(schema, "Vulnerability"):
+        vuln_rows = query_resource_roots(client, schema, VULNERABILITY_QUERY)
+        resources, images, packages, findings = transform_vulnerabilities(
+            vuln_rows,
+            tenant_id,
+        )
+        load_sysdig_data(
+            neo4j_session, SysdigResourceSchema(), resources, update_tag, tenant_id
+        )
+        load_sysdig_data(
+            neo4j_session, SysdigImageSchema(), images, update_tag, tenant_id
+        )
+        load_sysdig_data(
+            neo4j_session, SysdigPackageSchema(), packages, update_tag, tenant_id
+        )
+        load_sysdig_data(
+            neo4j_session,
+            SysdigVulnerabilityFindingSchema(),
+            findings,
+            update_tag,
+            tenant_id,
+        )
+
+    if schema_has_entity(schema, "RiskFinding"):
+        risk_rows = query_resource_roots(client, schema, RISK_QUERY)
+        resources, findings = transform_risk_findings(risk_rows, tenant_id)
+        load_sysdig_data(
+            neo4j_session, SysdigResourceSchema(), resources, update_tag, tenant_id
+        )
+        load_sysdig_data(
+            neo4j_session,
+            SysdigRiskFindingSchema(),
+            findings,
+            update_tag,
+            tenant_id,
+        )
+
+    for entity in SECURITY_FINDING_ENTITIES:
+        if not schema_has_entity(schema, entity):
+            continue
+        security_rows = query_resource_roots(
+            client,
+            schema,
+            SECURITY_FINDING_QUERY,
+            entity=entity,
+        )
+        resources, findings = transform_security_findings(
+            security_rows,
+            tenant_id,
+            entity,
+        )
+        load_sysdig_data(
+            neo4j_session, SysdigResourceSchema(), resources, update_tag, tenant_id
+        )
+        load_sysdig_data(
+            neo4j_session,
+            SysdigSecurityFindingSchema(),
+            findings,
+            update_tag,
+            tenant_id,
+        )
+
+    if schema_has_entity(schema, "RuntimeEvent"):
+        cutoff = (
+            datetime.now(timezone.utc) - timedelta(hours=runtime_event_lookback_hours)
+        ).isoformat()
+        runtime_rows = query_resource_roots(
+            client,
+            schema,
+            RUNTIME_EVENT_QUERY,
+            cutoff=cutoff,
+        )
+        resources, summaries = transform_runtime_event_summaries(
+            runtime_rows, tenant_id
+        )
+        load_sysdig_data(
+            neo4j_session, SysdigResourceSchema(), resources, update_tag, tenant_id
+        )
+        load_sysdig_data(
+            neo4j_session,
+            SysdigRuntimeEventSummarySchema(),
+            summaries,
+            update_tag,
+            tenant_id,
+        )
+
+    cleanup(neo4j_session, common_job_parameters)
+
+
+def query_resource_roots(
+    client: SysdigClient,
+    schema: dict[str, Any],
+    query_template: str,
+    **format_kwargs: Any,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for root in RESOURCE_ROOT_ENTITIES:
+        if not schema_has_entity(schema, root):
+            continue
+        rows.extend(client.query(query_template.format(root=root, **format_kwargs)))
+    return rows
+
+
+def load_sysdig_data(
+    neo4j_session: neo4j.Session,
+    schema: Any,
+    data: list[dict[str, Any]],
+    update_tag: int,
+    tenant_id: str | None = None,
+) -> None:
+    if not data:
+        return
+    kwargs: dict[str, Any] = {"lastupdated": update_tag}
+    if tenant_id is not None:
+        kwargs["TENANT_ID"] = tenant_id
+    load(neo4j_session, schema, data, **kwargs)
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    for schema in (
+        SysdigVulnerabilityFindingSchema(),
+        SysdigSecurityFindingSchema(),
+        SysdigRiskFindingSchema(),
+        SysdigRuntimeEventSummarySchema(),
+        SysdigPackageSchema(),
+        SysdigImageSchema(),
+        SysdigResourceSchema(),
+        SysdigTenantSchema(),
+    ):
+        GraphJob.from_node_schema(schema, common_job_parameters).run(neo4j_session)

--- a/cartography/intel/sysdig/client.py
+++ b/cartography/intel/sysdig/client.py
@@ -1,0 +1,147 @@
+import logging
+import random
+import time
+from typing import Any
+from urllib.parse import urljoin
+
+import requests
+import yaml
+
+logger = logging.getLogger(__name__)
+
+RETRYABLE_STATUSES = {408, 429, 504}
+
+
+class SysdigClient:
+    def __init__(
+        self,
+        api_url: str,
+        api_token: str,
+        page_size: int = 1000,
+        timeout: int = 60,
+        max_attempts: int = 4,
+    ) -> None:
+        self.api_url = api_url.rstrip("/")
+        self.api_token = api_token
+        self.page_size = page_size
+        self.timeout = timeout
+        self.max_attempts = max_attempts
+        self.session = requests.Session()
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        **kwargs: Any,
+    ) -> requests.Response:
+        url = urljoin(f"{self.api_url}/", path.lstrip("/"))
+        for attempt in range(self.max_attempts):
+            try:
+                response = self.session.request(
+                    method,
+                    url,
+                    headers=self._headers(),
+                    timeout=self.timeout,
+                    **kwargs,
+                )
+            except (requests.ConnectionError, requests.Timeout):
+                if attempt == self.max_attempts - 1:
+                    raise
+                self._sleep(attempt)
+                continue
+
+            if response.status_code in RETRYABLE_STATUSES:
+                if attempt == self.max_attempts - 1:
+                    response.raise_for_status()
+                self._sleep(attempt)
+                continue
+
+            response.raise_for_status()
+            return response
+
+        raise RuntimeError("Sysdig request retry loop exited unexpectedly")
+
+    @staticmethod
+    def _sleep(attempt: int) -> None:
+        time.sleep(min(2**attempt, 30) + random.uniform(0, 1))
+
+    def get_schema(self) -> dict[str, Any]:
+        response = self._request("GET", "/api/sysql/v2/schema")
+        try:
+            data = response.json()
+        except ValueError:
+            data = yaml.safe_load(response.text)
+        if isinstance(data, dict):
+            return data
+        return {"schema": data}
+
+    def query(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+        page_size: int | None = None,
+    ) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        limit = page_size or self.page_size
+        offset = 0
+
+        while True:
+            paged_query = f"{query.rstrip().rstrip(';')} LIMIT {limit} OFFSET {offset}"
+            payload: dict[str, Any] = {"query": paged_query}
+            if parameters:
+                payload["parameters"] = parameters
+
+            response = self._request(
+                "POST",
+                "/api/sysql/v2/query",
+                json=payload,
+            )
+            page = _extract_rows(response.json())
+            rows.extend(page)
+
+            if len(page) < limit:
+                break
+            offset += limit
+
+        return rows
+
+
+def _extract_rows(response_json: Any) -> list[dict[str, Any]]:
+    if isinstance(response_json, list):
+        return [row for row in response_json if isinstance(row, dict)]
+    if not isinstance(response_json, dict):
+        return []
+
+    for key in ("data", "results", "items", "rows"):
+        value = response_json.get(key)
+        if isinstance(value, list):
+            return [row for row in value if isinstance(row, dict)]
+
+    return []
+
+
+def schema_has_entity(schema: dict[str, Any], entity_name: str) -> bool:
+    needle = entity_name.lower()
+
+    def _walk(value: Any) -> bool:
+        if isinstance(value, str):
+            return value.lower() == needle
+        if isinstance(value, dict):
+            if any(isinstance(key, str) and key.lower() == needle for key in value):
+                return True
+            name = value.get("name") or value.get("label") or value.get("entity")
+            if isinstance(name, str) and name.lower() == needle:
+                return True
+            return any(_walk(v) for v in value.values())
+        if isinstance(value, list):
+            return any(_walk(item) for item in value)
+        return False
+
+    return _walk(schema)

--- a/cartography/intel/sysdig/transform.py
+++ b/cartography/intel/sysdig/transform.py
@@ -1,0 +1,463 @@
+import hashlib
+import re
+from collections import defaultdict
+from typing import Any
+from urllib.parse import urlparse
+
+from cartography.intel.trivy.util import make_normalized_package_id
+
+SEVERITY_MAP = {
+    "0": "informational",
+    "1": "low",
+    "2": "medium",
+    "3": "high",
+    "4": "critical",
+    "5": "critical",
+    "info": "informational",
+    "informational": "informational",
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+    "critical": "critical",
+}
+
+STATUS_MAP = {
+    "open": "open",
+    "active": "open",
+    "new": "open",
+    "accepted": "accepted",
+    "risk accepted": "accepted",
+    "fixed": "fixed",
+    "resolved": "resolved",
+    "closed": "closed",
+}
+
+
+def normalize_tenant_id(api_url: str) -> str:
+    hostname = urlparse(api_url).hostname
+    return hostname or api_url.rstrip("/")
+
+
+def transform_tenant(api_url: str, tenant_id: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": tenant_id,
+            "name": tenant_id,
+            "api_url": api_url.rstrip("/"),
+        },
+    ]
+
+
+def transform_vulnerabilities(
+    rows: list[dict[str, Any]],
+    tenant_id: str,
+) -> tuple[
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+]:
+    resources: list[dict[str, Any]] = []
+    images: list[dict[str, Any]] = []
+    packages: list[dict[str, Any]] = []
+    findings: list[dict[str, Any]] = []
+
+    for row in rows:
+        resource = _entity(row, "resource", "r", "CloudResource", "KubernetesResource")
+        vulnerability = _entity(row, "vulnerability", "finding", "v", "Vulnerability")
+        package = _entity(row, "package", "p", "Package")
+
+        resource_row = _resource_from_entity(resource, tenant_id)
+        if resource_row:
+            resources.append(resource_row)
+
+        image_row = _image_from_entities(resource, vulnerability)
+        if image_row:
+            images.append(image_row)
+
+        package_row = _package_from_entities(package, vulnerability, image_row)
+        if package_row:
+            packages.append(package_row)
+
+        finding_row = _vulnerability_finding_from_entities(
+            vulnerability,
+            resource_row,
+            package_row,
+            image_row,
+        )
+        if finding_row:
+            findings.append(finding_row)
+
+    return (
+        _dedupe(resources),
+        _dedupe(images),
+        _dedupe(packages),
+        _dedupe(findings),
+    )
+
+
+def transform_security_findings(
+    rows: list[dict[str, Any]],
+    tenant_id: str,
+    source_entity: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    resources: list[dict[str, Any]] = []
+    findings: list[dict[str, Any]] = []
+
+    for row in rows:
+        resource = _entity(row, "resource", "r", "CloudResource", "KubernetesResource")
+        finding = _entity(row, "finding", "security_finding", "f", source_entity)
+        resource_row = _resource_from_entity(resource, tenant_id)
+        if resource_row:
+            resources.append(resource_row)
+        finding_row = _generic_finding_from_entity(
+            finding,
+            resource_row,
+            source_entity,
+            "SYSDIG-SECURITY",
+        )
+        if finding_row:
+            findings.append(finding_row)
+
+    return _dedupe(resources), _dedupe(findings)
+
+
+def transform_risk_findings(
+    rows: list[dict[str, Any]],
+    tenant_id: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    resources: list[dict[str, Any]] = []
+    findings: list[dict[str, Any]] = []
+
+    for row in rows:
+        resource = _entity(row, "resource", "r", "CloudResource", "KubernetesResource")
+        finding = _entity(row, "finding", "risk_finding", "f", "RiskFinding")
+        resource_row = _resource_from_entity(resource, tenant_id)
+        if resource_row:
+            resources.append(resource_row)
+        finding_row = _generic_finding_from_entity(
+            finding,
+            resource_row,
+            "RiskFinding",
+            "SYSDIG-RISK",
+        )
+        if finding_row:
+            finding_row["definition_id"] = _first(
+                finding,
+                "definitionId",
+                "definition_id",
+                "riskId",
+                "risk_id",
+            )
+            findings.append(finding_row)
+
+    return _dedupe(resources), _dedupe(findings)
+
+
+def transform_runtime_event_summaries(
+    rows: list[dict[str, Any]],
+    tenant_id: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    resources: list[dict[str, Any]] = []
+    grouped: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
+
+    for row in rows:
+        resource = _entity(row, "resource", "r", "CloudResource", "KubernetesResource")
+        event = _entity(row, "event", "runtime_event", "e", "RuntimeEvent")
+        resource_row = _resource_from_entity(resource, tenant_id)
+        if resource_row:
+            resources.append(resource_row)
+        resource_id = (
+            resource_row["id"] if resource_row else _first(event, "resourceId")
+        )
+        key = (
+            resource_id,
+            _first(event, "ruleName", "rule_name", "rule"),
+            _first(event, "policyId", "policy_id"),
+            normalize_severity(_first(event, "severity", "priority")),
+            _first(event, "source"),
+            _first(event, "engine"),
+        )
+        grouped[key].append(event)
+
+    summaries: list[dict[str, Any]] = []
+    for key, events in grouped.items():
+        resource_id, rule_name, policy_id, severity, source, engine = key
+        if not resource_id or not rule_name:
+            continue
+        first_seen = min(
+            filter(None, (_timestamp(event) for event in events)), default=None
+        )
+        last_seen = max(
+            filter(None, (_timestamp(event) for event in events)), default=None
+        )
+        representative = events[0]
+        summaries.append(
+            {
+                "id": stable_id("SRE", *key),
+                "title": rule_name,
+                "severity": severity,
+                "type": "runtime_event",
+                "status": "open",
+                "first_seen": first_seen,
+                "last_seen": last_seen,
+                "event_count": len(events),
+                "rule_name": rule_name,
+                "rule_tags": _tags(representative),
+                "policy_id": policy_id,
+                "source": source,
+                "engine": engine,
+                "resource_id": resource_id,
+                "representative_event_id": _first(
+                    representative, "id", "eventId", "event_id"
+                ),
+                "url": _first(representative, "url", "link"),
+            }
+        )
+
+    return _dedupe(resources), _dedupe(summaries)
+
+
+def normalize_severity(value: Any) -> str | None:
+    if value is None:
+        return None
+    return SEVERITY_MAP.get(str(value).strip().lower(), str(value).strip().lower())
+
+
+def normalize_status(value: Any) -> str | None:
+    if value is None:
+        return None
+    return STATUS_MAP.get(str(value).strip().lower(), str(value).strip().lower())
+
+
+def normalize_digest(value: Any) -> str | None:
+    if not value:
+        return None
+    digest = str(value).strip()
+    if re.fullmatch(r"[a-fA-F0-9]{64}", digest):
+        return f"sha256:{digest.lower()}"
+    if digest.startswith("sha256:"):
+        return digest.lower()
+    return digest
+
+
+def stable_id(prefix: str, *parts: Any) -> str:
+    material = "|".join(str(part) for part in parts if part is not None)
+    digest = hashlib.sha256(material.encode("utf-8")).hexdigest()
+    return f"{prefix}|{digest}"
+
+
+def _entity(row: dict[str, Any], *names: str) -> dict[str, Any]:
+    for name in names:
+        value = row.get(name)
+        if isinstance(value, dict):
+            return value
+    for value in row.values():
+        if not isinstance(value, dict):
+            continue
+        entity_type = _first(value, "type", "entityType", "entity_type", "kind")
+        if entity_type and any(
+            str(entity_type).lower() == name.lower() for name in names
+        ):
+            return value
+    return {}
+
+
+def _resource_from_entity(
+    resource: dict[str, Any],
+    tenant_id: str,
+) -> dict[str, Any] | None:
+    if not resource:
+        return None
+    resource_id = _first(
+        resource,
+        "id",
+        "uid",
+        "resourceId",
+        "resource_id",
+        "arn",
+        "cloudResourceId",
+    )
+    if not resource_id:
+        resource_id = stable_id("SR", tenant_id, resource)
+
+    return {
+        "id": str(resource_id),
+        "name": _first(resource, "name", "resourceName", "resource_name"),
+        "type": _first(resource, "type", "kind", "resourceType", "resource_type"),
+        "cloud_provider": _first(resource, "cloudProvider", "cloud_provider"),
+        "cloud_account_id": _first(
+            resource, "accountId", "account_id", "cloudAccountId"
+        ),
+        "cloud_region": _first(resource, "region", "cloudRegion", "cloud_region"),
+        "cloud_resource_id": _first(
+            resource, "resourceId", "resource_id", "cloudResourceId"
+        ),
+        "cloud_resource_arn": _first(resource, "arn", "cloudResourceArn"),
+        "kubernetes_cluster": _first(resource, "cluster", "clusterName"),
+        "kubernetes_namespace": _first(resource, "namespace", "namespaceName"),
+        "kubernetes_workload": _first(
+            resource, "workload", "workloadName", "podName", "deployment"
+        ),
+        "kubernetes_kind": _first(resource, "kind", "kubernetesKind"),
+        "container_name": _first(resource, "containerName", "container_name"),
+        "image_digest": normalize_digest(_first(resource, "imageDigest", "digest")),
+        "image_uri": _first(resource, "image", "imageUri", "image_uri"),
+    }
+
+
+def _image_from_entities(
+    resource: dict[str, Any],
+    vulnerability: dict[str, Any],
+) -> dict[str, Any] | None:
+    digest = normalize_digest(
+        _first(vulnerability, "imageDigest", "image_digest", "digest")
+        or _first(resource, "imageDigest", "digest")
+    )
+    if not digest:
+        return None
+    return {
+        "id": digest,
+        "digest": digest,
+        "uri": _first(vulnerability, "image", "imageUri", "image_uri")
+        or _first(resource, "image", "imageUri", "image_uri"),
+        "architecture": _first(resource, "architecture", "arch"),
+        "os": _first(resource, "os", "operatingSystem"),
+    }
+
+
+def _package_from_entities(
+    package: dict[str, Any],
+    vulnerability: dict[str, Any],
+    image: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    name = _first(package, "name", "packageName", "package_name") or _first(
+        vulnerability, "packageName", "package_name"
+    )
+    version = _first(package, "version", "packageVersion", "package_version") or _first(
+        vulnerability, "packageVersion", "package_version"
+    )
+    pkg_type = _first(package, "type", "packageType", "package_type") or _first(
+        vulnerability, "packageType", "package_type"
+    )
+    purl = _first(package, "purl", "PURL") or _first(vulnerability, "purl", "PURL")
+    normalized_id = make_normalized_package_id(
+        purl=purl,
+        name=name,
+        version=version,
+        pkg_type=pkg_type,
+    )
+    if not normalized_id:
+        return None
+    return {
+        "id": normalized_id,
+        "normalized_id": normalized_id,
+        "name": name,
+        "version": version,
+        "type": pkg_type.lower() if isinstance(pkg_type, str) else pkg_type,
+        "purl": purl,
+        "image_digest": image["digest"] if image else None,
+    }
+
+
+def _vulnerability_finding_from_entities(
+    vulnerability: dict[str, Any],
+    resource: dict[str, Any] | None,
+    package: dict[str, Any] | None,
+    image: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    cve_id = _first(vulnerability, "cveId", "cve_id", "name", "id")
+    if not cve_id:
+        return None
+    resource_id = resource["id"] if resource else _first(vulnerability, "resourceId")
+    package_id = package["normalized_id"] if package else None
+    image_digest = image["digest"] if image else None
+    return {
+        "id": stable_id("SVF", cve_id, resource_id, package_id, image_digest),
+        "name": cve_id,
+        "cve_id": cve_id,
+        "title": _first(vulnerability, "title") or cve_id,
+        "description": _first(vulnerability, "description"),
+        "severity": normalize_severity(_first(vulnerability, "severity")),
+        "status": normalize_status(_first(vulnerability, "status")),
+        "fix_available": _first(vulnerability, "fixAvailable", "fix_available"),
+        "in_use": _first(vulnerability, "inUse", "in_use"),
+        "exploit_available": _first(
+            vulnerability, "exploitAvailable", "exploit_available"
+        ),
+        "first_seen": _first(vulnerability, "firstSeen", "first_seen", "createdAt"),
+        "last_seen": _first(vulnerability, "lastSeen", "last_seen", "updatedAt"),
+        "resource_id": resource_id,
+        "image_digest": image_digest,
+        "package_normalized_id": package_id,
+        "package_name": package["name"] if package else None,
+        "package_version": package["version"] if package else None,
+        "package_type": package["type"] if package else None,
+        "url": _first(vulnerability, "url", "link"),
+    }
+
+
+def _generic_finding_from_entity(
+    finding: dict[str, Any],
+    resource: dict[str, Any] | None,
+    source_entity: str,
+    prefix: str,
+) -> dict[str, Any] | None:
+    title = _first(finding, "title", "name", "ruleName", "controlName")
+    if not title:
+        return None
+    finding_id = _first(finding, "id", "uid", "findingId", "finding_id")
+    resource_id = resource["id"] if resource else _first(finding, "resourceId")
+    return {
+        "id": str(finding_id) if finding_id else stable_id(prefix, title, resource_id),
+        "title": title,
+        "severity": normalize_severity(_first(finding, "severity")),
+        "type": _first(finding, "type", "category") or source_entity,
+        "status": normalize_status(_first(finding, "status", "state")),
+        "first_seen": _first(finding, "firstSeen", "first_seen", "createdAt"),
+        "last_seen": _first(finding, "lastSeen", "last_seen", "updatedAt"),
+        "resource_id": resource_id,
+        "source_entity": source_entity,
+        "url": _first(finding, "url", "link"),
+    }
+
+
+def _first(source: dict[str, Any], *keys: str) -> Any:
+    if not source:
+        return None
+    for key in keys:
+        if key in source and source[key] not in ("", [], {}):
+            return source[key]
+        current: Any = source
+        found = True
+        for part in key.split("."):
+            if isinstance(current, dict) and part in current:
+                current = current[part]
+            else:
+                found = False
+                break
+        if found and current not in ("", [], {}):
+            return current
+    return None
+
+
+def _timestamp(event: dict[str, Any]) -> Any:
+    return _first(event, "timestamp", "time", "createdAt", "lastSeen")
+
+
+def _tags(event: dict[str, Any]) -> list[str] | None:
+    tags = _first(event, "ruleTags", "rule_tags", "tags")
+    if isinstance(tags, list):
+        return [str(tag) for tag in tags]
+    if isinstance(tags, str):
+        return [tag.strip() for tag in tags.split(",") if tag.strip()]
+    return None
+
+
+def _dedupe(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_id: dict[Any, dict[str, Any]] = {}
+    for row in rows:
+        row_id = row.get("id")
+        if row_id is not None:
+            by_id[row_id] = row
+    return list(by_id.values())

--- a/cartography/models/ontology/mapping/data/images.py
+++ b/cartography/models/ontology/mapping/data/images.py
@@ -65,8 +65,26 @@ gitlab_mapping = OntologyMapping(
     ],
 )
 
+sysdig_mapping = OntologyMapping(
+    module_name="sysdig",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="SysdigImage",
+            fields=[
+                OntologyFieldMapping(ontology_field="digest", node_field="digest"),
+                OntologyFieldMapping(ontology_field="uri", node_field="uri"),
+                OntologyFieldMapping(
+                    ontology_field="architecture", node_field="architecture"
+                ),
+                OntologyFieldMapping(ontology_field="os", node_field="os"),
+            ],
+        ),
+    ],
+)
+
 IMAGES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws": aws_ecr_mapping,
     "gcp": gcp_mapping,
     "gitlab": gitlab_mapping,
+    "sysdig": sysdig_mapping,
 }

--- a/cartography/models/ontology/mapping/data/packages.py
+++ b/cartography/models/ontology/mapping/data/packages.py
@@ -42,7 +42,28 @@ syft_mapping = OntologyMapping(
     ],
 )
 
+sysdig_mapping = OntologyMapping(
+    module_name="sysdig",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="SysdigPackage",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="normalized_id",
+                    node_field="normalized_id",
+                    required=True,
+                ),
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(ontology_field="version", node_field="version"),
+                OntologyFieldMapping(ontology_field="type", node_field="type"),
+                OntologyFieldMapping(ontology_field="purl", node_field="purl"),
+            ],
+        ),
+    ],
+)
+
 PACKAGES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "trivy": trivy_mapping,
     "syft": syft_mapping,
+    "sysdig": sysdig_mapping,
 }

--- a/cartography/models/ontology/mapping/data/security_issues.py
+++ b/cartography/models/ontology/mapping/data/security_issues.py
@@ -113,8 +113,63 @@ azure_mapping = OntologyMapping(
     ],
 )
 
+sysdig_mapping = OntologyMapping(
+    module_name="sysdig",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="SysdigSecurityFinding",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="title",
+                    node_field="title",
+                    required=True,
+                ),
+                OntologyFieldMapping(ontology_field="severity", node_field="severity"),
+                OntologyFieldMapping(ontology_field="type", node_field="type"),
+                OntologyFieldMapping(ontology_field="status", node_field="status"),
+                OntologyFieldMapping(
+                    ontology_field="first_seen", node_field="first_seen"
+                ),
+            ],
+        ),
+        OntologyNodeMapping(
+            node_label="SysdigRiskFinding",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="title",
+                    node_field="title",
+                    required=True,
+                ),
+                OntologyFieldMapping(ontology_field="severity", node_field="severity"),
+                OntologyFieldMapping(ontology_field="type", node_field="type"),
+                OntologyFieldMapping(ontology_field="status", node_field="status"),
+                OntologyFieldMapping(
+                    ontology_field="first_seen", node_field="first_seen"
+                ),
+            ],
+        ),
+        OntologyNodeMapping(
+            node_label="SysdigRuntimeEventSummary",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="title",
+                    node_field="title",
+                    required=True,
+                ),
+                OntologyFieldMapping(ontology_field="severity", node_field="severity"),
+                OntologyFieldMapping(ontology_field="type", node_field="type"),
+                OntologyFieldMapping(ontology_field="status", node_field="status"),
+                OntologyFieldMapping(
+                    ontology_field="first_seen", node_field="first_seen"
+                ),
+            ],
+        ),
+    ],
+)
+
 SECURITY_ISSUES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws": aws_mapping,
     "semgrep": semgrep_mapping,
     "azure": azure_mapping,
+    "sysdig": sysdig_mapping,
 }

--- a/cartography/models/ontology/mapping/data/tenants.py
+++ b/cartography/models/ontology/mapping/data/tenants.py
@@ -383,6 +383,21 @@ workos_tenants_mapping = OntologyMapping(
 
 # SubImage: No field to map in SubImageTenant (minimal properties beyond id)
 
+# Sysdig
+sysdig_mapping = OntologyMapping(
+    module_name="sysdig",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="SysdigTenant",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+            ],
+        ),
+    ],
+)
+
 # Socket.dev
 socketdev_mapping = OntologyMapping(
     module_name="socketdev",
@@ -437,6 +452,7 @@ TENANTS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "slack": slack_mapping,
     "spacelift": spacelift_mapping,
     "socketdev": socketdev_mapping,
+    "sysdig": sysdig_mapping,
     "workos": workos_tenants_mapping,
     "vercel": vercel_mapping,
 }

--- a/cartography/models/ontology/package.py
+++ b/cartography/models/ontology/package.py
@@ -51,6 +51,18 @@ class PackageToSyftPackageRel(CartographyRelSchema):
     properties: PackageToNodeRelProperties = PackageToNodeRelProperties()
 
 
+# (:Package)-[:DETECTED_AS]->(:SysdigPackage)
+@dataclass(frozen=True)
+class PackageToSysdigPackageRel(CartographyRelSchema):
+    target_node_label: str = "SysdigPackage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"normalized_id": PropertyRef("normalized_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "DETECTED_AS"
+    properties: PackageToNodeRelProperties = PackageToNodeRelProperties()
+
+
 # (:Package)-[:DETECTED_AS]->(:SocketDevDependency)
 @dataclass(frozen=True)
 class PackageToSocketDevDependencyRel(CartographyRelSchema):
@@ -117,6 +129,17 @@ class TrivyImageFindingToPackageRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class SysdigVulnerabilityFindingToPackageRel(CartographyRelSchema):
+    target_node_label: str = "SysdigVulnerabilityFinding"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "AFFECTS"
+    properties: PackageToNodeRelProperties = PackageToNodeRelProperties()
+
+
+@dataclass(frozen=True)
 class PackageSchema(CartographyNodeSchema):
     label: str = "Package"
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Ontology"])
@@ -128,10 +151,12 @@ class PackageSchema(CartographyNodeSchema):
         rels=[
             PackageToTrivyPackageRel(),
             PackageToSyftPackageRel(),
+            PackageToSysdigPackageRel(),
             PackageToSocketDevDependencyRel(),
             PackageToOntologyImageRel(),
             PackageToTrivyFixRel(),
             PackageToPackageDependsOnRel(),
             TrivyImageFindingToPackageRel(),
+            SysdigVulnerabilityFindingToPackageRel(),
         ],
     )

--- a/cartography/models/sysdig/__init__.py
+++ b/cartography/models/sysdig/__init__.py
@@ -1,0 +1,19 @@
+from cartography.models.sysdig.findings import SysdigRiskFindingSchema
+from cartography.models.sysdig.findings import SysdigRuntimeEventSummarySchema
+from cartography.models.sysdig.findings import SysdigSecurityFindingSchema
+from cartography.models.sysdig.findings import SysdigVulnerabilityFindingSchema
+from cartography.models.sysdig.image import SysdigImageSchema
+from cartography.models.sysdig.package import SysdigPackageSchema
+from cartography.models.sysdig.resource import SysdigResourceSchema
+from cartography.models.sysdig.tenant import SysdigTenantSchema
+
+__all__ = [
+    "SysdigImageSchema",
+    "SysdigPackageSchema",
+    "SysdigResourceSchema",
+    "SysdigRiskFindingSchema",
+    "SysdigRuntimeEventSummarySchema",
+    "SysdigSecurityFindingSchema",
+    "SysdigTenantSchema",
+    "SysdigVulnerabilityFindingSchema",
+]

--- a/cartography/models/sysdig/common.py
+++ b/cartography/models/sysdig/common.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class SysdigRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class SysdigNodeToTenantRel(CartographyRelSchema):
+    target_node_label: str = "SysdigTenant"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("TENANT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RESOURCE"
+    properties: SysdigRelProperties = SysdigRelProperties()
+
+
+@dataclass(frozen=True)
+class SysdigNodeToResourceRel(CartographyRelSchema):
+    target_node_label: str = "SysdigResource"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("resource_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "AFFECTS"
+    properties: SysdigRelProperties = SysdigRelProperties()
+
+
+@dataclass(frozen=True)
+class SysdigNodeToOntologyImageRel(CartographyRelSchema):
+    target_node_label: str = "Image"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"_ont_digest": PropertyRef("image_digest")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "AFFECTS"
+    properties: SysdigRelProperties = SysdigRelProperties()

--- a/cartography/models/sysdig/findings.py
+++ b/cartography/models/sysdig/findings.py
@@ -1,0 +1,168 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.sysdig.common import SysdigNodeToOntologyImageRel
+from cartography.models.sysdig.common import SysdigNodeToResourceRel
+from cartography.models.sysdig.common import SysdigNodeToTenantRel
+
+
+@dataclass(frozen=True)
+class SysdigFindingRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class SysdigFindingToPackageRel(CartographyRelSchema):
+    target_node_label: str = "SysdigPackage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"normalized_id": PropertyRef("package_normalized_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "AFFECTS"
+    properties: SysdigFindingRelProperties = SysdigFindingRelProperties()
+
+
+@dataclass(frozen=True)
+class SysdigVulnerabilityFindingNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    name: PropertyRef = PropertyRef("name")
+    cve_id: PropertyRef = PropertyRef("cve_id", extra_index=True)
+    title: PropertyRef = PropertyRef("title")
+    description: PropertyRef = PropertyRef("description")
+    severity: PropertyRef = PropertyRef("severity", extra_index=True)
+    status: PropertyRef = PropertyRef("status")
+    fix_available: PropertyRef = PropertyRef("fix_available")
+    in_use: PropertyRef = PropertyRef("in_use")
+    exploit_available: PropertyRef = PropertyRef("exploit_available")
+    first_seen: PropertyRef = PropertyRef("first_seen")
+    last_seen: PropertyRef = PropertyRef("last_seen")
+    resource_id: PropertyRef = PropertyRef("resource_id", extra_index=True)
+    image_digest: PropertyRef = PropertyRef("image_digest", extra_index=True)
+    package_normalized_id: PropertyRef = PropertyRef(
+        "package_normalized_id", extra_index=True
+    )
+    package_name: PropertyRef = PropertyRef("package_name")
+    package_version: PropertyRef = PropertyRef("package_version")
+    package_type: PropertyRef = PropertyRef("package_type")
+    url: PropertyRef = PropertyRef("url")
+
+
+@dataclass(frozen=True)
+class SysdigVulnerabilityFindingSchema(CartographyNodeSchema):
+    label: str = "SysdigVulnerabilityFinding"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Risk", "CVE"])
+    properties: SysdigVulnerabilityFindingNodeProperties = (
+        SysdigVulnerabilityFindingNodeProperties()
+    )
+    sub_resource_relationship: CartographyRelSchema = SysdigNodeToTenantRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            SysdigNodeToResourceRel(),
+            SysdigNodeToOntologyImageRel(),
+            SysdigFindingToPackageRel(),
+        ],
+    )
+
+
+@dataclass(frozen=True)
+class SysdigSecurityFindingNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    title: PropertyRef = PropertyRef("title")
+    severity: PropertyRef = PropertyRef("severity", extra_index=True)
+    type: PropertyRef = PropertyRef("type")
+    status: PropertyRef = PropertyRef("status")
+    first_seen: PropertyRef = PropertyRef("first_seen")
+    last_seen: PropertyRef = PropertyRef("last_seen")
+    resource_id: PropertyRef = PropertyRef("resource_id", extra_index=True)
+    source_entity: PropertyRef = PropertyRef("source_entity")
+    url: PropertyRef = PropertyRef("url")
+
+
+@dataclass(frozen=True)
+class SysdigSecurityFindingSchema(CartographyNodeSchema):
+    label: str = "SysdigSecurityFinding"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["SecurityIssue"])
+    properties: SysdigSecurityFindingNodeProperties = (
+        SysdigSecurityFindingNodeProperties()
+    )
+    sub_resource_relationship: CartographyRelSchema = SysdigNodeToTenantRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            SysdigNodeToResourceRel(),
+        ],
+    )
+
+
+@dataclass(frozen=True)
+class SysdigRiskFindingNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    title: PropertyRef = PropertyRef("title")
+    severity: PropertyRef = PropertyRef("severity", extra_index=True)
+    type: PropertyRef = PropertyRef("type")
+    status: PropertyRef = PropertyRef("status")
+    first_seen: PropertyRef = PropertyRef("first_seen")
+    last_seen: PropertyRef = PropertyRef("last_seen")
+    resource_id: PropertyRef = PropertyRef("resource_id", extra_index=True)
+    definition_id: PropertyRef = PropertyRef("definition_id")
+    url: PropertyRef = PropertyRef("url")
+
+
+@dataclass(frozen=True)
+class SysdigRiskFindingSchema(CartographyNodeSchema):
+    label: str = "SysdigRiskFinding"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["SecurityIssue"])
+    properties: SysdigRiskFindingNodeProperties = SysdigRiskFindingNodeProperties()
+    sub_resource_relationship: CartographyRelSchema = SysdigNodeToTenantRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            SysdigNodeToResourceRel(),
+        ],
+    )
+
+
+@dataclass(frozen=True)
+class SysdigRuntimeEventSummaryNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    title: PropertyRef = PropertyRef("title")
+    severity: PropertyRef = PropertyRef("severity", extra_index=True)
+    type: PropertyRef = PropertyRef("type")
+    status: PropertyRef = PropertyRef("status")
+    first_seen: PropertyRef = PropertyRef("first_seen")
+    last_seen: PropertyRef = PropertyRef("last_seen")
+    event_count: PropertyRef = PropertyRef("event_count")
+    rule_name: PropertyRef = PropertyRef("rule_name")
+    rule_tags: PropertyRef = PropertyRef("rule_tags")
+    policy_id: PropertyRef = PropertyRef("policy_id")
+    source: PropertyRef = PropertyRef("source")
+    engine: PropertyRef = PropertyRef("engine")
+    resource_id: PropertyRef = PropertyRef("resource_id", extra_index=True)
+    representative_event_id: PropertyRef = PropertyRef("representative_event_id")
+    url: PropertyRef = PropertyRef("url")
+
+
+@dataclass(frozen=True)
+class SysdigRuntimeEventSummarySchema(CartographyNodeSchema):
+    label: str = "SysdigRuntimeEventSummary"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["SecurityIssue"])
+    properties: SysdigRuntimeEventSummaryNodeProperties = (
+        SysdigRuntimeEventSummaryNodeProperties()
+    )
+    sub_resource_relationship: CartographyRelSchema = SysdigNodeToTenantRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            SysdigNodeToResourceRel(),
+        ],
+    )

--- a/cartography/models/sysdig/image.py
+++ b/cartography/models/sysdig/image.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.sysdig.common import SysdigNodeToTenantRel
+
+
+@dataclass(frozen=True)
+class SysdigImageNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    digest: PropertyRef = PropertyRef("digest", extra_index=True)
+    uri: PropertyRef = PropertyRef("uri")
+    architecture: PropertyRef = PropertyRef("architecture")
+    os: PropertyRef = PropertyRef("os")
+
+
+@dataclass(frozen=True)
+class SysdigImageSchema(CartographyNodeSchema):
+    label: str = "SysdigImage"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Image"])
+    properties: SysdigImageNodeProperties = SysdigImageNodeProperties()
+    sub_resource_relationship: CartographyRelSchema = SysdigNodeToTenantRel()

--- a/cartography/models/sysdig/package.py
+++ b/cartography/models/sysdig/package.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.sysdig.common import SysdigNodeToTenantRel
+
+
+@dataclass(frozen=True)
+class SysdigPackageNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    normalized_id: PropertyRef = PropertyRef("normalized_id", extra_index=True)
+    name: PropertyRef = PropertyRef("name")
+    version: PropertyRef = PropertyRef("version")
+    type: PropertyRef = PropertyRef("type")
+    purl: PropertyRef = PropertyRef("purl")
+    image_digest: PropertyRef = PropertyRef("image_digest", extra_index=True)
+
+
+@dataclass(frozen=True)
+class SysdigPackageRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class SysdigPackageToOntologyImageRel(CartographyRelSchema):
+    target_node_label: str = "Image"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"_ont_digest": PropertyRef("image_digest")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "DEPLOYED"
+    properties: SysdigPackageRelProperties = SysdigPackageRelProperties()
+
+
+@dataclass(frozen=True)
+class SysdigPackageSchema(CartographyNodeSchema):
+    label: str = "SysdigPackage"
+    properties: SysdigPackageNodeProperties = SysdigPackageNodeProperties()
+    sub_resource_relationship: CartographyRelSchema = SysdigNodeToTenantRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            SysdigPackageToOntologyImageRel(),
+        ],
+    )

--- a/cartography/models/sysdig/resource.py
+++ b/cartography/models/sysdig/resource.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.sysdig.common import SysdigNodeToTenantRel
+
+
+@dataclass(frozen=True)
+class SysdigResourceNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    name: PropertyRef = PropertyRef("name")
+    type: PropertyRef = PropertyRef("type")
+    cloud_provider: PropertyRef = PropertyRef("cloud_provider")
+    cloud_account_id: PropertyRef = PropertyRef("cloud_account_id")
+    cloud_region: PropertyRef = PropertyRef("cloud_region")
+    cloud_resource_id: PropertyRef = PropertyRef("cloud_resource_id", extra_index=True)
+    cloud_resource_arn: PropertyRef = PropertyRef(
+        "cloud_resource_arn", extra_index=True
+    )
+    kubernetes_cluster: PropertyRef = PropertyRef("kubernetes_cluster")
+    kubernetes_namespace: PropertyRef = PropertyRef("kubernetes_namespace")
+    kubernetes_workload: PropertyRef = PropertyRef("kubernetes_workload")
+    kubernetes_kind: PropertyRef = PropertyRef("kubernetes_kind")
+    container_name: PropertyRef = PropertyRef("container_name")
+    image_digest: PropertyRef = PropertyRef("image_digest", extra_index=True)
+    image_uri: PropertyRef = PropertyRef("image_uri")
+
+
+@dataclass(frozen=True)
+class SysdigResourceSchema(CartographyNodeSchema):
+    label: str = "SysdigResource"
+    properties: SysdigResourceNodeProperties = SysdigResourceNodeProperties()
+    sub_resource_relationship: CartographyRelSchema = SysdigNodeToTenantRel()

--- a/cartography/models/sysdig/tenant.py
+++ b/cartography/models/sysdig/tenant.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+
+
+@dataclass(frozen=True)
+class SysdigTenantNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    name: PropertyRef = PropertyRef("name")
+    api_url: PropertyRef = PropertyRef("api_url")
+
+
+@dataclass(frozen=True)
+class SysdigTenantSchema(CartographyNodeSchema):
+    label: str = "SysdigTenant"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Tenant"])
+    properties: SysdigTenantNodeProperties = SysdigTenantNodeProperties()

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -51,6 +51,7 @@ import cartography.intel.socketdev
 import cartography.intel.spacelift
 import cartography.intel.subimage
 import cartography.intel.syft
+import cartography.intel.sysdig
 import cartography.intel.tailscale
 import cartography.intel.trivy
 import cartography.intel.ubuntu
@@ -105,6 +106,7 @@ TOP_LEVEL_MODULES: OrderedDict[str, Callable[..., None]] = OrderedDict(
         "docker_scout": cartography.intel.docker_scout.start_docker_scout_ingestion,
         "trivy": cartography.intel.trivy.start_trivy_ingestion,
         "syft": cartography.intel.syft.start_syft_ingestion,
+        "sysdig": cartography.intel.sysdig.start_sysdig_ingestion,
         "aibom": cartography.intel.aibom.start_aibom_ingestion,
         "ubuntu": cartography.intel.ubuntu.start_ubuntu_ingestion,
         "sentinelone": cartography.intel.sentinelone.start_sentinelone_ingestion,

--- a/docs/root/modules/sysdig/config.md
+++ b/docs/root/modules/sysdig/config.md
@@ -1,0 +1,32 @@
+## Sysdig Configuration
+
+The Sysdig module uses the
+[Sysdig Secure SysQL API](https://docs.sysdig.com/en/developer-tools/sysql-api/).
+
+1. Create a Sysdig API token or service account token with read access to Search,
+   Inventory, findings, risk, vulnerability, and runtime event data.
+1. Store the token in an environment variable.
+1. Run Cartography with `--selected-modules sysdig` and pass the token
+   environment variable name with `--sysdig-api-token-env-var`.
+
+### Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--sysdig-api-token-env-var` | Environment variable containing the Sysdig API token. | None |
+| `--sysdig-api-url` | Sysdig API base URL. | `https://api.us1.sysdig.com` |
+| `--sysdig-tenant-id` | Stable tenant id for Sysdig data. Defaults to the API hostname. | API hostname |
+| `--sysdig-runtime-event-lookback-hours` | Lookback window for runtime event summaries. | `24` |
+| `--sysdig-page-size` | SysQL query page size. | `1000` |
+
+Example:
+
+```bash
+export SYSDIG_API_TOKEN=...
+cartography \
+  --selected-modules create-indexes,sysdig,ontology,analysis \
+  --sysdig-api-token-env-var SYSDIG_API_TOKEN
+```
+
+The module calls `GET /api/sysql/v2/schema` once per sync and uses
+`POST /api/sysql/v2/query` for paged SysQL queries.

--- a/docs/root/modules/sysdig/index.md
+++ b/docs/root/modules/sysdig/index.md
@@ -1,0 +1,16 @@
+## Sysdig
+
+The Sysdig module ingests security findings from Sysdig Secure into Cartography.
+It is findings-first: it uses Sysdig SysQL to load vulnerability findings,
+security/posture findings, risk findings, and aggregated runtime detection
+summaries. It does not mirror the full Sysdig inventory and does not ingest raw
+Falco event streams.
+
+Primary Sysdig references:
+
+- [SysQL API](https://docs.sysdig.com/en/developer-tools/sysql-api/)
+- [SysQL Reference Library](https://docs.sysdig.com/en/sysdig-secure/sysql-reference/)
+- [Search](https://docs.sysdig.com/en/sysdig-secure/search/)
+- [Risk](https://docs.sysdig.com/en/sysdig-secure/risks/)
+
+See [Configuration](config.md) and [Schema](schema.md).

--- a/docs/root/modules/sysdig/schema.md
+++ b/docs/root/modules/sysdig/schema.md
@@ -1,0 +1,60 @@
+## Sysdig Schema
+
+### SysdigTenant::Tenant
+
+Represents the Sysdig Secure tenant or API endpoint scope.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Tenant id. Defaults to the Sysdig API hostname. |
+| name | Tenant display name. |
+| api_url | Sysdig API base URL. |
+
+### SysdigResource
+
+Represents a Sysdig-observed resource. This node is intentionally not assigned
+broad ontology labels because Sysdig resources can describe many kinds of cloud,
+Kubernetes, container, and workload objects.
+
+### SysdigImage::Image
+
+Represents a container image when Sysdig provides a stable image digest.
+
+### SysdigPackage
+
+Represents a package involved in a Sysdig vulnerability finding.
+`normalized_id` follows the existing package ontology convention:
+`{type}|{namespace/}{normalized_name}|{version}`.
+
+### SysdigVulnerabilityFinding::Risk::CVE
+
+Represents a Sysdig vulnerability assertion. It includes CVE id, severity,
+status, fix availability, in-use context, exploitability, image digest, package
+context, and affected resource id when Sysdig provides those fields.
+
+Relationships:
+
+```text
+(SysdigVulnerabilityFinding)-[:AFFECTS]->(SysdigResource)
+(SysdigVulnerabilityFinding)-[:AFFECTS]->(Image)
+(SysdigVulnerabilityFinding)-[:AFFECTS]->(SysdigPackage)
+```
+
+### SysdigSecurityFinding::SecurityIssue
+
+Represents posture, compliance, or other schema-discovered security findings
+that map cleanly to Cartography's `SecurityIssue` semantics.
+
+### SysdigRiskFinding::SecurityIssue
+
+Represents Sysdig risk findings, preserving Sysdig's correlated risk assertion
+without introducing a new canonical risk ontology type.
+
+### SysdigRuntimeEventSummary::SecurityIssue
+
+Represents aggregated runtime detections. The module groups runtime events by
+resource id, rule name, policy id, severity, source, and engine, then stores
+`first_seen`, `last_seen`, `event_count`, `rule_tags`, and representative
+event metadata.
+
+The module does not ingest raw runtime/Falco events in v1.

--- a/docs/root/usage/schema.md
+++ b/docs/root/usage/schema.md
@@ -141,6 +141,9 @@
 ```{include} ../modules/syft/schema.md
 ```
 
+```{include} ../modules/sysdig/schema.md
+```
+
 ```{include} ../modules/spacelift/schema.md
 ```
 

--- a/tests/integration/cartography/intel/sysdig/test_sysdig.py
+++ b/tests/integration/cartography/intel/sysdig/test_sysdig.py
@@ -1,0 +1,200 @@
+from cartography.intel.sysdig import sync
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_DIGEST = "sha256:" + "a" * 64
+
+
+class FakeSysdigClient:
+    def get_schema(self):
+        return {
+            "entities": [
+                {"name": "Vulnerability"},
+                {"name": "RiskFinding"},
+                {"name": "PostureFinding"},
+                {"name": "RuntimeEvent"},
+                {"name": "KubeWorkload"},
+            ],
+        }
+
+    def query(self, query, parameters=None):
+        if "Vulnerability" in query:
+            return [
+                {
+                    "resource": {
+                        "id": "resource-1",
+                        "name": "prod-pod",
+                        "type": "KubernetesResource",
+                        "cluster": "prod",
+                        "namespace": "default",
+                        "imageDigest": TEST_DIGEST,
+                    },
+                    "vulnerability": {
+                        "cveId": "CVE-2026-0001",
+                        "title": "openssl vuln",
+                        "severity": "high",
+                        "status": "active",
+                        "packageName": "openssl",
+                        "packageVersion": "3.0.0",
+                        "packageType": "apk",
+                    },
+                    "package": {
+                        "name": "openssl",
+                        "version": "3.0.0",
+                        "type": "apk",
+                    },
+                }
+            ]
+        if "RiskFinding" in query:
+            return [
+                {
+                    "resource": {"id": "resource-1", "name": "prod-pod"},
+                    "finding": {
+                        "id": "risk-1",
+                        "title": "Public workload with exploitable CVE",
+                        "severity": "critical",
+                        "status": "open",
+                    },
+                }
+            ]
+        if "PostureFinding" in query:
+            return [
+                {
+                    "resource": {"id": "resource-1", "name": "prod-pod"},
+                    "finding": {
+                        "id": "posture-1",
+                        "title": "Privileged container",
+                        "severity": "high",
+                        "status": "open",
+                    },
+                }
+            ]
+        if "RuntimeEvent" in query:
+            return [
+                {
+                    "resource": {"id": "resource-1", "name": "prod-pod"},
+                    "event": {
+                        "id": "event-1",
+                        "ruleName": "Terminal shell in container",
+                        "policyId": "policy-1",
+                        "severity": "high",
+                        "source": "syscall",
+                        "engine": "falco",
+                        "timestamp": "2026-04-25T00:00:00Z",
+                    },
+                },
+                {
+                    "resource": {"id": "resource-1", "name": "prod-pod"},
+                    "event": {
+                        "id": "event-2",
+                        "ruleName": "Terminal shell in container",
+                        "policyId": "policy-1",
+                        "severity": "high",
+                        "source": "syscall",
+                        "engine": "falco",
+                        "timestamp": "2026-04-25T01:00:00Z",
+                    },
+                },
+            ]
+        return []
+
+
+def test_sysdig_sync_loads_findings_and_relationships(neo4j_session):
+    neo4j_session.run("MATCH (n:SysdigTenant) DETACH DELETE n")
+    neo4j_session.run("MATCH (n:SysdigResource) DETACH DELETE n")
+    neo4j_session.run("MATCH (n:SysdigImage) DETACH DELETE n")
+    neo4j_session.run("MATCH (n:SysdigPackage) DETACH DELETE n")
+    neo4j_session.run("MATCH (n:SysdigVulnerabilityFinding) DETACH DELETE n")
+    neo4j_session.run("MATCH (n:SysdigSecurityFinding) DETACH DELETE n")
+    neo4j_session.run("MATCH (n:SysdigRiskFinding) DETACH DELETE n")
+    neo4j_session.run("MATCH (n:SysdigRuntimeEventSummary) DETACH DELETE n")
+
+    sync(
+        neo4j_session,
+        FakeSysdigClient(),
+        "https://api.us1.sysdig.com",
+        "api.us1.sysdig.com",
+        TEST_UPDATE_TAG,
+        24,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert check_nodes(neo4j_session, "SysdigTenant", ["id"]) == {
+        ("api.us1.sysdig.com",),
+    }
+    assert check_nodes(neo4j_session, "SysdigResource", ["id", "name"]) == {
+        ("resource-1", "prod-pod"),
+    }
+    assert check_nodes(neo4j_session, "SysdigImage", ["id", "digest"]) == {
+        (TEST_DIGEST, TEST_DIGEST),
+    }
+    assert check_nodes(
+        neo4j_session, "SysdigPackage", ["normalized_id", "name", "version"]
+    ) == {
+        ("apk|openssl|3.0.0", "openssl", "3.0.0"),
+    }
+    assert check_nodes(
+        neo4j_session, "SysdigRuntimeEventSummary", ["rule_name", "event_count"]
+    ) == {
+        ("Terminal shell in container", 2),
+    }
+
+    finding_rows = neo4j_session.run(
+        """
+        MATCH (f:SysdigVulnerabilityFinding)
+        RETURN f.cve_id AS cve_id, f.severity AS severity
+        """
+    )
+    assert {(row["cve_id"], row["severity"]) for row in finding_rows} == {
+        ("CVE-2026-0001", "high"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "SysdigVulnerabilityFinding",
+        "cve_id",
+        "SysdigPackage",
+        "normalized_id",
+        "AFFECTS",
+    ) == {
+        ("CVE-2026-0001", "apk|openssl|3.0.0"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "SysdigPackage",
+        "normalized_id",
+        "SysdigImage",
+        "digest",
+        "DEPLOYED",
+    ) == {
+        ("apk|openssl|3.0.0", TEST_DIGEST),
+    }
+
+
+def test_sysdig_cleanup_does_not_delete_unrelated_nodes(neo4j_session):
+    neo4j_session.run(
+        "MERGE (:AWSAccount {id: '123456789012', lastupdated: 1, name: 'prod'})"
+    )
+    neo4j_session.run(
+        """
+        MERGE (t:SysdigTenant {id: 'api.us1.sysdig.com', lastupdated: 1})
+        MERGE (r:SysdigResource {id: 'stale-resource', lastupdated: 1})
+        MERGE (r)-[:RESOURCE {lastupdated: 1}]->(t)
+        """
+    )
+
+    sync(
+        neo4j_session,
+        FakeSysdigClient(),
+        "https://api.us1.sysdig.com",
+        "api.us1.sysdig.com",
+        TEST_UPDATE_TAG,
+        24,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert check_nodes(neo4j_session, "AWSAccount", ["id"]) == {("123456789012",)}
+    assert ("stale-resource",) not in check_nodes(
+        neo4j_session, "SysdigResource", ["id"]
+    )

--- a/tests/unit/cartography/intel/ontology/test_package_cleanup_queries.py
+++ b/tests/unit/cartography/intel/ontology/test_package_cleanup_queries.py
@@ -8,10 +8,12 @@ def test_package_cleanup_queries_cover_derived_relationships():
     expected_rel_clauses = [
         "MATCH (n)-[r:DETECTED_AS]->(:TrivyPackage)",
         "MATCH (n)-[r:DETECTED_AS]->(:SyftPackage)",
+        "MATCH (n)-[r:DETECTED_AS]->(:SysdigPackage)",
         "MATCH (n)-[r:DEPLOYED]->(:Image)",
         "MATCH (n)-[r:SHOULD_UPDATE_TO]->(:TrivyFix)",
         "MATCH (n)-[r:DEPENDS_ON]->(:Package)",
         "MATCH (n)<-[r:AFFECTS]-(:TrivyImageFinding)",
+        "MATCH (n)<-[r:AFFECTS]-(:SysdigVulnerabilityFinding)",
     ]
 
     for clause in expected_rel_clauses:

--- a/tests/unit/cartography/intel/sysdig/test_client.py
+++ b/tests/unit/cartography/intel/sysdig/test_client.py
@@ -1,0 +1,78 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from cartography.intel.sysdig.client import schema_has_entity
+from cartography.intel.sysdig.client import SysdigClient
+
+
+def test_query_paginates_until_short_page() -> None:
+    client = SysdigClient("https://api.us1.sysdig.com", "token", page_size=2)
+    first = Mock(status_code=200)
+    first.json.return_value = {"data": [{"id": "1"}, {"id": "2"}]}
+    second = Mock(status_code=200)
+    second.json.return_value = {"data": [{"id": "3"}]}
+
+    with patch.object(client.session, "request", side_effect=[first, second]) as req:
+        assert client.query("MATCH n RETURN n") == [
+            {"id": "1"},
+            {"id": "2"},
+            {"id": "3"},
+        ]
+
+    assert req.call_args_list[0].kwargs["json"]["query"].endswith("LIMIT 2 OFFSET 0")
+    assert req.call_args_list[1].kwargs["json"]["query"].endswith("LIMIT 2 OFFSET 2")
+
+
+def test_query_retries_retryable_status() -> None:
+    client = SysdigClient("https://api.us1.sysdig.com", "token", page_size=2)
+    retry = Mock(status_code=429)
+    retry.raise_for_status.side_effect = requests.HTTPError("rate limited")
+    ok = Mock(status_code=200)
+    ok.json.return_value = {"data": []}
+
+    with (
+        patch("cartography.intel.sysdig.client.time.sleep"),
+        patch.object(client.session, "request", side_effect=[retry, ok]) as req,
+    ):
+        assert client.query("MATCH n RETURN n") == []
+
+    assert req.call_count == 2
+
+
+def test_query_fails_fast_on_auth_status() -> None:
+    client = SysdigClient("https://api.us1.sysdig.com", "token", page_size=2)
+    forbidden = Mock(status_code=403)
+    forbidden.raise_for_status.side_effect = requests.HTTPError("forbidden")
+
+    with patch.object(client.session, "request", return_value=forbidden):
+        with pytest.raises(requests.HTTPError):
+            client.query("MATCH n RETURN n")
+
+
+def test_schema_has_entity_walks_nested_schema() -> None:
+    schema = {
+        "entities": [
+            {"name": "Vulnerability"},
+            {"relationships": [{"target": {"name": "RuntimeEvent"}}]},
+        ],
+    }
+
+    assert schema_has_entity(schema, "Vulnerability")
+    assert schema_has_entity(schema, "RuntimeEvent")
+    assert schema_has_entity({"KubeWorkload": {"fields": []}}, "KubeWorkload")
+    assert not schema_has_entity(schema, "NotReal")
+
+
+def test_get_schema_accepts_yaml_response() -> None:
+    client = SysdigClient("https://api.us1.sysdig.com", "token")
+    response = Mock(status_code=200)
+    response.json.side_effect = ValueError("not json")
+    response.text = "index:\n  - type: Entity\n    name: KubeWorkload\n"
+
+    with patch.object(client.session, "request", return_value=response):
+        schema = client.get_schema()
+
+    assert schema_has_entity(schema, "KubeWorkload")

--- a/tests/unit/cartography/intel/sysdig/test_transform.py
+++ b/tests/unit/cartography/intel/sysdig/test_transform.py
@@ -1,0 +1,94 @@
+from cartography.intel.sysdig.transform import normalize_severity
+from cartography.intel.sysdig.transform import normalize_status
+from cartography.intel.sysdig.transform import transform_runtime_event_summaries
+from cartography.intel.sysdig.transform import transform_vulnerabilities
+
+
+def test_transform_vulnerability_rows() -> None:
+    rows = [
+        {
+            "resource": {
+                "id": "aws:arn:resource",
+                "name": "prod-pod",
+                "type": "KubernetesResource",
+                "cluster": "prod",
+                "namespace": "default",
+                "imageDigest": "f" * 64,
+                "imageUri": "example.com/app@sha256:" + "f" * 64,
+            },
+            "vulnerability": {
+                "cveId": "CVE-2026-0001",
+                "severity": "4",
+                "status": "ACTIVE",
+                "fixAvailable": True,
+                "inUse": True,
+                "exploitAvailable": False,
+                "packageName": "Requests",
+                "packageVersion": "2.31.0",
+                "packageType": "pypi",
+            },
+            "package": {
+                "name": "Requests",
+                "version": "2.31.0",
+                "type": "pypi",
+                "purl": "pkg:pypi/Requests@2.31.0",
+            },
+        }
+    ]
+
+    resources, images, packages, findings = transform_vulnerabilities(rows, "tenant")
+
+    assert resources[0]["id"] == "aws:arn:resource"
+    assert images[0]["digest"] == "sha256:" + "f" * 64
+    assert packages[0]["normalized_id"] == "pypi|requests|2.31.0"
+    assert findings[0]["cve_id"] == "CVE-2026-0001"
+    assert findings[0]["severity"] == "critical"
+    assert findings[0]["status"] == "open"
+    assert findings[0]["package_normalized_id"] == "pypi|requests|2.31.0"
+
+
+def test_runtime_events_aggregate_by_rule_and_resource() -> None:
+    rows = [
+        {
+            "resource": {"id": "resource-1", "name": "pod-a"},
+            "event": {
+                "id": "evt-1",
+                "ruleName": "Terminal shell in container",
+                "policyId": "policy-1",
+                "severity": "high",
+                "source": "syscall",
+                "engine": "falco",
+                "timestamp": "2026-04-25T00:00:00Z",
+                "ruleTags": ["container"],
+            },
+        },
+        {
+            "resource": {"id": "resource-1", "name": "pod-a"},
+            "event": {
+                "id": "evt-2",
+                "ruleName": "Terminal shell in container",
+                "policyId": "policy-1",
+                "severity": "high",
+                "source": "syscall",
+                "engine": "falco",
+                "timestamp": "2026-04-25T01:00:00Z",
+                "ruleTags": ["container"],
+            },
+        },
+    ]
+
+    resources, summaries = transform_runtime_event_summaries(rows, "tenant")
+
+    assert len(resources) == 1
+    assert len(summaries) == 1
+    assert summaries[0]["event_count"] == 2
+    assert summaries[0]["first_seen"] == "2026-04-25T00:00:00Z"
+    assert summaries[0]["last_seen"] == "2026-04-25T01:00:00Z"
+    assert summaries[0]["rule_tags"] == ["container"]
+
+
+def test_normalization_helpers() -> None:
+    assert normalize_severity("1") == "low"
+    assert normalize_severity("CRITICAL") == "critical"
+    assert normalize_status("risk accepted") == "accepted"
+    assert normalize_status("ACTIVE") == "open"


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary
Adds a findings-first Sysdig Secure intel module backed by SysQL. The module ingests vulnerability findings, schema-discovered security/risk findings, Sysdig-observed resources, images, packages, and aggregated runtime event summaries without importing raw event streams or mirroring full Sysdig inventory.

The implementation also wires Sysdig into Cartography config/CLI/sync, adds ontology mappings where Sysdig has stable identifiers, and extends package ontology analysis so Sysdig packages and vulnerability findings can connect to canonical Package/Image views.


### Related issues or links

- Sysdig SysQL API: https://docs.sysdig.com/en/developer-tools/sysql-api/
- Sysdig SysQL reference: https://docs.sysdig.com/en/sysdig-secure/sysql-reference/


### Breaking changes

None.


### How was this tested?

- Not tested yet

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [x] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

This first version intentionally focuses on security assertions rather than full inventory replication. Broad Sysdig resource rows remain provider-specific unless they have stable identifiers suitable for ontology mapping.

Runtime events are aggregated by resource, rule, policy, severity, source, and engine. Raw per-event ingestion is intentionally out of scope.

No live Sysdig tenant logs are included in this PR; validation is covered with unit tests and mocked integration tests.
