### PR TITLE
fix(gcp): retry transient Cloud Run list failures

### DIFF
--- a/cartography/intel/gcp/cloudrun/execution.py
+++ b/cartography/intel/gcp/cloudrun/execution.py
@@ -29,8 +29,9 @@ def get_executions(
 
     def fetch_for_location(location: str) -> list[dict]:
         return list_cloud_run_resources_for_location(
-            fetcher=lambda: client.list_executions(
+            fetcher=lambda **kw: client.list_executions(
                 parent=f"{location}/jobs/-",
+                **kw,
             ),
             resource_type="executions",
             location=location,

--- a/cartography/intel/gcp/cloudrun/job.py
+++ b/cartography/intel/gcp/cloudrun/job.py
@@ -36,9 +36,7 @@ def get_jobs(
 
     def fetch_for_location(location: str) -> list[dict]:
         return list_cloud_run_resources_for_location(
-            fetcher=lambda: client.list_jobs(
-                parent=location,
-            ),
+            fetcher=lambda **kw: client.list_jobs(parent=location, **kw),
             resource_type="jobs",
             location=location,
             project_id=project_id,

--- a/cartography/intel/gcp/cloudrun/revision.py
+++ b/cartography/intel/gcp/cloudrun/revision.py
@@ -29,8 +29,9 @@ def get_revisions(
 
     def fetch_for_location(location: str) -> list[dict]:
         return list_cloud_run_resources_for_location(
-            fetcher=lambda: client.list_revisions(
+            fetcher=lambda **kw: client.list_revisions(
                 parent=f"{location}/services/-",
+                **kw,
             ),
             resource_type="revisions",
             location=location,

--- a/cartography/intel/gcp/cloudrun/service.py
+++ b/cartography/intel/gcp/cloudrun/service.py
@@ -38,9 +38,7 @@ def get_services(
 
     def fetch_for_location(location: str) -> list[dict]:
         return list_cloud_run_resources_for_location(
-            fetcher=lambda: client.list_services(
-                parent=location,
-            ),
+            fetcher=lambda **kw: client.list_services(parent=location, **kw),
             resource_type="services",
             location=location,
             project_id=project_id,

--- a/cartography/intel/gcp/cloudrun/util.py
+++ b/cartography/intel/gcp/cloudrun/util.py
@@ -8,9 +8,14 @@ from collections.abc import Iterable
 from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
 
+from google.api_core.exceptions import DeadlineExceeded
 from google.api_core.exceptions import GoogleAPICallError
 from google.api_core.exceptions import NotFound
 from google.api_core.exceptions import PermissionDenied
+from google.api_core.exceptions import ResourceExhausted
+from google.api_core.exceptions import ServiceUnavailable
+from google.api_core.retry import if_exception_type
+from google.api_core.retry import Retry
 from google.auth.credentials import Credentials as GoogleCredentials
 from googleapiclient.discovery import Resource
 from googleapiclient.errors import HttpError
@@ -25,6 +30,11 @@ logger = logging.getLogger(__name__)
 
 CLOUD_RUN_LABEL_BATCH_SIZE = 1000
 DEFAULT_CLOUD_RUN_LOCATION_WORKERS = 8
+CLOUD_RUN_LIST_RETRY_INITIAL = 1.0
+CLOUD_RUN_LIST_RETRY_MAX = 10.0
+CLOUD_RUN_LIST_RETRY_MULTIPLIER = 1.3
+CLOUD_RUN_LIST_RETRY_TIMEOUT = 60.0
+CLOUD_RUN_LIST_TIMEOUT = 30.0
 
 
 def _normalize_cloud_run_location_name(location_name: str) -> str:
@@ -35,6 +45,37 @@ def _normalize_cloud_run_location_name(location_name: str) -> str:
 
 def _cloud_run_location_short_name(location_name: str) -> str:
     return location_name.rsplit("/", 1)[-1]
+
+
+def build_cloud_run_resource_retry(
+    *,
+    resource_type: str,
+    location: str,
+    project_id: str,
+) -> Retry:
+    location_short = _cloud_run_location_short_name(location)
+
+    def _on_error(exc: Exception) -> None:
+        logger.warning(
+            "Retrying Cloud Run %s list in %s for project %s after transient error: %s",
+            resource_type,
+            location_short,
+            project_id,
+            exc,
+        )
+
+    return Retry(
+        predicate=if_exception_type(
+            DeadlineExceeded,
+            ResourceExhausted,
+            ServiceUnavailable,
+        ),
+        initial=CLOUD_RUN_LIST_RETRY_INITIAL,
+        maximum=CLOUD_RUN_LIST_RETRY_MAX,
+        multiplier=CLOUD_RUN_LIST_RETRY_MULTIPLIER,
+        timeout=CLOUD_RUN_LIST_RETRY_TIMEOUT,
+        on_error=_on_error,
+    )
 
 
 def _service_discovered_cloud_run_locations(
@@ -178,14 +219,22 @@ def discover_cloud_run_locations(
 
 def list_cloud_run_resources_for_location(
     *,
-    fetcher: Callable[[], Iterable[object]],
+    fetcher: Callable[..., Iterable[object]],
     resource_type: str,
     location: str,
     project_id: str,
 ) -> list[dict]:
     location_name = _cloud_run_location_short_name(location)
+    retry = build_cloud_run_resource_retry(
+        resource_type=resource_type,
+        location=location,
+        project_id=project_id,
+    )
     try:
-        resources = [proto_message_to_dict(resource) for resource in fetcher()]
+        resources = [
+            proto_message_to_dict(resource)
+            for resource in fetcher(retry=retry, timeout=CLOUD_RUN_LIST_TIMEOUT)
+        ]
     except NotFound:
         logger.debug(
             "Cloud Run %s not found in %s for project %s.",

--- a/tests/unit/cartography/intel/gcp/test_cloudrun_util.py
+++ b/tests/unit/cartography/intel/gcp/test_cloudrun_util.py
@@ -2,10 +2,13 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from google.api_core.exceptions import DeadlineExceeded
 from google.api_core.exceptions import GoogleAPICallError
 from google.api_core.exceptions import PermissionDenied
 from googleapiclient.errors import HttpError
 
+from cartography.intel.gcp.cloudrun.util import build_cloud_run_resource_retry
+from cartography.intel.gcp.cloudrun.util import CLOUD_RUN_LIST_TIMEOUT
 from cartography.intel.gcp.cloudrun.util import discover_cloud_run_locations
 from cartography.intel.gcp.cloudrun.util import fetch_cloud_run_resources_for_locations
 from cartography.intel.gcp.cloudrun.util import list_cloud_run_resources_for_location
@@ -161,8 +164,11 @@ def test_discover_cloud_run_locations_falls_back_when_v1_returns_no_locations():
 
 
 def test_list_cloud_run_resources_for_location_skips_permission_denied():
+    def _fetcher(**_):
+        raise PermissionDenied("nope")
+
     result = list_cloud_run_resources_for_location(
-        fetcher=lambda: (_ for _ in ()).throw(PermissionDenied("nope")),
+        fetcher=_fetcher,
         resource_type="jobs",
         location="projects/test-project/locations/us-central1",
         project_id="test-project",
@@ -172,13 +178,107 @@ def test_list_cloud_run_resources_for_location_skips_permission_denied():
 
 
 def test_list_cloud_run_resources_for_location_reraises_google_api_call_error():
+    def _fetcher(**_):
+        raise GoogleAPICallError("boom")
+
     with pytest.raises(GoogleAPICallError):
         list_cloud_run_resources_for_location(
-            fetcher=lambda: (_ for _ in ()).throw(GoogleAPICallError("boom")),
+            fetcher=_fetcher,
             resource_type="jobs",
             location="projects/test-project/locations/us-central1",
             project_id="test-project",
         )
+
+
+def test_list_cloud_run_resources_for_location_passes_retry_and_timeout(mocker):
+    mock_retry = MagicMock()
+    mock_build_retry = mocker.patch(
+        "cartography.intel.gcp.cloudrun.util.build_cloud_run_resource_retry",
+        return_value=mock_retry,
+    )
+    mocker.patch(
+        "cartography.intel.gcp.cloudrun.util.proto_message_to_dict",
+        side_effect=lambda resource: resource,
+    )
+    received_kwargs = {}
+
+    def _fetcher(**kwargs):
+        received_kwargs.update(kwargs)
+        return [{"id": "service-1"}]
+
+    result = list_cloud_run_resources_for_location(
+        fetcher=_fetcher,
+        resource_type="services",
+        location="projects/test-project/locations/us-central1",
+        project_id="test-project",
+    )
+
+    assert result == [{"id": "service-1"}]
+    assert received_kwargs == {
+        "retry": mock_retry,
+        "timeout": CLOUD_RUN_LIST_TIMEOUT,
+    }
+    mock_build_retry.assert_called_once_with(
+        resource_type="services",
+        location="projects/test-project/locations/us-central1",
+        project_id="test-project",
+    )
+
+
+def test_build_cloud_run_resource_retry_retries_deadline_exceeded(mocker):
+    mocker.patch("time.sleep")
+    retry = build_cloud_run_resource_retry(
+        resource_type="services",
+        location="projects/test-project/locations/us-central1",
+        project_id="test-project",
+    )
+
+    calls = 0
+
+    def fetch_resource():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise DeadlineExceeded("slow")
+        return [{"id": "service-1"}]
+
+    result = retry(fetch_resource)()
+
+    assert result == [{"id": "service-1"}]
+    assert calls == 2
+
+
+def test_list_cloud_run_resources_for_location_uses_retry_for_deadline_exceeded(
+    mocker,
+):
+    mocker.patch("time.sleep")
+    mocker.patch(
+        "cartography.intel.gcp.cloudrun.util.proto_message_to_dict",
+        side_effect=lambda resource: resource,
+    )
+    calls = 0
+
+    def _fetcher(*, retry, timeout):
+        assert timeout == CLOUD_RUN_LIST_TIMEOUT
+
+        def _list_resources():
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise DeadlineExceeded("slow")
+            return [{"id": "service-1"}]
+
+        return retry(_list_resources)()
+
+    result = list_cloud_run_resources_for_location(
+        fetcher=_fetcher,
+        resource_type="services",
+        location="projects/test-project/locations/us-central1",
+        project_id="test-project",
+    )
+
+    assert result == [{"id": "service-1"}]
+    assert calls == 2
 
 
 def test_fetch_cloud_run_resources_for_locations_dedupes_and_preserves_input_order():


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary

Cloud Run v2 list calls were using the generated client defaults, which leave each regional list RPC with a short 10 second timeout/retry budget. A transient `DeadlineExceeded`, `ResourceExhausted`, or `ServiceUnavailable` from one region could therefore bubble up and fail the whole Cloud Run project sync after a single slow response.

This adds one shared Cloud Run list retry policy and applies it to services, jobs, revisions, and executions. The policy extends the per-attempt timeout to 30 seconds and the total retry budget to 60 seconds for transient gRPC errors. If retries are exhausted, the error still propagates so cleanup does not interpret an ambiguous read as an empty result set.


### Related issues or links

- Fixes #


### Breaking changes

None.


### How was this tested?

- Added tests that mimic same issue we saw in prod


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

This changes only Cloud Run read resilience. It does not alter load schemas, cleanup scope, or the behavior after retry exhaustion.