### PR TITLE
fix(ci): poll PyPI install path before docker build

### DIFF
--- a/.github/workflows/publish-to-ghcr-and-pypi.yml
+++ b/.github/workflows/publish-to-ghcr-and-pypi.yml
@@ -127,29 +127,37 @@ jobs:
           # for more detailed information.
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Get the cartography version from the GitHub release event metadata and verify it's available on PyPI
+      # Get the cartography version from the GitHub release event metadata and
+      # poll PyPI until the wheel is actually fetchable by pip. We don't poll
+      # the JSON metadata API because it can report a version as available
+      # before the wheel has propagated to the Fastly edges that pip/uv hit;
+      # exercising `pip download` against the simple index matches what
+      # `uv tool install` will do in the Docker build below.
       - name: Extract version and verify PyPI availability
         id: version
         env:
           VERSION: ${{ github.event.release.tag_name }}
         run: |
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "Waiting for cartography==$VERSION to be available on PyPI..."
+          echo "Waiting for cartography==$VERSION to be installable from PyPI..."
 
-          # Poll PyPI for up to 5 minutes
-          MAX_ATTEMPTS=30
+          MAX_ATTEMPTS=60
           ATTEMPT=0
+          TMPDIR=$(mktemp -d)
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-            if curl --fail --silent --show-error "https://pypi.org/pypi/cartography/$VERSION/json" > /dev/null; then
-              echo "✅ cartography==$VERSION is now available on PyPI"
+            if python3 -m pip download --no-deps --no-cache-dir \
+                 --index-url https://pypi.org/simple/ \
+                 --dest "$TMPDIR" \
+                 "cartography==$VERSION" > /dev/null 2>&1; then
+              echo "cartography==$VERSION is installable from PyPI"
               exit 0
             fi
             ATTEMPT=$((ATTEMPT + 1))
-            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: Package not yet available, waiting 10 seconds..."
+            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: not yet installable, retrying in 10s..."
             sleep 10
           done
 
-          echo "❌ Failed to verify cartography==$VERSION on PyPI after $MAX_ATTEMPTS attempts"
+          echo "Timed out waiting for cartography==$VERSION on PyPI after $MAX_ATTEMPTS attempts"
           exit 1
 
       - name: Build and push


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

The release workflow waits for the new PyPI release before building the GHCR docker image. The wait used to poll PyPI's JSON metadata API, which can return 200 before the wheel has propagated to the Fastly edges that pip/uv actually hit. When that race lost, the downstream `uv tool install cartography==X.Y.Z` in the docker build failed and the GHCR image for that release was not published (see referenced issue).

Switch the wait to `python3 -m pip download --no-deps` against the simple index, which exercises the same resolution and download path as `uv tool install` in the Dockerfile. If `pip download` succeeds on the runner, `uv tool install` will succeed in buildx for both `linux/amd64` and `linux/arm64`. Also bump the budget from 5 to 10 minutes for slow PyPI propagation days.


### Related issues or links

- Refs https://github.com/cartography-cncf/cartography/issues/2646


### How was this tested?

Smoke-tested the new command shape locally:

```sh
TMP=$(mktemp -d)
python3 -m pip download --no-deps --no-cache-dir --index-url https://pypi.org/simple/ --dest "$TMP" cartography==0.136.0
# -> exit 0, cartography-0.136.0-py3-none-any.whl in $TMP

python3 -m pip download --no-deps --no-cache-dir --index-url https://pypi.org/simple/ --dest "$TMP" cartography==99.99.99
# -> exit non-zero (loop continues)
```

End-to-end verification will happen on the next real release. If propagation is still slow, the loop fails with a clear "Timed out waiting for cartography==X.Y.Z on PyPI" message rather than a confusing pip resolver error inside the Docker build.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.


### Notes for reviewers

CI-only change; no runtime impact on the cartography package or graph. The step still runs only when `github.event.release.tag_name` is set, same as before.