### PR TITLE
fix(syft): link packages with current image digests

### DIFF
--- a/cartography/intel/syft/parser.py
+++ b/cartography/intel/syft/parser.py
@@ -73,19 +73,13 @@ def _append_repo_digests(digests: list[str], repo_digests: Any) -> None:
 
 def _extract_image_digests(data: dict[str, Any]) -> list[str]:
     """
-    Extract image digest candidates from legacy and current Syft source shapes.
+    Extract image digest candidates from Syft's current source metadata shape.
     """
     source = data.get("source", {})
     if not isinstance(source, dict) or source.get("type") != "image":
         return []
 
     digests: list[str] = []
-
-    target = source.get("target", {})
-    if isinstance(target, dict):
-        _append_digest(digests, target.get("digest"))
-        _append_digest(digests, target.get("manifestDigest"))
-        _append_repo_digests(digests, target.get("repoDigests"))
 
     metadata = source.get("metadata", {})
     if isinstance(metadata, dict):

--- a/cartography/intel/syft/parser.py
+++ b/cartography/intel/syft/parser.py
@@ -14,7 +14,7 @@ Syft JSON Format Reference:
         ],
         "source": {
             "type": "image",
-            "target": {"digest": "sha256:...", "tags": ["myimage:latest"]}
+            "metadata": {"manifestDigest": "sha256:...", "repoDigests": ["myimage@sha256:..."]}
         },
         "schema": {"version": "16.0.0"}
     }
