### PR TITLE
fix(github): handle 400 from GHCR packages endpoint gracefully

### DIFF
--- a/cartography/intel/github/packages.py
+++ b/cartography/intel/github/packages.py
@@ -53,11 +53,12 @@ def get_container_packages(
     Fetch every container package owned by ``organization`` via the GitHub
     REST API. Returns the raw payloads alongside a ``cleanup_safe`` flag.
 
-    The ``/orgs/{org}/packages`` endpoint returns 404 on older GHES versions
-    and 403 when the token is missing the ``read:packages`` scope (the most
-    common misconfiguration in the wild — fine-grained PATs always 403 here).
-    Both cases set ``cleanup_safe=False`` so previously-synced packages are
-    not purged by a missing-scope or endpoint-outage condition.
+    The ``/orgs/{org}/packages`` endpoint returns 404 on older GHES versions,
+    403 when the token is missing the ``read:packages`` scope (the most
+    common misconfiguration in the wild: fine-grained PATs always 403 here),
+    and 400 when the account is not actually an organization or has packages
+    disabled. All three cases set ``cleanup_safe=False`` so previously-synced
+    packages are not purged by a missing-scope or endpoint-outage condition.
     """
     base_url = rest_api_base_url(api_url)
     endpoint = (
@@ -69,7 +70,7 @@ def get_container_packages(
             base_url,
             endpoint,
             result_key="packages",
-            raise_on_status=(403, 404),
+            raise_on_status=(400, 403, 404),
         )
         return ContainerPackagesFetchResult(packages=packages, cleanup_safe=True)
     except requests.exceptions.HTTPError as err:
@@ -89,6 +90,16 @@ def get_container_packages(
                 "PATs cannot access Packages and always 403 here). GHCR sync "
                 "will be skipped and cleanup deferred to preserve previously "
                 "synced packages.",
+                organization,
+            )
+            return ContainerPackagesFetchResult(packages=[], cleanup_safe=False)
+        if status == 400:
+            logger.warning(
+                "GitHub Packages endpoint rejected request for org %s (400). "
+                "The account is most likely not an organization (user accounts "
+                "are not supported by /orgs/{org}/packages) or has packages "
+                "disabled. GHCR sync will be skipped and cleanup deferred to "
+                "preserve previously synced packages.",
                 organization,
             )
             return ContainerPackagesFetchResult(packages=[], cleanup_safe=False)


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

The GHCR sync added in #2710 calls `/orgs/{org}/packages?package_type=container` and gracefully handles 403 (missing `read:packages` scope) and 404 (older GHES) by skipping the sync and deferring cleanup. It does not handle 400, which the same endpoint returns when:

- the account is actually a user (not an organization), or
- the organization has GitHub Packages disabled.

In that case the HTTPError bubbles up through `start_github_ingestion`, aborting the entire GitHub sync stage for the org. Observed in the wild:

```
ERROR cartography.sync: Unhandled exception during sync stage 'github'
...
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url:
  https://api.github.com/orgs/<org>/packages?package_type=container&per_page=100
```

This PR extends the existing resilience pattern to also catch 400: log a warning, return an empty packages list, and set `cleanup_safe=False` so previously-synced `GitHubPackage` nodes are not purged by an endpoint outage.

### Related issues or links

- Fixes #


### How was this tested?

- `make lint` (pre-commit) passes locally.
- The change is isolated to the existing 403/404 graceful-skip path in `get_container_packages`; same mechanism, one more status code.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

### Notes for reviewers

The handler mirrors the existing 403 and 404 branches verbatim, just with a 400-specific warning that explains the likely cause (user account vs organization, or packages disabled). Adding 400 to `raise_on_status` ensures we short-circuit the retry loop in `fetch_all_rest_api_pages` instead of waiting through 5 retries before raising.