### PR TITLE
Handle pre-2002 CVEs in NVD yearly feeds

### DIFF
--- a/cartography/intel/cve_metadata/nvd.py
+++ b/cartography/intel/cve_metadata/nvd.py
@@ -20,6 +20,7 @@ DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 # NVD API rate limits: 50 req/30s with key. 0.6s/req would hit the limit exactly;
 # keep a margin at 1s.
 API_SLEEP_TIME = 1.0
+NVD_YEARLY_FEED_START_YEAR = 2002
 
 
 def _extract_years_from_cve_ids(cve_ids: set[str]) -> set[str]:
@@ -30,6 +31,30 @@ def _extract_years_from_cve_ids(cve_ids: set[str]) -> set[str]:
         if len(parts) >= 2:
             years.add(parts[1])
     return years
+
+
+def _get_years_with_yearly_nvd_feeds(cve_ids: set[str]) -> set[str]:
+    """Return CVE years that have yearly NVD feed files.
+
+    NVD yearly feeds are published starting at 2002. Older CVE years are
+    included in the 2002 feed.
+    """
+    candidate_years = _extract_years_from_cve_ids(cve_ids)
+    valid_years = {
+        str(max(int(year), NVD_YEARLY_FEED_START_YEAR))
+        for year in candidate_years
+        if year.isdigit()
+    }
+
+    skipped_years = sorted(year for year in candidate_years if not year.isdigit())
+    if skipped_years:
+        logger.info(
+            "Skipping unsupported yearly NVD feed years %s."
+            " NVD yearly feeds start at %s and include older CVEs in 2002.",
+            skipped_years,
+            NVD_YEARLY_FEED_START_YEAR,
+        )
+    return valid_years
 
 
 @timeit
@@ -237,7 +262,10 @@ def _get_nvd_cves_from_feeds(
     cve_ids_in_graph: set[str],
 ) -> dict[str, dict[Any, Any]]:
     """Download NVD yearly feed files for the years matching CVE IDs in the graph."""
-    years = _extract_years_from_cve_ids(cve_ids_in_graph)
+    years = _get_years_with_yearly_nvd_feeds(cve_ids_in_graph)
+    if not years:
+        logger.info("No supported NVD yearly feed years found in graph CVE IDs.")
+        return {}
     logger.info(
         "Downloading NVD feeds for years %s to enrich %d CVEs",
         sorted(years),

--- a/tests/unit/cartography/intel/cve_metadata/test_nvd.py
+++ b/tests/unit/cartography/intel/cve_metadata/test_nvd.py
@@ -1,6 +1,8 @@
 import copy
 from datetime import datetime
+from unittest.mock import MagicMock
 
+from cartography.intel.cve_metadata import nvd
 from cartography.intel.cve_metadata.nvd import merge_nvd_into_cves
 from cartography.intel.cve_metadata.nvd import transform_cves
 from tests.data.cve_metadata.nvd import GET_NVD_API_DATA
@@ -121,3 +123,48 @@ def test_merge_nvd_into_cves():
     assert cves[0]["baseScore"] == 6.1
     # CVE not in NVD should remain a stub
     assert "baseScore" not in cves[1]
+
+
+def test_get_nvd_cves_from_feeds_skips_pre_2002_years(monkeypatch):
+    http_session = MagicMock()
+    cve_ids_in_graph = {"CVE-1999-0001", "CVE-2002-0001"}
+
+    captured_years = []
+
+    def _fake_download(_http_session, year):
+        captured_years.append(year)
+        return {"vulnerabilities": []}
+
+    monkeypatch.setattr(nvd, "_download_nvd_feed", _fake_download)
+
+    result = nvd._get_nvd_cves_from_feeds(http_session, cve_ids_in_graph)
+    assert result == {}
+    assert captured_years == ["2002"]
+
+
+def test_get_nvd_cves_from_feeds_maps_pre_2002_years_to_2002_feed(monkeypatch):
+    http_session = MagicMock()
+    cve_ids_in_graph = {"CVE-1999-0001"}
+
+    captured_years = []
+
+    def _fake_download(_http_session, year):
+        captured_years.append(year)
+        return {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "id": "CVE-1999-0001",
+                        "descriptions": [
+                            {"lang": "en", "value": "old vulnerability"},
+                        ],
+                    },
+                },
+            ],
+        }
+
+    monkeypatch.setattr(nvd, "_download_nvd_feed", _fake_download)
+
+    result = nvd._get_nvd_cves_from_feeds(http_session, cve_ids_in_graph)
+    assert set(result) == {"CVE-1999-0001"}
+    assert captured_years == ["2002"]


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

NVD yearly feeds start at 2002, and pre-2002 CVEs are included in the 2002 feed. This change normalizes pre-2002 CVE years to the 2002 feed instead of trying to download unsupported yearly feed files or dropping those CVEs from feed enrichment.


### Related issues or links

N/A


### Breaking changes

None.


### How was this tested?

- `/Users/kunaalsikka/src/cartography/.venv/bin/pytest tests/unit/cartography/intel/cve_metadata/test_nvd.py`
- Commit hooks passed: isort, black, flake8, pyupgrade, mypy



Live validation against the NVD 2002 yearly feed with 4,378 pre-2002 CVE nodes:

```text
INFO:cartography.intel.cve_metadata:Found 4378 CVE nodes in graph to enrich.
INFO:cartography.intel.cve_metadata.nvd:Downloading NVD feeds for years ['2002'] to enrich 4378 CVEs
INFO:cartography.intel.cve_metadata:NVD enriched 4378 CVEs.
INFO:cartography.client.core.tx:Loaded 1 CVEMetadataFeed nodes
INFO:cartography.intel.cve_metadata:Loading 4378 CVEMetadata nodes into the graph.
INFO:cartography.client.core.tx:Loaded 4378 CVEMetadata nodes
INFO:cartography.graph.statement:Completed CVEMetadata statement #1
INFO:cartography.graph.statement:Completed CVEMetadata statement #2
INFO:cartography.graph.statement:Completed CVEMetadata statement #3
```

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

This only changes feed-year selection for CVE metadata enrichment and does not modify any graph schema.
