### PR TITLE
feat(gcp): ingest workload identity principal sets

### DIFF
--- a/cartography/intel/gcp/permission_relationships.py
+++ b/cartography/intel/gcp/permission_relationships.py
@@ -134,11 +134,11 @@ def calculate_permission_relationships_for_resource(
     permissions: list[str],
 ) -> list[dict[str, Any]]:
     allowed_mappings: list[dict[str, Any]] = []
-    for principal_email, policy_bindings in principals.items():
+    for principal_id, policy_bindings in principals.items():
         if principal_allowed_on_resource(policy_bindings, resource_scope, permissions):
             allowed_mappings.append(
                 {
-                    "principal_email": principal_email,
+                    "principal_id": principal_id,
                     "resource_id": resource_id,
                 }
             )
@@ -184,7 +184,7 @@ def get_principals_for_project(
     neo4j_session: neo4j.Session, project_id: str
 ) -> dict[str, Any]:
     """
-    Get all principals (users, service accounts, groups) with their policy bindings
+    Get all principals with their policy bindings
     for a given GCP project.
     """
     get_principals_query = """
@@ -196,7 +196,7 @@ def get_principals_for_project(
     (principal:GCPPrincipal)-[:HAS_ALLOW_POLICY]->(binding)
     WHERE binding.has_condition = false
     RETURN
-    DISTINCT principal.email as principal_email, binding.id as binding_id,
+    DISTINCT principal.principal_id as principal_id, binding.id as binding_id,
     binding.resource as binding_resource, role.permissions as role_permissions
     """
 
@@ -208,13 +208,13 @@ def get_principals_for_project(
 
     principals: dict[str, Any] = {}
     for r in results:
-        principal_email = r["principal_email"]
+        principal_id = r["principal_id"]
         binding_id = r["binding_id"]
         binding_resource = r["binding_resource"]
         role_permissions = r["role_permissions"] or []
 
-        if principal_email not in principals:
-            principals[principal_email] = {}
+        if principal_id not in principals:
+            principals[principal_id] = {}
 
         # Compile permissions from role
         compiled_permissions = compile_permissions_from_role(role_permissions)
@@ -222,7 +222,7 @@ def get_principals_for_project(
             resolve_gcp_scope(binding_resource, project_id)
         )
 
-        principals[principal_email][binding_id] = {
+        principals[principal_id][binding_id] = {
             "permissions": compiled_permissions,
             "scope": compiled_scope,
         }

--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import re
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -22,11 +23,19 @@ from google.protobuf.json_format import MessageToDict
 from cartography.client.core.tx import load
 from cartography.client.core.tx import load_matchlinks
 from cartography.graph.job import GraphJob
+from cartography.models.gcp.policy_bindings import GCPExternalPrincipalSchema
 from cartography.models.gcp.policy_bindings import GCPPolicyBindingAppliesToMatchLink
 from cartography.models.gcp.policy_bindings import GCPPolicyBindingSchema
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
+
+_SUPPORTED_EMAIL_MEMBER_TYPES = {"user", "serviceAccount", "group"}
+_WORKLOAD_IDENTITY_MEMBER_RE = re.compile(
+    r"^(?P<principal_type>principal|principalSet)://iam\.googleapis\.com/"
+    r"projects/(?P<project_number>[^/]+)/locations/(?P<location>[^/]+)/"
+    r"workloadIdentityPools/(?P<pool_id>[^/]+)(?:/(?P<selector>.+))?$"
+)
 
 
 @dataclass(frozen=True)
@@ -184,6 +193,67 @@ def _parse_full_resource_name(full_name: str) -> tuple[str | None, str | None]:
         # version) resolve to the nearest ancestor in the ontology via the
         # mapping order defined above.
         return mapping.label, "/".join(parts[: marker_idx + 2])
+    return None, None
+
+
+def _parse_workload_identity_member(member: str) -> dict[str, str | None] | None:
+    match = _WORKLOAD_IDENTITY_MEMBER_RE.match(member)
+    if not match:
+        return None
+
+    selector = match.group("selector")
+    if selector is None:
+        return None
+
+    selector_type = None
+    selector_name = None
+    selector_value = None
+    if selector == "*":
+        selector_type = "pool"
+        selector_value = "*"
+    elif selector:
+        selector_type, _, selector_value = selector.partition("/")
+        if not selector_value:
+            return None
+        if selector_type.startswith("attribute."):
+            selector_name = selector_type.removeprefix("attribute.")
+            selector_type = "attribute"
+        elif selector_type not in {"subject", "group"}:
+            return None
+
+    principal_type = match.group("principal_type")
+    if principal_type == "principal" and selector_type != "subject":
+        return None
+    if principal_type == "principalSet" and selector_type == "subject":
+        return None
+
+    return {
+        "id": member,
+        "principal_id": member,
+        "principal_type": principal_type,
+        "workload_identity_pool_project_number": match.group("project_number"),
+        "location": match.group("location"),
+        "workload_identity_pool_id": match.group("pool_id"),
+        "selector_type": selector_type,
+        "selector_name": selector_name,
+        "selector_value": selector_value,
+    }
+
+
+def _transform_policy_member(
+    member: str,
+) -> tuple[str | None, dict[str, str | None] | None]:
+    if ":" not in member:
+        return None, None
+
+    member_type, identifier = member.split(":", 1)
+    if member_type in _SUPPORTED_EMAIL_MEMBER_TYPES:
+        return identifier, None
+
+    external_principal = _parse_workload_identity_member(member)
+    if external_principal:
+        return member, external_principal
+
     return None, None
 
 
@@ -354,9 +424,12 @@ def get_policy_bindings(
     }
 
 
-def transform_bindings(data: dict[str, Any]) -> list[dict[str, Any]]:
+def transform_bindings(
+    data: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, str | None]]]:
     project_id = data["project_id"]
     bindings: dict[tuple[str, str, str | None], dict[str, Any]] = {}
