### PR TITLE
perf(cve_metadata): reduce NVD feed memory usage

### DIFF
--- a/cartography/intel/cve_metadata/nvd.py
+++ b/cartography/intel/cve_metadata/nvd.py
@@ -1,11 +1,10 @@
 import json
 import logging
+import os
 import tempfile
 import time
 import zipfile
 from datetime import datetime
-from functools import reduce
-from io import BytesIO
 from typing import Any
 
 from requests import Session
@@ -17,6 +16,7 @@ logger = logging.getLogger(__name__)
 NVD_API_BASE_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
 NVD_FEED_BASE_URL = "https://nvd.nist.gov/feeds/json/cve/2.0"
 CONNECT_AND_READ_TIMEOUT = (30, 120)
+DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 # NVD API rate limits: 50 req/30s with key. 0.6s/req would hit the limit exactly;
 # keep a margin at 1s.
 API_SLEEP_TIME = 1.0
@@ -54,19 +54,94 @@ def _fetch_cve_from_api(
 
 @timeit
 def _download_nvd_feed(http_session: Session, year: str) -> dict[Any, Any]:
-    """Download and extract a yearly NVD JSON feed zip into a temp directory."""
+    """Download and parse a yearly NVD JSON feed zip."""
     url = f"{NVD_FEED_BASE_URL}/nvdcve-2.0-{year}.json.zip"
     logger.debug("Downloading NVD feed for year %s from %s", year, url)
 
-    response = http_session.get(url, timeout=CONNECT_AND_READ_TIMEOUT)
-    response.raise_for_status()
+    with http_session.get(
+        url,
+        stream=True,
+        timeout=CONNECT_AND_READ_TIMEOUT,
+    ) as response:
+        response.raise_for_status()
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        with zipfile.ZipFile(BytesIO(response.content)) as zf:
-            zf.extractall(tmp_dir)
-            json_filename = zf.namelist()[0]
-            with open(f"{tmp_dir}/{json_filename}") as f:
-                return json.load(f)
+        zip_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as zip_file:
+                zip_path = zip_file.name
+                for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+                    if chunk:
+                        zip_file.write(chunk)
+
+            with zipfile.ZipFile(zip_path) as zf:
+                json_filename = zf.namelist()[0]
+                with zf.open(json_filename) as f:
+                    return json.load(f)
+        finally:
+            if zip_path:
+                os.unlink(zip_path)
+
+
+def _get_english_descriptions(cve: dict[str, Any]) -> str | None:
+    en_descriptions = [
+        desc["value"] for desc in cve.get("descriptions", []) if desc["lang"] == "en"
+    ]
+    return "\n".join(en_descriptions) if en_descriptions else None
+
+
+def _get_english_weaknesses(cve: dict[str, Any]) -> list[str]:
+    return [
+        description["value"]
+        for weakness in cve.get("weaknesses", [])
+        for description in weakness.get("description", [])
+        if description["lang"] == "en"
+    ]
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value)
+
+
+def _transform_cve(cve: dict[str, Any]) -> dict[str, Any]:
+    transformed = {
+        "id": cve["id"],
+        "description_en": _get_english_descriptions(cve),
+        "references_urls": [ref["url"] for ref in cve.get("references", [])],
+        "weaknesses": _get_english_weaknesses(cve),
+        "published": _parse_datetime(cve.get("published")),
+        "lastModified": _parse_datetime(cve.get("lastModified")),
+        "vulnStatus": cve.get("vulnStatus"),
+        "is_kev": cve.get("cisaExploitAdd") is not None,
+        "cisaExploitAdd": cve.get("cisaExploitAdd"),
+        "cisaActionDue": cve.get("cisaActionDue"),
+        "cisaRequiredAction": cve.get("cisaRequiredAction"),
+        "cisaVulnerabilityName": cve.get("cisaVulnerabilityName"),
+    }
+
+    cvss_metric, cvss_version = _get_best_cvss(cve.get("metrics", {}))
+    if cvss_metric:
+        cvss_data = cvss_metric.get("cvssData", {})
+        transformed.update(
+            {
+                "cvss_version": cvss_version,
+                "vectorString": cvss_data.get("vectorString"),
+                "attackVector": cvss_data.get("attackVector"),
+                "attackComplexity": cvss_data.get("attackComplexity"),
+                "privilegesRequired": cvss_data.get("privilegesRequired"),
+                "userInteraction": cvss_data.get("userInteraction"),
+                "scope": cvss_data.get("scope"),
+                "confidentialityImpact": cvss_data.get("confidentialityImpact"),
+                "integrityImpact": cvss_data.get("integrityImpact"),
+                "availabilityImpact": cvss_data.get("availabilityImpact"),
+                "baseScore": cvss_data.get("baseScore"),
+                "baseSeverity": cvss_data.get("baseSeverity"),
+                "exploitabilityScore": cvss_metric.get("exploitabilityScore"),
+                "impactScore": cvss_metric.get("impactScore"),
+            },
+        )
+    return transformed
 
 
 def _get_primary_metric(metrics: list[dict[str, Any]] | None) -> dict[str, Any] | None:
