### PR TITLE
fix(kubernetes): map load balancer port status fields

### DIFF
--- a/cartography/intel/kubernetes/services.py
+++ b/cartography/intel/kubernetes/services.py
@@ -58,9 +58,9 @@ def _format_load_balancer_ingress(ingress: list[V1LoadBalancerIngress] | None) -
         for port in ports:
             ingress_ports.append(
                 {
-                    "error": port.port,
-                    "port": port.protocol,
-                    "protocol": port.ip,
+                    "error": port.error,
+                    "port": port.port,
+                    "protocol": port.protocol,
                 }
             )
         return ingress_ports

--- a/tests/unit/cartography/intel/kubernetes/test_services.py
+++ b/tests/unit/cartography/intel/kubernetes/test_services.py
@@ -1,0 +1,63 @@
+import json
+
+from kubernetes.client.models import V1LoadBalancerIngress
+from kubernetes.client.models import V1LoadBalancerStatus
+from kubernetes.client.models import V1ObjectMeta
+from kubernetes.client.models import V1PortStatus
+from kubernetes.client.models import V1Service
+from kubernetes.client.models import V1ServiceSpec
+from kubernetes.client.models import V1ServiceStatus
+
+from cartography.intel.kubernetes.services import transform_services
+
+
+def test_transform_services_formats_load_balancer_port_status():
+    service = V1Service(
+        metadata=V1ObjectMeta(
+            uid="service-1",
+            name="web",
+            namespace="default",
+            creation_timestamp=None,
+            deletion_timestamp=None,
+        ),
+        spec=V1ServiceSpec(
+            type="LoadBalancer",
+            selector={"app": "web"},
+            cluster_ip="10.0.0.1",
+            load_balancer_ip=None,
+        ),
+        status=V1ServiceStatus(
+            load_balancer=V1LoadBalancerStatus(
+                ingress=[
+                    V1LoadBalancerIngress(
+                        hostname="lb.example.com",
+                        ports=[
+                            V1PortStatus(
+                                error="PortAllocationFailed",
+                                port=443,
+                                protocol="TCP",
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ),
+    )
+
+    [transformed] = transform_services([service], all_pods=[])
+
+    assert json.loads(transformed["load_balancer_ingress"]) == [
+        {
+            "hostname": "lb.example.com",
+            "ip": None,
+            "ip_mode": None,
+            "ports": [
+                {
+                    "error": "PortAllocationFailed",
+                    "port": 443,
+                    "protocol": "TCP",
+                },
+            ],
+        },
+    ]
+    assert transformed["load_balancer_dns_names"] == ["lb.example.com"]


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
Fix the Kubernetes Service transform for LoadBalancer ingress port status entries.

`V1PortStatus` exposes `error`, `port`, and `protocol`; it does not expose `ip`. The previous transform rotated those fields and attempted to read `port.ip`, so Services with populated `status.loadBalancer.ingress[].ports` failed during transformation.


### Related issues or links
- Kubernetes API reference: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceStatus
- Kubernetes Python client `V1PortStatus`: https://github.com/kubernetes-client/python/blob/v35.0.0/kubernetes/client/models/v1_port_status.py


### Breaking changes
None.


### How was this tested?
- Verified locally 


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
This only changes the JSON value produced for existing LoadBalancer ingress port status data. It does not add or change graph schema.
