### PR TITLE
Match package ontology sources by canonical PURL

### DIFF
--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -22,6 +22,7 @@ from cartography.intel.github.util import fetch_all
 from cartography.intel.github.util import fetch_page
 from cartography.intel.github.util import handle_rate_limit_sleep
 from cartography.intel.github.util import PaginatedGraphqlData
+from cartography.intel.trivy.util import make_canonical_purl
 from cartography.intel.trivy.util import make_normalized_package_id
 from cartography.intel.trivy.util import parse_purl
 from cartography.models.github.branch_protection_rules import (
@@ -1150,10 +1151,11 @@ def _transform_dependency_graph(
 
             # Extract ontology fields from GitHub's native PURL
             dep_purl = dep.get("packageUrl") or None
-            parsed = parse_purl(dep_purl)
+            canonical_purl = make_canonical_purl(purl=dep_purl)
+            parsed = parse_purl(canonical_purl)
             dep_version = parsed["version"] if parsed else None
             dep_type = parsed["type"] if parsed else None
-            dep_normalized_id = make_normalized_package_id(purl=dep_purl)
+            dep_normalized_id = make_normalized_package_id(purl=canonical_purl)
 
             out_dependencies_list.append(
                 {
@@ -1171,7 +1173,7 @@ def _transform_dependency_graph(
                     ),
                     "version": dep_version,
                     "type": dep_type,
-                    "purl": dep_purl,
+                    "purl": canonical_purl,
                     "normalized_id": dep_normalized_id,
                 }
             )

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -1151,11 +1151,11 @@ def _transform_dependency_graph(
 
             # Extract ontology fields from GitHub's native PURL
             dep_purl = dep.get("packageUrl") or None
-            canonical_purl = make_canonical_purl(purl=dep_purl)
-            parsed = parse_purl(canonical_purl)
+            package_url = make_canonical_purl(purl=dep_purl)
+            parsed = parse_purl(package_url)
             dep_version = parsed["version"] if parsed else None
             dep_type = parsed["type"] if parsed else None
-            dep_normalized_id = make_normalized_package_id(purl=canonical_purl)
+            dep_normalized_id = make_normalized_package_id(purl=package_url)
 
             out_dependencies_list.append(
                 {
@@ -1173,7 +1173,8 @@ def _transform_dependency_graph(
                     ),
                     "version": dep_version,
                     "type": dep_type,
-                    "purl": canonical_purl,
+                    "purl": dep_purl,
+                    "package_url": package_url,
                     "normalized_id": dep_normalized_id,
                 }
             )

--- a/cartography/intel/semgrep/dependencies.py
+++ b/cartography/intel/semgrep/dependencies.py
@@ -154,14 +154,14 @@ def transform_dependencies(raw_deps: List[Dict[str, Any]]) -> List[Dict[str, Any
         name = raw_dep["package"]["name"]
         version = raw_dep["package"]["versionSpecifier"]
         id = f"{name}|{version}"
-        canonical_purl = make_canonical_purl(
+        package_url = make_canonical_purl(
             name=name,
             version=version,
             pkg_type=raw_dep["ecosystem"],
         )
         package_type = normalize_package_type(raw_dep["ecosystem"])
         normalized_id = make_normalized_package_id(
-            purl=canonical_purl,
+            purl=package_url,
             name=name,
             version=version,
             pkg_type=raw_dep["ecosystem"],
@@ -180,7 +180,8 @@ def transform_dependencies(raw_deps: List[Dict[str, Any]]) -> List[Dict[str, Any
                 "specifier": specifier,
                 "version": version,
                 "type": package_type,
-                "purl": canonical_purl,
+                "purl": package_url,
+                "package_url": package_url,
                 "normalized_id": normalized_id,
                 "repo_url": repo_url,
                 # Semgrep-specific properties:

--- a/cartography/intel/semgrep/dependencies.py
+++ b/cartography/intel/semgrep/dependencies.py
@@ -11,6 +11,9 @@ from requests.exceptions import ReadTimeout
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.trivy.util import make_canonical_purl
+from cartography.intel.trivy.util import make_normalized_package_id
+from cartography.intel.trivy.util import normalize_package_type
 from cartography.models.semgrep.dependencies import SemgrepGoLibrarySchema
 from cartography.models.semgrep.dependencies import SemgrepNpmLibrarySchema
 from cartography.stats import get_stats_client
@@ -151,6 +154,18 @@ def transform_dependencies(raw_deps: List[Dict[str, Any]]) -> List[Dict[str, Any
         name = raw_dep["package"]["name"]
         version = raw_dep["package"]["versionSpecifier"]
         id = f"{name}|{version}"
+        canonical_purl = make_canonical_purl(
+            name=name,
+            version=version,
+            pkg_type=raw_dep["ecosystem"],
+        )
+        package_type = normalize_package_type(raw_dep["ecosystem"])
+        normalized_id = make_normalized_package_id(
+            purl=canonical_purl,
+            name=name,
+            version=version,
+            pkg_type=raw_dep["ecosystem"],
+        )
 
         # As of November 2024, Semgrep does not import dependencies with version specifiers such as >, <, etc.
         # For now, hardcode the specifier to ==<version> to align with GitHub-sourced Python dependencies.
@@ -164,6 +179,9 @@ def transform_dependencies(raw_deps: List[Dict[str, Any]]) -> List[Dict[str, Any
                 "name": name,
                 "specifier": specifier,
                 "version": version,
+                "type": package_type,
+                "purl": canonical_purl,
+                "normalized_id": normalized_id,
                 "repo_url": repo_url,
                 # Semgrep-specific properties:
                 "ecosystem": raw_dep["ecosystem"],

--- a/cartography/intel/syft/parser.py
+++ b/cartography/intel/syft/parser.py
@@ -126,14 +126,14 @@ def transform_artifacts(data: dict[str, Any]) -> list[dict[str, Any]]:
         if not parent_name or not parent_version:
             continue
 
-        parent_purl = make_canonical_purl(
+        parent_package_url = make_canonical_purl(
             purl=parent.get("purl"),
             name=parent_name,
             version=parent_version,
             pkg_type=parent.get("type"),
         )
         parent_norm_id = make_normalized_package_id(
-            purl=parent_purl,
+            purl=parent_package_url,
             name=parent_name,
             version=parent_version,
             pkg_type=parent.get("type"),
@@ -158,14 +158,14 @@ def transform_artifacts(data: dict[str, Any]) -> list[dict[str, Any]]:
             logger.debug("Skipping artifact %s: missing name or version", artifact_id)
             continue
 
-        canonical_purl = make_canonical_purl(
+        package_url = make_canonical_purl(
             purl=artifact.get("purl"),
             name=name,
             version=version,
             pkg_type=artifact.get("type"),
         )
         normalized_id = make_normalized_package_id(
-            purl=canonical_purl,
+            purl=package_url,
             name=name,
             version=version,
             pkg_type=artifact.get("type"),
@@ -176,7 +176,8 @@ def transform_artifacts(data: dict[str, Any]) -> list[dict[str, Any]]:
                 "name": name,
                 "version": version,
                 "type": artifact.get("type"),
-                "purl": canonical_purl,
+                "purl": artifact.get("purl"),
+                "package_url": package_url,
                 "normalized_id": normalized_id,
                 "language": artifact.get("language"),
                 "found_by": artifact.get("foundBy"),

--- a/cartography/intel/syft/parser.py
+++ b/cartography/intel/syft/parser.py
@@ -32,6 +32,7 @@ Direct vs Transitive Dependencies:
 import logging
 from typing import Any
 
+from cartography.intel.trivy.util import make_canonical_purl
 from cartography.intel.trivy.util import make_normalized_package_id
 
 logger = logging.getLogger(__name__)
@@ -125,8 +126,14 @@ def transform_artifacts(data: dict[str, Any]) -> list[dict[str, Any]]:
         if not parent_name or not parent_version:
             continue
 
-        parent_norm_id = make_normalized_package_id(
+        parent_purl = make_canonical_purl(
             purl=parent.get("purl"),
+            name=parent_name,
+            version=parent_version,
+            pkg_type=parent.get("type"),
+        )
+        parent_norm_id = make_normalized_package_id(
+            purl=parent_purl,
             name=parent_name,
             version=parent_version,
             pkg_type=parent.get("type"),
@@ -151,8 +158,14 @@ def transform_artifacts(data: dict[str, Any]) -> list[dict[str, Any]]:
             logger.debug("Skipping artifact %s: missing name or version", artifact_id)
             continue
 
-        normalized_id = make_normalized_package_id(
+        canonical_purl = make_canonical_purl(
             purl=artifact.get("purl"),
+            name=name,
+            version=version,
+            pkg_type=artifact.get("type"),
+        )
+        normalized_id = make_normalized_package_id(
+            purl=canonical_purl,
             name=name,
             version=version,
             pkg_type=artifact.get("type"),
@@ -163,7 +176,7 @@ def transform_artifacts(data: dict[str, Any]) -> list[dict[str, Any]]:
                 "name": name,
                 "version": version,
                 "type": artifact.get("type"),
-                "purl": artifact.get("purl"),
+                "purl": canonical_purl,
                 "normalized_id": normalized_id,
                 "language": artifact.get("language"),
                 "found_by": artifact.get("foundBy"),

--- a/cartography/intel/trivy/scanner.py
+++ b/cartography/intel/trivy/scanner.py
@@ -134,7 +134,7 @@ def transform_scan_results(
                 # Transform package data
                 package_id = f"{result['InstalledVersion']}|{result['PkgName']}"
 
-                canonical_purl = make_canonical_purl(
+                package_url = make_canonical_purl(
                     purl=purl,
                     name=result["PkgName"],
                     version=result["InstalledVersion"],
@@ -143,7 +143,7 @@ def transform_scan_results(
                 # Compute normalized ID for cross-tool matching
                 # This enables Syft to match packages despite naming differences
                 normalized_id = make_normalized_package_id(
-                    purl=canonical_purl,
+                    purl=package_url,
                     name=result["PkgName"],
                     version=result["InstalledVersion"],
                     pkg_type=scan_class["Type"],
@@ -159,7 +159,8 @@ def transform_scan_results(
                         "ImageDigest": image_digest,  # For DEPLOYED relationship
                         "FindingId": finding["id"],  # For AFFECTS relationship
                         # Additional fields
-                        "PURL": canonical_purl,
+                        "PURL": purl,
+                        "package_url": package_url,
                         "PkgID": result.get("PkgID"),
                         "normalized_id": normalized_id,
                     }
@@ -225,14 +226,14 @@ def transform_all_packages(
             if "Identifier" in pkg and pkg["Identifier"]:
                 purl = pkg["Identifier"].get("PURL")
 
-            canonical_purl = make_canonical_purl(
+            package_url = make_canonical_purl(
                 purl=purl,
                 name=name,
                 version=version,
                 pkg_type=pkg_type,
             )
             normalized_id = make_normalized_package_id(
-                purl=canonical_purl,
+                purl=package_url,
                 name=name,
                 version=version,
                 pkg_type=pkg_type,
@@ -247,7 +248,8 @@ def transform_all_packages(
                     "Type": pkg_type,
                     "ImageDigest": image_digest,
                     "FindingId": None,
-                    "PURL": canonical_purl,
+                    "PURL": purl,
+                    "package_url": package_url,
                     "PkgID": pkg.get("ID"),
                     "normalized_id": normalized_id,
                 },

--- a/cartography/intel/trivy/scanner.py
+++ b/cartography/intel/trivy/scanner.py
@@ -12,6 +12,7 @@ from cartography.intel.common.object_store import filter_report_refs
 from cartography.intel.common.object_store import read_text_report
 from cartography.intel.common.object_store import ReportRef
 from cartography.intel.common.object_store import S3BucketReader
+from cartography.intel.trivy.util import make_canonical_purl
 from cartography.intel.trivy.util import make_normalized_package_id
 from cartography.models.trivy.findings import TrivyImageFindingSchema
 from cartography.models.trivy.fix import TrivyFixSchema
@@ -133,10 +134,16 @@ def transform_scan_results(
                 # Transform package data
                 package_id = f"{result['InstalledVersion']}|{result['PkgName']}"
 
+                canonical_purl = make_canonical_purl(
+                    purl=purl,
+                    name=result["PkgName"],
+                    version=result["InstalledVersion"],
+                    pkg_type=scan_class["Type"],
+                )
                 # Compute normalized ID for cross-tool matching
                 # This enables Syft to match packages despite naming differences
                 normalized_id = make_normalized_package_id(
-                    purl=purl,
+                    purl=canonical_purl,
                     name=result["PkgName"],
                     version=result["InstalledVersion"],
                     pkg_type=scan_class["Type"],
@@ -152,7 +159,7 @@ def transform_scan_results(
                         "ImageDigest": image_digest,  # For DEPLOYED relationship
                         "FindingId": finding["id"],  # For AFFECTS relationship
                         # Additional fields
-                        "PURL": purl,
+                        "PURL": canonical_purl,
                         "PkgID": result.get("PkgID"),
                         "normalized_id": normalized_id,
                     }
@@ -218,8 +225,14 @@ def transform_all_packages(
             if "Identifier" in pkg and pkg["Identifier"]:
                 purl = pkg["Identifier"].get("PURL")
 
-            normalized_id = make_normalized_package_id(
+            canonical_purl = make_canonical_purl(
                 purl=purl,
+                name=name,
+                version=version,
+                pkg_type=pkg_type,
+            )
+            normalized_id = make_normalized_package_id(
+                purl=canonical_purl,
                 name=name,
                 version=version,
                 pkg_type=pkg_type,
@@ -234,7 +247,7 @@ def transform_all_packages(
                     "Type": pkg_type,
                     "ImageDigest": image_digest,
                     "FindingId": None,
-                    "PURL": purl,
+                    "PURL": canonical_purl,
                     "PkgID": pkg.get("ID"),
                     "normalized_id": normalized_id,
                 },

--- a/cartography/intel/trivy/util.py
+++ b/cartography/intel/trivy/util.py
@@ -10,7 +10,13 @@ import re
 from packageurl import PackageURL
 
 _PACKAGE_TYPE_ALIASES = {
+    "gobinary": "golang",
+    "go-module": "golang",
     "gomod": "golang",
+    "jar": "maven",
+    "java-archive": "maven",
+    "node-pkg": "npm",
+    "python-pkg": "pypi",
 }
 
 
@@ -78,14 +84,28 @@ def make_canonical_purl(
     pkg_type: str | None = None,
 ) -> str | None:
     """
-    Create a deterministic Package URL for cross-tool package matching.
+    Create a deterministic package identity URL for cross-tool matching.
 
-    Prefer a source PURL when present. If a source only provides package
-    components, build a PURL from type, name, and version.
+    Prefer a source PURL when present, but keep only the package identity
+    components. Source-specific qualifiers like architecture, distro, or
+    upstream package remain useful on raw scanner nodes but make cross-tool
+    package identity matching too strict.
+
+    If a source only provides package components, build a PURL from type, name,
+    and version.
     """
     if purl:
         try:
-            return PackageURL.from_string(purl).to_string()
+            parsed = PackageURL.from_string(purl)
+            normalized_type = normalize_package_type(parsed.type)
+            return PackageURL(
+                type=normalized_type or parsed.type,
+                namespace=parsed.namespace,
+                name=normalize_package_name(
+                    parsed.name, normalized_type or parsed.type
+                ),
+                version=parsed.version,
+            ).to_string()
         except ValueError:
             pass
 

--- a/cartography/intel/trivy/util.py
+++ b/cartography/intel/trivy/util.py
@@ -9,6 +9,17 @@ import re
 
 from packageurl import PackageURL
 
+_PACKAGE_TYPE_ALIASES = {
+    "gomod": "golang",
+}
+
+
+def normalize_package_type(pkg_type: str | None) -> str | None:
+    if not pkg_type:
+        return None
+    pkg_type_lower = pkg_type.lower()
+    return _PACKAGE_TYPE_ALIASES.get(pkg_type_lower, pkg_type_lower)
+
 
 def normalize_package_name(name: str, pkg_type: str) -> str:
     """
@@ -60,6 +71,35 @@ def parse_purl(purl: str | None) -> dict | None:
     }
 
 
+def make_canonical_purl(
+    purl: str | None = None,
+    name: str | None = None,
+    version: str | None = None,
+    pkg_type: str | None = None,
+) -> str | None:
+    """
+    Create a deterministic Package URL for cross-tool package matching.
+
+    Prefer a source PURL when present. If a source only provides package
+    components, build a PURL from type, name, and version.
+    """
+    if purl:
+        try:
+            return PackageURL.from_string(purl).to_string()
+        except ValueError:
+            pass
+
+    normalized_type = normalize_package_type(pkg_type)
+    if name and version and normalized_type:
+        return PackageURL(
+            type=normalized_type,
+            name=normalize_package_name(name, normalized_type),
+            version=version,
+        ).to_string()
+
+    return None
+
+
 def make_normalized_package_id(
     purl: str | None = None,
     name: str | None = None,
@@ -88,8 +128,9 @@ def make_normalized_package_id(
     Returns:
         Normalized ID in format "{type}|{namespace/}{normalized_name}|{version}" or None
     """
-    if purl:
-        parsed = parse_purl(purl)
+    canonical_purl = make_canonical_purl(purl, name, version, pkg_type)
+    if canonical_purl:
+        parsed = parse_purl(canonical_purl)
         if parsed and parsed["name"] and parsed["version"]:
             norm_name = normalize_package_name(parsed["name"], parsed["type"])
             ns_prefix = f"{parsed['namespace']}/" if parsed.get("namespace") else ""
@@ -97,8 +138,9 @@ def make_normalized_package_id(
 
     # Fallback to provided components
     if name and version and pkg_type:
-        norm_name = normalize_package_name(name, pkg_type)
-        pkg_type_lower = pkg_type.lower() if pkg_type else "unknown"
+        normalized_type = normalize_package_type(pkg_type)
+        norm_name = normalize_package_name(name, normalized_type or "")
+        pkg_type_lower = normalized_type or "unknown"
         return f"{pkg_type_lower}|{norm_name}|{version}"
 
     return None

--- a/cartography/models/github/dependencies.py
+++ b/cartography/models/github/dependencies.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -68,6 +69,7 @@ class DependencyGraphManifestToDependencyRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class GitHubDependencySchema(CartographyNodeSchema):
     label: str = "Dependency"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["GitHubDependency"])
     properties: GitHubDependencyNodeProperties = GitHubDependencyNodeProperties()
     sub_resource_relationship: GitHubDependencyToRepositoryRel = (
         GitHubDependencyToRepositoryRel()

--- a/cartography/models/github/dependencies.py
+++ b/cartography/models/github/dependencies.py
@@ -24,6 +24,7 @@ class GitHubDependencyNodeProperties(CartographyNodeProperties):
     version: PropertyRef = PropertyRef("version")
     type: PropertyRef = PropertyRef("type")
     purl: PropertyRef = PropertyRef("purl")
+    package_url: PropertyRef = PropertyRef("package_url", extra_index=True)
     normalized_id: PropertyRef = PropertyRef("normalized_id", extra_index=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 

--- a/cartography/models/ontology/mapping/data/packages.py
+++ b/cartography/models/ontology/mapping/data/packages.py
@@ -15,7 +15,7 @@ trivy_mapping = OntologyMapping(
                 ),
                 OntologyFieldMapping(
                     ontology_field="purl",
-                    node_field="purl",
+                    node_field="package_url",
                     required=True,
                 ),
                 OntologyFieldMapping(ontology_field="name", node_field="name"),
@@ -39,7 +39,7 @@ syft_mapping = OntologyMapping(
                 ),
                 OntologyFieldMapping(
                     ontology_field="purl",
-                    node_field="purl",
+                    node_field="package_url",
                     required=True,
                 ),
                 OntologyFieldMapping(ontology_field="name", node_field="name"),
@@ -63,7 +63,7 @@ github_mapping = OntologyMapping(
                 ),
                 OntologyFieldMapping(
                     ontology_field="purl",
-                    node_field="purl",
+                    node_field="package_url",
                     required=True,
                 ),
                 OntologyFieldMapping(ontology_field="name", node_field="name"),
@@ -87,7 +87,7 @@ semgrep_mapping = OntologyMapping(
                 ),
                 OntologyFieldMapping(
                     ontology_field="purl",
-                    node_field="purl",
+                    node_field="package_url",
                     required=True,
                 ),
                 OntologyFieldMapping(ontology_field="name", node_field="name"),

--- a/cartography/models/ontology/mapping/data/packages.py
+++ b/cartography/models/ontology/mapping/data/packages.py
@@ -13,10 +13,14 @@ trivy_mapping = OntologyMapping(
                     node_field="normalized_id",
                     required=True,
                 ),
+                OntologyFieldMapping(
+                    ontology_field="purl",
+                    node_field="purl",
+                    required=True,
+                ),
                 OntologyFieldMapping(ontology_field="name", node_field="name"),
                 OntologyFieldMapping(ontology_field="version", node_field="version"),
                 OntologyFieldMapping(ontology_field="type", node_field="type"),
-                OntologyFieldMapping(ontology_field="purl", node_field="purl"),
             ],
         ),
     ],
@@ -33,10 +37,62 @@ syft_mapping = OntologyMapping(
                     node_field="normalized_id",
                     required=True,
                 ),
+                OntologyFieldMapping(
+                    ontology_field="purl",
+                    node_field="purl",
+                    required=True,
+                ),
                 OntologyFieldMapping(ontology_field="name", node_field="name"),
                 OntologyFieldMapping(ontology_field="version", node_field="version"),
                 OntologyFieldMapping(ontology_field="type", node_field="type"),
-                OntologyFieldMapping(ontology_field="purl", node_field="purl"),
+            ],
+        ),
+    ],
+)
+
+github_mapping = OntologyMapping(
+    module_name="github",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="GitHubDependency",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="normalized_id",
+                    node_field="normalized_id",
+                    required=True,
+                ),
+                OntologyFieldMapping(
+                    ontology_field="purl",
+                    node_field="purl",
+                    required=True,
+                ),
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(ontology_field="version", node_field="version"),
+                OntologyFieldMapping(ontology_field="type", node_field="type"),
+            ],
+        ),
+    ],
+)
+
+semgrep_mapping = OntologyMapping(
+    module_name="semgrep",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="SemgrepDependency",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="normalized_id",
+                    node_field="normalized_id",
+                    required=True,
+                ),
+                OntologyFieldMapping(
+                    ontology_field="purl",
+                    node_field="purl",
+                    required=True,
+                ),
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(ontology_field="version", node_field="version"),
+                OntologyFieldMapping(ontology_field="type", node_field="type"),
             ],
         ),
     ],
@@ -45,4 +101,6 @@ syft_mapping = OntologyMapping(
 PACKAGES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "trivy": trivy_mapping,
     "syft": syft_mapping,
+    "github": github_mapping,
+    "semgrep": semgrep_mapping,
 }

--- a/cartography/models/ontology/package.py
+++ b/cartography/models/ontology/package.py
@@ -32,7 +32,7 @@ class PackageToNodeRelProperties(CartographyRelProperties):
 class PackageToTrivyPackageRel(CartographyRelSchema):
     target_node_label: str = "TrivyPackage"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"purl": PropertyRef("purl")},
+        {"package_url": PropertyRef("purl")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "DETECTED_AS"
@@ -44,7 +44,7 @@ class PackageToTrivyPackageRel(CartographyRelSchema):
 class PackageToSyftPackageRel(CartographyRelSchema):
     target_node_label: str = "SyftPackage"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"purl": PropertyRef("purl")},
+        {"package_url": PropertyRef("purl")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "DETECTED_AS"
@@ -68,7 +68,7 @@ class PackageToSocketDevDependencyRel(CartographyRelSchema):
 class PackageToGitHubDependencyRel(CartographyRelSchema):
     target_node_label: str = "GitHubDependency"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"purl": PropertyRef("purl")},
+        {"package_url": PropertyRef("purl")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "DETECTED_AS"
@@ -80,7 +80,7 @@ class PackageToGitHubDependencyRel(CartographyRelSchema):
 class PackageToSemgrepDependencyRel(CartographyRelSchema):
     target_node_label: str = "SemgrepDependency"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"purl": PropertyRef("purl")},
+        {"package_url": PropertyRef("purl")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "DETECTED_AS"

--- a/cartography/models/ontology/package.py
+++ b/cartography/models/ontology/package.py
@@ -19,7 +19,7 @@ class PackageNodeProperties(CartographyNodeProperties):
     name: PropertyRef = PropertyRef("name")
     version: PropertyRef = PropertyRef("version")
     type: PropertyRef = PropertyRef("type")
-    purl: PropertyRef = PropertyRef("purl")
+    purl: PropertyRef = PropertyRef("purl", extra_index=True)
 
 
 @dataclass(frozen=True)
@@ -32,7 +32,7 @@ class PackageToNodeRelProperties(CartographyRelProperties):
 class PackageToTrivyPackageRel(CartographyRelSchema):
     target_node_label: str = "TrivyPackage"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"normalized_id": PropertyRef("normalized_id")},
+        {"purl": PropertyRef("purl")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "DETECTED_AS"
@@ -44,7 +44,7 @@ class PackageToTrivyPackageRel(CartographyRelSchema):
 class PackageToSyftPackageRel(CartographyRelSchema):
     target_node_label: str = "SyftPackage"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"normalized_id": PropertyRef("normalized_id")},
+        {"purl": PropertyRef("purl")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "DETECTED_AS"
@@ -57,6 +57,30 @@ class PackageToSocketDevDependencyRel(CartographyRelSchema):
     target_node_label: str = "SocketDevDependency"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"normalized_id": PropertyRef("normalized_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "DETECTED_AS"
+    properties: PackageToNodeRelProperties = PackageToNodeRelProperties()
+
+
+# (:Package)-[:DETECTED_AS]->(:GitHubDependency)
+@dataclass(frozen=True)
+class PackageToGitHubDependencyRel(CartographyRelSchema):
+    target_node_label: str = "GitHubDependency"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"purl": PropertyRef("purl")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "DETECTED_AS"
+    properties: PackageToNodeRelProperties = PackageToNodeRelProperties()
+
+
+# (:Package)-[:DETECTED_AS]->(:SemgrepDependency)
+@dataclass(frozen=True)
+class PackageToSemgrepDependencyRel(CartographyRelSchema):
+    target_node_label: str = "SemgrepDependency"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"purl": PropertyRef("purl")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "DETECTED_AS"
@@ -129,6 +153,8 @@ class PackageSchema(CartographyNodeSchema):
             PackageToTrivyPackageRel(),
             PackageToSyftPackageRel(),
             PackageToSocketDevDependencyRel(),
+            PackageToGitHubDependencyRel(),
+            PackageToSemgrepDependencyRel(),
             PackageToOntologyImageRel(),
             PackageToTrivyFixRel(),
             PackageToPackageDependsOnRel(),

--- a/cartography/models/semgrep/dependencies.py
+++ b/cartography/models/semgrep/dependencies.py
@@ -22,6 +22,7 @@ class SemgrepDependencyNodeProperties(CartographyNodeProperties):
     version: PropertyRef = PropertyRef("version")
     type: PropertyRef = PropertyRef("type")
     purl: PropertyRef = PropertyRef("purl")
+    package_url: PropertyRef = PropertyRef("package_url", extra_index=True)
     normalized_id: PropertyRef = PropertyRef("normalized_id", extra_index=True)
 
 

--- a/cartography/models/semgrep/dependencies.py
+++ b/cartography/models/semgrep/dependencies.py
@@ -20,6 +20,9 @@ class SemgrepDependencyNodeProperties(CartographyNodeProperties):
     name: PropertyRef = PropertyRef("name")
     ecosystem: PropertyRef = PropertyRef("ecosystem")
     version: PropertyRef = PropertyRef("version")
+    type: PropertyRef = PropertyRef("type")
+    purl: PropertyRef = PropertyRef("purl")
+    normalized_id: PropertyRef = PropertyRef("normalized_id", extra_index=True)
 
 
 @dataclass(frozen=True)

--- a/cartography/models/syft/package.py
+++ b/cartography/models/syft/package.py
@@ -27,6 +27,7 @@ class SyftPackageNodeProperties(CartographyNodeProperties):
     version: PropertyRef = PropertyRef("version")
     type: PropertyRef = PropertyRef("type")
     purl: PropertyRef = PropertyRef("purl")
+    package_url: PropertyRef = PropertyRef("package_url", extra_index=True)
     normalized_id: PropertyRef = PropertyRef("normalized_id", extra_index=True)
     language: PropertyRef = PropertyRef("language")
     found_by: PropertyRef = PropertyRef("found_by")

--- a/cartography/models/trivy/package.py
+++ b/cartography/models/trivy/package.py
@@ -21,6 +21,7 @@ class TrivyPackageNodeProperties(CartographyNodeProperties):
     type: PropertyRef = PropertyRef("Type")
     # Additional fields from Trivy scan results
     purl: PropertyRef = PropertyRef("PURL")
+    package_url: PropertyRef = PropertyRef("package_url", extra_index=True)
     pkg_id: PropertyRef = PropertyRef("PkgID")
     # Normalized ID for cross-tool matching (format: {type}|{namespace/}{normalized_name}|{version})
     # Namespace included when present (e.g., deb packages). Uses PEP 503 normalization for Python.

--- a/docs/root/modules/github/schema.md
+++ b/docs/root/modules/github/schema.md
@@ -432,10 +432,11 @@ Represents a software dependency from GitHub's dependency graph manifests. This 
 | **manifest_file** | Manifest filename (package.json, requirements.txt, etc.) |
 | version | Exact version if pinned (e.g., `"18.2.0"`). `null` for ranges or unpinned dependencies. |
 | type | Package URL type (e.g., `npm`, `pypi`, `maven`). `null` if version is not exact. |
-| purl | Package URL (e.g., `"pkg:npm/react@18.2.0"`). `null` if version is not exact. |
+| purl | Source Package URL from GitHub dependency graph (e.g., `"pkg:npm/react@18.2.0"`). `null` if version is not exact. |
+| package_url | Canonical package identity URL used for ontology matching. `null` if version is not exact. |
 | **normalized_id** | Normalized ID for cross-tool matching (format: `{type}\|{namespace/}{name}\|{version}`). Indexed. `null` if version is not exact. |
 
-> **Ontology Mapping**: Exact-version dependency nodes also have the extra label `GitHubDependency` and can link to the canonical `Package` ontology node by canonical Package URL.
+> **Ontology Mapping**: Exact-version dependency nodes also have the extra label `GitHubDependency` and can link to the canonical `Package` ontology node by `package_url`.
 
 #### Relationships
 

--- a/docs/root/modules/github/schema.md
+++ b/docs/root/modules/github/schema.md
@@ -435,6 +435,8 @@ Represents a software dependency from GitHub's dependency graph manifests. This 
 | purl | Package URL (e.g., `"pkg:npm/react@18.2.0"`). `null` if version is not exact. |
 | **normalized_id** | Normalized ID for cross-tool matching (format: `{type}\|{namespace/}{name}\|{version}`). Indexed. `null` if version is not exact. |
 
+> **Ontology Mapping**: Exact-version dependency nodes also have the extra label `GitHubDependency` and can link to the canonical `Package` ontology node by canonical Package URL.
+
 #### Relationships
 
 - **GitHubRepository** via **REQUIRES** relationship

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -783,6 +783,8 @@ Package nodes are deduplicated by their `id`, which uses the format `{type}|{nam
     ```
     (:Package)-[:DETECTED_AS]->(:TrivyPackage)
     (:Package)-[:DETECTED_AS]->(:SyftPackage)
+    (:Package)-[:DETECTED_AS]->(:GitHubDependency)
+    (:Package)-[:DETECTED_AS]->(:SemgrepDependency)
     ```
 - `Package` can be deployed in one or many container images (propagated from TrivyPackage and SyftPackage):
     ```

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -775,7 +775,7 @@ Package nodes are deduplicated by their `id`, which uses the format `{type}|{nam
 | name | Name of the package. |
 | version | Version of the package. |
 | type | Package ecosystem type (e.g., npm, pypi, deb). |
-| purl | Package URL (e.g., `pkg:npm/express@4.18.2`). |
+| purl | Canonical package identity URL (e.g., `pkg:npm/express@4.18.2`). Indexed. |
 
 #### Relationships
 
@@ -786,6 +786,7 @@ Package nodes are deduplicated by their `id`, which uses the format `{type}|{nam
     (:Package)-[:DETECTED_AS]->(:GitHubDependency)
     (:Package)-[:DETECTED_AS]->(:SemgrepDependency)
     ```
+  These links match `Package.purl` to the source node's `package_url`, preserving raw scanner/source PURLs on the source nodes.
 - `Package` can be deployed in one or many container images (propagated from TrivyPackage and SyftPackage):
     ```
     (:Package)-[:DEPLOYED]->(:Image)

--- a/docs/root/modules/semgrep/schema.md
+++ b/docs/root/modules/semgrep/schema.md
@@ -263,7 +263,12 @@ Represents a dependency of a repository as returned by the Semgrep
 | **id** | Unique id formed by the name and version of the dependency |
 | name | Name of the dependency |
 | version | Version of the dependency |
+| type | Package URL type normalized for cross-tool matching (e.g. `npm`, `golang`) |
+| purl | Canonical Package URL for exact package matching |
+| **normalized_id** | Normalized ID for cross-tool matching (format: `{type}\|{namespace/}{name}\|{version}`). Indexed. |
 | ecosystem | Ecosystem of the dependency, e.g. "gomod" for dependencies defined in go.mod files. (see [API docs](https://semgrep.dev/api/v1/docs/#tag/SupplyChainService/operation/semgrep_app.products.sca.handlers.dependency.list_dependencies_conexxion) for full list of options) |
+
+> **Ontology Mapping**: SemgrepDependency nodes can link to the canonical `Package` ontology node by canonical Package URL.
 
 
 ### GoLibrary

--- a/docs/root/modules/semgrep/schema.md
+++ b/docs/root/modules/semgrep/schema.md
@@ -265,10 +265,11 @@ Represents a dependency of a repository as returned by the Semgrep
 | version | Version of the dependency |
 | type | Package URL type normalized for cross-tool matching (e.g. `npm`, `golang`) |
 | purl | Canonical Package URL for exact package matching |
+| package_url | Canonical package identity URL used for ontology matching. |
 | **normalized_id** | Normalized ID for cross-tool matching (format: `{type}\|{namespace/}{name}\|{version}`). Indexed. |
 | ecosystem | Ecosystem of the dependency, e.g. "gomod" for dependencies defined in go.mod files. (see [API docs](https://semgrep.dev/api/v1/docs/#tag/SupplyChainService/operation/semgrep_app.products.sca.handlers.dependency.list_dependencies_conexxion) for full list of options) |
 
-> **Ontology Mapping**: SemgrepDependency nodes can link to the canonical `Package` ontology node by canonical Package URL.
+> **Ontology Mapping**: SemgrepDependency nodes can link to the canonical `Package` ontology node by `package_url`.
 
 
 ### GoLibrary

--- a/docs/root/modules/syft/schema.md
+++ b/docs/root/modules/syft/schema.md
@@ -12,7 +12,8 @@ Representation of a software package discovered by Syft, created from Syft's `ar
 | name | Package name |
 | version | Package version |
 | type | Package type (e.g., `npm`, `pypi`, `deb`) |
-| purl | Package URL |
+| purl | Source Package URL from Syft, including source qualifiers when Syft reports them. |
+| package_url | Canonical package identity URL used for ontology matching. Indexed. |
 | **normalized_id** | Normalized ID for cross-tool matching (format: `{type}\|{namespace/}{name}\|{version}`). Indexed. |
 | language | Programming language |
 | found_by | Syft cataloger that discovered the package |

--- a/docs/root/modules/trivy/schema.md
+++ b/docs/root/modules/trivy/schema.md
@@ -49,7 +49,8 @@ Representation of a package installed in a container image, as detected by Trivy
 | version | Version of the package (same as installed_version) |
 | class_name | Class of the package (e.g. os, library) |
 | type | Type of the package |
-| purl | Package URL (e.g., `pkg:npm/express@4.18.2`) |
+| purl | Source Package URL from Trivy, including source qualifiers when Trivy reports them. |
+| package_url | Canonical package identity URL used for ontology matching. Indexed. |
 | pkg_id | Package identifier from Trivy |
 | **normalized_id** | Normalized ID for cross-tool matching (format: `{type}\|{namespace/}{name}\|{version}`). Indexed. |
 

--- a/tests/data/github/repos.py
+++ b/tests/data/github/repos.py
@@ -14,7 +14,7 @@ DEPENDENCY_GRAPH_WITH_MULTIPLE_ECOSYSTEMS = {
                 "nodes": [
                     {
                         "packageName": "react",
-                        "packageUrl": "pkg:npm/react@18.2.0",
+                        "packageUrl": "pkg:npm/react@18.2.0?repository_url=https%3A%2F%2Fregistry.npmjs.org%2Freact",
                         "requirements": "18.2.0",
                         "packageManager": "NPM",
                     },

--- a/tests/data/syft/syft_sample.py
+++ b/tests/data/syft/syft_sample.py
@@ -26,7 +26,7 @@ SYFT_SAMPLE = {
             "licenses": [{"value": "MIT"}],
             "language": "javascript",
             "cpes": ["cpe:2.3:a:express:express:4.18.2:*:*:*:*:node.js:*:*"],
-            "purl": "pkg:npm/express@4.18.2",
+            "purl": "pkg:npm/express@4.18.2?repository_url=https%3A%2F%2Fregistry.npmjs.org%2Fexpress",
             "metadata": {"name": "express", "version": "4.18.2"},
         },
         {

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -385,23 +385,38 @@ def test_sync_github_dependencies(
         actual_repo_dependency_relationships
     )
 
-    # Assert - Verify new ontology fields (normalized_id, version, type, purl)
+    # Assert - Verify new ontology fields (normalized_id, version, type, package_url)
     expected_ontology_fields = {
-        (react_id, "npm|react|18.2.0", "18.2.0", "npm", "pkg:npm/react@18.2.0"),
-        (lodash_id, None, None, None, None),
-        (django_id, "pypi|django|4.2.0", "4.2.0", "pypi", "pkg:pypi/django@4.2.0"),
+        (
+            react_id,
+            "npm|react|18.2.0",
+            "18.2.0",
+            "npm",
+            "pkg:npm/react@18.2.0?repository_url=https%3A%2F%2Fregistry.npmjs.org%2Freact",
+            "pkg:npm/react@18.2.0",
+        ),
+        (lodash_id, None, None, None, None, None),
+        (
+            django_id,
+            "pypi|django|4.2.0",
+            "4.2.0",
+            "pypi",
+            "pkg:pypi/django@4.2.0",
+            "pkg:pypi/django@4.2.0",
+        ),
         (
             spring_core_id,
             "maven|org.springframework/spring-core|5.3.21",
             "5.3.21",
             "maven",
             "pkg:maven/org.springframework/spring-core@5.3.21",
+            "pkg:maven/org.springframework/spring-core@5.3.21",
         ),
     }
     actual_ontology_fields = check_nodes(
         neo4j_session,
         "Dependency",
-        ["id", "normalized_id", "version", "type", "purl"],
+        ["id", "normalized_id", "version", "type", "purl", "package_url"],
     )
     assert expected_ontology_fields.issubset(actual_ontology_fields)
 
@@ -409,7 +424,7 @@ def test_sync_github_dependencies(
     actual_github_dependency_nodes = check_nodes(
         neo4j_session,
         "GitHubDependency",
-        ["id", "normalized_id", "version", "type", "purl"],
+        ["id", "normalized_id", "version", "type", "purl", "package_url"],
     )
     assert expected_ontology_fields.issubset(actual_github_dependency_nodes)
 

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -405,6 +405,14 @@ def test_sync_github_dependencies(
     )
     assert expected_ontology_fields.issubset(actual_ontology_fields)
 
+    # Assert - GitHub dependency graph nodes have a source-specific label for ontology mapping
+    actual_github_dependency_nodes = check_nodes(
+        neo4j_session,
+        "GitHubDependency",
+        ["id", "normalized_id", "version", "type", "purl"],
+    )
+    assert expected_ontology_fields.issubset(actual_github_dependency_nodes)
+
 
 @patch.object(
     cartography.intel.github.repos,

--- a/tests/integration/cartography/intel/ontology/test_packages.py
+++ b/tests/integration/cartography/intel/ontology/test_packages.py
@@ -18,7 +18,8 @@ def _setup_trivy_graph(neo4j_session):
         MERGE (p:TrivyPackage {id: 'npm|express|4.18.2'})
         SET p.normalized_id = 'npm|express|4.18.2',
             p.name = 'express', p.version = '4.18.2',
-            p.type = 'npm'
+            p.type = 'npm',
+            p.purl = 'pkg:npm/express@4.18.2'
         MERGE (img:ECRImage {id: 'sha256:abc123'})
         MERGE (p)-[:DEPLOYED]->(img)
         MERGE (ont_img:Image {id: 'ont-img-abc123'})
@@ -38,7 +39,8 @@ def _setup_trivy_graph(neo4j_session):
         MERGE (p:TrivyPackage {id: 'pypi|requests|2.31.0'})
         SET p.normalized_id = 'pypi|requests|2.31.0',
             p.name = 'requests', p.version = '2.31.0',
-            p.type = 'pypi'
+            p.type = 'pypi',
+            p.purl = 'pkg:pypi/requests@2.31.0'
         MERGE (img:GitLabContainerImage {id: 'sha256:def456'})
         MERGE (p)-[:DEPLOYED]->(img)
         MERGE (ont_img:Image {id: 'ont-img-def456'})
@@ -55,16 +57,37 @@ def _setup_syft_graph(neo4j_session):
         MERGE (p1:SyftPackage {id: 'npm|express|4.18.2'})
         SET p1.normalized_id = 'npm|express|4.18.2',
             p1.name = 'express', p1.version = '4.18.2',
-            p1.type = 'npm'
+            p1.type = 'npm',
+            p1.purl = 'pkg:npm/express@4.18.2'
         MERGE (p2:SyftPackage {id: 'npm|body-parser|1.20.2'})
         SET p2.normalized_id = 'npm|body-parser|1.20.2',
             p2.name = 'body-parser', p2.version = '1.20.2',
-            p2.type = 'npm'
+            p2.type = 'npm',
+            p2.purl = 'pkg:npm/body-parser@1.20.2'
         MERGE (p1)-[:DEPENDS_ON]->(p2)
         MERGE (ont_img:Image {id: 'ont-img-syft'})
         SET ont_img._ont_digest = 'sha256:syft789'
         MERGE (p1)-[:DEPLOYED]->(ont_img)
         MERGE (p2)-[:DEPLOYED]->(ont_img)
+        """,
+    )
+
+
+def _setup_dependency_graph(neo4j_session):
+    """Create GitHub and Semgrep dependency nodes for package ontology linking."""
+    neo4j_session.run(
+        """
+        MERGE (gh:Dependency:GitHubDependency {id: 'express|4.18.2'})
+        SET gh.normalized_id = 'npm|express|4.18.2',
+            gh.name = 'express', gh.version = '4.18.2',
+            gh.type = 'npm',
+            gh.purl = 'pkg:npm/express@4.18.2'
+        MERGE (sg:Dependency:SemgrepDependency:NpmLibrary {id: 'express|4.18.2'})
+        SET sg.normalized_id = 'npm|express|4.18.2',
+            sg.name = 'express', sg.version = '4.18.2',
+            sg.type = 'npm',
+            sg.ecosystem = 'npm',
+            sg.purl = 'pkg:npm/express@4.18.2'
         """,
     )
 
@@ -102,6 +125,7 @@ def test_load_ontology_packages(_mock_get_source_nodes, neo4j_session):
     # Arrange
     _setup_trivy_graph(neo4j_session)
     _setup_syft_graph(neo4j_session)
+    _setup_dependency_graph(neo4j_session)
 
     # Act
     cartography.intel.ontology.packages.sync(
@@ -160,6 +184,31 @@ def test_load_ontology_packages(_mock_get_source_nodes, neo4j_session):
         rel_direction_right=True,
     )
     assert actual_syft_rels == expected_syft_rels
+
+    # Assert - Check DETECTED_AS relationships to GitHubDependency and SemgrepDependency
+    expected_dependency_rels = {
+        ("npm|express|4.18.2", "pkg:npm/express@4.18.2"),
+    }
+    actual_github_dependency_rels = check_rels(
+        neo4j_session,
+        "Package",
+        "id",
+        "GitHubDependency",
+        "purl",
+        "DETECTED_AS",
+        rel_direction_right=True,
+    )
+    assert actual_github_dependency_rels == expected_dependency_rels
+    actual_semgrep_dependency_rels = check_rels(
+        neo4j_session,
+        "Package",
+        "id",
+        "SemgrepDependency",
+        "purl",
+        "DETECTED_AS",
+        rel_direction_right=True,
+    )
+    assert actual_semgrep_dependency_rels == expected_dependency_rels
 
     # Assert - Check DEPLOYED propagated to Package -> ontology Image
     expected_deployed_image = {

--- a/tests/integration/cartography/intel/ontology/test_packages.py
+++ b/tests/integration/cartography/intel/ontology/test_packages.py
@@ -19,7 +19,8 @@ def _setup_trivy_graph(neo4j_session):
         SET p.normalized_id = 'npm|express|4.18.2',
             p.name = 'express', p.version = '4.18.2',
             p.type = 'npm',
-            p.purl = 'pkg:npm/express@4.18.2'
+            p.purl = 'pkg:npm/express@4.18.2',
+            p.package_url = 'pkg:npm/express@4.18.2'
         MERGE (img:ECRImage {id: 'sha256:abc123'})
         MERGE (p)-[:DEPLOYED]->(img)
         MERGE (ont_img:Image {id: 'ont-img-abc123'})
@@ -40,7 +41,8 @@ def _setup_trivy_graph(neo4j_session):
         SET p.normalized_id = 'pypi|requests|2.31.0',
             p.name = 'requests', p.version = '2.31.0',
             p.type = 'pypi',
-            p.purl = 'pkg:pypi/requests@2.31.0'
+            p.purl = 'pkg:pypi/requests@2.31.0',
+            p.package_url = 'pkg:pypi/requests@2.31.0'
         MERGE (img:GitLabContainerImage {id: 'sha256:def456'})
         MERGE (p)-[:DEPLOYED]->(img)
         MERGE (ont_img:Image {id: 'ont-img-def456'})
@@ -58,12 +60,14 @@ def _setup_syft_graph(neo4j_session):
         SET p1.normalized_id = 'npm|express|4.18.2',
             p1.name = 'express', p1.version = '4.18.2',
             p1.type = 'npm',
-            p1.purl = 'pkg:npm/express@4.18.2'
+            p1.purl = 'pkg:npm/express@4.18.2',
+            p1.package_url = 'pkg:npm/express@4.18.2'
         MERGE (p2:SyftPackage {id: 'npm|body-parser|1.20.2'})
         SET p2.normalized_id = 'npm|body-parser|1.20.2',
             p2.name = 'body-parser', p2.version = '1.20.2',
             p2.type = 'npm',
-            p2.purl = 'pkg:npm/body-parser@1.20.2'
+            p2.purl = 'pkg:npm/body-parser@1.20.2',
+            p2.package_url = 'pkg:npm/body-parser@1.20.2'
         MERGE (p1)-[:DEPENDS_ON]->(p2)
         MERGE (ont_img:Image {id: 'ont-img-syft'})
         SET ont_img._ont_digest = 'sha256:syft789'
@@ -81,13 +85,15 @@ def _setup_dependency_graph(neo4j_session):
         SET gh.normalized_id = 'npm|express|4.18.2',
             gh.name = 'express', gh.version = '4.18.2',
             gh.type = 'npm',
-            gh.purl = 'pkg:npm/express@4.18.2'
+            gh.purl = 'pkg:npm/express@4.18.2',
+            gh.package_url = 'pkg:npm/express@4.18.2'
         MERGE (sg:Dependency:SemgrepDependency:NpmLibrary {id: 'express|4.18.2'})
         SET sg.normalized_id = 'npm|express|4.18.2',
             sg.name = 'express', sg.version = '4.18.2',
             sg.type = 'npm',
             sg.ecosystem = 'npm',
-            sg.purl = 'pkg:npm/express@4.18.2'
+            sg.purl = 'pkg:npm/express@4.18.2',
+            sg.package_url = 'pkg:npm/express@4.18.2'
         """,
     )
 
@@ -194,7 +200,7 @@ def test_load_ontology_packages(_mock_get_source_nodes, neo4j_session):
         "Package",
         "id",
         "GitHubDependency",
-        "purl",
+        "package_url",
         "DETECTED_AS",
         rel_direction_right=True,
     )
@@ -204,7 +210,7 @@ def test_load_ontology_packages(_mock_get_source_nodes, neo4j_session):
         "Package",
         "id",
         "SemgrepDependency",
-        "purl",
+        "package_url",
         "DETECTED_AS",
         rel_direction_right=True,
     )

--- a/tests/integration/cartography/intel/semgrep/test_dependencies.py
+++ b/tests/integration/cartography/intel/semgrep/test_dependencies.py
@@ -96,6 +96,7 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "ecosystem",
             "type",
             "purl",
+            "package_url",
             "normalized_id",
         ],
     ) == {
@@ -107,6 +108,7 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "gomod",
             "golang",
             "pkg:golang/github.com/foo/baz@1.2.3",
+            "pkg:golang/github.com/foo/baz@1.2.3",
             "golang|github.com/foo/baz|1.2.3",
         ),
         (
@@ -117,6 +119,7 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "gomod",
             "golang",
             "pkg:golang/github.com/foo/buzz@4.5.0",
+            "pkg:golang/github.com/foo/buzz@4.5.0",
             "golang|github.com/foo/buzz|4.5.0",
         ),
         (
@@ -126,6 +129,7 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "5.0.0",
             "npm",
             "npm",
+            "pkg:npm/github.com/foo/biz@5.0.0",
             "pkg:npm/github.com/foo/biz@5.0.0",
             "npm|github.com/foo/biz|5.0.0",
         ),
@@ -142,6 +146,7 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "ecosystem",
             "type",
             "purl",
+            "package_url",
             "normalized_id",
         ],
     ) == {
@@ -153,6 +158,7 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "gomod",
             "golang",
             "pkg:golang/github.com/foo/baz@1.2.3",
+            "pkg:golang/github.com/foo/baz@1.2.3",
             "golang|github.com/foo/baz|1.2.3",
         ),
         (
@@ -162,6 +168,7 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "4.5.0",
             "gomod",
             "golang",
+            "pkg:golang/github.com/foo/buzz@4.5.0",
             "pkg:golang/github.com/foo/buzz@4.5.0",
             "golang|github.com/foo/buzz|4.5.0",
         ),
@@ -178,6 +185,7 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "ecosystem",
             "type",
             "purl",
+            "package_url",
             "normalized_id",
         ],
     ) == {
@@ -188,6 +196,7 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "5.0.0",
             "npm",
             "npm",
+            "pkg:npm/github.com/foo/biz@5.0.0",
             "pkg:npm/github.com/foo/biz@5.0.0",
             "npm|github.com/foo/biz|5.0.0",
         ),

--- a/tests/integration/cartography/intel/semgrep/test_dependencies.py
+++ b/tests/integration/cartography/intel/semgrep/test_dependencies.py
@@ -94,6 +94,9 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "name",
             "version",
             "ecosystem",
+            "type",
+            "purl",
+            "normalized_id",
         ],
     ) == {
         (
@@ -102,6 +105,9 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "github.com/foo/baz",
             "1.2.3",
             "gomod",
+            "golang",
+            "pkg:golang/github.com/foo/baz@1.2.3",
+            "golang|github.com/foo/baz|1.2.3",
         ),
         (
             "github.com/foo/buzz|4.5.0",
@@ -109,6 +115,9 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "github.com/foo/buzz",
             "4.5.0",
             "gomod",
+            "golang",
+            "pkg:golang/github.com/foo/buzz@4.5.0",
+            "golang|github.com/foo/buzz|4.5.0",
         ),
         (
             "github.com/foo/biz|5.0.0",
@@ -116,6 +125,9 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "github.com/foo/biz",
             "5.0.0",
             "npm",
+            "npm",
+            "pkg:npm/github.com/foo/biz@5.0.0",
+            "npm|github.com/foo/biz|5.0.0",
         ),
     }
 
@@ -128,6 +140,9 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "name",
             "version",
             "ecosystem",
+            "type",
+            "purl",
+            "normalized_id",
         ],
     ) == {
         (
@@ -136,6 +151,9 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "github.com/foo/baz",
             "1.2.3",
             "gomod",
+            "golang",
+            "pkg:golang/github.com/foo/baz@1.2.3",
+            "golang|github.com/foo/baz|1.2.3",
         ),
         (
             "github.com/foo/buzz|4.5.0",
@@ -143,6 +161,9 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "github.com/foo/buzz",
             "4.5.0",
             "gomod",
+            "golang",
+            "pkg:golang/github.com/foo/buzz@4.5.0",
+            "golang|github.com/foo/buzz|4.5.0",
         ),
     }
 
@@ -155,6 +176,9 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "name",
             "version",
             "ecosystem",
+            "type",
+            "purl",
+            "normalized_id",
         ],
     ) == {
         (
@@ -163,6 +187,9 @@ def test_sync_dependencies(mock_get_dependencies, mock_get_deployment, neo4j_ses
             "github.com/foo/biz",
             "5.0.0",
             "npm",
+            "npm",
+            "pkg:npm/github.com/foo/biz@5.0.0",
+            "npm|github.com/foo/biz|5.0.0",
         ),
     }
 

--- a/tests/integration/cartography/intel/syft/test_syft.py
+++ b/tests/integration/cartography/intel/syft/test_syft.py
@@ -185,7 +185,8 @@ def test_sync_single_syft_creates_syft_package_nodes(neo4j_session):
         """
         MATCH (p:SyftPackage {id: 'npm|express|4.18.2'})
         RETURN p.name AS name, p.version AS version, p.type AS type,
-               p.purl AS purl, p.language AS language, p.found_by AS found_by,
+               p.purl AS purl, p.package_url AS package_url,
+               p.language AS language, p.found_by AS found_by,
                p.normalized_id AS normalized_id, p.lastupdated AS lastupdated
         """,
     ).single()
@@ -193,7 +194,11 @@ def test_sync_single_syft_creates_syft_package_nodes(neo4j_session):
     assert result["name"] == "express"
     assert result["version"] == "4.18.2"
     assert result["type"] == "npm"
-    assert result["purl"] == "pkg:npm/express@4.18.2"
+    assert (
+        result["purl"]
+        == "pkg:npm/express@4.18.2?repository_url=https%3A%2F%2Fregistry.npmjs.org%2Fexpress"
+    )
+    assert result["package_url"] == "pkg:npm/express@4.18.2"
     assert result["language"] == "javascript"
     assert result["found_by"] == "javascript-package-cataloger"
     assert result["normalized_id"] == "npm|express|4.18.2"

--- a/tests/integration/cartography/intel/trivy/test_helpers.py
+++ b/tests/integration/cartography/intel/trivy/test_helpers.py
@@ -309,7 +309,8 @@ def assert_trivy_package_extended_fields(neo4j_session: Session) -> None:
         """
         MATCH (p:TrivyPackage)
         WHERE p.purl IS NOT NULL
-        RETURN p.id AS id, p.purl AS purl, p.pkg_id AS pkg_id
+        RETURN p.id AS id, p.purl AS purl, p.package_url AS package_url,
+               p.pkg_id AS pkg_id
         LIMIT 5
         """
     ).data()
@@ -317,6 +318,9 @@ def assert_trivy_package_extended_fields(neo4j_session: Session) -> None:
     assert len(result) > 0, "Expected at least one package with extended fields"
     for row in result:
         assert row["purl"] is not None, f"purl should be set for {row['id']}"
+        assert (
+            row["package_url"] is not None
+        ), f"package_url should be set for {row['id']}"
         assert row["pkg_id"] is not None, f"pkg_id should be set for {row['id']}"
 
 

--- a/tests/unit/cartography/intel/ontology/test_ontology_mapping.py
+++ b/tests/unit/cartography/intel/ontology/test_ontology_mapping.py
@@ -40,6 +40,26 @@ def _get_model_by_node_label(node_label: str) -> list[Type[CartographyNodeSchema
     return models
 
 
+def _get_models_by_extra_node_label(
+    node_label: str,
+) -> list[Type[CartographyNodeSchema]]:
+    models = []
+    for _, node_class in MODELS:
+        if not issubclass(node_class, CartographyNodeSchema):
+            continue
+        model_instance = node_class()
+        if not model_instance.extra_node_labels:
+            continue
+        for label in model_instance.extra_node_labels.labels:
+            if isinstance(label, str):
+                extra_label = label
+            else:
+                extra_label = label.label
+            if extra_label == node_label:
+                models.append(node_class)
+    return models
+
+
 def _get_models_with_properties_for_label(
     node_label: str,
 ) -> list[Type[CartographyNodeSchema]]:
@@ -48,10 +68,12 @@ def _get_models_with_properties_for_label(
     This includes:
     1. Models with the exact label
     2. Models targeting any of the extra_node_labels of the primary models (composite schemas)
+    3. Models that declare the given label as an extra label
     """
     # First get the primary models for this label
     primary_models = _get_model_by_node_label(node_label)
     all_models = list(primary_models)
+    all_models.extend(_get_models_by_extra_node_label(node_label))
 
     # Collect all extra_node_labels from primary models
     # Need to instantiate to get the actual value (property returns None on class if not defined)

--- a/tests/unit/cartography/intel/syft/test_parser.py
+++ b/tests/unit/cartography/intel/syft/test_parser.py
@@ -45,7 +45,11 @@ class TestTransformArtifacts:
         assert express["name"] == "express"
         assert express["version"] == "4.18.2"
         assert express["type"] == "npm"
-        assert express["purl"] == "pkg:npm/express@4.18.2"
+        assert (
+            express["purl"]
+            == "pkg:npm/express@4.18.2?repository_url=https%3A%2F%2Fregistry.npmjs.org%2Fexpress"
+        )
+        assert express["package_url"] == "pkg:npm/express@4.18.2"
         assert express["language"] == "javascript"
         assert express["found_by"] == "javascript-package-cataloger"
         assert express["normalized_id"] == "npm|express|4.18.2"

--- a/tests/unit/cartography/intel/trivy/test_util.py
+++ b/tests/unit/cartography/intel/trivy/test_util.py
@@ -134,6 +134,14 @@ class TestMakeCanonicalPurl:
             make_canonical_purl(purl="pkg:pypi/PyNaCl@1.5.0") == "pkg:pypi/pynacl@1.5.0"
         )
 
+    def test_from_source_purl_strips_qualifiers_for_package_identity(self):
+        assert (
+            make_canonical_purl(
+                purl="pkg:deb/debian/bash@5.2.15-2%2Bb10?arch=amd64&distro=debian-12&upstream=bash%405.2.15-2",
+            )
+            == "pkg:deb/debian/bash@5.2.15-2%2Bb10"
+        )
+
     def test_from_gomod_components_uses_golang_type(self):
         assert (
             make_canonical_purl(

--- a/tests/unit/cartography/intel/trivy/test_util.py
+++ b/tests/unit/cartography/intel/trivy/test_util.py
@@ -5,6 +5,7 @@ Tests the package normalization functions used for cross-tool matching
 between Trivy and Syft.
 """
 
+from cartography.intel.trivy.util import make_canonical_purl
 from cartography.intel.trivy.util import make_normalized_package_id
 from cartography.intel.trivy.util import normalize_package_name
 from cartography.intel.trivy.util import parse_purl
@@ -111,3 +112,45 @@ class TestMakeNormalizedPackageId:
         assert make_normalized_package_id() is None
         assert make_normalized_package_id(name="express") is None
         assert make_normalized_package_id(name="express", version="4.18.2") is None
+
+
+class TestMakeCanonicalPurl:
+    """Tests for make_canonical_purl function."""
+
+    def test_from_npm_components(self):
+        assert (
+            make_canonical_purl(name="Express", version="4.18.2", pkg_type="npm")
+            == "pkg:npm/express@4.18.2"
+        )
+
+    def test_from_scoped_npm_purl(self):
+        assert (
+            make_canonical_purl(purl="pkg:npm/@types/node@18.0.0")
+            == "pkg:npm/%40types/node@18.0.0"
+        )
+
+    def test_from_pypi_purl_normalizes(self):
+        assert (
+            make_canonical_purl(purl="pkg:pypi/PyNaCl@1.5.0") == "pkg:pypi/pynacl@1.5.0"
+        )
+
+    def test_from_gomod_components_uses_golang_type(self):
+        assert (
+            make_canonical_purl(
+                name="github.com/foo/bar",
+                version="1.2.3",
+                pkg_type="gomod",
+            )
+            == "pkg:golang/github.com/foo/bar@1.2.3"
+        )
+
+    def test_invalid_purl_falls_back_to_components(self):
+        assert (
+            make_canonical_purl(
+                purl="invalid-purl",
+                name="express",
+                version="4.18.2",
+                pkg_type="npm",
+            )
+            == "pkg:npm/express@4.18.2"
+        )


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

This adds canonical package URL identity generation and matching for package evidence across Trivy, Syft, GitHub dependency graph, and Semgrep.

The package ontology now indexes `Package.purl` and uses each source node's derived `package_url` for `Package-[:DETECTED_AS]->...` links, while preserving source-provided `purl` values on scanner/dependency nodes and preserving `Package.id` as the existing normalized package identifier for compatibility. This makes package correlation more precise across tools that may report the same package with different source-specific identifiers or source PURL qualifiers.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

N/A


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

None expected. `Package.id` remains the normalized package identifier.


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- `uv run pytest tests/unit/cartography/intel/trivy/test_util.py`
- `uv run pytest tests/integration/cartography/intel/github/test_repos.py`
- `uv run pytest tests/integration/cartography/intel/semgrep/test_findings.py tests/integration/cartography/intel/semgrep/test_dependencies.py`
- `uv run pytest tests/integration/cartography/intel/ontology/test_packages.py tests/integration/cartography/intel/ontology/test_packages_end_to_end.py`
- `git diff --check`


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

The implementation intentionally keeps `Package.id = normalized_id` and adds canonical PURL as an indexed ontology field used for cross-source matching.

