### PR TITLE
fix(gitlab): ingest dependency artifacts by job id

### DIFF
--- a/cartography/intel/gitlab/dependencies.py
+++ b/cartography/intel/gitlab/dependencies.py
@@ -375,9 +375,6 @@ def get_dependencies(
     except zipfile.BadZipFile as e:
         logger.error(f"Invalid ZIP file for job ID {job_id}: {e}")
         return []
-    except gzip.BadGzipFile as e:
-        logger.error(f"Invalid gzip file in CycloneDX SBOM for job ID {job_id}: {e}")
-        return []
     except json.JSONDecodeError as e:
         logger.error(f"Invalid JSON in CycloneDX SBOM: {e}")
         return []

--- a/cartography/intel/gitlab/dependencies.py
+++ b/cartography/intel/gitlab/dependencies.py
@@ -96,26 +96,22 @@ def _get_successful_jobs(
         jobs.extend(page_jobs)
 
         next_page = response.headers.get("X-Next-Page")
-        if next_page:
-            page = int(next_page)
-            continue
-        if len(page_jobs) < DEPENDENCY_SCAN_JOBS_PER_PAGE:
+        if not next_page:
             break
-        page += 1
+        page = int(next_page)
 
     return jobs
 
 
 def _is_cyclonedx_artifact(path: str) -> bool:
     filename = path.rsplit("/", 1)[-1]
-    if not filename.startswith("gl-sbom"):
-        return False
-    if not filename.endswith(CYCLONEDX_ARTIFACT_SUFFIXES):
-        return False
     return filename in {
         "gl-sbom.cdx.json",
         "gl-sbom.cdx.json.gz",
-    } or filename.startswith("gl-sbom-")
+    } or (
+        filename.startswith("gl-sbom-")
+        and filename.endswith(CYCLONEDX_ARTIFACT_SUFFIXES)
+    )
 
 
 def _load_cyclonedx_json(content: bytes, path: str) -> dict[str, Any]:
@@ -371,9 +367,6 @@ def get_dependencies(
 
     except requests.exceptions.RequestException as e:
         logger.error(f"Error downloading artifacts for job ID {job_id}: {e}")
-        return []
-    except zipfile.BadZipFile as e:
-        logger.error(f"Invalid ZIP file for job ID {job_id}: {e}")
         return []
     except json.JSONDecodeError as e:
         logger.error(f"Invalid JSON in CycloneDX SBOM: {e}")

--- a/cartography/intel/gitlab/dependencies.py
+++ b/cartography/intel/gitlab/dependencies.py
@@ -4,6 +4,7 @@ GitLab Dependencies Intelligence Module
 Fetches and parses individual dependencies from dependency scanning job artifacts.
 """
 
+import gzip
 import io
 import json
 import logging
@@ -33,18 +34,23 @@ DEFAULT_DEPENDENCY_SCAN_JOB_NAMES = frozenset(
         AUTODEVOPS_MAVEN_DEPENDENCY_SCAN_JOB_NAME,
     )
 )
+DEPENDENCY_SCAN_JOBS_PER_PAGE = 100
+CYCLONEDX_ARTIFACT_SUFFIXES = (".cdx.json", ".cdx.json.gz")
 
 
 def _select_dependency_scan_job(
     jobs: list[dict[str, Any]],
     dependency_scan_job_name: str | None,
+    default_branch: str | None = None,
 ) -> dict[str, Any] | None:
     """
     Select the latest dependency scan job from successful jobs.
 
     If no custom job name is configured, support all known GitLab dependency
     scan job names (default + AutoDevOps language-specific names). For any
-    custom job name, only that specific name is matched.
+    custom job name, only that specific name is matched. Prefer jobs that ran
+    on the project default branch so branch-scoped dependency data wins over
+    newer merge request or feature branch jobs.
     """
     candidate_names: set[str] | frozenset[str]
     if dependency_scan_job_name is None:
@@ -52,10 +58,169 @@ def _select_dependency_scan_job(
     else:
         candidate_names = {dependency_scan_job_name}
 
-    for job in jobs:
-        if job.get("name") in candidate_names:
-            return job
-    return None
+    matching_jobs = [job for job in jobs if job.get("name") in candidate_names]
+    if not matching_jobs:
+        return None
+
+    if default_branch:
+        for job in matching_jobs:
+            if job.get("ref") == default_branch:
+                return job
+
+    return matching_jobs[0]
+
+
+def _get_successful_jobs(
+    gitlab_url: str,
+    headers: dict[str, str],
+    project_id: int,
+) -> list[dict[str, Any]]:
+    jobs: list[dict[str, Any]] = []
+    jobs_url = f"{gitlab_url}/api/v4/projects/{project_id}/jobs"
+    page = 1
+
+    while True:
+        params: dict[str, Any] = {
+            "page": page,
+            "per_page": DEPENDENCY_SCAN_JOBS_PER_PAGE,
+            "scope[]": ["success"],
+        }
+        response = make_request_with_retry("GET", jobs_url, headers, params)
+        response.raise_for_status()
+        check_rate_limit_remaining(response)
+
+        page_jobs = response.json()
+        if not page_jobs:
+            break
+
+        jobs.extend(page_jobs)
+
+        next_page = response.headers.get("X-Next-Page")
+        if next_page:
+            page = int(next_page)
+            continue
+        if len(page_jobs) < DEPENDENCY_SCAN_JOBS_PER_PAGE:
+            break
+        page += 1
+
+    return jobs
+
+
+def _is_cyclonedx_artifact(path: str) -> bool:
+    filename = path.rsplit("/", 1)[-1]
+    if not filename.startswith("gl-sbom"):
+        return False
+    if not filename.endswith(CYCLONEDX_ARTIFACT_SUFFIXES):
+        return False
+    return filename in {
+        "gl-sbom.cdx.json",
+        "gl-sbom.cdx.json.gz",
+    } or filename.startswith("gl-sbom-")
+
+
+def _load_cyclonedx_json(content: bytes, path: str) -> dict[str, Any]:
+    if path.endswith(".gz"):
+        content = gzip.decompress(content)
+    return json.loads(content.decode("utf-8"))
+
+
+def _parse_cyclonedx_artifact(
+    content: bytes,
+    path: str,
+    dependency_files: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    report_data = _load_cyclonedx_json(content, path)
+    return _parse_cyclonedx_sbom(report_data, dependency_files)
+
+
+def _parse_cyclonedx_artifacts_zip(
+    content: bytes,
+    dependency_files: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    all_dependencies: list[dict[str, Any]] = []
+    with zipfile.ZipFile(io.BytesIO(content)) as artifacts_zip:
+        cdx_files = [f for f in artifacts_zip.namelist() if _is_cyclonedx_artifact(f)]
+
+        if not cdx_files:
+            logger.debug("No CycloneDX SBOM files found in artifacts archive.")
+            logger.debug("Available files: %s", artifacts_zip.namelist())
+            return []
+
+        for cdx_file in cdx_files:
+            logger.debug("Parsing CycloneDX SBOM file: %s", cdx_file)
+            with artifacts_zip.open(cdx_file) as report_file:
+                all_dependencies.extend(
+                    _parse_cyclonedx_artifact(
+                        report_file.read(),
+                        cdx_file,
+                        dependency_files,
+                    )
+                )
+
+    return all_dependencies
+
+
+def _get_dependency_scan_artifact_paths(job: dict[str, Any]) -> list[str]:
+    artifact_paths: list[str] = []
+    for artifact in job.get("artifacts") or []:
+        path = artifact.get("filename")
+        if path and _is_cyclonedx_artifact(path):
+            artifact_paths.append(path)
+    return artifact_paths
+
+
+def _download_raw_cyclonedx_artifacts(
+    gitlab_url: str,
+    headers: dict[str, str],
+    project_id: int,
+    job_id: int,
+    artifact_paths: list[str],
+    dependency_files: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    all_dependencies: list[dict[str, Any]] = []
+    for artifact_path in artifact_paths:
+        artifacts_url = (
+            f"{gitlab_url}/api/v4/projects/{project_id}/jobs/"
+            f"{job_id}/artifacts/{artifact_path}"
+        )
+        response = make_request_with_retry("GET", artifacts_url, headers)
+        if response.status_code == 404:
+            logger.debug(
+                "CycloneDX artifact %s was listed for job ID %s but is not downloadable.",
+                artifact_path,
+                job_id,
+            )
+            continue
+        if response.status_code in (401, 403):
+            _log_artifact_permission_warning(project_id, job_id, response.status_code)
+            return []
+        response.raise_for_status()
+        check_rate_limit_remaining(response)
+        all_dependencies.extend(
+            _parse_cyclonedx_artifact(
+                response.content,
+                artifact_path,
+                dependency_files,
+            )
+        )
+
+    return all_dependencies
+
+
+def _log_artifact_permission_warning(
+    project_id: int,
+    job_id: int | None,
+    status_code: int,
+) -> None:
+    logger.warning(
+        "GitLab returned %s while downloading dependency scanning artifacts for "
+        "project ID %s job ID %s. Ensure the token user can download CI job "
+        "artifacts for this project; artifacts:access restrictions may require "
+        "Developer or Maintainer access.",
+        status_code,
+        project_id,
+        job_id,
+    )
 
 
 def get_dependencies(
@@ -69,8 +234,8 @@ def get_dependencies(
     """
     Fetch dependencies from the latest dependency scanning job artifacts.
 
-    Finds the most recent successful dependency scanning job, downloads its artifacts,
-    and parses the dependency scanning report.
+    Finds a successful dependency scanning job, downloads its artifacts by job ID,
+    and parses CycloneDX dependency scanning reports.
 
     Uses retry logic with exponential backoff for rate limiting and transient errors.
 
@@ -96,23 +261,17 @@ def get_dependencies(
         f"Fetching dependencies from scanning artifacts for project ID {project_id}"
     )
 
-    # Find the latest successful dependency scanning job
-    jobs_url = f"{gitlab_url}/api/v4/projects/{project_id}/jobs"
-    params: dict[str, Any] = {
-        "per_page": 10,
-        "scope[]": ["success"],
-    }
-
     job_id: int | None = None
     dep_scan_job: dict[str, Any] | None = None
     try:
-        response = make_request_with_retry("GET", jobs_url, headers, params)
-        response.raise_for_status()
-        check_rate_limit_remaining(response)
-        jobs = response.json()
+        jobs = _get_successful_jobs(gitlab_url, headers, project_id)
 
         # Find the most recent dependency scanning job matching the configured name
-        dep_scan_job = _select_dependency_scan_job(jobs, dependency_scan_job_name)
+        dep_scan_job = _select_dependency_scan_job(
+            jobs,
+            dependency_scan_job_name,
+            default_branch,
+        )
 
         if not dep_scan_job:
             configured_job_name = (
@@ -129,9 +288,10 @@ def get_dependencies(
         job_id = dep_scan_job.get("id")
         job_name = dep_scan_job.get("name", DEFAULT_DEPENDENCY_SCAN_JOB_NAME)
         logger.debug(
-            "Found dependency scanning job '%s' (ID %s) for project ID %s",
+            "Found dependency scanning job '%s' (ID %s, ref %s) for project ID %s",
             job_name,
             job_id,
+            dep_scan_job.get("ref"),
             project_id,
         )
 
@@ -143,66 +303,70 @@ def get_dependencies(
     if not dep_scan_job:
         return []
 
-    artifacts_url = f"{gitlab_url}/api/v4/projects/{project_id}/jobs/artifacts/{default_branch}/download"
-    params_artifacts: dict[str, str] = {"job": dep_scan_job["name"]}
+    if job_id is None:
+        logger.info(
+            "Dependency scanning job for project ID %s did not include a job ID.",
+            project_id,
+        )
+        return []
+
+    artifacts_url = f"{gitlab_url}/api/v4/projects/{project_id}/jobs/{job_id}/artifacts"
 
     logger.debug(
-        f"Downloading artifacts from branch '{default_branch}' for project ID {project_id}"
+        "Downloading artifacts for project ID %s job ID %s", project_id, job_id
     )
 
     try:
-        response = make_request_with_retry(
-            "GET", artifacts_url, headers, params_artifacts
-        )
+        response = make_request_with_retry("GET", artifacts_url, headers)
 
         logger.debug(f"Artifacts download response status: {response.status_code}")
 
         if response.status_code == 404:
             logger.info(
-                "No artifacts found for dependency scanning job in project %s",
+                "No artifacts found for dependency scanning job in project ID %s",
                 project_id,
             )
             return []
 
-        if response.status_code == 401:
-            # Auth errors are systemic - fail fast rather than silently skipping
-            raise requests.exceptions.HTTPError(
-                "Unauthorized (401) - token may need 'api' or 'read_api' scope",
-                response=response,
-            )
+        if response.status_code in (401, 403):
+            _log_artifact_permission_warning(project_id, job_id, response.status_code)
+            return []
 
         response.raise_for_status()
         check_rate_limit_remaining(response)
 
-        # The response is a ZIP file containing the artifacts
-        artifacts_zip = zipfile.ZipFile(io.BytesIO(response.content))
-
-        # Find and parse CycloneDX SBOM files (gl-sbom-*.cdx.json)
-        # GitLab now uses CycloneDX format instead of the old gl-dependency-scanning-report.json
-        cdx_files = [
-            f
-            for f in artifacts_zip.namelist()
-            if f.startswith("gl-sbom-") and f.endswith(".cdx.json")
-        ]
-
-        if not cdx_files:
-            logger.debug(
-                f"No CycloneDX SBOM files found in artifacts for project ID {project_id}"
+        try:
+            all_dependencies = _parse_cyclonedx_artifacts_zip(
+                response.content,
+                dependency_files,
             )
-            logger.debug(f"Available files: {artifacts_zip.namelist()}")
-            return []
+        except zipfile.BadZipFile:
+            all_dependencies = _parse_cyclonedx_artifact(
+                response.content,
+                (
+                    "gl-sbom.cdx.json.gz"
+                    if response.content.startswith(b"\x1f\x8b")
+                    else "gl-sbom.cdx.json"
+                ),
+                dependency_files,
+            )
 
-        # Parse all CycloneDX files (there may be multiple for different package managers)
-        all_dependencies: list[dict[str, Any]] = []
-        for cdx_file in cdx_files:
-            logger.debug(f"Parsing CycloneDX SBOM file: {cdx_file}")
-            with artifacts_zip.open(cdx_file) as report_file:
-                report_data = json.load(report_file)
-                deps = _parse_cyclonedx_sbom(report_data, dependency_files)
-                all_dependencies.extend(deps)
+        if not all_dependencies:
+            artifact_paths = _get_dependency_scan_artifact_paths(dep_scan_job)
+            all_dependencies = _download_raw_cyclonedx_artifacts(
+                gitlab_url,
+                headers,
+                project_id,
+                job_id,
+                artifact_paths,
+                dependency_files,
+            )
 
         logger.debug(
-            f"Successfully parsed {len(cdx_files)} CycloneDX SBOM file(s) for project ID {project_id}"
+            "Successfully parsed %s dependencies from CycloneDX SBOM artifact(s) "
+            "for project ID %s",
+            len(all_dependencies),
+            project_id,
         )
 
     except requests.exceptions.RequestException as e:
@@ -210,6 +374,9 @@ def get_dependencies(
         return []
     except zipfile.BadZipFile as e:
         logger.error(f"Invalid ZIP file for job ID {job_id}: {e}")
+        return []
+    except gzip.BadGzipFile as e:
+        logger.error(f"Invalid gzip file in CycloneDX SBOM for job ID {job_id}: {e}")
         return []
     except json.JSONDecodeError as e:
         logger.error(f"Invalid JSON in CycloneDX SBOM: {e}")

--- a/docs/root/modules/gitlab/config.md
+++ b/docs/root/modules/gitlab/config.md
@@ -28,16 +28,24 @@ The token requires the following scopes:
 |-------|---------|
 | `read_user` | Access user profile information for group/project membership |
 | `read_repository` | Access repository metadata, branches, and file contents |
-| `read_api` | Access groups, projects, dependencies, language statistics, and group/project-level CI/CD runners |
+| `read_api` | Access groups, projects, dependency scanning artifacts, language statistics, and group/project-level CI/CD runners |
 
 These scopes provide read-only access to:
 - Organizations (top-level groups) and nested groups
 - Projects and their metadata
 - Branches and default branch information
 - Dependency files (package.json, requirements.txt, etc.)
-- Dependencies extracted from dependency files
+- Dependency files and dependencies extracted from GitLab dependency scanning artifacts
 - Project language statistics
 - Group-level and project-level CI/CD runners
+
+#### Dependency scanning artifact access
+
+Cartography ingests GitLab dependencies from CycloneDX SBOM artifacts produced by GitLab dependency scanning jobs, not from GitLab's dependency list API. The token scopes above are required, and the token's user must also be allowed to download CI job artifacts for each project.
+
+GitLab projects can restrict artifact downloads with [`artifacts:access`](https://docs.gitlab.com/ci/yaml/#artifactsaccess). If a dependency scanning job uses `artifacts:access: developer` or `artifacts:access: maintainer`, a token that belongs to a Reporter-level user can receive `403 Forbidden` when Cartography downloads the job artifacts. Grant the token's user a project role that satisfies the artifact access policy.
+
+Dependency scanning jobs must produce CycloneDX SBOM artifacts, such as `gl-sbom-*.cdx.json`, `gl-sbom.cdx.json`, or gzipped equivalents. GitLab documents these SBOMs as job artifacts of the dependency scanning job. Cartography can only ingest artifacts that GitLab still serves, so expired or deleted job artifacts cannot be recovered during sync.
 
 #### Optional: instance-level runners
 

--- a/tests/unit/cartography/intel/gitlab/test_dependencies.py
+++ b/tests/unit/cartography/intel/gitlab/test_dependencies.py
@@ -1,3 +1,4 @@
+import gzip
 import io
 import json
 import zipfile
@@ -15,12 +16,19 @@ from cartography.intel.gitlab.dependencies import DEFAULT_DEPENDENCY_SCAN_JOB_NA
 from cartography.intel.gitlab.dependencies import get_dependencies
 
 
-def _build_artifacts_zip(files: dict[str, dict]) -> bytes:
+def _build_artifacts_zip(files: dict[str, dict | bytes]) -> bytes:
     buffer = io.BytesIO()
     with zipfile.ZipFile(buffer, "w") as archive:
         for path, payload in files.items():
-            archive.writestr(path, json.dumps(payload))
+            if isinstance(payload, bytes):
+                archive.writestr(path, payload)
+            else:
+                archive.writestr(path, json.dumps(payload))
     return buffer.getvalue()
+
+
+def _build_gzip_json(payload: dict) -> bytes:
+    return gzip.compress(json.dumps(payload).encode("utf-8"))
 
 
 def _build_response(
@@ -28,10 +36,11 @@ def _build_response(
     status_code: int = 200,
     json_data: list[dict] | None = None,
     content: bytes = b"",
+    headers: dict[str, str] | None = None,
 ) -> Mock:
     response = Mock()
     response.status_code = status_code
-    response.headers = {}
+    response.headers = headers or {}
     response.content = content
     response.raise_for_status.return_value = None
     if json_data is not None:
@@ -287,8 +296,16 @@ def test_parse_cyclonedx_sbom_skips_components_without_name():
 
 def test_select_dependency_scan_job_supports_autodevops_job_names():
     jobs = [
-        {"id": 300, "name": AUTODEVOPS_PYTHON_DEPENDENCY_SCAN_JOB_NAME},
-        {"id": 299, "name": DEFAULT_DEPENDENCY_SCAN_JOB_NAME},
+        {
+            "id": 300,
+            "name": AUTODEVOPS_PYTHON_DEPENDENCY_SCAN_JOB_NAME,
+            "ref": "feature-branch",
+        },
+        {
+            "id": 299,
+            "name": DEFAULT_DEPENDENCY_SCAN_JOB_NAME,
+            "ref": "main",
+        },
     ]
 
     job = _select_dependency_scan_job(jobs, None)
@@ -296,6 +313,27 @@ def test_select_dependency_scan_job_supports_autodevops_job_names():
     assert job is not None
     assert job["id"] == 300
     assert job["name"] == AUTODEVOPS_PYTHON_DEPENDENCY_SCAN_JOB_NAME
+
+
+def test_select_dependency_scan_job_prefers_default_branch():
+    jobs = [
+        {
+            "id": 300,
+            "name": AUTODEVOPS_PYTHON_DEPENDENCY_SCAN_JOB_NAME,
+            "ref": "feature-branch",
+        },
+        {
+            "id": 299,
+            "name": DEFAULT_DEPENDENCY_SCAN_JOB_NAME,
+            "ref": "main",
+        },
+    ]
+
+    job = _select_dependency_scan_job(jobs, None, "main")
+
+    assert job is not None
+    assert job["id"] == 299
+    assert job["name"] == DEFAULT_DEPENDENCY_SCAN_JOB_NAME
 
 
 def test_select_dependency_scan_job_honors_custom_name_only():
@@ -309,13 +347,21 @@ def test_select_dependency_scan_job_honors_custom_name_only():
     assert job is None
 
 
-def test_get_dependencies_uses_discovered_autodevops_job_name_for_artifacts(
+def test_get_dependencies_uses_selected_job_id_for_artifacts(
     mocker,
 ) -> None:
     jobs_response = _build_response(
         json_data=[
-            {"id": 300, "name": AUTODEVOPS_PYTHON_DEPENDENCY_SCAN_JOB_NAME},
-            {"id": 299, "name": DEFAULT_DEPENDENCY_SCAN_JOB_NAME},
+            {
+                "id": 300,
+                "name": AUTODEVOPS_PYTHON_DEPENDENCY_SCAN_JOB_NAME,
+                "ref": "main",
+            },
+            {
+                "id": 299,
+                "name": DEFAULT_DEPENDENCY_SCAN_JOB_NAME,
+                "ref": "main",
+            },
         ]
     )
     artifacts_response = _build_response(
@@ -369,6 +415,340 @@ def test_get_dependencies_uses_discovered_autodevops_job_name_for_artifacts(
             "manifest_id": "https://gitlab.example.com/group/project/-/blob/main/package.json",
         },
     ]
-    assert request.call_args_list[1].args[3] == {
-        "job": AUTODEVOPS_PYTHON_DEPENDENCY_SCAN_JOB_NAME
-    }
+    assert (
+        request.call_args_list[1].args[1]
+        == "https://gitlab.example.com/api/v4/projects/42/jobs/300/artifacts"
+    )
+    assert len(request.call_args_list[1].args) == 3
+
+
+def test_get_dependencies_paginates_jobs_and_prefers_default_branch(mocker) -> None:
+    first_page_jobs = [
+        {
+            "id": index,
+            "name": "test",
+            "ref": "main",
+        }
+        for index in range(1000, 1100)
+    ]
+    first_page = _build_response(
+        json_data=first_page_jobs,
+        headers={"X-Next-Page": "2"},
+    )
+    second_page = _build_response(
+        json_data=[
+            {
+                "id": 501,
+                "name": AUTODEVOPS_PYTHON_DEPENDENCY_SCAN_JOB_NAME,
+                "ref": "feature-branch",
+                "artifacts": [],
+            },
+            {
+                "id": 500,
+                "name": DEFAULT_DEPENDENCY_SCAN_JOB_NAME,
+                "ref": "main",
+                "artifacts": [],
+            },
+        ],
+    )
+    artifacts_response = _build_response(
+        content=_build_artifacts_zip(
+            {
+                "gl-sbom-pypi-pip.cdx.json": {
+                    "metadata": {
+                        "properties": [
+                            {
+                                "name": "gitlab:dependency_scanning:input_file:path",
+                                "value": "requirements.txt",
+                            },
+                        ],
+                    },
+                    "components": [
+                        {
+                            "type": "library",
+                            "name": "requests",
+                            "version": "2.31.0",
+                            "purl": "pkg:pypi/requests@2.31.0",
+                        },
+                    ],
+                },
+            }
+        )
+    )
+    request = mocker.patch(
+        "cartography.intel.gitlab.dependencies.make_request_with_retry",
+        side_effect=[first_page, second_page, artifacts_response],
+    )
+    mocker.patch("cartography.intel.gitlab.dependencies.check_rate_limit_remaining")
+
+    dependencies = get_dependencies(
+        "https://gitlab.example.com",
+        "token",
+        42,
+        [
+            {
+                "id": "https://gitlab.example.com/group/project/-/blob/main/requirements.txt",
+                "path": "requirements.txt",
+            },
+        ],
+        default_branch="main",
+    )
+
+    assert dependencies == [
+        {
+            "name": "requests",
+            "version": "2.31.0",
+            "package_manager": "pypi",
+            "manifest_path": "requirements.txt",
+            "manifest_id": "https://gitlab.example.com/group/project/-/blob/main/requirements.txt",
+        },
+    ]
+    assert request.call_args_list[0].args[3]["page"] == 1
+    assert request.call_args_list[1].args[3]["page"] == 2
+    assert (
+        request.call_args_list[2].args[1]
+        == "https://gitlab.example.com/api/v4/projects/42/jobs/500/artifacts"
+    )
+
+
+def test_get_dependencies_parses_gzipped_cyclonedx_from_archive(mocker) -> None:
+    jobs_response = _build_response(
+        json_data=[
+            {
+                "id": 700,
+                "name": AUTODEVOPS_PYTHON_DEPENDENCY_SCAN_JOB_NAME,
+                "ref": "main",
+                "artifacts": [
+                    {
+                        "file_type": "cyclonedx",
+                        "filename": "gl-sbom.cdx.json.gz",
+                        "size": 2151,
+                    },
+                ],
+            },
+        ]
+    )
+    artifacts_response = _build_response(
+        content=_build_artifacts_zip(
+            {
+                "gl-sbom.cdx.json.gz": _build_gzip_json(
+                    {
+                        "metadata": {
+                            "properties": [
+                                {
+                                    "name": "gitlab:dependency_scanning:input_file:path",
+                                    "value": "requirements.txt",
+                                },
+                            ],
+                        },
+                        "components": [
+                            {
+                                "type": "library",
+                                "name": "urllib3",
+                                "version": "2.2.1",
+                                "purl": "pkg:pypi/urllib3@2.2.1",
+                            },
+                        ],
+                    }
+                ),
+            }
+        )
+    )
+    mocker.patch(
+        "cartography.intel.gitlab.dependencies.make_request_with_retry",
+        side_effect=[jobs_response, artifacts_response],
+    )
+    mocker.patch("cartography.intel.gitlab.dependencies.check_rate_limit_remaining")
+
+    dependencies = get_dependencies(
+        "https://gitlab.example.com",
+        "token",
+        42,
+        [
+            {
+                "id": "https://gitlab.example.com/group/project/-/blob/main/requirements.txt",
+                "path": "requirements.txt",
+            },
+        ],
+        default_branch="main",
+    )
+
+    assert dependencies == [
+        {
+            "name": "urllib3",
+            "version": "2.2.1",
+            "package_manager": "pypi",
+            "manifest_path": "requirements.txt",
+            "manifest_id": "https://gitlab.example.com/group/project/-/blob/main/requirements.txt",
+        },
+    ]
+
+
+def test_get_dependencies_parses_direct_gzipped_cyclonedx_response(mocker) -> None:
+    jobs_response = _build_response(
+        json_data=[
+            {
+                "id": 701,
+                "name": AUTODEVOPS_PYTHON_DEPENDENCY_SCAN_JOB_NAME,
+                "ref": "main",
+                "artifacts": [
+                    {
+                        "file_type": "cyclonedx",
+                        "filename": "gl-sbom.cdx.json.gz",
+                        "size": 2151,
+                    },
+                ],
+            },
+        ]
+    )
+    artifacts_response = _build_response(
+        content=_build_gzip_json(
+            {
+                "metadata": {
+                    "properties": [
+                        {
+                            "name": "gitlab:dependency_scanning:input_file:path",
+                            "value": "requirements.txt",
+                        },
+                    ],
+                },
+                "components": [
+                    {
+                        "type": "library",
+                        "name": "urllib3",
+                        "version": "2.2.1",
+                        "purl": "pkg:pypi/urllib3@2.2.1",
+                    },
+                ],
+            }
+        )
+    )
+    mocker.patch(
+        "cartography.intel.gitlab.dependencies.make_request_with_retry",
+        side_effect=[jobs_response, artifacts_response],
+    )
+    mocker.patch("cartography.intel.gitlab.dependencies.check_rate_limit_remaining")
+
+    dependencies = get_dependencies(
+        "https://gitlab.example.com",
+        "token",
+        42,
+        [
+            {
+                "id": "https://gitlab.example.com/group/project/-/blob/main/requirements.txt",
+                "path": "requirements.txt",
+            },
+        ],
+        default_branch="main",
+    )
+
+    assert dependencies == [
+        {
+            "name": "urllib3",
+            "version": "2.2.1",
+            "package_manager": "pypi",
+            "manifest_path": "requirements.txt",
+            "manifest_id": "https://gitlab.example.com/group/project/-/blob/main/requirements.txt",
+        },
+    ]
+
+
+def test_get_dependencies_downloads_raw_cyclonedx_artifact_when_archive_has_no_sbom(
+    mocker,
+) -> None:
+    jobs_response = _build_response(
+        json_data=[
+            {
+                "id": 702,
+                "name": AUTODEVOPS_PYTHON_DEPENDENCY_SCAN_JOB_NAME,
+                "ref": "main",
+                "artifacts": [
+                    {
+                        "file_type": "archive",
+                        "filename": "artifacts.zip",
+                        "size": 2250,
+                    },
+                    {
+                        "file_type": "cyclonedx",
+                        "filename": "gl-sbom.cdx.json.gz",
+                        "size": 2151,
+                    },
+                ],
+            },
+        ]
+    )
+    archive_response = _build_response(content=_build_artifacts_zip({}))
+    raw_artifact_response = _build_response(
+        content=_build_gzip_json(
+            {
+                "components": [
+                    {
+                        "type": "library",
+                        "name": "urllib3",
+                        "version": "2.2.1",
+                        "purl": "pkg:pypi/urllib3@2.2.1",
+                    },
+                ],
+            }
+        )
+    )
+    request = mocker.patch(
+        "cartography.intel.gitlab.dependencies.make_request_with_retry",
+        side_effect=[jobs_response, archive_response, raw_artifact_response],
+    )
+    mocker.patch("cartography.intel.gitlab.dependencies.check_rate_limit_remaining")
+
+    dependencies = get_dependencies(
+        "https://gitlab.example.com",
+        "token",
+        42,
+        [],
+        default_branch="main",
+    )
+
+    assert dependencies == [
+        {
+            "name": "urllib3",
+            "version": "2.2.1",
+            "package_manager": "pypi",
+            "manifest_path": "",
+        },
+    ]
+    assert (
+        request.call_args_list[2].args[1]
+        == "https://gitlab.example.com/api/v4/projects/42/jobs/702/artifacts/gl-sbom.cdx.json.gz"
+    )
+
+
+def test_get_dependencies_returns_empty_and_logs_warning_on_forbidden_artifacts(
+    mocker,
+    caplog,
+) -> None:
+    jobs_response = _build_response(
+        json_data=[
+            {
+                "id": 703,
+                "name": AUTODEVOPS_PYTHON_DEPENDENCY_SCAN_JOB_NAME,
+                "ref": "main",
+                "artifacts": [],
+            },
+        ]
+    )
+    artifacts_response = _build_response(status_code=403)
+    mocker.patch(
+        "cartography.intel.gitlab.dependencies.make_request_with_retry",
+        side_effect=[jobs_response, artifacts_response],
+    )
+    mocker.patch("cartography.intel.gitlab.dependencies.check_rate_limit_remaining")
+
+    dependencies = get_dependencies(
+        "https://gitlab.example.com",
+        "token",
+        42,
+        [],
+        default_branch="main",
+    )
+
+    assert dependencies == []
+    assert "download CI job artifacts" in caplog.text
+    assert "Developer or Maintainer access" in caplog.text

--- a/tests/unit/cartography/intel/gitlab/test_dependencies.py
+++ b/tests/unit/cartography/intel/gitlab/test_dependencies.py
@@ -4,6 +4,8 @@ import json
 import zipfile
 from unittest.mock import Mock
 
+import pytest
+
 from cartography.intel.gitlab.dependencies import _parse_cyclonedx_sbom
 from cartography.intel.gitlab.dependencies import _select_dependency_scan_job
 from cartography.intel.gitlab.dependencies import (
@@ -752,3 +754,38 @@ def test_get_dependencies_returns_empty_and_logs_warning_on_forbidden_artifacts(
     assert dependencies == []
     assert "download CI job artifacts" in caplog.text
     assert "Developer or Maintainer access" in caplog.text
+
+
+def test_get_dependencies_propagates_invalid_gzip_cyclonedx(mocker) -> None:
+    jobs_response = _build_response(
+        json_data=[
+            {
+                "id": 704,
+                "name": AUTODEVOPS_PYTHON_DEPENDENCY_SCAN_JOB_NAME,
+                "ref": "main",
+                "artifacts": [
+                    {
+                        "file_type": "cyclonedx",
+                        "filename": "gl-sbom.cdx.json.gz",
+                    },
+                ],
+            },
+        ]
+    )
+    artifacts_response = _build_response(
+        content=_build_artifacts_zip({"gl-sbom.cdx.json.gz": b"not gzip"})
+    )
+    mocker.patch(
+        "cartography.intel.gitlab.dependencies.make_request_with_retry",
+        side_effect=[jobs_response, artifacts_response],
+    )
+    mocker.patch("cartography.intel.gitlab.dependencies.check_rate_limit_remaining")
+
+    with pytest.raises(gzip.BadGzipFile):
+        get_dependencies(
+            "https://gitlab.example.com",
+            "token",
+            42,
+            [],
+            default_branch="main",
+        )


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update


### Summary
GitLab dependency ingestion currently discovers a successful dependency scanning job but downloads artifacts through the ref/job-name endpoint. That can miss the selected job when the latest matching job is not in the latest default-branch successful pipeline, and it also misses newer/gzipped CycloneDX artifact names.

This changes the dependency artifact download path to use the selected job ID, paginates successful job discovery, prefers default-branch dependency scanning jobs, and parses CycloneDX SBOM artifacts from ZIP archives or direct artifact responses, including gzipped reports. Invalid gzipped CycloneDX artifacts now surface as parse failures instead of being treated as an empty dependency list. The GitLab module docs now also call out the CI artifact download permissions needed for dependency ingestion.

Docs referenced while validating this change:
- GitLab Job Artifacts API: https://docs.gitlab.com/api/job_artifacts/
- GitLab job artifact access controls: https://docs.gitlab.com/ci/jobs/job_artifacts/
- GitLab artifacts:access: https://docs.gitlab.com/ci/yaml/#artifactsaccess
- GitLab dependency scanning SBOM artifacts: https://docs.gitlab.com/user/application_security/dependency_scanning/dependency_scanning_sbom/


### Related issues or links
N/A


### Breaking changes
None.


### How was this tested?
- Local GitLab.com sync against a test group with a successful `gemnasium-dependency_scanning` job and a CycloneDX artifact archive
- Updated tests


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`; this checkout does not define `make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

Redacted local GitLab.com validation excerpt:

```text
INFO:cartography.sync:Starting sync stage 'gitlab'
INFO:cartography.intel.gitlab:Starting GitLab sync for organization <gitlab_group_id> at https://gitlab.com
INFO:cartography.client.core.tx:Loaded 1 GitLabOrganization nodes
INFO:cartography.client.core.tx:Loaded 2 GitLabGroup nodes
INFO:cartography.client.core.tx:Loaded 4 GitLabProject nodes

INFO:cartography.intel.gitlab.dependency_files:Syncing GitLab dependency files for 4 projects
DEBUG:cartography.intel.gitlab.dependency_files:Found manifest file: package-lock.json
DEBUG:cartography.intel.gitlab.dependency_files:Found manifest file: package.json
INFO:cartography.client.core.tx:Loaded 2 GitLabDependencyFile nodes

INFO:cartography.intel.gitlab.dependencies:Syncing GitLab dependencies for 4 projects
DEBUG:cartography.intel.gitlab.dependencies:Found dependency scanning job 'gemnasium-dependency_scanning' (ID <job_id>, ref main) for project ID <project_id>
DEBUG:cartography.intel.gitlab.dependencies:Downloading artifacts for project ID <project_id> job ID <job_id>
DEBUG:cartography.intel.gitlab.dependencies:Artifacts download response status: 200
DEBUG:cartography.intel.gitlab.dependencies:Parsing CycloneDX SBOM file: gl-sbom-npm-npm.cdx.json
DEBUG:cartography.intel.gitlab.dependencies:Successfully parsed 2 dependencies from CycloneDX SBOM artifact(s) for project ID <project_id>
INFO:cartography.intel.gitlab.dependencies:Transformed 2 dependencies
INFO:cartography.client.core.tx:Loaded 2 GitLabDependency nodes
INFO:cartography.intel.gitlab.dependencies:GitLab dependencies sync completed
INFO:cartography.intel.gitlab:GitLab ingestion completed for organization <gitlab_group_id>
```

Graph verification from the local validation database:

```text
GitLabDependency nodes:
- npm:express@4.18.2
- npm:lodash@4.17.21

GitLabDependencyFile HAS_DEP relationships:
- package-lock.json -> npm:express@4.18.2
- package-lock.json -> npm:lodash@4.17.21
```

#### If you are adding or modifying a synced entity
- [x] Included Cartography sync logs from a real environment demonstrating successful synchronization of the modified ingestion path. Logs show:
  - The sync job starting and completing without errors
  - The number of dependency file and dependency nodes created or updated

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
This does not add GitLab Dependencies API support or manifest-file dependency parsing. It keeps dependency ingestion on dependency scanning artifacts and only changes artifact discovery/download/parsing behavior.
