### PR TITLE
fix(aws): fetch IAM tags once per sync, not per region

### DIFF
--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -21,6 +21,12 @@ stat_handler = get_stats_client(__name__)
 
 DEFAULT_CLEANUP_BATCH_SIZE = 1000
 
+# IAM is a global service, so its tags are not regional. We use a "global"
+# marker on the AWSTag.region property and fetch IAM tags once per sync rather
+# than once per region.
+GLOBAL_REGION = "global"
+IAM_TAG_RESOURCE_TYPES = frozenset({"iam:role", "iam:user"})
+
 
 def get_short_id_from_ec2_arn(arn: str) -> str:
     """
@@ -198,14 +204,6 @@ def get_tags(
 ) -> list[dict[str, Any]]:
     """Retrieve tag data for the provided resource types."""
     resources: list[dict[str, Any]] = []
-
-    if "iam:role" in resource_types:
-        resources.extend(get_role_tags(boto3_session))
-        resource_types = [rt for rt in resource_types if rt != "iam:role"]
-
-    if "iam:user" in resource_types:
-        resources.extend(get_user_tags(boto3_session))
-        resource_types = [rt for rt in resource_types if rt != "iam:user"]
 
     if not resource_types:
         return resources
@@ -466,6 +464,30 @@ def cleanup(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:
     )
 
 
+def _load_resource_type_tags(
+    neo4j_session: neo4j.Session,
+    grouped_tag_data: Dict[str, List[Dict]],
+    resource_types: List[str],
+    region: str,
+    current_aws_account_id: str,
+    update_tag: int,
+) -> None:
+    for resource_type in resource_types:
+        tag_data = grouped_tag_data.get(resource_type, [])
+        transform_tags(tag_data, resource_type)  # type: ignore[arg-type]
+        logger.info(
+            f"Loading {len(tag_data)} tags for resource type {resource_type} (region={region})",
+        )
+        load_tags(
+            neo4j_session=neo4j_session,
+            tag_data=tag_data,  # type: ignore[arg-type]
+            resource_type=resource_type,
+            region=region,
+            current_aws_account_id=current_aws_account_id,
+            aws_update_tag=update_tag,
+        )
+
+
 @timeit
 def sync(
     neo4j_session: neo4j.Session,
@@ -476,30 +498,50 @@ def sync(
     common_job_parameters: Dict,
     tag_resource_type_mappings: Dict = TAG_RESOURCE_TYPE_MAPPINGS,
 ) -> None:
+    iam_resource_types = [
+        rt for rt in tag_resource_type_mappings if rt in IAM_TAG_RESOURCE_TYPES
+    ]
+    regional_resource_types = [
+        rt for rt in tag_resource_type_mappings if rt not in IAM_TAG_RESOURCE_TYPES
+    ]
+
+    if iam_resource_types:
+        logger.info(
+            f"Syncing AWS IAM tags (global) for account {current_aws_account_id}",
+        )
+        iam_tag_data: List[Dict] = []
+        if "iam:role" in iam_resource_types:
+            iam_tag_data.extend(get_role_tags(boto3_session))
+        if "iam:user" in iam_resource_types:
+            iam_tag_data.extend(get_user_tags(boto3_session))
+        iam_grouped = _group_tag_data_by_resource_type(
+            iam_tag_data, tag_resource_type_mappings
+        )
+        _load_resource_type_tags(
+            neo4j_session=neo4j_session,
+            grouped_tag_data=iam_grouped,
+            resource_types=iam_resource_types,
+            region=GLOBAL_REGION,
+            current_aws_account_id=current_aws_account_id,
+            update_tag=update_tag,
+        )
+
     for region in regions:
         logger.info(
             f"Syncing AWS tags for account {current_aws_account_id} and region {region}",
         )
-        all_tag_data = get_tags(
-            boto3_session, list(tag_resource_type_mappings.keys()), region
-        )
+        all_tag_data = get_tags(boto3_session, regional_resource_types, region)
         grouped = _group_tag_data_by_resource_type(
             all_tag_data, tag_resource_type_mappings
         )
-        for resource_type in tag_resource_type_mappings.keys():
-            tag_data = grouped.get(resource_type, [])
-            transform_tags(tag_data, resource_type)  # type: ignore
-            logger.info(
-                f"Loading {len(tag_data)} tags for resource type {resource_type}",
-            )
-            load_tags(
-                neo4j_session=neo4j_session,
-                tag_data=tag_data,  # type: ignore
-                resource_type=resource_type,
-                region=region,
-                current_aws_account_id=current_aws_account_id,
-                aws_update_tag=update_tag,
-            )
+        _load_resource_type_tags(
+            neo4j_session=neo4j_session,
+            grouped_tag_data=grouped,
+            resource_types=regional_resource_types,
+            region=region,
+            current_aws_account_id=current_aws_account_id,
+            update_tag=update_tag,
+        )
     cleanup(
         neo4j_session,
         common_job_parameters,

--- a/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
+++ b/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
@@ -93,18 +93,16 @@ def test_load_tags_empty_data():
     mock_neo4j_session.execute_write.assert_not_called()
 
 
-def test_get_tags_includes_iam_users_and_roles(mocker):
-    mocker.patch(
+def test_get_tags_does_not_call_iam(mocker):
+    """
+    get_tags() handles only regional resource types. IAM tags are fetched
+    once per sync from sync(), not per region from get_tags().
+    """
+    role_mock = mocker.patch(
         "cartography.intel.aws.resourcegroupstaggingapi.get_role_tags",
-        return_value=[
-            {"ResourceARN": "arn:aws:iam::123456789012:role/test-role", "Tags": []}
-        ],
     )
-    mocker.patch(
+    user_mock = mocker.patch(
         "cartography.intel.aws.resourcegroupstaggingapi.get_user_tags",
-        return_value=[
-            {"ResourceARN": "arn:aws:iam::123456789012:user/test-user", "Tags": []}
-        ],
     )
     mock_session = MagicMock()
     mock_client = MagicMock()
@@ -119,15 +117,82 @@ def test_get_tags_includes_iam_users_and_roles(mocker):
     mock_client.get_paginator.return_value = mock_paginator
     mock_session.client.return_value = mock_client
 
-    result = rgta.get_tags(
-        mock_session,
-        ["iam:role", "iam:user", "s3"],
-        "us-east-1",
+    result = rgta.get_tags(mock_session, ["s3"], "us-east-1")
+
+    assert [item["ResourceARN"] for item in result] == ["arn:aws:s3:::bucket"]
+    role_mock.assert_not_called()
+    user_mock.assert_not_called()
+    mock_paginator.paginate.assert_called_once_with(ResourceTypeFilters=["s3"])
+
+
+def test_sync_fetches_iam_tags_once_across_regions(mocker):
+    """
+    IAM is global, so get_role_tags and get_user_tags must be called exactly
+    once per sync, regardless of how many regions are synced. IAM tags must
+    be loaded with the GLOBAL_REGION marker.
+    """
+    role_mock = mocker.patch(
+        "cartography.intel.aws.resourcegroupstaggingapi.get_role_tags",
+        return_value=[
+            {
+                "ResourceARN": "arn:aws:iam::123456789012:role/test-role",
+                "Tags": [{"Key": "k", "Value": "v"}],
+            }
+        ],
+    )
+    user_mock = mocker.patch(
+        "cartography.intel.aws.resourcegroupstaggingapi.get_user_tags",
+        return_value=[
+            {
+                "ResourceARN": "arn:aws:iam::123456789012:user/test-user",
+                "Tags": [{"Key": "k", "Value": "v"}],
+            }
+        ],
+    )
+    get_tags_mock = mocker.patch(
+        "cartography.intel.aws.resourcegroupstaggingapi.get_tags",
+        return_value=[],
+    )
+    load_tags_mock = mocker.patch(
+        "cartography.intel.aws.resourcegroupstaggingapi.load_tags",
+    )
+    mocker.patch("cartography.intel.aws.resourcegroupstaggingapi.cleanup")
+
+    regions = ["us-east-1", "us-west-2", "eu-west-1"]
+    mapping = {
+        "iam:role": rgta.TAG_RESOURCE_TYPE_MAPPINGS["iam:role"],
+        "iam:user": rgta.TAG_RESOURCE_TYPE_MAPPINGS["iam:user"],
+        "s3": rgta.TAG_RESOURCE_TYPE_MAPPINGS["s3"],
+    }
+
+    rgta.sync(
+        neo4j_session=MagicMock(),
+        boto3_session=MagicMock(),
+        regions=regions,
+        current_aws_account_id="123456789012",
+        update_tag=42,
+        common_job_parameters={"UPDATE_TAG": 42, "AWS_ID": "123456789012"},
+        tag_resource_type_mappings=mapping,
     )
 
-    assert {item["ResourceARN"] for item in result} == {
-        "arn:aws:iam::123456789012:role/test-role",
-        "arn:aws:iam::123456789012:user/test-user",
-        "arn:aws:s3:::bucket",
-    }
-    mock_paginator.paginate.assert_called_once_with(ResourceTypeFilters=["s3"])
+    role_mock.assert_called_once()
+    user_mock.assert_called_once()
+
+    # get_tags() is called once per region, never with iam:* in the type list
+    assert get_tags_mock.call_count == len(regions)
+    for call in get_tags_mock.call_args_list:
+        regional_types = (
+            call.args[1] if len(call.args) > 1 else call.kwargs["resource_types"]
+        )
+        assert "iam:role" not in regional_types
+        assert "iam:user" not in regional_types
+
+    # IAM resource types are loaded with region="global", not a real region
+    iam_load_calls = [
+        c
+        for c in load_tags_mock.call_args_list
+        if c.kwargs["resource_type"] in {"iam:role", "iam:user"}
+    ]
+    assert len(iam_load_calls) == 2
+    for call in iam_load_calls:
+        assert call.kwargs["region"] == rgta.GLOBAL_REGION


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary

`cartography.intel.aws.resourcegroupstaggingapi.sync()` calls `get_role_tags` / `get_user_tags` from inside the regional loop. IAM is a global service, so every role and user is listed N times per sync (~17 with the default region set), making AWS tagging a major bottleneck and causing boto3 sessions to time out on large accounts.

This PR lifts the IAM tag fetch out of the regional loop:

- `sync()` calls `get_role_tags` / `get_user_tags` exactly once per sync, before iterating regions, and loads their tags with `region="global"`.
- `get_tags()` no longer special-cases `iam:role` / `iam:user`; it only handles regional resource types.
- A small `_load_resource_type_tags()` helper deduplicates the transform/load loop shared by the IAM (global) and regional paths.

This addresses the perf root cause shared by both linked issues. Two related asks are intentionally left to follow-up PRs because they are more invasive:

- #1094 ask 2: drop `region` from the `AWSTag` node model (data-model migration).
- #1137 ask 2: region-aware MATCH so tags attach to the correct regional resource when names collide across regions.


### Related issues or links

- Refs #1094
- Refs #1137


### How was this tested?

- `make test_lint` passes.
- `pytest tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py` — 11 passed, including:
  - `test_get_tags_does_not_call_iam` (replaces the old `test_get_tags_includes_iam_users_and_roles`): asserts `get_tags()` no longer touches the IAM helpers.
  - `test_sync_fetches_iam_tags_once_across_regions`: runs `sync()` with `["us-east-1", "us-west-2", "eu-west-1"]` and asserts each IAM helper is called exactly once and IAM tags are loaded with `region="global"`.
- `pytest tests/integration/cartography/intel/aws/test_resourcegroupstaggingapi.py` — existing EC2-tag integration test still passes (proves the regional path is unchanged).


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.


### Notes for reviewers

`AWSTag.region` is a single property on a node whose `id` is `Key:Value`, shared across resources. Pre-fix, an IAM tag co-occurring with a regional tag already had its `region` overwritten by whichever region was synced last, so setting `region="global"` for IAM-only tags is at least as accurate as the previous behavior. A clean fix (dropping `region` from `AWSTag`, or scoping by resource) is tracked in #1094 and #1137 and out of scope here.