### PR TITLE
refactor: unify workload chain across providers via WORKLOAD_PARENT

### DIFF
--- a/cartography/intel/aws/ecs.py
+++ b/cartography/intel/aws/ecs.py
@@ -231,6 +231,12 @@ def transform_ecs_tasks(tasks: list[dict[str, Any]]) -> list[dict[str, Any]]:
         if group and group.startswith("service:"):
             task["serviceName"] = group.split("service:", 1)[1]
 
+        # Standalone tasks (no service) attach WORKLOAD_PARENT directly to the
+        # cluster; service-attached tasks chain through the service instead so
+        # the matcher stays null and only one parent edge fires.
+        if not task.get("serviceName"):
+            task["_workload_parent_cluster_arn"] = task.get("clusterArn")
+
         # Extract network interface ID from task attachments
         for attachment in task.get("attachments", []):
             if attachment.get("type") == "ElasticNetworkInterface":

--- a/cartography/models/aws/ecs/containers.py
+++ b/cartography/models/aws/ecs/containers.py
@@ -59,6 +59,7 @@ class ECSContainerToTaskRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
+# DEPRECATED: replaced by WORKLOAD_PARENT, will be removed in v1.0.0
 @dataclass(frozen=True)
 class ECSContainerToTaskRel(CartographyRelSchema):
     target_node_label: str = "ECSTask"
@@ -68,6 +69,25 @@ class ECSContainerToTaskRel(CartographyRelSchema):
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS_CONTAINER"
     properties: ECSContainerToTaskRelProperties = ECSContainerToTaskRelProperties()
+
+
+@dataclass(frozen=True)
+class ECSContainerToECSTaskWorkloadParentRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ECSContainer)-[:WORKLOAD_PARENT]->(:ECSTask)
+class ECSContainerToECSTaskWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "ECSTask"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("taskArn")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: ECSContainerToECSTaskWorkloadParentRelProperties = (
+        ECSContainerToECSTaskWorkloadParentRelProperties()
+    )
 
 
 @dataclass(frozen=True)
@@ -170,6 +190,7 @@ class ECSContainerSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             ECSContainerToTaskRel(),
+            ECSContainerToECSTaskWorkloadParentRel(),
             ECSContainerToECRImageRel(),
             ECSContainerToGitLabContainerImageRel(),
             ECSContainerToGCPArtifactRegistryContainerImageRel(),

--- a/cartography/models/aws/ecs/services.py
+++ b/cartography/models/aws/ecs/services.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -55,6 +56,7 @@ class ECSServiceToECSClusterRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
+# DEPRECATED: replaced by WORKLOAD_PARENT, will be removed in v1.0.0
 @dataclass(frozen=True)
 class ECSServiceToECSClusterRel(CartographyRelSchema):
     target_node_label: str = "ECSCluster"
@@ -65,6 +67,25 @@ class ECSServiceToECSClusterRel(CartographyRelSchema):
     rel_label: str = "HAS_SERVICE"
     properties: ECSServiceToECSClusterRelProperties = (
         ECSServiceToECSClusterRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ECSServiceToECSClusterWorkloadParentRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ECSService)-[:WORKLOAD_PARENT]->(:ECSCluster)
+class ECSServiceToECSClusterWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "ECSCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ClusterArn", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: ECSServiceToECSClusterWorkloadParentRelProperties = (
+        ECSServiceToECSClusterWorkloadParentRelProperties()
     )
 
 
@@ -109,6 +130,7 @@ class ECSServiceToECSTaskRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
+# DEPRECATED: replaced by WORKLOAD_PARENT, will be removed in v1.0.0
 @dataclass(frozen=True)
 class ECSServiceToECSTaskRel(CartographyRelSchema):
     target_node_label: str = "ECSTask"
@@ -126,11 +148,13 @@ class ECSServiceToECSTaskRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class ECSServiceSchema(CartographyNodeSchema):
     label: str = "ECSService"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeService"])
     properties: ECSServiceNodeProperties = ECSServiceNodeProperties()
     sub_resource_relationship: ECSServiceToAWSAccountRel = ECSServiceToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
             ECSServiceToECSClusterRel(),
+            ECSServiceToECSClusterWorkloadParentRel(),
             ECSServiceToTaskDefinitionRel(),
             ECSServiceToECSTaskRel(),
         ]

--- a/cartography/models/aws/ecs/tasks.py
+++ b/cartography/models/aws/ecs/tasks.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -57,6 +58,7 @@ class ECSTaskToECSClusterRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
+# DEPRECATED: replaced by WORKLOAD_PARENT, will be removed in v1.0.0
 @dataclass(frozen=True)
 class ECSTaskToECSClusterRel(CartographyRelSchema):
     target_node_label: str = "ECSCluster"
@@ -66,6 +68,53 @@ class ECSTaskToECSClusterRel(CartographyRelSchema):
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "HAS_TASK"
     properties: ECSTaskToECSClusterRelProperties = ECSTaskToECSClusterRelProperties()
+
+
+@dataclass(frozen=True)
+class ECSTaskToECSServiceWorkloadParentRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ECSTask)-[:WORKLOAD_PARENT]->(:ECSService)
+# Only fires when the task is associated with a service (serviceName extracted
+# from the task's `group` field by the loader). Standalone tasks fall through
+# to ECSTaskToECSClusterWorkloadParentRel.
+class ECSTaskToECSServiceWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "ECSService"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "name": PropertyRef("serviceName"),
+            "cluster_arn": PropertyRef("clusterArn"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: ECSTaskToECSServiceWorkloadParentRelProperties = (
+        ECSTaskToECSServiceWorkloadParentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ECSTaskToECSClusterWorkloadParentRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ECSTask)-[:WORKLOAD_PARENT]->(:ECSCluster)
+# Fallback parent for standalone tasks (no service). The matcher is gated on
+# `_workload_parent_cluster_arn`, which the ECS loader sets only when the task
+# has no serviceName, so service-attached tasks don't get a duplicate edge.
+class ECSTaskToECSClusterWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "ECSCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("_workload_parent_cluster_arn")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: ECSTaskToECSClusterWorkloadParentRelProperties = (
+        ECSTaskToECSClusterWorkloadParentRelProperties()
+    )
 
 
 @dataclass(frozen=True)
@@ -123,12 +172,15 @@ class ECSTaskToNetworkInterfaceRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class ECSTaskSchema(CartographyNodeSchema):
     label: str = "ECSTask"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputePod"])
     properties: ECSTaskNodeProperties = ECSTaskNodeProperties()
     sub_resource_relationship: ECSTaskToAWSAccountRel = ECSTaskToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
             ECSTaskToContainerInstanceRel(),
             ECSTaskToECSClusterRel(),
+            ECSTaskToECSServiceWorkloadParentRel(),
+            ECSTaskToECSClusterWorkloadParentRel(),
             ECSTaskToNetworkInterfaceRel(),
         ]
     )

