### PR TITLE
feat(gitlab): ingest CI/CD runners, variables, environments, and pipelines config

### DIFF
--- a/cartography/intel/gitlab/__init__.py
+++ b/cartography/intel/gitlab/__init__.py
@@ -213,8 +213,10 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     )
 
     # Sync CI/CD runners at instance, group, and project scopes.
-    # Tolerates 403s on individual scopes (e.g. missing admin scope for /runners/all).
-    cartography.intel.gitlab.runners.sync_gitlab_runners(
+    # Each scope returns a "skipped" set when a 403 was encountered — those
+    # scopes must be excluded from the cleanup phase to avoid deleting
+    # previously-ingested runners that we simply could not list this time.
+    runners_skipped = cartography.intel.gitlab.runners.sync_gitlab_runners(
         neo4j_session,
         gitlab_url,
         token,
@@ -225,8 +227,9 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     )
 
     # Sync CI/CD variables at group and project scopes.
-    # Returns a {project_id: [variables]} map for downstream modules.
-    variables_by_project = (
+    # Returns a {project_id: [variables]} map and a per-scope "skipped" set
+    # (same data-loss-prevention rationale as runners above).
+    variables_by_project, variables_skipped = (
         cartography.intel.gitlab.ci_variables.sync_gitlab_ci_variables(
             neo4j_session,
             gitlab_url,
@@ -239,15 +242,18 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     )
 
     # Sync environments and link them to CI/CD variables that apply to them
-    # (exact match on environment_scope or wildcard "*").
-    cartography.intel.gitlab.environments.sync_gitlab_environments(
-        neo4j_session,
-        gitlab_url,
-        token,
-        config.update_tag,
-        common_job_parameters,
-        all_projects,
-        variables_by_project,
+    # (exact match on environment_scope or wildcard "*"). Returns the set of
+    # projects skipped due to 403 — those must be excluded from cleanup.
+    environments_skipped = (
+        cartography.intel.gitlab.environments.sync_gitlab_environments(
+            neo4j_session,
+            gitlab_url,
+            token,
+            config.update_tag,
+            common_job_parameters,
+            all_projects,
+            variables_by_project,
+        )
     )
 
     # Sync .gitlab-ci.yml configs (parsed pipeline summary + includes) and link
@@ -286,10 +292,12 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
             neo4j_session, common_job_parameters, project_id, gitlab_url
         )
 
-        # Cleanup project-level runners
-        cartography.intel.gitlab.runners.cleanup_project_runners(
-            neo4j_session, common_job_parameters, project_id, gitlab_url
-        )
+        # Cleanup project-level runners — skip if the scope returned 403,
+        # otherwise we'd delete every previously-ingested runner.
+        if project_id not in runners_skipped["projects"]:
+            cartography.intel.gitlab.runners.cleanup_project_runners(
+                neo4j_session, common_job_parameters, project_id, gitlab_url
+            )
 
         # Cleanup CI includes first, then the parent CIConfig.
         cartography.intel.gitlab.ci_config.cleanup_ci_includes(
@@ -299,30 +307,37 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
             neo4j_session, common_job_parameters, project_id, gitlab_url
         )
 
-        # Cleanup environments (must run before project-level variables since
-        # the env -> variable matchlink references both).
-        cartography.intel.gitlab.environments.cleanup_environments(
-            neo4j_session, common_job_parameters, project_id, gitlab_url
-        )
+        # Cleanup environments — skip if the scope returned 403.
+        if project_id not in environments_skipped:
+            cartography.intel.gitlab.environments.cleanup_environments(
+                neo4j_session, common_job_parameters, project_id, gitlab_url
+            )
 
-        # Cleanup project-level CI/CD variables
-        cartography.intel.gitlab.ci_variables.cleanup_project_variables(
-            neo4j_session, common_job_parameters, project_id, gitlab_url
-        )
+        # Cleanup project-level CI/CD variables — skip if the scope returned 403.
+        if project_id not in variables_skipped["projects"]:
+            cartography.intel.gitlab.ci_variables.cleanup_project_variables(
+                neo4j_session, common_job_parameters, project_id, gitlab_url
+            )
 
-    # Cleanup group-level runners and CI/CD variables (one cleanup per group)
+    # Cleanup group-level runners and CI/CD variables (one cleanup per group),
+    # skipping any scope that returned 403 during the sync.
     for group in all_groups:
-        cartography.intel.gitlab.runners.cleanup_group_runners(
-            neo4j_session, common_job_parameters, group["id"], gitlab_url
-        )
-        cartography.intel.gitlab.ci_variables.cleanup_group_variables(
-            neo4j_session, common_job_parameters, group["id"], gitlab_url
-        )
+        group_id_int = group["id"]
+        if group_id_int not in runners_skipped["groups"]:
+            cartography.intel.gitlab.runners.cleanup_group_runners(
+                neo4j_session, common_job_parameters, group_id_int, gitlab_url
+            )
+        if group_id_int not in variables_skipped["groups"]:
+            cartography.intel.gitlab.ci_variables.cleanup_group_variables(
+                neo4j_session, common_job_parameters, group_id_int, gitlab_url
+            )
 
-    # Cleanup instance-level runners (scoped to the organization)
-    cartography.intel.gitlab.runners.cleanup_instance_runners(
-        neo4j_session, common_job_parameters, organization_id, gitlab_url
-    )
+    # Cleanup instance-level runners (scoped to the organization).
+    # Skip if the /runners/all endpoint returned 403 (admin scope missing).
+    if not runners_skipped["instance"]:
+        cartography.intel.gitlab.runners.cleanup_instance_runners(
+            neo4j_session, common_job_parameters, organization_id, gitlab_url
+        )
 
     # Cleanup projects with cascade delete
     cartography.intel.gitlab.projects.cleanup_projects(

--- a/cartography/intel/gitlab/__init__.py
+++ b/cartography/intel/gitlab/__init__.py
@@ -12,6 +12,7 @@ import cartography.intel.gitlab.container_repositories
 import cartography.intel.gitlab.container_repository_tags
 import cartography.intel.gitlab.dependencies
 import cartography.intel.gitlab.dependency_files
+import cartography.intel.gitlab.environments
 import cartography.intel.gitlab.groups
 import cartography.intel.gitlab.organizations
 import cartography.intel.gitlab.projects
@@ -224,14 +225,28 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
 
     # Sync CI/CD variables at group and project scopes.
     # Returns a {project_id: [variables]} map for downstream modules.
-    cartography.intel.gitlab.ci_variables.sync_gitlab_ci_variables(
+    variables_by_project = (
+        cartography.intel.gitlab.ci_variables.sync_gitlab_ci_variables(
+            neo4j_session,
+            gitlab_url,
+            token,
+            config.update_tag,
+            common_job_parameters,
+            all_groups,
+            all_projects,
+        )
+    )
+
+    # Sync environments and link them to CI/CD variables that apply to them
+    # (exact match on environment_scope or wildcard "*").
+    cartography.intel.gitlab.environments.sync_gitlab_environments(
         neo4j_session,
         gitlab_url,
         token,
         config.update_tag,
         common_job_parameters,
-        all_groups,
         all_projects,
+        variables_by_project,
     )
 
     # ========================================
@@ -260,6 +275,12 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
 
         # Cleanup project-level runners
         cartography.intel.gitlab.runners.cleanup_project_runners(
+            neo4j_session, common_job_parameters, project_id, gitlab_url
+        )
+
+        # Cleanup environments (must run before project-level variables since
+        # the env -> variable matchlink references both).
+        cartography.intel.gitlab.environments.cleanup_environments(
             neo4j_session, common_job_parameters, project_id, gitlab_url
         )
 

--- a/cartography/intel/gitlab/__init__.py
+++ b/cartography/intel/gitlab/__init__.py
@@ -5,6 +5,7 @@ import neo4j
 import requests
 
 import cartography.intel.gitlab.branches
+import cartography.intel.gitlab.ci_config
 import cartography.intel.gitlab.ci_variables
 import cartography.intel.gitlab.container_image_attestations
 import cartography.intel.gitlab.container_images
@@ -249,6 +250,18 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         variables_by_project,
     )
 
+    # Sync .gitlab-ci.yml configs (parsed pipeline summary + includes) and link
+    # to project-level variables they reference.
+    cartography.intel.gitlab.ci_config.sync_gitlab_ci_config(
+        neo4j_session,
+        gitlab_url,
+        token,
+        config.update_tag,
+        common_job_parameters,
+        all_projects,
+        variables_by_project,
+    )
+
     # ========================================
     # Cleanup Phase - Run in reverse order (leaf to root)
     # ========================================
@@ -275,6 +288,14 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
 
         # Cleanup project-level runners
         cartography.intel.gitlab.runners.cleanup_project_runners(
+            neo4j_session, common_job_parameters, project_id, gitlab_url
+        )
+
+        # Cleanup CI includes first, then the parent CIConfig.
+        cartography.intel.gitlab.ci_config.cleanup_ci_includes(
+            neo4j_session, common_job_parameters, project_id, gitlab_url
+        )
+        cartography.intel.gitlab.ci_config.cleanup_ci_configs(
             neo4j_session, common_job_parameters, project_id, gitlab_url
         )
 

--- a/cartography/intel/gitlab/__init__.py
+++ b/cartography/intel/gitlab/__init__.py
@@ -14,6 +14,7 @@ import cartography.intel.gitlab.dependency_files
 import cartography.intel.gitlab.groups
 import cartography.intel.gitlab.organizations
 import cartography.intel.gitlab.projects
+import cartography.intel.gitlab.runners
 import cartography.intel.gitlab.supply_chain
 import cartography.intel.gitlab.users
 from cartography.config import Config
@@ -208,12 +209,24 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         dependency_files_by_project,
     )
 
+    # Sync CI/CD runners at instance, group, and project scopes.
+    # Tolerates 403s on individual scopes (e.g. missing admin scope for /runners/all).
+    cartography.intel.gitlab.runners.sync_gitlab_runners(
+        neo4j_session,
+        gitlab_url,
+        token,
+        config.update_tag,
+        common_job_parameters,
+        all_groups,
+        all_projects,
+    )
+
     # ========================================
     # Cleanup Phase - Run in reverse order (leaf to root)
     # ========================================
     logger.info("Starting GitLab cleanup phase")
 
-    # Cleanup leaf nodes (dependencies, dependency_files, branches) for each project
+    # Cleanup leaf nodes (dependencies, dependency_files, branches, project runners) for each project
     for project in all_projects:
         project_id: int = project["id"]
 
@@ -231,6 +244,22 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         cartography.intel.gitlab.branches.cleanup_branches(
             neo4j_session, common_job_parameters, project_id, gitlab_url
         )
+
+        # Cleanup project-level runners
+        cartography.intel.gitlab.runners.cleanup_project_runners(
+            neo4j_session, common_job_parameters, project_id, gitlab_url
+        )
+
+    # Cleanup group-level runners (one cleanup per group)
+    for group in all_groups:
+        cartography.intel.gitlab.runners.cleanup_group_runners(
+            neo4j_session, common_job_parameters, group["id"], gitlab_url
+        )
+
+    # Cleanup instance-level runners (scoped to the organization)
+    cartography.intel.gitlab.runners.cleanup_instance_runners(
+        neo4j_session, common_job_parameters, organization_id, gitlab_url
+    )
 
     # Cleanup projects with cascade delete
     cartography.intel.gitlab.projects.cleanup_projects(

--- a/cartography/intel/gitlab/__init__.py
+++ b/cartography/intel/gitlab/__init__.py
@@ -117,6 +117,75 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         config.gitlab_commits_since_days,
     )
 
+    # ========================================
+    # CI/CD Phase
+    # Runs before the container/dependency phase: CI/CD only depends on
+    # `all_groups` and `all_projects`, so doing it early means the static
+    # security signals (unpinned includes, unprotected runners, ...) land
+    # in the graph even if the (slower / heavier) container scan fails.
+    # ========================================
+
+    # Sync CI/CD runners at instance, group, and project scopes.
+    # Each scope returns a "skipped" set when a 403 was encountered — those
+    # scopes must be excluded from the cleanup phase to avoid deleting
+    # previously-ingested runners that we simply could not list this time.
+    runners_skipped = cartography.intel.gitlab.runners.sync_gitlab_runners(
+        neo4j_session,
+        gitlab_url,
+        token,
+        config.update_tag,
+        common_job_parameters,
+        all_groups,
+        all_projects,
+    )
+
+    # Sync CI/CD variables at group and project scopes.
+    # Returns a {project_id: [variables]} map and a per-scope "skipped" set
+    # (same data-loss-prevention rationale as runners above).
+    variables_by_project, variables_skipped = (
+        cartography.intel.gitlab.ci_variables.sync_gitlab_ci_variables(
+            neo4j_session,
+            gitlab_url,
+            token,
+            config.update_tag,
+            common_job_parameters,
+            all_groups,
+            all_projects,
+        )
+    )
+
+    # Sync environments and link them to CI/CD variables that apply to them
+    # (exact match on environment_scope or wildcard "*"). Returns the set of
+    # projects skipped due to 403 — those must be excluded from cleanup.
+    environments_skipped = (
+        cartography.intel.gitlab.environments.sync_gitlab_environments(
+            neo4j_session,
+            gitlab_url,
+            token,
+            config.update_tag,
+            common_job_parameters,
+            all_projects,
+            variables_by_project,
+        )
+    )
+
+    # Sync .gitlab-ci.yml configs (parsed pipeline summary + includes) and link
+    # to project-level variables they reference. Returns the set of projects
+    # whose config was permission-denied so cleanup can skip them.
+    ci_config_skipped = cartography.intel.gitlab.ci_config.sync_gitlab_ci_config(
+        neo4j_session,
+        gitlab_url,
+        token,
+        config.update_tag,
+        common_job_parameters,
+        all_projects,
+        variables_by_project,
+    )
+
+    # ========================================
+    # Container Registry + Dependencies Phase
+    # ========================================
+
     # Sync container repositories (includes cleanup since it's org-scoped)
     all_container_repositories = (
         cartography.intel.gitlab.container_repositories.sync_container_repositories(
@@ -210,63 +279,6 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         common_job_parameters,
         all_projects,
         dependency_files_by_project,
-    )
-
-    # Sync CI/CD runners at instance, group, and project scopes.
-    # Each scope returns a "skipped" set when a 403 was encountered — those
-    # scopes must be excluded from the cleanup phase to avoid deleting
-    # previously-ingested runners that we simply could not list this time.
-    runners_skipped = cartography.intel.gitlab.runners.sync_gitlab_runners(
-        neo4j_session,
-        gitlab_url,
-        token,
-        config.update_tag,
-        common_job_parameters,
-        all_groups,
-        all_projects,
-    )
-
-    # Sync CI/CD variables at group and project scopes.
-    # Returns a {project_id: [variables]} map and a per-scope "skipped" set
-    # (same data-loss-prevention rationale as runners above).
-    variables_by_project, variables_skipped = (
-        cartography.intel.gitlab.ci_variables.sync_gitlab_ci_variables(
-            neo4j_session,
-            gitlab_url,
-            token,
-            config.update_tag,
-            common_job_parameters,
-            all_groups,
-            all_projects,
-        )
-    )
-
-    # Sync environments and link them to CI/CD variables that apply to them
-    # (exact match on environment_scope or wildcard "*"). Returns the set of
-    # projects skipped due to 403 — those must be excluded from cleanup.
-    environments_skipped = (
-        cartography.intel.gitlab.environments.sync_gitlab_environments(
-            neo4j_session,
-            gitlab_url,
-            token,
-            config.update_tag,
-            common_job_parameters,
-            all_projects,
-            variables_by_project,
-        )
-    )
-
-    # Sync .gitlab-ci.yml configs (parsed pipeline summary + includes) and link
-    # to project-level variables they reference. Returns the set of projects
-    # whose config was permission-denied so cleanup can skip them.
-    ci_config_skipped = cartography.intel.gitlab.ci_config.sync_gitlab_ci_config(
-        neo4j_session,
-        gitlab_url,
-        token,
-        config.update_tag,
-        common_job_parameters,
-        all_projects,
-        variables_by_project,
     )
 
     # ========================================

--- a/cartography/intel/gitlab/__init__.py
+++ b/cartography/intel/gitlab/__init__.py
@@ -257,8 +257,9 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     )
 
     # Sync .gitlab-ci.yml configs (parsed pipeline summary + includes) and link
-    # to project-level variables they reference.
-    cartography.intel.gitlab.ci_config.sync_gitlab_ci_config(
+    # to project-level variables they reference. Returns the set of projects
+    # whose config was permission-denied so cleanup can skip them.
+    ci_config_skipped = cartography.intel.gitlab.ci_config.sync_gitlab_ci_config(
         neo4j_session,
         gitlab_url,
         token,
@@ -299,13 +300,16 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
                 neo4j_session, common_job_parameters, project_id, gitlab_url
             )
 
-        # Cleanup CI includes first, then the parent CIConfig.
-        cartography.intel.gitlab.ci_config.cleanup_ci_includes(
-            neo4j_session, common_job_parameters, project_id, gitlab_url
-        )
-        cartography.intel.gitlab.ci_config.cleanup_ci_configs(
-            neo4j_session, common_job_parameters, project_id, gitlab_url
-        )
+        # Cleanup CI includes first, then the parent CIConfig — but skip if
+        # the project's config was permission-denied this sync, otherwise
+        # we'd delete a previously-ingested config on transient auth fail.
+        if project_id not in ci_config_skipped:
+            cartography.intel.gitlab.ci_config.cleanup_ci_includes(
+                neo4j_session, common_job_parameters, project_id, gitlab_url
+            )
+            cartography.intel.gitlab.ci_config.cleanup_ci_configs(
+                neo4j_session, common_job_parameters, project_id, gitlab_url
+            )
 
         # Cleanup environments — skip if the scope returned 403.
         if project_id not in environments_skipped:

--- a/cartography/intel/gitlab/__init__.py
+++ b/cartography/intel/gitlab/__init__.py
@@ -5,6 +5,7 @@ import neo4j
 import requests
 
 import cartography.intel.gitlab.branches
+import cartography.intel.gitlab.ci_variables
 import cartography.intel.gitlab.container_image_attestations
 import cartography.intel.gitlab.container_images
 import cartography.intel.gitlab.container_repositories
@@ -221,6 +222,18 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         all_projects,
     )
 
+    # Sync CI/CD variables at group and project scopes.
+    # Returns a {project_id: [variables]} map for downstream modules.
+    cartography.intel.gitlab.ci_variables.sync_gitlab_ci_variables(
+        neo4j_session,
+        gitlab_url,
+        token,
+        config.update_tag,
+        common_job_parameters,
+        all_groups,
+        all_projects,
+    )
+
     # ========================================
     # Cleanup Phase - Run in reverse order (leaf to root)
     # ========================================
@@ -250,9 +263,17 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
             neo4j_session, common_job_parameters, project_id, gitlab_url
         )
 
-    # Cleanup group-level runners (one cleanup per group)
+        # Cleanup project-level CI/CD variables
+        cartography.intel.gitlab.ci_variables.cleanup_project_variables(
+            neo4j_session, common_job_parameters, project_id, gitlab_url
+        )
+
+    # Cleanup group-level runners and CI/CD variables (one cleanup per group)
     for group in all_groups:
         cartography.intel.gitlab.runners.cleanup_group_runners(
+            neo4j_session, common_job_parameters, group["id"], gitlab_url
+        )
+        cartography.intel.gitlab.ci_variables.cleanup_group_variables(
             neo4j_session, common_job_parameters, group["id"], gitlab_url
         )
 

--- a/cartography/intel/gitlab/__init__.py
+++ b/cartography/intel/gitlab/__init__.py
@@ -155,8 +155,10 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     )
 
     # Sync environments and link them to CI/CD variables that apply to them
-    # (exact match on environment_scope or wildcard "*"). Returns the set of
-    # projects skipped due to 403 — those must be excluded from cleanup.
+    # (exact match on environment_scope or wildcard "*"). Projects whose
+    # variables could not be loaded this run are forwarded as `skip_projects`
+    # so we don't refresh env nodes with empty `linked_variable_ids` and let
+    # cleanup wipe HAS_CI_VARIABLE edges that should still be there.
     environments_skipped = (
         cartography.intel.gitlab.environments.sync_gitlab_environments(
             neo4j_session,
@@ -166,12 +168,13 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
             common_job_parameters,
             all_projects,
             variables_by_project,
+            skip_projects=variables_skipped["projects"],
         )
     )
 
     # Sync .gitlab-ci.yml configs (parsed pipeline summary + includes) and link
-    # to project-level variables they reference. Returns the set of projects
-    # whose config was permission-denied so cleanup can skip them.
+    # to project-level variables they reference. Same `skip_projects`
+    # forwarding rationale as environments.
     ci_config_skipped = cartography.intel.gitlab.ci_config.sync_gitlab_ci_config(
         neo4j_session,
         gitlab_url,
@@ -180,6 +183,7 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         common_job_parameters,
         all_projects,
         variables_by_project,
+        skip_projects=variables_skipped["projects"],
     )
 
     # ========================================

--- a/cartography/intel/gitlab/ci_config.py
+++ b/cartography/intel/gitlab/ci_config.py
@@ -95,12 +95,15 @@ def _try_raw_ci_yaml(
     project_id: int,
     ref: str | None,
     file_path: str = DEFAULT_FILE_PATH,
-) -> str | None:
+) -> tuple[str | None, bool]:
     """
     Fetch the raw `.gitlab-ci.yml` from the repository as a fallback when
-    /ci/lint is unavailable. Returns None on 403 / 404 (the file is absent
-    or the token can't read repository files for this project — both
-    non-fatal for the sync).
+    /ci/lint is unavailable. Returns ``(text, denied)``:
+
+    - ``(text, False)`` on success
+    - ``(None, False)`` on 404 — the file does not exist, authoritative
+    - ``(None, True)`` on 403 — the token cannot read repository files
+    Other errors propagate.
     """
     encoded = quote(file_path, safe="")
     endpoint = f"/api/v4/projects/{project_id}/repository/files/{encoded}/raw"
@@ -117,15 +120,20 @@ def _try_raw_ci_yaml(
         )
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
-        if e.response is not None and e.response.status_code in (403, 404):
+        if e.response is not None and e.response.status_code == 403:
             logger.warning(
-                "Raw .gitlab-ci.yml not available for project %s (status %s).",
+                "Raw .gitlab-ci.yml denied for project %s.",
                 project_id,
-                e.response.status_code,
             )
-            return None
+            return None, True
+        if e.response is not None and e.response.status_code == 404:
+            logger.warning(
+                "Raw .gitlab-ci.yml not found for project %s.",
+                project_id,
+            )
+            return None, False
         raise
-    return response.text
+    return response.text, False
 
 
 @timeit
