### PR TITLE
perf(matchlinks): Support opt-in scoped MatchLinks

### DIFF
--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -9,6 +9,7 @@ from cartography.models.core.nodes import ConditionalNodeLabel
 from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import MatchLinkSubResource
 from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
@@ -1508,9 +1509,9 @@ def build_create_index_queries_for_matchlink(
         existing nodes in the graph. It requires source_node_matcher to be defined
         and creates composite indexes for relationship performance.
     """
-    if not rel_schema.source_node_matcher:
+    if not rel_schema.source_node_matcher or not rel_schema.source_node_label:
         logger.warning(
-            "No source node matcher found for %s; returning empty list. "
+            "No source node matcher or source node label found for %s; returning empty list. "
             "Please note that build_create_index_queries_for_matchlink() is only used for load_matchlinks() where we match on "
             "and connect existing nodes in the graph.",
             rel_schema.rel_label,
@@ -1522,20 +1523,35 @@ def build_create_index_queries_for_matchlink(
     )
 
     result = []
+
+    def append_index_query(node_label: str, node_attribute: str) -> None:
+        query = index_template.safe_substitute(
+            NodeLabel=node_label,
+            NodeAttribute=node_attribute,
+        )
+        if query not in result:
+            result.append(query)
+
     for source_key in asdict(rel_schema.source_node_matcher).keys():
-        result.append(
-            index_template.safe_substitute(
-                NodeLabel=rel_schema.source_node_label,
-                NodeAttribute=source_key,
-            ),
-        )
+        append_index_query(rel_schema.source_node_label, source_key)
     for target_key in asdict(rel_schema.target_node_matcher).keys():
-        result.append(
-            index_template.safe_substitute(
-                NodeLabel=rel_schema.target_node_label,
-                NodeAttribute=target_key,
-            ),
-        )
+        append_index_query(rel_schema.target_node_label, target_key)
+    if rel_schema.source_node_sub_resource:
+        for source_sub_resource_key in asdict(
+            rel_schema.source_node_sub_resource.target_node_matcher
+        ).keys():
+            append_index_query(
+                rel_schema.source_node_sub_resource.target_node_label,
+                source_sub_resource_key,
+            )
+    if rel_schema.target_node_sub_resource:
+        for target_sub_resource_key in asdict(
+            rel_schema.target_node_sub_resource.target_node_matcher
+        ).keys():
+            append_index_query(
+                rel_schema.target_node_sub_resource.target_node_label,
+                target_sub_resource_key,
+            )
 
     # Create a composite relationship index that matches the cleanup predicate shape.
     # Matchlink cleanup filters by sub-resource equality first and then uses lastupdated
@@ -1561,6 +1577,64 @@ def build_create_index_queries_for_matchlink(
             )
         )
     return result
+
+
+def _build_matchlink_sub_resource_match(
+    sub_resource_var: str,
+    sub_resource: MatchLinkSubResource,
+) -> str:
+    return Template(
+        "MATCH ($sub_resource_var:$sub_resource_label{$match_clause})"
+    ).safe_substitute(
+        sub_resource_var=sub_resource_var,
+        sub_resource_label=sub_resource.target_node_label,
+        match_clause=_build_match_clause(sub_resource.target_node_matcher),
+    )
+
+
+def _build_scoped_matchlink_endpoint_match(
+    endpoint_var: str,
+    endpoint_label: str,
+    matcher: TargetNodeMatcher | SourceNodeMatcher,
+    sub_resource_var: str,
+    sub_resource: MatchLinkSubResource,
+) -> str:
+    if sub_resource.direction == LinkDirection.INWARD:
+        rel_pattern = f"<-[:{sub_resource.rel_label}]-({sub_resource_var})"
+    else:
+        rel_pattern = f"-[:{sub_resource.rel_label}]->({sub_resource_var})"
+    return Template(
+        "MATCH ($endpoint_var:$endpoint_label{$match_clause})$rel_pattern"
+    ).safe_substitute(
+        endpoint_var=endpoint_var,
+        endpoint_label=endpoint_label,
+        match_clause=_build_match_clause(matcher),
+        rel_pattern=rel_pattern,
+    )
+
+
+def _build_matchlink_endpoint_match(
+    endpoint_var: str,
+    endpoint_label: str,
+    matcher: TargetNodeMatcher | SourceNodeMatcher,
+    sub_resource_var: str,
+    sub_resource: MatchLinkSubResource | None,
+) -> str:
+    if not sub_resource:
+        return Template(
+            "MATCH ($endpoint_var:$endpoint_label{$match_clause})"
+        ).safe_substitute(
+            endpoint_var=endpoint_var,
+            endpoint_label=endpoint_label,
+            match_clause=_build_match_clause(matcher),
+        )
+    return _build_scoped_matchlink_endpoint_match(
+        endpoint_var,
+        endpoint_label,
+        matcher,
+        sub_resource_var,
+        sub_resource,
+    )
 
 
 def build_matchlink_query(rel_schema: CartographyRelSchema) -> str:
@@ -1630,8 +1704,13 @@ def build_matchlink_query(rel_schema: CartographyRelSchema) -> str:
             "Please include `_sub_resource_id: PropertyRef = PropertyRef('_sub_resource_id', set_in_kwargs=True)`"
         )
 
-    matchlink_query_template = Template(
-        """
+    source_sub_resource = rel_schema.source_node_sub_resource
+    target_sub_resource = rel_schema.target_node_sub_resource
+
+    if source_sub_resource or target_sub_resource:
+        matchlink_query_template = Template(
+            """
+        $sub_resource_match
         UNWIND $DictList as item
             $source_match
             $target_match
@@ -1642,20 +1721,53 @@ def build_matchlink_query(rel_schema: CartographyRelSchema) -> str:
                 r._module_version = "$module_version",
                 $set_rel_properties_statement;
         """
+        )
+        sub_resource_matches = []
+        if source_sub_resource:
+            sub_resource_matches.append(
+                _build_matchlink_sub_resource_match(
+                    "source_sub_resource",
+                    source_sub_resource,
+                ),
+            )
+        if target_sub_resource:
+            sub_resource_matches.append(
+                _build_matchlink_sub_resource_match(
+                    "target_sub_resource",
+                    target_sub_resource,
+                ),
+            )
+        sub_resource_match = "\n        ".join(sub_resource_matches)
+    else:
+        matchlink_query_template = Template(
+            """
+        UNWIND $DictList as item
+            $source_match
+            $target_match
+            MERGE $rel
+            ON CREATE SET r.firstseen = timestamp()
+            SET
+                r._module_name = "$module_name",
+                r._module_version = "$module_version",
+                $set_rel_properties_statement;
+        """
+        )
+        sub_resource_match = ""
+
+    source_match = _build_matchlink_endpoint_match(
+        "from",
+        rel_schema.source_node_label,
+        rel_schema.source_node_matcher,
+        "source_sub_resource",
+        source_sub_resource,
     )
 
-    source_match = Template(
-        "MATCH (from:$source_node_label{$match_clause})"
-    ).safe_substitute(
-        source_node_label=rel_schema.source_node_label,
-        match_clause=_build_match_clause(rel_schema.source_node_matcher),
-    )
-
-    target_match = Template(
-        "MATCH (to:$target_node_label{$match_clause})"
-    ).safe_substitute(
-        target_node_label=rel_schema.target_node_label,
-        match_clause=_build_match_clause(rel_schema.target_node_matcher),
+    target_match = _build_matchlink_endpoint_match(
+        "to",
+        rel_schema.target_node_label,
+        rel_schema.target_node_matcher,
+        "target_sub_resource",
+        target_sub_resource,
     )
 
     if rel_schema.direction == LinkDirection.INWARD:
@@ -1664,6 +1776,7 @@ def build_matchlink_query(rel_schema: CartographyRelSchema) -> str:
         rel = f"(from)-[r:{rel_schema.rel_label}]->(to)"
 
     return matchlink_query_template.safe_substitute(
+        sub_resource_match=sub_resource_match,
         source_match=source_match,
         target_match=target_match,
         rel=rel,

--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -1592,24 +1592,24 @@ def _build_matchlink_sub_resource_match(
     )
 
 
-def _build_scoped_matchlink_endpoint_match(
-    endpoint_var: str,
-    endpoint_label: str,
+def _matcher_signature(
     matcher: TargetNodeMatcher | SourceNodeMatcher,
-    sub_resource_var: str,
-    sub_resource: MatchLinkSubResource,
-) -> str:
-    if sub_resource.direction == LinkDirection.INWARD:
-        rel_pattern = f"<-[:{sub_resource.rel_label}]-({sub_resource_var})"
-    else:
-        rel_pattern = f"-[:{sub_resource.rel_label}]->({sub_resource_var})"
-    return Template(
-        "MATCH ($endpoint_var:$endpoint_label{$match_clause})$rel_pattern"
-    ).safe_substitute(
-        endpoint_var=endpoint_var,
-        endpoint_label=endpoint_label,
-        match_clause=_build_match_clause(matcher),
-        rel_pattern=rel_pattern,
+) -> dict[str, dict]:
+    # PropertyRef has no __eq__, so compare via its __dict__. asdict() can't help
+    # because PropertyRef is not a dataclass and is passed through by reference.
+    return {key: vars(prop_ref) for key, prop_ref in vars(matcher).items()}
+
+
+def _matchlink_sub_resources_equal(
+    a: MatchLinkSubResource,
+    b: MatchLinkSubResource,
+) -> bool:
+    return (
+        a.target_node_label == b.target_node_label
+        and a.direction == b.direction
+        and a.rel_label == b.rel_label
+        and _matcher_signature(a.target_node_matcher)
+        == _matcher_signature(b.target_node_matcher)
     )
 
 
@@ -1617,23 +1617,22 @@ def _build_matchlink_endpoint_match(
     endpoint_var: str,
     endpoint_label: str,
     matcher: TargetNodeMatcher | SourceNodeMatcher,
-    sub_resource_var: str,
+    sub_resource_var: str | None,
     sub_resource: MatchLinkSubResource | None,
 ) -> str:
-    if not sub_resource:
-        return Template(
-            "MATCH ($endpoint_var:$endpoint_label{$match_clause})"
-        ).safe_substitute(
-            endpoint_var=endpoint_var,
-            endpoint_label=endpoint_label,
-            match_clause=_build_match_clause(matcher),
-        )
-    return _build_scoped_matchlink_endpoint_match(
-        endpoint_var,
-        endpoint_label,
-        matcher,
-        sub_resource_var,
-        sub_resource,
+    rel_pattern = ""
+    if sub_resource and sub_resource_var:
+        if sub_resource.direction == LinkDirection.INWARD:
+            rel_pattern = f"<-[:{sub_resource.rel_label}]-({sub_resource_var})"
+        else:
+            rel_pattern = f"-[:{sub_resource.rel_label}]->({sub_resource_var})"
+    return Template(
+        "MATCH ($endpoint_var:$endpoint_label{$match_clause})$rel_pattern"
+    ).safe_substitute(
+        endpoint_var=endpoint_var,
+        endpoint_label=endpoint_label,
+        match_clause=_build_match_clause(matcher),
+        rel_pattern=rel_pattern,
     )
 
 
@@ -1707,6 +1706,10 @@ def build_matchlink_query(rel_schema: CartographyRelSchema) -> str:
     source_sub_resource = rel_schema.source_node_sub_resource
     target_sub_resource = rel_schema.target_node_sub_resource
 
+    source_sub_resource_var: str | None = None
+    target_sub_resource_var: str | None = None
+    sub_resource_match_statements: list[str] = []
+
     if source_sub_resource or target_sub_resource:
         matchlink_query_template = Template(
             """
@@ -1722,22 +1725,35 @@ def build_matchlink_query(rel_schema: CartographyRelSchema) -> str:
                 $set_rel_properties_statement;
         """
         )
-        sub_resource_matches = []
-        if source_sub_resource:
-            sub_resource_matches.append(
+        if (
+            source_sub_resource
+            and target_sub_resource
+            and _matchlink_sub_resources_equal(source_sub_resource, target_sub_resource)
+        ):
+            # Same sub-resource on both sides — match it once and reuse the
+            # variable to avoid a redundant index lookup per query.
+            source_sub_resource_var = "sub_resource"
+            target_sub_resource_var = "sub_resource"
+            sub_resource_match_statements.append(
                 _build_matchlink_sub_resource_match(
-                    "source_sub_resource",
-                    source_sub_resource,
+                    source_sub_resource_var, source_sub_resource
                 ),
             )
-        if target_sub_resource:
-            sub_resource_matches.append(
-                _build_matchlink_sub_resource_match(
-                    "target_sub_resource",
-                    target_sub_resource,
-                ),
-            )
-        sub_resource_match = "\n        ".join(sub_resource_matches)
+        else:
+            if source_sub_resource:
+                source_sub_resource_var = "source_sub_resource"
+                sub_resource_match_statements.append(
+                    _build_matchlink_sub_resource_match(
+                        source_sub_resource_var, source_sub_resource
+                    ),
+                )
+            if target_sub_resource:
+                target_sub_resource_var = "target_sub_resource"
+                sub_resource_match_statements.append(
+                    _build_matchlink_sub_resource_match(
+                        target_sub_resource_var, target_sub_resource
+                    ),
+                )
     else:
         matchlink_query_template = Template(
             """
@@ -1752,13 +1768,13 @@ def build_matchlink_query(rel_schema: CartographyRelSchema) -> str:
                 $set_rel_properties_statement;
         """
         )
-        sub_resource_match = ""
+    sub_resource_match = "\n        ".join(sub_resource_match_statements)
 
     source_match = _build_matchlink_endpoint_match(
         "from",
         rel_schema.source_node_label,
         rel_schema.source_node_matcher,
-        "source_sub_resource",
+        source_sub_resource_var,
         source_sub_resource,
     )
 
@@ -1766,7 +1782,7 @@ def build_matchlink_query(rel_schema: CartographyRelSchema) -> str:
         "to",
         rel_schema.target_node_label,
         rel_schema.target_node_matcher,
-        "target_sub_resource",
+        target_sub_resource_var,
         target_sub_resource,
     )
 

--- a/cartography/models/core/relationships.py
+++ b/cartography/models/core/relationships.py
@@ -236,6 +236,8 @@ class MatchLinkSubResource:
 
     This helper lets a MatchLink schema opt into matching an endpoint through its
     sub-resource relationship, such as:
+        MATCH (sub_resource:Parent {id: $PARENT_ID})
+        UNWIND $DictList as item
         MATCH (from:Child {id: item.child_id})<-[:RESOURCE]-(sub_resource)
 
     Direction follows the same convention as CartographyRelSchema: it describes

--- a/cartography/models/core/relationships.py
+++ b/cartography/models/core/relationships.py
@@ -247,6 +247,15 @@ class MatchLinkSubResource:
     direction: LinkDirection
     rel_label: str
 
+    def __post_init__(self) -> None:
+        for key, property_ref in vars(self.target_node_matcher).items():
+            if not property_ref.set_in_kwargs:
+                raise ValueError(
+                    "MatchLinkSubResource target_node_matcher PropertyRefs must "
+                    f"have set_in_kwargs=True. Got {key}="
+                    f"PropertyRef({property_ref.name!r})."
+                )
+
 
 @dataclass(frozen=True)
 class CartographyRelSchema(abc.ABC):

--- a/cartography/models/core/relationships.py
+++ b/cartography/models/core/relationships.py
@@ -230,6 +230,25 @@ def make_source_node_matcher(key_ref_dict: Dict[str, PropertyRef]) -> SourceNode
 
 
 @dataclass(frozen=True)
+class MatchLinkSubResource:
+    """
+    Sub-resource scoping metadata for load_matchlinks() source or target matches.
+
+    This helper lets a MatchLink schema opt into matching an endpoint through its
+    sub-resource relationship, such as:
+        MATCH (from:Child {id: item.child_id})<-[:RESOURCE]-(sub_resource)
+
+    Direction follows the same convention as CartographyRelSchema: it describes
+    the relationship from the MatchLink endpoint node to the sub-resource node.
+    """
+
+    target_node_label: str
+    target_node_matcher: TargetNodeMatcher
+    direction: LinkDirection
+    rel_label: str
+
+
+@dataclass(frozen=True)
 class CartographyRelSchema(abc.ABC):
     """
     Abstract base class representing a cartography relationship schema.
@@ -368,6 +387,30 @@ class CartographyRelSchema(abc.ABC):
 
             Use `make_source_node_matcher()` to create the matcher with the
             appropriate key-value pairs for your specific use case.
+        """
+        return None
+
+    @property
+    def source_node_sub_resource(self) -> MatchLinkSubResource | None:
+        """
+        Optional sub-resource scope for load_matchlinks() source node matches.
+
+        When set, build_matchlink_query() first matches this sub-resource from
+        kwargs and then matches the source node through the configured relationship.
+        This is opt-in because not all MatchLink source labels are safely scoped
+        by the same sub-resource used for cleanup.
+        """
+        return None
+
+    @property
+    def target_node_sub_resource(self) -> MatchLinkSubResource | None:
+        """
+        Optional sub-resource scope for load_matchlinks() target node matches.
+
+        When set, build_matchlink_query() first matches this sub-resource from
+        kwargs and then matches the target node through the configured relationship.
+        This is opt-in because not all MatchLink target labels are safely scoped
+        by the same sub-resource used for cleanup.
         """
         return None
 

--- a/cartography/models/gcp/policy_bindings.py
+++ b/cartography/models/gcp/policy_bindings.py
@@ -8,6 +8,7 @@ from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_source_node_matcher
 from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import MatchLinkSubResource
 from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
@@ -127,4 +128,12 @@ class GCPPolicyBindingAppliesToMatchLink(CartographyRelSchema):
     rel_label: str = "APPLIES_TO"
     properties: GCPPolicyBindingAppliesToRelProperties = (
         GCPPolicyBindingAppliesToRelProperties()
+    )
+    source_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
+        target_node_label="GCPProject",
+        target_node_matcher=make_target_node_matcher(
+            {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
+        ),
+        direction=LinkDirection.INWARD,
+        rel_label="RESOURCE",
     )

--- a/cartography/models/microsoft/intune/detected_app.py
+++ b/cartography/models/microsoft/intune/detected_app.py
@@ -8,6 +8,7 @@ from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_source_node_matcher
 from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import MatchLinkSubResource
 from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
@@ -67,6 +68,22 @@ class IntuneManagedDeviceToDetectedAppMatchLink(CartographyRelSchema):
     rel_label: str = "HAS_APP"
     properties: IntuneManagedDeviceHasAppRelProperties = (
         IntuneManagedDeviceHasAppRelProperties()
+    )
+    source_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
+        target_node_label="EntraTenant",
+        target_node_matcher=make_target_node_matcher(
+            {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
+        ),
+        direction=LinkDirection.INWARD,
+        rel_label="RESOURCE",
+    )
+    target_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
+        target_node_label="EntraTenant",
+        target_node_matcher=make_target_node_matcher(
+            {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
+        ),
+        direction=LinkDirection.INWARD,
+        rel_label="RESOURCE",
     )
 
 

--- a/docs/root/agents/add-relationship.md
+++ b/docs/root/agents/add-relationship.md
@@ -254,6 +254,44 @@ def cleanup(neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any])
     ).run(neo4j_session)
 ```
 
+### Optional Sub-Resource-Scoped MatchLinks
+
+MatchLinks can opt into matching source and/or target nodes through their sub-resource relationship. This is useful when a MatchLink endpoint is only unique within a tenant, account, project, or similar sub-resource.
+
+Use `MatchLinkSubResource` on the MatchLink schema:
+
+```python
+from cartography.models.core.relationships import MatchLinkSubResource
+
+@dataclass(frozen=True)
+class YourMatchLinkSchema(CartographyRelSchema):
+    # ... normal MatchLink fields ...
+
+    source_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
+        target_node_label="YourTenant",
+        target_node_matcher=make_target_node_matcher({
+            "id": PropertyRef("_sub_resource_id", set_in_kwargs=True),
+        }),
+        direction=LinkDirection.INWARD,
+        rel_label="RESOURCE",
+    )
+```
+
+This changes the generated source match from a label-wide node lookup:
+
+```cypher
+MATCH (from:YourNode{id: item.source_id})
+```
+
+to a scoped match through the sub-resource:
+
+```cypher
+MATCH (source_sub_resource:YourTenant{id: $_sub_resource_id})
+MATCH (from:YourNode{id: item.source_id})<-[:RESOURCE]-(source_sub_resource)
+```
+
+Only enable this when the endpoint is guaranteed to be connected to the same sub-resource supplied to `load_matchlinks()`. For broad semantic labels or cross-module labels, review each endpoint separately and scope only the side that is semantically safe.
+
 ---
 
 ## Multiple Intel Modules Modifying the Same Node Type

--- a/docs/root/agents/add-relationship.md
+++ b/docs/root/agents/add-relationship.md
@@ -290,7 +290,7 @@ MATCH (source_sub_resource:YourTenant{id: $_sub_resource_id})
 MATCH (from:YourNode{id: item.source_id})<-[:RESOURCE]-(source_sub_resource)
 ```
 
-Only enable this when the endpoint is guaranteed to be connected to the same sub-resource supplied to `load_matchlinks()`. For broad semantic labels or cross-module labels, review each endpoint separately and scope only the side that is semantically safe.
+Only enable this when the endpoint is guaranteed to be connected to the same sub-resource supplied to `load_matchlinks()`. `MatchLinkSubResource.target_node_matcher` must use `PropertyRef(..., set_in_kwargs=True)` because the sub-resource is matched before `UNWIND $DictList AS item`. For broad semantic labels or cross-module labels, review each endpoint separately and scope only the side that is semantically safe.
 
 ---
 

--- a/tests/data/graph/matchlink/iam_permissions.py
+++ b/tests/data/graph/matchlink/iam_permissions.py
@@ -99,6 +99,28 @@ class PrincipalToS3BucketScopedPermissionRel(PrincipalToS3BucketPermissionRel):
 
 
 @dataclass(frozen=True)
+class PrincipalToS3BucketUnequalScopedPermissionRel(PrincipalToS3BucketPermissionRel):
+    """Test relationship schema with distinct source and target sub-resource scoping."""
+
+    source_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
+        target_node_label="AWSAccount",
+        target_node_matcher=make_target_node_matcher(
+            {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
+        ),
+        direction=LinkDirection.INWARD,
+        rel_label="RESOURCE",
+    )
+    target_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
+        target_node_label="AWSOrganization",
+        target_node_matcher=make_target_node_matcher(
+            {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
+        ),
+        direction=LinkDirection.INWARD,
+        rel_label="RESOURCE",
+    )
+
+
+@dataclass(frozen=True)
 class PrincipalToS3BucketTargetScopedOutwardPermissionRel(
     PrincipalToS3BucketPermissionRel
 ):

--- a/tests/data/graph/matchlink/iam_permissions.py
+++ b/tests/data/graph/matchlink/iam_permissions.py
@@ -10,6 +10,7 @@ from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_source_node_matcher
 from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import MatchLinkSubResource
 from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
 
@@ -45,3 +46,69 @@ class PrincipalToS3BucketPermissionRel(CartographyRelSchema):
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "CAN_ACCESS"
     properties: IAMAccessRelProps = IAMAccessRelProps()
+
+
+@dataclass(frozen=True)
+class PrincipalToS3BucketSourceScopedPermissionRel(PrincipalToS3BucketPermissionRel):
+    """Test relationship schema with source-side sub-resource scoping."""
+
+    source_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
+        target_node_label="AWSAccount",
+        target_node_matcher=make_target_node_matcher(
+            {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
+        ),
+        direction=LinkDirection.INWARD,
+        rel_label="RESOURCE",
+    )
+
+
+@dataclass(frozen=True)
+class PrincipalToS3BucketTargetScopedPermissionRel(PrincipalToS3BucketPermissionRel):
+    """Test relationship schema with target-side sub-resource scoping."""
+
+    target_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
+        target_node_label="AWSAccount",
+        target_node_matcher=make_target_node_matcher(
+            {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
+        ),
+        direction=LinkDirection.INWARD,
+        rel_label="RESOURCE",
+    )
+
+
+@dataclass(frozen=True)
+class PrincipalToS3BucketScopedPermissionRel(PrincipalToS3BucketPermissionRel):
+    """Test relationship schema with source- and target-side sub-resource scoping."""
+
+    source_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
+        target_node_label="AWSAccount",
+        target_node_matcher=make_target_node_matcher(
+            {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
+        ),
+        direction=LinkDirection.INWARD,
+        rel_label="RESOURCE",
+    )
+    target_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
+        target_node_label="AWSAccount",
+        target_node_matcher=make_target_node_matcher(
+            {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
+        ),
+        direction=LinkDirection.INWARD,
+        rel_label="RESOURCE",
+    )
+
+
+@dataclass(frozen=True)
+class PrincipalToS3BucketTargetScopedOutwardPermissionRel(
+    PrincipalToS3BucketPermissionRel
+):
+    """Test relationship schema with outward target-side sub-resource scoping."""
+
+    target_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
+        target_node_label="AWSAccount",
+        target_node_matcher=make_target_node_matcher(
+            {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
+        ),
+        direction=LinkDirection.OUTWARD,
+        rel_label="RESOURCE",
+    )

--- a/tests/integration/cartography/graph/test_matchlink.py
+++ b/tests/integration/cartography/graph/test_matchlink.py
@@ -10,6 +10,9 @@ import pytest
 from cartography.client.core.tx import load_matchlinks
 from cartography.graph.job import GraphJob
 from tests.data.graph.matchlink.iam_permissions import PrincipalToS3BucketPermissionRel
+from tests.data.graph.matchlink.iam_permissions import (
+    PrincipalToS3BucketScopedPermissionRel,
+)
 from tests.integration.util import check_rels
 
 # Test data constants
@@ -17,6 +20,8 @@ TEST_UPDATE_TAG_1 = 1111
 TEST_UPDATE_TAG_2 = 2222
 TEST_ACCOUNT_1 = "9876"
 TEST_ACCOUNT_2 = "1234"
+TEST_SCOPED_ACCOUNT_1 = "scoped-account-1"
+TEST_SCOPED_ACCOUNT_2 = "scoped-account-2"
 
 
 def _setup_test_data(neo4j_session: neo4j.Session, update_tag: int) -> None:
@@ -74,6 +79,39 @@ def _setup_test_data(neo4j_session: neo4j.Session, update_tag: int) -> None:
             "account_id": TEST_ACCOUNT_2,
             "p3_arn": "arn:aws:iam::1234:role/Admin",
             "b4_name": "www-bucket",
+            "update_tag": update_tag,
+        },
+    )
+
+
+def _setup_duplicate_matchlink_test_data(
+    neo4j_session: neo4j.Session, update_tag: int
+) -> None:
+    """
+    Set up duplicate source and target matcher values across two accounts.
+
+    The duplicate properties intentionally model the case where a MatchLink's
+    endpoint matcher is only unique inside its sub-resource.
+    """
+    neo4j_session.run(
+        """
+        CREATE (acc1:AWSAccount {id: $account_1, lastupdated: $update_tag})
+        CREATE (p1:AWSPrincipal {principal_arn: $principal_arn, lastupdated: $update_tag})
+        CREATE (b1:S3Bucket {name: $bucket_name, lastupdated: $update_tag})
+        CREATE (acc1)-[:RESOURCE {lastupdated: $update_tag}]->(p1)
+        CREATE (acc1)-[:RESOURCE {lastupdated: $update_tag}]->(b1)
+
+        CREATE (acc2:AWSAccount {id: $account_2, lastupdated: $update_tag})
+        CREATE (p2:AWSPrincipal {principal_arn: $principal_arn, lastupdated: $update_tag})
+        CREATE (b2:S3Bucket {name: $bucket_name, lastupdated: $update_tag})
+        CREATE (acc2)-[:RESOURCE {lastupdated: $update_tag}]->(p2)
+        CREATE (acc2)-[:RESOURCE {lastupdated: $update_tag}]->(b2)
+        """,
+        {
+            "account_1": TEST_SCOPED_ACCOUNT_1,
+            "account_2": TEST_SCOPED_ACCOUNT_2,
+            "principal_arn": "shared-principal",
+            "bucket_name": "shared-bucket",
             "update_tag": update_tag,
         },
     )
