### PR TITLE
chore(logging): demote noisy per-region/per-tenant info logs to debug

### DIFF
--- a/cartography/graph/job.py
+++ b/cartography/graph/job.py
@@ -251,7 +251,7 @@ class GraphJob:
             if self.short_name
             else f"Finished job {self.name}"
         )
-        logger.info(log_msg)
+        logger.debug(log_msg)
 
     def as_dict(self) -> Dict:
         """

--- a/cartography/intel/aws/bedrock/agents.py
+++ b/cartography/intel/aws/bedrock/agents.py
@@ -33,7 +33,7 @@ def get_agents(
 
     This function first lists all agents, then gets detailed information for each agent
     """
-    logger.info("Fetching Bedrock agents in region %s", region)
+    logger.debug("Fetching Bedrock agents in region %s", region)
     client = create_boto3_client(
         boto3_session,
         "bedrock-agent",
@@ -88,7 +88,7 @@ def get_agents(
 
         agents.append(agent_details)
 
-    logger.info("Retrieved %d agents in region %s", len(agents), region)
+    logger.debug("Retrieved %d agents in region %s", len(agents), region)
 
     return agents
 

--- a/cartography/intel/aws/bedrock/custom_models.py
+++ b/cartography/intel/aws/bedrock/custom_models.py
@@ -45,7 +45,7 @@ def get_custom_models(
         )
         return []
 
-    logger.info("Fetching Bedrock custom models in region %s", region)
+    logger.debug("Fetching Bedrock custom models in region %s", region)
     client = create_boto3_client(
         boto3_session,
         "bedrock",
@@ -66,7 +66,7 @@ def get_custom_models(
         response = client.get_custom_model(modelIdentifier=model_arn)
         models.append(response)
 
-    logger.info("Retrieved %d custom models in region %s", len(models), region)
+    logger.debug("Retrieved %d custom models in region %s", len(models), region)
 
     return models
 

--- a/cartography/intel/aws/bedrock/foundation_models.py
+++ b/cartography/intel/aws/bedrock/foundation_models.py
@@ -34,7 +34,7 @@ def get_foundation_models(
     """
     Retrieve all foundation models available in AWS Bedrock for a given region.
     """
-    logger.info("Fetching Bedrock foundation models in region %s", region)
+    logger.debug("Fetching Bedrock foundation models in region %s", region)
     client = create_boto3_client(
         boto3_session,
         "bedrock",
@@ -46,7 +46,7 @@ def get_foundation_models(
     response = client.list_foundation_models()
     models = response.get("modelSummaries", [])
 
-    logger.info("Retrieved %d foundation models in region %s", len(models), region)
+    logger.debug("Retrieved %d foundation models in region %s", len(models), region)
 
     return models
 

--- a/cartography/intel/aws/bedrock/guardrails.py
+++ b/cartography/intel/aws/bedrock/guardrails.py
@@ -31,7 +31,7 @@ def get_guardrails(
     """
     Retrieve all guardrails in AWS Bedrock for a given region.
     """
-    logger.info("Fetching Bedrock guardrails in region %s", region)
+    logger.debug("Fetching Bedrock guardrails in region %s", region)
     client = create_boto3_client(
         boto3_session,
         "bedrock",
@@ -44,7 +44,7 @@ def get_guardrails(
     for page in paginator.paginate():
         guardrails.extend(page.get("guardrails", []))
 
-    logger.info("Retrieved %d guardrails in region %s", len(guardrails), region)
+    logger.debug("Retrieved %d guardrails in region %s", len(guardrails), region)
 
     return guardrails
 

--- a/cartography/intel/aws/bedrock/knowledge_bases.py
+++ b/cartography/intel/aws/bedrock/knowledge_bases.py
@@ -31,7 +31,7 @@ def get_knowledge_bases(
     """
     Retrieve all knowledge bases in AWS Bedrock for a given region.
     """
-    logger.info("Fetching Bedrock knowledge bases in region %s", region)
+    logger.debug("Fetching Bedrock knowledge bases in region %s", region)
     client = create_boto3_client(
         boto3_session,
         "bedrock-agent",

--- a/cartography/intel/aws/bedrock/provisioned_model_throughput.py
+++ b/cartography/intel/aws/bedrock/provisioned_model_throughput.py
@@ -33,7 +33,7 @@ def get_provisioned_throughputs(
     """
     Retrieve all provisioned model throughputs in AWS Bedrock for a given region.
     """
-    logger.info("Fetching Bedrock provisioned model throughputs in region %s", region)
+    logger.debug("Fetching Bedrock provisioned model throughputs in region %s", region)
     client = create_boto3_client(
         boto3_session,
         "bedrock",

--- a/cartography/intel/aws/cloudfront.py
+++ b/cartography/intel/aws/cloudfront.py
@@ -46,7 +46,7 @@ def get_cloudfront_distributions(
 
     CloudFront is a global service, so we query from us-east-1.
     """
-    logger.info("Fetching CloudFront distributions")
+    logger.debug("Fetching CloudFront distributions")
     client = create_boto3_client(
         boto3_session,
         "cloudfront",

--- a/cartography/intel/aws/cloudtrail_management_events.py
+++ b/cartography/intel/aws/cloudtrail_management_events.py
@@ -84,8 +84,11 @@ def get_assume_role_events(
     start_time = end_time - timedelta(hours=lookback_hours)
 
     logger.debug(
-        f"Fetching CloudTrail AssumeRole events for region '{region}' "
-        f"from {start_time} to {end_time} ({lookback_hours} hours)"
+        "Fetching CloudTrail AssumeRole events for region '%s' from %s to %s (%s hours)",
+        region,
+        start_time,
+        end_time,
+        lookback_hours,
     )
 
     paginator = client.get_paginator("lookup_events")
@@ -105,7 +108,7 @@ def get_assume_role_events(
     all_events = _collect_lookup_events(page_iterator)
 
     logger.debug(
-        f"Retrieved {len(all_events)} AssumeRole events from region '{region}'"
+        "Retrieved %s AssumeRole events from region '%s'", len(all_events), region
     )
 
     return all_events
@@ -137,8 +140,11 @@ def get_saml_role_events(
     start_time = end_time - timedelta(hours=lookback_hours)
 
     logger.debug(
-        f"Fetching CloudTrail AssumeRoleWithSAML events for region '{region}' "
-        f"from {start_time} to {end_time} ({lookback_hours} hours)"
+        "Fetching CloudTrail AssumeRoleWithSAML events for region '%s' from %s to %s (%s hours)",
+        region,
+        start_time,
+        end_time,
+        lookback_hours,
     )
 
     paginator = client.get_paginator("lookup_events")
@@ -158,7 +164,9 @@ def get_saml_role_events(
     all_events = _collect_lookup_events(page_iterator)
 
     logger.debug(
-        f"Retrieved {len(all_events)} AssumeRoleWithSAML events from region '{region}'"
+        "Retrieved %s AssumeRoleWithSAML events from region '%s'",
+        len(all_events),
+        region,
     )
 
     return all_events
@@ -190,8 +198,11 @@ def get_web_identity_role_events(
     start_time = end_time - timedelta(hours=lookback_hours)
 
     logger.debug(
-        f"Fetching CloudTrail AssumeRoleWithWebIdentity events for region '{region}' "
-        f"from {start_time} to {end_time} ({lookback_hours} hours)"
+        "Fetching CloudTrail AssumeRoleWithWebIdentity events for region '%s' from %s to %s (%s hours)",
+        region,
+        start_time,
+        end_time,
+        lookback_hours,
     )
 
     paginator = client.get_paginator("lookup_events")
@@ -211,7 +222,9 @@ def get_web_identity_role_events(
     all_events = _collect_lookup_events(page_iterator)
 
     logger.debug(
-        f"Retrieved {len(all_events)} AssumeRoleWithWebIdentity events from region '{region}'"
+        "Retrieved %s AssumeRoleWithWebIdentity events from region '%s'",
+        len(all_events),
+        region,
     )
 
     return all_events
@@ -239,7 +252,7 @@ def transform_assume_role_events_to_role_assumptions(
     """
     aggregated: Dict[tuple, Dict[str, Any]] = {}
     logger.debug(
-        f"Transforming {len(events)} CloudTrail AssumeRole events to role assumptions"
+        "Transforming %s CloudTrail AssumeRole events to role assumptions", len(events)
     )
 
     for event in events:
@@ -321,7 +334,8 @@ def transform_saml_role_events_to_role_assumptions(
     """
     aggregated: Dict[tuple, Dict[str, Any]] = {}
     logger.debug(
-        f"Transforming {len(events)} CloudTrail AssumeRoleWithSAML events to role assumptions"
+        "Transforming %s CloudTrail AssumeRoleWithSAML events to role assumptions",
+        len(events),
     )
 
     for event in events:
@@ -400,7 +414,8 @@ def transform_web_identity_role_events_to_role_assumptions(
     """
     github_aggregated: Dict[tuple, Dict[str, Any]] = {}
     logger.debug(
-        f"Transforming {len(events)} CloudTrail AssumeRoleWithWebIdentity events to role assumptions"
+        "Transforming %s CloudTrail AssumeRoleWithWebIdentity events to role assumptions",
+        len(events),
     )
 
     for event in events:
@@ -717,10 +732,10 @@ def sync_assume_role_events(
 
     # Process events region by region
     for region in regions:
-        logger.debug(f"Processing CloudTrail events for region {region}")
+        logger.debug("Processing CloudTrail events for region %s", region)
 
         # Process AssumeRole events specifically
-        logger.debug(f"Fetching AssumeRole events specifically for region {region}")
+        logger.debug("Fetching AssumeRole events specifically for region %s", region)
         try:
             assume_role_events = get_assume_role_events(
                 boto3_session=boto3_session,
@@ -750,7 +765,9 @@ def sync_assume_role_events(
         )
         total_role_assumptions += len(assume_role_assumptions)
         logger.debug(
-            f"Loaded {len(assume_role_assumptions)} AssumeRole assumptions for region {region}"
+            "Loaded %s AssumeRole assumptions for region %s",
+            len(assume_role_assumptions),
+            region,
         )
 
     if cleanup_safe:
@@ -818,11 +835,11 @@ def sync_saml_role_events(
 
     # Process events region by region
     for region in regions:
-        logger.debug(f"Processing CloudTrail SAML events for region {region}")
+        logger.debug("Processing CloudTrail SAML events for region %s", region)
 
         # Process AssumeRoleWithSAML events specifically
         logger.debug(
-            f"Fetching AssumeRoleWithSAML events specifically for region {region}"
+            "Fetching AssumeRoleWithSAML events specifically for region %s", region
         )
         try:
             saml_role_events = get_saml_role_events(
@@ -852,7 +869,9 @@ def sync_saml_role_events(
         )
         total_saml_role_assumptions += len(saml_role_assumptions)
         logger.debug(
-            f"Loaded {len(saml_role_assumptions)} SAML role assumptions for region {region}"
+            "Loaded %s SAML role assumptions for region %s",
+            len(saml_role_assumptions),
+            region,
         )
 
     logger.info(
@@ -912,11 +931,12 @@ def sync_web_identity_role_events(
 
     # Process events region by region
     for region in regions:
-        logger.debug(f"Processing CloudTrail WebIdentity events for region {region}")
+        logger.debug("Processing CloudTrail WebIdentity events for region %s", region)
 
         # Process AssumeRoleWithWebIdentity events specifically
         logger.debug(
-            f"Fetching AssumeRoleWithWebIdentity events specifically for region {region}"
+            "Fetching AssumeRoleWithWebIdentity events specifically for region %s",
+            region,
         )
         try:
             web_identity_role_events = get_web_identity_role_events(
@@ -948,7 +968,9 @@ def sync_web_identity_role_events(
         )
         total_web_identity_role_assumptions += len(web_identity_role_assumptions)
         logger.debug(
-            f"Loaded {len(web_identity_role_assumptions)} WebIdentity role assumptions for region {region}"
+            "Loaded %s WebIdentity role assumptions for region %s",
+            len(web_identity_role_assumptions),
+            region,
         )
 
     logger.info(

--- a/cartography/intel/aws/cloudtrail_management_events.py
+++ b/cartography/intel/aws/cloudtrail_management_events.py
@@ -104,7 +104,9 @@ def get_assume_role_events(
 
     all_events = _collect_lookup_events(page_iterator)
 
-    logger.debug(f"Retrieved {len(all_events)} AssumeRole events from region '{region}'")
+    logger.debug(
+        f"Retrieved {len(all_events)} AssumeRole events from region '{region}'"
+    )
 
     return all_events
 

--- a/cartography/intel/aws/cloudtrail_management_events.py
+++ b/cartography/intel/aws/cloudtrail_management_events.py
@@ -83,7 +83,7 @@ def get_assume_role_events(
     end_time = datetime.utcnow()
     start_time = end_time - timedelta(hours=lookback_hours)
 
-    logger.info(
+    logger.debug(
         f"Fetching CloudTrail AssumeRole events for region '{region}' "
         f"from {start_time} to {end_time} ({lookback_hours} hours)"
     )
@@ -104,7 +104,7 @@ def get_assume_role_events(
 
     all_events = _collect_lookup_events(page_iterator)
 
-    logger.info(f"Retrieved {len(all_events)} AssumeRole events from region '{region}'")
+    logger.debug(f"Retrieved {len(all_events)} AssumeRole events from region '{region}'")
 
     return all_events
 
@@ -134,7 +134,7 @@ def get_saml_role_events(
     end_time = datetime.utcnow()
     start_time = end_time - timedelta(hours=lookback_hours)
 
-    logger.info(
+    logger.debug(
         f"Fetching CloudTrail AssumeRoleWithSAML events for region '{region}' "
         f"from {start_time} to {end_time} ({lookback_hours} hours)"
     )
@@ -155,7 +155,7 @@ def get_saml_role_events(
 
     all_events = _collect_lookup_events(page_iterator)
 
-    logger.info(
+    logger.debug(
         f"Retrieved {len(all_events)} AssumeRoleWithSAML events from region '{region}'"
     )
 
@@ -187,7 +187,7 @@ def get_web_identity_role_events(
     end_time = datetime.utcnow()
     start_time = end_time - timedelta(hours=lookback_hours)
 
-    logger.info(
+    logger.debug(
         f"Fetching CloudTrail AssumeRoleWithWebIdentity events for region '{region}' "
         f"from {start_time} to {end_time} ({lookback_hours} hours)"
     )
@@ -208,7 +208,7 @@ def get_web_identity_role_events(
 
     all_events = _collect_lookup_events(page_iterator)
 
-    logger.info(
+    logger.debug(
         f"Retrieved {len(all_events)} AssumeRoleWithWebIdentity events from region '{region}'"
     )
 
@@ -236,7 +236,7 @@ def transform_assume_role_events_to_role_assumptions(
     :return: List of aggregated role assumption relationships ready for loading
     """
     aggregated: Dict[tuple, Dict[str, Any]] = {}
-    logger.info(
+    logger.debug(
         f"Transforming {len(events)} CloudTrail AssumeRole events to role assumptions"
     )
 
@@ -318,7 +318,7 @@ def transform_saml_role_events_to_role_assumptions(
              times_used, first_seen_in_time_window, last_used
     """
     aggregated: Dict[tuple, Dict[str, Any]] = {}
-    logger.info(
+    logger.debug(
         f"Transforming {len(events)} CloudTrail AssumeRoleWithSAML events to role assumptions"
     )
 
@@ -397,7 +397,7 @@ def transform_web_identity_role_events_to_role_assumptions(
              times_used, first_seen_in_time_window, last_used
     """
     github_aggregated: Dict[tuple, Dict[str, Any]] = {}
-    logger.info(
+    logger.debug(
         f"Transforming {len(events)} CloudTrail AssumeRoleWithWebIdentity events to role assumptions"
     )
 
@@ -715,10 +715,10 @@ def sync_assume_role_events(
 
     # Process events region by region
     for region in regions:
-        logger.info(f"Processing CloudTrail events for region {region}")
+        logger.debug(f"Processing CloudTrail events for region {region}")
 
         # Process AssumeRole events specifically
-        logger.info(f"Fetching AssumeRole events specifically for region {region}")
+        logger.debug(f"Fetching AssumeRole events specifically for region {region}")
         try:
             assume_role_events = get_assume_role_events(
                 boto3_session=boto3_session,
@@ -747,7 +747,7 @@ def sync_assume_role_events(
             aws_update_tag=update_tag,
         )
         total_role_assumptions += len(assume_role_assumptions)
-        logger.info(
+        logger.debug(
             f"Loaded {len(assume_role_assumptions)} AssumeRole assumptions for region {region}"
         )
 
@@ -816,10 +816,10 @@ def sync_saml_role_events(
 
     # Process events region by region
     for region in regions:
-        logger.info(f"Processing CloudTrail SAML events for region {region}")
+        logger.debug(f"Processing CloudTrail SAML events for region {region}")
 
         # Process AssumeRoleWithSAML events specifically
-        logger.info(
+        logger.debug(
             f"Fetching AssumeRoleWithSAML events specifically for region {region}"
         )
         try:
@@ -849,7 +849,7 @@ def sync_saml_role_events(
             aws_update_tag=update_tag,
         )
         total_saml_role_assumptions += len(saml_role_assumptions)
-        logger.info(
+        logger.debug(
             f"Loaded {len(saml_role_assumptions)} SAML role assumptions for region {region}"
         )
 
@@ -910,10 +910,10 @@ def sync_web_identity_role_events(
 
     # Process events region by region
     for region in regions:
-        logger.info(f"Processing CloudTrail WebIdentity events for region {region}")
+        logger.debug(f"Processing CloudTrail WebIdentity events for region {region}")
 
         # Process AssumeRoleWithWebIdentity events specifically
-        logger.info(
+        logger.debug(
             f"Fetching AssumeRoleWithWebIdentity events specifically for region {region}"
         )
         try:
@@ -945,7 +945,7 @@ def sync_web_identity_role_events(
             aws_update_tag=update_tag,
         )
         total_web_identity_role_assumptions += len(web_identity_role_assumptions)
-        logger.info(
+        logger.debug(
             f"Loaded {len(web_identity_role_assumptions)} WebIdentity role assumptions for region {region}"
         )
 

--- a/cartography/intel/aws/dynamodb.py
+++ b/cartography/intel/aws/dynamodb.py
@@ -208,9 +208,6 @@ def load_dynamodb_tables(
     current_aws_account_id: str,
     aws_update_tag: int,
 ) -> None:
-    logger.info(
-        f"Loading DynamoDB tables ({len(tables_data)}) for region '{region}' into graph.",
-    )
     load(
         neo4j_session,
         DynamoDBTableSchema(),
@@ -229,9 +226,6 @@ def load_dynamodb_gsi(
     current_aws_account_id: str,
     aws_update_tag: int,
 ) -> None:
-    logger.info(
-        f"Loading DynamoDB GSIs ({len(gsi_data)}) for region '{region}' into graph.",
-    )
     load(
         neo4j_session,
         DynamoDBGSISchema(),
@@ -249,9 +243,6 @@ def load_dynamodb_billing(
     current_aws_account_id: str,
     aws_update_tag: int,
 ) -> None:
-    logger.info(
-        f"Loading DynamoDB billing summaries ({len(billing_data)}) into graph.",
-    )
     load(
         neo4j_session,
         DynamoDBBillingModeSummarySchema(),
@@ -268,9 +259,6 @@ def load_dynamodb_streams(
     current_aws_account_id: str,
     aws_update_tag: int,
 ) -> None:
-    logger.info(
-        f"Loading DynamoDB streams ({len(stream_data)}) into graph.",
-    )
     load(
         neo4j_session,
         DynamoDBStreamSchema(),
@@ -287,9 +275,6 @@ def load_dynamodb_sse(
     current_aws_account_id: str,
     aws_update_tag: int,
 ) -> None:
-    logger.info(
-        f"Loading DynamoDB SSE descriptions ({len(sse_data)}) into graph.",
-    )
     load(
         neo4j_session,
         DynamoDBSSEDescriptionSchema(),
@@ -306,9 +291,6 @@ def load_dynamodb_archival(
     current_aws_account_id: str,
     aws_update_tag: int,
 ) -> None:
-    logger.info(
-        f"Loading DynamoDB archival summaries ({len(archival_data)}) into graph.",
-    )
     load(
         neo4j_session,
         DynamoDBArchivalSummarySchema(),
@@ -325,9 +307,6 @@ def load_dynamodb_restore(
     current_aws_account_id: str,
     aws_update_tag: int,
 ) -> None:
-    logger.info(
-        f"Loading DynamoDB restore summaries ({len(restore_data)}) into graph.",
-    )
     load(
         neo4j_session,
         DynamoDBRestoreSummarySchema(),
@@ -344,9 +323,6 @@ def load_dynamodb_backups(
     current_aws_account_id: str,
     aws_update_tag: int,
 ) -> None:
-    logger.info(
-        f"Loading DynamoDB backup stubs ({len(backup_data)}) into graph.",
-    )
     load(
         neo4j_session,
         DynamoDBBackupSchema(),

--- a/cartography/intel/aws/ecr.py
+++ b/cartography/intel/aws/ecr.py
@@ -38,7 +38,7 @@ def get_ecr_repositories(
     boto3_session: boto3.session.Session,
     region: str,
 ) -> List[Dict]:
-    logger.info("Getting ECR repositories for region '%s'.", region)
+    logger.debug("Getting ECR repositories for region '%s'.", region)
     client = create_boto3_client(boto3_session, "ecr", region_name=region)
     paginator = client.get_paginator("describe_repositories")
     ecr_repositories: List[Dict] = []

--- a/cartography/intel/aws/identitycenter.py
+++ b/cartography/intel/aws/identitycenter.py
@@ -369,7 +369,7 @@ def get_user_permissionsets(
     Although a permissionset can be assigned to multiple accounts, it is possible for the user
     to be assigned to just a subset of those!
     """
-    logger.debug(f"Getting permissionsets for {len(users)} users")
+    logger.debug("Getting permissionsets for %s users", len(users))
     client = create_boto3_client(boto3_session, "sso-admin", region_name=region)
     user_permissionsets = []
 
@@ -404,7 +404,7 @@ def get_group_permissionsets(
     """
     Get permissionsets for SSO groups, taking into account which accounts the group is assigned to.
     """
-    logger.debug(f"Getting permissionsets for {len(groups)} groups")
+    logger.debug("Getting permissionsets for %s groups", len(groups))
     client = create_boto3_client(boto3_session, "sso-admin", region_name=region)
     group_permissionsets: list[dict[str, Any]] = []
 

--- a/cartography/intel/aws/identitycenter.py
+++ b/cartography/intel/aws/identitycenter.py
@@ -369,7 +369,7 @@ def get_user_permissionsets(
     Although a permissionset can be assigned to multiple accounts, it is possible for the user
     to be assigned to just a subset of those!
     """
-    logger.info(f"Getting permissionsets for {len(users)} users")
+    logger.debug(f"Getting permissionsets for {len(users)} users")
     client = create_boto3_client(boto3_session, "sso-admin", region_name=region)
     user_permissionsets = []
 
@@ -404,7 +404,7 @@ def get_group_permissionsets(
     """
     Get permissionsets for SSO groups, taking into account which accounts the group is assigned to.
     """
-    logger.info(f"Getting permissionsets for {len(groups)} groups")
+    logger.debug(f"Getting permissionsets for {len(groups)} groups")
     client = create_boto3_client(boto3_session, "sso-admin", region_name=region)
     group_permissionsets: list[dict[str, Any]] = []
 

--- a/cartography/intel/aws/sagemaker/util.py
+++ b/cartography/intel/aws/sagemaker/util.py
@@ -116,7 +116,7 @@ def sync_sagemaker_resource(
             )
             continue
 
-        logger.info(
+        logger.debug(
             "Syncing SageMaker submodule '%s' for region '%s' in account '%s'.",
             submodule_name,
             region,

--- a/cartography/intel/cve_metadata/epss.py
+++ b/cartography/intel/cve_metadata/epss.py
@@ -57,7 +57,7 @@ def get_epss_scores(
                 logger.warning("Skipping malformed EPSS entry: %s", entry)
                 continue
 
-    logger.info("Fetched EPSS scores for %d CVEs", len(results))
+    logger.debug("Fetched EPSS scores for %d CVEs", len(results))
     return results
 
 

--- a/cartography/intel/duo/endpoints.py
+++ b/cartography/intel/duo/endpoints.py
@@ -36,7 +36,7 @@ def _get_endpoints(client: duo_client.Admin) -> List[Dict[str, Any]]:
     Fetch all endpoint data
     https://duo.com/docs/adminapi#endpoints
     """
-    logger.info("Fetching Duo endpoints")
+    logger.debug("Fetching Duo endpoints")
     return client.get_endpoints()
 
 
@@ -45,7 +45,7 @@ def _transform_endpoints(endpoints: List[Dict[str, Any]]) -> List[Dict[str, Any]
     """
     Reformat the data before loading
     """
-    logger.info(f"Transforming {len(endpoints)} duo endpoints")
+    logger.debug(f"Transforming {len(endpoints)} duo endpoints")
     transformed_endpoints = []
     for endpoint in endpoints:
         transformed_endpoint = {

--- a/cartography/intel/duo/endpoints.py
+++ b/cartography/intel/duo/endpoints.py
@@ -45,7 +45,7 @@ def _transform_endpoints(endpoints: List[Dict[str, Any]]) -> List[Dict[str, Any]
     """
     Reformat the data before loading
     """
-    logger.debug(f"Transforming {len(endpoints)} duo endpoints")
+    logger.debug("Transforming %s duo endpoints", len(endpoints))
     transformed_endpoints = []
     for endpoint in endpoints:
         transformed_endpoint = {

--- a/cartography/intel/duo/groups.py
+++ b/cartography/intel/duo/groups.py
@@ -34,7 +34,7 @@ def _get_groups(client: duo_client.Admin) -> List[Dict[str, Any]]:
     Fetch all group data
     https://duo.com/docs/adminapi#users
     """
-    logger.info("Fetching Duo groups")
+    logger.debug("Fetching Duo groups")
     return client.get_groups()
 
 

--- a/cartography/intel/duo/phones.py
+++ b/cartography/intel/duo/phones.py
@@ -35,7 +35,7 @@ def _get(client: duo_client.Admin) -> List[Dict[str, Any]]:
     Fetch all data
     https://duo.com/docs/adminapi#endpoints
     """
-    logger.debug(f"Fetching data for {Schema.label}")
+    logger.debug("Fetching data for %s", Schema.label)
     return client.get_phones()
 
 
@@ -44,7 +44,7 @@ def _transform(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Reformat the data before loading
     """
-    logger.debug(f"Transforming {len(data)} items for {Schema.label}")
+    logger.debug("Transforming %s items for %s", len(data), Schema.label)
     transformed_data = []
     for datum in data:
         transformed_datum = {

--- a/cartography/intel/duo/phones.py
+++ b/cartography/intel/duo/phones.py
@@ -35,7 +35,7 @@ def _get(client: duo_client.Admin) -> List[Dict[str, Any]]:
     Fetch all data
     https://duo.com/docs/adminapi#endpoints
     """
-    logger.info(f"Fetching data for {Schema.label}")
+    logger.debug(f"Fetching data for {Schema.label}")
     return client.get_phones()
 
 
@@ -44,7 +44,7 @@ def _transform(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Reformat the data before loading
     """
-    logger.info(f"Transforming {len(data)} items for {Schema.label}")
+    logger.debug(f"Transforming {len(data)} items for {Schema.label}")
     transformed_data = []
     for datum in data:
         transformed_datum = {

--- a/cartography/intel/duo/tokens.py
+++ b/cartography/intel/duo/tokens.py
@@ -36,7 +36,7 @@ def _get(client: duo_client.Admin) -> List[Dict[str, Any]]:
     Fetch all data
     https://duo.com/docs/adminapi#endpoints
     """
-    logger.info(f"Fetching data for {Schema.label}")
+    logger.debug(f"Fetching data for {Schema.label}")
     return client.get_tokens()
 
 
@@ -45,7 +45,7 @@ def _transform(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Reformat the data before loading
     """
-    logger.info(f"Transforming {len(data)} items for {Schema.label}")
+    logger.debug(f"Transforming {len(data)} items for {Schema.label}")
     transformed_data = []
     for datum in data:
         transformed_datum = {

--- a/cartography/intel/duo/tokens.py
+++ b/cartography/intel/duo/tokens.py
@@ -36,7 +36,7 @@ def _get(client: duo_client.Admin) -> List[Dict[str, Any]]:
     Fetch all data
     https://duo.com/docs/adminapi#endpoints
     """
-    logger.debug(f"Fetching data for {Schema.label}")
+    logger.debug("Fetching data for %s", Schema.label)
     return client.get_tokens()
 
 
@@ -45,7 +45,7 @@ def _transform(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Reformat the data before loading
     """
-    logger.debug(f"Transforming {len(data)} items for {Schema.label}")
+    logger.debug("Transforming %s items for %s", len(data), Schema.label)
     transformed_data = []
     for datum in data:
         transformed_datum = {

--- a/cartography/intel/duo/users.py
+++ b/cartography/intel/duo/users.py
@@ -36,7 +36,7 @@ def _get_users(client: duo_client.Admin) -> List[Dict[str, Any]]:
     Fetch all users data
     https://duo.com/docs/adminapi#users
     """
-    logger.info("Fetching Duo users")
+    logger.debug("Fetching Duo users")
     return client.get_users()
 
 
@@ -45,7 +45,7 @@ def _transform_users(users: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Reformat the data before loading
     """
-    logger.info(f"Transforming {len(users)} duo users")
+    logger.debug(f"Transforming {len(users)} duo users")
     transformed_users = []
     for user in users:
         transformed_user = {

--- a/cartography/intel/duo/users.py
+++ b/cartography/intel/duo/users.py
@@ -45,7 +45,7 @@ def _transform_users(users: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Reformat the data before loading
     """
-    logger.debug(f"Transforming {len(users)} duo users")
+    logger.debug("Transforming %s duo users", len(users))
     transformed_users = []
     for user in users:
         transformed_user = {

--- a/cartography/intel/duo/web_authn_credentials.py
+++ b/cartography/intel/duo/web_authn_credentials.py
@@ -37,7 +37,7 @@ def _get(client: duo_client.Admin) -> List[Dict[str, Any]]:
     Fetch all data
     https://duo.com/docs/adminapi#endpoints
     """
-    logger.debug(f"Fetching data for {Schema.label}")
+    logger.debug("Fetching data for %s", Schema.label)
     return client.get_webauthncredentials()
 
 
@@ -46,7 +46,7 @@ def _transform(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Reformat the data before loading
     """
-    logger.debug(f"Transforming {len(data)} items for {Schema.label}")
+    logger.debug("Transforming %s items for %s", len(data), Schema.label)
     transformed_data = []
     for datum in data:
         transformed_datum = {

--- a/cartography/intel/duo/web_authn_credentials.py
+++ b/cartography/intel/duo/web_authn_credentials.py
@@ -37,7 +37,7 @@ def _get(client: duo_client.Admin) -> List[Dict[str, Any]]:
     Fetch all data
     https://duo.com/docs/adminapi#endpoints
     """
-    logger.info(f"Fetching data for {Schema.label}")
+    logger.debug(f"Fetching data for {Schema.label}")
     return client.get_webauthncredentials()
 
 
@@ -46,7 +46,7 @@ def _transform(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Reformat the data before loading
     """
-    logger.info(f"Transforming {len(data)} items for {Schema.label}")
+    logger.debug(f"Transforming {len(data)} items for {Schema.label}")
     transformed_data = []
     for datum in data:
         transformed_datum = {

--- a/cartography/intel/gcp/cloudrun/util.py
+++ b/cartography/intel/gcp/cloudrun/util.py
@@ -213,7 +213,7 @@ def list_cloud_run_resources_for_location(
         )
         raise
 
-    logger.info(
+    logger.debug(
         "Found %s Cloud Run %s in %s for project %s",
         len(resources),
         resource_type,

--- a/cartography/intel/gcp/vertex/utils.py
+++ b/cartography/intel/gcp/vertex/utils.py
@@ -68,7 +68,7 @@ def list_vertex_ai_resources_for_location(
         )
         raise
 
-    logger.info(
+    logger.debug(
         "Found %s Vertex AI %s in %s for project %s",
         len(resources),
         resource_type,
@@ -255,7 +255,7 @@ def paginate_vertex_api(
         if not page_token:
             break
 
-    logger.info(
+    logger.debug(
         "Found %s Vertex AI %s in %s for project %s",
         len(resources),
         resource_type,

--- a/cartography/intel/github/commits.py
+++ b/cartography/intel/github/commits.py
@@ -271,7 +271,7 @@ def transform_commits_to_user_repo_relationships(
     :param organization: The Github organization name.
     :return: List of user-repository relationship records.
     """
-    logger.info("Transforming commit data into user-repository relationships")
+    logger.debug("Transforming commit data into user-repository relationships")
 
     # Group commits by user and repository
     user_repo_commits: dict[tuple[str, str], list[dict[str, Any]]] = {}

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -474,7 +474,7 @@ def _get_dep_manifests_for_repos(
                 exc_info=True,
             )
 
-    logger.info("Fetched dependency manifests for %d repos.", len(result))
+    logger.debug("Fetched dependency manifests for %d repos.", len(result))
     return result
 
 

--- a/cartography/intel/gitlab/container_repositories.py
+++ b/cartography/intel/gitlab/container_repositories.py
@@ -31,7 +31,7 @@ def get_container_repositories(
     Uses the group-level registry API to get all repositories across all projects
     in the organization.
     """
-    logger.debug(f"Fetching container repositories for group ID {group_id}")
+    logger.debug("Fetching container repositories for group ID %s", group_id)
     repositories = get_paginated(
         gitlab_url,
         token,

--- a/cartography/intel/gitlab/container_repositories.py
+++ b/cartography/intel/gitlab/container_repositories.py
@@ -31,7 +31,7 @@ def get_container_repositories(
     Uses the group-level registry API to get all repositories across all projects
     in the organization.
     """
-    logger.info(f"Fetching container repositories for group ID {group_id}")
+    logger.debug(f"Fetching container repositories for group ID {group_id}")
     repositories = get_paginated(
         gitlab_url,
         token,

--- a/cartography/intel/gitlab/container_repository_tags.py
+++ b/cartography/intel/gitlab/container_repository_tags.py
@@ -93,7 +93,9 @@ def get_all_container_repository_tags(
             tag["_repository_location"] = repository_location
         all_tags.extend(tags)
 
-    logger.debug(f"Fetched {len(all_tags)} tags across {len(repositories)} repositories")
+    logger.debug(
+        f"Fetched {len(all_tags)} tags across {len(repositories)} repositories"
+    )
     return all_tags
 
 

--- a/cartography/intel/gitlab/container_repository_tags.py
+++ b/cartography/intel/gitlab/container_repository_tags.py
@@ -93,7 +93,7 @@ def get_all_container_repository_tags(
             tag["_repository_location"] = repository_location
         all_tags.extend(tags)
 
-    logger.info(f"Fetched {len(all_tags)} tags across {len(repositories)} repositories")
+    logger.debug(f"Fetched {len(all_tags)} tags across {len(repositories)} repositories")
     return all_tags
 
 

--- a/cartography/intel/gitlab/container_repository_tags.py
+++ b/cartography/intel/gitlab/container_repository_tags.py
@@ -94,7 +94,7 @@ def get_all_container_repository_tags(
         all_tags.extend(tags)
 
     logger.debug(
-        f"Fetched {len(all_tags)} tags across {len(repositories)} repositories"
+        "Fetched %s tags across %s repositories", len(all_tags), len(repositories)
     )
     return all_tags
 

--- a/cartography/intel/gitlab/groups.py
+++ b/cartography/intel/gitlab/groups.py
@@ -24,11 +24,11 @@ def get_groups(gitlab_url: str, token: str, org_id: int) -> list[dict[str, Any]]
     """
     Fetch all descendant groups for a specific organization from GitLab.
     """
-    logger.debug(f"Fetching groups for organization ID {org_id}")
+    logger.debug("Fetching groups for organization ID %s", org_id)
     groups = get_paginated(
         gitlab_url, token, f"/api/v4/groups/{org_id}/descendant_groups"
     )
-    logger.debug(f"Fetched {len(groups)} groups for organization ID {org_id}")
+    logger.debug("Fetched %s groups for organization ID %s", len(groups), org_id)
     return groups
 
 

--- a/cartography/intel/gitlab/groups.py
+++ b/cartography/intel/gitlab/groups.py
@@ -24,11 +24,11 @@ def get_groups(gitlab_url: str, token: str, org_id: int) -> list[dict[str, Any]]
     """
     Fetch all descendant groups for a specific organization from GitLab.
     """
-    logger.info(f"Fetching groups for organization ID {org_id}")
+    logger.debug(f"Fetching groups for organization ID {org_id}")
     groups = get_paginated(
         gitlab_url, token, f"/api/v4/groups/{org_id}/descendant_groups"
     )
-    logger.info(f"Fetched {len(groups)} groups for organization ID {org_id}")
+    logger.debug(f"Fetched {len(groups)} groups for organization ID {org_id}")
     return groups
 
 

--- a/cartography/intel/gitlab/organizations.py
+++ b/cartography/intel/gitlab/organizations.py
@@ -20,7 +20,7 @@ def get_organization(gitlab_url: str, token: str, org_id: int) -> dict[str, Any]
     """
     Fetch a specific top-level group (organization) from GitLab by ID.
     """
-    logger.info(f"Fetching organization ID {org_id} from {gitlab_url}")
+    logger.debug(f"Fetching organization ID {org_id} from {gitlab_url}")
     return get_single(gitlab_url, token, f"/api/v4/groups/{org_id}")
 
 

--- a/cartography/intel/gitlab/organizations.py
+++ b/cartography/intel/gitlab/organizations.py
@@ -20,7 +20,7 @@ def get_organization(gitlab_url: str, token: str, org_id: int) -> dict[str, Any]
     """
     Fetch a specific top-level group (organization) from GitLab by ID.
     """
-    logger.debug(f"Fetching organization ID {org_id} from {gitlab_url}")
+    logger.debug("Fetching organization ID %s from %s", org_id, gitlab_url)
     return get_single(gitlab_url, token, f"/api/v4/groups/{org_id}")
 
 

--- a/cartography/intel/gitlab/projects.py
+++ b/cartography/intel/gitlab/projects.py
@@ -102,14 +102,14 @@ def get_projects(gitlab_url: str, token: str, group_id: int) -> list[dict[str, A
     """
     Fetch all projects for a specific group from GitLab.
     """
-    logger.debug(f"Fetching projects for group ID {group_id}")
+    logger.debug("Fetching projects for group ID %s", group_id)
     projects = get_paginated(
         gitlab_url,
         token,
         f"/api/v4/groups/{group_id}/projects",
         extra_params={"include_subgroups": True},
     )
-    logger.debug(f"Fetched {len(projects)} projects for group ID {group_id}")
+    logger.debug("Fetched %s projects for group ID %s", len(projects), group_id)
     return projects
 
 
@@ -261,7 +261,7 @@ def sync_gitlab_projects(
         return []
 
     # Fetch languages for all projects concurrently
-    logger.debug(f"Fetching languages for {len(raw_projects)} projects")
+    logger.debug("Fetching languages for %s projects", len(raw_projects))
     languages_by_project = asyncio.run(
         _fetch_all_languages(gitlab_url, token, raw_projects)
     )

--- a/cartography/intel/gitlab/projects.py
+++ b/cartography/intel/gitlab/projects.py
@@ -102,14 +102,14 @@ def get_projects(gitlab_url: str, token: str, group_id: int) -> list[dict[str, A
     """
     Fetch all projects for a specific group from GitLab.
     """
-    logger.info(f"Fetching projects for group ID {group_id}")
+    logger.debug(f"Fetching projects for group ID {group_id}")
     projects = get_paginated(
         gitlab_url,
         token,
         f"/api/v4/groups/{group_id}/projects",
         extra_params={"include_subgroups": True},
     )
-    logger.info(f"Fetched {len(projects)} projects for group ID {group_id}")
+    logger.debug(f"Fetched {len(projects)} projects for group ID {group_id}")
     return projects
 
 
@@ -261,7 +261,7 @@ def sync_gitlab_projects(
         return []
 
     # Fetch languages for all projects concurrently
-    logger.info(f"Fetching languages for {len(raw_projects)} projects")
+    logger.debug(f"Fetching languages for {len(raw_projects)} projects")
     languages_by_project = asyncio.run(
         _fetch_all_languages(gitlab_url, token, raw_projects)
     )

--- a/cartography/intel/gitlab/users.py
+++ b/cartography/intel/gitlab/users.py
@@ -405,7 +405,9 @@ def sync_gitlab_users(
     # Fetch organization members
     try:
         org_members = get_group_members(gitlab_url, token, organization_id)
-        logger.debug(f"Fetched {len(org_members)} members from organization {org_name}")
+        logger.debug(
+            "Fetched %s members from organization %s", len(org_members), org_name
+        )
     except Exception:
         logger.warning(
             f"Failed to fetch members for organization {org_name}", exc_info=True
@@ -495,7 +497,7 @@ def sync_gitlab_users(
             )
             continue
 
-    logger.debug(f"Fetched commits from {len(commits_by_project)} projects")
+    logger.debug("Fetched commits from %s projects", len(commits_by_project))
 
     # Transform and load commit activity
     if commits_by_project:

--- a/cartography/intel/gitlab/users.py
+++ b/cartography/intel/gitlab/users.py
@@ -405,7 +405,7 @@ def sync_gitlab_users(
     # Fetch organization members
     try:
         org_members = get_group_members(gitlab_url, token, organization_id)
-        logger.info(f"Fetched {len(org_members)} members from organization {org_name}")
+        logger.debug(f"Fetched {len(org_members)} members from organization {org_name}")
     except Exception:
         logger.warning(
             f"Failed to fetch members for organization {org_name}", exc_info=True
@@ -495,7 +495,7 @@ def sync_gitlab_users(
             )
             continue
 
-    logger.info(f"Fetched commits from {len(commits_by_project)} projects")
+    logger.debug(f"Fetched commits from {len(commits_by_project)} projects")
 
     # Transform and load commit activity
     if commits_by_project:

--- a/cartography/intel/jumpcloud/applications.py
+++ b/cartography/intel/jumpcloud/applications.py
@@ -69,7 +69,7 @@ def get(session: requests.Session) -> list[dict[str, Any]]:
         app_id = str(app["id"])
         app["users"] = _get_application_users(session, app_id)
         applications.append(app)
-    logger.info("Fetched %d applications total", len(applications))
+    logger.debug("Fetched %d applications total", len(applications))
     return applications
 
 

--- a/cartography/intel/microsoft/entra/app_role_assignments.py
+++ b/cartography/intel/microsoft/entra/app_role_assignments.py
@@ -36,7 +36,7 @@ async def get_app_role_assignments_for_app(
     :param app_id: Application ID
     :return: Generator of app role assignment data as dicts
     """
-    logger.debug(f"Fetching role assignments for application: {app_id}")
+    logger.debug("Fetching role assignments for application: %s", app_id)
 
     # Query the graph to get the service principal ID for this application
     query = """

--- a/cartography/intel/microsoft/entra/app_role_assignments.py
+++ b/cartography/intel/microsoft/entra/app_role_assignments.py
@@ -36,7 +36,7 @@ async def get_app_role_assignments_for_app(
     :param app_id: Application ID
     :return: Generator of app role assignment data as dicts
     """
-    logger.info(f"Fetching role assignments for application: {app_id}")
+    logger.debug(f"Fetching role assignments for application: {app_id}")
 
     # Query the graph to get the service principal ID for this application
     query = """

--- a/cartography/intel/microsoft/entra/applications.py
+++ b/cartography/intel/microsoft/entra/applications.py
@@ -74,7 +74,7 @@ async def get_entra_applications(
             )
             raise
 
-    logger.info(f"Retrieved {count} Entra applications total")
+    logger.debug(f"Retrieved {count} Entra applications total")
 
 
 def transform_applications(

--- a/cartography/intel/microsoft/entra/applications.py
+++ b/cartography/intel/microsoft/entra/applications.py
@@ -74,7 +74,7 @@ async def get_entra_applications(
             )
             raise
 
-    logger.debug(f"Retrieved {count} Entra applications total")
+    logger.debug("Retrieved %s Entra applications total", count)
 
 
 def transform_applications(

--- a/cartography/intel/microsoft/entra/service_principals.py
+++ b/cartography/intel/microsoft/entra/service_principals.py
@@ -66,7 +66,7 @@ async def get_entra_service_principals(
             )
             raise
 
-    logger.debug(f"Retrieved {count} Entra service principals total")
+    logger.debug("Retrieved %s Entra service principals total", count)
 
 
 async def get_service_principal_by_app_id(

--- a/cartography/intel/microsoft/entra/service_principals.py
+++ b/cartography/intel/microsoft/entra/service_principals.py
@@ -66,7 +66,7 @@ async def get_entra_service_principals(
             )
             raise
 
-    logger.info(f"Retrieved {count} Entra service principals total")
+    logger.debug(f"Retrieved {count} Entra service principals total")
 
 
 async def get_service_principal_by_app_id(

--- a/cartography/intel/semgrep/findings.py
+++ b/cartography/intel/semgrep/findings.py
@@ -82,7 +82,7 @@ def get_sca_vulns(semgrep_app_token: str, deployment_slug: str) -> List[Dict[str
         page += 1
         request_data["page"] = page
 
-    logger.info("Retrieved %d Semgrep SCA vulns in %d pages.", len(all_vulns), page)
+    logger.debug("Retrieved %d Semgrep SCA vulns in %d pages.", len(all_vulns), page)
     return all_vulns
 
 

--- a/cartography/intel/sentinelone/account.py
+++ b/cartography/intel/sentinelone/account.py
@@ -138,7 +138,7 @@ def get_sites(
         )
 
     if sites_data:
-        logger.info("Retrieved SentinelOne site data: %d sites", len(sites_data))
+        logger.debug("Retrieved SentinelOne site data: %d sites", len(sites_data))
     else:
         logger.warning("No SentinelOne sites retrieved")
 

--- a/cartography/intel/sentinelone/agent.py
+++ b/cartography/intel/sentinelone/agent.py
@@ -39,7 +39,9 @@ def get_agents(
         params=params,
     )
 
-    logger.debug(f"Retrieved {len(agents)} agents from SentinelOne account {account_id}")
+    logger.debug(
+        f"Retrieved {len(agents)} agents from SentinelOne account {account_id}"
+    )
     return agents
 
 

--- a/cartography/intel/sentinelone/agent.py
+++ b/cartography/intel/sentinelone/agent.py
@@ -40,7 +40,7 @@ def get_agents(
     )
 
     logger.debug(
-        f"Retrieved {len(agents)} agents from SentinelOne account {account_id}"
+        "Retrieved %s agents from SentinelOne account %s", len(agents), account_id
     )
     return agents
 

--- a/cartography/intel/sentinelone/agent.py
+++ b/cartography/intel/sentinelone/agent.py
@@ -39,7 +39,7 @@ def get_agents(
         params=params,
     )
 
-    logger.info(f"Retrieved {len(agents)} agents from SentinelOne account {account_id}")
+    logger.debug(f"Retrieved {len(agents)} agents from SentinelOne account {account_id}")
     return agents
 
 

--- a/cartography/intel/sentinelone/application.py
+++ b/cartography/intel/sentinelone/application.py
@@ -42,7 +42,7 @@ def get_application_data(
         params=params,
     )
 
-    logger.debug(f"Retrieved {len(applications)} applications from SentinelOne")
+    logger.debug("Retrieved %s applications from SentinelOne", len(applications))
     return applications
 
 

--- a/cartography/intel/sentinelone/application.py
+++ b/cartography/intel/sentinelone/application.py
@@ -42,7 +42,7 @@ def get_application_data(
         params=params,
     )
 
-    logger.info(f"Retrieved {len(applications)} applications from SentinelOne")
+    logger.debug(f"Retrieved {len(applications)} applications from SentinelOne")
     return applications
 
 

--- a/cartography/intel/sentinelone/finding.py
+++ b/cartography/intel/sentinelone/finding.py
@@ -31,7 +31,7 @@ def get(
         params=params,
     )
 
-    logger.info("Retrieved %d AppFindings from SentinelOne", len(cves))
+    logger.debug("Retrieved %d AppFindings from SentinelOne", len(cves))
     return cves
 
 

--- a/cartography/intel/spacelift/runs.py
+++ b/cartography/intel/spacelift/runs.py
@@ -97,7 +97,7 @@ def transform_entities_to_run_map(
     the runs that created or updated them.
     """
     logger.debug(
-        f"Transforming {len(entities_data)} entities into run-to-instances map"
+        "Transforming %s entities into run-to-instances map", len(entities_data)
     )
 
     run_to_instances: dict[str, list[dict[str, str]]] = {}
@@ -183,7 +183,9 @@ def get_runs(session: requests.Session, api_endpoint: str) -> list[dict[str, Any
             run["stack"] = stack_id
             all_runs.append(run)
 
-    logger.debug(f"Retrieved {len(all_runs)} Spacelift runs from {len(stacks)} stacks")
+    logger.debug(
+        "Retrieved %s Spacelift runs from %s stacks", len(all_runs), len(stacks)
+    )
     return all_runs
 
 
@@ -193,7 +195,7 @@ def transform_runs(
     account_id: str,
 ) -> list[dict[str, Any]]:
 
-    logger.debug(f"Transforming {len(runs_data)} runs")
+    logger.debug("Transforming %s runs", len(runs_data))
 
     result: list[dict[str, Any]] = []
 

--- a/cartography/intel/spacelift/runs.py
+++ b/cartography/intel/spacelift/runs.py
@@ -73,7 +73,7 @@ query {
 
 @timeit
 def get_entities(session: requests.Session, api_endpoint: str) -> list[dict[str, Any]]:
-    logger.info("Fetching Spacelift entities")
+    logger.debug("Fetching Spacelift entities")
 
     response = call_spacelift_api(session, api_endpoint, GET_ENTITIES_QUERY)
     stacks = response.get("data", {}).get("stacks", [])
@@ -96,7 +96,7 @@ def transform_entities_to_run_map(
     This function processes entities to extract EC2 instance IDs and maps them to
     the runs that created or updated them.
     """
-    logger.info(f"Transforming {len(entities_data)} entities into run-to-instances map")
+    logger.debug(f"Transforming {len(entities_data)} entities into run-to-instances map")
 
     run_to_instances: dict[str, list[dict[str, str]]] = {}
 
@@ -167,7 +167,7 @@ def transform_entities_to_run_map(
 
 @timeit
 def get_runs(session: requests.Session, api_endpoint: str) -> list[dict[str, Any]]:
-    logger.info("Fetching Spacelift runs")
+    logger.debug("Fetching Spacelift runs")
 
     response = call_spacelift_api(session, api_endpoint, GET_RUNS_QUERY)
     stacks = response.get("data", {}).get("stacks", [])
@@ -181,7 +181,7 @@ def get_runs(session: requests.Session, api_endpoint: str) -> list[dict[str, Any
             run["stack"] = stack_id
             all_runs.append(run)
 
-    logger.info(f"Retrieved {len(all_runs)} Spacelift runs from {len(stacks)} stacks")
+    logger.debug(f"Retrieved {len(all_runs)} Spacelift runs from {len(stacks)} stacks")
     return all_runs
 
 
@@ -191,7 +191,7 @@ def transform_runs(
     account_id: str,
 ) -> list[dict[str, Any]]:
 
-    logger.info(f"Transforming {len(runs_data)} runs")
+    logger.debug(f"Transforming {len(runs_data)} runs")
 
     result: list[dict[str, Any]] = []
 

--- a/cartography/intel/spacelift/runs.py
+++ b/cartography/intel/spacelift/runs.py
@@ -96,7 +96,9 @@ def transform_entities_to_run_map(
     This function processes entities to extract EC2 instance IDs and maps them to
     the runs that created or updated them.
     """
-    logger.debug(f"Transforming {len(entities_data)} entities into run-to-instances map")
+    logger.debug(
+        f"Transforming {len(entities_data)} entities into run-to-instances map"
+    )
 
     run_to_instances: dict[str, list[dict[str, str]]] = {}
 

--- a/cartography/intel/spacelift/spaces.py
+++ b/cartography/intel/spacelift/spaces.py
@@ -32,7 +32,7 @@ def get_spaces(session: requests.Session, api_endpoint: str) -> list[dict[str, A
     response = call_spacelift_api(session, api_endpoint, GET_SPACES_QUERY)
     spaces_data = response.get("data", {}).get("spaces", [])
 
-    logger.debug(f"Retrieved {len(spaces_data)} Spacelift spaces")
+    logger.debug("Retrieved %s Spacelift spaces", len(spaces_data))
     return spaces_data
 
 

--- a/cartography/intel/spacelift/spaces.py
+++ b/cartography/intel/spacelift/spaces.py
@@ -27,12 +27,12 @@ query {
 
 @timeit
 def get_spaces(session: requests.Session, api_endpoint: str) -> list[dict[str, Any]]:
-    logger.info("Fetching Spacelift spaces")
+    logger.debug("Fetching Spacelift spaces")
 
     response = call_spacelift_api(session, api_endpoint, GET_SPACES_QUERY)
     spaces_data = response.get("data", {}).get("spaces", [])
 
-    logger.info(f"Retrieved {len(spaces_data)} Spacelift spaces")
+    logger.debug(f"Retrieved {len(spaces_data)} Spacelift spaces")
     return spaces_data
 
 

--- a/cartography/intel/spacelift/stacks.py
+++ b/cartography/intel/spacelift/stacks.py
@@ -32,12 +32,12 @@ query {
 
 @timeit
 def get_stacks(session: requests.Session, api_endpoint: str) -> list[dict[str, Any]]:
-    logger.info("Fetching Spacelift stacks")
+    logger.debug("Fetching Spacelift stacks")
 
     response = call_spacelift_api(session, api_endpoint, GET_STACKS_QUERY)
     stacks_data = response.get("data", {}).get("stacks", [])
 
-    logger.info(f"Retrieved {len(stacks_data)} Spacelift stacks")
+    logger.debug(f"Retrieved {len(stacks_data)} Spacelift stacks")
     return stacks_data
 
 

--- a/cartography/intel/spacelift/stacks.py
+++ b/cartography/intel/spacelift/stacks.py
@@ -37,7 +37,7 @@ def get_stacks(session: requests.Session, api_endpoint: str) -> list[dict[str, A
     response = call_spacelift_api(session, api_endpoint, GET_STACKS_QUERY)
     stacks_data = response.get("data", {}).get("stacks", [])
 
-    logger.debug(f"Retrieved {len(stacks_data)} Spacelift stacks")
+    logger.debug("Retrieved %s Spacelift stacks", len(stacks_data))
     return stacks_data
 
 

--- a/cartography/intel/spacelift/workerpools.py
+++ b/cartography/intel/spacelift/workerpools.py
@@ -30,12 +30,12 @@ def get_worker_pools(
     session: requests.Session, api_endpoint: str
 ) -> list[dict[str, Any]]:
 
-    logger.info("Fetching Spacelift worker pools")
+    logger.debug("Fetching Spacelift worker pools")
 
     response = call_spacelift_api(session, api_endpoint, GET_WORKER_POOLS_QUERY)
     worker_pools_data = response.get("data", {}).get("workerPools", [])
 
-    logger.info(f"Retrieved {len(worker_pools_data)} Spacelift worker pools")
+    logger.debug(f"Retrieved {len(worker_pools_data)} Spacelift worker pools")
     return worker_pools_data
 
 

--- a/cartography/intel/spacelift/workerpools.py
+++ b/cartography/intel/spacelift/workerpools.py
@@ -35,7 +35,7 @@ def get_worker_pools(
     response = call_spacelift_api(session, api_endpoint, GET_WORKER_POOLS_QUERY)
     worker_pools_data = response.get("data", {}).get("workerPools", [])
 
-    logger.debug(f"Retrieved {len(worker_pools_data)} Spacelift worker pools")
+    logger.debug("Retrieved %s Spacelift worker pools", len(worker_pools_data))
     return worker_pools_data
 
 

--- a/cartography/intel/spacelift/workers.py
+++ b/cartography/intel/spacelift/workers.py
@@ -34,7 +34,7 @@ def get_workers(session: requests.Session, api_endpoint: str) -> list[dict[str, 
     Fetch all Spacelift workers from the API.
     Workers are nested under workerPools, so we query workerPools and flatten the workers.
     """
-    logger.info("Fetching Spacelift workers")
+    logger.debug("Fetching Spacelift workers")
 
     response = call_spacelift_api(session, api_endpoint, GET_WORKERS_QUERY)
     worker_pools = response.get("data", {}).get("workerPools", [])

--- a/cartography/intel/ubuntu/cves.py
+++ b/cartography/intel/ubuntu/cves.py
@@ -253,7 +253,7 @@ def _fetch_cves(
 
         offset += _PAGE_SIZE
 
-    logger.info("Fetched %d Ubuntu CVEs", total_fetched)
+    logger.debug("Fetched %d Ubuntu CVEs", total_fetched)
 
 
 @timeit

--- a/cartography/intel/ubuntu/notices.py
+++ b/cartography/intel/ubuntu/notices.py
@@ -251,7 +251,7 @@ def _fetch_notices(
 
         offset += _PAGE_SIZE
 
-    logger.info("Fetched %d Ubuntu notices", total_fetched)
+    logger.debug("Fetched %d Ubuntu notices", total_fetched)
 
 
 @timeit

--- a/cartography/intel/workday/people.py
+++ b/cartography/intel/workday/people.py
@@ -64,7 +64,7 @@ def _transform_people_data(
     :return: Tuple of (people_list, manager_relationships_list)
     """
     people = directory_data.get("Report_Entry", [])
-    logger.info(f"Transforming {len(people)} people from Workday")
+    logger.debug(f"Transforming {len(people)} people from Workday")
 
     people_transformed = []
     manager_relationships = []

--- a/cartography/intel/workday/people.py
+++ b/cartography/intel/workday/people.py
@@ -64,7 +64,7 @@ def _transform_people_data(
     :return: Tuple of (people_list, manager_relationships_list)
     """
     people = directory_data.get("Report_Entry", [])
-    logger.debug(f"Transforming {len(people)} people from Workday")
+    logger.debug("Transforming %s people from Workday", len(people))
 
     people_transformed = []
     manager_relationships = []

--- a/cartography/intel/workos/util.py
+++ b/cartography/intel/workos/util.py
@@ -42,5 +42,5 @@ def paginated_list(list_func: Callable, **kwargs: Any) -> List[Dict[str, Any]]:
         if not after:
             break
 
-    logger.info("Fetched %d items from WorkOS API", len(results))
+    logger.debug("Fetched %d items from WorkOS API", len(results))
     return results

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -542,7 +542,7 @@ def aws_paginate(
     paginator = client.get_paginator(method_name)
     for i, page in enumerate(paginator.paginate(**kwargs), start=1):
         if i % 100 == 0:
-            logger.info(f"fetching page number {i}")
+            logger.debug(f"fetching page number {i}")
         if object_name in page:
             items = page[object_name]
             yield from items

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -542,7 +542,7 @@ def aws_paginate(
     paginator = client.get_paginator(method_name)
     for i, page in enumerate(paginator.paginate(**kwargs), start=1):
         if i % 100 == 0:
-            logger.debug(f"fetching page number {i}")
+            logger.debug("fetching page number %s", i)
         if object_name in page:
             items = page[object_name]
             yield from items

--- a/docs/root/dev/writing-intel-modules.md
+++ b/docs/root/dev/writing-intel-modules.md
@@ -69,7 +69,6 @@ def load_emr_clusters(
         current_aws_account_id: str,
         aws_update_tag: int,
 ) -> None:
-    logger.info(f"Loading EMR {len(cluster_data)} clusters for region '{region}' into graph.")
     load(
         neo4j_session,
         EMRClusterSchema(),


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Reduce log volume in cartography by reserving `INFO` for sync-level start/complete and per-account recap messages, and demoting per-region / per-tenant step logs (`fetch`, `get`, `transform`, `retrieved`, ...) to `DEBUG`. The `AGENTS.md` and `docs/root/agents/create-module.md` examples already document this convention; this PR brings the rest of the codebase in line.

Highlights:
- `cartography/graph/job.py` — "Finished job" → DEBUG (fired ~620k/day across cleanup/relationship sub-jobs).
- `cartography/intel/aws/dynamodb.py` — removed the 8 "Loading DynamoDB ... into graph" calls; they duplicate the aggregate message already emitted by `cartography/client/core/tx.py`.
- `cartography/intel/aws/cloudtrail_management_events.py` — per-region `Processing/Fetching/Retrieved/Transforming/Loaded` calls → DEBUG. The per-account aggregates ("Syncing N regions ...", "... sync completed successfully ...") stay at INFO.
- `cartography/intel/gcp/vertex/utils.py`, `cartography/intel/gcp/cloudrun/util.py` — per (resource × region × project) "Found ..." → DEBUG (per-project recap logs stay INFO).
- `cartography/intel/aws/sagemaker/util.py` — per-(submodule × region × account) "Syncing ..." → DEBUG.
- Sweep: across AWS Bedrock, ECR, CloudFront, IdentityCenter, GitHub, GitLab, Microsoft Entra, Spacelift, SentinelOne, Duo, Ubuntu, Workday, WorkOS, Semgrep, JumpCloud, CVE EPSS, and `cartography/util.py`, all `Fetching/Fetched/Retrieved/Getting/Transforming` step logs → DEBUG.
- `docs/root/dev/writing-intel-modules.md` — removed the redundant "Loading EMR clusters ... into graph" line from the `load_emr_clusters` example so docs reflect the convention.

### Related issues or links


### How was this tested?

- Syntax check across the whole `cartography/` tree (`python3 -c \"import ast, pathlib; [ast.parse(p.read_text()) for p in pathlib.Path('cartography').rglob('*.py')]\"`).
- `make lint` locally.
- Manual review of the diff: every demoted call is a per-region / per-tenant step log; every remaining `logger.info` is a sync-level start/complete or per-account recap message.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

This PR only changes log levels and removes redundant log statements; no graph behavior changes, so no new tests or screenshots are warranted.

### Notes for reviewers

- Per-account aggregate INFO logs are intentionally preserved (e.g. CloudTrail `Syncing N regions with X hour lookback period`, `... sync completed successfully ...`).
- `cartography/intel/aws/emr.py:80` still has a "Loading EMR ... into graph" line equivalent to the ones removed from DynamoDB; left intact in this PR to keep scope tight, but it could be removed as a follow-up since `client/core/tx.py:830` already logs the same information.