### PR TITLE
fix(tailscale): tolerate 404 from Services endpoint

### DIFF
--- a/cartography/intel/tailscale/services.py
+++ b/cartography/intel/tailscale/services.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import Any
 
 import neo4j
@@ -8,6 +9,8 @@ from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.models.tailscale.service import TailscaleServiceSchema
 from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
 
 _TIMEOUT = 30
 
@@ -49,6 +52,13 @@ def get(
         f"{base_url}/tailnet/{org}/services",
         timeout=_TIMEOUT,
     )
+    if req.status_code == 404:
+        logger.warning(
+            "Tailscale Services endpoint returned 404 for tailnet %s; "
+            "skipping (Services may not be enabled for this tailnet).",
+            org,
+        )
+        return []
     req.raise_for_status()
     return req.json()["vipServices"]
 

--- a/tests/unit/cartography/intel/tailscale/test_services.py
+++ b/tests/unit/cartography/intel/tailscale/test_services.py
@@ -1,3 +1,8 @@
+from unittest.mock import MagicMock
+
+import requests
+
+from cartography.intel.tailscale.services import get
 from cartography.intel.tailscale.services import transform
 
 
@@ -31,3 +36,32 @@ def test_transform_adds_prefix_for_bare_service_name() -> None:
 
     assert result[0]["id"] == "svc:web-server"
     assert result[0]["name"] == "web-server"
+
+
+def test_get_returns_empty_list_on_404() -> None:
+    response = MagicMock(spec=requests.Response)
+    response.status_code = 404
+    api_session = MagicMock(spec=requests.Session)
+    api_session.get.return_value = response
+
+    result = get(api_session, "https://api.tailscale.com/api/v2", "example.com")
+
+    assert result == []
+    response.raise_for_status.assert_not_called()
+
+
+def test_get_raises_on_non_404_error() -> None:
+    response = MagicMock(spec=requests.Response)
+    response.status_code = 500
+    response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "500 Server Error",
+        response=response,
+    )
+    api_session = MagicMock(spec=requests.Session)
+    api_session.get.return_value = response
+
+    try:
+        get(api_session, "https://api.tailscale.com/api/v2", "example.com")
+    except requests.exceptions.HTTPError:
+        return
+    raise AssertionError("expected HTTPError to propagate for non-404 status")


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

`GET /api/v2/tailnet/{tailnet}/services` returns `404 Not Found` for tailnets that do not have Tailscale Services (still in public beta, gated behind the `services:read` OAuth scope) enabled. Today, `cartography/intel/tailscale/services.py` calls `raise_for_status()` unconditionally, which propagates the 404 as an `HTTPError` and crashes `start_tailscale_ingestion` before ACLs, grants, and posture resolution can run.

This change treats a 404 from this endpoint as "no Services to ingest for this tailnet": log a warning and return an empty list. Other HTTP errors (auth failures, 5xx, etc.) still raise as before. The endpoint URL and response shape (`{"vipServices": [...]}`) are confirmed against Tailscale's official OpenAPI spec at `https://api.tailscale.com/api/v2?outputOpenapiSchema=true`.

Downstream is already empty-list-safe: `transform([])` returns `[]`, `load_services` and `cleanup` are no-ops, and `grants.sync` accepts an empty `services` list.


### Related issues or links

- Fixes #


### How was this tested?

- New unit tests in `tests/unit/cartography/intel/tailscale/test_services.py`:
  - `test_get_returns_empty_list_on_404` mocks a 404 response and asserts `get(...)` returns `[]` without raising.
  - `test_get_raises_on_non_404_error` mocks a 500 response and asserts the `HTTPError` still propagates (regression guard).
- `make test_unit` (services tests) and pre-commit (`isort`, `black`, `flake8`, `mypy`, `pyupgrade`) pass locally.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.