### PR TITLE
fix(cve_metadata): load metadata one feed year at a time

### DIFF
--- a/cartography/intel/cve_metadata/__init__.py
+++ b/cartography/intel/cve_metadata/__init__.py
@@ -121,6 +121,9 @@ def start_cve_metadata_ingestion(
             skipped_cves,
         )
 
+    # Load the feed node first so each batch can attach RESOURCE links to it.
+    load_cve_metadata_feed(neo4j_session, config.update_tag, sources)
+
     if yearly_batches:
         session = Session()
         retry_policy = Retry(
@@ -135,7 +138,9 @@ def start_cve_metadata_ingestion(
         with session as http_session:
             # Step 2: Enrich and load one CVE year at a time to keep memory bounded.
             for batch_cve_ids in yearly_batches:
-                cves: list[dict[str, Any]] = [{"id": cve_id} for cve_id in batch_cve_ids]
+                cves: list[dict[str, Any]] = [
+                    {"id": cve_id} for cve_id in batch_cve_ids
+                ]
 
                 if "nvd" in sources:
                     nvd_data = nvd.get_and_transform_nvd_cves(
@@ -158,10 +163,7 @@ def start_cve_metadata_ingestion(
 
                 load_cve_metadata(neo4j_session, cves, config.update_tag)
 
-    # Step 4: Load into graph (always runs so cleanup removes stale CVEMetadata nodes)
-    load_cve_metadata_feed(neo4j_session, config.update_tag, sources)
-
-    # Step 5: Cleanup stale CVEMetadata nodes from previous syncs
+    # Step 4: Cleanup stale CVEMetadata nodes from previous syncs
     common_job_parameters = {
         "UPDATE_TAG": config.update_tag,
         "FEED_ID": CVE_METADATA_FEED_ID,

--- a/cartography/intel/cve_metadata/__init__.py
+++ b/cartography/intel/cve_metadata/__init__.py
@@ -26,6 +26,23 @@ CVE_METADATA_FEED_ID = "CVE_METADATA"
 ALL_SOURCES = {"nvd", "epss"}
 
 
+def _get_cve_feed_year(cve_id: str) -> str | None:
+    parts = cve_id.split("-")
+    if len(parts) < 2 or not parts[1].isdigit():
+        return None
+    return str(max(int(parts[1]), nvd.NVD_YEARLY_FEED_START_YEAR))
+
+
+def _build_yearly_cve_batches(cve_ids: list[str]) -> list[list[str]]:
+    by_year: dict[str, list[str]] = {}
+    for cve_id in sorted(cve_ids):
+        year_bucket = _get_cve_feed_year(cve_id)
+        if year_bucket is None:
+            continue
+        by_year.setdefault(year_bucket, []).append(cve_id)
+    return [by_year[year] for year in sorted(by_year)]
+
+
 @timeit
 def get_cve_ids_from_graph(neo4j_session: neo4j.Session) -> list[str]:
     """Query Neo4j for all CVE node IDs present in the graph."""
@@ -96,11 +113,15 @@ def start_cve_metadata_ingestion(
     # Step 1: Get all CVE IDs from the graph — this is the authoritative list
     cve_ids = get_cve_ids_from_graph(neo4j_session)
     logger.info("Found %d CVE nodes in graph to enrich.", len(cve_ids))
+    yearly_batches = _build_yearly_cve_batches(cve_ids)
+    skipped_cves = len(cve_ids) - sum(len(batch) for batch in yearly_batches)
+    if skipped_cves:
+        logger.warning(
+            "Skipping %d CVE IDs with unexpected format during CVE metadata enrichment.",
+            skipped_cves,
+        )
 
-    # Build one entry per graph CVE; each source enriches these dicts
-    cves: list[dict[str, Any]] = [{"id": cve_id} for cve_id in cve_ids]
-
-    if cve_ids:
+    if yearly_batches:
         session = Session()
         retry_policy = Retry(
             total=8,
@@ -112,30 +133,33 @@ def start_cve_metadata_ingestion(
         session.mount("https://", HTTPAdapter(max_retries=retry_policy))
 
         with session as http_session:
-            # Step 2: Enrich with NVD data (failures propagate — NVD is the primary source)
-            if "nvd" in sources:
-                nvd_data = nvd.get_and_transform_nvd_cves(
-                    http_session,
-                    set(cve_ids),
-                    api_key=config.cve_metadata_nist_api_key,
-                )
-                nvd.merge_nvd_into_cves(cves, nvd_data)
-                logger.info("NVD enriched %d CVEs.", len(nvd_data))
+            # Step 2: Enrich and load one CVE year at a time to keep memory bounded.
+            for batch_cve_ids in yearly_batches:
+                cves: list[dict[str, Any]] = [{"id": cve_id} for cve_id in batch_cve_ids]
 
-            # Step 3: Enrich with EPSS scores (non-fatal — optional enrichment)
-            if "epss" in sources:
-                try:
-                    epss_data = epss.get_epss_scores(http_session, cve_ids)
-                    epss.merge_epss_into_cves(cves, epss_data)
-                except requests.exceptions.RequestException:
-                    logger.warning(
-                        "Failed to fetch EPSS scores, continuing without EPSS enrichment.",
-                        exc_info=True,
+                if "nvd" in sources:
+                    nvd_data = nvd.get_and_transform_nvd_cves(
+                        http_session,
+                        set(batch_cve_ids),
+                        api_key=config.cve_metadata_nist_api_key,
                     )
+                    nvd.merge_nvd_into_cves(cves, nvd_data)
+                    logger.info("NVD enriched %d CVEs in batch.", len(nvd_data))
+
+                if "epss" in sources:
+                    try:
+                        epss_data = epss.get_epss_scores(http_session, batch_cve_ids)
+                        epss.merge_epss_into_cves(cves, epss_data)
+                    except requests.exceptions.RequestException:
+                        logger.warning(
+                            "Failed to fetch EPSS scores, continuing without EPSS enrichment.",
+                            exc_info=True,
+                        )
+
+                load_cve_metadata(neo4j_session, cves, config.update_tag)
 
     # Step 4: Load into graph (always runs so cleanup removes stale CVEMetadata nodes)
     load_cve_metadata_feed(neo4j_session, config.update_tag, sources)
-    load_cve_metadata(neo4j_session, cves, config.update_tag)
 
     # Step 5: Cleanup stale CVEMetadata nodes from previous syncs
     common_job_parameters = {

--- a/tests/unit/cartography/intel/cve_metadata/test_init.py
+++ b/tests/unit/cartography/intel/cve_metadata/test_init.py
@@ -1,8 +1,9 @@
-from unittest.mock import MagicMock
 from unittest.mock import call
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from cartography.config import Config
+from cartography.graph.job import GraphJob
 from cartography.intel import cve_metadata
 
 
@@ -25,7 +26,7 @@ def test_build_yearly_cve_batches_groups_by_feed_year():
 
 
 @patch.object(cve_metadata, "merge_module_sync_metadata")
-@patch.object(cve_metadata.GraphJob, "from_node_schema")
+@patch.object(GraphJob, "from_node_schema")
 @patch.object(cve_metadata, "load_cve_metadata_feed")
 @patch.object(cve_metadata, "load_cve_metadata")
 @patch.object(cve_metadata.epss, "merge_epss_into_cves")
@@ -88,6 +89,9 @@ def test_start_cve_metadata_ingestion_loads_one_year_at_a_time(
         call(http_session, ["CVE-2023-0001", "CVE-2023-0002"]),
         call(http_session, ["CVE-2024-0001"]),
     ]
+    assert mock_load_cve_metadata_feed.call_args_list == [
+        call(neo4j_session, 123, {"nvd", "epss"}),
+    ]
     assert mock_load_cve_metadata.call_args_list == [
         call(
             neo4j_session,
@@ -130,6 +134,5 @@ def test_start_cve_metadata_ingestion_loads_one_year_at_a_time(
             ),
         ],
     )
-    mock_load_cve_metadata_feed.assert_called_once_with(neo4j_session, 123, {"nvd", "epss"})
     mock_graphjob_from_node_schema.assert_called_once()
     mock_merge_module_sync_metadata.assert_called_once()

--- a/tests/unit/cartography/intel/cve_metadata/test_init.py
+++ b/tests/unit/cartography/intel/cve_metadata/test_init.py
@@ -1,0 +1,135 @@
+from unittest.mock import MagicMock
+from unittest.mock import call
+from unittest.mock import patch
+
+from cartography.config import Config
+from cartography.intel import cve_metadata
+
+
+def test_build_yearly_cve_batches_groups_by_feed_year():
+    cve_ids = [
+        "CVE-2024-0002",
+        "CVE-1999-0001",
+        "CVE-2024-0001",
+        "CVE-2023-0001",
+        "NOT-A-CVE",
+    ]
+
+    result = cve_metadata._build_yearly_cve_batches(cve_ids)
+
+    assert result == [
+        ["CVE-1999-0001"],
+        ["CVE-2023-0001"],
+        ["CVE-2024-0001", "CVE-2024-0002"],
+    ]
+
+
+@patch.object(cve_metadata, "merge_module_sync_metadata")
+@patch.object(cve_metadata.GraphJob, "from_node_schema")
+@patch.object(cve_metadata, "load_cve_metadata_feed")
+@patch.object(cve_metadata, "load_cve_metadata")
+@patch.object(cve_metadata.epss, "merge_epss_into_cves")
+@patch.object(cve_metadata.epss, "get_epss_scores")
+@patch.object(cve_metadata.nvd, "merge_nvd_into_cves")
+@patch.object(cve_metadata.nvd, "get_and_transform_nvd_cves")
+@patch.object(cve_metadata, "get_cve_ids_from_graph")
+@patch.object(cve_metadata, "Session")
+def test_start_cve_metadata_ingestion_loads_one_year_at_a_time(
+    mock_session_cls,
+    mock_get_cve_ids_from_graph,
+    mock_get_and_transform_nvd_cves,
+    mock_merge_nvd_into_cves,
+    mock_get_epss_scores,
+    mock_merge_epss_into_cves,
+    mock_load_cve_metadata,
+    mock_load_cve_metadata_feed,
+    mock_graphjob_from_node_schema,
+    mock_merge_module_sync_metadata,
+):
+    mock_get_cve_ids_from_graph.return_value = [
+        "CVE-2023-0002",
+        "CVE-2024-0001",
+        "CVE-2023-0001",
+    ]
+    http_session = MagicMock()
+    mock_session_cls.return_value.__enter__.return_value = http_session
+    mock_graphjob_from_node_schema.return_value.run = MagicMock()
+    mock_get_and_transform_nvd_cves.side_effect = [
+        {
+            "CVE-2023-0001": {"id": "CVE-2023-0001", "baseScore": 1.0},
+            "CVE-2023-0002": {"id": "CVE-2023-0002", "baseScore": 2.0},
+        },
+        {
+            "CVE-2024-0001": {"id": "CVE-2024-0001", "baseScore": 3.0},
+        },
+    ]
+    mock_get_epss_scores.side_effect = [
+        {
+            "CVE-2023-0001": {"epss_score": 0.1, "epss_percentile": 0.2},
+            "CVE-2023-0002": {"epss_score": 0.3, "epss_percentile": 0.4},
+        },
+        {
+            "CVE-2024-0001": {"epss_score": 0.5, "epss_percentile": 0.6},
+        },
+    ]
+    config = Config(
+        neo4j_uri="bolt://localhost:7687",
+        update_tag=123,
+    )
+    neo4j_session = MagicMock()
+
+    cve_metadata.start_cve_metadata_ingestion(neo4j_session, config)
+
+    assert mock_get_and_transform_nvd_cves.call_args_list == [
+        call(http_session, {"CVE-2023-0001", "CVE-2023-0002"}, api_key=None),
+        call(http_session, {"CVE-2024-0001"}, api_key=None),
+    ]
+    assert mock_get_epss_scores.call_args_list == [
+        call(http_session, ["CVE-2023-0001", "CVE-2023-0002"]),
+        call(http_session, ["CVE-2024-0001"]),
+    ]
+    assert mock_load_cve_metadata.call_args_list == [
+        call(
+            neo4j_session,
+            [{"id": "CVE-2023-0001"}, {"id": "CVE-2023-0002"}],
+            123,
+        ),
+        call(
+            neo4j_session,
+            [{"id": "CVE-2024-0001"}],
+            123,
+        ),
+    ]
+    mock_merge_nvd_into_cves.assert_has_calls(
+        [
+            call(
+                [{"id": "CVE-2023-0001"}, {"id": "CVE-2023-0002"}],
+                {
+                    "CVE-2023-0001": {"id": "CVE-2023-0001", "baseScore": 1.0},
+                    "CVE-2023-0002": {"id": "CVE-2023-0002", "baseScore": 2.0},
+                },
+            ),
+            call(
+                [{"id": "CVE-2024-0001"}],
+                {"CVE-2024-0001": {"id": "CVE-2024-0001", "baseScore": 3.0}},
+            ),
+        ],
+    )
+    mock_merge_epss_into_cves.assert_has_calls(
+        [
+            call(
+                [{"id": "CVE-2023-0001"}, {"id": "CVE-2023-0002"}],
+                {
+                    "CVE-2023-0001": {"epss_score": 0.1, "epss_percentile": 0.2},
+                    "CVE-2023-0002": {"epss_score": 0.3, "epss_percentile": 0.4},
+                },
+            ),
+            call(
+                [{"id": "CVE-2024-0001"}],
+                {"CVE-2024-0001": {"epss_score": 0.5, "epss_percentile": 0.6}},
+            ),
+        ],
+    )
+    mock_load_cve_metadata_feed.assert_called_once_with(neo4j_session, 123, {"nvd", "epss"})
+    mock_graphjob_from_node_schema.assert_called_once()
+    mock_merge_module_sync_metadata.assert_called_once()


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

This changes `cve_metadata` ingestion to process CVEs one NVD feed year at a time instead of building a single in-memory enrichment set for every CVE in the graph. The goal is to reduce peak memory usage in production while keeping the existing yearly-feed fallback behavior intact.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- Fixes #


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

None.


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- Ran `uv run pytest -q tests/unit/cartography/intel/cve_metadata`
- Added unit tests covering yearly batching and per-batch loading behavior


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

This intentionally keeps the existing NVD yearly-feed fallback path. The change is limited to orchestration in `cartography.intel.cve_metadata` so each year is enriched and loaded before moving on to the next year.