### PR TITLE
feat(AIBOM): Add AIBOM Runs_ON container rel through analysis job

### DIFF
--- a/cartography/data/jobs/analysis/aibom_runs_on_container_analysis.json
+++ b/cartography/data/jobs/analysis/aibom_runs_on_container_analysis.json
@@ -8,13 +8,8 @@
       "iterationsize": 1000
     },
     {
-      "__comment": "Create RUNS_ON by traversing AIBOMSource -[:SCANNED_IMAGE]-> Image <-[:HAS_IMAGE]- Container. Excludes ImageManifestList so the join is a deterministic digest-level match.",
-      "query": "MATCH (a:AIBOMSource)-[:SCANNED_IMAGE]->(i:Image)<-[:HAS_IMAGE]-(c:Container) WHERE NOT i:ImageManifestList MERGE (a)-[r:RUNS_ON]->(c) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
-      "iterative": false
-    },
-    {
-      "__comment": "Create RUNS_ON when AIBOMSource scans a child Image and the Container's HAS_IMAGE points at the parent ImageManifestList. Traverses backwards through CONTAINS_IMAGE to bridge them.",
-      "query": "MATCH (a:AIBOMSource)-[:SCANNED_IMAGE]->(i:Image)<-[:CONTAINS_IMAGE]-(:ImageManifestList)<-[:HAS_IMAGE]-(c:Container) MERGE (a)-[r:RUNS_ON]->(c) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "__comment": "Create RUNS_ON by joining AIBOMSource's SCANNED_IMAGE with the Container's RESOLVED_IMAGE on the same concrete Image. RESOLVED_IMAGE is created by resolved_image_analysis.json (which runs first) and already handles architecture matching and manifest list resolution.",
+      "query": "MATCH (a:AIBOMSource)-[:SCANNED_IMAGE]->(i:Image)<-[:RESOLVED_IMAGE]-(c:Container) MERGE (a)-[r:RUNS_ON]->(c) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     }
   ]

--- a/cartography/data/jobs/analysis/aibom_runs_on_container_analysis.json
+++ b/cartography/data/jobs/analysis/aibom_runs_on_container_analysis.json
@@ -1,0 +1,21 @@
+{
+  "name": "AIBOMSource RUNS_ON Container analysis",
+  "statements": [
+    {
+      "__comment": "Cleanup: remove stale RUNS_ON edges from AIBOMSource to Container from previous runs.",
+      "query": "MATCH (:AIBOMSource)-[r:RUNS_ON]->(:Container) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r RETURN COUNT(*) AS TotalCompleted",
+      "iterative": true,
+      "iterationsize": 1000
+    },
+    {
+      "__comment": "Create RUNS_ON by traversing AIBOMSource -[:SCANNED_IMAGE]-> Image <-[:HAS_IMAGE]- Container. Excludes ImageManifestList so the join is a deterministic digest-level match.",
+      "query": "MATCH (a:AIBOMSource)-[:SCANNED_IMAGE]->(i:Image)<-[:HAS_IMAGE]-(c:Container) WHERE NOT i:ImageManifestList MERGE (a)-[r:RUNS_ON]->(c) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "iterative": false
+    },
+    {
+      "__comment": "Create RUNS_ON when AIBOMSource scans a child Image and the Container's HAS_IMAGE points at the parent ImageManifestList. Traverses backwards through CONTAINS_IMAGE to bridge them.",
+      "query": "MATCH (a:AIBOMSource)-[:SCANNED_IMAGE]->(i:Image)<-[:CONTAINS_IMAGE]-(:ImageManifestList)<-[:HAS_IMAGE]-(c:Container) MERGE (a)-[r:RUNS_ON]->(c) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "iterative": false
+    }
+  ]
+}

--- a/cartography/intel/ontology/__init__.py
+++ b/cartography/intel/ontology/__init__.py
@@ -74,3 +74,10 @@ def run(neo4j_session: neo4j.Session, config: Config) -> None:
         neo4j_session,
         common_job_parameters,
     )
+    # Create RUNS_ON shortcut edges from :AIBOMSource to :Container by joining through the shared :Image.
+    # Runs after resolved_image_analysis so all semantic labels and HAS_IMAGE edges are in place.
+    run_analysis_job(
+        "aibom_runs_on_container_analysis.json",
+        neo4j_session,
+        common_job_parameters,
+    )

