### PR TITLE
fix(kubernetes): skip unsupported EKS access entries

### DIFF
--- a/cartography/intel/kubernetes/eks.py
+++ b/cartography/intel/kubernetes/eks.py
@@ -22,6 +22,9 @@ logger = logging.getLogger(__name__)
 
 
 AWS_AUTH_TEMPLATE_PATTERN = re.compile(r"{{[^}]+}}")
+ACCESS_ENTRIES_UNSUPPORTED_AUTH_MODE_MESSAGE = (
+    "authentication mode must be set to one of [API, API_AND_CONFIG_MAP]"
+)
 
 
 @timeit
@@ -81,6 +84,37 @@ def _contains_unsupported_template(value: str) -> bool:
         token not in {"{{AccountID}}", "{{SessionName}}", "{{SessionNameRaw}}"}
         for token in AWS_AUTH_TEMPLATE_PATTERN.findall(value)
     )
+
+
+def _is_access_entries_unsupported_auth_mode_error(error: ClientError) -> bool:
+    error_details = error.response.get("Error", {})
+    error_code = error_details.get("Code")
+    error_message = error_details.get("Message", "")
+    return (
+        error_code == "InvalidRequestException"
+        and ACCESS_ENTRIES_UNSUPPORTED_AUTH_MODE_MESSAGE in error_message
+    )
+
+
+def _list_access_entry_principal_arns(client: Any, cluster_name: str) -> list[str]:
+    principal_arns = []
+
+    try:
+        paginator = client.get_paginator("list_access_entries")
+        page_iterator = paginator.paginate(clusterName=cluster_name)
+        for page in page_iterator:
+            principal_arns.extend(page.get("accessEntries", []))
+    except ClientError as e:
+        if _is_access_entries_unsupported_auth_mode_error(e):
+            logger.info(
+                "EKS Access Entries are unavailable for cluster %s authentication "
+                "mode; skipping Access Entries.",
+                cluster_name,
+            )
+            return []
+        raise
+
+    return principal_arns
 
 
 def _replace_account_id_template(value: str, principal_arn: str) -> str | None:
