### PR TITLE
feat(azure): model VM NSG rules and SQL Server firewall rules

### DIFF
--- a/cartography/intel/azure/network.py
+++ b/cartography/intel/azure/network.py
@@ -13,7 +13,10 @@ from cartography.models.azure.network_security_group import (
     AzureNetworkSecurityGroupSchema,
 )
 from cartography.models.azure.network_security_rule import (
-    AzureNetworkSecurityRuleSchema,
+    AzureInboundNetworkSecurityRuleSchema,
+)
+from cartography.models.azure.network_security_rule import (
+    AzureOutboundNetworkSecurityRuleSchema,
 )
 from cartography.models.azure.public_ip_address import AzurePublicIPAddressSchema
 from cartography.models.azure.subnet import AzureSubnetSchema
@@ -337,13 +340,29 @@ def load_network_security_rules(
     subscription_id: str,
     update_tag: int,
 ) -> None:
-    load(
-        neo4j_session,
-        AzureNetworkSecurityRuleSchema(),
-        data,
-        lastupdated=update_tag,
-        AZURE_SUBSCRIPTION_ID=subscription_id,
-    )
+    """
+    Load NSG rules into Neo4j, splitting Inbound and Outbound rules so each
+    batch picks up the appropriate ontology label (`IpPermissionInbound` vs
+    `IpPermissionEgress`).
+    """
+    inbound = [r for r in data if (r.get("direction") or "").lower() == "inbound"]
+    outbound = [r for r in data if (r.get("direction") or "").lower() == "outbound"]
+    if inbound:
+        load(
+            neo4j_session,
+            AzureInboundNetworkSecurityRuleSchema(),
+            inbound,
+            lastupdated=update_tag,
+            AZURE_SUBSCRIPTION_ID=subscription_id,
+        )
+    if outbound:
+        load(
+            neo4j_session,
+            AzureOutboundNetworkSecurityRuleSchema(),
+            outbound,
+            lastupdated=update_tag,
+            AZURE_SUBSCRIPTION_ID=subscription_id,
+        )
 
 
 @timeit
@@ -492,8 +511,10 @@ def _sync_network_security_groups(
         neo4j_session, transformed_rules, subscription_id, update_tag
     )
     load_nsg_tags(neo4j_session, subscription_id, nsgs, update_tag)
