### PR TITLE
fix(matchlinks): log relationships actually created, not records sent

### DIFF
--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -927,7 +927,7 @@ def load_matchlinks(
         f"relationship.{src_label}.{rel_schema.rel_label.lower()}.{tgt_label}.loaded",
         rels_created,
     )
-    if rels_created != attempted:
+    if rels_created < attempted:
         logger.warning(
             "Created %d/%d (%s)-[%s]->(%s) relationships; %d row(s) had no matching source/target node.",
             rels_created,
@@ -938,10 +938,14 @@ def load_matchlinks(
             attempted - rels_created,
         )
     else:
+        # rels_created may exceed attempted when a single input row matches
+        # multiple source or target nodes (e.g. one-to-many matchers, or
+        # non-unique match properties), causing a fan-out.
         logger.info(
-            "Created %d (%s)-[%s]->(%s) relationships",
+            "Created %d (%s)-[%s]->(%s) relationships from %d input row(s)",
             rels_created,
             rel_schema.source_node_label,
             rel_schema.rel_label,
             rel_schema.target_node_label,
+            attempted,
         )

--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -615,6 +615,28 @@ def write_list_of_dicts_tx(
     tx.run(query, kwargs).consume()
 
 
+def _write_matchlinks_tx(
+    tx: neo4j.Transaction,
+    query: str,
+    **kwargs,
+) -> int:
+    """
+    Execute a matchlink write query and return the number of relationships
+    actually created or matched by the MERGE clause.
+
+    The matchlink query (built by ``build_matchlink_query``) ends with
+    ``RETURN count(r) AS rels_created``, where rows are emitted only when both
+    source and target ``MATCH`` clauses succeed. This makes the returned count
+    a reliable measure of the relationships truly written, rather than the
+    number of records sent to the query.
+    """
+    result = tx.run(query, kwargs)
+    record = result.single()
+    rels_created = int(record["rels_created"]) if record else 0
+    result.consume()
+    return rels_created
+
+
 def load_graph_data(
     neo4j_session: neo4j.Session,
     query: str,
@@ -886,22 +908,40 @@ def load_matchlinks(
     ensure_indexes_for_matchlinks(neo4j_session, rel_schema)
     matchlink_query = build_matchlink_query(rel_schema)
     logger.debug(f"Matchlink query: {matchlink_query}")
-    load_graph_data(
-        neo4j_session, matchlink_query, dict_list, batch_size=batch_size, **kwargs
-    )
+
+    rels_created = 0
+    for data_batch in batch(dict_list, size=batch_size):
+        rels_created += execute_write_with_retry(
+            neo4j_session,
+            _write_matchlinks_tx,
+            matchlink_query,
+            DictList=data_batch,
+            **kwargs,
+        )
 
     # Emit metrics for loaded relationships
-    rel_count = len(dict_list)
+    attempted = len(dict_list)
     src_label = (rel_schema.source_node_label or "unknown").lower()
     tgt_label = rel_schema.target_node_label.lower()
     stat_handler.incr(
         f"relationship.{src_label}.{rel_schema.rel_label.lower()}.{tgt_label}.loaded",
-        rel_count,
+        rels_created,
     )
-    logger.info(
-        "Loaded %d (%s)-[%s]->(%s) relationships",
-        rel_count,
-        rel_schema.source_node_label,
-        rel_schema.rel_label,
-        rel_schema.target_node_label,
-    )
+    if rels_created != attempted:
+        logger.warning(
+            "Created %d/%d (%s)-[%s]->(%s) relationships; %d row(s) had no matching source/target node.",
+            rels_created,
+            attempted,
+            rel_schema.source_node_label,
+            rel_schema.rel_label,
+            rel_schema.target_node_label,
+            attempted - rels_created,
+        )
+    else:
+        logger.info(
+            "Created %d (%s)-[%s]->(%s) relationships",
+            rels_created,
+            rel_schema.source_node_label,
+            rel_schema.rel_label,
+            rel_schema.target_node_label,
+        )

--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -1640,7 +1640,8 @@ def build_matchlink_query(rel_schema: CartographyRelSchema) -> str:
             SET
                 r._module_name = "$module_name",
                 r._module_version = "$module_version",
-                $set_rel_properties_statement;
+                $set_rel_properties_statement
+        RETURN count(r) AS rels_created;
         """
     )
 

--- a/tests/unit/cartography/client/core/test_tx.py
+++ b/tests/unit/cartography/client/core/test_tx.py
@@ -740,7 +740,7 @@ def test_load_no_metrics_for_empty_data(
     mock_logger.info.assert_not_called()
 
 
-@patch("cartography.client.core.tx.load_graph_data")
+@patch("cartography.client.core.tx.execute_write_with_retry")
 @patch("cartography.client.core.tx.ensure_indexes_for_matchlinks")
 @patch("cartography.client.core.tx.build_matchlink_query")
 @patch("cartography.client.core.tx.stat_handler")
@@ -750,9 +750,9 @@ def test_load_matchlinks_emits_metrics_and_logs(
     mock_stat_handler,
     mock_build_query,
     mock_ensure_indexes,
-    mock_load_graph_data,
+    mock_execute_write_with_retry,
 ):
-    """load_matchlinks() should emit a metric and log the count of loaded relationships."""
+    """load_matchlinks() should emit a metric and log the count of created relationships."""
     from cartography.client.core.tx import load_matchlinks
 
     # Setup mocks
@@ -762,6 +762,8 @@ def test_load_matchlinks_emits_metrics_and_logs(
     mock_rel_schema.source_node_label = "EC2Instance"
     mock_rel_schema.target_node_label = "AWSVpc"
     mock_build_query.return_value = "UNWIND ..."
+    # All rows match: created == attempted
+    mock_execute_write_with_retry.return_value = 2
 
     test_data = [
         {"source_id": "1", "target_id": "a"},
@@ -777,22 +779,80 @@ def test_load_matchlinks_emits_metrics_and_logs(
         _sub_resource_id="123456",
     )
 
-    # Verify metric includes source and target labels for disambiguation
+    # Verify metric reflects the actual number of relationships created/matched
     mock_stat_handler.incr.assert_called_once_with(
         "relationship.ec2instance.connected_to.awsvpc.loaded", 2
     )
 
-    # Verify info log was emitted
+    # Verify info log was emitted (no warning since attempted == created)
     mock_logger.info.assert_called_once_with(
-        "Loaded %d (%s)-[%s]->(%s) relationships",
+        "Created %d (%s)-[%s]->(%s) relationships",
         2,
         "EC2Instance",
         "CONNECTED_TO",
         "AWSVpc",
     )
+    mock_logger.warning.assert_not_called()
 
 
-@patch("cartography.client.core.tx.load_graph_data")
+@patch("cartography.client.core.tx.execute_write_with_retry")
+@patch("cartography.client.core.tx.ensure_indexes_for_matchlinks")
+@patch("cartography.client.core.tx.build_matchlink_query")
+@patch("cartography.client.core.tx.stat_handler")
+@patch("cartography.client.core.tx.logger")
+def test_load_matchlinks_warns_when_some_rows_did_not_match(
+    mock_logger,
+    mock_stat_handler,
+    mock_build_query,
+    mock_ensure_indexes,
+    mock_execute_write_with_retry,
+):
+    """load_matchlinks() should warn when fewer relationships are created than attempted."""
+    from cartography.client.core.tx import load_matchlinks
+
+    mock_session = MagicMock()
+    mock_rel_schema = MagicMock()
+    mock_rel_schema.rel_label = "CONNECTED_TO"
+    mock_rel_schema.source_node_label = "EC2Instance"
+    mock_rel_schema.target_node_label = "AWSVpc"
+    mock_build_query.return_value = "UNWIND ..."
+    # Only 1 of 3 rows had matching source+target nodes
+    mock_execute_write_with_retry.return_value = 1
+
+    test_data = [
+        {"source_id": "1", "target_id": "a"},
+        {"source_id": "2", "target_id": "b"},
+        {"source_id": "3", "target_id": "c"},
+    ]
+
+    load_matchlinks(
+        mock_session,
+        mock_rel_schema,
+        test_data,
+        lastupdated=12345,
+        _sub_resource_label="AWSAccount",
+        _sub_resource_id="123456",
+    )
+
+    # Metric reflects only the relationships that were actually created/matched
+    mock_stat_handler.incr.assert_called_once_with(
+        "relationship.ec2instance.connected_to.awsvpc.loaded", 1
+    )
+
+    # A warning is emitted, not an info, because some rows did not match
+    mock_logger.warning.assert_called_once_with(
+        "Created %d/%d (%s)-[%s]->(%s) relationships; %d row(s) had no matching source/target node.",
+        1,
+        3,
+        "EC2Instance",
+        "CONNECTED_TO",
+        "AWSVpc",
+        2,
+    )
+    mock_logger.info.assert_not_called()
+
+
+@patch("cartography.client.core.tx.execute_write_with_retry")
 @patch("cartography.client.core.tx.ensure_indexes_for_matchlinks")
 @patch("cartography.client.core.tx.build_matchlink_query")
 @patch("cartography.client.core.tx.stat_handler")
@@ -802,7 +862,7 @@ def test_load_matchlinks_no_metrics_for_empty_data(
     mock_stat_handler,
     mock_build_query,
     mock_ensure_indexes,
-    mock_load_graph_data,
+    mock_execute_write_with_retry,
 ):
     """load_matchlinks() should not emit metrics when there's no data to load."""
     from cartography.client.core.tx import load_matchlinks
@@ -823,3 +883,4 @@ def test_load_matchlinks_no_metrics_for_empty_data(
     # Verify no metric was emitted (function returns early for empty data)
     mock_stat_handler.incr.assert_not_called()
     mock_logger.info.assert_not_called()
+    mock_logger.warning.assert_not_called()

--- a/tests/unit/cartography/client/core/test_tx.py
+++ b/tests/unit/cartography/client/core/test_tx.py
@@ -786,11 +786,12 @@ def test_load_matchlinks_emits_metrics_and_logs(
 
     # Verify info log was emitted (no warning since attempted == created)
     mock_logger.info.assert_called_once_with(
-        "Created %d (%s)-[%s]->(%s) relationships",
+        "Created %d (%s)-[%s]->(%s) relationships from %d input row(s)",
         2,
         "EC2Instance",
         "CONNECTED_TO",
         "AWSVpc",
+        2,
     )
     mock_logger.warning.assert_not_called()
 
@@ -850,6 +851,59 @@ def test_load_matchlinks_warns_when_some_rows_did_not_match(
         2,
     )
     mock_logger.info.assert_not_called()
+
+
+@patch("cartography.client.core.tx.execute_write_with_retry")
+@patch("cartography.client.core.tx.ensure_indexes_for_matchlinks")
+@patch("cartography.client.core.tx.build_matchlink_query")
+@patch("cartography.client.core.tx.stat_handler")
+@patch("cartography.client.core.tx.logger")
+def test_load_matchlinks_handles_fan_out_without_warning(
+    mock_logger,
+    mock_stat_handler,
+    mock_build_query,
+    mock_ensure_indexes,
+    mock_execute_write_with_retry,
+):
+    """When a row matches multiple source/target nodes, rels_created can exceed
+    the number of attempted input rows. That is not an error, so no warning."""
+    from cartography.client.core.tx import load_matchlinks
+
+    mock_session = MagicMock()
+    mock_rel_schema = MagicMock()
+    mock_rel_schema.rel_label = "CONNECTED_TO"
+    mock_rel_schema.source_node_label = "EC2Instance"
+    mock_rel_schema.target_node_label = "AWSVpc"
+    mock_build_query.return_value = "UNWIND ..."
+    # 2 rows fan out into 5 relationships (e.g. one-to-many target match)
+    mock_execute_write_with_retry.return_value = 5
+
+    test_data = [
+        {"source_id": "1", "target_ids": ["a", "b", "c"]},
+        {"source_id": "2", "target_ids": ["d", "e"]},
+    ]
+
+    load_matchlinks(
+        mock_session,
+        mock_rel_schema,
+        test_data,
+        lastupdated=12345,
+        _sub_resource_label="AWSAccount",
+        _sub_resource_id="123456",
+    )
+
+    mock_stat_handler.incr.assert_called_once_with(
+        "relationship.ec2instance.connected_to.awsvpc.loaded", 5
+    )
+    mock_logger.info.assert_called_once_with(
+        "Created %d (%s)-[%s]->(%s) relationships from %d input row(s)",
+        5,
+        "EC2Instance",
+        "CONNECTED_TO",
+        "AWSVpc",
+        2,
+    )
+    mock_logger.warning.assert_not_called()
 
 
 @patch("cartography.client.core.tx.execute_write_with_retry")

--- a/tests/unit/cartography/graph/test_matchlink.py
+++ b/tests/unit/cartography/graph/test_matchlink.py
@@ -35,7 +35,8 @@ def test_build_matchlink_query(_mock_get_cartography_version):
                 r.lastupdated = $UPDATE_TAG,
                 r.permission_action = item.permission_action,
                 r._sub_resource_label = $_sub_resource_label,
-                r._sub_resource_id = $_sub_resource_id;
+                r._sub_resource_id = $_sub_resource_id
+        RETURN count(r) AS rels_created;
     """
 
     # Assert: compare query outputs while ignoring leading whitespace.


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

`load_matchlinks()` currently logs the length of `dict_list`, which is the number of records sent to the query — not the number of relationships actually created or matched in the database. When the source/target nodes referenced by a matchlink row do not exist, the Cypher `MATCH` clauses filter the row out and `MERGE` never runs, so the log message overstates the result. For example, a sync that sent 2 records and created 0 relationships would still log "Loaded 2 ... relationships".

This PR makes `load_matchlinks()` report the real count:

- `cartography/graph/querybuilder.py` — `build_matchlink_query()` now appends `RETURN count(r) AS rels_created` to the generated query. Because rows are emitted only when both `MATCH` clauses succeed, `count(r)` reflects the rows where `MERGE` actually created or matched a relationship.
- `cartography/client/core/tx.py` — added a small `_write_matchlinks_tx` helper that runs the matchlink query and returns the count, then rewired `load_matchlinks()` to iterate batches with `execute_write_with_retry`, sum the counts, and log/emit metrics based on the real value.
- When the created count is lower than the number of records attempted, `load_matchlinks()` now logs a `warning` that names the gap explicitly (e.g. "Created 0/2 ...; 2 row(s) had no matching source/target node."), making it obvious that some records did not result in a relationship.

The stats counter `relationship.<src>.<rel>.<tgt>.loaded` is unchanged in name but now reflects the relationships truly created/matched, matching what users would expect from the metric.

### Related issues or links


### How was this tested?

- Updated `tests/unit/cartography/graph/test_matchlink.py` to assert the new query template.
- Updated `tests/unit/cartography/client/core/test_tx.py`:
  - happy-path test now asserts the metric reflects the count returned by the query and the new `Created N ...` info log.
  - new test asserts the warning log is emitted when fewer relationships are created than attempted.
  - empty-data test now also asserts no warning is emitted.
- Ran the full unit suite (`uv run --frozen pytest tests/unit -q`) — 1559 passed.
- Ran the matchlink integration test (`tests/integration/cartography/graph/test_matchlink.py`) and all integration tests that exercise matchlinks (Microsoft Entra applications, ontology devices, GitHub commits, AWS ECS, AWS IdentityCenter, AWS EC2 LBv2) — all pass.
- `uv run --frozen pre-commit run --files ...` on the touched files — all checks pass.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

### Notes for reviewers

- The matchlink query already used `MERGE`, which both creates a new relationship and matches an existing one. `count(r)` aggregates over both, so the post-write number stays stable on idempotent re-runs — it counts "relationships that exist after this write", not "relationships newly created on this run".
- `load()` (the node loader) was not changed in this PR. Its log already corresponds to the number of nodes processed by `MERGE`, since the node `MERGE` does not depend on a prior `MATCH` that can filter rows out.