### PR TITLE
fix(crowdstrike): stop leaking CVE nodes when Spotlight vulns close

### DIFF
--- a/cartography/data/jobs/cleanup/crowdstrike_import_cleanup.json
+++ b/cartography/data/jobs/cleanup/crowdstrike_import_cleanup.json
@@ -6,18 +6,6 @@
       "iterationsize": 100
     },
     {
-      "query": "MATCH (:CrowdstrikeFinding)<-[hc:HAS_CVE]-(:SpotlightVulnerability) WHERE hc.lastupdated <> $UPDATE_TAG WITH hc LIMIT $LIMIT_SIZE DELETE (hc)",
-      "iterative": true,
-      "iterationsize": 100,
-      "__comment__": "If a CrowdstrikeFinding exists, but the vulnerability is gone, delete the relationship"
-    },
-    {
-      "query": "MATCH (c:CrowdstrikeFinding) WHERE c.lastupdated <> $UPDATE_TAG WITH c LIMIT $LIMIT_SIZE REMOVE c:CrowdstrikeFinding",
-      "iterative": true,
-      "iterationsize": 100,
-      "__comment__": "If the CrowdstrikeFinding no longer exists, remove the label from the CVE node."
-    },
-    {
       "query": "MATCH (:SpotlightVulnerability)<-[hv:HAS_VULNERABILITY]-(:CrowdstrikeHost) WHERE hv.lastupdated <> $UPDATE_TAG WITH hv LIMIT $LIMIT_SIZE DELETE (hv)",
       "iterative": true,
       "iterationsize": 100,

--- a/cartography/intel/crowdstrike/__init__.py
+++ b/cartography/intel/crowdstrike/__init__.py
@@ -9,6 +9,7 @@ from cartography.intel.crowdstrike.endpoints import sync_hosts
 from cartography.intel.crowdstrike.spotlight import sync_vulnerabilities
 from cartography.intel.crowdstrike.util import get_authorization
 from cartography.models.crowdstrike.hosts import CrowdstrikeHostSchema
+from cartography.models.crowdstrike.spotlight import CrowdstrikeCVESchema
 from cartography.stats import get_stats_client
 from cartography.util import merge_module_sync_metadata
 from cartography.util import run_cleanup_job
@@ -72,6 +73,9 @@ def cleanup(
 ) -> None:
     logger.info("Running Crowdstrike cleanup")
     GraphJob.from_node_schema(CrowdstrikeHostSchema(), common_job_parameters).run(
+        neo4j_session
+    )
+    GraphJob.from_node_schema(CrowdstrikeCVESchema(), common_job_parameters).run(
         neo4j_session
     )
 

--- a/cartography/models/crowdstrike/spotlight.py
+++ b/cartography/models/crowdstrike/spotlight.py
@@ -97,8 +97,9 @@ class CrowdstrikeCVEToSpotlightVulnerabilityRel(CartographyRelSchema):
 
 @dataclass(frozen=True)
 class CrowdstrikeCVESchema(CartographyNodeSchema):
-    label: str = "CVE"
-    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["CrowdstrikeFinding"])
+    label: str = "CrowdstrikeFinding"
+    scoped_cleanup: bool = False
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["CVE"])
     properties: CrowdstrikeCVENodeProperties = CrowdstrikeCVENodeProperties()
     other_relationships: OtherRelationships = OtherRelationships(
         [

--- a/docs/root/modules/crowdstrike/schema.md
+++ b/docs/root/modules/crowdstrike/schema.md
@@ -83,7 +83,7 @@ Representation of a Crowdstrike Vulnerability
     (SpotlightVulnerability)-[HAS_CVE]->(CVE)
     ```
 
-### CVE::CrowdstrikeFinding
+### CrowdstrikeFinding::CVE
 
 Representation of a CVE
 

--- a/tests/integration/cartography/intel/crowdstrike/test_spotlight.py
+++ b/tests/integration/cartography/intel/crowdstrike/test_spotlight.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import cartography.intel.crowdstrike
 import cartography.intel.crowdstrike.endpoints
 import cartography.intel.crowdstrike.spotlight
 from tests.data.crowdstrike.endpoints import GET_HOSTS
@@ -109,3 +110,70 @@ def test_sync_spotlight_vulnerabilities(
             "CVE-2019-5094",
         ),
     }
+
+    # Verify the CVE node also carries the :CrowdstrikeFinding label
+    assert check_nodes(neo4j_session, "CrowdstrikeFinding", ["id"]) == {
+        ("CVE-2019-5094",),
+    }
+
+
+@patch.object(cartography.intel.crowdstrike.spotlight, "Spotlight_Vulnerabilities")
+@patch.object(
+    cartography.intel.crowdstrike.spotlight,
+    "get_spotlight_vulnerabilities",
+)
+@patch.object(
+    cartography.intel.crowdstrike.spotlight,
+    "get_spotlight_vulnerability_ids",
+    return_value=[["dummy-id"]],
+)
+@patch.object(cartography.intel.crowdstrike.endpoints, "Hosts")
+@patch.object(
+    cartography.intel.crowdstrike.endpoints, "get_hosts", return_value=GET_HOSTS
+)
+@patch.object(
+    cartography.intel.crowdstrike.endpoints, "get_host_ids", return_value=[["dummy-id"]]
+)
+def test_cleanup_drops_orphan_crowdstrike_cves(
+    mock_host_ids,
+    mock_hosts,
+    mock_hosts_cls,
+    mock_vuln_ids,
+    mock_vulns,
+    mock_spotlight_cls,
+    neo4j_session,
+):
+    """
+    When a Spotlight vulnerability disappears from the API (e.g. status=closed
+    is filtered out on subsequent runs), the corresponding CVE node owned by
+    CrowdStrike must be cleaned up rather than leaking as an orphan.
+    """
+    authorization = MagicMock()
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG}
+
+    # First run: spotlight returns the vulnerability
+    mock_vulns.return_value = GET_SPOTLIGHT_VULNERABILITIES
+    cartography.intel.crowdstrike.endpoints.sync_hosts(
+        neo4j_session, TEST_UPDATE_TAG, authorization
+    )
+    cartography.intel.crowdstrike.spotlight.sync_vulnerabilities(
+        neo4j_session, TEST_UPDATE_TAG, authorization
+    )
+    cartography.intel.crowdstrike.cleanup(neo4j_session, common_job_parameters)
+
+    assert check_nodes(neo4j_session, "CVE", ["id"]) == {("CVE-2019-5094",)}
+
+    # Second run: vulnerability is closed -> not returned, update_tag advances
+    next_tag = TEST_UPDATE_TAG + 1
+    next_params = {"UPDATE_TAG": next_tag}
+    mock_vulns.return_value = []
+    cartography.intel.crowdstrike.endpoints.sync_hosts(
+        neo4j_session, next_tag, authorization
+    )
+    cartography.intel.crowdstrike.spotlight.sync_vulnerabilities(
+        neo4j_session, next_tag, authorization
+    )
+    cartography.intel.crowdstrike.cleanup(neo4j_session, next_params)
+
+    assert check_nodes(neo4j_session, "CrowdstrikeFinding", ["id"]) == set()
+    assert check_nodes(neo4j_session, "SpotlightVulnerability", ["id"]) == set()

--- a/tests/integration/cartography/intel/crowdstrike/test_spotlight.py
+++ b/tests/integration/cartography/intel/crowdstrike/test_spotlight.py
@@ -176,4 +176,5 @@ def test_cleanup_drops_orphan_crowdstrike_cves(
     cartography.intel.crowdstrike.cleanup(neo4j_session, next_params)
 
     assert check_nodes(neo4j_session, "CrowdstrikeFinding", ["id"]) == set()
+    assert check_nodes(neo4j_session, "CVE", ["id"]) == set()
     assert check_nodes(neo4j_session, "SpotlightVulnerability", ["id"]) == set()


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

The CrowdStrike Spotlight loader queries the API with `status:!"closed"`, so once a detection is closed it silently disappears from subsequent syncs. The current cleanup job ([`crowdstrike_import_cleanup.json`](cartography/data/jobs/cleanup/crowdstrike_import_cleanup.json)) only deletes the stale `:SpotlightVulnerability`, the `HAS_CVE` relationship and *strips* the `:CrowdstrikeFinding` label — but leaves the underlying `:CVE` node behind. Over time the graph accumulates orphan `:CVE` nodes (no relationships, no module owning them) that grow monotonically.

**Why it was modeled this way originally**

CrowdStrike's `CrowdstrikeCVESchema` uses `:CVE` as the **primary** label with `:CrowdstrikeFinding` as the extra label. Because cartography's `MERGE` is keyed on the primary label + id, this used to dedupe with the NIST `cve` module which also creates `(:CVE {id})`. Auto-generated cleanup via `GraphJob.from_node_schema` was unsafe because a `MATCH (n:CVE) DETACH DELETE` would also reap CVE nodes owned by other producers — hence the JSON workaround that only removed the label.

**Why we can change this now**

The `cve` module is **deprecated** and scheduled for removal in 1.0.0 (see [`cartography/intel/cve/__init__.py:119-123`](cartography/intel/cve/__init__.py#L119-L123)). Its replacement, `cve_metadata`, only *enriches* `:CVE` nodes via `(:CVEMetadata)-[:ENRICHES]->(:CVE)`; it does not create them. Other producers of `:CVE` (Trivy, Ubuntu) already use `:CVE` as an **extra** label with their own primary label (`TrivyImageFinding`, `UbuntuCVE`), and rely on `scoped_cleanup=False` to drive auto-cleanup. CrowdStrike was the outlier.

**The fix**

Align CrowdStrike with the Trivy/Ubuntu pattern:

- Primary label: `:CrowdstrikeFinding`
- Extra label: `:CVE`
- `scoped_cleanup=False`

This lets `GraphJob.from_node_schema(CrowdstrikeCVESchema())` generate a safe `MATCH (n:CrowdstrikeFinding) WHERE n.lastupdated <> $UPDATE_TAG DETACH DELETE n`, which never touches CVE nodes owned by other modules. The two now-redundant statements (delete `HAS_CVE` rel + remove `:CrowdstrikeFinding` label) are dropped from the JSON cleanup job.

Side effect on the graph shape: a `CVE-X` produced by the deprecated NIST `cve` feed and one produced by CrowdStrike are now distinct `:CVE` nodes (same as the existing Trivy/Ubuntu situation). Downstream relationships matching `target_node_label="CVE"` continue to work transparently. Once `cve` is removed in 1.0.0, only one `:CVE` node per id will exist again.


### Related issues or links

- Fixes #


### Breaking changes

None for consumers querying `:CVE` (the label is still present as an extra label). Code or queries that explicitly relied on `:CrowdstrikeFinding` being an *extra* label rather than the primary will see no behavioral difference at query time — both labels remain on the node.


### How was this tested?

- New regression test [`test_cleanup_drops_orphan_crowdstrike_cves`](tests/integration/cartography/intel/crowdstrike/test_spotlight.py): performs a sync, then a second sync with the vulnerability removed (simulating it being closed) and verifies that both `:SpotlightVulnerability` and `:CrowdstrikeFinding` (and therefore the `:CVE` node) are deleted.
- Existing `test_sync_spotlight_vulnerabilities` updated to additionally assert the `:CrowdstrikeFinding` label is present alongside `:CVE`.
- `make lint` (pre-commit) clean on changed files.
- `pytest tests/integration/cartography/intel/crowdstrike/` — 2/2 pass.
- `pytest tests/unit/ -k "crowdstrike or spotlight or cleanup"` — 57/57 pass.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](docs/root/modules/crowdstrike/schema.md) — heading renamed from `CVE::CrowdstrikeFinding` to `CrowdstrikeFinding::CVE` to reflect the swapped primary/extra labels.


### Notes for reviewers

The change makes CrowdStrike consistent with the existing `Trivy`/`Ubuntu` schemas (primary = module-specific label, extra = `:CVE`). Worth reviewing:

- [`cartography/models/crowdstrike/spotlight.py`](cartography/models/crowdstrike/spotlight.py) — the label swap and `scoped_cleanup=False`.
- [`cartography/intel/crowdstrike/__init__.py`](cartography/intel/crowdstrike/__init__.py) — addition of `GraphJob.from_node_schema(CrowdstrikeCVESchema())` in the cleanup function.
- The post-1.0.0 reasoning above (deprecation of the `cve` module) is the key justification for why this was *not* the right design before but *is* now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)