### PR TITLE
fix(gcp): resolve Cloud Run service image digests

### DIFF
--- a/cartography/intel/gcp/cloudrun/service.py
+++ b/cartography/intel/gcp/cloudrun/service.py
@@ -3,6 +3,9 @@ import re
 from typing import Any
 
 import neo4j
+from google.api_core.exceptions import GoogleAPICallError
+from google.api_core.exceptions import NotFound
+from google.api_core.exceptions import PermissionDenied
 from google.auth.credentials import Credentials as GoogleCredentials
 
 from cartography.client.core.tx import load
@@ -10,11 +13,15 @@ from cartography.graph.job import GraphJob
 from cartography.intel.container_arch import ARCH_SOURCE_PLATFORM_REQUIREMENT
 from cartography.intel.container_arch import normalize_architecture
 from cartography.intel.container_image import parse_image_uri
+from cartography.intel.gcp.clients import build_cloud_run_revision_client
 from cartography.intel.gcp.clients import build_cloud_run_service_client
+from cartography.intel.gcp.cloudrun.util import build_cloud_run_resource_retry
 from cartography.intel.gcp.cloudrun.util import CLOUD_RUN_LABEL_BATCH_SIZE
+from cartography.intel.gcp.cloudrun.util import CLOUD_RUN_LIST_TIMEOUT
 from cartography.intel.gcp.cloudrun.util import fetch_cloud_run_resources_for_locations
 from cartography.intel.gcp.cloudrun.util import list_cloud_run_resources_for_location
 from cartography.intel.gcp.labels import sync_labels
