### PR TITLE
feat(github): add GHCR container packages sync

### DIFF
--- a/cartography/intel/github/__init__.py
+++ b/cartography/intel/github/__init__.py
@@ -132,7 +132,7 @@ def start_github_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
 
         # Sync GHCR (container packages, image manifests, tags, attestations).
         # Runs before supply_chain.sync so the latter can correlate digests.
-        ghcr_packages = cartography.intel.github.packages.sync_packages(
+        ghcr_result = cartography.intel.github.packages.sync_packages(
             neo4j_session,
             token,
             api_url,
@@ -140,7 +140,7 @@ def start_github_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
             common_job_parameters["UPDATE_TAG"],
             common_job_parameters,
         )
-        if ghcr_packages:
+        if ghcr_result.packages:
             (
                 ghcr_manifests,
                 _ghcr_manifest_lists,
@@ -150,7 +150,7 @@ def start_github_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
                 token,
                 api_url,
                 org_name,
-                ghcr_packages,
+                ghcr_result.packages,
                 common_job_parameters["UPDATE_TAG"],
                 common_job_parameters,
             )

--- a/cartography/intel/github/__init__.py
+++ b/cartography/intel/github/__init__.py
@@ -8,6 +8,10 @@ import neo4j
 
 import cartography.intel.github.actions
 import cartography.intel.github.commits
+import cartography.intel.github.container_image_attestations
+import cartography.intel.github.container_image_tags
+import cartography.intel.github.container_images
+import cartography.intel.github.packages
 import cartography.intel.github.repos
 import cartography.intel.github.supply_chain
 import cartography.intel.github.teams
@@ -125,6 +129,48 @@ def start_github_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         )
         # Filter out None entries
         valid_repos = [r for r in repos_json if r is not None]
