### PR TITLE
fix(azure): skip transient data factory failures

### DIFF
--- a/cartography/intel/azure/__init__.py
+++ b/cartography/intel/azure/__init__.py
@@ -92,7 +92,8 @@ def _sync_data_factory(
     except AzureDataFactoryTransientError as error:
         logger.warning(
             "Skipping Azure Data Factory sync after transient API failures "
-            "(operation=%s, status_code=%s).",
+            "for subscription %s (operation=%s, status_code=%s).",
+            subscription_id,
             error.operation,
             error.status_code,
         )

--- a/cartography/intel/azure/__init__.py
+++ b/cartography/intel/azure/__init__.py
@@ -46,6 +46,58 @@ from .util.credentials import Credentials
 logger = logging.getLogger(__name__)
 
 
+def _sync_data_factory(
+    neo4j_session: neo4j.Session,
+    credentials: Credentials,
+    subscription_id: str,
+    update_tag: int,
+    common_job_parameters: Dict,
+) -> None:
+    try:
+        factories_raw = data_factory.sync_data_factories(
+            neo4j_session,
+            credentials,
+            subscription_id,
+            update_tag,
+            common_job_parameters,
+        )
+        linked_services_by_factory = (
+            data_factory_linked_service.sync_data_factory_linked_services(
+                neo4j_session,
+                credentials,
+                factories_raw,
+                subscription_id,
+                update_tag,
+                common_job_parameters,
+            )
+        )
+        datasets_by_factory = data_factory_dataset.sync_data_factory_datasets(
+            neo4j_session,
+            credentials,
+            factories_raw,
+            linked_services_by_factory,
+            subscription_id,
+            update_tag,
+            common_job_parameters,
+        )
+        data_factory_pipeline.sync_data_factory_pipelines(
+            neo4j_session,
+            credentials,
+            factories_raw,
+            datasets_by_factory,
+            subscription_id,
+            update_tag,
+            common_job_parameters,
+        )
+    except AzureDataFactoryTransientError as error:
+        logger.warning(
+            "Skipping Azure Data Factory sync after transient API failures "
+            "(operation=%s, status_code=%s).",
+            error.operation,
+            error.status_code,
+        )
+
+
 def _sync_one_subscription(
     neo4j_session: neo4j.Session,
     credentials: Credentials,
@@ -152,49 +204,13 @@ def _sync_one_subscription(
         update_tag,
         common_job_parameters,
     )
-    try:
-        factories_raw = data_factory.sync_data_factories(
-            neo4j_session,
-            credentials,
-            subscription_id,
-            update_tag,
-            common_job_parameters,
-        )
-        linked_services_by_factory = (
-            data_factory_linked_service.sync_data_factory_linked_services(
-                neo4j_session,
-                credentials,
-                factories_raw,
-                subscription_id,
-                update_tag,
-                common_job_parameters,
-            )
-        )
-        datasets_by_factory = data_factory_dataset.sync_data_factory_datasets(
-            neo4j_session,
-            credentials,
-            factories_raw,
-            linked_services_by_factory,
-            subscription_id,
-            update_tag,
-            common_job_parameters,
-        )
-        data_factory_pipeline.sync_data_factory_pipelines(
-            neo4j_session,
-            credentials,
-            factories_raw,
-            datasets_by_factory,
-            subscription_id,
-            update_tag,
-            common_job_parameters,
-        )
-    except AzureDataFactoryTransientError as error:
-        logger.warning(
-            "Skipping Azure Data Factory sync after transient API failures "
-            "(operation=%s, status_code=%s).",
-            error.operation,
-            error.status_code,
-        )
+    _sync_data_factory(
+        neo4j_session,
+        credentials,
+        subscription_id,
+        update_tag,
+        common_job_parameters,
+    )
     data_lake.sync(
         neo4j_session,
         credentials,

--- a/cartography/intel/azure/__init__.py
+++ b/cartography/intel/azure/__init__.py
@@ -39,6 +39,7 @@ from . import storage
 from . import subscription
 from . import synapse
 from . import tenant
+from .data_factory_util import AzureDataFactoryTransientError
 from .util.credentials import Authenticator
 from .util.credentials import Credentials
 
@@ -151,41 +152,49 @@ def _sync_one_subscription(
         update_tag,
         common_job_parameters,
     )
-    factories_raw = data_factory.sync_data_factories(
-        neo4j_session,
-        credentials,
-        subscription_id,
-        update_tag,
-        common_job_parameters,
-    )
-    linked_services_by_factory = (
-        data_factory_linked_service.sync_data_factory_linked_services(
+    try:
+        factories_raw = data_factory.sync_data_factories(
             neo4j_session,
             credentials,
-            factories_raw,
             subscription_id,
             update_tag,
             common_job_parameters,
         )
-    )
-    datasets_by_factory = data_factory_dataset.sync_data_factory_datasets(
-        neo4j_session,
-        credentials,
-        factories_raw,
-        linked_services_by_factory,
-        subscription_id,
-        update_tag,
-        common_job_parameters,
-    )
-    data_factory_pipeline.sync_data_factory_pipelines(
-        neo4j_session,
-        credentials,
-        factories_raw,
-        datasets_by_factory,
-        subscription_id,
-        update_tag,
-        common_job_parameters,
-    )
+        linked_services_by_factory = (
+            data_factory_linked_service.sync_data_factory_linked_services(
+                neo4j_session,
+                credentials,
+                factories_raw,
+                subscription_id,
+                update_tag,
+                common_job_parameters,
+            )
+        )
+        datasets_by_factory = data_factory_dataset.sync_data_factory_datasets(
+            neo4j_session,
+            credentials,
+            factories_raw,
+            linked_services_by_factory,
+            subscription_id,
+            update_tag,
+            common_job_parameters,
+        )
+        data_factory_pipeline.sync_data_factory_pipelines(
+            neo4j_session,
+            credentials,
+            factories_raw,
+            datasets_by_factory,
+            subscription_id,
+            update_tag,
+            common_job_parameters,
+        )
+    except AzureDataFactoryTransientError as error:
+        logger.warning(
+            "Skipping Azure Data Factory sync after transient API failures "
+            "(operation=%s, status_code=%s).",
+            error.operation,
+            error.status_code,
+        )
     data_lake.sync(
         neo4j_session,
         credentials,

--- a/cartography/intel/azure/__init__.py
+++ b/cartography/intel/azure/__init__.py
@@ -1,6 +1,4 @@
 import logging
-from typing import Dict
-from typing import List
 
 import neo4j
 
@@ -51,7 +49,7 @@ def _sync_data_factory(
     credentials: Credentials,
     subscription_id: str,
     update_tag: int,
-    common_job_parameters: Dict,
+    common_job_parameters: dict,
 ) -> None:
     try:
         factories_raw = data_factory.sync_data_factories(
@@ -104,7 +102,7 @@ def _sync_one_subscription(
     credentials: Credentials,
     subscription_id: str,
     update_tag: int,
-    common_job_parameters: Dict,
+    common_job_parameters: dict,
 ) -> None:
     compute.sync(
         neo4j_session,
@@ -287,7 +285,7 @@ def _sync_tenant(
     neo4j_session: neo4j.Session,
     credentials: Credentials,
     update_tag: int,
-    common_job_parameters: Dict,
+    common_job_parameters: dict,
 ) -> None:
     logger.info("Syncing Azure Tenant: %s", credentials.tenant_id)
     tenant.sync(
@@ -303,9 +301,9 @@ def _sync_multiple_subscriptions(
     neo4j_session: neo4j.Session,
     credentials: Credentials,
     tenant_id: str,
-    subscriptions: List[Dict],
+    subscriptions: list[dict],
     update_tag: int,
-    common_job_parameters: Dict,
+    common_job_parameters: dict,
 ) -> None:
     logger.info("Syncing Azure subscriptions")
 

--- a/cartography/intel/azure/data_factory.py
+++ b/cartography/intel/azure/data_factory.py
@@ -6,6 +6,7 @@ from azure.mgmt.datafactory import DataFactoryManagementClient
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.azure.data_factory_util import call_data_factory_operation
 from cartography.models.azure.data_factory.data_factory import AzureDataFactorySchema
 from cartography.util import timeit
 
@@ -19,7 +20,10 @@ def get_factories(client: DataFactoryManagementClient) -> list[Any]:
     """
     Gets Data Factories for the subscription.
     """
-    return [f.as_dict() for f in client.factories.list()]
+    return call_data_factory_operation(
+        "list data factories",
+        lambda: [f.as_dict() for f in client.factories.list()],
+    )
 
 
 def transform_factories(factories_raw: list[Any]) -> list[dict[str, Any]]:

--- a/cartography/intel/azure/data_factory_dataset.py
+++ b/cartography/intel/azure/data_factory_dataset.py
@@ -6,6 +6,7 @@ from azure.mgmt.datafactory import DataFactoryManagementClient
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.azure.data_factory_util import call_data_factory_operation
 from cartography.models.azure.data_factory.data_factory_dataset import (
     AzureDataFactoryDatasetSchema,
 )
@@ -26,7 +27,12 @@ def get_datasets(
     """
     Gets Datasets for a given Data Factory.
     """
-    return [d.as_dict() for d in client.datasets.list_by_factory(rg_name, factory_name)]
+    return call_data_factory_operation(
+        "list data factory datasets",
+        lambda: [
+            d.as_dict() for d in client.datasets.list_by_factory(rg_name, factory_name)
+        ],
+    )
 
 
 def transform_datasets(

--- a/cartography/intel/azure/data_factory_linked_service.py
+++ b/cartography/intel/azure/data_factory_linked_service.py
@@ -6,6 +6,7 @@ from azure.mgmt.datafactory import DataFactoryManagementClient
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.azure.data_factory_util import call_data_factory_operation
 from cartography.models.azure.data_factory.data_factory_linked_service import (
     AzureDataFactoryLinkedServiceSchema,
 )
@@ -26,10 +27,13 @@ def get_linked_services(
     """
     Gets Linked Services for a given Data Factory.
     """
-    return [
-        ls.as_dict()
-        for ls in client.linked_services.list_by_factory(rg_name, factory_name)
-    ]
+    return call_data_factory_operation(
+        "list data factory linked services",
+        lambda: [
+            ls.as_dict()
+            for ls in client.linked_services.list_by_factory(rg_name, factory_name)
+        ],
+    )
 
 
 def transform_linked_services(

--- a/cartography/intel/azure/data_factory_pipeline.py
+++ b/cartography/intel/azure/data_factory_pipeline.py
@@ -6,6 +6,7 @@ from azure.mgmt.datafactory import DataFactoryManagementClient
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.azure.data_factory_util import call_data_factory_operation
 from cartography.models.azure.data_factory.data_factory_pipeline import (
     AzureDataFactoryPipelineSchema,
 )
@@ -26,9 +27,12 @@ def get_pipelines(
     """
     Gets Pipelines for a given Data Factory.
     """
-    return [
-        p.as_dict() for p in client.pipelines.list_by_factory(rg_name, factory_name)
-    ]
+    return call_data_factory_operation(
+        "list data factory pipelines",
+        lambda: [
+            p.as_dict() for p in client.pipelines.list_by_factory(rg_name, factory_name)
+        ],
+    )
 
 
 def transform_pipelines(

--- a/cartography/intel/azure/data_factory_util.py
+++ b/cartography/intel/azure/data_factory_util.py
@@ -1,15 +1,16 @@
 import logging
-import time
 from collections.abc import Callable
 from typing import TypeVar
 
+import backoff
 from azure.core.exceptions import HttpResponseError
+
+from cartography.helpers import backoff_handler
 
 logger = logging.getLogger(__name__)
 
 _RETRYABLE_STATUS_CODES = {408, 429, 500, 502, 503, 504}
-_MAX_ATTEMPTS = 3
-_RETRY_BACKOFF_SECONDS = 2
+_MAX_TRIES = 3
 
 T = TypeVar("T")
 
@@ -39,24 +40,28 @@ def _get_status_code(error: HttpResponseError) -> int | None:
         return None
 
 
+def _is_retryable_data_factory_error(error: HttpResponseError) -> bool:
+    status_code = _get_status_code(error)
+    return status_code in _RETRYABLE_STATUS_CODES
+
+
 def call_data_factory_operation(operation: str, func: Callable[[], T]) -> T:
-    for attempt in range(1, _MAX_ATTEMPTS + 1):
-        try:
-            return func()
-        except HttpResponseError as error:
-            status_code = _get_status_code(error)
-            if status_code not in _RETRYABLE_STATUS_CODES:
-                raise
+    @backoff.on_exception(  # type: ignore[misc]
+        backoff.expo,
+        HttpResponseError,
+        max_tries=_MAX_TRIES,
+        giveup=lambda error: not _is_retryable_data_factory_error(error),
+        on_backoff=backoff_handler,
+    )
+    def _call() -> T:
+        return func()
 
-            if attempt == _MAX_ATTEMPTS:
-                raise AzureDataFactoryTransientError(operation, status_code) from None
-
-            logger.warning(
-                "Transient Azure Data Factory API error during %s "
-                "(status_code=%s). Retrying.",
-                operation,
-                status_code,
-            )
-            time.sleep(_RETRY_BACKOFF_SECONDS**attempt)
-
-    raise RuntimeError("unreachable")
+    try:
+        return _call()
+    except HttpResponseError as error:
+        if not _is_retryable_data_factory_error(error):
+            raise
+        raise AzureDataFactoryTransientError(
+            operation,
+            _get_status_code(error),
+        ) from error

--- a/cartography/intel/azure/data_factory_util.py
+++ b/cartography/intel/azure/data_factory_util.py
@@ -52,6 +52,7 @@ def call_data_factory_operation(operation: str, func: Callable[[], T]) -> T:
         max_tries=_MAX_TRIES,
         giveup=lambda error: not _is_retryable_data_factory_error(error),
         on_backoff=backoff_handler,
+        logger=None,
     )
     def _call() -> T:
         return func()

--- a/cartography/intel/azure/data_factory_util.py
+++ b/cartography/intel/azure/data_factory_util.py
@@ -1,4 +1,3 @@
-import logging
 from collections.abc import Callable
 from typing import TypeVar
 
@@ -6,8 +5,6 @@ import backoff
 from azure.core.exceptions import HttpResponseError
 
 from cartography.helpers import backoff_handler
-
-logger = logging.getLogger(__name__)
 
 _RETRYABLE_STATUS_CODES = {408, 429, 500, 502, 503, 504}
 _MAX_TRIES = 3

--- a/cartography/intel/azure/data_factory_util.py
+++ b/cartography/intel/azure/data_factory_util.py
@@ -1,0 +1,62 @@
+import logging
+import time
+from collections.abc import Callable
+from typing import TypeVar
+
+from azure.core.exceptions import HttpResponseError
+
+logger = logging.getLogger(__name__)
+
+_RETRYABLE_STATUS_CODES = {408, 429, 500, 502, 503, 504}
+_MAX_ATTEMPTS = 3
+_RETRY_BACKOFF_SECONDS = 2
+
+T = TypeVar("T")
+
+
+class AzureDataFactoryTransientError(Exception):
+    def __init__(self, operation: str, status_code: int | None) -> None:
+        self.operation = operation
+        self.status_code = status_code
+        super().__init__(
+            "Transient Azure Data Factory API error during "
+            f"{operation} (status_code={status_code})",
+        )
+
+
+def _get_status_code(error: HttpResponseError) -> int | None:
+    status_code = getattr(error, "status_code", None)
+    if status_code is None:
+        response = getattr(error, "response", None)
+        status_code = getattr(response, "status_code", None)
+
+    if status_code is None:
+        return None
+
+    try:
+        return int(status_code)
+    except (TypeError, ValueError):
+        return None
+
+
+def call_data_factory_operation(operation: str, func: Callable[[], T]) -> T:
+    for attempt in range(1, _MAX_ATTEMPTS + 1):
+        try:
+            return func()
+        except HttpResponseError as error:
+            status_code = _get_status_code(error)
+            if status_code not in _RETRYABLE_STATUS_CODES:
+                raise
+
+            if attempt == _MAX_ATTEMPTS:
+                raise AzureDataFactoryTransientError(operation, status_code) from None
+
+            logger.warning(
+                "Transient Azure Data Factory API error during %s "
+                "(status_code=%s). Retrying.",
+                operation,
+                status_code,
+            )
+            time.sleep(_RETRY_BACKOFF_SECONDS**attempt)
+
+    raise RuntimeError("unreachable")

--- a/cartography/intel/azure/data_factory_util.py
+++ b/cartography/intel/azure/data_factory_util.py
@@ -38,28 +38,33 @@ def _get_status_code(error: HttpResponseError) -> int | None:
 
 
 def _is_retryable_data_factory_error(error: HttpResponseError) -> bool:
-    status_code = _get_status_code(error)
+    return _is_retryable_status_code(_get_status_code(error))
+
+
+def _is_retryable_status_code(status_code: int | None) -> bool:
     return status_code in _RETRYABLE_STATUS_CODES
 
 
-def call_data_factory_operation(operation: str, func: Callable[[], T]) -> T:
-    @backoff.on_exception(  # type: ignore[misc]
-        backoff.expo,
-        HttpResponseError,
-        max_tries=_MAX_TRIES,
-        giveup=lambda error: not _is_retryable_data_factory_error(error),
-        on_backoff=backoff_handler,
-        logger=None,
-    )
-    def _call() -> T:
-        return func()
+@backoff.on_exception(  # type: ignore[misc]
+    backoff.expo,
+    HttpResponseError,
+    max_tries=_MAX_TRIES,
+    giveup=lambda error: not _is_retryable_data_factory_error(error),
+    on_backoff=backoff_handler,
+    logger=None,
+)
+def _call_data_factory_operation(func: Callable[[], T]) -> T:
+    return func()
 
+
+def call_data_factory_operation(operation: str, func: Callable[[], T]) -> T:
     try:
-        return _call()
+        return _call_data_factory_operation(func)
     except HttpResponseError as error:
-        if not _is_retryable_data_factory_error(error):
+        status_code = _get_status_code(error)
+        if not _is_retryable_status_code(status_code):
             raise
         raise AzureDataFactoryTransientError(
             operation,
-            _get_status_code(error),
+            status_code,
         ) from error

--- a/tests/unit/cartography/intel/azure/test_data_factory.py
+++ b/tests/unit/cartography/intel/azure/test_data_factory.py
@@ -42,7 +42,7 @@ def test_get_factories_retries_transient_error() -> None:
     mock_sleep.assert_called_once()
 
 
-def test_sync_data_factories_raises_transient_error_without_cleanup() -> None:
+def test_sync_data_factories_skips_load_and_cleanup_on_transient_error() -> None:
     neo4j_session = MagicMock()
     credentials = MagicMock()
 

--- a/tests/unit/cartography/intel/azure/test_data_factory.py
+++ b/tests/unit/cartography/intel/azure/test_data_factory.py
@@ -1,4 +1,3 @@
-from contextlib import ExitStack
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -94,77 +93,29 @@ def test_get_factories_raises_transient_error_after_retry_exhaustion() -> None:
     assert mock_sleep.call_count == 2
 
 
-def test_sync_one_subscription_skips_data_factory_subtree_after_transient_error() -> (
-    None
-):
+def test_sync_data_factory_skips_child_syncs_after_transient_error() -> None:
     neo4j_session = MagicMock()
     credentials = MagicMock()
-    credentials.credential = MagicMock()
 
-    patches = [
-        "cartography.intel.azure.compute.sync",
-        "cartography.intel.azure.cosmosdb.sync",
-        "cartography.intel.azure.app_service.sync",
-        "cartography.intel.azure.functions.sync",
-        "cartography.intel.azure.event_grid.sync",
-        "cartography.intel.azure.logic_apps.sync",
-        "cartography.intel.azure.rbac.sync",
-        "cartography.intel.azure.sql.sync",
-        "cartography.intel.azure.storage.sync",
-        "cartography.intel.azure.resource_groups.sync",
-        "cartography.intel.azure.key_vaults.sync",
-        "cartography.intel.azure.aks.sync",
-        "cartography.intel.azure.event_hub.sync_event_hubs",
-        "cartography.intel.azure.network.sync",
-        "cartography.intel.azure.group_containers.sync_group_containers",
-        "cartography.intel.azure.container_instances.sync",
-        "cartography.intel.azure.firewall.sync",
-        "cartography.intel.azure.load_balancers.sync",
-        "cartography.intel.azure.synapse.sync",
-        "cartography.intel.azure.monitor.sync",
-        "cartography.intel.azure.security_center.sync",
-        "cartography.intel.azure.permission_relationships.sync",
-    ]
-
-    with ExitStack() as stack:
-        for target in patches:
-            stack.enter_context(patch(target))
-
-        stack.enter_context(
-            patch(
-                "cartography.intel.azure.event_hub_namespace.sync_event_hub_namespaces",
-                return_value=[],
+    with (
+        patch(
+            "cartography.intel.azure.data_factory.sync_data_factories",
+            side_effect=AzureDataFactoryTransientError(
+                "list data factories",
+                503,
             ),
-        )
-        stack.enter_context(
-            patch(
-                "cartography.intel.azure.data_factory.sync_data_factories",
-                side_effect=AzureDataFactoryTransientError(
-                    "list data factories",
-                    503,
-                ),
-            ),
-        )
-        mock_linked_services = stack.enter_context(
-            patch(
-                "cartography.intel.azure.data_factory_linked_service.sync_data_factory_linked_services"
-            ),
-        )
-        mock_datasets = stack.enter_context(
-            patch(
-                "cartography.intel.azure.data_factory_dataset.sync_data_factory_datasets"
-            ),
-        )
-        mock_pipelines = stack.enter_context(
-            patch(
-                "cartography.intel.azure.data_factory_pipeline.sync_data_factory_pipelines"
-            ),
-        )
-        mock_data_lake = stack.enter_context(
-            patch("cartography.intel.azure.data_lake.sync"),
-        )
-
-        azure._sync_one_subscription(
+        ),
+        patch(
+            "cartography.intel.azure.data_factory_linked_service.sync_data_factory_linked_services"
+        ) as mock_linked_services,
+        patch(
+            "cartography.intel.azure.data_factory_dataset.sync_data_factory_datasets"
+        ) as mock_datasets,
+        patch(
+            "cartography.intel.azure.data_factory_pipeline.sync_data_factory_pipelines"
+        ) as mock_pipelines,
+    ):
+        azure._sync_data_factory(
             neo4j_session,
             credentials,
             "subscription-1",
@@ -175,7 +126,74 @@ def test_sync_one_subscription_skips_data_factory_subtree_after_transient_error(
         mock_linked_services.assert_not_called()
         mock_datasets.assert_not_called()
         mock_pipelines.assert_not_called()
-        mock_data_lake.assert_called_once()
+
+
+def test_sync_data_factory_runs_child_syncs_with_fetched_data() -> None:
+    neo4j_session = MagicMock()
+    credentials = MagicMock()
+    common_job_parameters = {"UPDATE_TAG": 123}
+    factories = [{"id": "factory-1", "name": "factory-1"}]
+    linked_services = {"factory-1": [{"id": "linked-service-1"}]}
+    datasets = {"factory-1": [{"id": "dataset-1"}]}
+
+    with (
+        patch(
+            "cartography.intel.azure.data_factory.sync_data_factories",
+            return_value=factories,
+        ) as mock_factories,
+        patch(
+            "cartography.intel.azure.data_factory_linked_service.sync_data_factory_linked_services",
+            return_value=linked_services,
+        ) as mock_linked_services,
+        patch(
+            "cartography.intel.azure.data_factory_dataset.sync_data_factory_datasets",
+            return_value=datasets,
+        ) as mock_datasets,
+        patch(
+            "cartography.intel.azure.data_factory_pipeline.sync_data_factory_pipelines"
+        ) as mock_pipelines,
+    ):
+        azure._sync_data_factory(
+            neo4j_session,
+            credentials,
+            "subscription-1",
+            123,
+            common_job_parameters,
+        )
+
+    mock_factories.assert_called_once_with(
+        neo4j_session,
+        credentials,
+        "subscription-1",
+        123,
+        common_job_parameters,
+    )
+    mock_linked_services.assert_called_once_with(
+        neo4j_session,
+        credentials,
+        factories,
+        "subscription-1",
+        123,
+        common_job_parameters,
+    )
+    mock_datasets.assert_called_once_with(
+        neo4j_session,
+        credentials,
+        factories,
+        linked_services,
+        "subscription-1",
+        123,
+        common_job_parameters,
+    )
+    mock_pipelines.assert_called_once_with(
+        neo4j_session,
+        credentials,
+        factories,
+        datasets,
+        "subscription-1",
+        123,
+        common_job_parameters,
+    )
 
 
 def test_get_factories_does_not_retry_non_transient_error() -> None:

--- a/tests/unit/cartography/intel/azure/test_data_factory.py
+++ b/tests/unit/cartography/intel/azure/test_data_factory.py
@@ -34,7 +34,7 @@ def test_get_factories_retries_transient_error() -> None:
         [_AzureResource({"id": "factory-1"})],
     ]
 
-    with patch("cartography.intel.azure.data_factory_util.time.sleep") as mock_sleep:
+    with patch("time.sleep") as mock_sleep:
         result = data_factory.get_factories(client)
 
     assert result == [{"id": "factory-1"}]
@@ -81,14 +81,14 @@ def test_get_factories_raises_transient_error_after_retry_exhaustion() -> None:
     ]
 
     with (
-        patch("cartography.intel.azure.data_factory_util.time.sleep") as mock_sleep,
+        patch("time.sleep") as mock_sleep,
         pytest.raises(AzureDataFactoryTransientError) as excinfo,
     ):
         data_factory.get_factories(client)
 
     assert excinfo.value.operation == "list data factories"
     assert excinfo.value.status_code == 503
-    assert excinfo.value.__cause__ is None
+    assert isinstance(excinfo.value.__cause__, HttpResponseError)
     assert client.factories.list.call_count == 3
     assert mock_sleep.call_count == 2
 
@@ -126,6 +126,82 @@ def test_sync_data_factory_skips_child_syncs_after_transient_error() -> None:
         mock_linked_services.assert_not_called()
         mock_datasets.assert_not_called()
         mock_pipelines.assert_not_called()
+
+
+def test_sync_data_factory_skips_later_children_after_child_transient_error() -> None:
+    neo4j_session = MagicMock()
+    credentials = MagicMock()
+    common_job_parameters = {"UPDATE_TAG": 123}
+    factories = [{"id": "factory-1", "name": "factory-1"}]
+
+    with (
+        patch(
+            "cartography.intel.azure.data_factory.sync_data_factories",
+            return_value=factories,
+        ) as mock_factories,
+        patch(
+            "cartography.intel.azure.data_factory_linked_service.sync_data_factory_linked_services",
+            side_effect=AzureDataFactoryTransientError(
+                "list data factory linked services",
+                503,
+            ),
+        ) as mock_linked_services,
+        patch(
+            "cartography.intel.azure.data_factory_dataset.sync_data_factory_datasets"
+        ) as mock_datasets,
+        patch(
+            "cartography.intel.azure.data_factory_pipeline.sync_data_factory_pipelines"
+        ) as mock_pipelines,
+    ):
+        azure._sync_data_factory(
+            neo4j_session,
+            credentials,
+            "subscription-1",
+            123,
+            common_job_parameters,
+        )
+
+    mock_factories.assert_called_once_with(
+        neo4j_session,
+        credentials,
+        "subscription-1",
+        123,
+        common_job_parameters,
+    )
+    mock_linked_services.assert_called_once_with(
+        neo4j_session,
+        credentials,
+        factories,
+        "subscription-1",
+        123,
+        common_job_parameters,
+    )
+    mock_datasets.assert_not_called()
+    mock_pipelines.assert_not_called()
+
+
+def test_sync_data_factory_logs_subscription_when_skipping(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    neo4j_session = MagicMock()
+    credentials = MagicMock()
+
+    with patch(
+        "cartography.intel.azure.data_factory.sync_data_factories",
+        side_effect=AzureDataFactoryTransientError(
+            "list data factories",
+            503,
+        ),
+    ):
+        azure._sync_data_factory(
+            neo4j_session,
+            credentials,
+            "subscription-1",
+            123,
+            {"UPDATE_TAG": 123},
+        )
+
+    assert "subscription-1" in caplog.text
 
 
 def test_sync_data_factory_runs_child_syncs_with_fetched_data() -> None:
@@ -201,7 +277,7 @@ def test_get_factories_does_not_retry_non_transient_error() -> None:
     client.factories.list.side_effect = _SyntheticHttpResponseError(403)
 
     with (
-        patch("cartography.intel.azure.data_factory_util.time.sleep") as mock_sleep,
+        patch("time.sleep") as mock_sleep,
         pytest.raises(HttpResponseError),
     ):
         data_factory.get_factories(client)

--- a/tests/unit/cartography/intel/azure/test_data_factory.py
+++ b/tests/unit/cartography/intel/azure/test_data_factory.py
@@ -1,0 +1,192 @@
+from contextlib import ExitStack
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from azure.core.exceptions import HttpResponseError
+
+import cartography.intel.azure as azure
+import cartography.intel.azure.data_factory as data_factory
+from cartography.intel.azure.data_factory_util import AzureDataFactoryTransientError
+
+
+class _SyntheticHttpResponseError(HttpResponseError):
+    def __init__(self, status_code: int) -> None:
+        Exception.__init__(self, "synthetic")
+        self._status_code = status_code
+
+    @property
+    def status_code(self) -> int:
+        return self._status_code
+
+
+class _AzureResource:
+    def __init__(self, data: dict) -> None:
+        self.data = data
+
+    def as_dict(self) -> dict:
+        return self.data
+
+
+def test_get_factories_retries_transient_error() -> None:
+    client = MagicMock()
+    client.factories.list.side_effect = [
+        _SyntheticHttpResponseError(503),
+        [_AzureResource({"id": "factory-1"})],
+    ]
+
+    with patch("cartography.intel.azure.data_factory_util.time.sleep") as mock_sleep:
+        result = data_factory.get_factories(client)
+
+    assert result == [{"id": "factory-1"}]
+    assert client.factories.list.call_count == 2
+    mock_sleep.assert_called_once()
+
+
+def test_sync_data_factories_raises_transient_error_without_cleanup() -> None:
+    neo4j_session = MagicMock()
+    credentials = MagicMock()
+
+    with (
+        patch(
+            "cartography.intel.azure.data_factory.get_factories",
+            side_effect=AzureDataFactoryTransientError(
+                "list data factories",
+                503,
+            ),
+        ),
+        patch("cartography.intel.azure.data_factory.load_factories") as mock_load,
+        patch(
+            "cartography.intel.azure.data_factory.cleanup_data_factories"
+        ) as mock_cleanup,
+    ):
+        with pytest.raises(AzureDataFactoryTransientError):
+            data_factory.sync_data_factories(
+                neo4j_session,
+                credentials,
+                "subscription-1",
+                123,
+                {"UPDATE_TAG": 123},
+            )
+
+    mock_load.assert_not_called()
+    mock_cleanup.assert_not_called()
+
+
+def test_get_factories_raises_transient_error_after_retry_exhaustion() -> None:
+    client = MagicMock()
+    client.factories.list.side_effect = [
+        _SyntheticHttpResponseError(503),
+        _SyntheticHttpResponseError(503),
+        _SyntheticHttpResponseError(503),
+    ]
+
+    with (
+        patch("cartography.intel.azure.data_factory_util.time.sleep") as mock_sleep,
+        pytest.raises(AzureDataFactoryTransientError) as excinfo,
+    ):
+        data_factory.get_factories(client)
+
+    assert excinfo.value.operation == "list data factories"
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.__cause__ is None
+    assert client.factories.list.call_count == 3
+    assert mock_sleep.call_count == 2
+
+
+def test_sync_one_subscription_skips_data_factory_subtree_after_transient_error() -> (
+    None
+):
+    neo4j_session = MagicMock()
+    credentials = MagicMock()
+    credentials.credential = MagicMock()
+
+    patches = [
+        "cartography.intel.azure.compute.sync",
+        "cartography.intel.azure.cosmosdb.sync",
+        "cartography.intel.azure.app_service.sync",
+        "cartography.intel.azure.functions.sync",
+        "cartography.intel.azure.event_grid.sync",
+        "cartography.intel.azure.logic_apps.sync",
+        "cartography.intel.azure.rbac.sync",
+        "cartography.intel.azure.sql.sync",
+        "cartography.intel.azure.storage.sync",
+        "cartography.intel.azure.resource_groups.sync",
+        "cartography.intel.azure.key_vaults.sync",
+        "cartography.intel.azure.aks.sync",
+        "cartography.intel.azure.event_hub.sync_event_hubs",
+        "cartography.intel.azure.network.sync",
+        "cartography.intel.azure.group_containers.sync_group_containers",
+        "cartography.intel.azure.container_instances.sync",
+        "cartography.intel.azure.firewall.sync",
+        "cartography.intel.azure.load_balancers.sync",
+        "cartography.intel.azure.synapse.sync",
+        "cartography.intel.azure.monitor.sync",
+        "cartography.intel.azure.security_center.sync",
+        "cartography.intel.azure.permission_relationships.sync",
+    ]
+
+    with ExitStack() as stack:
+        for target in patches:
+            stack.enter_context(patch(target))
+
+        stack.enter_context(
+            patch(
+                "cartography.intel.azure.event_hub_namespace.sync_event_hub_namespaces",
+                return_value=[],
+            ),
+        )
+        stack.enter_context(
+            patch(
+                "cartography.intel.azure.data_factory.sync_data_factories",
+                side_effect=AzureDataFactoryTransientError(
+                    "list data factories",
+                    503,
+                ),
+            ),
+        )
+        mock_linked_services = stack.enter_context(
+            patch(
+                "cartography.intel.azure.data_factory_linked_service.sync_data_factory_linked_services"
+            ),
+        )
+        mock_datasets = stack.enter_context(
+            patch(
+                "cartography.intel.azure.data_factory_dataset.sync_data_factory_datasets"
+            ),
+        )
+        mock_pipelines = stack.enter_context(
+            patch(
+                "cartography.intel.azure.data_factory_pipeline.sync_data_factory_pipelines"
+            ),
+        )
+        mock_data_lake = stack.enter_context(
+            patch("cartography.intel.azure.data_lake.sync"),
+        )
+
+        azure._sync_one_subscription(
+            neo4j_session,
+            credentials,
+            "subscription-1",
+            123,
+            {"UPDATE_TAG": 123},
+        )
+
+        mock_linked_services.assert_not_called()
+        mock_datasets.assert_not_called()
+        mock_pipelines.assert_not_called()
+        mock_data_lake.assert_called_once()
+
+
+def test_get_factories_does_not_retry_non_transient_error() -> None:
+    client = MagicMock()
+    client.factories.list.side_effect = _SyntheticHttpResponseError(403)
+
+    with (
+        patch("cartography.intel.azure.data_factory_util.time.sleep") as mock_sleep,
+        pytest.raises(HttpResponseError),
+    ):
+        data_factory.get_factories(client)
+
+    assert client.factories.list.call_count == 1
+    mock_sleep.assert_not_called()

--- a/tests/unit/cartography/intel/azure/test_data_factory.py
+++ b/tests/unit/cartography/intel/azure/test_data_factory.py
@@ -284,3 +284,23 @@ def test_get_factories_does_not_retry_non_transient_error() -> None:
 
     assert client.factories.list.call_count == 1
     mock_sleep.assert_not_called()
+
+
+def test_get_factories_does_not_log_raw_error_body(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = MagicMock()
+    client.factories.list.side_effect = [
+        _SyntheticHttpResponseError(503),
+        [_AzureResource({"id": "factory-1"})],
+    ]
+
+    with (
+        patch("time.sleep"),
+        patch.object(
+            _SyntheticHttpResponseError, "__str__", return_value="raw-response-body"
+        ),
+    ):
+        data_factory.get_factories(client)
+
+    assert "raw-response-body" not in caplog.text


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
Azure Data Factory listing calls can fail with transient Azure Resource Manager errors. Previously, those errors could fail the full Azure sync, and treating them as empty results would risk stale cleanup from an incomplete API response.

This change adds a small Data Factory-scoped retry helper for transient HTTP statuses, raises a sanitized internal skip signal after retry exhaustion, and skips the Data Factory subtree for the affected subscription. Successful empty responses still go through normal load and cleanup.


### Related issues or links
- N/A


### Breaking changes
None.


### How was this tested?
- `uv run --frozen pytest -vvv tests/unit/cartography/intel/azure/test_data_factory.py`
- `uv run --frozen pytest -vvv tests/integration/cartography/intel/azure/test_data_factory.py`
- `make test_lint`


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`; this checkout does not define `make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
This does not change Azure Data Factory models or cleanup semantics for successful API responses. It only prevents cleanup from running when the Data Factory API result is known to be incomplete after transient retry exhaustion.

A transient failure in any Data Factory list stage skips the remaining Data Factory subtree for that subscription for the current run. The next successful run will resume normal load and cleanup behavior.