--- a/cartography/models/azure/container_instance.py
+++ b/cartography/models/azure/container_instance.py
@@ -52,6 +52,7 @@ class AzureGroupContainerToContainerInstanceRelProperties(CartographyRelProperti
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
+# DEPRECATED: replaced by WORKLOAD_PARENT, will be removed in v1.0.0
 @dataclass(frozen=True)
 class AzureGroupContainerToContainerInstanceRel(CartographyRelSchema):
     target_node_label: str = "AzureGroupContainer"
@@ -62,6 +63,27 @@ class AzureGroupContainerToContainerInstanceRel(CartographyRelSchema):
     rel_label: str = "CONTAINS"
     properties: AzureGroupContainerToContainerInstanceRelProperties = (
         AzureGroupContainerToContainerInstanceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AzureContainerInstanceToGroupContainerWorkloadParentRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AzureContainerInstance)-[:WORKLOAD_PARENT]->(:AzureGroupContainer)
+class AzureContainerInstanceToGroupContainerWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "AzureGroupContainer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("group_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: AzureContainerInstanceToGroupContainerWorkloadParentRelProperties = (
+        AzureContainerInstanceToGroupContainerWorkloadParentRelProperties()
     )
 
 
@@ -158,6 +180,7 @@ class AzureContainerInstanceSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             AzureGroupContainerToContainerInstanceRel(),
+            AzureContainerInstanceToGroupContainerWorkloadParentRel(),
             AzureContainerInstanceToECRImageRel(),
             AzureContainerInstanceToGitLabContainerImageRel(),
             AzureContainerInstanceToGCPArtifactRegistryContainerImageRel(),

--- a/cartography/models/azure/group_container.py
+++ b/cartography/models/azure/group_container.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -66,6 +67,7 @@ class AzureGroupContainerToSubnetRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class AzureGroupContainerSchema(CartographyNodeSchema):
     label: str = "AzureGroupContainer"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeService"])
     properties: AzureGroupContainerNodeProperties = AzureGroupContainerNodeProperties()
     sub_resource_relationship: AzureGroupContainerToSubscriptionRel = (
         AzureGroupContainerToSubscriptionRel()

--- a/cartography/models/azure/group_container.py
+++ b/cartography/models/azure/group_container.py
@@ -67,7 +67,7 @@ class AzureGroupContainerToSubnetRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class AzureGroupContainerSchema(CartographyNodeSchema):
     label: str = "AzureGroupContainer"
-    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeService"])
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputePod"])
     properties: AzureGroupContainerNodeProperties = AzureGroupContainerNodeProperties()
     sub_resource_relationship: AzureGroupContainerToSubscriptionRel = (
         AzureGroupContainerToSubscriptionRel()

--- a/cartography/models/gcp/cloudrun/job.py
+++ b/cartography/models/gcp/cloudrun/job.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -58,6 +59,7 @@ class CloudRunJobToServiceAccountRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class GCPCloudRunJobSchema(CartographyNodeSchema):
     label: str = "GCPCloudRunJob"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeService"])
     properties: GCPCloudRunJobProperties = GCPCloudRunJobProperties()
     sub_resource_relationship: ProjectToCloudRunJobRel = ProjectToCloudRunJobRel()
     other_relationships: OtherRelationships = OtherRelationships(

--- a/cartography/models/gcp/cloudrun/job_container.py
+++ b/cartography/models/gcp/cloudrun/job_container.py
@@ -49,6 +49,7 @@ class CloudRunJobToContainerRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
+# DEPRECATED: replaced by WORKLOAD_PARENT, will be removed in v1.0.0
 @dataclass(frozen=True)
 class CloudRunJobToContainerRel(CartographyRelSchema):
     target_node_label: str = "GCPCloudRunJob"
@@ -59,6 +60,25 @@ class CloudRunJobToContainerRel(CartographyRelSchema):
     rel_label: str = "CONTAINS"
     properties: CloudRunJobToContainerRelProperties = (
         CloudRunJobToContainerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class CloudRunJobContainerToJobWorkloadParentRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:GCPCloudRunJobContainer)-[:WORKLOAD_PARENT]->(:GCPCloudRunJob)
+class CloudRunJobContainerToJobWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "GCPCloudRunJob"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("job_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: CloudRunJobContainerToJobWorkloadParentRelProperties = (
+        CloudRunJobContainerToJobWorkloadParentRelProperties()
     )
 
 
@@ -149,6 +169,7 @@ class GCPCloudRunJobContainerSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             CloudRunJobToContainerRel(),
+            CloudRunJobContainerToJobWorkloadParentRel(),
             CloudRunJobContainerToECRImageRel(),
             CloudRunJobContainerToGitLabContainerImageRel(),
             CloudRunJobContainerToArtifactRegistryContainerImageRel(),

--- a/cartography/models/gcp/cloudrun/service.py
+++ b/cartography/models/gcp/cloudrun/service.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -64,6 +65,7 @@ class CloudRunServiceToServiceAccountRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class GCPCloudRunServiceSchema(CartographyNodeSchema):
     label: str = "GCPCloudRunService"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeService"])
     properties: GCPCloudRunServiceProperties = GCPCloudRunServiceProperties()
     sub_resource_relationship: ProjectToCloudRunServiceRel = (
         ProjectToCloudRunServiceRel()

--- a/cartography/models/gcp/cloudrun/service_container.py
+++ b/cartography/models/gcp/cloudrun/service_container.py
@@ -49,6 +49,7 @@ class CloudRunServiceToContainerRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
+# DEPRECATED: replaced by WORKLOAD_PARENT, will be removed in v1.0.0
 @dataclass(frozen=True)
 class CloudRunServiceToContainerRel(CartographyRelSchema):
     target_node_label: str = "GCPCloudRunService"
@@ -59,6 +60,27 @@ class CloudRunServiceToContainerRel(CartographyRelSchema):
     rel_label: str = "CONTAINS"
     properties: CloudRunServiceToContainerRelProperties = (
         CloudRunServiceToContainerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class CloudRunServiceContainerToServiceWorkloadParentRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:GCPCloudRunServiceContainer)-[:WORKLOAD_PARENT]->(:GCPCloudRunService)
+class CloudRunServiceContainerToServiceWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "GCPCloudRunService"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("service_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: CloudRunServiceContainerToServiceWorkloadParentRelProperties = (
+        CloudRunServiceContainerToServiceWorkloadParentRelProperties()
     )
 
 
@@ -153,6 +175,7 @@ class GCPCloudRunServiceContainerSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             CloudRunServiceToContainerRel(),
+            CloudRunServiceContainerToServiceWorkloadParentRel(),
             CloudRunServiceContainerToECRImageRel(),
             CloudRunServiceContainerToGitLabContainerImageRel(),
             CloudRunServiceContainerToArtifactRegistryContainerImageRel(),

--- a/cartography/models/kubernetes/containers.py
+++ b/cartography/models/kubernetes/containers.py
@@ -64,6 +64,7 @@ class KubernetesContainerToKubernetesNamespaceRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+# DEPRECATED: replaced by WORKLOAD_PARENT, will be removed in v1.0.0
 # (:KubernetesContainer)<-[:CONTAINS]-(:KubernetesPod)
 class KubernetesContainerToKubernetesPodRel(CartographyRelSchema):
     target_node_label: str = "KubernetesPod"
@@ -78,6 +79,31 @@ class KubernetesContainerToKubernetesPodRel(CartographyRelSchema):
     rel_label: str = "CONTAINS"
     properties: KubernetesContainerToKubernetesPodRelProperties = (
         KubernetesContainerToKubernetesPodRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesContainerToKubernetesPodWorkloadParentRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesContainer)-[:WORKLOAD_PARENT]->(:KubernetesPod)
+class KubernetesContainerToKubernetesPodWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesPod"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "cluster_name": PropertyRef("CLUSTER_NAME", set_in_kwargs=True),
+            "namespace": PropertyRef("namespace"),
+            "id": PropertyRef("pod_id"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: KubernetesContainerToKubernetesPodWorkloadParentRelProperties = (
+        KubernetesContainerToKubernetesPodWorkloadParentRelProperties()
     )
 
 
@@ -201,6 +227,7 @@ class KubernetesContainerSchema(CartographyNodeSchema):
         [
             KubernetesContainerToKubernetesNamespaceRel(),
             KubernetesContainerToKubernetesPodRel(),
+            KubernetesContainerToKubernetesPodWorkloadParentRel(),
             KubernetesContainerToECRImageRel(),
             KubernetesContainerToGitLabContainerImageRel(),
             KubernetesContainerToGCPArtifactRegistryContainerImageRel(),

--- a/cartography/models/kubernetes/namespaces.py
+++ b/cartography/models/kubernetes/namespaces.py
@@ -3,10 +3,12 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -43,9 +45,36 @@ class KubernetesNamespaceToKubernetesClusterRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class KubernetesNamespaceToKubernetesClusterWorkloadParentRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesNamespace)-[:WORKLOAD_PARENT]->(:KubernetesCluster)
+class KubernetesNamespaceToKubernetesClusterWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("CLUSTER_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: KubernetesNamespaceToKubernetesClusterWorkloadParentRelProperties = (
+        KubernetesNamespaceToKubernetesClusterWorkloadParentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class KubernetesNamespaceSchema(CartographyNodeSchema):
     label: str = "KubernetesNamespace"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeNamespace"])
     properties: KubernetesNamespaceNodeProperties = KubernetesNamespaceNodeProperties()
     sub_resource_relationship: KubernetesNamespaceToKubernetesClusterRel = (
         KubernetesNamespaceToKubernetesClusterRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            KubernetesNamespaceToKubernetesClusterWorkloadParentRel(),
+        ]
     )

--- a/cartography/models/kubernetes/pods.py
+++ b/cartography/models/kubernetes/pods.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -34,6 +35,7 @@ class KubernetesPodToKubernetesNamespaceRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
+# DEPRECATED: replaced by WORKLOAD_PARENT, will be removed in v1.0.0
 @dataclass(frozen=True)
 # (:KubernetesPod)<-[:CONTAINS]-(:KubernetesNamespace)
 class KubernetesPodToKubernetesNamespaceRel(CartographyRelSchema):
@@ -48,6 +50,30 @@ class KubernetesPodToKubernetesNamespaceRel(CartographyRelSchema):
     rel_label: str = "CONTAINS"
     properties: KubernetesPodToKubernetesNamespaceRelProperties = (
         KubernetesPodToKubernetesNamespaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesPodToKubernetesNamespaceWorkloadParentRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesPod)-[:WORKLOAD_PARENT]->(:KubernetesNamespace)
+class KubernetesPodToKubernetesNamespaceWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesNamespace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "cluster_name": PropertyRef("CLUSTER_NAME", set_in_kwargs=True),
+            "name": PropertyRef("namespace"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: KubernetesPodToKubernetesNamespaceWorkloadParentRelProperties = (
+        KubernetesPodToKubernetesNamespaceWorkloadParentRelProperties()
     )
 
 
@@ -150,6 +176,7 @@ class KubernetesPodToServiceAccountRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class KubernetesPodSchema(CartographyNodeSchema):
     label: str = "KubernetesPod"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputePod"])
     properties: KubernetesPodNodeProperties = KubernetesPodNodeProperties()
     sub_resource_relationship: KubernetesPodToKubernetesClusterRel = (
         KubernetesPodToKubernetesClusterRel()
@@ -157,6 +184,7 @@ class KubernetesPodSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             KubernetesPodToKubernetesNamespaceRel(),
+            KubernetesPodToKubernetesNamespaceWorkloadParentRel(),
             KubernetesPodToKubernetesNodeRel(),
             KubernetesPodToServiceAccountRel(),
             KubernetesPodToSecretVolumeRel(),

--- a/cartography/models/ontology/mapping/__init__.py
+++ b/cartography/models/ontology/mapping/__init__.py
@@ -13,6 +13,15 @@ from cartography.models.ontology.mapping.data.coderepositories import (
 from cartography.models.ontology.mapping.data.computeinstance import (
     COMPUTE_INSTANCE_ONTOLOGY_MAPPING,
 )
+from cartography.models.ontology.mapping.data.computenamespaces import (
+    COMPUTENAMESPACES_ONTOLOGY_MAPPING,
+)
+from cartography.models.ontology.mapping.data.computepods import (
+    COMPUTEPODS_ONTOLOGY_MAPPING,
+)
+from cartography.models.ontology.mapping.data.computeservices import (
+    COMPUTESERVICES_ONTOLOGY_MAPPING,
+)
 from cartography.models.ontology.mapping.data.containerregistries import (
     CONTAINERREGISTRIES_ONTOLOGY_MAPPING,
 )
@@ -93,6 +102,9 @@ SEMANTIC_LABELS_MAPPING: dict[str, dict[str, OntologyMapping]] = {
     "coderepositories": CODEREPOSITORIES_ONTOLOGY_MAPPING,
     "computeclusters": CLUSTERS_ONTOLOGY_MAPPING,
     "computeinstance": COMPUTE_INSTANCE_ONTOLOGY_MAPPING,
+    "computenamespaces": COMPUTENAMESPACES_ONTOLOGY_MAPPING,
+    "computepods": COMPUTEPODS_ONTOLOGY_MAPPING,
+    "computeservices": COMPUTESERVICES_ONTOLOGY_MAPPING,
     "containers": CONTAINER_ONTOLOGY_MAPPING,
     "containerregistries": CONTAINERREGISTRIES_ONTOLOGY_MAPPING,
     "databases": DATABASES_ONTOLOGY_MAPPING,

--- a/cartography/models/ontology/mapping/data/computenamespaces.py
+++ b/cartography/models/ontology/mapping/data/computenamespaces.py
@@ -1,0 +1,26 @@
+# Ontology mapping for the ComputeNamespace semantic label.
+#
+# _ont_name - The display name of the namespace.
+# _ont_status - Current lifecycle phase of the namespace (e.g., Active, Terminating).
+from cartography.models.ontology.mapping.specs import OntologyFieldMapping
+from cartography.models.ontology.mapping.specs import OntologyMapping
+from cartography.models.ontology.mapping.specs import OntologyNodeMapping
+
+kubernetes_mapping = OntologyMapping(
+    module_name="kubernetes",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="KubernetesNamespace",
+            fields=[
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(
+                    ontology_field="status", node_field="status_phase"
+                ),
+            ],
+        ),
+    ],
+)
+
+COMPUTENAMESPACES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
+    "kubernetes": kubernetes_mapping,
+}

--- a/cartography/models/ontology/mapping/data/computepods.py
+++ b/cartography/models/ontology/mapping/data/computepods.py
@@ -16,9 +16,7 @@ aws_ecs_mapping = OntologyMapping(
             fields=[
                 # name: ECS tasks have no human-readable name field; the closest
                 # identifier is the task ARN, already exposed as `id` / `arn`.
-                OntologyFieldMapping(
-                    ontology_field="status", node_field="last_status"
-                ),
+                OntologyFieldMapping(ontology_field="status", node_field="last_status"),
                 # namespace: Not applicable for ECS (AWS does not use namespaces).
                 # node: ECS surfaces a container-instance ARN rather than a node
                 # name, which would not match the cross-provider semantics.

--- a/cartography/models/ontology/mapping/data/computepods.py
+++ b/cartography/models/ontology/mapping/data/computepods.py
@@ -1,0 +1,52 @@
+# Ontology mapping for the ComputePod semantic label.
+#
+# _ont_name - The display name of the pod / task.
+# _ont_status - Current runtime status of the pod / task.
+# _ont_namespace - Namespace the pod runs in (where applicable).
+# _ont_node - Node or host the pod is scheduled on (where applicable).
+from cartography.models.ontology.mapping.specs import OntologyFieldMapping
+from cartography.models.ontology.mapping.specs import OntologyMapping
+from cartography.models.ontology.mapping.specs import OntologyNodeMapping
+
+aws_ecs_mapping = OntologyMapping(
+    module_name="aws",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="ECSTask",
+            fields=[
+                # name: ECS tasks have no human-readable name field; the closest
+                # identifier is the task ARN, already exposed as `id` / `arn`.
+                OntologyFieldMapping(
+                    ontology_field="status", node_field="last_status"
+                ),
+                # namespace: Not applicable for ECS (AWS does not use namespaces).
+                # node: ECS surfaces a container-instance ARN rather than a node
+                # name, which would not match the cross-provider semantics.
+            ],
+        ),
+    ],
+)
+
+kubernetes_mapping = OntologyMapping(
+    module_name="kubernetes",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="KubernetesPod",
+            fields=[
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(
+                    ontology_field="status", node_field="status_phase"
+                ),
+                OntologyFieldMapping(
+                    ontology_field="namespace", node_field="namespace"
+                ),
+                OntologyFieldMapping(ontology_field="node", node_field="node"),
+            ],
+        ),
+    ],
+)
+
+COMPUTEPODS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
+    "aws_ecs": aws_ecs_mapping,
+    "kubernetes": kubernetes_mapping,
+}

--- a/cartography/models/ontology/mapping/data/computepods.py
+++ b/cartography/models/ontology/mapping/data/computepods.py
@@ -44,7 +44,25 @@ kubernetes_mapping = OntologyMapping(
     ],
 )
 
+azure_aci_mapping = OntologyMapping(
+    module_name="azure",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="AzureGroupContainer",
+            fields=[
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(
+                    ontology_field="status", node_field="provisioning_state"
+                ),
+                # namespace: Not applicable for Azure Container Instances.
+                # node: ACI does not surface a node / host identifier.
+            ],
+        ),
+    ],
+)
+
 COMPUTEPODS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws_ecs": aws_ecs_mapping,
     "kubernetes": kubernetes_mapping,
+    "azure_aci": azure_aci_mapping,
 }

