### PR TITLE
feat(loader): preserve enrichment properties

### DIFF
--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -347,9 +347,8 @@ def _build_ontology_node_properties_statement(
             if mapping_statement:
                 set_clauses.append(mapping_statement)
         else:
-            simple_field_template = Template("i.$node_property = $property_ref")
             set_clauses.append(
-                simple_field_template.substitute(
+                _build_property_assignment(
                     node_property=ontology_field_name,
                     property_ref=node_propertyref,
                 )
@@ -358,6 +357,18 @@ def _build_ontology_node_properties_statement(
         return ""
     # Add initial newline
     return ",\n" + ",\n".join(set_clauses)
+
+
+def _build_property_assignment(
+    node_property: str,
+    property_ref: PropertyRef,
+) -> str:
+    if property_ref.preserve_existing:
+        if property_ref.prefer_existing:
+            return f"i.{node_property} = coalesce(i.{node_property}, {property_ref})"
+        return f"i.{node_property} = coalesce({property_ref}, i.{node_property})"
+
+    return f"i.{node_property} = {property_ref}"
 
 
 def _build_node_properties_statement(
@@ -402,11 +413,9 @@ def _build_node_properties_statement(
         handled by the MERGE clause in the query pattern. The variable 'i' refers
         to the Neo4j node being processed.
     """
-    ingest_fields_template = Template("i.$node_property = $property_ref")
-
     set_clause = ",\n".join(
         [
-            ingest_fields_template.safe_substitute(
+            _build_property_assignment(
                 node_property=node_property,
                 property_ref=property_ref,
             )

--- a/cartography/intel/aws/ecr_image_layers.py
+++ b/cartography/intel/aws/ecr_image_layers.py
@@ -597,7 +597,8 @@ def transform_ecr_image_layers(
     :param image_digest_map: Map of image URI to image digest
     :param history_by_diff_id: Map of diff_id to history command (created_by)
     :param image_attestation_map: Map of image URI to provenance data
-    :param existing_properties_map: Map of image digest to existing ECRImage properties (type, architecture, etc.)
+    :param existing_properties_map: Map of image digest to existing ECRImage metadata used for
+        manifest-list detection and architecture backfill.
     :return: List of layer objects ready for ingestion
     """
     if history_by_diff_id is None:
@@ -614,10 +615,9 @@ def transform_ecr_image_layers(
         image_digest = image_digest_map[image_uri]
 
         # Check if this is a manifest list
-        is_manifest_list = False
-        if image_digest in existing_properties_map:
-            image_type = existing_properties_map[image_digest].get("type")
-            is_manifest_list = image_type == "manifest_list"
+        existing_properties = existing_properties_map.get(image_digest, {})
+        image_type = existing_properties.get("type")
+        is_manifest_list = image_type == "manifest_list"
 
         # Skip creating layer relationships for manifest lists
         if is_manifest_list:
@@ -661,28 +661,25 @@ def transform_ecr_image_layers(
                 "layer_diff_ids": ordered_layers_for_image,
             }
 
-            # Preserve existing ECRImage properties (type, architecture, os, variant, etc.)
-            if image_digest in existing_properties_map:
-                membership.update(existing_properties_map[image_digest])
-                if not membership.get("architecture"):
-                    platform_values = list(platforms.keys())
-                    if len(platform_values) == 1:
-                        first_platform = platform_values[0]
-                        arch_hint = (
-                            first_platform.split("/")[1]
-                            if "/" in first_platform
-                            else first_platform
-                        )
-                        normalized_arch = normalize_architecture(arch_hint)
-                        if normalized_arch != "unknown":
-                            membership["architecture"] = normalized_arch
-                    elif len(platform_values) > 1:
-                        # Ambiguous platform hints for this digest; avoid arbitrary picks.
-                        logger.debug(
-                            "Skipping architecture backfill for %s due to multiple platform keys: %s",
-                            image_digest,
-                            platform_values,
-                        )
+            if existing_properties and not existing_properties.get("architecture"):
+                platform_values = list(platforms.keys())
+                if len(platform_values) == 1:
+                    first_platform = platform_values[0]
+                    arch_hint = (
+                        first_platform.split("/")[1]
+                        if "/" in first_platform
+                        else first_platform
+                    )
+                    normalized_arch = normalize_architecture(arch_hint)
+                    if normalized_arch != "unknown":
+                        membership["architecture"] = normalized_arch
+                elif len(platform_values) > 1:
+                    # Ambiguous platform hints for this digest; avoid arbitrary picks.
+                    logger.debug(
+                        "Skipping architecture backfill for %s due to multiple platform keys: %s",
+                        image_digest,
+                        platform_values,
+                    )
 
             # Add provenance data if available for this image
             if image_uri in image_attestation_map:
@@ -1310,7 +1307,7 @@ def sync(
             current_aws_account_id,
         )
 
-        # Query for ECR images with all their existing properties to preserve during layer sync
+        # Query for ECR images and the metadata needed to decide which images to fetch.
         query = """
         MATCH (img:ECRImage)<-[:IMAGE]-(repo_img:ECRRepositoryImage)<-[:REPO_IMAGE]-(repo:ECRRepository)
         MATCH (repo)<-[:RESOURCE]-(:AWSAccount {id: $AWS_ID})
@@ -1320,14 +1317,7 @@ def sync(
             repo_img.id AS uri,
             repo.uri AS repo_uri,
             img.type AS type,
-            img.architecture AS architecture,
-            img.os AS os,
-            img.variant AS variant,
-            img.attestation_type AS attestation_type,
-            img.attests_digest AS attests_digest,
-            img.media_type AS media_type,
-            img.artifact_media_type AS artifact_media_type,
-            img.child_image_digests AS child_image_digests
+            img.architecture AS architecture
         """
         from cartography.client.core.tx import read_list_of_dicts_tx
 
@@ -1347,17 +1337,9 @@ def sync(
             if digest not in seen_digests:
                 seen_digests.add(digest)
 
-                # Store existing properties for ALL images to preserve during updates
                 existing_properties[digest] = {
                     "type": image_type,
                     "architecture": img_data.get("architecture"),
-                    "os": img_data.get("os"),
-                    "variant": img_data.get("variant"),
-                    "attestation_type": img_data.get("attestation_type"),
-                    "attests_digest": img_data.get("attests_digest"),
-                    "media_type": img_data.get("media_type"),
-                    "artifact_media_type": img_data.get("artifact_media_type"),
-                    "child_image_digests": img_data.get("child_image_digests"),
                 }
 
                 repo_uri = img_data["repo_uri"]

--- a/cartography/intel/gcp/artifact_registry/supply_chain.py
+++ b/cartography/intel/gcp/artifact_registry/supply_chain.py
@@ -8,7 +8,6 @@ import neo4j
 from google.auth.credentials import Credentials as GoogleCredentials
 from google.auth.transport.requests import Request
 
-from cartography.client.core.tx import read_list_of_dicts_tx
 from cartography.graph.job import GraphJob
 from cartography.intel.container_arch import normalize_architecture
 from cartography.intel.gcp.artifact_registry.manifest import build_blob_url
@@ -456,89 +455,16 @@ def _build_layer_dicts(
     return list(layers_by_diff_id.values())
 
 
-PROVENANCE_UPDATE_FIELDS = (
-    "type",
-    "media_type",
-    "architecture",
-    "os",
-    "os_version",
-    "os_features",
-    "variant",
-    "layer_diff_ids",
-)
-
-PROVENANCE_SOURCE_FIELDS = (
-    "source_uri",
-    "source_revision",
-    "source_file",
-)
-
-PROVENANCE_FIELDS = (
-    *PROVENANCE_UPDATE_FIELDS,
-    *PROVENANCE_SOURCE_FIELDS,
-)
-
-
-def _merge_existing_image_provenance(
-    neo4j_session: neo4j.Session,
+def _normalize_blank_provenance_values(
     provenance_updates: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    digests = sorted(
-        {update["digest"] for update in provenance_updates if update.get("digest")}
-    )
-    if not digests:
-        return []
-
-    existing_rows = neo4j_session.execute_read(
-        read_list_of_dicts_tx,
-        """
-        UNWIND $digests AS digest
-        MATCH (img:GCPArtifactRegistryImage {digest: digest})
-        RETURN
-            img.digest AS digest,
-            img.type AS type,
-            img.media_type AS media_type,
-            img.architecture AS architecture,
-            img.os AS os,
-            img.os_version AS os_version,
-            img.os_features AS os_features,
-            img.variant AS variant,
-            img.source_uri AS source_uri,
-            img.source_revision AS source_revision,
-            img.source_file AS source_file,
-            img.layer_diff_ids AS layer_diff_ids
-        """,
-        digests=digests,
-    )
-    merged_by_digest = {
-        row["digest"]: {
-            "digest": row["digest"],
-            **{field: row.get(field) for field in PROVENANCE_FIELDS},
+    return [
+        {
+            key: None if isinstance(value, str) and not value.strip() else value
+            for key, value in update.items()
         }
-        for row in existing_rows
-    }
-
-    for update in provenance_updates:
-        digest = update.get("digest")
-        if not digest:
-            continue
-        merged = merged_by_digest.setdefault(
-            digest,
-            {"digest": digest, **dict.fromkeys(PROVENANCE_FIELDS)},
-        )
-        for field in PROVENANCE_UPDATE_FIELDS:
-            value = update.get(field)
-            if value is not None:
-                merged[field] = value
-        # Source fields are digest-level provenance. Keep existing non-null values
-        # so a later ref without equivalent source metadata does not erase or
-        # replace a source discovered through another ref for the same digest.
-        for field in PROVENANCE_SOURCE_FIELDS:
-            value = update.get(field)
-            if merged.get(field) is None and value is not None:
-                merged[field] = value
-
-    return list(merged_by_digest.values())
+        for update in provenance_updates
+    ]
 
 
 @timeit
@@ -551,14 +477,10 @@ def load_image_provenance(
     if not provenance_updates:
         return
 
-    merged_updates = _merge_existing_image_provenance(
-        neo4j_session,
-        provenance_updates,
-    )
     load_nodes_without_relationships(
         neo4j_session,
         GCPArtifactRegistryImageProvenanceSchema(),
-        merged_updates,
+        _normalize_blank_provenance_values(provenance_updates),
         batch_size=ARTIFACT_REGISTRY_LOAD_BATCH_SIZE,
         progress_description=(
             f"Artifact Registry image provenance updates for project {project_id}"

--- a/cartography/models/aws/ecr/image.py
+++ b/cartography/models/aws/ecr/image.py
@@ -40,27 +40,41 @@ class ECRImageNodeProperties(CartographyNodeProperties):
     digest: PropertyRef = PropertyRef("imageDigest", extra_index=True)
     region: PropertyRef = PropertyRef("Region", set_in_kwargs=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
-    layer_diff_ids: PropertyRef = PropertyRef("layer_diff_ids")
-    type: PropertyRef = PropertyRef("type", extra_index=True)
-    architecture: PropertyRef = PropertyRef("architecture")
-    os: PropertyRef = PropertyRef("os")
-    variant: PropertyRef = PropertyRef("variant")
-    attestation_type: PropertyRef = PropertyRef("attestation_type")
-    attests_digest: PropertyRef = PropertyRef("attests_digest")
-    media_type: PropertyRef = PropertyRef("media_type")
-    artifact_media_type: PropertyRef = PropertyRef("artifact_media_type")
-    child_image_digests: PropertyRef = PropertyRef("child_image_digests")
-    # SLSA Provenance: Source repository info from VCS metadata
-    source_uri: PropertyRef = PropertyRef("source_uri", extra_index=True)
-    source_revision: PropertyRef = PropertyRef("source_revision")
-    # SLSA Provenance: Build invocation info from CI
-    invocation_uri: PropertyRef = PropertyRef("invocation_uri", extra_index=True)
-    invocation_workflow: PropertyRef = PropertyRef(
-        "invocation_workflow", extra_index=True
+    layer_diff_ids: PropertyRef = PropertyRef("layer_diff_ids", preserve_existing=True)
+    type: PropertyRef = PropertyRef("type", extra_index=True, preserve_existing=True)
+    architecture: PropertyRef = PropertyRef("architecture", preserve_existing=True)
+    os: PropertyRef = PropertyRef("os", preserve_existing=True)
+    variant: PropertyRef = PropertyRef("variant", preserve_existing=True)
+    attestation_type: PropertyRef = PropertyRef(
+        "attestation_type", preserve_existing=True
     )
-    invocation_run_number: PropertyRef = PropertyRef("invocation_run_number")
+    attests_digest: PropertyRef = PropertyRef("attests_digest", preserve_existing=True)
+    media_type: PropertyRef = PropertyRef("media_type", preserve_existing=True)
+    artifact_media_type: PropertyRef = PropertyRef(
+        "artifact_media_type", preserve_existing=True
+    )
+    child_image_digests: PropertyRef = PropertyRef(
+        "child_image_digests", preserve_existing=True
+    )
+    # SLSA Provenance: Source repository info from VCS metadata
+    source_uri: PropertyRef = PropertyRef(
+        "source_uri", extra_index=True, preserve_existing=True
+    )
+    source_revision: PropertyRef = PropertyRef(
+        "source_revision", preserve_existing=True
+    )
+    # SLSA Provenance: Build invocation info from CI
+    invocation_uri: PropertyRef = PropertyRef(
+        "invocation_uri", extra_index=True, preserve_existing=True
+    )
+    invocation_workflow: PropertyRef = PropertyRef(
+        "invocation_workflow", extra_index=True, preserve_existing=True
+    )
+    invocation_run_number: PropertyRef = PropertyRef(
+        "invocation_run_number", preserve_existing=True
+    )
     # SLSA Provenance: Dockerfile path from configSource.entryPoint + vcs localdir
-    source_file: PropertyRef = PropertyRef("source_file")
+    source_file: PropertyRef = PropertyRef("source_file", preserve_existing=True)
 
 
 @dataclass(frozen=True)

--- a/cartography/models/core/common.py
+++ b/cartography/models/core/common.py
@@ -43,6 +43,8 @@ class PropertyRef:
         ignore_case=False,
         fuzzy_and_ignore_case=False,
         one_to_many=False,
+        preserve_existing=False,
+        prefer_existing=False,
     ):
         """
         Initialize a PropertyRef instance.
@@ -66,6 +68,12 @@ class PropertyRef:
                 associations. If True, this property ref points to a list stored on the data dict
                 where each item is an ID. Only has effect as part of a TargetNodeMatcher and is
                 not supported for sub resource relationships. Defaults to False.
+            preserve_existing (bool, optional): If True, node ingestion keeps the existing
+                graph property when the incoming value is null or absent. Only has effect
+                for node property SET clauses. Defaults to False.
+            prefer_existing (bool, optional): If True with preserve_existing, node ingestion
+                keeps the existing graph property whenever it is non-null and only fills it
+                from incoming data when the graph property is null. Defaults to False.
 
         Examples:
             Case-insensitive matching for GitHub usernames:
@@ -109,6 +117,8 @@ class PropertyRef:
         self.ignore_case = ignore_case
         self.fuzzy_and_ignore_case = fuzzy_and_ignore_case
         self.one_to_many = one_to_many
+        self.preserve_existing = preserve_existing
+        self.prefer_existing = prefer_existing
 
         if self.fuzzy_and_ignore_case and self.ignore_case:
             raise ValueError(
@@ -120,6 +130,18 @@ class PropertyRef:
             raise ValueError(
                 f'Error setting PropertyRef "{self.name}": one_to_many cannot be used together with '
                 "`ignore_case` or `fuzzy_and_ignore_case`.",
+            )
+
+        if self.prefer_existing and not self.preserve_existing:
+            raise ValueError(
+                f'Error setting PropertyRef "{self.name}": '
+                "`prefer_existing` requires `preserve_existing=True`.",
+            )
+
+        if self.set_in_kwargs and self.preserve_existing:
+            raise ValueError(
+                f'Error setting PropertyRef "{self.name}": '
+                "`preserve_existing` cannot be used with `set_in_kwargs=True`.",
             )
 
     def _parameterize_name(self) -> str:

--- a/cartography/models/gcp/artifact_registry/image.py
+++ b/cartography/models/gcp/artifact_registry/image.py
@@ -42,17 +42,30 @@ class GCPArtifactRegistryImageManifestChildNodeProperties(CartographyNodePropert
 class GCPArtifactRegistryImageProvenanceNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef("digest")
     digest: PropertyRef = PropertyRef("digest", extra_index=True)
-    type: PropertyRef = PropertyRef("type", extra_index=True)
-    media_type: PropertyRef = PropertyRef("media_type")
-    architecture: PropertyRef = PropertyRef("architecture")
-    os: PropertyRef = PropertyRef("os")
-    os_version: PropertyRef = PropertyRef("os_version")
-    os_features: PropertyRef = PropertyRef("os_features")
-    variant: PropertyRef = PropertyRef("variant")
-    source_uri: PropertyRef = PropertyRef("source_uri", extra_index=True)
-    source_revision: PropertyRef = PropertyRef("source_revision")
-    source_file: PropertyRef = PropertyRef("source_file")
-    layer_diff_ids: PropertyRef = PropertyRef("layer_diff_ids")
+    type: PropertyRef = PropertyRef("type", extra_index=True, preserve_existing=True)
+    media_type: PropertyRef = PropertyRef("media_type", preserve_existing=True)
+    architecture: PropertyRef = PropertyRef("architecture", preserve_existing=True)
+    os: PropertyRef = PropertyRef("os", preserve_existing=True)
+    os_version: PropertyRef = PropertyRef("os_version", preserve_existing=True)
+    os_features: PropertyRef = PropertyRef("os_features", preserve_existing=True)
+    variant: PropertyRef = PropertyRef("variant", preserve_existing=True)
+    source_uri: PropertyRef = PropertyRef(
+        "source_uri",
+        extra_index=True,
+        preserve_existing=True,
+        prefer_existing=True,
+    )
+    source_revision: PropertyRef = PropertyRef(
+        "source_revision",
+        preserve_existing=True,
+        prefer_existing=True,
+    )
+    source_file: PropertyRef = PropertyRef(
+        "source_file",
+        preserve_existing=True,
+        prefer_existing=True,
+    )
+    layer_diff_ids: PropertyRef = PropertyRef("layer_diff_ids", preserve_existing=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 

--- a/docs/root/dev/writing-intel-modules.md
+++ b/docs/root/dev/writing-intel-modules.md
@@ -103,6 +103,30 @@ An `EMRClusterSchema` object inherits from the `CartographyNodeSchema` class and
 
 Note that the typehints are necessary for Python dataclasses to work properly.
 
+#### Preserving existing node properties
+
+Most node properties should use the default overwrite behavior. If an API returns
+`None`, the generated loader query writes `None`, which removes the existing Neo4j
+property. This is useful when the current API response is authoritative and the
+graph should forget old values.
+
+For enrichment-only passes where `None` means "not observed this time" rather
+than "clear this value", mark that property with `preserve_existing=True`:
+
+```python
+source_uri: PropertyRef = PropertyRef(
+    "source_uri",
+    extra_index=True,
+    preserve_existing=True,
+)
+```
+
+The generated node load query will keep the existing graph value when the
+incoming value is null or absent from the data dict, while still accepting
+incoming non-null updates. If the existing graph value should win whenever it is
+already populated, add `prefer_existing=True` as well. Use these only for node
+properties whose absence is expected during partial enrichment; do not use them
+for fields where a null value should intentionally clear stale data.
 
 #### Defining node properties
 

--- a/tests/integration/cartography/intel/gcp/test_artifact_registry.py
+++ b/tests/integration/cartography/intel/gcp/test_artifact_registry.py
@@ -932,6 +932,27 @@ def test_load_image_provenance_preserves_source_and_updates_metadata(
         project_id,
         TEST_UPDATE_TAG + 1,
     )
+    load_image_provenance(
+        neo4j_session,
+        [
+            {
+                "digest": docker_image["digest"],
+                "type": None,
+                "media_type": None,
+                "architecture": None,
+                "os": None,
+                "os_version": None,
+                "os_features": None,
+                "variant": " ",
+                "source_uri": "",
+                "source_revision": " ",
+                "source_file": None,
+                "layer_diff_ids": None,
+            },
+        ],
+        project_id,
+        TEST_UPDATE_TAG + 2,
+    )
 
     result = neo4j_session.run(
         """
@@ -962,7 +983,7 @@ def test_load_image_provenance_preserves_source_and_updates_metadata(
     assert result["ont_architecture"] == "arm64"
     assert result["ont_os"] == "linux"
     assert result["ont_variant"] == "v9"
-    assert result["lastupdated"] == TEST_UPDATE_TAG + 1
+    assert result["lastupdated"] == TEST_UPDATE_TAG + 2
 
 
 def test_get_unmatched_gcp_images_with_history_uses_parent_ref_for_platform_child(

--- a/tests/unit/cartography/graph/test_querybuilder_simple.py
+++ b/tests/unit/cartography/graph/test_querybuilder_simple.py
@@ -1,5 +1,12 @@
+import pytest
+
+from cartography.graph.querybuilder import _build_node_properties_statement
 from cartography.graph.querybuilder import _get_module_from_schema
 from cartography.graph.querybuilder import build_ingestion_query
+from cartography.models.core.common import PropertyRef
+from cartography.models.gcp.artifact_registry.image import (
+    GCPArtifactRegistryImageProvenanceSchema,
+)
 from cartography.version import get_cartography_version
 from tests.data.graph.querybuilder.sample_models.fake_emps_githubusers import (
     FakeEmpSchema,
@@ -35,6 +42,50 @@ def test_simplenode_with_subresource_sanity_checks():
     # Assert that the unimplemented, non-abstract properties have None values.
     assert schema.extra_node_labels is None
     assert schema.other_relationships is None
+
+
+def test_build_node_properties_statement_preserves_existing_values():
+    query = _build_node_properties_statement(
+        {
+            "id": PropertyRef("id"),
+            "lastupdated": PropertyRef("lastupdated", set_in_kwargs=True),
+            "source_uri": PropertyRef("source_uri", preserve_existing=True),
+            "source_file": PropertyRef(
+                "source_file",
+                preserve_existing=True,
+                prefer_existing=True,
+            ),
+        },
+    )
+
+    assert "i.lastupdated = $lastupdated" in query
+    assert "i.source_uri = coalesce(item.source_uri, i.source_uri)" in query
+    assert "i.source_file = coalesce(i.source_file, item.source_file)" in query
+
+
+def test_propertyref_prefer_existing_requires_preserve_existing():
+    with pytest.raises(ValueError, match="`preserve_existing=True`"):
+        PropertyRef("source_uri", prefer_existing=True)
+
+
+def test_propertyref_preserve_existing_rejects_kwargs_source():
+    with pytest.raises(ValueError, match="`set_in_kwargs=True`"):
+        PropertyRef(
+            "source_uri",
+            set_in_kwargs=True,
+            preserve_existing=True,
+        )
+
+
+def test_build_ingestion_query_preserves_existing_ontology_values():
+    query = build_ingestion_query(GCPArtifactRegistryImageProvenanceSchema())
+
+    assert "i.architecture = coalesce(item.architecture, i.architecture)" in query
+    assert (
+        "i._ont_architecture = coalesce(item.architecture, i._ont_architecture)"
+        in query
+    )
+    assert "i.source_uri = coalesce(i.source_uri, item.source_uri)" in query
 
 
 def test_build_ingestion_query_with_sub_resource():

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_supply_chain.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_supply_chain.py
@@ -242,7 +242,7 @@ def test_sync_loads_provenance_and_layers_with_split_phases(patched_sync):
     assert layer_call_args[2:] == ("proj", 1)
 
 
-def test_load_image_provenance_preserves_existing_values(monkeypatch):
+def test_load_image_provenance_uses_schema_preservation(monkeypatch):
     load_nodes_without_relationships = MagicMock()
     monkeypatch.setattr(
         supply_chain,
@@ -250,23 +250,31 @@ def test_load_image_provenance_preserves_existing_values(monkeypatch):
         load_nodes_without_relationships,
     )
     neo4j_session = MagicMock()
-    neo4j_session.execute_read.return_value = [
+    updates = [
         {
             "digest": "sha256:img-1",
             "type": "image",
             "media_type": "application/vnd.oci.image.manifest.v1+json",
-            "architecture": "amd64",
-            "os": "linux",
+            "architecture": None,
+            "os": None,
             "os_version": None,
             "os_features": None,
-            "variant": "v8",
-            "source_uri": "https://github.com/foo/bar",
-            "source_revision": "deadbeef",
-            "source_file": "Dockerfile",
-            "layer_diff_ids": ["sha256:a"],
+            "variant": " ",
+            "source_uri": "",
+            "source_revision": " ",
+            "source_file": None,
+            "layer_diff_ids": None,
         },
     ]
-    updates = [
+
+    supply_chain.load_image_provenance(neo4j_session, updates, "proj", 1)
+
+    neo4j_session.execute_read.assert_not_called()
+    load_nodes_without_relationships.assert_called_once()
+    call = load_nodes_without_relationships.call_args
+    assert call.args[0] == neo4j_session
+    assert call.args[1].__class__.__name__ == "GCPArtifactRegistryImageProvenanceSchema"
+    assert call.args[2] == [
         {
             "digest": "sha256:img-1",
             "type": "image",
@@ -280,30 +288,6 @@ def test_load_image_provenance_preserves_existing_values(monkeypatch):
             "source_revision": None,
             "source_file": None,
             "layer_diff_ids": None,
-        },
-    ]
-
-    supply_chain.load_image_provenance(neo4j_session, updates, "proj", 1)
-
-    neo4j_session.execute_read.assert_called_once()
-    load_nodes_without_relationships.assert_called_once()
-    call = load_nodes_without_relationships.call_args
-    assert call.args[0] == neo4j_session
-    assert call.args[1].__class__.__name__ == "GCPArtifactRegistryImageProvenanceSchema"
-    assert call.args[2] == [
-        {
-            "digest": "sha256:img-1",
-            "type": "image",
-            "media_type": "application/vnd.oci.image.manifest.v1+json",
-            "architecture": "amd64",
-            "os": "linux",
-            "os_version": None,
-            "os_features": None,
-            "variant": "v8",
-            "source_uri": "https://github.com/foo/bar",
-            "source_revision": "deadbeef",
-            "source_file": "Dockerfile",
-            "layer_diff_ids": ["sha256:a"],
         },
     ]
     assert "provenance updates" in call.kwargs["progress_description"]


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary
Add opt-in loader support for enrichment schemas that should preserve existing graph values when a partial enrichment pass sends `None` or omits fields it did not observe.

- Add `PropertyRef(..., preserve_existing=True)` for node property SET clauses.
- Add `prefer_existing=True` for digest-level provenance fields where an existing graph value should win once populated.
- Generate preservation-aware assignments for normal node fields and simple ontology mirror fields like `_ont_architecture`.
- Move ECR image layer/provenance enrichment and GCP Artifact Registry provenance enrichment to schema-declared preservation.
- Remove module-local graph pre-read/merge paths that copied existing image properties into enrichment rows before calling the standard loader.
- Normalize blank/whitespace-only GAR provenance strings to `None` before loading, so they preserve existing values instead of clearing them.


### Related issues or links
Prior art / motivation:
- #2313 split ECR base image loading from layer/provenance enrichment so the basic ECR load would not clear provenance fields.
- #2690 applied the same two-schema pattern to GCP Artifact Registry provenance enrichment.
- #2743 introduced the canonical GCP Artifact Registry image model and surfaced the same preservation need during provenance enrichment.


### Breaking changes
None. Existing loader overwrite behavior remains the default unless a node property explicitly opts into preservation.


### How was this tested?
- `uv run --frozen pytest tests/unit/cartography/graph/test_querybuilder_simple.py tests/unit/cartography/intel/gcp/test_artifact_registry_supply_chain.py -q`
- `uv run --frozen pytest tests/integration/cartography/intel/gcp/test_artifact_registry.py::test_load_image_provenance_preserves_source_and_updates_metadata tests/integration/cartography/intel/gcp/test_artifact_registry.py::test_load_manifests_preserves_existing_source_fields -q`
- `uv run --frozen pytest tests/integration/cartography/intel/aws/test_ecr_layers.py::test_sync_layers_preserves_multi_arch_image_properties -q`
- `uv run --frozen pre-commit run --all-files`
- Claude Code simplify pass and no-edit review pass over the public diff; accepted the simplification suggestions and final review found no material blockers.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
N/A. This changes loader behavior for existing schemas; it does not add a new synced entity.

#### If you are changing a node or relationship
N/A. This does not add, remove, or rename graph nodes or relationships.

#### If you are implementing a new intel module
N/A.


### Notes for reviewers
The generated loader normally emits explicit assignments like `SET i.field = item.field`; in Cypher, missing map keys evaluate to null and clear the property. `preserve_existing=True` changes opted-in node fields to use `coalesce(incoming, existing)`, keeping the standard schema-driven loader path while avoiding stale module-local pre-read/merge copies.

`prefer_existing=True` is used only for GAR digest-level source provenance fields, matching the existing first-populated-source behavior.