@@ -112,63 +187,10 @@ def transform_cves(
             cve = data["cve"]
             if cve["id"] not in cve_ids_in_graph:
                 continue
-
-            # English description (join multiple entries into one string)
-            en_descriptions = [
-                desc["value"]
-                for desc in cve.get("descriptions", [])
-                if desc["lang"] == "en"
-            ]
-            cve["description_en"] = (
-                "\n".join(en_descriptions) if en_descriptions else None
-            )
-
-            # Reference URLs
-            cve["references_urls"] = [ref["url"] for ref in cve.get("references", [])]
-
-            # Weaknesses / CWEs
-            if cve.get("weaknesses"):
-                weakness_descriptions: list[dict[str, str]] = reduce(
-                    lambda x, y: x + y,
-                    [w["description"] for w in cve["weaknesses"]],
-                    [],
-                )
-                cve["weaknesses"] = [
-                    d["value"] for d in weakness_descriptions if d["lang"] == "en"
-                ]
-
-            # CVSS metrics — prefer v4.0, fallback v3.1, v3.0, v2.0
-            metrics = cve.get("metrics", {})
-            cvss_metric, cvss_version = _get_best_cvss(metrics)
-            if cvss_metric:
-                cvss_data = cvss_metric.get("cvssData", {})
-                cve["cvss_version"] = cvss_version
-                cve["vectorString"] = cvss_data.get("vectorString")
-                cve["attackVector"] = cvss_data.get("attackVector")
-                cve["attackComplexity"] = cvss_data.get("attackComplexity")
-                cve["privilegesRequired"] = cvss_data.get("privilegesRequired")
-                cve["userInteraction"] = cvss_data.get("userInteraction")
-                cve["scope"] = cvss_data.get("scope")
-                cve["confidentialityImpact"] = cvss_data.get("confidentialityImpact")
-                cve["integrityImpact"] = cvss_data.get("integrityImpact")
-                cve["availabilityImpact"] = cvss_data.get("availabilityImpact")
-                cve["baseScore"] = cvss_data.get("baseScore")
-                cve["baseSeverity"] = cvss_data.get("baseSeverity")
-                cve["exploitabilityScore"] = cvss_metric.get("exploitabilityScore")
-                cve["impactScore"] = cvss_metric.get("impactScore")
-
-            # Parse date strings to datetime objects
-            for date_field in ("published", "lastModified"):
-                if cve.get(date_field):
-                    cve[date_field] = datetime.fromisoformat(cve[date_field])
-
-            # CISA KEV fields are already top-level in cve dict if present
-            cve["is_kev"] = cve.get("cisaExploitAdd") is not None
-
+            cves[cve["id"]] = _transform_cve(cve)
         except Exception:
             logger.error("Failed to transform CVE data: %s", data)
             raise
-        cves[cve["id"]] = cve
     return cves
 
 

--- a/tests/unit/cartography/intel/cve_metadata/test_nvd.py
+++ b/tests/unit/cartography/intel/cve_metadata/test_nvd.py
@@ -85,6 +85,22 @@ def test_transform_cves_extracts_references():
     ]
 
 
+def test_transform_cves_drops_raw_nvd_fields():
+    data = _fresh_data()
+    raw_cve = data["vulnerabilities"][0]["cve"]
+    raw_cve["configurations"] = [{"nodes": [{"cpeMatch": ["unused"]}]}]
+
+    result = transform_cves(data, {"CVE-2023-41782"})
+    cve = result["CVE-2023-41782"]
+
+    assert cve is not raw_cve
+    assert "configurations" not in cve
+    assert "metrics" not in cve
+    assert "descriptions" not in cve
+    assert "references" not in cve
+    assert "sourceIdentifier" not in cve
+
+
 def test_transform_cves_empty_graph():
     """When no CVE IDs are in the graph, result should be empty."""
     result = transform_cves(_fresh_data(), set())


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Other (please describe): Performance improvement


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