+
+        # Sync GHCR (container packages, image manifests, tags, attestations).
+        # Runs before supply_chain.sync so the latter can correlate digests.
+        ghcr_packages = cartography.intel.github.packages.sync_packages(
+            neo4j_session,
+            token,
+            api_url,
+            org_name,
+            common_job_parameters["UPDATE_TAG"],
+            common_job_parameters,
+        )
+        if ghcr_packages:
+            (
+                ghcr_manifests,
+                _ghcr_manifest_lists,
+                ghcr_tag_rows,
+            ) = cartography.intel.github.container_images.sync_container_images(
+                neo4j_session,
+                token,
+                api_url,
+                org_name,
+                ghcr_packages,
+                common_job_parameters["UPDATE_TAG"],
+                common_job_parameters,
+            )
+            cartography.intel.github.container_image_tags.sync_container_image_tags(
+                neo4j_session,
+                org_name,
+                ghcr_tag_rows,
+                common_job_parameters["UPDATE_TAG"],
+                common_job_parameters,
+            )
+            cartography.intel.github.container_image_attestations.sync_container_image_attestations(
+                neo4j_session,
+                token,
+                api_url,
+                org_name,
+                ghcr_manifests,
+                common_job_parameters["UPDATE_TAG"],
+                common_job_parameters,
+            )
+
         if valid_repos:
             cartography.intel.github.supply_chain.sync(
                 neo4j_session,

--- a/cartography/intel/github/__init__.py
+++ b/cartography/intel/github/__init__.py
@@ -132,6 +132,11 @@ def start_github_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
 
         # Sync GHCR (container packages, image manifests, tags, attestations).
         # Runs before supply_chain.sync so the latter can correlate digests.
+        # Gate on cleanup_safe — not on the packages list — so an org that
+        # legitimately has zero packages still gets its stale GHCR images,
+        # tags, and attestations reaped. An endpoint outage or missing-scope
+        # condition flips cleanup_safe to False, which disables both the
+        # fetches and the downstream cleanups.
         ghcr_result = cartography.intel.github.packages.sync_packages(
             neo4j_session,
             token,
@@ -140,11 +145,12 @@ def start_github_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
             common_job_parameters["UPDATE_TAG"],
             common_job_parameters,
         )
-        if ghcr_result.packages:
+        if ghcr_result.cleanup_safe:
             (
                 ghcr_manifests,
                 _ghcr_manifest_lists,
                 ghcr_tag_rows,
+                ghcr_observed_and_skipped,
             ) = cartography.intel.github.container_images.sync_container_images(
                 neo4j_session,
                 token,
@@ -169,6 +175,7 @@ def start_github_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
                 ghcr_manifests,
                 common_job_parameters["UPDATE_TAG"],
                 common_job_parameters,
+                additional_observed_digests=ghcr_observed_and_skipped,
             )
 
         if valid_repos:

--- a/cartography/intel/github/container_image_attestations.py
+++ b/cartography/intel/github/container_image_attestations.py
@@ -54,8 +54,7 @@ def _digests_already_enriched(
     org_url: str,
 ) -> set[str]:
     query = """
-    MATCH (org:GitHubOrganization {id: $org_url})
-    MATCH (img:GitHubContainerImage)-[:RESOURCE]->(org)
+    MATCH (org:GitHubOrganization {id: $org_url})-[:RESOURCE]->(img:GitHubContainerImage)
     WHERE img.source_uri IS NOT NULL
     RETURN img.digest
     """

--- a/cartography/intel/github/container_image_attestations.py
+++ b/cartography/intel/github/container_image_attestations.py
@@ -1,0 +1,307 @@
+"""
+GitHub Container Image Attestations Intelligence Module.
+
+Pulls SLSA attestations for image digests via the GitHub Attestations API
+and uses the parsed payload to enrich each image with ``source_uri``,
+``source_revision`` and ``source_file``. The supply-chain matcher then
+relies on those properties to draw ``PACKAGED_FROM`` edges back to the
+``GitHubRepository`` that built the image.
+
+Cross-run de-duplication: digests that already have ``source_uri`` set in
+the graph are skipped — a previous sync already enriched them.
+"""
+
+import base64
+import binascii
+import json
+import logging
+from typing import Any
+from typing import cast
+from urllib.parse import quote
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.client.core.tx import read_list_of_values_tx
+from cartography.graph.job import GraphJob
+from cartography.intel.github.util import call_github_rest_api
+from cartography.intel.github.util import rest_api_base_url
+from cartography.models.github.container_image_attestations import (
+    GitHubContainerImageAttestationSchema,
+)
+from cartography.models.github.container_images import (
+    GitHubContainerImageProvenanceSchema,
+)
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+def _digests_from_manifests(raw_manifests: list[dict[str, Any]]) -> list[str]:
+    seen: set[str] = set()
+    digests: list[str] = []
+    for manifest in raw_manifests:
+        digest = manifest.get("_digest")
+        if digest and digest not in seen:
+            seen.add(digest)
+            digests.append(digest)
+    return digests
+
+
+def _digests_already_enriched(
+    neo4j_session: neo4j.Session,
+    org_url: str,
+) -> set[str]:
+    query = """
+    MATCH (org:GitHubOrganization {id: $org_url})
+    MATCH (img:GitHubContainerImage)-[:RESOURCE]->(org)
+    WHERE img.source_uri IS NOT NULL
+    RETURN img.digest
+    """
+    values = neo4j_session.execute_read(
+        read_list_of_values_tx,
+        query,
+        org_url=org_url,
+    )
+    return {v for v in cast(list[str], values) if v}
+
+
+def _decode_dsse_payload(envelope: dict[str, Any]) -> dict[str, Any] | None:
+    """Decode the in-toto statement carried in a DSSE envelope, if possible."""
+    payload_b64 = envelope.get("payload")
+    if not isinstance(payload_b64, str):
+        return None
+    try:
+        decoded = base64.b64decode(payload_b64).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError) as exc:
+        logger.debug("Failed to base64-decode DSSE payload: %s", exc)
+        return None
+    try:
+        result = json.loads(decoded)
+    except json.JSONDecodeError as exc:
+        logger.debug("Failed to JSON-decode DSSE payload: %s", exc)
+        return None
+    return result if isinstance(result, dict) else None
+
+
+def _extract_provenance(statement: dict[str, Any]) -> dict[str, str | None]:
+    """
+    Pull source URI / revision / file out of a SLSA in-toto statement.
+
+    Supports SLSA Provenance v1 (predicate.buildDefinition.externalParameters)
+    and the older v0.2 layout (predicate.invocation.configSource). Falls back
+    to ``None`` for fields we can't resolve.
+    """
+    predicate = statement.get("predicate") or {}
+    source_uri: str | None = None
+    source_revision: str | None = None
+    source_file: str | None = None
+
+    build_def = predicate.get("buildDefinition") or {}
+
+    # Resolved dependencies carry the actual commit SHA — preferred over the ref.
+    resolved_deps = build_def.get("resolvedDependencies") or []
+    if isinstance(resolved_deps, list) and resolved_deps:
+        first = resolved_deps[0]
+        if isinstance(first, dict):
+            source_uri = first.get("uri") or source_uri
+            digest = first.get("digest") or {}
+            if isinstance(digest, dict):
+                source_revision = (
+                    digest.get("gitCommit") or digest.get("sha1") or source_revision
+                )
+
+    external = build_def.get("externalParameters") or {}
+    if isinstance(external, dict):
+        workflow = external.get("workflow") or {}
+        if isinstance(workflow, dict):
+            # The workflow.repository is the cleaner human-friendly URL.
+            source_uri = workflow.get("repository") or source_uri
+            source_revision = source_revision or workflow.get("ref")
+            source_file = workflow.get("path") or source_file
+
+    invocation = predicate.get("invocation") or {}
+    if isinstance(invocation, dict):
+        config_source = invocation.get("configSource") or {}
+        if isinstance(config_source, dict):
+            source_uri = source_uri or config_source.get("uri")
+            digest = config_source.get("digest") or {}
+            if isinstance(digest, dict) and not source_revision:
+                source_revision = digest.get("sha1") or digest.get("gitCommit")
+            source_file = source_file or config_source.get("entryPoint")
+
+    return {
+        "source_uri": source_uri,
+        "source_revision": source_revision,
+        "source_file": source_file,
+    }
+
+
+def _attestations_endpoint(organization: str, digest: str) -> str:
+    return (
+        f"/orgs/{quote(organization)}/attestations/{quote(digest, safe='')}"
+        f"?per_page=100"
+    )
+
+
+@timeit
+def get_attestations_for_digest(
+    token: Any,
+    api_url: str,
+    organization: str,
+    digest: str,
+) -> list[dict[str, Any]]:
+    base_url = rest_api_base_url(api_url)
+    endpoint = _attestations_endpoint(organization, digest)
+    try:
+        response = call_github_rest_api(endpoint, token, base_url)
+    except requests.exceptions.HTTPError as err:
+        if err.response is not None and err.response.status_code == 404:
+            return []
+        raise
+    return response.get("attestations") or []
+
+
+def transform_attestations(
+    organization: str,
+    attestations_by_digest: dict[str, list[dict[str, Any]]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """
+    Build (attestation_rows, image_provenance_rows). Each attestation produces
+    a ``GitHubContainerImageAttestation`` node; the most informative one per
+    digest also populates the provenance enrichment row used by
+    ``GitHubContainerImageProvenanceSchema``.
+    """
+    attestation_rows: list[dict[str, Any]] = []
+    provenance_by_digest: dict[str, dict[str, Any]] = {}
+
+    for digest, attestations in attestations_by_digest.items():
+        for idx, attestation in enumerate(attestations):
+            bundle = attestation.get("bundle") or {}
+            envelope = bundle.get("dsseEnvelope") or {}
+            statement = _decode_dsse_payload(envelope) or {}
+            predicate_type = statement.get("predicateType") or attestation.get(
+                "predicate_type",
+            )
+            provenance = _extract_provenance(statement)
+
+            row_id = f"{organization}:{digest}:{predicate_type or 'unknown'}:{idx}"
+            attestation_rows.append(
+                {
+                    "id": row_id,
+                    "bundle_id": attestation.get("id"),
+                    "predicate_type": predicate_type,
+                    "attests_digest": digest,
+                    "source_uri": provenance["source_uri"],
+                    "source_revision": provenance["source_revision"],
+                    "source_file": provenance["source_file"],
+                },
+            )
+
+            existing = provenance_by_digest.get(digest)
+            # Prefer the first attestation that yields a usable source_uri.
+            if existing is None or (
+                not existing.get("source_uri") and provenance["source_uri"]
+            ):
+                provenance_by_digest[digest] = {
+                    "digest": digest,
+                    "source_uri": provenance["source_uri"],
+                    "source_revision": provenance["source_revision"],
+                    "source_file": provenance["source_file"],
+                    "parent_image_uri": None,
+                    "parent_image_digest": None,
+                }
+
+    return attestation_rows, list(provenance_by_digest.values())
+
+
+@timeit
+def load_attestations(
+    neo4j_session: neo4j.Session,
+    rows: list[dict[str, Any]],
+    org_url: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        GitHubContainerImageAttestationSchema(),
+        rows,
+        lastupdated=update_tag,
+        org_url=org_url,
+    )
+
+
+@timeit
+def load_image_provenance(
+    neo4j_session: neo4j.Session,
+    rows: list[dict[str, Any]],
+    org_url: str,
+    update_tag: int,
+) -> None:
+    if not rows:
+        return
+    load(
+        neo4j_session,
+        GitHubContainerImageProvenanceSchema(),
+        rows,
+        lastupdated=update_tag,
+        org_url=org_url,
+    )
+
+
+@timeit
+def cleanup_attestations(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(
+        GitHubContainerImageAttestationSchema(),
+        common_job_parameters,
+    ).run(neo4j_session)
+
+
+@timeit
+def sync_container_image_attestations(
+    neo4j_session: neo4j.Session,
+    token: Any,
+    api_url: str,
+    organization: str,
+    raw_manifests: list[dict[str, Any]],
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    org_url = f"https://github.com/{organization}"
+    digests = _digests_from_manifests(raw_manifests)
+    skip = _digests_already_enriched(neo4j_session, org_url)
+
+    attestations_by_digest: dict[str, list[dict[str, Any]]] = {}
+    for digest in digests:
+        if digest in skip:
+            continue
+        attestations = get_attestations_for_digest(
+            token,
+            api_url,
+            organization,
+            digest,
+        )
+        if attestations:
+            attestations_by_digest[digest] = attestations
+
+    attestation_rows, provenance_rows = transform_attestations(
+        organization,
+        attestations_by_digest,
+    )
+    if attestation_rows:
+        logger.info(
+            "Loading %d GHCR attestation nodes for %s",
+            len(attestation_rows),
+            organization,
+        )
+        load_attestations(neo4j_session, attestation_rows, org_url, update_tag)
+    if provenance_rows:
+        load_image_provenance(neo4j_session, provenance_rows, org_url, update_tag)
+
+    cleanup_params = dict(common_job_parameters)
+    cleanup_params["org_url"] = org_url
+    cleanup_attestations(neo4j_session, cleanup_params)

--- a/cartography/intel/github/container_image_attestations.py
+++ b/cartography/intel/github/container_image_attestations.py
@@ -152,6 +152,15 @@ def get_attestations_for_digest(
     organization: str,
     digest: str,
 ) -> list[dict[str, Any]]:
+    """Fetch attestations for one image digest.
+
+    Per the GitHub Attestations REST API, a 404 on
+    ``/orgs/{org}/attestations/{digest}`` is the documented response when the
+    digest has no attestations (it is *not* an error). Only that case is
+    converted into an empty list; every other HTTP error propagates so the
+    sync aborts before cleanup runs and existing attestation nodes are not
+    silently purged.
+    """
     base_url = rest_api_base_url(api_url)
     endpoint = _attestations_endpoint(organization, digest)
     try:

--- a/cartography/intel/github/container_image_attestations.py
+++ b/cartography/intel/github/container_image_attestations.py
@@ -20,12 +20,11 @@ from typing import cast
 from urllib.parse import quote
 
 import neo4j
-import requests
 
 from cartography.client.core.tx import load
 from cartography.client.core.tx import read_list_of_values_tx
 from cartography.graph.job import GraphJob
-from cartography.intel.github.util import call_github_rest_api
+from cartography.intel.github.util import fetch_all_rest_api_pages
 from cartography.intel.github.util import rest_api_base_url
 from cartography.models.github.container_image_attestations import (
     GitHubContainerImageAttestationSchema,
@@ -138,6 +137,7 @@ def _extract_provenance(statement: dict[str, Any]) -> dict[str, str | None]:
 
 
 def _attestations_endpoint(organization: str, digest: str) -> str:
+    # 100 is the documented per_page max for this endpoint.
     return (
         f"/orgs/{quote(organization)}/attestations/{quote(digest, safe='')}"
         f"?per_page=100"
@@ -151,24 +151,23 @@ def get_attestations_for_digest(
     organization: str,
     digest: str,
 ) -> list[dict[str, Any]]:
-    """Fetch attestations for one image digest.
+    """Fetch attestations for one image digest, paginated.
 
     Per the GitHub Attestations REST API, a 404 on
     ``/orgs/{org}/attestations/{digest}`` is the documented response when the
-    digest has no attestations (it is *not* an error). Only that case is
-    converted into an empty list; every other HTTP error propagates so the
-    sync aborts before cleanup runs and existing attestation nodes are not
-    silently purged.
+    digest has no attestations (it is *not* an error). The shared paginated
+    helper already converts 404 to ``[]``; every other HTTP error propagates
+    so the sync aborts before cleanup runs and existing attestation nodes
+    are not silently purged.
     """
     base_url = rest_api_base_url(api_url)
     endpoint = _attestations_endpoint(organization, digest)
-    try:
-        response = call_github_rest_api(endpoint, token, base_url)
-    except requests.exceptions.HTTPError as err:
-        if err.response is not None and err.response.status_code == 404:
-            return []
-        raise
-    return response.get("attestations") or []
+    return fetch_all_rest_api_pages(
+        token,
+        base_url,
+        endpoint,
+        result_key="attestations",
+    )
 
 
 def transform_attestations(
@@ -180,13 +179,27 @@ def transform_attestations(
     a ``GitHubContainerImageAttestation`` node; the most informative one per
     digest also populates the provenance enrichment row used by
     ``GitHubContainerImageProvenanceSchema``.
+
+    The GitHub Attestations API increasingly returns ``bundle: null`` with a
+    short-lived signed ``bundle_url`` pointing at the actual sigstore bundle
+    (snappy-compressed ``.json.sn``). Following that URL is a follow-up; for
+    now we skip attestations without an inline bundle so we do not pollute
+    the graph with rows that have no extractable provenance.
     """
     attestation_rows: list[dict[str, Any]] = []
     provenance_by_digest: dict[str, dict[str, Any]] = {}
+    skipped_lazy = 0
 
     for digest, attestations in attestations_by_digest.items():
         for idx, attestation in enumerate(attestations):
-            bundle = attestation.get("bundle") or {}
+            bundle = attestation.get("bundle")
+            if not bundle:
+                # bundle_url is lazy-served (snappy-compressed sigstore bundle).
+                # Until we add bundle_url support, skip rather than create an
+                # empty row.
+                if attestation.get("bundle_url"):
+                    skipped_lazy += 1
+                continue
             envelope = bundle.get("dsseEnvelope") or {}
             statement = _decode_dsse_payload(envelope) or {}
             predicate_type = statement.get("predicateType") or attestation.get(
@@ -220,6 +233,14 @@ def transform_attestations(
                     "parent_image_uri": None,
                     "parent_image_digest": None,
                 }
+
+    if skipped_lazy:
+        logger.warning(
+            "Skipped %d GitHub attestation(s) served via bundle_url; inline "
+            "bundle ingestion only — bundle_url follow-up needed for full "
+            "provenance coverage.",
+            skipped_lazy,
+        )
 
     return attestation_rows, list(provenance_by_digest.values())
 
@@ -258,6 +279,33 @@ def load_image_provenance(
     )
 
 
+def _refresh_skipped_attestation_lastupdated(
+    neo4j_session: neo4j.Session,
+    digests: set[str],
+    org_url: str,
+    update_tag: int,
+) -> None:
+    """
+    Bump ``lastupdated`` on attestations whose subject digest is still live in
+    GHCR but whose enrichment was short-circuited by the cross-run dedup.
+    Mirrors ``container_images._refresh_skipped_image_lastupdated``.
+    """
+    if not digests:
+        return
+    query = """
+    MATCH (org:GitHubOrganization {id: $org_url})-[r:RESOURCE]->(att:GitHubContainerImageAttestation)
+    WHERE att.attests_digest IN $digests
+    SET att.lastupdated = $update_tag,
+        r.lastupdated = $update_tag
+    """
+    neo4j_session.run(
+        query,
+        digests=list(digests),
+        org_url=org_url,
+        update_tag=update_tag,
+    )
+
+
 @timeit
 def cleanup_attestations(
     neo4j_session: neo4j.Session,
@@ -278,14 +326,31 @@ def sync_container_image_attestations(
     raw_manifests: list[dict[str, Any]],
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    additional_observed_digests: set[str] | None = None,
 ) -> None:
+    """
+    Sync attestations for every digest seen this run.
+
+    ``additional_observed_digests`` carries digests that the container-images
+    sync observed in the GHCR versions API but skipped via cross-run dedup —
+    they are still live in GHCR even though their manifest was not re-fetched,
+    so we must refresh ``lastupdated`` on their attestation nodes too.
+    """
     org_url = f"https://github.com/{organization}"
-    digests = _digests_from_manifests(raw_manifests)
+    digests = list(_digests_from_manifests(raw_manifests))
+    if additional_observed_digests:
+        seen = set(digests)
+        for d in additional_observed_digests:
+            if d not in seen:
+                digests.append(d)
+                seen.add(d)
     skip = _digests_already_enriched(neo4j_session, org_url)
 
     attestations_by_digest: dict[str, list[dict[str, Any]]] = {}
+    observed_and_skipped: set[str] = set()
     for digest in digests:
         if digest in skip:
+            observed_and_skipped.add(digest)
             continue
         attestations = get_attestations_for_digest(
             token,
@@ -309,6 +374,16 @@ def sync_container_image_attestations(
         load_attestations(neo4j_session, attestation_rows, org_url, update_tag)
     if provenance_rows:
         load_image_provenance(neo4j_session, provenance_rows, org_url, update_tag)
+
+    # Refresh lastupdated for digests we observed but whose attestations
+    # we skipped via cross-run dedup; otherwise cleanup reaps the still-live
+    # attestation nodes.
+    _refresh_skipped_attestation_lastupdated(
+        neo4j_session,
+        observed_and_skipped,
+        org_url,
+        update_tag,
+    )
 
     cleanup_params = dict(common_job_parameters)
     cleanup_params["org_url"] = org_url

--- a/cartography/intel/github/container_image_tags.py
+++ b/cartography/intel/github/container_image_tags.py
@@ -1,0 +1,69 @@
+"""
+GitHub Container Image Tags Intelligence Module.
+
+Loads ``GitHubContainerImageTag`` nodes that point each (package, tag-name)
+pair at its image digest. Tag rows are produced by
+``cartography.intel.github.container_images.sync_container_images`` while it
+walks per-package versions, since that is where the package context is in
+scope. This module is responsible for loading and cleanup only.
+"""
+
+import logging
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.models.github.container_image_tags import GitHubContainerImageTagSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def load_container_image_tags(
+    neo4j_session: neo4j.Session,
+    tags: list[dict[str, Any]],
+    org_url: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        GitHubContainerImageTagSchema(),
+        tags,
+        lastupdated=update_tag,
+        org_url=org_url,
+    )
+
+
+@timeit
+def cleanup_container_image_tags(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(
+        GitHubContainerImageTagSchema(),
+        common_job_parameters,
+    ).run(neo4j_session)
+
+
+@timeit
+def sync_container_image_tags(
+    neo4j_session: neo4j.Session,
+    organization: str,
+    tag_rows: list[dict[str, Any]],
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    org_url = f"https://github.com/{organization}"
+    if tag_rows:
+        logger.info(
+            "Loading %d GHCR tag nodes for %s",
+            len(tag_rows),
+            organization,
+        )
+        load_container_image_tags(neo4j_session, tag_rows, org_url, update_tag)
+    cleanup_params = dict(common_job_parameters)
+    cleanup_params["org_url"] = org_url
+    cleanup_container_image_tags(neo4j_session, cleanup_params)

--- a/cartography/intel/github/container_images.py
+++ b/cartography/intel/github/container_images.py
@@ -432,18 +432,21 @@ def _refresh_skipped_image_lastupdated(
     metadata) that were observed in the GHCR versions API this run but had
     their manifest+config fetch short-circuited by the cross-run dedup.
 
-    Without this, the cleanup job — which deletes nodes whose sub-resource
-    relationship's ``lastupdated`` doesn't match the current ``update_tag``
-    — would reap the live images.
+    Without this, the cleanup job — which deletes nodes / rels whose
+    ``lastupdated`` doesn't match the current ``update_tag`` — would reap
+    the live image, the per-layer rels (HAS_LAYER / HEAD / TAIL) and the
+    layer-chain ``NEXT`` rels that order the linked list.
     """
     if not digests:
         return
-    query = """
+
+    # First pass: refresh image node, RESOURCE rels and image->layer rels.
+    image_layer_query = """
     MATCH (org:GitHubOrganization {id: $org_url})-[r_org:RESOURCE]->(img:GitHubContainerImage)
     WHERE img.digest IN $digests
     SET img.lastupdated = $update_tag,
         r_org.lastupdated = $update_tag
-    WITH img, org
+    WITH org, img
     OPTIONAL MATCH (img)-[r_layer:HAS_LAYER|HEAD|TAIL]->(layer:GitHubContainerImageLayer)
     SET r_layer.lastupdated = $update_tag,
         layer.lastupdated = $update_tag
@@ -453,9 +456,25 @@ def _refresh_skipped_image_lastupdated(
     SET r_layer_org.lastupdated = $update_tag
     """
     neo4j_session.run(
-        query,
+        image_layer_query,
         digests=list(digests),
         org_url=org_url,
+        update_tag=update_tag,
+    )
+
+    # Second pass: refresh the NEXT rels that chain the layers of any
+    # refreshed image. Done in a second statement so we can constrain the
+    # NEXT match to layers belonging to the skipped images only.
+    next_rel_query = """
+    MATCH (img:GitHubContainerImage)-[:HAS_LAYER]->(l1:GitHubContainerImageLayer)
+    WHERE img.digest IN $digests
+    MATCH (l1)-[r_next:NEXT]->(l2:GitHubContainerImageLayer)
+    WHERE (img)-[:HAS_LAYER]->(l2)
+    SET r_next.lastupdated = $update_tag
+    """
+    neo4j_session.run(
+        next_rel_query,
+        digests=list(digests),
         update_tag=update_tag,
     )
 

--- a/cartography/intel/github/container_images.py
+++ b/cartography/intel/github/container_images.py
@@ -17,6 +17,7 @@ from typing import Any
 from typing import cast
 
 import neo4j
+import requests
 
 from cartography.client.core.tx import load
 from cartography.client.core.tx import read_list_of_values_tx
@@ -109,21 +110,28 @@ def _process_manifest(
         config_digest = config_ref.get("digest")
         if config_digest:
             if config_digest not in config_cache:
+                # Only swallow 404 (blob legitimately missing). Auth and 5xx
+                # errors propagate so the sync fails loudly rather than
+                # silently dropping layer/architecture data.
                 try:
                     config_cache[config_digest] = fetch_ghcr_blob(
                         token,
                         repository_name,
                         config_digest,
                     )
-                except Exception as exc:  # noqa: BLE001 — best-effort enrichment
+                except requests.exceptions.HTTPError as err:
+                    if err.response is None or err.response.status_code != 404:
+                        raise
                     logger.warning(
-                        "Failed to fetch GHCR config blob %s for %s: %s",
+                        "GHCR config blob %s missing for %s (404); image "
+                        "will be ingested without layer/arch metadata.",
                         config_digest,
                         repository_name,
-                        exc,
                     )
                     config_cache[config_digest] = None
-            manifest["_config"] = config_cache[config_digest] or {}
+            config_blob = config_cache[config_digest]
+            if config_blob is not None:
+                manifest["_config"] = config_blob
         else:
             manifest["_config"] = {}
 

--- a/cartography/intel/github/container_images.py
+++ b/cartography/intel/github/container_images.py
@@ -141,21 +141,30 @@ def get_container_images(
     organization: str,
     packages: list[dict[str, Any]],
     skip_digests: set[str] | None = None,
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+) -> tuple[
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    set[str],
+]:
     """
     Fetch every image manifest reachable from the org's container packages.
 
-    :returns: ``(all_manifests, manifest_lists, tag_rows)`` —
-        ``all_manifests`` is the list of single-image manifests AND manifest
+    :returns: ``(all_manifests, manifest_lists, tag_rows, observed_and_skipped)``
+        — ``all_manifests`` is the list of single-image manifests AND manifest
         lists (so each becomes a node); ``manifest_lists`` is the subset that
         are multi-arch indexes (used by the attestations sync); ``tag_rows``
-        is the list of ``GitHubContainerImageTag`` rows ready for ingestion.
+        is the list of ``GitHubContainerImageTag`` rows ready for ingestion;
+        ``observed_and_skipped`` is the set of digests that were present in
+        the versions API but skipped by the cross-run dedup so the caller can
+        refresh their ``lastupdated`` and avoid having cleanup reap them.
     """
     skip_digests = skip_digests or set()
     all_manifests: list[dict[str, Any]] = []
     manifest_lists: list[dict[str, Any]] = []
     tag_rows: list[dict[str, Any]] = []
     config_cache: dict[str, dict[str, Any] | None] = {}
+    observed_and_skipped: set[str] = set()
 
     for pkg in packages:
         package_name = pkg["name"]
@@ -185,8 +194,11 @@ def get_container_images(
                 )
 
             # Cross-run dedup: skip manifest/config fetches for digests we've
-            # already enriched. Tag rows are still produced above.
+            # already enriched. Tag rows are still produced above. The caller
+            # bumps `lastupdated` on these digests so cleanup leaves them
+            # alone — without that bump the optimization causes data loss.
             if digest in skip_digests:
+                observed_and_skipped.add(digest)
                 continue
 
             manifest = _process_manifest(
@@ -213,7 +225,10 @@ def get_container_images(
                     ):
                         continue
                     child_digest = child.get("digest")
-                    if not child_digest or child_digest in skip_digests:
+                    if not child_digest:
+                        continue
+                    if child_digest in skip_digests:
+                        observed_and_skipped.add(child_digest)
                         continue
                     _process_manifest(
                         token,
@@ -233,7 +248,7 @@ def get_container_images(
         len(tag_rows),
         len(packages),
     )
-    return all_manifests, manifest_lists, tag_rows
+    return all_manifests, manifest_lists, tag_rows, observed_and_skipped
 
 
 def transform_container_images(
@@ -406,6 +421,45 @@ def load_container_image_layers(
     )
 
 
+def _refresh_skipped_image_lastupdated(
+    neo4j_session: neo4j.Session,
+    digests: set[str],
+    org_url: str,
+    update_tag: int,
+) -> None:
+    """
+    Bump ``lastupdated`` on container images (and their layer/relationship
+    metadata) that were observed in the GHCR versions API this run but had
+    their manifest+config fetch short-circuited by the cross-run dedup.
+
+    Without this, the cleanup job — which deletes nodes whose sub-resource
+    relationship's ``lastupdated`` doesn't match the current ``update_tag``
+    — would reap the live images.
+    """
+    if not digests:
+        return
+    query = """
+    MATCH (org:GitHubOrganization {id: $org_url})-[r_org:RESOURCE]->(img:GitHubContainerImage)
+    WHERE img.digest IN $digests
+    SET img.lastupdated = $update_tag,
+        r_org.lastupdated = $update_tag
+    WITH img, org
+    OPTIONAL MATCH (img)-[r_layer:HAS_LAYER|HEAD|TAIL]->(layer:GitHubContainerImageLayer)
+    SET r_layer.lastupdated = $update_tag,
+        layer.lastupdated = $update_tag
+    WITH org, layer
+    WHERE layer IS NOT NULL
+    OPTIONAL MATCH (org)-[r_layer_org:RESOURCE]->(layer)
+    SET r_layer_org.lastupdated = $update_tag
+    """
+    neo4j_session.run(
+        query,
+        digests=list(digests),
+        org_url=org_url,
+        update_tag=update_tag,
+    )
+
+
 @timeit
 def cleanup_container_images(
     neo4j_session: neo4j.Session,
@@ -437,8 +491,13 @@ def sync_container_images(
     packages: list[dict[str, Any]],
     update_tag: int,
     common_job_parameters: dict[str, Any],
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
-    """Returns ``(raw_manifests, manifest_lists, tag_rows)``."""
+) -> tuple[
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    set[str],
+]:
+    """Returns ``(raw_manifests, manifest_lists, tag_rows, observed_and_skipped)``."""
     org_url = f"https://github.com/{organization}"
     skip_digests = _existing_digests_with_layers(neo4j_session, org_url)
     if skip_digests:
@@ -447,7 +506,12 @@ def sync_container_images(
             len(skip_digests),
         )
 
-    raw_manifests, manifest_lists, tag_rows = get_container_images(
+    (
+        raw_manifests,
+        manifest_lists,
+        tag_rows,
+        observed_and_skipped,
+    ) = get_container_images(
         token,
         api_url,
         organization,
@@ -462,8 +526,18 @@ def sync_container_images(
     if images:
         load_container_images(neo4j_session, images, org_url, update_tag)
 
+    # Refresh lastupdated for digests we observed in versions but whose
+    # manifest/config fetch we skipped via cross-run dedup. Must happen
+    # before cleanup, otherwise the still-live images get reaped.
+    _refresh_skipped_image_lastupdated(
+        neo4j_session,
+        observed_and_skipped,
+        org_url,
+        update_tag,
+    )
+
     cleanup_params = dict(common_job_parameters)
     cleanup_params["org_url"] = org_url
     cleanup_container_image_layers(neo4j_session, cleanup_params)
     cleanup_container_images(neo4j_session, cleanup_params)
-    return raw_manifests, manifest_lists, tag_rows
+    return raw_manifests, manifest_lists, tag_rows, observed_and_skipped

--- a/cartography/intel/github/container_images.py
+++ b/cartography/intel/github/container_images.py
@@ -1,0 +1,466 @@
+"""
+GitHub Container Images Intelligence Module.
+
+For each container package owned by an organization, fetches the OCI manifests
+(and child manifests for multi-arch images) from ghcr.io, plus the referenced
+image config blobs to extract layer diff IDs and platform metadata.
+
+Within-run de-duplication keeps ``(digest -> manifest)`` and
+``(config_digest -> config)`` maps so a config that is referenced by 50 tags
+is fetched once. Cross-run de-duplication checks the graph for digests that
+already have ``layer_diff_ids`` set and skips the manifest+config fetches —
+the previous sync already populated those properties.
+"""
+
+import logging
+from typing import Any
+from typing import cast
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.client.core.tx import read_list_of_values_tx
+from cartography.graph.job import GraphJob
+from cartography.intel.github.packages import get_package_versions
+from cartography.intel.github.util import fetch_ghcr_blob
+from cartography.intel.github.util import fetch_ghcr_manifest
+from cartography.models.github.container_image_layers import (
+    GitHubContainerImageLayerSchema,
+)
+from cartography.models.github.container_images import GitHubContainerImageSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+CONTAINER_IMAGE_BATCH_SIZE = 500
+CONTAINER_IMAGE_LAYER_BATCH_SIZE = 200
+
+MANIFEST_LIST_MEDIA_TYPES = {
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.oci.image.index.v1+json",
+}
+
+
+def _ghcr_repository_name(org_login: str, package_name: str) -> str:
+    return f"{org_login.lower()}/{package_name.lower()}"
+
+
+def _existing_digests_with_layers(
+    neo4j_session: neo4j.Session,
+    org_url: str,
+) -> set[str]:
+    """
+    Return the set of GHCR image digests that already have ``layer_diff_ids``
+    populated in the graph. We use this to skip manifest/config fetches for
+    images we've fully ingested in a previous run — the steady-state cost
+    drops from O(versions) to O(new versions).
+    """
+    query = """
+    MATCH (org:GitHubOrganization {id: $org_url})
+    MATCH (img:GitHubContainerImage)-[:RESOURCE]->(org)
+    WHERE img.layer_diff_ids IS NOT NULL AND size(img.layer_diff_ids) > 0
+    RETURN img.digest
+    """
+    values = neo4j_session.execute_read(
+        read_list_of_values_tx,
+        query,
+        org_url=org_url,
+    )
+    return {v for v in cast(list[str], values) if v}
+
+
+def _process_manifest(
+    token: Any,
+    repository_name: str,
+    digest: str,
+    package_id: str,
+    package_uri: str,
+    config_cache: dict[str, dict[str, Any] | None],
+    seen_digests: set[str],
+    out_manifests: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """
+    Fetch a single manifest, attach the resolved config blob, and append to
+    ``out_manifests``. Returns the manifest (or None if missing). Handles
+    in-run dedup via ``seen_digests``.
+    """
+    if digest in seen_digests:
+        return None
+    seen_digests.add(digest)
+
+    manifest = fetch_ghcr_manifest(token, repository_name, digest)
+    if manifest is None:
+        logger.debug(
+            "GHCR manifest %s for %s not found; skipping",
+            digest,
+            repository_name,
+        )
+        return None
+
+    manifest["_digest"] = digest
+    manifest["_repository_name"] = repository_name
+    manifest["_package_id"] = package_id
+    manifest["_package_uri"] = package_uri
+
+    media_type = manifest.get("mediaType")
+    if media_type not in MANIFEST_LIST_MEDIA_TYPES:
+        config_ref = manifest.get("config") or {}
+        config_digest = config_ref.get("digest")
+        if config_digest:
+            if config_digest not in config_cache:
+                try:
+                    config_cache[config_digest] = fetch_ghcr_blob(
+                        token,
+                        repository_name,
+                        config_digest,
+                    )
+                except Exception as exc:  # noqa: BLE001 — best-effort enrichment
+                    logger.warning(
+                        "Failed to fetch GHCR config blob %s for %s: %s",
+                        config_digest,
+                        repository_name,
+                        exc,
+                    )
+                    config_cache[config_digest] = None
+            manifest["_config"] = config_cache[config_digest] or {}
+        else:
+            manifest["_config"] = {}
+
+    out_manifests.append(manifest)
+    return manifest
+
+
+@timeit
+def get_container_images(
+    token: Any,
+    api_url: str,
+    organization: str,
+    packages: list[dict[str, Any]],
+    skip_digests: set[str] | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """
+    Fetch every image manifest reachable from the org's container packages.
+
+    :returns: ``(all_manifests, manifest_lists, tag_rows)`` —
+        ``all_manifests`` is the list of single-image manifests AND manifest
+        lists (so each becomes a node); ``manifest_lists`` is the subset that
+        are multi-arch indexes (used by the attestations sync); ``tag_rows``
+        is the list of ``GitHubContainerImageTag`` rows ready for ingestion.
+    """
+    skip_digests = skip_digests or set()
+    all_manifests: list[dict[str, Any]] = []
+    manifest_lists: list[dict[str, Any]] = []
+    tag_rows: list[dict[str, Any]] = []
+    config_cache: dict[str, dict[str, Any] | None] = {}
+
+    for pkg in packages:
+        package_name = pkg["name"]
+        package_id = pkg["html_url"]
+        package_uri = pkg["uri"]
+        repository_name = _ghcr_repository_name(organization, package_name)
+        seen_digests: set[str] = set()
+
+        versions = get_package_versions(token, api_url, organization, package_name)
+        for version in versions:
+            digest = version.get("name")
+            if not digest or not digest.startswith("sha256:"):
+                continue
+            tag_names = (
+                version.get("metadata", {}).get("container", {}).get("tags") or []
+            )
+            updated_at = version.get("updated_at")
+            for tag_name in tag_names:
+                tag_rows.append(
+                    {
+                        "name": tag_name,
+                        "uri": f"{package_uri}:{tag_name}",
+                        "digest": digest,
+                        "image_pushed_at": updated_at,
+                        "package_id": package_id,
+                    },
+                )
+
+            # Cross-run dedup: skip manifest/config fetches for digests we've
+            # already enriched. Tag rows are still produced above.
+            if digest in skip_digests:
+                continue
+
+            manifest = _process_manifest(
+                token,
+                repository_name,
+                digest,
+                package_id,
+                package_uri,
+                config_cache,
+                seen_digests,
+                all_manifests,
+            )
+            if manifest is None:
+                continue
+
+            media_type = manifest.get("mediaType")
+            if media_type in MANIFEST_LIST_MEDIA_TYPES:
+                manifest_lists.append(manifest)
+                for child in manifest.get("manifests", []) or []:
+                    annotations = child.get("annotations") or {}
+                    if (
+                        annotations.get("vnd.docker.reference.type")
+                        == "attestation-manifest"
+                    ):
+                        continue
+                    child_digest = child.get("digest")
+                    if not child_digest or child_digest in skip_digests:
+                        continue
+                    _process_manifest(
+                        token,
+                        repository_name,
+                        child_digest,
+                        package_id,
+                        package_uri,
+                        config_cache,
+                        seen_digests,
+                        all_manifests,
+                    )
+
+    logger.info(
+        "Fetched %d unique GHCR manifests (%d manifest lists, %d tags) across %d packages",
+        len(all_manifests),
+        len(manifest_lists),
+        len(tag_rows),
+        len(packages),
+    )
+    return all_manifests, manifest_lists, tag_rows
+
+
+def transform_container_images(
+    raw_manifests: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Shape OCI manifests for ``GitHubContainerImageSchema``."""
+    transformed: list[dict[str, Any]] = []
+    for manifest in raw_manifests:
+        media_type = manifest.get("mediaType")
+        is_manifest_list = media_type in MANIFEST_LIST_MEDIA_TYPES
+
+        child_image_digests: list[str] | None = None
+        if is_manifest_list:
+            children = manifest.get("manifests") or []
+            child_image_digests = [
+                c.get("digest")
+                for c in children
+                if c.get("digest")
+                and (c.get("annotations") or {}).get("vnd.docker.reference.type")
+                != "attestation-manifest"
+            ]
+
+        config = manifest.get("_config") or {}
+
+        layer_diff_ids: list[str] | None = None
+        head_layer_diff_id: str | None = None
+        tail_layer_diff_id: str | None = None
+        if not is_manifest_list:
+            diff_ids = (config.get("rootfs") or {}).get("diff_ids")
+            if isinstance(diff_ids, list) and diff_ids:
+                layer_diff_ids = diff_ids
+                head_layer_diff_id = diff_ids[0]
+                tail_layer_diff_id = diff_ids[-1]
+
+        package_uri = manifest.get("_package_uri")
+        digest = manifest.get("_digest")
+        uri = f"{package_uri}@{digest}" if package_uri and digest else None
+
+        transformed.append(
+            {
+                "digest": digest,
+                "uri": uri,
+                "media_type": media_type,
+                "schema_version": manifest.get("schemaVersion"),
+                "type": "manifest_list" if is_manifest_list else "image",
+                "architecture": config.get("architecture"),
+                "os": config.get("os"),
+                "variant": config.get("variant"),
+                "child_image_digests": child_image_digests,
+                "layer_diff_ids": layer_diff_ids,
+                "head_layer_diff_id": head_layer_diff_id,
+                "tail_layer_diff_id": tail_layer_diff_id,
+                "package_id": manifest.get("_package_id"),
+            },
+        )
+    return transformed
+
+
+def transform_container_image_layers(
+    raw_manifests: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Build layer rows keyed by ``diff_id``. NEXT relationships chain layers in
+    config order so the linked-list traversal matches the ECR/GitLab pattern.
+    """
+    layers_by_diff_id: dict[str, dict[str, Any]] = {}
+    skipped = 0
+
+    for manifest in raw_manifests:
+        if manifest.get("mediaType") in MANIFEST_LIST_MEDIA_TYPES:
+            continue
+
+        layers = manifest.get("layers") or []
+        config = manifest.get("_config") or {}
+        rootfs = config.get("rootfs") or {}
+        diff_ids = rootfs.get("diff_ids") or []
+        history = config.get("history") or []
+
+        # Align history entries to diff_ids — empty layers don't consume diff_ids.
+        history_by_diff_id: dict[str, str] = {}
+        idx = 0
+        for entry in history:
+            if not isinstance(entry, dict) or entry.get("empty_layer"):
+                continue
+            if idx >= len(diff_ids):
+                break
+            created_by = entry.get("created_by")
+            if created_by:
+                history_by_diff_id[str(diff_ids[idx])] = str(created_by)
+            idx += 1
+
+        for i, layer in enumerate(layers):
+            layer_digest = layer.get("digest")
+            diff_id = diff_ids[i] if i < len(diff_ids) else None
+            if not layer_digest or not diff_id:
+                skipped += 1
+                continue
+
+            entry = layers_by_diff_id.setdefault(
+                diff_id,
+                {
+                    "diff_id": diff_id,
+                    "digest": layer_digest,
+                    "media_type": layer.get("mediaType"),
+                    "size": layer.get("size"),
+                    "is_empty": False,
+                    "history": history_by_diff_id.get(str(diff_id)),
+                    "next_diff_ids": set(),
+                },
+            )
+            if i < len(layers) - 1:
+                next_diff_id = diff_ids[i + 1] if i + 1 < len(diff_ids) else None
+                if next_diff_id:
+                    entry["next_diff_ids"].add(next_diff_id)
+
+    out: list[dict[str, Any]] = []
+    for layer in layers_by_diff_id.values():
+        row: dict[str, Any] = {
+            "diff_id": layer["diff_id"],
+            "digest": layer["digest"],
+            "media_type": layer["media_type"],
+            "size": layer["size"],
+            "is_empty": layer["is_empty"],
+        }
+        if layer["history"]:
+            row["history"] = layer["history"]
+        if layer["next_diff_ids"]:
+            row["next_diff_ids"] = list(layer["next_diff_ids"])
+        out.append(row)
+
+    if skipped:
+        logger.warning(
+            "Skipped %d GHCR layer(s) due to missing digest or diff_id",
+            skipped,
+        )
+    return out
+
+
+@timeit
+def load_container_images(
+    neo4j_session: neo4j.Session,
+    images: list[dict[str, Any]],
+    org_url: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        GitHubContainerImageSchema(),
+        images,
+        batch_size=CONTAINER_IMAGE_BATCH_SIZE,
+        lastupdated=update_tag,
+        org_url=org_url,
+    )
+
+
+@timeit
+def load_container_image_layers(
+    neo4j_session: neo4j.Session,
+    layers: list[dict[str, Any]],
+    org_url: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        GitHubContainerImageLayerSchema(),
+        layers,
+        batch_size=CONTAINER_IMAGE_LAYER_BATCH_SIZE,
+        lastupdated=update_tag,
+        org_url=org_url,
+    )
+
+
+@timeit
+def cleanup_container_images(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(
+        GitHubContainerImageSchema(),
+        common_job_parameters,
+    ).run(neo4j_session)
+
+
+@timeit
+def cleanup_container_image_layers(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(
+        GitHubContainerImageLayerSchema(),
+        common_job_parameters,
+    ).run(neo4j_session)
+
+
+@timeit
+def sync_container_images(
+    neo4j_session: neo4j.Session,
+    token: Any,
+    api_url: str,
+    organization: str,
+    packages: list[dict[str, Any]],
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Returns ``(raw_manifests, manifest_lists, tag_rows)``."""
+    org_url = f"https://github.com/{organization}"
+    skip_digests = _existing_digests_with_layers(neo4j_session, org_url)
+    if skip_digests:
+        logger.info(
+            "Skipping manifest/config fetches for %d already-enriched GHCR digests",
+            len(skip_digests),
+        )
+
+    raw_manifests, manifest_lists, tag_rows = get_container_images(
+        token,
+        api_url,
+        organization,
+        packages,
+        skip_digests=skip_digests,
+    )
+    images = transform_container_images(raw_manifests)
+    layers = transform_container_image_layers(raw_manifests)
+
+    if layers:
+        load_container_image_layers(neo4j_session, layers, org_url, update_tag)
+    if images:
+        load_container_images(neo4j_session, images, org_url, update_tag)
+
+    cleanup_params = dict(common_job_parameters)
+    cleanup_params["org_url"] = org_url
+    cleanup_container_image_layers(neo4j_session, cleanup_params)
+    cleanup_container_images(neo4j_session, cleanup_params)
+    return raw_manifests, manifest_lists, tag_rows

--- a/cartography/intel/github/container_images.py
+++ b/cartography/intel/github/container_images.py
@@ -463,11 +463,13 @@ def _refresh_skipped_image_lastupdated(
     )
 
     # Second pass: refresh the NEXT rels that chain the layers of any
-    # refreshed image. Done in a second statement so we can constrain the
-    # NEXT match to layers belonging to the skipped images only.
+    # refreshed image. Scoped to the current org because image digests are
+    # content hashes — without that constraint a digest collision across
+    # orgs would update unrelated images' NEXT chains.
     next_rel_query = """
-    MATCH (img:GitHubContainerImage)-[:HAS_LAYER]->(l1:GitHubContainerImageLayer)
+    MATCH (org:GitHubOrganization {id: $org_url})-[:RESOURCE]->(img:GitHubContainerImage)
     WHERE img.digest IN $digests
+    MATCH (img)-[:HAS_LAYER]->(l1:GitHubContainerImageLayer)
     MATCH (l1)-[r_next:NEXT]->(l2:GitHubContainerImageLayer)
     WHERE (img)-[:HAS_LAYER]->(l2)
     SET r_next.lastupdated = $update_tag
@@ -475,6 +477,7 @@ def _refresh_skipped_image_lastupdated(
     neo4j_session.run(
         next_rel_query,
         digests=list(digests),
+        org_url=org_url,
         update_tag=update_tag,
     )
 

--- a/cartography/intel/github/container_images.py
+++ b/cartography/intel/github/container_images.py
@@ -58,7 +58,7 @@ def _existing_digests_with_layers(
     """
     query = """
     MATCH (org:GitHubOrganization {id: $org_url})
-    MATCH (img:GitHubContainerImage)-[:RESOURCE]->(org)
+    MATCH (org)-[:RESOURCE]->(img:GitHubContainerImage)
     WHERE img.layer_diff_ids IS NOT NULL AND size(img.layer_diff_ids) > 0
     RETURN img.digest
     """

--- a/cartography/intel/github/container_images.py
+++ b/cartography/intel/github/container_images.py
@@ -17,7 +17,6 @@ from typing import Any
 from typing import cast
 
 import neo4j
-import requests
 
 from cartography.client.core.tx import load
 from cartography.client.core.tx import read_list_of_values_tx
@@ -110,25 +109,21 @@ def _process_manifest(
         config_digest = config_ref.get("digest")
         if config_digest:
             if config_digest not in config_cache:
-                # Only swallow 404 (blob legitimately missing). Auth and 5xx
-                # errors propagate so the sync fails loudly rather than
-                # silently dropping layer/architecture data.
-                try:
-                    config_cache[config_digest] = fetch_ghcr_blob(
-                        token,
-                        repository_name,
-                        config_digest,
-                    )
-                except requests.exceptions.HTTPError as err:
-                    if err.response is None or err.response.status_code != 404:
-                        raise
+                # fetch_ghcr_blob returns None on 404 and raises on every other
+                # HTTP error, so the sync fails loudly on auth/5xx and only the
+                # legitimate "blob missing" case yields None here.
+                config_cache[config_digest] = fetch_ghcr_blob(
+                    token,
+                    repository_name,
+                    config_digest,
+                )
+                if config_cache[config_digest] is None:
                     logger.warning(
                         "GHCR config blob %s missing for %s (404); image "
                         "will be ingested without layer/arch metadata.",
                         config_digest,
                         repository_name,
                     )
-                    config_cache[config_digest] = None
             config_blob = config_cache[config_digest]
             if config_blob is not None:
                 manifest["_config"] = config_blob

--- a/cartography/intel/github/packages.py
+++ b/cartography/intel/github/packages.py
@@ -7,6 +7,7 @@ Only `package_type=container` packages are fetched — other package types
 """
 
 import logging
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import quote
 
@@ -24,6 +25,19 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class ContainerPackagesFetchResult:
+    """Result of fetching the org's container packages list.
+
+    ``cleanup_safe`` is False when the endpoint was unavailable (404 on older
+    GHES, for instance). Cleanup must be skipped in that case so an outage
+    does not purge previously-synced ``GitHubPackage`` nodes.
+    """
+
+    packages: list[dict[str, Any]]
+    cleanup_safe: bool
+
+
 def _ghcr_uri(org_login: str, package_name: str) -> str:
     """Build the canonical lowercase GHCR URI for a package."""
     return f"ghcr.io/{org_login.lower()}/{package_name.lower()}"
@@ -34,28 +48,30 @@ def get_container_packages(
     token: Any,
     api_url: str,
     organization: str,
-) -> list[dict[str, Any]]:
+) -> ContainerPackagesFetchResult:
     """
     Fetch every container package owned by ``organization`` via the GitHub
-    REST API. Returns the raw payloads (one per package).
+    REST API. Returns the raw payloads alongside a ``cleanup_safe`` flag.
     """
     base_url = rest_api_base_url(api_url)
     endpoint = (
         f"/orgs/{quote(organization)}/packages?package_type=container&per_page=100"
     )
     try:
-        return fetch_all_rest_api_pages(
+        packages = fetch_all_rest_api_pages(
             token, base_url, endpoint, result_key="packages"
         )
+        return ContainerPackagesFetchResult(packages=packages, cleanup_safe=True)
     except requests.exceptions.HTTPError as err:
         # Older GitHub Enterprise versions don't expose this endpoint.
         if err.response is not None and err.response.status_code == 404:
             logger.warning(
                 "GitHub Packages endpoint not available for org %s (404). "
-                "GHCR sync will be skipped for this organization.",
+                "GHCR sync will be skipped and cleanup deferred so previously "
+                "synced packages are not purged by an endpoint outage.",
                 organization,
             )
-            return []
+            return ContainerPackagesFetchResult(packages=[], cleanup_safe=False)
         raise
 
 
@@ -95,23 +111,25 @@ def transform_packages(
     raw_packages: list[dict[str, Any]],
     organization: str,
 ) -> list[dict[str, Any]]:
-    """Shape the package payload for ingestion."""
+    """Shape the package payload for ingestion.
+
+    ``name`` and ``html_url`` are required fields per the REST API contract;
+    we let ``KeyError`` surface if GitHub ever returns a malformed payload so
+    the failure is loud rather than silently dropping the package.
+    """
     transformed: list[dict[str, Any]] = []
     for pkg in raw_packages:
-        name = pkg.get("name")
-        if not name:
-            continue
         repository = pkg.get("repository") or {}
         repository_url = (
             repository.get("html_url") if isinstance(repository, dict) else None
         )
         transformed.append(
             {
-                "name": name,
+                "name": pkg["name"],
                 "package_type": pkg.get("package_type", "container"),
                 "visibility": pkg.get("visibility"),
-                "uri": _ghcr_uri(organization, name),
-                "html_url": pkg.get("html_url"),
+                "uri": _ghcr_uri(organization, pkg["name"]),
+                "html_url": pkg["html_url"],
                 "repository_url": repository_url,
                 "created_at": pkg.get("created_at"),
                 "updated_at": pkg.get("updated_at"),
@@ -154,15 +172,16 @@ def sync_packages(
     organization: str,
     update_tag: int,
     common_job_parameters: dict[str, Any],
-) -> list[dict[str, Any]]:
+) -> ContainerPackagesFetchResult:
     """
-    Sync container packages for ``organization``. Returns the transformed
-    package list so downstream syncs (versions, tags, attestations) can reuse
-    it without re-fetching.
+    Sync container packages for ``organization``. Returns the fetch result
+    (transformed packages + ``cleanup_safe`` flag) so downstream syncs can
+    reuse the data and so the orchestrator can propagate the cleanup_safe
+    signal.
     """
     org_url = f"https://github.com/{organization}"
-    raw_packages = get_container_packages(token, api_url, organization)
-    packages = transform_packages(raw_packages, organization)
+    fetch_result = get_container_packages(token, api_url, organization)
+    packages = transform_packages(fetch_result.packages, organization)
     if packages:
         logger.info(
             "Loading %d GitHub container packages for org %s",
@@ -170,10 +189,20 @@ def sync_packages(
             organization,
         )
         load_packages(neo4j_session, packages, org_url, update_tag)
-    cleanup_params = dict(common_job_parameters)
-    cleanup_params["org_url"] = org_url
-    cleanup_packages(neo4j_session, cleanup_params)
-    return packages
+    if fetch_result.cleanup_safe:
+        cleanup_params = dict(common_job_parameters)
+        cleanup_params["org_url"] = org_url
+        cleanup_packages(neo4j_session, cleanup_params)
+    else:
+        logger.warning(
+            "Skipping GitHubPackage cleanup for org %s because the packages "
+            "endpoint discovery was incomplete.",
+            organization,
+        )
+    return ContainerPackagesFetchResult(
+        packages=packages,
+        cleanup_safe=fetch_result.cleanup_safe,
+    )
 
 
 __all__ = [

--- a/cartography/intel/github/packages.py
+++ b/cartography/intel/github/packages.py
@@ -1,0 +1,185 @@
+"""
+GitHub Packages Intelligence Module.
+
+Syncs container packages (GitHub Container Registry) into the graph.
+Only `package_type=container` packages are fetched — other package types
+(npm, maven, etc.) are out of scope for this module.
+"""
+
+import logging
+from typing import Any
+from urllib.parse import quote
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.github.util import call_github_rest_api
+from cartography.intel.github.util import fetch_all_rest_api_pages
+from cartography.intel.github.util import rest_api_base_url
+from cartography.models.github.packages import GitHubPackageSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+def _ghcr_uri(org_login: str, package_name: str) -> str:
+    """Build the canonical lowercase GHCR URI for a package."""
+    return f"ghcr.io/{org_login.lower()}/{package_name.lower()}"
+
+
+@timeit
+def get_container_packages(
+    token: Any,
+    api_url: str,
+    organization: str,
+) -> list[dict[str, Any]]:
+    """
+    Fetch every container package owned by ``organization`` via the GitHub
+    REST API. Returns the raw payloads (one per package).
+    """
+    base_url = rest_api_base_url(api_url)
+    endpoint = (
+        f"/orgs/{quote(organization)}/packages?package_type=container&per_page=100"
+    )
+    try:
+        return fetch_all_rest_api_pages(
+            token, base_url, endpoint, result_key="packages"
+        )
+    except requests.exceptions.HTTPError as err:
+        # Older GitHub Enterprise versions don't expose this endpoint.
+        if err.response is not None and err.response.status_code == 404:
+            logger.warning(
+                "GitHub Packages endpoint not available for org %s (404). "
+                "GHCR sync will be skipped for this organization.",
+                organization,
+            )
+            return []
+        raise
+
+
+@timeit
+def get_package_versions(
+    token: Any,
+    api_url: str,
+    organization: str,
+    package_name: str,
+) -> list[dict[str, Any]]:
+    """
+    Fetch every version of a single container package. The list endpoint is
+    paginated; each version corresponds to a unique manifest digest and may
+    carry one or more tags in its metadata.
+    """
+    base_url = rest_api_base_url(api_url)
+    endpoint = (
+        f"/orgs/{quote(organization)}/packages/container/"
+        f"{quote(package_name, safe='')}/versions?per_page=100"
+    )
+    try:
+        return fetch_all_rest_api_pages(
+            token, base_url, endpoint, result_key="versions"
+        )
+    except requests.exceptions.HTTPError as err:
+        if err.response is not None and err.response.status_code == 404:
+            logger.debug(
+                "Versions endpoint not found for package %s/%s; skipping",
+                organization,
+                package_name,
+            )
+            return []
+        raise
+
+
+def transform_packages(
+    raw_packages: list[dict[str, Any]],
+    organization: str,
+) -> list[dict[str, Any]]:
+    """Shape the package payload for ingestion."""
+    transformed: list[dict[str, Any]] = []
+    for pkg in raw_packages:
+        name = pkg.get("name")
+        if not name:
+            continue
+        repository = pkg.get("repository") or {}
+        repository_url = (
+            repository.get("html_url") if isinstance(repository, dict) else None
+        )
+        transformed.append(
+            {
+                "name": name,
+                "package_type": pkg.get("package_type", "container"),
+                "visibility": pkg.get("visibility"),
+                "uri": _ghcr_uri(organization, name),
+                "html_url": pkg.get("html_url"),
+                "repository_url": repository_url,
+                "created_at": pkg.get("created_at"),
+                "updated_at": pkg.get("updated_at"),
+            },
+        )
+    return transformed
+
+
+@timeit
+def load_packages(
+    neo4j_session: neo4j.Session,
+    packages: list[dict[str, Any]],
+    org_url: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        GitHubPackageSchema(),
+        packages,
+        lastupdated=update_tag,
+        org_url=org_url,
+    )
+
+
+@timeit
+def cleanup_packages(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(GitHubPackageSchema(), common_job_parameters).run(
+        neo4j_session,
+    )
+
+
+@timeit
+def sync_packages(
+    neo4j_session: neo4j.Session,
+    token: Any,
+    api_url: str,
+    organization: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """
+    Sync container packages for ``organization``. Returns the transformed
+    package list so downstream syncs (versions, tags, attestations) can reuse
+    it without re-fetching.
+    """
+    org_url = f"https://github.com/{organization}"
+    raw_packages = get_container_packages(token, api_url, organization)
+    packages = transform_packages(raw_packages, organization)
+    if packages:
+        logger.info(
+            "Loading %d GitHub container packages for org %s",
+            len(packages),
+            organization,
+        )
+        load_packages(neo4j_session, packages, org_url, update_tag)
+    cleanup_params = dict(common_job_parameters)
+    cleanup_params["org_url"] = org_url
+    cleanup_packages(neo4j_session, cleanup_params)
+    return packages
+
+
+__all__ = [
+    "call_github_rest_api",  # re-exported for tests that patch this symbol
+    "get_container_packages",
+    "get_package_versions",
+    "sync_packages",
+    "transform_packages",
+]

--- a/cartography/intel/github/packages.py
+++ b/cartography/intel/github/packages.py
@@ -52,6 +52,12 @@ def get_container_packages(
     """
     Fetch every container package owned by ``organization`` via the GitHub
     REST API. Returns the raw payloads alongside a ``cleanup_safe`` flag.
+
+    The ``/orgs/{org}/packages`` endpoint returns 404 on older GHES versions
+    and 403 when the token is missing the ``read:packages`` scope (the most
+    common misconfiguration in the wild — fine-grained PATs always 403 here).
+    Both cases set ``cleanup_safe=False`` so previously-synced packages are
+    not purged by a missing-scope or endpoint-outage condition.
     """
     base_url = rest_api_base_url(api_url)
     endpoint = (
@@ -59,16 +65,30 @@ def get_container_packages(
     )
     try:
         packages = fetch_all_rest_api_pages(
-            token, base_url, endpoint, result_key="packages"
+            token,
+            base_url,
+            endpoint,
+            result_key="packages",
+            raise_on_status=(403, 404),
         )
         return ContainerPackagesFetchResult(packages=packages, cleanup_safe=True)
     except requests.exceptions.HTTPError as err:
-        # Older GitHub Enterprise versions don't expose this endpoint.
-        if err.response is not None and err.response.status_code == 404:
+        status = err.response.status_code if err.response is not None else None
+        if status == 404:
             logger.warning(
                 "GitHub Packages endpoint not available for org %s (404). "
                 "GHCR sync will be skipped and cleanup deferred so previously "
                 "synced packages are not purged by an endpoint outage.",
+                organization,
+            )
+            return ContainerPackagesFetchResult(packages=[], cleanup_safe=False)
+        if status == 403:
+            logger.warning(
+                "GitHub Packages endpoint refused for org %s (403). The token "
+                "is most likely missing the read:packages scope (fine-grained "
+                "PATs cannot access Packages and always 403 here). GHCR sync "
+                "will be skipped and cleanup deferred to preserve previously "
+                "synced packages.",
                 organization,
             )
             return ContainerPackagesFetchResult(packages=[], cleanup_safe=False)

--- a/cartography/intel/github/supply_chain.py
+++ b/cartography/intel/github/supply_chain.py
@@ -54,9 +54,13 @@ def _get_unmatched_ghcr_image_owner_repos(
     """
     # Filter on the generic ``Image`` label so manifest lists (multi-arch
     # indexes) are excluded — only platform-specific images claim a build repo.
+    # Match against PACKAGED_FROM relationships from THIS run only (lastupdated
+    # = update_tag); stale rels from previous runs must not block the fallback,
+    # they will be reaped by the cleanup that runs after this step.
     query = """
     MATCH (org:GitHubOrganization {id: $org_url})-[:RESOURCE]->(img:GitHubContainerImage)
-    WHERE img:Image AND NOT exists((img)-[:PACKAGED_FROM]->())
+    WHERE img:Image
+      AND NOT exists((img)-[:PACKAGED_FROM {lastupdated: $update_tag}]->())
     MATCH (pkg:GitHubPackage)-[:HAS_IMAGE]->(img)
     MATCH (repo:GitHubRepository)-[:HAS_PACKAGE]->(pkg)
     WITH img, collect(DISTINCT repo.id) AS repo_ids

--- a/cartography/intel/github/supply_chain.py
+++ b/cartography/intel/github/supply_chain.py
@@ -18,6 +18,9 @@ from cartography.models.github.packaged_matchlink import (
     GitHubRepoDockerfilePackagedFromMatchLink,
 )
 from cartography.models.github.packaged_matchlink import (
+    GitHubRepoPackageOwnerPackagedFromMatchLink,
+)
+from cartography.models.github.packaged_matchlink import (
     GitHubRepoProvenancePackagedFromMatchLink,
 )
 from cartography.models.github.packaged_matchlink import (
@@ -30,6 +33,43 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_IMAGE_LIMIT: int | None = None
 _DEFAULT_MIN_MATCH_CONFIDENCE: float = 0.5
+
+# Confidence applied to the package-owner fallback (GHCR HAS_PACKAGE -> repo).
+# The link is deterministic (one repo per package per the GitHub API) but the
+# repo isn't guaranteed to be the build source — it's the repo that owns the
+# package, which usually but not always matches the build source.
+_PACKAGE_OWNER_FALLBACK_CONFIDENCE: float = 0.6
+
+
+def _get_unmatched_ghcr_image_owner_repos(
+    neo4j_session: neo4j.Session,
+    organization: str,
+    update_tag: int,
+) -> list[dict[str, Any]]:
+    """
+    Return ``[{image_digest, repo_url}, ...]`` for every GHCR image scoped to
+    ``organization`` that has no ``PACKAGED_FROM`` relationship after the
+    higher-confidence steps ran, but whose owning ``GitHubPackage`` has a
+    single ``HAS_PACKAGE`` link back to a ``GitHubRepository``.
+    """
+    # Filter on the generic ``Image`` label so manifest lists (multi-arch
+    # indexes) are excluded — only platform-specific images claim a build repo.
+    query = """
+    MATCH (org:GitHubOrganization {id: $org_url})-[:RESOURCE]->(img:GitHubContainerImage)
+    WHERE img:Image AND NOT exists((img)-[:PACKAGED_FROM]->())
+    MATCH (pkg:GitHubPackage)-[:HAS_IMAGE]->(img)
+    MATCH (repo:GitHubRepository)-[:HAS_PACKAGE]->(pkg)
+    WITH img, collect(DISTINCT repo.id) AS repo_ids
+    WHERE size(repo_ids) = 1
+    RETURN img.digest AS image_digest, repo_ids[0] AS repo_url
+    """
+    org_url = f"https://github.com/{organization}"
+    result = neo4j_session.run(query, org_url=org_url, update_tag=update_tag)
+    return [
+        {"image_digest": record["image_digest"], "repo_url": record["repo_url"]}
+        for record in result
+        if record["image_digest"] and record["repo_url"]
+    ]
 
 
 @timeit
@@ -371,10 +411,14 @@ def sync(
     """
     Sync supply chain relationships for a GitHub organization.
 
-    Uses a three-stage matching approach:
+    Uses a four-stage matching approach:
     1. PACKAGED_BY: Workflow provenance (Image -> GitHubWorkflow)
     2. PACKAGED_FROM (provenance): SLSA provenance-based matching (100% confidence)
     3. PACKAGED_FROM (dockerfile): Dockerfile command matching for unmatched images
+    4. PACKAGED_FROM (package_owner_repo): For any GHCR image still without a
+       PACKAGED_FROM, link it to the repo that owns its GitHubPackage when the
+       HAS_PACKAGE relation is unique. Lower confidence than the previous
+       stages but deterministic (one repo per package per the GitHub API).
 
     Only images without an existing PACKAGED_FROM relationship go through the
     expensive Dockerfile analysis step.
@@ -489,7 +533,37 @@ def sync(
                         _sub_resource_id=organization,
                     )
 
-    # 5. Cleanup stale relationships
+    # 5. PACKAGED_FROM (package-owner fallback): GHCR images still without a
+    # PACKAGED_FROM after steps 1-4 inherit the repo that owns their package.
+    package_owner_data = _get_unmatched_ghcr_image_owner_repos(
+        neo4j_session,
+        organization,
+        update_tag,
+    )
+    if package_owner_data:
+        for entry in package_owner_data:
+            entry.update(
+                match_method="package_owner_repo",
+                dockerfile_path=None,
+                confidence=_PACKAGE_OWNER_FALLBACK_CONFIDENCE,
+                matched_commands=0,
+                total_commands=0,
+                command_similarity=0.0,
+            )
+        logger.info(
+            "Loading %d package-owner PACKAGED_FROM relationships",
+            len(package_owner_data),
+        )
+        load_matchlinks(
+            neo4j_session,
+            GitHubRepoPackageOwnerPackagedFromMatchLink(),
+            package_owner_data,
+            lastupdated=update_tag,
+            _sub_resource_label="GitHubOrganization",
+            _sub_resource_id=organization,
+        )
+
+    # 6. Cleanup stale relationships
     GraphJob.from_matchlink(
         ImagePackagedByWorkflowMatchLink(),
         "GitHubOrganization",
@@ -511,7 +585,14 @@ def sync(
         update_tag,
     ).run(neo4j_session)
 
-    # 6. Enrich PACKAGED_FROM with source_file from Image provenance
+    GraphJob.from_matchlink(
+        GitHubRepoPackageOwnerPackagedFromMatchLink(),
+        "GitHubOrganization",
+        organization,
+        update_tag,
+    ).run(neo4j_session)
+
+    # 7. Enrich PACKAGED_FROM with source_file from Image provenance
     run_analysis_job(
         "supply_chain_source_file.json",
         neo4j_session,

--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -678,11 +678,17 @@ def _ghcr_auth_header(token: Any) -> str:
     """
     Build the Authorization header value for GHCR's OCI Distribution API.
 
-    A GitHub PAT with the ``read:packages`` scope is sent as a plain Bearer
-    credential. Base64 encoding only applies to ``docker login`` (HTTP Basic
-    of ``user:pat``); the OCI v2 API expects the PAT itself.
+    GHCR is an unusual OCI registry: instead of the standard token-exchange
+    flow, GitHub documents a shortcut where the PAT is base64-encoded and
+    sent as a Bearer credential.
+
+    See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry
+
+    Sending the raw PAT (as on the REST API) returns 403 from
+    ``ghcr.io/v2/...`` even with ``read:packages`` granted.
     """
-    return f"Bearer {_resolve_token(token)}"
+    raw = _resolve_token(token).encode("utf-8")
+    return f"Bearer {base64.b64encode(raw).decode('ascii')}"
 
 
 def fetch_ghcr_manifest(

--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -381,6 +381,13 @@ def _get_rest_api_base_url(graphql_url: str) -> str:
     return base
 
 
+def rest_api_base_url(api_url: str) -> str:
+    """Public wrapper that accepts a REST or GraphQL URL and returns the REST base URL."""
+    if api_url.endswith("/graphql"):
+        return _get_rest_api_base_url(api_url)
+    return api_url.rstrip("/")
+
+
 def handle_rest_rate_limit_sleep(token: str, base_url: str) -> None:
     """
     Check the remaining REST API rate limit and sleep if remaining is below threshold.
@@ -652,3 +659,140 @@ def get_file_content(
             logger.debug("File not found: %s/%s/%s", owner, repo, path)
             return None
         raise
+
+
+# --- GHCR (GitHub Container Registry) ---------------------------------------
+
+DEFAULT_GHCR_URL = "https://ghcr.io"
+GHCR_MANIFEST_ACCEPT_HEADER = ", ".join(
+    [
+        "application/vnd.docker.distribution.manifest.v2+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.oci.image.index.v1+json",
+    ],
+)
+
+
+def _ghcr_auth_header(token: Any) -> str:
+    """
+    Build the Authorization header value for GHCR's OCI Distribution API.
+
+    GHCR accepts a base64-encoded personal access token (with read:packages)
+    as a Bearer credential. The same encoding is what `docker login ghcr.io`
+    submits.
+    """
+    raw = _resolve_token(token).encode("utf-8")
+    return f"Bearer {base64.b64encode(raw).decode('ascii')}"
+
+
+def fetch_ghcr_manifest(
+    token: Any,
+    repository_name: str,
+    reference: str,
+    registry_url: str = DEFAULT_GHCR_URL,
+    retries: int = 3,
+) -> dict[str, Any] | None:
+    """
+    Fetch an OCI manifest (or manifest list) from GHCR.
+
+    :param token: GitHub PAT or AppCredential with read:packages.
+    :param repository_name: Path under the registry, e.g. "myorg/myimage".
+    :param reference: Manifest digest (sha256:...) or tag.
+    :param registry_url: Registry base URL (defaults to ghcr.io).
+    :param retries: Transient-error retry count.
+    :return: Parsed manifest dict or None when the manifest does not exist (404).
+    """
+    url = f"{registry_url.rstrip('/')}/v2/{repository_name}/manifests/{reference}"
+    last_exc: Any = None
+    for attempt in range(max(retries, 1)):
+        headers = {
+            "Authorization": _ghcr_auth_header(token),
+            "Accept": GHCR_MANIFEST_ACCEPT_HEADER,
+        }
+        try:
+            response = requests.get(url, headers=headers, timeout=_TIMEOUT)
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+            result: dict[str, Any] = response.json()
+            return result
+        except requests.exceptions.Timeout as err:
+            last_exc = err
+        except requests.exceptions.HTTPError as err:
+            if (
+                err.response is not None
+                and err.response.status_code not in _TRANSIENT_STATUS_CODES
+            ):
+                raise
+            last_exc = err
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ChunkedEncodingError,
+        ) as err:
+            last_exc = err
+
+        logger.warning(
+            "GHCR manifest fetch transient error for %s (attempt %d/%d): %s",
+            url,
+            attempt + 1,
+            retries,
+            last_exc,
+        )
+        if attempt < retries - 1:
+            time.sleep(2 ** (attempt + 1))
+
+    raise last_exc
+
+
+def fetch_ghcr_blob(
+    token: Any,
+    repository_name: str,
+    blob_digest: str,
+    registry_url: str = DEFAULT_GHCR_URL,
+    retries: int = 3,
+) -> dict[str, Any] | None:
+    """
+    Fetch a config blob (typically the OCI image config JSON) from GHCR.
+
+    Returns the parsed JSON or None on 404. Raises on non-transient HTTP
+    errors. Used by the GHCR sync to pull `layer_diff_ids`, architecture and
+    OS from the config that the manifest references.
+    """
+    url = f"{registry_url.rstrip('/')}/v2/{repository_name}/blobs/{blob_digest}"
+    last_exc: Any = None
+    for attempt in range(max(retries, 1)):
+        headers = {"Authorization": _ghcr_auth_header(token)}
+        try:
+            response = requests.get(url, headers=headers, timeout=_TIMEOUT)
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+            result: dict[str, Any] = response.json()
+            return result
+        except requests.exceptions.Timeout as err:
+            last_exc = err
+        except requests.exceptions.HTTPError as err:
+            if (
+                err.response is not None
+                and err.response.status_code not in _TRANSIENT_STATUS_CODES
+            ):
+                raise
+            last_exc = err
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ChunkedEncodingError,
+        ) as err:
+            last_exc = err
+
+        logger.warning(
+            "GHCR blob fetch transient error for %s (attempt %d/%d): %s",
+            url,
+            attempt + 1,
+            retries,
+            last_exc,
+        )
+        if attempt < retries - 1:
+            time.sleep(2 ** (attempt + 1))
+
+    raise last_exc

--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -424,6 +424,7 @@ def fetch_all_rest_api_pages(
     endpoint: str,
     result_key: str,
     retries: int = 5,
+    raise_on_status: tuple[int, ...] = (),
 ) -> list[dict[str, Any]]:
     """
     Fetch all pages from a GitHub REST API endpoint using Link header pagination.
@@ -434,6 +435,13 @@ def fetch_all_rest_api_pages(
     :param result_key: The key in the response JSON that contains the list of results
                        (e.g., 'workflows', 'secrets', 'variables').
     :param retries: Number of retries to perform on transient errors.
+    :param raise_on_status: HTTP statuses that the caller wants to handle itself
+                            instead of being silently converted to an empty list.
+                            By default 404 and 403 return ``[]`` (legacy behavior
+                            relied on by most callers); pass e.g. ``(403,)`` if
+                            the caller needs to distinguish "no data" from
+                            "missing scope" — for example to skip a cleanup
+                            that would otherwise reap previously-synced data.
     :return: A list of all items from all pages.
     """
     results: list[dict[str, Any]] = []
@@ -457,12 +465,15 @@ def fetch_all_rest_api_pages(
             retry += 1
             exc = err
         except requests.exceptions.HTTPError as err:
+            status = err.response.status_code if err.response is not None else None
+            if status is not None and status in raise_on_status:
+                raise
             # Handle 404 gracefully - resource may not exist (e.g., no environments)
-            if err.response is not None and err.response.status_code == 404:
+            if status == 404:
                 logger.debug(f"GitHub REST API: 404 for {url}, returning empty list")
                 return []
             # Handle 403 gracefully
-            if err.response is not None and err.response.status_code == 403:
+            if status == 403:
                 logger.warning(
                     f"GitHub REST API: 403 Forbidden for {url}. "
                     "This is likely due to insufficient permissions. "

--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -678,12 +678,11 @@ def _ghcr_auth_header(token: Any) -> str:
     """
     Build the Authorization header value for GHCR's OCI Distribution API.
 
-    GHCR accepts a base64-encoded personal access token (with read:packages)
-    as a Bearer credential. The same encoding is what `docker login ghcr.io`
-    submits.
+    A GitHub PAT with the ``read:packages`` scope is sent as a plain Bearer
+    credential. Base64 encoding only applies to ``docker login`` (HTTP Basic
+    of ``user:pat``); the OCI v2 API expects the PAT itself.
     """
-    raw = _resolve_token(token).encode("utf-8")
-    return f"Bearer {base64.b64encode(raw).decode('ascii')}"
+    return f"Bearer {_resolve_token(token)}"
 
 
 def fetch_ghcr_manifest(

--- a/cartography/models/github/container_image_attestations.py
+++ b/cartography/models/github/container_image_attestations.py
@@ -1,0 +1,79 @@
+"""
+GitHub Container Image Attestation Schema.
+
+Represents SLSA attestations (build provenance) returned by the GitHub
+Attestations API for container images pushed to GHCR.
+
+See: https://docs.github.com/en/rest/users/attestations
+"""
+
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageAttestationNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", extra_index=True)
+    bundle_id: PropertyRef = PropertyRef("bundle_id")
+    predicate_type: PropertyRef = PropertyRef("predicate_type", extra_index=True)
+    attests_digest: PropertyRef = PropertyRef("attests_digest", extra_index=True)
+    source_uri: PropertyRef = PropertyRef("source_uri")
+    source_revision: PropertyRef = PropertyRef("source_revision")
+    source_file: PropertyRef = PropertyRef("source_file")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageAttestationRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageAttestationToOrgRel(CartographyRelSchema):
+    target_node_label: str = "GitHubOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("org_url", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GitHubContainerImageAttestationRelProperties = (
+        GitHubContainerImageAttestationRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageAttestationAttestsRel(CartographyRelSchema):
+    """Links an attestation to the image digest it attests."""
+
+    target_node_label: str = "GitHubContainerImage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"digest": PropertyRef("attests_digest")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "ATTESTS"
+    properties: GitHubContainerImageAttestationRelProperties = (
+        GitHubContainerImageAttestationRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageAttestationSchema(CartographyNodeSchema):
+    label: str = "GitHubContainerImageAttestation"
+    properties: GitHubContainerImageAttestationNodeProperties = (
+        GitHubContainerImageAttestationNodeProperties()
+    )
+    sub_resource_relationship: GitHubContainerImageAttestationToOrgRel = (
+        GitHubContainerImageAttestationToOrgRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [GitHubContainerImageAttestationAttestsRel()],
+    )

--- a/cartography/models/github/container_image_layers.py
+++ b/cartography/models/github/container_image_layers.py
@@ -1,0 +1,90 @@
+"""
+GitHub Container Image Layer Schema.
+
+Represents individual layers within container images stored in GitHub
+Container Registry. Layers are identified by their diff_id (the uncompressed
+sha256) and can be shared across multiple images via Docker's layer
+deduplication.
+
+See: https://distribution.github.io/distribution/spec/manifest-v2-2/
+"""
+
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageLayerNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("diff_id")
+    diff_id: PropertyRef = PropertyRef("diff_id", extra_index=True)
+    digest: PropertyRef = PropertyRef("digest", extra_index=True)
+    media_type: PropertyRef = PropertyRef("media_type")
+    size: PropertyRef = PropertyRef("size")
+    is_empty: PropertyRef = PropertyRef("is_empty")
+    history: PropertyRef = PropertyRef("history")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageLayerRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageLayerToOrgRel(CartographyRelSchema):
+    """
+    Sub-resource relationship from GitHubContainerImageLayer to GitHubOrganization.
+    """
+
+    target_node_label: str = "GitHubOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("org_url", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GitHubContainerImageLayerRelProperties = (
+        GitHubContainerImageLayerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageLayerToNextRel(CartographyRelSchema):
+    """
+    Linked-list ordering: each layer points to the next layer(s) it appears
+    immediately before in some image stack.
+    """
+
+    target_node_label: str = "GitHubContainerImageLayer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"diff_id": PropertyRef("next_diff_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "NEXT"
+    properties: GitHubContainerImageLayerRelProperties = (
+        GitHubContainerImageLayerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageLayerSchema(CartographyNodeSchema):
+    label: str = "GitHubContainerImageLayer"
+    properties: GitHubContainerImageLayerNodeProperties = (
+        GitHubContainerImageLayerNodeProperties()
+    )
+    sub_resource_relationship: GitHubContainerImageLayerToOrgRel = (
+        GitHubContainerImageLayerToOrgRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [GitHubContainerImageLayerToNextRel()],
+    )
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ImageLayer"])

--- a/cartography/models/github/container_image_tags.py
+++ b/cartography/models/github/container_image_tags.py
@@ -1,0 +1,104 @@
+"""
+GitHub Container Image Tag Schema.
+
+Represents tags within a GitHub container package. Tags are pointers to
+specific container images identified by digest. Multiple tags can point to
+the same image digest (e.g., "latest" and "v1.0.0").
+"""
+
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageTagNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("uri")
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    uri: PropertyRef = PropertyRef("uri", extra_index=True)
+    digest: PropertyRef = PropertyRef("digest", extra_index=True)
+    image_pushed_at: PropertyRef = PropertyRef("image_pushed_at")
+    package_id: PropertyRef = PropertyRef("package_id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageTagRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageTagToOrgRel(CartographyRelSchema):
+    target_node_label: str = "GitHubOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("org_url", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GitHubContainerImageTagRelProperties = (
+        GitHubContainerImageTagRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageTagToImageRel(CartographyRelSchema):
+    """
+    Generic cross-registry edge from ImageTag to Image. The supply-chain
+    matcher in cartography/intel/github/supply_chain.py traverses this edge
+    via the (:Image)<-[:IMAGE]-(:ImageTag)<-[:REPO_IMAGE]-(:ContainerRegistry)
+    pattern, so the relationship label and direction must match GitLab/AWS.
+    """
+
+    target_node_label: str = "GitHubContainerImage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("digest")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "IMAGE"
+    properties: GitHubContainerImageTagRelProperties = (
+        GitHubContainerImageTagRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageTagToPackageRel(CartographyRelSchema):
+    """
+    Generic cross-registry edge from ContainerRegistry to ImageTag.
+    """
+
+    target_node_label: str = "GitHubPackage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("package_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "REPO_IMAGE"
+    properties: GitHubContainerImageTagRelProperties = (
+        GitHubContainerImageTagRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageTagSchema(CartographyNodeSchema):
+    label: str = "GitHubContainerImageTag"
+    properties: GitHubContainerImageTagNodeProperties = (
+        GitHubContainerImageTagNodeProperties()
+    )
+    sub_resource_relationship: GitHubContainerImageTagToOrgRel = (
+        GitHubContainerImageTagToOrgRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            GitHubContainerImageTagToPackageRel(),
+            GitHubContainerImageTagToImageRel(),
+        ],
+    )
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ImageTag"])

--- a/cartography/models/github/container_images.py
+++ b/cartography/models/github/container_images.py
@@ -1,0 +1,243 @@
+"""
+GitHub Container Image Schema.
+
+Represents container images stored in GitHub Container Registry (ghcr.io).
+Images are identified by their digest (sha256:...) and can be referenced by
+multiple tags. Manifest lists (multi-architecture images) contain references
+to platform-specific images.
+
+See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry
+"""
+
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ConditionalNodeLabel
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("digest")
+    digest: PropertyRef = PropertyRef("digest", extra_index=True)
+    uri: PropertyRef = PropertyRef("uri", extra_index=True)
+    media_type: PropertyRef = PropertyRef("media_type")
+    schema_version: PropertyRef = PropertyRef("schema_version")
+    type: PropertyRef = PropertyRef("type", extra_index=True)
+    architecture: PropertyRef = PropertyRef("architecture")
+    os: PropertyRef = PropertyRef("os")
+    variant: PropertyRef = PropertyRef("variant")
+    source_uri: PropertyRef = PropertyRef("source_uri", extra_index=True)
+    source_revision: PropertyRef = PropertyRef("source_revision")
+    source_file: PropertyRef = PropertyRef("source_file")
+    parent_image_uri: PropertyRef = PropertyRef("parent_image_uri")
+    parent_image_digest: PropertyRef = PropertyRef("parent_image_digest")
+    child_image_digests: PropertyRef = PropertyRef("child_image_digests")
+    layer_diff_ids: PropertyRef = PropertyRef("layer_diff_ids")
+    head_layer_diff_id: PropertyRef = PropertyRef("head_layer_diff_id")
+    tail_layer_diff_id: PropertyRef = PropertyRef("tail_layer_diff_id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageToOrgRel(CartographyRelSchema):
+    """
+    Sub-resource relationship from GitHubContainerImage to GitHubOrganization.
+    Images are scoped to organizations for cleanup and to allow cross-package
+    deduplication.
+    """
+
+    target_node_label: str = "GitHubOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("org_url", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GitHubContainerImageRelProperties = GitHubContainerImageRelProperties()
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageContainsImageRel(CartographyRelSchema):
+    """
+    Relationship from a manifest list to its platform-specific child images.
+    Only applies to images with type="manifest_list".
+    """
+
+    target_node_label: str = "GitHubContainerImage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"digest": PropertyRef("child_image_digests", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "CONTAINS_IMAGE"
+    properties: GitHubContainerImageRelProperties = GitHubContainerImageRelProperties()
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageToLayerRel(CartographyRelSchema):
+    """
+    Relationship from an image to its constituent layers.
+    Only applies to single-image manifests (type="image").
+    """
+
+    target_node_label: str = "GitHubContainerImageLayer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"diff_id": PropertyRef("layer_diff_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_LAYER"
+    properties: GitHubContainerImageRelProperties = GitHubContainerImageRelProperties()
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageToHeadLayerRel(CartographyRelSchema):
+    target_node_label: str = "GitHubContainerImageLayer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"diff_id": PropertyRef("head_layer_diff_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HEAD"
+    properties: GitHubContainerImageRelProperties = GitHubContainerImageRelProperties()
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageToTailLayerRel(CartographyRelSchema):
+    target_node_label: str = "GitHubContainerImageLayer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"diff_id": PropertyRef("tail_layer_diff_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "TAIL"
+    properties: GitHubContainerImageRelProperties = GitHubContainerImageRelProperties()
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageToParentImageRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    from_attestation: PropertyRef = PropertyRef("from_attestation")
+    parent_image_uri: PropertyRef = PropertyRef("parent_image_uri")
+    confidence: PropertyRef = PropertyRef("confidence")
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageToParentImageRel(CartographyRelSchema):
+    """
+    Relationship from a GitHubContainerImage to its parent/base image.
+    """
+
+    target_node_label: str = "GitHubContainerImage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"digest": PropertyRef("parent_image_digest")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "BUILT_FROM"
+    properties: GitHubContainerImageToParentImageRelProperties = (
+        GitHubContainerImageToParentImageRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageToPackageRel(CartographyRelSchema):
+    """
+    Links a container image to the package (registry repository) that hosts it.
+    """
+
+    target_node_label: str = "GitHubPackage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("package_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_IMAGE"
+    properties: GitHubContainerImageRelProperties = GitHubContainerImageRelProperties()
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageSchema(CartographyNodeSchema):
+    """
+    Schema for GitHub Container Image nodes.
+
+    Relationships:
+    - RESOURCE: Sub-resource to GitHubOrganization for cleanup
+    - CONTAINS_IMAGE: From manifest lists to platform-specific images
+    - HAS_LAYER / HEAD / TAIL: Image layer structure
+    - BUILT_FROM: Parent/base image
+    - HAS_IMAGE: Inverse of (GitHubPackage)-[:HAS_IMAGE]->(image)
+
+    Extra labels:
+    - Image: Applied to single image manifests (type="image")
+    - ImageManifestList: Applied to manifest lists (type="manifest_list")
+    """
+
+    label: str = "GitHubContainerImage"
+    properties: GitHubContainerImageNodeProperties = (
+        GitHubContainerImageNodeProperties()
+    )
+    sub_resource_relationship: GitHubContainerImageToOrgRel = (
+        GitHubContainerImageToOrgRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            GitHubContainerImageToPackageRel(),
+            GitHubContainerImageContainsImageRel(),
+            GitHubContainerImageToLayerRel(),
+            GitHubContainerImageToHeadLayerRel(),
+            GitHubContainerImageToTailLayerRel(),
+            GitHubContainerImageToParentImageRel(),
+        ],
+    )
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        [
+            ConditionalNodeLabel(
+                label="Image",
+                conditions={"type": "image"},
+            ),
+            ConditionalNodeLabel(
+                label="ImageManifestList",
+                conditions={"type": "manifest_list"},
+            ),
+        ],
+    )
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageProvenanceNodeProperties(CartographyNodeProperties):
+    """
+    Minimal property set for provenance-only updates on existing
+    GitHubContainerImage nodes. Used by the attestation enrichment step so
+    base manifest fields don't get nulled out on re-load.
+    """
+
+    id: PropertyRef = PropertyRef("digest")
+    source_uri: PropertyRef = PropertyRef("source_uri", extra_index=True)
+    source_revision: PropertyRef = PropertyRef("source_revision")
+    source_file: PropertyRef = PropertyRef("source_file")
+    parent_image_uri: PropertyRef = PropertyRef("parent_image_uri")
+    parent_image_digest: PropertyRef = PropertyRef("parent_image_digest")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitHubContainerImageProvenanceSchema(CartographyNodeSchema):
+    """
+    Schema for provenance-only enrichment of GitHubContainerImage nodes.
+    """
+
+    label: str = "GitHubContainerImage"
+    properties: GitHubContainerImageProvenanceNodeProperties = (
+        GitHubContainerImageProvenanceNodeProperties()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [GitHubContainerImageToParentImageRel()],
+    )

--- a/cartography/models/github/packaged_matchlink.py
+++ b/cartography/models/github/packaged_matchlink.py
@@ -90,6 +90,38 @@ class GitHubRepoDockerfilePackagedFromMatchLink(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class GitHubRepoPackageOwnerPackagedFromMatchLink(CartographyRelSchema):
+    """
+    MatchLink for the package-owner fallback:
+    ``(Image)-[:PACKAGED_FROM]->(GitHubRepository)`` when the image lives in a
+    ``GitHubPackage`` that has a single ``HAS_PACKAGE`` rel back to a repo and
+    no higher-confidence match (provenance / dockerfile) was produced.
+
+    Matches ``Image.digest`` to the repo URL. Lower confidence than the
+    Dockerfile match — used as a deterministic fallback because GitHub's
+    Packages API returns at most one repository per package.
+    """
+
+    target_node_label: str = "GitHubRepository"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("repo_url"),
+        },
+    )
+    source_node_label: str = "Image"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {
+            "digest": PropertyRef("image_digest"),
+        },
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "PACKAGED_FROM"
+    properties: GitHubRepoPackagedFromMatchLinkProperties = (
+        GitHubRepoPackagedFromMatchLinkProperties()
+    )
+
+
+@dataclass(frozen=True)
 class ImagePackagedByWorkflowMatchLinkProperties(CartographyRelProperties):
     """
     Properties for the PACKAGED_BY relationship between Image and GitHubWorkflow.

--- a/cartography/models/github/packages.py
+++ b/cartography/models/github/packages.py
@@ -1,0 +1,80 @@
+"""
+GitHub Package Schema.
+
+Represents container packages hosted on GitHub Container Registry (ghcr.io).
+
+See: https://docs.github.com/en/rest/packages/packages
+"""
+
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GitHubPackageNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("html_url")
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    package_type: PropertyRef = PropertyRef("package_type", extra_index=True)
+    visibility: PropertyRef = PropertyRef("visibility")
+    uri: PropertyRef = PropertyRef("uri", extra_index=True)
+    html_url: PropertyRef = PropertyRef("html_url", extra_index=True)
+    created_at: PropertyRef = PropertyRef("created_at")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitHubPackageRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitHubPackageToOrgRel(CartographyRelSchema):
+    """
+    Sub-resource relationship from GitHubPackage to GitHubOrganization.
+    """
+
+    target_node_label: str = "GitHubOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("org_url", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GitHubPackageRelProperties = GitHubPackageRelProperties()
+
+
+@dataclass(frozen=True)
+class GitHubPackageToRepositoryRel(CartographyRelSchema):
+    """
+    Links a package to the repository that owns it. Best-effort — not every
+    package payload has a `repository` field.
+    """
+
+    target_node_label: str = "GitHubRepository"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("repository_url")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_PACKAGE"
+    properties: GitHubPackageRelProperties = GitHubPackageRelProperties()
+
+
+@dataclass(frozen=True)
+class GitHubPackageSchema(CartographyNodeSchema):
+    label: str = "GitHubPackage"
+    properties: GitHubPackageNodeProperties = GitHubPackageNodeProperties()
+    sub_resource_relationship: GitHubPackageToOrgRel = GitHubPackageToOrgRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [GitHubPackageToRepositoryRel()],
+    )
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ContainerRegistry"])

--- a/docs/root/modules/github/config.md
+++ b/docs/root/modules/github/config.md
@@ -40,6 +40,7 @@ Fine-grained PATs offer better security through minimal permissions and organiza
    | Permission | Access | Required | Why |
    |------------|--------|----------|-----|
    | **Members** | Read | Yes | Organization members, teams, team membership, user profiles/emails. |
+   | **Packages** | Read | Optional | GHCR (GitHub Container Registry) packages, image manifests, layers, tags, and SLSA attestations. Without this, Cartography logs a `403 Forbidden` warning on `/orgs/{org}/packages` and skips GHCR ingestion. |
    | **Secrets** | Read | Optional | Organization secrets metadata (names, creation dates). |
    | **Variables** | Read | Optional | Organization variables for Actions workflows. |
 
@@ -65,6 +66,7 @@ Classic PATs use broader OAuth scopes. Use this option if fine-grained PATs are 
    | `read:org` | Organization membership and team data |
    | `read:user` | User profile information |
    | `user:email` | User email addresses |
+   | `read:packages` | Optional. GHCR (GitHub Container Registry) packages, image manifests, layers, tags, and SLSA attestations. Without this, Cartography skips GHCR ingestion. |
 
 4. Click **Generate token** and copy it immediately.
 
@@ -175,6 +177,7 @@ For GitHub Enterprise, use the same token scopes/permissions as above. Set the `
 | Issue | Solution |
 |-------|----------|
 | `FORBIDDEN` warnings for collaborators/branch protection rules | Ensure fine-grained PAT includes `Repository -> Administration: Read` and the token owner has Organization Owner or repository Admin rights; otherwise Cartography will skip this enrichment and continue. |
+| `403 Forbidden for /orgs/{org}/packages` and no `GitHubPackage` nodes | Grant `Organization -> Packages: Read` (fine-grained) or the `read:packages` scope (classic). Without it, GHCR (container packages, images, layers, tags, attestations) is skipped. |
 | Empty dependency data | Ensure the [dependency graph](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph) is enabled on your repositories. |
 | Missing 2FA status | Only visible to Organization Owners. |
 | Rate limiting | Cartography handles rate limits automatically by sleeping until the quota resets. |

--- a/docs/root/modules/github/config.md
+++ b/docs/root/modules/github/config.md
@@ -40,9 +40,10 @@ Fine-grained PATs offer better security through minimal permissions and organiza
    | Permission | Access | Required | Why |
    |------------|--------|----------|-----|
    | **Members** | Read | Yes | Organization members, teams, team membership, user profiles/emails. |
-   | **Packages** | Read | Optional | GHCR (GitHub Container Registry) packages, image manifests, layers, tags, and SLSA attestations. Without this, Cartography logs a `403 Forbidden` warning on `/orgs/{org}/packages` and skips GHCR ingestion. |
    | **Secrets** | Read | Optional | Organization secrets metadata (names, creation dates). |
    | **Variables** | Read | Optional | Organization variables for Actions workflows. |
+
+   > **Note:** Fine-grained PATs [cannot access GitHub Packages](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens-limitations). To enable GHCR (GitHub Container Registry) ingestion — packages, image manifests, layers, tags, and SLSA attestations — use a classic PAT (Option B) with the `read:packages` scope or a GitHub App.
 
    > **Note:** The Secrets permission only provides access to secret **metadata** (name, creation date, update date). GitHub never exposes the actual secret values through its API—they are encrypted and cannot be retrieved.
 
@@ -177,7 +178,7 @@ For GitHub Enterprise, use the same token scopes/permissions as above. Set the `
 | Issue | Solution |
 |-------|----------|
 | `FORBIDDEN` warnings for collaborators/branch protection rules | Ensure fine-grained PAT includes `Repository -> Administration: Read` and the token owner has Organization Owner or repository Admin rights; otherwise Cartography will skip this enrichment and continue. |
-| `403 Forbidden for /orgs/{org}/packages` and no `GitHubPackage` nodes | Grant `Organization -> Packages: Read` (fine-grained) or the `read:packages` scope (classic). Without it, GHCR (container packages, images, layers, tags, attestations) is skipped. |
+| `403 Forbidden for /orgs/{org}/packages` and no `GitHubPackage` nodes | GHCR ingestion requires the `read:packages` scope on a classic PAT (or a GitHub App). Fine-grained PATs [cannot access GitHub Packages](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens-limitations). |
 | Empty dependency data | Ensure the [dependency graph](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph) is enabled on your repositories. |
 | Missing 2FA status | Only visible to Organization Owners. |
 | Rate limiting | Cartography handles rate limits automatically by sleeping until the quota resets. |

--- a/tests/data/github/packages.py
+++ b/tests/data/github/packages.py
@@ -1,0 +1,200 @@
+"""Fixture payloads for the GHCR (packages + container registry) sync tests."""
+
+from copy import deepcopy
+
+GET_CONTAINER_PACKAGES = [
+    {
+        "id": 1001,
+        "name": "api",
+        "package_type": "container",
+        "owner": {"login": "simpsoncorp"},
+        "version_count": 2,
+        "visibility": "private",
+        "url": "https://api.github.com/orgs/simpsoncorp/packages/container/api",
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-04-01T00:00:00Z",
+        "html_url": "https://github.com/orgs/simpsoncorp/packages/container/package/api",
+        "repository": {
+            "id": 1,
+            "html_url": "https://github.com/simpsoncorp/sample_repo",
+        },
+    },
+    {
+        "id": 1002,
+        "name": "worker",
+        "package_type": "container",
+        "owner": {"login": "simpsoncorp"},
+        "version_count": 1,
+        "visibility": "internal",
+        "url": "https://api.github.com/orgs/simpsoncorp/packages/container/worker",
+        "created_at": "2025-02-01T00:00:00Z",
+        "updated_at": "2025-04-15T00:00:00Z",
+        "html_url": "https://github.com/orgs/simpsoncorp/packages/container/package/worker",
+        "repository": None,
+    },
+]
+
+# Two versions for "api": one single-image manifest, one multi-arch manifest list.
+# One version for "worker": single image, no source attestation.
+DIGEST_API_LATEST = (
+    "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+)
+DIGEST_API_INDEX = (
+    "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+)
+DIGEST_API_AMD64 = (
+    "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+)
+DIGEST_API_ARM64 = (
+    "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+)
+DIGEST_WORKER = (
+    "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+)
+
+LAYER_DIFF_A = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+LAYER_DIFF_B = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+LAYER_DIFF_C = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+PACKAGE_VERSIONS_BY_NAME = {
+    "api": [
+        {
+            "id": 11,
+            "name": DIGEST_API_LATEST,
+            "url": "...",
+            "package_html_url": "...",
+            "created_at": "2025-04-01T10:00:00Z",
+            "updated_at": "2025-04-01T10:00:00Z",
+            "metadata": {
+                "package_type": "container",
+                "container": {"tags": ["latest", "v1.0.0"]},
+            },
+        },
+        {
+            "id": 12,
+            "name": DIGEST_API_INDEX,
+            "url": "...",
+            "created_at": "2025-04-10T10:00:00Z",
+            "updated_at": "2025-04-10T10:00:00Z",
+            "metadata": {
+                "package_type": "container",
+                "container": {"tags": ["v1.1.0"]},
+            },
+        },
+    ],
+    "worker": [
+        {
+            "id": 21,
+            "name": DIGEST_WORKER,
+            "url": "...",
+            "created_at": "2025-04-15T08:00:00Z",
+            "updated_at": "2025-04-15T08:00:00Z",
+            "metadata": {
+                "package_type": "container",
+                "container": {"tags": ["latest"]},
+            },
+        },
+    ],
+}
+
+
+def _config(layers, arch="amd64", os_name="linux", history=None):
+    return {
+        "architecture": arch,
+        "os": os_name,
+        "rootfs": {"type": "layers", "diff_ids": layers},
+        "history": history
+        or [{"created_by": f"COPY layer-{i}"} for i in range(len(layers))],
+    }
+
+
+def _manifest(layers, config_digest):
+    return {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": config_digest,
+            "size": 1234,
+        },
+        "layers": [
+            {
+                "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                "digest": f"sha256:layer-blob-{i}",
+                "size": 1024,
+            }
+            for i, _ in enumerate(layers)
+        ],
+    }
+
+
+CONFIG_BLOB_API_AMD64 = _config([LAYER_DIFF_A, LAYER_DIFF_B])
+CONFIG_BLOB_API_ARM64 = _config([LAYER_DIFF_A, LAYER_DIFF_C], arch="arm64")
+CONFIG_BLOB_WORKER = _config([LAYER_DIFF_C])
+
+MANIFEST_API_LATEST = _manifest([LAYER_DIFF_A, LAYER_DIFF_B], "sha256:cfg-api-amd64")
+MANIFEST_API_AMD64 = _manifest([LAYER_DIFF_A, LAYER_DIFF_B], "sha256:cfg-api-amd64")
+MANIFEST_API_ARM64 = _manifest([LAYER_DIFF_A, LAYER_DIFF_C], "sha256:cfg-api-arm64")
+MANIFEST_WORKER = _manifest([LAYER_DIFF_C], "sha256:cfg-worker")
+
+MANIFEST_API_INDEX = {
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.oci.image.index.v1+json",
+    "manifests": [
+        {
+            "digest": DIGEST_API_AMD64,
+            "platform": {"architecture": "amd64", "os": "linux"},
+        },
+        {
+            "digest": DIGEST_API_ARM64,
+            "platform": {"architecture": "arm64", "os": "linux"},
+        },
+    ],
+}
+
+
+MANIFESTS_BY_REFERENCE = {
+    ("simpsoncorp/api", DIGEST_API_LATEST): deepcopy(MANIFEST_API_LATEST),
+    ("simpsoncorp/api", DIGEST_API_INDEX): deepcopy(MANIFEST_API_INDEX),
+    ("simpsoncorp/api", DIGEST_API_AMD64): deepcopy(MANIFEST_API_AMD64),
+    ("simpsoncorp/api", DIGEST_API_ARM64): deepcopy(MANIFEST_API_ARM64),
+    ("simpsoncorp/worker", DIGEST_WORKER): deepcopy(MANIFEST_WORKER),
+}
+
+CONFIG_BLOBS_BY_DIGEST = {
+    "sha256:cfg-api-amd64": deepcopy(CONFIG_BLOB_API_AMD64),
+    "sha256:cfg-api-arm64": deepcopy(CONFIG_BLOB_API_ARM64),
+    "sha256:cfg-worker": deepcopy(CONFIG_BLOB_WORKER),
+}
+
+# A SLSA v1 in-toto statement for DIGEST_API_LATEST. The DSSE payload is
+# base64-encoded JSON; we keep it as a Python dict here and encode in tests.
+SLSA_STATEMENT_API_LATEST = {
+    "_type": "https://in-toto.io/Statement/v1",
+    "subject": [
+        {
+            "name": "ghcr.io/simpsoncorp/api",
+            "digest": {"sha256": DIGEST_API_LATEST.split(":")[1]},
+        }
+    ],
+    "predicateType": "https://slsa.dev/provenance/v1",
+    "predicate": {
+        "buildDefinition": {
+            "buildType": "https://actions.github.io/buildtypes/workflow/v1",
+            "externalParameters": {
+                "workflow": {
+                    "ref": "refs/heads/main",
+                    "repository": "https://github.com/simpsoncorp/sample_repo",
+                    "path": ".github/workflows/build.yml",
+                },
+            },
+            "resolvedDependencies": [
+                {
+                    "uri": "git+https://github.com/simpsoncorp/sample_repo@refs/heads/main",
+                    "digest": {"gitCommit": "abc123def456abc123def456abc123def4567890"},
+                },
+            ],
+        },
+        "runDetails": {"builder": {"id": "https://github.com/actions/runner/v2"}},
+    },
+}

--- a/tests/integration/cartography/intel/github/test_packages.py
+++ b/tests/integration/cartography/intel/github/test_packages.py
@@ -1,0 +1,277 @@
+"""Integration tests for the GHCR (packages + container registry) sync."""
+
+import base64
+import json
+from unittest.mock import patch
+
+import cartography.intel.github.container_image_attestations
+import cartography.intel.github.container_images
+import cartography.intel.github.packages
+from tests.data.github.packages import CONFIG_BLOBS_BY_DIGEST
+from tests.data.github.packages import DIGEST_API_AMD64
+from tests.data.github.packages import DIGEST_API_ARM64
+from tests.data.github.packages import DIGEST_API_INDEX
+from tests.data.github.packages import DIGEST_API_LATEST
+from tests.data.github.packages import DIGEST_WORKER
+from tests.data.github.packages import GET_CONTAINER_PACKAGES
+from tests.data.github.packages import LAYER_DIFF_A
+from tests.data.github.packages import LAYER_DIFF_B
+from tests.data.github.packages import LAYER_DIFF_C
+from tests.data.github.packages import MANIFESTS_BY_REFERENCE
+from tests.data.github.packages import PACKAGE_VERSIONS_BY_NAME
+from tests.data.github.packages import SLSA_STATEMENT_API_LATEST
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_JOB_PARAMS = {"UPDATE_TAG": TEST_UPDATE_TAG}
+TEST_GITHUB_URL = "https://api.github.com/graphql"
+TEST_ORG = "simpsoncorp"
+FAKE_TOKEN = "fake-pat"
+
+ORG_URL = f"https://github.com/{TEST_ORG}"
+REPO_URL = f"https://github.com/{TEST_ORG}/sample_repo"
+
+
+def _seed_org_and_repo(neo4j_session):
+    neo4j_session.run(
+        """
+        MERGE (org:GitHubOrganization {id: $org_url})
+        SET org.username = $org_login
+        MERGE (repo:GitHubRepository {id: $repo_url})
+        SET repo.name = 'sample_repo'
+        MERGE (repo)-[:OWNER]->(org)
+        """,
+        org_url=ORG_URL,
+        org_login=TEST_ORG,
+        repo_url=REPO_URL,
+    )
+
+
+def _packages_pagination_side_effect(token, base_url, endpoint, result_key):
+    if "/packages" in endpoint and "versions" not in endpoint:
+        return GET_CONTAINER_PACKAGES
+    if "/versions" in endpoint:
+        # endpoint shape: /orgs/{org}/packages/container/{name}/versions?...
+        # parse the package name out of the path.
+        path = endpoint.split("?")[0]
+        parts = path.split("/")
+        package_name = parts[parts.index("container") + 1]
+        return PACKAGE_VERSIONS_BY_NAME.get(package_name, [])
+    return []
+
+
+def _manifest_side_effect(token, repository_name, reference, **kwargs):
+    return MANIFESTS_BY_REFERENCE.get((repository_name, reference))
+
+
+def _blob_side_effect(token, repository_name, blob_digest, **kwargs):
+    return CONFIG_BLOBS_BY_DIGEST.get(blob_digest)
+
+
+def _attestation_response(digest):
+    if digest != DIGEST_API_LATEST:
+        return {"attestations": []}
+    payload = base64.b64encode(
+        json.dumps(SLSA_STATEMENT_API_LATEST).encode("utf-8"),
+    ).decode("ascii")
+    return {
+        "attestations": [
+            {
+                "id": 9001,
+                "predicate_type": SLSA_STATEMENT_API_LATEST["predicateType"],
+                "bundle": {"dsseEnvelope": {"payload": payload}},
+            },
+        ],
+    }
+
+
+def _attestation_side_effect(endpoint, token, base_url, params=None):
+    # endpoint: /orgs/{org}/attestations/{digest}?per_page=100. The digest is
+    # URL-encoded (`:` -> `%3A`) so we decode it before lookup.
+    from urllib.parse import unquote
+
+    digest = unquote(endpoint.split("/attestations/")[1].split("?")[0])
+    return _attestation_response(digest)
+
+
+@patch.object(
+    cartography.intel.github.container_image_attestations,
+    "call_github_rest_api",
+    side_effect=_attestation_side_effect,
+)
+@patch.object(
+    cartography.intel.github.container_images,
+    "fetch_ghcr_blob",
+    side_effect=_blob_side_effect,
+)
+@patch.object(
+    cartography.intel.github.container_images,
+    "fetch_ghcr_manifest",
+    side_effect=_manifest_side_effect,
+)
+@patch(
+    "cartography.intel.github.packages.fetch_all_rest_api_pages",
+    side_effect=_packages_pagination_side_effect,
+)
+def test_sync_ghcr_full_pipeline(
+    mock_pages,
+    mock_manifest,
+    mock_blob,
+    mock_attestations,
+    neo4j_session,
+):
+    _seed_org_and_repo(neo4j_session)
+
+    # Act
+    packages = cartography.intel.github.packages.sync_packages(
+        neo4j_session,
+        FAKE_TOKEN,
+        TEST_GITHUB_URL,
+        TEST_ORG,
+        TEST_UPDATE_TAG,
+        TEST_JOB_PARAMS,
+    )
+    raw_manifests, _, tag_rows = (
+        cartography.intel.github.container_images.sync_container_images(
+            neo4j_session,
+            FAKE_TOKEN,
+            TEST_GITHUB_URL,
+            TEST_ORG,
+            packages,
+            TEST_UPDATE_TAG,
+            TEST_JOB_PARAMS,
+        )
+    )
+    cartography.intel.github.container_image_tags.sync_container_image_tags(
+        neo4j_session,
+        TEST_ORG,
+        tag_rows,
+        TEST_UPDATE_TAG,
+        TEST_JOB_PARAMS,
+    )
+    cartography.intel.github.container_image_attestations.sync_container_image_attestations(
+        neo4j_session,
+        FAKE_TOKEN,
+        TEST_GITHUB_URL,
+        TEST_ORG,
+        raw_manifests,
+        TEST_UPDATE_TAG,
+        TEST_JOB_PARAMS,
+    )
+
+    # Packages
+    assert check_nodes(neo4j_session, "GitHubPackage", ["name", "uri"]) == {
+        ("api", "ghcr.io/simpsoncorp/api"),
+        ("worker", "ghcr.io/simpsoncorp/worker"),
+    }
+    # GitHubPackage gets the ContainerRegistry generic label
+    assert check_nodes(neo4j_session, "ContainerRegistry", ["name"]) >= {
+        ("api",),
+        ("worker",),
+    }
+
+    # HAS_PACKAGE only for the package that has a repository link
+    assert check_rels(
+        neo4j_session,
+        "GitHubRepository",
+        "id",
+        "GitHubPackage",
+        "name",
+        "HAS_PACKAGE",
+        rel_direction_right=True,
+    ) == {(REPO_URL, "api")}
+
+    # Container images: 4 manifests (latest single + index + 2 children) + worker
+    image_digests = check_nodes(neo4j_session, "GitHubContainerImage", ["digest"])
+    assert image_digests == {
+        (DIGEST_API_LATEST,),
+        (DIGEST_API_INDEX,),
+        (DIGEST_API_AMD64,),
+        (DIGEST_API_ARM64,),
+        (DIGEST_WORKER,),
+    }
+
+    # Generic ontology labels
+    assert check_nodes(neo4j_session, "Image", ["digest"]) >= {
+        (DIGEST_API_LATEST,),
+        (DIGEST_API_AMD64,),
+        (DIGEST_API_ARM64,),
+        (DIGEST_WORKER,),
+    }
+    assert (DIGEST_API_INDEX,) in check_nodes(
+        neo4j_session,
+        "ImageManifestList",
+        ["digest"],
+    )
+
+    # Layers: A, B, C de-duplicated across images
+    assert check_nodes(neo4j_session, "GitHubContainerImageLayer", ["diff_id"]) == {
+        (LAYER_DIFF_A,),
+        (LAYER_DIFF_B,),
+        (LAYER_DIFF_C,),
+    }
+    assert check_nodes(neo4j_session, "ImageLayer", ["diff_id"]) >= {
+        (LAYER_DIFF_A,),
+        (LAYER_DIFF_B,),
+        (LAYER_DIFF_C,),
+    }
+
+    # CONTAINS_IMAGE from the manifest list to the two children
+    assert check_rels(
+        neo4j_session,
+        "GitHubContainerImage",
+        "digest",
+        "GitHubContainerImage",
+        "digest",
+        "CONTAINS_IMAGE",
+        rel_direction_right=True,
+    ) == {
+        (DIGEST_API_INDEX, DIGEST_API_AMD64),
+        (DIGEST_API_INDEX, DIGEST_API_ARM64),
+    }
+
+    # Tag nodes (3 unique URIs)
+    assert check_nodes(neo4j_session, "GitHubContainerImageTag", ["uri"]) == {
+        ("ghcr.io/simpsoncorp/api:latest",),
+        ("ghcr.io/simpsoncorp/api:v1.0.0",),
+        ("ghcr.io/simpsoncorp/api:v1.1.0",),
+        ("ghcr.io/simpsoncorp/worker:latest",),
+    }
+
+    # Cross-registry edges expected by supply_chain.py:
+    # (:ContainerRegistry)-[:REPO_IMAGE]->(:ImageTag)-[:IMAGE]->(:Image)
+    assert check_rels(
+        neo4j_session,
+        "GitHubPackage",
+        "name",
+        "GitHubContainerImageTag",
+        "uri",
+        "REPO_IMAGE",
+        rel_direction_right=True,
+    ) >= {
+        ("api", "ghcr.io/simpsoncorp/api:latest"),
+        ("api", "ghcr.io/simpsoncorp/api:v1.0.0"),
+        ("api", "ghcr.io/simpsoncorp/api:v1.1.0"),
+        ("worker", "ghcr.io/simpsoncorp/worker:latest"),
+    }
+
+    # Attestation node + provenance enrichment on the image
+    assert check_nodes(
+        neo4j_session,
+        "GitHubContainerImageAttestation",
+        ["attests_digest"],
+    ) == {(DIGEST_API_LATEST,)}
+
+    enriched = neo4j_session.run(
+        """
+        MATCH (img:GitHubContainerImage {digest: $digest})
+        RETURN img.source_uri AS uri,
+               img.source_revision AS rev,
+               img.source_file AS file
+        """,
+        digest=DIGEST_API_LATEST,
+    ).single()
+    assert enriched["uri"] == "https://github.com/simpsoncorp/sample_repo"
+    assert enriched["rev"] == "abc123def456abc123def456abc123def4567890"
+    assert enriched["file"] == ".github/workflows/build.yml"

--- a/tests/integration/cartography/intel/github/test_packages.py
+++ b/tests/integration/cartography/intel/github/test_packages.py
@@ -124,7 +124,7 @@ def test_sync_ghcr_full_pipeline(
     _seed_org_and_repo(neo4j_session)
 
     # Act
-    packages = cartography.intel.github.packages.sync_packages(
+    fetch_result = cartography.intel.github.packages.sync_packages(
         neo4j_session,
         FAKE_TOKEN,
         TEST_GITHUB_URL,
@@ -132,13 +132,14 @@ def test_sync_ghcr_full_pipeline(
         TEST_UPDATE_TAG,
         TEST_JOB_PARAMS,
     )
+    assert fetch_result.cleanup_safe is True
     raw_manifests, _, tag_rows = (
         cartography.intel.github.container_images.sync_container_images(
             neo4j_session,
             FAKE_TOKEN,
             TEST_GITHUB_URL,
             TEST_ORG,
-            packages,
+            fetch_result.packages,
             TEST_UPDATE_TAG,
             TEST_JOB_PARAMS,
         )

--- a/tests/integration/cartography/intel/github/test_packages.py
+++ b/tests/integration/cartography/intel/github/test_packages.py
@@ -5,8 +5,10 @@ import json
 from unittest.mock import patch
 
 import cartography.intel.github.container_image_attestations
+import cartography.intel.github.container_image_tags
 import cartography.intel.github.container_images
 import cartography.intel.github.packages
+import cartography.intel.github.supply_chain
 from tests.data.github.packages import CONFIG_BLOBS_BY_DIGEST
 from tests.data.github.packages import DIGEST_API_AMD64
 from tests.data.github.packages import DIGEST_API_ARM64
@@ -276,3 +278,116 @@ def test_sync_ghcr_full_pipeline(
     assert enriched["uri"] == "https://github.com/simpsoncorp/sample_repo"
     assert enriched["rev"] == "abc123def456abc123def456abc123def4567890"
     assert enriched["file"] == ".github/workflows/build.yml"
+
+
+@patch.object(
+    cartography.intel.github.supply_chain,
+    "get_dockerfiles_for_repos",
+    return_value=[],
+)
+@patch.object(
+    cartography.intel.github.container_image_attestations,
+    "call_github_rest_api",
+    side_effect=_attestation_side_effect,
+)
+@patch.object(
+    cartography.intel.github.container_images,
+    "fetch_ghcr_blob",
+    side_effect=_blob_side_effect,
+)
+@patch.object(
+    cartography.intel.github.container_images,
+    "fetch_ghcr_manifest",
+    side_effect=_manifest_side_effect,
+)
+@patch(
+    "cartography.intel.github.packages.fetch_all_rest_api_pages",
+    side_effect=_packages_pagination_side_effect,
+)
+def test_supply_chain_package_owner_fallback(
+    mock_pages,
+    mock_manifest,
+    mock_blob,
+    mock_attestations,
+    mock_dockerfiles,
+    neo4j_session,
+):
+    """
+    The package-owner fallback links GHCR images that have no provenance match
+    (and no Dockerfile match) to the GitHubRepository carrying their package's
+    ``HAS_PACKAGE`` rel. ``DIGEST_API_INDEX`` and its child digests have no
+    SLSA attestation in the fixtures, but the ``api`` package is owned by
+    ``sample_repo`` so the fallback should kick in. ``DIGEST_WORKER`` lives in
+    a package without a repository link, so it should remain unmatched.
+    """
+    _seed_org_and_repo(neo4j_session)
+
+    fetch_result = cartography.intel.github.packages.sync_packages(
+        neo4j_session,
+        FAKE_TOKEN,
+        TEST_GITHUB_URL,
+        TEST_ORG,
+        TEST_UPDATE_TAG,
+        TEST_JOB_PARAMS,
+    )
+    raw_manifests, _, tag_rows = (
+        cartography.intel.github.container_images.sync_container_images(
+            neo4j_session,
+            FAKE_TOKEN,
+            TEST_GITHUB_URL,
+            TEST_ORG,
+            fetch_result.packages,
+            TEST_UPDATE_TAG,
+            TEST_JOB_PARAMS,
+        )
+    )
+    cartography.intel.github.container_image_tags.sync_container_image_tags(
+        neo4j_session,
+        TEST_ORG,
+        tag_rows,
+        TEST_UPDATE_TAG,
+        TEST_JOB_PARAMS,
+    )
+    cartography.intel.github.container_image_attestations.sync_container_image_attestations(
+        neo4j_session,
+        FAKE_TOKEN,
+        TEST_GITHUB_URL,
+        TEST_ORG,
+        raw_manifests,
+        TEST_UPDATE_TAG,
+        TEST_JOB_PARAMS,
+    )
+
+    # Run the supply-chain matcher with one repo (so SLSA provenance can match
+    # DIGEST_API_LATEST via its source_uri) and no dockerfiles.
+    cartography.intel.github.supply_chain.sync(
+        neo4j_session,
+        FAKE_TOKEN,
+        TEST_GITHUB_URL,
+        TEST_ORG,
+        TEST_UPDATE_TAG,
+        TEST_JOB_PARAMS,
+        [{"url": REPO_URL}],
+        workflows=None,
+    )
+
+    packaged_from = neo4j_session.run(
+        """
+        MATCH (img:GitHubContainerImage)-[r:PACKAGED_FROM]->(repo:GitHubRepository)
+        RETURN img.digest AS digest,
+               repo.id AS repo_url,
+               r.match_method AS method
+        """,
+    ).data()
+    rows = {(r["digest"], r["repo_url"], r["method"]) for r in packaged_from}
+
+    # Provenance match for the attested image
+    assert (DIGEST_API_LATEST, REPO_URL, "provenance") in rows
+    # Package-owner fallback for the un-attested platform images of the
+    # `api` package. The manifest-list digest itself is intentionally NOT
+    # linked — only its child images claim a build repo.
+    assert (DIGEST_API_AMD64, REPO_URL, "package_owner_repo") in rows
+    assert (DIGEST_API_ARM64, REPO_URL, "package_owner_repo") in rows
+    assert not any(digest == DIGEST_API_INDEX for digest, _, _ in rows)
+    # `worker` package has no repo link → its image stays unmatched
+    assert not any(digest == DIGEST_WORKER for digest, _, _ in rows)

--- a/tests/integration/cartography/intel/github/test_packages.py
+++ b/tests/integration/cartography/intel/github/test_packages.py
@@ -50,7 +50,7 @@ def _seed_org_and_repo(neo4j_session):
     )
 
 
-def _packages_pagination_side_effect(token, base_url, endpoint, result_key):
+def _packages_pagination_side_effect(token, base_url, endpoint, result_key, **_kw):
     if "/packages" in endpoint and "versions" not in endpoint:
         return GET_CONTAINER_PACKAGES
     if "/versions" in endpoint:
@@ -71,36 +71,34 @@ def _blob_side_effect(token, repository_name, blob_digest, **kwargs):
     return CONFIG_BLOBS_BY_DIGEST.get(blob_digest)
 
 
-def _attestation_response(digest):
+def _attestations_for_digest(digest):
     if digest != DIGEST_API_LATEST:
-        return {"attestations": []}
+        return []
     payload = base64.b64encode(
         json.dumps(SLSA_STATEMENT_API_LATEST).encode("utf-8"),
     ).decode("ascii")
-    return {
-        "attestations": [
-            {
-                "id": 9001,
-                "predicate_type": SLSA_STATEMENT_API_LATEST["predicateType"],
-                "bundle": {"dsseEnvelope": {"payload": payload}},
-            },
-        ],
-    }
+    return [
+        {
+            "id": 9001,
+            "predicate_type": SLSA_STATEMENT_API_LATEST["predicateType"],
+            "bundle": {"dsseEnvelope": {"payload": payload}},
+        },
+    ]
 
 
-def _attestation_side_effect(endpoint, token, base_url, params=None):
-    # endpoint: /orgs/{org}/attestations/{digest}?per_page=100. The digest is
-    # URL-encoded (`:` -> `%3A`) so we decode it before lookup.
+def _attestations_paginated_side_effect(token, base_url, endpoint, result_key):
+    # endpoint: /orgs/{org}/attestations/{digest}?per_page=100 — digest is
+    # URL-encoded (`:` -> `%3A`) so unquote before lookup.
     from urllib.parse import unquote
 
     digest = unquote(endpoint.split("/attestations/")[1].split("?")[0])
-    return _attestation_response(digest)
+    return _attestations_for_digest(digest)
 
 
 @patch.object(
     cartography.intel.github.container_image_attestations,
-    "call_github_rest_api",
-    side_effect=_attestation_side_effect,
+    "fetch_all_rest_api_pages",
+    side_effect=_attestations_paginated_side_effect,
 )
 @patch.object(
     cartography.intel.github.container_images,
@@ -135,7 +133,7 @@ def test_sync_ghcr_full_pipeline(
         TEST_JOB_PARAMS,
     )
     assert fetch_result.cleanup_safe is True
-    raw_manifests, _, tag_rows = (
+    raw_manifests, _, tag_rows, observed_skipped = (
         cartography.intel.github.container_images.sync_container_images(
             neo4j_session,
             FAKE_TOKEN,
@@ -161,6 +159,7 @@ def test_sync_ghcr_full_pipeline(
         raw_manifests,
         TEST_UPDATE_TAG,
         TEST_JOB_PARAMS,
+        additional_observed_digests=observed_skipped,
     )
 
     # Packages
@@ -287,8 +286,8 @@ def test_sync_ghcr_full_pipeline(
 )
 @patch.object(
     cartography.intel.github.container_image_attestations,
-    "call_github_rest_api",
-    side_effect=_attestation_side_effect,
+    "fetch_all_rest_api_pages",
+    side_effect=_attestations_paginated_side_effect,
 )
 @patch.object(
     cartography.intel.github.container_images,
@@ -330,7 +329,7 @@ def test_supply_chain_package_owner_fallback(
         TEST_UPDATE_TAG,
         TEST_JOB_PARAMS,
     )
-    raw_manifests, _, tag_rows = (
+    raw_manifests, _, tag_rows, observed_skipped = (
         cartography.intel.github.container_images.sync_container_images(
             neo4j_session,
             FAKE_TOKEN,
@@ -356,6 +355,7 @@ def test_supply_chain_package_owner_fallback(
         raw_manifests,
         TEST_UPDATE_TAG,
         TEST_JOB_PARAMS,
+        additional_observed_digests=observed_skipped,
     )
 
     # Run the supply-chain matcher with one repo (so SLSA provenance can match
@@ -391,3 +391,120 @@ def test_supply_chain_package_owner_fallback(
     assert not any(digest == DIGEST_API_INDEX for digest, _, _ in rows)
     # `worker` package has no repo link → its image stays unmatched
     assert not any(digest == DIGEST_WORKER for digest, _, _ in rows)
+
+
+@patch.object(
+    cartography.intel.github.container_image_attestations,
+    "fetch_all_rest_api_pages",
+    side_effect=_attestations_paginated_side_effect,
+)
+@patch.object(
+    cartography.intel.github.container_images,
+    "fetch_ghcr_blob",
+    side_effect=_blob_side_effect,
+)
+@patch.object(
+    cartography.intel.github.container_images,
+    "fetch_ghcr_manifest",
+    side_effect=_manifest_side_effect,
+)
+@patch(
+    "cartography.intel.github.packages.fetch_all_rest_api_pages",
+    side_effect=_packages_pagination_side_effect,
+)
+def test_sync_ghcr_idempotent_across_runs(
+    mock_pages,
+    mock_manifest,
+    mock_blob,
+    mock_attestations,
+    neo4j_session,
+):
+    """
+    Running the GHCR sync twice must not delete live images: the second run
+    should re-tag every image, layer, and attestation with the new
+    update_tag even when manifest fetches are short-circuited by the
+    cross-run dedup. Regression test for the data-loss bug Kunaal flagged
+    on the original PR (skipped digests vs. cleanup_lastupdated).
+    """
+    _seed_org_and_repo(neo4j_session)
+    second_update_tag = TEST_UPDATE_TAG + 1
+
+    def run_full_sync(update_tag):
+        params = {"UPDATE_TAG": update_tag}
+        fetch_result = cartography.intel.github.packages.sync_packages(
+            neo4j_session,
+            FAKE_TOKEN,
+            TEST_GITHUB_URL,
+            TEST_ORG,
+            update_tag,
+            params,
+        )
+        raw_manifests, _, tag_rows, observed_skipped = (
+            cartography.intel.github.container_images.sync_container_images(
+                neo4j_session,
+                FAKE_TOKEN,
+                TEST_GITHUB_URL,
+                TEST_ORG,
+                fetch_result.packages,
+                update_tag,
+                params,
+            )
+        )
+        cartography.intel.github.container_image_tags.sync_container_image_tags(
+            neo4j_session,
+            TEST_ORG,
+            tag_rows,
+            update_tag,
+            params,
+        )
+        cartography.intel.github.container_image_attestations.sync_container_image_attestations(
+            neo4j_session,
+            FAKE_TOKEN,
+            TEST_GITHUB_URL,
+            TEST_ORG,
+            raw_manifests,
+            update_tag,
+            params,
+            additional_observed_digests=observed_skipped,
+        )
+
+    run_full_sync(TEST_UPDATE_TAG)
+    expected_image_digests = {
+        (DIGEST_API_LATEST,),
+        (DIGEST_API_INDEX,),
+        (DIGEST_API_AMD64,),
+        (DIGEST_API_ARM64,),
+        (DIGEST_WORKER,),
+    }
+    assert (
+        check_nodes(neo4j_session, "GitHubContainerImage", ["digest"])
+        == expected_image_digests
+    )
+
+    run_full_sync(second_update_tag)
+
+    # Every image must still be present after the second run.
+    assert (
+        check_nodes(neo4j_session, "GitHubContainerImage", ["digest"])
+        == expected_image_digests
+    )
+    # Layers must survive too.
+    assert check_nodes(neo4j_session, "GitHubContainerImageLayer", ["diff_id"]) == {
+        (LAYER_DIFF_A,),
+        (LAYER_DIFF_B,),
+        (LAYER_DIFF_C,),
+    }
+    # And the attestation node carrying provenance for DIGEST_API_LATEST.
+    assert check_nodes(
+        neo4j_session,
+        "GitHubContainerImageAttestation",
+        ["attests_digest"],
+    ) == {(DIGEST_API_LATEST,)}
+
+    # Every surviving image's lastupdated must reflect the second run, not
+    # the first — that is the bump the cross-run dedup must perform.
+    rows = neo4j_session.run(
+        "MATCH (img:GitHubContainerImage) RETURN img.digest AS d, img.lastupdated AS u",
+    ).data()
+    stale = [r for r in rows if r["u"] != second_update_tag]
+    assert not stale, f"stale lastupdated on: {stale}"

--- a/tests/integration/cartography/intel/github/test_packages.py
+++ b/tests/integration/cartography/intel/github/test_packages.py
@@ -508,3 +508,15 @@ def test_sync_ghcr_idempotent_across_runs(
     ).data()
     stale = [r for r in rows if r["u"] != second_update_tag]
     assert not stale, f"stale lastupdated on: {stale}"
+
+    # NEXT rels (layer linked-list ordering) must also be refreshed,
+    # otherwise cleanup deletes them and the chain is broken.
+    next_rows = neo4j_session.run(
+        """
+        MATCH (:GitHubContainerImageLayer)-[r:NEXT]->(:GitHubContainerImageLayer)
+        RETURN r.lastupdated AS u
+        """,
+    ).data()
+    assert next_rows, "expected at least one NEXT rel between layers"
+    stale_next = [r for r in next_rows if r["u"] != second_update_tag]
+    assert not stale_next, f"stale lastupdated on NEXT rels: {stale_next}"

--- a/tests/unit/cartography/intel/github/test_github.py
+++ b/tests/unit/cartography/intel/github/test_github.py
@@ -13,6 +13,7 @@ from requests import Response
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import HTTPError
 
+import cartography.intel.github.packages
 from cartography.intel.github.util import _GRAPHQL_RATE_LIMIT_REMAINING_THRESHOLD
 from cartography.intel.github.util import fetch_all
 from cartography.intel.github.util import fetch_all_rest_api_pages
@@ -24,6 +25,13 @@ from tests.data.github.rate_limit import RATE_LIMIT_RESPONSE_JSON
 @patch("cartography.intel.github.repos.cleanup_global_resources")
 @patch("cartography.intel.github.users.cleanup")
 @patch("cartography.intel.github.supply_chain.sync")
+@patch(
+    "cartography.intel.github.packages.sync_packages",
+    return_value=cartography.intel.github.packages.ContainerPackagesFetchResult(
+        packages=[],
+        cleanup_safe=True,
+    ),
+)
 @patch("cartography.intel.github.repos.get", return_value=[])
 @patch("cartography.intel.github.commits.sync_github_commits")
 @patch("cartography.intel.github._get_repos_from_graph", return_value=[])
@@ -41,6 +49,7 @@ def test_start_github_ingestion_defers_global_cleanup_until_after_all_orgs(
     mock_get_repos_from_graph: Mock,
     mock_sync_github_commits: Mock,
     mock_get_repos: Mock,
+    mock_packages_sync: Mock,
     mock_supply_chain_sync: Mock,
     mock_users_cleanup: Mock,
     mock_cleanup_global_resources: Mock,

--- a/tests/unit/cartography/intel/github/test_github.py
+++ b/tests/unit/cartography/intel/github/test_github.py
@@ -26,6 +26,14 @@ from tests.data.github.rate_limit import RATE_LIMIT_RESPONSE_JSON
 @patch("cartography.intel.github.users.cleanup")
 @patch("cartography.intel.github.supply_chain.sync")
 @patch(
+    "cartography.intel.github.container_image_attestations.sync_container_image_attestations"
+)
+@patch("cartography.intel.github.container_image_tags.sync_container_image_tags")
+@patch(
+    "cartography.intel.github.container_images.sync_container_images",
+    return_value=([], [], [], set()),
+)
+@patch(
     "cartography.intel.github.packages.sync_packages",
     return_value=cartography.intel.github.packages.ContainerPackagesFetchResult(
         packages=[],
@@ -50,6 +58,9 @@ def test_start_github_ingestion_defers_global_cleanup_until_after_all_orgs(
     mock_sync_github_commits: Mock,
     mock_get_repos: Mock,
     mock_packages_sync: Mock,
+    mock_container_images_sync: Mock,
+    mock_container_tags_sync: Mock,
+    mock_attestations_sync: Mock,
     mock_supply_chain_sync: Mock,
     mock_users_cleanup: Mock,
     mock_cleanup_global_resources: Mock,


### PR DESCRIPTION
### Type of change

- [x] New feature (non-breaking change that adds functionality)


### Summary

Sync container packages hosted on GitHub Container Registry (`ghcr.io`) for each configured GitHub organization. Cartography already covers ECR, GCP Artifact Registry, and GitLab container registries; GHCR was the missing piece, and without it images pushed to GHCR could not be tied to their `GitHubRepository` source or to deployed assets.

The new pipeline mirrors the existing GitLab container-registry split inside `cartography/intel/github/`:

1. **Packages** → `GitHubPackage` (one per `/orgs/{org}/packages?package_type=container`). Carries the `ContainerRegistry` extra label and is linked to its `GitHubRepository` via `HAS_PACKAGE` when the package payload includes a repo.
2. **Versions → Container images** → `GitHubContainerImage` with conditional `Image` / `ImageManifestList` labels. Manifests come from `ghcr.io/v2/{org}/{name}/manifests/{digest}`; image config blobs supply `layer_diff_ids`, `architecture`, `os`.
3. **Layers** → `GitHubContainerImageLayer` with `HAS_LAYER` / `HEAD` / `TAIL` / `NEXT` rels (linked-list ordering matching the ECR/GitLab pattern).
4. **Tags** → `GitHubContainerImageTag` with `(:ContainerRegistry)-[:REPO_IMAGE]->(:ImageTag)-[:IMAGE]->(:Image)` so the existing supply-chain matcher picks GHCR images up without changes.
5. **Attestations** (SLSA via `/orgs/{org}/attestations/{digest}`) enrich images with `source_uri` / `source_revision` / `source_file` through a provenance-only schema (same trick as `GCPArtifactRegistryContainerImageProvenanceSchema` to avoid nulling out enrichment fields on re-load).

API call shape is bounded — there is no bulk endpoint, so the sync de-duplicates per-run by digest and config-digest, and skips manifest/config/attestation fetches for digests already enriched in a prior run, dropping steady-state cost from `O(versions)` to `O(new versions)`.

The configured GitHub token is reused for GHCR; the OCI Distribution endpoints accept the same Bearer credential, just base64-encoded. The token must have the `read:packages` scope. No CLI surface change.


### Related issues or links

- Closes https://github.com/cartography-cncf/cartography/issues/2315


### How was this tested?

- `uv run --frozen pytest -vvv tests/integration/cartography/intel/github/test_packages.py` — new end-to-end test exercising packages + manifests + layers + tags + attestations through the full pipeline (mocked REST and registry calls).
- `uv run --frozen pytest -vvv tests/integration/cartography/intel/github/` — full GitHub integration suite (29 tests, no regressions).
- `make test_lint` — pre-commit/black/isort/mypy clean on changed files.


### Notes for reviewers

- The supply-chain Cypher in `cartography/intel/github/supply_chain.py:60-67` matches on the generic `Image` / `ImageTag` / `ContainerRegistry` labels; once GHCR nodes carry those labels, no Cypher changes are needed for cross-registry digest matching.
- `fetch_ghcr_manifest` / `fetch_ghcr_blob` were added next to `call_github_rest_api` in `cartography/intel/github/util.py` and reuse `_resolve_token` so AppCredential refresh continues to work.
- `repos_json` and the workflow list are passed in from `repos.sync` / `actions.sync`; no extra REST calls beyond the GHCR-specific endpoints.

### Test plan

- [ ] Run `make test_lint` and `uv run --frozen pytest -vvv tests/integration/cartography/intel/github/`.
- [ ] Run cartography against a real org with GHCR images using a token that has `read:packages`. Verify in the Neo4j browser:
  - `MATCH (p:GitHubPackage) RETURN count(p)` is non-zero.
  - `MATCH (i:GitHubContainerImage)-[:HAS_LAYER]->(l) RETURN count(*)` is non-zero for multi-layer images.
  - `MATCH (img:GitHubContainerImage)-[:PACKAGED_FROM]->(repo:GitHubRepository) RETURN repo.url, count(img)` confirms cross-registry supply-chain matching picks up GHCR images.
- [ ] Re-run the sync twice and confirm cleanup deletes stale tags/versions (delete a tag in GHCR between runs to verify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)