+from cartography.intel.gcp.util import proto_message_to_dict
 from cartography.models.gcp.cloudrun.service import GCPCloudRunServiceSchema
 from cartography.models.gcp.cloudrun.service_container import (
     GCPCloudRunServiceContainerSchema,
@@ -87,12 +94,126 @@ def transform_services(services_data: list[dict], project_id: str) -> list[dict]
     return transformed
 
 
-def transform_containers(services_data: list[dict], project_id: str) -> list[dict]:
+def _get_revision_location(revision_name: str) -> str | None:
+    name_match = re.match(
+        r"(projects/[^/]+/locations/[^/]+)/services/[^/]+/revisions/[^/]+",
+        revision_name,
+    )
+    return name_match.group(1) if name_match else None
+
+
+def _service_has_tag_only_container(service: dict) -> bool:
+    template = service.get("template") or {}
+    containers = template.get("containers", []) or []
+    return any(
+        parse_image_uri(container.get("image"))[1] is None for container in containers
+    )
+
+
+@timeit
+def get_latest_ready_revisions(
+    services_data: list[dict],
+    project_id: str,
+    credentials: GoogleCredentials,
+) -> dict[str, dict]:
+    """
+    Fetch latestReadyRevision records only for services whose inline template
+    containers do not already include image digests.
+    """
+    revision_names = sorted(
+        {
+            service["latestReadyRevision"]
+            for service in services_data
+            if service.get("latestReadyRevision")
+            and _service_has_tag_only_container(service)
+        },
+    )
+    if not revision_names:
+        return {}
+
+    client = build_cloud_run_revision_client(credentials=credentials)
+    revisions: dict[str, dict] = {}
+    for revision_name in revision_names:
+        revision_location = _get_revision_location(revision_name) or project_id
+        retry = build_cloud_run_resource_retry(
+            resource_type="revision",
+            location=revision_location,
+            project_id=project_id,
+        )
+        try:
+            revision = client.get_revision(
+                name=revision_name,
+                retry=retry,
+                timeout=CLOUD_RUN_LIST_TIMEOUT,
+            )
+        except (NotFound, PermissionDenied, GoogleAPICallError) as e:
+            logger.warning(
+                "Could not retrieve Cloud Run latestReadyRevision %s for project %s: %s",
+                revision_name,
+                project_id,
+                e,
+            )
+            continue
+
+        revision_data = proto_message_to_dict(revision)
+        revisions[revision_data["name"]] = revision_data
+
+    return revisions
+
+
+def _revision_container_by_name_or_index(
+    revision: dict | None,
+    container_name: str,
+    index: int,
+) -> dict | None:
+    if not revision:
+        return None
+
+    containers = revision.get("containers", []) or []
+    for container in containers:
+        if container.get("name") and container["name"] == container_name:
+            return container
+
+    if index < len(containers):
+        return containers[index]
+
+    return None
+
+
+def _resolve_image_digest_from_revision(
+    service: dict,
+    container_name: str,
+    index: int,
+    latest_ready_revisions: dict[str, dict],
+) -> str | None:
+    revision_name = service.get("latestReadyRevision")
+    if not isinstance(revision_name, str):
+        return None
+
+    revision_container = _revision_container_by_name_or_index(
+        latest_ready_revisions.get(revision_name),
+        container_name,
+        index,
+    )
+    if not revision_container:
+        return None
+
+    _, revision_image_digest = parse_image_uri(revision_container.get("image"))
+    return revision_image_digest
+
+
+def transform_containers(
+    services_data: list[dict],
+    project_id: str,
+    latest_ready_revisions: dict[str, dict] | None = None,
+) -> list[dict]:
     """
     Flatten service.template.containers[] into one record per individual container.
-    The Cloud Run v2 API returns the latestReadyRevision's spec inline as service.template,
-    so this captures the current canonical container set per service.
+    The Cloud Run v2 API may return tag-only images in service.template even when
+    latestReadyRevision has digest-pinned images, so use the revision digest when
+    the template image is not already pinned.
     """
+    latest_ready_revisions = latest_ready_revisions or {}
     transformed: list[dict[str, Any]] = []
     for service in services_data:
         service_id = service["name"]
@@ -102,6 +223,13 @@ def transform_containers(services_data: list[dict], project_id: str) -> list[dic
         for index, container in enumerate(containers):
             image, image_digest = parse_image_uri(container.get("image"))
             container_name = container.get("name") or str(index)
+            if image_digest is None:
+                image_digest = _resolve_image_digest_from_revision(
+                    service,
+                    container_name,
+                    index,
+                    latest_ready_revisions,
+                )
             transformed.append(
                 {
                     "id": f"{service_id}/containers/{container_name}",
@@ -194,7 +322,16 @@ def sync_services(
     services = transform_services(services_raw, project_id)
     load_services(neo4j_session, services, project_id, update_tag)
 
-    containers = transform_containers(services_raw, project_id)
+    latest_ready_revisions = get_latest_ready_revisions(
+        services_raw,
+        project_id,
+        credentials,
+    )
+    containers = transform_containers(
+        services_raw,
+        project_id,
+        latest_ready_revisions,
+    )
     load_containers(neo4j_session, containers, project_id, update_tag)
 
     sync_labels(

--- a/cartography/intel/gcp/cloudrun/service.py
+++ b/cartography/intel/gcp/cloudrun/service.py
@@ -188,15 +188,15 @@ def _revision_container_by_name_or_index(
     return None
 
 
-def _resolve_image_from_revision(
+def _resolve_image_digest_from_revision(
     service: dict,
     explicit_container_name: str | None,
     index: int,
     latest_ready_revisions: dict[str, dict],
-) -> tuple[str | None, str | None]:
+) -> str | None:
     revision_name = service.get("latestReadyRevision")
     if not isinstance(revision_name, str):
-        return None, None
+        return None
 
     revision_container = _revision_container_by_name_or_index(
         latest_ready_revisions.get(revision_name),
@@ -204,12 +204,10 @@ def _resolve_image_from_revision(
         index,
     )
     if not revision_container:
-        return None, None
+        return None
 
-    revision_image, revision_image_digest = parse_image_uri(
-        revision_container.get("image")
-    )
-    return revision_image, revision_image_digest
+    _, revision_image_digest = parse_image_uri(revision_container.get("image"))
+    return revision_image_digest
 
 
 def transform_containers(
@@ -235,14 +233,13 @@ def transform_containers(
             explicit_container_name = container.get("name")
             container_name = explicit_container_name or str(index)
             if image_digest is None:
-                revision_image, revision_image_digest = _resolve_image_from_revision(
+                revision_image_digest = _resolve_image_digest_from_revision(
                     service,
                     explicit_container_name,
                     index,
                     latest_ready_revisions,
                 )
                 if revision_image_digest is not None:
-                    image = revision_image
                     image_digest = revision_image_digest
             transformed.append(
                 {

--- a/cartography/intel/gcp/cloudrun/service.py
+++ b/cartography/intel/gcp/cloudrun/service.py
@@ -3,7 +3,6 @@ import re
 from typing import Any
 
 import neo4j
-from google.api_core.exceptions import GoogleAPICallError
 from google.api_core.exceptions import NotFound
 from google.api_core.exceptions import PermissionDenied
 from google.auth.credentials import Credentials as GoogleCredentials
@@ -134,7 +133,14 @@ def get_latest_ready_revisions(
     client = build_cloud_run_revision_client(credentials=credentials)
     revisions: dict[str, dict] = {}
     for revision_name in revision_names:
-        revision_location = _get_revision_location(revision_name) or project_id
+        revision_location = _get_revision_location(revision_name)
+        if revision_location is None:
+            logger.debug(
+                "Could not parse Cloud Run revision location from %s for project %s.",
+                revision_name,
+                project_id,
+            )
+            revision_location = project_id
         retry = build_cloud_run_resource_retry(
             resource_type="revision",
             location=revision_location,
@@ -146,7 +152,7 @@ def get_latest_ready_revisions(
                 retry=retry,
                 timeout=CLOUD_RUN_LIST_TIMEOUT,
             )
-        except (NotFound, PermissionDenied, GoogleAPICallError) as e:
+        except (NotFound, PermissionDenied) as e:
             logger.warning(
                 "Could not retrieve Cloud Run latestReadyRevision %s for project %s: %s",
                 revision_name,

--- a/cartography/intel/gcp/cloudrun/service.py
+++ b/cartography/intel/gcp/cloudrun/service.py
@@ -163,16 +163,18 @@ def get_latest_ready_revisions(
 
 def _revision_container_by_name_or_index(
     revision: dict | None,
-    container_name: str,
+    explicit_container_name: str | None,
     index: int,
 ) -> dict | None:
     if not revision:
         return None
 
     containers = revision.get("containers", []) or []
-    for container in containers:
-        if container.get("name") and container["name"] == container_name:
-            return container
+    if explicit_container_name:
+        for container in containers:
+            if container.get("name") == explicit_container_name:
+                return container
+        return None
 
     if index < len(containers):
         return containers[index]
@@ -180,26 +182,28 @@ def _revision_container_by_name_or_index(
     return None
 
 
-def _resolve_image_digest_from_revision(
+def _resolve_image_from_revision(
     service: dict,
-    container_name: str,
+    explicit_container_name: str | None,
     index: int,
     latest_ready_revisions: dict[str, dict],
-) -> str | None:
+) -> tuple[str | None, str | None]:
     revision_name = service.get("latestReadyRevision")
     if not isinstance(revision_name, str):
-        return None
+        return None, None
 
     revision_container = _revision_container_by_name_or_index(
         latest_ready_revisions.get(revision_name),
-        container_name,
+        explicit_container_name,
         index,
     )
     if not revision_container:
-        return None
+        return None, None
 
-    _, revision_image_digest = parse_image_uri(revision_container.get("image"))
-    return revision_image_digest
+    revision_image, revision_image_digest = parse_image_uri(
+        revision_container.get("image")
+    )
+    return revision_image, revision_image_digest
 
 
 def transform_containers(
@@ -222,14 +226,18 @@ def transform_containers(
 
         for index, container in enumerate(containers):
             image, image_digest = parse_image_uri(container.get("image"))
-            container_name = container.get("name") or str(index)
+            explicit_container_name = container.get("name")
+            container_name = explicit_container_name or str(index)
             if image_digest is None:
-                image_digest = _resolve_image_digest_from_revision(
+                revision_image, revision_image_digest = _resolve_image_from_revision(
                     service,
-                    container_name,
+                    explicit_container_name,
                     index,
                     latest_ready_revisions,
                 )
+                if revision_image_digest is not None:
+                    image = revision_image
+                    image_digest = revision_image_digest
             transformed.append(
                 {
                     "id": f"{service_id}/containers/{container_name}",

--- a/cartography/intel/gcp/cloudrun/util.py
+++ b/cartography/intel/gcp/cloudrun/util.py
@@ -57,7 +57,7 @@ def build_cloud_run_resource_retry(
 
     def _on_error(exc: Exception) -> None:
         logger.warning(
-            "Retrying Cloud Run %s list in %s for project %s after transient error: %s",
+            "Retrying Cloud Run %s request in %s for project %s after transient error: %s",
             resource_type,
             location_short,
             project_id,

--- a/tests/data/gcp/cloudrun.py
+++ b/tests/data/gcp/cloudrun.py
@@ -135,7 +135,26 @@ MOCK_SERVICE_WITH_TAG_ONLY_TEMPLATE_AND_DIGESTED_REVISION = [
                 },
                 {
                     "name": "metrics",
-                    "image": "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/metrics:def5678",
+                    "image": "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/metrics:def5678"
+                    f"@{TEST_REVISION_SIDECAR_DIGEST}",
+                },
+            ],
+        },
+    },
+    {
+        "name": "projects/test-project/locations/us-central1/services/digest-service",
+        "labels": {},
+        "description": "Test Cloud Run service with digest-pinned template",
+        "uri": "https://digest-service-abc123-uc.a.run.app",
+        "ingress": "INGRESS_TRAFFIC_ALL",
+        "latestReadyRevision": "projects/test-project/locations/us-central1/services/digest-service/revisions/digest-service-00001-abc",
+        "template": {
+            "serviceAccount": "test-sa@test-project.iam.gserviceaccount.com",
+            "containers": [
+                {
+                    "name": "server",
+                    "image": "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/digest-service/server"
+                    f"@{TEST_REVISION_PRIMARY_DIGEST}",
                 },
             ],
         },
@@ -148,14 +167,14 @@ MOCK_LATEST_READY_REVISION_WITH_DIGESTED_IMAGES = {
         "service": "test-service",
         "containers": [
             {
-                "name": "server",
-                "image": "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/server:abc1234"
-                f"@{TEST_REVISION_PRIMARY_DIGEST}",
-            },
-            {
                 "name": "metrics",
                 "image": "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/metrics:def5678"
                 f"@{TEST_REVISION_SIDECAR_DIGEST}",
+            },
+            {
+                "name": "server",
+                "image": "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/server:abc1234"
+                f"@{TEST_REVISION_PRIMARY_DIGEST}",
             },
         ],
         "serviceAccount": "test-sa@test-project.iam.gserviceaccount.com",

--- a/tests/data/gcp/cloudrun.py
+++ b/tests/data/gcp/cloudrun.py
@@ -118,6 +118,51 @@ MOCK_SERVICE_WITH_DIGEST = [
     },
 ]
 
+MOCK_SERVICE_WITH_TAG_ONLY_TEMPLATE_AND_DIGESTED_REVISION = [
+    {
+        "name": "projects/test-project/locations/us-central1/services/test-service",
+        "labels": {},
+        "description": "Test Cloud Run service",
+        "uri": "https://test-service-abc123-uc.a.run.app",
+        "ingress": "INGRESS_TRAFFIC_ALL",
+        "latestReadyRevision": "projects/test-project/locations/us-central1/services/test-service/revisions/test-service-00001-abc",
+        "template": {
+            "serviceAccount": "test-sa@test-project.iam.gserviceaccount.com",
+            "containers": [
+                {
+                    "name": "server",
+                    "image": "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/server:abc1234",
+                },
+                {
+                    "name": "metrics",
+                    "image": "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/metrics:def5678",
+                },
+            ],
+        },
+    },
+]
+
+MOCK_LATEST_READY_REVISION_WITH_DIGESTED_IMAGES = {
+    "projects/test-project/locations/us-central1/services/test-service/revisions/test-service-00001-abc": {
+        "name": "projects/test-project/locations/us-central1/services/test-service/revisions/test-service-00001-abc",
+        "service": "test-service",
+        "containers": [
+            {
+                "name": "server",
+                "image": "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/server:abc1234"
+                f"@{TEST_REVISION_PRIMARY_DIGEST}",
+            },
+            {
+                "name": "metrics",
+                "image": "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/metrics:def5678"
+                f"@{TEST_REVISION_SIDECAR_DIGEST}",
+            },
+        ],
+        "serviceAccount": "test-sa@test-project.iam.gserviceaccount.com",
+        "logUri": "https://console.cloud.google.com/logs/viewer?project=test-project",
+    },
+}
+
 MOCK_JOB_WITH_DIGEST = [
     {
         "name": "projects/test-project/locations/us-west1/jobs/test-job",

--- a/tests/integration/cartography/intel/gcp/test_cloudrun.py
+++ b/tests/integration/cartography/intel/gcp/test_cloudrun.py
@@ -566,6 +566,10 @@ def test_cloud_run_service_container_uses_latest_ready_revision_digest(
 
     service_primary_container_id = f"{TEST_SERVICE_ID}/containers/server"
     service_sidecar_container_id = f"{TEST_SERVICE_ID}/containers/metrics"
+    digest_service_container_id = (
+        "projects/test-project/locations/us-central1/services/digest-service"
+        "/containers/server"
+    )
 
     assert check_nodes(
         neo4j_session,
@@ -584,6 +588,12 @@ def test_cloud_run_service_container_uses_latest_ready_revision_digest(
             f"@{TEST_REVISION_SIDECAR_DIGEST}",
             TEST_REVISION_SIDECAR_DIGEST,
         ),
+        (
+            digest_service_container_id,
+            "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/digest-service/server"
+            f"@{TEST_REVISION_PRIMARY_DIGEST}",
+            TEST_REVISION_PRIMARY_DIGEST,
+        ),
     }
 
     assert check_rels(
@@ -596,4 +606,5 @@ def test_cloud_run_service_container_uses_latest_ready_revision_digest(
     ) == {
         (service_primary_container_id, TEST_REVISION_PRIMARY_DIGEST),
         (service_sidecar_container_id, TEST_REVISION_SIDECAR_DIGEST),
+        (digest_service_container_id, TEST_REVISION_PRIMARY_DIGEST),
     }

--- a/tests/integration/cartography/intel/gcp/test_cloudrun.py
+++ b/tests/integration/cartography/intel/gcp/test_cloudrun.py
@@ -578,8 +578,7 @@ def test_cloud_run_service_container_uses_latest_ready_revision_digest(
     ) == {
         (
             service_primary_container_id,
-            "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/server:abc1234"
-            f"@{TEST_REVISION_PRIMARY_DIGEST}",
+            "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/server:abc1234",
             TEST_REVISION_PRIMARY_DIGEST,
         ),
         (

--- a/tests/integration/cartography/intel/gcp/test_cloudrun.py
+++ b/tests/integration/cartography/intel/gcp/test_cloudrun.py
@@ -1,3 +1,4 @@
+from unittest.mock import ANY
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -8,9 +9,13 @@ import cartography.intel.gcp.cloudrun.service as cloudrun_service
 from tests.data.gcp.cloudrun import MOCK_EXECUTIONS
 from tests.data.gcp.cloudrun import MOCK_JOB_WITH_DIGEST
 from tests.data.gcp.cloudrun import MOCK_JOBS
+from tests.data.gcp.cloudrun import MOCK_LATEST_READY_REVISION_WITH_DIGESTED_IMAGES
 from tests.data.gcp.cloudrun import MOCK_REVISION_WITH_DIGEST
 from tests.data.gcp.cloudrun import MOCK_REVISIONS
 from tests.data.gcp.cloudrun import MOCK_SERVICE_WITH_DIGEST
+from tests.data.gcp.cloudrun import (
+    MOCK_SERVICE_WITH_TAG_ONLY_TEMPLATE_AND_DIGESTED_REVISION,
+)
 from tests.data.gcp.cloudrun import MOCK_SERVICES
 from tests.data.gcp.cloudrun import TEST_JOB_PRIMARY_DIGEST
 from tests.data.gcp.cloudrun import TEST_JOB_SIDECAR_DIGEST
@@ -143,9 +148,11 @@ def _create_image_registry_nodes(neo4j_session):
 @patch("cartography.intel.gcp.cloudrun.execution.get_executions")
 @patch("cartography.intel.gcp.cloudrun.job.get_jobs")
 @patch("cartography.intel.gcp.cloudrun.revision.get_revisions")
+@patch("cartography.intel.gcp.cloudrun.service.get_latest_ready_revisions")
 @patch("cartography.intel.gcp.cloudrun.service.get_services")
 def test_sync_cloudrun(
     mock_get_services,
+    mock_get_latest_ready_revisions,
     mock_get_revisions,
     mock_get_jobs,
     mock_get_executions,
@@ -160,6 +167,7 @@ def test_sync_cloudrun(
 
     # Arrange: Mock all 4 API calls
     mock_get_services.return_value = MOCK_SERVICES["services"]
+    mock_get_latest_ready_revisions.return_value = {}
     mock_get_revisions.return_value = MOCK_REVISIONS["revisions"]
     mock_get_jobs.return_value = MOCK_JOBS["jobs"]
     mock_get_executions.return_value = MOCK_EXECUTIONS["executions"]
@@ -504,4 +512,86 @@ def test_cloud_run_image_prerequisites(
     assert {(r["id"], r["state"]) for r in job_container_states} == {
         (job_primary_container_id, "running"),
         (job_sidecar_container_id, "running"),
+    }
+
+
+@patch("cartography.intel.gcp.cloudrun.service.proto_message_to_dict")
+@patch("cartography.intel.gcp.cloudrun.service.build_cloud_run_revision_client")
+@patch("cartography.intel.gcp.cloudrun.service.get_services")
+def test_cloud_run_service_container_uses_latest_ready_revision_digest(
+    mock_get_services,
+    mock_build_cloud_run_revision_client,
+    mock_proto_message_to_dict,
+    neo4j_session,
+):
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+
+    mock_get_services.return_value = (
+        MOCK_SERVICE_WITH_TAG_ONLY_TEMPLATE_AND_DIGESTED_REVISION
+    )
+    revision_response = object()
+    mock_revision_client = MagicMock()
+    mock_revision_client.get_revision.return_value = revision_response
+    mock_build_cloud_run_revision_client.return_value = mock_revision_client
+    mock_proto_message_to_dict.return_value = next(
+        iter(MOCK_LATEST_READY_REVISION_WITH_DIGESTED_IMAGES.values()),
+    )
+
+    _create_prerequisite_nodes(neo4j_session)
+    _create_image_registry_nodes(neo4j_session)
+
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "PROJECT_ID": TEST_PROJECT_ID,
+    }
+    mock_credentials = MagicMock()
+
+    cloudrun_service.sync_services(
+        neo4j_session,
+        TEST_PROJECT_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+        TEST_CLOUD_RUN_LOCATIONS,
+        mock_credentials,
+    )
+    mock_build_cloud_run_revision_client.assert_called_once_with(
+        credentials=mock_credentials,
+    )
+    mock_revision_client.get_revision.assert_called_once_with(
+        name=TEST_REVISION_ID,
+        retry=ANY,
+        timeout=cloudrun_service.CLOUD_RUN_LIST_TIMEOUT,
+    )
+    mock_proto_message_to_dict.assert_called_once_with(revision_response)
+
+    service_primary_container_id = f"{TEST_SERVICE_ID}/containers/server"
+    service_sidecar_container_id = f"{TEST_SERVICE_ID}/containers/metrics"
+
+    assert check_nodes(
+        neo4j_session,
+        "GCPCloudRunServiceContainer",
+        ["id", "image", "image_digest"],
+    ) == {
+        (
+            service_primary_container_id,
+            "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/server:abc1234",
+            TEST_REVISION_PRIMARY_DIGEST,
+        ),
+        (
+            service_sidecar_container_id,
+            "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/metrics:def5678",
+            TEST_REVISION_SIDECAR_DIGEST,
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "GCPCloudRunServiceContainer",
+        "id",
+        "GCPArtifactRegistryImage",
+        "digest",
+        "HAS_IMAGE",
+    ) == {
+        (service_primary_container_id, TEST_REVISION_PRIMARY_DIGEST),
+        (service_sidecar_container_id, TEST_REVISION_SIDECAR_DIGEST),
     }

--- a/tests/integration/cartography/intel/gcp/test_cloudrun.py
+++ b/tests/integration/cartography/intel/gcp/test_cloudrun.py
@@ -574,12 +574,14 @@ def test_cloud_run_service_container_uses_latest_ready_revision_digest(
     ) == {
         (
             service_primary_container_id,
-            "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/server:abc1234",
+            "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/server:abc1234"
+            f"@{TEST_REVISION_PRIMARY_DIGEST}",
             TEST_REVISION_PRIMARY_DIGEST,
         ),
         (
             service_sidecar_container_id,
-            "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/metrics:def5678",
+            "us-central1-docker.pkg.dev/test-project/runtime-repo/github.com/example-org/test-service/metrics:def5678"
+            f"@{TEST_REVISION_SIDECAR_DIGEST}",
             TEST_REVISION_SIDECAR_DIGEST,
         ),
     }


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
Goal: Cloud Run service containers whose service template only exposes a tag should still link to the canonical container image node that Cartography already loaded from Artifact Registry.

`GCPCloudRunServiceContainer` creates `HAS_IMAGE` relationships by matching `image_digest` to image nodes such as `GCPArtifactRegistryImage`. In some Cloud Run v2 responses, `service.template.containers[]` contains tag-only image refs, while `latestReadyRevision` contains the digest-pinned refs for the deployed revision. Without that digest, the service container is still loaded but no `HAS_IMAGE` relationship is created, so downstream `RESOLVED_IMAGE` analysis cannot connect the running Cloud Run container to the GAR image.

This updates Cloud Run service container sync to fetch the latest ready revision only for services with tag-only template images, then use the revision image reference to populate `image_digest` while preserving the provider-reported service template `image`. Existing model behavior then handles the rest automatically:

```cypher
(:GCPCloudRunServiceContainer:Container)
  -[:HAS_IMAGE]->
(:GCPArtifactRegistryImage:Image)
```

and `resolved_image_analysis` can create the concrete `RESOLVED_IMAGE` edge as usual.


### Related issues or links
- Fixes #


### Breaking changes
None.


### How was this tested?
- `uv run --frozen pytest -vv tests/integration/cartography/intel/gcp/test_cloudrun.py`
- `uv run --frozen pre-commit run --all-files --show-diff-on-failure`


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
This keeps Cloud Run revisions as version marker nodes. It does not reintroduce revision-scoped container nodes; it only uses latest ready revision image metadata to complete the service container image digest when the service template image is tag-only.