### PR TITLE
perf(gcp): tighten permission relationship reads

### DIFF
--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -138,6 +138,7 @@ def _sync_project_resources(
     common_job_parameters: Dict,
     credentials: GoogleCredentials,
     requested_syncs: Set[str] | None = None,
+    org_role_permissions_by_name: dict[str, list[str]] | None = None,
 ) -> None:
     """
     Syncs GCP service-specific resources (Compute, Storage, GKE, DNS, IAM) for each project.
@@ -173,6 +174,10 @@ def _sync_project_resources(
         project_id = project["projectId"]
         common_job_parameters["PROJECT_ID"] = project_id
         policy_bindings_status: policy_bindings.PolicyBindingsSyncStatus | None = None
+        permission_context: (
+            permission_relationships.GCPPrincipalPermissionContext | None
+        ) = None
+        role_permissions_by_name = dict(org_role_permissions_by_name or {})
         enabled_services = _services_enabled_on_project(
             build_client("serviceusage", "v1", credentials=credentials),
             project_id,
@@ -251,12 +256,15 @@ def _sync_project_resources(
         if service_names.iam in enabled_services:
             logger.info("Syncing GCP project %s for IAM.", project_id)
             iam_cred = build_client("iam", "v1", credentials=credentials)
-            iam.sync(
+            project_roles = iam.sync(
                 neo4j_session,
                 iam_cred,
                 project_id,
                 gcp_update_tag,
                 common_job_parameters,
+            )
+            role_permissions_by_name.update(
+                iam.build_role_permissions_by_name(project_roles)
             )
             iam_sync_succeeded = True
         if service_names.kms in enabled_services:
@@ -290,12 +298,15 @@ def _sync_project_resources(
                 project_id,
             )
             try:
-                cai.sync(
+                project_roles = cai.sync(
                     neo4j_session,
                     cai_rest_client,
                     project_id,
                     gcp_update_tag,
                     common_job_parameters,
+                )
+                role_permissions_by_name.update(
+                    iam.build_role_permissions_by_name(project_roles)
                 )
                 iam_sync_succeeded = True
             except HttpError as e:
@@ -658,13 +669,16 @@ def _sync_project_resources(
                     "Syncing IAM policies for GCP project %s.",
                     project_id,
                 )
-                policy_bindings_status = policy_bindings.sync(
+                policy_bindings_result = policy_bindings.sync(
                     neo4j_session,
                     project_id,
                     gcp_update_tag,
                     common_job_parameters,
                     cai_grpc_client,
+                    role_permissions_by_name,
                 )
+                policy_bindings_status = policy_bindings_result.status
+                permission_context = policy_bindings_result.permission_context
                 # Track if we have permission. Once set to False (permission denied),
                 # the outer condition will skip policy_bindings for remaining projects.
                 if (
@@ -673,10 +687,18 @@ def _sync_project_resources(
                 ):
                     policy_bindings_permission_ok = False
 
-        if requested_syncs is None or "permission_relationships" in requested_syncs:
-            if (
-                policy_bindings_requested
-                and policy_bindings_status
+        permission_relationships_requested = (
+            requested_syncs is None or "permission_relationships" in requested_syncs
+        )
+        if permission_relationships_requested:
+            if not policy_bindings_requested:
+                logger.warning(
+                    "Skipping GCP permission relationships for project %s because policy bindings were not requested. "
+                    "Permission relationships are calculated from policy bindings in the same sync run.",
+                    project_id,
+                )
+            elif (
+                policy_bindings_status
                 != policy_bindings.PolicyBindingsSyncStatus.SUCCESS
             ):
                 assert policy_bindings_status is not None
@@ -688,11 +710,13 @@ def _sync_project_resources(
                     status_label,
                 )
             else:
+                assert permission_context is not None
                 permission_relationships.sync(
                     neo4j_session,
                     project_id,
                     gcp_update_tag,
                     common_job_parameters,
+                    permission_context,
                 )
 
         # Clean up project-level IAM resources (service accounts and project roles)
@@ -849,13 +873,16 @@ def start_gcp_ingestion(
                 f"Syncing organization-level IAM for {org_resource_name}",
             )
             iam_client = build_client("iam", "v1", credentials=credentials)
-            iam.sync_org_iam(
+            org_roles = iam.sync_org_iam(
                 neo4j_session,
                 iam_client,
                 org_resource_name,
                 config.update_tag,
                 common_job_parameters,
             )
+            org_role_permissions_by_name = iam.build_role_permissions_by_name(org_roles)
+        else:
+            org_role_permissions_by_name = {}
 
         # Ingest per-project resources (these run their own cleanup immediately since they're leaf nodes)
         _sync_project_resources(
@@ -865,6 +892,7 @@ def start_gcp_ingestion(
             common_job_parameters,
             credentials=credentials,
             requested_syncs=requested_syncs,
+            org_role_permissions_by_name=org_role_permissions_by_name,
         )
 
         # Clean up org-level roles for this org (after all project resources have been synced)

--- a/cartography/intel/gcp/cai.py
+++ b/cartography/intel/gcp/cai.py
@@ -218,7 +218,7 @@ def sync(
     project_id: str,
     gcp_update_tag: int,
     common_job_parameters: Dict[str, Any],
-) -> None:
+) -> list[dict[str, Any]]:
     """
     Sync GCP IAM resources for a given project using Cloud Asset Inventory API.
 