@@ -227,6 +265,57 @@ def test_load_rels_and_cleanup_integration(neo4j_session):
         f"Data isolation test failed: Account {TEST_ACCOUNT_2} relationships "
         f"should be set to timestamp {TEST_UPDATE_TAG_1}"
     )
+
+
+def test_scoped_matchlinks_do_not_cross_sub_resources(neo4j_session):
+    matchlink = PrincipalToS3BucketScopedPermissionRel()
+    _setup_duplicate_matchlink_test_data(neo4j_session, TEST_UPDATE_TAG_1)
+
+    load_matchlinks(
+        neo4j_session,
+        matchlink,
+        [
+            {
+                "principal_arn": "shared-principal",
+                "BucketName": "shared-bucket",
+                "permission_action": "s3:GetObject",
+            },
+        ],
+        UPDATE_TAG=TEST_UPDATE_TAG_1,
+        _sub_resource_label="AWSAccount",
+        _sub_resource_id=TEST_SCOPED_ACCOUNT_1,
+    )
+
+    scoped_counts = neo4j_session.run(
+        """
+        MATCH (account:AWSAccount)-[:RESOURCE]->(principal:AWSPrincipal)
+        WHERE account.id IN $account_ids
+        MATCH (account)-[:RESOURCE]->(bucket:S3Bucket)
+        OPTIONAL MATCH (principal)-[r:CAN_ACCESS]->(bucket)
+        RETURN account.id AS account_id, count(r) AS rel_count
+        ORDER BY account_id
+        """,
+        {"account_ids": [TEST_SCOPED_ACCOUNT_1, TEST_SCOPED_ACCOUNT_2]},
+    )
+
+    assert [(row["account_id"], row["rel_count"]) for row in scoped_counts] == [
+        (TEST_SCOPED_ACCOUNT_1, 1),
+        (TEST_SCOPED_ACCOUNT_2, 0),
+    ]
+
+    cross_scope_count = neo4j_session.run(
+        """
+        MATCH (source_account:AWSAccount)-[:RESOURCE]->(principal:AWSPrincipal)
+        MATCH (target_account:AWSAccount)-[:RESOURCE]->(bucket:S3Bucket)
+        MATCH (principal)-[r:CAN_ACCESS]->(bucket)
+        WHERE source_account.id IN $account_ids
+            AND target_account.id IN $account_ids
+            AND source_account.id <> target_account.id
+        RETURN count(r) AS rel_count
+        """,
+        {"account_ids": [TEST_SCOPED_ACCOUNT_1, TEST_SCOPED_ACCOUNT_2]},
+    ).single()["rel_count"]
+    assert cross_scope_count == 0
 
 
 def test_load_rels_missing_kwargs(neo4j_session):

