### PR TITLE
feat(rules): add SLSA provenance coverage rule and tighten subimage coverage

### DIFF
--- a/cartography/rules/data/rules/__init__.py
+++ b/cartography/rules/data/rules/__init__.py
@@ -123,6 +123,9 @@ from cartography.rules.data.rules.policy_administration_privileges import (
 from cartography.rules.data.rules.subimage_coverage import aws_account_not_synced
 from cartography.rules.data.rules.subimage_coverage import container_image_not_found
 from cartography.rules.data.rules.subimage_coverage import (
+    repository_without_slsa_provenance,
+)
+from cartography.rules.data.rules.subimage_coverage import (
     subimage_framework_disabled_module_enabled,
 )
 from cartography.rules.data.rules.subimage_coverage import (
@@ -164,6 +167,7 @@ RULES = {
     subimage_module_not_configured.id: subimage_module_not_configured,
     subimage_framework_disabled_module_enabled.id: subimage_framework_disabled_module_enabled,
     container_image_not_found.id: container_image_not_found,
+    repository_without_slsa_provenance.id: repository_without_slsa_provenance,
     aws_account_not_synced.id: aws_account_not_synced,
     # Security Rules
     compute_instance_exposed.id: compute_instance_exposed,

--- a/cartography/rules/data/rules/subimage_coverage.py
+++ b/cartography/rules/data/rules/subimage_coverage.py
@@ -30,7 +30,7 @@ _subimage_module_not_configured_fact = Fact(
     MATCH (m:SubImageModule)
     WHERE m.is_configured = false
     MATCH (app:ThirdPartyApp)
-    WHERE toLower(app._ont_name) CONTAINS m.id
+    WHERE toLower(app._ont_name) = toLower(m.id)
     RETURN m.name AS module_name, app.name AS app_name, app.source AS app_source
     ORDER BY m.name
     """,
@@ -38,14 +38,14 @@ _subimage_module_not_configured_fact = Fact(
     MATCH (m:SubImageModule)
     WHERE m.is_configured = false
     MATCH (app:ThirdPartyApp)
-    WHERE toLower(app._ont_name) CONTAINS m.id
+    WHERE toLower(app._ont_name) = toLower(m.id)
     RETURN *
     """,
     cypher_count_query="""
     MATCH (m:SubImageModule)
     WHERE m.is_configured = false
     MATCH (app:ThirdPartyApp)
-    WHERE toLower(app._ont_name) CONTAINS m.id
+    WHERE toLower(app._ont_name) = toLower(m.id)
     RETURN count(m) AS count
     """,
     module=Module.SUBIMAGE,
@@ -170,6 +170,8 @@ _container_image_not_found_fact = Fact(
     cypher_query="""
     MATCH (c:Container)
     WHERE NOT (c)-[:HAS_IMAGE]->()
+      AND NOT coalesce(c.image, '') CONTAINS 'amazon/cloudwatch-agent'
+      AND NOT coalesce(c.name, '') STARTS WITH 'aws-guardduty-agent'
     OPTIONAL MATCH (c)<-[:HAS_CONTAINER]-(cluster)
     RETURN c.name AS container_name, c.id AS container_id,
            c.image AS image, cluster.name AS cluster_name
@@ -178,12 +180,16 @@ _container_image_not_found_fact = Fact(
     cypher_visual_query="""
     MATCH (c:Container)
     WHERE NOT (c)-[:HAS_IMAGE]->()
+      AND NOT coalesce(c.image, '') CONTAINS 'amazon/cloudwatch-agent'
+      AND NOT coalesce(c.name, '') STARTS WITH 'aws-guardduty-agent'
     OPTIONAL MATCH (c)<-[:HAS_CONTAINER]-(cluster)
     RETURN *
     """,
     cypher_count_query="""
     MATCH (c:Container)
     WHERE NOT (c)-[:HAS_IMAGE]->()
+      AND NOT coalesce(c.image, '') CONTAINS 'amazon/cloudwatch-agent'
+      AND NOT coalesce(c.name, '') STARTS WITH 'aws-guardduty-agent'
     RETURN count(c) AS count
     """,
     module=Module.CROSS_CLOUD,
@@ -291,6 +297,86 @@ aws_account_not_synced = Rule(
             name=COVERAGE_FRAMEWORK_NAME,
             short_name=COVERAGE_FRAMEWORK_SHORT_NAME,
             requirement="2.2",
+            scope=COVERAGE_FRAMEWORK_SCOPE,
+        ),
+    ),
+)
+
+# =============================================================================
+# Rule 5: Repository Without SLSA Provenance
+# Detects repos that have at least one image linked via PACKAGED_FROM with a
+# match_method other than "provenance", encouraging adoption of SLSA provenance.
+# =============================================================================
+
+_repository_without_slsa_provenance_fact = Fact(
+    id="repository-without-slsa-provenance",
+    name="Repository Without SLSA Provenance",
+    description=(
+        "Detects repositories that have at least one image linked via "
+        "PACKAGED_FROM with a match_method other than 'provenance', "
+        "indicating images were matched by Dockerfile analysis instead of "
+        "SLSA attestation."
+    ),
+    cypher_query="""
+    MATCH (i:Image)-[r:PACKAGED_FROM]->(repo)
+    WHERE (repo:GitHubRepository OR repo:GitLabProject)
+      AND r.match_method <> 'provenance'
+    WITH repo, collect(DISTINCT r.match_method) AS match_methods,
+         count(DISTINCT i) AS image_count
+    RETURN repo.id AS repo_id, repo.name AS repo_name,
+           head(labels(repo)) AS repo_kind,
+           image_count, match_methods
+    ORDER BY repo.name
+    """,
+    cypher_visual_query="""
+    MATCH (i:Image)-[r:PACKAGED_FROM]->(repo)
+    WHERE (repo:GitHubRepository OR repo:GitLabProject)
+      AND r.match_method <> 'provenance'
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (i:Image)-[r:PACKAGED_FROM]->(repo)
+    WHERE (repo:GitHubRepository OR repo:GitLabProject)
+      AND r.match_method <> 'provenance'
+    RETURN count(DISTINCT repo) AS count
+    """,
+    module=Module.SUBIMAGE,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+class RepositoryWithoutSLSAProvenanceOutput(Finding):
+    repo_id: str | None = None
+    repo_name: str | None = None
+    repo_kind: str | None = None
+    image_count: int | None = None
+    match_methods: list[str] | None = None
+
+
+repository_without_slsa_provenance = Rule(
+    id="repository_without_slsa_provenance",
+    name="Repository Without SLSA Provenance",
+    description=(
+        "Detects repositories with at least one image linked via "
+        "PACKAGED_FROM whose match_method is not 'provenance'. SLSA "
+        "provenance attestations give the strongest source-to-image "
+        "guarantee; repos relying on Dockerfile analysis should adopt "
+        "SLSA-compliant builds."
+    ),
+    output_model=RepositoryWithoutSLSAProvenanceOutput,
+    tags=(
+        "subimage",
+        "coverage",
+        "supply-chain",
+        "slsa",
+    ),
+    facts=(_repository_without_slsa_provenance_fact,),
+    version="0.1.0",
+    frameworks=(
+        Framework(
+            name=COVERAGE_FRAMEWORK_NAME,
+            short_name=COVERAGE_FRAMEWORK_SHORT_NAME,
+            requirement="3.1",
             scope=COVERAGE_FRAMEWORK_SCOPE,
         ),
     ),

--- a/cartography/rules/data/rules/subimage_coverage.py
+++ b/cartography/rules/data/rules/subimage_coverage.py
@@ -169,7 +169,7 @@ _container_image_not_found_fact = Fact(
     ),
     cypher_query="""
     MATCH (c:Container)
-    WHERE NOT (c)-[:HAS_IMAGE]->()
+    WHERE NOT (c)-[:RESOLVED_IMAGE]->(:Image)
       AND NOT coalesce(c.image, '') CONTAINS 'amazon/cloudwatch-agent'
       AND NOT coalesce(c.name, '') STARTS WITH 'aws-guardduty-agent'
     OPTIONAL MATCH (c)<-[:HAS_CONTAINER]-(cluster)
@@ -179,7 +179,7 @@ _container_image_not_found_fact = Fact(
     """,
     cypher_visual_query="""
     MATCH (c:Container)
-    WHERE NOT (c)-[:HAS_IMAGE]->()
+    WHERE NOT (c)-[:RESOLVED_IMAGE]->(:Image)
       AND NOT coalesce(c.image, '') CONTAINS 'amazon/cloudwatch-agent'
       AND NOT coalesce(c.name, '') STARTS WITH 'aws-guardduty-agent'
     OPTIONAL MATCH (c)<-[:HAS_CONTAINER]-(cluster)
@@ -187,7 +187,7 @@ _container_image_not_found_fact = Fact(
     """,
     cypher_count_query="""
     MATCH (c:Container)
-    WHERE NOT (c)-[:HAS_IMAGE]->()
+    WHERE NOT (c)-[:RESOLVED_IMAGE]->(:Image)
       AND NOT coalesce(c.image, '') CONTAINS 'amazon/cloudwatch-agent'
       AND NOT coalesce(c.name, '') STARTS WITH 'aws-guardduty-agent'
     RETURN count(c) AS count

--- a/cartography/rules/data/rules/subimage_coverage.py
+++ b/cartography/rules/data/rules/subimage_coverage.py
@@ -318,9 +318,8 @@ _repository_without_slsa_provenance_fact = Fact(
         "SLSA attestation."
     ),
     cypher_query="""
-    MATCH (i:Image)-[r:PACKAGED_FROM]->(repo)
-    WHERE (repo:GitHubRepository OR repo:GitLabProject)
-      AND r.match_method <> 'provenance'
+    MATCH (i:Image)-[r:PACKAGED_FROM]->(repo:CodeRepository)
+    WHERE r.match_method <> 'provenance'
     WITH repo, collect(DISTINCT r.match_method) AS match_methods,
          count(DISTINCT i) AS image_count
     RETURN repo.id AS repo_id, repo.name AS repo_name,
@@ -329,15 +328,13 @@ _repository_without_slsa_provenance_fact = Fact(
     ORDER BY repo.name
     """,
     cypher_visual_query="""
-    MATCH (i:Image)-[r:PACKAGED_FROM]->(repo)
-    WHERE (repo:GitHubRepository OR repo:GitLabProject)
-      AND r.match_method <> 'provenance'
+    MATCH (i:Image)-[r:PACKAGED_FROM]->(repo:CodeRepository)
+    WHERE r.match_method <> 'provenance'
     RETURN *
     """,
     cypher_count_query="""
-    MATCH (i:Image)-[r:PACKAGED_FROM]->(repo)
-    WHERE (repo:GitHubRepository OR repo:GitLabProject)
-      AND r.match_method <> 'provenance'
+    MATCH (i:Image)-[r:PACKAGED_FROM]->(repo:CodeRepository)
+    WHERE r.match_method <> 'provenance'
     RETURN count(DISTINCT repo) AS count
     """,
     module=Module.SUBIMAGE,
@@ -357,11 +354,10 @@ repository_without_slsa_provenance = Rule(
     id="repository_without_slsa_provenance",
     name="Repository Without SLSA Provenance",
     description=(
-        "Detects repositories with at least one image linked via "
-        "PACKAGED_FROM whose match_method is not 'provenance'. SLSA "
-        "provenance attestations give the strongest source-to-image "
-        "guarantee; repos relying on Dockerfile analysis should adopt "
-        "SLSA-compliant builds."
+        "SLSA provenance attestations are the only source-to-image link "
+        "trusted enough to guarantee build traceability. Repositories "
+        "still relying on Dockerfile analysis lack that guarantee and "
+        "should adopt SLSA-compliant builds."
     ),
     output_model=RepositoryWithoutSLSAProvenanceOutput,
     tags=(


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Three changes to the SubImage Coverage rule pack in `cartography/rules/data/rules/subimage_coverage.py`:

- **New rule `repository_without_slsa_provenance`**: flags `GitHubRepository` and `GitLabProject` nodes that have at least one `(:Image)-[:PACKAGED_FROM]->(repo)` whose `match_method` is not `"provenance"`. The intent is to encourage adoption of SLSA-attested builds — repos relying on Dockerfile analysis matching only get flagged for follow-up.
- **Tighter `subimage_module_not_configured`**: replaced the `toLower(app._ont_name) CONTAINS m.id` predicate with case-insensitive strict equality (`toLower(app._ont_name) = toLower(m.id)`). The previous `CONTAINS` was too loose and produced false positives on partial matches.
- **Exceptions for `container_image_not_found`**: skip containers whose `image` contains `amazon/cloudwatch-agent`, and containers whose `name` starts with `aws-guardduty-agent`. These are AWS-managed agents that legitimately have no `HAS_IMAGE` relationship in the graph.


### Related issues or links

N/A


### How was this tested?

- `make test_lint` — passes locally (pre-commit + mypy clean)
- `make test_unit` — 1583 passed
- Imported the rules registry to confirm the new rule is wired up:
  ```
  total rules: 66
  new rule: Repository Without SLSA Provenance
  ```


### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally.
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

#### If you are changing a node or relationship
N/A — no node or relationship schema changes.

#### If you are implementing a new intel module
N/A — rule-only change.


### Notes for reviewers

The user-facing rule talked about a `BUILD_FROM` relationship; the actual relationship in the codebase is `PACKAGED_FROM` with a `match_method` property whose values are `"provenance"` (SLSA) or `"dockerfile_analysis"`. The new rule uses that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)