### PR TITLE
docs(github): clarify image provenance relationship

### DIFF
--- a/docs/root/modules/github/schema.md
+++ b/docs/root/modules/github/schema.md
@@ -34,7 +34,7 @@ T -- {ROLE} --> R
 T -- MEMBER_OF_TEAM --> T
 U -- MEMBER --> T
 U -- MAINTAINER --> T
-IT(ImageTag) -- PACKAGED_FROM --> R
+I(Image) -- PACKAGED_FROM --> R
 I(Image) -- PACKAGED_BY --> W
 ```
 
@@ -452,15 +452,15 @@ Represents a software dependency from GitHub's dependency graph manifests. This 
     (DependencyGraphManifest)-[:HAS_DEP]->(Dependency)
     ```
 
-### ImageTag to GitHubRepository (Cross-module relationship)
+### Image to GitHubRepository (Cross-module relationship)
 
-Container images (ImageTag nodes from any registry: ECR, GitLab, GCR, etc.) can be linked to the GitHubRepository that contains the Dockerfile used to build them. This relationship is created by analyzing Dockerfile content and matching layer commands against image history.
+Container images (`Image` nodes from any registry: ECR, GitLab, GCP Artifact Registry, etc.) can be linked to the GitHubRepository that contains the Dockerfile used to build them. This relationship is created from provenance metadata or by analyzing Dockerfile content and matching layer commands against image history.
 
 #### Relationships
 
-- ImageTag nodes may be packaged from a GitHubRepository
+- Image nodes may be packaged from a GitHubRepository
     ```
-    (:ImageTag)-[:PACKAGED_FROM]->(:GitHubRepository)
+    (:Image)-[:PACKAGED_FROM]->(:GitHubRepository)
     ```
 
     Relationship properties:
@@ -471,7 +471,7 @@ Container images (ImageTag nodes from any registry: ECR, GitLab, GCR, etc.) can 
     - **total_commands**: Total number of commands compared (only for `dockerfile_analysis` method)
     - **command_similarity**: Average similarity score of matched commands (only for `dockerfile_analysis` method)
 
-    Note: This relationship uses the generic `ImageTag` semantic label, enabling cross-registry querying (ECR, GitLab, GCR, etc.).
+    Note: This relationship uses the generic `Image` semantic label, enabling cross-registry querying across image registries. Registry-specific pullable references can be reached from `ImageTag` nodes through `(:ImageTag)-[:IMAGE]->(:Image)`.
 
 ### Dependency::PythonLibrary
 


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

Updates the GitHub schema docs to show `PACKAGED_FROM` on semantic `Image` nodes instead of `ImageTag` nodes.

This matches the current MatchLink model, where provenance, Dockerfile analysis, and package-owner fallback relationships all originate from `Image` and point to the source repository. The docs still note that pullable registry references can be reached through `ImageTag -> IMAGE -> Image`.



### Checklist

#### General
- [ ] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

Docs-only correction. The implementation already uses `Image` as the `PACKAGED_FROM` source label.