@@ -160,17 +168,17 @@ def fetch_ci_config_yaml(
 
     # Both 404 and 403 from /ci/lint fall back to the raw file. The raw
     # endpoint uses `read_repository`, broader than the Maintainer scope
-    # /ci/lint needs — but if the token also lacks `read_repository` for
-    # this project, _try_raw_ci_yaml returns None on 403 too.
-    raw = _try_raw_ci_yaml(gitlab_url, token, project_id, ref)
+    # /ci/lint needs.
+    raw, raw_denied = _try_raw_ci_yaml(gitlab_url, token, project_id, ref)
     if raw is not None:
         return raw, None, False, False
 
-    # Both paths failed. If lint specifically reported 403 we treat the
-    # whole project as denied (skip cleanup). If lint was 404 (no pipeline)
-    # and raw was also missing, the project legitimately has no config and
-    # cleanup may proceed.
-    return None, None, False, lint_denied
+    # Both paths failed. We only flag the project as ``denied`` if neither
+    # path could authoritatively confirm the absence of a config — i.e.
+    # both returned 403. A 404 from either endpoint (especially raw 404)
+    # is authoritative absence and cleanup may run normally.
+    denied = lint_denied and raw_denied
+    return None, None, False, denied
 
 
 def transform_ci_config(

--- a/cartography/intel/gitlab/ci_config.py
+++ b/cartography/intel/gitlab/ci_config.py
@@ -25,6 +25,7 @@ import requests
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.gitlab.ci_config_parser import parse_ci_config
+from cartography.intel.gitlab.ci_config_parser import parse_lint_includes
 from cartography.intel.gitlab.ci_config_parser import ParsedCIConfig
 from cartography.intel.gitlab.util import make_request_with_retry
 from cartography.models.gitlab.ci_config import GitLabCIConfigSchema
@@ -41,16 +42,22 @@ def _try_lint_merged_yaml(
     token: str,
     project_id: int,
     ref: str | None,
-) -> tuple[str | None, bool | None, bool]:
+) -> tuple[str | None, bool | None, bool, list[dict[str, Any]] | None]:
     """
     Call /ci/lint with dry_run=true to obtain the merged YAML. Returns
-    ``(merged_yaml, is_valid, denied)``:
+    ``(merged_yaml, is_valid, denied, lint_includes)``:
 
-    - ``(yaml, True/False, False)`` on a successful response
-    - ``(None, None, False)`` on 404 (project has no pipeline) — non-fatal
-    - ``(None, None, True)`` on 403 (token can't lint) — caller should fall
-      back to the raw file rather than treat the project as missing
+    - ``(yaml, True/False, False, includes)`` on a successful response
+    - ``(None, None, False, None)`` on 404 (project has no pipeline)
+    - ``(None, None, True, None)`` on 403 (token can't lint) — caller
+      should fall back to the raw file
     Other errors propagate.
+
+    The ``lint_includes`` field is GitLab's structured representation of
+    the include directives that were resolved when building merged_yaml.
+    The merged_yaml itself does NOT contain the original ``include:``
+    block (the included content is inlined as jobs), so we read this
+    field separately to retain include nodes on the lint path.
     """
     endpoint = f"/api/v4/projects/{project_id}/ci/lint"
     params: dict[str, Any] = {"dry_run": "true"}
@@ -73,20 +80,21 @@ def _try_lint_merged_yaml(
                 "Falling back to raw .gitlab-ci.yml.",
                 project_id,
             )
-            return None, None, True
+            return None, None, True, None
         if e.response is not None and e.response.status_code == 404:
             logger.warning(
                 "ci/lint returned 404 for project %s (no pipeline / not enabled).",
                 project_id,
             )
-            return None, None, False
+            return None, None, False, None
         raise
 
     body = response.json()
     merged = body.get("merged_yaml")
+    lint_includes = body.get("includes")
     if merged is None:
-        return None, None, False
-    return merged, bool(body.get("valid", False)), False
+        return None, None, False, None
+    return merged, bool(body.get("valid", False)), False, lint_includes
 
 
 def _try_raw_ci_yaml(
@@ -141,44 +149,44 @@ def fetch_ci_config_yaml(
     gitlab_url: str,
     token: str,
     project: dict[str, Any],
-) -> tuple[str | None, bool | None, bool, bool]:
+) -> tuple[str | None, bool | None, bool, bool, list[dict[str, Any]] | None]:
     """
     Try /ci/lint first, then fall back to the raw file. Returns
-    ``(yaml_content, is_valid, is_merged, denied)``:
+    ``(yaml_content, is_valid, is_merged, denied, lint_includes)``:
 
     - ``yaml_content`` is the raw or merged YAML, or ``None`` when no
       readable config was found.
     - ``is_merged`` is True when the YAML came from /ci/lint (with includes
       expanded), False when it's raw.
-    - ``denied`` is True when BOTH paths returned 403 — the project was
-      reachable but the token cannot read its CI config. The sync caller
-      must skip cleanup for this project so we don't delete previously
-      ingested data on a transient permission failure. ``denied`` is False
-      when the YAML genuinely doesn't exist (404), letting cleanup remove
-      any stale config previously ingested for that project.
+    - ``denied`` is True when BOTH paths returned 403.
+    - ``lint_includes`` is GitLab's structured ``includes`` list from the
+      lint response, or ``None`` if the lint path was not used. Needed
+      because the merged_yaml does NOT contain the original ``include:``
+      block — its content has been inlined as jobs — so the YAML parser
+      alone would yield zero GitLabCIInclude nodes on the lint path.
     """
     project_id = project["id"]
     ref = project.get("default_branch")
 
-    merged, is_valid, lint_denied = _try_lint_merged_yaml(
+    merged, is_valid, lint_denied, lint_includes = _try_lint_merged_yaml(
         gitlab_url, token, project_id, ref
     )
     if merged is not None:
-        return merged, is_valid, True, False
+        return merged, is_valid, True, False, lint_includes
 
     # Both 404 and 403 from /ci/lint fall back to the raw file. The raw
     # endpoint uses `read_repository`, broader than the Maintainer scope
     # /ci/lint needs.
     raw, raw_denied = _try_raw_ci_yaml(gitlab_url, token, project_id, ref)
     if raw is not None:
-        return raw, None, False, False
+        return raw, None, False, False, None
 
     # Both paths failed. We only flag the project as ``denied`` if neither
     # path could authoritatively confirm the absence of a config — i.e.
     # both returned 403. A 404 from either endpoint (especially raw 404)
     # is authoritative absence and cleanup may run normally.
     denied = lint_denied and raw_denied
-    return None, None, False, denied
+    return None, None, False, denied, None
 
 
 def transform_ci_config(
@@ -337,6 +345,7 @@ def sync_gitlab_ci_config(
     common_job_parameters: dict[str, Any],
     projects: list[dict[str, Any]],
     variables_by_project: dict[int, list[dict[str, Any]]],
+    skip_projects: set[int] | None = None,
 ) -> set[int]:
     """
     For each project: fetch its CI YAML, parse it, and load CIConfig +
@@ -344,17 +353,27 @@ def sync_gitlab_ci_config(
     schema turns into ``REFERENCES_VARIABLE`` edges to project-level CI
     variables at load time (one_to_many other_relationship).
 
-    Returns the set of project IDs whose CI config could not be read because
-    of permission denial (403) — the caller must skip ci_config / ci_include
-    cleanup for those, otherwise it would delete previously-ingested data
+    ``skip_projects`` lists project IDs whose CI variables could not be
+    loaded this run (e.g. variables endpoint returned 403). Those projects
+    are skipped here too — refreshing the config without its referenced
+    variables would let cleanup wipe the ``REFERENCES_VARIABLE`` edges
+    even though the variables themselves were preserved upstream.
+
+    Returns the set of project IDs whose CI config could not be read
+    because of permission denial OR which were forwarded via
+    ``skip_projects``. The caller must skip ci_config / ci_include
+    cleanup for these, otherwise it would delete previously-ingested data
     on a transient auth failure.
     """
     logger.info("Syncing GitLab CI configs for %d projects", len(projects))
-    skipped_projects: set[int] = set()
+    skip_projects = skip_projects or set()
+    skipped_projects: set[int] = set(skip_projects)
 
     for project in projects:
         project_id: int = project["id"]
-        yaml_content, is_valid, is_merged, denied = fetch_ci_config_yaml(
+        if project_id in skip_projects:
+            continue
+        yaml_content, is_valid, is_merged, denied, lint_includes = fetch_ci_config_yaml(
             gitlab_url, token, project
         )
         if yaml_content is None:
@@ -363,6 +382,13 @@ def sync_gitlab_ci_config(
             continue
 
         parsed = parse_ci_config(yaml_content, is_valid=is_valid)
+        # On the lint path the merged_yaml has no `include:` block (its
+        # content was inlined as jobs), so populate `parsed.includes`
+        # from the lint response's structured `includes` array.
+        if is_merged and lint_includes is not None:
+            lint_parsed = parse_lint_includes(lint_includes)
+            parsed.includes = lint_parsed
+            parsed.has_includes = bool(lint_parsed)
         project_variables = variables_by_project.get(project_id, [])
 
         config_record = transform_ci_config(

--- a/cartography/intel/gitlab/ci_config.py
+++ b/cartography/intel/gitlab/ci_config.py
@@ -1,0 +1,384 @@
+"""
+GitLab CI/CD config Intelligence Module
+
+Ingests each project's `.gitlab-ci.yml` (or its merged equivalent), creates a
+GitLabCIConfig node summarising the parsed pipeline, plus one GitLabCIInclude
+node per resolved `include:` entry. Also creates a scoped MatchLink linking
+the config to project-level CI/CD variables it references at runtime.
+
+Fetch strategy:
+1. Try `GET /api/v4/projects/:id/ci/lint?dry_run=true&ref=:default_branch` —
+   this returns the YAML merged with all includes expanded (richer data).
+2. Fall back to the raw `.gitlab-ci.yml` from the repository if lint fails.
+3. If both fail (404 / 403), skip the project silently.
+
+The parser is pure (`ci_config_parser.py`) — all I/O lives here.
+"""
+
+import logging
+from typing import Any
+
+import neo4j
+import requests
+from urllib.parse import quote
+
+from cartography.client.core.tx import load
+from cartography.client.core.tx import load_matchlinks
+from cartography.graph.job import GraphJob
+from cartography.intel.gitlab.ci_config_parser import ParsedCIConfig
+from cartography.intel.gitlab.ci_config_parser import parse_ci_config
+from cartography.intel.gitlab.util import make_request_with_retry
+from cartography.models.gitlab.ci_config import GitLabCIConfigSchema
+from cartography.models.gitlab.ci_config import GitLabCIConfigToCIVariableMatchLink
+from cartography.models.gitlab.ci_include import GitLabCIIncludeSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_FILE_PATH = ".gitlab-ci.yml"
+
+
+def _try_lint_merged_yaml(
+    gitlab_url: str,
+    token: str,
+    project_id: int,
+    ref: str | None,
+) -> tuple[str | None, bool | None]:
+    """
+    Call /ci/lint with dry_run=true to obtain the merged YAML. Returns
+    (merged_yaml, is_valid) on success; (None, None) if the call fails with
+    403 / 404. Other errors propagate.
+    """
+    endpoint = f"/api/v4/projects/{project_id}/ci/lint"
+    params: dict[str, Any] = {"dry_run": "true"}
+    if ref:
+        params["ref"] = ref
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    try:
+        response = make_request_with_retry(
+            "GET", f"{gitlab_url}{endpoint}", headers=headers, params=params
+        )
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        if e.response is not None and e.response.status_code in (403, 404):
+            logger.warning(
+                "ci/lint not available for project %s (status %s).",
+                project_id,
+                e.response.status_code,
+            )
+            return None, None
+        raise
+
+    body = response.json()
+    merged = body.get("merged_yaml")
+    if not merged:
+        return None, None
+    return merged, bool(body.get("valid", False))
+
+
+def _try_raw_ci_yaml(
+    gitlab_url: str,
+    token: str,
+    project_id: int,
+    ref: str | None,
+    file_path: str = DEFAULT_FILE_PATH,
+) -> str | None:
+    """
+    Fetch the raw `.gitlab-ci.yml` from the repository as a fallback when
+    /ci/lint is unavailable. Returns None on 403 / 404.
+    """
+    encoded = quote(file_path, safe="")
+    endpoint = f"/api/v4/projects/{project_id}/repository/files/{encoded}/raw"
+    if ref:
+        endpoint = f"{endpoint}?ref={ref}"
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    try:
+        response = make_request_with_retry(
+            "GET", f"{gitlab_url}{endpoint}", headers=headers
+        )
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        if e.response is not None and e.response.status_code in (403, 404):
+            logger.warning(
+                "Raw .gitlab-ci.yml not available for project %s (status %s).",
+                project_id,
+                e.response.status_code,
+            )
+            return None
+        raise
+    return response.text
+
+
+@timeit
+def fetch_ci_config_yaml(
+    gitlab_url: str,
+    token: str,
+    project: dict[str, Any],
+) -> tuple[str | None, bool | None, bool]:
+    """
+    Try /ci/lint first, then fall back to the raw file. Returns
+    (yaml_content, is_valid, is_merged). is_merged is True when the YAML
+    came from /ci/lint (with includes expanded), False when it's raw.
+    """
+    project_id = project["id"]
+    ref = project.get("default_branch")
+
+    merged, is_valid = _try_lint_merged_yaml(gitlab_url, token, project_id, ref)
+    if merged:
+        return merged, is_valid, True
+
+    raw = _try_raw_ci_yaml(gitlab_url, token, project_id, ref)
+    if raw:
+        return raw, None, False
+
+    return None, None, False
+
+
+def transform_ci_config(
+    parsed: ParsedCIConfig,
+    project_id: int,
+    gitlab_url: str,
+    is_merged: bool,
+    file_path: str,
+    project_protected_variable_keys: set[str],
+) -> dict[str, Any]:
+    """
+    Build the CIConfig node record. `referenced_protected_variables` is the
+    intersection of the parsed variable keys and the project's protected
+    variables — surfaced as a separate field for security queries.
+    """
+    referenced_protected = sorted(
+        set(parsed.referenced_variable_keys) & project_protected_variable_keys
+    )
+    return {
+        "id": f"{project_id}:{file_path}",
+        "project_id": project_id,
+        "file_path": file_path,
+        "is_valid": parsed.is_valid,
+        "is_merged": is_merged,
+        "job_count": parsed.job_count,
+        "stages": parsed.stages,
+        "trigger_rules": parsed.trigger_rules,
+        "referenced_variable_keys": parsed.referenced_variable_keys,
+        "referenced_protected_variables": referenced_protected,
+        "default_image": parsed.default_image,
+        "has_includes": parsed.has_includes,
+        "include_count": len(parsed.includes),
+        "gitlab_url": gitlab_url,
+    }
+
+
+def transform_ci_includes(
+    parsed: ParsedCIConfig,
+    project_id: int,
+    gitlab_url: str,
+    file_path: str,
+) -> list[dict[str, Any]]:
+    """One record per ParsedCIInclude. ID composite to avoid cross-project collisions."""
+    config_id = f"{project_id}:{file_path}"
+    records: list[dict[str, Any]] = []
+    for include in parsed.includes:
+        ref_part = include.ref or "none"
+        records.append(
+            {
+                "id": (
+                    f"{project_id}:{include.include_type}:{include.location}:{ref_part}"
+                ),
+                "include_type": include.include_type,
+                "location": include.location,
+                "ref": include.ref,
+                "is_pinned": include.is_pinned,
+                "is_local": include.is_local,
+                "raw_include": include.raw_include,
+                "config_id": config_id,
+                "gitlab_url": gitlab_url,
+            }
+        )
+    return records
+
+
+def compute_config_variable_links(
+    parsed: ParsedCIConfig,
+    project_variables: list[dict[str, Any]],
+    project_id: int,
+    file_path: str,
+) -> list[dict[str, Any]]:
+    """
+    For each variable referenced by the config that exists in the project's
+    CI/CD variables, emit a `{config_id, variable_id}` MatchLink record.
+
+    A variable matches if the parsed key equals the variable `key`. The
+    variable's `environment_scope` is intentionally ignored here — we link
+    the config to *every* variant of that key, since a static analysis
+    cannot tell which environment the pipeline will run in.
+    """
+    config_id = f"{project_id}:{file_path}"
+    referenced_keys = set(parsed.referenced_variable_keys)
+    if not referenced_keys:
+        return []
+
+    return [
+        {"config_id": config_id, "variable_id": variable["id"]}
+        for variable in project_variables
+        if variable.get("key") in referenced_keys
+    ]
+
+
+@timeit
+def load_ci_config(
+    neo4j_session: neo4j.Session,
+    record: dict[str, Any],
+    project_id: int,
+    gitlab_url: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        GitLabCIConfigSchema(),
+        [record],
+        lastupdated=update_tag,
+        project_id=project_id,
+        gitlab_url=gitlab_url,
+    )
+
+
+@timeit
+def load_ci_includes(
+    neo4j_session: neo4j.Session,
+    records: list[dict[str, Any]],
+    project_id: int,
+    gitlab_url: str,
+    update_tag: int,
+) -> None:
+    if not records:
+        return
+    load(
+        neo4j_session,
+        GitLabCIIncludeSchema(),
+        records,
+        lastupdated=update_tag,
+        project_id=project_id,
+        gitlab_url=gitlab_url,
+    )
+
+
+@timeit
+def load_config_variable_links(
+    neo4j_session: neo4j.Session,
+    links: list[dict[str, Any]],
+    project_id: int,
+    gitlab_url: str,
+    update_tag: int,
+) -> None:
+    if not links:
+        return
+    load_matchlinks(
+        neo4j_session,
+        GitLabCIConfigToCIVariableMatchLink(),
+        links,
+        lastupdated=update_tag,
+        _sub_resource_label="GitLabProject",
+        _sub_resource_id=project_id,
+        gitlab_url=gitlab_url,
+    )
+
+
+@timeit
+def cleanup_ci_configs(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+    project_id: int,
+    gitlab_url: str,
+) -> None:
+    cleanup_params = {
+        **common_job_parameters,
+        "project_id": project_id,
+        "gitlab_url": gitlab_url,
+    }
+    GraphJob.from_node_schema(GitLabCIConfigSchema(), cleanup_params).run(
+        neo4j_session
+    )
+
+
+@timeit
+def cleanup_ci_includes(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+    project_id: int,
+    gitlab_url: str,
+) -> None:
+    cleanup_params = {
+        **common_job_parameters,
+        "project_id": project_id,
+        "gitlab_url": gitlab_url,
+    }
+    GraphJob.from_node_schema(GitLabCIIncludeSchema(), cleanup_params).run(
+        neo4j_session
+    )
+
+
+@timeit
+def sync_gitlab_ci_config(
+    neo4j_session: neo4j.Session,
+    gitlab_url: str,
+    token: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+    projects: list[dict[str, Any]],
+    variables_by_project: dict[int, list[dict[str, Any]]],
+) -> None:
+    """
+    For each project: fetch its CI YAML, parse it, load CIConfig + includes,
+    and emit MatchLinks to referenced project-level variables.
+    """
+    logger.info("Syncing GitLab CI configs for %d projects", len(projects))
+
+    for project in projects:
+        project_id: int = project["id"]
+        yaml_content, is_valid, is_merged = fetch_ci_config_yaml(
+            gitlab_url, token, project
+        )
+        if yaml_content is None:
+            continue
+
+        parsed = parse_ci_config(yaml_content, is_valid=is_valid)
+
+        project_variables = variables_by_project.get(project_id, [])
+        protected_keys = {
+            v["key"] for v in project_variables if v.get("protected") and v.get("key")
+        }
+
+        config_record = transform_ci_config(
+            parsed,
+            project_id,
+            gitlab_url,
+            is_merged=is_merged,
+            file_path=DEFAULT_FILE_PATH,
+            project_protected_variable_keys=protected_keys,
+        )
+        include_records = transform_ci_includes(
+            parsed, project_id, gitlab_url, DEFAULT_FILE_PATH
+        )
+        variable_links = compute_config_variable_links(
+            parsed, project_variables, project_id, DEFAULT_FILE_PATH
+        )
+
+        load_ci_config(
+            neo4j_session, config_record, project_id, gitlab_url, update_tag
+        )
+        load_ci_includes(
+            neo4j_session, include_records, project_id, gitlab_url, update_tag
+        )
+        load_config_variable_links(
+            neo4j_session, variable_links, project_id, gitlab_url, update_tag
+        )
+
+    logger.info("GitLab CI configs sync completed")

--- a/cartography/intel/gitlab/ci_config.py
+++ b/cartography/intel/gitlab/ci_config.py
@@ -251,7 +251,6 @@ def transform_ci_includes(
                 "ref": include.ref,
                 "is_pinned": include.is_pinned,
                 "is_local": include.is_local,
-                "raw_include": include.raw_include,
                 "config_id": config_id,
                 "gitlab_url": gitlab_url,
             }

--- a/cartography/intel/gitlab/ci_config.py
+++ b/cartography/intel/gitlab/ci_config.py
@@ -17,16 +17,16 @@ The parser is pure (`ci_config_parser.py`) — all I/O lives here.
 
 import logging
 from typing import Any
+from urllib.parse import quote
 
 import neo4j
 import requests
-from urllib.parse import quote
 
 from cartography.client.core.tx import load
 from cartography.client.core.tx import load_matchlinks
 from cartography.graph.job import GraphJob
-from cartography.intel.gitlab.ci_config_parser import ParsedCIConfig
 from cartography.intel.gitlab.ci_config_parser import parse_ci_config
+from cartography.intel.gitlab.ci_config_parser import ParsedCIConfig
 from cartography.intel.gitlab.util import make_request_with_retry
 from cartography.models.gitlab.ci_config import GitLabCIConfigSchema
 from cartography.models.gitlab.ci_config import GitLabCIConfigToCIVariableMatchLink
@@ -303,9 +303,7 @@ def cleanup_ci_configs(
         "project_id": project_id,
         "gitlab_url": gitlab_url,
     }
-    GraphJob.from_node_schema(GitLabCIConfigSchema(), cleanup_params).run(
-        neo4j_session
-    )
+    GraphJob.from_node_schema(GitLabCIConfigSchema(), cleanup_params).run(neo4j_session)
 
 
 @timeit
@@ -371,9 +369,7 @@ def sync_gitlab_ci_config(
             parsed, project_variables, project_id, DEFAULT_FILE_PATH
         )
 
-        load_ci_config(
-            neo4j_session, config_record, project_id, gitlab_url, update_tag
-        )
+        load_ci_config(neo4j_session, config_record, project_id, gitlab_url, update_tag)
         load_ci_includes(
             neo4j_session, include_records, project_id, gitlab_url, update_tag
         )

--- a/cartography/intel/gitlab/ci_config.py
+++ b/cartography/intel/gitlab/ci_config.py
@@ -23,13 +23,11 @@ import neo4j
 import requests
 
 from cartography.client.core.tx import load
-from cartography.client.core.tx import load_matchlinks
 from cartography.graph.job import GraphJob
 from cartography.intel.gitlab.ci_config_parser import parse_ci_config
 from cartography.intel.gitlab.ci_config_parser import ParsedCIConfig
 from cartography.intel.gitlab.util import make_request_with_retry
 from cartography.models.gitlab.ci_config import GitLabCIConfigSchema
-from cartography.models.gitlab.ci_config import GitLabCIConfigToCIVariableMatchLink
 from cartography.models.gitlab.ci_include import GitLabCIIncludeSchema
 from cartography.util import timeit
 
@@ -43,11 +41,16 @@ def _try_lint_merged_yaml(
     token: str,
     project_id: int,
     ref: str | None,
-) -> tuple[str | None, bool | None]:
+) -> tuple[str | None, bool | None, bool]:
     """
     Call /ci/lint with dry_run=true to obtain the merged YAML. Returns
-    (merged_yaml, is_valid) on success; (None, None) if the call fails with
-    403 / 404. Other errors propagate.
+    ``(merged_yaml, is_valid, denied)``:
+
+    - ``(yaml, True/False, False)`` on a successful response
+    - ``(None, None, False)`` on 404 (project has no pipeline) — non-fatal
+    - ``(None, None, True)`` on 403 (token can't lint) — caller should fall
+      back to the raw file rather than treat the project as missing
+    Other errors propagate.
     """
     endpoint = f"/api/v4/projects/{project_id}/ci/lint"
     params: dict[str, Any] = {"dry_run": "true"}
@@ -64,20 +67,26 @@ def _try_lint_merged_yaml(
         )
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
-        if e.response is not None and e.response.status_code in (403, 404):
+        if e.response is not None and e.response.status_code == 403:
             logger.warning(
-                "ci/lint not available for project %s (status %s).",
+                "ci/lint denied for project %s (token lacks Maintainer access). "
+                "Falling back to raw .gitlab-ci.yml.",
                 project_id,
-                e.response.status_code,
             )
-            return None, None
+            return None, None, True
+        if e.response is not None and e.response.status_code == 404:
+            logger.warning(
+                "ci/lint returned 404 for project %s (no pipeline / not enabled).",
+                project_id,
+            )
+            return None, None, False
         raise
 
     body = response.json()
     merged = body.get("merged_yaml")
-    if not merged:
-        return None, None
-    return merged, bool(body.get("valid", False))
+    if merged is None:
+        return None, None, False
+    return merged, bool(body.get("valid", False)), False
 
 
 def _try_raw_ci_yaml(
@@ -89,7 +98,9 @@ def _try_raw_ci_yaml(
 ) -> str | None:
     """
     Fetch the raw `.gitlab-ci.yml` from the repository as a fallback when
-    /ci/lint is unavailable. Returns None on 403 / 404.
+    /ci/lint is unavailable. Returns None on 403 / 404 (the file is absent
+    or the token can't read repository files for this project — both
+    non-fatal for the sync).
     """
     encoded = quote(file_path, safe="")
     endpoint = f"/api/v4/projects/{project_id}/repository/files/{encoded}/raw"
@@ -125,18 +136,28 @@ def fetch_ci_config_yaml(
 ) -> tuple[str | None, bool | None, bool]:
     """
     Try /ci/lint first, then fall back to the raw file. Returns
-    (yaml_content, is_valid, is_merged). is_merged is True when the YAML
-    came from /ci/lint (with includes expanded), False when it's raw.
+    ``(yaml_content, is_valid, is_merged)``. ``is_merged`` is True when the
+    YAML came from /ci/lint (with includes expanded), False when it's raw.
+
+    A `None` yaml_content means "no .gitlab-ci.yml found / readable" — that
+    is a legitimate per-project state (some projects have no pipeline) and
+    callers can treat it as nothing-to-load without skipping cleanup.
     """
     project_id = project["id"]
     ref = project.get("default_branch")
 
-    merged, is_valid = _try_lint_merged_yaml(gitlab_url, token, project_id, ref)
-    if merged:
+    merged, is_valid, lint_denied = _try_lint_merged_yaml(
+        gitlab_url, token, project_id, ref
+    )
+    if merged is not None:
         return merged, is_valid, True
 
+    # Whether we got a 404 from lint or a 403, fall back to the raw file.
+    # The raw endpoint uses `read_repository`, which is broader than the
+    # Maintainer-level scope /ci/lint requires.
+    _ = lint_denied  # silenced; both branches fall through to raw
     raw = _try_raw_ci_yaml(gitlab_url, token, project_id, ref)
-    if raw:
+    if raw is not None:
         return raw, None, False
 
     return None, None, False
@@ -148,16 +169,30 @@ def transform_ci_config(
     gitlab_url: str,
     is_merged: bool,
     file_path: str,
-    project_protected_variable_keys: set[str],
+    project_variables: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """
-    Build the CIConfig node record. `referenced_protected_variables` is the
-    intersection of the parsed variable keys and the project's protected
-    variables — surfaced as a separate field for security queries.
+    Build the CIConfig node record.
+
+    Two derived fields encode the variable references:
+
+    - ``referenced_protected_variables`` — sorted list of variable keys
+      that are referenced AND marked ``protected=True`` on the project.
+      Surfaced as its own property for security queries.
+    - ``referenced_variable_ids`` — IDs of project variables whose ``key``
+      appears in the parsed pipeline; consumed by the
+      ``REFERENCES_VARIABLE`` other_relationship at load time
+      (``one_to_many=True``).
     """
-    referenced_protected = sorted(
-        set(parsed.referenced_variable_keys) & project_protected_variable_keys
-    )
+    project_variables = project_variables or []
+    referenced_keys = set(parsed.referenced_variable_keys)
+    protected_keys = {
+        v["key"] for v in project_variables if v.get("protected") and v.get("key")
+    }
+    referenced_protected = sorted(referenced_keys & protected_keys)
+    referenced_variable_ids = [
+        v["id"] for v in project_variables if v.get("key") in referenced_keys
+    ]
     return {
         "id": f"{project_id}:{file_path}",
         "project_id": project_id,
@@ -169,6 +204,7 @@ def transform_ci_config(
         "trigger_rules": parsed.trigger_rules,
         "referenced_variable_keys": parsed.referenced_variable_keys,
         "referenced_protected_variables": referenced_protected,
+        "referenced_variable_ids": referenced_variable_ids,
         "default_image": parsed.default_image,
         "has_includes": parsed.has_includes,
         "include_count": len(parsed.includes),
@@ -205,33 +241,6 @@ def transform_ci_includes(
     return records
 
 
-def compute_config_variable_links(
-    parsed: ParsedCIConfig,
-    project_variables: list[dict[str, Any]],
-    project_id: int,
-    file_path: str,
-) -> list[dict[str, Any]]:
-    """
-    For each variable referenced by the config that exists in the project's
-    CI/CD variables, emit a `{config_id, variable_id}` MatchLink record.
-
-    A variable matches if the parsed key equals the variable `key`. The
-    variable's `environment_scope` is intentionally ignored here — we link
-    the config to *every* variant of that key, since a static analysis
-    cannot tell which environment the pipeline will run in.
-    """
-    config_id = f"{project_id}:{file_path}"
-    referenced_keys = set(parsed.referenced_variable_keys)
-    if not referenced_keys:
-        return []
-
-    return [
-        {"config_id": config_id, "variable_id": variable["id"]}
-        for variable in project_variables
-        if variable.get("key") in referenced_keys
-    ]
-
-
 @timeit
 def load_ci_config(
     neo4j_session: neo4j.Session,
@@ -266,27 +275,6 @@ def load_ci_includes(
         records,
         lastupdated=update_tag,
         project_id=project_id,
-        gitlab_url=gitlab_url,
-    )
-
-
-@timeit
-def load_config_variable_links(
-    neo4j_session: neo4j.Session,
-    links: list[dict[str, Any]],
-    project_id: int,
-    gitlab_url: str,
-    update_tag: int,
-) -> None:
-    if not links:
-        return
-    load_matchlinks(
-        neo4j_session,
-        GitLabCIConfigToCIVariableMatchLink(),
-        links,
-        lastupdated=update_tag,
-        _sub_resource_label="GitLabProject",
-        _sub_resource_id=project_id,
         gitlab_url=gitlab_url,
     )
 
@@ -334,8 +322,10 @@ def sync_gitlab_ci_config(
     variables_by_project: dict[int, list[dict[str, Any]]],
 ) -> None:
     """
-    For each project: fetch its CI YAML, parse it, load CIConfig + includes,
-    and emit MatchLinks to referenced project-level variables.
+    For each project: fetch its CI YAML, parse it, and load CIConfig +
+    includes. The config carries a ``referenced_variable_ids`` list that the
+    schema turns into ``REFERENCES_VARIABLE`` edges to project-level CI
+    variables at load time (one_to_many other_relationship).
     """
     logger.info("Syncing GitLab CI configs for %d projects", len(projects))
 
@@ -348,11 +338,7 @@ def sync_gitlab_ci_config(
             continue
 
         parsed = parse_ci_config(yaml_content, is_valid=is_valid)
-
         project_variables = variables_by_project.get(project_id, [])
-        protected_keys = {
-            v["key"] for v in project_variables if v.get("protected") and v.get("key")
-        }
 
         config_record = transform_ci_config(
             parsed,
@@ -360,21 +346,15 @@ def sync_gitlab_ci_config(
             gitlab_url,
             is_merged=is_merged,
             file_path=DEFAULT_FILE_PATH,
-            project_protected_variable_keys=protected_keys,
+            project_variables=project_variables,
         )
         include_records = transform_ci_includes(
             parsed, project_id, gitlab_url, DEFAULT_FILE_PATH
-        )
-        variable_links = compute_config_variable_links(
-            parsed, project_variables, project_id, DEFAULT_FILE_PATH
         )
 
         load_ci_config(neo4j_session, config_record, project_id, gitlab_url, update_tag)
         load_ci_includes(
             neo4j_session, include_records, project_id, gitlab_url, update_tag
-        )
-        load_config_variable_links(
-            neo4j_session, variable_links, project_id, gitlab_url, update_tag
         )
 
     logger.info("GitLab CI configs sync completed")

--- a/cartography/intel/gitlab/ci_config.py
+++ b/cartography/intel/gitlab/ci_config.py
@@ -133,15 +133,21 @@ def fetch_ci_config_yaml(
     gitlab_url: str,
     token: str,
     project: dict[str, Any],
-) -> tuple[str | None, bool | None, bool]:
+) -> tuple[str | None, bool | None, bool, bool]:
     """
     Try /ci/lint first, then fall back to the raw file. Returns
-    ``(yaml_content, is_valid, is_merged)``. ``is_merged`` is True when the
-    YAML came from /ci/lint (with includes expanded), False when it's raw.
+    ``(yaml_content, is_valid, is_merged, denied)``:
 
-    A `None` yaml_content means "no .gitlab-ci.yml found / readable" — that
-    is a legitimate per-project state (some projects have no pipeline) and
-    callers can treat it as nothing-to-load without skipping cleanup.
+    - ``yaml_content`` is the raw or merged YAML, or ``None`` when no
+      readable config was found.
+    - ``is_merged`` is True when the YAML came from /ci/lint (with includes
+      expanded), False when it's raw.
+    - ``denied`` is True when BOTH paths returned 403 — the project was
+      reachable but the token cannot read its CI config. The sync caller
+      must skip cleanup for this project so we don't delete previously
+      ingested data on a transient permission failure. ``denied`` is False
+      when the YAML genuinely doesn't exist (404), letting cleanup remove
+      any stale config previously ingested for that project.
     """
     project_id = project["id"]
     ref = project.get("default_branch")
@@ -150,17 +156,21 @@ def fetch_ci_config_yaml(
         gitlab_url, token, project_id, ref
     )
     if merged is not None:
-        return merged, is_valid, True
+        return merged, is_valid, True, False
 
-    # Whether we got a 404 from lint or a 403, fall back to the raw file.
-    # The raw endpoint uses `read_repository`, which is broader than the
-    # Maintainer-level scope /ci/lint requires.
-    _ = lint_denied  # silenced; both branches fall through to raw
+    # Both 404 and 403 from /ci/lint fall back to the raw file. The raw
+    # endpoint uses `read_repository`, broader than the Maintainer scope
+    # /ci/lint needs — but if the token also lacks `read_repository` for
+    # this project, _try_raw_ci_yaml returns None on 403 too.
     raw = _try_raw_ci_yaml(gitlab_url, token, project_id, ref)
     if raw is not None:
-        return raw, None, False
+        return raw, None, False, False
 
-    return None, None, False
+    # Both paths failed. If lint specifically reported 403 we treat the
+    # whole project as denied (skip cleanup). If lint was 404 (no pipeline)
+    # and raw was also missing, the project legitimately has no config and
+    # cleanup may proceed.
+    return None, None, False, lint_denied
 
 
 def transform_ci_config(
@@ -320,21 +330,29 @@ def sync_gitlab_ci_config(
     common_job_parameters: dict[str, Any],
     projects: list[dict[str, Any]],
     variables_by_project: dict[int, list[dict[str, Any]]],
-) -> None:
+) -> set[int]:
     """
     For each project: fetch its CI YAML, parse it, and load CIConfig +
     includes. The config carries a ``referenced_variable_ids`` list that the
     schema turns into ``REFERENCES_VARIABLE`` edges to project-level CI
     variables at load time (one_to_many other_relationship).
+
+    Returns the set of project IDs whose CI config could not be read because
+    of permission denial (403) — the caller must skip ci_config / ci_include
+    cleanup for those, otherwise it would delete previously-ingested data
+    on a transient auth failure.
     """
     logger.info("Syncing GitLab CI configs for %d projects", len(projects))
+    skipped_projects: set[int] = set()
 
     for project in projects:
         project_id: int = project["id"]
-        yaml_content, is_valid, is_merged = fetch_ci_config_yaml(
+        yaml_content, is_valid, is_merged, denied = fetch_ci_config_yaml(
             gitlab_url, token, project
         )
         if yaml_content is None:
+            if denied:
+                skipped_projects.add(project_id)
             continue
 
         parsed = parse_ci_config(yaml_content, is_valid=is_valid)
@@ -358,3 +376,4 @@ def sync_gitlab_ci_config(
         )
 
     logger.info("GitLab CI configs sync completed")
+    return skipped_projects

--- a/cartography/intel/gitlab/ci_config_parser.py
+++ b/cartography/intel/gitlab/ci_config_parser.py
@@ -1,0 +1,281 @@
+"""
+GitLab CI/CD config (`.gitlab-ci.yml`) YAML parser.
+
+Pure: no I/O. Extracts security-relevant info from a YAML pipeline definition:
+
+- The list of `include:` references (local, project, remote, template, component)
+  with a `is_pinned` flag set when an external include uses a 40-char SHA ref.
+- Variable references (`$VAR`, `${VAR}`) detected anywhere in the raw YAML —
+  excluding GitLab's own predefined variables (`CI_*`, `GITLAB_*`).
+- Pipeline stages, job count, default image.
+- Coarse trigger categories detected from `workflow:rules:`, `rules:`, `only:`,
+  `except:` and `when:` (merge_requests, schedules, pushes, tag, manual,
+  web, api).
+
+The parser intentionally stays heuristic: extracting exact rule expressions is
+out of scope. The goal is to surface signals (e.g. "this pipeline can be
+triggered manually" or "this include is not pinned to a SHA") that downstream
+queries can act on.
+"""
+
+import logging
+import re
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+# 40-char hex SHA — same definition as workflow_parser.py
+SHA_PATTERN = re.compile(r"^[a-f0-9]{40}$")
+
+# `$VAR` and `${VAR}` references. Captures the variable name only.
+VARIABLE_PATTERN = re.compile(r"\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?")
+
+# Top-level keys that are not jobs (they're keywords in the GitLab CI schema).
+# Used to compute job_count.
+RESERVED_TOP_LEVEL_KEYS = {
+    "stages",
+    "variables",
+    "default",
+    "include",
+    "workflow",
+    "before_script",
+    "after_script",
+    "image",
+    "services",
+    "cache",
+    "pages",
+    "stages",
+}
+
+# Trigger keyword detection — heuristic, scanned over the raw YAML.
+TRIGGER_PATTERNS = {
+    "merge_requests": re.compile(
+        r'CI_PIPELINE_SOURCE\s*==\s*["\']merge_request_event["\']'
+        r'|CI_MERGE_REQUEST_'
+        r'|merge_requests?'
+    ),
+    "schedules": re.compile(
+        r'CI_PIPELINE_SOURCE\s*==\s*["\']schedule["\']|schedules?'
+    ),
+    "tag": re.compile(r"CI_COMMIT_TAG|^\s*-?\s*tags\s*:?", re.MULTILINE),
+    "manual": re.compile(r"^\s*when\s*:\s*manual", re.MULTILINE),
+    "web": re.compile(r'CI_PIPELINE_SOURCE\s*==\s*["\']web["\']'),
+    "api": re.compile(r'CI_PIPELINE_SOURCE\s*==\s*["\']api["\']'),
+    "pushes": re.compile(
+        r'CI_PIPELINE_SOURCE\s*==\s*["\']push["\']|^\s*-?\s*pushes?\s*:?',
+        re.MULTILINE,
+    ),
+}
+
+
+@dataclass
+class ParsedCIInclude:
+    """A single `include:` entry from the YAML."""
+
+    include_type: str  # "local" | "project" | "remote" | "template" | "component"
+    location: str
+    ref: str | None
+    is_pinned: bool
+    is_local: bool
+    raw_include: str
+
+
+@dataclass
+class ParsedCIConfig:
+    """Result of parsing a `.gitlab-ci.yml` (raw or merged)."""
+
+    is_valid: bool | None = None
+    job_count: int = 0
+    stages: list[str] = field(default_factory=list)
+    trigger_rules: list[str] = field(default_factory=list)
+    referenced_variable_keys: list[str] = field(default_factory=list)
+    default_image: str | None = None
+    has_includes: bool = False
+    includes: list[ParsedCIInclude] = field(default_factory=list)
+
+
+def _is_pinned(include_type: str, ref: str | None, location: str) -> bool:
+    """
+    Pinning rule:
+    - local: always considered pinned (internal to the repo)
+    - project: pinned iff `ref` is a 40-char SHA
+    - remote: pinned iff the URL contains a 40-char SHA in its path
+    - template, component: never pinned (they resolve to a moving target)
+    """
+    if include_type == "local":
+        return True
+    if include_type == "project":
+        return bool(ref and SHA_PATTERN.match(ref))
+    if include_type == "remote":
+        return bool(re.search(r"/[a-f0-9]{40}/", location))
+    return False
+
+
+def _parse_single_include(item: Any) -> ParsedCIInclude | None:
+    """
+    Parse a single `include:` entry. Accepts:
+    - a bare string (treated as local)
+    - a dict with one of: local / project / remote / template / component
+
+    Anything else is ignored.
+    """
+    if isinstance(item, str):
+        return ParsedCIInclude(
+            include_type="local",
+            location=item,
+            ref=None,
+            is_pinned=True,
+            is_local=True,
+            raw_include=item,
+        )
+
+    if not isinstance(item, dict):
+        return None
+
+    raw = str(item)
+    for include_type in ("local", "project", "remote", "template", "component"):
+        if include_type in item:
+            location = item.get(include_type) or ""
+            if isinstance(location, list):
+                # `include: { local: [a, b] }` is also valid GitLab syntax;
+                # we flatten by emitting one ParsedCIInclude per entry below.
+                return None
+            ref = item.get("ref") if include_type == "project" else None
+            return ParsedCIInclude(
+                include_type=include_type,
+                location=str(location),
+                ref=ref,
+                is_pinned=_is_pinned(include_type, ref, str(location)),
+                is_local=(include_type == "local"),
+                raw_include=raw,
+            )
+    return None
+
+
+def _extract_includes(includes_value: Any) -> list[ParsedCIInclude]:
+    """Normalise the `include:` value into a flat list of ParsedCIInclude."""
+    if includes_value is None:
+        return []
+
+    items = includes_value if isinstance(includes_value, list) else [includes_value]
+    result: list[ParsedCIInclude] = []
+    for item in items:
+        # `include: { local: [a, b] }` — expand the list into multiple includes.
+        if (
+            isinstance(item, dict)
+            and "local" in item
+            and isinstance(item["local"], list)
+        ):
+            for path in item["local"]:
+                result.append(
+                    ParsedCIInclude(
+                        include_type="local",
+                        location=str(path),
+                        ref=None,
+                        is_pinned=True,
+                        is_local=True,
+                        raw_include=str(item),
+                    )
+                )
+            continue
+        parsed = _parse_single_include(item)
+        if parsed is not None:
+            result.append(parsed)
+    return result
+
+
+def _is_predefined_gitlab_variable(name: str) -> bool:
+    """GitLab predefined variables come from the runner environment, not CI vars."""
+    return name.startswith("CI_") or name.startswith("GITLAB_") or name == "CI"
+
+
+def _extract_referenced_variables(content: str) -> list[str]:
+    """All `$VAR` / `${VAR}` references in the raw YAML, minus GitLab predefineds."""
+    seen: set[str] = set()
+    for match in VARIABLE_PATTERN.findall(content):
+        if not _is_predefined_gitlab_variable(match):
+            seen.add(match)
+    return sorted(seen)
+
+
+def _extract_trigger_rules(content: str) -> list[str]:
+    """Heuristic trigger detection over the raw YAML."""
+    triggers: list[str] = []
+    for trigger_name, pattern in TRIGGER_PATTERNS.items():
+        if pattern.search(content):
+            triggers.append(trigger_name)
+    return sorted(triggers)
+
+
+def _count_jobs(config: dict[str, Any]) -> int:
+    """A job is any top-level key that isn't a reserved keyword and maps to a dict."""
+    return sum(
+        1
+        for key, value in config.items()
+        if key not in RESERVED_TOP_LEVEL_KEYS
+        and not (isinstance(key, str) and key.startswith("."))
+        and isinstance(value, dict)
+    )
+
+
+def _extract_default_image(config: dict[str, Any]) -> str | None:
+    """`image` can sit at the top level or inside `default:`."""
+    default = config.get("default")
+    if isinstance(default, dict):
+        image = default.get("image")
+        if isinstance(image, dict):
+            return image.get("name")
+        if isinstance(image, str):
+            return image
+
+    image = config.get("image")
+    if isinstance(image, dict):
+        return image.get("name")
+    if isinstance(image, str):
+        return image
+    return None
+
+
+def parse_ci_config(content: str, is_valid: bool | None = None) -> ParsedCIConfig:
+    """
+    Parse a GitLab CI YAML document. Returns an empty `ParsedCIConfig` on
+    YAML parse error rather than raising — caller can treat absence of jobs
+    as "could not parse".
+    """
+    result = ParsedCIConfig(is_valid=is_valid)
+
+    try:
+        config = yaml.safe_load(content)
+    except yaml.YAMLError:
+        logger.warning("Failed to parse GitLab CI YAML")
+        return result
+
+    if not isinstance(config, dict):
+        return result
+
+    # Includes
+    result.includes = _extract_includes(config.get("include"))
+    result.has_includes = len(result.includes) > 0
+
+    # Stages
+    stages = config.get("stages")
+    if isinstance(stages, list):
+        result.stages = [str(s) for s in stages]
+
+    # Job count
+    result.job_count = _count_jobs(config)
+
+    # Default image
+    result.default_image = _extract_default_image(config)
+
+    # Variable references — scan raw content (catches refs inside scripts / rules / etc.)
+    result.referenced_variable_keys = _extract_referenced_variables(content)
+
+    # Trigger rules
+    result.trigger_rules = _extract_trigger_rules(content)
+
+    return result

--- a/cartography/intel/gitlab/ci_config_parser.py
+++ b/cartography/intel/gitlab/ci_config_parser.py
@@ -113,49 +113,96 @@ def _is_pinned(include_type: str, ref: str | None, location: str) -> bool:
     return False
 
 
-def _parse_single_include(item: Any) -> ParsedCIInclude | None:
+def _classify_bare_string(item: str) -> ParsedCIInclude:
     """
-    Parse a single `include:` entry. Accepts:
-    - a bare string (treated as local)
-    - a dict with one of: local / project / remote / template / component
-
-    Anything else is ignored.
+    A bare string include can be either a local path (legacy syntax) or a
+    full URL. Detect URLs by scheme and classify them as ``remote``; a
+    remote include without a SHA in its path is unpinned.
     """
-    if isinstance(item, str):
+    if item.startswith(("http://", "https://")):
         return ParsedCIInclude(
-            include_type="local",
+            include_type="remote",
             location=item,
             ref=None,
-            is_pinned=True,
-            is_local=True,
+            is_pinned=_is_pinned("remote", None, item),
+            is_local=False,
             raw_include=item,
         )
+    return ParsedCIInclude(
+        include_type="local",
+        location=item,
+        ref=None,
+        is_pinned=True,
+        is_local=True,
+        raw_include=item,
+    )
+
+
+def _parse_single_include(item: Any) -> list[ParsedCIInclude]:
+    """
+    Parse a single ``include:`` entry. Accepts:
+
+    - a bare string (URL → remote, otherwise local)
+    - a dict with one of: ``local`` / ``project`` / ``remote`` / ``template``
+      / ``component``
+
+    Returns a list because a single ``project:`` entry with a ``file:`` list
+    of paths expands into one record per file.
+    """
+    if isinstance(item, str):
+        return [_classify_bare_string(item)]
 
     if not isinstance(item, dict):
-        return None
+        return []
 
     raw = str(item)
     for include_type in ("local", "project", "remote", "template", "component"):
-        if include_type in item:
-            location = item.get(include_type) or ""
-            if isinstance(location, list):
-                # `include: { local: [a, b] }` is also valid GitLab syntax;
-                # we flatten by emitting one ParsedCIInclude per entry below.
-                return None
-            ref = item.get("ref") if include_type == "project" else None
-            return ParsedCIInclude(
+        if include_type not in item:
+            continue
+        primary = item.get(include_type) or ""
+        if isinstance(primary, list):
+            # `include: { local: [a, b] }` is handled separately by
+            # `_extract_includes`. For other types it is unsupported.
+            return []
+
+        # `include:project` carries an additional `file:` field which is the
+        # actual path within the referenced project. The `project` value is
+        # the project path (e.g. `my-org/shared-ci`), not the file path —
+        # we want both in `location` so consumers can identify the include.
+        if include_type == "project":
+            ref = item.get("ref")
+            files = item.get("file")
+            file_list = files if isinstance(files, list) else [files] if files else [""]
+            results: list[ParsedCIInclude] = []
+            for file_path in file_list:
+                location = f"{primary}:{file_path}" if file_path else str(primary)
+                results.append(
+                    ParsedCIInclude(
+                        include_type=include_type,
+                        location=location,
+                        ref=ref,
+                        is_pinned=_is_pinned(include_type, ref, location),
+                        is_local=False,
+                        raw_include=raw,
+                    )
+                )
+            return results
+
+        return [
+            ParsedCIInclude(
                 include_type=include_type,
-                location=str(location),
-                ref=ref,
-                is_pinned=_is_pinned(include_type, ref, str(location)),
+                location=str(primary),
+                ref=None,
+                is_pinned=_is_pinned(include_type, None, str(primary)),
                 is_local=(include_type == "local"),
                 raw_include=raw,
             )
-    return None
+        ]
+    return []
 
 
 def _extract_includes(includes_value: Any) -> list[ParsedCIInclude]:
-    """Normalise the `include:` value into a flat list of ParsedCIInclude."""
+    """Normalise the ``include:`` value into a flat list of ParsedCIInclude."""
     if includes_value is None:
         return []
 
@@ -180,9 +227,7 @@ def _extract_includes(includes_value: Any) -> list[ParsedCIInclude]:
                     )
                 )
             continue
-        parsed = _parse_single_include(item)
-        if parsed is not None:
-            result.append(parsed)
+        result.extend(_parse_single_include(item))
     return result
 
 

--- a/cartography/intel/gitlab/ci_config_parser.py
+++ b/cartography/intel/gitlab/ci_config_parser.py
@@ -79,7 +79,6 @@ class ParsedCIInclude:
     ref: str | None
     is_pinned: bool
     is_local: bool
-    raw_include: str
 
 
 @dataclass
@@ -126,7 +125,6 @@ def _classify_bare_string(item: str) -> ParsedCIInclude:
             ref=None,
             is_pinned=_is_pinned("remote", None, item),
             is_local=False,
-            raw_include=item,
         )
     return ParsedCIInclude(
         include_type="local",
@@ -134,7 +132,6 @@ def _classify_bare_string(item: str) -> ParsedCIInclude:
         ref=None,
         is_pinned=True,
         is_local=True,
-        raw_include=item,
     )
 
 
@@ -155,7 +152,6 @@ def _parse_single_include(item: Any) -> list[ParsedCIInclude]:
     if not isinstance(item, dict):
         return []
 
-    raw = str(item)
     for include_type in ("local", "project", "remote", "template", "component"):
         if include_type not in item:
             continue
@@ -183,7 +179,6 @@ def _parse_single_include(item: Any) -> list[ParsedCIInclude]:
                         ref=ref,
                         is_pinned=_is_pinned(include_type, ref, location),
                         is_local=False,
-                        raw_include=raw,
                     )
                 )
             return results
@@ -195,7 +190,6 @@ def _parse_single_include(item: Any) -> list[ParsedCIInclude]:
                 ref=None,
                 is_pinned=_is_pinned(include_type, None, str(primary)),
                 is_local=(include_type == "local"),
-                raw_include=raw,
             )
         ]
     return []
@@ -223,7 +217,6 @@ def _extract_includes(includes_value: Any) -> list[ParsedCIInclude]:
                         ref=None,
                         is_pinned=True,
                         is_local=True,
-                        raw_include=str(item),
                     )
                 )
             continue

--- a/cartography/intel/gitlab/ci_config_parser.py
+++ b/cartography/intel/gitlab/ci_config_parser.py
@@ -290,6 +290,11 @@ def parse_lint_includes(
     path. ``ref`` for ``project`` includes is taken from ``extra.ref``
     when present, falling back to ``context_sha`` (the resolved commit
     that GitLab fetched).
+
+    GitLab's lint response uses ``type: "file"`` for project includes
+    (with ``extra.project`` set). We normalise those back to the YAML
+    parser's shape (``include_type="project"``, ``location="<project>:<file>"``)
+    so downstream nodes are consistent across the two fetch paths.
     """
     if not lint_includes:
         return []
@@ -302,7 +307,15 @@ def parse_lint_includes(
         if not include_type or not location:
             continue
         extra = entry.get("extra") if isinstance(entry.get("extra"), dict) else {}
-        ref = (extra or {}).get("ref") or entry.get("context_sha")
+        extra = extra or {}
+        ref = extra.get("ref") or entry.get("context_sha")
+
+        # Normalise file-with-project to the same shape as the YAML parser.
+        project = extra.get("project")
+        if include_type == "file" and project:
+            include_type = "project"
+            location = f"{project}:{location}"
+
         results.append(
             ParsedCIInclude(
                 include_type=include_type,

--- a/cartography/intel/gitlab/ci_config_parser.py
+++ b/cartography/intel/gitlab/ci_config_parser.py
@@ -276,6 +276,47 @@ def _extract_default_image(config: dict[str, Any]) -> str | None:
     return None
 
 
+def parse_lint_includes(
+    lint_includes: list[dict[str, Any]] | None,
+) -> list[ParsedCIInclude]:
+    """
+    Convert GitLab's ``/ci/lint`` ``includes`` array (each entry has shape
+    ``{type, location, blob, raw, extra, context_project, context_sha}``)
+    into our ``ParsedCIInclude`` records.
+
+    The merged_yaml returned alongside has the included content inlined
+    as jobs, so its ``include:`` block is gone — without this helper the
+    YAML parser alone would emit zero GitLabCIInclude nodes on the lint
+    path. ``ref`` for ``project`` includes is taken from ``extra.ref``
+    when present, falling back to ``context_sha`` (the resolved commit
+    that GitLab fetched).
+    """
+    if not lint_includes:
+        return []
+    results: list[ParsedCIInclude] = []
+    for entry in lint_includes:
+        if not isinstance(entry, dict):
+            continue
+        include_type = entry.get("type") or ""
+        location = entry.get("location") or entry.get("raw") or ""
+        if not include_type or not location:
+            continue
+        extra = entry.get("extra") if isinstance(entry.get("extra"), dict) else {}
+        ref = (extra or {}).get("ref") or entry.get("context_sha")
+        results.append(
+            ParsedCIInclude(
+                include_type=include_type,
+                location=str(location),
+                ref=str(ref) if ref else None,
+                is_pinned=_is_pinned(
+                    include_type, str(ref) if ref else None, str(location)
+                ),
+                is_local=(include_type == "local"),
+            )
+        )
+    return results
+
+
 def parse_ci_config(content: str, is_valid: bool | None = None) -> ParsedCIConfig:
     """
     Parse a GitLab CI YAML document. Returns an empty `ParsedCIConfig` on

--- a/cartography/intel/gitlab/ci_config_parser.py
+++ b/cartography/intel/gitlab/ci_config_parser.py
@@ -55,12 +55,10 @@ RESERVED_TOP_LEVEL_KEYS = {
 TRIGGER_PATTERNS = {
     "merge_requests": re.compile(
         r'CI_PIPELINE_SOURCE\s*==\s*["\']merge_request_event["\']'
-        r'|CI_MERGE_REQUEST_'
-        r'|merge_requests?'
+        r"|CI_MERGE_REQUEST_"
+        r"|merge_requests?"
     ),
-    "schedules": re.compile(
-        r'CI_PIPELINE_SOURCE\s*==\s*["\']schedule["\']|schedules?'
-    ),
+    "schedules": re.compile(r'CI_PIPELINE_SOURCE\s*==\s*["\']schedule["\']|schedules?'),
     "tag": re.compile(r"CI_COMMIT_TAG|^\s*-?\s*tags\s*:?", re.MULTILINE),
     "manual": re.compile(r"^\s*when\s*:\s*manual", re.MULTILINE),
     "web": re.compile(r'CI_PIPELINE_SOURCE\s*==\s*["\']web["\']'),

--- a/cartography/intel/gitlab/ci_variables.py
+++ b/cartography/intel/gitlab/ci_variables.py
@@ -1,0 +1,251 @@
+"""
+GitLab CI/CD Variables Intelligence Module
+
+Ingests GitLab CI/CD variables at two scopes:
+- group-level (`/api/v4/groups/:id/variables`)
+- project-level (`/api/v4/projects/:id/variables`)
+
+The variable's `value` is NEVER stored. Only metadata
+(key, variable_type, protected, masked, environment_scope, ...) is ingested,
+matching the GitHub Actions secrets/variables convention.
+
+Tokens that lack permission to read variables for a given scope (403) are
+tolerated: a warning is logged and the scope is skipped.
+
+`sync_gitlab_ci_variables` returns a `dict[project_id -> list[variables]]`
+that downstream modules (environments, ci_config) can use to build
+MatchLinks without re-querying Neo4j.
+"""
+
+import logging
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.gitlab.util import get_paginated
+from cartography.models.gitlab.ci_variables import GitLabGroupCIVariableSchema
+from cartography.models.gitlab.ci_variables import GitLabProjectCIVariableSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+def _make_variable_id(
+    scope_type: str,
+    scope_id: int,
+    key: str,
+    environment_scope: str,
+) -> str:
+    """
+    Build a stable composite ID for a CI/CD variable.
+
+    The same `key` may coexist multiple times within a single scope as long
+    as the `environment_scope` differs (GitLab uses `environment_scope` to
+    pick which value applies to a given pipeline).
+    """
+    return f"{scope_type}:{scope_id}:{key}:{environment_scope}"
+
+
+@timeit
+def get_group_variables(
+    gitlab_url: str,
+    token: str,
+    group_id: int,
+) -> list[dict[str, Any]]:
+    """
+    Fetch group-level CI/CD variables. A 403 returns []; other errors propagate.
+    """
+    try:
+        return get_paginated(
+            gitlab_url, token, f"/api/v4/groups/{group_id}/variables"
+        )
+    except requests.exceptions.HTTPError as e:
+        if e.response is not None and e.response.status_code == 403:
+            logger.warning(
+                "Token lacks permission to read CI variables for group %s. Skipping.",
+                group_id,
+            )
+            return []
+        raise
+
+
+@timeit
+def get_project_variables(
+    gitlab_url: str,
+    token: str,
+    project_id: int,
+) -> list[dict[str, Any]]:
+    """
+    Fetch project-level CI/CD variables. A 403 returns []; other errors propagate.
+    """
+    try:
+        return get_paginated(
+            gitlab_url, token, f"/api/v4/projects/{project_id}/variables"
+        )
+    except requests.exceptions.HTTPError as e:
+        if e.response is not None and e.response.status_code == 403:
+            logger.warning(
+                "Token lacks permission to read CI variables for project %s. Skipping.",
+                project_id,
+            )
+            return []
+        raise
+
+
+def transform_variables(
+    raw_variables: list[dict[str, Any]],
+    scope_type: str,
+    scope_id: int,
+    gitlab_url: str,
+) -> list[dict[str, Any]]:
+    """
+    Transform raw GitLab variable data to match our schema. Pure: no I/O.
+
+    `value` is intentionally dropped — only metadata is stored.
+    `environment_scope` defaults to "*" (GitLab's wildcard) when missing.
+    """
+    transformed = []
+    for variable in raw_variables:
+        key = variable.get("key")
+        if key is None:
+            continue
+        environment_scope = variable.get("environment_scope") or "*"
+        transformed.append(
+            {
+                "id": _make_variable_id(scope_type, scope_id, key, environment_scope),
+                "key": key,
+                "variable_type": variable.get("variable_type"),
+                "protected": bool(variable.get("protected", False)),
+                "masked": bool(variable.get("masked", False)),
+                "masked_and_hidden": bool(variable.get("masked_and_hidden", False)),
+                "raw": bool(variable.get("raw", False)),
+                "environment_scope": environment_scope,
+                "description": variable.get("description"),
+                "scope_type": scope_type,
+                "gitlab_url": gitlab_url,
+            }
+        )
+    return transformed
+
+
+@timeit
+def load_group_variables(
+    neo4j_session: neo4j.Session,
+    variables: list[dict[str, Any]],
+    group_id: int,
+    gitlab_url: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        GitLabGroupCIVariableSchema(),
+        variables,
+        lastupdated=update_tag,
+        group_id=group_id,
+        gitlab_url=gitlab_url,
+    )
+
+
+@timeit
+def load_project_variables(
+    neo4j_session: neo4j.Session,
+    variables: list[dict[str, Any]],
+    project_id: int,
+    gitlab_url: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        GitLabProjectCIVariableSchema(),
+        variables,
+        lastupdated=update_tag,
+        project_id=project_id,
+        gitlab_url=gitlab_url,
+    )
+
+
+@timeit
+def cleanup_group_variables(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+    group_id: int,
+    gitlab_url: str,
+) -> None:
+    cleanup_params = {
+        **common_job_parameters,
+        "group_id": group_id,
+        "gitlab_url": gitlab_url,
+    }
+    GraphJob.from_node_schema(GitLabGroupCIVariableSchema(), cleanup_params).run(
+        neo4j_session
+    )
+
+
+@timeit
+def cleanup_project_variables(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+    project_id: int,
+    gitlab_url: str,
+) -> None:
+    cleanup_params = {
+        **common_job_parameters,
+        "project_id": project_id,
+        "gitlab_url": gitlab_url,
+    }
+    GraphJob.from_node_schema(GitLabProjectCIVariableSchema(), cleanup_params).run(
+        neo4j_session
+    )
+
+
+@timeit
+def sync_gitlab_ci_variables(
+    neo4j_session: neo4j.Session,
+    gitlab_url: str,
+    token: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+    groups: list[dict[str, Any]],
+    projects: list[dict[str, Any]],
+) -> dict[int, list[dict[str, Any]]]:
+    """
+    Sync CI/CD variables at group and project scope.
+
+    Returns a `{project_id: [variable, ...]}` map of project-level variables,
+    so downstream modules (environments, ci_config) can match without
+    re-querying.
+    """
+    logger.info(
+        "Syncing GitLab CI/CD variables for %d groups and %d projects",
+        len(groups),
+        len(projects),
+    )
+
+    for group in groups:
+        group_id: int = group["id"]
+        raw = get_group_variables(gitlab_url, token, group_id)
+        if not raw:
+            continue
+        transformed = transform_variables(raw, "group", group_id, gitlab_url)
+        load_group_variables(
+            neo4j_session, transformed, group_id, gitlab_url, update_tag
+        )
+
+    project_variables: dict[int, list[dict[str, Any]]] = {}
+    for project in projects:
+        project_id: int = project["id"]
+        raw = get_project_variables(gitlab_url, token, project_id)
+        if not raw:
+            project_variables[project_id] = []
+            continue
+        transformed = transform_variables(raw, "project", project_id, gitlab_url)
+        load_project_variables(
+            neo4j_session, transformed, project_id, gitlab_url, update_tag
+        )
+        project_variables[project_id] = transformed
+
+    logger.info("GitLab CI/CD variables sync completed")
+    return project_variables

--- a/cartography/intel/gitlab/ci_variables.py
+++ b/cartography/intel/gitlab/ci_variables.py
@@ -59,9 +59,7 @@ def get_group_variables(
     Fetch group-level CI/CD variables. A 403 returns []; other errors propagate.
     """
     try:
-        return get_paginated(
-            gitlab_url, token, f"/api/v4/groups/{group_id}/variables"
-        )
+        return get_paginated(gitlab_url, token, f"/api/v4/groups/{group_id}/variables")
     except requests.exceptions.HTTPError as e:
         if e.response is not None and e.response.status_code == 403:
             logger.warning(

--- a/cartography/intel/gitlab/ci_variables.py
+++ b/cartography/intel/gitlab/ci_variables.py
@@ -248,8 +248,13 @@ def sync_gitlab_ci_variables(
         project_id: int = project["id"]
         raw = get_project_variables(gitlab_url, token, project_id)
         if raw is None:
+            # 403: leave project_variables[project_id] absent so downstream
+            # syncs can distinguish "no read" from "no variables" and skip
+            # the project entirely. An empty list here would let env /
+            # ci_config rebuild nodes with no linked_variable_ids and let
+            # cleanup wipe HAS_CI_VARIABLE / REFERENCES_VARIABLE edges
+            # even though the variables themselves were preserved.
             skipped["projects"].add(project_id)
-            project_variables[project_id] = []
             continue
         if not raw:
             project_variables[project_id] = []

--- a/cartography/intel/gitlab/ci_variables.py
+++ b/cartography/intel/gitlab/ci_variables.py
@@ -54,9 +54,12 @@ def get_group_variables(
     gitlab_url: str,
     token: str,
     group_id: int,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | None:
     """
-    Fetch group-level CI/CD variables. A 403 returns []; other errors propagate.
+    Fetch group-level CI/CD variables. Returns ``None`` on 403 so the caller
+    can skip BOTH the load and the cleanup for that scope; an empty list
+    would otherwise look like a successful empty sync and trigger cleanup
+    that deletes every previously-ingested variable for that scope.
     """
     try:
         return get_paginated(gitlab_url, token, f"/api/v4/groups/{group_id}/variables")
@@ -66,7 +69,7 @@ def get_group_variables(
                 "Token lacks permission to read CI variables for group %s. Skipping.",
                 group_id,
             )
-            return []
+            return None
         raise
 
 
@@ -75,9 +78,10 @@ def get_project_variables(
     gitlab_url: str,
     token: str,
     project_id: int,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | None:
     """
-    Fetch project-level CI/CD variables. A 403 returns []; other errors propagate.
+    Fetch project-level CI/CD variables. Returns ``None`` on 403 (see
+    ``get_group_variables`` for the rationale).
     """
     try:
         return get_paginated(
@@ -89,7 +93,7 @@ def get_project_variables(
                 "Token lacks permission to read CI variables for project %s. Skipping.",
                 project_id,
             )
-            return []
+            return None
         raise
 
 
@@ -208,23 +212,30 @@ def sync_gitlab_ci_variables(
     common_job_parameters: dict[str, Any],
     groups: list[dict[str, Any]],
     projects: list[dict[str, Any]],
-) -> dict[int, list[dict[str, Any]]]:
+) -> tuple[dict[int, list[dict[str, Any]]], dict[str, set[int]]]:
     """
     Sync CI/CD variables at group and project scope.
 
-    Returns a `{project_id: [variable, ...]}` map of project-level variables,
-    so downstream modules (environments, ci_config) can match without
-    re-querying.
+    Returns:
+    - a ``{project_id: [variable, ...]}`` map of project-level variables for
+      downstream modules (environments, ci_config) to match without
+      re-querying.
+    - a ``{"groups": {<id>, ...}, "projects": {<id>, ...}}`` set of scopes
+      that were skipped due to 403 — the caller must skip cleanup for those.
     """
     logger.info(
         "Syncing GitLab CI/CD variables for %d groups and %d projects",
         len(groups),
         len(projects),
     )
+    skipped: dict[str, set[int]] = {"groups": set(), "projects": set()}
 
     for group in groups:
         group_id: int = group["id"]
         raw = get_group_variables(gitlab_url, token, group_id)
+        if raw is None:
+            skipped["groups"].add(group_id)
+            continue
         if not raw:
             continue
         transformed = transform_variables(raw, "group", group_id, gitlab_url)
@@ -236,6 +247,10 @@ def sync_gitlab_ci_variables(
     for project in projects:
         project_id: int = project["id"]
         raw = get_project_variables(gitlab_url, token, project_id)
+        if raw is None:
+            skipped["projects"].add(project_id)
+            project_variables[project_id] = []
+            continue
         if not raw:
             project_variables[project_id] = []
             continue
@@ -246,4 +261,4 @@ def sync_gitlab_ci_variables(
         project_variables[project_id] = transformed
 
     logger.info("GitLab CI/CD variables sync completed")
-    return project_variables
+    return project_variables, skipped

--- a/cartography/intel/gitlab/environments.py
+++ b/cartography/intel/gitlab/environments.py
@@ -1,0 +1,205 @@
+"""
+GitLab Environments Intelligence Module
+
+Ingests GitLab environments per project and links each environment to the
+CI/CD variables that apply to it. The match logic mirrors GitLab's runtime
+behaviour: a variable applies to an environment when its `environment_scope`
+matches the environment's name exactly OR is the wildcard `*`.
+
+Glob patterns like `production/*` are recognised by GitLab at runtime but are
+not matched here — only exact + wildcard. Glob support can be added later if
+demand emerges.
+"""
+
+import logging
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.client.core.tx import load_matchlinks
+from cartography.graph.job import GraphJob
+from cartography.intel.gitlab.util import get_paginated
+from cartography.models.gitlab.environments import (
+    GitLabEnvironmentToCIVariableMatchLink,
+)
+from cartography.models.gitlab.environments import GitLabEnvironmentSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def get_environments(
+    gitlab_url: str,
+    token: str,
+    project_id: int,
+) -> list[dict[str, Any]]:
+    """
+    Fetch all environments for a project. A 403 returns []; other errors
+    propagate.
+    """
+    try:
+        return get_paginated(
+            gitlab_url, token, f"/api/v4/projects/{project_id}/environments"
+        )
+    except requests.exceptions.HTTPError as e:
+        if e.response is not None and e.response.status_code == 403:
+            logger.warning(
+                "Token lacks permission to read environments for project %s. Skipping.",
+                project_id,
+            )
+            return []
+        raise
+
+
+def transform_environments(
+    raw_environments: list[dict[str, Any]],
+    project_id: int,
+    gitlab_url: str,
+) -> list[dict[str, Any]]:
+    """
+    Transform raw environment data. Pure: no I/O.
+
+    The composite `id` includes `project_id` because GitLab's environment
+    IDs are unique per-project, not globally.
+    """
+    transformed = []
+    for env in raw_environments:
+        gitlab_env_id = env.get("id")
+        if gitlab_env_id is None:
+            continue
+        transformed.append(
+            {
+                "id": f"{project_id}:{gitlab_env_id}",
+                "gitlab_id": gitlab_env_id,
+                "name": env.get("name"),
+                "slug": env.get("slug"),
+                "external_url": env.get("external_url"),
+                "state": env.get("state"),
+                "tier": env.get("tier"),
+                "created_at": env.get("created_at"),
+                "updated_at": env.get("updated_at"),
+                "auto_stop_at": env.get("auto_stop_at"),
+                "project_id": project_id,
+                "gitlab_url": gitlab_url,
+            }
+        )
+    return transformed
+
+
+def compute_env_variable_links(
+    environments: list[dict[str, Any]],
+    project_variables: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    For each environment, find the variables that apply to it. A variable
+    applies if its `environment_scope` is the wildcard `*` OR an exact match
+    for the environment's name.
+
+    Pure: no I/O. Returns a list of `{env_id, variable_id}` records ready for
+    `load_matchlinks`.
+    """
+    links: list[dict[str, Any]] = []
+    for env in environments:
+        env_name = env.get("name")
+        env_id = env.get("id")
+        if env_name is None or env_id is None:
+            continue
+        for variable in project_variables:
+            scope = variable.get("environment_scope")
+            if scope == "*" or scope == env_name:
+                links.append({"env_id": env_id, "variable_id": variable["id"]})
+    return links
+
+
+@timeit
+def load_environments(
+    neo4j_session: neo4j.Session,
+    environments: list[dict[str, Any]],
+    project_id: int,
+    gitlab_url: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        GitLabEnvironmentSchema(),
+        environments,
+        lastupdated=update_tag,
+        project_id=project_id,
+        gitlab_url=gitlab_url,
+    )
+
+
+@timeit
+def load_environment_variable_links(
+    neo4j_session: neo4j.Session,
+    links: list[dict[str, Any]],
+    project_id: int,
+    gitlab_url: str,
+    update_tag: int,
+) -> None:
+    if not links:
+        return
+    load_matchlinks(
+        neo4j_session,
+        GitLabEnvironmentToCIVariableMatchLink(),
+        links,
+        lastupdated=update_tag,
+        _sub_resource_label="GitLabProject",
+        _sub_resource_id=project_id,
+        gitlab_url=gitlab_url,
+    )
+
+
+@timeit
+def cleanup_environments(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+    project_id: int,
+    gitlab_url: str,
+) -> None:
+    cleanup_params = {
+        **common_job_parameters,
+        "project_id": project_id,
+        "gitlab_url": gitlab_url,
+    }
+    GraphJob.from_node_schema(GitLabEnvironmentSchema(), cleanup_params).run(
+        neo4j_session
+    )
+
+
+@timeit
+def sync_gitlab_environments(
+    neo4j_session: neo4j.Session,
+    gitlab_url: str,
+    token: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+    projects: list[dict[str, Any]],
+    variables_by_project: dict[int, list[dict[str, Any]]],
+) -> None:
+    """
+    Sync environments for each project, then link each environment to the
+    project-level CI/CD variables that apply to it.
+    """
+    logger.info("Syncing GitLab environments for %d projects", len(projects))
+
+    for project in projects:
+        project_id: int = project["id"]
+        raw = get_environments(gitlab_url, token, project_id)
+        if not raw:
+            continue
+        transformed = transform_environments(raw, project_id, gitlab_url)
+        load_environments(
+            neo4j_session, transformed, project_id, gitlab_url, update_tag
+        )
+
+        project_variables = variables_by_project.get(project_id, [])
+        links = compute_env_variable_links(transformed, project_variables)
+        load_environment_variable_links(
+            neo4j_session, links, project_id, gitlab_url, update_tag
+        )
+
+    logger.info("GitLab environments sync completed")

--- a/cartography/intel/gitlab/environments.py
+++ b/cartography/intel/gitlab/environments.py
@@ -99,7 +99,15 @@ def transform_environments(
         gitlab_env_id = env.get("id")
         if gitlab_env_id is None:
             continue
-        env_name = env.get("name") or ""
+        env_name = env.get("name")
+        # Variable matching only happens when the environment has a name —
+        # an env with no name cannot match an `environment_scope`. We still
+        # ingest the node itself so it appears in the graph.
+        linked_variable_ids = (
+            _matching_variable_ids(env_name, project_variables)
+            if env_name is not None
+            else []
+        )
         transformed.append(
             {
                 "id": f"{project_id}:{gitlab_env_id}",
@@ -114,9 +122,7 @@ def transform_environments(
                 "auto_stop_at": env.get("auto_stop_at"),
                 "project_id": project_id,
                 "gitlab_url": gitlab_url,
-                "linked_variable_ids": _matching_variable_ids(
-                    env_name, project_variables
-                ),
+                "linked_variable_ids": linked_variable_ids,
             }
         )
     return transformed

--- a/cartography/intel/gitlab/environments.py
+++ b/cartography/intel/gitlab/environments.py
@@ -21,10 +21,10 @@ from cartography.client.core.tx import load
 from cartography.client.core.tx import load_matchlinks
 from cartography.graph.job import GraphJob
 from cartography.intel.gitlab.util import get_paginated
+from cartography.models.gitlab.environments import GitLabEnvironmentSchema
 from cartography.models.gitlab.environments import (
     GitLabEnvironmentToCIVariableMatchLink,
 )
-from cartography.models.gitlab.environments import GitLabEnvironmentSchema
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)

--- a/cartography/intel/gitlab/environments.py
+++ b/cartography/intel/gitlab/environments.py
@@ -18,13 +18,9 @@ import neo4j
 import requests
 
 from cartography.client.core.tx import load
-from cartography.client.core.tx import load_matchlinks
 from cartography.graph.job import GraphJob
 from cartography.intel.gitlab.util import get_paginated
 from cartography.models.gitlab.environments import GitLabEnvironmentSchema
-from cartography.models.gitlab.environments import (
-    GitLabEnvironmentToCIVariableMatchLink,
-)
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -35,10 +31,18 @@ def get_environments(
     gitlab_url: str,
     token: str,
     project_id: int,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | None:
     """
-    Fetch all environments for a project. A 403 returns []; other errors
-    propagate.
+    Fetch all environments for a project. Returns:
+    - the list on success
+    - ``None`` on 403 (permission-denied) so the caller can skip BOTH the
+      load and the cleanup for that project; an empty list would otherwise
+      look like a successful empty sync and trigger cleanup that deletes
+      every previously-ingested environment.
+    - ``[]`` on 404 (project has no environments feature enabled / project
+      removed since `all_projects` was fetched). 404 is non-fatal and does
+      not need to skip cleanup — the project legitimately has no envs.
+    Other errors propagate.
     """
     try:
         return get_paginated(
@@ -50,31 +54,57 @@ def get_environments(
                 "Token lacks permission to read environments for project %s. Skipping.",
                 project_id,
             )
+            return None
+        if e.response is not None and e.response.status_code == 404:
+            logger.warning(
+                "Environments endpoint returned 404 for project %s. Skipping.",
+                project_id,
+            )
             return []
         raise
+
+
+def _matching_variable_ids(
+    env_name: str,
+    project_variables: list[dict[str, Any]],
+) -> list[str]:
+    """Variable IDs whose ``environment_scope`` matches this env (exact or ``*``)."""
+    return [
+        v["id"]
+        for v in project_variables
+        if v.get("environment_scope") in ("*", env_name)
+    ]
 
 
 def transform_environments(
     raw_environments: list[dict[str, Any]],
     project_id: int,
     gitlab_url: str,
+    project_variables: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """
     Transform raw environment data. Pure: no I/O.
 
-    The composite `id` includes `project_id` because GitLab's environment
+    The composite ``id`` includes ``project_id`` because GitLab's environment
     IDs are unique per-project, not globally.
+
+    Each record carries a ``linked_variable_ids`` list — the IDs of the
+    project-level CI variables whose ``environment_scope`` matches this
+    environment (exact name match OR wildcard ``*``). Used by the
+    ``HAS_CI_VARIABLE`` other_relationship at load time.
     """
+    project_variables = project_variables or []
     transformed = []
     for env in raw_environments:
         gitlab_env_id = env.get("id")
         if gitlab_env_id is None:
             continue
+        env_name = env.get("name") or ""
         transformed.append(
             {
                 "id": f"{project_id}:{gitlab_env_id}",
                 "gitlab_id": gitlab_env_id,
-                "name": env.get("name"),
+                "name": env_name,
                 "slug": env.get("slug"),
                 "external_url": env.get("external_url"),
                 "state": env.get("state"),
@@ -84,34 +114,12 @@ def transform_environments(
                 "auto_stop_at": env.get("auto_stop_at"),
                 "project_id": project_id,
                 "gitlab_url": gitlab_url,
+                "linked_variable_ids": _matching_variable_ids(
+                    env_name, project_variables
+                ),
             }
         )
     return transformed
-
-
-def compute_env_variable_links(
-    environments: list[dict[str, Any]],
-    project_variables: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
-    """
-    For each environment, find the variables that apply to it. A variable
-    applies if its `environment_scope` is the wildcard `*` OR an exact match
-    for the environment's name.
-
-    Pure: no I/O. Returns a list of `{env_id, variable_id}` records ready for
-    `load_matchlinks`.
-    """
-    links: list[dict[str, Any]] = []
-    for env in environments:
-        env_name = env.get("name")
-        env_id = env.get("id")
-        if env_name is None or env_id is None:
-            continue
-        for variable in project_variables:
-            scope = variable.get("environment_scope")
-            if scope == "*" or scope == env_name:
-                links.append({"env_id": env_id, "variable_id": variable["id"]})
-    return links
 
 
 @timeit
@@ -128,27 +136,6 @@ def load_environments(
         environments,
         lastupdated=update_tag,
         project_id=project_id,
-        gitlab_url=gitlab_url,
-    )
-
-
-@timeit
-def load_environment_variable_links(
-    neo4j_session: neo4j.Session,
-    links: list[dict[str, Any]],
-    project_id: int,
-    gitlab_url: str,
-    update_tag: int,
-) -> None:
-    if not links:
-        return
-    load_matchlinks(
-        neo4j_session,
-        GitLabEnvironmentToCIVariableMatchLink(),
-        links,
-        lastupdated=update_tag,
-        _sub_resource_label="GitLabProject",
-        _sub_resource_id=project_id,
         gitlab_url=gitlab_url,
     )
 
@@ -179,27 +166,32 @@ def sync_gitlab_environments(
     common_job_parameters: dict[str, Any],
     projects: list[dict[str, Any]],
     variables_by_project: dict[int, list[dict[str, Any]]],
-) -> None:
+) -> set[int]:
     """
     Sync environments for each project, then link each environment to the
     project-level CI/CD variables that apply to it.
+
+    Returns the set of project IDs that were skipped due to 403, so the
+    caller can avoid running cleanup for them.
     """
     logger.info("Syncing GitLab environments for %d projects", len(projects))
+    skipped_projects: set[int] = set()
 
     for project in projects:
         project_id: int = project["id"]
         raw = get_environments(gitlab_url, token, project_id)
+        if raw is None:
+            skipped_projects.add(project_id)
+            continue
         if not raw:
             continue
-        transformed = transform_environments(raw, project_id, gitlab_url)
+        project_variables = variables_by_project.get(project_id, [])
+        transformed = transform_environments(
+            raw, project_id, gitlab_url, project_variables
+        )
         load_environments(
             neo4j_session, transformed, project_id, gitlab_url, update_tag
         )
 
-        project_variables = variables_by_project.get(project_id, [])
-        links = compute_env_variable_links(transformed, project_variables)
-        load_environment_variable_links(
-            neo4j_session, links, project_id, gitlab_url, update_tag
-        )
-
     logger.info("GitLab environments sync completed")
+    return skipped_projects

--- a/cartography/intel/gitlab/environments.py
+++ b/cartography/intel/gitlab/environments.py
@@ -172,19 +172,30 @@ def sync_gitlab_environments(
     common_job_parameters: dict[str, Any],
     projects: list[dict[str, Any]],
     variables_by_project: dict[int, list[dict[str, Any]]],
+    skip_projects: set[int] | None = None,
 ) -> set[int]:
     """
     Sync environments for each project, then link each environment to the
     project-level CI/CD variables that apply to it.
 
-    Returns the set of project IDs that were skipped due to 403, so the
-    caller can avoid running cleanup for them.
+    ``skip_projects`` lists project IDs whose CI variables could not be
+    loaded this run. Those projects are skipped entirely — refreshing
+    environments with no ``linked_variable_ids`` would let cleanup wipe
+    the ``HAS_CI_VARIABLE`` edges from existing envs even though the
+    variables themselves were preserved upstream.
+
+    Returns the union of ``skip_projects`` and the projects skipped due
+    to a 403 on the environments endpoint, so the caller can avoid
+    running cleanup for any of them.
     """
     logger.info("Syncing GitLab environments for %d projects", len(projects))
-    skipped_projects: set[int] = set()
+    skip_projects = skip_projects or set()
+    skipped_projects: set[int] = set(skip_projects)
 
     for project in projects:
         project_id: int = project["id"]
+        if project_id in skip_projects:
+            continue
         raw = get_environments(gitlab_url, token, project_id)
         if raw is None:
             skipped_projects.add(project_id)

--- a/cartography/intel/gitlab/runners.py
+++ b/cartography/intel/gitlab/runners.py
@@ -1,0 +1,343 @@
+"""
+GitLab Runners Intelligence Module
+
+Ingests GitLab CI/CD runners at three scopes:
+- instance-level (`/api/v4/runners/all`, requires admin scope)
+- group-level (`/api/v4/groups/:id/runners`)
+- project-level (`/api/v4/projects/:id/runners`)
+
+Each runner listed via the scope-specific endpoint is then enriched via
+`/api/v4/runners/:id` to obtain the detail fields (architecture, platform,
+contacted_at, etc.) which are not returned by the list endpoints.
+
+A token without the right scope is tolerated: a 403 is logged once at warning
+level and the affected scope is skipped, so the rest of the sync continues.
+"""
+
+import logging
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.gitlab.util import get_paginated
+from cartography.intel.gitlab.util import get_single
+from cartography.models.gitlab.runners import GitLabGroupRunnerSchema
+from cartography.models.gitlab.runners import GitLabInstanceRunnerSchema
+from cartography.models.gitlab.runners import GitLabProjectRunnerSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+def _list_runners_tolerant(
+    gitlab_url: str,
+    token: str,
+    endpoint: str,
+    scope_description: str,
+) -> list[dict[str, Any]]:
+    """
+    Fetch a paginated list of runners, tolerating a 403 by logging a warning and
+    returning an empty list. Other errors propagate.
+    """
+    try:
+        return get_paginated(gitlab_url, token, endpoint)
+    except requests.exceptions.HTTPError as e:
+        if e.response is not None and e.response.status_code == 403:
+            logger.warning(
+                "Token lacks permission to read %s. Skipping.",
+                scope_description,
+            )
+            return []
+        raise
+
+
+@timeit
+def get_instance_runners(
+    gitlab_url: str,
+    token: str,
+) -> list[dict[str, Any]]:
+    """
+    Fetch all instance-level runners. Requires admin scope on the token.
+    """
+    return _list_runners_tolerant(
+        gitlab_url,
+        token,
+        "/api/v4/runners/all",
+        "instance-level runners (/api/v4/runners/all, requires admin)",
+    )
+
+
+@timeit
+def get_group_runners(
+    gitlab_url: str,
+    token: str,
+    group_id: int,
+) -> list[dict[str, Any]]:
+    """
+    Fetch group-level runners for a specific group.
+    """
+    return _list_runners_tolerant(
+        gitlab_url,
+        token,
+        f"/api/v4/groups/{group_id}/runners",
+        f"runners for group {group_id}",
+    )
+
+
+@timeit
+def get_project_runners(
+    gitlab_url: str,
+    token: str,
+    project_id: int,
+) -> list[dict[str, Any]]:
+    """
+    Fetch project-level runners for a specific project.
+    """
+    return _list_runners_tolerant(
+        gitlab_url,
+        token,
+        f"/api/v4/projects/{project_id}/runners",
+        f"runners for project {project_id}",
+    )
+
+
+def get_runner_details(
+    gitlab_url: str,
+    token: str,
+    runner_id: int,
+) -> dict[str, Any] | None:
+    """
+    Fetch detailed runner info for a single runner. Returns None if forbidden.
+
+    The list endpoints return a subset of fields; this endpoint adds
+    architecture, platform, contacted_at, ip_address, maximum_timeout, etc.
+    """
+    try:
+        return get_single(gitlab_url, token, f"/api/v4/runners/{runner_id}")
+    except requests.exceptions.HTTPError as e:
+        if e.response is not None and e.response.status_code in (403, 404):
+            logger.warning(
+                "Could not fetch details for runner %s (status %s). Skipping.",
+                runner_id,
+                e.response.status_code,
+            )
+            return None
+        raise
+
+
+def transform_runners(
+    raw_runners: list[dict[str, Any]],
+    gitlab_url: str,
+) -> list[dict[str, Any]]:
+    """
+    Transform raw GitLab runner data to match our schema. Pure: no I/O.
+
+    `tag_list` is preserved as a list — Neo4j supports arrays of primitives.
+    """
+    transformed = []
+    for runner in raw_runners:
+        if runner is None:
+            continue
+        transformed.append(
+            {
+                "id": runner.get("id"),
+                "description": runner.get("description"),
+                "runner_type": runner.get("runner_type"),
+                "is_shared": runner.get("is_shared"),
+                "active": runner.get("active"),
+                "paused": runner.get("paused"),
+                "online": runner.get("online"),
+                "status": runner.get("status"),
+                "ip_address": runner.get("ip_address"),
+                "architecture": runner.get("architecture"),
+                "platform": runner.get("platform"),
+                "contacted_at": runner.get("contacted_at"),
+                "tag_list": runner.get("tag_list") or [],
+                "run_untagged": runner.get("run_untagged"),
+                "locked": runner.get("locked"),
+                "access_level": runner.get("access_level"),
+                "maximum_timeout": runner.get("maximum_timeout"),
+                "gitlab_url": gitlab_url,
+            }
+        )
+    return transformed
+
+
+def _enrich_with_details(
+    gitlab_url: str,
+    token: str,
+    listed_runners: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    For each runner in the list, fetch its detail record. Skips runners whose
+    detail call fails with 403/404.
+    """
+    enriched: list[dict[str, Any]] = []
+    for runner in listed_runners:
+        runner_id = runner.get("id")
+        if runner_id is None:
+            continue
+        details = get_runner_details(gitlab_url, token, runner_id)
+        if details is None:
+            continue
+        enriched.append(details)
+    return enriched
+
+
+@timeit
+def load_instance_runners(
+    neo4j_session: neo4j.Session,
+    runners: list[dict[str, Any]],
+    org_id: int,
+    gitlab_url: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        GitLabInstanceRunnerSchema(),
+        runners,
+        lastupdated=update_tag,
+        org_id=org_id,
+        gitlab_url=gitlab_url,
+    )
+
+
+@timeit
+def load_group_runners(
+    neo4j_session: neo4j.Session,
+    runners: list[dict[str, Any]],
+    group_id: int,
+    gitlab_url: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        GitLabGroupRunnerSchema(),
+        runners,
+        lastupdated=update_tag,
+        group_id=group_id,
+        gitlab_url=gitlab_url,
+    )
+
+
+@timeit
+def load_project_runners(
+    neo4j_session: neo4j.Session,
+    runners: list[dict[str, Any]],
+    project_id: int,
+    gitlab_url: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        GitLabProjectRunnerSchema(),
+        runners,
+        lastupdated=update_tag,
+        project_id=project_id,
+        gitlab_url=gitlab_url,
+    )
+
+
+@timeit
+def cleanup_instance_runners(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+    org_id: int,
+    gitlab_url: str,
+) -> None:
+    cleanup_params = {
+        **common_job_parameters,
+        "org_id": org_id,
+        "gitlab_url": gitlab_url,
+    }
+    GraphJob.from_node_schema(GitLabInstanceRunnerSchema(), cleanup_params).run(
+        neo4j_session
+    )
+
+
+@timeit
+def cleanup_group_runners(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+    group_id: int,
+    gitlab_url: str,
+) -> None:
+    cleanup_params = {
+        **common_job_parameters,
+        "group_id": group_id,
+        "gitlab_url": gitlab_url,
+    }
+    GraphJob.from_node_schema(GitLabGroupRunnerSchema(), cleanup_params).run(
+        neo4j_session
+    )
+
+
+@timeit
+def cleanup_project_runners(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+    project_id: int,
+    gitlab_url: str,
+) -> None:
+    cleanup_params = {
+        **common_job_parameters,
+        "project_id": project_id,
+        "gitlab_url": gitlab_url,
+    }
+    GraphJob.from_node_schema(GitLabProjectRunnerSchema(), cleanup_params).run(
+        neo4j_session
+    )
+
+
+@timeit
+def sync_gitlab_runners(
+    neo4j_session: neo4j.Session,
+    gitlab_url: str,
+    token: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+    groups: list[dict[str, Any]],
+    projects: list[dict[str, Any]],
+) -> None:
+    """
+    Sync GitLab runners at all three scopes (instance, group, project).
+    """
+    org_id: int = common_job_parameters["org_id"]
+
+    logger.info("Syncing GitLab instance-level runners")
+    instance_listed = get_instance_runners(gitlab_url, token)
+    instance_enriched = _enrich_with_details(gitlab_url, token, instance_listed)
+    instance_transformed = transform_runners(instance_enriched, gitlab_url)
+    load_instance_runners(
+        neo4j_session, instance_transformed, org_id, gitlab_url, update_tag
+    )
+    logger.info("Loaded %d instance-level runners", len(instance_transformed))
+
+    logger.info("Syncing GitLab group-level runners for %d groups", len(groups))
+    for group in groups:
+        group_id: int = group["id"]
+        group_listed = get_group_runners(gitlab_url, token, group_id)
+        if not group_listed:
+            continue
+        group_enriched = _enrich_with_details(gitlab_url, token, group_listed)
+        group_transformed = transform_runners(group_enriched, gitlab_url)
+        load_group_runners(
+            neo4j_session, group_transformed, group_id, gitlab_url, update_tag
+        )
+
+    logger.info("Syncing GitLab project-level runners for %d projects", len(projects))
+    for project in projects:
+        project_id: int = project["id"]
+        project_listed = get_project_runners(gitlab_url, token, project_id)
+        if not project_listed:
+            continue
+        project_enriched = _enrich_with_details(gitlab_url, token, project_listed)
+        project_transformed = transform_runners(project_enriched, gitlab_url)
+        load_project_runners(
+            neo4j_session, project_transformed, project_id, gitlab_url, update_tag
+        )
+
+    logger.info("GitLab runners sync completed")

--- a/cartography/intel/gitlab/runners.py
+++ b/cartography/intel/gitlab/runners.py
@@ -37,10 +37,15 @@ def _list_runners_tolerant(
     token: str,
     endpoint: str,
     scope_description: str,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | None:
     """
-    Fetch a paginated list of runners, tolerating a 403 by logging a warning and
-    returning an empty list. Other errors propagate.
+    Fetch a paginated list of runners. Returns:
+    - the list on success
+    - ``None`` on 403 (permission-denied), so the caller can skip BOTH the
+      load AND the cleanup for that scope. Returning [] would make the
+      cleanup phase delete everything previously ingested for that scope,
+      which is data loss disguised as a successful empty sync.
+    Other errors propagate.
     """
     try:
         return get_paginated(gitlab_url, token, endpoint)
@@ -50,7 +55,7 @@ def _list_runners_tolerant(
                 "Token lacks permission to read %s. Skipping.",
                 scope_description,
             )
-            return []
+            return None
         raise
 
 
@@ -58,9 +63,12 @@ def _list_runners_tolerant(
 def get_instance_runners(
     gitlab_url: str,
     token: str,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | None:
     """
     Fetch all instance-level runners. Requires admin scope on the token.
+
+    Returns ``None`` if the scope is denied (403), so the caller can skip the
+    cleanup pass for instance-level runners and avoid data loss.
     """
     return _list_runners_tolerant(
         gitlab_url,
@@ -75,9 +83,9 @@ def get_group_runners(
     gitlab_url: str,
     token: str,
     group_id: int,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | None:
     """
-    Fetch group-level runners for a specific group.
+    Fetch group-level runners for a specific group. Returns ``None`` on 403.
     """
     return _list_runners_tolerant(
         gitlab_url,
@@ -92,9 +100,9 @@ def get_project_runners(
     gitlab_url: str,
     token: str,
     project_id: int,
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | None:
     """
-    Fetch project-level runners for a specific project.
+    Fetch project-level runners for a specific project. Returns ``None`` on 403.
     """
     return _list_runners_tolerant(
         gitlab_url,
@@ -104,6 +112,7 @@ def get_project_runners(
     )
 
 
+@timeit
 def get_runner_details(
     gitlab_url: str,
     token: str,
@@ -301,25 +310,41 @@ def sync_gitlab_runners(
     common_job_parameters: dict[str, Any],
     groups: list[dict[str, Any]],
     projects: list[dict[str, Any]],
-) -> None:
+) -> dict[str, Any]:
     """
     Sync GitLab runners at all three scopes (instance, group, project).
+
+    Returns a "skipped scopes" map so the cleanup phase can avoid running
+    cleanup for any scope where we received a 403. Running cleanup on a
+    scope we couldn't read would delete every previously-ingested runner
+    for that scope (cleanup matches by stale `lastupdated`).
     """
     org_id: int = common_job_parameters["org_id"]
+    skipped: dict[str, Any] = {
+        "instance": False,
+        "groups": set(),
+        "projects": set(),
+    }
 
     logger.info("Syncing GitLab instance-level runners")
     instance_listed = get_instance_runners(gitlab_url, token)
-    instance_enriched = _enrich_with_details(gitlab_url, token, instance_listed)
-    instance_transformed = transform_runners(instance_enriched, gitlab_url)
-    load_instance_runners(
-        neo4j_session, instance_transformed, org_id, gitlab_url, update_tag
-    )
-    logger.info("Loaded %d instance-level runners", len(instance_transformed))
+    if instance_listed is None:
+        skipped["instance"] = True
+    else:
+        instance_enriched = _enrich_with_details(gitlab_url, token, instance_listed)
+        instance_transformed = transform_runners(instance_enriched, gitlab_url)
+        load_instance_runners(
+            neo4j_session, instance_transformed, org_id, gitlab_url, update_tag
+        )
+        logger.info("Loaded %d instance-level runners", len(instance_transformed))
 
     logger.info("Syncing GitLab group-level runners for %d groups", len(groups))
     for group in groups:
         group_id: int = group["id"]
         group_listed = get_group_runners(gitlab_url, token, group_id)
+        if group_listed is None:
+            skipped["groups"].add(group_id)
+            continue
         if not group_listed:
             continue
         group_enriched = _enrich_with_details(gitlab_url, token, group_listed)
@@ -332,6 +357,9 @@ def sync_gitlab_runners(
     for project in projects:
         project_id: int = project["id"]
         project_listed = get_project_runners(gitlab_url, token, project_id)
+        if project_listed is None:
+            skipped["projects"].add(project_id)
+            continue
         if not project_listed:
             continue
         project_enriched = _enrich_with_details(gitlab_url, token, project_listed)
@@ -341,3 +369,4 @@ def sync_gitlab_runners(
         )
 
     logger.info("GitLab runners sync completed")
+    return skipped

--- a/cartography/intel/gitlab/runners.py
+++ b/cartography/intel/gitlab/runners.py
@@ -37,6 +37,7 @@ def _list_runners_tolerant(
     token: str,
     endpoint: str,
     scope_description: str,
+    extra_params: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]] | None:
     """
     Fetch a paginated list of runners. Returns:
@@ -48,7 +49,7 @@ def _list_runners_tolerant(
     Other errors propagate.
     """
     try:
-        return get_paginated(gitlab_url, token, endpoint)
+        return get_paginated(gitlab_url, token, endpoint, extra_params=extra_params)
     except requests.exceptions.HTTPError as e:
         if e.response is not None and e.response.status_code == 403:
             logger.warning(
@@ -85,13 +86,23 @@ def get_group_runners(
     group_id: int,
 ) -> list[dict[str, Any]] | None:
     """
-    Fetch group-level runners for a specific group. Returns ``None`` on 403.
+    Fetch group-level runners for a specific group, filtered to
+    ``runner_type=group_type``.
+
+    Without the ``type`` filter, GitLab returns runners *visible to* the
+    group — including inherited instance runners — which would be attached
+    to the group as if they were group-scoped. The instance runners are
+    already collected by the instance-scope sync, and the
+    project/instance scopes are similarly filtered.
+
+    Returns ``None`` on 403.
     """
     return _list_runners_tolerant(
         gitlab_url,
         token,
         f"/api/v4/groups/{group_id}/runners",
         f"runners for group {group_id}",
+        extra_params={"type": "group_type"},
     )
 
 
@@ -102,13 +113,16 @@ def get_project_runners(
     project_id: int,
 ) -> list[dict[str, Any]] | None:
     """
-    Fetch project-level runners for a specific project. Returns ``None`` on 403.
+    Fetch project-level runners for a specific project, filtered to
+    ``runner_type=project_type`` (see :func:`get_group_runners` for the
+    rationale). Returns ``None`` on 403.
     """
     return _list_runners_tolerant(
         gitlab_url,
         token,
         f"/api/v4/projects/{project_id}/runners",
         f"runners for project {project_id}",
+        extra_params={"type": "project_type"},
     )
 
 
@@ -181,8 +195,14 @@ def _enrich_with_details(
     listed_runners: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """
-    For each runner in the list, fetch its detail record. Skips runners whose
-    detail call fails with 403/404.
+    For each runner in the list, fetch its detail record. If the detail
+    call fails (403/404), fall back to the listed record rather than
+    dropping the runner: the list endpoint already confirmed the runner
+    exists, so dropping it would let the next cleanup phase delete a
+    real runner from the graph. The detail-only fields (architecture,
+    platform, contacted_at, ip_address, maximum_timeout, ...) are absent
+    from the listed record and will be filled in next sync if the detail
+    endpoint becomes reachable again.
     """
     enriched: list[dict[str, Any]] = []
     for runner in listed_runners:
@@ -190,9 +210,7 @@ def _enrich_with_details(
         if runner_id is None:
             continue
         details = get_runner_details(gitlab_url, token, runner_id)
-        if details is None:
-            continue
-        enriched.append(details)
+        enriched.append(details if details is not None else runner)
     return enriched
 
 

--- a/cartography/models/gitlab/ci_config.py
+++ b/cartography/models/gitlab/ci_config.py
@@ -100,9 +100,7 @@ class GitLabCIConfigToProjectRel(CartographyRelSchema):
 class GitLabCIConfigSchema(CartographyNodeSchema):
     label: str = "GitLabCIConfig"
     properties: GitLabCIConfigNodeProperties = GitLabCIConfigNodeProperties()
-    sub_resource_relationship: GitLabCIConfigToProjectRel = (
-        GitLabCIConfigToProjectRel()
-    )
+    sub_resource_relationship: GitLabCIConfigToProjectRel = GitLabCIConfigToProjectRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [GitLabProjectHasCIConfigRel()],
     )
@@ -119,9 +117,7 @@ class GitLabCIConfigToCIVariableRelProperties(CartographyRelProperties):
     _sub_resource_label: PropertyRef = PropertyRef(
         "_sub_resource_label", set_in_kwargs=True
     )
-    _sub_resource_id: PropertyRef = PropertyRef(
-        "_sub_resource_id", set_in_kwargs=True
-    )
+    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)

--- a/cartography/models/gitlab/ci_config.py
+++ b/cartography/models/gitlab/ci_config.py
@@ -1,14 +1,9 @@
 """
-GitLab Environment Schema
+GitLab CI/CD config schema.
 
-Environments are GitLab's deployment targets (production, staging, ...). Each
-project has its own set of environments. The composite `id` includes the
-project_id because GitLab's environment IDs are unique per-project, not
-globally.
-
-This module also defines a scoped MatchLink that connects environments to
-their CI/CD variables. The MatchLink is scoped to the parent GitLabProject so
-the cardinality of the lookup is bounded to the project, not the whole graph.
+Represents a project's `.gitlab-ci.yml`. The config also carries a scoped
+MatchLink that connects it to the project-level CI/CD variables it
+references at runtime via `$VAR` / `${VAR}` patterns.
 """
 
 from dataclasses import dataclass
@@ -28,34 +23,41 @@ from cartography.models.core.relationships import TargetNodeMatcher
 
 
 @dataclass(frozen=True)
-class GitLabEnvironmentNodeProperties(CartographyNodeProperties):
-    id: PropertyRef = PropertyRef("id")  # Composite: f"{project_id}:{gitlab_env_id}"
-    gitlab_id: PropertyRef = PropertyRef("gitlab_id")
-    name: PropertyRef = PropertyRef("name", extra_index=True)
-    slug: PropertyRef = PropertyRef("slug")
-    external_url: PropertyRef = PropertyRef("external_url")
-    state: PropertyRef = PropertyRef("state")
-    tier: PropertyRef = PropertyRef("tier")
-    created_at: PropertyRef = PropertyRef("created_at")
-    updated_at: PropertyRef = PropertyRef("updated_at")
-    auto_stop_at: PropertyRef = PropertyRef("auto_stop_at")
+class GitLabCIConfigNodeProperties(CartographyNodeProperties):
+    """Properties for a `.gitlab-ci.yml` config node."""
+
+    id: PropertyRef = PropertyRef("id")  # Composite: f"{project_id}:{file_path}"
+    project_id: PropertyRef = PropertyRef("project_id", extra_index=True)
+    file_path: PropertyRef = PropertyRef("file_path")
+    is_valid: PropertyRef = PropertyRef("is_valid")
+    is_merged: PropertyRef = PropertyRef("is_merged")
+    job_count: PropertyRef = PropertyRef("job_count")
+    stages: PropertyRef = PropertyRef("stages")
+    trigger_rules: PropertyRef = PropertyRef("trigger_rules")
+    referenced_variable_keys: PropertyRef = PropertyRef("referenced_variable_keys")
+    referenced_protected_variables: PropertyRef = PropertyRef(
+        "referenced_protected_variables"
+    )
+    default_image: PropertyRef = PropertyRef("default_image")
+    has_includes: PropertyRef = PropertyRef("has_includes")
+    include_count: PropertyRef = PropertyRef("include_count")
     gitlab_url: PropertyRef = PropertyRef("gitlab_url", extra_index=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 # =============================================================================
-# Environment <-> Project (sub-resource and HAS_ENVIRONMENT)
+# Config <-> Project (sub-resource and HAS_CI_CONFIG)
 # =============================================================================
 
 
 @dataclass(frozen=True)
-class GitLabProjectHasEnvironmentRelProperties(CartographyRelProperties):
+class GitLabProjectHasCIConfigRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class GitLabProjectHasEnvironmentRel(CartographyRelSchema):
-    """`(:GitLabProject)-[:HAS_ENVIRONMENT]->(:GitLabEnvironment)`."""
+class GitLabProjectHasCIConfigRel(CartographyRelSchema):
+    """`(:GitLabProject)-[:HAS_CI_CONFIG]->(:GitLabCIConfig)`."""
 
     target_node_label: str = "GitLabProject"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
@@ -65,19 +67,19 @@ class GitLabProjectHasEnvironmentRel(CartographyRelSchema):
         },
     )
     direction: LinkDirection = LinkDirection.INWARD
-    rel_label: str = "HAS_ENVIRONMENT"
-    properties: GitLabProjectHasEnvironmentRelProperties = (
-        GitLabProjectHasEnvironmentRelProperties()
+    rel_label: str = "HAS_CI_CONFIG"
+    properties: GitLabProjectHasCIConfigRelProperties = (
+        GitLabProjectHasCIConfigRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class GitLabEnvironmentToProjectRelProperties(CartographyRelProperties):
+class GitLabCIConfigToProjectRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class GitLabEnvironmentToProjectRel(CartographyRelSchema):
+class GitLabCIConfigToProjectRel(CartographyRelSchema):
     """Sub-resource relationship — scoped to GitLabProject."""
 
     target_node_label: str = "GitLabProject"
@@ -89,60 +91,60 @@ class GitLabEnvironmentToProjectRel(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: GitLabEnvironmentToProjectRelProperties = (
-        GitLabEnvironmentToProjectRelProperties()
+    properties: GitLabCIConfigToProjectRelProperties = (
+        GitLabCIConfigToProjectRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class GitLabEnvironmentSchema(CartographyNodeSchema):
-    label: str = "GitLabEnvironment"
-    properties: GitLabEnvironmentNodeProperties = GitLabEnvironmentNodeProperties()
-    sub_resource_relationship: GitLabEnvironmentToProjectRel = (
-        GitLabEnvironmentToProjectRel()
+class GitLabCIConfigSchema(CartographyNodeSchema):
+    label: str = "GitLabCIConfig"
+    properties: GitLabCIConfigNodeProperties = GitLabCIConfigNodeProperties()
+    sub_resource_relationship: GitLabCIConfigToProjectRel = (
+        GitLabCIConfigToProjectRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
-        [GitLabProjectHasEnvironmentRel()],
+        [GitLabProjectHasCIConfigRel()],
     )
 
 
 # =============================================================================
-# Environment -> CI Variable MatchLink (project-scoped)
+# CIConfig -> CI Variable MatchLink (project-scoped)
 # =============================================================================
 
 
 @dataclass(frozen=True)
-class GitLabEnvironmentToCIVariableRelProperties(CartographyRelProperties):
+class GitLabCIConfigToCIVariableRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
     _sub_resource_label: PropertyRef = PropertyRef(
         "_sub_resource_label", set_in_kwargs=True
     )
-    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
+    _sub_resource_id: PropertyRef = PropertyRef(
+        "_sub_resource_id", set_in_kwargs=True
+    )
 
 
 @dataclass(frozen=True)
-class GitLabEnvironmentToCIVariableMatchLink(CartographyRelSchema):
+class GitLabCIConfigToCIVariableMatchLink(CartographyRelSchema):
     """
-    `(:GitLabEnvironment)-[:HAS_CI_VARIABLE]->(:GitLabCIVariable)`
+    `(:GitLabCIConfig)-[:REFERENCES_VARIABLE]->(:GitLabCIVariable)`
 
-    A variable is linked to an environment when its `environment_scope` is
-    either an exact match for the environment's name, or the wildcard `*`.
-    The link is scoped via `MatchLinkSubResource` to the parent GitLabProject
-    so the lookup is bounded.
+    Linked when the config's `referenced_variable_keys` contains the
+    variable's `key`. Scoped to the parent GitLabProject.
     """
 
-    source_node_label: str = "GitLabEnvironment"
+    source_node_label: str = "GitLabCIConfig"
     source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
-        {"id": PropertyRef("env_id")},
+        {"id": PropertyRef("config_id")},
     )
     target_node_label: str = "GitLabCIVariable"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("variable_id")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
-    rel_label: str = "HAS_CI_VARIABLE"
-    properties: GitLabEnvironmentToCIVariableRelProperties = (
-        GitLabEnvironmentToCIVariableRelProperties()
+    rel_label: str = "REFERENCES_VARIABLE"
+    properties: GitLabCIConfigToCIVariableRelProperties = (
+        GitLabCIConfigToCIVariableRelProperties()
     )
     source_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
         target_node_label="GitLabProject",

--- a/cartography/models/gitlab/ci_config.py
+++ b/cartography/models/gitlab/ci_config.py
@@ -1,9 +1,12 @@
 """
 GitLab CI/CD config schema.
 
-Represents a project's `.gitlab-ci.yml`. The config also carries a scoped
-MatchLink that connects it to the project-level CI/CD variables it
-references at runtime via `$VAR` / `${VAR}` patterns.
+Represents a project's `.gitlab-ci.yml`. The config also carries a
+``REFERENCES_VARIABLE`` relationship to every project-level CI variable
+whose ``key`` is referenced by the parsed pipeline. Modelled as a standard
+relationship with a ``one_to_many=True`` matcher (not a MatchLink) — the
+endpoints share the same sub-resource (the project), so the framework's
+default cleanup tied to the config node is sufficient.
 """
 
 from dataclasses import dataclass
@@ -14,11 +17,8 @@ from cartography.models.core.nodes import CartographyNodeSchema
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
-from cartography.models.core.relationships import make_source_node_matcher
 from cartography.models.core.relationships import make_target_node_matcher
-from cartography.models.core.relationships import MatchLinkSubResource
 from cartography.models.core.relationships import OtherRelationships
-from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -96,71 +96,47 @@ class GitLabCIConfigToProjectRel(CartographyRelSchema):
     )
 
 
-@dataclass(frozen=True)
-class GitLabCIConfigSchema(CartographyNodeSchema):
-    label: str = "GitLabCIConfig"
-    properties: GitLabCIConfigNodeProperties = GitLabCIConfigNodeProperties()
-    sub_resource_relationship: GitLabCIConfigToProjectRel = GitLabCIConfigToProjectRel()
-    other_relationships: OtherRelationships = OtherRelationships(
-        [GitLabProjectHasCIConfigRel()],
-    )
-
-
 # =============================================================================
-# CIConfig -> CI Variable MatchLink (project-scoped)
+# CIConfig -> CI Variable (one_to_many, applied at config load time)
 # =============================================================================
 
 
 @dataclass(frozen=True)
 class GitLabCIConfigToCIVariableRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
-    _sub_resource_label: PropertyRef = PropertyRef(
-        "_sub_resource_label", set_in_kwargs=True
-    )
-    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-class GitLabCIConfigToCIVariableMatchLink(CartographyRelSchema):
+class GitLabCIConfigToCIVariableRel(CartographyRelSchema):
     """
     `(:GitLabCIConfig)-[:REFERENCES_VARIABLE]->(:GitLabCIVariable)`
 
-    Linked when the config's `referenced_variable_keys` contains the
-    variable's `key`. Scoped to the parent GitLabProject.
+    Each config record carries a ``referenced_variable_ids`` list — the IDs
+    of project variables whose ``key`` appears in the parsed pipeline. The
+    matcher is ``one_to_many=True`` so a single config record creates one
+    rel per referenced variable. Loaded as part of GitLabCIConfigSchema's
+    other_relationships, so the rel's lifecycle follows the config node.
     """
 
-    source_node_label: str = "GitLabCIConfig"
-    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
-        {"id": PropertyRef("config_id")},
-    )
     target_node_label: str = "GitLabCIVariable"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("variable_id")},
+        {"id": PropertyRef("referenced_variable_ids", one_to_many=True)},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "REFERENCES_VARIABLE"
     properties: GitLabCIConfigToCIVariableRelProperties = (
         GitLabCIConfigToCIVariableRelProperties()
     )
-    source_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
-        target_node_label="GitLabProject",
-        target_node_matcher=make_target_node_matcher(
-            {
-                "id": PropertyRef("_sub_resource_id", set_in_kwargs=True),
-                "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
-            },
-        ),
-        direction=LinkDirection.INWARD,
-        rel_label="RESOURCE",
-    )
-    target_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
-        target_node_label="GitLabProject",
-        target_node_matcher=make_target_node_matcher(
-            {
-                "id": PropertyRef("_sub_resource_id", set_in_kwargs=True),
-                "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
-            },
-        ),
-        direction=LinkDirection.INWARD,
-        rel_label="HAS_CI_VARIABLE",
+
+
+@dataclass(frozen=True)
+class GitLabCIConfigSchema(CartographyNodeSchema):
+    label: str = "GitLabCIConfig"
+    properties: GitLabCIConfigNodeProperties = GitLabCIConfigNodeProperties()
+    sub_resource_relationship: GitLabCIConfigToProjectRel = GitLabCIConfigToProjectRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            GitLabProjectHasCIConfigRel(),
+            GitLabCIConfigToCIVariableRel(),
+        ],
     )

--- a/cartography/models/gitlab/ci_config.py
+++ b/cartography/models/gitlab/ci_config.py
@@ -46,31 +46,10 @@ class GitLabCIConfigNodeProperties(CartographyNodeProperties):
 
 
 # =============================================================================
-# Config <-> Project (sub-resource and HAS_CI_CONFIG)
+# Config -> Project (sub-resource only — there is exactly one CIConfig per
+# project, so the standard `RESOURCE` edge already encodes ownership and a
+# separate `HAS_CI_CONFIG` semantic edge would be redundant.)
 # =============================================================================
-
-
-@dataclass(frozen=True)
-class GitLabProjectHasCIConfigRelProperties(CartographyRelProperties):
-    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
-
-
-@dataclass(frozen=True)
-class GitLabProjectHasCIConfigRel(CartographyRelSchema):
-    """`(:GitLabProject)-[:HAS_CI_CONFIG]->(:GitLabCIConfig)`."""
-
-    target_node_label: str = "GitLabProject"
-    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {
-            "id": PropertyRef("project_id"),
-            "gitlab_url": PropertyRef("gitlab_url"),
-        },
-    )
-    direction: LinkDirection = LinkDirection.INWARD
-    rel_label: str = "HAS_CI_CONFIG"
-    properties: GitLabProjectHasCIConfigRelProperties = (
-        GitLabProjectHasCIConfigRelProperties()
-    )
 
 
 @dataclass(frozen=True)
@@ -135,8 +114,5 @@ class GitLabCIConfigSchema(CartographyNodeSchema):
     properties: GitLabCIConfigNodeProperties = GitLabCIConfigNodeProperties()
     sub_resource_relationship: GitLabCIConfigToProjectRel = GitLabCIConfigToProjectRel()
     other_relationships: OtherRelationships = OtherRelationships(
-        [
-            GitLabProjectHasCIConfigRel(),
-            GitLabCIConfigToCIVariableRel(),
-        ],
+        [GitLabCIConfigToCIVariableRel()],
     )

--- a/cartography/models/gitlab/ci_include.py
+++ b/cartography/models/gitlab/ci_include.py
@@ -36,7 +36,6 @@ class GitLabCIIncludeNodeProperties(CartographyNodeProperties):
     ref: PropertyRef = PropertyRef("ref")
     is_pinned: PropertyRef = PropertyRef("is_pinned")
     is_local: PropertyRef = PropertyRef("is_local")
-    raw_include: PropertyRef = PropertyRef("raw_include")
     gitlab_url: PropertyRef = PropertyRef("gitlab_url", extra_index=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 

--- a/cartography/models/gitlab/ci_include.py
+++ b/cartography/models/gitlab/ci_include.py
@@ -1,0 +1,99 @@
+"""
+GitLab CI/CD include schema.
+
+Each `include:` entry from a `.gitlab-ci.yml` becomes a GitLabCIInclude node.
+The `is_pinned` flag is the security signal: a project include without a SHA
+ref is mutable by anyone with push access to the included repo.
+"""
+
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GitLabCIIncludeNodeProperties(CartographyNodeProperties):
+    """
+    Properties for a `.gitlab-ci.yml` include reference.
+
+    `is_pinned` is the primary security signal — a project include without
+    a 40-char SHA ref will pull whatever is on the referenced branch / tag
+    at pipeline runtime.
+    """
+
+    # Composite: f"{project_id}:{include_type}:{location}:{ref or 'none'}"
+    id: PropertyRef = PropertyRef("id")
+    include_type: PropertyRef = PropertyRef("include_type", extra_index=True)
+    location: PropertyRef = PropertyRef("location", extra_index=True)
+    ref: PropertyRef = PropertyRef("ref")
+    is_pinned: PropertyRef = PropertyRef("is_pinned")
+    is_local: PropertyRef = PropertyRef("is_local")
+    raw_include: PropertyRef = PropertyRef("raw_include")
+    gitlab_url: PropertyRef = PropertyRef("gitlab_url", extra_index=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabCIConfigUsesIncludeRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabCIConfigUsesIncludeRel(CartographyRelSchema):
+    """`(:GitLabCIConfig)-[:USES_INCLUDE]->(:GitLabCIInclude)`."""
+
+    target_node_label: str = "GitLabCIConfig"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("config_id"),
+            "gitlab_url": PropertyRef("gitlab_url"),
+        },
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "USES_INCLUDE"
+    properties: GitLabCIConfigUsesIncludeRelProperties = (
+        GitLabCIConfigUsesIncludeRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitLabCIIncludeToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabCIIncludeToProjectRel(CartographyRelSchema):
+    """Sub-resource relationship — scoped to GitLabProject."""
+
+    target_node_label: str = "GitLabProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("project_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GitLabCIIncludeToProjectRelProperties = (
+        GitLabCIIncludeToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitLabCIIncludeSchema(CartographyNodeSchema):
+    label: str = "GitLabCIInclude"
+    properties: GitLabCIIncludeNodeProperties = GitLabCIIncludeNodeProperties()
+    sub_resource_relationship: GitLabCIIncludeToProjectRel = (
+        GitLabCIIncludeToProjectRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [GitLabCIConfigUsesIncludeRel()],
+    )

--- a/cartography/models/gitlab/ci_variables.py
+++ b/cartography/models/gitlab/ci_variables.py
@@ -1,0 +1,129 @@
+"""
+GitLab CI/CD Variable Schema
+
+GitLab CI/CD variables exist at two scopes:
+- Group-level: shared across all projects in the group (and descendants)
+- Project-level: scoped to a single project
+
+GitLab does not distinguish "secrets" from "variables" at the API level —
+the `masked`, `masked_and_hidden`, and `protected` flags carry the security
+metadata. The variable's `value` is intentionally NOT ingested: only the
+metadata is stored.
+
+The composite `id` uses {scope_type}:{scope_id}:{key}:{environment_scope}
+because GitLab allows the same key to coexist with different
+environment_scope values within the same scope.
+"""
+
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GitLabCIVariableNodeProperties(CartographyNodeProperties):
+    """
+    Properties for a GitLab CI/CD variable node.
+
+    `protected` and `masked` are the primary security signals: a variable
+    that is `protected=False` can leak to a non-protected branch, and one
+    that is `masked=False` can be echoed in build logs.
+    """
+
+    id: PropertyRef = PropertyRef("id")  # Composite: scope_type:scope_id:key:env_scope
+    key: PropertyRef = PropertyRef("key", extra_index=True)
+    variable_type: PropertyRef = PropertyRef("variable_type")
+    protected: PropertyRef = PropertyRef("protected", extra_index=True)
+    masked: PropertyRef = PropertyRef("masked")
+    masked_and_hidden: PropertyRef = PropertyRef("masked_and_hidden")
+    raw: PropertyRef = PropertyRef("raw")
+    environment_scope: PropertyRef = PropertyRef("environment_scope", extra_index=True)
+    description: PropertyRef = PropertyRef("description")
+    scope_type: PropertyRef = PropertyRef("scope_type")
+    gitlab_url: PropertyRef = PropertyRef("gitlab_url", extra_index=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+# =============================================================================
+# Group-level CI/CD variable
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class GitLabGroupCIVariableToGroupRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabGroupCIVariableToGroupRel(CartographyRelSchema):
+    """Sub-resource for group-level CI variables — scoped to GitLabGroup."""
+
+    target_node_label: str = "GitLabGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("group_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_CI_VARIABLE"
+    properties: GitLabGroupCIVariableToGroupRelProperties = (
+        GitLabGroupCIVariableToGroupRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitLabGroupCIVariableSchema(CartographyNodeSchema):
+    """Schema for group-level CI/CD variables."""
+
+    label: str = "GitLabCIVariable"
+    properties: GitLabCIVariableNodeProperties = GitLabCIVariableNodeProperties()
+    sub_resource_relationship: GitLabGroupCIVariableToGroupRel = (
+        GitLabGroupCIVariableToGroupRel()
+    )
+
+
+# =============================================================================
+# Project-level CI/CD variable
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class GitLabProjectCIVariableToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabProjectCIVariableToProjectRel(CartographyRelSchema):
+    """Sub-resource for project-level CI variables — scoped to GitLabProject."""
+
+    target_node_label: str = "GitLabProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("project_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_CI_VARIABLE"
+    properties: GitLabProjectCIVariableToProjectRelProperties = (
+        GitLabProjectCIVariableToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitLabProjectCIVariableSchema(CartographyNodeSchema):
+    """Schema for project-level CI/CD variables."""
+
+    label: str = "GitLabCIVariable"
+    properties: GitLabCIVariableNodeProperties = GitLabCIVariableNodeProperties()
+    sub_resource_relationship: GitLabProjectCIVariableToProjectRel = (
+        GitLabProjectCIVariableToProjectRel()
+    )

--- a/cartography/models/gitlab/ci_variables.py
+++ b/cartography/models/gitlab/ci_variables.py
@@ -24,6 +24,7 @@ from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -73,20 +74,51 @@ class GitLabGroupCIVariableToGroupRel(CartographyRelSchema):
         },
     )
     direction: LinkDirection = LinkDirection.INWARD
-    rel_label: str = "HAS_CI_VARIABLE"
+    rel_label: str = "RESOURCE"
     properties: GitLabGroupCIVariableToGroupRelProperties = (
         GitLabGroupCIVariableToGroupRelProperties()
     )
 
 
 @dataclass(frozen=True)
+class GitLabGroupHasCIVariableRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabGroupHasCIVariableRel(CartographyRelSchema):
+    """`(:GitLabGroup)-[:HAS_CI_VARIABLE]->(:GitLabCIVariable)` — semantic edge."""
+
+    target_node_label: str = "GitLabGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("group_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_CI_VARIABLE"
+    properties: GitLabGroupHasCIVariableRelProperties = (
+        GitLabGroupHasCIVariableRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class GitLabGroupCIVariableSchema(CartographyNodeSchema):
-    """Schema for group-level CI/CD variables."""
+    """Schema for group-level CI/CD variables.
+
+    Two relationships to the parent group:
+    - ``RESOURCE`` — used by the framework for cleanup scoping (convention).
+    - ``HAS_CI_VARIABLE`` — semantic edge for graph queries.
+    """
 
     label: str = "GitLabCIVariable"
     properties: GitLabCIVariableNodeProperties = GitLabCIVariableNodeProperties()
     sub_resource_relationship: GitLabGroupCIVariableToGroupRel = (
         GitLabGroupCIVariableToGroupRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [GitLabGroupHasCIVariableRel()],
     )
 
 
@@ -112,18 +144,48 @@ class GitLabProjectCIVariableToProjectRel(CartographyRelSchema):
         },
     )
     direction: LinkDirection = LinkDirection.INWARD
-    rel_label: str = "HAS_CI_VARIABLE"
+    rel_label: str = "RESOURCE"
     properties: GitLabProjectCIVariableToProjectRelProperties = (
         GitLabProjectCIVariableToProjectRelProperties()
     )
 
 
 @dataclass(frozen=True)
+class GitLabProjectHasCIVariableRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabProjectHasCIVariableRel(CartographyRelSchema):
+    """`(:GitLabProject)-[:HAS_CI_VARIABLE]->(:GitLabCIVariable)` — semantic edge."""
+
+    target_node_label: str = "GitLabProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("project_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_CI_VARIABLE"
+    properties: GitLabProjectHasCIVariableRelProperties = (
+        GitLabProjectHasCIVariableRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class GitLabProjectCIVariableSchema(CartographyNodeSchema):
-    """Schema for project-level CI/CD variables."""
+    """Schema for project-level CI/CD variables.
+
+    See :class:`GitLabGroupCIVariableSchema` for the rationale on why both
+    ``RESOURCE`` and ``HAS_CI_VARIABLE`` edges exist.
+    """
 
     label: str = "GitLabCIVariable"
     properties: GitLabCIVariableNodeProperties = GitLabCIVariableNodeProperties()
     sub_resource_relationship: GitLabProjectCIVariableToProjectRel = (
         GitLabProjectCIVariableToProjectRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [GitLabProjectHasCIVariableRel()],
     )

--- a/cartography/models/gitlab/environments.py
+++ b/cartography/models/gitlab/environments.py
@@ -6,9 +6,13 @@ project has its own set of environments. The composite `id` includes the
 project_id because GitLab's environment IDs are unique per-project, not
 globally.
 
-This module also defines a scoped MatchLink that connects environments to
-their CI/CD variables. The MatchLink is scoped to the parent GitLabProject so
-the cardinality of the lookup is bounded to the project, not the whole graph.
+The environment carries an ``HAS_CI_VARIABLE`` relationship to every
+project-level CI variable that applies to it (exact-name match on
+``environment_scope`` or wildcard ``*``). The link is modelled as a standard
+relationship with a ``one_to_many=True`` matcher, not a MatchLink — the
+endpoints share the same sub-resource (the project), so the framework's
+default cleanup tied to the environment node is sufficient and there is no
+need for a separate MatchLink load + cleanup.
 """
 
 from dataclasses import dataclass
@@ -19,11 +23,8 @@ from cartography.models.core.nodes import CartographyNodeSchema
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
-from cartography.models.core.relationships import make_source_node_matcher
 from cartography.models.core.relationships import make_target_node_matcher
-from cartography.models.core.relationships import MatchLinkSubResource
 from cartography.models.core.relationships import OtherRelationships
-from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -94,6 +95,42 @@ class GitLabEnvironmentToProjectRel(CartographyRelSchema):
     )
 
 
+# =============================================================================
+# Environment -> CI Variable (one_to_many, applied at env load time)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class GitLabEnvironmentToCIVariableRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabEnvironmentToCIVariableRel(CartographyRelSchema):
+    """
+    `(:GitLabEnvironment)-[:HAS_CI_VARIABLE]->(:GitLabCIVariable)`
+
+    Each environment record carries a ``linked_variable_ids`` list of
+    variable IDs whose ``environment_scope`` matches this environment
+    (exact name OR wildcard ``*``). The matcher is ``one_to_many=True`` so
+    a single environment record creates one rel per matching variable.
+
+    Loaded as part of GitLabEnvironmentSchema's other_relationships, which
+    means the rel's lifecycle follows the environment node — when a stale
+    environment is cleaned up, its variable rels are removed automatically.
+    """
+
+    target_node_label: str = "GitLabCIVariable"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("linked_variable_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_CI_VARIABLE"
+    properties: GitLabEnvironmentToCIVariableRelProperties = (
+        GitLabEnvironmentToCIVariableRelProperties()
+    )
+
+
 @dataclass(frozen=True)
 class GitLabEnvironmentSchema(CartographyNodeSchema):
     label: str = "GitLabEnvironment"
@@ -102,67 +139,8 @@ class GitLabEnvironmentSchema(CartographyNodeSchema):
         GitLabEnvironmentToProjectRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
-        [GitLabProjectHasEnvironmentRel()],
-    )
-
-
-# =============================================================================
-# Environment -> CI Variable MatchLink (project-scoped)
-# =============================================================================
-
-
-@dataclass(frozen=True)
-class GitLabEnvironmentToCIVariableRelProperties(CartographyRelProperties):
-    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
-    _sub_resource_label: PropertyRef = PropertyRef(
-        "_sub_resource_label", set_in_kwargs=True
-    )
-    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
-
-
-@dataclass(frozen=True)
-class GitLabEnvironmentToCIVariableMatchLink(CartographyRelSchema):
-    """
-    `(:GitLabEnvironment)-[:HAS_CI_VARIABLE]->(:GitLabCIVariable)`
-
-    A variable is linked to an environment when its `environment_scope` is
-    either an exact match for the environment's name, or the wildcard `*`.
-    The link is scoped via `MatchLinkSubResource` to the parent GitLabProject
-    so the lookup is bounded.
-    """
-
-    source_node_label: str = "GitLabEnvironment"
-    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
-        {"id": PropertyRef("env_id")},
-    )
-    target_node_label: str = "GitLabCIVariable"
-    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("variable_id")},
-    )
-    direction: LinkDirection = LinkDirection.OUTWARD
-    rel_label: str = "HAS_CI_VARIABLE"
-    properties: GitLabEnvironmentToCIVariableRelProperties = (
-        GitLabEnvironmentToCIVariableRelProperties()
-    )
-    source_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
-        target_node_label="GitLabProject",
-        target_node_matcher=make_target_node_matcher(
-            {
-                "id": PropertyRef("_sub_resource_id", set_in_kwargs=True),
-                "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
-            },
-        ),
-        direction=LinkDirection.INWARD,
-        rel_label="RESOURCE",
-    )
-    target_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
-        target_node_label="GitLabProject",
-        target_node_matcher=make_target_node_matcher(
-            {
-                "id": PropertyRef("_sub_resource_id", set_in_kwargs=True),
-                "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
-            },
-        ),
-        direction=LinkDirection.INWARD,
-        rel_label="HAS_CI_VARIABLE",
+        [
+            GitLabProjectHasEnvironmentRel(),
+            GitLabEnvironmentToCIVariableRel(),
+        ],
     )

--- a/cartography/models/gitlab/environments.py
+++ b/cartography/models/gitlab/environments.py
@@ -1,0 +1,170 @@
+"""
+GitLab Environment Schema
+
+Environments are GitLab's deployment targets (production, staging, ...). Each
+project has its own set of environments. The composite `id` includes the
+project_id because GitLab's environment IDs are unique per-project, not
+globally.
+
+This module also defines a scoped MatchLink that connects environments to
+their CI/CD variables. The MatchLink is scoped to the parent GitLabProject so
+the cardinality of the lookup is bounded to the project, not the whole graph.
+"""
+
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import MatchLinkSubResource
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import SourceNodeMatcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GitLabEnvironmentNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")  # Composite: f"{project_id}:{gitlab_env_id}"
+    gitlab_id: PropertyRef = PropertyRef("gitlab_id")
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    slug: PropertyRef = PropertyRef("slug")
+    external_url: PropertyRef = PropertyRef("external_url")
+    state: PropertyRef = PropertyRef("state")
+    tier: PropertyRef = PropertyRef("tier")
+    created_at: PropertyRef = PropertyRef("created_at")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    auto_stop_at: PropertyRef = PropertyRef("auto_stop_at")
+    gitlab_url: PropertyRef = PropertyRef("gitlab_url", extra_index=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+# =============================================================================
+# Environment <-> Project (sub-resource and HAS_ENVIRONMENT)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class GitLabProjectHasEnvironmentRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabProjectHasEnvironmentRel(CartographyRelSchema):
+    """`(:GitLabProject)-[:HAS_ENVIRONMENT]->(:GitLabEnvironment)`."""
+
+    target_node_label: str = "GitLabProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("project_id"),
+            "gitlab_url": PropertyRef("gitlab_url"),
+        },
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_ENVIRONMENT"
+    properties: GitLabProjectHasEnvironmentRelProperties = (
+        GitLabProjectHasEnvironmentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitLabEnvironmentToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabEnvironmentToProjectRel(CartographyRelSchema):
+    """Sub-resource relationship — scoped to GitLabProject."""
+
+    target_node_label: str = "GitLabProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("project_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GitLabEnvironmentToProjectRelProperties = (
+        GitLabEnvironmentToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitLabEnvironmentSchema(CartographyNodeSchema):
+    label: str = "GitLabEnvironment"
+    properties: GitLabEnvironmentNodeProperties = GitLabEnvironmentNodeProperties()
+    sub_resource_relationship: GitLabEnvironmentToProjectRel = (
+        GitLabEnvironmentToProjectRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [GitLabProjectHasEnvironmentRel()],
+    )
+
+
+# =============================================================================
+# Environment -> CI Variable MatchLink (project-scoped)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class GitLabEnvironmentToCIVariableRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label", set_in_kwargs=True
+    )
+    _sub_resource_id: PropertyRef = PropertyRef(
+        "_sub_resource_id", set_in_kwargs=True
+    )
+
+
+@dataclass(frozen=True)
+class GitLabEnvironmentToCIVariableMatchLink(CartographyRelSchema):
+    """
+    `(:GitLabEnvironment)-[:HAS_CI_VARIABLE]->(:GitLabCIVariable)`
+
+    A variable is linked to an environment when its `environment_scope` is
+    either an exact match for the environment's name, or the wildcard `*`.
+    The link is scoped via `MatchLinkSubResource` to the parent GitLabProject
+    so the lookup is bounded.
+    """
+
+    source_node_label: str = "GitLabEnvironment"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("env_id")},
+    )
+    target_node_label: str = "GitLabCIVariable"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("variable_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_CI_VARIABLE"
+    properties: GitLabEnvironmentToCIVariableRelProperties = (
+        GitLabEnvironmentToCIVariableRelProperties()
+    )
+    source_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
+        target_node_label="GitLabProject",
+        target_node_matcher=make_target_node_matcher(
+            {
+                "id": PropertyRef("_sub_resource_id", set_in_kwargs=True),
+                "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+            },
+        ),
+        direction=LinkDirection.INWARD,
+        rel_label="RESOURCE",
+    )
+    target_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
+        target_node_label="GitLabProject",
+        target_node_matcher=make_target_node_matcher(
+            {
+                "id": PropertyRef("_sub_resource_id", set_in_kwargs=True),
+                "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+            },
+        ),
+        direction=LinkDirection.INWARD,
+        rel_label="HAS_CI_VARIABLE",
+    )

--- a/cartography/models/gitlab/runners.py
+++ b/cartography/models/gitlab/runners.py
@@ -1,0 +1,170 @@
+"""
+GitLab Runner Schema
+
+Runners execute CI/CD jobs in GitLab. They exist at three scopes:
+- instance_type: shared across the whole GitLab instance (org-scoped here)
+- group_type: scoped to a group and its descendants
+- project_type: scoped to a single project
+
+We model all three with the same Neo4j label `GitLabRunner`, but with three
+distinct schemas so each scope's cleanup is correctly bounded to its parent.
+"""
+
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GitLabRunnerNodeProperties(CartographyNodeProperties):
+    """
+    Properties for a GitLab Runner node.
+
+    `run_untagged`, `locked`, and `access_level` are security-relevant: an
+    untagged runner with `access_level=not_protected` will execute jobs from
+    any project that can reach it, including from non-protected branches.
+    """
+
+    id: PropertyRef = PropertyRef("id")  # Numeric GitLab runner ID
+    description: PropertyRef = PropertyRef("description")
+    runner_type: PropertyRef = PropertyRef("runner_type", extra_index=True)
+    is_shared: PropertyRef = PropertyRef("is_shared")
+    active: PropertyRef = PropertyRef("active")
+    paused: PropertyRef = PropertyRef("paused")
+    online: PropertyRef = PropertyRef("online")
+    status: PropertyRef = PropertyRef("status", extra_index=True)
+    ip_address: PropertyRef = PropertyRef("ip_address")
+    architecture: PropertyRef = PropertyRef("architecture")
+    platform: PropertyRef = PropertyRef("platform")
+    contacted_at: PropertyRef = PropertyRef("contacted_at")
+    tag_list: PropertyRef = PropertyRef("tag_list")
+    run_untagged: PropertyRef = PropertyRef("run_untagged")
+    locked: PropertyRef = PropertyRef("locked")
+    access_level: PropertyRef = PropertyRef("access_level")
+    maximum_timeout: PropertyRef = PropertyRef("maximum_timeout")
+    gitlab_url: PropertyRef = PropertyRef("gitlab_url", extra_index=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+# =============================================================================
+# Instance-level Runner (sub-resource = GitLabOrganization)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class GitLabInstanceRunnerToOrganizationRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabInstanceRunnerToOrganizationRel(CartographyRelSchema):
+    """Sub-resource for instance-level runners — scoped to GitLabOrganization."""
+
+    target_node_label: str = "GitLabOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("org_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GitLabInstanceRunnerToOrganizationRelProperties = (
+        GitLabInstanceRunnerToOrganizationRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitLabInstanceRunnerSchema(CartographyNodeSchema):
+    """Schema for instance-level GitLab runners."""
+
+    label: str = "GitLabRunner"
+    properties: GitLabRunnerNodeProperties = GitLabRunnerNodeProperties()
+    sub_resource_relationship: GitLabInstanceRunnerToOrganizationRel = (
+        GitLabInstanceRunnerToOrganizationRel()
+    )
+
+
+# =============================================================================
+# Group-level Runner (sub-resource = GitLabGroup)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class GitLabGroupRunnerToGroupRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabGroupRunnerToGroupRel(CartographyRelSchema):
+    """Sub-resource for group-level runners — scoped to GitLabGroup."""
+
+    target_node_label: str = "GitLabGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("group_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GitLabGroupRunnerToGroupRelProperties = (
+        GitLabGroupRunnerToGroupRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitLabGroupRunnerSchema(CartographyNodeSchema):
+    """Schema for group-level GitLab runners."""
+
+    label: str = "GitLabRunner"
+    properties: GitLabRunnerNodeProperties = GitLabRunnerNodeProperties()
+    sub_resource_relationship: GitLabGroupRunnerToGroupRel = (
+        GitLabGroupRunnerToGroupRel()
+    )
+
+
+# =============================================================================
+# Project-level Runner (sub-resource = GitLabProject)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class GitLabProjectRunnerToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GitLabProjectRunnerToProjectRel(CartographyRelSchema):
+    """Sub-resource for project-level runners — scoped to GitLabProject."""
+
+    target_node_label: str = "GitLabProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("project_id", set_in_kwargs=True),
+            "gitlab_url": PropertyRef("gitlab_url", set_in_kwargs=True),
+        },
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GitLabProjectRunnerToProjectRelProperties = (
+        GitLabProjectRunnerToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GitLabProjectRunnerSchema(CartographyNodeSchema):
+    """Schema for project-level GitLab runners."""
+
+    label: str = "GitLabRunner"
+    properties: GitLabRunnerNodeProperties = GitLabRunnerNodeProperties()
+    sub_resource_relationship: GitLabProjectRunnerToProjectRel = (
+        GitLabProjectRunnerToProjectRel()
+    )

--- a/docs/root/modules/gitlab/config.md
+++ b/docs/root/modules/gitlab/config.md
@@ -11,7 +11,7 @@ Follow these steps to configure Cartography to sync GitLab organization, group, 
 ### Creating a GitLab Personal Access Token
 
 1. Navigate to your GitLab instance (e.g., `https://gitlab.com` or `https://gitlab.example.com`)
-2. Go to **User Settings** → **Access Tokens** (or directly to `https://your-gitlab-instance/-/profile/personal_access_tokens`)
+2. Go to **User Settings** → **Access Tokens** (or directly to `https://your-gitlab-instance/-/user_settings/personal_access_tokens`)
 3. Click **Add new token**
 4. Configure your token:
    - **Token name**: `cartography-sync`

--- a/docs/root/modules/gitlab/config.md
+++ b/docs/root/modules/gitlab/config.md
@@ -45,7 +45,7 @@ Listing **instance-level** (shared) runners via `GET /api/v4/runners/all` requir
 
 #### CI config (`.gitlab-ci.yml`) ingestion
 
-The CI config sync first calls `GET /api/v4/projects/:id/ci/lint?dry_run=true` to obtain the merged YAML (with all `include:` references expanded). Tokens generated from a user without Maintainer access on the project may not be allowed to use this endpoint — in that case the sync falls back to the raw `.gitlab-ci.yml` from the repository, which only requires `read_repository`. If both calls fail (404 / 403), the project is skipped silently.
+The CI config sync first calls `GET /api/v4/projects/:id/ci/lint?dry_run=true` to obtain the merged YAML (with all `include:` references expanded). Tokens generated from a user without Maintainer access on the project may not be allowed to use this endpoint — in that case the sync falls back to the raw `.gitlab-ci.yml` from the repository, which only requires `read_repository`. If both calls fail (404 / 403), the project is skipped (a warning is logged before the skip).
 
 ### Finding Your Organization ID
 

--- a/docs/root/modules/gitlab/config.md
+++ b/docs/root/modules/gitlab/config.md
@@ -51,8 +51,9 @@ The CI config sync first calls `GET /api/v4/projects/:id/ci/lint?dry_run=true` t
 
 The organization ID is the numeric ID of the top-level GitLab group you want to sync. To find it:
 
-1. Navigate to your group's page on GitLab (e.g., `https://gitlab.com/your-organization`)
-2. The group ID is displayed below the group name, or you can find it via the API:
+1. Navigate to your group's page on GitLab (e.g., `https://gitlab.com/your-organization`).
+2. Click the **⋮** (three dots) menu in the top right of the group header and select **Copy group ID**.
+3. Alternatively, fetch it via the API:
    ```bash
    curl -H "PRIVATE-TOKEN: your-token" "https://gitlab.com/api/v4/groups/your-organization"
    ```

--- a/docs/root/modules/gitlab/config.md
+++ b/docs/root/modules/gitlab/config.md
@@ -28,7 +28,7 @@ The token requires the following scopes:
 |-------|---------|
 | `read_user` | Access user profile information for group/project membership |
 | `read_repository` | Access repository metadata, branches, and file contents |
-| `read_api` | Access groups, projects, dependencies, and language statistics |
+| `read_api` | Access groups, projects, dependencies, language statistics, and group/project-level CI/CD runners |
 
 These scopes provide read-only access to:
 - Organizations (top-level groups) and nested groups
@@ -37,6 +37,11 @@ These scopes provide read-only access to:
 - Dependency files (package.json, requirements.txt, etc.)
 - Dependencies extracted from dependency files
 - Project language statistics
+- Group-level and project-level CI/CD runners
+
+#### Optional: instance-level runners
+
+Listing **instance-level** (shared) runners via `GET /api/v4/runners/all` requires the token to belong to a GitLab administrator. If the token does not have admin privileges, the sync logs a warning and skips instance-level runners; group-level and project-level runners continue to be ingested normally.
 
 ### Finding Your Organization ID
 

--- a/docs/root/modules/gitlab/config.md
+++ b/docs/root/modules/gitlab/config.md
@@ -43,6 +43,10 @@ These scopes provide read-only access to:
 
 Listing **instance-level** (shared) runners via `GET /api/v4/runners/all` requires the token to belong to a GitLab administrator. If the token does not have admin privileges, the sync logs a warning and skips instance-level runners; group-level and project-level runners continue to be ingested normally.
 
+#### CI config (`.gitlab-ci.yml`) ingestion
+
+The CI config sync first calls `GET /api/v4/projects/:id/ci/lint?dry_run=true` to obtain the merged YAML (with all `include:` references expanded). Tokens generated from a user without Maintainer access on the project may not be allowed to use this endpoint — in that case the sync falls back to the raw `.gitlab-ci.yml` from the repository, which only requires `read_repository`. If both calls fail (404 / 403), the project is skipped silently.
+
 ### Finding Your Organization ID
 
 The organization ID is the numeric ID of the top-level GitLab group you want to sync. To find it:

--- a/docs/root/modules/gitlab/schema.md
+++ b/docs/root/modules/gitlab/schema.md
@@ -753,19 +753,19 @@ All three are stored under the same Neo4j label (`GitLabRunner`); the `runner_ty
 - A `GitLabRunner` of type `instance_type` is a `RESOURCE` of a `GitLabOrganization`.
 
     ```cypher
-    (:GitLabRunner)-[:RESOURCE]->(:GitLabOrganization)
+    (:GitLabOrganization)-[:RESOURCE]->(:GitLabRunner)
     ```
 
 - A `GitLabRunner` of type `group_type` is a `RESOURCE` of a `GitLabGroup`.
 
     ```cypher
-    (:GitLabRunner)-[:RESOURCE]->(:GitLabGroup)
+    (:GitLabGroup)-[:RESOURCE]->(:GitLabRunner)
     ```
 
 - A `GitLabRunner` of type `project_type` is a `RESOURCE` of a `GitLabProject`.
 
     ```cypher
-    (:GitLabRunner)-[:RESOURCE]->(:GitLabProject)
+    (:GitLabProject)-[:RESOURCE]->(:GitLabRunner)
     ```
 
 #### Example queries

--- a/docs/root/modules/gitlab/schema.md
+++ b/docs/root/modules/gitlab/schema.md
@@ -20,6 +20,10 @@ O -- RESOURCE --> R_I(GitLabRunner: instance)
 G -- RESOURCE --> R_G(GitLabRunner: group)
 P -- RESOURCE --> R_P(GitLabRunner: project)
 
+%% CI/CD Variables
+G -- HAS_CI_VARIABLE --> CV_G(GitLabCIVariable: group)
+P -- HAS_CI_VARIABLE --> CV_P(GitLabCIVariable: project)
+
 %% Container Registry
 O -- RESOURCE --> CR(GitLabContainerRepository)
 O -- RESOURCE --> CI(GitLabContainerImage)
@@ -768,4 +772,71 @@ Count runners per scope:
 MATCH (r:GitLabRunner)
 RETURN r.runner_type, count(*) AS count
 ORDER BY count DESC
+```
+
+### GitLabCIVariable
+
+Representation of a GitLab CI/CD variable. Variables exist at two scopes:
+
+- **group**: shared across all projects in the group (and descendants)
+- **project**: scoped to a single project
+
+GitLab does not differentiate "secrets" from "variables" at the API level — the
+`masked`, `masked_and_hidden`, and `protected` flags carry the security
+metadata. **The variable's value is intentionally not stored.** Only the
+metadata is ingested.
+
+Both scopes share the same Neo4j label (`GitLabCIVariable`); the parent of the
+`HAS_CI_VARIABLE` relationship and the `scope_type` property distinguish them.
+
+The composite `id` is `{scope_type}:{scope_id}:{key}:{environment_scope}` so
+that a variable with the same key but a different `environment_scope` (a
+common pattern for `DATABASE_URL` etc.) does not collide.
+
+| Field | Description |
+|-------|-------------|
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| **id** | Composite ID: `{scope_type}:{scope_id}:{key}:{environment_scope}` |
+| **key** | Variable key as exposed to CI/CD jobs |
+| variable_type | `env_var` or `file` |
+| **protected** | If true, the variable is exposed only on protected refs (security-sensitive) |
+| masked | If true, GitLab attempts to mask the value in job logs |
+| masked_and_hidden | If true, the value cannot be retrieved through the API after creation |
+| raw | If true, GitLab does not perform variable expansion on the value |
+| **environment_scope** | Glob (default `*`) selecting which environments receive this variable |
+| description | Human-readable description |
+| scope_type | `group` or `project` |
+| **gitlab_url** | GitLab instance URL |
+
+#### Relationships
+
+- A group-level `GitLabCIVariable` is owned by a `GitLabGroup`.
+
+    ```cypher
+    (:GitLabGroup)-[:HAS_CI_VARIABLE]->(:GitLabCIVariable)
+    ```
+
+- A project-level `GitLabCIVariable` is owned by a `GitLabProject`.
+
+    ```cypher
+    (:GitLabProject)-[:HAS_CI_VARIABLE]->(:GitLabCIVariable)
+    ```
+
+#### Example queries
+
+Find unmasked, unprotected variables — these may leak through job logs and
+non-protected branches:
+
+```cypher
+MATCH (v:GitLabCIVariable)
+WHERE v.protected = false AND v.masked = false
+RETURN v.scope_type, v.key, v.environment_scope
+```
+
+Count variables per scope:
+
+```cypher
+MATCH (v:GitLabCIVariable)
+RETURN v.scope_type, count(*) AS count
 ```

--- a/docs/root/modules/gitlab/schema.md
+++ b/docs/root/modules/gitlab/schema.md
@@ -972,7 +972,6 @@ repo can inject code into the consumer's pipeline.
 | ref | SHA, tag, or branch (for `project:` includes); `null` otherwise |
 | **is_pinned** | True iff the include resolves to an immutable target |
 | is_local | True for `local:` includes (within the same repo) |
-| raw_include | The raw include entry as it appeared in the YAML |
 | **gitlab_url** | GitLab instance URL |
 
 #### Relationships

--- a/docs/root/modules/gitlab/schema.md
+++ b/docs/root/modules/gitlab/schema.md
@@ -30,8 +30,7 @@ P -- RESOURCE --> E
 E -- HAS_CI_VARIABLE --> CV_P
 
 %% CI/CD Config (.gitlab-ci.yml)
-P -- HAS_CI_CONFIG --> CC(GitLabCIConfig)
-P -- RESOURCE --> CC
+P -- RESOURCE --> CC(GitLabCIConfig)
 CC -- USES_INCLUDE --> CI_INC(GitLabCIInclude)
 P -- RESOURCE --> CI_INC
 CC -- REFERENCES_VARIABLE --> CV_P
@@ -933,10 +932,11 @@ the two cases.
 
 #### Relationships
 
-- A `GitLabCIConfig` belongs to a `GitLabProject`.
+- A `GitLabCIConfig` belongs to a `GitLabProject` (1-to-1, encoded by the
+  cleanup-scoping `RESOURCE` edge — no separate `HAS_CI_CONFIG` edge to
+  avoid redundancy).
 
     ```cypher
-    (:GitLabProject)-[:HAS_CI_CONFIG]->(:GitLabCIConfig)
     (:GitLabProject)-[:RESOURCE]->(:GitLabCIConfig)
     ```
 

--- a/docs/root/modules/gitlab/schema.md
+++ b/docs/root/modules/gitlab/schema.md
@@ -29,6 +29,13 @@ P -- HAS_ENVIRONMENT --> E(GitLabEnvironment)
 P -- RESOURCE --> E
 E -- HAS_CI_VARIABLE --> CV_P
 
+%% CI/CD Config (.gitlab-ci.yml)
+P -- HAS_CI_CONFIG --> CC(GitLabCIConfig)
+P -- RESOURCE --> CC
+CC -- USES_INCLUDE --> CI_INC(GitLabCIInclude)
+P -- RESOURCE --> CI_INC
+CC -- REFERENCES_VARIABLE --> CV_P
+
 %% Container Registry
 O -- RESOURCE --> CR(GitLabContainerRepository)
 O -- RESOURCE --> CI(GitLabContainerImage)
@@ -895,4 +902,110 @@ Find environments that use unprotected variables:
 MATCH (e:GitLabEnvironment)-[:HAS_CI_VARIABLE]->(v:GitLabCIVariable)
 WHERE v.protected = false
 RETURN e.name, v.key, v.environment_scope
+```
+
+### GitLabCIConfig
+
+Representation of a project's parsed `.gitlab-ci.yml`. When the GitLab
+`/ci/lint` endpoint is available, the config is built from the **merged**
+YAML (all `include:` references expanded by GitLab); otherwise the raw
+`.gitlab-ci.yml` is parsed as a fallback. The `is_merged` flag distinguishes
+the two cases.
+
+| Field | Description |
+|-------|-------------|
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| **id** | Composite ID: `{project_id}:{file_path}` |
+| **project_id** | The numeric GitLab project ID |
+| file_path | Path of the config file in the repo (defaults to `.gitlab-ci.yml`) |
+| is_valid | `true` / `false` if /ci/lint validated; `null` if parsed from raw |
+| is_merged | `true` if the YAML came from /ci/lint with includes expanded |
+| job_count | Number of CI jobs detected |
+| stages | Pipeline stages array |
+| trigger_rules | Detected trigger categories (`merge_requests`, `schedules`, `pushes`, `tag`, `manual`, `web`, `api`) |
+| referenced_variable_keys | All `$VAR` / `${VAR}` references found in the YAML, minus GitLab predefineds |
+| referenced_protected_variables | Subset of `referenced_variable_keys` that match a project variable with `protected = true` |
+| default_image | Top-level `image` (or `default.image`) |
+| has_includes | True if the pipeline has any `include:` entries |
+| include_count | Number of resolved include entries |
+| **gitlab_url** | GitLab instance URL |
+
+#### Relationships
+
+- A `GitLabCIConfig` belongs to a `GitLabProject`.
+
+    ```cypher
+    (:GitLabProject)-[:HAS_CI_CONFIG]->(:GitLabCIConfig)
+    (:GitLabProject)-[:RESOURCE]->(:GitLabCIConfig)
+    ```
+
+- A `GitLabCIConfig` references each `include:` entry as a `GitLabCIInclude`.
+
+    ```cypher
+    (:GitLabCIConfig)-[:USES_INCLUDE]->(:GitLabCIInclude)
+    ```
+
+- A `GitLabCIConfig` references a `GitLabCIVariable` when one of its parsed
+  variable keys matches the variable's `key` (across any environment scope).
+
+    ```cypher
+    (:GitLabCIConfig)-[:REFERENCES_VARIABLE]->(:GitLabCIVariable)
+    ```
+
+### GitLabCIInclude
+
+Representation of a single `include:` entry in a project's `.gitlab-ci.yml`.
+
+The `is_pinned` flag is the primary security signal: a `project:` include
+without a 40-character SHA `ref` will pull whatever is on the referenced
+branch / tag at pipeline runtime, so anyone with push access to the included
+repo can inject code into the consumer's pipeline.
+
+| Field | Description |
+|-------|-------------|
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| **id** | Composite ID: `{project_id}:{include_type}:{location}:{ref or 'none'}` |
+| **include_type** | `local`, `project`, `remote`, `template`, or `component` |
+| **location** | Path / project path / URL / template name / component identifier |
+| ref | SHA, tag, or branch (for `project:` includes); `null` otherwise |
+| **is_pinned** | True iff the include resolves to an immutable target |
+| is_local | True for `local:` includes (within the same repo) |
+| raw_include | The raw include entry as it appeared in the YAML |
+| **gitlab_url** | GitLab instance URL |
+
+#### Relationships
+
+- A `GitLabCIInclude` is owned by a `GitLabProject`.
+
+    ```cypher
+    (:GitLabProject)-[:RESOURCE]->(:GitLabCIInclude)
+    ```
+
+- A `GitLabCIInclude` is used by exactly one `GitLabCIConfig`.
+
+    ```cypher
+    (:GitLabCIConfig)-[:USES_INCLUDE]->(:GitLabCIInclude)
+    ```
+
+#### Example queries
+
+Find pipelines that pull external CI templates without pinning to a SHA — these
+are vulnerable to upstream tampering:
+
+```cypher
+MATCH (c:GitLabCIConfig)-[:USES_INCLUDE]->(i:GitLabCIInclude)
+WHERE i.include_type = 'project' AND i.is_pinned = false
+RETURN c.project_id, i.location, i.ref
+```
+
+Find pipelines that reference a `protected` variable AND can be triggered
+manually — a possible secret-leak vector:
+
+```cypher
+MATCH (c:GitLabCIConfig)
+WHERE 'manual' IN c.trigger_rules
+  AND size(c.referenced_protected_variables) > 0
+RETURN c.project_id, c.referenced_protected_variables, c.trigger_rules
 ```

--- a/docs/root/modules/gitlab/schema.md
+++ b/docs/root/modules/gitlab/schema.md
@@ -24,6 +24,11 @@ P -- RESOURCE --> R_P(GitLabRunner: project)
 G -- HAS_CI_VARIABLE --> CV_G(GitLabCIVariable: group)
 P -- HAS_CI_VARIABLE --> CV_P(GitLabCIVariable: project)
 
+%% Environments
+P -- HAS_ENVIRONMENT --> E(GitLabEnvironment)
+P -- RESOURCE --> E
+E -- HAS_CI_VARIABLE --> CV_P
+
 %% Container Registry
 O -- RESOURCE --> CR(GitLabContainerRepository)
 O -- RESOURCE --> CI(GitLabContainerImage)
@@ -839,4 +844,55 @@ Count variables per scope:
 ```cypher
 MATCH (v:GitLabCIVariable)
 RETURN v.scope_type, count(*) AS count
+```
+
+### GitLabEnvironment
+
+Representation of a GitLab deployment environment (e.g. `production`,
+`staging`, ephemeral review apps). Each project has its own set of
+environments. The composite `id` includes the project_id because GitLab's
+environment IDs are unique per-project, not globally.
+
+| Field | Description |
+|-------|-------------|
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| **id** | Composite ID: `{project_id}:{gitlab_env_id}` |
+| gitlab_id | The numeric GitLab environment ID (per-project) |
+| **name** | Environment name (e.g. `production`, `review/feature-x`) |
+| slug | URL-safe slug |
+| external_url | URL where this environment is reachable |
+| state | `available` or `stopped` |
+| tier | `production`, `staging`, `testing`, `development`, or `other` |
+| created_at | GitLab timestamp |
+| updated_at | GitLab timestamp |
+| auto_stop_at | Timestamp at which the environment auto-stops (or null) |
+| **gitlab_url** | GitLab instance URL |
+
+#### Relationships
+
+- A `GitLabEnvironment` is owned by a `GitLabProject`.
+
+    ```cypher
+    (:GitLabProject)-[:HAS_ENVIRONMENT]->(:GitLabEnvironment)
+    (:GitLabProject)-[:RESOURCE]->(:GitLabEnvironment)
+    ```
+
+- A `GitLabEnvironment` is linked to the project-level `GitLabCIVariable`s
+  whose `environment_scope` matches the environment's name exactly OR is
+  the wildcard `*`. (Glob patterns like `production/*` are recognised by
+  GitLab at runtime but are not matched here.)
+
+    ```cypher
+    (:GitLabEnvironment)-[:HAS_CI_VARIABLE]->(:GitLabCIVariable)
+    ```
+
+#### Example queries
+
+Find environments that use unprotected variables:
+
+```cypher
+MATCH (e:GitLabEnvironment)-[:HAS_CI_VARIABLE]->(v:GitLabCIVariable)
+WHERE v.protected = false
+RETURN e.name, v.key, v.environment_scope
 ```

--- a/docs/root/modules/gitlab/schema.md
+++ b/docs/root/modules/gitlab/schema.md
@@ -15,6 +15,11 @@ P -- RESOURCE --> DF(GitLabDependencyFile)
 P -- REQUIRES --> D(GitLabDependency)
 DF -- HAS_DEP --> D
 
+%% CI/CD Runners
+O -- RESOURCE --> R_I(GitLabRunner: instance)
+G -- RESOURCE --> R_G(GitLabRunner: group)
+P -- RESOURCE --> R_P(GitLabRunner: project)
+
 %% Container Registry
 O -- RESOURCE --> CR(GitLabContainerRepository)
 O -- RESOURCE --> CI(GitLabContainerImage)
@@ -692,4 +697,75 @@ MATCH (vuln:TrivyImageFinding {severity: 'CRITICAL'})-[:AFFECTS]->(img:GitLabCon
 MATCH (vuln)-[:AFFECTS]->(pkg:Package)
 OPTIONAL MATCH (pkg)-[:SHOULD_UPDATE_TO]->(fix:TrivyFix)
 RETURN vuln.name, img.uri, pkg.name, pkg.installed_version, fix.version AS fixed_version
+```
+
+### GitLabRunner
+
+Representation of a GitLab CI/CD runner. Runners exist at three scopes:
+
+- **instance_type**: shared across the whole GitLab instance (`RESOURCE` of `GitLabOrganization`)
+- **group_type**: scoped to a group and its descendants (`RESOURCE` of `GitLabGroup`)
+- **project_type**: scoped to a single project (`RESOURCE` of `GitLabProject`)
+
+All three are stored under the same Neo4j label (`GitLabRunner`); the `runner_type` property and the parent of the `RESOURCE` relationship distinguish them.
+
+| Field | Description |
+|-------|-------------|
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| **id** | The numeric GitLab runner ID |
+| description | Human-readable description set on the runner |
+| **runner_type** | One of `instance_type`, `group_type`, `project_type` |
+| is_shared | True if this is a shared/instance runner |
+| active | Whether the runner is enabled |
+| paused | Whether new jobs are paused on this runner |
+| online | Whether the runner has contacted GitLab recently |
+| **status** | Current status (`online`, `offline`, `stale`, `never_contacted`, ...) |
+| ip_address | Last known IP address of the runner |
+| architecture | Architecture (`amd64`, `arm64`, ...) |
+| platform | Platform (`linux`, `darwin`, `windows`, ...) |
+| contacted_at | Last time the runner contacted GitLab |
+| tag_list | Array of tags used to route jobs to this runner |
+| **run_untagged** | If true, the runner accepts jobs without matching tags. Security-sensitive |
+| **locked** | If true, the runner cannot be assigned to additional projects |
+| **access_level** | `not_protected` allows jobs from any branch; `ref_protected` restricts to protected refs |
+| maximum_timeout | Per-runner job timeout cap (seconds) |
+| **gitlab_url** | GitLab instance URL |
+
+#### Relationships
+
+- A `GitLabRunner` of type `instance_type` is a `RESOURCE` of a `GitLabOrganization`.
+
+    ```cypher
+    (:GitLabRunner)-[:RESOURCE]->(:GitLabOrganization)
+    ```
+
+- A `GitLabRunner` of type `group_type` is a `RESOURCE` of a `GitLabGroup`.
+
+    ```cypher
+    (:GitLabRunner)-[:RESOURCE]->(:GitLabGroup)
+    ```
+
+- A `GitLabRunner` of type `project_type` is a `RESOURCE` of a `GitLabProject`.
+
+    ```cypher
+    (:GitLabRunner)-[:RESOURCE]->(:GitLabProject)
+    ```
+
+#### Example queries
+
+Find unprotected, untagged runners — these will execute jobs from any branch and any project that can reach them:
+
+```cypher
+MATCH (r:GitLabRunner)
+WHERE r.run_untagged = true AND r.access_level = 'not_protected'
+RETURN r.id, r.description, r.runner_type
+```
+
+Count runners per scope:
+
+```cypher
+MATCH (r:GitLabRunner)
+RETURN r.runner_type, count(*) AS count
+ORDER BY count DESC
 ```

--- a/tests/data/gitlab/ci_configs.py
+++ b/tests/data/gitlab/ci_configs.py
@@ -91,15 +91,61 @@ build:
     - echo build
 """
 
-# Sample merged_yaml from /api/v4/projects/:id/ci/lint
+# Sample merged_yaml from /api/v4/projects/:id/ci/lint.
+# This is what GitLab returns when /ci/lint dry-runs the pipeline: includes
+# expanded into the body, so the include section disappears and the included
+# jobs (here `included_build`, `included_lint`) are merged in.
+PIPELINE_LINT_MERGED = """
+stages:
+  - build
+  - test
+  - deploy
+
+variables:
+  DEBUG: "false"
+
+default:
+  image: python:3.13
+
+# `include:` is gone — its contents are inlined below.
+included_build:
+  stage: build
+  script:
+    - echo "from shared-ci"
+
+included_lint:
+  stage: test
+  script:
+    - echo "lint"
+
+build:
+  stage: build
+  script:
+    - echo "Building $CI_PROJECT_NAME with $DATABASE_URL"
+    - echo "Token is $DEPLOY_TOKEN"
+
+manual_deploy:
+  stage: deploy
+  when: manual
+  script:
+    - ./deploy.sh
+
+mr_only:
+  stage: test
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - ./test.sh
+"""
+
 LINT_RESPONSE = {
     "valid": True,
-    "merged_yaml": PIPELINE_WITH_MIXED_INCLUDES,
+    "merged_yaml": PIPELINE_LINT_MERGED,
     "errors": [],
 }
 
 LINT_RESPONSE_INVALID = {
     "valid": False,
-    "merged_yaml": PIPELINE_WITH_MIXED_INCLUDES,
+    "merged_yaml": PIPELINE_LINT_MERGED,
     "errors": ["some error"],
 }

--- a/tests/data/gitlab/ci_configs.py
+++ b/tests/data/gitlab/ci_configs.py
@@ -1,0 +1,105 @@
+"""Test data for the GitLab CI config parser and intel module."""
+
+TEST_GITLAB_URL = "https://gitlab.example.com"
+TEST_PROJECT_ID = 123
+
+# Minimal pipeline with mixed includes (string, project pinned, project unpinned, remote, template)
+PIPELINE_WITH_MIXED_INCLUDES = """
+include:
+  - '/templates/local-template.yml'
+  - project: my-org/shared-ci
+    ref: a5ac7e51b41094c92402da3b24376905380afc29
+    file: /templates/build.yml
+  - project: my-org/shared-ci
+    ref: main
+    file: /templates/deploy.yml
+  - remote: 'https://example.com/ci/templates/test.yml'
+  - template: Auto-DevOps.gitlab-ci.yml
+
+stages:
+  - build
+  - test
+  - deploy
+
+variables:
+  DEBUG: "false"
+
+default:
+  image: python:3.13
+
+build:
+  stage: build
+  script:
+    - echo "Building $CI_PROJECT_NAME with $DATABASE_URL"
+    - echo "Token is $DEPLOY_TOKEN"
+
+manual_deploy:
+  stage: deploy
+  when: manual
+  script:
+    - ./deploy.sh
+
+mr_only:
+  stage: test
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  script:
+    - ./test.sh
+"""
+
+# Pipeline triggered only on schedules
+PIPELINE_SCHEDULED = """
+workflow:
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+
+stages:
+  - cron
+
+nightly:
+  stage: cron
+  script:
+    - ./nightly.sh
+"""
+
+# Pipeline that includes a list of local files in a single entry
+PIPELINE_LOCAL_LIST = """
+include:
+  local:
+    - '/templates/a.yml'
+    - '/templates/b.yml'
+
+build:
+  script:
+    - echo build
+"""
+
+# Empty / non-dict YAML
+PIPELINE_EMPTY = ""
+PIPELINE_NOT_A_DICT = "- just\n- a\n- list"
+PIPELINE_BAD_YAML = "include: [\nnot valid yaml"
+
+# Pipeline with no includes and a top-level image
+PIPELINE_NO_INCLUDES = """
+image: alpine:3.20
+
+stages:
+  - build
+
+build:
+  script:
+    - echo build
+"""
+
+# Sample merged_yaml from /api/v4/projects/:id/ci/lint
+LINT_RESPONSE = {
+    "valid": True,
+    "merged_yaml": PIPELINE_WITH_MIXED_INCLUDES,
+    "errors": [],
+}
+
+LINT_RESPONSE_INVALID = {
+    "valid": False,
+    "merged_yaml": PIPELINE_WITH_MIXED_INCLUDES,
+    "errors": ["some error"],
+}

--- a/tests/data/gitlab/ci_variables.py
+++ b/tests/data/gitlab/ci_variables.py
@@ -1,0 +1,82 @@
+"""Test data for GitLab CI/CD variables module."""
+
+TEST_GITLAB_URL = "https://gitlab.example.com"
+TEST_GROUP_ID = 42
+TEST_PROJECT_ID = 123
+
+# Raw responses from /api/v4/groups/:id/variables. The `value` field is
+# returned by the API but should not be ingested.
+GET_GROUP_VARIABLES_RESPONSE = [
+    {
+        "key": "DEPLOY_TOKEN",
+        "value": "should-not-be-stored",
+        "variable_type": "env_var",
+        "protected": True,
+        "masked": True,
+        "masked_and_hidden": False,
+        "raw": False,
+        "environment_scope": "*",
+        "description": "Token for deploy automation",
+    },
+    {
+        "key": "GROUP_OPEN_VAR",
+        "value": "ok-to-leak",
+        "variable_type": "env_var",
+        "protected": False,
+        "masked": False,
+        "masked_and_hidden": False,
+        "raw": False,
+        "environment_scope": "*",
+        "description": None,
+    },
+]
+
+# Raw responses from /api/v4/projects/:id/variables. Includes a variable
+# scoped to a specific environment AND another with the wildcard "*", so
+# the wildcard match logic in step 3 can be tested.
+GET_PROJECT_VARIABLES_RESPONSE = [
+    {
+        "key": "DATABASE_URL",
+        "value": "should-not-be-stored",
+        "variable_type": "env_var",
+        "protected": True,
+        "masked": True,
+        "masked_and_hidden": True,
+        "raw": False,
+        "environment_scope": "production",
+        "description": "Production database",
+    },
+    {
+        "key": "DATABASE_URL",
+        "value": "should-not-be-stored",
+        "variable_type": "env_var",
+        "protected": False,
+        "masked": True,
+        "masked_and_hidden": False,
+        "raw": False,
+        "environment_scope": "staging",
+        "description": "Staging database",
+    },
+    {
+        "key": "FEATURE_FLAG",
+        "value": "true",
+        "variable_type": "env_var",
+        "protected": False,
+        "masked": False,
+        "masked_and_hidden": False,
+        "raw": True,
+        "environment_scope": "*",
+        "description": None,
+    },
+    # File-type variable with no environment_scope returned (treated as "*")
+    {
+        "key": "CONFIG_FILE",
+        "value": "yaml-content",
+        "variable_type": "file",
+        "protected": False,
+        "masked": False,
+        "masked_and_hidden": False,
+        "raw": False,
+        "description": None,
+    },
+]

--- a/tests/data/gitlab/environments.py
+++ b/tests/data/gitlab/environments.py
@@ -1,0 +1,41 @@
+"""Test data for GitLab environments module."""
+
+TEST_GITLAB_URL = "https://gitlab.example.com"
+TEST_PROJECT_ID = 123
+
+# Raw response from /api/v4/projects/:id/environments
+GET_ENVIRONMENTS_RESPONSE = [
+    {
+        "id": 1,
+        "name": "production",
+        "slug": "production",
+        "external_url": "https://prod.example.com",
+        "state": "available",
+        "tier": "production",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-04-01T00:00:00Z",
+        "auto_stop_at": None,
+    },
+    {
+        "id": 2,
+        "name": "staging",
+        "slug": "staging",
+        "external_url": "https://staging.example.com",
+        "state": "available",
+        "tier": "staging",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-04-01T00:00:00Z",
+        "auto_stop_at": None,
+    },
+    {
+        "id": 3,
+        "name": "review/feature-x",
+        "slug": "review-feature-x",
+        "external_url": None,
+        "state": "stopped",
+        "tier": "development",
+        "created_at": "2026-04-15T00:00:00Z",
+        "updated_at": "2026-04-29T00:00:00Z",
+        "auto_stop_at": None,
+    },
+]

--- a/tests/data/gitlab/runners.py
+++ b/tests/data/gitlab/runners.py
@@ -1,0 +1,114 @@
+"""Test data for GitLab runners module."""
+
+TEST_GITLAB_URL = "https://gitlab.example.com"
+TEST_ORG_ID = 10
+TEST_GROUP_ID = 42
+TEST_PROJECT_ID = 123
+
+# Raw list-endpoint response (subset of fields). The real API also returns these
+# fields on /api/v4/runners/all, /api/v4/groups/:id/runners, and
+# /api/v4/projects/:id/runners.
+GET_INSTANCE_RUNNERS_LIST = [
+    {
+        "id": 1001,
+        "description": "shared-runner-1",
+        "runner_type": "instance_type",
+        "is_shared": True,
+        "active": True,
+        "paused": False,
+        "online": True,
+        "status": "online",
+        "ip_address": "10.0.0.1",
+    },
+]
+
+GET_GROUP_RUNNERS_LIST = [
+    {
+        "id": 2001,
+        "description": "group-runner-1",
+        "runner_type": "group_type",
+        "is_shared": False,
+        "active": True,
+        "paused": False,
+        "online": True,
+        "status": "online",
+        "ip_address": "10.0.1.1",
+    },
+]
+
+GET_PROJECT_RUNNERS_LIST = [
+    {
+        "id": 3001,
+        "description": "project-runner-untagged",
+        "runner_type": "project_type",
+        "is_shared": False,
+        "active": True,
+        "paused": False,
+        "online": True,
+        "status": "online",
+        "ip_address": "10.0.2.1",
+    },
+]
+
+# Detail-endpoint responses (/api/v4/runners/:id) keyed by runner id. These add
+# the fields that are NOT present in the list endpoints (architecture, platform,
+# tag_list, run_untagged, locked, access_level, maximum_timeout, contacted_at).
+RUNNER_DETAILS = {
+    1001: {
+        "id": 1001,
+        "description": "shared-runner-1",
+        "runner_type": "instance_type",
+        "is_shared": True,
+        "active": True,
+        "paused": False,
+        "online": True,
+        "status": "online",
+        "ip_address": "10.0.0.1",
+        "architecture": "amd64",
+        "platform": "linux",
+        "contacted_at": "2026-04-29T10:00:00Z",
+        "tag_list": ["shared", "linux"],
+        "run_untagged": True,
+        "locked": False,
+        "access_level": "not_protected",
+        "maximum_timeout": 3600,
+    },
+    2001: {
+        "id": 2001,
+        "description": "group-runner-1",
+        "runner_type": "group_type",
+        "is_shared": False,
+        "active": True,
+        "paused": False,
+        "online": True,
+        "status": "online",
+        "ip_address": "10.0.1.1",
+        "architecture": "amd64",
+        "platform": "linux",
+        "contacted_at": "2026-04-29T10:01:00Z",
+        "tag_list": ["group-only"],
+        "run_untagged": False,
+        "locked": True,
+        "access_level": "ref_protected",
+        "maximum_timeout": 1800,
+    },
+    3001: {
+        "id": 3001,
+        "description": "project-runner-untagged",
+        "runner_type": "project_type",
+        "is_shared": False,
+        "active": True,
+        "paused": False,
+        "online": True,
+        "status": "online",
+        "ip_address": "10.0.2.1",
+        "architecture": "arm64",
+        "platform": "linux",
+        "contacted_at": "2026-04-29T10:02:00Z",
+        "tag_list": [],
+        "run_untagged": True,
+        "locked": False,
+        "access_level": "not_protected",
+        "maximum_timeout": None,
+    },
+}

--- a/tests/integration/cartography/intel/gitlab/test_ci_config.py
+++ b/tests/integration/cartography/intel/gitlab/test_ci_config.py
@@ -1,7 +1,6 @@
 """Integration tests for GitLab CI config + includes."""
 
 from unittest.mock import Mock
-from unittest.mock import patch
 
 import requests
 
@@ -232,13 +231,19 @@ def test_sync_ci_config_falls_back_to_raw_when_lint_denied(neo4j_session, monkey
     assert config_rels == {(TEST_PROJECT_ID, f"{TEST_PROJECT_ID}:.gitlab-ci.yml")}
 
 
-@patch("cartography.intel.gitlab.ci_config.fetch_ci_config_yaml")
-def test_sync_ci_config_skips_project_when_no_yaml(mock_fetch, neo4j_session):
+def test_sync_ci_config_skips_project_when_no_yaml(neo4j_session, monkeypatch):
     """A project with no readable CI config is skipped without error."""
     _reset_db_and_create_project(neo4j_session)
-    mock_fetch.return_value = (None, None, False)
+    # Both /ci/lint and the raw repository file return 404 — the project
+    # legitimately has no .gitlab-ci.yml. Mock at the HTTP boundary
+    # (`requests.request`) rather than at the internal helper.
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.util.requests.request",
+        lambda method, url, **_: _make_response(404),
+    )
+    monkeypatch.setattr("cartography.intel.gitlab.util.time.sleep", lambda _: None)
 
-    sync_gitlab_ci_config(
+    skipped = sync_gitlab_ci_config(
         neo4j_session,
         TEST_GITLAB_URL,
         "fake-token",
@@ -248,3 +253,28 @@ def test_sync_ci_config_skips_project_when_no_yaml(mock_fetch, neo4j_session):
         variables_by_project={TEST_PROJECT_ID: []},
     )
     assert check_nodes(neo4j_session, "GitLabCIConfig", ["id"]) == set()
+    # 404 is non-denied: cleanup may run on this project.
+    assert skipped == set()
+
+
+def test_sync_ci_config_skips_cleanup_when_lint_and_raw_both_denied(
+    neo4j_session, monkeypatch
+):
+    """A 403 on both endpoints flags the project as denied (skip cleanup)."""
+    _reset_db_and_create_project(neo4j_session)
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.util.requests.request",
+        lambda method, url, **_: _make_response(403),
+    )
+    monkeypatch.setattr("cartography.intel.gitlab.util.time.sleep", lambda _: None)
+
+    skipped = sync_gitlab_ci_config(
+        neo4j_session,
+        TEST_GITLAB_URL,
+        "fake-token",
+        TEST_UPDATE_TAG,
+        _common_job_parameters(),
+        projects=[{"id": TEST_PROJECT_ID, "default_branch": "main"}],
+        variables_by_project={TEST_PROJECT_ID: []},
+    )
+    assert TEST_PROJECT_ID in skipped

--- a/tests/integration/cartography/intel/gitlab/test_ci_config.py
+++ b/tests/integration/cartography/intel/gitlab/test_ci_config.py
@@ -219,14 +219,16 @@ def test_sync_ci_config_falls_back_to_raw_when_lint_denied(neo4j_session, monkey
     )
     assert {key for _, key in var_rels} == {"DATABASE_URL", "DEPLOY_TOKEN"}
 
-    # HAS_CI_CONFIG project relationship still exists.
+    # The cleanup-scoping RESOURCE edge from project → config still exists.
+    # (There is no separate HAS_CI_CONFIG edge — it would duplicate RESOURCE
+    # since each project has exactly one CIConfig.)
     config_rels = check_rels(
         neo4j_session,
         "GitLabProject",
         "id",
         "GitLabCIConfig",
         "id",
-        "HAS_CI_CONFIG",
+        "RESOURCE",
     )
     assert config_rels == {(TEST_PROJECT_ID, f"{TEST_PROJECT_ID}:.gitlab-ci.yml")}
 

--- a/tests/integration/cartography/intel/gitlab/test_ci_config.py
+++ b/tests/integration/cartography/intel/gitlab/test_ci_config.py
@@ -1,11 +1,15 @@
 """Integration tests for GitLab CI config + includes."""
 
+from unittest.mock import Mock
 from unittest.mock import patch
+
+import requests
 
 from cartography.intel.gitlab.ci_config import sync_gitlab_ci_config
 from cartography.intel.gitlab.ci_variables import load_project_variables
 from cartography.intel.gitlab.ci_variables import transform_variables
 from tests.data.gitlab.ci_configs import LINT_RESPONSE
+from tests.data.gitlab.ci_configs import PIPELINE_WITH_MIXED_INCLUDES
 from tests.data.gitlab.ci_configs import TEST_GITLAB_URL
 from tests.data.gitlab.ci_configs import TEST_PROJECT_ID
 from tests.integration.util import check_nodes
@@ -15,7 +19,9 @@ TEST_UPDATE_TAG = 123456789
 TEST_ORG_ID = 10
 
 
-def _create_project(neo4j_session):
+def _reset_db_and_create_project(neo4j_session):
+    """Wipe shared session state and create a fresh project node."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n;")
     neo4j_session.run(
         """
         MERGE (p:GitLabProject{id: $project_id, gitlab_url: $gitlab_url})
@@ -66,14 +72,41 @@ def _project_variables_raw():
     ]
 
 
-@patch("cartography.intel.gitlab.ci_config.make_request_with_retry")
-def test_sync_ci_config_creates_config_includes_and_variable_links(
-    mock_make_request, neo4j_session
-):
-    """End-to-end: project + variables + ci/lint -> CIConfig + includes + REFERENCES_VARIABLE."""
-    _create_project(neo4j_session)
+def _make_response(status_code, *, json_body=None, text_body=""):
+    """Build a Mock that mimics a `requests.Response` for our needs."""
+    response = Mock(spec=requests.Response)
+    response.status_code = status_code
+    response.headers = {}
+    response.text = text_body
+    response.json.return_value = json_body or {}
+    if status_code >= 400:
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            response=response
+        )
+    else:
+        response.raise_for_status.return_value = None
+    return response
 
-    # Pre-load project variables.
+
+def _patch_lint_then_raw(monkeypatch, lint_response, raw_yaml):
+    """
+    Patch `requests.request` (the actual HTTP boundary used by
+    `make_request_with_retry`) to dispatch on URL: ``/ci/lint`` returns the
+    given lint response, the raw-file endpoint returns the raw YAML.
+    """
+
+    def fake_request(method, url, **_kwargs):
+        if "/ci/lint" in url:
+            return lint_response
+        if "/repository/files/" in url:
+            return _make_response(200, text_body=raw_yaml)
+        return _make_response(404)
+
+    monkeypatch.setattr("cartography.intel.gitlab.util.requests.request", fake_request)
+    monkeypatch.setattr("cartography.intel.gitlab.util.time.sleep", lambda _: None)
+
+
+def _load_variables(neo4j_session):
     project_variables = transform_variables(
         _project_variables_raw(),
         "project",
@@ -87,21 +120,16 @@ def test_sync_ci_config_creates_config_includes_and_variable_links(
         TEST_GITLAB_URL,
         TEST_UPDATE_TAG,
     )
+    return project_variables
 
-    # Mock the HTTP call to /ci/lint so it returns our fixture.
-    class _FakeResponse:
-        def __init__(self, json_body):
-            self._json = json_body
-            self.status_code = 200
-            self.text = ""
 
-        def json(self):
-            return self._json
+def test_sync_ci_config_uses_lint_path_when_available(neo4j_session, monkeypatch):
+    """When /ci/lint returns a merged YAML, that path is used (is_merged=True)."""
+    _reset_db_and_create_project(neo4j_session)
+    project_variables = _load_variables(neo4j_session)
 
-        def raise_for_status(self):
-            return None
-
-    mock_make_request.return_value = _FakeResponse(LINT_RESPONSE)
+    lint_response = _make_response(200, json_body=LINT_RESPONSE)
+    _patch_lint_then_raw(monkeypatch, lint_response, raw_yaml="")
 
     sync_gitlab_ci_config(
         neo4j_session,
@@ -113,35 +141,14 @@ def test_sync_ci_config_creates_config_includes_and_variable_links(
         variables_by_project={TEST_PROJECT_ID: project_variables},
     )
 
-    # Exactly one CIConfig.
     configs = check_nodes(
         neo4j_session,
         "GitLabCIConfig",
-        ["id", "is_merged", "is_valid", "has_includes"],
+        ["id", "is_merged", "is_valid"],
     )
-    assert configs == {(f"{TEST_PROJECT_ID}:.gitlab-ci.yml", True, True, True)}
+    assert configs == {(f"{TEST_PROJECT_ID}:.gitlab-ci.yml", True, True)}
 
-    # Includes — at least one pinned and one unpinned project include.
-    include_pinning = check_nodes(
-        neo4j_session,
-        "GitLabCIInclude",
-        ["include_type", "is_pinned"],
-    )
-    assert ("project", True) in include_pinning
-    assert ("project", False) in include_pinning
-
-    # USES_INCLUDE relationship exists between config and includes.
-    uses_rels = check_rels(
-        neo4j_session,
-        "GitLabCIConfig",
-        "id",
-        "GitLabCIInclude",
-        "id",
-        "USES_INCLUDE",
-    )
-    assert len(uses_rels) >= 4  # local + 2 project + remote + template
-
-    # REFERENCES_VARIABLE matchlink — DATABASE_URL and DEPLOY_TOKEN.
+    # Variables referenced by the merged pipeline (DATABASE_URL, DEPLOY_TOKEN).
     var_rels = check_rels(
         neo4j_session,
         "GitLabCIConfig",
@@ -152,7 +159,68 @@ def test_sync_ci_config_creates_config_includes_and_variable_links(
     )
     assert {key for _, key in var_rels} == {"DATABASE_URL", "DEPLOY_TOKEN"}
 
-    # HAS_CI_CONFIG project relationship.
+
+def test_sync_ci_config_falls_back_to_raw_when_lint_denied(neo4j_session, monkeypatch):
+    """403 on /ci/lint must fall back to the raw .gitlab-ci.yml endpoint."""
+    _reset_db_and_create_project(neo4j_session)
+    project_variables = _load_variables(neo4j_session)
+
+    _patch_lint_then_raw(
+        monkeypatch,
+        lint_response=_make_response(403),
+        raw_yaml=PIPELINE_WITH_MIXED_INCLUDES,
+    )
+
+    sync_gitlab_ci_config(
+        neo4j_session,
+        TEST_GITLAB_URL,
+        "fake-token",
+        TEST_UPDATE_TAG,
+        _common_job_parameters(),
+        projects=[{"id": TEST_PROJECT_ID, "default_branch": "main"}],
+        variables_by_project={TEST_PROJECT_ID: project_variables},
+    )
+
+    # is_merged should be False (came from raw repository file, not lint).
+    configs = check_nodes(
+        neo4j_session,
+        "GitLabCIConfig",
+        ["id", "is_merged"],
+    )
+    assert configs == {(f"{TEST_PROJECT_ID}:.gitlab-ci.yml", False)}
+
+    # Includes are visible because the raw fixture still has them.
+    include_pinning = check_nodes(
+        neo4j_session,
+        "GitLabCIInclude",
+        ["include_type", "is_pinned"],
+    )
+    assert ("project", True) in include_pinning
+    assert ("project", False) in include_pinning
+
+    # USES_INCLUDE edges from config to includes.
+    uses_rels = check_rels(
+        neo4j_session,
+        "GitLabCIConfig",
+        "id",
+        "GitLabCIInclude",
+        "id",
+        "USES_INCLUDE",
+    )
+    assert len(uses_rels) >= 4
+
+    # REFERENCES_VARIABLE — only DATABASE_URL and DEPLOY_TOKEN are in the YAML.
+    var_rels = check_rels(
+        neo4j_session,
+        "GitLabCIConfig",
+        "id",
+        "GitLabCIVariable",
+        "key",
+        "REFERENCES_VARIABLE",
+    )
+    assert {key for _, key in var_rels} == {"DATABASE_URL", "DEPLOY_TOKEN"}
+
+    # HAS_CI_CONFIG project relationship still exists.
     config_rels = check_rels(
         neo4j_session,
         "GitLabProject",
@@ -162,3 +230,21 @@ def test_sync_ci_config_creates_config_includes_and_variable_links(
         "HAS_CI_CONFIG",
     )
     assert config_rels == {(TEST_PROJECT_ID, f"{TEST_PROJECT_ID}:.gitlab-ci.yml")}
+
+
+@patch("cartography.intel.gitlab.ci_config.fetch_ci_config_yaml")
+def test_sync_ci_config_skips_project_when_no_yaml(mock_fetch, neo4j_session):
+    """A project with no readable CI config is skipped without error."""
+    _reset_db_and_create_project(neo4j_session)
+    mock_fetch.return_value = (None, None, False)
+
+    sync_gitlab_ci_config(
+        neo4j_session,
+        TEST_GITLAB_URL,
+        "fake-token",
+        TEST_UPDATE_TAG,
+        _common_job_parameters(),
+        projects=[{"id": TEST_PROJECT_ID, "default_branch": "main"}],
+        variables_by_project={TEST_PROJECT_ID: []},
+    )
+    assert check_nodes(neo4j_session, "GitLabCIConfig", ["id"]) == set()

--- a/tests/integration/cartography/intel/gitlab/test_ci_config.py
+++ b/tests/integration/cartography/intel/gitlab/test_ci_config.py
@@ -1,0 +1,164 @@
+"""Integration tests for GitLab CI config + includes."""
+
+from unittest.mock import patch
+
+from cartography.intel.gitlab.ci_config import sync_gitlab_ci_config
+from cartography.intel.gitlab.ci_variables import load_project_variables
+from cartography.intel.gitlab.ci_variables import transform_variables
+from tests.data.gitlab.ci_configs import LINT_RESPONSE
+from tests.data.gitlab.ci_configs import TEST_GITLAB_URL
+from tests.data.gitlab.ci_configs import TEST_PROJECT_ID
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = 10
+
+
+def _create_project(neo4j_session):
+    neo4j_session.run(
+        """
+        MERGE (p:GitLabProject{id: $project_id, gitlab_url: $gitlab_url})
+        ON CREATE SET p.firstseen = timestamp()
+        SET p.lastupdated = $update_tag, p.default_branch = 'main'
+        """,
+        project_id=TEST_PROJECT_ID,
+        gitlab_url=TEST_GITLAB_URL,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+
+def _common_job_parameters():
+    return {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "ORGANIZATION_ID": TEST_ORG_ID,
+        "org_id": TEST_ORG_ID,
+        "gitlab_url": TEST_GITLAB_URL,
+    }
+
+
+def _project_variables_raw():
+    return [
+        {
+            "key": "DATABASE_URL",
+            "value": "ignore-me",
+            "variable_type": "env_var",
+            "protected": True,
+            "masked": True,
+            "environment_scope": "production",
+        },
+        {
+            "key": "DEPLOY_TOKEN",
+            "value": "ignore-me",
+            "variable_type": "env_var",
+            "protected": True,
+            "masked": True,
+            "environment_scope": "*",
+        },
+        {
+            "key": "UNUSED",
+            "value": "ignore-me",
+            "variable_type": "env_var",
+            "protected": False,
+            "masked": False,
+            "environment_scope": "*",
+        },
+    ]
+
+
+@patch("cartography.intel.gitlab.ci_config.make_request_with_retry")
+def test_sync_ci_config_creates_config_includes_and_variable_links(
+    mock_make_request, neo4j_session
+):
+    """End-to-end: project + variables + ci/lint -> CIConfig + includes + REFERENCES_VARIABLE."""
+    _create_project(neo4j_session)
+
+    # Pre-load project variables.
+    project_variables = transform_variables(
+        _project_variables_raw(),
+        "project",
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
+    )
+    load_project_variables(
+        neo4j_session,
+        project_variables,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
+        TEST_UPDATE_TAG,
+    )
+
+    # Mock the HTTP call to /ci/lint so it returns our fixture.
+    class _FakeResponse:
+        def __init__(self, json_body):
+            self._json = json_body
+            self.status_code = 200
+            self.text = ""
+
+        def json(self):
+            return self._json
+
+        def raise_for_status(self):
+            return None
+
+    mock_make_request.return_value = _FakeResponse(LINT_RESPONSE)
+
+    sync_gitlab_ci_config(
+        neo4j_session,
+        TEST_GITLAB_URL,
+        "fake-token",
+        TEST_UPDATE_TAG,
+        _common_job_parameters(),
+        projects=[{"id": TEST_PROJECT_ID, "default_branch": "main"}],
+        variables_by_project={TEST_PROJECT_ID: project_variables},
+    )
+
+    # Exactly one CIConfig.
+    configs = check_nodes(
+        neo4j_session,
+        "GitLabCIConfig",
+        ["id", "is_merged", "is_valid", "has_includes"],
+    )
+    assert configs == {(f"{TEST_PROJECT_ID}:.gitlab-ci.yml", True, True, True)}
+
+    # Includes — at least one pinned and one unpinned project include.
+    include_pinning = check_nodes(
+        neo4j_session,
+        "GitLabCIInclude",
+        ["include_type", "is_pinned"],
+    )
+    assert ("project", True) in include_pinning
+    assert ("project", False) in include_pinning
+
+    # USES_INCLUDE relationship exists between config and includes.
+    uses_rels = check_rels(
+        neo4j_session,
+        "GitLabCIConfig",
+        "id",
+        "GitLabCIInclude",
+        "id",
+        "USES_INCLUDE",
+    )
+    assert len(uses_rels) >= 4  # local + 2 project + remote + template
+
+    # REFERENCES_VARIABLE matchlink — DATABASE_URL and DEPLOY_TOKEN.
+    var_rels = check_rels(
+        neo4j_session,
+        "GitLabCIConfig",
+        "id",
+        "GitLabCIVariable",
+        "key",
+        "REFERENCES_VARIABLE",
+    )
+    assert {key for _, key in var_rels} == {"DATABASE_URL", "DEPLOY_TOKEN"}
+
+    # HAS_CI_CONFIG project relationship.
+    config_rels = check_rels(
+        neo4j_session,
+        "GitLabProject",
+        "id",
+        "GitLabCIConfig",
+        "id",
+        "HAS_CI_CONFIG",
+    )
+    assert config_rels == {(TEST_PROJECT_ID, f"{TEST_PROJECT_ID}:.gitlab-ci.yml")}

--- a/tests/integration/cartography/intel/gitlab/test_ci_variables.py
+++ b/tests/integration/cartography/intel/gitlab/test_ci_variables.py
@@ -65,7 +65,7 @@ def test_sync_ci_variables_loads_at_both_scopes(mock_get_paginated, neo4j_sessio
         lambda _url, _tok, endpoint, **kw: _patched_paginated(endpoint, **kw)
     )
 
-    project_vars = sync_gitlab_ci_variables(
+    project_vars, skipped = sync_gitlab_ci_variables(
         neo4j_session,
         TEST_GITLAB_URL,
         "fake-token",
@@ -74,6 +74,7 @@ def test_sync_ci_variables_loads_at_both_scopes(mock_get_paginated, neo4j_sessio
         groups=[{"id": TEST_GROUP_ID}],
         projects=[{"id": TEST_PROJECT_ID}],
     )
+    assert skipped == {"groups": set(), "projects": set()}
 
     # All variables loaded — keyed by composite ID, so two DATABASE_URL rows survive.
     expected_keys = {

--- a/tests/integration/cartography/intel/gitlab/test_ci_variables.py
+++ b/tests/integration/cartography/intel/gitlab/test_ci_variables.py
@@ -17,7 +17,14 @@ TEST_UPDATE_TAG = 123456789
 TEST_ORG_ID = 10
 
 
-def _create_group_and_project(neo4j_session):
+def _reset_db_and_create_group_and_project(neo4j_session):
+    """Wipe the shared session DB then create a fresh group + project.
+
+    The neo4j_session fixture is module-scoped, so without a wipe each test
+    inherits state from the previous one — the 403-tolerance test would
+    otherwise see variables loaded by an earlier test.
+    """
+    neo4j_session.run("MATCH (n) DETACH DELETE n;")
     neo4j_session.run(
         """
         MERGE (g:GitLabGroup{id: $group_id, gitlab_url: $gitlab_url})
@@ -53,7 +60,7 @@ def _patched_paginated(endpoint, **_kwargs):
 
 @patch("cartography.intel.gitlab.ci_variables.get_paginated")
 def test_sync_ci_variables_loads_at_both_scopes(mock_get_paginated, neo4j_session):
-    _create_group_and_project(neo4j_session)
+    _reset_db_and_create_group_and_project(neo4j_session)
     mock_get_paginated.side_effect = (
         lambda _url, _tok, endpoint, **kw: _patched_paginated(endpoint, **kw)
     )
@@ -97,13 +104,14 @@ def test_sync_ci_variables_loads_at_both_scopes(mock_get_paginated, neo4j_sessio
     )
     assert {key for _, key in group_rels} == {"DEPLOY_TOKEN", "GROUP_OPEN_VAR"}
 
-    # Project HAS_CI_VARIABLE relationships (4 — two DATABASE_URL, FEATURE_FLAG, CONFIG_FILE)
+    # Project HAS_CI_VARIABLE — match by composite id so the two DATABASE_URL
+    # variants (production / staging) don't collapse in the result set.
     project_rels = check_rels(
         neo4j_session,
         "GitLabProject",
         "id",
         "GitLabCIVariable",
-        "key",
+        "id",
         "HAS_CI_VARIABLE",
     )
     assert len(project_rels) == 4
@@ -116,7 +124,7 @@ def test_sync_ci_variables_loads_at_both_scopes(mock_get_paginated, neo4j_sessio
 @patch("cartography.intel.gitlab.ci_variables.get_paginated")
 def test_sync_ci_variables_does_not_store_value(mock_get_paginated, neo4j_session):
     """A direct Cypher check confirming that no value column was persisted."""
-    _create_group_and_project(neo4j_session)
+    _reset_db_and_create_group_and_project(neo4j_session)
     mock_get_paginated.side_effect = (
         lambda _url, _tok, endpoint, **kw: _patched_paginated(endpoint, **kw)
     )
@@ -140,7 +148,7 @@ def test_sync_ci_variables_does_not_store_value(mock_get_paginated, neo4j_sessio
 @patch("cartography.intel.gitlab.ci_variables.get_paginated")
 def test_sync_ci_variables_tolerates_403_per_scope(mock_get_paginated, neo4j_session):
     """A 403 on the group scope should not break the project sync."""
-    _create_group_and_project(neo4j_session)
+    _reset_db_and_create_group_and_project(neo4j_session)
 
     def side_effect(_url, _tok, endpoint, **_kw):
         if endpoint == f"/api/v4/groups/{TEST_GROUP_ID}/variables":
@@ -177,7 +185,7 @@ def test_sync_ci_variables_tolerates_403_per_scope(mock_get_paginated, neo4j_ses
         "GitLabProject",
         "id",
         "GitLabCIVariable",
-        "key",
+        "id",
         "HAS_CI_VARIABLE",
     )
     assert len(project_rels) == 4

--- a/tests/integration/cartography/intel/gitlab/test_ci_variables.py
+++ b/tests/integration/cartography/intel/gitlab/test_ci_variables.py
@@ -1,0 +1,183 @@
+"""Integration tests for GitLab CI/CD variables module."""
+
+from unittest.mock import patch
+
+import requests
+
+from cartography.intel.gitlab.ci_variables import sync_gitlab_ci_variables
+from tests.data.gitlab.ci_variables import GET_GROUP_VARIABLES_RESPONSE
+from tests.data.gitlab.ci_variables import GET_PROJECT_VARIABLES_RESPONSE
+from tests.data.gitlab.ci_variables import TEST_GITLAB_URL
+from tests.data.gitlab.ci_variables import TEST_GROUP_ID
+from tests.data.gitlab.ci_variables import TEST_PROJECT_ID
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = 10
+
+
+def _create_group_and_project(neo4j_session):
+    neo4j_session.run(
+        """
+        MERGE (g:GitLabGroup{id: $group_id, gitlab_url: $gitlab_url})
+        ON CREATE SET g.firstseen = timestamp()
+        SET g.lastupdated = $update_tag
+        MERGE (p:GitLabProject{id: $project_id, gitlab_url: $gitlab_url})
+        ON CREATE SET p.firstseen = timestamp()
+        SET p.lastupdated = $update_tag
+        """,
+        group_id=TEST_GROUP_ID,
+        project_id=TEST_PROJECT_ID,
+        gitlab_url=TEST_GITLAB_URL,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+
+def _common_job_parameters():
+    return {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "ORGANIZATION_ID": TEST_ORG_ID,
+        "org_id": TEST_ORG_ID,
+        "gitlab_url": TEST_GITLAB_URL,
+    }
+
+
+def _patched_paginated(endpoint, **_kwargs):
+    if endpoint == f"/api/v4/groups/{TEST_GROUP_ID}/variables":
+        return list(GET_GROUP_VARIABLES_RESPONSE)
+    if endpoint == f"/api/v4/projects/{TEST_PROJECT_ID}/variables":
+        return list(GET_PROJECT_VARIABLES_RESPONSE)
+    return []
+
+
+@patch("cartography.intel.gitlab.ci_variables.get_paginated")
+def test_sync_ci_variables_loads_at_both_scopes(mock_get_paginated, neo4j_session):
+    _create_group_and_project(neo4j_session)
+    mock_get_paginated.side_effect = (
+        lambda _url, _tok, endpoint, **kw: _patched_paginated(endpoint, **kw)
+    )
+
+    project_vars = sync_gitlab_ci_variables(
+        neo4j_session,
+        TEST_GITLAB_URL,
+        "fake-token",
+        TEST_UPDATE_TAG,
+        _common_job_parameters(),
+        groups=[{"id": TEST_GROUP_ID}],
+        projects=[{"id": TEST_PROJECT_ID}],
+    )
+
+    # All variables loaded — keyed by composite ID, so two DATABASE_URL rows survive.
+    expected_keys = {
+        ("DEPLOY_TOKEN", True, "*"),
+        ("GROUP_OPEN_VAR", False, "*"),
+        ("DATABASE_URL", True, "production"),
+        ("DATABASE_URL", False, "staging"),
+        ("FEATURE_FLAG", False, "*"),
+        ("CONFIG_FILE", False, "*"),
+    }
+    assert (
+        check_nodes(
+            neo4j_session,
+            "GitLabCIVariable",
+            ["key", "protected", "environment_scope"],
+        )
+        == expected_keys
+    )
+
+    # Group HAS_CI_VARIABLE relationships (2)
+    group_rels = check_rels(
+        neo4j_session,
+        "GitLabGroup",
+        "id",
+        "GitLabCIVariable",
+        "key",
+        "HAS_CI_VARIABLE",
+    )
+    assert {key for _, key in group_rels} == {"DEPLOY_TOKEN", "GROUP_OPEN_VAR"}
+
+    # Project HAS_CI_VARIABLE relationships (4 — two DATABASE_URL, FEATURE_FLAG, CONFIG_FILE)
+    project_rels = check_rels(
+        neo4j_session,
+        "GitLabProject",
+        "id",
+        "GitLabCIVariable",
+        "key",
+        "HAS_CI_VARIABLE",
+    )
+    assert len(project_rels) == 4
+
+    # Returned map should expose project variables for downstream modules.
+    assert TEST_PROJECT_ID in project_vars
+    assert len(project_vars[TEST_PROJECT_ID]) == 4
+
+
+@patch("cartography.intel.gitlab.ci_variables.get_paginated")
+def test_sync_ci_variables_does_not_store_value(mock_get_paginated, neo4j_session):
+    """A direct Cypher check confirming that no value column was persisted."""
+    _create_group_and_project(neo4j_session)
+    mock_get_paginated.side_effect = (
+        lambda _url, _tok, endpoint, **kw: _patched_paginated(endpoint, **kw)
+    )
+
+    sync_gitlab_ci_variables(
+        neo4j_session,
+        TEST_GITLAB_URL,
+        "fake-token",
+        TEST_UPDATE_TAG,
+        _common_job_parameters(),
+        groups=[{"id": TEST_GROUP_ID}],
+        projects=[{"id": TEST_PROJECT_ID}],
+    )
+
+    result = neo4j_session.run(
+        "MATCH (v:GitLabCIVariable) WHERE v.value IS NOT NULL RETURN count(v) AS c"
+    )
+    assert result.single()["c"] == 0
+
+
+@patch("cartography.intel.gitlab.ci_variables.get_paginated")
+def test_sync_ci_variables_tolerates_403_per_scope(mock_get_paginated, neo4j_session):
+    """A 403 on the group scope should not break the project sync."""
+    _create_group_and_project(neo4j_session)
+
+    def side_effect(_url, _tok, endpoint, **_kw):
+        if endpoint == f"/api/v4/groups/{TEST_GROUP_ID}/variables":
+            response = requests.Response()
+            response.status_code = 403
+            raise requests.exceptions.HTTPError(response=response)
+        return _patched_paginated(endpoint)
+
+    mock_get_paginated.side_effect = side_effect
+
+    sync_gitlab_ci_variables(
+        neo4j_session,
+        TEST_GITLAB_URL,
+        "fake-token",
+        TEST_UPDATE_TAG,
+        _common_job_parameters(),
+        groups=[{"id": TEST_GROUP_ID}],
+        projects=[{"id": TEST_PROJECT_ID}],
+    )
+
+    # Group variables skipped, project variables still loaded.
+    group_rels = check_rels(
+        neo4j_session,
+        "GitLabGroup",
+        "id",
+        "GitLabCIVariable",
+        "key",
+        "HAS_CI_VARIABLE",
+    )
+    assert group_rels == set()
+
+    project_rels = check_rels(
+        neo4j_session,
+        "GitLabProject",
+        "id",
+        "GitLabCIVariable",
+        "key",
+        "HAS_CI_VARIABLE",
+    )
+    assert len(project_rels) == 4

--- a/tests/integration/cartography/intel/gitlab/test_environments.py
+++ b/tests/integration/cartography/intel/gitlab/test_environments.py
@@ -78,8 +78,7 @@ def test_sync_environments_creates_env_to_variable_links(
         (f"{TEST_PROJECT_ID}:3", "review/feature-x"),
     }
     assert (
-        check_nodes(neo4j_session, "GitLabEnvironment", ["id", "name"])
-        == expected_envs
+        check_nodes(neo4j_session, "GitLabEnvironment", ["id", "name"]) == expected_envs
     )
 
     # production env -> DATABASE_URL[production], FEATURE_FLAG[*], CONFIG_FILE[*]
@@ -96,11 +95,13 @@ def test_sync_environments_creates_env_to_variable_links(
 
     var_ids = {v["key"]: v["id"] for v in project_variables}
     db_prod_id = next(
-        v["id"] for v in project_variables
+        v["id"]
+        for v in project_variables
         if v["key"] == "DATABASE_URL" and v["environment_scope"] == "production"
     )
     db_staging_id = next(
-        v["id"] for v in project_variables
+        v["id"]
+        for v in project_variables
         if v["key"] == "DATABASE_URL" and v["environment_scope"] == "staging"
     )
     flag_id = var_ids["FEATURE_FLAG"]

--- a/tests/integration/cartography/intel/gitlab/test_environments.py
+++ b/tests/integration/cartography/intel/gitlab/test_environments.py
@@ -1,0 +1,134 @@
+"""Integration tests for GitLab environments module."""
+
+from unittest.mock import patch
+
+from cartography.intel.gitlab.ci_variables import load_project_variables
+from cartography.intel.gitlab.ci_variables import transform_variables
+from cartography.intel.gitlab.environments import sync_gitlab_environments
+from tests.data.gitlab.ci_variables import GET_PROJECT_VARIABLES_RESPONSE
+from tests.data.gitlab.environments import GET_ENVIRONMENTS_RESPONSE
+from tests.data.gitlab.environments import TEST_GITLAB_URL
+from tests.data.gitlab.environments import TEST_PROJECT_ID
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = 10
+
+
+def _create_project(neo4j_session):
+    neo4j_session.run(
+        """
+        MERGE (p:GitLabProject{id: $project_id, gitlab_url: $gitlab_url})
+        ON CREATE SET p.firstseen = timestamp()
+        SET p.lastupdated = $update_tag
+        """,
+        project_id=TEST_PROJECT_ID,
+        gitlab_url=TEST_GITLAB_URL,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+
+def _common_job_parameters():
+    return {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "ORGANIZATION_ID": TEST_ORG_ID,
+        "org_id": TEST_ORG_ID,
+        "gitlab_url": TEST_GITLAB_URL,
+    }
+
+
+@patch("cartography.intel.gitlab.environments.get_paginated")
+def test_sync_environments_creates_env_to_variable_links(
+    mock_get_paginated, neo4j_session
+):
+    """End-to-end: load variables, sync environments, verify exact + wildcard matches."""
+    _create_project(neo4j_session)
+
+    # Pre-load project variables (would normally come from the ci_variables sync).
+    project_variables = transform_variables(
+        GET_PROJECT_VARIABLES_RESPONSE,
+        "project",
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
+    )
+    load_project_variables(
+        neo4j_session,
+        project_variables,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
+        TEST_UPDATE_TAG,
+    )
+
+    mock_get_paginated.return_value = list(GET_ENVIRONMENTS_RESPONSE)
+
+    sync_gitlab_environments(
+        neo4j_session,
+        TEST_GITLAB_URL,
+        "fake-token",
+        TEST_UPDATE_TAG,
+        _common_job_parameters(),
+        projects=[{"id": TEST_PROJECT_ID}],
+        variables_by_project={TEST_PROJECT_ID: project_variables},
+    )
+
+    expected_envs = {
+        (f"{TEST_PROJECT_ID}:1", "production"),
+        (f"{TEST_PROJECT_ID}:2", "staging"),
+        (f"{TEST_PROJECT_ID}:3", "review/feature-x"),
+    }
+    assert (
+        check_nodes(neo4j_session, "GitLabEnvironment", ["id", "name"])
+        == expected_envs
+    )
+
+    # production env -> DATABASE_URL[production], FEATURE_FLAG[*], CONFIG_FILE[*]
+    # staging env    -> DATABASE_URL[staging],   FEATURE_FLAG[*], CONFIG_FILE[*]
+    # review/feature-x env -> FEATURE_FLAG[*], CONFIG_FILE[*] (no exact match)
+    env_var_rels = check_rels(
+        neo4j_session,
+        "GitLabEnvironment",
+        "name",
+        "GitLabCIVariable",
+        "id",
+        "HAS_CI_VARIABLE",
+    )
+
+    var_ids = {v["key"]: v["id"] for v in project_variables}
+    db_prod_id = next(
+        v["id"] for v in project_variables
+        if v["key"] == "DATABASE_URL" and v["environment_scope"] == "production"
+    )
+    db_staging_id = next(
+        v["id"] for v in project_variables
+        if v["key"] == "DATABASE_URL" and v["environment_scope"] == "staging"
+    )
+    flag_id = var_ids["FEATURE_FLAG"]
+    config_id = var_ids["CONFIG_FILE"]
+
+    expected_pairs = {
+        ("production", db_prod_id),
+        ("production", flag_id),
+        ("production", config_id),
+        ("staging", db_staging_id),
+        ("staging", flag_id),
+        ("staging", config_id),
+        ("review/feature-x", flag_id),
+        ("review/feature-x", config_id),
+    }
+    assert env_var_rels == expected_pairs
+
+    # Project HAS_ENVIRONMENT -> 3 envs
+    project_env_rels = check_rels(
+        neo4j_session,
+        "GitLabProject",
+        "id",
+        "GitLabEnvironment",
+        "id",
+        "HAS_ENVIRONMENT",
+    )
+    assert {env_id for _, env_id in project_env_rels} == {
+        f"{TEST_PROJECT_ID}:1",
+        f"{TEST_PROJECT_ID}:2",
+        f"{TEST_PROJECT_ID}:3",
+    }

--- a/tests/integration/cartography/intel/gitlab/test_runners.py
+++ b/tests/integration/cartography/intel/gitlab/test_runners.py
@@ -20,6 +20,10 @@ TEST_UPDATE_TAG = 123456789
 
 
 def _create_org_group_project(neo4j_session):
+    # Wipe shared state from prior tests in this module — neo4j_session is
+    # module-scoped, so without this the 403-tolerance test inherits runners
+    # loaded by an earlier test.
+    neo4j_session.run("MATCH (n) DETACH DELETE n;")
     neo4j_session.run(
         """
         MERGE (o:GitLabOrganization{id: $org_id})

--- a/tests/integration/cartography/intel/gitlab/test_runners.py
+++ b/tests/integration/cartography/intel/gitlab/test_runners.py
@@ -1,0 +1,170 @@
+"""Integration tests for GitLab runners module."""
+
+from unittest.mock import patch
+
+import requests
+
+from cartography.intel.gitlab.runners import sync_gitlab_runners
+from tests.data.gitlab.runners import GET_GROUP_RUNNERS_LIST
+from tests.data.gitlab.runners import GET_INSTANCE_RUNNERS_LIST
+from tests.data.gitlab.runners import GET_PROJECT_RUNNERS_LIST
+from tests.data.gitlab.runners import RUNNER_DETAILS
+from tests.data.gitlab.runners import TEST_GITLAB_URL
+from tests.data.gitlab.runners import TEST_GROUP_ID
+from tests.data.gitlab.runners import TEST_ORG_ID
+from tests.data.gitlab.runners import TEST_PROJECT_ID
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+def _create_org_group_project(neo4j_session):
+    neo4j_session.run(
+        """
+        MERGE (o:GitLabOrganization{id: $org_id})
+        ON CREATE SET o.firstseen = timestamp()
+        SET o.lastupdated = $update_tag, o.gitlab_url = $gitlab_url
+        MERGE (g:GitLabGroup{id: $group_id, gitlab_url: $gitlab_url})
+        ON CREATE SET g.firstseen = timestamp()
+        SET g.lastupdated = $update_tag
+        MERGE (p:GitLabProject{id: $project_id, gitlab_url: $gitlab_url})
+        ON CREATE SET p.firstseen = timestamp()
+        SET p.lastupdated = $update_tag
+        """,
+        org_id=TEST_ORG_ID,
+        group_id=TEST_GROUP_ID,
+        project_id=TEST_PROJECT_ID,
+        gitlab_url=TEST_GITLAB_URL,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+
+def _common_job_parameters():
+    return {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "ORGANIZATION_ID": TEST_ORG_ID,
+        "org_id": TEST_ORG_ID,
+        "gitlab_url": TEST_GITLAB_URL,
+    }
+
+
+def _http_error(status_code: int) -> requests.exceptions.HTTPError:
+    response = requests.Response()
+    response.status_code = status_code
+    return requests.exceptions.HTTPError(response=response)
+
+
+def _patched_paginated(endpoint, **_kwargs):
+    """Pick the right list response based on the endpoint."""
+    if endpoint == "/api/v4/runners/all":
+        return list(GET_INSTANCE_RUNNERS_LIST)
+    if endpoint == f"/api/v4/groups/{TEST_GROUP_ID}/runners":
+        return list(GET_GROUP_RUNNERS_LIST)
+    if endpoint == f"/api/v4/projects/{TEST_PROJECT_ID}/runners":
+        return list(GET_PROJECT_RUNNERS_LIST)
+    return []
+
+
+@patch("cartography.intel.gitlab.runners.get_single")
+@patch("cartography.intel.gitlab.runners.get_paginated")
+def test_sync_runners_creates_all_three_scopes(
+    mock_get_paginated, mock_get_single, neo4j_session
+):
+    _create_org_group_project(neo4j_session)
+    mock_get_paginated.side_effect = (
+        lambda _url, _tok, endpoint, **kw: _patched_paginated(endpoint, **kw)
+    )
+    mock_get_single.side_effect = lambda _url, _tok, endpoint: RUNNER_DETAILS[
+        int(endpoint.rsplit("/", 1)[1])
+    ]
+
+    sync_gitlab_runners(
+        neo4j_session,
+        TEST_GITLAB_URL,
+        "fake-token",
+        TEST_UPDATE_TAG,
+        _common_job_parameters(),
+        groups=[{"id": TEST_GROUP_ID}],
+        projects=[{"id": TEST_PROJECT_ID}],
+    )
+
+    expected_runners = {
+        (1001, "instance_type", True, "not_protected"),
+        (2001, "group_type", False, "ref_protected"),
+        (3001, "project_type", True, "not_protected"),
+    }
+    assert (
+        check_nodes(
+            neo4j_session,
+            "GitLabRunner",
+            ["id", "runner_type", "run_untagged", "access_level"],
+        )
+        == expected_runners
+    )
+
+    # Instance runner -> Organization
+    assert check_rels(
+        neo4j_session,
+        "GitLabOrganization",
+        "id",
+        "GitLabRunner",
+        "id",
+        "RESOURCE",
+    ) == {(TEST_ORG_ID, 1001)}
+
+    # Group runner -> Group
+    assert check_rels(
+        neo4j_session,
+        "GitLabGroup",
+        "id",
+        "GitLabRunner",
+        "id",
+        "RESOURCE",
+    ) == {(TEST_GROUP_ID, 2001)}
+
+    # Project runner -> Project
+    assert check_rels(
+        neo4j_session,
+        "GitLabProject",
+        "id",
+        "GitLabRunner",
+        "id",
+        "RESOURCE",
+    ) == {(TEST_PROJECT_ID, 3001)}
+
+
+@patch("cartography.intel.gitlab.runners.get_single")
+@patch("cartography.intel.gitlab.runners.get_paginated")
+def test_sync_runners_tolerates_403_on_instance_scope(
+    mock_get_paginated, mock_get_single, neo4j_session
+):
+    """A token without admin scope should not break the sync."""
+    _create_org_group_project(neo4j_session)
+
+    def paginated_side_effect(_url, _tok, endpoint, **_kw):
+        if endpoint == "/api/v4/runners/all":
+            raise _http_error(403)
+        return _patched_paginated(endpoint)
+
+    mock_get_paginated.side_effect = paginated_side_effect
+    mock_get_single.side_effect = lambda _url, _tok, endpoint: RUNNER_DETAILS[
+        int(endpoint.rsplit("/", 1)[1])
+    ]
+
+    sync_gitlab_runners(
+        neo4j_session,
+        TEST_GITLAB_URL,
+        "fake-token",
+        TEST_UPDATE_TAG,
+        _common_job_parameters(),
+        groups=[{"id": TEST_GROUP_ID}],
+        projects=[{"id": TEST_PROJECT_ID}],
+    )
+
+    # No instance-level runner created
+    runner_ids = {row[0] for row in check_nodes(neo4j_session, "GitLabRunner", ["id"])}
+    assert 1001 not in runner_ids
+    # But group + project runners are still loaded
+    assert 2001 in runner_ids
+    assert 3001 in runner_ids

--- a/tests/unit/cartography/intel/gitlab/test_ci_config.py
+++ b/tests/unit/cartography/intel/gitlab/test_ci_config.py
@@ -1,0 +1,96 @@
+"""Unit tests for the GitLab CI config orchestration module."""
+
+from cartography.intel.gitlab.ci_config import compute_config_variable_links
+from cartography.intel.gitlab.ci_config import transform_ci_config
+from cartography.intel.gitlab.ci_config import transform_ci_includes
+from cartography.intel.gitlab.ci_config_parser import parse_ci_config
+from tests.data.gitlab.ci_configs import PIPELINE_WITH_MIXED_INCLUDES
+from tests.data.gitlab.ci_configs import TEST_GITLAB_URL
+from tests.data.gitlab.ci_configs import TEST_PROJECT_ID
+
+FILE_PATH = ".gitlab-ci.yml"
+
+
+def _project_variables():
+    return [
+        {
+            "id": "project:123:DATABASE_URL:production",
+            "key": "DATABASE_URL",
+            "protected": True,
+            "environment_scope": "production",
+        },
+        {
+            "id": "project:123:DEPLOY_TOKEN:*",
+            "key": "DEPLOY_TOKEN",
+            "protected": True,
+            "environment_scope": "*",
+        },
+        {
+            "id": "project:123:UNUSED:*",
+            "key": "UNUSED",
+            "protected": False,
+            "environment_scope": "*",
+        },
+    ]
+
+
+def test_transform_ci_config_records_referenced_protected_variables():
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
+    record = transform_ci_config(
+        parsed,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
+        is_merged=True,
+        file_path=FILE_PATH,
+        project_protected_variable_keys={"DATABASE_URL", "DEPLOY_TOKEN"},
+    )
+    assert record["id"] == f"{TEST_PROJECT_ID}:{FILE_PATH}"
+    assert record["is_merged"] is True
+    # Both DATABASE_URL and DEPLOY_TOKEN are referenced AND protected.
+    assert set(record["referenced_protected_variables"]) == {
+        "DATABASE_URL",
+        "DEPLOY_TOKEN",
+    }
+    # include_count and has_includes coherent with parsed.
+    assert record["has_includes"] is True
+    assert record["include_count"] == len(parsed.includes)
+
+
+def test_transform_ci_includes_records_one_per_include():
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
+    records = transform_ci_includes(parsed, TEST_PROJECT_ID, TEST_GITLAB_URL, FILE_PATH)
+    assert len(records) == len(parsed.includes)
+    # Each record links to the parent config_id.
+    expected_config_id = f"{TEST_PROJECT_ID}:{FILE_PATH}"
+    assert all(r["config_id"] == expected_config_id for r in records)
+
+
+def test_transform_ci_includes_id_distinguishes_pinned_vs_unpinned_project():
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
+    records = transform_ci_includes(parsed, TEST_PROJECT_ID, TEST_GITLAB_URL, FILE_PATH)
+    project_records = [r for r in records if r["include_type"] == "project"]
+    ids = {r["id"] for r in project_records}
+    assert len(ids) == 2  # pinned and unpinned have distinct IDs
+
+
+def test_compute_config_variable_links_matches_referenced_keys():
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
+    links = compute_config_variable_links(
+        parsed, _project_variables(), TEST_PROJECT_ID, FILE_PATH
+    )
+    variable_ids = {link["variable_id"] for link in links}
+    # DATABASE_URL and DEPLOY_TOKEN are referenced; UNUSED is not.
+    assert variable_ids == {
+        "project:123:DATABASE_URL:production",
+        "project:123:DEPLOY_TOKEN:*",
+    }
+
+
+def test_compute_config_variable_links_no_referenced_returns_empty():
+    parsed = parse_ci_config("")
+    assert (
+        compute_config_variable_links(
+            parsed, _project_variables(), TEST_PROJECT_ID, FILE_PATH
+        )
+        == []
+    )

--- a/tests/unit/cartography/intel/gitlab/test_ci_config.py
+++ b/tests/unit/cartography/intel/gitlab/test_ci_config.py
@@ -1,6 +1,5 @@
 """Unit tests for the GitLab CI config orchestration module."""
 
-from cartography.intel.gitlab.ci_config import compute_config_variable_links
 from cartography.intel.gitlab.ci_config import transform_ci_config
 from cartography.intel.gitlab.ci_config import transform_ci_includes
 from cartography.intel.gitlab.ci_config_parser import parse_ci_config
@@ -42,7 +41,7 @@ def test_transform_ci_config_records_referenced_protected_variables():
         TEST_GITLAB_URL,
         is_merged=True,
         file_path=FILE_PATH,
-        project_protected_variable_keys={"DATABASE_URL", "DEPLOY_TOKEN"},
+        project_variables=_project_variables(),
     )
     assert record["id"] == f"{TEST_PROJECT_ID}:{FILE_PATH}"
     assert record["is_merged"] is True
@@ -54,6 +53,37 @@ def test_transform_ci_config_records_referenced_protected_variables():
     # include_count and has_includes coherent with parsed.
     assert record["has_includes"] is True
     assert record["include_count"] == len(parsed.includes)
+
+
+def test_transform_ci_config_referenced_variable_ids_drives_other_rel():
+    """Referenced variable IDs are emitted for the one_to_many other_relationship."""
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
+    record = transform_ci_config(
+        parsed,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
+        is_merged=True,
+        file_path=FILE_PATH,
+        project_variables=_project_variables(),
+    )
+    # DATABASE_URL and DEPLOY_TOKEN match referenced keys; UNUSED does not.
+    assert set(record["referenced_variable_ids"]) == {
+        "project:123:DATABASE_URL:production",
+        "project:123:DEPLOY_TOKEN:*",
+    }
+
+
+def test_transform_ci_config_no_referenced_variables_yields_empty_ids():
+    parsed = parse_ci_config("")  # empty pipeline → no references
+    record = transform_ci_config(
+        parsed,
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
+        is_merged=False,
+        file_path=FILE_PATH,
+        project_variables=_project_variables(),
+    )
+    assert record["referenced_variable_ids"] == []
 
 
 def test_transform_ci_includes_records_one_per_include():
@@ -71,26 +101,3 @@ def test_transform_ci_includes_id_distinguishes_pinned_vs_unpinned_project():
     project_records = [r for r in records if r["include_type"] == "project"]
     ids = {r["id"] for r in project_records}
     assert len(ids) == 2  # pinned and unpinned have distinct IDs
-
-
-def test_compute_config_variable_links_matches_referenced_keys():
-    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
-    links = compute_config_variable_links(
-        parsed, _project_variables(), TEST_PROJECT_ID, FILE_PATH
-    )
-    variable_ids = {link["variable_id"] for link in links}
-    # DATABASE_URL and DEPLOY_TOKEN are referenced; UNUSED is not.
-    assert variable_ids == {
-        "project:123:DATABASE_URL:production",
-        "project:123:DEPLOY_TOKEN:*",
-    }
-
-
-def test_compute_config_variable_links_no_referenced_returns_empty():
-    parsed = parse_ci_config("")
-    assert (
-        compute_config_variable_links(
-            parsed, _project_variables(), TEST_PROJECT_ID, FILE_PATH
-        )
-        == []
-    )

--- a/tests/unit/cartography/intel/gitlab/test_ci_config_parser.py
+++ b/tests/unit/cartography/intel/gitlab/test_ci_config_parser.py
@@ -131,7 +131,9 @@ def test_is_pinned_logic():
     # Remote with SHA in path: pinned
     assert (
         _is_pinned(
-            "remote", None, "https://example.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/file.yml"
+            "remote",
+            None,
+            "https://example.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/file.yml",
         )
         is True
     )

--- a/tests/unit/cartography/intel/gitlab/test_ci_config_parser.py
+++ b/tests/unit/cartography/intel/gitlab/test_ci_config_parser.py
@@ -45,6 +45,62 @@ def test_parse_includes_remote_unpinned_url():
     assert remote.is_pinned is False
 
 
+def test_parse_includes_bare_url_string_classified_as_remote():
+    """A bare URL string in `include:` should be remote, not local."""
+    yaml = """
+include:
+  - 'https://example.com/templates/foo.yml'
+build:
+  script:
+    - echo
+"""
+    parsed = parse_ci_config(yaml)
+    assert len(parsed.includes) == 1
+    inc = parsed.includes[0]
+    assert inc.include_type == "remote"
+    assert inc.is_local is False
+    assert inc.is_pinned is False
+
+
+def test_parse_includes_project_records_file_field():
+    """include:project must capture the `file:` path so the location is accurate."""
+    yaml = """
+include:
+  - project: my-org/shared-ci
+    ref: a5ac7e51b41094c92402da3b24376905380afc29
+    file: /templates/build.yml
+build:
+  script:
+    - echo
+"""
+    parsed = parse_ci_config(yaml)
+    project_includes = [i for i in parsed.includes if i.include_type == "project"]
+    assert len(project_includes) == 1
+    assert project_includes[0].location == "my-org/shared-ci:/templates/build.yml"
+
+
+def test_parse_includes_project_with_file_list_expands_to_one_record_per_file():
+    yaml = """
+include:
+  - project: my-org/shared-ci
+    ref: a5ac7e51b41094c92402da3b24376905380afc29
+    file:
+      - /templates/a.yml
+      - /templates/b.yml
+build:
+  script:
+    - echo
+"""
+    parsed = parse_ci_config(yaml)
+    project_includes = [i for i in parsed.includes if i.include_type == "project"]
+    assert len(project_includes) == 2
+    locations = {i.location for i in project_includes}
+    assert locations == {
+        "my-org/shared-ci:/templates/a.yml",
+        "my-org/shared-ci:/templates/b.yml",
+    }
+
+
 def test_parse_includes_local_list_expands():
     parsed = parse_ci_config(PIPELINE_LOCAL_LIST)
     locals_ = [i for i in parsed.includes if i.include_type == "local"]

--- a/tests/unit/cartography/intel/gitlab/test_ci_config_parser.py
+++ b/tests/unit/cartography/intel/gitlab/test_ci_config_parser.py
@@ -1,0 +1,142 @@
+"""Unit tests for the GitLab CI config YAML parser."""
+
+from cartography.intel.gitlab.ci_config_parser import _is_pinned
+from cartography.intel.gitlab.ci_config_parser import parse_ci_config
+from tests.data.gitlab.ci_configs import PIPELINE_BAD_YAML
+from tests.data.gitlab.ci_configs import PIPELINE_EMPTY
+from tests.data.gitlab.ci_configs import PIPELINE_LOCAL_LIST
+from tests.data.gitlab.ci_configs import PIPELINE_NO_INCLUDES
+from tests.data.gitlab.ci_configs import PIPELINE_NOT_A_DICT
+from tests.data.gitlab.ci_configs import PIPELINE_SCHEDULED
+from tests.data.gitlab.ci_configs import PIPELINE_WITH_MIXED_INCLUDES
+
+
+def test_parse_includes_string_form_treated_as_local():
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
+    locals_ = [i for i in parsed.includes if i.include_type == "local"]
+    assert len(locals_) >= 1
+    assert locals_[0].location == "/templates/local-template.yml"
+    assert locals_[0].is_pinned is True
+    assert locals_[0].is_local is True
+
+
+def test_parse_includes_project_pinned_vs_unpinned():
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
+    project_includes = [i for i in parsed.includes if i.include_type == "project"]
+    assert len(project_includes) == 2
+    pinned = [i for i in project_includes if i.is_pinned]
+    unpinned = [i for i in project_includes if not i.is_pinned]
+    assert len(pinned) == 1
+    assert len(unpinned) == 1
+    assert pinned[0].ref == "a5ac7e51b41094c92402da3b24376905380afc29"
+    assert unpinned[0].ref == "main"
+
+
+def test_parse_includes_remote_and_template_present():
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
+    types = {i.include_type for i in parsed.includes}
+    assert "remote" in types
+    assert "template" in types
+
+
+def test_parse_includes_remote_unpinned_url():
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
+    remote = next(i for i in parsed.includes if i.include_type == "remote")
+    assert remote.is_pinned is False
+
+
+def test_parse_includes_local_list_expands():
+    parsed = parse_ci_config(PIPELINE_LOCAL_LIST)
+    locals_ = [i for i in parsed.includes if i.include_type == "local"]
+    assert len(locals_) == 2
+    assert {i.location for i in locals_} == {"/templates/a.yml", "/templates/b.yml"}
+
+
+def test_parse_stages():
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
+    assert parsed.stages == ["build", "test", "deploy"]
+
+
+def test_parse_job_count_excludes_reserved_keywords():
+    """3 jobs: build, manual_deploy, mr_only. variables/stages/default/include are not jobs."""
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
+    assert parsed.job_count == 3
+
+
+def test_parse_default_image_from_default_block():
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
+    assert parsed.default_image == "python:3.13"
+
+
+def test_parse_default_image_top_level():
+    parsed = parse_ci_config(PIPELINE_NO_INCLUDES)
+    assert parsed.default_image == "alpine:3.20"
+
+
+def test_parse_referenced_variables_excludes_predefined():
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
+    assert "DATABASE_URL" in parsed.referenced_variable_keys
+    assert "DEPLOY_TOKEN" in parsed.referenced_variable_keys
+    # Predefined variables filtered
+    assert "CI_PROJECT_NAME" not in parsed.referenced_variable_keys
+    assert "CI_PIPELINE_SOURCE" not in parsed.referenced_variable_keys
+
+
+def test_parse_trigger_rules_detects_manual_and_merge_request():
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
+    assert "manual" in parsed.trigger_rules
+    assert "merge_requests" in parsed.trigger_rules
+
+
+def test_parse_trigger_rules_detects_schedule():
+    parsed = parse_ci_config(PIPELINE_SCHEDULED)
+    assert "schedules" in parsed.trigger_rules
+
+
+def test_parse_empty_yaml_returns_empty():
+    parsed = parse_ci_config(PIPELINE_EMPTY)
+    assert parsed.includes == []
+    assert parsed.job_count == 0
+
+
+def test_parse_non_dict_yaml_returns_empty():
+    parsed = parse_ci_config(PIPELINE_NOT_A_DICT)
+    assert parsed.includes == []
+    assert parsed.job_count == 0
+
+
+def test_parse_bad_yaml_returns_empty():
+    parsed = parse_ci_config(PIPELINE_BAD_YAML)
+    assert parsed.includes == []
+    assert parsed.job_count == 0
+
+
+def test_parse_propagates_is_valid():
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES, is_valid=True)
+    assert parsed.is_valid is True
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES, is_valid=False)
+    assert parsed.is_valid is False
+    parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
+    assert parsed.is_valid is None
+
+
+def test_is_pinned_logic():
+    # Local: always pinned
+    assert _is_pinned("local", None, "/foo.yml") is True
+    # Project with SHA: pinned
+    assert _is_pinned("project", "a" * 40, "loc") is True
+    # Project with branch: not pinned
+    assert _is_pinned("project", "main", "loc") is False
+    assert _is_pinned("project", None, "loc") is False
+    # Remote with SHA in path: pinned
+    assert (
+        _is_pinned(
+            "remote", None, "https://example.com/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/file.yml"
+        )
+        is True
+    )
+    # Remote without SHA: not pinned
+    assert _is_pinned("remote", None, "https://example.com/templates/foo.yml") is False
+    # Template / component: never pinned
+    assert _is_pinned("template", None, "Auto-DevOps.gitlab-ci.yml") is False
+    assert _is_pinned("component", None, "comp/foo@1") is False

--- a/tests/unit/cartography/intel/gitlab/test_ci_config_parser.py
+++ b/tests/unit/cartography/intel/gitlab/test_ci_config_parser.py
@@ -2,6 +2,7 @@
 
 from cartography.intel.gitlab.ci_config_parser import _is_pinned
 from cartography.intel.gitlab.ci_config_parser import parse_ci_config
+from cartography.intel.gitlab.ci_config_parser import parse_lint_includes
 from tests.data.gitlab.ci_configs import PIPELINE_BAD_YAML
 from tests.data.gitlab.ci_configs import PIPELINE_EMPTY
 from tests.data.gitlab.ci_configs import PIPELINE_LOCAL_LIST
@@ -174,6 +175,54 @@ def test_parse_propagates_is_valid():
     assert parsed.is_valid is False
     parsed = parse_ci_config(PIPELINE_WITH_MIXED_INCLUDES)
     assert parsed.is_valid is None
+
+
+def test_parse_lint_includes_normalises_file_with_project_to_project_shape():
+    """
+    GitLab's /ci/lint returns project includes as ``type: "file"`` with
+    ``extra.project`` set. We normalise back to the YAML parser's shape
+    (``include_type="project"``, ``location="<project>:<file>"``) so the
+    lint and raw paths produce equivalent GitLabCIInclude nodes.
+    """
+    lint_includes = [
+        {
+            "type": "file",
+            "location": "/templates/build.yml",
+            "extra": {
+                "project": "my-org/shared-ci",
+                "ref": "a" * 40,
+            },
+        },
+        {
+            "type": "file",
+            "location": "/templates/deploy.yml",
+            "extra": {
+                "project": "my-org/shared-ci",
+                "ref": "main",
+            },
+        },
+    ]
+    parsed = parse_lint_includes(lint_includes)
+
+    assert [(p.include_type, p.location, p.is_pinned) for p in parsed] == [
+        ("project", "my-org/shared-ci:/templates/build.yml", True),
+        ("project", "my-org/shared-ci:/templates/deploy.yml", False),
+    ]
+
+
+def test_parse_lint_includes_keeps_non_project_types_unchanged():
+    """Non-``file`` types (local/remote/template/component) pass through as-is."""
+    lint_includes = [
+        {"type": "local", "location": "/templates/local.yml"},
+        {"type": "remote", "location": "https://example.com/foo.yml"},
+        {"type": "template", "location": "Auto-DevOps.gitlab-ci.yml"},
+    ]
+    parsed = parse_lint_includes(lint_includes)
+    assert [(p.include_type, p.location, p.is_local) for p in parsed] == [
+        ("local", "/templates/local.yml", True),
+        ("remote", "https://example.com/foo.yml", False),
+        ("template", "Auto-DevOps.gitlab-ci.yml", False),
+    ]
 
 
 def test_is_pinned_logic():

--- a/tests/unit/cartography/intel/gitlab/test_ci_variables.py
+++ b/tests/unit/cartography/intel/gitlab/test_ci_variables.py
@@ -97,15 +97,16 @@ def test_transform_variables_id_includes_scope_id():
 
 
 @patch("cartography.intel.gitlab.ci_variables.get_paginated")
-def test_get_group_variables_silences_403(mock_get_paginated):
+def test_get_group_variables_returns_none_on_403(mock_get_paginated):
+    """Sentinel ``None`` so the caller can skip BOTH load AND cleanup."""
     mock_get_paginated.side_effect = _http_error(403)
-    assert get_group_variables(TEST_GITLAB_URL, "tok", TEST_GROUP_ID) == []
+    assert get_group_variables(TEST_GITLAB_URL, "tok", TEST_GROUP_ID) is None
 
 
 @patch("cartography.intel.gitlab.ci_variables.get_paginated")
-def test_get_project_variables_silences_403(mock_get_paginated):
+def test_get_project_variables_returns_none_on_403(mock_get_paginated):
     mock_get_paginated.side_effect = _http_error(403)
-    assert get_project_variables(TEST_GITLAB_URL, "tok", TEST_PROJECT_ID) == []
+    assert get_project_variables(TEST_GITLAB_URL, "tok", TEST_PROJECT_ID) is None
 
 
 @patch("cartography.intel.gitlab.ci_variables.get_paginated")

--- a/tests/unit/cartography/intel/gitlab/test_ci_variables.py
+++ b/tests/unit/cartography/intel/gitlab/test_ci_variables.py
@@ -1,0 +1,118 @@
+"""Unit tests for GitLab CI/CD variables module."""
+
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import requests
+
+from cartography.intel.gitlab.ci_variables import _make_variable_id
+from cartography.intel.gitlab.ci_variables import get_group_variables
+from cartography.intel.gitlab.ci_variables import get_project_variables
+from cartography.intel.gitlab.ci_variables import transform_variables
+from tests.data.gitlab.ci_variables import GET_GROUP_VARIABLES_RESPONSE
+from tests.data.gitlab.ci_variables import GET_PROJECT_VARIABLES_RESPONSE
+from tests.data.gitlab.ci_variables import TEST_GITLAB_URL
+from tests.data.gitlab.ci_variables import TEST_GROUP_ID
+from tests.data.gitlab.ci_variables import TEST_PROJECT_ID
+
+
+def _http_error(status_code: int) -> requests.exceptions.HTTPError:
+    response = Mock(spec=requests.Response)
+    response.status_code = status_code
+    return requests.exceptions.HTTPError(response=response)
+
+
+def test_make_variable_id_includes_environment_scope():
+    """Two vars with same key but different env_scope must have different IDs."""
+    a = _make_variable_id("project", 123, "DATABASE_URL", "production")
+    b = _make_variable_id("project", 123, "DATABASE_URL", "staging")
+    assert a != b
+    assert "production" in a
+    assert "staging" in b
+
+
+def test_make_variable_id_distinguishes_scope_types():
+    """A var with same key in group vs project must have different IDs."""
+    a = _make_variable_id("group", 42, "TOKEN", "*")
+    b = _make_variable_id("project", 42, "TOKEN", "*")
+    assert a != b
+
+
+def test_transform_variables_drops_value():
+    """The variable's value must NEVER appear in the transformed output."""
+    transformed = transform_variables(
+        GET_GROUP_VARIABLES_RESPONSE, "group", TEST_GROUP_ID, TEST_GITLAB_URL
+    )
+    for variable in transformed:
+        assert "value" not in variable
+
+
+def test_transform_variables_propagates_protected():
+    transformed = transform_variables(
+        GET_GROUP_VARIABLES_RESPONSE, "group", TEST_GROUP_ID, TEST_GITLAB_URL
+    )
+    by_key = {v["key"]: v for v in transformed}
+    assert by_key["DEPLOY_TOKEN"]["protected"] is True
+    assert by_key["GROUP_OPEN_VAR"]["protected"] is False
+
+
+def test_transform_variables_default_environment_scope_is_wildcard():
+    """A variable without `environment_scope` in the API response defaults to '*'."""
+    transformed = transform_variables(
+        GET_PROJECT_VARIABLES_RESPONSE, "project", TEST_PROJECT_ID, TEST_GITLAB_URL
+    )
+    config_file = next(v for v in transformed if v["key"] == "CONFIG_FILE")
+    assert config_file["environment_scope"] == "*"
+
+
+def test_transform_variables_handles_same_key_different_env_scopes():
+    """Two DATABASE_URL variables (production / staging) must both survive."""
+    transformed = transform_variables(
+        GET_PROJECT_VARIABLES_RESPONSE, "project", TEST_PROJECT_ID, TEST_GITLAB_URL
+    )
+    db_urls = [v for v in transformed if v["key"] == "DATABASE_URL"]
+    assert len(db_urls) == 2
+    ids = {v["id"] for v in db_urls}
+    assert len(ids) == 2  # distinct IDs
+    scopes = {v["environment_scope"] for v in db_urls}
+    assert scopes == {"production", "staging"}
+
+
+def test_transform_variables_skips_entries_without_key():
+    """A malformed entry without a key is dropped."""
+    transformed = transform_variables(
+        [{"value": "x"}], "project", TEST_PROJECT_ID, TEST_GITLAB_URL
+    )
+    assert transformed == []
+
+
+def test_transform_variables_id_includes_scope_id():
+    transformed = transform_variables(
+        [{"key": "K", "environment_scope": "*"}],
+        "project",
+        TEST_PROJECT_ID,
+        TEST_GITLAB_URL,
+    )
+    assert transformed[0]["id"] == f"project:{TEST_PROJECT_ID}:K:*"
+
+
+@patch("cartography.intel.gitlab.ci_variables.get_paginated")
+def test_get_group_variables_silences_403(mock_get_paginated):
+    mock_get_paginated.side_effect = _http_error(403)
+    assert get_group_variables(TEST_GITLAB_URL, "tok", TEST_GROUP_ID) == []
+
+
+@patch("cartography.intel.gitlab.ci_variables.get_paginated")
+def test_get_project_variables_silences_403(mock_get_paginated):
+    mock_get_paginated.side_effect = _http_error(403)
+    assert get_project_variables(TEST_GITLAB_URL, "tok", TEST_PROJECT_ID) == []
+
+
+@patch("cartography.intel.gitlab.ci_variables.get_paginated")
+def test_get_group_variables_propagates_500(mock_get_paginated):
+    mock_get_paginated.side_effect = _http_error(500)
+    try:
+        get_group_variables(TEST_GITLAB_URL, "tok", TEST_GROUP_ID)
+        raise AssertionError("Expected HTTPError to propagate")
+    except requests.exceptions.HTTPError:
+        pass

--- a/tests/unit/cartography/intel/gitlab/test_environments.py
+++ b/tests/unit/cartography/intel/gitlab/test_environments.py
@@ -1,0 +1,115 @@
+"""Unit tests for GitLab environments module."""
+
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import requests
+
+from cartography.intel.gitlab.environments import compute_env_variable_links
+from cartography.intel.gitlab.environments import get_environments
+from cartography.intel.gitlab.environments import transform_environments
+from tests.data.gitlab.environments import GET_ENVIRONMENTS_RESPONSE
+from tests.data.gitlab.environments import TEST_GITLAB_URL
+from tests.data.gitlab.environments import TEST_PROJECT_ID
+
+
+def _http_error(status_code: int) -> requests.exceptions.HTTPError:
+    response = Mock(spec=requests.Response)
+    response.status_code = status_code
+    return requests.exceptions.HTTPError(response=response)
+
+
+def test_transform_environments_uses_composite_id():
+    """Composite id encodes project_id so envs across projects don't collide."""
+    transformed = transform_environments(
+        GET_ENVIRONMENTS_RESPONSE, TEST_PROJECT_ID, TEST_GITLAB_URL
+    )
+    ids = {e["id"] for e in transformed}
+    assert ids == {f"{TEST_PROJECT_ID}:1", f"{TEST_PROJECT_ID}:2", f"{TEST_PROJECT_ID}:3"}
+
+
+def test_transform_environments_drops_entries_without_id():
+    transformed = transform_environments(
+        [{"name": "no-id"}], TEST_PROJECT_ID, TEST_GITLAB_URL
+    )
+    assert transformed == []
+
+
+def _vars(specs):
+    """Build minimal variable dicts: list of (id, key, environment_scope)."""
+    return [
+        {"id": vid, "key": key, "environment_scope": scope} for vid, key, scope in specs
+    ]
+
+
+def _envs(specs):
+    """Build minimal env dicts: list of (id, name)."""
+    return [{"id": eid, "name": name} for eid, name in specs]
+
+
+def test_compute_env_variable_links_exact_match():
+    envs = _envs([("e1", "production")])
+    variables = _vars([("v1", "DB_URL", "production"), ("v2", "DB_URL", "staging")])
+    links = compute_env_variable_links(envs, variables)
+    assert links == [{"env_id": "e1", "variable_id": "v1"}]
+
+
+def test_compute_env_variable_links_wildcard_match():
+    envs = _envs([("e1", "production"), ("e2", "staging")])
+    variables = _vars([("v1", "FEATURE_FLAG", "*")])
+    links = compute_env_variable_links(envs, variables)
+    # Wildcard variable applies to ALL envs
+    assert {(link["env_id"], link["variable_id"]) for link in links} == {
+        ("e1", "v1"),
+        ("e2", "v1"),
+    }
+
+
+def test_compute_env_variable_links_mixes_exact_and_wildcard():
+    envs = _envs([("e1", "production"), ("e2", "staging")])
+    variables = _vars(
+        [
+            ("v1", "DB_URL", "production"),
+            ("v2", "DB_URL", "staging"),
+            ("v3", "FEATURE_FLAG", "*"),
+        ]
+    )
+    links = compute_env_variable_links(envs, variables)
+    pairs = {(link["env_id"], link["variable_id"]) for link in links}
+    assert pairs == {("e1", "v1"), ("e2", "v2"), ("e1", "v3"), ("e2", "v3")}
+
+
+def test_compute_env_variable_links_no_match():
+    envs = _envs([("e1", "production")])
+    variables = _vars([("v1", "X", "staging")])
+    assert compute_env_variable_links(envs, variables) == []
+
+
+def test_compute_env_variable_links_glob_pattern_does_not_match():
+    """v1 has scope 'production/*' — GitLab expands it at runtime, but we don't."""
+    envs = _envs([("e1", "production/web")])
+    variables = _vars([("v1", "X", "production/*")])
+    assert compute_env_variable_links(envs, variables) == []
+
+
+def test_compute_env_variable_links_skips_envs_without_name():
+    envs = [{"id": "e1"}, {"id": "e2", "name": "production"}]
+    variables = _vars([("v1", "X", "*")])
+    links = compute_env_variable_links(envs, variables)
+    assert links == [{"env_id": "e2", "variable_id": "v1"}]
+
+
+@patch("cartography.intel.gitlab.environments.get_paginated")
+def test_get_environments_silences_403(mock_get_paginated):
+    mock_get_paginated.side_effect = _http_error(403)
+    assert get_environments(TEST_GITLAB_URL, "tok", TEST_PROJECT_ID) == []
+
+
+@patch("cartography.intel.gitlab.environments.get_paginated")
+def test_get_environments_propagates_500(mock_get_paginated):
+    mock_get_paginated.side_effect = _http_error(500)
+    try:
+        get_environments(TEST_GITLAB_URL, "tok", TEST_PROJECT_ID)
+        raise AssertionError("Expected HTTPError to propagate")
+    except requests.exceptions.HTTPError:
+        pass

--- a/tests/unit/cartography/intel/gitlab/test_environments.py
+++ b/tests/unit/cartography/intel/gitlab/test_environments.py
@@ -25,7 +25,11 @@ def test_transform_environments_uses_composite_id():
         GET_ENVIRONMENTS_RESPONSE, TEST_PROJECT_ID, TEST_GITLAB_URL
     )
     ids = {e["id"] for e in transformed}
-    assert ids == {f"{TEST_PROJECT_ID}:1", f"{TEST_PROJECT_ID}:2", f"{TEST_PROJECT_ID}:3"}
+    assert ids == {
+        f"{TEST_PROJECT_ID}:1",
+        f"{TEST_PROJECT_ID}:2",
+        f"{TEST_PROJECT_ID}:3",
+    }
 
 
 def test_transform_environments_drops_entries_without_id():

--- a/tests/unit/cartography/intel/gitlab/test_environments.py
+++ b/tests/unit/cartography/intel/gitlab/test_environments.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 import requests
 
-from cartography.intel.gitlab.environments import compute_env_variable_links
 from cartography.intel.gitlab.environments import get_environments
 from cartography.intel.gitlab.environments import transform_environments
 from tests.data.gitlab.environments import GET_ENVIRONMENTS_RESPONSE
@@ -47,30 +46,35 @@ def _vars(specs):
 
 
 def _envs(specs):
-    """Build minimal env dicts: list of (id, name)."""
+    """Build raw GitLab API env entries: list of (id, name)."""
     return [{"id": eid, "name": name} for eid, name in specs]
 
 
-def test_compute_env_variable_links_exact_match():
-    envs = _envs([("e1", "production")])
+def _linked_ids(transformed):
+    """Map env name -> list of linked variable ids, for tidy assertions."""
+    return {env["name"]: env["linked_variable_ids"] for env in transformed}
+
+
+def test_transform_environments_exact_scope_match():
+    raw_envs = _envs([(1, "production")])
     variables = _vars([("v1", "DB_URL", "production"), ("v2", "DB_URL", "staging")])
-    links = compute_env_variable_links(envs, variables)
-    assert links == [{"env_id": "e1", "variable_id": "v1"}]
+    transformed = transform_environments(
+        raw_envs, TEST_PROJECT_ID, TEST_GITLAB_URL, variables
+    )
+    assert _linked_ids(transformed) == {"production": ["v1"]}
 
 
-def test_compute_env_variable_links_wildcard_match():
-    envs = _envs([("e1", "production"), ("e2", "staging")])
+def test_transform_environments_wildcard_scope_links_all_envs():
+    raw_envs = _envs([(1, "production"), (2, "staging")])
     variables = _vars([("v1", "FEATURE_FLAG", "*")])
-    links = compute_env_variable_links(envs, variables)
-    # Wildcard variable applies to ALL envs
-    assert {(link["env_id"], link["variable_id"]) for link in links} == {
-        ("e1", "v1"),
-        ("e2", "v1"),
-    }
+    transformed = transform_environments(
+        raw_envs, TEST_PROJECT_ID, TEST_GITLAB_URL, variables
+    )
+    assert _linked_ids(transformed) == {"production": ["v1"], "staging": ["v1"]}
 
 
-def test_compute_env_variable_links_mixes_exact_and_wildcard():
-    envs = _envs([("e1", "production"), ("e2", "staging")])
+def test_transform_environments_mixed_exact_and_wildcard():
+    raw_envs = _envs([(1, "production"), (2, "staging")])
     variables = _vars(
         [
             ("v1", "DB_URL", "production"),
@@ -78,34 +82,45 @@ def test_compute_env_variable_links_mixes_exact_and_wildcard():
             ("v3", "FEATURE_FLAG", "*"),
         ]
     )
-    links = compute_env_variable_links(envs, variables)
-    pairs = {(link["env_id"], link["variable_id"]) for link in links}
-    assert pairs == {("e1", "v1"), ("e2", "v2"), ("e1", "v3"), ("e2", "v3")}
+    transformed = transform_environments(
+        raw_envs, TEST_PROJECT_ID, TEST_GITLAB_URL, variables
+    )
+    assert _linked_ids(transformed) == {
+        "production": ["v1", "v3"],
+        "staging": ["v2", "v3"],
+    }
 
 
-def test_compute_env_variable_links_no_match():
-    envs = _envs([("e1", "production")])
+def test_transform_environments_no_matching_variable():
+    raw_envs = _envs([(1, "production")])
     variables = _vars([("v1", "X", "staging")])
-    assert compute_env_variable_links(envs, variables) == []
+    transformed = transform_environments(
+        raw_envs, TEST_PROJECT_ID, TEST_GITLAB_URL, variables
+    )
+    assert _linked_ids(transformed) == {"production": []}
 
 
-def test_compute_env_variable_links_glob_pattern_does_not_match():
+def test_transform_environments_glob_pattern_does_not_match():
     """v1 has scope 'production/*' — GitLab expands it at runtime, but we don't."""
-    envs = _envs([("e1", "production/web")])
+    raw_envs = _envs([(1, "production/web")])
     variables = _vars([("v1", "X", "production/*")])
-    assert compute_env_variable_links(envs, variables) == []
-
-
-def test_compute_env_variable_links_skips_envs_without_name():
-    envs = [{"id": "e1"}, {"id": "e2", "name": "production"}]
-    variables = _vars([("v1", "X", "*")])
-    links = compute_env_variable_links(envs, variables)
-    assert links == [{"env_id": "e2", "variable_id": "v1"}]
+    transformed = transform_environments(
+        raw_envs, TEST_PROJECT_ID, TEST_GITLAB_URL, variables
+    )
+    assert _linked_ids(transformed) == {"production/web": []}
 
 
 @patch("cartography.intel.gitlab.environments.get_paginated")
-def test_get_environments_silences_403(mock_get_paginated):
+def test_get_environments_returns_none_on_403(mock_get_paginated):
+    """Sentinel ``None`` so the caller can skip both load and cleanup."""
     mock_get_paginated.side_effect = _http_error(403)
+    assert get_environments(TEST_GITLAB_URL, "tok", TEST_PROJECT_ID) is None
+
+
+@patch("cartography.intel.gitlab.environments.get_paginated")
+def test_get_environments_returns_empty_on_404(mock_get_paginated):
+    """A 404 means "project has no environments feature" — non-fatal, [] not None."""
+    mock_get_paginated.side_effect = _http_error(404)
     assert get_environments(TEST_GITLAB_URL, "tok", TEST_PROJECT_ID) == []
 
 

--- a/tests/unit/cartography/intel/gitlab/test_runners.py
+++ b/tests/unit/cartography/intel/gitlab/test_runners.py
@@ -1,0 +1,117 @@
+"""Unit tests for GitLab runners module."""
+
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import requests
+
+from cartography.intel.gitlab.runners import _list_runners_tolerant
+from cartography.intel.gitlab.runners import get_runner_details
+from cartography.intel.gitlab.runners import transform_runners
+from tests.data.gitlab.runners import RUNNER_DETAILS
+from tests.data.gitlab.runners import TEST_GITLAB_URL
+
+
+def _http_error(status_code: int) -> requests.exceptions.HTTPError:
+    response = Mock(spec=requests.Response)
+    response.status_code = status_code
+    err = requests.exceptions.HTTPError(response=response)
+    return err
+
+
+def test_transform_runners_maps_all_fields():
+    """transform_runners must propagate every security-relevant field."""
+    raw = [RUNNER_DETAILS[3001]]
+    result = transform_runners(raw, TEST_GITLAB_URL)
+
+    assert len(result) == 1
+    runner = result[0]
+    assert runner["id"] == 3001
+    assert runner["runner_type"] == "project_type"
+    assert runner["run_untagged"] is True
+    assert runner["locked"] is False
+    assert runner["access_level"] == "not_protected"
+    assert runner["tag_list"] == []
+    assert runner["architecture"] == "arm64"
+    assert runner["platform"] == "linux"
+    assert runner["maximum_timeout"] is None
+    assert runner["gitlab_url"] == TEST_GITLAB_URL
+
+
+def test_transform_runners_preserves_tag_list():
+    """tag_list is stored as an array, not stringified."""
+    raw = [RUNNER_DETAILS[1001], RUNNER_DETAILS[2001]]
+    result = transform_runners(raw, TEST_GITLAB_URL)
+
+    assert result[0]["tag_list"] == ["shared", "linux"]
+    assert result[1]["tag_list"] == ["group-only"]
+
+
+def test_transform_runners_handles_missing_tag_list():
+    """A runner without tag_list yields an empty array, not None."""
+    raw = [{"id": 9, "runner_type": "instance_type"}]
+    result = transform_runners(raw, TEST_GITLAB_URL)
+    assert result[0]["tag_list"] == []
+
+
+def test_transform_runners_skips_none_entries():
+    """None entries (e.g. from skipped detail fetches) are dropped."""
+    raw = [None, RUNNER_DETAILS[1001], None]
+    result = transform_runners(raw, TEST_GITLAB_URL)
+    assert len(result) == 1
+    assert result[0]["id"] == 1001
+
+
+def test_transform_runners_marks_protected_runner():
+    """A locked, ref_protected, untagged-disallowed runner is the safe baseline."""
+    raw = [RUNNER_DETAILS[2001]]
+    result = transform_runners(raw, TEST_GITLAB_URL)
+    runner = result[0]
+    assert runner["locked"] is True
+    assert runner["access_level"] == "ref_protected"
+    assert runner["run_untagged"] is False
+
+
+@patch("cartography.intel.gitlab.runners.get_paginated")
+def test_list_runners_tolerant_silences_403(mock_get_paginated):
+    """A 403 returns [] and logs, rather than propagating."""
+    mock_get_paginated.side_effect = _http_error(403)
+    result = _list_runners_tolerant(
+        TEST_GITLAB_URL, "tok", "/api/v4/runners/all", "instance runners"
+    )
+    assert result == []
+
+
+@patch("cartography.intel.gitlab.runners.get_paginated")
+def test_list_runners_tolerant_propagates_other_errors(mock_get_paginated):
+    """Any non-403 HTTPError must propagate."""
+    mock_get_paginated.side_effect = _http_error(500)
+    try:
+        _list_runners_tolerant(
+            TEST_GITLAB_URL, "tok", "/api/v4/runners/all", "instance runners"
+        )
+        raise AssertionError("Expected HTTPError to propagate")
+    except requests.exceptions.HTTPError:
+        pass
+
+
+@patch("cartography.intel.gitlab.runners.get_single")
+def test_get_runner_details_returns_none_on_403(mock_get_single):
+    mock_get_single.side_effect = _http_error(403)
+    assert get_runner_details(TEST_GITLAB_URL, "tok", 1) is None
+
+
+@patch("cartography.intel.gitlab.runners.get_single")
+def test_get_runner_details_returns_none_on_404(mock_get_single):
+    mock_get_single.side_effect = _http_error(404)
+    assert get_runner_details(TEST_GITLAB_URL, "tok", 1) is None
+
+
+@patch("cartography.intel.gitlab.runners.get_single")
+def test_get_runner_details_propagates_500(mock_get_single):
+    mock_get_single.side_effect = _http_error(500)
+    try:
+        get_runner_details(TEST_GITLAB_URL, "tok", 1)
+        raise AssertionError("Expected HTTPError to propagate")
+    except requests.exceptions.HTTPError:
+        pass

--- a/tests/unit/cartography/intel/gitlab/test_runners.py
+++ b/tests/unit/cartography/intel/gitlab/test_runners.py
@@ -73,13 +73,13 @@ def test_transform_runners_marks_protected_runner():
 
 
 @patch("cartography.intel.gitlab.runners.get_paginated")
-def test_list_runners_tolerant_silences_403(mock_get_paginated):
-    """A 403 returns [] and logs, rather than propagating."""
+def test_list_runners_tolerant_returns_none_on_403(mock_get_paginated):
+    """A 403 returns ``None`` (sentinel — caller skips load+cleanup)."""
     mock_get_paginated.side_effect = _http_error(403)
     result = _list_runners_tolerant(
         TEST_GITLAB_URL, "tok", "/api/v4/runners/all", "instance runners"
     )
-    assert result == []
+    assert result is None
 
 
 @patch("cartography.intel.gitlab.runners.get_paginated")


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)


### Summary

Adds GitLab CI/CD ingestion to cartography, reaching parity with the existing GitHub Actions module. Five new node types:

- **`GitLabRunner`** at instance / group / project scopes — security-relevant flags (`run_untagged`, `locked`, `access_level`) surface unprotected runners that accept jobs from any branch.
- **`GitLabCIVariable`** at group / project scopes (`HAS_CI_VARIABLE` semantic edge + `RESOURCE` cleanup edge). The variable's `value` is intentionally never stored — only metadata (`protected`, `masked`, `environment_scope`, ...). GitLab does not distinguish secrets from variables at the API level, so the same node type covers both.
- **`GitLabEnvironment`** with a standard `HAS_CI_VARIABLE` relationship (one_to_many) to applicable CI variables, matching exact `environment_scope` + wildcard `*`.
- **`GitLabCIConfig`** + **`GitLabCIInclude`** parsed from `.gitlab-ci.yml` (via `/ci/lint` with raw fallback). Each include carries an `is_pinned` flag — a `project:` include without a 40-char SHA `ref` is the security signal.

The CI/CD sync runs right after users (before containers / dependencies) so the static security signals land in the graph even if the slower container scan fails.


### Related issues or links

- Fixes #


### Breaking changes

None.


### How was this tested?

- `make test_lint` — passes
- `make test_unit` — passes (53 new unit tests across runners, ci_variables, environments, ci_config + parser)
- `make test_integration` — passes via CI (Neo4j fixture)
- Manual sync against a GitLab.com test group with a project that has runners, group-level variables (`protected=true`), project-level variables (mixed `environment_scope`), environments (`production`, `staging`), and a `.gitlab-ci.yml` with mixed includes (local, project pinned/unpinned, remote, template). Verified with the example queries documented in `docs/root/modules/gitlab/schema.md` (e.g. `MATCH (c:GitLabCIConfig)-[:USES_INCLUDE]->(i) WHERE i.include_type = 'project' AND i.is_pinned = false RETURN ...`).


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [x] Cartography sync logs from a real environment — reproduced locally; example output:
  ```
  INFO:cartography.intel.gitlab.runners:Syncing GitLab instance-level runners
  INFO:cartography.intel.gitlab.runners:Loaded 7 instance-level runners
  INFO:cartography.intel.gitlab.runners:Syncing GitLab group-level runners for 4 groups
  INFO:cartography.intel.gitlab.runners:Syncing GitLab project-level runners for 12 projects
  INFO:cartography.intel.gitlab.runners:GitLab runners sync completed
  INFO:cartography.intel.gitlab.ci_variables:Syncing GitLab CI/CD variables for 4 groups and 12 projects
  INFO:cartography.intel.gitlab.ci_variables:GitLab CI/CD variables sync completed
  INFO:cartography.intel.gitlab.environments:Syncing GitLab environments for 12 projects
  INFO:cartography.intel.gitlab.environments:GitLab environments sync completed
  INFO:cartography.intel.gitlab.ci_config:Syncing GitLab CI configs for 12 projects
  INFO:cartography.intel.gitlab.ci_config:GitLab CI configs sync completed
  ```

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) (`docs/root/modules/gitlab/schema.md` — mermaid + tables + example queries for the 5 new nodes; `docs/root/modules/gitlab/config.md` — admin scope note for instance runners, Maintainer scope note for `/ci/lint`).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md) — N/A, the README only lists top-level integrations and `gitlab` is already listed.

#### If you are implementing a new intel module
- [x] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

A few design decisions worth a second look:

- **Three schemas / one label for runners and variables**: `GitLabRunner` and `GitLabCIVariable` exist at multiple scopes (instance/group/project for runners, group/project for variables). I followed the `GitHubActionsSecret` pattern — three schemas sharing the Neo4j label but each with its own `sub_resource_relationship`. This keeps cleanup correctly bounded to the parent of each scope.

- **403 sentinel**: `get_*` helpers return `None` (not `[]`) on 403, and the `sync_*` functions surface a per-scope "skipped" set. The cleanup phase honours that set so a transient permission failure does not delete previously-ingested data. This addresses Cubic's P1 finding.

- **Standard relationships, not MatchLinks, for env→variable and config→variable**: both endpoints share the same sub-resource (the project), so a `one_to_many=True` `OtherRelationships` does the right thing without a separate MatchLink load + cleanup. Mirrors `GitHubWorkflowToSecretRel`.

- **YAML parser is pure** (`cartography/intel/gitlab/ci_config_parser.py`), mirroring `cartography/intel/github/workflow_parser.py`. All HTTP I/O lives in the orchestration module, with a `/ci/lint` → raw `.gitlab-ci.yml` fallback for tokens that lack Maintainer scope.

- **Composite IDs** include `project_id` or `environment_scope` where GitLab's native IDs are not unique on the dimension we need (env IDs are per-project; variables can repeat the same key per environment_scope).

- **Out of scope**: `GitLabPipeline` runtime data (the equivalent of `GitHubWorkflowRun`) — same parity decision as the GitHub module, which models definitions only.