--- a/docs/root/modules/aibom/schema.md
+++ b/docs/root/modules/aibom/schema.md
@@ -59,6 +59,12 @@ Representation of one scanned target within the AIBOM output. In practice this i
     (:AIBOMSource)-[:HAS_WORKFLOW]->(:AIBOMWorkflow)
     ```
 
+- An analysis job creates a shortcut edge from a source to every container running the scanned image. This is computed by joining through the shared `:Image` node and covers three cases: direct image match, both sides referencing the same `ImageManifestList`, and the manifest-list-to-child-image hop.
+
+    ```
+    (:AIBOMSource)-[:RUNS_ON]->(:Container)
+    ```
+
 ### AIBOMComponent
 
 Representation of one detected AI component occurrence within a source.

--- a/docs/root/modules/aibom/schema.md
+++ b/docs/root/modules/aibom/schema.md
@@ -59,7 +59,7 @@ Representation of one scanned target within the AIBOM output. In practice this i
     (:AIBOMSource)-[:HAS_WORKFLOW]->(:AIBOMWorkflow)
     ```
 
-- An analysis job creates a shortcut edge from a source to every container running the scanned image. This is computed by joining through the shared `:Image` node and covers three cases: direct image match, both sides referencing the same `ImageManifestList`, and the manifest-list-to-child-image hop.
+- An analysis job creates a shortcut edge from a source to every container running the scanned image. This is computed by joining `SCANNED_IMAGE` with `RESOLVED_IMAGE` on the same concrete `:Image` node, inheriting the architecture matching and determinism guards from `resolved_image_analysis.json`.
 
     ```
     (:AIBOMSource)-[:RUNS_ON]->(:Container)

--- a/tests/data/aibom/aibom_sample.py
+++ b/tests/data/aibom/aibom_sample.py
@@ -19,6 +19,7 @@ CONTAINER_ON_MANIFEST_LIST = {
     "image_pull_policy": "Always",
     "status_image_id": "ml-image-id",
     "status_image_sha": tests.data.aws.ecr.MANIFEST_LIST_DIGEST,
+    "architecture_normalized": "amd64",
     "status_ready": True,
     "status_started": True,
     "status_state": "running",

--- a/tests/data/aibom/aibom_sample.py
+++ b/tests/data/aibom/aibom_sample.py
@@ -6,6 +6,47 @@ TEST_DIGEST_BASED_IMAGE_URI = (
     f"@{tests.data.aws.ecr.SINGLE_PLATFORM_DIGEST}"
 )
 
+TEST_CLUSTER_ID = "arn:aws:eks:us-east-1:000000000000:cluster/test-cluster"
+TEST_CLUSTER_NAME = "test-cluster"
+
+# Container whose status_image_sha matches the manifest list digest.
+CONTAINER_ON_MANIFEST_LIST = {
+    "uid": "container-on-ml",
+    "name": "ml-container",
+    "image": "000000000000.dkr.ecr.us-east-1.amazonaws.com/multi-arch-repository:v1.0",
+    "namespace": "default",
+    "pod_id": "pod-ml",
+    "image_pull_policy": "Always",
+    "status_image_id": "ml-image-id",
+    "status_image_sha": tests.data.aws.ecr.MANIFEST_LIST_DIGEST,
+    "status_ready": True,
+    "status_started": True,
+    "status_state": "running",
+    "memory_request": None,
+    "cpu_request": None,
+    "memory_limit": None,
+    "cpu_limit": None,
+}
+
+# Container whose status_image_sha matches the single-platform digest.
+CONTAINER_ON_SINGLE_PLATFORM = {
+    "uid": "container-on-sp",
+    "name": "sp-container",
+    "image": "000000000000.dkr.ecr.us-east-1.amazonaws.com/single-platform-repository:latest",
+    "namespace": "default",
+    "pod_id": "pod-sp",
+    "image_pull_policy": "Always",
+    "status_image_id": "sp-image-id",
+    "status_image_sha": tests.data.aws.ecr.SINGLE_PLATFORM_DIGEST,
+    "status_ready": True,
+    "status_started": True,
+    "status_state": "running",
+    "memory_request": None,
+    "cpu_request": None,
+    "memory_limit": None,
+    "cpu_limit": None,
+}
+
 TEST_IMAGE_URI = (
     "000000000000.dkr.ecr.us-east-1.amazonaws.com/multi-arch-repository:v1.0"
 )

--- a/tests/integration/cartography/intel/aibom/test_aibom.py
+++ b/tests/integration/cartography/intel/aibom/test_aibom.py
@@ -1014,12 +1014,12 @@ def test_runs_on_analysis_direct_image(mock_json_files, mock_file_open, neo4j_se
     "cartography.intel.aibom._get_json_files_in_dir",
     return_value={"/tmp/aibom.json"},
 )
-def test_runs_on_analysis_manifest_list_reverse_hop(
+def test_runs_on_analysis_via_resolved_manifest_list(
     mock_json_files,
     mock_file_open,
     neo4j_session,
 ):
-    """RUNS_ON is created when AIBOMSource scans a child Image and the Container's HAS_IMAGE points at the parent ImageManifestList."""
+    """RUNS_ON is created when a manifest-list-backed Container resolves to a concrete child Image that matches the AIBOMSource's SCANNED_IMAGE."""
     _seed_aibom_with_containers(
         neo4j_session,
         _seed_manifest_list_graph,

--- a/tests/integration/cartography/intel/aibom/test_aibom.py
+++ b/tests/integration/cartography/intel/aibom/test_aibom.py
@@ -10,11 +10,17 @@ import tests.data.aws.ecr
 from cartography.intel.aibom import sync_aibom_from_dir
 from cartography.intel.aibom import sync_aibom_from_s3
 from cartography.intel.aibom.cleanup import cleanup_aibom
+from cartography.intel.kubernetes.pods import load_containers
+from cartography.util import run_analysis_job
 from tests.data.aibom.aibom_sample import AIBOM_DIGEST_BASED_REPORT
 from tests.data.aibom.aibom_sample import AIBOM_INCOMPLETE_REPORT
 from tests.data.aibom.aibom_sample import AIBOM_REPORT
 from tests.data.aibom.aibom_sample import AIBOM_SINGLE_PLATFORM_REPORT
 from tests.data.aibom.aibom_sample import AIBOM_UNMATCHED_REPORT
+from tests.data.aibom.aibom_sample import CONTAINER_ON_MANIFEST_LIST
+from tests.data.aibom.aibom_sample import CONTAINER_ON_SINGLE_PLATFORM
+from tests.data.aibom.aibom_sample import TEST_CLUSTER_ID
+from tests.data.aibom.aibom_sample import TEST_CLUSTER_NAME
 from tests.data.aibom.aibom_sample import TEST_DIGEST_BASED_IMAGE_URI
 from tests.data.aibom.aibom_sample import TEST_IMAGE_URI
 from tests.data.aibom.aibom_sample import TEST_SOURCE_KEY
@@ -930,3 +936,98 @@ def test_sync_aibom_tag_manifest_list_fans_out_to_child_images(
         ("pydantic_ai.Agent", tests.data.aws.ecr.MANIFEST_LIST_AMD64_DIGEST),
         ("pydantic_ai.Agent", tests.data.aws.ecr.MANIFEST_LIST_ARM64_DIGEST),
     }
+
+
+def _seed_aibom_with_containers(neo4j_session, aibom_report, ecr_seed_fn, containers):
+    """Seed ECR images, load AIBOM, load containers, then run the analysis job."""
+    ecr_seed_fn(neo4j_session)
+
+    # Prerequisite cluster node for container sub_resource_relationship
+    neo4j_session.run(
+        "MERGE (c:KubernetesCluster {id: $id}) SET c.lastupdated = $tag",
+        id=TEST_CLUSTER_ID,
+        tag=TEST_UPDATE_TAG,
+    )
+
+    sync_aibom_from_dir(
+        neo4j_session,
+        "/tmp",
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    load_containers(
+        neo4j_session,
+        containers,
+        TEST_UPDATE_TAG,
+        cluster_id=TEST_CLUSTER_ID,
+        cluster_name=TEST_CLUSTER_NAME,
+    )
+
+    run_analysis_job(
+        "aibom_runs_on_container_analysis.json",
+        neo4j_session,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+
+@patch(
+    "builtins.open",
+    new_callable=mock_open,
+    read_data=json.dumps(AIBOM_SINGLE_PLATFORM_REPORT).encode("utf-8"),
+)
+@patch(
+    "cartography.intel.aibom._get_json_files_in_dir",
+    return_value={"/tmp/aibom.json"},
+)
+def test_runs_on_analysis_direct_image(mock_json_files, mock_file_open, neo4j_session):
+    """RUNS_ON is created when AIBOMSource and Container share the same concrete Image."""
+    _seed_aibom_with_containers(
+        neo4j_session,
+        AIBOM_SINGLE_PLATFORM_REPORT,
+        _seed_single_platform_graph,
+        [CONTAINER_ON_SINGLE_PLATFORM],
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "AIBOMSource",
+        "source_key",
+        "Container",
+        "id",
+        "RUNS_ON",
+        rel_direction_right=True,
+    ) == {(TEST_SOURCE_KEY, CONTAINER_ON_SINGLE_PLATFORM["uid"])}
+
+
+@patch(
+    "builtins.open",
+    new_callable=mock_open,
+    read_data=json.dumps(AIBOM_REPORT).encode("utf-8"),
+)
+@patch(
+    "cartography.intel.aibom._get_json_files_in_dir",
+    return_value={"/tmp/aibom.json"},
+)
+def test_runs_on_analysis_manifest_list_reverse_hop(
+    mock_json_files,
+    mock_file_open,
+    neo4j_session,
+):
+    """RUNS_ON is created when AIBOMSource scans a child Image and the Container's HAS_IMAGE points at the parent ImageManifestList."""
+    _seed_aibom_with_containers(
+        neo4j_session,
+        AIBOM_REPORT,
+        _seed_manifest_list_graph,
+        [CONTAINER_ON_MANIFEST_LIST],
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "AIBOMSource",
+        "source_key",
+        "Container",
+        "id",
+        "RUNS_ON",
+        rel_direction_right=True,
+    ) == {(TEST_SOURCE_KEY, CONTAINER_ON_MANIFEST_LIST["uid"])}

--- a/tests/integration/cartography/intel/aibom/test_aibom.py
+++ b/tests/integration/cartography/intel/aibom/test_aibom.py
@@ -938,8 +938,8 @@ def test_sync_aibom_tag_manifest_list_fans_out_to_child_images(
     }
 
 
-def _seed_aibom_with_containers(neo4j_session, aibom_report, ecr_seed_fn, containers):
-    """Seed ECR images, load AIBOM, load containers, then run the analysis job."""
+def _seed_aibom_with_containers(neo4j_session, ecr_seed_fn, containers):
+    """Seed ECR images, load AIBOM, load containers, then run the analysis jobs."""
     ecr_seed_fn(neo4j_session)
 
     # Prerequisite cluster node for container sub_resource_relationship
@@ -964,6 +964,12 @@ def _seed_aibom_with_containers(neo4j_session, aibom_report, ecr_seed_fn, contai
         cluster_name=TEST_CLUSTER_NAME,
     )
 
+    # RESOLVED_IMAGE must exist before RUNS_ON can join through it.
+    run_analysis_job(
+        "resolved_image_analysis.json",
+        neo4j_session,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
     run_analysis_job(
         "aibom_runs_on_container_analysis.json",
         neo4j_session,
@@ -984,7 +990,6 @@ def test_runs_on_analysis_direct_image(mock_json_files, mock_file_open, neo4j_se
     """RUNS_ON is created when AIBOMSource and Container share the same concrete Image."""
     _seed_aibom_with_containers(
         neo4j_session,
-        AIBOM_SINGLE_PLATFORM_REPORT,
         _seed_single_platform_graph,
         [CONTAINER_ON_SINGLE_PLATFORM],
     )
@@ -1017,7 +1022,6 @@ def test_runs_on_analysis_manifest_list_reverse_hop(
     """RUNS_ON is created when AIBOMSource scans a child Image and the Container's HAS_IMAGE points at the parent ImageManifestList."""
     _seed_aibom_with_containers(
         neo4j_session,
-        AIBOM_REPORT,
         _seed_manifest_list_graph,
         [CONTAINER_ON_MANIFEST_LIST],
     )


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

- This PR adds and analysis job for AIBOMSource ---RUNS_ON--->Container rel by traversing these paths 
    - AIBOMSource -[:SCANNED_IMAGE]-> Image <-[:HAS_IMAGE]- Container
    - AIBOMSource -[:SCANNED_IMAGE]-> Image <-[:CONTAINS_IMAGE]- ImageManifestList <-[:HAS_IMAGE]- Container


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- Builds on work done in https://github.com/cartography-cncf/cartography/pull/2692



### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

<img width="1111" height="1094" alt="image" src="https://github.com/user-attachments/assets/78831023-3d9f-4930-98cb-2ab04f665f1d" />


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [x] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.


#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).