### PR TITLE
perf(sync): defer provider SDK loading until a stage runs

### DIFF
--- a/.agents/skills/create-module/SKILL.md
+++ b/.agents/skills/create-module/SKILL.md
@@ -47,7 +47,23 @@ In `cartography/cli.py`:
 
 In `cartography/config.py`, extend `Config.__init__` with the new fields. Then in your module entry point, validate them and short-circuit with `logger.info("... not configured - skipping module")` when missing.
 
-### Step 3 — Implement the sync pattern
+### Step 3 — Register the module in `cartography/sync.py`
+
+Add one entry to `TOP_LEVEL_MODULES` using the lazy wrapper. **Do not add a top-level `import cartography.intel.your_service` to `sync.py`** — that defeats lazy SDK loading and reintroduces the slow-startup problem.
+
+```python
+TOP_LEVEL_MODULES = OrderedDict({
+    ...
+    "your_service": _LazyStage("cartography.intel.your_service", "start_your_service_ingestion"),
+    ...
+    # `analysis` must remain last
+    "analysis": _LazyStage("cartography.intel.analysis", "run"),
+})
+```
+
+Pick a sensible position relative to neighbors (cloud providers grouped together, etc.). The provider's heavy SDK imports stay where they are — they only fire when this stage is selected and run.
+
+### Step 4 — Implement the sync pattern
 
 For each domain (users, devices, projects, ...):
 
