### PR TITLE
fix(gcp): skip Cloud SQL user/database sync on non-running instances

### DIFF
--- a/cartography/intel/gcp/cloud_sql_database.py
+++ b/cartography/intel/gcp/cloud_sql_database.py
@@ -118,6 +118,20 @@ def sync_sql_databases(
         if not instance_name or not instance_id:
             continue
 
+        # The Cloud SQL Admin API rejects databases.list with HTTP 400 on instances
+        # that are not running (SUSPENDED, PENDING_CREATE, MAINTENANCE, FAILED, ...,
+        # or RUNNABLE but stopped by owner via activationPolicy=NEVER).
+        state = inst.get("state")
+        activation_policy = inst.get("settings", {}).get("activationPolicy")
+        if state != "RUNNABLE" or activation_policy == "NEVER":
+            logger.info(
+                "Skipping SQL databases sync for instance %s: state=%s activationPolicy=%s.",
+                instance_name,
+                state,
+                activation_policy,
+            )
+            continue
+
         try:
             databases_raw = get_sql_databases(client, project_id, instance_name)
             # Skip this instance if API is not enabled or access denied

--- a/cartography/intel/gcp/cloud_sql_user.py
+++ b/cartography/intel/gcp/cloud_sql_user.py
@@ -116,6 +116,20 @@ def sync_sql_users(
         if not instance_name or not instance_id:
             continue
 
+        # The Cloud SQL Admin API rejects users.list with HTTP 400 on instances
+        # that are not running (SUSPENDED, PENDING_CREATE, MAINTENANCE, FAILED, ...,
+        # or RUNNABLE but stopped by owner via activationPolicy=NEVER).
+        state = inst.get("state")
+        activation_policy = inst.get("settings", {}).get("activationPolicy")
+        if state != "RUNNABLE" or activation_policy == "NEVER":
+            logger.info(
+                "Skipping SQL users sync for instance %s: state=%s activationPolicy=%s.",
+                instance_name,
+                state,
+                activation_policy,
+            )
+            continue
+
         try:
             users_raw = get_sql_users(client, project_id, instance_name)
             # Skip this instance if API is not enabled or access denied


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

The Cloud SQL Admin API rejects `users.list` and `databases.list` with HTTP 400 (`Invalid request since instance is not running.`) on any instance that is not actively serving — i.e. any state other than `RUNNABLE`, or `RUNNABLE` but stopped by the owner via `activationPolicy=NEVER`. Today the `sync_sql_users` / `sync_sql_databases` loops just catch and log a warning with a full traceback per offending instance, which is noisy during normal syncs of accounts that have stopped/suspended/failed instances.

This change skips those instances proactively (with a single `INFO` log line) before issuing the per-instance API call, so the traceback noise goes away and we don't burn API quota on calls we know will fail.

Example log we no longer emit:

```
WARNING:cartography.intel.gcp.cloud_sql_user:Failed to get SQL users for instance free-trial-first-project
googleapiclient.errors.HttpError: <HttpError 400 when requesting https://sqladmin.googleapis.com/sql/v1beta4/projects/.../instances/free-trial-first-project/users?alt=json returned "Invalid request: Invalid request since instance is not running.">
```


### Related issues or links

- Fixes #


### How was this tested?

Reproduced the original 400 traceback against a real GCP project containing a stopped Cloud SQL instance (`activationPolicy=NEVER`). After the change, the instance is skipped with an `INFO:cartography.intel.gcp.cloud_sql_user:Skipping SQL users sync for instance <name>: state=RUNNABLE activationPolicy=NEVER.` line and the rest of the project syncs cleanly. Running instances continue to sync users and databases as before.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.


### Notes for reviewers

The guard checks both `state != "RUNNABLE"` and `settings.activationPolicy == "NEVER"`. The `activationPolicy` check is needed because Cloud SQL keeps `state=RUNNABLE` even when the owner has stopped the instance, and that case still triggers the same 400 from the users/databases endpoints (per the v1beta4 discovery doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)