@@ -48,6 +48,51 @@ def _build_artifact_lookup(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
         Dictionary mapping artifact ID -> artifact data dict
     """
     return {artifact["id"]: artifact for artifact in data.get("artifacts", [])}
+
+
+def _append_digest(digests: list[str], digest: Any) -> None:
+    if (
+        isinstance(digest, str)
+        and digest.startswith("sha256:")
+        and digest not in digests
+    ):
+        digests.append(digest)
+
+
+def _append_repo_digests(digests: list[str], repo_digests: Any) -> None:
+    if not isinstance(repo_digests, list):
+        return
+
+    for repo_digest in repo_digests:
+        if not isinstance(repo_digest, str):
+            continue
+        _, separator, digest = repo_digest.rpartition("@")
+        if separator:
+            _append_digest(digests, digest)
+
+
+def _extract_image_digests(data: dict[str, Any]) -> list[str]:
+    """
+    Extract image digest candidates from legacy and current Syft source shapes.
+    """
+    source = data.get("source", {})
+    if not isinstance(source, dict) or source.get("type") != "image":
+        return []
+
+    digests: list[str] = []
+
+    target = source.get("target", {})
+    if isinstance(target, dict):
+        _append_digest(digests, target.get("digest"))
+        _append_digest(digests, target.get("manifestDigest"))
+        _append_repo_digests(digests, target.get("repoDigests"))
+
+    metadata = source.get("metadata", {})
+    if isinstance(metadata, dict):
+        _append_digest(digests, metadata.get("manifestDigest"))
+        _append_repo_digests(digests, metadata.get("repoDigests"))
+
+    return digests
 
 
 def transform_artifacts(data: dict[str, Any]) -> list[dict[str, Any]]:
@@ -94,10 +139,7 @@ def transform_artifacts(data: dict[str, Any]) -> list[dict[str, Any]]:
             continue
         dep_map.setdefault(child_id, []).append(parent_norm_id)
 
-    # Extract image digest from source metadata when available
-    source = data.get("source", {})
-    target = source.get("target", {}) if source.get("type") == "image" else {}
-    image_digest = target.get("digest")
+    image_digests = _extract_image_digests(data)
 
     packages: list[dict[str, Any]] = []
     for artifact_id, artifact in artifacts.items():
@@ -124,7 +166,7 @@ def transform_artifacts(data: dict[str, Any]) -> list[dict[str, Any]]:
                 "language": artifact.get("language"),
                 "found_by": artifact.get("foundBy"),
                 "dependency_ids": dep_map.get(artifact_id, []),
-                "ImageDigest": image_digest,
+                "ImageDigestCandidates": image_digests,
             }
         )
 

--- a/cartography/intel/syft/parser.py
+++ b/cartography/intel/syft/parser.py
@@ -74,6 +74,8 @@ def _append_repo_digests(digests: list[str], repo_digests: Any) -> None:
 def _extract_image_digests(data: dict[str, Any]) -> list[str]:
     """
     Extract image digest candidates from Syft's current source metadata shape.
+
+    The order is deterministic: manifestDigest first, then repoDigests.
     """
     source = data.get("source", {})
     if not isinstance(source, dict) or source.get("type") != "image":
@@ -134,6 +136,12 @@ def transform_artifacts(data: dict[str, Any]) -> list[dict[str, Any]]:
         dep_map.setdefault(child_id, []).append(parent_norm_id)
 
     image_digests = _extract_image_digests(data)
+    source = data.get("source", {})
+    if isinstance(source, dict) and source.get("type") == "image" and not image_digests:
+        logger.warning(
+            "Syft image source did not include image digest candidates; "
+            "SyftPackage DEPLOYED relationships to Image nodes will be skipped.",
+        )
 
     packages: list[dict[str, Any]] = []
     for artifact_id, artifact in artifacts.items():

--- a/cartography/models/syft/package.py
+++ b/cartography/models/syft/package.py
@@ -63,7 +63,7 @@ class SyftPackageToOntologyImageRelProperties(CartographyRelProperties):
 class SyftPackageToOntologyImageRel(CartographyRelSchema):
     target_node_label: str = "Image"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"_ont_digest": PropertyRef("ImageDigest")},
+        {"_ont_digest": PropertyRef("ImageDigestCandidates", one_to_many=True)},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "DEPLOYED"

--- a/tests/data/syft/syft_sample.py
+++ b/tests/data/syft/syft_sample.py
@@ -106,8 +106,11 @@ SYFT_SAMPLE = {
         # express and lodash are roots (nothing depends on them)
     ],
     "source": {
+        "id": "sha256:source",
+        "name": "myapp",
+        "version": "latest",
         "type": "image",
-        "target": {
+        "metadata": {
             "userInput": "myapp:latest",
             "imageID": "sha256:abc123def456",
             "manifestDigest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",

--- a/tests/integration/cartography/intel/ontology/test_packages_end_to_end.py
+++ b/tests/integration/cartography/intel/ontology/test_packages_end_to_end.py
@@ -53,7 +53,7 @@ SYFT_TRIVY_OVERLAP_SAMPLE = {
     ],
     "source": {
         "type": "image",
-        "target": {"digest": TEST_IMAGE_DIGEST},
+        "metadata": {"manifestDigest": TEST_IMAGE_DIGEST},
     },
 }
 

--- a/tests/integration/cartography/intel/syft/test_syft.py
+++ b/tests/integration/cartography/intel/syft/test_syft.py
@@ -55,7 +55,7 @@ SYFT_CURRENT_SOURCE_SAMPLE = {
     },
 }
 
-SYFT_CURRENT_DIGEST_SOURCE_SAMPLE = {
+SYFT_CURRENT_REPO_DIGEST_SOURCE_SAMPLE = {
     **SYFT_SAMPLE,
     "source": {
         "id": "sha256:source",
@@ -286,18 +286,18 @@ def test_sync_single_syft_creates_deployed_to_current_source_image_digest(
     assert actual_rels == expected_rels
 
 
-def test_sync_single_syft_creates_deployed_to_digest_qualified_image(
+def test_sync_single_syft_creates_deployed_from_repo_digest_candidate(
     neo4j_session,
 ):
     """
-    Test digest-qualified current Syft output links to the scanned platform Image.
+    Test current Syft repoDigests can link to the scanned platform Image.
     """
     neo4j_session.run("MATCH (n:SyftPackage) DETACH DELETE n")
     _sync_single_platform_image(neo4j_session, "sha256:platform")
 
     sync_single_syft(
         neo4j_session,
-        SYFT_CURRENT_DIGEST_SOURCE_SAMPLE,
+        SYFT_CURRENT_REPO_DIGEST_SOURCE_SAMPLE,
         TEST_UPDATE_TAG,
     )
 

--- a/tests/integration/cartography/intel/syft/test_syft.py
+++ b/tests/integration/cartography/intel/syft/test_syft.py
@@ -9,15 +9,147 @@ import json
 from unittest.mock import mock_open
 from unittest.mock import patch
 
+import cartography.intel.aws.ecr
 from cartography.intel.syft import sync_single_syft
 from cartography.intel.syft import sync_syft_from_dir
 from tests.data.syft.syft_sample import EXPECTED_SYFT_PACKAGE_DEPENDENCIES
 from tests.data.syft.syft_sample import EXPECTED_SYFT_PACKAGES
 from tests.data.syft.syft_sample import SYFT_SAMPLE
+from tests.integration.cartography.intel.aws.common import create_test_account
 from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
+TEST_ACCOUNT_ID = "000000000000"
+TEST_REGION = "us-east-1"
+TEST_REPOSITORY_URI = (
+    "000000000000.dkr.ecr.us-east-1.amazonaws.com/syft-test-repository"
+)
+TEST_REPOSITORY = {
+    "repositoryArn": (
+        "arn:aws:ecr:us-east-1:000000000000:repository/syft-test-repository"
+    ),
+    "registryId": TEST_ACCOUNT_ID,
+    "repositoryName": "syft-test-repository",
+    "repositoryUri": TEST_REPOSITORY_URI,
+    "createdAt": "2025-01-01T00:00:00.000000-00:00",
+}
+
+SYFT_CURRENT_SOURCE_SAMPLE = {
+    **SYFT_SAMPLE,
+    "source": {
+        "id": "sha256:source",
+        "name": "alpine",
+        "version": "3.19",
+        "type": "image",
+        "metadata": {
+            "userInput": "alpine:3.19",
+            "imageID": "sha256:image-config",
+            "manifestDigest": "sha256:platform",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tags": ["alpine:3.19"],
+            "repoDigests": ["alpine@sha256:index"],
+            "architecture": "arm64",
+            "os": "linux",
+        },
+    },
+}
+
+SYFT_CURRENT_DIGEST_SOURCE_SAMPLE = {
+    **SYFT_SAMPLE,
+    "source": {
+        "id": "sha256:source",
+        "name": "alpine",
+        "version": "sha256:platform",
+        "type": "image",
+        "metadata": {
+            "userInput": "alpine@sha256:platform",
+            "imageID": "sha256:image-config",
+            "manifestDigest": "sha256:local-manifest",
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "tags": [],
+            "repoDigests": ["alpine@sha256:platform"],
+            "architecture": "arm64",
+            "os": "linux",
+        },
+    },
+}
+
+
+def _sync_ecr_repository_images(
+    neo4j_session,
+    image_details: list[dict],
+) -> None:
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    cartography.intel.aws.ecr.load_ecr_repositories(
+        neo4j_session,
+        [TEST_REPOSITORY],
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+    repo_images_list, ecr_images_list = (
+        cartography.intel.aws.ecr.transform_ecr_repository_images(
+            {TEST_REPOSITORY_URI: image_details},
+        )
+    )
+    cartography.intel.aws.ecr.load_ecr_repository_images(
+        neo4j_session,
+        repo_images_list,
+        ecr_images_list,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+def _sync_single_platform_image(
+    neo4j_session,
+    image_digest: str,
+) -> None:
+    _sync_ecr_repository_images(
+        neo4j_session,
+        [
+            {
+                "imageDigest": image_digest,
+                "imageTag": "latest",
+                "repositoryName": "syft-test-repository",
+                "imageManifestMediaType": (
+                    "application/vnd.docker.distribution.manifest.v2+json"
+                ),
+            },
+        ],
+    )
+
+
+def _sync_manifest_list_with_platform_image(
+    neo4j_session,
+    manifest_list_digest: str,
+    platform_image_digest: str,
+) -> None:
+    _sync_ecr_repository_images(
+        neo4j_session,
+        [
+            {
+                "imageDigest": manifest_list_digest,
+                "imageTag": "latest",
+                "repositoryName": "syft-test-repository",
+                "imageManifestMediaType": "application/vnd.oci.image.index.v1+json",
+                "_manifest_images": [
+                    {
+                        "digest": platform_image_digest,
+                        "type": "image",
+                        "architecture": "arm64",
+                        "os": "linux",
+                        "variant": None,
+                        "media_type": (
+                            "application/vnd.docker.distribution.manifest.v2+json"
+                        ),
+                    },
+                ],
+            },
+        ],
+    )
 
 
 def test_sync_single_syft_creates_syft_package_nodes(neo4j_session):
@@ -85,15 +217,9 @@ def test_sync_single_syft_creates_deployed_to_image(neo4j_session):
     Test that sync_single_syft creates DEPLOYED relationships to ontology Image nodes.
     """
     neo4j_session.run("MATCH (n:SyftPackage) DETACH DELETE n")
-
-    # Create an ontology Image node with matching _ont_digest
-    neo4j_session.run(
-        """
-        MERGE (img:Image {id: 'test-image'})
-        SET img._ont_digest = 'sha256:0000000000000000000000000000000000000000000000000000000000000000',
-            img.lastupdated = $update_tag
-        """,
-        update_tag=TEST_UPDATE_TAG,
+    _sync_single_platform_image(
+        neo4j_session,
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     )
 
     sync_single_syft(
@@ -119,6 +245,73 @@ def test_sync_single_syft_creates_deployed_to_image(neo4j_session):
         )
         for pkg_id in EXPECTED_SYFT_PACKAGES
     }
+    assert actual_rels == expected_rels
+
+
+def test_sync_single_syft_creates_deployed_to_current_source_image_digest(
+    neo4j_session,
+):
+    """
+    Test that current Syft source.metadata digests link to Image, not ImageManifestList.
+    """
+    neo4j_session.run("MATCH (n:SyftPackage) DETACH DELETE n")
+    _sync_manifest_list_with_platform_image(
+        neo4j_session, "sha256:index", "sha256:platform"
+    )
+
+    assert check_nodes(neo4j_session, "Image", ["_ont_digest"]) >= {
+        ("sha256:platform",),
+    }
+    assert check_nodes(neo4j_session, "ImageManifestList", ["_ont_digest"]) >= {
+        ("sha256:index",),
+    }
+
+    sync_single_syft(
+        neo4j_session,
+        SYFT_CURRENT_SOURCE_SAMPLE,
+        TEST_UPDATE_TAG,
+    )
+
+    actual_rels = check_rels(
+        neo4j_session,
+        "SyftPackage",
+        "id",
+        "Image",
+        "_ont_digest",
+        "DEPLOYED",
+        rel_direction_right=True,
+    )
+
+    expected_rels = {(pkg_id, "sha256:platform") for pkg_id in EXPECTED_SYFT_PACKAGES}
+    assert actual_rels == expected_rels
+
+
+def test_sync_single_syft_creates_deployed_to_digest_qualified_image(
+    neo4j_session,
+):
+    """
+    Test digest-qualified current Syft output links to the scanned platform Image.
+    """
+    neo4j_session.run("MATCH (n:SyftPackage) DETACH DELETE n")
+    _sync_single_platform_image(neo4j_session, "sha256:platform")
+
+    sync_single_syft(
+        neo4j_session,
+        SYFT_CURRENT_DIGEST_SOURCE_SAMPLE,
+        TEST_UPDATE_TAG,
+    )
+
+    actual_rels = check_rels(
+        neo4j_session,
+        "SyftPackage",
+        "id",
+        "Image",
+        "_ont_digest",
+        "DEPLOYED",
+        rel_direction_right=True,
+    )
+
+    expected_rels = {(pkg_id, "sha256:platform") for pkg_id in EXPECTED_SYFT_PACKAGES}
     assert actual_rels == expected_rels
 
 

--- a/tests/integration/cartography/intel/syft/test_syft.py
+++ b/tests/integration/cartography/intel/syft/test_syft.py
@@ -75,6 +75,17 @@ SYFT_CURRENT_REPO_DIGEST_SOURCE_SAMPLE = {
     },
 }
 