@@ -68,7 +84,7 @@ def sync(
 
 `get()` should be minimal: set timeouts, call `response.raise_for_status()`, and let errors propagate. AWS get-functions wrap with `@aws_handle_regions`. See `references/sync-pattern.md` for the long-form template, error-handling rules, and transform examples.
 
-### Step 4 — Define the data model
+### Step 5 — Define the data model
 
 Create dataclasses in `cartography/models/your_service/`. Required for every node:
 
@@ -96,7 +112,7 @@ class YourServiceUserSchema(CartographyNodeSchema):
 
 For advanced node configurations (extra labels, conditional labels, scoped cleanup, one-to-many) see the `add-node-type` skill. For relationships, MatchLinks, and multi-module patterns see the `add-relationship` skill. See `references/data-model.md` for the full reference.
 
-### Step 5 — Load + cleanup
+### Step 6 — Load + cleanup
 
 ```python
 def load_users(neo4j_session, data, tenant_id, update_tag):
@@ -109,19 +125,19 @@ def cleanup(neo4j_session, common_job_parameters):
 
 If you hand-write a Cypher write query during prototyping, use `run_write_query()` (managed transaction + retries), never `neo4j_session.run()`.
 
-### Step 6 — Integration test
+### Step 7 — Integration test
 
 In `tests/integration/cartography/intel/your_service/test_users.py`, patch only `get()` and call `sync()` end-to-end. Assert outcomes (nodes + relationships) using `tests.integration.util.check_nodes` / `check_rels`. Do not assert on mock call counts or internal parameters. See `references/testing.md` for a full template and the test boundary policy.
 
-### Step 7 — Schema documentation
+### Step 8 — Schema documentation
 
 Add a page at `docs/root/modules/your_service/schema.md`. Use `###` for node names, `####` for the "Relationships" subsection, **bold** indexed/primary fields. If the node has a semantic label, add the standard ontology mapping blockquote (see the `enrich-ontology` skill).
 
-### Step 8 — Optional: analysis jobs
+### Step 9 — Optional: analysis jobs
 
 If the module needs post-ingestion enrichment (internet exposure, permission inheritance, cross-resource linking), call `run_analysis_job()` / `run_scoped_analysis_job()` at the end of the entry point. See the `analysis-jobs` skill.
 
-### Step 9 — Pre-submission checks
+### Step 10 — Pre-submission checks
 
 ```bash
 make lint
@@ -135,6 +151,7 @@ Sign every commit: `git commit -s -m "..."`. Update the PR description to match 
 
 - [ ] Entry point validates config and skips cleanly when unconfigured
 - [ ] CLI panel + `Config` fields wired, secrets resolved from env vars
+- [ ] Module registered in `cartography/sync.py:TOP_LEVEL_MODULES` via `_LazyStage`, with no top-level `import cartography.intel.<service>` added to `sync.py`
 - [ ] Sync follows GET -> TRANSFORM -> LOAD -> CLEANUP
 - [ ] All schemas use only standard fields (`label`, `properties`, `sub_resource_relationship`, `other_relationships`, `extra_node_labels`, `scoped_cleanup`)
 - [ ] Sub-resource relationship targets a tenant-like node

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -1,62 +1,16 @@
+import importlib
 import logging
 import re
 import time
 from collections import OrderedDict
 from pkgutil import iter_modules
+from typing import Any
 from typing import Callable
 
 import neo4j.exceptions
 from neo4j import GraphDatabase
 from statsd import StatsClient
 
-import cartography.intel.aibom
-import cartography.intel.airbyte
-import cartography.intel.analysis
-import cartography.intel.anthropic
-import cartography.intel.aws
-import cartography.intel.azure
-import cartography.intel.bigfix
-import cartography.intel.cloudflare
-import cartography.intel.create_indexes
-import cartography.intel.crowdstrike
-import cartography.intel.cve
-import cartography.intel.cve_metadata
-import cartography.intel.digitalocean
-import cartography.intel.docker_scout
-import cartography.intel.duo
-import cartography.intel.gcp
-import cartography.intel.github
-import cartography.intel.gitlab
-import cartography.intel.googleworkspace
-import cartography.intel.gsuite
-import cartography.intel.jamf
-import cartography.intel.jumpcloud
-import cartography.intel.kandji
-import cartography.intel.keycloak
-import cartography.intel.kubernetes
-import cartography.intel.lastpass
-import cartography.intel.microsoft
-import cartography.intel.oci
-import cartography.intel.okta
-import cartography.intel.ontology
-import cartography.intel.openai
-import cartography.intel.pagerduty
-import cartography.intel.scaleway
-import cartography.intel.semgrep
-import cartography.intel.sentinelone
-import cartography.intel.sentry
-import cartography.intel.slack
-import cartography.intel.snipeit
-import cartography.intel.socketdev
-import cartography.intel.spacelift
-import cartography.intel.subimage
-import cartography.intel.syft
-import cartography.intel.tailscale
-import cartography.intel.trivy
-import cartography.intel.ubuntu
-import cartography.intel.vercel
-import cartography.intel.workday
-import cartography.intel.workos
 from cartography.config import Config
 from cartography.stats import set_stats_client
 from cartography.util import STATUS_FAILURE
@@ -65,57 +19,116 @@ from cartography.util import STATUS_SUCCESS
 logger = logging.getLogger(__name__)
 
 
+class _LazyStage:
+    """Callable that defers `from cartography.intel.X import func` until first invocation.
+
+    Keeps `import cartography.sync` cheap: provider SDKs (boto3, azure-mgmt-*,
+    google-cloud-*, etc.) only load when the stage is actually run.
+    """
+
+    __slots__ = ("_module", "_attr", "_resolved")
+
+    def __init__(self, module: str, attr: str) -> None:
+        self._module = module
+        self._attr = attr
+        self._resolved: Callable[..., None] | None = None
+
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
+        if self._resolved is None:
+            self._resolved = getattr(importlib.import_module(self._module), self._attr)
+        self._resolved(*args, **kwargs)
+
+    def __repr__(self) -> str:
+        return f"_LazyStage({self._module}.{self._attr})"
+
+
 TOP_LEVEL_MODULES: OrderedDict[str, Callable[..., None]] = OrderedDict(
     {  # preserve order so that the default sync always runs `analysis` at the very end
-        "create-indexes": cartography.intel.create_indexes.run,
-        "airbyte": cartography.intel.airbyte.start_airbyte_ingestion,
-        "anthropic": cartography.intel.anthropic.start_anthropic_ingestion,
-        "aws": cartography.intel.aws.start_aws_ingestion,
-        "azure": cartography.intel.azure.start_azure_ingestion,
-        "microsoft": cartography.intel.microsoft.start_microsoft_ingestion,
-        "cloudflare": cartography.intel.cloudflare.start_cloudflare_ingestion,
-        "crowdstrike": cartography.intel.crowdstrike.start_crowdstrike_ingestion,
-        "gcp": cartography.intel.gcp.start_gcp_ingestion,
-        "googleworkspace": cartography.intel.googleworkspace.start_googleworkspace_ingestion,
-        "gsuite": cartography.intel.gsuite.start_gsuite_ingestion,
-        "cve": cartography.intel.cve.start_cve_ingestion,
-        "cve_metadata": cartography.intel.cve_metadata.start_cve_metadata_ingestion,
-        "oci": cartography.intel.oci.start_oci_ingestion,
-        "okta": cartography.intel.okta.start_okta_ingestion,
-        "openai": cartography.intel.openai.start_openai_ingestion,
-        "github": cartography.intel.github.start_github_ingestion,
-        "gitlab": cartography.intel.gitlab.start_gitlab_ingestion,
-        "digitalocean": cartography.intel.digitalocean.start_digitalocean_ingestion,
-        "kandji": cartography.intel.kandji.start_kandji_ingestion,
-        "keycloak": cartography.intel.keycloak.start_keycloak_ingestion,
-        "kubernetes": cartography.intel.kubernetes.start_k8s_ingestion,
-        "jumpcloud": cartography.intel.jumpcloud.start_jumpcloud_ingestion,
-        "lastpass": cartography.intel.lastpass.start_lastpass_ingestion,
-        "bigfix": cartography.intel.bigfix.start_bigfix_ingestion,
-        "duo": cartography.intel.duo.start_duo_ingestion,
-        "workday": cartography.intel.workday.start_workday_ingestion,
-        "scaleway": cartography.intel.scaleway.start_scaleway_ingestion,
-        "semgrep": cartography.intel.semgrep.start_semgrep_ingestion,
-        "sentry": cartography.intel.sentry.start_sentry_ingestion,
-        "snipeit": cartography.intel.snipeit.start_snipeit_ingestion,
-        "socketdev": cartography.intel.socketdev.start_socketdev_ingestion,
-        "tailscale": cartography.intel.tailscale.start_tailscale_ingestion,
-        "jamf": cartography.intel.jamf.start_jamf_ingestion,
-        "pagerduty": cartography.intel.pagerduty.start_pagerduty_ingestion,
-        "docker_scout": cartography.intel.docker_scout.start_docker_scout_ingestion,
-        "trivy": cartography.intel.trivy.start_trivy_ingestion,
-        "syft": cartography.intel.syft.start_syft_ingestion,
-        "aibom": cartography.intel.aibom.start_aibom_ingestion,
-        "ubuntu": cartography.intel.ubuntu.start_ubuntu_ingestion,
-        "sentinelone": cartography.intel.sentinelone.start_sentinelone_ingestion,
-        "slack": cartography.intel.slack.start_slack_ingestion,
-        "spacelift": cartography.intel.spacelift.start_spacelift_ingestion,
-        "workos": cartography.intel.workos.start_workos_ingestion,
-        "subimage": cartography.intel.subimage.start_subimage_ingestion,
-        "vercel": cartography.intel.vercel.start_vercel_ingestion,
-        "ontology": cartography.intel.ontology.run,
+        "create-indexes": _LazyStage("cartography.intel.create_indexes", "run"),
+        "airbyte": _LazyStage("cartography.intel.airbyte", "start_airbyte_ingestion"),
+        "anthropic": _LazyStage(
+            "cartography.intel.anthropic", "start_anthropic_ingestion"
+        ),
+        "aws": _LazyStage("cartography.intel.aws", "start_aws_ingestion"),
+        "azure": _LazyStage("cartography.intel.azure", "start_azure_ingestion"),
+        "microsoft": _LazyStage(
+            "cartography.intel.microsoft", "start_microsoft_ingestion"
+        ),
+        "cloudflare": _LazyStage(
+            "cartography.intel.cloudflare", "start_cloudflare_ingestion"
+        ),
+        "crowdstrike": _LazyStage(
+            "cartography.intel.crowdstrike", "start_crowdstrike_ingestion"
+        ),
+        "gcp": _LazyStage("cartography.intel.gcp", "start_gcp_ingestion"),
+        "googleworkspace": _LazyStage(
+            "cartography.intel.googleworkspace", "start_googleworkspace_ingestion"
+        ),
+        "gsuite": _LazyStage("cartography.intel.gsuite", "start_gsuite_ingestion"),
+        "cve": _LazyStage("cartography.intel.cve", "start_cve_ingestion"),
+        "cve_metadata": _LazyStage(
+            "cartography.intel.cve_metadata", "start_cve_metadata_ingestion"
+        ),
+        "oci": _LazyStage("cartography.intel.oci", "start_oci_ingestion"),
+        "okta": _LazyStage("cartography.intel.okta", "start_okta_ingestion"),
+        "openai": _LazyStage("cartography.intel.openai", "start_openai_ingestion"),
+        "github": _LazyStage("cartography.intel.github", "start_github_ingestion"),
+        "gitlab": _LazyStage("cartography.intel.gitlab", "start_gitlab_ingestion"),
+        "digitalocean": _LazyStage(
+            "cartography.intel.digitalocean", "start_digitalocean_ingestion"
+        ),
+        "kandji": _LazyStage("cartography.intel.kandji", "start_kandji_ingestion"),
+        "keycloak": _LazyStage(
+            "cartography.intel.keycloak", "start_keycloak_ingestion"
+        ),
+        "kubernetes": _LazyStage("cartography.intel.kubernetes", "start_k8s_ingestion"),
+        "jumpcloud": _LazyStage(
+            "cartography.intel.jumpcloud", "start_jumpcloud_ingestion"
+        ),
+        "lastpass": _LazyStage(
+            "cartography.intel.lastpass", "start_lastpass_ingestion"
+        ),
+        "bigfix": _LazyStage("cartography.intel.bigfix", "start_bigfix_ingestion"),
+        "duo": _LazyStage("cartography.intel.duo", "start_duo_ingestion"),
+        "workday": _LazyStage("cartography.intel.workday", "start_workday_ingestion"),
+        "scaleway": _LazyStage(
+            "cartography.intel.scaleway", "start_scaleway_ingestion"
+        ),
+        "semgrep": _LazyStage("cartography.intel.semgrep", "start_semgrep_ingestion"),
+        "sentry": _LazyStage("cartography.intel.sentry", "start_sentry_ingestion"),
+        "snipeit": _LazyStage("cartography.intel.snipeit", "start_snipeit_ingestion"),
+        "socketdev": _LazyStage(
+            "cartography.intel.socketdev", "start_socketdev_ingestion"
+        ),
+        "tailscale": _LazyStage(
+            "cartography.intel.tailscale", "start_tailscale_ingestion"
+        ),
+        "jamf": _LazyStage("cartography.intel.jamf", "start_jamf_ingestion"),
+        "pagerduty": _LazyStage(
+            "cartography.intel.pagerduty", "start_pagerduty_ingestion"
+        ),
+        "docker_scout": _LazyStage(
+            "cartography.intel.docker_scout", "start_docker_scout_ingestion"
+        ),
+        "trivy": _LazyStage("cartography.intel.trivy", "start_trivy_ingestion"),
+        "syft": _LazyStage("cartography.intel.syft", "start_syft_ingestion"),
+        "aibom": _LazyStage("cartography.intel.aibom", "start_aibom_ingestion"),
+        "ubuntu": _LazyStage("cartography.intel.ubuntu", "start_ubuntu_ingestion"),
+        "sentinelone": _LazyStage(
+            "cartography.intel.sentinelone", "start_sentinelone_ingestion"
+        ),
+        "slack": _LazyStage("cartography.intel.slack", "start_slack_ingestion"),
+        "spacelift": _LazyStage(
+            "cartography.intel.spacelift", "start_spacelift_ingestion"
+        ),
+        "workos": _LazyStage("cartography.intel.workos", "start_workos_ingestion"),
+        "subimage": _LazyStage(
+            "cartography.intel.subimage", "start_subimage_ingestion"
+        ),
+        "vercel": _LazyStage("cartography.intel.vercel", "start_vercel_ingestion"),
+        "ontology": _LazyStage("cartography.intel.ontology", "run"),
         # Analysis should be the last stage
-        "analysis": cartography.intel.analysis.run,
+        "analysis": _LazyStage("cartography.intel.analysis", "run"),
     }
 )
 
@@ -304,11 +317,14 @@ class Sync:
             The 'create-indexes' and 'analysis' modules are handled specially
             to ensure consistent ordering regardless of discovery order.
         """
+        intel_pkg = importlib.import_module("cartography.intel")
         available_modules = OrderedDict({})
-        available_modules["create-indexes"] = cartography.intel.create_indexes.run
+        available_modules["create-indexes"] = importlib.import_module(
+            "cartography.intel.create_indexes"
+        ).run
         callable_regex = re.compile(r"^start_(.+)_ingestion$")
         # Load built-in modules
-        for intel_module_info in iter_modules(cartography.intel.__path__):
+        for intel_module_info in iter_modules(intel_pkg.__path__):
             if intel_module_info.name in ("analysis", "create_indexes", "entra"):
                 continue
             try:
@@ -345,8 +361,12 @@ class Sync:
                         intel_module_info.name,
                     )
                 available_modules[intel_module_info.name] = v
-        available_modules["ontology"] = cartography.intel.ontology.run
-        available_modules["analysis"] = cartography.intel.analysis.run
+        available_modules["ontology"] = importlib.import_module(
+            "cartography.intel.ontology"
+        ).run
+        available_modules["analysis"] = importlib.import_module(
+            "cartography.intel.analysis"
+        ).run
         return available_modules
 
 


### PR DESCRIPTION
### Type of change
- [x] Refactoring (no functional changes)

### Summary

Importing `cartography.sync` (used by both the CLI and library callers) used to eagerly load all 46 `cartography.intel.*` provider packages, pulling in `boto3` + `aioboto3`, 20+ `azure-mgmt-*` + `azure-identity`, `google-cloud-*` + `googleapiclient`, `msgraph-sdk`, `kubernetes`, `oci`, `okta`, `crowdstrike-falconpy`, and ~15 more SDKs at startup even when only one provider was being used.

This PR replaces the direct attribute references in `TOP_LEVEL_MODULES` with a tiny `_LazyStage` callable that resolves `cartography.intel.<provider>.<func>` via `importlib` at first invocation. The public surface (`TOP_LEVEL_MODULES` keys, `build_default_sync`, `build_sync`, `Sync.run` signature, stage call signature `(neo4j_session, config) -> None`) is unchanged.

`Sync.list_intel_modules()` already does deep eager iteration by design (discovery utility), so its three direct references to `create_indexes` / `ontology` / `analysis` were swapped to `importlib.import_module` rather than re-introduced as top-level imports.

### Perf impact

Measured on Python 3.13.13 / macOS, median of 5 runs (each in a fresh subprocess):

| Scenario                  | Before    | After    | Delta         |
|---------------------------|-----------|----------|---------------|
| `import cartography.sync` | 5409.8 ms | 177.6 ms | **-96.7%, 30x** |
| `build_sync('azure')`     | 5443.8 ms | 173.5 ms | -96.8%        |
| `build_default_sync()`    | 5402.7 ms | 174.9 ms | -96.8%        |
| RSS, `import cartography.sync`     | 578.5 MB  | 79.3 MB  | **-499 MB** |
| RSS, `build_sync('azure')`         | 578.9 MB  | 79.4 MB  | -499 MB       |
| Python heap (`tracemalloc`)        | 463.3 MB  | 47.4 MB  | -415 MB       |

`python -X importtime -c "import cartography.sync"` drops from **8385 import lines / 6.04 s cumulative** to **660 lines / 0.18 s cumulative**.

When a stage actually runs, its provider package and the SDK behind it load on first call, so steady-state cost during a real sync is unchanged.

### How was this tested?

- `make test_unit` — 1740 tests pass.
- `make test_lint` — clean (ruff / black / isort / mypy / flake8 / pyupgrade).
- Smoke: `from cartography.sync import build_default_sync, build_sync, TOP_LEVEL_MODULES` works; `TOP_LEVEL_MODULES['aws']` is callable; `analysis` is still last; `build_sync('azure')` produces a single-stage Sync without resolving the AWS / GCP / Microsoft modules.
- The contributor-facing `create-module` skill was updated with a "Register the module" step that mandates `_LazyStage` and warns against re-introducing a top-level `import cartography.intel.<service>` to `sync.py`.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works. (no new behavior; existing tests cover the public surface — `tests/unit/cartography/test_sync.py`, `tests/unit/rules/test_model.py`, `tests/unit/cartography/intel/ontology/test_ontology_mapping.py`).