### PR TITLE
Simplify NVD yearly feed selection

### DIFF
--- a/cartography/intel/cve_metadata/nvd.py
+++ b/cartography/intel/cve_metadata/nvd.py
@@ -23,38 +23,17 @@ API_SLEEP_TIME = 1.0
 NVD_YEARLY_FEED_START_YEAR = 2002
 
 
-def _extract_years_from_cve_ids(cve_ids: set[str]) -> set[str]:
-    """Extract unique years from CVE IDs (e.g., CVE-2023-12345 → 2023)."""
+def _get_years_with_yearly_nvd_feeds(cve_ids: set[str]) -> set[str]:
+    """Return CVE years mapped to their yearly NVD feed file.
+
+    NVD yearly feeds start at 2002; older CVEs are folded into the 2002 feed.
+    """
     years: set[str] = set()
     for cve_id in cve_ids:
         parts = cve_id.split("-")
-        if len(parts) >= 2:
-            years.add(parts[1])
+        if len(parts) >= 2 and parts[1].isdigit():
+            years.add(str(max(int(parts[1]), NVD_YEARLY_FEED_START_YEAR)))
     return years
-
-
-def _get_years_with_yearly_nvd_feeds(cve_ids: set[str]) -> set[str]:
-    """Return CVE years that have yearly NVD feed files.
-
-    NVD yearly feeds are published starting at 2002. Older CVE years are
-    included in the 2002 feed.
-    """
-    candidate_years = _extract_years_from_cve_ids(cve_ids)
-    valid_years = {
-        str(max(int(year), NVD_YEARLY_FEED_START_YEAR))
-        for year in candidate_years
-        if year.isdigit()
-    }
-
-    skipped_years = sorted(year for year in candidate_years if not year.isdigit())
-    if skipped_years:
-        logger.info(
-            "Skipping unsupported yearly NVD feed years %s."
-            " NVD yearly feeds start at %s and include older CVEs in 2002.",
-            skipped_years,
-            NVD_YEARLY_FEED_START_YEAR,
-        )
-    return valid_years
 
 
 @timeit
@@ -264,7 +243,6 @@ def _get_nvd_cves_from_feeds(
     """Download NVD yearly feed files for the years matching CVE IDs in the graph."""
     years = _get_years_with_yearly_nvd_feeds(cve_ids_in_graph)
     if not years:
-        logger.info("No supported NVD yearly feed years found in graph CVE IDs.")
         return {}
     logger.info(
         "Downloading NVD feeds for years %s to enrich %d CVEs",

--- a/tests/unit/cartography/intel/cve_metadata/test_nvd.py
+++ b/tests/unit/cartography/intel/cve_metadata/test_nvd.py
@@ -125,7 +125,7 @@ def test_merge_nvd_into_cves():
     assert "baseScore" not in cves[1]
 
 
-def test_get_nvd_cves_from_feeds_skips_pre_2002_years(monkeypatch):
+def test_get_nvd_cves_from_feeds_deduplicates_2002_feed_year(monkeypatch):
     http_session = MagicMock()
     cve_ids_in_graph = {"CVE-1999-0001", "CVE-2002-0001"}
 


### PR DESCRIPTION
### Type of change
- [x] Refactoring (no functional changes)


### Summary

Follow-up to #2717. This simplifies the NVD yearly feed selection helper by parsing and normalizing CVE years in one pass. Pre-2002 CVEs still map to the 2002 NVD feed, modern CVE years stay unchanged, and non-numeric year segments are ignored.

This also renames the pre-2002 unit test so the test name matches the intended behavior after #2717: old CVEs and 2002 CVEs should deduplicate to one 2002 feed download.


### Related issues or links

- Follow-up to #2717


### Breaking changes

None.


### How was this tested?

- `/Users/kunaalsikka/src/cartography/.venv/bin/pytest tests/unit/cartography/intel/cve_metadata/test_nvd.py`
- Commit hooks passed: isort, black, flake8, pyupgrade, mypy


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

No behavior change intended; this is just a small cleanup of the helper introduced in #2717.