Reduce peak memory usage while enriching CVE metadata from NVD yearly feeds.

This changes the NVD feed path to stream the downloaded zip into a temporary file instead of wrapping `response.content` in `BytesIO`, then transforms matching CVEs into a schema-shaped metadata dict instead of retaining the raw NVD CVE object. Existing enrichment behavior is preserved for descriptions, references, weaknesses, CVSS selection, published and modified dates, vulnerability status, and CISA KEV fields.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- N/A


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

None.


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- Updated test

Local validation:
- Seeded a disposable local Neo4j database with 10,317 `:CVE` nodes across 21 CVE years.
- Ran only the `cve_metadata` stage with `cve_metadata_src=['nvd']` against a deterministic local NVD-shaped feed mirror.
- Sampled Cartography process RSS with `ps`; peak sampled RSS was `725.0 MiB`.
- Verified graph output after the run:
  - cve_count=10317
  - metadata_count=10317
  - feed_count=1
  - resource_rels=10317
  - enriches_rels=10317
  - scored_metadata=10317

Raw Cartography output from the large local validation:

```text
INFO:cartography.sync:Starting sync with update tag '1777445001'
INFO:cartography.sync:Starting sync stage 'cve_metadata'
INFO:cartography.intel.cve_metadata:Found 10317 CVE nodes in graph to enrich.
INFO:cartography.intel.cve_metadata.nvd:Downloading NVD feeds for years ['2004', '2005', '2007', '2008', '2010', '2011', '2012', '2013', '2014', '2015', '2016', '2017', '2018', '2019', '2020', '2021', '2022', '2023', '2024', '2025', '2026'] to enrich 10317 CVEs
INFO:cartography.intel.cve_metadata:NVD enriched 10317 CVEs.
INFO:cartography.client.core.tx:Loaded 1 CVEMetadataFeed nodes
INFO:cartography.intel.cve_metadata:Loading 10317 CVEMetadata nodes into the graph.
INFO:neo4j.notifications:Received notification from DBMS server: <GqlStatusObject gql_status='00NA0', status_description="note: successful completion - index or constraint already exists. The command 'CREATE RANGE INDEX IF NOT EXISTS FOR (e:CVEMetadataFeed) ON (e.id)' has no effect. The index or constraint specified by 'RANGE INDEX index_ab0bceb7 FOR (e:CVEMetadataFeed) ON (e.id)' already exists.", position=None, raw_classification='SCHEMA', classification=<NotificationClassification.SCHEMA: 'SCHEMA'>, raw_severity='INFORMATION', severity=<NotificationSeverity.INFORMATION: 'INFORMATION'>, diagnostic_record={'_classification': 'SCHEMA', '_severity': 'INFORMATION', 'OPERATION': '', 'OPERATION_CODE': '0', 'CURRENT_SCHEMA': '/'}> for query: 'CREATE INDEX IF NOT EXISTS FOR (n:CVEMetadataFeed) ON (n.id);'
INFO:neo4j.notifications:Received notification from DBMS server: <GqlStatusObject gql_status='00NA0', status_description="note: successful completion - index or constraint already exists. The command 'CREATE RANGE INDEX IF NOT EXISTS FOR (e:CVE) ON (e.cve_id)' has no effect. The index or constraint specified by 'RANGE INDEX cve_cve_id FOR (e:CVE) ON (e.cve_id)' already exists.", position=None, raw_classification='SCHEMA', classification=<NotificationClassification.SCHEMA: 'SCHEMA'>, raw_severity='INFORMATION', severity=<NotificationSeverity.INFORMATION: 'INFORMATION'>, diagnostic_record={'_classification': 'SCHEMA', '_severity': 'INFORMATION', 'OPERATION': '', 'OPERATION_CODE': '0', 'CURRENT_SCHEMA': '/'}> for query: 'CREATE INDEX IF NOT EXISTS FOR (n:CVE) ON (n.cve_id);'
INFO:cartography.client.core.tx:Loaded 10317 CVEMetadata nodes
INFO:cartography.graph.statement:Completed CVEMetadata statement #1
INFO:cartography.graph.statement:Completed CVEMetadata statement #2
INFO:cartography.graph.statement:Completed CVEMetadata statement #3
INFO:cartography.sync:Finishing sync stage 'cve_metadata'
INFO:cartography.sync:Finishing sync with update tag '1777445001'
CARTOGRAPHY_EXIT_CODE 0
```


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

No schema or relationship shape changes are intended. The new unit test verifies raw NVD-only fields are not retained in transformed CVE metadata.