@@ -357,27 +391,25 @@ def get_access_entries(
     if cluster_name.startswith("arn:aws:eks:"):
         cluster_name = cluster_name.split("/")[-1]
 
-    paginator = client.get_paginator("list_access_entries")
-    page_iterator = paginator.paginate(clusterName=cluster_name)
+    principal_arns = _list_access_entry_principal_arns(client, cluster_name)
 
     # Get detailed information for each access entry
-    for page in page_iterator:
-        for principal_arn in page.get("accessEntries", []):
-            try:
-                detail_response = client.describe_access_entry(
-                    clusterName=cluster_name, principalArn=principal_arn
+    for principal_arn in principal_arns:
+        try:
+            detail_response = client.describe_access_entry(
+                clusterName=cluster_name, principalArn=principal_arn
+            )
+            access_entries.append(detail_response["accessEntry"])
+        except ClientError as e:
+            # If the access entry is not found, we can safely skip it.
+            if e.response["Error"]["Code"] == "ResourceNotFoundException":
+                logger.warning(
+                    f"Access entry lookup failed for principal {principal_arn}: {e}"
                 )
-                access_entries.append(detail_response["accessEntry"])
-            except ClientError as e:
-                # If the access entry is not found, we can safely skip it.
-                if e.response["Error"]["Code"] == "ResourceNotFoundException":
-                    logger.warning(
-                        f"Access entry lookup failed for principal {principal_arn}: {e}"
-                    )
-                    continue
-                # For other errors (e.g. AccessDenied, Throttling), we re-raise to avoid
-                # returning partial data which could cause destructive cleanup.
-                raise
+                continue
+            # For other errors (e.g. AccessDenied, Throttling), we re-raise to avoid
+            # returning partial data which could cause destructive cleanup.
+            raise
 
     logger.info(
         f"Retrieved {len(access_entries)} access entries for cluster {cluster_name}"

--- a/tests/unit/cartography/intel/kubernetes/test_eks.py
+++ b/tests/unit/cartography/intel/kubernetes/test_eks.py
@@ -1,0 +1,102 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from botocore.exceptions import ClientError
+from kubernetes.client.models import V1ConfigMap
+
+from cartography.intel.kubernetes import eks
+
+EXAMPLE_CLUSTER_NAME = "example-cluster"
+TEST_REGION = "us-west-2"
+TEST_UPDATE_TAG = 123456789
+TEST_CLUSTER_ID = "example-cluster-id"
+
+
+def _list_access_entries_client_error(code: str, message: str) -> ClientError:
+    return ClientError(
+        {"Error": {"Code": code, "Message": message}},
+        "ListAccessEntries",
+    )
+
+
+def _eks_client_with_list_access_entries_error(error: ClientError):
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.side_effect = error
+
+    mock_eks_client = MagicMock()
+    mock_eks_client.get_paginator.return_value = mock_paginator
+    return mock_eks_client
+
+
+def test_list_access_entry_principal_arns_skips_config_map_auth_mode(caplog):
+    error = _list_access_entries_client_error(
+        "InvalidRequestException",
+        "The cluster's authentication mode must be set to one of "
+        "[API, API_AND_CONFIG_MAP] to perform this operation.",
+    )
+    mock_eks_client = _eks_client_with_list_access_entries_error(error)
+
+    with caplog.at_level("INFO"):
+        result = eks._list_access_entry_principal_arns(
+            mock_eks_client,
+            EXAMPLE_CLUSTER_NAME,
+        )
+
+    assert result == []
+    assert any(
+        "EKS Access Entries are unavailable" in record.message
+        for record in caplog.records
+    )
+
+
+def test_list_access_entry_principal_arns_raises_unexpected_invalid_request():
+    error = _list_access_entries_client_error(
+        "InvalidRequestException",
+        "The cluster is not in a valid state for this request.",
+    )
+    mock_eks_client = _eks_client_with_list_access_entries_error(error)
+
+    with pytest.raises(ClientError):
+        eks._list_access_entry_principal_arns(
+            mock_eks_client,
+            EXAMPLE_CLUSTER_NAME,
+        )
+
+
+@patch("cartography.intel.kubernetes.eks.cleanup")
+@patch("cartography.intel.kubernetes.eks.get_oidc_provider", return_value=[])
+@patch("cartography.intel.kubernetes.eks.get_access_entries", return_value=[])
+def test_sync_continues_to_oidc_when_access_entries_are_unavailable(
+    mock_get_access_entries,
+    mock_get_oidc_provider,
+    mock_cleanup,
+):
+    mock_k8s_client = MagicMock()
+    mock_k8s_client.name = EXAMPLE_CLUSTER_NAME
+    mock_k8s_client.core.read_namespaced_config_map.return_value = V1ConfigMap(
+        data={},
+    )
+    mock_boto3_session = MagicMock()
+
+    eks.sync(
+        MagicMock(),
+        mock_k8s_client,
+        mock_boto3_session,
+        TEST_REGION,
+        TEST_UPDATE_TAG,
+        TEST_CLUSTER_ID,
+        EXAMPLE_CLUSTER_NAME,
+    )
+
+    mock_get_access_entries.assert_called_once_with(
+        mock_boto3_session,
+        TEST_REGION,
+        EXAMPLE_CLUSTER_NAME,
+    )
+    mock_get_oidc_provider.assert_called_once_with(
+        mock_boto3_session,
+        TEST_REGION,
+        EXAMPLE_CLUSTER_NAME,
+    )
+    mock_cleanup.assert_called_once()


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
EKS clusters using `CONFIG_MAP` authentication mode do not support EKS Access Entries. When Cartography called `ListAccessEntries` for those clusters, AWS returned an `InvalidRequestException` for the expected cluster auth mode state, and the generic regional AWS wrapper retried before failing the Kubernetes sync.

This change detects only that known Access Entries unsupported-auth-mode response, logs a concise skip message, returns an empty Access Entries list, and lets the rest of EKS enrichment continue. Other `InvalidRequestException` responses and unexpected EKS errors still raise normally.


### Related issues or links
N/A


### Breaking changes
None.


### How was this tested?
- `uv run --frozen pytest -vv tests/unit/cartography/intel/kubernetes/test_eks.py tests/integration/cartography/intel/kubernetes/test_eks.py`
- `uv run --frozen pre-commit run --files cartography/intel/kubernetes/eks.py tests/unit/cartography/intel/kubernetes/test_eks.py tests/integration/cartography/intel/kubernetes/test_eks.py`


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`). Targeted pre-commit passed for the touched files.
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
This intentionally does not treat every `InvalidRequestException` as skippable. The skip is limited to the Access Entries auth-mode message returned for clusters that do not enable the EKS API authentication method.

