### PR TITLE
fix(googleworkspace): skip suspended users in OAuth token sync

### DIFF
--- a/cartography/intel/googleworkspace/oauth_apps.py
+++ b/cartography/intel/googleworkspace/oauth_apps.py
@@ -57,6 +57,9 @@ def get_oauth_tokens_for_user(admin: Resource, user_id: str) -> list[dict]:
         elif e.resp.status == 404:
             # User has no OAuth tokens, this is normal
             return []
+        elif e.resp.status == 401:
+            # Suspended/deleted users return 401; expected and not actionable.
+            logger.debug(f"Skipping OAuth token fetch for user {user_id}: 401")
         else:
             logger.warning(f"Error fetching OAuth tokens for user: {e}")
         return []

--- a/cartography/intel/googleworkspace/users.py
+++ b/cartography/intel/googleworkspace/users.py
@@ -114,7 +114,7 @@ def sync_googleworkspace_users(
     See https://googleapis.github.io/google-api-python-client/docs/epy/googleapiclient.discovery-module.html#build.
     :param googleworkspace_update_tag: The timestamp value to set our new Neo4j nodes with
     :param common_job_parameters: Parameters to carry to the Neo4j jobs
-    :return: List of user IDs
+    :return: List of active (non-suspended) user IDs
     """
     logger.debug("Syncing Google Workspace Users")
 
@@ -135,4 +135,6 @@ def sync_googleworkspace_users(
     # 4. CLEANUP - Remove stale data
     cleanup_googleworkspace_users(neo4j_session, common_job_parameters)
 
-    return [user["id"] for user in raw_users]
+    # Suspended users return 401 from the per-user OAuth tokens endpoint, so
+    # exclude them from downstream callers that fetch user-scoped resources.
+    return [user["id"] for user in raw_users if not user.get("suspended", False)]

--- a/tests/unit/cartography/intel/googleworkspace/test_oauth_apps.py
+++ b/tests/unit/cartography/intel/googleworkspace/test_oauth_apps.py
@@ -1,0 +1,42 @@
+import logging
+from unittest.mock import MagicMock
+
+from googleapiclient.errors import HttpError
+
+from cartography.intel.googleworkspace.oauth_apps import get_oauth_tokens_for_user
+
+
+def _make_http_error(status: int) -> HttpError:
+    resp = MagicMock()
+    resp.status = status
+    resp.reason = "Unauthorized"
+    return HttpError(resp=resp, content=b'{"error": "unauthorized"}')
+
+
+def test_get_oauth_tokens_for_user_skips_401(caplog):
+    admin = MagicMock()
+    admin.tokens.return_value.list.return_value.execute.side_effect = _make_http_error(
+        401
+    )
+
+    with caplog.at_level(
+        logging.DEBUG, logger="cartography.intel.googleworkspace.oauth_apps"
+    ):
+        result = get_oauth_tokens_for_user(admin, "suspended-user")
+
+    assert result == []
+    warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warning_records == []
+    debug_messages = [
+        r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG
+    ]
+    assert any("suspended-user" in m and "401" in m for m in debug_messages)
+
+
+def test_get_oauth_tokens_for_user_returns_empty_on_404():
+    admin = MagicMock()
+    admin.tokens.return_value.list.return_value.execute.side_effect = _make_http_error(
+        404
+    )
+
+    assert get_oauth_tokens_for_user(admin, "no-tokens-user") == []

--- a/tests/unit/cartography/intel/googleworkspace/test_users.py
+++ b/tests/unit/cartography/intel/googleworkspace/test_users.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.googleworkspace.users
+from cartography.intel.googleworkspace.users import sync_googleworkspace_users
+
+_USERS_RESPONSE = [
+    {
+        "users": [
+            {"id": "active-user", "primaryEmail": "a@example.com", "suspended": False},
+            {
+                "id": "suspended-user",
+                "primaryEmail": "s@example.com",
+                "suspended": True,
+            },
+            {"id": "default-user", "primaryEmail": "d@example.com"},
+        ],
+    },
+]
+
+
+@patch.object(cartography.intel.googleworkspace.users, "cleanup_googleworkspace_users")
+@patch.object(cartography.intel.googleworkspace.users, "load_googleworkspace_users")
+@patch.object(
+    cartography.intel.googleworkspace.users,
+    "get_all_users",
+    return_value=_USERS_RESPONSE,
+)
+def test_sync_googleworkspace_users_excludes_suspended(
+    _mock_get_all_users, _mock_load, _mock_cleanup
+):
+    user_ids = sync_googleworkspace_users(
+        neo4j_session=MagicMock(),
+        admin=MagicMock(),
+        googleworkspace_update_tag=12345,
+        common_job_parameters={"CUSTOMER_ID": "C123"},
+    )
+
+    assert user_ids == ["active-user", "default-user"]


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

The Google Workspace sync calls `admin.tokens().list(userKey=user_id)` once per user to ingest OAuth app authorizations. Suspended (and recently deleted) Google Workspace users return `401 Unauthorized` from that endpoint. Today the per-user error handler in `get_oauth_tokens_for_user()` only special-cases 403 (insufficient scopes) and 404 (user has no tokens); 401 falls through to a generic `logger.warning(...)`, generating thousands of WARN-level logs per week that drown out real sync issues.

This PR addresses the noise in two complementary ways:

1. **Skip suspended users at the source.** `sync_googleworkspace_users()` now returns only the IDs of users where `suspended` is falsy. Suspended users are still ingested as `GoogleWorkspaceUser` nodes (no behavior change there); only the downstream OAuth-token fetch loop excludes them. `user_ids` is consumed exclusively by `oauth_apps.sync_googleworkspace_oauth_apps()`, so this filter is safe.
2. **Downgrade residual 401 to DEBUG.** Users can be suspended/deleted between the `users.list` page and the per-user token call. Adding an explicit `elif e.resp.status == 401:` branch logs at DEBUG and returns `[]`, mirroring the existing 404 handling.

### Related issues or links

- Same defensive pattern as #2720 (Secrets Manager `ResourceNotFoundException`).

### How was this tested?

- New unit tests in `tests/unit/cartography/intel/googleworkspace/`:
  - `test_get_oauth_tokens_for_user_skips_401` asserts that a 401 from the API yields an empty result, no WARN log, and a DEBUG log mentioning the user id and 401.
  - `test_get_oauth_tokens_for_user_returns_empty_on_404` documents the existing 404 contract.
  - `test_sync_googleworkspace_users_excludes_suspended` mocks `get_all_users` with mixed suspended/active/default users and asserts the returned ID list contains only the active ones.
- All existing googleworkspace integration tests still pass:
  ```
  $ uv run --frozen pytest tests/integration/cartography/intel/googleworkspace/
  10 passed in 9.45s
  ```
- `make lint` (pre-commit on the changed files) is clean.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

### Test plan

- [ ] Run `pytest tests/unit/cartography/intel/googleworkspace/` and confirm 3 passing tests.
- [ ] Run `pytest tests/integration/cartography/intel/googleworkspace/` against a Neo4j instance and confirm 10 passing tests.
- [ ] In a tenant with suspended users, run a Google Workspace sync and verify (a) no `Error fetching OAuth tokens for user` WARN logs from the OAuth path, (b) suspended `GoogleWorkspaceUser` nodes are still present, (c) no `:AUTHORIZED` edges are created from suspended users.