--- a/tests/unit/cartography/graph/test_matchlink.py
+++ b/tests/unit/cartography/graph/test_matchlink.py
@@ -114,11 +114,10 @@ def test_build_scoped_matchlink_query(_mock_get_cartography_version):
     link_query = build_matchlink_query(rel_schema)
 
     expected = """
-        MATCH (source_sub_resource:AWSAccount{id: $_sub_resource_id})
-        MATCH (target_sub_resource:AWSAccount{id: $_sub_resource_id})
+        MATCH (sub_resource:AWSAccount{id: $_sub_resource_id})
         UNWIND $DictList as item
-            MATCH (from:AWSPrincipal{principal_arn: item.principal_arn})<-[:RESOURCE]-(source_sub_resource)
-            MATCH (to:S3Bucket{name: item.BucketName})<-[:RESOURCE]-(target_sub_resource)
+            MATCH (from:AWSPrincipal{principal_arn: item.principal_arn})<-[:RESOURCE]-(sub_resource)
+            MATCH (to:S3Bucket{name: item.BucketName})<-[:RESOURCE]-(sub_resource)
             MERGE (from)-[r:CAN_ACCESS]->(to)
             ON CREATE SET r.firstseen = timestamp()
             SET

--- a/tests/unit/cartography/graph/test_matchlink.py
+++ b/tests/unit/cartography/graph/test_matchlink.py
@@ -10,6 +10,18 @@ from cartography.graph.cleanupbuilder import build_cleanup_query_for_matchlink
 from cartography.graph.querybuilder import build_create_index_queries_for_matchlink
 from cartography.graph.querybuilder import build_matchlink_query
 from tests.data.graph.matchlink.iam_permissions import PrincipalToS3BucketPermissionRel
+from tests.data.graph.matchlink.iam_permissions import (
+    PrincipalToS3BucketScopedPermissionRel,
+)
+from tests.data.graph.matchlink.iam_permissions import (
+    PrincipalToS3BucketSourceScopedPermissionRel,
+)
+from tests.data.graph.matchlink.iam_permissions import (
+    PrincipalToS3BucketTargetScopedOutwardPermissionRel,
+)
+from tests.data.graph.matchlink.iam_permissions import (
+    PrincipalToS3BucketTargetScopedPermissionRel,
+)
 from tests.unit.cartography.graph.helpers import (
     remove_leading_whitespace_and_empty_lines,
 )
@@ -39,6 +51,111 @@ def test_build_matchlink_query(_mock_get_cartography_version):
     """
 
     # Assert: compare query outputs while ignoring leading whitespace.