+    external_principals: dict[str, dict[str, str | None]] = {}
 
     for policy_result in data["policy_results"]:
         for policy in policy_result.get("policies", []):
@@ -382,18 +455,14 @@ def transform_bindings(data: dict[str, Any]) -> list[dict[str, Any]]:
                 if not role or not members:
                     continue
 
-                # Filter members to only user:, serviceAccount:, and group: types
-                # Extract email part from each member (format: "type:email@example.com")
                 filtered_members = []
                 for member in members:
-                    if ":" not in member:
-                        continue
-                    member_type, identifier = member.split(":", 1)
-                    if member_type in ("user", "serviceAccount", "group"):
-                        # Store only the email part
-                        filtered_members.append(identifier)
+                    principal_id, external_principal = _transform_policy_member(member)
+                    if principal_id:
+                        filtered_members.append(principal_id)
+                    if external_principal:
+                        external_principals[member] = external_principal
 
-                # Don't process if members(principals) are not from the supported types. For example -> allUsers:, allAuthenticatedUsers, etc.
                 if not filtered_members:
                     continue
 
@@ -410,7 +479,7 @@ def transform_bindings(data: dict[str, Any]) -> list[dict[str, Any]]:
                 if key in bindings:
                     existing_members = set(bindings[key]["members"])
                     existing_members.update(filtered_members)
-                    bindings[key]["members"] = list(existing_members)
+                    bindings[key]["members"] = sorted(existing_members)
                 else:
                     # Generate unique ID that includes condition expression hash
                     condition_hash = ""
@@ -438,7 +507,7 @@ def transform_bindings(data: dict[str, Any]) -> list[dict[str, Any]]:
                         "condition_expression": condition_expression,
                     }
 
