### PR TITLE
feat(aws): model Identity Center account assignments

### DIFF
--- a/cartography/intel/aws/identitycenter.py
+++ b/cartography/intel/aws/identitycenter.py
@@ -10,6 +10,15 @@ from cartography.client.core.tx import load_matchlinks
 from cartography.client.core.tx import read_list_of_dicts_tx
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.util.botocore_config import create_boto3_client
+from cartography.models.aws.identitycenter.awsaccountassignment import (
+    AWSSSOAccountAssignmentSchema,
+)
+from cartography.models.aws.identitycenter.awsaccountassignment import (
+    AWSSSOAccountAssignmentToSSOGroupMatchLink,
+)
+from cartography.models.aws.identitycenter.awsaccountassignment import (
+    AWSSSOAccountAssignmentToSSOUserMatchLink,
+)
 from cartography.models.aws.identitycenter.awsidentitycenter import (
     AWSIdentityCenterInstanceSchema,
 )
@@ -302,6 +311,52 @@ def transform_sso_groups(
     return transformed_groups
 
 
+def transform_account_assignments(
+    assignments: list[dict[str, Any]],
+    principal_type: str,
+    instance_arn: str,
+    identity_store_id: str,
+    region: str,
+) -> list[dict[str, Any]]:
+    """
+    Transform AWS Identity Center account assignment data into first-class graph nodes.
+    """
+    if principal_type not in {"USER", "GROUP"}:
+        raise ValueError(
+            f"Unsupported Identity Center principal type: {principal_type}"
+        )
+    principal_id_key = "UserId" if principal_type == "USER" else "GroupId"
+    transformed_assignments = []
+    for assignment in assignments:
+        principal_id = assignment[principal_id_key]
+        account_id = assignment["AccountId"]
+        permission_set_arn = assignment["PermissionSetArn"]
+        assignment_id = "|".join(
+            [
+                instance_arn,
+                account_id,
+                permission_set_arn,
+                principal_type,
+                principal_id,
+            ],
+        )
+        transformed_assignments.append(
+            {
+                **assignment,
+                "AssignmentId": assignment_id,
+                "AccountId": account_id,
+                "PermissionSetArn": permission_set_arn,
+                "PrincipalId": principal_id,
+                "PrincipalType": principal_type,
+                "IdentityStoreId": identity_store_id,
+                "InstanceArn": instance_arn,
+                "Region": region,
+                "RoleArn": assignment.get("RoleArn"),
+            },
+        )
+    return transformed_assignments
+
+
 @timeit
 def load_sso_users(
     neo4j_session: neo4j.Session,
@@ -577,6 +632,53 @@ def load_group_roles(
 
 
 @timeit
+def load_account_assignments(
+    neo4j_session: neo4j.Session,
+    assignments: list[dict[str, Any]],
+    aws_account_id: str,
+    aws_update_tag: int,
+) -> None:
+    """
+    Load first-class Identity Center account assignment nodes and principal links.
+    """
+    load(
+        neo4j_session,
+        AWSSSOAccountAssignmentSchema(),
+        assignments,
+        lastupdated=aws_update_tag,
+        AWS_ID=aws_account_id,
+    )
+
+    user_assignments = [
+        assignment
+        for assignment in assignments
+        if assignment.get("PrincipalType") == "USER"
+    ]
+    load_matchlinks(
+        neo4j_session,
+        AWSSSOAccountAssignmentToSSOUserMatchLink(),
+        user_assignments,
+        lastupdated=aws_update_tag,
+        _sub_resource_label="AWSAccount",
+        _sub_resource_id=aws_account_id,
+    )
+
+    group_assignments = [
+        assignment
+        for assignment in assignments
+        if assignment.get("PrincipalType") == "GROUP"
+    ]
+    load_matchlinks(
+        neo4j_session,
+        AWSSSOAccountAssignmentToSSOGroupMatchLink(),
+        group_assignments,
+        lastupdated=aws_update_tag,
+        _sub_resource_label="AWSAccount",
+        _sub_resource_id=aws_account_id,
+    )
+
+
+@timeit
 def cleanup(
     neo4j_session: neo4j.Session,
     common_job_parameters: dict[str, Any],
@@ -594,10 +696,28 @@ def cleanup(
     GraphJob.from_node_schema(AWSSSOGroupSchema(), common_job_parameters).run(
         neo4j_session,
     )
+    GraphJob.from_node_schema(
+        AWSSSOAccountAssignmentSchema(),
+        common_job_parameters,
+    ).run(
+        neo4j_session,
+    )
 
-    # Clean up role assignment MatchLinks
+    # Clean up role assignment and account assignment MatchLinks
     GraphJob.from_matchlink(
         AWSRoleToSSOUserMatchLink(),
+        "AWSAccount",
+        common_job_parameters["AWS_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    ).run(neo4j_session)
+    GraphJob.from_matchlink(
+        AWSSSOAccountAssignmentToSSOUserMatchLink(),
+        "AWSAccount",
+        common_job_parameters["AWS_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    ).run(neo4j_session)
+    GraphJob.from_matchlink(
+        AWSSSOAccountAssignmentToSSOGroupMatchLink(),
         "AWSAccount",
         common_job_parameters["AWS_ID"],
         common_job_parameters["UPDATE_TAG"],
@@ -742,7 +862,9 @@ def _sync_role_assignments(
     neo4j_session: neo4j.Session,
     user_permissionsets_raw: list[dict[str, Any]],
     group_permissionsets_raw: list[dict[str, Any]],
+    instance_arn: str,
     identity_store_id: str,
+    region: str,
     current_aws_account_id: str,
     update_tag: int,
 ) -> None:
@@ -760,11 +882,33 @@ def _sync_role_assignments(
     user_roles = get_principal_roles(neo4j_session, user_permissionsets_raw)
     for role in user_roles:
         role["IdentityStoreId"] = identity_store_id
-    load_user_roles(neo4j_session, user_roles, current_aws_account_id, update_tag)
 
     group_roles = get_principal_roles(neo4j_session, group_permissionsets_raw)
     for role in group_roles:
         role["IdentityStoreId"] = identity_store_id
+
+    user_account_assignments = transform_account_assignments(
+        user_roles,
+        "USER",
+        instance_arn,
+        identity_store_id,
+        region,
+    )
+    group_account_assignments = transform_account_assignments(
+        group_roles,
+        "GROUP",
+        instance_arn,
+        identity_store_id,
+        region,
+    )
+    load_account_assignments(
+        neo4j_session,
+        user_account_assignments + group_account_assignments,
+        current_aws_account_id,
+        update_tag,
+    )
+
+    load_user_roles(neo4j_session, user_roles, current_aws_account_id, update_tag)
     load_group_roles(neo4j_session, group_roles, current_aws_account_id, update_tag)
 
 
@@ -813,7 +957,9 @@ def _sync_instance(
             neo4j_session,
             user_assignments,
             group_assignments,
+            instance_arn,
             identity_store_id,
+            region,
             current_aws_account_id,
             update_tag,
         )

--- a/cartography/models/aws/identitycenter/awsaccountassignment.py
+++ b/cartography/models/aws/identitycenter/awsaccountassignment.py
@@ -1,0 +1,185 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import SourceNodeMatcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AWSSSOAccountAssignmentProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("AssignmentId")
+    account_id: PropertyRef = PropertyRef("AccountId")
+    permission_set_arn: PropertyRef = PropertyRef("PermissionSetArn")
+    principal_id: PropertyRef = PropertyRef("PrincipalId")
+    principal_type: PropertyRef = PropertyRef("PrincipalType")
+    identity_store_id: PropertyRef = PropertyRef("IdentityStoreId")
+    instance_arn: PropertyRef = PropertyRef("InstanceArn")
+    region: PropertyRef = PropertyRef("Region")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AWSSSOAccountAssignmentToAWSAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AWSSSOAccountAssignmentToAWSAccountRel(CartographyRelSchema):
+    target_node_label: str = "AWSAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AWSSSOAccountAssignmentToAWSAccountRelProperties = (
+        AWSSSOAccountAssignmentToAWSAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AWSSSOAccountAssignmentTargetsAWSAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AWSSSOAccountAssignmentTargetsAWSAccountRel(CartographyRelSchema):
+    target_node_label: str = "AWSAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AccountId")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "TARGETS_ACCOUNT"
+    properties: AWSSSOAccountAssignmentTargetsAWSAccountRelProperties = (
+        AWSSSOAccountAssignmentTargetsAWSAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AWSSSOAccountAssignmentGrantsPermissionSetRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AWSSSOAccountAssignmentGrantsPermissionSetRel(CartographyRelSchema):
+    target_node_label: str = "AWSPermissionSet"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("PermissionSetArn")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "GRANTS_PERMISSION_SET"
+    properties: AWSSSOAccountAssignmentGrantsPermissionSetRelProperties = (
+        AWSSSOAccountAssignmentGrantsPermissionSetRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AWSSSOAccountAssignmentInIdentityCenterRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AWSSSOAccountAssignmentInIdentityCenterRel(CartographyRelSchema):
+    target_node_label: str = "AWSIdentityCenter"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("InstanceArn")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "ASSIGNMENT_IN"
+    properties: AWSSSOAccountAssignmentInIdentityCenterRelProperties = (
+        AWSSSOAccountAssignmentInIdentityCenterRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AWSSSOAccountAssignmentMaterializesAsAWSRoleRelProperties(
+    CartographyRelProperties,
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AWSSSOAccountAssignmentMaterializesAsAWSRoleRel(CartographyRelSchema):
+    target_node_label: str = "AWSRole"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("RoleArn")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MATERIALIZES_AS"
+    properties: AWSSSOAccountAssignmentMaterializesAsAWSRoleRelProperties = (
+        AWSSSOAccountAssignmentMaterializesAsAWSRoleRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AWSSSOAccountAssignmentSchema(CartographyNodeSchema):
+    label: str = "AWSSSOAccountAssignment"
+    properties: AWSSSOAccountAssignmentProperties = AWSSSOAccountAssignmentProperties()
+    sub_resource_relationship: AWSSSOAccountAssignmentToAWSAccountRel = (
+        AWSSSOAccountAssignmentToAWSAccountRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AWSSSOAccountAssignmentTargetsAWSAccountRel(),
+            AWSSSOAccountAssignmentGrantsPermissionSetRel(),
+            AWSSSOAccountAssignmentInIdentityCenterRel(),
+            AWSSSOAccountAssignmentMaterializesAsAWSRoleRel(),
+        ],
+    )
+
+
+@dataclass(frozen=True)
+class AWSSSOAccountAssignmentToPrincipalRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label",
+        set_in_kwargs=True,
+    )
+    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AWSSSOAccountAssignmentToSSOUserMatchLink(CartographyRelSchema):
+    source_node_label: str = "AWSSSOAccountAssignment"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("AssignmentId")},
+    )
+    target_node_label: str = "AWSSSOUser"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("PrincipalId"),
+            "identity_store_id": PropertyRef("IdentityStoreId"),
+        },
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "ASSIGNED_TO"
+    properties: AWSSSOAccountAssignmentToPrincipalRelProperties = (
+        AWSSSOAccountAssignmentToPrincipalRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AWSSSOAccountAssignmentToSSOGroupMatchLink(CartographyRelSchema):
+    source_node_label: str = "AWSSSOAccountAssignment"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("AssignmentId")},
+    )
+    target_node_label: str = "AWSSSOGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("PrincipalId"),
+            "identity_store_id": PropertyRef("IdentityStoreId"),
+        },
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "ASSIGNED_TO"
+    properties: AWSSSOAccountAssignmentToPrincipalRelProperties = (
+        AWSSSOAccountAssignmentToPrincipalRelProperties()
+    )

--- a/cartography/models/aws/identitycenter/awssogroup.py
+++ b/cartography/models/aws/identitycenter/awssogroup.py
@@ -47,6 +47,7 @@ class AWSSSOGroupToPermissionSetRelProperties(CartographyRelProperties):
 
 
 @dataclass(frozen=True)
+# DEPRECATED: principal HAS_PERMISSION_SET summary edges will be removed in v1.0.0.
 class AWSSSOGroupToPermissionSetRel(CartographyRelSchema):
     target_node_label: str = "AWSPermissionSet"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(

--- a/cartography/models/aws/identitycenter/awsssouser.py
+++ b/cartography/models/aws/identitycenter/awsssouser.py
@@ -81,6 +81,7 @@ class AWSSSOUserToPermissionSetRelProperties(CartographyRelProperties):
 
 
 @dataclass(frozen=True)
+# DEPRECATED: principal HAS_PERMISSION_SET summary edges will be removed in v1.0.0.
 class AWSSSOUserToPermissionSetRel(CartographyRelSchema):
     target_node_label: str = "AWSPermissionSet"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -5493,6 +5493,11 @@ Representation of an AWS Identity Center.
     (:AWSIdentityCenter)-[:HAS_PERMISSION_SET]->(:AWSPermissionSet)
     ```
 
+- AWSIdentityCenter contains account assignment records.
+    ```
+    (:AWSSSOAccountAssignment)-[:ASSIGNMENT_IN]->(:AWSIdentityCenter)
+    ```
+
 - Entra service principals can federate to AWS Identity Center via SAML
 
     ```cypher
@@ -5528,10 +5533,11 @@ Representation of an AWS SSO User.
     (:AWSSSOUser)-[:MEMBER_OF_SSO_GROUP]->(:AWSSSOGroup)
     ```
 
-- AWSSSOUsers can be assigned to AWSRoles. This happens when the user is assigned to a permission set for a specific account. This includes both direct assignments to the user and assignments inherited through AWSSSOGroup membership. Note: The AWS Identity Center API (`list_account_assignments_for_principal`) automatically resolves group memberships server-side, so users receive `ALLOWED_BY` relationships for roles they can access through groups they belong to.
+- AWSSSOUsers can be assigned to AWSRoles. This happens when the user is assigned to a permission set for a specific account. This includes both direct assignments to the user and assignments inherited through AWSSSOGroup membership.
     ```
     (:AWSSSOUser)<-[:ALLOWED_BY]-(:AWSRole)
     ```
+    Note: This is a compatibility relationship for permitted role access. Use `AWSSSOAccountAssignment` when you need assignment provenance, the target AWS account, or the permission set grant that produced the access.
 
 - OktaUsers can assume AWS SSO users via SAML federation
      ```
@@ -5542,13 +5548,18 @@ Representation of an AWS SSO User.
     (:UserAccount)-[:CAN_ASSUME_IDENTITY]->(:AWSSSOUser)
     ```
 
-- An AWSSSOUser can be assigned to one or more AWSPermissionSets. This includes both direct assignments and assignments inherited through AWSSSOGroup membership.
+- An AWSSSOUser can be assigned to one or more AWSPermissionSets.
     ```
     (:AWSSSOUser)-[:HAS_PERMISSION_SET]->(:AWSPermissionSet)
     ```
     Notes:
-    - The AWS Identity Center API (`list_account_assignments_for_principal`) automatically resolves group memberships server-side, so users receive `HAS_PERMISSION_SET` relationships for permission sets they have access to through groups they belong to. This means if a user is only in a group that has a permission set assignment, the user will still have a direct `HAS_PERMISSION_SET` relationship to that permission set.
-    - This is a **summary relationship** that does not indicate which specific accounts the user has access to, only that they have been assigned to the permission set. For a user to have access to an AWS account, they must be assigned to a permission set for that specific account. This is captured by the `ALLOWED_BY` relationship.
+    - DEPRECATED: This compatibility summary relationship will be removed in v1.0.0. Use `AWSSSOAccountAssignment` for the canonical account-scoped grant.
+    - This relationship does not preserve whether the grant is direct or inherited through an `AWSSSOGroup`, and it does not indicate which AWS account is targeted.
+
+- Direct AWSSSOUser account assignments are represented as first-class grant records.
+    ```
+    (:AWSSSOAccountAssignment)-[:ASSIGNED_TO]->(:AWSSSOUser)
+    ```
 
 - AWSSSOUser can assume AWS roles via SAML (recorded from CloudTrail management events).
     ```
@@ -5594,18 +5605,73 @@ Representation of an AWS SSO Group.
     ```
     (:AWSSSOGroup)<-[:ALLOWED_BY]-(:AWSRole)
     ```
+    Note: This is a compatibility relationship for permitted role access. Use `AWSSSOAccountAssignment` when you need assignment provenance, the target AWS account, or the permission set grant that produced the access.
 
-- An AWSSSOGroup has assigned permission sets. AWSSSOUsers in the group will receive all permission sets that the group is assigned to.
+- An AWSSSOGroup has assigned permission sets.
     ```
     (:AWSSSOGroup)-[:HAS_PERMISSION_SET]->(:AWSPermissionSet)
     ```
     Notes:
-    - This relationship does not indicate which accounts the group has access to, only that it has been assigned to the permission set. For a group to have access to an AWS account, it must be assigned to a permission set for that specific account. This is captured by the `ALLOWED_BY` relationship.
-    - The AWS Identity Center API (`list_account_assignments_for_principal`) automatically resolves group memberships server-side, so users receive `HAS_PERMISSION_SET` relationships for permission sets they have access to through groups they belong to. This means if a user is only in a group that has a permission set assignment, the user will still have a direct `HAS_PERMISSION_SET` relationship to that permission set.
+    - DEPRECATED: This compatibility summary relationship will be removed in v1.0.0. Use `AWSSSOAccountAssignment` for the canonical account-scoped grant.
+    - This relationship does not indicate which AWS account the group has access to. For account-scoped access, query the assignment node and its `TARGETS_ACCOUNT` relationship.
+
+- AWSSSOGroup account assignments are represented as first-class grant records.
+    ```
+    (:AWSSSOAccountAssignment)-[:ASSIGNED_TO]->(:AWSSSOGroup)
+    ```
 
 - AWSSSOUsers can be members of AWSSSOGroups. In effect, the AWSSSOUser will receive all permission sets that the group is assigned to.
     ```
     (:AWSSSOUser)-[:MEMBER_OF_SSO_GROUP]->(:AWSSSOGroup)
+    ```
+
+### AWSSSOAccountAssignment
+
+Representation of an AWS IAM Identity Center account assignment. This is the canonical account-scoped grant object for Identity Center permission set access.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Stable identifier composed of instance ARN, target account ID, permission set ARN, principal type, and principal ID |
+| account_id | The AWS account targeted by the assignment |
+| permission_set_arn | The ARN of the assigned permission set |
+| principal_id | The AWS Identity Store user or group ID receiving the assignment |
+| principal_type | The assignment principal type: `USER` or `GROUP` |
+| identity_store_id | The AWS Identity Store ID containing the principal |
+| instance_arn | The ARN of the AWS Identity Center instance containing the assignment |
+| region | The AWS region |
+| firstseen | Timestamp of when a sync job first discovered this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+- An AWSSSOAccountAssignment is part of the AWS account that owns the Identity Center instance.
+    ```
+    (:AWSAccount)-[:RESOURCE]->(:AWSSSOAccountAssignment)
+    ```
+
+- An AWSSSOAccountAssignment targets an AWS account.
+    ```
+    (:AWSSSOAccountAssignment)-[:TARGETS_ACCOUNT]->(:AWSAccount)
+    ```
+
+- An AWSSSOAccountAssignment grants a permission set.
+    ```
+    (:AWSSSOAccountAssignment)-[:GRANTS_PERMISSION_SET]->(:AWSPermissionSet)
+    ```
+
+- An AWSSSOAccountAssignment belongs to an Identity Center instance.
+    ```
+    (:AWSSSOAccountAssignment)-[:ASSIGNMENT_IN]->(:AWSIdentityCenter)
+    ```
+
+- An AWSSSOAccountAssignment is assigned to either an SSO user or an SSO group.
+    ```
+    (:AWSSSOAccountAssignment)-[:ASSIGNED_TO]->(:AWSSSOUser)
+    (:AWSSSOAccountAssignment)-[:ASSIGNED_TO]->(:AWSSSOGroup)
+    ```
+
+- An AWSSSOAccountAssignment can materialize as an AWS reserved SSO role in the target account when Cartography has ingested the matching IAM role.
+    ```
+    (:AWSSSOAccountAssignment)-[:MATERIALIZES_AS]->(:AWSRole)
     ```
 
 ### AWSPermissionSet
@@ -5638,19 +5704,24 @@ Representation of an AWS Identity Center Permission Set.
     (:AWSPermissionSet)-[:ASSIGNED_TO_ROLE]->(:AWSRole)
     ```
 
-- An AWSSSOUser can be assigned to one or more AWSPermissionSets. This includes both direct assignments and assignments inherited through AWSSSOGroup membership.
+- An AWSSSOUser can be assigned to one or more AWSPermissionSets.
     ```
     (:AWSSSOUser)-[:HAS_PERMISSION_SET]->(:AWSPermissionSet)
     ```
     Notes:
-    - The AWS Identity Center API (`list_account_assignments_for_principal`) automatically resolves group memberships server-side, so users receive `HAS_PERMISSION_SET` relationships for permission sets they have access to through groups they belong to. This means if a user is only in a group that has a permission set assignment, the user will still have a direct `HAS_PERMISSION_SET` relationship to that permission set.
-    - This is a **summary relationship** that does not indicate which specific accounts the user has access to, only that they have been assigned to the permission set. For a user to have access to an AWS account, they must be assigned to a permission set _for that specific account_. This is captured by the `ALLOWED_BY` relationship.
+    - DEPRECATED: This compatibility summary relationship will be removed in v1.0.0. Use `AWSSSOAccountAssignment` for the canonical account-scoped grant.
+    - This relationship does not preserve direct-vs-group provenance and does not indicate which AWS account is targeted.
 
-- An AWSSSOGroup has assigned permission sets. AWSSSOUsers in the group will receive all permission sets that the group is assigned to.
+- An AWSSSOGroup has assigned permission sets.
     ```
     (:AWSSSOGroup)-[:HAS_PERMISSION_SET]->(:AWSPermissionSet)
     ```
-    Note: This relationship does not indicate which accounts the group has access to, only that it has been assigned to the permission set. For a group to have access to an AWS account, it must be assigned to a permission set for that specific account. This is captured by the `ALLOWED_BY` relationship.
+    Note: DEPRECATED: This compatibility summary relationship will be removed in v1.0.0. Use `AWSSSOAccountAssignment` for the canonical account-scoped grant.
+
+- AWSPermissionSets are granted by account assignment records.
+    ```
+    (:AWSSSOAccountAssignment)-[:GRANTS_PERMISSION_SET]->(:AWSPermissionSet)
+    ```
 
 ### EC2RouteTable
 

--- a/docs/root/usage/samplequeries.md
+++ b/docs/root/usage/samplequeries.md
@@ -177,30 +177,39 @@ RETURN repo.name, dep.name, edge.specifier, dep.version
 
 ### What AWS accounts and roles can a given AWS Identity Center user access? Via what permission sets?
 ```cypher
-MATCH (user:AWSSSOUser{user_name:"myuser"})<-[:ALLOWED_BY]-(role:AWSRole)<-[:RESOURCE]-(account:AWSAccount)
-MATCH (role)<-[:ASSIGNED_TO_ROLE]-(ps:AWSPermissionSet)
-RETURN account.id, account.name, role.arn, ps.name
-```
-[test it locally](http://localhost:7474/browser/?preselectAuthMethod=NO_AUTH&db=neo4j&connectURL=bolt://neo4j:neo4j@localhost:7474&cmd=edit&arg=MATCH%20%28user%3AAWSSSOUser%7Buser_name%3A%22myuser%22%7D%29%3C-%5B%3AALLOWED_BY%5D-%28role%3AAWSRole%29%3C-%5B%3ARESOURCE%5D-%3E%28account%3AAWSAccount%29%0A%20%20%20%20MATCH%20%28role%29%3C-%5B%3AASSIGNED_TO_ROLE%5D-%28ps%3AAWSPermissionSet%29%0A%20%20%20%20RETURN%20account.id%2C%20account.name%2C%20role.arn%2C%20ps.name)
-
-### What are the users and groups that can assume a given AWSRole via Identity Center?
-```cypher
-// Users
-MATCH (r:AWSRole {arn: "arn:aws:iam::123456789012:role/myrole"})-[:ALLOWED_BY]->(u:AWSSSOUser)
-RETURN 'user' AS principal_type,  u.id AS principal_id,  u.user_name AS principal_name
+MATCH (user:AWSSSOUser {user_name: "myuser"})
+MATCH (assignment:AWSSSOAccountAssignment)-[:ASSIGNED_TO]->(user)
+MATCH (assignment)-[:TARGETS_ACCOUNT]->(account:AWSAccount)
+MATCH (assignment)-[:GRANTS_PERMISSION_SET]->(ps:AWSPermissionSet)
+OPTIONAL MATCH (assignment)-[:MATERIALIZES_AS]->(role:AWSRole)
+RETURN "direct" AS assignment_type, account.id, account.name, role.arn, ps.name
 
 UNION
 
-// Groups
-MATCH (r:AWSRole {arn: "arn:aws:iam::123456789012:role/myrole"})-[:ALLOWED_BY]->(g:AWSSSOGroup)
-RETURN 'group' AS principal_type, g.id AS principal_id, g.display_name AS principal_name
+MATCH (user:AWSSSOUser {user_name: "myuser"})-[:MEMBER_OF_SSO_GROUP]->(group:AWSSSOGroup)
+MATCH (assignment:AWSSSOAccountAssignment)-[:ASSIGNED_TO]->(group)
+MATCH (assignment)-[:TARGETS_ACCOUNT]->(account:AWSAccount)
+MATCH (assignment)-[:GRANTS_PERMISSION_SET]->(ps:AWSPermissionSet)
+OPTIONAL MATCH (assignment)-[:MATERIALIZES_AS]->(role:AWSRole)
+RETURN "group" AS assignment_type, account.id, account.name, role.arn, ps.name
 ```
-[test it locally](http://localhost:7474/browser/?preselectAuthMethod=NO_AUTH&db=neo4j&connectURL=bolt://neo4j:neo4j@localhost:7474&cmd=edit&arg=MATCH%20%28r%3AAWSRole%20%7Barn%3A%20%22arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fmyrole%22%7D%29-%5B%3AALLOWED_BY%5D-%3E%28u%3AAWSSSOUser%29%0ARETURN%20%27user%27%20AS%20principal_type%2C%20u.id%20AS%20principal_id%2C%20u.user_name%20AS%20principal_name%0A%0AUNION%0A%0A%2F%2F%20Groups%0AMATCH%20%28r%3AAWSRole%20%7Barn%3A%20%22arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fmyrole%22%7D%29-%5B%3AALLOWED_BY%5D-%3E%28g%3AAWSSSOGroup%29%0ARETURN%20%27group%27%20AS%20principal_type%2C%20g.id%20AS%20principal_id%2C%20g.display_name%20AS%20principal_name)
+### What are the users and groups that can assume a given AWSRole via Identity Center?
+```cypher
+MATCH (role:AWSRole {arn: "arn:aws:iam::123456789012:role/myrole"})
+MATCH (assignment:AWSSSOAccountAssignment)-[:MATERIALIZES_AS]->(role)
+MATCH (assignment)-[:ASSIGNED_TO]->(u:AWSSSOUser)
+RETURN "USER" AS principal_type, u.id AS principal_id, u.user_name AS principal_name
 
+UNION
+
+MATCH (role:AWSRole {arn: "arn:aws:iam::123456789012:role/myrole"})
+MATCH (assignment:AWSSSOAccountAssignment)-[:MATERIALIZES_AS]->(role)
+MATCH (assignment)-[:ASSIGNED_TO]->(g:AWSSSOGroup)
+RETURN "GROUP" AS principal_type, g.id AS principal_id, g.display_name AS principal_name
+```
 ### What are the permissionsets provisioned to a given AWS Account?
 ```cypher
-MATCH (account:AWSAccount{id:"123456789012"})-[:RESOURCE]->(role:AWSRole)
-MATCH (role)<-[:ASSIGNED_TO_ROLE]-(ps:AWSPermissionSet)
-RETURN ps.arn as permission_set_arn, ps.name as permission_set_name
+MATCH (account:AWSAccount {id: "123456789012"})<-[:TARGETS_ACCOUNT]-(assignment:AWSSSOAccountAssignment)
+MATCH (assignment)-[:GRANTS_PERMISSION_SET]->(ps:AWSPermissionSet)
+RETURN DISTINCT ps.arn AS permission_set_arn, ps.name AS permission_set_name
 ```
-[test it locally](http://localhost:7474/browser/?preselectAuthMethod=NO_AUTH&db=neo4j&connectURL=bolt://neo4j:neo4j@localhost:7474&cmd=edit&arg=MATCH%20%28account%3AAWSAccount%7Bid%3A%22123456789012%22%7D%29-%5B%3ARESOURCE%5D-%3E%28role%3AAWSRole%29%0A%20%20%20%20MATCH%20%28role%29%3C-%5B%3AASSIGNED_TO_ROLE%5D-%28ps%3AAWSPermissionSet%29%0A%20%20%20%20RETURN%20ps.arn%20as%20permission_set_arn%2C%20ps.name%20as%20permission_set_name)

--- a/tests/integration/cartography/intel/aws/test_identitycenter.py
+++ b/tests/integration/cartography/intel/aws/test_identitycenter.py
@@ -7,13 +7,16 @@ import pytest
 import cartography.intel.aws.identitycenter
 import tests.data.aws.identitycenter
 from cartography.client.core.tx import load
+from cartography.intel.aws.identitycenter import cleanup
 from cartography.intel.aws.identitycenter import get_permission_sets
+from cartography.intel.aws.identitycenter import load_account_assignments
 from cartography.intel.aws.identitycenter import load_group_roles
 from cartography.intel.aws.identitycenter import load_identity_center_instances
 from cartography.intel.aws.identitycenter import load_permission_sets
 from cartography.intel.aws.identitycenter import load_sso_groups
 from cartography.intel.aws.identitycenter import load_sso_users
 from cartography.intel.aws.identitycenter import PermissionSetSyncNotSupported
+from cartography.intel.aws.identitycenter import transform_account_assignments
 from cartography.intel.aws.identitycenter import transform_permission_sets
 from cartography.intel.aws.identitycenter import transform_sso_groups
 from cartography.intel.aws.identitycenter import transform_sso_users
@@ -24,6 +27,16 @@ from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
 
 TEST_ACCOUNT_ID = "1234567890"
+TEST_INSTANCE_ARN = "arn:aws:sso:::instance/ssoins-12345678901234567"
+TEST_IDENTITY_STORE_ID = "d-1234567890"
+TEST_REGION = "us-west-2"
+
+
+def _ensure_aws_account(neo4j_session, account_id=TEST_ACCOUNT_ID):
+    neo4j_session.run(
+        "MERGE (:AWSAccount {id: $account_id})",
+        account_id=account_id,
+    )
 
 
 def test_load_sso_users(neo4j_session):
@@ -305,6 +318,398 @@ def test_link_sso_user_to_permission_set(neo4j_session):
             user["UserId"],
             ps["PermissionSetArn"],
         )
+    }
+
+
+def test_load_user_account_assignment(neo4j_session):
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _ensure_aws_account(neo4j_session)
+    user = transform_sso_users(tests.data.aws.identitycenter.LIST_USERS)[0]
+    permission_set = tests.data.aws.identitycenter.LIST_PERMISSION_SETS[0]
+    role_arn = (
+        f"arn:aws:iam::{TEST_ACCOUNT_ID}:role/aws-reserved/"
+        "sso.amazonaws.com/AWSReservedSSO_AdministratorAccess_Test"
+    )
+
+    load_identity_center_instances(
+        neo4j_session,
+        tests.data.aws.identitycenter.LIST_INSTANCES,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        "test_tag",
+    )
+    load_sso_users(
+        neo4j_session,
+        [user],
+        TEST_IDENTITY_STORE_ID,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        "test_tag",
+    )
+    load_permission_sets(
+        neo4j_session,
+        [permission_set],
+        TEST_INSTANCE_ARN,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        "test_tag",
+    )
+    load(
+        neo4j_session,
+        AWSRoleSchema(),
+        [
+            {
+                "arn": role_arn,
+                "name": "AWSReservedSSO_AdministratorAccess_Test",
+                "roleid": "AIDAROLEASSIGNMENT",
+                "path": "/aws-reserved/sso.amazonaws.com/",
+                "createdate": "2023-01-01",
+                "trusted_aws_principals": [],
+            },
+        ],
+        lastupdated="test_tag",
+        AWS_ID=TEST_ACCOUNT_ID,
+    )
+
+    assignments = transform_account_assignments(
+        [
+            {
+                "UserId": user["UserId"],
+                "AccountId": TEST_ACCOUNT_ID,
+                "PermissionSetArn": permission_set["PermissionSetArn"],
+                "RoleArn": role_arn,
+            },
+        ],
+        "USER",
+        TEST_INSTANCE_ARN,
+        TEST_IDENTITY_STORE_ID,
+        TEST_REGION,
+    )
+    load_account_assignments(
+        neo4j_session,
+        assignments,
+        TEST_ACCOUNT_ID,
+        "test_tag",
+    )
+
+    assignment_id = assignments[0]["AssignmentId"]
+    assert check_nodes(
+        neo4j_session,
+        "AWSSSOAccountAssignment",
+        ["id", "principal_type", "principal_id"],
+    ) == {
+        (assignment_id, "USER", user["UserId"]),
+    }
+    assert check_rels(
+        neo4j_session,
+        "AWSSSOAccountAssignment",
+        "id",
+        "AWSSSOUser",
+        "id",
+        "ASSIGNED_TO",
+        True,
+    ) == {
+        (assignment_id, user["UserId"]),
+    }
+    assert check_rels(
+        neo4j_session,
+        "AWSSSOAccountAssignment",
+        "id",
+        "AWSPermissionSet",
+        "arn",
+        "GRANTS_PERMISSION_SET",
+        True,
+    ) == {
+        (assignment_id, permission_set["PermissionSetArn"]),
+    }
+    assert check_rels(
+        neo4j_session,
+        "AWSSSOAccountAssignment",
+        "id",
+        "AWSAccount",
+        "id",
+        "TARGETS_ACCOUNT",
+        True,
+    ) == {
+        (assignment_id, TEST_ACCOUNT_ID),
+    }
+    assert check_rels(
+        neo4j_session,
+        "AWSSSOAccountAssignment",
+        "id",
+        "AWSIdentityCenter",
+        "id",
+        "ASSIGNMENT_IN",
+        True,
+    ) == {
+        (assignment_id, TEST_INSTANCE_ARN),
+    }
+    assert check_rels(
+        neo4j_session,
+        "AWSSSOAccountAssignment",
+        "id",
+        "AWSRole",
+        "arn",
+        "MATERIALIZES_AS",
+        True,
+    ) == {
+        (assignment_id, role_arn),
+    }
+
+
+def test_load_group_account_assignment_and_inherited_user_query(neo4j_session):
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _ensure_aws_account(neo4j_session)
+    user = transform_sso_users(
+        tests.data.aws.identitycenter.LIST_USERS,
+        {
+            tests.data.aws.identitycenter.LIST_USERS[0]["UserId"]: [
+                tests.data.aws.identitycenter.LIST_GROUPS[0]["GroupId"]
+            ]
+        },
+    )[0]
+    group = transform_sso_groups(tests.data.aws.identitycenter.LIST_GROUPS)[0]
+    permission_set = tests.data.aws.identitycenter.LIST_PERMISSION_SETS[0]
+
+    load_sso_groups(
+        neo4j_session,
+        [group],
+        TEST_IDENTITY_STORE_ID,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        "test_tag",
+    )
+    load_sso_users(
+        neo4j_session,
+        [user],
+        TEST_IDENTITY_STORE_ID,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        "test_tag",
+    )
+    load_permission_sets(
+        neo4j_session,
+        [permission_set],
+        TEST_INSTANCE_ARN,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        "test_tag",
+    )
+
+    assignments = transform_account_assignments(
+        [
+            {
+                "GroupId": group["GroupId"],
+                "AccountId": TEST_ACCOUNT_ID,
+                "PermissionSetArn": permission_set["PermissionSetArn"],
+            },
+        ],
+        "GROUP",
+        TEST_INSTANCE_ARN,
+        TEST_IDENTITY_STORE_ID,
+        TEST_REGION,
+    )
+    load_account_assignments(
+        neo4j_session,
+        assignments,
+        TEST_ACCOUNT_ID,
+        "test_tag",
+    )
+
+    assignment_id = assignments[0]["AssignmentId"]
+    assert check_nodes(
+        neo4j_session,
+        "AWSSSOAccountAssignment",
+        ["id", "principal_type", "principal_id"],
+    ) == {
+        (assignment_id, "GROUP", group["GroupId"]),
+    }
+    assert check_rels(
+        neo4j_session,
+        "AWSSSOAccountAssignment",
+        "id",
+        "AWSSSOGroup",
+        "id",
+        "ASSIGNED_TO",
+        True,
+    ) == {
+        (assignment_id, group["GroupId"]),
+    }
+
+    inherited_assignments = neo4j_session.run(
+        """
+        MATCH (user:AWSSSOUser {id: $user_id})-[:MEMBER_OF_SSO_GROUP]->(group:AWSSSOGroup)
+        MATCH (group)<-[:ASSIGNED_TO]-(assignment:AWSSSOAccountAssignment)
+        RETURN assignment.id AS assignment_id
+        """,
+        user_id=user["UserId"],
+    )
+    assert {record["assignment_id"] for record in inherited_assignments} == {
+        assignment_id,
+    }
+
+
+def test_direct_and_group_assignments_do_not_collapse_provenance(neo4j_session):
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _ensure_aws_account(neo4j_session)
+    user = transform_sso_users(tests.data.aws.identitycenter.LIST_USERS)[0]
+    group = transform_sso_groups(tests.data.aws.identitycenter.LIST_GROUPS)[0]
+    permission_set = tests.data.aws.identitycenter.LIST_PERMISSION_SETS[0]
+
+    load_sso_users(
+        neo4j_session,
+        [user],
+        TEST_IDENTITY_STORE_ID,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        "test_tag",
+    )
+    load_sso_groups(
+        neo4j_session,
+        [group],
+        TEST_IDENTITY_STORE_ID,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        "test_tag",
+    )
+    load_permission_sets(
+        neo4j_session,
+        [permission_set],
+        TEST_INSTANCE_ARN,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        "test_tag",
+    )
+
+    user_assignments = transform_account_assignments(
+        [
+            {
+                "UserId": user["UserId"],
+                "AccountId": TEST_ACCOUNT_ID,
+                "PermissionSetArn": permission_set["PermissionSetArn"],
+            },
+        ],
+        "USER",
+        TEST_INSTANCE_ARN,
+        TEST_IDENTITY_STORE_ID,
+        TEST_REGION,
+    )
+    group_assignments = transform_account_assignments(
+        [
+            {
+                "GroupId": group["GroupId"],
+                "AccountId": TEST_ACCOUNT_ID,
+                "PermissionSetArn": permission_set["PermissionSetArn"],
+            },
+        ],
+        "GROUP",
+        TEST_INSTANCE_ARN,
+        TEST_IDENTITY_STORE_ID,
+        TEST_REGION,
+    )
+    load_account_assignments(
+        neo4j_session,
+        user_assignments + group_assignments,
+        TEST_ACCOUNT_ID,
+        "test_tag",
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "AWSSSOAccountAssignment",
+        ["principal_type", "principal_id", "permission_set_arn"],
+    ) == {
+        ("USER", user["UserId"], permission_set["PermissionSetArn"]),
+        ("GROUP", group["GroupId"], permission_set["PermissionSetArn"]),
+    }
+
+
+def test_cleanup_removes_stale_account_assignments_and_matchlinks(neo4j_session):
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    stale_account_id = "111111111111"
+    _ensure_aws_account(neo4j_session)
+    _ensure_aws_account(neo4j_session, stale_account_id)
+    user = transform_sso_users(tests.data.aws.identitycenter.LIST_USERS)[0]
+    permission_set = tests.data.aws.identitycenter.LIST_PERMISSION_SETS[0]
+
+    load_sso_users(
+        neo4j_session,
+        [user],
+        TEST_IDENTITY_STORE_ID,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        2,
+    )
+    load_permission_sets(
+        neo4j_session,
+        [permission_set],
+        TEST_INSTANCE_ARN,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        2,
+    )
+
+    stale_assignments = transform_account_assignments(
+        [
+            {
+                "UserId": user["UserId"],
+                "AccountId": stale_account_id,
+                "PermissionSetArn": permission_set["PermissionSetArn"],
+            },
+        ],
+        "USER",
+        TEST_INSTANCE_ARN,
+        TEST_IDENTITY_STORE_ID,
+        TEST_REGION,
+    )
+    current_assignments = transform_account_assignments(
+        [
+            {
+                "UserId": user["UserId"],
+                "AccountId": TEST_ACCOUNT_ID,
+                "PermissionSetArn": permission_set["PermissionSetArn"],
+            },
+        ],
+        "USER",
+        TEST_INSTANCE_ARN,
+        TEST_IDENTITY_STORE_ID,
+        TEST_REGION,
+    )
+    load_account_assignments(
+        neo4j_session,
+        stale_assignments,
+        TEST_ACCOUNT_ID,
+        1,
+    )
+    load_account_assignments(
+        neo4j_session,
+        current_assignments,
+        TEST_ACCOUNT_ID,
+        2,
+    )
+
+    cleanup(
+        neo4j_session,
+        {"AWS_ID": TEST_ACCOUNT_ID, "UPDATE_TAG": 2},
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "AWSSSOAccountAssignment",
+        ["id"],
+    ) == {
+        (current_assignments[0]["AssignmentId"],),
+    }
+    assert check_rels(
+        neo4j_session,
+        "AWSSSOAccountAssignment",
+        "id",
+        "AWSSSOUser",
+        "id",
+        "ASSIGNED_TO",
+        True,
+    ) == {
+        (current_assignments[0]["AssignmentId"], user["UserId"]),
     }
 
 

--- a/tests/unit/cartography/intel/aws/test_identitycenter.py
+++ b/tests/unit/cartography/intel/aws/test_identitycenter.py
@@ -7,6 +7,7 @@ from cartography.intel.aws.identitycenter import (
 )
 from cartography.intel.aws.identitycenter import get_permission_sets
 from cartography.intel.aws.identitycenter import get_user_permissionsets
+from cartography.intel.aws.identitycenter import transform_account_assignments
 from cartography.intel.aws.util.botocore_config import get_botocore_config
 
 
@@ -153,3 +154,35 @@ def test_is_permission_set_sync_unsupported_error_returns_false_for_access_denie
     )
 
     assert not _is_permission_set_sync_unsupported_error(error)
+
+
+def test_transform_account_assignments_adds_stable_id_and_principal_fields():
+    transformed = transform_account_assignments(
+        [
+            {
+                "UserId": "user-1",
+                "AccountId": "123456789012",
+                "PermissionSetArn": "arn:aws:sso:::permissionSet/ssoins-1/ps-1",
+                "RoleArn": "arn:aws:iam::123456789012:role/test-role",
+            },
+        ],
+        "USER",
+        "arn:aws:sso:::instance/ssoins-1",
+        "d-1234567890",
+        "us-east-1",
+    )
+
+    assert transformed == [
+        {
+            "UserId": "user-1",
+            "AccountId": "123456789012",
+            "PermissionSetArn": "arn:aws:sso:::permissionSet/ssoins-1/ps-1",
+            "RoleArn": "arn:aws:iam::123456789012:role/test-role",
+            "AssignmentId": "arn:aws:sso:::instance/ssoins-1|123456789012|arn:aws:sso:::permissionSet/ssoins-1/ps-1|USER|user-1",
+            "PrincipalId": "user-1",
+            "PrincipalType": "USER",
+            "IdentityStoreId": "d-1234567890",
+            "InstanceArn": "arn:aws:sso:::instance/ssoins-1",
+            "Region": "us-east-1",
+        },
+    ]


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update


### Summary
Adds first-class AWS IAM Identity Center account assignment nodes so the graph preserves assignment provenance, principal type, target AWS account, permission set, and materialized IAM role when available.

Existing principal-to-permission-set and role-to-principal relationships are preserved for compatibility, while the schema docs now identify principal `HAS_PERMISSION_SET` edges as deprecated summary edges and point users to `AWSSSOAccountAssignment` for account-scoped grants.


### Related issues or links

- N/A


### Breaking changes

None in this PR. Existing compatibility edges are preserved. The docs mark principal `HAS_PERMISSION_SET` summary edges as deprecated because they do not preserve account scope or direct-vs-group assignment provenance.


### How was this tested?

- Tested locally and added new tests


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs were not included; this PR is validated with focused unit and integration coverage.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md). This checkout does not contain `docs/schema/README.md`; `docs/root/usage/samplequeries.md` was updated instead.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node). N/A; this updates an existing module.


### Notes for reviewers

The new `AWSSSOAccountAssignment` node is the canonical account-scoped grant record. It is linked to the assigned user or group, target account, permission set, Identity Center instance, and matching reserved SSO role when that IAM role exists in the graph.


### Graph model

#### Old summary model
```mermaid
flowchart LR
    U["AWSSSOUser"] -->|"HAS_PERMISSION_SET summary"| PS["AWSPermissionSet"]
    G["AWSSSOGroup"] -->|"HAS_PERMISSION_SET summary"| PS
    U -->|"MEMBER_OF_SSO_GROUP"| G
    PS -->|"ASSIGNED_TO_ROLE"| R["AWSRole"]
    R -->|"ALLOWED_BY compatibility"| U
    R -->|"ALLOWED_BY compatibility"| G
```

#### New account assignment model
```mermaid
flowchart LR
    Owner["AWSAccount owner"] -->|"RESOURCE"| A["AWSSSOAccountAssignment"]
    A -->|"ASSIGNMENT_IN"| IC["AWSIdentityCenter"]
    A -->|"TARGETS_ACCOUNT"| Target["AWSAccount target"]
    A -->|"GRANTS_PERMISSION_SET"| PS["AWSPermissionSet"]
    A -->|"MATERIALIZES_AS"| R["AWSRole"]
    A -->|"ASSIGNED_TO direct"| U["AWSSSOUser"]
    A -->|"ASSIGNED_TO group"| G["AWSSSOGroup"]
    U -->|"MEMBER_OF_SSO_GROUP"| G
```