+SYFT_NO_DIGEST_SOURCE_SAMPLE = {
+    **SYFT_SAMPLE,
+    "source": {
+        "id": "sha256:source",
+        "name": "alpine",
+        "version": "3.19",
+        "type": "image",
+        "metadata": {},
+    },
+}
+
 
 def _sync_ecr_repository_images(
     neo4j_session,
@@ -313,6 +324,34 @@ def test_sync_single_syft_creates_deployed_from_repo_digest_candidate(
 
     expected_rels = {(pkg_id, "sha256:platform") for pkg_id in EXPECTED_SYFT_PACKAGES}
     assert actual_rels == expected_rels
+
+
+def test_sync_single_syft_skips_deployed_without_image_digest_candidates(
+    neo4j_session,
+):
+    """
+    Test malformed Syft image metadata does not create package-to-image links.
+    """
+    neo4j_session.run("MATCH (n:SyftPackage) DETACH DELETE n")
+    _sync_single_platform_image(neo4j_session, "sha256:platform")
+
+    sync_single_syft(
+        neo4j_session,
+        SYFT_NO_DIGEST_SOURCE_SAMPLE,
+        TEST_UPDATE_TAG,
+    )
+
+    actual_rels = check_rels(
+        neo4j_session,
+        "SyftPackage",
+        "id",
+        "Image",
+        "_ont_digest",
+        "DEPLOYED",
+        rel_direction_right=True,
+    )
+
+    assert actual_rels == set()
 
 
 @patch(

--- a/tests/unit/cartography/intel/syft/test_parser.py
+++ b/tests/unit/cartography/intel/syft/test_parser.py
@@ -135,7 +135,7 @@ class TestTransformArtifacts:
             "sha256:index",
         ]
 
-    def test_extract_image_digests_deduplicates_and_ignores_non_metadata_fields(self):
+    def test_extract_image_digests_ignores_source_version_and_target(self):
         data = {
             "source": {
                 "type": "image",
@@ -156,3 +156,38 @@ class TestTransformArtifacts:
             "sha256:metadata",
             "sha256:repo",
         ]
+
+    def test_extract_image_digests_returns_empty_without_metadata_digests(self):
+        data = {
+            "source": {
+                "type": "image",
+                "metadata": {
+                    "manifestDigest": "not-a-digest",
+                    "repoDigests": ["alpine:3.19", "alpine@not-a-digest"],
+                },
+            },
+        }
+
+        assert _extract_image_digests(data) == []
+
+    def test_transform_artifacts_warns_when_image_source_has_no_digest_candidates(
+        self,
+        caplog,
+    ):
+        data = {
+            "artifacts": [
+                {"id": "a", "name": "pkg-a", "version": "1.0.0", "type": "npm"},
+            ],
+            "artifactRelationships": [],
+            "source": {
+                "type": "image",
+                "metadata": {},
+            },
+        }
+
+        packages = transform_artifacts(data)
+
+        assert packages[0]["ImageDigestCandidates"] == []
+        assert (
+            "Syft image source did not include image digest candidates" in caplog.text
+        )

--- a/tests/unit/cartography/intel/syft/test_parser.py
+++ b/tests/unit/cartography/intel/syft/test_parser.py
@@ -2,6 +2,7 @@
 Unit tests for cartography.intel.syft.parser module.
 """
 
+from cartography.intel.syft.parser import _extract_image_digests
 from cartography.intel.syft.parser import transform_artifacts
 from tests.data.syft.syft_sample import EXPECTED_SYFT_PACKAGES
 from tests.data.syft.syft_sample import SYFT_SAMPLE
@@ -48,6 +49,9 @@ class TestTransformArtifacts:
         assert express["language"] == "javascript"
         assert express["found_by"] == "javascript-package-cataloger"
         assert express["normalized_id"] == "npm|express|4.18.2"
+        assert express["ImageDigestCandidates"] == [
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        ]
 
     def test_transform_artifacts_empty(self):
         """Test with empty artifacts."""
@@ -111,3 +115,63 @@ class TestTransformArtifacts:
         assert pkg_by_id["npm|pkg-b|2.0.0"]["dependency_ids"] == ["npm|pkg-a|1.0.0"]
         # a has no deps (image-root is not an artifact)
         assert pkg_by_id["npm|pkg-a|1.0.0"]["dependency_ids"] == []
+
+    def test_extract_image_digests_from_legacy_source_target(self):
+        data = {
+            "source": {
+                "type": "image",
+                "target": {
+                    "digest": "sha256:target",
+                    "manifestDigest": "sha256:manifest",
+                    "repoDigests": ["repo.example/app@sha256:repo"],
+                },
+            },
+        }
+
+        assert _extract_image_digests(data) == [
+            "sha256:target",
+            "sha256:manifest",
+            "sha256:repo",
+        ]
+
+    def test_extract_image_digests_from_current_source_metadata(self):
+        data = {
+            "source": {
+                "id": "sha256:source",
+                "name": "alpine",
+                "version": "3.19",
+                "type": "image",
+                "metadata": {
+                    "manifestDigest": "sha256:platform",
+                    "repoDigests": ["alpine@sha256:index"],
+                },
+            },
+        }
+
+        assert _extract_image_digests(data) == [
+            "sha256:platform",
+            "sha256:index",
+        ]
+
+    def test_extract_image_digests_deduplicates_and_ignores_source_version(self):
+        data = {
+            "source": {
+                "type": "image",
+                "version": "sha256:not-image-metadata",
+                "target": {
+                    "digest": "sha256:target",
+                    "manifestDigest": "sha256:target",
+                    "repoDigests": ["repo.example/app@sha256:repo"],
+                },
+                "metadata": {
+                    "manifestDigest": "sha256:metadata",
+                    "repoDigests": ["repo.example/app@sha256:target"],
+                },
+            },
+        }
+
+        assert _extract_image_digests(data) == [
+            "sha256:target",
+            "sha256:repo",
+            "sha256:metadata",
+        ]

--- a/tests/unit/cartography/intel/syft/test_parser.py
+++ b/tests/unit/cartography/intel/syft/test_parser.py
@@ -116,24 +116,6 @@ class TestTransformArtifacts:
         # a has no deps (image-root is not an artifact)
         assert pkg_by_id["npm|pkg-a|1.0.0"]["dependency_ids"] == []
 
-    def test_extract_image_digests_from_legacy_source_target(self):
-        data = {
-            "source": {
-                "type": "image",
-                "target": {
-                    "digest": "sha256:target",
-                    "manifestDigest": "sha256:manifest",
-                    "repoDigests": ["repo.example/app@sha256:repo"],
-                },
-            },
-        }
-
-        assert _extract_image_digests(data) == [
-            "sha256:target",
-            "sha256:manifest",
-            "sha256:repo",
-        ]
-
     def test_extract_image_digests_from_current_source_metadata(self):
         data = {
             "source": {
@@ -153,25 +135,24 @@ class TestTransformArtifacts:
             "sha256:index",
         ]
 
-    def test_extract_image_digests_deduplicates_and_ignores_source_version(self):
+    def test_extract_image_digests_deduplicates_and_ignores_non_metadata_fields(self):
         data = {
             "source": {
                 "type": "image",
                 "version": "sha256:not-image-metadata",
                 "target": {
-                    "digest": "sha256:target",
-                    "manifestDigest": "sha256:target",
-                    "repoDigests": ["repo.example/app@sha256:repo"],
+                    "digest": "sha256:ignored-target",
+                    "manifestDigest": "sha256:ignored-manifest",
+                    "repoDigests": ["repo.example/app@sha256:ignored-repo"],
                 },
                 "metadata": {
                     "manifestDigest": "sha256:metadata",
-                    "repoDigests": ["repo.example/app@sha256:target"],
+                    "repoDigests": ["repo.example/app@sha256:repo"],
                 },
             },
         }
 
         assert _extract_image_digests(data) == [
-            "sha256:target",
-            "sha256:repo",
             "sha256:metadata",
+            "sha256:repo",
         ]


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
Cartography's Syft parser read image identity from `source.target.digest`, but current Syft JSON reports the scanned image under `source.metadata`. Package nodes could still load from `artifacts`, but `SyftPackage` -> `Image` `DEPLOYED` relationships were missed because the package payload had no matching image digest.

This updates Syft ingestion to extract ordered, deduplicated image digest candidates from the current documented Syft image metadata fields:

- `source.metadata.manifestDigest`
- digest suffixes from `source.metadata.repoDigests[]`

The candidate list is intentional: a single Syft report still represents one scanned image, but Syft can expose both the selected platform manifest digest and repository digest references depending on how the image was addressed. The relationship target remains `Image`, so package attachment stays scoped to concrete single-platform ontology images and does not create `DEPLOYED` links to `ImageManifestList` nodes.

The parser intentionally avoids generic fields such as `source.version` and older `source.target` fixture-style data. Those are not the current documented image identity fields, and keeping them would expand Cartography's compatibility surface without clear evidence that they are part of Syft's supported native JSON contract. If an image-typed Syft report has no usable metadata digest, ingestion now emits a sanitized warning and skips only the package-to-image links.


### Related issues or links

- Found this issue when working on https://github.com/cartography-cncf/cartography/pull/2620


### Breaking changes

None.


### How was this tested?
- Live Syft 1.42.0 source-shape validation across 10 image/source cases, then passed each generated SBOM through `_extract_image_digests()` locally:
  - `registry:alpine:3.19`
  - `registry:alpine:3.19 --platform linux/arm64`
  - `registry:alpine:3.19 --platform linux/amd64`
  - `registry:alpine@sha256:<platform-manifest-digest>`
  - `docker:alpine:3.19`
  - `docker-archive:<alpine docker save tar>`
  - `oci-archive:<alpine OCI archive>`
  - `oci-dir:<alpine OCI layout>`
  - `registry:registry.k8s.io/pause:3.9 --platform linux/arm64`
  - `registry:cgr.dev/chainguard/static:latest --platform linux/arm64`
- Spot-checked retained Syft 1.42 reports: all used `source.metadata.manifestDigest`, none used `source.target`.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally for touched files (`uv run pre-commit run --files ...`; this checkout exposes `make test_lint`, not `make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

The new integration coverage seeds image data through ECR ingestion instead of raw test Cypher. That verifies Cartography applies the real `Image` and `ImageManifestList` labels before Syft ingestion runs, and then asserts Syft packages link only to the matching `Image` digest.
