### PR TITLE
fix(aws): skip deleted Secrets Manager versions

### DIFF
--- a/cartography/intel/aws/secretsmanager.py
+++ b/cartography/intel/aws/secretsmanager.py
@@ -4,6 +4,7 @@ from typing import List
 
 import boto3
 import neo4j
+from botocore.exceptions import ClientError
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
@@ -119,7 +120,16 @@ def get_secret_versions(
         if next_token:
             params["NextToken"] = next_token
 
-        response = client.list_secret_version_ids(**params)
+        try:
+            response = client.list_secret_version_ids(**params)
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") == "ResourceNotFoundException":
+                logger.info(
+                    "Secret %s no longer exists while fetching versions; skipping.",
+                    secret_arn,
+                )
+                return []
+            raise
 
         for version in response.get("Versions", []):
             version["SecretId"] = secret_arn

--- a/tests/unit/cartography/intel/aws/test_secretsmanager.py
+++ b/tests/unit/cartography/intel/aws/test_secretsmanager.py
@@ -1,6 +1,12 @@
 import datetime
 from datetime import timezone as tz
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
+from botocore.exceptions import ClientError
+
+import cartography.intel.aws.secretsmanager
+from cartography.intel.aws.secretsmanager import get_secret_versions
 from cartography.intel.aws.secretsmanager import transform_secrets
 from tests.data.aws.secretsmanager import SECRETS_RAW_DATA
 
@@ -87,4 +93,32 @@ def test_transform_secrets_happy_path():
     # Should handle None values gracefully for missing optional date fields
     assert minimal_secret.get("LastRotatedDate") is None or isinstance(
         minimal_secret.get("LastRotatedDate"), int
+    )
+
+
+@patch.object(cartography.intel.aws.secretsmanager, "create_boto3_client")
+def test_get_secret_versions_skips_deleted_secret(mock_create_boto3_client):
+    secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:deleted-AbCdEf"
+    client = MagicMock()
+    client.list_secret_version_ids.side_effect = ClientError(
+        {
+            "Error": {
+                "Code": "ResourceNotFoundException",
+                "Message": "Secrets Manager can't find the specified secret.",
+            }
+        },
+        "ListSecretVersionIds",
+    )
+    mock_create_boto3_client.return_value = client
+
+    result = get_secret_versions(
+        MagicMock(),
+        "us-east-1",
+        secret_arn,
+    )
+
+    assert result == []
+    client.list_secret_version_ids.assert_called_once_with(
+        SecretId=secret_arn,
+        IncludeDeprecated=True,
     )


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
Secrets Manager secrets can be deleted after `ListSecrets` returns them but before Cartography calls `ListSecretVersionIds` for each secret ARN.

This catches that specific `ResourceNotFoundException` while fetching versions, skips the deleted secret's versions, and leaves other Secrets Manager errors unchanged.


### Related issues or links
N/A


### Breaking changes
None.


### How was this tested?
- Added test


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
This is limited to the per-secret version lookup. The secret list and graph load behavior are unchanged.
