### PR TITLE
feat(github): allow skipping unscoped cleanup

### DIFF
--- a/cartography/intel/github/__init__.py
+++ b/cartography/intel/github/__init__.py
@@ -49,11 +49,45 @@ def _get_repos_from_graph(neo4j_session: neo4j.Session, organization: str) -> li
 
 
 @timeit
-def start_github_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
+def cleanup_unscoped_github_resources(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    """
+    Clean up GitHub resources that are not scoped to a single organization.
+
+    External orchestrators that call start_github_ingestion() with
+    skip_unscoped_cleanup=True should call this once after all organizations
+    have been refreshed with the same update tag.
+    """
+    cartography.intel.github.users.cleanup(neo4j_session, common_job_parameters)
+    cartography.intel.github.repos.cleanup_global_resources(
+        neo4j_session,
+        common_job_parameters,
+    )
+
+    # DEPRECATED: one-time migration, run once per sync cycle (not per org)
+    cartography.intel.github.repos.cleanup_orphaned_github_branches(
+        neo4j_session,
+        common_job_parameters,
+    )
+
+
+@timeit
+def start_github_ingestion(
+    neo4j_session: neo4j.Session,
+    config: Config,
+    *,
+    skip_unscoped_cleanup: bool = False,
+) -> None:
     """
     If this module is configured, perform ingestion of Github  data. Otherwise warn and exit
     :param neo4j_session: Neo4J session for database interface
     :param config: A cartography.config object
+    :param skip_unscoped_cleanup: Skip cleanup of GitHub resources that are not
+        scoped to a single organization. External orchestrators that set this
+        to True should call cleanup_unscoped_github_resources() once after all
+        organizations have been refreshed with the same update tag.
     :return: None
     """
     if not config.github_config:
@@ -192,16 +226,8 @@ def start_github_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
 
         processed_any_org = True
 
-    if processed_any_org:
-        # Clean up unscoped GitHub nodes once after all orgs have been refreshed.
-        cartography.intel.github.users.cleanup(neo4j_session, common_job_parameters)
-        cartography.intel.github.repos.cleanup_global_resources(
-            neo4j_session,
-            common_job_parameters,
-        )
-
-        # DEPRECATED: one-time migration, run once per sync cycle (not per org)
-        cartography.intel.github.repos.cleanup_orphaned_github_branches(
+    if processed_any_org and not skip_unscoped_cleanup:
+        cleanup_unscoped_github_resources(
             neo4j_session,
             common_job_parameters,
         )

--- a/tests/unit/cartography/intel/github/test_github.py
+++ b/tests/unit/cartography/intel/github/test_github.py
@@ -97,6 +97,70 @@ def test_start_github_ingestion_defers_global_cleanup_until_after_all_orgs(
     assert mock_supply_chain_sync.call_count == 0
 
 
+@patch("cartography.intel.github.cleanup_unscoped_github_resources")
+@patch("cartography.intel.github.supply_chain.sync")
+@patch(
+    "cartography.intel.github.container_image_attestations.sync_container_image_attestations"
+)
+@patch("cartography.intel.github.container_image_tags.sync_container_image_tags")
+@patch(
+    "cartography.intel.github.container_images.sync_container_images",
+    return_value=([], [], [], set()),
+)
+@patch(
+    "cartography.intel.github.packages.sync_packages",
+    return_value=cartography.intel.github.packages.ContainerPackagesFetchResult(
+        packages=[],
+        cleanup_safe=True,
+    ),
+)
+@patch("cartography.intel.github.repos.get", return_value=[])
+@patch("cartography.intel.github.commits.sync_github_commits")
+@patch("cartography.intel.github._get_repos_from_graph", return_value=[])
+@patch("cartography.intel.github.actions.sync", return_value=[])
+@patch("cartography.intel.github.teams.sync_github_teams")
+@patch("cartography.intel.github.repos.sync")
+@patch("cartography.intel.github.users.sync")
+@patch("cartography.intel.github.make_credential", return_value="token-1")
+def test_start_github_ingestion_can_skip_unscoped_cleanup(
+    mock_make_credential: Mock,
+    mock_users_sync: Mock,
+    mock_repos_sync: Mock,
+    mock_teams_sync: Mock,
+    mock_actions_sync: Mock,
+    mock_get_repos_from_graph: Mock,
+    mock_sync_github_commits: Mock,
+    mock_get_repos: Mock,
+    mock_packages_sync: Mock,
+    mock_container_images_sync: Mock,
+    mock_container_tags_sync: Mock,
+    mock_attestations_sync: Mock,
+    mock_supply_chain_sync: Mock,
+    mock_cleanup_unscoped_github_resources: Mock,
+) -> None:
+    github_config = {
+        "organization": [
+            {"name": "org-1", "url": "https://api.github.com/graphql"},
+        ],
+    }
+    config = Mock(
+        github_config=b64encode(json.dumps(github_config).encode()).decode(),
+        update_tag=123,
+        github_commit_lookback_days=7,
+    )
+
+    from cartography.intel.github import start_github_ingestion
+
+    neo4j_session = Mock()
+    start_github_ingestion(neo4j_session, config, skip_unscoped_cleanup=True)
+
+    mock_make_credential.assert_called_once_with(github_config["organization"][0])
+    mock_users_sync.assert_called_once()
+    mock_repos_sync.assert_called_once()
+    mock_cleanup_unscoped_github_resources.assert_not_called()
+    assert mock_supply_chain_sync.call_count == 0
+
+
 @patch("cartography.intel.github.repos.cleanup_orphaned_github_branches")
 @patch("cartography.intel.github.repos.cleanup_global_resources")
 @patch("cartography.intel.github.users.cleanup")
@@ -123,6 +187,32 @@ def test_start_github_ingestion_skips_global_cleanup_when_no_orgs_configured(
     mock_users_cleanup.assert_not_called()
     mock_cleanup_global_resources.assert_not_called()
     mock_cleanup_orphaned_branches.assert_not_called()
+
+
+@patch("cartography.intel.github.repos.cleanup_orphaned_github_branches")
+@patch("cartography.intel.github.repos.cleanup_global_resources")
+@patch("cartography.intel.github.users.cleanup")
+def test_cleanup_unscoped_github_resources(
+    mock_users_cleanup: Mock,
+    mock_cleanup_global_resources: Mock,
+    mock_cleanup_orphaned_branches: Mock,
+) -> None:
+    from cartography.intel.github import cleanup_unscoped_github_resources
+
+    neo4j_session = Mock()
+    common_job_parameters = {"UPDATE_TAG": 123}
+
+    cleanup_unscoped_github_resources(neo4j_session, common_job_parameters)
+
+    mock_users_cleanup.assert_called_once_with(neo4j_session, common_job_parameters)
+    mock_cleanup_global_resources.assert_called_once_with(
+        neo4j_session,
+        common_job_parameters,
+    )
+    mock_cleanup_orphaned_branches.assert_called_once_with(
+        neo4j_session,
+        common_job_parameters,
+    )
 
 
 @patch("cartography.intel.github.util.time.sleep")


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)


### Summary
Add a keyword-only `skip_unscoped_cleanup` option to `start_github_ingestion()` so callers that orchestrate GitHub organization syncs separately can run the global cleanup pass once after all organizations are refreshed.

This also exposes `cleanup_unscoped_github_resources()` as a public helper for that final cleanup pass. The default behavior is unchanged.


### Related issues or links
- N/A


### Breaking changes
None.


### How was this tested?
- Updated tests


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
This is intended for callers that split GitHub organization ingestion across separate `start_github_ingestion()` invocations and want to avoid repeating the unscoped cleanup pass for each invocation. Existing CLI and default sync callers continue to run the cleanup at the end of GitHub ingestion.
