### PR TITLE
perf(aws): Batch ECR image layer relationship loads

### DIFF
--- a/cartography/intel/aws/ecr_image_layers.py
+++ b/cartography/intel/aws/ecr_image_layers.py
@@ -19,7 +19,6 @@ from types_aiobotocore_ecr import ECRClient
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
-from cartography.graph.statement import GraphStatement
 from cartography.intel.aws.util.botocore_config import create_aioboto3_client
 from cartography.intel.container_arch import normalize_architecture
 from cartography.intel.supply_chain import extract_container_parent_image
@@ -695,9 +694,8 @@ def load_ecr_image_layers(
     """
     Load image layers into Neo4j.
 
-    Uses a conservative batch size (ECR_LAYER_LOAD_BATCH_SIZE) to avoid Neo4j
-    transaction memory limits, since layer objects can contain large arrays of
-    relationships.
+    Load layer nodes separately from NEXT/HEAD/TAIL relationships so each
+    transaction handles a bounded amount of node or relationship data.
     """
     logger.info(
         f"Loading {len(image_layers)} image layers for region {region} into graph.",
@@ -772,9 +770,8 @@ def load_ecr_image_layer_memberships(
     """
     Load image layer memberships into Neo4j.
 
-    Uses a conservative batch size (ECR_LAYER_MEMBERSHIP_BATCH_SIZE) to avoid
-    Neo4j transaction memory limits, since membership objects can contain large
-    arrays of layer diff_ids.
+    Load ECRImage layer metadata separately from HAS_LAYER relationships so
+    each transaction handles a bounded amount of node or relationship data.
     """
     load(
         neo4j_session,
@@ -1163,29 +1160,6 @@ def cleanup(neo4j_session: neo4j.Session, common_job_parameters: dict) -> None:
     GraphJob.from_node_schema(ECRImageLayerSchema(), common_job_parameters).run(
         neo4j_session
     )
-    _cleanup_has_layer_relationships(neo4j_session, common_job_parameters)
-
-
-def _cleanup_has_layer_relationships(
-    neo4j_session: neo4j.Session,
-    common_job_parameters: dict,
-) -> None:
-    statement = GraphStatement(
-        """
-        MATCH (:AWSAccount {id: $AWS_ID})-[:RESOURCE]->(:ECRImage)
-            -[r:HAS_LAYER]->(:ECRImageLayer)
-        WHERE r.lastupdated <> $UPDATE_TAG
-        WITH r LIMIT $LIMIT_SIZE
-        DELETE r
-        RETURN count(*) AS TotalCompleted
-        """,
-        common_job_parameters,
-        iterative=True,
-        iterationsize=ECR_LAYER_REL_BATCH_SIZE,
-        parent_job_name="HAS_LAYER",
-        parent_job_sequence_num=1,
-    )
-    statement.run(neo4j_session)
 
 
 @timeit

--- a/cartography/intel/aws/ecr_image_layers.py
+++ b/cartography/intel/aws/ecr_image_layers.py
@@ -18,20 +18,20 @@ from botocore.exceptions import ClientError
 from types_aiobotocore_ecr import ECRClient
 
 from cartography.client.core.tx import load
-from cartography.client.core.tx import load_matchlinks
 from cartography.graph.job import GraphJob
+from cartography.graph.statement import GraphStatement
 from cartography.intel.aws.util.botocore_config import create_aioboto3_client
 from cartography.intel.container_arch import normalize_architecture
 from cartography.intel.supply_chain import extract_container_parent_image
 from cartography.intel.supply_chain import extract_image_source_provenance
 from cartography.intel.supply_chain import extract_workflow_path_from_ref
-from cartography.models.aws.ecr.image import ECRImageHasLayerMatchLinkSchema
+from cartography.models.aws.ecr.image import ECRImageHasLayerRelSchema
 from cartography.models.aws.ecr.image import ECRImageLayerEnrichmentSchema
-from cartography.models.aws.ecr.image_layer import ECRImageLayerHeadMatchLinkSchema
-from cartography.models.aws.ecr.image_layer import ECRImageLayerNextMatchLinkSchema
+from cartography.models.aws.ecr.image_layer import ECRImageLayerHeadRelSchema
+from cartography.models.aws.ecr.image_layer import ECRImageLayerNextRelSchema
 from cartography.models.aws.ecr.image_layer import ECRImageLayerNodeSchema
 from cartography.models.aws.ecr.image_layer import ECRImageLayerSchema
-from cartography.models.aws.ecr.image_layer import ECRImageLayerTailMatchLinkSchema
+from cartography.models.aws.ecr.image_layer import ECRImageLayerTailRelSchema
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -648,11 +648,11 @@ def transform_ecr_image_layers(
     return layers, memberships
 
 
-def _build_next_relationships(image_layers: list[dict]) -> list[dict[str, str]]:
+def _build_next_relationships(image_layers: list[dict]) -> list[dict[str, Any]]:
     return [
         {
-            "source_diff_id": layer["diff_id"],
-            "target_diff_id": next_diff_id,
+            "diff_id": layer["diff_id"],
+            "next_diff_ids": [next_diff_id],
         }
         for layer in image_layers
         for next_diff_id in layer.get("next_diff_ids", [])
@@ -662,22 +662,22 @@ def _build_next_relationships(image_layers: list[dict]) -> list[dict[str, str]]:
 def _build_image_to_layer_relationships(
     image_layers: list[dict],
     image_id_field: str,
-) -> list[dict[str, str]]:
+) -> list[dict[str, Any]]:
     return [
         {
-            "image_id": image_id,
             "diff_id": layer["diff_id"],
+            image_id_field: [image_id],
         }
         for layer in image_layers
         for image_id in layer.get(image_id_field, [])
     ]
 
 
-def _build_has_layer_relationships(memberships: list[dict]) -> list[dict[str, str]]:
+def _build_has_layer_relationships(memberships: list[dict]) -> list[dict[str, Any]]:
     return [
         {
-            "image_id": membership["imageDigest"],
-            "diff_id": diff_id,
+            "imageDigest": membership["imageDigest"],
+            "layer_diff_ids": [diff_id],
         }
         for membership in memberships
         for diff_id in membership.get("layer_diff_ids", [])
@@ -718,14 +718,12 @@ def load_ecr_image_layers(
         len(next_relationships),
         region,
     )
-    load_matchlinks(
+    load(
         neo4j_session,
-        ECRImageLayerNextMatchLinkSchema(),
+        ECRImageLayerNextRelSchema(),
         next_relationships,
         batch_size=ECR_LAYER_REL_BATCH_SIZE,
         lastupdated=aws_update_tag,
-        _sub_resource_label="AWSAccount",
-        _sub_resource_id=current_aws_account_id,
     )
 
     head_relationships = _build_image_to_layer_relationships(
@@ -737,14 +735,12 @@ def load_ecr_image_layers(
         len(head_relationships),
         region,
     )
-    load_matchlinks(
+    load(
         neo4j_session,
-        ECRImageLayerHeadMatchLinkSchema(),
+        ECRImageLayerHeadRelSchema(),
         head_relationships,
         batch_size=ECR_LAYER_REL_BATCH_SIZE,
         lastupdated=aws_update_tag,
-        _sub_resource_label="AWSAccount",
-        _sub_resource_id=current_aws_account_id,
     )
 
     tail_relationships = _build_image_to_layer_relationships(
@@ -756,14 +752,12 @@ def load_ecr_image_layers(
         len(tail_relationships),
         region,
     )
-    load_matchlinks(
+    load(
         neo4j_session,
-        ECRImageLayerTailMatchLinkSchema(),
+        ECRImageLayerTailRelSchema(),
         tail_relationships,
         batch_size=ECR_LAYER_REL_BATCH_SIZE,
         lastupdated=aws_update_tag,
-        _sub_resource_label="AWSAccount",
-        _sub_resource_id=current_aws_account_id,
     )
 
 
@@ -798,14 +792,12 @@ def load_ecr_image_layer_memberships(
         len(has_layer_relationships),
         region,
     )
-    load_matchlinks(
+    load(
         neo4j_session,
-        ECRImageHasLayerMatchLinkSchema(),
+        ECRImageHasLayerRelSchema(),
         has_layer_relationships,
         batch_size=ECR_LAYER_REL_BATCH_SIZE,
         lastupdated=aws_update_tag,
-        _sub_resource_label="AWSAccount",
-        _sub_resource_id=current_aws_account_id,
     )
 
 
@@ -1168,27 +1160,32 @@ async def fetch_image_layers_async(
 
 def cleanup(neo4j_session: neo4j.Session, common_job_parameters: dict) -> None:
     logger.debug("Running image layer cleanup job.")
-    # Use the legacy fan-out schema for cleanup so pre-existing NEXT/HEAD/TAIL
-    # relationships created before matchlink loading are swept by update tag.
     GraphJob.from_node_schema(ECRImageLayerSchema(), common_job_parameters).run(
         neo4j_session
     )
-    update_tag = common_job_parameters["UPDATE_TAG"]
-    aws_account_id = common_job_parameters["AWS_ID"]
-    matchlink_cleanup_jobs = [
-        ECRImageLayerNextMatchLinkSchema(),
-        ECRImageLayerHeadMatchLinkSchema(),
-        ECRImageLayerTailMatchLinkSchema(),
-        ECRImageHasLayerMatchLinkSchema(),
-    ]
-    for rel_schema in matchlink_cleanup_jobs:
-        GraphJob.from_matchlink(
-            rel_schema,
-            "AWSAccount",
-            aws_account_id,
-            update_tag,
-            iterationsize=ECR_LAYER_REL_BATCH_SIZE,
-        ).run(neo4j_session)
+    _cleanup_has_layer_relationships(neo4j_session, common_job_parameters)
+
+
+def _cleanup_has_layer_relationships(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict,
+) -> None:
+    statement = GraphStatement(
+        """
+        MATCH (:AWSAccount {id: $AWS_ID})-[:RESOURCE]->(:ECRImage)
+            -[r:HAS_LAYER]->(:ECRImageLayer)
+        WHERE r.lastupdated <> $UPDATE_TAG
+        WITH r LIMIT $LIMIT_SIZE
+        DELETE r
+        RETURN count(*) AS TotalCompleted
+        """,
+        common_job_parameters,
+        iterative=True,
+        iterationsize=ECR_LAYER_REL_BATCH_SIZE,
+        parent_job_name="HAS_LAYER",
+        parent_job_sequence_num=1,
+    )
+    statement.run(neo4j_session)
 
 
 @timeit

--- a/cartography/intel/aws/ecr_image_layers.py
+++ b/cartography/intel/aws/ecr_image_layers.py
@@ -18,14 +18,20 @@ from botocore.exceptions import ClientError
 from types_aiobotocore_ecr import ECRClient
 
 from cartography.client.core.tx import load
+from cartography.client.core.tx import load_matchlinks
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.util.botocore_config import create_aioboto3_client
 from cartography.intel.container_arch import normalize_architecture
 from cartography.intel.supply_chain import extract_container_parent_image
 from cartography.intel.supply_chain import extract_image_source_provenance
 from cartography.intel.supply_chain import extract_workflow_path_from_ref
-from cartography.models.aws.ecr.image import ECRImageSchema
+from cartography.models.aws.ecr.image import ECRImageHasLayerMatchLinkSchema
+from cartography.models.aws.ecr.image import ECRImageLayerEnrichmentSchema
+from cartography.models.aws.ecr.image_layer import ECRImageLayerHeadMatchLinkSchema
+from cartography.models.aws.ecr.image_layer import ECRImageLayerNextMatchLinkSchema
+from cartography.models.aws.ecr.image_layer import ECRImageLayerNodeSchema
 from cartography.models.aws.ecr.image_layer import ECRImageLayerSchema
+from cartography.models.aws.ecr.image_layer import ECRImageLayerTailMatchLinkSchema
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -39,8 +45,11 @@ EMPTY_LAYER_DIFF_ID = (
     "sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef"
 )
 
-# Keep per-transaction memory low; each record fan-outs to many relationships.
+# Keep per-transaction memory low; each node record can carry large layer metadata.
 ECR_LAYER_BATCH_SIZE = 200
+# Matchlink rows are simple source/target pairs, so use larger batches while
+# keeping relationship transactions bounded and predictable.
+ECR_LAYER_REL_BATCH_SIZE = 1000
 
 # ECR manifest media types
 ECR_DOCKER_INDEX_MT = "application/vnd.docker.distribution.manifest.list.v2+json"
@@ -639,6 +648,42 @@ def transform_ecr_image_layers(
     return layers, memberships
 
 
+def _build_next_relationships(image_layers: list[dict]) -> list[dict[str, str]]:
+    return [
+        {
+            "source_diff_id": layer["diff_id"],
+            "target_diff_id": next_diff_id,
+        }
+        for layer in image_layers
+        for next_diff_id in layer.get("next_diff_ids", [])
+    ]
+
+
+def _build_image_to_layer_relationships(
+    image_layers: list[dict],
+    image_id_field: str,
+) -> list[dict[str, str]]:
+    return [
+        {
+            "image_id": image_id,
+            "diff_id": layer["diff_id"],
+        }
+        for layer in image_layers
+        for image_id in layer.get(image_id_field, [])
+    ]
+
+
+def _build_has_layer_relationships(memberships: list[dict]) -> list[dict[str, str]]:
+    return [
+        {
+            "image_id": membership["imageDigest"],
+            "diff_id": diff_id,
+        }
+        for membership in memberships
+        for diff_id in membership.get("layer_diff_ids", [])
+    ]
+
+
 @timeit
 def load_ecr_image_layers(
     neo4j_session: neo4j.Session,
@@ -660,11 +705,65 @@ def load_ecr_image_layers(
 
     load(
         neo4j_session,
-        ECRImageLayerSchema(),
+        ECRImageLayerNodeSchema(),
         image_layers,
         batch_size=ECR_LAYER_BATCH_SIZE,
         lastupdated=aws_update_tag,
         AWS_ID=current_aws_account_id,
+    )
+
+    next_relationships = _build_next_relationships(image_layers)
+    logger.info(
+        "Loading %d ECR image layer NEXT relationships for region %s into graph.",
+        len(next_relationships),
+        region,
+    )
+    load_matchlinks(
+        neo4j_session,
+        ECRImageLayerNextMatchLinkSchema(),
+        next_relationships,
+        batch_size=ECR_LAYER_REL_BATCH_SIZE,
+        lastupdated=aws_update_tag,
+        _sub_resource_label="AWSAccount",
+        _sub_resource_id=current_aws_account_id,
+    )
+
+    head_relationships = _build_image_to_layer_relationships(
+        image_layers,
+        "head_image_ids",
+    )
+    logger.info(
+        "Loading %d ECR image HEAD relationships for region %s into graph.",
+        len(head_relationships),
+        region,
+    )
+    load_matchlinks(
+        neo4j_session,
+        ECRImageLayerHeadMatchLinkSchema(),
+        head_relationships,
+        batch_size=ECR_LAYER_REL_BATCH_SIZE,
+        lastupdated=aws_update_tag,
+        _sub_resource_label="AWSAccount",
+        _sub_resource_id=current_aws_account_id,
+    )
+
+    tail_relationships = _build_image_to_layer_relationships(
+        image_layers,
+        "tail_image_ids",
+    )
+    logger.info(
+        "Loading %d ECR image TAIL relationships for region %s into graph.",
+        len(tail_relationships),
+        region,
+    )
+    load_matchlinks(
+        neo4j_session,
+        ECRImageLayerTailMatchLinkSchema(),
+        tail_relationships,
+        batch_size=ECR_LAYER_REL_BATCH_SIZE,
+        lastupdated=aws_update_tag,
+        _sub_resource_label="AWSAccount",
+        _sub_resource_id=current_aws_account_id,
     )
 
 
@@ -685,12 +784,28 @@ def load_ecr_image_layer_memberships(
     """
     load(
         neo4j_session,
-        ECRImageSchema(),
+        ECRImageLayerEnrichmentSchema(),
         memberships,
         batch_size=ECR_LAYER_BATCH_SIZE,
         lastupdated=aws_update_tag,
         Region=region,
         AWS_ID=current_aws_account_id,
+    )
+
+    has_layer_relationships = _build_has_layer_relationships(memberships)
+    logger.info(
+        "Loading %d ECR image HAS_LAYER relationships for region %s into graph.",
+        len(has_layer_relationships),
+        region,
+    )
+    load_matchlinks(
+        neo4j_session,
+        ECRImageHasLayerMatchLinkSchema(),
+        has_layer_relationships,
+        batch_size=ECR_LAYER_REL_BATCH_SIZE,
+        lastupdated=aws_update_tag,
+        _sub_resource_label="AWSAccount",
+        _sub_resource_id=current_aws_account_id,
     )
 
 
@@ -1053,9 +1168,27 @@ async def fetch_image_layers_async(
 
 def cleanup(neo4j_session: neo4j.Session, common_job_parameters: dict) -> None:
     logger.debug("Running image layer cleanup job.")
+    # Use the legacy fan-out schema for cleanup so pre-existing NEXT/HEAD/TAIL
+    # relationships created before matchlink loading are swept by update tag.
     GraphJob.from_node_schema(ECRImageLayerSchema(), common_job_parameters).run(
         neo4j_session
     )
+    update_tag = common_job_parameters["UPDATE_TAG"]
+    aws_account_id = common_job_parameters["AWS_ID"]
+    matchlink_cleanup_jobs = [
+        ECRImageLayerNextMatchLinkSchema(),
+        ECRImageLayerHeadMatchLinkSchema(),
+        ECRImageLayerTailMatchLinkSchema(),
+        ECRImageHasLayerMatchLinkSchema(),
+    ]
+    for rel_schema in matchlink_cleanup_jobs:
+        GraphJob.from_matchlink(
+            rel_schema,
+            "AWSAccount",
+            aws_account_id,
+            update_tag,
+            iterationsize=ECR_LAYER_REL_BATCH_SIZE,
+        ).run(neo4j_session)
 
 
 @timeit

--- a/cartography/models/aws/ecr/image.py
+++ b/cartography/models/aws/ecr/image.py
@@ -8,10 +8,8 @@ from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
-from cartography.models.core.relationships import make_source_node_matcher
 from cartography.models.core.relationships import make_target_node_matcher
 from cartography.models.core.relationships import OtherRelationships
-from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -272,30 +270,18 @@ class ECRImageLayerEnrichmentSchema(CartographyNodeSchema):
 
 
 @dataclass(frozen=True)
-class ECRImageHasLayerMatchLinkRelProperties(CartographyRelProperties):
+class ECRImageHasLayerRelLoadProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("imageDigest")
+    digest: PropertyRef = PropertyRef("imageDigest")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
-    _sub_resource_label: PropertyRef = PropertyRef(
-        "_sub_resource_label",
-        set_in_kwargs=True,
-    )
-    _sub_resource_id: PropertyRef = PropertyRef(
-        "_sub_resource_id",
-        set_in_kwargs=True,
-    )
 
 
 @dataclass(frozen=True)
-class ECRImageHasLayerMatchLinkSchema(CartographyRelSchema):
-    target_node_label: str = "ECRImageLayer"
-    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"diff_id": PropertyRef("diff_id")}
-    )
-    source_node_label: str = "ECRImage"
-    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
-        {"id": PropertyRef("image_id")}
-    )
-    direction: LinkDirection = LinkDirection.OUTWARD
-    rel_label: str = "HAS_LAYER"
-    properties: ECRImageHasLayerMatchLinkRelProperties = (
-        ECRImageHasLayerMatchLinkRelProperties()
+class ECRImageHasLayerRelSchema(CartographyNodeSchema):
+    """Load bounded HAS_LAYER relationship rows without reloading image metadata."""
+
+    label: str = "ECRImage"
+    properties: ECRImageHasLayerRelLoadProperties = ECRImageHasLayerRelLoadProperties()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [ECRImageHasLayerRel()],
     )

--- a/cartography/models/aws/ecr/image.py
+++ b/cartography/models/aws/ecr/image.py
@@ -8,8 +8,10 @@ from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
 from cartography.models.core.relationships import make_target_node_matcher
 from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -234,4 +236,66 @@ class ECRImageSchema(CartographyNodeSchema):
                 conditions={"type": "manifest_list"},
             ),
         ],
+    )
+
+
+@dataclass(frozen=True)
+class ECRImageLayerEnrichmentSchema(CartographyNodeSchema):
+    """Load ECRImage layer/provenance properties without fan-out HAS_LAYER edges."""
+
+    label: str = "ECRImage"
+    properties: ECRImageNodeProperties = ECRImageNodeProperties()
+    sub_resource_relationship: ECRImageToAWSAccountRel = ECRImageToAWSAccountRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            ECRImageToParentImageRel(),
+            ECRImageContainsImageRel(),
+            ECRImageAttestsRel(),
+        ],
+    )
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        [
+            ConditionalNodeLabel(
+                label="Image",
+                conditions={"type": "image"},
+            ),
+            ConditionalNodeLabel(
+                label="ImageAttestation",
+                conditions={"type": "attestation"},
+            ),
+            ConditionalNodeLabel(
+                label="ImageManifestList",
+                conditions={"type": "manifest_list"},
+            ),
+        ],
+    )
+
+
+@dataclass(frozen=True)
+class ECRImageHasLayerMatchLinkRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label",
+        set_in_kwargs=True,
+    )
+    _sub_resource_id: PropertyRef = PropertyRef(
+        "_sub_resource_id",
+        set_in_kwargs=True,
+    )
+
+
+@dataclass(frozen=True)
+class ECRImageHasLayerMatchLinkSchema(CartographyRelSchema):
+    target_node_label: str = "ECRImageLayer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"diff_id": PropertyRef("diff_id")}
+    )
+    source_node_label: str = "ECRImage"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("image_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_LAYER"
+    properties: ECRImageHasLayerMatchLinkRelProperties = (
+        ECRImageHasLayerMatchLinkRelProperties()
     )

--- a/cartography/models/aws/ecr/image_layer.py
+++ b/cartography/models/aws/ecr/image_layer.py
@@ -7,10 +7,8 @@ from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
-from cartography.models.core.relationships import make_source_node_matcher
 from cartography.models.core.relationships import make_target_node_matcher
 from cartography.models.core.relationships import OtherRelationships
-from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -123,64 +121,40 @@ class ECRImageLayerNodeSchema(CartographyNodeSchema):
 
 
 @dataclass(frozen=True)
-class ECRImageLayerMatchLinkRelProperties(CartographyRelProperties):
+class ECRImageLayerRelLoadProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("diff_id")
+    diff_id: PropertyRef = PropertyRef("diff_id")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
-    _sub_resource_label: PropertyRef = PropertyRef(
-        "_sub_resource_label",
-        set_in_kwargs=True,
-    )
-    _sub_resource_id: PropertyRef = PropertyRef(
-        "_sub_resource_id",
-        set_in_kwargs=True,
+
+
+@dataclass(frozen=True)
+class ECRImageLayerNextRelSchema(CartographyNodeSchema):
+    """Load bounded NEXT relationship rows without reloading layer metadata."""
+
+    label: str = "ECRImageLayer"
+    properties: ECRImageLayerRelLoadProperties = ECRImageLayerRelLoadProperties()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [ECRImageLayerToNextRel()],
     )
 
 
 @dataclass(frozen=True)
-class ECRImageLayerNextMatchLinkSchema(CartographyRelSchema):
-    target_node_label: str = "ECRImageLayer"
-    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"diff_id": PropertyRef("target_diff_id")}
-    )
-    source_node_label: str = "ECRImageLayer"
-    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
-        {"diff_id": PropertyRef("source_diff_id")}
-    )
-    direction: LinkDirection = LinkDirection.OUTWARD
-    rel_label: str = "NEXT"
-    properties: ECRImageLayerMatchLinkRelProperties = (
-        ECRImageLayerMatchLinkRelProperties()
+class ECRImageLayerHeadRelSchema(CartographyNodeSchema):
+    """Load bounded HEAD relationship rows without reloading layer metadata."""
+
+    label: str = "ECRImageLayer"
+    properties: ECRImageLayerRelLoadProperties = ECRImageLayerRelLoadProperties()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [ECRImageLayerHeadOfImageRel()],
     )
 
 
 @dataclass(frozen=True)
-class ECRImageLayerHeadMatchLinkSchema(CartographyRelSchema):
-    target_node_label: str = "ECRImageLayer"
-    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"diff_id": PropertyRef("diff_id")}
-    )
-    source_node_label: str = "ECRImage"
-    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
-        {"id": PropertyRef("image_id")}
-    )
-    direction: LinkDirection = LinkDirection.OUTWARD
-    rel_label: str = "HEAD"
-    properties: ECRImageLayerMatchLinkRelProperties = (
-        ECRImageLayerMatchLinkRelProperties()
-    )
+class ECRImageLayerTailRelSchema(CartographyNodeSchema):
+    """Load bounded TAIL relationship rows without reloading layer metadata."""
 
-
-@dataclass(frozen=True)
-class ECRImageLayerTailMatchLinkSchema(CartographyRelSchema):
-    target_node_label: str = "ECRImageLayer"
-    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"diff_id": PropertyRef("diff_id")}
-    )
-    source_node_label: str = "ECRImage"
-    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
-        {"id": PropertyRef("image_id")}
-    )
-    direction: LinkDirection = LinkDirection.OUTWARD
-    rel_label: str = "TAIL"
-    properties: ECRImageLayerMatchLinkRelProperties = (
-        ECRImageLayerMatchLinkRelProperties()
+    label: str = "ECRImageLayer"
+    properties: ECRImageLayerRelLoadProperties = ECRImageLayerRelLoadProperties()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [ECRImageLayerTailOfImageRel()],
     )

--- a/cartography/models/aws/ecr/image_layer.py
+++ b/cartography/models/aws/ecr/image_layer.py
@@ -7,8 +7,10 @@ from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
 from cartography.models.core.relationships import make_target_node_matcher
 from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -106,3 +108,79 @@ class ECRImageLayerSchema(CartographyNodeSchema):
         ]
     )
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ImageLayer"])
+
+
+@dataclass(frozen=True)
+class ECRImageLayerNodeSchema(CartographyNodeSchema):
+    """Load ECRImageLayer nodes without high-fanout one-to-many relationships."""
+
+    label: str = "ECRImageLayer"
+    properties: ECRImageLayerNodeProperties = ECRImageLayerNodeProperties()
+    sub_resource_relationship: ECRImageLayerToAWSAccountRel = (
+        ECRImageLayerToAWSAccountRel()
+    )
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ImageLayer"])
+
+
+@dataclass(frozen=True)
+class ECRImageLayerMatchLinkRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label",
+        set_in_kwargs=True,
+    )
+    _sub_resource_id: PropertyRef = PropertyRef(
+        "_sub_resource_id",
+        set_in_kwargs=True,
+    )
+
+
+@dataclass(frozen=True)
+class ECRImageLayerNextMatchLinkSchema(CartographyRelSchema):
+    target_node_label: str = "ECRImageLayer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"diff_id": PropertyRef("target_diff_id")}
+    )
+    source_node_label: str = "ECRImageLayer"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"diff_id": PropertyRef("source_diff_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "NEXT"
+    properties: ECRImageLayerMatchLinkRelProperties = (
+        ECRImageLayerMatchLinkRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ECRImageLayerHeadMatchLinkSchema(CartographyRelSchema):
+    target_node_label: str = "ECRImageLayer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"diff_id": PropertyRef("diff_id")}
+    )
+    source_node_label: str = "ECRImage"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("image_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HEAD"
+    properties: ECRImageLayerMatchLinkRelProperties = (
+        ECRImageLayerMatchLinkRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ECRImageLayerTailMatchLinkSchema(CartographyRelSchema):
+    target_node_label: str = "ECRImageLayer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"diff_id": PropertyRef("diff_id")}
+    )
+    source_node_label: str = "ECRImage"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("image_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "TAIL"
+    properties: ECRImageLayerMatchLinkRelProperties = (
+        ECRImageLayerMatchLinkRelProperties()
+    )

--- a/tests/unit/cartography/intel/aws/test_ecr_image_layers.py
+++ b/tests/unit/cartography/intel/aws/test_ecr_image_layers.py
@@ -18,6 +18,155 @@ from cartography.intel.aws.ecr_image_layers import transform_ecr_image_layers
 from cartography.intel.supply_chain import extract_workflow_path_from_ref
 
 
+def test_load_ecr_image_layers_flattens_relationships(monkeypatch):
+    load_mock = MagicMock()
+    load_matchlinks_mock = MagicMock()
+    monkeypatch.setattr(ecr_layers, "load", load_mock)
+    monkeypatch.setattr(ecr_layers, "load_matchlinks", load_matchlinks_mock)
+
+    layers = [
+        {
+            "diff_id": "sha256:layer-1",
+            "is_empty": False,
+            "next_diff_ids": ["sha256:layer-2", "sha256:layer-3"],
+            "head_image_ids": ["sha256:image-1"],
+            "tail_image_ids": ["sha256:image-2"],
+        },
+        {
+            "diff_id": "sha256:layer-2",
+            "is_empty": False,
+        },
+    ]
+
+    ecr_layers.load_ecr_image_layers(
+        MagicMock(),
+        layers,
+        "us-east-1",
+        "123456789012",
+        123,
+    )
+
+    assert load_mock.call_args.args[1].__class__.__name__ == "ECRImageLayerNodeSchema"
+    assert load_mock.call_args.kwargs["batch_size"] == ecr_layers.ECR_LAYER_BATCH_SIZE
+
+    next_call, head_call, tail_call = load_matchlinks_mock.call_args_list
+    assert next_call.args[1].__class__.__name__ == "ECRImageLayerNextMatchLinkSchema"
+    assert next_call.args[2] == [
+        {"source_diff_id": "sha256:layer-1", "target_diff_id": "sha256:layer-2"},
+        {"source_diff_id": "sha256:layer-1", "target_diff_id": "sha256:layer-3"},
+    ]
+    assert head_call.args[1].__class__.__name__ == "ECRImageLayerHeadMatchLinkSchema"
+    assert head_call.args[2] == [
+        {"image_id": "sha256:image-1", "diff_id": "sha256:layer-1"},
+    ]
+    assert tail_call.args[1].__class__.__name__ == "ECRImageLayerTailMatchLinkSchema"
+    assert tail_call.args[2] == [
+        {"image_id": "sha256:image-2", "diff_id": "sha256:layer-1"},
+    ]
+    assert all(
+        call.kwargs["batch_size"] == ecr_layers.ECR_LAYER_REL_BATCH_SIZE
+        for call in load_matchlinks_mock.call_args_list
+    )
+    assert all(
+        call.kwargs["_sub_resource_id"] == "123456789012"
+        for call in load_matchlinks_mock.call_args_list
+    )
+
+
+def test_load_ecr_image_layer_memberships_flattens_has_layer(monkeypatch):
+    load_mock = MagicMock()
+    load_matchlinks_mock = MagicMock()
+    monkeypatch.setattr(ecr_layers, "load", load_mock)
+    monkeypatch.setattr(ecr_layers, "load_matchlinks", load_matchlinks_mock)
+
+    memberships = [
+        {
+            "imageDigest": "sha256:image-1",
+            "layer_diff_ids": ["sha256:layer-1", "sha256:layer-2"],
+        },
+        {
+            "imageDigest": "sha256:image-2",
+            "layer_diff_ids": ["sha256:layer-3"],
+        },
+    ]
+
+    ecr_layers.load_ecr_image_layer_memberships(
+        MagicMock(),
+        memberships,
+        "us-east-1",
+        "123456789012",
+        123,
+    )
+
+    assert (
+        load_mock.call_args.args[1].__class__.__name__
+        == "ECRImageLayerEnrichmentSchema"
+    )
+    assert load_mock.call_args.kwargs["batch_size"] == ecr_layers.ECR_LAYER_BATCH_SIZE
+
+    assert (
+        load_matchlinks_mock.call_args.args[1].__class__.__name__
+        == "ECRImageHasLayerMatchLinkSchema"
+    )
+    assert load_matchlinks_mock.call_args.args[2] == [
+        {"image_id": "sha256:image-1", "diff_id": "sha256:layer-1"},
+        {"image_id": "sha256:image-1", "diff_id": "sha256:layer-2"},
+        {"image_id": "sha256:image-2", "diff_id": "sha256:layer-3"},
+    ]
+    assert (
+        load_matchlinks_mock.call_args.kwargs["batch_size"]
+        == ecr_layers.ECR_LAYER_REL_BATCH_SIZE
+    )
+    assert load_matchlinks_mock.call_args.kwargs["_sub_resource_id"] == "123456789012"
+
+
+def test_cleanup_runs_legacy_and_matchlink_cleanup_jobs(monkeypatch):
+    from_node_schema_mock = MagicMock(return_value=MagicMock())
+    from_matchlink_mock = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(
+        ecr_layers.GraphJob,
+        "from_node_schema",
+        from_node_schema_mock,
+    )
+    monkeypatch.setattr(
+        ecr_layers.GraphJob,
+        "from_matchlink",
+        from_matchlink_mock,
+    )
+
+    neo4j_session = MagicMock()
+    ecr_layers.cleanup(
+        neo4j_session,
+        {
+            "UPDATE_TAG": 123,
+            "AWS_ID": "123456789012",
+        },
+    )
+
+    assert from_node_schema_mock.call_args.args[0].__class__.__name__ == (
+        "ECRImageLayerSchema"
+    )
+
+    assert [
+        call.args[0].__class__.__name__ for call in from_matchlink_mock.call_args_list
+    ] == [
+        "ECRImageLayerNextMatchLinkSchema",
+        "ECRImageLayerHeadMatchLinkSchema",
+        "ECRImageLayerTailMatchLinkSchema",
+        "ECRImageHasLayerMatchLinkSchema",
+    ]
+    assert all(
+        call.args[1:] == ("AWSAccount", "123456789012", 123)
+        for call in from_matchlink_mock.call_args_list
+    )
+    assert all(
+        call.kwargs["iterationsize"] == ecr_layers.ECR_LAYER_REL_BATCH_SIZE
+        for call in from_matchlink_mock.call_args_list
+    )
+    assert from_node_schema_mock.return_value.run.call_args.args == (neo4j_session,)
+    assert from_matchlink_mock.return_value.run.call_count == 4
+
+
 @pytest.mark.parametrize(
     "input_uri,expected_repo_uri",
     [

--- a/tests/unit/cartography/intel/aws/test_ecr_image_layers.py
+++ b/tests/unit/cartography/intel/aws/test_ecr_image_layers.py
@@ -20,9 +20,7 @@ from cartography.intel.supply_chain import extract_workflow_path_from_ref
 
 def test_load_ecr_image_layers_flattens_relationships(monkeypatch):
     load_mock = MagicMock()
-    load_matchlinks_mock = MagicMock()
     monkeypatch.setattr(ecr_layers, "load", load_mock)
-    monkeypatch.setattr(ecr_layers, "load_matchlinks", load_matchlinks_mock)
 
     layers = [
         {
@@ -46,38 +44,31 @@ def test_load_ecr_image_layers_flattens_relationships(monkeypatch):
         123,
     )
 
-    assert load_mock.call_args.args[1].__class__.__name__ == "ECRImageLayerNodeSchema"
-    assert load_mock.call_args.kwargs["batch_size"] == ecr_layers.ECR_LAYER_BATCH_SIZE
-
-    next_call, head_call, tail_call = load_matchlinks_mock.call_args_list
-    assert next_call.args[1].__class__.__name__ == "ECRImageLayerNextMatchLinkSchema"
+    node_call, next_call, head_call, tail_call = load_mock.call_args_list
+    assert node_call.args[1].__class__.__name__ == "ECRImageLayerNodeSchema"
+    assert node_call.kwargs["batch_size"] == ecr_layers.ECR_LAYER_BATCH_SIZE
+    assert next_call.args[1].__class__.__name__ == "ECRImageLayerNextRelSchema"
     assert next_call.args[2] == [
-        {"source_diff_id": "sha256:layer-1", "target_diff_id": "sha256:layer-2"},
-        {"source_diff_id": "sha256:layer-1", "target_diff_id": "sha256:layer-3"},
+        {"diff_id": "sha256:layer-1", "next_diff_ids": ["sha256:layer-2"]},
+        {"diff_id": "sha256:layer-1", "next_diff_ids": ["sha256:layer-3"]},
     ]
-    assert head_call.args[1].__class__.__name__ == "ECRImageLayerHeadMatchLinkSchema"
+    assert head_call.args[1].__class__.__name__ == "ECRImageLayerHeadRelSchema"
     assert head_call.args[2] == [
-        {"image_id": "sha256:image-1", "diff_id": "sha256:layer-1"},
+        {"head_image_ids": ["sha256:image-1"], "diff_id": "sha256:layer-1"},
     ]
-    assert tail_call.args[1].__class__.__name__ == "ECRImageLayerTailMatchLinkSchema"
+    assert tail_call.args[1].__class__.__name__ == "ECRImageLayerTailRelSchema"
     assert tail_call.args[2] == [
-        {"image_id": "sha256:image-2", "diff_id": "sha256:layer-1"},
+        {"tail_image_ids": ["sha256:image-2"], "diff_id": "sha256:layer-1"},
     ]
     assert all(
         call.kwargs["batch_size"] == ecr_layers.ECR_LAYER_REL_BATCH_SIZE
-        for call in load_matchlinks_mock.call_args_list
-    )
-    assert all(
-        call.kwargs["_sub_resource_id"] == "123456789012"
-        for call in load_matchlinks_mock.call_args_list
+        for call in load_mock.call_args_list[1:]
     )
 
 
 def test_load_ecr_image_layer_memberships_flattens_has_layer(monkeypatch):
     load_mock = MagicMock()
-    load_matchlinks_mock = MagicMock()
     monkeypatch.setattr(ecr_layers, "load", load_mock)
-    monkeypatch.setattr(ecr_layers, "load_matchlinks", load_matchlinks_mock)
 
     memberships = [
         {
@@ -98,40 +89,31 @@ def test_load_ecr_image_layer_memberships_flattens_has_layer(monkeypatch):
         123,
     )
 
-    assert (
-        load_mock.call_args.args[1].__class__.__name__
-        == "ECRImageLayerEnrichmentSchema"
-    )
-    assert load_mock.call_args.kwargs["batch_size"] == ecr_layers.ECR_LAYER_BATCH_SIZE
-
-    assert (
-        load_matchlinks_mock.call_args.args[1].__class__.__name__
-        == "ECRImageHasLayerMatchLinkSchema"
-    )
-    assert load_matchlinks_mock.call_args.args[2] == [
-        {"image_id": "sha256:image-1", "diff_id": "sha256:layer-1"},
-        {"image_id": "sha256:image-1", "diff_id": "sha256:layer-2"},
-        {"image_id": "sha256:image-2", "diff_id": "sha256:layer-3"},
+    enrichment_call = load_mock.call_args_list[0]
+    has_layer_call = load_mock.call_args_list[1]
+    assert enrichment_call.args[1].__class__.__name__ == "ECRImageLayerEnrichmentSchema"
+    assert enrichment_call.kwargs["batch_size"] == ecr_layers.ECR_LAYER_BATCH_SIZE
+    assert has_layer_call.args[1].__class__.__name__ == "ECRImageHasLayerRelSchema"
+    assert has_layer_call.args[2] == [
+        {"imageDigest": "sha256:image-1", "layer_diff_ids": ["sha256:layer-1"]},
+        {"imageDigest": "sha256:image-1", "layer_diff_ids": ["sha256:layer-2"]},
+        {"imageDigest": "sha256:image-2", "layer_diff_ids": ["sha256:layer-3"]},
     ]
-    assert (
-        load_matchlinks_mock.call_args.kwargs["batch_size"]
-        == ecr_layers.ECR_LAYER_REL_BATCH_SIZE
-    )
-    assert load_matchlinks_mock.call_args.kwargs["_sub_resource_id"] == "123456789012"
+    assert has_layer_call.kwargs["batch_size"] == ecr_layers.ECR_LAYER_REL_BATCH_SIZE
 
 
-def test_cleanup_runs_legacy_and_matchlink_cleanup_jobs(monkeypatch):
+def test_cleanup_runs_layer_and_has_layer_cleanup_jobs(monkeypatch):
     from_node_schema_mock = MagicMock(return_value=MagicMock())
-    from_matchlink_mock = MagicMock(return_value=MagicMock())
+    graph_statement_mock = MagicMock(return_value=MagicMock())
     monkeypatch.setattr(
         ecr_layers.GraphJob,
         "from_node_schema",
         from_node_schema_mock,
     )
     monkeypatch.setattr(
-        ecr_layers.GraphJob,
-        "from_matchlink",
-        from_matchlink_mock,
+        ecr_layers,
+        "GraphStatement",
+        graph_statement_mock,
     )
 
     neo4j_session = MagicMock()
@@ -146,25 +128,16 @@ def test_cleanup_runs_legacy_and_matchlink_cleanup_jobs(monkeypatch):
     assert from_node_schema_mock.call_args.args[0].__class__.__name__ == (
         "ECRImageLayerSchema"
     )
-
-    assert [
-        call.args[0].__class__.__name__ for call in from_matchlink_mock.call_args_list
-    ] == [
-        "ECRImageLayerNextMatchLinkSchema",
-        "ECRImageLayerHeadMatchLinkSchema",
-        "ECRImageLayerTailMatchLinkSchema",
-        "ECRImageHasLayerMatchLinkSchema",
-    ]
-    assert all(
-        call.args[1:] == ("AWSAccount", "123456789012", 123)
-        for call in from_matchlink_mock.call_args_list
-    )
-    assert all(
-        call.kwargs["iterationsize"] == ecr_layers.ECR_LAYER_REL_BATCH_SIZE
-        for call in from_matchlink_mock.call_args_list
-    )
     assert from_node_schema_mock.return_value.run.call_args.args == (neo4j_session,)
-    assert from_matchlink_mock.return_value.run.call_count == 4
+    graph_statement_mock.assert_called_once()
+    assert graph_statement_mock.call_args.args[1] == {
+        "UPDATE_TAG": 123,
+        "AWS_ID": "123456789012",
+    }
+    assert graph_statement_mock.call_args.kwargs["iterationsize"] == (
+        ecr_layers.ECR_LAYER_REL_BATCH_SIZE
+    )
+    assert graph_statement_mock.return_value.run.call_args.args == (neo4j_session,)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cartography/intel/aws/test_ecr_image_layers.py
+++ b/tests/unit/cartography/intel/aws/test_ecr_image_layers.py
@@ -102,18 +102,12 @@ def test_load_ecr_image_layer_memberships_flattens_has_layer(monkeypatch):
     assert has_layer_call.kwargs["batch_size"] == ecr_layers.ECR_LAYER_REL_BATCH_SIZE
 
 
-def test_cleanup_runs_layer_and_has_layer_cleanup_jobs(monkeypatch):
+def test_cleanup_runs_layer_cleanup_job(monkeypatch):
     from_node_schema_mock = MagicMock(return_value=MagicMock())
-    graph_statement_mock = MagicMock(return_value=MagicMock())
     monkeypatch.setattr(
         ecr_layers.GraphJob,
         "from_node_schema",
         from_node_schema_mock,
-    )
-    monkeypatch.setattr(
-        ecr_layers,
-        "GraphStatement",
-        graph_statement_mock,
     )
 
     neo4j_session = MagicMock()
@@ -129,15 +123,6 @@ def test_cleanup_runs_layer_and_has_layer_cleanup_jobs(monkeypatch):
         "ECRImageLayerSchema"
     )
     assert from_node_schema_mock.return_value.run.call_args.args == (neo4j_session,)
-    graph_statement_mock.assert_called_once()
-    assert graph_statement_mock.call_args.args[1] == {
-        "UPDATE_TAG": 123,
-        "AWS_ID": "123456789012",
-    }
-    assert graph_statement_mock.call_args.kwargs["iterationsize"] == (
-        ecr_layers.ECR_LAYER_REL_BATCH_SIZE
-    )
-    assert graph_statement_mock.return_value.run.call_args.args == (neo4j_session,)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
Split ECR image layer relationship writes out of high-fanout node ingestion queries and load them as scoped matchlinks in smaller batches.

This keeps the existing graph model intact while reducing transaction memory pressure for repositories with many image layers.

### Related issues or links
N/A

### Breaking changes
None.

### How was this tested?
- Tested locally 
```
2026-04-26 16:54:21,267 INFO cartography.intel.aws.ecr Loading 1 ECR repositories for region us-east-1 into graph.
2026-04-26 16:54:21,382 INFO cartography.client.core.tx Loaded 1 ECRRepository nodes
2026-04-26 16:54:21,382 INFO cartography.intel.aws.ecr Loading 1 ECR images and 1 ECR repository images in us-east-1 into graph.
2026-04-26 16:54:21,790 INFO cartography.client.core.tx Loaded 1 ECRImage nodes
2026-04-26 16:54:21,904 INFO cartography.client.core.tx Loaded 1 ECRRepositoryImage nodes
2026-04-26 16:54:21,904 INFO cartography.intel.aws.ecr_image_layers Syncing ECR image layers for region 'us-east-1' in account '<AWS_ACCOUNT_ID>'.
2026-04-26 16:54:21,944 INFO cartography.intel.aws.ecr_image_layers Found 1 distinct ECR image digests in graph for region us-east-1
2026-04-26 16:54:21,944 INFO cartography.intel.aws.ecr_image_layers Starting to fetch layers for 1 images...
2026-04-26 16:54:21,960 INFO cartography.intel.aws.ecr_image_layers Fetching layers for 1 images with 200 concurrent connections...
2026-04-26 16:54:22,738 INFO cartography.intel.aws.ecr_image_layers Fetched layer metadata for 1/1 images (100.0%)
2026-04-26 16:54:22,738 INFO cartography.intel.aws.ecr_image_layers Successfully fetched layers for 1/1 images
2026-04-26 16:54:22,738 INFO cartography.intel.aws.ecr_image_layers Extracted history commands for 10 layers
2026-04-26 16:54:22,739 INFO cartography.intel.aws.ecr_image_layers Successfully fetched layers for 1 images
2026-04-26 16:54:22,739 INFO cartography.intel.aws.ecr_image_layers Loading 10 image layers for region us-east-1 into graph.
2026-04-26 16:54:22,820 INFO cartography.client.core.tx Loaded 10 ECRImageLayer nodes
2026-04-26 16:54:22,820 INFO cartography.intel.aws.ecr_image_layers Loading 9 ECR image layer NEXT relationships for region us-east-1 into graph.
2026-04-26 16:54:22,857 INFO cartography.client.core.tx Loaded 9 (ECRImageLayer)-[NEXT]->(ECRImageLayer) relationships
2026-04-26 16:54:22,857 INFO cartography.intel.aws.ecr_image_layers Loading 1 ECR image HEAD relationships for region us-east-1 into graph.
2026-04-26 16:54:22,888 INFO cartography.client.core.tx Loaded 1 (ECRImage)-[HEAD]->(ECRImageLayer) relationships
2026-04-26 16:54:22,888 INFO cartography.intel.aws.ecr_image_layers Loading 1 ECR image TAIL relationships for region us-east-1 into graph.
2026-04-26 16:54:22,918 INFO cartography.client.core.tx Loaded 1 (ECRImage)-[TAIL]->(ECRImageLayer) relationships
2026-04-26 16:54:23,150 INFO cartography.client.core.tx Loaded 1 ECRImage nodes
2026-04-26 16:54:23,150 INFO cartography.intel.aws.ecr_image_layers Loading 10 ECR image HAS_LAYER relationships for region us-east-1 into graph.
2026-04-26 16:54:23,184 INFO cartography.client.core.tx Loaded 10 (ECRImage)-[HAS_LAYER]->(ECRImageLayer) relationships
2026-04-26 16:54:23,206 INFO cartography.graph.statement Completed ECRImageLayer statement #1
2026-04-26 16:54:23,225 INFO cartography.graph.statement Completed ECRImageLayer statement #2
2026-04-26 16:54:23,246 INFO cartography.graph.statement Completed ECRImageLayer statement #3
2026-04-26 16:54:23,266 INFO cartography.graph.statement Completed ECRImageLayer statement #4
2026-04-26 16:54:23,286 INFO cartography.graph.statement Completed ECRImageLayer statement #5
2026-04-26 16:54:23,286 INFO cartography.graph.job Finished job ECRImageLayer
2026-04-26 16:54:23,307 INFO cartography.graph.statement Completed NEXT statement #1
2026-04-26 16:54:23,307 INFO cartography.graph.job Finished job NEXT
2026-04-26 16:54:23,326 INFO cartography.graph.statement Completed HEAD statement #1
2026-04-26 16:54:23,326 INFO cartography.graph.job Finished job HEAD
2026-04-26 16:54:23,345 INFO cartography.graph.statement Completed TAIL statement #1
2026-04-26 16:54:23,345 INFO cartography.graph.job Finished job TAIL
2026-04-26 16:54:23,365 INFO cartography.graph.statement Completed HAS_LAYER statement #1
2026-04-26 16:54:23,365 INFO cartography.graph.job Finished job HAS_LAYER
```

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
N/A

#### If you are changing a node or relationship
N/A. This changes the load strategy for existing ECR image layer relationships; it does not add or rename graph nodes or relationships.

#### If you are implementing a new intel module
N/A

### Notes for reviewers
The main behavior change is that `NEXT`, `HEAD`, `TAIL`, and `HAS_LAYER` are loaded as flattened matchlink rows instead of as one-to-many relationship arrays during node ingestion.