### PR TITLE
feat(indexes): add extra_index to AzureRoleAssignment.scope and K8s CRB role_name

### DIFF
--- a/cartography/models/azure/rbac.py
+++ b/cartography/models/azure/rbac.py
@@ -21,7 +21,7 @@ class AzureRoleAssignmentProperties(CartographyNodeProperties):
     principal_id: PropertyRef = PropertyRef("principalId")
     principal_type: PropertyRef = PropertyRef("principalType")
     role_definition_id: PropertyRef = PropertyRef("roleDefinitionId")
-    scope: PropertyRef = PropertyRef("scope")
+    scope: PropertyRef = PropertyRef("scope", extra_index=True)
     scope_type: PropertyRef = PropertyRef("scopeType")
     created_on: PropertyRef = PropertyRef("createdOn")
     updated_on: PropertyRef = PropertyRef("updatedOn")

--- a/cartography/models/kubernetes/clusterrolebindings.py
+++ b/cartography/models/kubernetes/clusterrolebindings.py
@@ -18,7 +18,7 @@ class KubernetesClusterRoleBindingNodeProperties(CartographyNodeProperties):
     uid: PropertyRef = PropertyRef("uid")
     creation_timestamp: PropertyRef = PropertyRef("creation_timestamp")
     resource_version: PropertyRef = PropertyRef("resource_version")
-    role_name: PropertyRef = PropertyRef("role_name")
+    role_name: PropertyRef = PropertyRef("role_name", extra_index=True)
     role_kind: PropertyRef = PropertyRef("role_kind")
     service_account_ids: PropertyRef = PropertyRef("service_account_ids")
     user_ids: PropertyRef = PropertyRef("user_ids")


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Two medium-impact properties used in attack-path WHERE clauses lack Neo4j indexes:

- `AzureRoleAssignment.scope`
- `KubernetesClusterRoleBinding.role_name`

These properties are used to filter privilege-escalation queries (e.g. matching role-assignment scope paths and `cluster-admin` role names). Without indexes, the planner falls back to full label scans. Setting `extra_index=True` on each `PropertyRef` makes cartography emit `CREATE INDEX` statements at sync time so the queries can use `NodeIndexSeek`.


### Related issues or links

N/A


### How was this tested?

- `make lint` (pre-commit) passes locally.
- `extra_index=True` is the documented mechanism for declaring frequently-queried properties; index creation is exercised by the existing schema-build path. After running a sync, `SHOW INDEXES` reports indexes on `AzureRoleAssignment(scope)` and `KubernetesClusterRoleBinding(role_name)`.


### Test plan

- [ ] Run a sync against a Neo4j instance with Azure RBAC and Kubernetes data.
- [ ] `SHOW INDEXES YIELD labelsOrTypes, properties WHERE 'AzureRoleAssignment' IN labelsOrTypes AND 'scope' IN properties` returns one row.
- [ ] `SHOW INDEXES YIELD labelsOrTypes, properties WHERE 'KubernetesClusterRoleBinding' IN labelsOrTypes AND 'role_name' IN properties` returns one row.
- [ ] `EXPLAIN` on a query filtering on `AzureRoleAssignment.scope` shows `NodeIndexSeek` instead of `NodeByLabelScan`.
- [ ] `EXPLAIN` on a query filtering on `KubernetesClusterRoleBinding.role_name` shows `NodeIndexSeek` instead of `NodeByLabelScan`.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization.

#### If you are changing a node or relationship
- [ ] Updated the schema documentation.
- [ ] Updated the schema README.


### Notes for reviewers

This is a metadata-only change: it adds `extra_index=True` to two existing `PropertyRef` definitions. No node, relationship, or sync logic changes. Cartography's schema builder already creates `CREATE INDEX IF NOT EXISTS` statements for properties marked with `extra_index=True`, so this is picked up automatically on the next sync without any migration.