-    return list(bindings.values())
+    return list(bindings.values()), list(external_principals.values())
 
 
 def _group_applies_to_links(
@@ -466,9 +535,19 @@ def _group_applies_to_links(
 def load_bindings(
     neo4j_session: neo4j.Session,
     bindings: list[dict[str, Any]],
+    external_principals: list[dict[str, str | None]],
     project_id: str,
     update_tag: int,
 ) -> None:
+    if external_principals:
+        load(
+            neo4j_session,
+            GCPExternalPrincipalSchema(),
+            external_principals,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+
     load(
         neo4j_session,
         GCPPolicyBindingSchema(),
@@ -497,6 +576,10 @@ def cleanup(
 
     GraphJob.from_node_schema(
         GCPPolicyBindingSchema(),
+        common_job_parameters,
+    ).run(neo4j_session)
+    GraphJob.from_node_schema(
+        GCPExternalPrincipalSchema(),
         common_job_parameters,
     ).run(neo4j_session)
 
@@ -573,8 +656,16 @@ def sync(
         )
         return PolicyBindingsSyncStatus.SKIPPED_RETRY_EXHAUSTED
 
-    transformed_bindings_data = transform_bindings(bindings_data)
+    transformed_bindings, transformed_external_principals = transform_bindings(
+        bindings_data
+    )
 
-    load_bindings(neo4j_session, transformed_bindings_data, project_id, update_tag)
+    load_bindings(
+        neo4j_session,
+        transformed_bindings,
+        transformed_external_principals,
+        project_id,
+        update_tag,
+    )
     cleanup(neo4j_session, common_job_parameters)
     return PolicyBindingsSyncStatus.SUCCESS

--- a/cartography/models/gcp/iam.py
+++ b/cartography/models/gcp/iam.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 @dataclass(frozen=True)
 class GCPServiceAccountNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef("id", extra_index=True)
+    principal_id: PropertyRef = PropertyRef("email", extra_index=True)
     email: PropertyRef = PropertyRef("email", extra_index=True)
     display_name: PropertyRef = PropertyRef("displayName")
     oauth2_client_id: PropertyRef = PropertyRef("oauth2ClientId")

--- a/cartography/models/gcp/permission_relationships.py
+++ b/cartography/models/gcp/permission_relationships.py
@@ -41,11 +41,12 @@ class GCPPermissionMatchLink(CartographyRelSchema):
     - GCPUser (from GSuite)
     - GCPServiceAccount
     - GCPGroup (from GSuite)
+    - GCPExternalPrincipal (from Workload Identity Federation IAM members)
     """
 
     source_node_label: str = "GCPPrincipal"
     source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
-        {"email": PropertyRef("principal_email")},
+        {"principal_id": PropertyRef("principal_id")},
     )
 
     target_node_label: str = (

--- a/cartography/models/gcp/policy_bindings.py
+++ b/cartography/models/gcp/policy_bindings.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -53,7 +54,7 @@ class GCPPolicyBindingToPrincipalRelProperties(CartographyRelProperties):
 class GCPPolicyBindingToPrincipalRel(CartographyRelSchema):
     target_node_label: str = "GCPPrincipal"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"email": PropertyRef("members", one_to_many=True)},
+        {"principal_id": PropertyRef("members", one_to_many=True)},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS_ALLOW_POLICY"
@@ -93,6 +94,52 @@ class GCPPolicyBindingSchema(CartographyNodeSchema):
             GCPPolicyBindingToRoleRel(),
         ]
     )
+
+
+@dataclass(frozen=True)
+class GCPExternalPrincipalNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", extra_index=True)
+    principal_id: PropertyRef = PropertyRef("principal_id", extra_index=True)
+    principal_type: PropertyRef = PropertyRef("principal_type")
+    workload_identity_pool_project_number: PropertyRef = PropertyRef(
+        "workload_identity_pool_project_number"
+    )
+    location: PropertyRef = PropertyRef("location")
+    workload_identity_pool_id: PropertyRef = PropertyRef("workload_identity_pool_id")
+    selector_type: PropertyRef = PropertyRef("selector_type")
+    selector_name: PropertyRef = PropertyRef("selector_name")
+    selector_value: PropertyRef = PropertyRef("selector_value")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPExternalPrincipalToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPExternalPrincipalToProjectRel(CartographyRelSchema):
+    target_node_label: str = "GCPProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPExternalPrincipalToProjectRelProperties = (
+        GCPExternalPrincipalToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GCPExternalPrincipalSchema(CartographyNodeSchema):
+    label: str = "GCPExternalPrincipal"
+    properties: GCPExternalPrincipalNodeProperties = (
+        GCPExternalPrincipalNodeProperties()
+    )
+    sub_resource_relationship: GCPExternalPrincipalToProjectRel = (
+        GCPExternalPrincipalToProjectRel()
+    )
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["GCPPrincipal"])
 
 
 @dataclass(frozen=True)

--- a/cartography/models/googleworkspace/group.py
+++ b/cartography/models/googleworkspace/group.py
@@ -25,6 +25,7 @@ class GoogleWorkspaceGroupNodeProperties(CartographyNodeProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
     # Group identifiers and basic info
+    principal_id: PropertyRef = PropertyRef("email", extra_index=True)
     email: PropertyRef = PropertyRef("email", extra_index=True)
     description: PropertyRef = PropertyRef("description")
 

--- a/cartography/models/googleworkspace/user.py
+++ b/cartography/models/googleworkspace/user.py
@@ -22,6 +22,7 @@ class GoogleWorkspaceUserNodeProperties(CartographyNodeProperties):
 
     # User identifiers and basic info
     user_id: PropertyRef = PropertyRef("id")  # Alias for id
+    principal_id: PropertyRef = PropertyRef("primaryEmail", extra_index=True)
     primary_email: PropertyRef = PropertyRef("primaryEmail", extra_index=True)
     email: PropertyRef = PropertyRef(
         "primaryEmail", extra_index=True

--- a/cartography/models/gsuite/group.py
+++ b/cartography/models/gsuite/group.py
@@ -25,6 +25,7 @@ class GSuiteGroupNodeProperties(CartographyNodeProperties):
 
     # Group identifiers and basic info
     group_id: PropertyRef = PropertyRef("id")  # Alias for id
+    principal_id: PropertyRef = PropertyRef("email", extra_index=True)
     email: PropertyRef = PropertyRef("email", extra_index=True)
     name: PropertyRef = PropertyRef("name")
     description: PropertyRef = PropertyRef("description")

--- a/cartography/models/gsuite/user.py
+++ b/cartography/models/gsuite/user.py
@@ -22,6 +22,7 @@ class GSuiteUserNodeProperties(CartographyNodeProperties):
 
     # User identifiers and basic info
     user_id: PropertyRef = PropertyRef("id")  # Alias for id
+    principal_id: PropertyRef = PropertyRef("primaryEmail", extra_index=True)
     email: PropertyRef = PropertyRef("primaryEmail", extra_index=True)
     primary_email: PropertyRef = PropertyRef("primaryEmail")
     name: PropertyRef = PropertyRef("name")

--- a/docs/root/modules/gcp/permission-mapping.md
+++ b/docs/root/modules/gcp/permission-mapping.md
@@ -1,7 +1,7 @@
 ## Permissions Mapping
 
 ### How to use Permissions Mapping
-A GCP principal (GCPUser, GCPServiceAccount, or GCPGroup) can be assigned GCP roles which contain permissions that grant access to GCP resources. Cartography can map permission relationships between GCP principals and the resources they have permission to.
+A GCP principal (GCPUser, GCPServiceAccount, GCPGroup, or GCPExternalPrincipal from Workload Identity Federation IAM members) can be assigned GCP roles which contain permissions that grant access to GCP resources. Cartography can map permission relationships between GCP principals and the resources they have permission to.
 
 As mapping all permissions is infeasible both to calculate and store, Cartography will only map the relationships defined in the [permission relationship file](https://github.com/cartography-cncf/cartography/blob/master/cartography/data/gcp_permission_relationships.yaml) which includes some default permission mappings including GCP Bucket read access.
 

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -758,6 +758,7 @@ Representation of a GCP [Service Account](https://cloud.google.com/iam/docs/refe
 | Field          | Description                                                                                     |
 | -------------- | ----------------------------------------------------------------------------------------------- |
 | id             | The unique identifier for the service account.                                                  |
+| principal_id   | The stable GCP principal identifier used for permission matching.                                |
 | email          | The email address associated with the service account.                                          |
 | displayName    | The display name of the service account.                                                        |
 | oauth2ClientId | The OAuth2 client ID associated with the service account.                                       |
@@ -873,7 +874,7 @@ Representation of a GCP [Crypto Key](https://cloud.google.com/kms/docs/reference
 
 ### GCPPolicyBinding
 
-Representation of a GCP [IAM Policy Binding](https://cloud.google.com/iam/docs/reference/rest/v1/Policy#Binding). Policy bindings connect principals (users, service accounts, groups) to roles on specific resources.
+Representation of a GCP [IAM Policy Binding](https://cloud.google.com/iam/docs/reference/rest/v1/Policy#Binding). Policy bindings connect principals (users, service accounts, groups, and Workload Identity Federation external principals) to roles on specific resources.
 
 | Field                | Description                                                                      |
 | -------------------- | -------------------------------------------------------------------------------- |
@@ -881,7 +882,7 @@ Representation of a GCP [IAM Policy Binding](https://cloud.google.com/iam/docs/r
 | role                 | The name of the GCP role being granted.                                          |
 | resource             | The full resource name where the policy binding is attached.                     |
 | resource_type        | The type of resource.                                                            |
-| members              | A list of principal email addresses that are granted the role.                   |
+| members              | A list of principal identifiers that are granted the role. Email-backed principals use email addresses; Workload Identity Federation principals use the full IAM principal identifier. |
 | has_condition        | A boolean indicating if the policy binding has a condition attached.             |
 | condition_title      | The title of the condition.                                                      |
 | condition_expression | The expression of the condition.                                                 |
@@ -918,6 +919,39 @@ Representation of a GCP [IAM Policy Binding](https://cloud.google.com/iam/docs/r
 
     ```
     (GCPPolicyBinding)-[:APPLIES_TO]->(:GCPProject|GCPBucket|GCPCryptoKey|...)
+    ```
+
+### GCPExternalPrincipal
+
+Representation of a Workload Identity Federation principal discovered from a GCP IAM policy binding member such as `principal://iam.googleapis.com/...` or `principalSet://iam.googleapis.com/...`.
+
+| Field                                  | Description                                                       |
+| -------------------------------------- | ----------------------------------------------------------------- |
+| id                                     | The full IAM principal identifier.                                |
+| principal_id                           | The stable GCP principal identifier used for permission matching. |
+| principal_type                         | `principal` or `principalSet`.                                    |
+| workload_identity_pool_project_number  | The project number that owns the workload identity pool.          |
+| location                               | The workload identity pool location.                              |
+| workload_identity_pool_id              | The workload identity pool ID.                                    |
+| selector_type                          | The selector type, such as `subject`, `group`, `attribute`, or `pool`. |
+| selector_name                          | The attribute name for `attribute.*` selectors.                   |
+| selector_value                         | The selected subject, group, attribute value, or `*`.             |
+| firstseen                              | Timestamp of when a sync job first discovered this node.          |
+| lastupdated                            | Timestamp of the last time the node was updated.                  |
+
+#### Relationships
+
+- GCPExternalPrincipals are resources of the GCPProject whose policy binding exposed them.
+
+    ```
+    (GCPProject)-[:RESOURCE]->(GCPExternalPrincipal)
+    ```
+
+- GCPExternalPrincipals are GCPPrincipals and can have allow policies and permission relationships.
+
+    ```
+    (GCPExternalPrincipal:GCPPrincipal)-[:HAS_ALLOW_POLICY]->(GCPPolicyBinding)
+    (GCPExternalPrincipal:GCPPrincipal)-[:CAN_READ]->(GCPBucket)
     ```
 
 ### GCPBigtableInstance

--- a/docs/root/modules/googleworkspace/schema.md
+++ b/docs/root/modules/googleworkspace/schema.md
@@ -67,6 +67,7 @@ https://developers.google.com/admin-sdk/directory/v1/reference/users#resource
 |-------|--------------|
 | id | The unique ID for the user as a string. A user id can be used as a user request URI's userKey
 | user_id | duplicate of id.
+| principal_id | The stable GCP principal identifier used for permission matching. |
 | agreed_to_terms |  This property is true if the user has completed an initial login and accepted the Terms of Service agreement.
 | change_password_at_next_login | Indicates if the user is forced to change their password at next login. This setting doesn't apply when the user signs in via a third-party identity provider.
 | creation_time | The time the user's account was created. The value is in ISO 8601 date and time format. The time is the complete date plus hours, minutes, and seconds in the form YYYY-MM-DDThh:mm:ssTZD. For example, 2010-04-05T17:30:04+01:00.
@@ -157,6 +158,7 @@ https://developers.google.com/admin-sdk/directory/v1/reference/groups
 |-------|--------------|
 | id | The unique ID of a group. A group id can be used as a group request URI's groupKey.
 | group_id | duplicate of id.
+| principal_id | The stable GCP principal identifier used for permission matching. |
 | admin_created | Value is true if this group was created by an administrator rather than a user.
 | description |  An extended description to help users determine the purpose of a group. For example, you can include information about who should join the group, the types of messages to send to the group, links to FAQs about the group, or related groups. Maximum length is 4,096 characters.
 | direct_members_count | The number of users that are direct members of the group. If a group is a member (child) of this group (the parent), members of the child group are not counted in the directMembersCount property of the parent group

--- a/docs/root/modules/gsuite/schema.md
+++ b/docs/root/modules/gsuite/schema.md
@@ -43,6 +43,7 @@ https://developers.google.com/admin-sdk/directory/v1/reference/users#resource
 |-------|--------------|
 | id | The unique ID for the user as a string. A user id can be used as a user request URI's userKey
 | user_id | duplicate of id.
+| principal_id | The stable GCP principal identifier used for permission matching. |
 | agreed_to_terms |  This property is true if the user has completed an initial login and accepted the Terms of Service agreement.
 | change_password_at_next_login | Indicates if the user is forced to change their password at next login. This setting doesn't apply when the user signs in via a third-party identity provider.
 | creation_time | The time the user's account was created. The value is in ISO 8601 date and time format. The time is the complete date plus hours, minutes, and seconds in the form YYYY-MM-DDThh:mm:ssTZD. For example, 2010-04-05T17:30:04+01:00.
@@ -84,6 +85,7 @@ https://developers.google.com/admin-sdk/directory/v1/reference/groups
 | Field | Description |
 |-------|--------------|
 | id | The unique ID of a group. A group id can be used as a group request URI's groupKey.
+| principal_id | The stable GCP principal identifier used for permission matching. |
 | admin_created | Value is true if this group was created by an administrator rather than a user.
 | description |  An extended description to help users determine the purpose of a group. For example, you can include information about who should join the group, the types of messages to send to the group, links to FAQs about the group, or related groups. Maximum length is 4,096 characters.
 | direct_members_count | The number of users that are direct members of the group. If a group is a member (child) of this group (the parent), members of the child group are not counted in the directMembersCount property of the parent group

--- a/tests/data/gcp/policy_bindings.py
+++ b/tests/data/gcp/policy_bindings.py
@@ -1,4 +1,10 @@
 # flake8: noqa
+MOCK_WIF_AWS_ROLE_PRINCIPAL_SET = (
+    "principalSet://iam.googleapis.com/projects/123456789012/locations/global/"
+    "workloadIdentityPools/test-pool/attribute.aws_role/"
+    "arn:aws:sts::000000000000:assumed-role/test-readonly"
+)
+
 MOCK_IAM_ROLES = [
     {
         "name": "roles/editor",
@@ -207,6 +213,7 @@ MOCK_POLICY_BINDINGS_RESPONSE = {
                                 "role": "roles/storage.objectViewer",
                                 "members": [
                                     "user:alice@example.com",  # GSuite user
+                                    MOCK_WIF_AWS_ROLE_PRINCIPAL_SET,
                                 ],
                             },
                         ],

--- a/tests/integration/cartography/intel/gcp/test_permission_relationships.py
+++ b/tests/integration/cartography/intel/gcp/test_permission_relationships.py
@@ -17,6 +17,7 @@ from tests.data.gcp.policy_bindings import MOCK_GSUITE_USERS
 from tests.data.gcp.policy_bindings import MOCK_IAM_ROLES
 from tests.data.gcp.policy_bindings import MOCK_IAM_SERVICE_ACCOUNTS
 from tests.data.gcp.policy_bindings import MOCK_POLICY_BINDINGS_RESPONSE
+from tests.data.gcp.policy_bindings import MOCK_WIF_AWS_ROLE_PRINCIPAL_SET
 from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
 
@@ -233,13 +234,14 @@ def test_sync_gcp_permission_relationships(
     assert check_rels(
         neo4j_session,
         "GCPPrincipal",
-        "email",
+        "principal_id",
         "GCPBucket",
         "id",
         "CAN_READ",
         rel_direction_right=True,
     ) == {
         ("alice@example.com", "test-bucket"),
+        (MOCK_WIF_AWS_ROLE_PRINCIPAL_SET, "test-bucket"),
     }
 
     # Check permission relationships: GCPPrincipal CAN_GET_ACCELERATOR_TYPES GCPInstance
@@ -248,7 +250,7 @@ def test_sync_gcp_permission_relationships(
     assert check_rels(
         neo4j_session,
         "GCPPrincipal",
-        "email",
+        "principal_id",
         "GCPInstance",
         "id",
         "CAN_GET_ACCELERATOR_TYPES",

--- a/tests/integration/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/integration/cartography/intel/gcp/test_policy_bindings.py
@@ -8,6 +8,7 @@ import cartography.intel.gcp.policy_bindings
 import cartography.intel.gsuite.groups
 import cartography.intel.gsuite.users
 import tests.data.gcp.policy_bindings
+from tests.data.gcp.policy_bindings import MOCK_WIF_AWS_ROLE_PRINCIPAL_SET
 from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
 
@@ -225,7 +226,7 @@ def test_sync_gcp_policy_bindings(
     assert check_rels(
         neo4j_session,
         "GCPPrincipal",
-        "email",
+        "principal_id",
         "GCPPolicyBinding",
         "id",
         "HAS_ALLOW_POLICY",
@@ -253,6 +254,35 @@ def test_sync_gcp_policy_bindings(
         (
             "viewers@example.com",
             "//cloudresourcemanager.googleapis.com/projects/project-abc_roles/viewer",
+        ),
+        # WIF external principal
+        (
+            MOCK_WIF_AWS_ROLE_PRINCIPAL_SET,
+            "//storage.googleapis.com/buckets/test-bucket_roles/storage.objectViewer",
+        ),
+    }
+
+    assert check_nodes(
+        neo4j_session,
+        "GCPExternalPrincipal",
+        [
+            "principal_id",
+            "principal_type",
+            "workload_identity_pool_project_number",
+            "workload_identity_pool_id",
+            "selector_type",
+            "selector_name",
+            "selector_value",
+        ],
+    ) == {
+        (
+            MOCK_WIF_AWS_ROLE_PRINCIPAL_SET,
+            "principalSet",
+            "123456789012",
+            "test-pool",
+            "attribute",
+            "aws_role",
+            "arn:aws:sts::000000000000:assumed-role/test-readonly",
         ),
     }
 

--- a/tests/unit/cartography/intel/gcp/test_permission_relationships.py
+++ b/tests/unit/cartography/intel/gcp/test_permission_relationships.py
@@ -62,10 +62,10 @@ def test_iter_permission_relationship_batches_preserves_matches():
 
     assert all(len(batch) <= 2 for batch in batches)
     assert {tuple(sorted(mapping.items())) for mapping in flattened} == {
-        (("principal_email", "alice@example.com"), ("resource_id", "bucket-1")),
-        (("principal_email", "alice@example.com"), ("resource_id", "bucket-2")),
-        (("principal_email", "alice@example.com"), ("resource_id", "bucket-3")),
-        (("principal_email", "bob@example.com"), ("resource_id", "bucket-2")),
+        (("principal_id", "alice@example.com"), ("resource_id", "bucket-1")),
+        (("principal_id", "alice@example.com"), ("resource_id", "bucket-2")),
+        (("principal_id", "alice@example.com"), ("resource_id", "bucket-3")),
+        (("principal_id", "bob@example.com"), ("resource_id", "bucket-2")),
     }
 
 

--- a/tests/unit/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/unit/cartography/intel/gcp/test_policy_bindings.py
@@ -131,6 +131,127 @@ def test_parse_full_resource_name(full_name, expected):
     assert _parse_full_resource_name(full_name) == expected
 
 
+@pytest.mark.parametrize(
+    "member, expected",
+    [
+        (
+            "principal://iam.googleapis.com/projects/123456789012/locations/global/workloadIdentityPools/test-pool/subject/repo:example/app",
+            {
+                "principal_type": "principal",
+                "workload_identity_pool_project_number": "123456789012",
+                "location": "global",
+                "workload_identity_pool_id": "test-pool",
+                "selector_type": "subject",
+                "selector_name": None,
+                "selector_value": "repo:example/app",
+            },
+        ),
+        (
+            "principalSet://iam.googleapis.com/projects/123456789012/locations/global/workloadIdentityPools/test-pool/group/security",
+            {
+                "principal_type": "principalSet",
+                "workload_identity_pool_project_number": "123456789012",
+                "location": "global",
+                "workload_identity_pool_id": "test-pool",
+                "selector_type": "group",
+                "selector_name": None,
+                "selector_value": "security",
+            },
+        ),
+        (
+            "principalSet://iam.googleapis.com/projects/123456789012/locations/global/workloadIdentityPools/test-pool/attribute.aws_role/arn:aws:sts::000000000000:assumed-role/test-readonly",
+            {
+                "principal_type": "principalSet",
+                "workload_identity_pool_project_number": "123456789012",
+                "location": "global",
+                "workload_identity_pool_id": "test-pool",
+                "selector_type": "attribute",
+                "selector_name": "aws_role",
+                "selector_value": "arn:aws:sts::000000000000:assumed-role/test-readonly",
+            },
+        ),
+        (
+            "principalSet://iam.googleapis.com/projects/123456789012/locations/global/workloadIdentityPools/test-pool/*",
+            {
+                "principal_type": "principalSet",
+                "workload_identity_pool_project_number": "123456789012",
+                "location": "global",
+                "workload_identity_pool_id": "test-pool",
+                "selector_type": "pool",
+                "selector_name": None,
+                "selector_value": "*",
+            },
+        ),
+    ],
+)
+def test_parse_workload_identity_member(member, expected):
+    result = policy_bindings._parse_workload_identity_member(member)
+
+    assert result is not None
+    assert result["id"] == member
+    assert result["principal_id"] == member
+    assert {key: result[key] for key in expected} == expected
+
+
+@pytest.mark.parametrize(
+    "member",
+    [
+        "allUsers",
+        "allAuthenticatedUsers",
+        "domain:example.com",
+        "principalSet://iam.googleapis.com/locations/global/workforcePools/pool/group/security",
+        "principalSet://iam.googleapis.com/projects/123456789012/locations/global/workloadIdentityPools/test-pool/unsupported/value",
+    ],
+)
+def test_transform_policy_member_ignores_unsupported_members(member):
+    assert policy_bindings._transform_policy_member(member) == (None, None)
+
+
+def test_transform_bindings_preserves_wif_only_binding():
+    wif_member = (
+        "principalSet://iam.googleapis.com/projects/123456789012/locations/global/"
+        "workloadIdentityPools/test-pool/attribute.aws_role/"
+        "arn:aws:sts::000000000000:assumed-role/test-readonly"
+    )
+    bindings, external_principals = policy_bindings.transform_bindings(
+        {
+            "project_id": TEST_PROJECT_ID,
+            "policy_results": [
+                {
+                    "policies": [
+                        {
+                            "attached_resource": f"//cloudresourcemanager.googleapis.com/projects/{TEST_PROJECT_ID}",
+                            "policy": {
+                                "bindings": [
+                                    {
+                                        "role": "roles/viewer",
+                                        "members": [wif_member],
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                }
+            ],
+        }
+    )
+
+    assert bindings[0]["members"] == [wif_member]
+    assert external_principals == [
+        {
+            "id": wif_member,
+            "principal_id": wif_member,
+            "principal_type": "principalSet",
+            "workload_identity_pool_project_number": "123456789012",
+            "location": "global",
+            "workload_identity_pool_id": "test-pool",
+            "selector_type": "attribute",
+            "selector_name": "aws_role",
+            "selector_value": "arn:aws:sts::000000000000:assumed-role/test-readonly",
+        }
+    ]
+
+
 def test_wait_for_cai_policy_bindings_slot_reserves_per_operation_slots():
     original_state = policy_bindings._CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION.copy()
     policy_bindings._CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION.clear()


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update


### Summary
Adds support for GCP Workload Identity Federation IAM members discovered through the existing Cloud Asset Inventory policy-binding sync.

This introduces `GCPExternalPrincipal` nodes for supported `principal://...` and `principalSet://...` workload identity pool members, keys all GCP principals with `principal_id`, and lets existing policy-binding and permission-relationship syncs create `HAS_ALLOW_POLICY` and `CAN_*` relationships for external principals.


### Related issues or links

- Fixes #


### Breaking changes

None expected. Existing email-backed GCP principals keep their email fields; `principal_id` is added as the stable matching key for GCP IAM permission relationships.


### How was this tested?

- `uv run --frozen pytest tests/unit/cartography/intel/gcp/test_policy_bindings.py tests/unit/cartography/intel/gcp/test_permission_relationships.py tests/integration/cartography/intel/gcp/test_policy_bindings.py tests/integration/cartography/intel/gcp/test_permission_relationships.py`
- `make test_lint`


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

This intentionally does not ingest workload identity pool or provider inventory. It only models WIF IAM members that are already present in CAI policy-binding results.