@@ -262,3 +262,5 @@ def sync(
 
     if roles:
         load_gcp_roles_cai(neo4j_session, roles, project_id, gcp_update_tag)
+
+    return roles

--- a/cartography/intel/gcp/iam.py
+++ b/cartography/intel/gcp/iam.py
@@ -213,6 +213,16 @@ def transform_project_roles(
     return result
 
 
+def build_role_permissions_by_name(
+    roles: list[dict[str, Any]],
+) -> dict[str, list[str]]:
+    return {
+        role["name"]: role.get("includedPermissions", [])
+        for role in roles
+        if role.get("name")
+    }
+
+
 @timeit
 def load_org_roles(
     neo4j_session: neo4j.Session,
@@ -334,7 +344,7 @@ def sync_org_iam(
     org_id: str,
     gcp_update_tag: int,
     common_job_parameters: Dict[str, Any],
-) -> None:
+) -> list[dict[str, Any]]:
     """
     Sync organization-level IAM resources (predefined roles + custom org roles).
 
@@ -367,6 +377,7 @@ def sync_org_iam(
 
     # Load roles with organization as parent
     load_org_roles(neo4j_session, roles, org_id, gcp_update_tag)
+    return roles
 
 
 @timeit
@@ -376,7 +387,7 @@ def sync(
     project_id: str,
     gcp_update_tag: int,
     common_job_parameters: Dict[str, Any],
-) -> None:
+) -> list[dict[str, Any]]:
     """
     Sync GCP IAM resources for a given project.
 
@@ -412,6 +423,8 @@ def sync(
         f"Found {len(project_roles_raw)} custom project roles in project {project_id}"
     )
 
-    if project_roles_raw:
-        roles = transform_project_roles(project_roles_raw, project_id)
+    roles = transform_project_roles(project_roles_raw, project_id)
+    if roles:
         load_project_roles(neo4j_session, roles, project_id, gcp_update_tag)
+
+    return roles

--- a/cartography/intel/gcp/iam.py
+++ b/cartography/intel/gcp/iam.py
@@ -216,11 +216,13 @@ def transform_project_roles(
 def build_role_permissions_by_name(
     roles: list[dict[str, Any]],
 ) -> dict[str, list[str]]:
-    return {
-        role["name"]: role.get("includedPermissions", [])
-        for role in roles
-        if role.get("name")
-    }
+    role_permissions_by_name: dict[str, list[str]] = {}
+    for role in roles:
+        name = role.get("name")
+        permissions = role.get("includedPermissions")
+        if name and permissions:
+            role_permissions_by_name[name] = permissions
+    return role_permissions_by_name
 
 
 @timeit

--- a/cartography/intel/gcp/permission_relationships.py
+++ b/cartography/intel/gcp/permission_relationships.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import re
-import time
 from collections.abc import Iterator
 from string import Template
 from typing import Any
@@ -11,17 +10,15 @@ import neo4j
 import yaml
 
 from cartography.client.core.tx import load_matchlinks
-from cartography.client.core.tx import read_list_of_dicts_tx
 from cartography.client.core.tx import read_list_of_values_tx
 from cartography.graph.job import GraphJob
-from cartography.helpers import batch as batch_items
 from cartography.models.gcp.permission_relationships import GCPPermissionMatchLink
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 GCP_PERMISSION_RELATIONSHIP_BATCH_SIZE = 500
-GCP_POLICY_BINDING_READ_BATCH_SIZE = 500
+GCPPrincipalPermissionContext = dict[str, dict[str, dict[str, Any]]]
 
 
 def resolve_gcp_scope(scope: str, project_id: str) -> str:
@@ -183,133 +180,58 @@ def iter_permission_relationship_batches(
 
 
 @timeit
-def get_principals_for_project(
-    neo4j_session: neo4j.Session, project_id: str
-) -> dict[str, Any]:
+def build_principals_from_policy_bindings(
+    policy_bindings: list[dict[str, Any]],
+    role_permissions_by_name: dict[str, list[str]],
+    project_id: str,
+) -> GCPPrincipalPermissionContext:
     """
-    Get all principals (users, service accounts, groups) with their policy bindings
-    for a given GCP project.
+    Build the permission evaluation input directly from the current sync's
+    transformed policy bindings and IAM role payloads.
     """
-    binding_ids = get_policy_binding_ids_for_project(neo4j_session, project_id)
-    logger.info(
-        "Found %d GCP policy bindings eligible for permission relationships in project '%s'.",
-        len(binding_ids),
-        project_id,
-    )
-    if not binding_ids:
-        return {}
-
-    principals: dict[str, Any] = {}
+    principals: GCPPrincipalPermissionContext = {}
     compiled_assignments: dict[str, dict[str, Any]] = {}
-    total_rows = 0
-    read_batches = 0
-    for binding_ids_batch in batch_items(
-        binding_ids,
-        size=GCP_POLICY_BINDING_READ_BATCH_SIZE,
-    ):
-        batch_start = time.perf_counter()
-        results = get_principal_rows_for_policy_bindings(
-            neo4j_session,
-            project_id,
-            binding_ids_batch,
-        )
-        merge_principal_rows(
-            principals,
-            results,
-            project_id,
-            compiled_assignments,
-        )
-        total_rows += len(results)
-        read_batches += 1
-        logger.debug(
-            "Processed GCP principal policy binding batch for project '%s': binding_count=%d elapsed=%.3fs",
-            project_id,
-            len(binding_ids_batch),
-            time.perf_counter() - batch_start,
-        )
+    skipped_conditional = 0
+    skipped_missing_roles = 0
+    total_member_assignments = 0
 
-    logger.info(
-        "Completed GCP principal read for permission relationships in project '%s': eligible_bindings=%d, read_batches=%d, rows=%d, principals=%d, bindings=%d",
-        project_id,
-        len(binding_ids),
-        read_batches,
-        total_rows,
-        len(principals),
-        len(compiled_assignments),
-    )
+    for binding in policy_bindings:
+        if binding["has_condition"]:
+            skipped_conditional += 1
+            continue
 
-    return principals
+        role = binding["role"]
+        role_permissions = role_permissions_by_name.get(role)
+        if role_permissions is None:
+            skipped_missing_roles += 1
+            continue
 
-
-@timeit
-def get_policy_binding_ids_for_project(
-    neo4j_session: neo4j.Session,
-    project_id: str,
-) -> list[str]:
-    get_binding_ids_query = """
-    MATCH (:GCPProject{id: $ProjectId})-[:RESOURCE]->(binding:GCPPolicyBinding)
-    WHERE binding.has_condition = false
-    RETURN DISTINCT binding.id
-    ORDER BY binding.id
-    """
-    return neo4j_session.execute_read(
-        read_list_of_values_tx,
-        get_binding_ids_query,
-        ProjectId=project_id,
-    )
-
-
-@timeit
-def get_principal_rows_for_policy_bindings(
-    neo4j_session: neo4j.Session,
-    project_id: str,
-    binding_ids: list[str],
-) -> list[dict[str, Any]]:
-    get_principals_query = """
-    MATCH
-    (project:GCPProject{id: $ProjectId})-[:RESOURCE]->
-    (binding:GCPPolicyBinding)-[:GRANTS_ROLE]->
-    (role:GCPRole)
-    MATCH (principal:GCPPrincipal)-[:HAS_ALLOW_POLICY]->(binding)
-    WHERE binding.has_condition = false
-    AND binding.id IN $BindingIds
-    RETURN
-    DISTINCT principal.email as principal_email, binding.id as binding_id,
-    binding.resource as binding_resource, role.permissions as role_permissions
-    """
-
-    return neo4j_session.execute_read(
-        read_list_of_dicts_tx,
-        get_principals_query,
-        ProjectId=project_id,
-        BindingIds=binding_ids,
-    )
-
-
-def merge_principal_rows(
-    principals: dict[str, Any],
-    rows: list[dict[str, Any]],
-    project_id: str,
-    compiled_assignments: dict[str, dict[str, Any]],
-) -> None:
-    for r in rows:
-        principal_email = r["principal_email"]
-        binding_id = r["binding_id"]
-
-        if principal_email not in principals:
-            principals[principal_email] = {}
-
+        binding_id = binding["id"]
         if binding_id not in compiled_assignments:
-            binding_resource = r["binding_resource"]
-            role_permissions = r["role_permissions"] or []
             compiled_assignments[binding_id] = {
                 "permissions": compile_permissions_from_role(role_permissions),
                 "scope": compile_gcp_regex(
-                    resolve_gcp_scope(binding_resource, project_id)
+                    resolve_gcp_scope(binding["resource"], project_id)
                 ),
             }
 
-        principals[principal_email][binding_id] = compiled_assignments[binding_id]
+        for principal_email in binding["members"]:
+            principals.setdefault(principal_email, {})[binding_id] = (
+                compiled_assignments[binding_id]
+            )
+            total_member_assignments += 1
+
+    logger.info(
+        "Built GCP permission evaluation context for project '%s': bindings=%d, usable_bindings=%d, member_assignments=%d, principals=%d, skipped_conditional=%d, skipped_missing_roles=%d",
+        project_id,
+        len(policy_bindings),
+        len(compiled_assignments),
+        total_member_assignments,
+        len(principals),
+        skipped_conditional,
+        skipped_missing_roles,
+    )
+    return principals
 
 
 def compile_permissions_from_role(role_permissions: list[str]) -> dict[str, Any]:
@@ -430,7 +352,7 @@ def load_principal_mappings(
 @timeit
 def evaluate_and_load_permission_relationships(
     neo4j_session: neo4j.Session,
-    principals: dict[str, Any],
+    principals: GCPPrincipalPermissionContext,
     resource_dict: dict[str, str],
     permissions: list[str],
     matchlink_schema: GCPPermissionMatchLink,
@@ -524,6 +446,7 @@ def sync(
     project_id: str,
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    principals: GCPPrincipalPermissionContext,
 ) -> None:
     logger.info("Syncing GCP Permission Relationships for project '%s'.", project_id)
 
@@ -535,13 +458,10 @@ def sync(
         )
         return
 
-    # 1. GET - Fetch all GCP principals in suitable dict format
-    principals = get_principals_for_project(neo4j_session, project_id)
-
-    # 2. PARSE - Parse relationship file
+    # 1. PARSE - Parse relationship file
     relationship_mapping = parse_permission_relationships_file(pr_file)
 
-    # 3. EVALUATE - Evaluate each relationship and resource ID
+    # 2. EVALUATE - Evaluate each relationship and resource ID
     for rpr in relationship_mapping:
         if not is_valid_gcp_rpr(rpr):
             logger.error(f"Invalid permission relationship configuration: {rpr}")

--- a/cartography/intel/gcp/permission_relationships.py
+++ b/cartography/intel/gcp/permission_relationships.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import time
 from collections.abc import Iterator
 from string import Template
 from typing import Any
@@ -199,21 +200,43 @@ def get_principals_for_project(
         return {}
 
     principals: dict[str, Any] = {}
+    compiled_assignments: dict[str, dict[str, Any]] = {}
+    total_rows = 0
+    read_batches = 0
     for binding_ids_batch in batch_items(
         binding_ids,
         size=GCP_POLICY_BINDING_READ_BATCH_SIZE,
     ):
-        logger.debug(
-            "Fetching GCP principal policy bindings for project '%s' with %d binding ids.",
-            project_id,
-            len(binding_ids_batch),
-        )
+        batch_start = time.perf_counter()
         results = get_principal_rows_for_policy_bindings(
             neo4j_session,
             project_id,
             binding_ids_batch,
         )
-        merge_principal_rows(principals, results, project_id)
+        merge_principal_rows(
+            principals,
+            results,
+            project_id,
+            compiled_assignments,
+        )
+        total_rows += len(results)
+        read_batches += 1
+        logger.debug(
+            "Processed GCP principal policy binding batch for project '%s': binding_count=%d elapsed=%.3fs",
+            project_id,
+            len(binding_ids_batch),
+            time.perf_counter() - batch_start,
+        )
+
+    logger.info(
+        "Completed GCP principal read for permission relationships in project '%s': eligible_bindings=%d, read_batches=%d, rows=%d, principals=%d, bindings=%d",
+        project_id,
+        len(binding_ids),
+        read_batches,
+        total_rows,
+        len(principals),
+        len(compiled_assignments),
+    )
 
     return principals
 
@@ -265,26 +288,26 @@ def merge_principal_rows(
     principals: dict[str, Any],
     rows: list[dict[str, Any]],
     project_id: str,
+    compiled_assignments: dict[str, dict[str, Any]],
 ) -> None:
     for r in rows:
         principal_email = r["principal_email"]
         binding_id = r["binding_id"]
-        binding_resource = r["binding_resource"]
-        role_permissions = r["role_permissions"] or []
 
         if principal_email not in principals:
             principals[principal_email] = {}
 
-        # Compile permissions from role
-        compiled_permissions = compile_permissions_from_role(role_permissions)
-        compiled_scope = compile_gcp_regex(
-            resolve_gcp_scope(binding_resource, project_id)
-        )
+        if binding_id not in compiled_assignments:
+            binding_resource = r["binding_resource"]
+            role_permissions = r["role_permissions"] or []
+            compiled_assignments[binding_id] = {
+                "permissions": compile_permissions_from_role(role_permissions),
+                "scope": compile_gcp_regex(
+                    resolve_gcp_scope(binding_resource, project_id)
+                ),
+            }
 
-        principals[principal_email][binding_id] = {
-            "permissions": compiled_permissions,
-            "scope": compiled_scope,
-        }
+        principals[principal_email][binding_id] = compiled_assignments[binding_id]
 
 
 def compile_permissions_from_role(role_permissions: list[str]) -> dict[str, Any]:

--- a/cartography/intel/gcp/permission_relationships.py
+++ b/cartography/intel/gcp/permission_relationships.py
@@ -13,12 +13,14 @@ from cartography.client.core.tx import load_matchlinks
 from cartography.client.core.tx import read_list_of_dicts_tx
 from cartography.client.core.tx import read_list_of_values_tx
 from cartography.graph.job import GraphJob
+from cartography.helpers import batch as batch_items
 from cartography.models.gcp.permission_relationships import GCPPermissionMatchLink
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 GCP_PERMISSION_RELATIONSHIP_BATCH_SIZE = 500
+GCP_POLICY_BINDING_READ_BATCH_SIZE = 500
 
 
 def resolve_gcp_scope(scope: str, project_id: str) -> str:
@@ -187,27 +189,84 @@ def get_principals_for_project(
     Get all principals (users, service accounts, groups) with their policy bindings
     for a given GCP project.
     """
+    binding_ids = get_policy_binding_ids_for_project(neo4j_session, project_id)
+    logger.info(
+        "Found %d GCP policy bindings eligible for permission relationships in project '%s'.",
+        len(binding_ids),
+        project_id,
+    )
+    if not binding_ids:
+        return {}
+
+    principals: dict[str, Any] = {}
+    for binding_ids_batch in batch_items(
+        binding_ids,
+        size=GCP_POLICY_BINDING_READ_BATCH_SIZE,
+    ):
+        logger.debug(
+            "Fetching GCP principal policy bindings for project '%s' with %d binding ids.",
+            project_id,
+            len(binding_ids_batch),
+        )
+        results = get_principal_rows_for_policy_bindings(
+            neo4j_session,
+            project_id,
+            binding_ids_batch,
+        )
+        merge_principal_rows(principals, results, project_id)
+
+    return principals
+
+
+def get_policy_binding_ids_for_project(
+    neo4j_session: neo4j.Session,
+    project_id: str,
+) -> list[str]:
+    get_binding_ids_query = """
+    MATCH (:GCPProject{id: $ProjectId})-[:RESOURCE]->(binding:GCPPolicyBinding)
+    WHERE binding.has_condition = false
+    RETURN DISTINCT binding.id
+    ORDER BY binding.id
+    """
+    return neo4j_session.execute_read(
+        read_list_of_values_tx,
+        get_binding_ids_query,
+        ProjectId=project_id,
+    )
+
+
+def get_principal_rows_for_policy_bindings(
+    neo4j_session: neo4j.Session,
+    project_id: str,
+    binding_ids: list[str],
+) -> list[dict[str, Any]]:
     get_principals_query = """
     MATCH
     (project:GCPProject{id: $ProjectId})-[:RESOURCE]->
     (binding:GCPPolicyBinding)-[:GRANTS_ROLE]->
     (role:GCPRole)
-    MATCH
-    (principal:GCPPrincipal)-[:HAS_ALLOW_POLICY]->(binding)
+    MATCH (principal:GCPPrincipal)-[:HAS_ALLOW_POLICY]->(binding)
     WHERE binding.has_condition = false
+    AND binding.id IN $BindingIds
     RETURN
     DISTINCT principal.email as principal_email, binding.id as binding_id,
     binding.resource as binding_resource, role.permissions as role_permissions
     """
 
-    results = neo4j_session.execute_read(
+    return neo4j_session.execute_read(
         read_list_of_dicts_tx,
         get_principals_query,
         ProjectId=project_id,
+        BindingIds=binding_ids,
     )
 
-    principals: dict[str, Any] = {}
-    for r in results:
+
+def merge_principal_rows(
+    principals: dict[str, Any],
+    rows: list[dict[str, Any]],
+    project_id: str,
+) -> None:
+    for r in rows:
         principal_email = r["principal_email"]
         binding_id = r["binding_id"]
         binding_resource = r["binding_resource"]
@@ -226,8 +285,6 @@ def get_principals_for_project(
             "permissions": compiled_permissions,
             "scope": compiled_scope,
         }
-
-    return principals
 
 
 def compile_permissions_from_role(role_permissions: list[str]) -> dict[str, Any]:

--- a/cartography/intel/gcp/permission_relationships.py
+++ b/cartography/intel/gcp/permission_relationships.py
@@ -215,6 +215,8 @@ def build_principals_from_policy_bindings(
                 ),
             }
 
+        # Share the compiled assignment across members of the same binding. Treat
+        # it as read-only during relationship evaluation.
         for principal_email in binding["members"]:
             principals.setdefault(principal_email, {})[binding_id] = (
                 compiled_assignments[binding_id]

--- a/cartography/intel/gcp/permission_relationships.py
+++ b/cartography/intel/gcp/permission_relationships.py
@@ -241,6 +241,7 @@ def get_principals_for_project(
     return principals
 
 
+@timeit
 def get_policy_binding_ids_for_project(
     neo4j_session: neo4j.Session,
     project_id: str,
@@ -258,6 +259,7 @@ def get_policy_binding_ids_for_project(
     )
 
 
+@timeit
 def get_principal_rows_for_policy_bindings(
     neo4j_session: neo4j.Session,
     project_id: str,

--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -22,6 +22,10 @@ from google.protobuf.json_format import MessageToDict
 from cartography.client.core.tx import load
 from cartography.client.core.tx import load_matchlinks
 from cartography.graph.job import GraphJob
+from cartography.intel.gcp.permission_relationships import (
+    build_principals_from_policy_bindings,
+)
+from cartography.intel.gcp.permission_relationships import GCPPrincipalPermissionContext
 from cartography.models.gcp.policy_bindings import GCPPolicyBindingAppliesToMatchLink
 from cartography.models.gcp.policy_bindings import GCPPolicyBindingSchema
 from cartography.util import timeit
@@ -193,6 +197,12 @@ class PolicyBindingsSyncStatus(str, Enum):
     SKIPPED_PERMISSION_DENIED = "skipped_permission_denied"
     SKIPPED_RATE_LIMIT = "skipped_rate_limit"
     SKIPPED_RETRY_EXHAUSTED = "skipped_retry_exhausted"
+
+
+@dataclass(frozen=True)
+class PolicyBindingsSyncResult:
+    status: PolicyBindingsSyncStatus
+    permission_context: GCPPrincipalPermissionContext
 
 
 CAI_POLICY_BINDINGS_RETRY_INITIAL = 1.0
@@ -521,7 +531,8 @@ def sync(
     update_tag: int,
     common_job_parameters: dict[str, Any],
     client: AssetServiceClient,
-) -> PolicyBindingsSyncStatus:
+    role_permissions_by_name: dict[str, list[str]],
+) -> PolicyBindingsSyncResult:
     """
     Sync GCP IAM policy bindings for a project.
 
@@ -539,7 +550,10 @@ def sync(
             project_id,
             e,
         )
-        return PolicyBindingsSyncStatus.SKIPPED_PERMISSION_DENIED
+        return PolicyBindingsSyncResult(
+            PolicyBindingsSyncStatus.SKIPPED_PERMISSION_DENIED,
+            {},
+        )
     except RetryError as e:
         if _is_rate_limit_retry_error(e):
             logger.warning(
@@ -548,14 +562,20 @@ def sync(
                 project_id,
                 e,
             )
-            return PolicyBindingsSyncStatus.SKIPPED_RATE_LIMIT
+            return PolicyBindingsSyncResult(
+                PolicyBindingsSyncStatus.SKIPPED_RATE_LIMIT,
+                {},
+            )
         logger.warning(
             "Cloud Asset policy bindings retries exhausted for project %s after transient gRPC errors. "
             "Preserving existing policy-binding and permission-relationship data. Error: %s",
             project_id,
             e,
         )
-        return PolicyBindingsSyncStatus.SKIPPED_RETRY_EXHAUSTED
+        return PolicyBindingsSyncResult(
+            PolicyBindingsSyncStatus.SKIPPED_RETRY_EXHAUSTED,
+            {},
+        )
     except (DeadlineExceeded, ResourceExhausted, ServiceUnavailable) as e:
         if isinstance(e, ResourceExhausted):
             logger.warning(
@@ -564,17 +584,31 @@ def sync(
                 project_id,
                 e,
             )
-            return PolicyBindingsSyncStatus.SKIPPED_RATE_LIMIT
+            return PolicyBindingsSyncResult(
+                PolicyBindingsSyncStatus.SKIPPED_RATE_LIMIT,
+                {},
+            )
         logger.warning(
             "Cloud Asset policy bindings failed for project %s with a transient gRPC error. "
             "Preserving existing policy-binding and permission-relationship data. Error: %s",
             project_id,
             e,
         )
-        return PolicyBindingsSyncStatus.SKIPPED_RETRY_EXHAUSTED
+        return PolicyBindingsSyncResult(
+            PolicyBindingsSyncStatus.SKIPPED_RETRY_EXHAUSTED,
+            {},
+        )
 
     transformed_bindings_data = transform_bindings(bindings_data)
+    permission_context = build_principals_from_policy_bindings(
+        transformed_bindings_data,
+        role_permissions_by_name,
+        project_id,
+    )
 
     load_bindings(neo4j_session, transformed_bindings_data, project_id, update_tag)
     cleanup(neo4j_session, common_job_parameters)
-    return PolicyBindingsSyncStatus.SUCCESS
+    return PolicyBindingsSyncResult(
+        PolicyBindingsSyncStatus.SUCCESS,
+        permission_context,
+    )

--- a/docs/root/modules/gcp/config.md
+++ b/docs/root/modules/gcp/config.md
@@ -91,7 +91,7 @@ Cartography uses the [Cloud Asset Inventory API](https://cloud.google.com/asset-
 1. **IAM Fallback**: When the IAM API is disabled on a target project, Cartography falls back to CAI to retrieve service accounts and custom roles.
 2. **Policy Bindings**: Sync effective IAM policies (including inherited policies from parent orgs/folders) for all resources.
 
-GCP permission relationship syncs depend on policy bindings being present in the graph. In practice, that means permission relationship syncs require the CAI-backed policy bindings sync to succeed.
+GCP permission relationship syncs depend on the current run's policy binding context. In practice, that means permission relationship syncs require the CAI-backed policy bindings sync to succeed in the same run.
 
 #### Setup
 
@@ -114,4 +114,4 @@ When using a service account, CAI API calls are automatically billed against the
 
 - **IAM Fallback**: Requires the Cloud Asset Inventory API to be enabled on the service account's host project. If the API is not enabled or the identity lacks permissions, Cartography will log a warning and skip the CAI fallback (other sync operations will continue normally). Note: The CAI fallback only syncs service accounts and project-level custom roles. Predefined roles and organization-level custom roles are synced separately at the organization level via the IAM API.
 - **Policy Bindings**: Requires organization-level `roles/cloudasset.viewer`. If this role is missing, Cartography will log a warning and skip policy bindings sync (other sync operations will continue normally).
-- **Permission Relationships**: Depend on policy bindings being present in the graph. If CAI is unavailable or `roles/cloudasset.viewer` is missing, permission relationships will not have the policy binding data they need and may produce no results.
+- **Permission Relationships**: Depend on policy bindings being refreshed in the same sync run. If CAI is unavailable or `roles/cloudasset.viewer` is missing, permission relationships will not have the policy binding data they need and will be skipped for that project.

--- a/docs/root/modules/gcp/permission-mapping.md
+++ b/docs/root/modules/gcp/permission-mapping.md
@@ -7,7 +7,7 @@ As mapping all permissions is infeasible both to calculate and store, Cartograph
 
 You can specify your own permission mapping file using the `--gcp-permission-relationships-file` command line parameter
 
-Permission relationship syncs depend on GCP policy bindings already being present in the graph. In the normal GCP sync flow, those policy bindings come from the CAI-backed policy bindings sync.
+Permission relationship syncs depend on policy bindings being refreshed in the same GCP sync run. In the normal GCP sync flow, those policy bindings come from the CAI-backed policy bindings sync, which passes the current policy-binding context directly into permission relationship evaluation.
 
 #### Permission Mapping File
 The [permission relationship file](https://github.com/cartography-cncf/cartography/blob/master/cartography/data/gcp_permission_relationships.yaml) is a yaml file that specifies what permission relationships should be created in the graph. It consists of RPR (Resource Permission Relationship) sections that are going to map specific permissions between GCP principals and resources

--- a/tests/integration/cartography/intel/gcp/test_permission_relationships.py
+++ b/tests/integration/cartography/intel/gcp/test_permission_relationships.py
@@ -148,7 +148,7 @@ def test_sync_gcp_permission_relationships(
     mock_asset_client = MagicMock()
 
     # Sync org-level IAM (predefined roles) first
-    cartography.intel.gcp.iam.sync_org_iam(
+    org_roles = cartography.intel.gcp.iam.sync_org_iam(
         neo4j_session,
         mock_iam_client,
         COMMON_JOB_PARAMS["ORG_RESOURCE_NAME"],
@@ -157,7 +157,7 @@ def test_sync_gcp_permission_relationships(
     )
 
     # Sync project-level IAM (service accounts and project custom roles)
-    cartography.intel.gcp.iam.sync(
+    project_roles = cartography.intel.gcp.iam.sync(
         neo4j_session,
         mock_iam_client,
         TEST_PROJECT_ID,
@@ -179,12 +179,16 @@ def test_sync_gcp_permission_relationships(
         GSUITE_COMMON_PARAMS,
     )
 
-    cartography.intel.gcp.policy_bindings.sync(
+    role_permissions_by_name = cartography.intel.gcp.iam.build_role_permissions_by_name(
+        org_roles + project_roles
+    )
+    policy_bindings_result = cartography.intel.gcp.policy_bindings.sync(
         neo4j_session,
         TEST_PROJECT_ID,
         TEST_UPDATE_TAG,
         COMMON_JOB_PARAMS,
         mock_asset_client,
+        role_permissions_by_name,
     )
 
     cartography.intel.gcp.storage.sync_gcp_buckets(
@@ -210,6 +214,7 @@ def test_sync_gcp_permission_relationships(
         TEST_PROJECT_ID,
         TEST_UPDATE_TAG,
         COMMON_JOB_PARAMS,
+        policy_bindings_result.permission_context,
     )
 
     # ASSERT

--- a/tests/integration/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/integration/cartography/intel/gcp/test_policy_bindings.py
@@ -156,6 +156,9 @@ def test_sync_gcp_policy_bindings(
         TEST_UPDATE_TAG,
         GSUITE_COMMON_PARAMS,
     )
+    role_permissions_by_name = cartography.intel.gcp.iam.build_role_permissions_by_name(
+        tests.data.gcp.policy_bindings.MOCK_IAM_ROLES
+    )
 
     # ACT
     cartography.intel.gcp.policy_bindings.sync(
@@ -164,6 +167,7 @@ def test_sync_gcp_policy_bindings(
         TEST_UPDATE_TAG,
         COMMON_JOB_PARAMS,
         mock_asset_client,
+        role_permissions_by_name,
     )
 
     # ASSERT
@@ -353,11 +357,12 @@ def test_sync_gcp_policy_bindings_permission_denied(
         TEST_UPDATE_TAG,
         COMMON_JOB_PARAMS,
         mock_asset_client,
+        {},
     )
 
     # ASSERT - sync should return a skipped status and not raise an exception
     assert (
-        result
+        result.status
         == cartography.intel.gcp.policy_bindings.PolicyBindingsSyncStatus.SKIPPED_PERMISSION_DENIED
     )
     mock_get_policy_bindings.assert_called_once()

--- a/tests/integration/cartography/intel/gcp/test_selective_sync.py
+++ b/tests/integration/cartography/intel/gcp/test_selective_sync.py
@@ -52,6 +52,7 @@ def test_permission_relationships_fresh_graph_no_relationships(
         TEST_PROJECT_ID,
         TEST_UPDATE_TAG,
         COMMON_JOB_PARAMS,
+        {},
     )
 
     # ASSERT - No CAN_READ relationships were created (from the YAML config's GCPBucket entry)

--- a/tests/unit/cartography/intel/gcp/test_iam.py
+++ b/tests/unit/cartography/intel/gcp/test_iam.py
@@ -1,0 +1,24 @@
+from cartography.intel.gcp import iam
+
+
+def test_build_role_permissions_by_name_skips_empty_permission_roles():
+    roles = [
+        {
+            "name": "roles/storage.objectViewer",
+            "includedPermissions": ["storage.objects.get"],
+        },
+        {
+            "name": "roles/empty",
+            "includedPermissions": [],
+        },
+        {
+            "name": "roles/missing",
+        },
+        {
+            "includedPermissions": ["storage.objects.create"],
+        },
+    ]
+
+    assert iam.build_role_permissions_by_name(roles) == {
+        "roles/storage.objectViewer": ["storage.objects.get"],
+    }

--- a/tests/unit/cartography/intel/gcp/test_permission_relationships.py
+++ b/tests/unit/cartography/intel/gcp/test_permission_relationships.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -133,6 +134,74 @@ def test_get_principals_for_project_reads_policy_bindings_in_batches(monkeypatch
     }
 
 
+def test_get_principals_for_project_logs_batch_diagnostics(monkeypatch, caplog):
+    monkeypatch.setattr(
+        permission_relationships,
+        "GCP_POLICY_BINDING_READ_BATCH_SIZE",
+        2,
+    )
+    rows_by_binding_id = {
+        "binding-1": [
+            {
+                "principal_email": "alice@example.com",
+                "binding_id": "binding-1",
+                "binding_resource": "//cloudresourcemanager.googleapis.com/projects/project-abc",
+                "role_permissions": ["storage.objects.get"],
+            }
+        ],
+        "binding-2": [
+            {
+                "principal_email": "bob@example.com",
+                "binding_id": "binding-2",
+                "binding_resource": "//storage.googleapis.com/buckets/bucket-2",
+                "role_permissions": ["storage.objects.get"],
+            }
+        ],
+        "binding-3": [
+            {
+                "principal_email": "alice@example.com",
+                "binding_id": "binding-3",
+                "binding_resource": "//storage.googleapis.com/buckets/bucket-3",
+                "role_permissions": ["storage.objects.create"],
+            }
+        ],
+    }
+
+    def execute_read(tx_func, query, **kwargs):
+        if tx_func is permission_relationships.read_list_of_values_tx:
+            return ["binding-1", "binding-2", "binding-3"]
+
+        return [
+            row
+            for binding_id in kwargs["BindingIds"]
+            for row in rows_by_binding_id[binding_id]
+        ]
+
+    neo4j_session = MagicMock()
+    neo4j_session.execute_read.side_effect = execute_read
+
+    with caplog.at_level(logging.DEBUG):
+        permission_relationships.get_principals_for_project(
+            neo4j_session,
+            TEST_PROJECT_ID,
+        )
+
+    assert any(
+        "binding_count=2" in record.message and "elapsed=" in record.message
+        for record in caplog.records
+        if record.levelno == logging.DEBUG
+    )
+    assert any(
+        "eligible_bindings=3" in record.message
+        and "read_batches=2" in record.message
+        and "rows=3" in record.message
+        and "principals=2" in record.message
+        and "bindings=3" in record.message
+        for record in caplog.records
+        if record.levelno == logging.INFO
+    )
+
+
 def test_get_principals_for_project_returns_empty_without_policy_bindings():
     neo4j_session = MagicMock()
     neo4j_session.execute_read.return_value = []
@@ -144,6 +213,68 @@ def test_get_principals_for_project_returns_empty_without_policy_bindings():
 
     assert principals == {}
     neo4j_session.execute_read.assert_called_once()
+
+
+def test_merge_principal_rows_reuses_compiled_assignments_per_binding():
+    principals: dict[str, Any] = {}
+    compiled_assignments: dict[str, Any] = {}
+    rows = [
+        {
+            "principal_email": "alice@example.com",
+            "binding_id": "binding-1",
+            "binding_resource": "//storage.googleapis.com/buckets/shared-bucket",
+            "role_permissions": ["storage.objects.get"],
+        },
+        {
+            "principal_email": "bob@example.com",
+            "binding_id": "binding-1",
+            "binding_resource": "//storage.googleapis.com/buckets/shared-bucket",
+            "role_permissions": ["storage.objects.get"],
+        },
+    ]
+    compiled_permissions = {"permissions": ["compiled"], "denied_permissions": []}
+    compiled_scope = MagicMock()
+
+    with (
+        patch.object(
+            permission_relationships,
+            "compile_permissions_from_role",
+            return_value=compiled_permissions,
+        ) as mock_compile_permissions,
+        patch.object(
+            permission_relationships,
+            "resolve_gcp_scope",
+            return_value="project/project-abc/resource/shared-bucket",
+        ),
+        patch.object(
+            permission_relationships,
+            "compile_gcp_regex",
+            return_value=compiled_scope,
+        ) as mock_compile_scope,
+    ):
+        permission_relationships.merge_principal_rows(
+            principals,
+            rows,
+            TEST_PROJECT_ID,
+            compiled_assignments,
+        )
+
+    mock_compile_permissions.assert_called_once_with(["storage.objects.get"])
+    mock_compile_scope.assert_called_once_with(
+        "project/project-abc/resource/shared-bucket"
+    )
+    assert (
+        principals["alice@example.com"]["binding-1"]["permissions"]
+        is compiled_permissions
+    )
+    assert (
+        principals["bob@example.com"]["binding-1"]["permissions"]
+        is compiled_permissions
+    )
+    assert principals["alice@example.com"]["binding-1"]["scope"] is compiled_scope
+    assert principals["bob@example.com"]["binding-1"]["scope"] is compiled_scope
+    assert compiled_assignments["binding-1"]["permissions"] is compiled_permissions
+    assert compiled_assignments["binding-1"]["scope"] is compiled_scope
 
 
 def test_iter_permission_relationship_batches_preserves_matches():

--- a/tests/unit/cartography/intel/gcp/test_permission_relationships.py
+++ b/tests/unit/cartography/intel/gcp/test_permission_relationships.py
@@ -53,64 +53,41 @@ def _normalize_principals(principals: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
-def test_get_principals_for_project_reads_policy_bindings_in_batches(monkeypatch):
-    monkeypatch.setattr(
-        permission_relationships,
-        "GCP_POLICY_BINDING_READ_BATCH_SIZE",
-        2,
-    )
-    rows_by_binding_id = {
-        "binding-1": [
-            {
-                "principal_email": "alice@example.com",
-                "binding_id": "binding-1",
-                "binding_resource": "//cloudresourcemanager.googleapis.com/projects/project-abc",
-                "role_permissions": ["storage.objects.get"],
-            }
-        ],
-        "binding-2": [
-            {
-                "principal_email": "bob@example.com",
-                "binding_id": "binding-2",
-                "binding_resource": "//storage.googleapis.com/buckets/bucket-2",
-                "role_permissions": ["storage.objects.get"],
-            }
-        ],
-        "binding-3": [
-            {
-                "principal_email": "alice@example.com",
-                "binding_id": "binding-3",
-                "binding_resource": "//storage.googleapis.com/buckets/bucket-3",
-                "role_permissions": ["storage.objects.create"],
-            }
-        ],
+def test_build_principals_from_policy_bindings_uses_in_memory_role_permissions():
+    policy_bindings = [
+        {
+            "id": "binding-1",
+            "role": "roles/storage.objectViewer",
+            "resource": "//cloudresourcemanager.googleapis.com/projects/project-abc",
+            "members": ["alice@example.com"],
+            "has_condition": False,
+        },
+        {
+            "id": "binding-2",
+            "role": "roles/storage.objectViewer",
+            "resource": "//storage.googleapis.com/buckets/bucket-2",
+            "members": ["bob@example.com"],
+            "has_condition": False,
+        },
+        {
+            "id": "binding-3",
+            "role": "roles/storage.objectCreator",
+            "resource": "//storage.googleapis.com/buckets/bucket-3",
+            "members": ["alice@example.com"],
+            "has_condition": False,
+        },
+    ]
+    role_permissions_by_name = {
+        "roles/storage.objectViewer": ["storage.objects.get"],
+        "roles/storage.objectCreator": ["storage.objects.create"],
     }
-    binding_batches = []
 
-    def execute_read(tx_func, query, **kwargs):
-        if tx_func is permission_relationships.read_list_of_values_tx:
-            assert kwargs == {"ProjectId": TEST_PROJECT_ID}
-            return ["binding-1", "binding-2", "binding-3"]
-
-        assert tx_func is permission_relationships.read_list_of_dicts_tx
-        assert kwargs["ProjectId"] == TEST_PROJECT_ID
-        binding_batches.append(kwargs["BindingIds"])
-        return [
-            row
-            for binding_id in kwargs["BindingIds"]
-            for row in rows_by_binding_id[binding_id]
-        ]
-
-    neo4j_session = MagicMock()
-    neo4j_session.execute_read.side_effect = execute_read
-
-    principals = permission_relationships.get_principals_for_project(
-        neo4j_session,
+    principals = permission_relationships.build_principals_from_policy_bindings(
+        policy_bindings,
+        role_permissions_by_name,
         TEST_PROJECT_ID,
     )
 
-    assert binding_batches == [["binding-1", "binding-2"], ["binding-3"]]
-    assert neo4j_session.execute_read.call_count == 3
     assert _normalize_principals(principals) == {
         "alice@example.com": {
             "binding-1": {
@@ -134,102 +111,73 @@ def test_get_principals_for_project_reads_policy_bindings_in_batches(monkeypatch
     }
 
 
-def test_get_principals_for_project_logs_batch_diagnostics(monkeypatch, caplog):
-    monkeypatch.setattr(
-        permission_relationships,
-        "GCP_POLICY_BINDING_READ_BATCH_SIZE",
-        2,
-    )
-    rows_by_binding_id = {
-        "binding-1": [
-            {
-                "principal_email": "alice@example.com",
-                "binding_id": "binding-1",
-                "binding_resource": "//cloudresourcemanager.googleapis.com/projects/project-abc",
-                "role_permissions": ["storage.objects.get"],
-            }
-        ],
-        "binding-2": [
-            {
-                "principal_email": "bob@example.com",
-                "binding_id": "binding-2",
-                "binding_resource": "//storage.googleapis.com/buckets/bucket-2",
-                "role_permissions": ["storage.objects.get"],
-            }
-        ],
-        "binding-3": [
-            {
-                "principal_email": "alice@example.com",
-                "binding_id": "binding-3",
-                "binding_resource": "//storage.googleapis.com/buckets/bucket-3",
-                "role_permissions": ["storage.objects.create"],
-            }
-        ],
-    }
-
-    def execute_read(tx_func, query, **kwargs):
-        if tx_func is permission_relationships.read_list_of_values_tx:
-            return ["binding-1", "binding-2", "binding-3"]
-
-        return [
-            row
-            for binding_id in kwargs["BindingIds"]
-            for row in rows_by_binding_id[binding_id]
-        ]
-
-    neo4j_session = MagicMock()
-    neo4j_session.execute_read.side_effect = execute_read
-
+def test_build_principals_from_policy_bindings_logs_context_diagnostics(caplog):
+    policy_bindings = [
+        {
+            "id": "binding-1",
+            "role": "roles/storage.objectViewer",
+            "resource": "//cloudresourcemanager.googleapis.com/projects/project-abc",
+            "members": ["alice@example.com"],
+            "has_condition": False,
+        },
+        {
+            "id": "binding-2",
+            "role": "roles/storage.objectViewer",
+            "resource": "//storage.googleapis.com/buckets/bucket-2",
+            "members": ["bob@example.com"],
+            "has_condition": False,
+        },
+        {
+            "id": "binding-3",
+            "role": "roles/storage.admin",
+            "resource": "//storage.googleapis.com/buckets/bucket-3",
+            "members": ["alice@example.com"],
+            "has_condition": True,
+        },
+        {
+            "id": "binding-4",
+            "role": "roles/missing",
+            "resource": "//storage.googleapis.com/buckets/bucket-4",
+            "members": ["carol@example.com"],
+            "has_condition": False,
+        },
+    ]
     with caplog.at_level(logging.DEBUG):
-        permission_relationships.get_principals_for_project(
-            neo4j_session,
+        permission_relationships.build_principals_from_policy_bindings(
+            policy_bindings,
+            {"roles/storage.objectViewer": ["storage.objects.get"]},
             TEST_PROJECT_ID,
         )
 
     assert any(
-        "binding_count=2" in record.message and "elapsed=" in record.message
-        for record in caplog.records
-        if record.levelno == logging.DEBUG
-    )
-    assert any(
-        "eligible_bindings=3" in record.message
-        and "read_batches=2" in record.message
-        and "rows=3" in record.message
+        "usable_bindings=2" in record.message
+        and "member_assignments=2" in record.message
         and "principals=2" in record.message
-        and "bindings=3" in record.message
+        and "skipped_conditional=1" in record.message
+        and "skipped_missing_roles=1" in record.message
         for record in caplog.records
         if record.levelno == logging.INFO
     )
 
 
-def test_get_principals_for_project_returns_empty_without_policy_bindings():
-    neo4j_session = MagicMock()
-    neo4j_session.execute_read.return_value = []
-
-    principals = permission_relationships.get_principals_for_project(
-        neo4j_session,
+def test_build_principals_from_policy_bindings_returns_empty_without_policy_bindings():
+    principals = permission_relationships.build_principals_from_policy_bindings(
+        [],
+        {},
         TEST_PROJECT_ID,
     )
 
     assert principals == {}
-    neo4j_session.execute_read.assert_called_once()
 
 
-def test_merge_principal_rows_reuses_compiled_assignments_per_binding():
-    principals: dict[str, Any] = {}
-    compiled_assignments: dict[str, Any] = {}
-    rows = [
+def test_build_principals_from_policy_bindings_reuses_compiled_assignments_per_binding():
+    policy_bindings = [
         {
-            "principal_email": "alice@example.com",
-            "binding_id": "binding-1",
-            "binding_resource": "//storage.googleapis.com/buckets/shared-bucket",
-            "role_permissions": ["storage.objects.get"],
-        },
-        {
-            "principal_email": "bob@example.com",
-            "binding_id": "binding-1",
-            "binding_resource": "//storage.googleapis.com/buckets/shared-bucket",
-            "role_permissions": ["storage.objects.get"],
+            "id": "binding-1",
+            "role": "roles/storage.objectViewer",
+            "resource": "//storage.googleapis.com/buckets/shared-bucket",
+            "members": ["alice@example.com", "bob@example.com"],
+            "has_condition": False,
         },
     ]
     compiled_permissions = {"permissions": ["compiled"], "denied_permissions": []}
@@ -252,11 +200,10 @@ def test_merge_principal_rows_reuses_compiled_assignments_per_binding():
             return_value=compiled_scope,
         ) as mock_compile_scope,
     ):
-        permission_relationships.merge_principal_rows(
-            principals,
-            rows,
+        principals = permission_relationships.build_principals_from_policy_bindings(
+            policy_bindings,
+            {"roles/storage.objectViewer": ["storage.objects.get"]},
             TEST_PROJECT_ID,
-            compiled_assignments,
         )
 
     mock_compile_permissions.assert_called_once_with(["storage.objects.get"])
@@ -273,8 +220,6 @@ def test_merge_principal_rows_reuses_compiled_assignments_per_binding():
     )
     assert principals["alice@example.com"]["binding-1"]["scope"] is compiled_scope
     assert principals["bob@example.com"]["binding-1"]["scope"] is compiled_scope
-    assert compiled_assignments["binding-1"]["permissions"] is compiled_permissions
-    assert compiled_assignments["binding-1"]["scope"] is compiled_scope
 
 
 def test_iter_permission_relationship_batches_preserves_matches():
@@ -344,11 +289,6 @@ def test_sync_loads_permission_relationships_in_multiple_batches(monkeypatch):
     with (
         patch.object(
             permission_relationships,
-            "get_principals_for_project",
-            return_value=principals,
-        ),
-        patch.object(
-            permission_relationships,
             "parse_permission_relationships_file",
             return_value=relationship_mapping,
         ),
@@ -371,6 +311,7 @@ def test_sync_loads_permission_relationships_in_multiple_batches(monkeypatch):
             TEST_PROJECT_ID,
             TEST_UPDATE_TAG,
             COMMON_JOB_PARAMS,
+            principals,
         )
 
     assert mock_load_principal_mappings.call_count == 2
@@ -412,11 +353,6 @@ def test_sync_skips_cleanup_when_batch_load_fails(monkeypatch):
     with (
         patch.object(
             permission_relationships,
-            "get_principals_for_project",
-            return_value=principals,
-        ),
-        patch.object(
-            permission_relationships,
             "parse_permission_relationships_file",
             return_value=relationship_mapping,
         ),
@@ -441,6 +377,7 @@ def test_sync_skips_cleanup_when_batch_load_fails(monkeypatch):
                 TEST_PROJECT_ID,
                 TEST_UPDATE_TAG,
                 COMMON_JOB_PARAMS,
+                principals,
             )
 
     mock_cleanup_rpr.assert_not_called()

--- a/tests/unit/cartography/intel/gcp/test_permission_relationships.py
+++ b/tests/unit/cartography/intel/gcp/test_permission_relationships.py
@@ -143,12 +143,28 @@ def test_build_principals_from_policy_bindings_logs_context_diagnostics(caplog):
         },
     ]
     with caplog.at_level(logging.DEBUG):
-        permission_relationships.build_principals_from_policy_bindings(
+        principals = permission_relationships.build_principals_from_policy_bindings(
             policy_bindings,
             {"roles/storage.objectViewer": ["storage.objects.get"]},
             TEST_PROJECT_ID,
         )
 
+    assert _normalize_principals(principals) == {
+        "alice@example.com": {
+            "binding-1": {
+                "permissions": ["storage\\.objects\\.get"],
+                "denied_permissions": [],
+                "scope": "project/project-abc/.*",
+            },
+        },
+        "bob@example.com": {
+            "binding-2": {
+                "permissions": ["storage\\.objects\\.get"],
+                "denied_permissions": [],
+                "scope": "project/project-abc/resource/bucket-2",
+            },
+        },
+    }
     assert any(
         "usable_bindings=2" in record.message
         and "member_assignments=2" in record.message

--- a/tests/unit/cartography/intel/gcp/test_permission_relationships.py
+++ b/tests/unit/cartography/intel/gcp/test_permission_relationships.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -30,6 +31,119 @@ def _build_policy_bindings(
             "scope": permission_relationships.compile_gcp_regex(scope),
         }
     }
+
+
+def _normalize_principals(principals: dict[str, Any]) -> dict[str, Any]:
+    normalized: dict[str, Any] = {}
+    for principal_email, bindings in principals.items():
+        normalized[principal_email] = {}
+        for binding_id, binding_data in bindings.items():
+            normalized[principal_email][binding_id] = {
+                "permissions": [
+                    pattern.pattern
+                    for pattern in binding_data["permissions"]["permissions"]
+                ],
+                "denied_permissions": [
+                    pattern.pattern
+                    for pattern in binding_data["permissions"]["denied_permissions"]
+                ],
+                "scope": binding_data["scope"].pattern,
+            }
+    return normalized
+
+
+def test_get_principals_for_project_reads_policy_bindings_in_batches(monkeypatch):
+    monkeypatch.setattr(
+        permission_relationships,
+        "GCP_POLICY_BINDING_READ_BATCH_SIZE",
+        2,
+    )
+    rows_by_binding_id = {
+        "binding-1": [
+            {
+                "principal_email": "alice@example.com",
+                "binding_id": "binding-1",
+                "binding_resource": "//cloudresourcemanager.googleapis.com/projects/project-abc",
+                "role_permissions": ["storage.objects.get"],
+            }
+        ],
+        "binding-2": [
+            {
+                "principal_email": "bob@example.com",
+                "binding_id": "binding-2",
+                "binding_resource": "//storage.googleapis.com/buckets/bucket-2",
+                "role_permissions": ["storage.objects.get"],
+            }
+        ],
+        "binding-3": [
+            {
+                "principal_email": "alice@example.com",
+                "binding_id": "binding-3",
+                "binding_resource": "//storage.googleapis.com/buckets/bucket-3",
+                "role_permissions": ["storage.objects.create"],
+            }
+        ],
+    }
+    binding_batches = []
+
+    def execute_read(tx_func, query, **kwargs):
+        if tx_func is permission_relationships.read_list_of_values_tx:
+            assert kwargs == {"ProjectId": TEST_PROJECT_ID}
+            return ["binding-1", "binding-2", "binding-3"]
+
+        assert tx_func is permission_relationships.read_list_of_dicts_tx
+        assert kwargs["ProjectId"] == TEST_PROJECT_ID
+        binding_batches.append(kwargs["BindingIds"])
+        return [
+            row
+            for binding_id in kwargs["BindingIds"]
+            for row in rows_by_binding_id[binding_id]
+        ]
+
+    neo4j_session = MagicMock()
+    neo4j_session.execute_read.side_effect = execute_read
+
+    principals = permission_relationships.get_principals_for_project(
+        neo4j_session,
+        TEST_PROJECT_ID,
+    )
+
+    assert binding_batches == [["binding-1", "binding-2"], ["binding-3"]]
+    assert neo4j_session.execute_read.call_count == 3
+    assert _normalize_principals(principals) == {
+        "alice@example.com": {
+            "binding-1": {
+                "permissions": ["storage\\.objects\\.get"],
+                "denied_permissions": [],
+                "scope": "project/project-abc/.*",
+            },
+            "binding-3": {
+                "permissions": ["storage\\.objects\\.create"],
+                "denied_permissions": [],
+                "scope": "project/project-abc/resource/bucket-3",
+            },
+        },
+        "bob@example.com": {
+            "binding-2": {
+                "permissions": ["storage\\.objects\\.get"],
+                "denied_permissions": [],
+                "scope": "project/project-abc/resource/bucket-2",
+            },
+        },
+    }
+
+
+def test_get_principals_for_project_returns_empty_without_policy_bindings():
+    neo4j_session = MagicMock()
+    neo4j_session.execute_read.return_value = []
+
+    principals = permission_relationships.get_principals_for_project(
+        neo4j_session,
+        TEST_PROJECT_ID,
+    )
+
+    assert principals == {}
+    neo4j_session.execute_read.assert_called_once()
 
 
 def test_iter_permission_relationship_batches_preserves_matches():

--- a/tests/unit/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/unit/cartography/intel/gcp/test_policy_bindings.py
@@ -244,9 +244,10 @@ def test_sync_skips_load_and_cleanup_on_rate_limit_retry_exhaustion(
             TEST_UPDATE_TAG,
             COMMON_JOB_PARAMS,
             MagicMock(),
+            {},
         )
 
-    assert result == policy_bindings.PolicyBindingsSyncStatus.SKIPPED_RATE_LIMIT
+    assert result.status == policy_bindings.PolicyBindingsSyncStatus.SKIPPED_RATE_LIMIT
     mock_get_policy_bindings.assert_called_once()
     mock_load_bindings.assert_not_called()
     mock_cleanup.assert_not_called()
@@ -262,7 +263,10 @@ def test_sync_skips_load_and_cleanup_on_rate_limit_retry_exhaustion(
 @patch("cartography.intel.gcp.permission_relationships.sync")
 @patch(
     "cartography.intel.gcp.policy_bindings.sync",
-    return_value=policy_bindings.PolicyBindingsSyncStatus.SKIPPED_RATE_LIMIT,
+    return_value=policy_bindings.PolicyBindingsSyncResult(
+        policy_bindings.PolicyBindingsSyncStatus.SKIPPED_RATE_LIMIT,
+        {},
+    ),
 )
 @patch(
     "cartography.intel.gcp._services_enabled_on_project",


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
GCP permission relationship sync has two distinct hot paths on large projects:
- the relationship evaluation/write path
- the principal-policy-binding Neo4j read that gathers principals, bindings, and roles before evaluation

`#2673` already batched the evaluation/write side. This PR keeps the same graph semantics while tightening the remaining read-side hot path.

The sync now:
- reads eligible policy binding ids for the project first
- fetches principal rows in batches of 500 binding ids instead of one large read transaction
- reuses compiled permission/scope assignments per binding id while merging rows back into the principals structure
- emits aggregate read-phase diagnostics so it is easier to tell whether the principal read is still the dominant cost in production

### Impact
This reduces peak Neo4j read transaction memory during GCP permission relationship syncs and removes repeated Python-side compile work for duplicate binding rows.

For large GCP environments, this should make permission relationship syncs more reliable and should reduce CPU spent repeatedly compiling the same binding-derived assignment data. It does not change the generated graph semantics, cleanup behavior, or permission relationship meaning.

The existing write-side batching from `#2673` remains unchanged. This PR specifically continues the same hot-path work by narrowing the previously large principal-policy-binding read phase.

### Related issues or links

N/A

### Breaking changes

None.

### How was this tested?
- Added new tests
- Tested locally

Redacted logs here:
<details>

```
INFO botocore.tokens: Loading cached SSO token for subimage
INFO cartography.intel.create_indexes: Creating indexes for cartography node types.
INFO cartography.client.core.tx: Loaded 1 GCPOrganization nodes
INFO cartography.intel.gcp.iam: Syncing organization-level IAM for organizations/ORG_REDACTED
INFO cartography.intel.gcp.iam: Found 2297 predefined roles
INFO cartography.intel.gcp.iam: Found 11 custom organization roles in organizations/ORG_REDACTED
INFO cartography.client.core.tx: Loaded 2308 GCPRole nodes
INFO cartography.client.core.tx: Loaded 5 GCPProject nodes
INFO cartography.intel.gcp: Syncing resources for 5 GCP projects.
INFO cartography.intel.gcp: Syncing GCP project PROJECT_1 for Storage.
INFO cartography.intel.gcp.storage: Syncing Storage objects for project PROJECT_1.
INFO cartography.client.core.tx: Loaded 2 GCPBucket nodes
INFO cartography.graph.statement: Completed GCPBucketLabel statement #1
INFO cartography.graph.statement: Completed GCPBucketLabel statement #2
INFO cartography.graph.statement: Completed GCPBucketLabel statement #3
INFO cartography.graph.job: Finished job GCPBucketLabel
INFO cartography.graph.statement: Completed GCPBucket statement #1
INFO cartography.graph.statement: Completed GCPBucket statement #2
INFO cartography.graph.job: Finished job GCPBucket
INFO cartography.intel.gcp: Syncing GCP project PROJECT_1 for IAM.
INFO cartography.intel.gcp.iam: Syncing GCP IAM for project PROJECT_1
INFO cartography.intel.gcp.iam: Found 15 service accounts in project PROJECT_1
INFO cartography.client.core.tx: Loaded 15 GCPServiceAccount nodes
INFO cartography.intel.gcp.iam: Found 1 custom project roles in project PROJECT_1
INFO cartography.client.core.tx: Loaded 1 GCPRole nodes
INFO cartography.intel.gcp: Syncing GCP project PROJECT_1 for Secret Manager.
INFO cartography.intel.gcp.secretsmanager: Syncing Secret Manager for project PROJECT_1.
INFO cartography.client.core.tx: Loaded 2 GCPSecretManagerSecret nodes
INFO cartography.intel.gcp.secretsmanager: Loading 4 secret versions for project PROJECT_1 into graph.
INFO cartography.client.core.tx: Loaded 4 GCPSecretManagerSecretVersion nodes
INFO cartography.graph.statement: Completed GCPSecretManagerSecretVersion statement #1
INFO cartography.graph.statement: Completed GCPSecretManagerSecretVersion statement #2
INFO cartography.graph.statement: Completed GCPSecretManagerSecretVersion statement #3
INFO cartography.graph.job: Finished job GCPSecretManagerSecretVersion
INFO cartography.graph.statement: Completed GCPSecretManagerSecret statement #1
INFO cartography.graph.statement: Completed GCPSecretManagerSecret statement #2
INFO cartography.graph.job: Finished job GCPSecretManagerSecret
INFO cartography.intel.gcp: CAI enabled, will sync policy bindings for all projects.
INFO cartography.intel.gcp: Syncing IAM policies for GCP project PROJECT_1.
INFO cartography.intel.gcp.permission_relationships: Built GCP permission evaluation context for project 'PROJECT_1': bindings=6792, usable_bindings=6630, member_assignments=6886, principals=125, skipped_conditional=162, skipped_missing_roles=0
INFO cartography.client.core.tx: Loaded 6792 GCPPolicyBinding nodes
INFO cartography.client.core.tx: Loaded 39 (GCPPolicyBinding)-[APPLIES_TO]->(GCPProject) relationships
INFO cartography.client.core.tx: Loaded 56 (GCPPolicyBinding)-[APPLIES_TO]->(GCPFolder) relationships
INFO cartography.client.core.tx: Loaded 189 (GCPPolicyBinding)-[APPLIES_TO]->(GCPOrganization) relationships
INFO cartography.client.core.tx: Loaded 6036 (GCPPolicyBinding)-[APPLIES_TO]->(GCPArtifactRegistryRepository) relationships
INFO cartography.client.core.tx: Loaded 2 (GCPPolicyBinding)-[APPLIES_TO]->(GCPSecretManagerSecret) relationships
INFO cartography.client.core.tx: Loaded 2 (GCPPolicyBinding)-[APPLIES_TO]->(GCPCloudRunService) relationships
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #1
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #2
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #3
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #4
INFO cartography.graph.job: Finished job GCPPolicyBinding
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.intel.gcp.permission_relationships: Syncing GCP Permission Relationships for project 'PROJECT_1'.
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_READ' for resource type 'GCPBucket' in project 'PROJECT_1' with 1 permissions, 125 principals, and 2 resources
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_READ' for 'GCPBucket': processed 1/2 resources (50.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_READ' for 'GCPBucket': processed 2/2 resources (100.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Loading 32 CAN_READ relationships for GCPPrincipal -> GCPBucket
INFO cartography.client.core.tx: Loaded 32 (GCPPrincipal)-[CAN_READ]->(GCPBucket) relationships
INFO cartography.intel.gcp.permission_relationships: Completed relationship 'CAN_READ' for 'GCPBucket': processed 2 resources and loaded 32 relationships
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_READ' for resource type 'GCPBucket' in project 'PROJECT_1' with 32 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_READ' for node label 'GCPBucket'
INFO cartography.graph.statement: Completed CAN_READ statement #1
INFO cartography.graph.job: Finished job CAN_READ
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_WRITE' for resource type 'GCPBucket' in project 'PROJECT_1' with 2 permissions, 125 principals, and 2 resources
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_WRITE' for 'GCPBucket': processed 1/2 resources (50.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_WRITE' for 'GCPBucket': processed 2/2 resources (100.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Loading 18 CAN_WRITE relationships for GCPPrincipal -> GCPBucket
INFO cartography.client.core.tx: Loaded 18 (GCPPrincipal)-[CAN_WRITE]->(GCPBucket) relationships
INFO cartography.intel.gcp.permission_relationships: Completed relationship 'CAN_WRITE' for 'GCPBucket': processed 2 resources and loaded 18 relationships
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_WRITE' for resource type 'GCPBucket' in project 'PROJECT_1' with 18 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_WRITE' for node label 'GCPBucket'
INFO cartography.graph.statement: Completed CAN_WRITE statement #1
INFO cartography.graph.job: Finished job CAN_WRITE
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_DELETE' for resource type 'GCPBucket' in project 'PROJECT_1' with 1 permissions, 125 principals, and 2 resources
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_DELETE' for 'GCPBucket': processed 1/2 resources (50.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_DELETE' for 'GCPBucket': processed 2/2 resources (100.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Loading 16 CAN_DELETE relationships for GCPPrincipal -> GCPBucket
INFO cartography.client.core.tx: Loaded 16 (GCPPrincipal)-[CAN_DELETE]->(GCPBucket) relationships
INFO cartography.intel.gcp.permission_relationships: Completed relationship 'CAN_DELETE' for 'GCPBucket': processed 2 resources and loaded 16 relationships
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_DELETE' for resource type 'GCPBucket' in project 'PROJECT_1' with 16 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_DELETE' for node label 'GCPBucket'
INFO cartography.graph.statement: Completed CAN_DELETE statement #1
INFO cartography.graph.job: Finished job CAN_DELETE
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_READ' for resource type 'GCPSecretManagerSecret' in project 'PROJECT_1' with 1 permissions, 125 principals, and 2 resources
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_READ' for 'GCPSecretManagerSecret': processed 1/2 resources (50.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_READ' for 'GCPSecretManagerSecret': processed 2/2 resources (100.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Loading 16 CAN_READ relationships for GCPPrincipal -> GCPSecretManagerSecret
INFO cartography.client.core.tx: Loaded 16 (GCPPrincipal)-[CAN_READ]->(GCPSecretManagerSecret) relationships
INFO cartography.intel.gcp.permission_relationships: Completed relationship 'CAN_READ' for 'GCPSecretManagerSecret': processed 2 resources and loaded 16 relationships
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_READ' for resource type 'GCPSecretManagerSecret' in project 'PROJECT_1' with 16 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_READ' for node label 'GCPSecretManagerSecret'
INFO cartography.graph.statement: Completed CAN_READ statement #1
INFO cartography.graph.job: Finished job CAN_READ
INFO cartography.intel.gcp.permission_relationships: Completed GCP Permission Relationships sync for project PROJECT_1
INFO cartography.graph.statement: Completed GCPServiceAccount statement #1
INFO cartography.graph.statement: Completed GCPServiceAccount statement #2
INFO cartography.graph.job: Finished job GCPServiceAccount
INFO cartography.graph.statement: Completed GCPRole statement #1
INFO cartography.graph.statement: Completed GCPRole statement #2
INFO cartography.graph.job: Finished job GCPRole
INFO cartography.intel.gcp: Syncing GCP project PROJECT_2 for Storage.
INFO cartography.intel.gcp.storage: Syncing Storage objects for project PROJECT_2.
INFO cartography.client.core.tx: Loaded 2 GCPBucket nodes
INFO cartography.graph.statement: Completed GCPBucketLabel statement #1
INFO cartography.graph.statement: Completed GCPBucketLabel statement #2
INFO cartography.graph.statement: Completed GCPBucketLabel statement #3
INFO cartography.graph.job: Finished job GCPBucketLabel
INFO cartography.graph.statement: Completed GCPBucket statement #1
INFO cartography.graph.statement: Completed GCPBucket statement #2
INFO cartography.graph.job: Finished job GCPBucket
INFO cartography.intel.gcp: Syncing GCP project PROJECT_2 for IAM.
INFO cartography.intel.gcp.iam: Syncing GCP IAM for project PROJECT_2
INFO cartography.intel.gcp.iam: Found 13 service accounts in project PROJECT_2
INFO cartography.client.core.tx: Loaded 13 GCPServiceAccount nodes
INFO cartography.intel.gcp.iam: Found 1 custom project roles in project PROJECT_2
INFO cartography.client.core.tx: Loaded 1 GCPRole nodes
INFO cartography.intel.gcp: Syncing GCP project PROJECT_2 for Secret Manager.
INFO cartography.intel.gcp.secretsmanager: Syncing Secret Manager for project PROJECT_2.
INFO cartography.client.core.tx: Loaded 1 GCPSecretManagerSecret nodes
INFO cartography.intel.gcp.secretsmanager: Loading 2 secret versions for project PROJECT_2 into graph.
INFO cartography.client.core.tx: Loaded 2 GCPSecretManagerSecretVersion nodes
INFO cartography.graph.statement: Completed GCPSecretManagerSecretVersion statement #1
INFO cartography.graph.statement: Completed GCPSecretManagerSecretVersion statement #2
INFO cartography.graph.statement: Completed GCPSecretManagerSecretVersion statement #3
INFO cartography.graph.job: Finished job GCPSecretManagerSecretVersion
INFO cartography.graph.statement: Completed GCPSecretManagerSecret statement #1
INFO cartography.graph.statement: Completed GCPSecretManagerSecret statement #2
INFO cartography.graph.job: Finished job GCPSecretManagerSecret
INFO cartography.intel.gcp: Syncing IAM policies for GCP project PROJECT_2.
INFO cartography.intel.gcp.permission_relationships: Built GCP permission evaluation context for project 'PROJECT_2': bindings=6593, usable_bindings=6427, member_assignments=6583, principals=112, skipped_conditional=166, skipped_missing_roles=0
INFO cartography.client.core.tx: Loaded 6593 GCPPolicyBinding nodes
INFO cartography.client.core.tx: Loaded 46 (GCPPolicyBinding)-[APPLIES_TO]->(GCPProject) relationships
INFO cartography.client.core.tx: Loaded 56 (GCPPolicyBinding)-[APPLIES_TO]->(GCPFolder) relationships
INFO cartography.client.core.tx: Loaded 189 (GCPPolicyBinding)-[APPLIES_TO]->(GCPOrganization) relationships
INFO cartography.client.core.tx: Loaded 6030 (GCPPolicyBinding)-[APPLIES_TO]->(GCPArtifactRegistryRepository) relationships
INFO cartography.client.core.tx: Loaded 4 (GCPPolicyBinding)-[APPLIES_TO]->(GCPCloudRunService) relationships
INFO cartography.client.core.tx: Loaded 1 (GCPPolicyBinding)-[APPLIES_TO]->(GCPSecretManagerSecret) relationships
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #1
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #2
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #3
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #4
INFO cartography.graph.job: Finished job GCPPolicyBinding
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.intel.gcp.permission_relationships: Syncing GCP Permission Relationships for project 'PROJECT_2'.
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_READ' for resource type 'GCPBucket' in project 'PROJECT_2' with 1 permissions, 112 principals, and 2 resources
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_READ' for 'GCPBucket': processed 1/2 resources (50.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_READ' for 'GCPBucket': processed 2/2 resources (100.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Loading 36 CAN_READ relationships for GCPPrincipal -> GCPBucket
INFO cartography.client.core.tx: Loaded 36 (GCPPrincipal)-[CAN_READ]->(GCPBucket) relationships
INFO cartography.intel.gcp.permission_relationships: Completed relationship 'CAN_READ' for 'GCPBucket': processed 2 resources and loaded 36 relationships
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_READ' for resource type 'GCPBucket' in project 'PROJECT_2' with 36 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_READ' for node label 'GCPBucket'
INFO cartography.graph.statement: Completed CAN_READ statement #1
INFO cartography.graph.job: Finished job CAN_READ
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_WRITE' for resource type 'GCPBucket' in project 'PROJECT_2' with 2 permissions, 112 principals, and 2 resources
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_WRITE' for 'GCPBucket': processed 1/2 resources (50.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_WRITE' for 'GCPBucket': processed 2/2 resources (100.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Loading 22 CAN_WRITE relationships for GCPPrincipal -> GCPBucket
INFO cartography.client.core.tx: Loaded 22 (GCPPrincipal)-[CAN_WRITE]->(GCPBucket) relationships
INFO cartography.intel.gcp.permission_relationships: Completed relationship 'CAN_WRITE' for 'GCPBucket': processed 2 resources and loaded 22 relationships
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_WRITE' for resource type 'GCPBucket' in project 'PROJECT_2' with 22 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_WRITE' for node label 'GCPBucket'
INFO cartography.graph.statement: Completed CAN_WRITE statement #1
INFO cartography.graph.job: Finished job CAN_WRITE
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_DELETE' for resource type 'GCPBucket' in project 'PROJECT_2' with 1 permissions, 112 principals, and 2 resources
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_DELETE' for 'GCPBucket': processed 1/2 resources (50.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_DELETE' for 'GCPBucket': processed 2/2 resources (100.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Loading 20 CAN_DELETE relationships for GCPPrincipal -> GCPBucket
INFO cartography.client.core.tx: Loaded 20 (GCPPrincipal)-[CAN_DELETE]->(GCPBucket) relationships
INFO cartography.intel.gcp.permission_relationships: Completed relationship 'CAN_DELETE' for 'GCPBucket': processed 2 resources and loaded 20 relationships
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_DELETE' for resource type 'GCPBucket' in project 'PROJECT_2' with 20 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_DELETE' for node label 'GCPBucket'
INFO cartography.graph.statement: Completed CAN_DELETE statement #1
INFO cartography.graph.job: Finished job CAN_DELETE
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_READ' for resource type 'GCPSecretManagerSecret' in project 'PROJECT_2' with 1 permissions, 112 principals, and 1 resources
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_READ' for 'GCPSecretManagerSecret': processed 1/1 resources (100.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Loading 7 CAN_READ relationships for GCPPrincipal -> GCPSecretManagerSecret
INFO cartography.client.core.tx: Loaded 7 (GCPPrincipal)-[CAN_READ]->(GCPSecretManagerSecret) relationships
INFO cartography.intel.gcp.permission_relationships: Completed relationship 'CAN_READ' for 'GCPSecretManagerSecret': processed 1 resources and loaded 7 relationships
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_READ' for resource type 'GCPSecretManagerSecret' in project 'PROJECT_2' with 7 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_READ' for node label 'GCPSecretManagerSecret'
INFO cartography.graph.statement: Completed CAN_READ statement #1
INFO cartography.graph.job: Finished job CAN_READ
INFO cartography.intel.gcp.permission_relationships: Completed GCP Permission Relationships sync for project PROJECT_2
INFO cartography.graph.statement: Completed GCPServiceAccount statement #1
INFO cartography.graph.statement: Completed GCPServiceAccount statement #2
INFO cartography.graph.job: Finished job GCPServiceAccount
INFO cartography.graph.statement: Completed GCPRole statement #1
INFO cartography.graph.statement: Completed GCPRole statement #2
INFO cartography.graph.job: Finished job GCPRole
INFO cartography.intel.gcp: Syncing GCP project PROJECT_3 for IAM.
INFO cartography.intel.gcp.iam: Syncing GCP IAM for project PROJECT_3
INFO cartography.intel.gcp.iam: Found 4 service accounts in project PROJECT_3
INFO cartography.client.core.tx: Loaded 4 GCPServiceAccount nodes
INFO cartography.intel.gcp.iam: Found 0 custom project roles in project PROJECT_3
INFO cartography.intel.gcp: Syncing GCP project PROJECT_3 for Secret Manager.
INFO cartography.intel.gcp.secretsmanager: Syncing Secret Manager for project PROJECT_3.
INFO cartography.client.core.tx: Loaded 1 GCPSecretManagerSecret nodes
INFO cartography.intel.gcp.labels: Syncing 1 secret_manager_secret labels for project PROJECT_3 with batch_size=10000.
INFO cartography.client.core.tx: Loaded 1 GCPLabel nodes
INFO cartography.intel.gcp.secretsmanager: Loading 1 secret versions for project PROJECT_3 into graph.
INFO cartography.client.core.tx: Loaded 1 GCPSecretManagerSecretVersion nodes
INFO cartography.graph.statement: Completed GCPSecretManagerSecretVersion statement #1
INFO cartography.graph.statement: Completed GCPSecretManagerSecretVersion statement #2
INFO cartography.graph.statement: Completed GCPSecretManagerSecretVersion statement #3
INFO cartography.graph.job: Finished job GCPSecretManagerSecretVersion
INFO cartography.graph.statement: Completed GCPSecretManagerSecret statement #1
INFO cartography.graph.statement: Completed GCPSecretManagerSecret statement #2
INFO cartography.graph.job: Finished job GCPSecretManagerSecret
INFO cartography.intel.gcp: Syncing IAM policies for GCP project PROJECT_3.
INFO cartography.intel.gcp.permission_relationships: Built GCP permission evaluation context for project 'PROJECT_3': bindings=601, usable_bindings=437, member_assignments=487, principals=56, skipped_conditional=164, skipped_missing_roles=0
INFO cartography.client.core.tx: Loaded 601 GCPPolicyBinding nodes
INFO cartography.client.core.tx: Loaded 18 (GCPPolicyBinding)-[APPLIES_TO]->(GCPProject) relationships
INFO cartography.client.core.tx: Loaded 56 (GCPPolicyBinding)-[APPLIES_TO]->(GCPFolder) relationships
INFO cartography.client.core.tx: Loaded 189 (GCPPolicyBinding)-[APPLIES_TO]->(GCPOrganization) relationships
INFO cartography.client.core.tx: Loaded 327 (GCPPolicyBinding)-[APPLIES_TO]->(GCPArtifactRegistryRepository) relationships
INFO cartography.client.core.tx: Loaded 1 (GCPPolicyBinding)-[APPLIES_TO]->(GCPCloudRunService) relationships
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #1
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #2
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #3
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #4
INFO cartography.graph.job: Finished job GCPPolicyBinding
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.intel.gcp.permission_relationships: Syncing GCP Permission Relationships for project 'PROJECT_3'.
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_READ' for resource type 'GCPBucket' in project 'PROJECT_3' with 1 permissions, 56 principals, and 0 resources
INFO cartography.intel.gcp.permission_relationships: No GCPBucket resources found for relationship 'CAN_READ' in project 'PROJECT_3'.
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_READ' for resource type 'GCPBucket' in project 'PROJECT_3' with 0 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_READ' for node label 'GCPBucket'
INFO cartography.graph.statement: Completed CAN_READ statement #1
INFO cartography.graph.job: Finished job CAN_READ
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_WRITE' for resource type 'GCPBucket' in project 'PROJECT_3' with 2 permissions, 56 principals, and 0 resources
INFO cartography.intel.gcp.permission_relationships: No GCPBucket resources found for relationship 'CAN_WRITE' in project 'PROJECT_3'.
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_WRITE' for resource type 'GCPBucket' in project 'PROJECT_3' with 0 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_WRITE' for node label 'GCPBucket'
INFO cartography.graph.statement: Completed CAN_WRITE statement #1
INFO cartography.graph.job: Finished job CAN_WRITE
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_DELETE' for resource type 'GCPBucket' in project 'PROJECT_3' with 1 permissions, 56 principals, and 0 resources
INFO cartography.intel.gcp.permission_relationships: No GCPBucket resources found for relationship 'CAN_DELETE' in project 'PROJECT_3'.
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_DELETE' for resource type 'GCPBucket' in project 'PROJECT_3' with 0 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_DELETE' for node label 'GCPBucket'
INFO cartography.graph.statement: Completed CAN_DELETE statement #1
INFO cartography.graph.job: Finished job CAN_DELETE
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_READ' for resource type 'GCPSecretManagerSecret' in project 'PROJECT_3' with 1 permissions, 56 principals, and 1 resources
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_READ' for 'GCPSecretManagerSecret': processed 1/1 resources (100.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Loading 5 CAN_READ relationships for GCPPrincipal -> GCPSecretManagerSecret
INFO cartography.client.core.tx: Loaded 5 (GCPPrincipal)-[CAN_READ]->(GCPSecretManagerSecret) relationships
INFO cartography.intel.gcp.permission_relationships: Completed relationship 'CAN_READ' for 'GCPSecretManagerSecret': processed 1 resources and loaded 5 relationships
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_READ' for resource type 'GCPSecretManagerSecret' in project 'PROJECT_3' with 5 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_READ' for node label 'GCPSecretManagerSecret'
INFO cartography.graph.statement: Completed CAN_READ statement #1
INFO cartography.graph.job: Finished job CAN_READ
INFO cartography.intel.gcp.permission_relationships: Completed GCP Permission Relationships sync for project PROJECT_3
INFO cartography.graph.statement: Completed GCPServiceAccount statement #1
INFO cartography.graph.statement: Completed GCPServiceAccount statement #2
INFO cartography.graph.job: Finished job GCPServiceAccount
INFO cartography.graph.statement: Completed GCPRole statement #1
INFO cartography.graph.statement: Completed GCPRole statement #2
INFO cartography.graph.job: Finished job GCPRole
INFO cartography.intel.gcp: Syncing GCP project PROJECT_4 for IAM.
INFO cartography.intel.gcp.iam: Syncing GCP IAM for project PROJECT_4
INFO cartography.intel.gcp.iam: Found 8 service accounts in project PROJECT_4
INFO cartography.client.core.tx: Loaded 8 GCPServiceAccount nodes
INFO cartography.intel.gcp.iam: Found 1 custom project roles in project PROJECT_4
INFO cartography.client.core.tx: Loaded 1 GCPRole nodes
INFO cartography.intel.gcp: Syncing GCP project PROJECT_4 for Secret Manager.
INFO cartography.intel.gcp.secretsmanager: Syncing Secret Manager for project PROJECT_4.
INFO cartography.intel.gcp.secretsmanager: Loading 0 secret versions for project PROJECT_4 into graph.
INFO cartography.graph.statement: Completed GCPSecretManagerSecretVersion statement #1
INFO cartography.graph.statement: Completed GCPSecretManagerSecretVersion statement #2
INFO cartography.graph.statement: Completed GCPSecretManagerSecretVersion statement #3
INFO cartography.graph.job: Finished job GCPSecretManagerSecretVersion
INFO cartography.graph.statement: Completed GCPSecretManagerSecret statement #1
INFO cartography.graph.statement: Completed GCPSecretManagerSecret statement #2
INFO cartography.graph.job: Finished job GCPSecretManagerSecret
INFO cartography.intel.gcp: Syncing IAM policies for GCP project PROJECT_4.
INFO cartography.intel.gcp.permission_relationships: Built GCP permission evaluation context for project 'PROJECT_4': bindings=2956, usable_bindings=2794, member_assignments=2897, principals=84, skipped_conditional=162, skipped_missing_roles=0
INFO cartography.client.core.tx: Loaded 2956 GCPPolicyBinding nodes
INFO cartography.client.core.tx: Loaded 25 (GCPPolicyBinding)-[APPLIES_TO]->(GCPProject) relationships
INFO cartography.client.core.tx: Loaded 56 (GCPPolicyBinding)-[APPLIES_TO]->(GCPFolder) relationships
INFO cartography.client.core.tx: Loaded 189 (GCPPolicyBinding)-[APPLIES_TO]->(GCPOrganization) relationships
INFO cartography.client.core.tx: Loaded 2558 (GCPPolicyBinding)-[APPLIES_TO]->(GCPArtifactRegistryRepository) relationships
INFO cartography.client.core.tx: Loaded 2 (GCPPolicyBinding)-[APPLIES_TO]->(GCPCloudRunService) relationships
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #1
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #2
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #3
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #4
INFO cartography.graph.job: Finished job GCPPolicyBinding
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.intel.gcp.permission_relationships: Syncing GCP Permission Relationships for project 'PROJECT_4'.
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_READ' for resource type 'GCPBucket' in project 'PROJECT_4' with 1 permissions, 84 principals, and 0 resources
INFO cartography.intel.gcp.permission_relationships: No GCPBucket resources found for relationship 'CAN_READ' in project 'PROJECT_4'.
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_READ' for resource type 'GCPBucket' in project 'PROJECT_4' with 0 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_READ' for node label 'GCPBucket'
INFO cartography.graph.statement: Completed CAN_READ statement #1
INFO cartography.graph.job: Finished job CAN_READ
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_WRITE' for resource type 'GCPBucket' in project 'PROJECT_4' with 2 permissions, 84 principals, and 0 resources
INFO cartography.intel.gcp.permission_relationships: No GCPBucket resources found for relationship 'CAN_WRITE' in project 'PROJECT_4'.
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_WRITE' for resource type 'GCPBucket' in project 'PROJECT_4' with 0 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_WRITE' for node label 'GCPBucket'
INFO cartography.graph.statement: Completed CAN_WRITE statement #1
INFO cartography.graph.job: Finished job CAN_WRITE
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_DELETE' for resource type 'GCPBucket' in project 'PROJECT_4' with 1 permissions, 84 principals, and 0 resources
INFO cartography.intel.gcp.permission_relationships: No GCPBucket resources found for relationship 'CAN_DELETE' in project 'PROJECT_4'.
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_DELETE' for resource type 'GCPBucket' in project 'PROJECT_4' with 0 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_DELETE' for node label 'GCPBucket'
INFO cartography.graph.statement: Completed CAN_DELETE statement #1
INFO cartography.graph.job: Finished job CAN_DELETE
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_READ' for resource type 'GCPSecretManagerSecret' in project 'PROJECT_4' with 1 permissions, 84 principals, and 0 resources
INFO cartography.intel.gcp.permission_relationships: No GCPSecretManagerSecret resources found for relationship 'CAN_READ' in project 'PROJECT_4'.
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_READ' for resource type 'GCPSecretManagerSecret' in project 'PROJECT_4' with 0 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_READ' for node label 'GCPSecretManagerSecret'
INFO cartography.graph.statement: Completed CAN_READ statement #1
INFO cartography.graph.job: Finished job CAN_READ
INFO cartography.intel.gcp.permission_relationships: Completed GCP Permission Relationships sync for project PROJECT_4
INFO cartography.graph.statement: Completed GCPServiceAccount statement #1
INFO cartography.graph.statement: Completed GCPServiceAccount statement #2
INFO cartography.graph.job: Finished job GCPServiceAccount
INFO cartography.graph.statement: Completed GCPRole statement #1
INFO cartography.graph.statement: Completed GCPRole statement #2
INFO cartography.graph.job: Finished job GCPRole
INFO cartography.intel.gcp: Syncing GCP project PROJECT_5 for IAM.
INFO cartography.intel.gcp.iam: Syncing GCP IAM for project PROJECT_5
INFO cartography.intel.gcp.iam: Found 8 service accounts in project PROJECT_5
INFO cartography.client.core.tx: Loaded 8 GCPServiceAccount nodes
INFO cartography.intel.gcp.iam: Found 0 custom project roles in project PROJECT_5
INFO cartography.intel.gcp: Syncing GCP project PROJECT_5 for Secret Manager.
INFO cartography.intel.gcp.secretsmanager: Syncing Secret Manager for project PROJECT_5.
INFO cartography.client.core.tx: Loaded 1 GCPSecretManagerSecret nodes
INFO cartography.intel.gcp.labels: Syncing 1 secret_manager_secret labels for project PROJECT_5 with batch_size=10000.
INFO cartography.client.core.tx: Loaded 1 GCPLabel nodes
INFO cartography.intel.gcp.secretsmanager: Loading 1 secret versions for project PROJECT_5 into graph.
INFO cartography.client.core.tx: Loaded 1 GCPSecretManagerSecretVersion nodes
INFO cartography.graph.statement: Completed GCPSecretManagerSecretVersion statement #1
INFO cartography.graph.statement: Completed GCPSecretManagerSecretVersion statement #2
INFO cartography.graph.statement: Completed GCPSecretManagerSecretVersion statement #3
INFO cartography.graph.job: Finished job GCPSecretManagerSecretVersion
INFO cartography.graph.statement: Completed GCPSecretManagerSecret statement #1
INFO cartography.graph.statement: Completed GCPSecretManagerSecret statement #2
INFO cartography.graph.job: Finished job GCPSecretManagerSecret
INFO cartography.intel.gcp: Syncing IAM policies for GCP project PROJECT_5.
INFO cartography.intel.gcp.permission_relationships: Built GCP permission evaluation context for project 'PROJECT_5': bindings=633, usable_bindings=462, member_assignments=556, principals=78, skipped_conditional=171, skipped_missing_roles=0
INFO cartography.client.core.tx: Loaded 633 GCPPolicyBinding nodes
INFO cartography.client.core.tx: Loaded 27 (GCPPolicyBinding)-[APPLIES_TO]->(GCPProject) relationships
INFO cartography.client.core.tx: Loaded 56 (GCPPolicyBinding)-[APPLIES_TO]->(GCPFolder) relationships
INFO cartography.client.core.tx: Loaded 189 (GCPPolicyBinding)-[APPLIES_TO]->(GCPOrganization) relationships
INFO cartography.client.core.tx: Loaded 304 (GCPPolicyBinding)-[APPLIES_TO]->(GCPArtifactRegistryRepository) relationships
INFO cartography.client.core.tx: Loaded 2 (GCPPolicyBinding)-[APPLIES_TO]->(GCPCloudRunService) relationships
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #1
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #2
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #3
INFO cartography.graph.statement: Completed GCPPolicyBinding statement #4
INFO cartography.graph.job: Finished job GCPPolicyBinding
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.graph.statement: Completed APPLIES_TO statement #1
INFO cartography.graph.job: Finished job APPLIES_TO
INFO cartography.intel.gcp.permission_relationships: Syncing GCP Permission Relationships for project 'PROJECT_5'.
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_READ' for resource type 'GCPBucket' in project 'PROJECT_5' with 1 permissions, 78 principals, and 0 resources
INFO cartography.intel.gcp.permission_relationships: No GCPBucket resources found for relationship 'CAN_READ' in project 'PROJECT_5'.
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_READ' for resource type 'GCPBucket' in project 'PROJECT_5' with 0 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_READ' for node label 'GCPBucket'
INFO cartography.graph.statement: Completed CAN_READ statement #1
INFO cartography.graph.job: Finished job CAN_READ
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_WRITE' for resource type 'GCPBucket' in project 'PROJECT_5' with 2 permissions, 78 principals, and 0 resources
INFO cartography.intel.gcp.permission_relationships: No GCPBucket resources found for relationship 'CAN_WRITE' in project 'PROJECT_5'.
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_WRITE' for resource type 'GCPBucket' in project 'PROJECT_5' with 0 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_WRITE' for node label 'GCPBucket'
INFO cartography.graph.statement: Completed CAN_WRITE statement #1
INFO cartography.graph.job: Finished job CAN_WRITE
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_DELETE' for resource type 'GCPBucket' in project 'PROJECT_5' with 1 permissions, 78 principals, and 0 resources
INFO cartography.intel.gcp.permission_relationships: No GCPBucket resources found for relationship 'CAN_DELETE' in project 'PROJECT_5'.
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_DELETE' for resource type 'GCPBucket' in project 'PROJECT_5' with 0 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_DELETE' for node label 'GCPBucket'
INFO cartography.graph.statement: Completed CAN_DELETE statement #1
INFO cartography.graph.job: Finished job CAN_DELETE
INFO cartography.intel.gcp.permission_relationships: Starting relationship 'CAN_READ' for resource type 'GCPSecretManagerSecret' in project 'PROJECT_5' with 1 permissions, 78 principals, and 1 resources
INFO cartography.intel.gcp.permission_relationships: Relationship 'CAN_READ' for 'GCPSecretManagerSecret': processed 1/1 resources (100.0%), loaded 0 relationships so far
INFO cartography.intel.gcp.permission_relationships: Loading 5 CAN_READ relationships for GCPPrincipal -> GCPSecretManagerSecret
INFO cartography.client.core.tx: Loaded 5 (GCPPrincipal)-[CAN_READ]->(GCPSecretManagerSecret) relationships
INFO cartography.intel.gcp.permission_relationships: Completed relationship 'CAN_READ' for 'GCPSecretManagerSecret': processed 1 resources and loaded 5 relationships
INFO cartography.intel.gcp.permission_relationships: Finished loading relationship 'CAN_READ' for resource type 'GCPSecretManagerSecret' in project 'PROJECT_5' with 5 total relationships before cleanup
INFO cartography.intel.gcp.permission_relationships: Cleaning up relationship 'CAN_READ' for node label 'GCPSecretManagerSecret'
INFO cartography.graph.statement: Completed CAN_READ statement #1
INFO cartography.graph.job: Finished job CAN_READ
INFO cartography.intel.gcp.permission_relationships: Completed GCP Permission Relationships sync for project PROJECT_5
INFO cartography.graph.statement: Completed GCPServiceAccount statement #1
INFO cartography.graph.statement: Completed GCPServiceAccount statement #2
INFO cartography.graph.job: Finished job GCPServiceAccount
INFO cartography.graph.statement: Completed GCPRole statement #1
INFO cartography.graph.statement: Completed GCPRole statement #2
INFO cartography.graph.job: Finished job GCPRole

```

</details>

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

### Notes for reviewers
This does not change the GCP permission relationship model or generated relationship semantics. It keeps the PR narrow to the permission-relationship hot path by reducing peak Neo4j read transaction memory, avoiding repeated Python-side assignment compilation, and adding just enough diagnostics to judge whether the read phase remains the bottleneck.