+    actual_query = remove_leading_whitespace_and_empty_lines(link_query)
+    expected_query = remove_leading_whitespace_and_empty_lines(expected)
+    assert actual_query == expected_query
+
+
+@patch("cartography.graph.querybuilder.get_cartography_version", return_value="3.14.16")
+def test_build_source_scoped_matchlink_query(_mock_get_cartography_version):
+    rel_schema = PrincipalToS3BucketSourceScopedPermissionRel()
+    link_query = build_matchlink_query(rel_schema)
+
+    expected = """
+        MATCH (source_sub_resource:AWSAccount{id: $_sub_resource_id})
+        UNWIND $DictList as item
+            MATCH (from:AWSPrincipal{principal_arn: item.principal_arn})<-[:RESOURCE]-(source_sub_resource)
+            MATCH (to:S3Bucket{name: item.BucketName})
+            MERGE (from)-[r:CAN_ACCESS]->(to)
+            ON CREATE SET r.firstseen = timestamp()
+            SET
+                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions",
+                r._module_version = "3.14.16",
+                r.lastupdated = $UPDATE_TAG,
+                r.permission_action = item.permission_action,
+                r._sub_resource_label = $_sub_resource_label,
+                r._sub_resource_id = $_sub_resource_id;
+    """
+
+    actual_query = remove_leading_whitespace_and_empty_lines(link_query)
+    expected_query = remove_leading_whitespace_and_empty_lines(expected)
+    assert actual_query == expected_query
+
+
+@patch("cartography.graph.querybuilder.get_cartography_version", return_value="3.14.16")
+def test_build_target_scoped_matchlink_query(_mock_get_cartography_version):
+    rel_schema = PrincipalToS3BucketTargetScopedPermissionRel()
+    link_query = build_matchlink_query(rel_schema)
+
+    expected = """
+        MATCH (target_sub_resource:AWSAccount{id: $_sub_resource_id})
+        UNWIND $DictList as item
+            MATCH (from:AWSPrincipal{principal_arn: item.principal_arn})
+            MATCH (to:S3Bucket{name: item.BucketName})<-[:RESOURCE]-(target_sub_resource)
+            MERGE (from)-[r:CAN_ACCESS]->(to)
+            ON CREATE SET r.firstseen = timestamp()
+            SET
+                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions",
+                r._module_version = "3.14.16",
+                r.lastupdated = $UPDATE_TAG,
+                r.permission_action = item.permission_action,
+                r._sub_resource_label = $_sub_resource_label,
+                r._sub_resource_id = $_sub_resource_id;
+    """
+
+    actual_query = remove_leading_whitespace_and_empty_lines(link_query)
+    expected_query = remove_leading_whitespace_and_empty_lines(expected)
+    assert actual_query == expected_query
+
+
+@patch("cartography.graph.querybuilder.get_cartography_version", return_value="3.14.16")
+def test_build_scoped_matchlink_query(_mock_get_cartography_version):
+    rel_schema = PrincipalToS3BucketScopedPermissionRel()
+    link_query = build_matchlink_query(rel_schema)
+
+    expected = """
+        MATCH (source_sub_resource:AWSAccount{id: $_sub_resource_id})
+        MATCH (target_sub_resource:AWSAccount{id: $_sub_resource_id})
+        UNWIND $DictList as item
+            MATCH (from:AWSPrincipal{principal_arn: item.principal_arn})<-[:RESOURCE]-(source_sub_resource)
+            MATCH (to:S3Bucket{name: item.BucketName})<-[:RESOURCE]-(target_sub_resource)
+            MERGE (from)-[r:CAN_ACCESS]->(to)
+            ON CREATE SET r.firstseen = timestamp()
+            SET
+                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions",
+                r._module_version = "3.14.16",
+                r.lastupdated = $UPDATE_TAG,
+                r.permission_action = item.permission_action,
+                r._sub_resource_label = $_sub_resource_label,
+                r._sub_resource_id = $_sub_resource_id;
+    """
+
+    actual_query = remove_leading_whitespace_and_empty_lines(link_query)
+    expected_query = remove_leading_whitespace_and_empty_lines(expected)
+    assert actual_query == expected_query
+
+
+@patch("cartography.graph.querybuilder.get_cartography_version", return_value="3.14.16")
+def test_build_outward_scoped_matchlink_query(_mock_get_cartography_version):
+    rel_schema = PrincipalToS3BucketTargetScopedOutwardPermissionRel()
+    link_query = build_matchlink_query(rel_schema)
+
+    expected = """
+        MATCH (target_sub_resource:AWSAccount{id: $_sub_resource_id})
+        UNWIND $DictList as item
+            MATCH (from:AWSPrincipal{principal_arn: item.principal_arn})
+            MATCH (to:S3Bucket{name: item.BucketName})-[:RESOURCE]->(target_sub_resource)
+            MERGE (from)-[r:CAN_ACCESS]->(to)
+            ON CREATE SET r.firstseen = timestamp()
+            SET
+                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions",
+                r._module_version = "3.14.16",
+                r.lastupdated = $UPDATE_TAG,
+                r.permission_action = item.permission_action,
+                r._sub_resource_label = $_sub_resource_label,
+                r._sub_resource_id = $_sub_resource_id;
+    """
+
     actual_query = remove_leading_whitespace_and_empty_lines(link_query)
     expected_query = remove_leading_whitespace_and_empty_lines(expected)
     assert actual_query == expected_query
