### PR TITLE
fix(gcp): retry transient Vertex AI GAPIC errors

### DIFF
--- a/cartography/intel/gcp/vertex/utils.py
+++ b/cartography/intel/gcp/vertex/utils.py
@@ -9,11 +9,19 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from typing import cast
 
+import backoff
 from google.api_core.exceptions import GoogleAPICallError
 from google.api_core.exceptions import NotFound
 from google.api_core.exceptions import PermissionDenied
+from google.api_core.exceptions import ServerError
+from google.api_core.exceptions import TooManyRequests
 from google.auth.credentials import Credentials as GoogleCredentials
 
+from cartography.intel.gcp.util import GCP_API_BACKOFF_BASE
+from cartography.intel.gcp.util import gcp_api_backoff_handler
+from cartography.intel.gcp.util import GCP_API_BACKOFF_MAX
+from cartography.intel.gcp.util import gcp_api_giveup_handler
+from cartography.intel.gcp.util import GCP_API_MAX_RETRIES
 from cartography.intel.gcp.util import proto_message_to_dict
 from cartography.util import timeit
 
@@ -31,6 +39,20 @@ def get_vertex_credentials(aiplatform_or_credentials: Any) -> GoogleCredentials:
     return cast(GoogleCredentials, aiplatform_or_credentials)
 
 
+@backoff.on_exception(  # type: ignore[misc]
+    backoff.expo,
+    (ServerError, TooManyRequests),
+    max_tries=GCP_API_MAX_RETRIES,
+    on_backoff=gcp_api_backoff_handler,
+    on_giveup=gcp_api_giveup_handler,
+    logger=None,
+    base=GCP_API_BACKOFF_BASE,
+    max_value=GCP_API_BACKOFF_MAX,
+)
+def _list_vertex_ai_resources_with_retry(fetcher: Callable[[], Any]) -> list[dict]:
+    return [proto_message_to_dict(resource) for resource in fetcher()]
+
+
 def list_vertex_ai_resources_for_location(
     *,
     fetcher: Callable[[], Any],
@@ -39,7 +61,7 @@ def list_vertex_ai_resources_for_location(
     project_id: str,
 ) -> list[dict]:
     try:
-        resources = [proto_message_to_dict(resource) for resource in fetcher()]
+        resources = _list_vertex_ai_resources_with_retry(fetcher)
     except NotFound:
         logger.debug(
             "Vertex AI %s not found in %s for project %s. This location may not have any %s.",

--- a/tests/unit/cartography/intel/gcp/vertex/test_utils.py
+++ b/tests/unit/cartography/intel/gcp/vertex/test_utils.py
@@ -1,7 +1,83 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import pytest
 from google.api_core.exceptions import GoogleAPICallError
+from google.api_core.exceptions import PermissionDenied
+from google.api_core.exceptions import ServiceUnavailable
 
+from cartography.intel.gcp import vertex
+from cartography.intel.gcp.util import GCP_API_MAX_RETRIES
 from cartography.intel.gcp.vertex.utils import list_vertex_ai_resources_for_location
+
+
+@patch("time.sleep", return_value=None)
+def test_list_vertex_ai_resources_for_location_retries_transient_gapic_errors(
+    _mock_sleep,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        vertex.utils,
+        "proto_message_to_dict",
+        lambda resource: {"name": resource.name},
+    )
+    calls = 0
+
+    def fetcher():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ServiceUnavailable("transient backend error")
+        return [SimpleNamespace(name="model-1")]
+
+    assert list_vertex_ai_resources_for_location(
+        fetcher=fetcher,
+        resource_type="models",
+        location="us-central1",
+        project_id="test-project",
+    ) == [{"name": "model-1"}]
+    assert calls == 2
+
+
+@patch("time.sleep", return_value=None)
+def test_list_vertex_ai_resources_for_location_raises_after_exhausting_transient_gapic_errors(
+    _mock_sleep,
+):
+    calls = 0
+
+    def fetcher():
+        nonlocal calls
+        calls += 1
+        raise ServiceUnavailable("transient backend error")
+
+    with pytest.raises(ServiceUnavailable):
+        list_vertex_ai_resources_for_location(
+            fetcher=fetcher,
+            resource_type="models",
+            location="us-central1",
+            project_id="test-project",
+        )
+    assert calls == GCP_API_MAX_RETRIES
+
+
+def test_list_vertex_ai_resources_for_location_permission_denied_returns_empty():
+    calls = 0
+
+    def fetcher():
+        nonlocal calls
+        calls += 1
+        raise PermissionDenied("permission denied")
+
+    assert (
+        list_vertex_ai_resources_for_location(
+            fetcher=fetcher,
+            resource_type="models",
+            location="us-central1",
+            project_id="test-project",
+        )
+        == []
+    )
+    assert calls == 1
 
 
 def test_list_vertex_ai_resources_for_location_reraises_google_api_call_errors():


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)



### Summary
Vertex AI GAPIC list calls can raise retryable server-side Google API errors while materializing pagers. The shared Vertex AI helper was re-raising those errors immediately, so a transient server error from one location could fail the resource sync.

This wraps Vertex AI per-location pager materialization with Cartography's existing GCP backoff policy, while preserving the existing `NotFound` and `PermissionDenied` handling.


### Related issues or links
- N/A


### Breaking changes
None.


### How was this tested?
- Added integration test using error I saw in our prod env


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`, the repo lint target).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
N/A. This does not add or modify a synced entity.

#### If you are changing a node or relationship
N/A. This does not change graph schema.

#### If you are implementing a new intel module
N/A. This is not a new intel module.


### Notes for reviewers
This reuses the existing GCP retry constants and handlers so Vertex AI GAPIC pagination behaves consistently with other GCP API fetch paths.
