### PR TITLE
fix(syft): skip malformed JSON files instead of aborting sync

### DIFF
--- a/cartography/intel/syft/__init__.py
+++ b/cartography/intel/syft/__init__.py
@@ -128,8 +128,12 @@ def sync_syft_from_dir(
     logger.info("Processing %d local Syft result files", len(json_files))
 
     for file_path in json_files:
-        with open(file_path, encoding="utf-8") as f:
-            syft_data = json.load(f)
+        try:
+            with open(file_path, encoding="utf-8") as f:
+                syft_data = json.load(f)
+        except json.JSONDecodeError as e:
+            logger.error("Failed to read Syft data from %s: %s", file_path, e)
+            continue
         sync_single_syft(
             neo4j_session,
             syft_data,


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

A single corrupt or empty JSON file in the Syft results directory currently raises `JSONDecodeError` out of `sync_syft_from_dir`, aborting ingestion of every remaining file in the batch.

This change mirrors the behavior already implemented for Trivy in [`cartography/intel/trivy/__init__.py`](https://github.com/cartography-cncf/cartography/blob/master/cartography/intel/trivy/__init__.py): catch `JSONDecodeError` per file, log it at error level, and continue with the next file so that one bad input does not poison the whole sync.


### Related issues or links

- Fixes #


### How was this tested?

- `make test_lint` passes locally.
- Manually verified the symmetry against the existing Trivy `try/except json.JSONDecodeError` block — same control flow, same log level, same `continue` on failure. Logging follows the `%`-style formatting already used by the surrounding Syft logger calls.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.


### Notes for reviewers

No new test added: the fix is a defensive `try/except` symmetric to the one already shipped for Trivy, which itself has no dedicated test for the `JSONDecodeError` path. Happy to add one if maintainers prefer — let me know.