@@ -80,4 +197,18 @@ def test_build_create_index_queries_for_matchlink():
     }
 
     # Assert: compare the list of index queries
+    assert set(index_queries) == expected_queries
+
+
+def test_build_create_index_queries_for_scoped_matchlink():
+    rel_schema = PrincipalToS3BucketScopedPermissionRel()
+    index_queries = build_create_index_queries_for_matchlink(rel_schema)
+
+    expected_queries = {
+        "CREATE INDEX IF NOT EXISTS FOR (n:AWSPrincipal) ON (n.principal_arn);",
+        "CREATE INDEX IF NOT EXISTS FOR (n:S3Bucket) ON (n.name);",
+        "CREATE INDEX IF NOT EXISTS FOR (n:AWSAccount) ON (n.id);",
+        "CREATE INDEX IF NOT EXISTS FOR ()-[r:CAN_ACCESS]->() ON (r._sub_resource_label, r._sub_resource_id, r.lastupdated);",
+    }
+
     assert set(index_queries) == expected_queries

--- a/tests/unit/cartography/graph/test_matchlink.py
+++ b/tests/unit/cartography/graph/test_matchlink.py
@@ -22,6 +22,9 @@ from tests.data.graph.matchlink.iam_permissions import (
 from tests.data.graph.matchlink.iam_permissions import (
     PrincipalToS3BucketTargetScopedPermissionRel,
 )
+from tests.data.graph.matchlink.iam_permissions import (
+    PrincipalToS3BucketUnequalScopedPermissionRel,
+)
 from tests.unit.cartography.graph.helpers import (
     remove_leading_whitespace_and_empty_lines,
 )
@@ -118,6 +121,33 @@ def test_build_scoped_matchlink_query(_mock_get_cartography_version):
         UNWIND $DictList as item
             MATCH (from:AWSPrincipal{principal_arn: item.principal_arn})<-[:RESOURCE]-(sub_resource)
             MATCH (to:S3Bucket{name: item.BucketName})<-[:RESOURCE]-(sub_resource)
+            MERGE (from)-[r:CAN_ACCESS]->(to)
+            ON CREATE SET r.firstseen = timestamp()
+            SET
+                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions",
+                r._module_version = "3.14.16",
+                r.lastupdated = $UPDATE_TAG,
+                r.permission_action = item.permission_action,
+                r._sub_resource_label = $_sub_resource_label,
+                r._sub_resource_id = $_sub_resource_id;
+    """
+
+    actual_query = remove_leading_whitespace_and_empty_lines(link_query)
+    expected_query = remove_leading_whitespace_and_empty_lines(expected)
+    assert actual_query == expected_query
+
+
+@patch("cartography.graph.querybuilder.get_cartography_version", return_value="3.14.16")
+def test_build_unequal_scoped_matchlink_query(_mock_get_cartography_version):
+    rel_schema = PrincipalToS3BucketUnequalScopedPermissionRel()
+    link_query = build_matchlink_query(rel_schema)
+
+    expected = """
+        MATCH (source_sub_resource:AWSAccount{id: $_sub_resource_id})
+        MATCH (target_sub_resource:AWSOrganization{id: $_sub_resource_id})
+        UNWIND $DictList as item
+            MATCH (from:AWSPrincipal{principal_arn: item.principal_arn})<-[:RESOURCE]-(source_sub_resource)
+            MATCH (to:S3Bucket{name: item.BucketName})<-[:RESOURCE]-(target_sub_resource)
             MERGE (from)-[r:CAN_ACCESS]->(to)
             ON CREATE SET r.firstseen = timestamp()
             SET

--- a/tests/unit/cartography/graph/test_model.py
+++ b/tests/unit/cartography/graph/test_model.py
@@ -4,12 +4,17 @@ from typing import Dict
 from typing import Set
 from typing import Type
 
+import pytest
+
 import cartography.models
+from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import MatchLinkSubResource
 from tests.utils import load_models
 
 logger = logging.getLogger(__name__)
@@ -99,3 +104,18 @@ def test_sub_resource_relationship():
                 UserWarning,
             )
         # TODO: assert len(nodes) > 1
+
+
+def test_matchlink_sub_resource_requires_kwargs_matcher():
+    with pytest.raises(
+        ValueError,
+        match="MatchLinkSubResource target_node_matcher PropertyRefs must have set_in_kwargs=True",
+    ):
+        MatchLinkSubResource(
+            target_node_label="AWSAccount",
+            target_node_matcher=make_target_node_matcher(
+                {"id": PropertyRef("account_id")},
+            ),
+            direction=LinkDirection.INWARD,
+            rel_label="RESOURCE",
+        )


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update


### Summary
h/t @jychp for the idea

Adds an opt-in MatchLink sub-resource scope so selected source and/or target node matches can be anchored through their tenant/account/project relationship instead of matching only by label-wide endpoint properties.

This keeps existing MatchLinks unchanged by default and enables the scoped query shape for two high-confidence cases where the endpoint nodes are already scoped to the same sub-resource used by `load_matchlinks()`.


### Related issues or links

N/A


### Breaking changes

None.


### How was this tested?

- Unit and integration tests


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

This does not change the graph schema or MatchLink cleanup semantics. `_sub_resource_label` and `_sub_resource_id` are still relationship properties used for cleanup; the new fields only opt specific MatchLink endpoint matches into an anchored query shape.
