### PR TITLE
fix(gcp): persist Artifact Registry image platform

### DIFF
--- a/cartography/intel/gcp/artifact_registry/supply_chain.py
+++ b/cartography/intel/gcp/artifact_registry/supply_chain.py
@@ -9,6 +9,7 @@ from google.auth.credentials import Credentials as GoogleCredentials
 from google.auth.transport.requests import Request
 
 from cartography.graph.job import GraphJob
+from cartography.intel.container_arch import normalize_architecture
 from cartography.intel.gcp.artifact_registry.manifest import build_blob_url
 from cartography.intel.gcp.artifact_registry.manifest import build_manifest_url
 from cartography.intel.gcp.artifact_registry.manifest import parse_docker_image_uri
@@ -275,6 +276,14 @@ async def _process_single_image(
     if not config:
         return None, False
 
+    raw_architecture = config.get("architecture")
+    architecture = (
+        normalize_architecture(raw_architecture)
+        if raw_architecture is not None
+        else None
+    )
+    os_name = config.get("os")
+    variant = config.get("variant")
     provenance = extract_provenance_from_oci_config(config)
     fetch_failed = False
 
@@ -302,13 +311,20 @@ async def _process_single_image(
             provenance.update(slsa_provenance)
 
     diff_ids, layer_history = extract_layers_from_oci_config(config)
+    has_platform = any(value is not None for value in (architecture, os_name, variant))
 
-    if not provenance.get("source_uri") and not diff_ids:
+    if not provenance.get("source_uri") and not diff_ids and not has_platform:
         return None, fetch_failed
 
     result: dict[str, Any] = {
         "id": name,
     }
+    if architecture is not None:
+        result["architecture"] = architecture
+    if os_name is not None:
+        result["os"] = os_name
+    if variant is not None:
+        result["variant"] = variant
     if provenance.get("source_uri"):
         result["source_uri"] = provenance["source_uri"]
     if provenance.get("source_revision"):
@@ -527,6 +543,9 @@ def sync(
                 "source_revision": e.get("source_revision"),
                 "source_file": e.get("source_file"),
                 "layer_diff_ids": e.get("layer_diff_ids"),
+                "architecture": e.get("architecture"),
+                "os": e.get("os"),
+                "variant": e.get("variant"),
             }
             for e in enrichments
         ]

--- a/cartography/intel/gcp/artifact_registry/supply_chain.py
+++ b/cartography/intel/gcp/artifact_registry/supply_chain.py
@@ -255,6 +255,11 @@ async def _process_single_image(
     """
     name = artifact.get("name", "")
     uri = artifact.get("uri", "")
+    media_type = artifact.get("mediaType", "")
+
+    if media_type not in SINGLE_IMAGE_MEDIA_TYPES:
+        logger.debug("Skipping OCI config enrichment for non-image artifact %s", name)
+        return None, False
 
     parsed = parse_docker_image_uri(uri)
     if not parsed:

--- a/cartography/models/gcp/artifact_registry/container_image.py
+++ b/cartography/models/gcp/artifact_registry/container_image.py
@@ -169,6 +169,9 @@ class GCPArtifactRegistryContainerImageProvenanceNodeProperties(
 ):
     id: PropertyRef = PropertyRef("id", extra_index=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    architecture: PropertyRef = PropertyRef("architecture")
+    os: PropertyRef = PropertyRef("os")
+    variant: PropertyRef = PropertyRef("variant")
     source_uri: PropertyRef = PropertyRef("source_uri", extra_index=True)
     source_revision: PropertyRef = PropertyRef("source_revision")
     source_file: PropertyRef = PropertyRef("source_file")

--- a/cartography/models/ontology/mapping/data/images.py
+++ b/cartography/models/ontology/mapping/data/images.py
@@ -33,6 +33,10 @@ gcp_mapping = OntologyMapping(
             fields=[
                 OntologyFieldMapping(ontology_field="digest", node_field="digest"),
                 OntologyFieldMapping(ontology_field="uri", node_field="uri"),
+                OntologyFieldMapping(
+                    ontology_field="architecture", node_field="architecture"
+                ),
+                OntologyFieldMapping(ontology_field="os", node_field="os"),
             ],
         ),
         OntologyNodeMapping(

--- a/cartography/models/ontology/mapping/data/images.py
+++ b/cartography/models/ontology/mapping/data/images.py
@@ -8,6 +8,7 @@ from cartography.models.ontology.mapping.specs import OntologyNodeMapping
 # - uri: Full URI to pull the image
 # - architecture: CPU architecture (amd64, arm64, etc.)
 # - os: Operating system (linux, windows)
+# - variant: Architecture variant (v8, etc.)
 
 aws_ecr_mapping = OntologyMapping(
     module_name="aws",
@@ -37,6 +38,7 @@ gcp_mapping = OntologyMapping(
                     ontology_field="architecture", node_field="architecture"
                 ),
                 OntologyFieldMapping(ontology_field="os", node_field="os"),
+                OntologyFieldMapping(ontology_field="variant", node_field="variant"),
             ],
         ),
         OntologyNodeMapping(
@@ -47,6 +49,7 @@ gcp_mapping = OntologyMapping(
                     ontology_field="architecture", node_field="architecture"
                 ),
                 OntologyFieldMapping(ontology_field="os", node_field="os"),
+                OntologyFieldMapping(ontology_field="variant", node_field="variant"),
             ],
         ),
     ],

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -1692,6 +1692,9 @@ Representation of a [Docker Image](https://cloud.google.com/artifact-registry/do
 | update_time | Timestamp when the image was last updated |
 | repository_id | Full resource name of the parent repository |
 | project_id | The GCP project ID |
+| architecture | CPU architecture for single-image manifests, extracted from the OCI image config (e.g., `amd64`, `arm64`) |
+| os | Operating system for single-image manifests, extracted from the OCI image config (e.g., `linux`, `windows`) |
+| variant | Platform variant for single-image manifests, extracted from the OCI image config (e.g., `v8`) |
 | source_uri | Source repository URL extracted from OCI image config provenance (e.g., `https://github.com/org/repo`) |
 | source_revision | Git commit hash from build provenance |
 | source_file | Dockerfile path from build provenance |

--- a/tests/data/gcp/artifact_registry.py
+++ b/tests/data/gcp/artifact_registry.py
@@ -76,6 +76,48 @@ MOCK_DOCKER_IMAGES = [
     },
 ]
 
+MOCK_SINGLE_IMAGE_MANIFEST = {
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    "config": {
+        "mediaType": "application/vnd.oci.image.config.v1+json",
+        "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000abc",
+        "size": 4096,
+    },
+    "layers": [
+        {
+            "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+            "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+            "size": 8192,
+        },
+    ],
+}
+
+MOCK_SINGLE_IMAGE_CONFIG = {
+    "architecture": "arm64",
+    "os": "linux",
+    "variant": "v8",
+    "created": "2024-01-10T00:00:00Z",
+    "config": {
+        "Labels": {
+            "org.opencontainers.image.source": "https://github.com/example/widgets.git",
+            "org.opencontainers.image.revision": "0123456789abcdef",
+        },
+    },
+    "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+            "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        ],
+    },
+    "history": [
+        {
+            "created": "2024-01-10T00:00:00Z",
+            "created_by": "COPY app /app",
+        },
+    ],
+}
+
 MOCK_HELM_CHARTS = [
     {
         "name": "projects/test-project/locations/us-central1/repositories/docker-repo/dockerImages/my-chart@sha256:xyz789",

--- a/tests/integration/cartography/intel/gcp/test_artifact_registry.py
+++ b/tests/integration/cartography/intel/gcp/test_artifact_registry.py
@@ -131,7 +131,7 @@ def _make_platform_image(parent_artifact_id: str, project_id: str, index: int) -
         "os": "linux",
         "os_version": None,
         "os_features": None,
-        "variant": None,
+        "variant": "v8" if index % 2 else None,
         "media_type": TEST_SINGLE_IMAGE_MEDIA_TYPE,
         "parent_artifact_id": parent_artifact_id,
         "project_id": project_id,
@@ -599,6 +599,7 @@ def test_load_gar_supply_chain_enrichment_split_phases_are_idempotent_and_cleane
             image.variant AS variant,
             image._ont_architecture AS ont_architecture,
             image._ont_os AS ont_os,
+            image._ont_variant AS ont_variant,
             labels(image) AS labels
         """,
         project_id=project_id,
@@ -612,11 +613,22 @@ def test_load_gar_supply_chain_enrichment_split_phases_are_idempotent_and_cleane
     assert image_result["variant"] is None
     assert image_result["ont_architecture"] == "amd64"
     assert image_result["ont_os"] == "linux"
+    assert image_result["ont_variant"] is None
     assert image_result["layer_diff_ids"] == [
         f"sha256:{project_id}-shared",
         f"sha256:{project_id}-0",
     ]
     assert "Image" in image_result["labels"]
+
+    image_with_variant = neo4j_session.run(
+        """
+        MATCH (image:GCPArtifactRegistryContainerImage {id: $image_id})
+        RETURN image.variant AS variant, image._ont_variant AS ont_variant
+        """,
+        image_id=docker_images[1]["id"],
+    ).single()
+    assert image_with_variant["variant"] == "v8"
+    assert image_with_variant["ont_variant"] == "v8"
 
     layer_result = neo4j_session.run(
         """
@@ -764,6 +776,7 @@ def test_load_manifests_large_parent_relationships_are_idempotent(neo4j_session)
             image._ont_digest AS ont_digest,
             image._ont_architecture AS ont_architecture,
             image._ont_os AS ont_os,
+            image._ont_variant AS ont_variant,
             labels(image) AS labels,
             r.firstseen AS rel_firstseen,
             r.lastupdated AS rel_lastupdated,
@@ -779,6 +792,7 @@ def test_load_manifests_large_parent_relationships_are_idempotent(neo4j_session)
     assert result["ont_digest"] == platform_images[0]["digest"]
     assert result["ont_architecture"] == platform_images[0]["architecture"]
     assert result["ont_os"] == platform_images[0]["os"]
+    assert result["ont_variant"] == platform_images[0]["variant"]
     assert "Image" in result["labels"]
     assert result["rel_lastupdated"] == TEST_UPDATE_TAG
     assert result["rel_module_name"] == "cartography:gcp"
@@ -788,6 +802,16 @@ def test_load_manifests_large_parent_relationships_are_idempotent(neo4j_session)
 
     first_node_firstseen = result["node_firstseen"]
     first_rel_firstseen = result["rel_firstseen"]
+
+    platform_with_variant = neo4j_session.run(
+        """
+        MATCH (image:GCPArtifactRegistryPlatformImage {id: $image_id})
+        RETURN image.variant AS variant, image._ont_variant AS ont_variant
+        """,
+        image_id=platform_images[1]["id"],
+    ).single()
+    assert platform_with_variant["variant"] == "v8"
+    assert platform_with_variant["ont_variant"] == "v8"
     parent_rel_result = neo4j_session.run(
         """
         MATCH (:GCPArtifactRegistryContainerImage {id: $parent_id})

--- a/tests/integration/cartography/intel/gcp/test_artifact_registry.py
+++ b/tests/integration/cartography/intel/gcp/test_artifact_registry.py
@@ -537,6 +537,9 @@ def test_load_gar_supply_chain_enrichment_split_phases_are_idempotent_and_cleane
         enrichments.append(
             {
                 "id": image["id"],
+                "architecture": "amd64" if index % 2 == 0 else "arm64",
+                "os": "linux",
+                "variant": "v8" if index % 2 else None,
                 "source_uri": "https://github.com/foo/bar",
                 "source_revision": f"revision-{index}",
                 "source_file": "Dockerfile",
@@ -555,6 +558,9 @@ def test_load_gar_supply_chain_enrichment_split_phases_are_idempotent_and_cleane
             "source_revision": enrichment.get("source_revision"),
             "source_file": enrichment.get("source_file"),
             "layer_diff_ids": enrichment.get("layer_diff_ids"),
+            "architecture": enrichment.get("architecture"),
+            "os": enrichment.get("os"),
+            "variant": enrichment.get("variant"),
         }
         for enrichment in enrichments
     ]
@@ -588,6 +594,11 @@ def test_load_gar_supply_chain_enrichment_split_phases_are_idempotent_and_cleane
             image.source_revision AS source_revision,
             image.source_file AS source_file,
             image.layer_diff_ids AS layer_diff_ids,
+            image.architecture AS architecture,
+            image.os AS os,
+            image.variant AS variant,
+            image._ont_architecture AS ont_architecture,
+            image._ont_os AS ont_os,
             labels(image) AS labels
         """,
         project_id=project_id,
@@ -596,6 +607,11 @@ def test_load_gar_supply_chain_enrichment_split_phases_are_idempotent_and_cleane
     assert image_result["source_uri"] == "https://github.com/foo/bar"
     assert image_result["source_revision"] == "revision-0"
     assert image_result["source_file"] == "Dockerfile"
+    assert image_result["architecture"] == "amd64"
+    assert image_result["os"] == "linux"
+    assert image_result["variant"] is None
+    assert image_result["ont_architecture"] == "amd64"
+    assert image_result["ont_os"] == "linux"
     assert image_result["layer_diff_ids"] == [
         f"sha256:{project_id}-shared",
         f"sha256:{project_id}-0",

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_supply_chain.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_supply_chain.py
@@ -424,6 +424,34 @@ async def test_process_single_image_extracts_platform_from_oci_config():
     }
 
 
+@pytest.mark.asyncio
+async def test_process_single_image_skips_manifest_list():
+    image_uri = (
+        "us-central1-docker.pkg.dev/test-project/docker-repo/widgets-api"
+        "@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    )
+    artifact_name = (
+        "projects/test-project/locations/us-central1/repositories/docker-repo/"
+        "dockerImages/widgets-api@"
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    )
+    client = MagicMock()
+
+    result, fetch_failed = await _process_single_image(
+        client,
+        _fake_token_manager(),
+        {
+            "name": artifact_name,
+            "uri": image_uri,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+        },
+    )
+
+    assert result is None
+    assert fetch_failed is False
+    client.get.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Referrers / DSSE attestation discovery
 # ---------------------------------------------------------------------------

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_supply_chain.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_supply_chain.py
@@ -9,8 +9,11 @@ from cartography.intel.gcp.artifact_registry.supply_chain import _build_layer_di
 from cartography.intel.gcp.artifact_registry.supply_chain import (
     _fetch_attestation_provenance,
 )
+from cartography.intel.gcp.artifact_registry.supply_chain import _process_single_image
 from cartography.intel.gcp.artifact_registry.supply_chain import _TokenManager
 from cartography.intel.supply_chain import extract_provenance_from_oci_config
+from tests.data.gcp.artifact_registry import MOCK_SINGLE_IMAGE_CONFIG
+from tests.data.gcp.artifact_registry import MOCK_SINGLE_IMAGE_MANIFEST
 
 # ---------------------------------------------------------------------------
 # OCI label provenance
@@ -200,6 +203,9 @@ def test_sync_loads_provenance_and_layers_with_split_phases(patched_sync):
                 "source_revision": "deadbeef",
                 "source_file": "Dockerfile",
                 "layer_diff_ids": ["sha256:a", "sha256:b"],
+                "architecture": None,
+                "os": None,
+                "variant": None,
             },
             {
                 "id": "img-2",
@@ -207,6 +213,9 @@ def test_sync_loads_provenance_and_layers_with_split_phases(patched_sync):
                 "source_revision": None,
                 "source_file": None,
                 "layer_diff_ids": ["sha256:a"],
+                "architecture": None,
+                "os": None,
+                "variant": None,
             },
         ],
         "proj",
@@ -345,6 +354,74 @@ def test_sync_skips_cleanup_when_discovery_unsafe(patched_sync):
     )
 
     assert cleanup_runs == []
+
+
+# ---------------------------------------------------------------------------
+# OCI config extraction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_process_single_image_extracts_platform_from_oci_config():
+    image_digest = (
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    )
+    image_uri = (
+        "us-central1-docker.pkg.dev/test-project/docker-repo/widgets-api"
+        f"@{image_digest}"
+    )
+    artifact_name = (
+        "projects/test-project/locations/us-central1/repositories/docker-repo/"
+        f"dockerImages/widgets-api@{image_digest}"
+    )
+    manifest_url = (
+        "https://us-central1-docker.pkg.dev/v2/test-project/docker-repo/"
+        f"widgets-api/manifests/{image_digest}"
+    )
+    config_digest = MOCK_SINGLE_IMAGE_MANIFEST["config"]["digest"]
+    config_url = (
+        "https://us-central1-docker.pkg.dev/v2/test-project/docker-repo/"
+        f"widgets-api/blobs/{config_digest}"
+    )
+    client = _FakeClient(
+        {
+            manifest_url: _FakeResponse(
+                200,
+                json_body=MOCK_SINGLE_IMAGE_MANIFEST,
+                headers={"Docker-Content-Digest": image_digest},
+            ),
+            config_url: _FakeResponse(200, json_body=MOCK_SINGLE_IMAGE_CONFIG),
+        },
+    )
+
+    result, fetch_failed = await _process_single_image(
+        client,
+        _fake_token_manager(),
+        {
+            "name": artifact_name,
+            "uri": image_uri,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        },
+    )
+
+    assert fetch_failed is False
+    assert result == {
+        "id": artifact_name,
+        "architecture": "arm64",
+        "os": "linux",
+        "variant": "v8",
+        "source_uri": "https://github.com/example/widgets",
+        "source_revision": "0123456789abcdef",
+        "layer_diff_ids": [
+            "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        ],
+        "layer_history": [
+            {
+                "created_by": "COPY app /app",
+                "empty_layer": False,
+            },
+        ],
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary

Persist platform metadata for single-manifest GCP Artifact Registry container images. The GAR supply-chain enrichment path already fetches each single image OCI config for provenance and layer data; this change also records the config's architecture, OS, and variant on the existing `GCPArtifactRegistryContainerImage` node.

This keeps multi-architecture behavior unchanged: manifest list/index parents remain `ImageManifestList` nodes, while child `GCPArtifactRegistryPlatformImage` nodes continue to carry their own platform metadata.


### Breaking changes

None.


### How was this tested?

- Tested locally and update integration tests


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).