--- a/cartography/models/ontology/mapping/data/computeservices.py
+++ b/cartography/models/ontology/mapping/data/computeservices.py
@@ -51,25 +51,8 @@ gcp_cloudrun_job_mapping = OntologyMapping(
     ],
 )
 
-azure_aci_mapping = OntologyMapping(
-    module_name="azure",
-    nodes=[
-        OntologyNodeMapping(
-            node_label="AzureGroupContainer",
-            fields=[
-                OntologyFieldMapping(ontology_field="name", node_field="name"),
-                OntologyFieldMapping(ontology_field="region", node_field="location"),
-                OntologyFieldMapping(
-                    ontology_field="status", node_field="provisioning_state"
-                ),
-            ],
-        ),
-    ],
-)
-
 COMPUTESERVICES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws_ecs": aws_ecs_mapping,
     "gcp_cloudrun_service": gcp_cloudrun_service_mapping,
     "gcp_cloudrun_job": gcp_cloudrun_job_mapping,
-    "azure_aci": azure_aci_mapping,
 }

--- a/cartography/models/ontology/mapping/data/computeservices.py
+++ b/cartography/models/ontology/mapping/data/computeservices.py
@@ -1,0 +1,75 @@
+# Ontology mapping for the ComputeService semantic label.
+#
+# _ont_name - The display name of the service / orchestrator.
+# _ont_region - The region or location where the service is deployed.
+# _ont_status - Current provisioning or operational status of the service.
+from cartography.models.ontology.mapping.specs import OntologyFieldMapping
+from cartography.models.ontology.mapping.specs import OntologyMapping
+from cartography.models.ontology.mapping.specs import OntologyNodeMapping
+
+aws_ecs_mapping = OntologyMapping(
+    module_name="aws",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="ECSService",
+            fields=[
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(ontology_field="region", node_field="region"),
+                OntologyFieldMapping(ontology_field="status", node_field="status"),
+            ],
+        ),
+    ],
+)
+
+gcp_cloudrun_service_mapping = OntologyMapping(
+    module_name="gcp",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="GCPCloudRunService",
+            fields=[
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(ontology_field="region", node_field="location"),
+                # status: GCPCloudRunService does not surface a single provisioning
+                # status field; revision-level state lives on GCPCloudRunRevision.
+            ],
+        ),
+    ],
+)
+
+gcp_cloudrun_job_mapping = OntologyMapping(
+    module_name="gcp",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="GCPCloudRunJob",
+            fields=[
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(ontology_field="region", node_field="location"),
+                # status: GCPCloudRunJob does not surface a single provisioning
+                # status field; per-execution state lives on GCPCloudRunExecution.
+            ],
+        ),
+    ],
+)
+
+azure_aci_mapping = OntologyMapping(
+    module_name="azure",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="AzureGroupContainer",
+            fields=[
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(ontology_field="region", node_field="location"),
+                OntologyFieldMapping(
+                    ontology_field="status", node_field="provisioning_state"
+                ),
+            ],
+        ),
+    ],
+)
+
+COMPUTESERVICES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
+    "aws_ecs": aws_ecs_mapping,
+    "gcp_cloudrun_service": gcp_cloudrun_service_mapping,
+    "gcp_cloudrun_job": gcp_cloudrun_job_mapping,
+    "azure_aci": azure_aci_mapping,
+}

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -4926,7 +4926,7 @@ Representation of an AWS ECS [Container Instance](https://docs.aws.amazon.com/Am
 
 Representation of an AWS ECS [Service](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Service.html)
 
-> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for compute orchestrators across different systems (e.g., KubernetesService, GCPCloudRunService, AzureGroupContainer).
+> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for compute orchestrators across different systems (e.g., GCPCloudRunService, GCPCloudRunJob).
 
 | Field | Description |
 |-------|-------------|
@@ -5071,7 +5071,7 @@ Representation of an AWS ECS [Container Definition](https://docs.aws.amazon.com/
 
 Representation of an AWS ECS [Task](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Task.html)
 
-> **Ontology Mapping**: This node has the extra label `ComputePod` to enable cross-platform queries for the smallest schedulable workload unit across different systems (e.g., KubernetesPod).
+> **Ontology Mapping**: This node has the extra label `ComputePod` to enable cross-platform queries for the smallest schedulable workload unit across different systems (e.g., KubernetesPod, AzureGroupContainer).
 
 | Field | Description |
 |-------|-------------|

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -4926,6 +4926,8 @@ Representation of an AWS ECS [Container Instance](https://docs.aws.amazon.com/Am
 
 Representation of an AWS ECS [Service](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Service.html)
 
+> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for compute orchestrators across different systems (e.g., KubernetesService, GCPCloudRunService, AzureGroupContainer).
+
 | Field | Description |
 |-------|-------------|
 | firstseen| Timestamp of when a sync job first discovered this node  |
@@ -4957,14 +4959,19 @@ Representation of an AWS ECS [Service](https://docs.aws.amazon.com/AmazonECS/lat
 
 #### Relationships
 
-- An ECSCluster has ECSService
+- An ECSCluster has ECSService (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
     ```
     (:ECSCluster)-[:HAS_SERVICE]->(:ECSService)
     ```
 
-- An ECSService has ECSTasks
+- An ECSService has ECSTasks (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
     ```
     (:ECSService)-[:HAS_TASK]->(:ECSTask)
+    ```
+
+- An ECSService points at its parent cluster via the unified workload chain.
+    ```
+    (:ECSService)-[:WORKLOAD_PARENT]->(:ECSCluster)
     ```
 
 ### ECSTaskDefinition
@@ -5064,6 +5071,8 @@ Representation of an AWS ECS [Container Definition](https://docs.aws.amazon.com/
 
 Representation of an AWS ECS [Task](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Task.html)
 
+> **Ontology Mapping**: This node has the extra label `ComputePod` to enable cross-platform queries for the smallest schedulable workload unit across different systems (e.g., KubernetesPod).
+
 | Field | Description |
 |-------|-------------|
 | firstseen| Timestamp of when a sync job first discovered this node  |
@@ -5109,7 +5118,7 @@ Representation of an AWS ECS [Task](https://docs.aws.amazon.com/AmazonECS/latest
     (:AWSAccount)-[:RESOURCE]->(:ECSTask)
     ```
 
-- ECSClusters have ECSTasks
+- ECSClusters have ECSTasks (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
     ```
     (:ECSCluster)-[:HAS_TASK]->(:ECSTask)
     ```
@@ -5127,6 +5136,12 @@ Representation of an AWS ECS [Task](https://docs.aws.amazon.com/AmazonECS/latest
 - ECSTasks in awsvpc network mode have NetworkInterfaces
     ```
     (:ECSTask)-[:NETWORK_INTERFACE]->(:NetworkInterface)
+    ```
+
+- ECSTasks point at their parent in the unified workload chain. Service-attached tasks point at the ECSService; standalone tasks point directly at the ECSCluster.
+    ```
+    (:ECSTask)-[:WORKLOAD_PARENT]->(:ECSService)
+    (:ECSTask)-[:WORKLOAD_PARENT]->(:ECSCluster)
     ```
 
 ### ECSContainer
@@ -5162,9 +5177,14 @@ Representation of an AWS ECS [Container](https://docs.aws.amazon.com/AmazonECS/l
 
 #### Relationships
 
-- ECSTasks have ECSContainers
+- ECSTasks have ECSContainers (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
     ```
     (:ECSTask)-[:HAS_CONTAINER]->(:ECSContainer)
+    ```
+
+- ECSContainers point at their parent ECSTask via the unified workload chain.
+    ```
+    (:ECSContainer)-[:WORKLOAD_PARENT]->(:ECSTask)
     ```
 
 - ECSContainers have images. HAS_IMAGE edges are created at ingest time by matching the container's runtime `imageDigest` against image nodes from every supported registry.

--- a/docs/root/modules/azure/schema.md
+++ b/docs/root/modules/azure/schema.md
@@ -1911,7 +1911,7 @@ Representation of an [Azure Kubernetes Service Agent Pool](https://learn.microso
 
 Representation of an [Azure Container Group](https://learn.microsoft.com/en-us/rest/api/container-instances/container-groups/get). In Azure's API this resource is a *container group* that holds one or more individual containers (modeled as [AzureContainerInstance](#azurecontainerinstance)) — analogous to an ECS Task or Kubernetes Pod rather than an individual container.
 
-> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for compute orchestrators across different systems (e.g., `ECSService`, `GCPCloudRunService`, `GCPCloudRunJob`).
+> **Ontology Mapping**: This node has the extra label `ComputePod` to enable cross-platform queries for the smallest schedulable workload unit (a co-scheduled, co-located group of containers sharing network and storage) across different systems (e.g., `KubernetesPod`, `ECSTask`). An ACI container group matches Kubernetes Pod semantics, not those of a service / orchestrator.
 
 |**id**| The full resource ID of the Container Group. |
 |name| The name of the Container Group. |

--- a/docs/root/modules/azure/schema.md
+++ b/docs/root/modules/azure/schema.md
@@ -1911,6 +1911,8 @@ Representation of an [Azure Kubernetes Service Agent Pool](https://learn.microso
 
 Representation of an [Azure Container Group](https://learn.microsoft.com/en-us/rest/api/container-instances/container-groups/get). In Azure's API this resource is a *container group* that holds one or more individual containers (modeled as [AzureContainerInstance](#azurecontainerinstance)) — analogous to an ECS Task or Kubernetes Pod rather than an individual container.
 
+> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for compute orchestrators across different systems (e.g., `ECSService`, `GCPCloudRunService`, `GCPCloudRunJob`).
+
 |**id**| The full resource ID of the Container Group. |
 |name| The name of the Container Group. |
 |location| The Azure region where the Container Group is deployed. |
@@ -1934,7 +1936,7 @@ Representation of an [Azure Container Group](https://learn.microsoft.com/en-us/r
     ```cypher
     (AzureGroupContainer)-[:ATTACHED_TO]->(:AzureSubnet)
     ```
-- An Azure Container Group contains one or more AzureContainerInstances.
+- An Azure Container Group contains one or more AzureContainerInstances. (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
     ```cypher
     (AzureGroupContainer)-[:CONTAINS]->(:AzureContainerInstance)
     ```
@@ -1969,9 +1971,13 @@ Representation of an individual container within an [Azure Container Group](http
     ```cypher
     (AzureSubscription)-[:RESOURCE]->(:AzureContainerInstance)
     ```
-- An Azure Container Group contains its AzureContainerInstances.
+- An Azure Container Group contains its AzureContainerInstances. (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
     ```cypher
     (AzureGroupContainer)-[:CONTAINS]->(:AzureContainerInstance)
+    ```
+- An AzureContainerInstance points at its parent AzureGroupContainer via the unified workload chain.
+    ```cypher
+    (:AzureContainerInstance)-[:WORKLOAD_PARENT]->(:AzureGroupContainer)
     ```
 - AzureContainerInstances are linked to the image they run when the image is pinned by digest.
     ```cypher

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -1929,7 +1929,7 @@ graph LR
 
 Representation of a GCP [Cloud Run Service](https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.services).
 
-> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for compute orchestrators across different systems (e.g., `ECSService`, `GCPCloudRunJob`, `AzureGroupContainer`). Its child `GCPCloudRunServiceContainer` nodes carry `:Container` and `HAS_IMAGE`.
+> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for compute orchestrators across different systems (e.g., `ECSService`, `GCPCloudRunJob`). Its child `GCPCloudRunServiceContainer` nodes carry `:Container` and `HAS_IMAGE`.
 
 | Field | Description |
 |---|---|
@@ -2001,7 +2001,7 @@ Representation of a GCP [Cloud Run Revision](https://cloud.google.com/run/docs/r
 
 Representation of a GCP [Cloud Run Job](https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.jobs). The Job is a pure grouping node: image references, digests, architecture and the `:Container` ontology label live on the child [GCPCloudRunJobContainer](#gcpcloudrunjobcontainer) nodes, analogous to `ECSTask` / `ECSContainer` in AWS.
 
-> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for compute orchestrators across different systems (e.g., `ECSService`, `GCPCloudRunService`, `AzureGroupContainer`).
+> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for compute orchestrators across different systems (e.g., `ECSService`, `GCPCloudRunService`).
 
 | Field | Description |
 |---|---|

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -1946,7 +1946,7 @@ Representation of a GCP [Cloud Run Service](https://cloud.google.com/run/docs/re
 | exposed_internet | Set to `true` if `ingress` is `INGRESS_TRAFFIC_ALL`. Set to `false` if `ingress` is `INGRESS_TRAFFIC_INTERNAL_ONLY` or `INGRESS_TRAFFIC_NONE`. Other values are currently left unset because they may still be internet-reachable via load balancers. |
 | exposed_internet_type | Set to `'direct'` when the service allows all ingress traffic. |
 
-Cloud Run Service is treated as an orchestrator (analogous to `ECSService`) and carries no ontology label of its own. The container specs from the `latestReadyRevision` (returned inline in `service.template.containers`) are materialized as child `GCPCloudRunServiceContainer` nodes that carry `:Container` and `HAS_IMAGE`. Older revisions are tracked as pure metadata via `GCPCloudRunRevision`, with no image data attached.
+Cloud Run Service is treated as an orchestrator (analogous to `ECSService`) and carries the `:ComputeService` semantic label. The container specs from the `latestReadyRevision` (returned inline in `service.template.containers`) are materialized as child `GCPCloudRunServiceContainer` nodes that carry `:Container` and `HAS_IMAGE`. Older revisions are tracked as pure metadata via `GCPCloudRunRevision`, with no image data attached.
 
 #### Relationships
 

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -1929,7 +1929,7 @@ graph LR
 
 Representation of a GCP [Cloud Run Service](https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.services).
 
-> **Ontology Mapping**: This node carries no ontology label of its own. Cloud Run Service is an orchestrator (analogous to `ECSService`); its child `GCPCloudRunServiceContainer` nodes carry `:Container` and HAS_IMAGE.
+> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for compute orchestrators across different systems (e.g., `ECSService`, `GCPCloudRunJob`, `AzureGroupContainer`). Its child `GCPCloudRunServiceContainer` nodes carry `:Container` and `HAS_IMAGE`.
 
 | Field | Description |
 |---|---|
@@ -1962,7 +1962,7 @@ Cloud Run Service is treated as an orchestrator (analogous to `ECSService`) and 
     ```
     (GCPCloudRunService)-[:USES_SERVICE_ACCOUNT]->(GCPServiceAccount)
     ```
-  - GCPCloudRunServices contain one GCPCloudRunServiceContainer per container declared in the `latestReadyRevision` spec (including sidecars).
+  - GCPCloudRunServices contain one GCPCloudRunServiceContainer per container declared in the `latestReadyRevision` spec (including sidecars). (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
     ```
     (GCPCloudRunService)-[:CONTAINS]->(GCPCloudRunServiceContainer)
     ```
@@ -2001,6 +2001,8 @@ Representation of a GCP [Cloud Run Revision](https://cloud.google.com/run/docs/r
 
 Representation of a GCP [Cloud Run Job](https://cloud.google.com/run/docs/reference/rest/v2/projects.locations.jobs). The Job is a pure grouping node: image references, digests, architecture and the `:Container` ontology label live on the child [GCPCloudRunJobContainer](#gcpcloudrunjobcontainer) nodes, analogous to `ECSTask` / `ECSContainer` in AWS.
 
+> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for compute orchestrators across different systems (e.g., `ECSService`, `GCPCloudRunService`, `AzureGroupContainer`).
+
 | Field | Description |
 |---|---|
 | firstseen | Timestamp of when a sync job first discovered this node |
@@ -2025,7 +2027,7 @@ Representation of a GCP [Cloud Run Job](https://cloud.google.com/run/docs/refere
     ```
     (GCPCloudRunJob)-[:USES_SERVICE_ACCOUNT]->(GCPServiceAccount)
     ```
-  - GCPCloudRunJobs contain one GCPCloudRunJobContainer per container declared in the task template (including sidecars).
+  - GCPCloudRunJobs contain one GCPCloudRunJobContainer per container declared in the task template (including sidecars). (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
     ```
     (GCPCloudRunJob)-[:CONTAINS]->(GCPCloudRunJobContainer)
     ```
@@ -2056,9 +2058,13 @@ Representation of an individual container spec from a [Cloud Run Job](https://cl
     ```
     (GCPProject)-[:RESOURCE]->(GCPCloudRunJobContainer)
     ```
-  - GCPCloudRunJobContainers live inside a GCPCloudRunJob.
+  - GCPCloudRunJobContainers live inside a GCPCloudRunJob. (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
     ```
     (GCPCloudRunJob)-[:CONTAINS]->(GCPCloudRunJobContainer)
+    ```
+  - GCPCloudRunJobContainers point at their parent GCPCloudRunJob via the unified workload chain.
+    ```
+    (GCPCloudRunJobContainer)-[:WORKLOAD_PARENT]->(GCPCloudRunJob)
     ```
   - GCPCloudRunJobContainers link to the image they run when the image is pinned by digest.
     ```
@@ -2098,9 +2104,13 @@ Representation of an individual container spec from a [Cloud Run Service](https:
     ```
     (GCPProject)-[:RESOURCE]->(GCPCloudRunServiceContainer)
     ```
-  - GCPCloudRunServiceContainers live inside a GCPCloudRunService (sourced from the `latestReadyRevision` spec).
+  - GCPCloudRunServiceContainers live inside a GCPCloudRunService (sourced from the `latestReadyRevision` spec). (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
     ```
     (GCPCloudRunService)-[:CONTAINS]->(GCPCloudRunServiceContainer)
+    ```
+  - GCPCloudRunServiceContainers point at their parent GCPCloudRunService via the unified workload chain.
+    ```
+    (GCPCloudRunServiceContainer)-[:WORKLOAD_PARENT]->(GCPCloudRunService)
     ```
   - GCPCloudRunServiceContainers link to the image they run when the image is pinned by digest.
     ```

--- a/docs/root/modules/kubernetes/schema.md
+++ b/docs/root/modules/kubernetes/schema.md
@@ -127,7 +127,7 @@ Representation of a [Kubernetes Namespace.](https://kubernetes.io/docs/concepts/
 ### KubernetesPod
 Representation of a [Kubernetes Pod.](https://kubernetes.io/docs/concepts/workloads/pods/)
 
-> **Ontology Mapping**: This node has the extra label `ComputePod` to enable cross-platform queries for the smallest schedulable workload unit across different systems (e.g., ECSTask).
+> **Ontology Mapping**: This node has the extra label `ComputePod` to enable cross-platform queries for the smallest schedulable workload unit across different systems (e.g., ECSTask, AzureGroupContainer).
 
 | Field | Description |
 |-------|-------------|

--- a/docs/root/modules/kubernetes/schema.md
+++ b/docs/root/modules/kubernetes/schema.md
@@ -91,6 +91,8 @@ Representation of a [Kubernetes Node.](https://kubernetes.io/docs/concepts/archi
 ### KubernetesNamespace
 Representation of a [Kubernetes Namespace.](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)
 
+> **Ontology Mapping**: This node has the extra label `ComputeNamespace` to enable cross-platform queries for workload-isolation scopes across different systems.
+
 | Field | Description |
 |-------|-------------|
 | **id** | UID of the Kubernetes namespace |
@@ -116,9 +118,16 @@ Representation of a [Kubernetes Namespace.](https://kubernetes.io/docs/concepts/
                                          ...)
     ```
 
+- `KubernetesNamespace` points at its parent `KubernetesCluster` via the unified workload chain.
+    ```
+    (:KubernetesNamespace)-[:WORKLOAD_PARENT]->(:KubernetesCluster)
+    ```
+
 
 ### KubernetesPod
 Representation of a [Kubernetes Pod.](https://kubernetes.io/docs/concepts/workloads/pods/)
+
+> **Ontology Mapping**: This node has the extra label `ComputePod` to enable cross-platform queries for the smallest schedulable workload unit across different systems (e.g., ECSTask).
 
 | Field | Description |
 |-------|-------------|
@@ -144,9 +153,19 @@ Representation of a [Kubernetes Pod.](https://kubernetes.io/docs/concepts/worklo
     (:KubernetesPod)-[:USES_SERVICE_ACCOUNT]->(:KubernetesServiceAccount)
     ```
 
-- `KubernetesPod` has `KubernetesContainer`.
+- `KubernetesPod` has `KubernetesContainer`. (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
     ```
     (:KubernetesPod)-[:CONTAINS]->(:KubernetesContainer)
+    ```
+
+- A `KubernetesNamespace` contains a `KubernetesPod`. (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
+    ```
+    (:KubernetesNamespace)-[:CONTAINS]->(:KubernetesPod)
+    ```
+
+- `KubernetesPod` points at its parent `KubernetesNamespace` via the unified workload chain.
+    ```
+    (:KubernetesPod)-[:WORKLOAD_PARENT]->(:KubernetesNamespace)
     ```
 
 - `KubernetesPod` runs on a `KubernetesNode`. Not created for unscheduled pods.
@@ -189,9 +208,14 @@ Representation of a [Kubernetes Container.](https://kubernetes.io/docs/concepts/
 
 
 #### Relationships
-- `KubernetesPod` has `KubernetesContainer`.
+- `KubernetesPod` has `KubernetesContainer`. (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
     ```
     (:KubernetesPod)-[:CONTAINS]->(:KubernetesContainer)
+    ```
+
+- `KubernetesContainer` points at its parent `KubernetesPod` via the unified workload chain.
+    ```
+    (:KubernetesContainer)-[:WORKLOAD_PARENT]->(:KubernetesPod)
     ```
 
 - `KubernetesContainer` references container images from registries.

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -361,9 +361,9 @@ ComputeService is a semantic label.
 ```
 
 A compute service represents an orchestrator that schedules, scales, and manages a set of workloads.
-It generalizes concepts like AWS ECS services, GCP Cloud Run services and jobs, and Azure Container Groups.
+It generalizes concepts like AWS ECS services and GCP Cloud Run services and jobs.
 
-`ComputeService` participates in the unified workload chain as the parent of workload nodes. Its position depends on the provider: in cluster-backed providers (AWS ECS) it sits between `ComputeCluster` and `ComputePod`, while in serverless providers (GCP Cloud Run, Azure Container Instances) it is the top-of-chain terminus reached directly by `:Container` nodes.
+`ComputeService` participates in the unified workload chain as the parent of workload nodes. Its position depends on the provider: in cluster-backed providers (AWS ECS) it sits between `ComputeCluster` and `ComputePod`, while in serverless providers like GCP Cloud Run it is the top-of-chain terminus reached directly by `:Container` nodes.
 
 | Field | Description |
 |-------|-------------|
@@ -417,7 +417,7 @@ ComputePod is a semantic label.
 ```
 
 A compute pod represents the smallest schedulable workload unit on a compute platform: a co-scheduled, co-located group of containers sharing network and storage.
-It generalizes concepts like Kubernetes Pods and AWS ECS Tasks.
+It generalizes concepts like Kubernetes Pods, AWS ECS Tasks, and Azure Container Instance container groups.
 
 | Field | Description |
 |-------|-------------|
@@ -432,7 +432,7 @@ It generalizes concepts like Kubernetes Pods and AWS ECS Tasks.
     ```
     (:Container)-[:WORKLOAD_PARENT]->(:ComputePod)
     ```
-- `ComputePod` points at its parent in the unified workload chain. Depending on the provider this is a `ComputeService` (ECS task attached to a service), a `ComputeNamespace` (Kubernetes pod), or directly a `ComputeCluster` (standalone ECS task).
+- `ComputePod` points at its parent in the unified workload chain. Depending on the provider this is a `ComputeService` (ECS task attached to a service), a `ComputeNamespace` (Kubernetes pod), or directly a `ComputeCluster` (standalone ECS task). In serverless providers like Azure Container Instances, the pod is the top-of-chain terminus and has no `WORKLOAD_PARENT` outgoing.
     ```
     (:ComputePod)-[:WORKLOAD_PARENT]->(:ComputeService)
     (:ComputePod)-[:WORKLOAD_PARENT]->(:ComputeNamespace)

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -16,6 +16,14 @@ CERT{{Certificate}}
 LB{{LoadBalancer}} -- EXPOSE --> CI{{ComputeInstance}}
 LB{{LoadBalancer}} -- EXPOSE --> CT{{Container}}
 CL{{ComputeCluster}}
+CS{{ComputeService}}
+CNS{{ComputeNamespace}}
+CP{{ComputePod}}
+CT -- WORKLOAD_PARENT --> CP
+CP -- WORKLOAD_PARENT --> CS
+CP -- WORKLOAD_PARENT --> CNS
+CS -- WORKLOAD_PARENT --> CL
+CNS -- WORKLOAD_PARENT --> CL
 DB{{Database}}
 DZ{{DNSZone}}
 OS{{ObjectStorage}}
@@ -342,6 +350,46 @@ It generalizes concepts like AWS EKS clusters, AWS ECS clusters, AWS EMR cluster
 | _ont_version | The version of the cluster engine (e.g., Kubernetes version, EMR release label). |
 | _ont_endpoint | The API endpoint or FQDN for the cluster. |
 | _ont_status | The current status of the cluster (e.g., ACTIVE, RUNNING, Succeeded). |
+
+
+### ComputeService
+
+```{note}
+ComputeService is a semantic label.
+```
+
+A compute service represents an orchestrator that schedules, scales, and manages a set of workloads.
+It generalizes concepts like AWS ECS services, GCP Cloud Run services and jobs, and Azure Container Groups.
+
+`ComputeService` sits between `ComputeCluster` and `ComputePod` in the unified workload chain. Walk the chain with the `WORKLOAD_PARENT` relationship:
+
+```
+(:Container)-[:WORKLOAD_PARENT*1..]->(parent)
+```
+
+
+### ComputeNamespace
+
+```{note}
+ComputeNamespace is a semantic label.
+```
+
+A compute namespace represents a workload-isolation scope within a `ComputeCluster`.
+Today it generalizes the Kubernetes Namespace concept; other providers may join when an analogous scope is modeled.
+
+`ComputeNamespace` sits between `ComputeCluster` and `ComputePod` in the unified workload chain. Walk the chain with the `WORKLOAD_PARENT` relationship.
+
+
+### ComputePod
+
+```{note}
+ComputePod is a semantic label.
+```
+
+A compute pod represents the smallest schedulable workload unit on a compute platform: a co-scheduled, co-located group of containers sharing network and storage.
+It generalizes concepts like Kubernetes Pods and AWS ECS Tasks.
+
+`ComputePod` is the parent of one or more `:Container` nodes in the unified workload chain. Walk upward with `WORKLOAD_PARENT` to reach the enclosing service, namespace, or cluster.
 
 
 ### ThirdPartyApp

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -367,6 +367,12 @@ It generalizes concepts like AWS ECS services, GCP Cloud Run services and jobs, 
 (:Container)-[:WORKLOAD_PARENT*1..]->(parent)
 ```
 
+| Field | Description |
+|-------|-------------|
+| _ont_name | The display name of the service / orchestrator. |
+| _ont_region | The region or location where the service is deployed. |
+| _ont_status | Current provisioning or operational status of the service (when available from the provider). |
+
 
 ### ComputeNamespace
 
@@ -379,6 +385,11 @@ Today it generalizes the Kubernetes Namespace concept; other providers may join 
 
 `ComputeNamespace` sits between `ComputeCluster` and `ComputePod` in the unified workload chain. Walk the chain with the `WORKLOAD_PARENT` relationship.
 
+| Field | Description |
+|-------|-------------|
+| _ont_name | The display name of the namespace. |
+| _ont_status | Current lifecycle phase of the namespace (e.g., `Active`, `Terminating`). |
+
 
 ### ComputePod
 
@@ -390,6 +401,13 @@ A compute pod represents the smallest schedulable workload unit on a compute pla
 It generalizes concepts like Kubernetes Pods and AWS ECS Tasks.
 
 `ComputePod` is the parent of one or more `:Container` nodes in the unified workload chain. Walk upward with `WORKLOAD_PARENT` to reach the enclosing service, namespace, or cluster.
+
+| Field | Description |
+|-------|-------------|
+| _ont_name | The display name of the pod / task (when the provider exposes one). |
+| _ont_status | Current runtime status of the pod / task (e.g., `Running`, `Pending`). |
+| _ont_namespace | Namespace the pod runs in (Kubernetes only). |
+| _ont_node | Node or host the pod is scheduled on (Kubernetes only). |
 
 
 ### ThirdPartyApp

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -20,8 +20,10 @@ CS{{ComputeService}}
 CNS{{ComputeNamespace}}
 CP{{ComputePod}}
 CT -- WORKLOAD_PARENT --> CP
+CT -- WORKLOAD_PARENT --> CS
 CP -- WORKLOAD_PARENT --> CS
 CP -- WORKLOAD_PARENT --> CNS
+CP -- WORKLOAD_PARENT --> CL
 CS -- WORKLOAD_PARENT --> CL
 CNS -- WORKLOAD_PARENT --> CL
 DB{{Database}}
@@ -361,17 +363,25 @@ ComputeService is a semantic label.
 A compute service represents an orchestrator that schedules, scales, and manages a set of workloads.
 It generalizes concepts like AWS ECS services, GCP Cloud Run services and jobs, and Azure Container Groups.
 
-`ComputeService` sits between `ComputeCluster` and `ComputePod` in the unified workload chain. Walk the chain with the `WORKLOAD_PARENT` relationship:
-
-```
-(:Container)-[:WORKLOAD_PARENT*1..]->(parent)
-```
+`ComputeService` participates in the unified workload chain as the parent of workload nodes. Its position depends on the provider: in cluster-backed providers (AWS ECS) it sits between `ComputeCluster` and `ComputePod`, while in serverless providers (GCP Cloud Run, Azure Container Instances) it is the top-of-chain terminus reached directly by `:Container` nodes.
 
 | Field | Description |
 |-------|-------------|
 | _ont_name | The display name of the service / orchestrator. |
 | _ont_region | The region or location where the service is deployed. |
 | _ont_status | Current provisioning or operational status of the service (when available from the provider). |
+
+#### Relationships
+
+- `ComputeService` points at its parent `ComputeCluster` when one exists (AWS ECS).
+    ```
+    (:ComputeService)-[:WORKLOAD_PARENT]->(:ComputeCluster)
+    ```
+- A workload (`ComputePod` or, in serverless providers, `:Container` directly) points at its parent `ComputeService`.
+    ```
+    (:ComputePod)-[:WORKLOAD_PARENT]->(:ComputeService)
+    (:Container)-[:WORKLOAD_PARENT]->(:ComputeService)
+    ```
 
 
 ### ComputeNamespace
@@ -383,12 +393,21 @@ ComputeNamespace is a semantic label.
 A compute namespace represents a workload-isolation scope within a `ComputeCluster`.
 Today it generalizes the Kubernetes Namespace concept; other providers may join when an analogous scope is modeled.
 
-`ComputeNamespace` sits between `ComputeCluster` and `ComputePod` in the unified workload chain. Walk the chain with the `WORKLOAD_PARENT` relationship.
-
 | Field | Description |
 |-------|-------------|
 | _ont_name | The display name of the namespace. |
 | _ont_status | Current lifecycle phase of the namespace (e.g., `Active`, `Terminating`). |
+
+#### Relationships
+
+- `ComputeNamespace` points at its parent `ComputeCluster`.
+    ```
+    (:ComputeNamespace)-[:WORKLOAD_PARENT]->(:ComputeCluster)
+    ```
+- A `ComputePod` in a namespaced provider points at its enclosing `ComputeNamespace`.
+    ```
+    (:ComputePod)-[:WORKLOAD_PARENT]->(:ComputeNamespace)
+    ```
 
 
 ### ComputePod
@@ -400,14 +419,25 @@ ComputePod is a semantic label.
 A compute pod represents the smallest schedulable workload unit on a compute platform: a co-scheduled, co-located group of containers sharing network and storage.
 It generalizes concepts like Kubernetes Pods and AWS ECS Tasks.
 
-`ComputePod` is the parent of one or more `:Container` nodes in the unified workload chain. Walk upward with `WORKLOAD_PARENT` to reach the enclosing service, namespace, or cluster.
-
 | Field | Description |
 |-------|-------------|
 | _ont_name | The display name of the pod / task (when the provider exposes one). |
 | _ont_status | Current runtime status of the pod / task (e.g., `Running`, `Pending`). |
 | _ont_namespace | Namespace the pod runs in (Kubernetes only). |
 | _ont_node | Node or host the pod is scheduled on (Kubernetes only). |
+
+#### Relationships
+
+- A `:Container` points at its parent `ComputePod` in cluster-backed providers (AWS ECS, Kubernetes).
+    ```
+    (:Container)-[:WORKLOAD_PARENT]->(:ComputePod)
+    ```
+- `ComputePod` points at its parent in the unified workload chain. Depending on the provider this is a `ComputeService` (ECS task attached to a service), a `ComputeNamespace` (Kubernetes pod), or directly a `ComputeCluster` (standalone ECS task).
+    ```
+    (:ComputePod)-[:WORKLOAD_PARENT]->(:ComputeService)
+    (:ComputePod)-[:WORKLOAD_PARENT]->(:ComputeNamespace)
+    (:ComputePod)-[:WORKLOAD_PARENT]->(:ComputeCluster)
+    ```
 
 
 ### ThirdPartyApp


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary

Introduce a uniform `child -[:WORKLOAD_PARENT]-> parent` relationship across every provider that models a compute workload chain (AWS ECS, Kubernetes, GCP Cloud Run, Azure Container Instances), and tag intermediate nodes with role-distinct ontology labels (`ComputeService`, `ComputeNamespace`, `ComputePod`) joining the existing `ComputeCluster`, `Container`, and `Function` vocabulary.

The goal is to let any consumer walk a workload from leaf to top with a single variable-length Cypher pattern instead of bespoke per-provider queries:

```cypher
MATCH path = (c:Container)-[:WORKLOAD_PARENT*1..6]->(top)
WHERE NOT (top)-[:WORKLOAD_PARENT]->()
RETURN path
```

The new chains wired in this PR:

| Provider | Chain |
|---|---|
| AWS ECS | `ECSContainer -> ECSTask -> ECSService -> ECSCluster` (standalone tasks fall back directly to `ECSCluster`) |
| Kubernetes | `KubernetesContainer -> KubernetesPod -> KubernetesNamespace -> KubernetesCluster` |
| GCP Cloud Run | `GCPCloudRun{Service,Job}Container -> GCPCloudRun{Service,Job}` (serverless: chain stops at the orchestrator) |
| Azure ACI | `AzureContainerInstance -> AzureGroupContainer` (serverless: chain stops at the group) |

Existing chain rels (`HAS_SERVICE`, `HAS_TASK`, `HAS_CONTAINER`, namespace/pod/container `CONTAINS`) stay in place in parallel and are flagged with `# DEPRECATED: replaced by WORKLOAD_PARENT, will be removed in v1.0.0` so consumers have time to migrate.

A few implementation notes:

- For ECS, service-attached tasks chain through the service; standalone tasks chain directly to the cluster. The ECS loader's `transform_ecs_tasks` sets a transient `_workload_parent_cluster_arn` only when the task lacks `serviceName`, gating the cluster matcher so each task gets exactly one `WORKLOAD_PARENT` edge.
- Kubernetes namespace and pod sub-resource `RESOURCE` rels stay untouched because they back scoped cleanup. Only the `CONTAINS` chain rels (`namespace -> pod`, `pod -> container`) are flagged deprecated.
- The PR is split commit-by-commit per provider plus a final ontology doc commit, so reviewers can step through one cloud at a time.


### Related issues or links

- Fixes #


### Breaking changes

None. Legacy chain relationships are kept in parallel and only flagged as deprecated; their removal is deferred to v1.0.0.


### How was this tested?

- `make test_lint` (pre-commit clean: black, isort, flake8, mypy)
- `uv run pytest tests/unit/cartography/intel/{aws,kubernetes,gcp,azure}` -> 450 passed
- `uv run pytest tests/integration/cartography/intel/aws/test_ecs.py tests/integration/cartography/intel/kubernetes/{test_namespaces,test_pods,test_containers}.py tests/integration/cartography/intel/gcp/test_cloudrun.py tests/integration/cartography/intel/azure/{test_container_instances,test_group_containers}.py` -> 28 passed

After re-syncing a tenant with all four providers active, the following Cypher queries should report:

```cypher
// New labels populated
MATCH (n) WHERE n:ComputeService OR n:ComputeNamespace OR n:ComputePod
RETURN labels(n)[0] AS primary, count(*) AS count;
// Expect non-zero counts per active provider.

// New relationship type exists and chains terminate at the right top
MATCH path = (c:Container)-[:WORKLOAD_PARENT*1..6]->(top)
WHERE NOT (top)-[:WORKLOAD_PARENT]->()
RETURN labels(c)[0], labels(top) LIMIT 20;
// Expect ECSContainer/KubernetesContainer chains end at ECSCluster/KubernetesCluster;
// Cloud Run / ACI containers end at their service / group (no cluster).

// Legacy rels still present in parallel
MATCH (s:ECSService)<-[:HAS_SERVICE]-(:ECSCluster) RETURN count(*);
// Expect non-zero. Same for HAS_TASK, HAS_CONTAINER, CONTAINS.
```


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) (per-provider docs + ontology schema doc).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

- The PR is structured as one commit per provider plus a closing ontology doc commit; reviewing one cloud at a time should keep the diff manageable.
- The biggest design call is around ECS tasks with vs. without a service. The transform-side `_workload_parent_cluster_arn` field is the cleanest way I found to keep "exactly one `WORKLOAD_PARENT` per task" without splitting the data into two load passes; happy to revisit if you'd prefer two separate load steps instead.
- Kubernetes namespace/pod sub-resource `RESOURCE` rels are intentionally not deprecated: they back scoped cleanup, and removing them would break the cleanup boundary. Only the `CONTAINS` chain rels are flagged.