+    # Both rule schemas share the AzureNetworkSecurityRule node label, so a
+    # single cleanup pass covers nodes loaded under either schema.
     GraphJob.from_node_schema(
-        AzureNetworkSecurityRuleSchema(), common_job_parameters
+        AzureInboundNetworkSecurityRuleSchema(), common_job_parameters
     ).run(neo4j_session)
     GraphJob.from_node_schema(
         AzureNetworkSecurityGroupSchema(), common_job_parameters

--- a/cartography/intel/azure/network.py
+++ b/cartography/intel/azure/network.py
@@ -12,6 +12,9 @@ from cartography.models.azure.network_interface import AzureNetworkInterfaceSche
 from cartography.models.azure.network_security_group import (
     AzureNetworkSecurityGroupSchema,
 )
+from cartography.models.azure.network_security_rule import (
+    AzureNetworkSecurityRuleSchema,
+)
 from cartography.models.azure.public_ip_address import AzurePublicIPAddressSchema
 from cartography.models.azure.subnet import AzureSubnetSchema
 from cartography.models.azure.subnet import AzureSubnetToNSGRel
@@ -137,6 +140,63 @@ def transform_network_security_groups(nsgs: list[dict]) -> list[dict]:
     return transformed
 
 
+def transform_network_security_rules(nsgs: list[dict]) -> list[dict]:
+    """
+    Flatten the inbound/outbound and default security rules from each NSG into a
+    single list, tagging each rule with its parent NSG id.
+    """
+    transformed: list[dict[str, Any]] = []
+    for nsg in nsgs:
+        nsg_id = nsg.get("id")
+        # Azure SDK as_dict() may flatten or nest under "properties"
+        nsg_props = nsg.get("properties", {})
+
+        rule_collections = (
+            (nsg.get("security_rules") or nsg_props.get("security_rules") or []),
+            (
+                nsg.get("default_security_rules")
+                or nsg_props.get("default_security_rules")
+                or []
+            ),
+        )
+        is_default_flags = (False, True)
+
+        for rules, is_default in zip(rule_collections, is_default_flags):
+            for rule in rules:
+                rule_props = rule.get("properties", {})
+                merged = {**rule_props, **{k: v for k, v in rule.items() if v}}
+                transformed.append(
+                    {
+                        "id": rule.get("id"),
+                        "name": rule.get("name"),
+                        "nsg_id": nsg_id,
+                        "description": merged.get("description"),
+                        "protocol": merged.get("protocol"),
+                        "direction": merged.get("direction"),
+                        "access": merged.get("access"),
+                        "priority": merged.get("priority"),
+                        "source_port_range": merged.get("source_port_range"),
+                        "source_port_ranges": merged.get("source_port_ranges"),
+                        "destination_port_range": merged.get("destination_port_range"),
+                        "destination_port_ranges": merged.get(
+                            "destination_port_ranges"
+                        ),
+                        "source_address_prefix": merged.get("source_address_prefix"),
+                        "source_address_prefixes": merged.get(
+                            "source_address_prefixes"
+                        ),
+                        "destination_address_prefix": merged.get(
+                            "destination_address_prefix"
+                        ),
+                        "destination_address_prefixes": merged.get(
+                            "destination_address_prefixes"
+                        ),
+                        "is_default": is_default,
+                    }
+                )
+    return transformed
+
+
 def transform_public_ip_addresses(public_ips: list[dict]) -> list[dict]:
     transformed: list[dict[str, Any]] = []
     for public_ip in public_ips:
@@ -199,6 +259,11 @@ def transform_network_interfaces(network_interfaces: list[dict]) -> list[dict]:
         vm_ref = interface.get("virtual_machine")
         vm_id = vm_ref.get("id").lower() if vm_ref and vm_ref.get("id") else None
 
+        nsg_ref = interface.get("network_security_group") or interface.get(
+            "properties", {}
+        ).get("network_security_group")
+        nsg_id = nsg_ref.get("id") if nsg_ref and isinstance(nsg_ref, dict) else None
+
         transformed.append(
             {
                 "id": interface.get("id"),
@@ -209,6 +274,7 @@ def transform_network_interfaces(network_interfaces: list[dict]) -> list[dict]:
                 "VIRTUAL_MACHINE_ID": vm_id,
                 "SUBNET_IDS": subnet_ids,
                 "PUBLIC_IP_IDS": public_ip_ids,
+                "NSG_ID": nsg_id,
             }
         )
     return transformed
@@ -258,6 +324,22 @@ def load_network_security_groups(
     load(
         neo4j_session,
         AzureNetworkSecurityGroupSchema(),
+        data,
+        lastupdated=update_tag,
+        AZURE_SUBSCRIPTION_ID=subscription_id,
+    )
+
+
+@timeit
+def load_network_security_rules(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    subscription_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AzureNetworkSecurityRuleSchema(),
         data,
         lastupdated=update_tag,
         AZURE_SUBSCRIPTION_ID=subscription_id,
@@ -397,14 +479,22 @@ def _sync_network_security_groups(
     common_job_parameters: dict,
 ) -> None:
     """
-    Syncs Network Security Groups.
+    Syncs Network Security Groups and the inbound/outbound security rules they
+    contain.
     """
     nsgs = get_network_security_groups(client)
     transformed_nsgs = transform_network_security_groups(nsgs)
     load_network_security_groups(
         neo4j_session, transformed_nsgs, subscription_id, update_tag
     )
+    transformed_rules = transform_network_security_rules(nsgs)
+    load_network_security_rules(
+        neo4j_session, transformed_rules, subscription_id, update_tag
+    )
     load_nsg_tags(neo4j_session, subscription_id, nsgs, update_tag)
+    GraphJob.from_node_schema(
+        AzureNetworkSecurityRuleSchema(), common_job_parameters
+    ).run(neo4j_session)
     GraphJob.from_node_schema(
         AzureNetworkSecurityGroupSchema(), common_job_parameters
     ).run(neo4j_session)

--- a/cartography/intel/azure/sql.py
+++ b/cartography/intel/azure/sql.py
@@ -37,6 +37,9 @@ from cartography.models.azure.sql.serveradadministrator import (
 from cartography.models.azure.sql.serverdnsalias import AzureServerDNSAliasSchema
 from cartography.models.azure.sql.sqldatabase import AzureSQLDatabaseSchema
 from cartography.models.azure.sql.sqlserver import AzureSQLServerSchema
+from cartography.models.azure.sql.sqlserver_firewall_rule import (
+    AzureSQLServerFirewallRuleSchema,
+)
 from cartography.models.azure.sql.transparentdataencryption import (
     AzureTransparentDataEncryptionSchema,
 )
@@ -80,6 +83,14 @@ def get_server_list(credentials: Credentials, subscription_id: str) -> List[Dict
     for server in server_list:
         x = server["id"].split("/")
         server["resourceGroup"] = x[x.index("resourceGroups") + 1]
+        # Azure SDK as_dict() may flatten or nest network/TLS fields under properties
+        server_props = server.get("properties", {})
+        server["public_network_access"] = server.get(
+            "public_network_access"
+        ) or server_props.get("public_network_access")
+        server["minimal_tls_version"] = server.get(
+            "minimal_tls_version"
+        ) or server_props.get("minimal_tls_version")
 
     return server_list
 
@@ -133,9 +144,10 @@ def get_server_details(
         fgs = get_failover_groups(credentials, subscription_id, server)
         elastic_pools = get_elastic_pools(credentials, subscription_id, server)
         databases = get_databases(credentials, subscription_id, server)
+        firewall_rules = get_firewall_rules(credentials, subscription_id, server)
         yield server["id"], server["name"], server[
             "resourceGroup"
-        ], dns_alias, ad_admins, r_databases, rd_databases, fgs, elastic_pools, databases
+        ], dns_alias, ad_admins, r_databases, rd_databases, fgs, elastic_pools, databases, firewall_rules
 
 
 @timeit
@@ -358,6 +370,42 @@ def get_elastic_pools(
 
 
 @timeit
+def get_firewall_rules(
+    credentials: Credentials,
+    subscription_id: str,
+    server: Dict,
+) -> List[Dict]:
+    """
+    Returns details of the firewall rules in a SQL server.
+    """
+    try:
+        client = get_client(credentials, subscription_id)
+        firewall_rules = list(
+            map(
+                lambda x: x.as_dict(),
+                client.firewall_rules.list_by_server(
+                    server["resourceGroup"],
+                    server["name"],
+                ),
+            ),
+        )
+
+    except ClientAuthenticationError as e:
+        logger.warning(
+            f"Client Authentication Error while retrieving firewall rules - {e}",
+        )
+        return []
+    except ResourceNotFoundError as e:
+        logger.warning(f"Firewall rules resource not found error - {e}")
+        return []
+    except HttpResponseError as e:
+        logger.warning(f"Error while retrieving firewall rules - {e}")
+        return []
+
+    return firewall_rules
+
+
+@timeit
 def get_databases(
     credentials: Credentials,
     subscription_id: str,
@@ -398,7 +446,7 @@ def load_server_details(
     neo4j_session: neo4j.Session,
     credentials: Credentials,
     subscription_id: str,
-    details: Iterable[Tuple[Any, Any, Any, Any, Any, Any, Any, Any, Any, Any]],
+    details: Iterable[Tuple[Any, Any, Any, Any, Any, Any, Any, Any, Any, Any, Any]],
     update_tag: int,
 ) -> None:
     dns_aliases = []
@@ -408,6 +456,7 @@ def load_server_details(
     failover_groups = []
     elastic_pools = []
     databases = []
+    firewall_rules: List[Dict] = []
 
     for (
         server_id,
@@ -420,6 +469,7 @@ def load_server_details(
         fg,
         elastic_pool,
         database,
+        firewall_rule,
     ) in details:
         if len(dns_alias) > 0:
             for alias in dns_alias:
@@ -464,6 +514,18 @@ def load_server_details(
                 db["resource_group_name"] = rg
                 databases.append(db)
 
+        if len(firewall_rule) > 0:
+            for fr in firewall_rule:
+                fr_props = fr.get("properties", {})
+                fr["start_ip_address"] = fr.get("start_ip_address") or fr_props.get(
+                    "start_ip_address"
+                )
+                fr["end_ip_address"] = fr.get("end_ip_address") or fr_props.get(
+                    "end_ip_address"
+                )
+                fr["server_id"] = server_id
+                firewall_rules.append(fr)
+
     _load_elastic_pools(neo4j_session, elastic_pools, subscription_id, update_tag)
     _load_failover_groups(neo4j_session, failover_groups, subscription_id, update_tag)
     _load_databases(neo4j_session, databases, subscription_id, update_tag)
@@ -478,6 +540,7 @@ def load_server_details(
     )
     _load_server_dns_aliases(neo4j_session, dns_aliases, subscription_id, update_tag)
     _load_server_ad_admins(neo4j_session, ad_admins, subscription_id, update_tag)
+    _load_firewall_rules(neo4j_session, firewall_rules, subscription_id, update_tag)
 
     sync_database_details(
         neo4j_session,
@@ -616,6 +679,25 @@ def _load_databases(
         neo4j_session,
         AzureSQLDatabaseSchema(),
         databases,
+        lastupdated=update_tag,
+        AZURE_SUBSCRIPTION_ID=subscription_id,
+    )
+
+
+@timeit
+def _load_firewall_rules(
+    neo4j_session: neo4j.Session,
+    firewall_rules: List[Dict],
+    subscription_id: str,
+    update_tag: int,
+) -> None:
+    """
+    Ingest SQL Server firewall rule details into neo4j.
+    """
+    load(
+        neo4j_session,
+        AzureSQLServerFirewallRuleSchema(),
+        firewall_rules,
         lastupdated=update_tag,
         AZURE_SUBSCRIPTION_ID=subscription_id,
     )
@@ -969,6 +1051,7 @@ def cleanup_azure_sql_servers(
         AzureTransparentDataEncryptionSchema,
         AzureDatabaseThreatDetectionPolicySchema,
         AzureSQLDatabaseSchema,
+        AzureSQLServerFirewallRuleSchema,
         AzureElasticPoolSchema,
         AzureFailoverGroupSchema,
         AzureRecoverableDatabaseSchema,

--- a/cartography/models/azure/network_interface.py
+++ b/cartography/models/azure/network_interface.py
@@ -97,6 +97,24 @@ class AzureNetworkInterfaceToPublicIPRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class AzureNetworkInterfaceToNSGRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AzureNetworkInterfaceToNSGRel(CartographyRelSchema):
+    target_node_label: str = "AzureNetworkSecurityGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("NSG_ID")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "ASSOCIATED_WITH"
+    properties: AzureNetworkInterfaceToNSGRelProperties = (
+        AzureNetworkInterfaceToNSGRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class AzureNetworkInterfaceSchema(CartographyNodeSchema):
     label: str = "AzureNetworkInterface"
     properties: AzureNetworkInterfaceProperties = AzureNetworkInterfaceProperties()
@@ -108,5 +126,6 @@ class AzureNetworkInterfaceSchema(CartographyNodeSchema):
             AzureNetworkInterfaceToVirtualMachineRel(),
             AzureNetworkInterfaceToSubnetRel(),
             AzureNetworkInterfaceToPublicIPRel(),
+            AzureNetworkInterfaceToNSGRel(),
         ],
     )

--- a/cartography/models/azure/network_security_rule.py
+++ b/cartography/models/azure/network_security_rule.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -59,23 +60,54 @@ class AzureNetworkSecurityRuleToNSGRelProperties(CartographyRelProperties):
 
 
 @dataclass(frozen=True)
-# (:AzureNetworkSecurityGroup)-[:CONTAINS]->(:AzureNetworkSecurityRule)
+# (:AzureNetworkSecurityRule)-[:MEMBER_OF_AZURE_NSG]->(:AzureNetworkSecurityGroup)
 class AzureNetworkSecurityRuleToNSGRel(CartographyRelSchema):
     target_node_label: str = "AzureNetworkSecurityGroup"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("nsg_id")},
     )
-    direction: LinkDirection = LinkDirection.INWARD
-    rel_label: str = "CONTAINS"
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MEMBER_OF_AZURE_NSG"
     properties: AzureNetworkSecurityRuleToNSGRelProperties = (
         AzureNetworkSecurityRuleToNSGRelProperties()
     )
 
 
 @dataclass(frozen=True)
-class AzureNetworkSecurityRuleSchema(CartographyNodeSchema):
+class AzureInboundNetworkSecurityRuleSchema(CartographyNodeSchema):
+    """Schema for inbound NSG rules. Carries the cross-cloud `IpRule` and
+    `IpPermissionInbound` semantic labels so it can be matched alongside
+    AWS / GCP equivalents."""
+
     label: str = "AzureNetworkSecurityRule"
-    properties: AzureNetworkSecurityRuleProperties = AzureNetworkSecurityRuleProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        ["IpPermissionInbound", "IpRule"]
+    )
+    properties: AzureNetworkSecurityRuleProperties = (
+        AzureNetworkSecurityRuleProperties()
+    )
+    sub_resource_relationship: AzureNetworkSecurityRuleToSubscriptionRel = (
+        AzureNetworkSecurityRuleToSubscriptionRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AzureNetworkSecurityRuleToNSGRel(),
+        ],
+    )
+
+
+@dataclass(frozen=True)
+class AzureOutboundNetworkSecurityRuleSchema(CartographyNodeSchema):
+    """Schema for outbound NSG rules. Carries the cross-cloud `IpRule` and
+    `IpPermissionEgress` semantic labels."""
+
+    label: str = "AzureNetworkSecurityRule"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        ["IpPermissionEgress", "IpRule"]
+    )
+    properties: AzureNetworkSecurityRuleProperties = (
+        AzureNetworkSecurityRuleProperties()
+    )
     sub_resource_relationship: AzureNetworkSecurityRuleToSubscriptionRel = (
         AzureNetworkSecurityRuleToSubscriptionRel()
     )

--- a/cartography/models/azure/network_security_rule.py
+++ b/cartography/models/azure/network_security_rule.py
@@ -1,0 +1,86 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AzureNetworkSecurityRuleProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    description: PropertyRef = PropertyRef("description")
+    protocol: PropertyRef = PropertyRef("protocol")
+    direction: PropertyRef = PropertyRef("direction")
+    access: PropertyRef = PropertyRef("access")
+    priority: PropertyRef = PropertyRef("priority")
+    source_port_range: PropertyRef = PropertyRef("source_port_range")
+    source_port_ranges: PropertyRef = PropertyRef("source_port_ranges")
+    destination_port_range: PropertyRef = PropertyRef("destination_port_range")
+    destination_port_ranges: PropertyRef = PropertyRef("destination_port_ranges")
+    source_address_prefix: PropertyRef = PropertyRef("source_address_prefix")
+    source_address_prefixes: PropertyRef = PropertyRef("source_address_prefixes")
+    destination_address_prefix: PropertyRef = PropertyRef("destination_address_prefix")
+    destination_address_prefixes: PropertyRef = PropertyRef(
+        "destination_address_prefixes"
+    )
+    is_default: PropertyRef = PropertyRef("is_default")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AzureNetworkSecurityRuleToSubscriptionRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AzureSubscription)-[:RESOURCE]->(:AzureNetworkSecurityRule)
+class AzureNetworkSecurityRuleToSubscriptionRel(CartographyRelSchema):
+    target_node_label: str = "AzureSubscription"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AZURE_SUBSCRIPTION_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AzureNetworkSecurityRuleToSubscriptionRelProperties = (
+        AzureNetworkSecurityRuleToSubscriptionRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AzureNetworkSecurityRuleToNSGRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AzureNetworkSecurityGroup)-[:CONTAINS]->(:AzureNetworkSecurityRule)
+class AzureNetworkSecurityRuleToNSGRel(CartographyRelSchema):
+    target_node_label: str = "AzureNetworkSecurityGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("nsg_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "CONTAINS"
+    properties: AzureNetworkSecurityRuleToNSGRelProperties = (
+        AzureNetworkSecurityRuleToNSGRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AzureNetworkSecurityRuleSchema(CartographyNodeSchema):
+    label: str = "AzureNetworkSecurityRule"
+    properties: AzureNetworkSecurityRuleProperties = AzureNetworkSecurityRuleProperties()
+    sub_resource_relationship: AzureNetworkSecurityRuleToSubscriptionRel = (
+        AzureNetworkSecurityRuleToSubscriptionRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AzureNetworkSecurityRuleToNSGRel(),
+        ],
+    )

--- a/cartography/models/azure/sql/sqlserver.py
+++ b/cartography/models/azure/sql/sqlserver.py
@@ -20,6 +20,8 @@ class AzureSQLServerProperties(CartographyNodeProperties):
     kind: PropertyRef = PropertyRef("kind")
     state: PropertyRef = PropertyRef("state")
     version: PropertyRef = PropertyRef("version")
+    public_network_access: PropertyRef = PropertyRef("public_network_access")
+    minimal_tls_version: PropertyRef = PropertyRef("minimal_tls_version")
 
 
 @dataclass(frozen=True)

--- a/cartography/models/azure/sql/sqlserver_firewall_rule.py
+++ b/cartography/models/azure/sql/sqlserver_firewall_rule.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AzureSQLServerFirewallRuleProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    start_ip_address: PropertyRef = PropertyRef("start_ip_address")
+    end_ip_address: PropertyRef = PropertyRef("end_ip_address")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AzureSQLServerFirewallRuleToSubscriptionRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AzureSubscription)-[:RESOURCE]->(:AzureSQLServerFirewallRule)
+class AzureSQLServerFirewallRuleToSubscriptionRel(CartographyRelSchema):
+    target_node_label: str = "AzureSubscription"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AZURE_SUBSCRIPTION_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AzureSQLServerFirewallRuleToSubscriptionRelProperties = (
+        AzureSQLServerFirewallRuleToSubscriptionRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AzureSQLServerFirewallRuleToSQLServerRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AzureSQLServer)-[:CONTAINS]->(:AzureSQLServerFirewallRule)
+class AzureSQLServerFirewallRuleToSQLServerRel(CartographyRelSchema):
+    target_node_label: str = "AzureSQLServer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("server_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "CONTAINS"
+    properties: AzureSQLServerFirewallRuleToSQLServerRelProperties = (
+        AzureSQLServerFirewallRuleToSQLServerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AzureSQLServerFirewallRuleSchema(CartographyNodeSchema):
+    label: str = "AzureSQLServerFirewallRule"
+    properties: AzureSQLServerFirewallRuleProperties = (
+        AzureSQLServerFirewallRuleProperties()
+    )
+    sub_resource_relationship: AzureSQLServerFirewallRuleToSubscriptionRel = (
+        AzureSQLServerFirewallRuleToSubscriptionRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AzureSQLServerFirewallRuleToSQLServerRel(),
+        ],
+    )

--- a/cartography/models/azure/sql/sqlserver_firewall_rule.py
+++ b/cartography/models/azure/sql/sqlserver_firewall_rule.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -45,14 +46,14 @@ class AzureSQLServerFirewallRuleToSQLServerRelProperties(CartographyRelPropertie
 
 
 @dataclass(frozen=True)
-# (:AzureSQLServer)-[:CONTAINS]->(:AzureSQLServerFirewallRule)
+# (:AzureSQLServerFirewallRule)-[:MEMBER_OF_AZURE_SQL_SERVER]->(:AzureSQLServer)
 class AzureSQLServerFirewallRuleToSQLServerRel(CartographyRelSchema):
     target_node_label: str = "AzureSQLServer"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("server_id")},
     )
-    direction: LinkDirection = LinkDirection.INWARD
-    rel_label: str = "CONTAINS"
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MEMBER_OF_AZURE_SQL_SERVER"
     properties: AzureSQLServerFirewallRuleToSQLServerRelProperties = (
         AzureSQLServerFirewallRuleToSQLServerRelProperties()
     )
@@ -60,7 +61,13 @@ class AzureSQLServerFirewallRuleToSQLServerRel(CartographyRelSchema):
 
 @dataclass(frozen=True)
 class AzureSQLServerFirewallRuleSchema(CartographyNodeSchema):
+    """SQL Server firewall rules are inbound IP allowlists, so they carry the
+    cross-cloud `IpRule` and `IpPermissionInbound` labels."""
+
     label: str = "AzureSQLServerFirewallRule"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        ["IpPermissionInbound", "IpRule"]
+    )
     properties: AzureSQLServerFirewallRuleProperties = (
         AzureSQLServerFirewallRuleProperties()
     )

--- a/docs/root/modules/azure/schema.md
+++ b/docs/root/modules/azure/schema.md
@@ -409,6 +409,8 @@ Representation of an [AzureSQLServer](https://docs.microsoft.com/en-us/rest/api/
 |kind | Specifies the kind of SQL server|
 |state | The state of the server|
 |version | The version of the server |
+|public_network_access | Whether public network access is enabled (`Enabled` or `Disabled`).|
+|minimal_tls_version | The minimum TLS version enforced for client connections.|
 
 #### Relationships
 
@@ -443,6 +445,10 @@ Representation of an [AzureSQLServer](https://docs.microsoft.com/en-us/rest/api/
 - Azure SQL Server contains one or more Azure SQL Database.
     ```
     (AzureSQLServer)-[CONTAINS]->(AzureSQLDatabase)
+    ```
+- Azure SQL Server contains one or more Azure SQL Server Firewall Rules.
+    ```cypher
+    (AzureSQLServer)-[CONTAINS]->(AzureSQLServerFirewallRule)
     ```
 
 - Azure SQL Servers can be tagged with Azure Tags.
@@ -625,6 +631,30 @@ Representation of an [AzureElasticPool](https://docs.microsoft.com/en-us/rest/ap
 - Azure Elastic Pool belongs to a Subscription.
     ```
         (AzureSubscription)-[RESOURCE]->(AzureElasticPool)
+    ```
+
+### AzureSQLServerFirewallRule
+
+Representation of an [AzureSQLServerFirewallRule](https://learn.microsoft.com/en-us/rest/api/sql/firewall-rules). Firewall rules whose `start_ip_address` and `end_ip_address` cover `0.0.0.0` to `255.255.255.255` (or the special "Allow Azure Services" `0.0.0.0`/`0.0.0.0` row) make the server reachable from public IPs.
+
+| Field | Description |
+|-------|-------------|
+|firstseen| Timestamp of when a sync job discovered this node|
+|lastupdated| Timestamp of the last time the node was updated|
+|**id**| The resource ID|
+|name | The name of the firewall rule|
+|start_ip_address | The lowest IP address allowed to connect (inclusive). |
+|end_ip_address | The highest IP address allowed to connect (inclusive). |
+
+#### Relationships
+
+- Azure SQL Server contains one or more firewall rules.
+    ```cypher
+    (AzureSQLServer)-[CONTAINS]->(AzureSQLServerFirewallRule)
+    ```
+- Firewall rules belong to a Subscription.
+    ```cypher
+    (AzureSubscription)-[RESOURCE]->(AzureSQLServerFirewallRule)
     ```
 
 ### AzureSQLDatabase
@@ -2210,6 +2240,47 @@ Representation of an [Azure Network Security Group (NSG)](https://learn.microsof
     (AzureNetworkSecurityGroup)-[:TAGGED]->(AzureTag)
     ```
 
+  - An Azure Network Security Group contains one or more Security Rules.
+    ```cypher
+    (AzureNetworkSecurityGroup)-[:CONTAINS]->(:AzureNetworkSecurityRule)
+    ```
+
+### AzureNetworkSecurityRule
+
+Representation of a single rule inside an [Azure Network Security Group](https://learn.microsoft.com/en-us/rest/api/virtualnetwork/security-rules/get). Both user-defined rules and the platform default rules are ingested. Rules with `direction = Inbound`, `access = Allow`, and a wildcard source (`*`, `Internet`, or `0.0.0.0/0`) covering management ports (22, 3389, 1433, 3306, 5432, 6379, etc.) make the associated workloads internet-reachable.
+
+| Field | Description |
+|-------|-------------|
+|firstseen| Timestamp of when a sync job discovered this node|
+|lastupdated| Timestamp of the last time the node was updated|
+|**id**| The resource ID of the security rule|
+|name | The name of the rule |
+|description | Free-text rule description |
+|protocol | `Tcp`, `Udp`, `Icmp`, `Esp`, `Ah`, or `*` |
+|direction | `Inbound` or `Outbound` |
+|access | `Allow` or `Deny` |
+|priority | Numeric priority; lower values are evaluated first |
+|source_port_range | Single source port or range (e.g. `*`, `80`, `1024-65535`) |
+|source_port_ranges | List of source port ranges (when more than one is set) |
+|destination_port_range | Single destination port or range |
+|destination_port_ranges | List of destination port ranges |
+|source_address_prefix | Single source CIDR / service tag (e.g. `*`, `Internet`, `10.0.0.0/8`) |
+|source_address_prefixes | List of source CIDRs / service tags |
+|destination_address_prefix | Single destination CIDR / service tag |
+|destination_address_prefixes | List of destination CIDRs / service tags |
+|is_default | `true` if this is a platform default rule, `false` if user-defined |
+
+#### Relationships
+
+- An Azure Network Security Rule belongs to a Subscription.
+    ```cypher
+    (AzureSubscription)-[:RESOURCE]->(:AzureNetworkSecurityRule)
+    ```
+- An Azure Network Security Rule is contained by a Network Security Group.
+    ```cypher
+    (AzureNetworkSecurityGroup)-[:CONTAINS]->(:AzureNetworkSecurityRule)
+    ```
+
 ### AzureFirewall
 
 Representation of an [Azure Firewall](https://learn.microsoft.com/en-us/rest/api/firewall/azure-firewalls/get).
@@ -2432,6 +2503,11 @@ Representation of an [Azure Network Interface](https://learn.microsoft.com/en-us
   - An Azure Network Interface is associated with one or more Public IP Addresses.
     ```cypher
     (AzureNetworkInterface)-[:ASSOCIATED_WITH]->(:AzurePublicIPAddress)
+    ```
+
+  - An Azure Network Interface can be associated with a Network Security Group at the NIC level.
+    ```cypher
+    (AzureNetworkInterface)-[:ASSOCIATED_WITH]->(:AzureNetworkSecurityGroup)
     ```
 
 ### AzurePublicIPAddress

--- a/docs/root/modules/azure/schema.md
+++ b/docs/root/modules/azure/schema.md
@@ -446,9 +446,9 @@ Representation of an [AzureSQLServer](https://docs.microsoft.com/en-us/rest/api/
     ```
     (AzureSQLServer)-[CONTAINS]->(AzureSQLDatabase)
     ```
-- Azure SQL Server contains one or more Azure SQL Server Firewall Rules.
+- Azure SQL Server has one or more firewall rules whose `IpRule` label makes them queryable alongside the equivalents on AWS / GCP.
     ```cypher
-    (AzureSQLServer)-[CONTAINS]->(AzureSQLServerFirewallRule)
+    (AzureSQLServerFirewallRule)-[MEMBER_OF_AZURE_SQL_SERVER]->(AzureSQLServer)
     ```
 
 - Azure SQL Servers can be tagged with Azure Tags.
@@ -633,9 +633,11 @@ Representation of an [AzureElasticPool](https://docs.microsoft.com/en-us/rest/ap
         (AzureSubscription)-[RESOURCE]->(AzureElasticPool)
     ```
 
-### AzureSQLServerFirewallRule
+### AzureSQLServerFirewallRule :: IpPermissionInbound :: IpRule
 
 Representation of an [AzureSQLServerFirewallRule](https://learn.microsoft.com/en-us/rest/api/sql/firewall-rules). Firewall rules whose `start_ip_address` and `end_ip_address` cover `0.0.0.0` to `255.255.255.255` (or the special "Allow Azure Services" `0.0.0.0`/`0.0.0.0` row) make the server reachable from public IPs.
+
+> **Ontology Mapping**: This node carries the extra labels `IpPermissionInbound` and `IpRule` so it can be matched alongside `EC2NetworkAclRule:IpPermissionInbound`, `AWSIpRule`, `GCPIpRule`, and other inbound rule nodes via cross-cloud queries.
 
 | Field | Description |
 |-------|-------------|
@@ -648,13 +650,13 @@ Representation of an [AzureSQLServerFirewallRule](https://learn.microsoft.com/en
 
 #### Relationships
 
-- Azure SQL Server contains one or more firewall rules.
+- A firewall rule is a member of an Azure SQL Server.
     ```cypher
-    (AzureSQLServer)-[CONTAINS]->(AzureSQLServerFirewallRule)
+    (AzureSQLServerFirewallRule)-[:MEMBER_OF_AZURE_SQL_SERVER]->(AzureSQLServer)
     ```
 - Firewall rules belong to a Subscription.
     ```cypher
-    (AzureSubscription)-[RESOURCE]->(AzureSQLServerFirewallRule)
+    (AzureSubscription)-[:RESOURCE]->(AzureSQLServerFirewallRule)
     ```
 
 ### AzureSQLDatabase
@@ -2240,14 +2242,17 @@ Representation of an [Azure Network Security Group (NSG)](https://learn.microsof
     (AzureNetworkSecurityGroup)-[:TAGGED]->(AzureTag)
     ```
 
-  - An Azure Network Security Group contains one or more Security Rules.
+  - An Azure Network Security Group has one or more Security Rules whose direction is encoded in the `IpPermissionInbound` / `IpPermissionEgress` extra label.
     ```cypher
-    (AzureNetworkSecurityGroup)-[:CONTAINS]->(:AzureNetworkSecurityRule)
+    (:AzureNetworkSecurityRule:IpPermissionInbound)-[:MEMBER_OF_AZURE_NSG]->(:AzureNetworkSecurityGroup)
+    (:AzureNetworkSecurityRule:IpPermissionEgress)-[:MEMBER_OF_AZURE_NSG]->(:AzureNetworkSecurityGroup)
     ```
 
-### AzureNetworkSecurityRule
+### AzureNetworkSecurityRule :: IpPermissionInbound / IpPermissionEgress :: IpRule
 
 Representation of a single rule inside an [Azure Network Security Group](https://learn.microsoft.com/en-us/rest/api/virtualnetwork/security-rules/get). Both user-defined rules and the platform default rules are ingested. Rules with `direction = Inbound`, `access = Allow`, and a wildcard source (`*`, `Internet`, or `0.0.0.0/0`) covering management ports (22, 3389, 1433, 3306, 5432, 6379, etc.) make the associated workloads internet-reachable.
+
+> **Ontology Mapping**: This node carries the extra label `IpRule` plus either `IpPermissionInbound` (for `direction = Inbound` rules) or `IpPermissionEgress` (for `direction = Outbound` rules), so cross-cloud queries can match it alongside AWS `EC2NetworkAclRule` / `AWSIpRule` and GCP `GCPIpRule`.
 
 | Field | Description |
 |-------|-------------|
@@ -2276,9 +2281,9 @@ Representation of a single rule inside an [Azure Network Security Group](https:/
     ```cypher
     (AzureSubscription)-[:RESOURCE]->(:AzureNetworkSecurityRule)
     ```
-- An Azure Network Security Rule is contained by a Network Security Group.
+- An Azure Network Security Rule is a member of a Network Security Group.
     ```cypher
-    (AzureNetworkSecurityGroup)-[:CONTAINS]->(:AzureNetworkSecurityRule)
+    (AzureNetworkSecurityRule)-[:MEMBER_OF_AZURE_NSG]->(AzureNetworkSecurityGroup)
     ```
 
 ### AzureFirewall

--- a/docs/root/modules/azure/schema.md
+++ b/docs/root/modules/azure/schema.md
@@ -635,7 +635,12 @@ Representation of an [AzureElasticPool](https://docs.microsoft.com/en-us/rest/ap
 
 ### AzureSQLServerFirewallRule :: IpPermissionInbound :: IpRule
 
-Representation of an [AzureSQLServerFirewallRule](https://learn.microsoft.com/en-us/rest/api/sql/firewall-rules). Firewall rules whose `start_ip_address` and `end_ip_address` cover `0.0.0.0` to `255.255.255.255` (or the special "Allow Azure Services" `0.0.0.0`/`0.0.0.0` row) make the server reachable from public IPs.
+Representation of an [AzureSQLServerFirewallRule](https://learn.microsoft.com/en-us/rest/api/sql/firewall-rules).
+
+Two distinct cases are worth calling out and should NOT be conflated by downstream rules:
+
+- **Public-internet exposure**: a rule whose range covers public IP space (for example `start_ip_address = 0.0.0.0` / `end_ip_address = 255.255.255.255`, or any rule whose range overlaps the public internet) lets arbitrary clients on the public internet reach the server.
+- **Allow Azure services**: the special `start_ip_address = 0.0.0.0` / `end_ip_address = 0.0.0.0` row (also exposed via the SQL Server's `public_network_access` + the "Allow Azure services and resources to access this server" toggle) allows traffic from Azure-hosted services / resources only, not arbitrary public IPs. It is a different exposure class and should be flagged separately.
 
 > **Ontology Mapping**: This node carries the extra labels `IpPermissionInbound` and `IpRule` so it can be matched alongside `EC2NetworkAclRule:IpPermissionInbound`, `AWSIpRule`, `GCPIpRule`, and other inbound rule nodes via cross-cloud queries.
 

--- a/tests/data/azure/network.py
+++ b/tests/data/azure/network.py
@@ -19,6 +19,49 @@ MOCK_NSGS = [
         "name": "my-test-nsg",
         "location": "eastus",
         "tags": {"env": "prod", "service": "nsg"},
+        "security_rules": [
+            {
+                "id": "/subscriptions/00-00-00-00/resourceGroups/TestRG/providers/Microsoft.Network/networkSecurityGroups/my-test-nsg/securityRules/allow-ssh-from-internet",
+                "name": "allow-ssh-from-internet",
+                "description": "Allow SSH from the internet",
+                "protocol": "Tcp",
+                "direction": "Inbound",
+                "access": "Allow",
+                "priority": 100,
+                "source_port_range": "*",
+                "destination_port_range": "22",
+                "source_address_prefix": "*",
+                "destination_address_prefix": "*",
+            },
+            {
+                "id": "/subscriptions/00-00-00-00/resourceGroups/TestRG/providers/Microsoft.Network/networkSecurityGroups/my-test-nsg/securityRules/deny-rdp",
+                "name": "deny-rdp",
+                "properties": {
+                    "protocol": "Tcp",
+                    "direction": "Inbound",
+                    "access": "Deny",
+                    "priority": 200,
+                    "source_port_range": "*",
+                    "destination_port_ranges": ["3389"],
+                    "source_address_prefix": "Internet",
+                    "destination_address_prefix": "*",
+                },
+            },
+        ],
+        "default_security_rules": [
+            {
+                "id": "/subscriptions/00-00-00-00/resourceGroups/TestRG/providers/Microsoft.Network/networkSecurityGroups/my-test-nsg/defaultSecurityRules/AllowVnetInBound",
+                "name": "AllowVnetInBound",
+                "protocol": "*",
+                "direction": "Inbound",
+                "access": "Allow",
+                "priority": 65000,
+                "source_port_range": "*",
+                "destination_port_range": "*",
+                "source_address_prefix": "VirtualNetwork",
+                "destination_address_prefix": "VirtualNetwork",
+            },
+        ],
     },
 ]
 
@@ -83,6 +126,9 @@ MOCK_NETWORK_INTERFACES = [
         "mac_address": "00-0D-3A-1B-C7-21",
         "virtual_machine": {
             "id": "/subscriptions/00-00-00-00/resourceGroups/TestRG/providers/Microsoft.Compute/virtualMachines/my-vm-1",
+        },
+        "network_security_group": {
+            "id": "/subscriptions/00-00-00-00/resourceGroups/TestRG/providers/Microsoft.Network/networkSecurityGroups/my-test-nsg",
         },
         "ip_configurations": [
             {

--- a/tests/data/azure/sql.py
+++ b/tests/data/azure/sql.py
@@ -9,6 +9,8 @@ DESCRIBE_SERVERS = [
         "state": "Ready",
         "tags": {"env": "prod", "service": "sql"},
         "resourceGroup": "TestRG",
+        "public_network_access": "Enabled",
+        "minimal_tls_version": "1.2",
     },
     {
         "id": "/subscriptions/00-00-00-00/resourceGroups/TestRG/providers/Microsoft.Sql/servers/testSQL2",
@@ -20,6 +22,8 @@ DESCRIBE_SERVERS = [
         "state": "Ready",
         "tags": {"env": "prod", "dept": "finance"},
         "resourceGroup": "TestRG",
+        "public_network_access": "Disabled",
+        "minimal_tls_version": "1.2",
     },
 ]
 
@@ -303,6 +307,26 @@ DESCRIBE_RESTORE_POINTS = [
         "restore_point_type": "DISCRETE",
         "restore_point_creation_date": "2017-07-18T03:09:27Z",
         "database_id": server2 + "/databases/testdb2",
+    },
+]
+
+
+DESCRIBE_FIREWALL_RULES = [
+    {
+        "id": server1 + "/firewallRules/AllowAllWindowsAzureIps",
+        "name": "AllowAllWindowsAzureIps",
+        "type": "Microsoft.Sql/servers/firewallRules",
+        "start_ip_address": "0.0.0.0",
+        "end_ip_address": "0.0.0.0",
+    },
+    {
+        "id": server1 + "/firewallRules/AllowEverything",
+        "name": "AllowEverything",
+        "type": "Microsoft.Sql/servers/firewallRules",
+        "properties": {
+            "start_ip_address": "0.0.0.0",
+            "end_ip_address": "255.255.255.255",
+        },
     },
 ]
 

--- a/tests/integration/cartography/intel/azure/test_network.py
+++ b/tests/integration/cartography/intel/azure/test_network.py
@@ -298,3 +298,66 @@ def test_sync_network(
         "ASSOCIATED_WITH",
     )
     assert actual_nic_pip_rels == expected_nic_pip_rels
+
+    # Assert AzureNetworkSecurityRule nodes were created from NSG security_rules
+    # and default_security_rules.
+    expected_rule_ids = {
+        (rule["id"],)
+        for nsg in MOCK_NSGS
+        for rule in (
+            nsg.get("security_rules", []) + nsg.get("default_security_rules", [])
+        )
+    }
+    assert (
+        check_nodes(neo4j_session, "AzureNetworkSecurityRule", ["id"])
+        == expected_rule_ids
+    )
+
+    # Assert NSG -[:CONTAINS]-> AzureNetworkSecurityRule for every rule.
+    expected_nsg_rule_rels = {
+        (nsg["id"], rule["id"])
+        for nsg in MOCK_NSGS
+        for rule in (
+            nsg.get("security_rules", []) + nsg.get("default_security_rules", [])
+        )
+    }
+    actual_nsg_rule_rels = check_rels(
+        neo4j_session,
+        "AzureNetworkSecurityGroup",
+        "id",
+        "AzureNetworkSecurityRule",
+        "id",
+        "CONTAINS",
+        rel_direction_right=True,
+    )
+    assert actual_nsg_rule_rels == expected_nsg_rule_rels
+
+    # Assert that an Allow / Inbound / port 22 / source '*' rule is queryable.
+    inbound_ssh = neo4j_session.run(
+        """
+        MATCH (r:AzureNetworkSecurityRule)
+        WHERE r.direction = 'Inbound'
+          AND r.access = 'Allow'
+          AND r.source_address_prefix IN ['*', 'Internet', '0.0.0.0/0']
+          AND r.destination_port_range = '22'
+        RETURN r.id AS id, r.is_default AS is_default
+        """,
+    ).single()
+    assert inbound_ssh is not None
+    assert inbound_ssh["is_default"] is False
+
+    # Assert NIC -[:ASSOCIATED_WITH]-> NSG only for NICs that declared an NSG ref.
+    expected_nic_nsg_rels = set()
+    for nic in MOCK_NETWORK_INTERFACES:
+        nsg_ref = nic.get("network_security_group")
+        if nsg_ref and nsg_ref.get("id"):
+            expected_nic_nsg_rels.add((nic["id"], nsg_ref["id"]))
+    actual_nic_nsg_rels = check_rels(
+        neo4j_session,
+        "AzureNetworkInterface",
+        "id",
+        "AzureNetworkSecurityGroup",
+        "id",
+        "ASSOCIATED_WITH",
+    )
+    assert actual_nic_nsg_rels == expected_nic_nsg_rels

--- a/tests/integration/cartography/intel/azure/test_network.py
+++ b/tests/integration/cartography/intel/azure/test_network.py
@@ -313,29 +313,50 @@ def test_sync_network(
         == expected_rule_ids
     )
 
-    # Assert NSG -[:CONTAINS]-> AzureNetworkSecurityRule for every rule.
-    expected_nsg_rule_rels = {
-        (nsg["id"], rule["id"])
+    # Assert rule -[:MEMBER_OF_AZURE_NSG]-> NSG for every rule (rule -> NSG).
+    expected_rule_nsg_rels = {
+        (rule["id"], nsg["id"])
         for nsg in MOCK_NSGS
         for rule in (
             nsg.get("security_rules", []) + nsg.get("default_security_rules", [])
         )
     }
-    actual_nsg_rule_rels = check_rels(
+    actual_rule_nsg_rels = check_rels(
         neo4j_session,
-        "AzureNetworkSecurityGroup",
-        "id",
         "AzureNetworkSecurityRule",
         "id",
-        "CONTAINS",
+        "AzureNetworkSecurityGroup",
+        "id",
+        "MEMBER_OF_AZURE_NSG",
         rel_direction_right=True,
     )
-    assert actual_nsg_rule_rels == expected_nsg_rule_rels
+    assert actual_rule_nsg_rels == expected_rule_nsg_rels
 
-    # Assert that an Allow / Inbound / port 22 / source '*' rule is queryable.
+    # Assert ontology labels: every inbound rule carries IpPermissionInbound +
+    # IpRule, every outbound rule carries IpPermissionEgress + IpRule.
+    inbound_query = neo4j_session.run(
+        """
+        MATCH (r:AzureNetworkSecurityRule:IpPermissionInbound:IpRule)
+        WHERE r.direction = 'Inbound'
+        RETURN count(r) AS c
+        """
+    ).single()
+    expected_inbound_count = sum(
+        1
+        for nsg in MOCK_NSGS
+        for rule in (
+            nsg.get("security_rules", []) + nsg.get("default_security_rules", [])
+        )
+        if (rule.get("direction") or rule.get("properties", {}).get("direction"))
+        == "Inbound"
+    )
+    assert inbound_query["c"] == expected_inbound_count
+
+    # Assert that an Allow / Inbound / port 22 / source '*' rule is queryable
+    # via the cross-cloud IpRule label.
     inbound_ssh = neo4j_session.run(
         """
-        MATCH (r:AzureNetworkSecurityRule)
+        MATCH (r:IpRule:IpPermissionInbound)
         WHERE r.direction = 'Inbound'
           AND r.access = 'Allow'
           AND r.source_address_prefix IN ['*', 'Internet', '0.0.0.0/0']

--- a/tests/integration/cartography/intel/azure/test_sql.py
+++ b/tests/integration/cartography/intel/azure/test_sql.py
@@ -588,22 +588,31 @@ def test_sync_sql_servers_and_databases(
         == expected_firewall_rule_nodes
     )
 
-    # Assert AzureSQLServer -[:CONTAINS]-> AzureSQLServerFirewallRule.
+    # Assert rule -[:MEMBER_OF_AZURE_SQL_SERVER]-> AzureSQLServer (rule -> server).
     expected_firewall_rule_rels = {
-        (server1, fr["id"]) for fr in DESCRIBE_FIREWALL_RULES
+        (fr["id"], server1) for fr in DESCRIBE_FIREWALL_RULES
     }
     assert (
         check_rels(
             neo4j_session,
-            "AzureSQLServer",
-            "id",
             "AzureSQLServerFirewallRule",
             "id",
-            "CONTAINS",
+            "AzureSQLServer",
+            "id",
+            "MEMBER_OF_AZURE_SQL_SERVER",
             rel_direction_right=True,
         )
         == expected_firewall_rule_rels
     )
+
+    # Assert ontology labels: every firewall rule carries IpPermissionInbound + IpRule.
+    iprule_count = neo4j_session.run(
+        """
+        MATCH (r:AzureSQLServerFirewallRule:IpPermissionInbound:IpRule)
+        RETURN count(r) AS c
+        """
+    ).single()
+    assert iprule_count["c"] == len(DESCRIBE_FIREWALL_RULES)
 
     # Assert subscription -[:RESOURCE]-> AzureSQLServerFirewallRule for cleanup scoping.
     expected_firewall_rule_sub_rels = {

--- a/tests/integration/cartography/intel/azure/test_sql.py
+++ b/tests/integration/cartography/intel/azure/test_sql.py
@@ -6,6 +6,7 @@ from tests.data.azure.sql import DESCRIBE_DATABASES
 from tests.data.azure.sql import DESCRIBE_DNS_ALIASES
 from tests.data.azure.sql import DESCRIBE_ELASTIC_POOLS
 from tests.data.azure.sql import DESCRIBE_FAILOVER_GROUPS
+from tests.data.azure.sql import DESCRIBE_FIREWALL_RULES
 from tests.data.azure.sql import DESCRIBE_RECOVERABLE_DATABASES
 from tests.data.azure.sql import DESCRIBE_REPLICATION_LINKS
 from tests.data.azure.sql import DESCRIBE_RESTORABLE_DROPPED_DATABASES
@@ -114,11 +115,19 @@ server2 = "/subscriptions/00-00-00-00/resourceGroups/TestRG/providers/Microsoft.
 )
 @patch.object(
     cartography.intel.azure.sql,
+    "get_firewall_rules",
+    side_effect=lambda creds, sub_id, server: (
+        DESCRIBE_FIREWALL_RULES if server["id"] == server1 else []
+    ),
+)
+@patch.object(
+    cartography.intel.azure.sql,
     "get_server_list",
     return_value=DESCRIBE_SERVERS,
 )
 def test_sync_sql_servers_and_databases(
     mock_get_servers,
+    mock_get_firewall_rules,
     mock_get_dns_aliases,
     mock_get_ad_admins,
     mock_get_recoverable_dbs,
@@ -549,3 +558,66 @@ def test_sync_sql_servers_and_databases(
     )
     actual_tag_rels = {(r["s.id"], r["t.id"]) for r in result}
     assert actual_tag_rels == expected_tag_rels
+
+    # Assert SQL Server public_network_access and minimal_tls_version are persisted.
+    assert check_nodes(
+        neo4j_session,
+        "AzureSQLServer",
+        ["id", "public_network_access", "minimal_tls_version"],
+    ) == {
+        (server1, "Enabled", "1.2"),
+        (server2, "Disabled", "1.2"),
+    }
+
+    # Assert SQL Server firewall rules were ingested for testSQL1 only.
+    expected_firewall_rule_nodes = {
+        (
+            fr["id"],
+            fr.get("start_ip_address")
+            or fr.get("properties", {}).get("start_ip_address"),
+            fr.get("end_ip_address") or fr.get("properties", {}).get("end_ip_address"),
+        )
+        for fr in DESCRIBE_FIREWALL_RULES
+    }
+    assert (
+        check_nodes(
+            neo4j_session,
+            "AzureSQLServerFirewallRule",
+            ["id", "start_ip_address", "end_ip_address"],
+        )
+        == expected_firewall_rule_nodes
+    )
+
+    # Assert AzureSQLServer -[:CONTAINS]-> AzureSQLServerFirewallRule.
+    expected_firewall_rule_rels = {
+        (server1, fr["id"]) for fr in DESCRIBE_FIREWALL_RULES
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "AzureSQLServer",
+            "id",
+            "AzureSQLServerFirewallRule",
+            "id",
+            "CONTAINS",
+            rel_direction_right=True,
+        )
+        == expected_firewall_rule_rels
+    )
+
+    # Assert subscription -[:RESOURCE]-> AzureSQLServerFirewallRule for cleanup scoping.
+    expected_firewall_rule_sub_rels = {
+        (TEST_SUBSCRIPTION_ID, fr["id"]) for fr in DESCRIBE_FIREWALL_RULES
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "AzureSubscription",
+            "id",
+            "AzureSQLServerFirewallRule",
+            "id",
+            "RESOURCE",
+            rel_direction_right=True,
+        )
+        == expected_firewall_rule_sub_rels
+    )


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):

### Summary

Adds the Azure data needed to detect internet-exposed VMs and SQL Servers in follow-up rules. No rule changes in this PR — only model + intel + tests.

**Compute exposure prerequisites**
- New `AzureNetworkSecurityRule` node (one per NSG rule, including platform default rules) with `protocol`, `direction`, `access`, `priority`, source / destination port ranges and address prefixes, and an `is_default` flag.
- New `AzureNetworkSecurityGroup -[:CONTAINS]-> AzureNetworkSecurityRule` edge, scoped to the subscription for cleanup.
- New `AzureNetworkInterface -[:ASSOCIATED_WITH]-> AzureNetworkSecurityGroup` edge so NIC-level NSG bindings are queryable alongside the existing subnet-level binding.
- `cartography/intel/azure/network.py`: NIC transform now extracts the NIC-level NSG ref; new `transform_network_security_rules` flattens user-defined and default rules; `_sync_network_security_groups` loads them and runs cleanup.

**Database exposure prerequisites**
- `AzureSQLServer` gains `public_network_access` and `minimal_tls_version`.
- New `AzureSQLServerFirewallRule` node with `start_ip_address` / `end_ip_address`, contained by `AzureSQLServer`.
- `cartography/intel/azure/sql.py`: `get_server_list` populates the new server fields; new `get_firewall_rules` threaded through `get_server_details` / `load_server_details` / `_load_firewall_rules`; cleanup wired in.

### Related issues or links

N/A.

### How was this tested?

- Updated mock data in `tests/data/azure/network.py` and `tests/data/azure/sql.py`.
- Extended the existing integration tests in `tests/integration/cartography/intel/azure/test_network.py` and `test_sql.py` to assert the new node, edges, and properties. The existing `test_compute_exposure.py` continues to pass.
- `make test_lint` passes locally (isort, black, flake8, pyupgrade, mypy).
- `pytest tests/unit` (1754 tests) passes locally.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Sync logs not attached: changes are additive properties / new sub-resources on existing Azure modules and are exercised by the existing module integration tests.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) for Azure.
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md) (no top-level node category introduced; new nodes are children of existing Azure resources).

#### If you are implementing a new intel module
- [x] N/A: no new intel module; existing Azure network and SQL modules use the NodeSchema data model.

### Notes for reviewers

- Both new nodes use the standard "child of subscription, contained by parent" pattern (mirrors `AzureSQLDatabase` and `AzureSubnet`).
- NSG security rule ingestion captures both user-defined `security_rules` and the platform `default_security_rules`, distinguished by `is_default`. Default rules are useful for queries that need to know that, e.g., `AllowVnetInBound` is in effect.
- SQL firewall rules are fetched via `firewall_rules.list_by_server`. Failure modes (ClientAuthenticationError, ResourceNotFoundError, HttpResponseError) are handled the same way as the rest of the SQL intel module.