### PR TITLE
fix(aws): index DynamoDB table ARNs

### DIFF
--- a/cartography/models/aws/dynamodb/tables.py
+++ b/cartography/models/aws/dynamodb/tables.py
@@ -14,7 +14,7 @@ from cartography.models.core.relationships import TargetNodeMatcher
 @dataclass(frozen=True)
 class DynamoDBTableNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef("Arn")
-    arn: PropertyRef = PropertyRef("Arn")
+    arn: PropertyRef = PropertyRef("Arn", extra_index=True)
     name: PropertyRef = PropertyRef("TableName")
     region: PropertyRef = PropertyRef("Region", set_in_kwargs=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)

--- a/tests/unit/cartography/graph/test_querybuilder_indexcreation.py
+++ b/tests/unit/cartography/graph/test_querybuilder_indexcreation.py
@@ -1,4 +1,5 @@
 from cartography.graph.querybuilder import build_create_index_queries
+from cartography.models.aws.dynamodb.tables import DynamoDBTableSchema
 from cartography.models.aws.emr import EMRClusterSchema
 from tests.data.graph.querybuilder.sample_models.interesting_asset import (
     InterestingAssetSchema,
@@ -40,3 +41,9 @@ def test_build_create_index_queries_for_emr():
         "CREATE INDEX IF NOT EXISTS FOR (n:ComputeCluster) ON (n._ont_region);",
         "CREATE INDEX IF NOT EXISTS FOR (n:ComputeCluster) ON (n._ont_version);",
     }.issubset(set(result))
+
+
+def test_build_create_index_queries_for_dynamodb_table_arn():
+    result = build_create_index_queries(DynamoDBTableSchema())
+
+    assert "CREATE INDEX IF NOT EXISTS FOR (n:DynamoDBTable) ON (n.arn);" in result


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

AWS permission relationship loading matches target resources by `arn`. `DynamoDBTable` stores `arn`, but its schema only generated the default `id` and `lastupdated` indexes. This adds `extra_index=True` to `DynamoDBTable.arn` so the handwritten permission relationship load path can use an index when matching DynamoDB tables by ARN.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- None


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

None.


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- Updated tests


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

Not applicable: this only adds generated index metadata for an existing property and does not add or modify a synced entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

Not applicable: this does not change the node or relationship shape exposed in schema docs.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

This intentionally leaves `indexes.cypher` unchanged; modern data-model schemas generate indexes from `PropertyRef(..., extra_index=True)`.
