### PR TITLE
feat(rules): close AWS / GCP / Azure coverage gap on standalone rules

### DIFF
--- a/cartography/rules/cli.py
+++ b/cartography/rules/cli.py
@@ -345,7 +345,7 @@ def run_cmd(
         cartography-rules run all --framework CIS
         cartography-rules run all --framework CIS:aws:5.0
         cartography-rules run mfa-missing
-        cartography-rules run mfa-missing missing-mfa-cloudflare
+        cartography-rules run mfa-missing missing-mfa-ontology
     """
     # If no rule specified but framework filter provided, run all rules
     if rule is None and framework:

--- a/cartography/rules/data/rules/compute_instance_exposed.py
+++ b/cartography/rules/data/rules/compute_instance_exposed.py
@@ -83,6 +83,94 @@ _gcp_instance_internet_exposed = Fact(
 )
 
 
+# Azure Facts
+_azure_vm_internet_exposed = Fact(
+    id="azure_vm_internet_exposed",
+    name="Internet-Exposed Azure VMs on Common Management Ports",
+    description=(
+        "Azure Virtual Machines reachable from the public internet on ports "
+        "22, 3389, 3306, 5432, 6379, 9200, or 27017. A VM is considered "
+        "internet-reachable when it has a NIC associated with a public IP and "
+        "an inbound NSG rule (NIC-level or subnet-level) that allows traffic "
+        "from `*` / `Internet` / `0.0.0.0/0` on a TCP / `*` protocol covering "
+        "one of those ports. Effective evaluation does not currently account "
+        "for higher-priority deny rules that may shadow the allow."
+    ),
+    cypher_query="""
+    MATCH (sub:AzureSubscription)-[:RESOURCE]->(vm:AzureVirtualMachine)
+    MATCH (vm)<-[:ATTACHED_TO]-(nic:AzureNetworkInterface)
+    MATCH (nic)-[:ASSOCIATED_WITH]->(pip:AzurePublicIPAddress)
+    WHERE pip.ip_address IS NOT NULL
+    MATCH (rule:AzureNetworkSecurityRule:IpPermissionInbound)-[:MEMBER_OF_AZURE_NSG]->(nsg:AzureNetworkSecurityGroup)
+    WHERE rule.access = 'Allow'
+      AND rule.protocol IN ['Tcp', '*']
+      AND (
+        EXISTS { (nic)-[:ASSOCIATED_WITH]->(nsg) }
+        OR EXISTS { (nic)-[:ATTACHED_TO]->(:AzureSubnet)-[:ASSOCIATED_WITH]->(nsg) }
+      )
+      AND (
+        coalesce(rule.source_address_prefix, '') IN ['*', 'Internet', '0.0.0.0/0']
+        OR ANY(
+          src IN coalesce(rule.source_address_prefixes, [])
+          WHERE src IN ['*', 'Internet', '0.0.0.0/0']
+        )
+      )
+    UNWIND [22, 3389, 3306, 5432, 6379, 9200, 27017] AS managed_port
+    WITH sub, vm, nsg, rule, managed_port,
+         coalesce(rule.destination_port_range, '') AS port_single,
+         coalesce(rule.destination_port_ranges, []) AS port_list
+    WHERE port_single = '*'
+       OR port_single = toString(managed_port)
+       OR (
+         port_single CONTAINS '-'
+         AND toInteger(split(port_single, '-')[0]) <= managed_port
+         AND toInteger(split(port_single, '-')[1]) >= managed_port
+       )
+       OR ANY(
+         p IN port_list
+         WHERE p = '*'
+            OR p = toString(managed_port)
+            OR (
+              p CONTAINS '-'
+              AND toInteger(split(p, '-')[0]) <= managed_port
+              AND toInteger(split(p, '-')[1]) >= managed_port
+            )
+       )
+    RETURN DISTINCT
+        sub.id AS account_id,
+        sub.id AS account,
+        vm.id AS instance_id,
+        vm.name AS instance,
+        managed_port AS port,
+        nsg.name AS security_group
+    """,
+    cypher_visual_query="""
+    MATCH p1=(sub:AzureSubscription)-[:RESOURCE]->(vm:AzureVirtualMachine)
+    MATCH p2=(vm)<-[:ATTACHED_TO]-(nic:AzureNetworkInterface)-[:ASSOCIATED_WITH]->(pip:AzurePublicIPAddress)
+    MATCH p3=(rule:AzureNetworkSecurityRule:IpPermissionInbound)-[:MEMBER_OF_AZURE_NSG]->(nsg:AzureNetworkSecurityGroup)
+    WHERE rule.access = 'Allow'
+      AND rule.protocol IN ['Tcp', '*']
+      AND (
+        EXISTS { (nic)-[:ASSOCIATED_WITH]->(nsg) }
+        OR EXISTS { (nic)-[:ATTACHED_TO]->(:AzureSubnet)-[:ASSOCIATED_WITH]->(nsg) }
+      )
+      AND (
+        coalesce(rule.source_address_prefix, '') IN ['*', 'Internet', '0.0.0.0/0']
+        OR ANY(src IN coalesce(rule.source_address_prefixes, [])
+               WHERE src IN ['*', 'Internet', '0.0.0.0/0'])
+      )
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (vm:AzureVirtualMachine)
+    RETURN COUNT(vm) AS count
+    """,
+    asset_id_field="instance_id",
+    module=Module.AZURE,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
 # AWS Facts
 _aws_ec2_instance_internet_exposed = Fact(
     id="aws_ec2_instance_internet_exposed",
@@ -131,6 +219,7 @@ compute_instance_exposed = Rule(
     output_model=ComputeInstanceExposed,
     facts=(
         _aws_ec2_instance_internet_exposed,
+        _azure_vm_internet_exposed,
         _gcp_instance_internet_exposed,
     ),
     tags=(

--- a/cartography/rules/data/rules/compute_instance_exposed.py
+++ b/cartography/rules/data/rules/compute_instance_exposed.py
@@ -198,14 +198,17 @@ _aws_ec2_instance_internet_exposed = Fact(
     name="Internet-Exposed EC2 Instances on Common Management Ports",
     description=(
         "EC2 instances exposed to the internet on ports 22, 3389, 3306, "
-        "5432, 6379, 9200, 27017. Matches inbound 0.0.0.0/0 SG rules whose "
-        "port range covers any of those ports, including all-ports rules "
-        "(`fromport` IS NULL) and ranges like 0-65535. Aligned with the "
-        "GCP and Azure facts in this same rule."
+        "5432, 6379, 9200, 27017. Matches inbound 0.0.0.0/0 SG rules over "
+        "TCP (or `-1` / `all` covering every protocol) whose port range "
+        "covers any of those ports, including all-ports rules "
+        "(`fromport` IS NULL) and ranges like 0-65535. UDP / ICMP rules "
+        "are intentionally skipped so a wide-open UDP rule does not flag "
+        "TCP management ports. Aligned with the GCP and Azure facts."
     ),
     cypher_query="""
     MATCH (a:AWSAccount)-[:RESOURCE]->(ec2:EC2Instance)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)<-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound)
     MATCH (rule)<-[:MEMBER_OF_IP_RULE]-(ip:AWSIpRange{range:'0.0.0.0/0'})
+    WHERE coalesce(rule.protocol, '') IN ['tcp', '-1', 'all']
     UNWIND [22, 3389, 3306, 5432, 6379, 9200, 27017] AS managed_port
     WITH a, ec2, sg, rule, managed_port
     WHERE rule.fromport IS NULL
@@ -224,10 +227,13 @@ _aws_ec2_instance_internet_exposed = Fact(
     cypher_visual_query="""
     MATCH p=(a:AWSAccount)-[:RESOURCE]->(ec2:EC2Instance)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)<-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound)
     MATCH p2=(rule)<-[:MEMBER_OF_IP_RULE]-(ip:AWSIpRange{range:'0.0.0.0/0'})
-    WHERE rule.fromport IS NULL
-       OR ANY(managed_port IN [22, 3389, 3306, 5432, 6379, 9200, 27017]
-              WHERE coalesce(rule.fromport, 0) <= managed_port
-                AND coalesce(rule.toport, rule.fromport, 0) >= managed_port)
+    WHERE coalesce(rule.protocol, '') IN ['tcp', '-1', 'all']
+      AND (
+        rule.fromport IS NULL
+        OR ANY(managed_port IN [22, 3389, 3306, 5432, 6379, 9200, 27017]
+               WHERE coalesce(rule.fromport, 0) <= managed_port
+                 AND coalesce(rule.toport, rule.fromport, 0) >= managed_port)
+      )
     RETURN *
     """,
     cypher_count_query="""

--- a/cartography/rules/data/rules/compute_instance_exposed.py
+++ b/cartography/rules/data/rules/compute_instance_exposed.py
@@ -148,7 +148,8 @@ _azure_vm_internet_exposed = Fact(
     MATCH p1=(sub:AzureSubscription)-[:RESOURCE]->(vm:AzureVirtualMachine)
     MATCH p2=(vm)<-[:ATTACHED_TO]-(nic:AzureNetworkInterface)-[:ASSOCIATED_WITH]->(pip:AzurePublicIPAddress)
     MATCH p3=(rule:AzureNetworkSecurityRule:IpPermissionInbound)-[:MEMBER_OF_AZURE_NSG]->(nsg:AzureNetworkSecurityGroup)
-    WHERE rule.access = 'Allow'
+    WHERE pip.ip_address IS NOT NULL
+      AND rule.access = 'Allow'
       AND rule.protocol IN ['Tcp', '*']
       AND (
         EXISTS { (nic)-[:ASSOCIATED_WITH]->(nsg) }
@@ -159,6 +160,26 @@ _azure_vm_internet_exposed = Fact(
         OR ANY(src IN coalesce(rule.source_address_prefixes, [])
                WHERE src IN ['*', 'Internet', '0.0.0.0/0'])
       )
+      // Mirror the finding query: keep only rules whose destination port
+      // (or port range / list) covers a management port.
+      AND ANY(managed_port IN [22, 3389, 3306, 5432, 6379, 9200, 27017]
+              WHERE
+                coalesce(rule.destination_port_range, '') = '*'
+                OR coalesce(rule.destination_port_range, '') = toString(managed_port)
+                OR (
+                  coalesce(rule.destination_port_range, '') CONTAINS '-'
+                  AND toInteger(split(rule.destination_port_range, '-')[0]) <= managed_port
+                  AND toInteger(split(rule.destination_port_range, '-')[1]) >= managed_port
+                )
+                OR ANY(p IN coalesce(rule.destination_port_ranges, [])
+                       WHERE p = '*'
+                          OR p = toString(managed_port)
+                          OR (
+                            p CONTAINS '-'
+                            AND toInteger(split(p, '-')[0]) <= managed_port
+                            AND toInteger(split(p, '-')[1]) >= managed_port
+                          ))
+              )
     RETURN *
     """,
     cypher_count_query="""

--- a/cartography/rules/data/rules/compute_instance_exposed.py
+++ b/cartography/rules/data/rules/compute_instance_exposed.py
@@ -176,18 +176,37 @@ _aws_ec2_instance_internet_exposed = Fact(
     id="aws_ec2_instance_internet_exposed",
     name="Internet-Exposed EC2 Instances on Common Management Ports",
     description=(
-        "EC2 instances exposed to the internet on ports 22, 3389, 3306, 5432, 6379, 9200, 27017"
+        "EC2 instances exposed to the internet on ports 22, 3389, 3306, "
+        "5432, 6379, 9200, 27017. Matches inbound 0.0.0.0/0 SG rules whose "
+        "port range covers any of those ports, including all-ports rules "
+        "(`fromport` IS NULL) and ranges like 0-65535. Aligned with the "
+        "GCP and Azure facts in this same rule."
     ),
     cypher_query="""
     MATCH (a:AWSAccount)-[:RESOURCE]->(ec2:EC2Instance)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)<-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound)
     MATCH (rule)<-[:MEMBER_OF_IP_RULE]-(ip:AWSIpRange{range:'0.0.0.0/0'})
-    WHERE rule.fromport IN [22, 3389, 3306, 5432, 6379, 9200, 27017]
-    RETURN a.id as account_id, a.name AS account, ec2.instanceid AS instance_id, rule.fromport AS port, sg.groupid AS security_group order by account, instance_id, port, security_group
+    UNWIND [22, 3389, 3306, 5432, 6379, 9200, 27017] AS managed_port
+    WITH a, ec2, sg, rule, managed_port
+    WHERE rule.fromport IS NULL
+       OR (
+         coalesce(rule.fromport, 0) <= managed_port
+         AND coalesce(rule.toport, rule.fromport, 0) >= managed_port
+       )
+    RETURN DISTINCT
+        a.id AS account_id,
+        a.name AS account,
+        ec2.instanceid AS instance_id,
+        managed_port AS port,
+        sg.groupid AS security_group
+    ORDER BY account, instance_id, port, security_group
     """,
     cypher_visual_query="""
     MATCH p=(a:AWSAccount)-[:RESOURCE]->(ec2:EC2Instance)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)<-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound)
     MATCH p2=(rule)<-[:MEMBER_OF_IP_RULE]-(ip:AWSIpRange{range:'0.0.0.0/0'})
-    WHERE rule.fromport IN [22, 3389, 3306, 5432, 6379, 9200, 27017]
+    WHERE rule.fromport IS NULL
+       OR ANY(managed_port IN [22, 3389, 3306, 5432, 6379, 9200, 27017]
+              WHERE coalesce(rule.fromport, 0) <= managed_port
+                AND coalesce(rule.toport, rule.fromport, 0) >= managed_port)
     RETURN *
     """,
     cypher_count_query="""

--- a/cartography/rules/data/rules/database_instance_exposed.py
+++ b/cartography/rules/data/rules/database_instance_exposed.py
@@ -4,6 +4,128 @@ from cartography.rules.spec.model import Maturity
 from cartography.rules.spec.model import Module
 from cartography.rules.spec.model import Rule
 
+# Azure Facts
+# SQL Server firewall rules need to be split into two distinct exposure
+# classes (per Microsoft's documentation): the special start_ip=end_ip=0.0.0.0
+# row only allows Azure services / resources, not arbitrary public IPs, while
+# any rule that actually covers public IP space exposes the server to the
+# internet.
+_azure_sql_internet_exposed = Fact(
+    id="azure_sql_internet_exposed",
+    name="Internet-Accessible Azure SQL Server Attack Surface",
+    description=(
+        "Azure SQL Servers reachable from the public internet. Triggered "
+        "when public_network_access = 'Enabled' and a firewall rule allows "
+        "traffic from public IP space (start_ip=0.0.0.0, end_ip!=0.0.0.0)."
+    ),
+    cypher_query="""
+    MATCH (sub:AzureSubscription)-[:RESOURCE]->(server:AzureSQLServer)
+    MATCH (rule:AzureSQLServerFirewallRule)-[:MEMBER_OF_AZURE_SQL_SERVER]->(server)
+    WHERE coalesce(server.public_network_access, 'Enabled') = 'Enabled'
+      AND rule.start_ip_address = '0.0.0.0'
+      AND rule.end_ip_address IS NOT NULL
+      AND rule.end_ip_address <> '0.0.0.0'
+    RETURN
+        server.id AS id,
+        server.name AS host,
+        'Microsoft.Sql' AS engine,
+        1433 AS port,
+        server.location AS region,
+        server.minimal_tls_version AS encrypted
+    """,
+    cypher_visual_query="""
+    MATCH p=(sub:AzureSubscription)-[:RESOURCE]->(server:AzureSQLServer)<-[:MEMBER_OF_AZURE_SQL_SERVER]-(rule:AzureSQLServerFirewallRule)
+    WHERE coalesce(server.public_network_access, 'Enabled') = 'Enabled'
+      AND rule.start_ip_address = '0.0.0.0'
+      AND rule.end_ip_address IS NOT NULL
+      AND rule.end_ip_address <> '0.0.0.0'
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (server:AzureSQLServer)
+    RETURN COUNT(server) AS count
+    """,
+    asset_id_field="id",
+    module=Module.AZURE,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+_azure_sql_allow_azure_services = Fact(
+    id="azure_sql_allow_azure_services",
+    name="Azure SQL Server with Allow-Azure-Services Firewall Rule",
+    description=(
+        "Azure SQL Servers with the special start_ip=0.0.0.0 / end_ip=0.0.0.0 "
+        "firewall rule. Microsoft documents this row as 'allow Azure-hosted "
+        "services and resources to access this server', which is a different "
+        "exposure class than public-internet reachability and should be "
+        "evaluated separately."
+    ),
+    cypher_query="""
+    MATCH (sub:AzureSubscription)-[:RESOURCE]->(server:AzureSQLServer)
+    MATCH (rule:AzureSQLServerFirewallRule)-[:MEMBER_OF_AZURE_SQL_SERVER]->(server)
+    WHERE rule.start_ip_address = '0.0.0.0'
+      AND rule.end_ip_address = '0.0.0.0'
+    RETURN
+        server.id AS id,
+        server.name AS host,
+        'Microsoft.Sql' AS engine,
+        1433 AS port,
+        server.location AS region,
+        server.minimal_tls_version AS encrypted
+    """,
+    cypher_visual_query="""
+    MATCH p=(sub:AzureSubscription)-[:RESOURCE]->(server:AzureSQLServer)<-[:MEMBER_OF_AZURE_SQL_SERVER]-(rule:AzureSQLServerFirewallRule)
+    WHERE rule.start_ip_address = '0.0.0.0'
+      AND rule.end_ip_address = '0.0.0.0'
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (server:AzureSQLServer)
+    RETURN COUNT(server) AS count
+    """,
+    asset_id_field="id",
+    module=Module.AZURE,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+_azure_cosmosdb_public_access = Fact(
+    id="azure_cosmosdb_public_access",
+    name="Internet-Accessible Azure Cosmos DB Account",
+    description=(
+        "Azure Cosmos DB accounts with publicnetworkaccess = 'Enabled' and "
+        "no IP allowlist or VNet filter, leaving the account reachable from "
+        "any public IP."
+    ),
+    cypher_query="""
+    MATCH (sub:AzureSubscription)-[:RESOURCE]->(account:AzureCosmosDBAccount)
+    WHERE account.publicnetworkaccess = 'Enabled'
+      AND coalesce(account.virtualnetworkfilterenabled, false) = false
+      AND (account.ipranges IS NULL OR account.ipranges = '')
+    RETURN
+        account.id AS id,
+        account.documentendpoint AS host,
+        coalesce(account.kind, 'Microsoft.DocumentDB') AS engine,
+        account.location AS region
+    """,
+    cypher_visual_query="""
+    MATCH p=(sub:AzureSubscription)-[:RESOURCE]->(account:AzureCosmosDBAccount)
+    WHERE account.publicnetworkaccess = 'Enabled'
+      AND coalesce(account.virtualnetworkfilterenabled, false) = false
+      AND (account.ipranges IS NULL OR account.ipranges = '')
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (account:AzureCosmosDBAccount)
+    RETURN COUNT(account) AS count
+    """,
+    asset_id_field="id",
+    module=Module.AZURE,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
 # GCP Facts
 _gcp_cloud_sql_public_access = Fact(
     id="gcp_cloud_sql_public_access",
@@ -85,6 +207,9 @@ database_instance_exposed = Rule(
     output_model=DatabaseInstanceExposed,
     facts=(
         _aws_rds_public_access,
+        _azure_sql_internet_exposed,
+        _azure_sql_allow_azure_services,
+        _azure_cosmosdb_public_access,
         _gcp_cloud_sql_public_access,
     ),
     tags=(

--- a/cartography/rules/data/rules/database_instance_exposed.py
+++ b/cartography/rules/data/rules/database_instance_exposed.py
@@ -127,9 +127,11 @@ _aws_rds_public_access = Fact(
     description=(
         "AWS RDS instances reachable from the public internet. The DB must "
         "have publicly_accessible = true AND at least one attached security "
-        "group with an inbound rule permitting 0.0.0.0/0 on a port range "
-        "that covers the DB's endpoint_port (or all ports). Either flag "
-        "alone is not sufficient for actual public reachability."
+        "group with an inbound rule permitting 0.0.0.0/0 over TCP "
+        "(or `-1` / `all` covering every protocol) on a port range that "
+        "covers the DB's endpoint_port. Either flag alone is not sufficient "
+        "for actual public reachability, and a UDP-only wide-open rule does "
+        "not expose the TCP DB port."
     ),
     cypher_query="""
     MATCH (rds:RDSInstance {publicly_accessible: true})
@@ -137,11 +139,14 @@ _aws_rds_public_access = Fact(
     MATCH (rds)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)
         <-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound)
     MATCH (rule)<-[:MEMBER_OF_IP_RULE]-(:AWSIpRange {range: '0.0.0.0/0'})
-    WHERE rule.fromport IS NULL
-       OR (
-         coalesce(rule.fromport, 0) <= rds.endpoint_port
-         AND coalesce(rule.toport, rule.fromport, 0) >= rds.endpoint_port
-       )
+    WHERE coalesce(rule.protocol, '') IN ['tcp', '-1', 'all']
+      AND (
+        rule.fromport IS NULL
+        OR (
+          coalesce(rule.fromport, 0) <= rds.endpoint_port
+          AND coalesce(rule.toport, rule.fromport, 0) >= rds.endpoint_port
+        )
+      )
     RETURN DISTINCT
         rds.id AS id,
         rds.engine AS engine,
@@ -157,6 +162,7 @@ _aws_rds_public_access = Fact(
         <-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound:AWSIpRule)
     MATCH p3=(rule)<-[:MEMBER_OF_IP_RULE]-(ip:AWSIpRange {range: '0.0.0.0/0'})
     WHERE rds.endpoint_port IS NOT NULL
+      AND coalesce(rule.protocol, '') IN ['tcp', '-1', 'all']
       AND (
         rule.fromport IS NULL
         OR (

--- a/cartography/rules/data/rules/database_instance_exposed.py
+++ b/cartography/rules/data/rules/database_instance_exposed.py
@@ -5,18 +5,18 @@ from cartography.rules.spec.model import Module
 from cartography.rules.spec.model import Rule
 
 # Azure Facts
-# SQL Server firewall rules need to be split into two distinct exposure
-# classes (per Microsoft's documentation): the special start_ip=end_ip=0.0.0.0
-# row only allows Azure services / resources, not arbitrary public IPs, while
-# any rule that actually covers public IP space exposes the server to the
-# internet.
+# Only the public-internet exposure class belongs in this rule. The special
+# Azure SQL `start_ip=end_ip=0.0.0.0` "Allow Azure services" row is a
+# different exposure class (per Microsoft's documentation) and should be
+# tracked under a dedicated rule, not lumped here.
 _azure_sql_internet_exposed = Fact(
     id="azure_sql_internet_exposed",
     name="Internet-Accessible Azure SQL Server Attack Surface",
     description=(
         "Azure SQL Servers reachable from the public internet. Triggered "
         "when public_network_access = 'Enabled' and a firewall rule allows "
-        "traffic from public IP space (start_ip=0.0.0.0, end_ip!=0.0.0.0)."
+        "traffic from public IP space (start_ip=0.0.0.0, end_ip is set and "
+        "not also 0.0.0.0)."
     ),
     cypher_query="""
     MATCH (sub:AzureSubscription)-[:RESOURCE]->(server:AzureSQLServer)
@@ -30,8 +30,7 @@ _azure_sql_internet_exposed = Fact(
         server.name AS host,
         'Microsoft.Sql' AS engine,
         1433 AS port,
-        server.location AS region,
-        server.minimal_tls_version AS encrypted
+        server.location AS region
     """,
     cypher_visual_query="""
     MATCH p=(sub:AzureSubscription)-[:RESOURCE]->(server:AzureSQLServer)<-[:MEMBER_OF_AZURE_SQL_SERVER]-(rule:AzureSQLServerFirewallRule)
@@ -39,45 +38,6 @@ _azure_sql_internet_exposed = Fact(
       AND rule.start_ip_address = '0.0.0.0'
       AND rule.end_ip_address IS NOT NULL
       AND rule.end_ip_address <> '0.0.0.0'
-    RETURN *
-    """,
-    cypher_count_query="""
-    MATCH (server:AzureSQLServer)
-    RETURN COUNT(server) AS count
-    """,
-    asset_id_field="id",
-    module=Module.AZURE,
-    maturity=Maturity.EXPERIMENTAL,
-)
-
-
-_azure_sql_allow_azure_services = Fact(
-    id="azure_sql_allow_azure_services",
-    name="Azure SQL Server with Allow-Azure-Services Firewall Rule",
-    description=(
-        "Azure SQL Servers with the special start_ip=0.0.0.0 / end_ip=0.0.0.0 "
-        "firewall rule. Microsoft documents this row as 'allow Azure-hosted "
-        "services and resources to access this server', which is a different "
-        "exposure class than public-internet reachability and should be "
-        "evaluated separately."
-    ),
-    cypher_query="""
-    MATCH (sub:AzureSubscription)-[:RESOURCE]->(server:AzureSQLServer)
-    MATCH (rule:AzureSQLServerFirewallRule)-[:MEMBER_OF_AZURE_SQL_SERVER]->(server)
-    WHERE rule.start_ip_address = '0.0.0.0'
-      AND rule.end_ip_address = '0.0.0.0'
-    RETURN
-        server.id AS id,
-        server.name AS host,
-        'Microsoft.Sql' AS engine,
-        1433 AS port,
-        server.location AS region,
-        server.minimal_tls_version AS encrypted
-    """,
-    cypher_visual_query="""
-    MATCH p=(sub:AzureSubscription)-[:RESOURCE]->(server:AzureSQLServer)<-[:MEMBER_OF_AZURE_SQL_SERVER]-(rule:AzureSQLServerFirewallRule)
-    WHERE rule.start_ip_address = '0.0.0.0'
-      AND rule.end_ip_address = '0.0.0.0'
     RETURN *
     """,
     cypher_count_query="""
@@ -96,13 +56,15 @@ _azure_cosmosdb_public_access = Fact(
     description=(
         "Azure Cosmos DB accounts with publicnetworkaccess = 'Enabled' and "
         "no IP allowlist or VNet filter, leaving the account reachable from "
-        "any public IP."
+        "any public IP. The intel layer normalises ipruleslist into a list "
+        "(possibly empty), so the empty-list case is the no-allowlist "
+        "signal here."
     ),
     cypher_query="""
     MATCH (sub:AzureSubscription)-[:RESOURCE]->(account:AzureCosmosDBAccount)
     WHERE account.publicnetworkaccess = 'Enabled'
       AND coalesce(account.virtualnetworkfilterenabled, false) = false
-      AND (account.ipranges IS NULL OR account.ipranges = '')
+      AND size(coalesce(account.ipranges, [])) = 0
     RETURN
         account.id AS id,
         account.documentendpoint AS host,
@@ -113,7 +75,7 @@ _azure_cosmosdb_public_access = Fact(
     MATCH p=(sub:AzureSubscription)-[:RESOURCE]->(account:AzureCosmosDBAccount)
     WHERE account.publicnetworkaccess = 'Enabled'
       AND coalesce(account.virtualnetworkfilterenabled, false) = false
-      AND (account.ipranges IS NULL OR account.ipranges = '')
+      AND size(coalesce(account.ipranges, [])) = 0
     RETURN *
     """,
     cypher_count_query="""
@@ -208,7 +170,6 @@ database_instance_exposed = Rule(
     facts=(
         _aws_rds_public_access,
         _azure_sql_internet_exposed,
-        _azure_sql_allow_azure_services,
         _azure_cosmosdb_public_access,
         _gcp_cloud_sql_public_access,
     ),

--- a/cartography/rules/data/rules/database_instance_exposed.py
+++ b/cartography/rules/data/rules/database_instance_exposed.py
@@ -124,11 +124,19 @@ _gcp_cloud_sql_public_access = Fact(
 _aws_rds_public_access = Fact(
     id="aws_rds_public_access",
     name="Internet-Accessible RDS Database Attack Surface",
-    description="AWS RDS instances accessible from the internet",
+    description=(
+        "AWS RDS instances reachable from the public internet. The DB must "
+        "have publicly_accessible = true AND at least one attached security "
+        "group with an inbound rule permitting 0.0.0.0/0. Either flag alone "
+        "is not sufficient for actual public reachability."
+    ),
     cypher_query="""
-    MATCH (rds:RDSInstance)
-    WHERE rds.publicly_accessible = true
-    RETURN rds.id AS id,
+    MATCH (rds:RDSInstance {publicly_accessible: true})
+    MATCH (rds)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)
+        <-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound)
+    MATCH (rule)<-[:MEMBER_OF_IP_RULE]-(:AWSIpRange {range: '0.0.0.0/0'})
+    RETURN DISTINCT
+        rds.id AS id,
         rds.engine AS engine,
         rds.db_instance_class AS instance_class,
         rds.endpoint_address AS host,
@@ -137,10 +145,10 @@ _aws_rds_public_access = Fact(
         rds.storage_encrypted AS encrypted
     """,
     cypher_visual_query="""
-    MATCH p1=(rds:RDSInstance{publicly_accessible: true})
-    OPTIONAL MATCH p2=(rds)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)
-    OPTIONAL MATCH p3=(rds)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)<-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound:AWSIpRule)
-    OPTIONAL MATCH p4=(rds)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)<-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound:AWSIpRule)<-[:MEMBER_OF_IP_RULE]-(ip:AWSIpRange)
+    MATCH p1=(rds:RDSInstance {publicly_accessible: true})
+    MATCH p2=(rds)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)
+        <-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound:AWSIpRule)
+    MATCH p3=(rule)<-[:MEMBER_OF_IP_RULE]-(ip:AWSIpRange {range: '0.0.0.0/0'})
     RETURN *
     """,
     cypher_count_query="""

--- a/cartography/rules/data/rules/database_instance_exposed.py
+++ b/cartography/rules/data/rules/database_instance_exposed.py
@@ -127,14 +127,21 @@ _aws_rds_public_access = Fact(
     description=(
         "AWS RDS instances reachable from the public internet. The DB must "
         "have publicly_accessible = true AND at least one attached security "
-        "group with an inbound rule permitting 0.0.0.0/0. Either flag alone "
-        "is not sufficient for actual public reachability."
+        "group with an inbound rule permitting 0.0.0.0/0 on a port range "
+        "that covers the DB's endpoint_port (or all ports). Either flag "
+        "alone is not sufficient for actual public reachability."
     ),
     cypher_query="""
     MATCH (rds:RDSInstance {publicly_accessible: true})
+    WHERE rds.endpoint_port IS NOT NULL
     MATCH (rds)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)
         <-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound)
     MATCH (rule)<-[:MEMBER_OF_IP_RULE]-(:AWSIpRange {range: '0.0.0.0/0'})
+    WHERE rule.fromport IS NULL
+       OR (
+         coalesce(rule.fromport, 0) <= rds.endpoint_port
+         AND coalesce(rule.toport, rule.fromport, 0) >= rds.endpoint_port
+       )
     RETURN DISTINCT
         rds.id AS id,
         rds.engine AS engine,
@@ -149,6 +156,14 @@ _aws_rds_public_access = Fact(
     MATCH p2=(rds)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)
         <-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound:AWSIpRule)
     MATCH p3=(rule)<-[:MEMBER_OF_IP_RULE]-(ip:AWSIpRange {range: '0.0.0.0/0'})
+    WHERE rds.endpoint_port IS NOT NULL
+      AND (
+        rule.fromport IS NULL
+        OR (
+          coalesce(rule.fromport, 0) <= rds.endpoint_port
+          AND coalesce(rule.toport, rule.fromport, 0) >= rds.endpoint_port
+        )
+      )
     RETURN *
     """,
     cypher_count_query="""

--- a/cartography/rules/data/rules/delegation_boundary_modifiable.py
+++ b/cartography/rules/data/rules/delegation_boundary_modifiable.py
@@ -97,9 +97,12 @@ _gcp_trust_relationship_manipulation = Fact(
         "AssumeRolePolicy modification."
     ),
     cypher_query="""
-    MATCH (project:GCPProject)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH (binding:GCPPolicyBinding)-[:APPLIES_TO]->(scope)
+    WHERE any(label IN labels(scope)
+              WHERE label IN ['GCPProject', 'GCPFolder', 'GCPOrganization'])
+    MATCH (binding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
     MATCH (binding)-[:GRANTS_ROLE]->(role:GCPRole)
-    WITH project, principal, role,
+    WITH scope, principal, role,
         [
             'iam.serviceAccounts.actAs',
             'iam.serviceAccounts.implicitDelegation',
@@ -108,23 +111,25 @@ _gcp_trust_relationship_manipulation = Fact(
             'iam.serviceAccounts.signJwt',
             'iam.serviceAccountKeys.create'
         ] AS patterns
-    WITH project, principal, role, patterns,
+    WITH scope, principal, role, patterns,
          [perm IN coalesce(role.permissions, [])
             WHERE perm IN patterns OR perm = 'iam.*' OR perm = '*'] AS matched
     WHERE size(matched) > 0
     RETURN DISTINCT
-        project.id AS account,
-        project.id AS account_id,
+        scope.id AS account,
+        scope.id AS account_id,
         coalesce(principal.email, principal.id) AS principal_name,
         principal.id AS principal_identifier,
         [label IN labels(principal) WHERE label <> 'GCPPrincipal'][0] AS principal_type,
         role.name AS policy_name,
         matched AS actions,
-        [project.id] AS resources
+        [scope.id] AS resources
     ORDER BY account, principal_name
     """,
     cypher_visual_query="""
-    MATCH p1=(project:GCPProject)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH p1=(scope)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    WHERE any(label IN labels(scope)
+              WHERE label IN ['GCPProject', 'GCPFolder', 'GCPOrganization'])
     MATCH p2=(binding)-[:GRANTS_ROLE]->(role:GCPRole)
     WHERE ANY(perm IN coalesce(role.permissions, []) WHERE
         perm IN [
@@ -167,30 +172,37 @@ _azure_trust_relationship_manipulation = Fact(
     MATCH (principal)-[:HAS_ROLE_ASSIGNMENT]->(ra)
     WHERE any(label IN labels(principal)
               WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal'])
+    // Expand each searched pattern through actions, then subtract any
+    // pattern shadowed by not_actions, so wildcards like `*` /
+    // `Microsoft.Authorization/*` correctly drop the assignment patterns
+    // when the role's not_actions exclude them (built-in Contributor).
     WITH sub, ra, rd, perm, principal,
+         coalesce(perm.actions, []) AS role_actions,
+         coalesce(perm.not_actions, []) AS role_not_actions,
         [
             'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action',
             'Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action',
             'Microsoft.Authorization/roleAssignments/write'
         ] AS patterns
-    WITH sub, ra, rd, perm, principal, patterns,
-         [a IN coalesce(perm.actions, [])
-            WHERE a IN patterns
-              OR a = 'Microsoft.ManagedIdentity/*'
-              OR a = 'Microsoft.Authorization/*'
-              OR a = '*'] AS matched
-    WHERE size(matched) > 0
-      // Shadow matched actions if a not_action equals '*', equals one of
-      // them, or is a trailing-wildcard prefix. Inner wildcards
-      // (e.g. Microsoft.Authorization/*/write) are not currently expanded.
-      AND NOT ANY(na IN coalesce(perm.not_actions, []) WHERE
-            na = '*'
-            OR na IN matched
-            OR (
-              na ENDS WITH '*'
-              AND ANY(a IN matched WHERE a STARTS WITH split(na, '*')[0])
+    WITH sub, ra, rd, perm, principal, role_not_actions,
+        [
+            p IN patterns
+            WHERE ANY(a IN role_actions WHERE
+                a = '*'
+                OR a = p
+                OR (a ENDS WITH '*' AND p STARTS WITH split(a, '*')[0])
             )
-          )
+        ] AS granted
+    WITH sub, ra, rd, perm, principal,
+        [
+            p IN granted
+            WHERE NOT ANY(na IN role_not_actions WHERE
+                na = '*'
+                OR na = p
+                OR (na ENDS WITH '*' AND p STARTS WITH split(na, '*')[0])
+            )
+        ] AS matched
+    WHERE size(matched) > 0
     RETURN DISTINCT
         sub.id AS account,
         sub.id AS account_id,

--- a/cartography/rules/data/rules/delegation_boundary_modifiable.py
+++ b/cartography/rules/data/rules/delegation_boundary_modifiable.py
@@ -100,7 +100,7 @@ _gcp_trust_relationship_manipulation = Fact(
     MATCH (binding:GCPPolicyBinding)-[:APPLIES_TO]->(scope)
     WHERE any(label IN labels(scope)
               WHERE label IN ['GCPProject', 'GCPFolder', 'GCPOrganization'])
-    MATCH (binding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH (principal:GCPPrincipal)-[:HAS_ALLOW_POLICY]->(binding)
     MATCH (binding)-[:GRANTS_ROLE]->(role:GCPRole)
     WITH scope, principal, role,
         [
@@ -127,7 +127,7 @@ _gcp_trust_relationship_manipulation = Fact(
     ORDER BY account, principal_name
     """,
     cypher_visual_query="""
-    MATCH p1=(scope)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH p1=(principal:GCPPrincipal)-[:HAS_ALLOW_POLICY]->(binding:GCPPolicyBinding)-[:APPLIES_TO]->(scope)
     WHERE any(label IN labels(scope)
               WHERE label IN ['GCPProject', 'GCPFolder', 'GCPOrganization'])
     MATCH p2=(binding)-[:GRANTS_ROLE]->(role:GCPRole)

--- a/cartography/rules/data/rules/delegation_boundary_modifiable.py
+++ b/cartography/rules/data/rules/delegation_boundary_modifiable.py
@@ -120,7 +120,12 @@ _gcp_trust_relationship_manipulation = Fact(
         scope.id AS account_id,
         coalesce(principal.email, principal.id) AS principal_name,
         principal.id AS principal_identifier,
-        [label IN labels(principal) WHERE label <> 'GCPPrincipal'][0] AS principal_type,
+        coalesce(
+            head([l IN ['GCPServiceAccount', 'GoogleWorkspaceUser', 'GoogleWorkspaceGroup']
+                  WHERE l IN labels(principal)]),
+            head([l IN ['ServiceAccount', 'UserAccount', 'UserGroup']
+                  WHERE l IN labels(principal)])
+        ) AS principal_type,
         role.name AS policy_name,
         matched AS actions,
         [scope.id] AS resources

--- a/cartography/rules/data/rules/delegation_boundary_modifiable.py
+++ b/cartography/rules/data/rules/delegation_boundary_modifiable.py
@@ -180,7 +180,17 @@ _azure_trust_relationship_manipulation = Fact(
               OR a = 'Microsoft.Authorization/*'
               OR a = '*'] AS matched
     WHERE size(matched) > 0
-      AND NOT ANY(na IN coalesce(perm.not_actions, []) WHERE na = '*' OR na IN matched)
+      // Shadow matched actions if a not_action equals '*', equals one of
+      // them, or is a trailing-wildcard prefix. Inner wildcards
+      // (e.g. Microsoft.Authorization/*/write) are not currently expanded.
+      AND NOT ANY(na IN coalesce(perm.not_actions, []) WHERE
+            na = '*'
+            OR na IN matched
+            OR (
+              na ENDS WITH '*'
+              AND ANY(a IN matched WHERE a STARTS WITH split(na, '*')[0])
+            )
+          )
     RETURN DISTINCT
         sub.id AS account,
         sub.id AS account_id,

--- a/cartography/rules/data/rules/delegation_boundary_modifiable.py
+++ b/cartography/rules/data/rules/delegation_boundary_modifiable.py
@@ -172,34 +172,30 @@ _azure_trust_relationship_manipulation = Fact(
     MATCH (principal)-[:HAS_ROLE_ASSIGNMENT]->(ra)
     WHERE any(label IN labels(principal)
               WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal'])
-    // Expand each searched pattern through actions, then subtract any
-    // pattern shadowed by not_actions, so wildcards like `*` /
-    // `Microsoft.Authorization/*` correctly drop the assignment patterns
-    // when the role's not_actions exclude them (built-in Contributor).
+    // Treat each action / not_action as a case-insensitive glob: `.` is
+    // escaped to the regex char class `[.]`, `*` becomes `.*`. A `*`
+    // anywhere now correctly matches; Contributor (actions=['*'],
+    // not_actions including `Microsoft.Authorization/*/Write`) is
+    // shadowed for the role-assignment write pattern.
     WITH sub, ra, rd, perm, principal,
          coalesce(perm.actions, []) AS role_actions,
          coalesce(perm.not_actions, []) AS role_not_actions,
         [
             'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action',
-            'Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action',
             'Microsoft.Authorization/roleAssignments/write'
         ] AS patterns
     WITH sub, ra, rd, perm, principal, role_not_actions,
         [
             p IN patterns
             WHERE ANY(a IN role_actions WHERE
-                a = '*'
-                OR a = p
-                OR (a ENDS WITH '*' AND p STARTS WITH split(a, '*')[0])
+                toLower(p) =~ replace(replace(toLower(a), '.', '[.]'), '*', '.*')
             )
         ] AS granted
     WITH sub, ra, rd, perm, principal,
         [
             p IN granted
             WHERE NOT ANY(na IN role_not_actions WHERE
-                na = '*'
-                OR na = p
-                OR (na ENDS WITH '*' AND p STARTS WITH split(na, '*')[0])
+                toLower(p) =~ replace(replace(toLower(na), '.', '[.]'), '*', '.*')
             )
         ] AS matched
     WHERE size(matched) > 0

--- a/cartography/rules/data/rules/delegation_boundary_modifiable.py
+++ b/cartography/rules/data/rules/delegation_boundary_modifiable.py
@@ -219,15 +219,17 @@ _azure_trust_relationship_manipulation = Fact(
     MATCH p3=(principal)-[:HAS_ROLE_ASSIGNMENT]->(ra)
     WHERE any(label IN labels(principal)
               WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal'])
-      AND any(a IN coalesce(perm.actions, []) WHERE
-        a IN [
-          'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action',
-          'Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action',
-          'Microsoft.Authorization/roleAssignments/write'
+      // Mirror the finding query: at least one searched pattern is granted
+      // by actions AND not shadowed by not_actions.
+      AND ANY(p IN [
+            'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action',
+            'Microsoft.Authorization/roleAssignments/write'
         ]
-        OR a = 'Microsoft.ManagedIdentity/*'
-        OR a = 'Microsoft.Authorization/*'
-        OR a = '*')
+        WHERE ANY(a IN coalesce(perm.actions, []) WHERE
+                  toLower(p) =~ replace(replace(toLower(a), '.', '[.]'), '*', '.*'))
+          AND NOT ANY(na IN coalesce(perm.not_actions, []) WHERE
+                  toLower(p) =~ replace(replace(toLower(na), '.', '[.]'), '*', '.*'))
+      )
     RETURN *
     """,
     cypher_count_query="""

--- a/cartography/rules/data/rules/delegation_boundary_modifiable.py
+++ b/cartography/rules/data/rules/delegation_boundary_modifiable.py
@@ -84,6 +84,144 @@ _aws_trust_relationship_manipulation = Fact(
 )
 
 
+# GCP
+_gcp_trust_relationship_manipulation = Fact(
+    id="gcp_trust_relationship_manipulation",
+    name="GCP Principals with Service Account Impersonation Permissions",
+    description=(
+        "GCP principals bound to a role granting `iam.serviceAccounts.actAs` "
+        "(impersonate any service account in the project), "
+        "`iam.serviceAccounts.implicitDelegation` (chain SA tokens), or "
+        "`iam.serviceAccountKeys.create` (mint long-lived SA keys). All "
+        "three open lateral identity-takeover paths analogous to AWS "
+        "AssumeRolePolicy modification."
+    ),
+    cypher_query="""
+    MATCH (project:GCPProject)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH (binding)-[:GRANTS_ROLE]->(role:GCPRole)
+    WITH project, principal, role,
+        [
+            'iam.serviceAccounts.actAs',
+            'iam.serviceAccounts.implicitDelegation',
+            'iam.serviceAccounts.getAccessToken',
+            'iam.serviceAccounts.signBlob',
+            'iam.serviceAccounts.signJwt',
+            'iam.serviceAccountKeys.create'
+        ] AS patterns
+    WITH project, principal, role, patterns,
+         [perm IN coalesce(role.permissions, [])
+            WHERE perm IN patterns OR perm = 'iam.*' OR perm = '*'] AS matched
+    WHERE size(matched) > 0
+    RETURN DISTINCT
+        project.id AS account,
+        project.id AS account_id,
+        coalesce(principal.email, principal.id) AS principal_name,
+        principal.id AS principal_identifier,
+        [label IN labels(principal) WHERE label <> 'GCPPrincipal'][0] AS principal_type,
+        role.name AS policy_name,
+        matched AS actions,
+        [project.id] AS resources
+    ORDER BY account, principal_name
+    """,
+    cypher_visual_query="""
+    MATCH p1=(project:GCPProject)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH p2=(binding)-[:GRANTS_ROLE]->(role:GCPRole)
+    WHERE ANY(perm IN coalesce(role.permissions, []) WHERE
+        perm IN [
+            'iam.serviceAccounts.actAs',
+            'iam.serviceAccounts.implicitDelegation',
+            'iam.serviceAccounts.getAccessToken',
+            'iam.serviceAccounts.signBlob',
+            'iam.serviceAccounts.signJwt',
+            'iam.serviceAccountKeys.create'
+        ]
+        OR perm = 'iam.*' OR perm = '*'
+    )
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (principal:GCPPrincipal)
+    RETURN COUNT(principal) AS count
+    """,
+    asset_id_field="principal_identifier",
+    module=Module.GCP,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+# Azure
+_azure_trust_relationship_manipulation = Fact(
+    id="azure_trust_relationship_manipulation",
+    name="Azure Principals with Managed Identity Assignment Permissions",
+    description=(
+        "Entra principals holding a role assignment whose role definition "
+        "grants `Microsoft.ManagedIdentity/userAssignedIdentities/.../"
+        "assign/action` (attach a UAMI to a workload, the closest analog "
+        "to AWS UpdateAssumeRolePolicy) or "
+        "`Microsoft.Authorization/roleAssignments/write` (grant arbitrary "
+        "role assignments to other principals)."
+    ),
+    cypher_query="""
+    MATCH (sub:AzureSubscription)-[:RESOURCE]->(ra:AzureRoleAssignment)
+    MATCH (ra)-[:ROLE_ASSIGNED]->(rd:AzureRoleDefinition)-[:HAS_PERMISSIONS]->(perm:AzurePermissions)
+    MATCH (principal)-[:HAS_ROLE_ASSIGNMENT]->(ra)
+    WHERE any(label IN labels(principal)
+              WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal'])
+    WITH sub, ra, rd, perm, principal,
+        [
+            'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action',
+            'Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action',
+            'Microsoft.Authorization/roleAssignments/write'
+        ] AS patterns
+    WITH sub, ra, rd, perm, principal, patterns,
+         [a IN coalesce(perm.actions, [])
+            WHERE a IN patterns
+              OR a = 'Microsoft.ManagedIdentity/*'
+              OR a = 'Microsoft.Authorization/*'
+              OR a = '*'] AS matched
+    WHERE size(matched) > 0
+      AND NOT ANY(na IN coalesce(perm.not_actions, []) WHERE na = '*' OR na IN matched)
+    RETURN DISTINCT
+        sub.id AS account,
+        sub.id AS account_id,
+        coalesce(principal.user_principal_name,
+                 principal.display_name,
+                 principal.id) AS principal_name,
+        principal.id AS principal_identifier,
+        [label IN labels(principal)
+            WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal']][0] AS principal_type,
+        rd.role_name AS policy_name,
+        matched AS actions,
+        [ra.scope] AS resources
+    ORDER BY account, principal_name
+    """,
+    cypher_visual_query="""
+    MATCH p1=(sub:AzureSubscription)-[:RESOURCE]->(ra:AzureRoleAssignment)
+    MATCH p2=(ra)-[:ROLE_ASSIGNED]->(rd:AzureRoleDefinition)-[:HAS_PERMISSIONS]->(perm:AzurePermissions)
+    MATCH p3=(principal)-[:HAS_ROLE_ASSIGNMENT]->(ra)
+    WHERE any(label IN labels(principal)
+              WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal'])
+      AND any(a IN coalesce(perm.actions, []) WHERE
+        a IN [
+          'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action',
+          'Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action',
+          'Microsoft.Authorization/roleAssignments/write'
+        ]
+        OR a = 'Microsoft.ManagedIdentity/*'
+        OR a = 'Microsoft.Authorization/*'
+        OR a = '*')
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (ra:AzureRoleAssignment)
+    RETURN COUNT(ra) AS count
+    """,
+    asset_id_field="principal_identifier",
+    module=Module.AZURE,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
 # Rule
 class DelegationBoundaryModifiable(Finding):
     principal_name: str | None = None
@@ -104,7 +242,11 @@ delegation_boundary_modifiable = Rule(
         "allowing cross-account or lateral impersonation paths."
     ),
     output_model=DelegationBoundaryModifiable,
-    facts=(_aws_trust_relationship_manipulation,),
+    facts=(
+        _aws_trust_relationship_manipulation,
+        _azure_trust_relationship_manipulation,
+        _gcp_trust_relationship_manipulation,
+    ),
     tags=(
         "iam",
         "stride:elevation_of_privilege",

--- a/cartography/rules/data/rules/delegation_boundary_modifiable.py
+++ b/cartography/rules/data/rules/delegation_boundary_modifiable.py
@@ -181,7 +181,7 @@ _azure_trust_relationship_manipulation = Fact(
          coalesce(perm.actions, []) AS role_actions,
          coalesce(perm.not_actions, []) AS role_not_actions,
         [
-            'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action',
+            'Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action',
             'Microsoft.Authorization/roleAssignments/write'
         ] AS patterns
     WITH sub, ra, rd, perm, principal, role_not_actions,
@@ -222,7 +222,7 @@ _azure_trust_relationship_manipulation = Fact(
       // Mirror the finding query: at least one searched pattern is granted
       // by actions AND not shadowed by not_actions.
       AND ANY(p IN [
-            'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action',
+            'Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action',
             'Microsoft.Authorization/roleAssignments/write'
         ]
         WHERE ANY(a IN coalesce(perm.actions, []) WHERE

--- a/cartography/rules/data/rules/eol_software.py
+++ b/cartography/rules/data/rules/eol_software.py
@@ -8,7 +8,10 @@ from cartography.rules.spec.model import RuleReference
 _OLDEST_SUPPORTED_UPSTREAM_KUBERNETES_MINOR = 33
 _OLDEST_SUPPORTED_EKS_KUBERNETES_MINOR = 29
 _OLDEST_SUPPORTED_GKE_KUBERNETES_MINOR = 30
-_OLDEST_SUPPORTED_AKS_KUBERNETES_MINOR = 30
+# Microsoft AKS supported versions table starts at 1.33 as of 2026-05; 1.32
+# reached community EOL in March 2026. See:
+# https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions
+_OLDEST_SUPPORTED_AKS_KUBERNETES_MINOR = 33
 _AMAZON_LINUX_2_EOL_DATE = "2026-06-30"
 
 EOL_SOFTWARE_REFERENCES = [

--- a/cartography/rules/data/rules/eol_software.py
+++ b/cartography/rules/data/rules/eol_software.py
@@ -7,6 +7,8 @@ from cartography.rules.spec.model import RuleReference
 
 _OLDEST_SUPPORTED_UPSTREAM_KUBERNETES_MINOR = 33
 _OLDEST_SUPPORTED_EKS_KUBERNETES_MINOR = 29
+_OLDEST_SUPPORTED_GKE_KUBERNETES_MINOR = 30
+_OLDEST_SUPPORTED_AKS_KUBERNETES_MINOR = 30
 _AMAZON_LINUX_2_EOL_DATE = "2026-06-30"
 
 EOL_SOFTWARE_REFERENCES = [
@@ -21,6 +23,14 @@ EOL_SOFTWARE_REFERENCES = [
     RuleReference(
         text="Amazon EKS Kubernetes version lifecycle",
         url="https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html",
+    ),
+    RuleReference(
+        text="GKE release schedule and support",
+        url="https://cloud.google.com/kubernetes-engine/docs/release-schedule",
+    ),
+    RuleReference(
+        text="AKS supported Kubernetes versions",
+        url="https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions",
     ),
     RuleReference(
         text="Amazon Linux 2 release notes",
@@ -109,6 +119,110 @@ _eks_cluster_kubernetes_version_eol = Fact(
     module=Module.AWS,
     maturity=Maturity.EXPERIMENTAL,
 )
+
+_gke_cluster_kubernetes_version_eol = Fact(
+    id="gke_cluster_kubernetes_version_eol",
+    name="GKE clusters running end-of-life Kubernetes versions",
+    description=(
+        "Detects GKE clusters whose control-plane (current_master_version) "
+        f"runs a Kubernetes minor older than {_OLDEST_SUPPORTED_GKE_KUBERNETES_MINOR}, "
+        "the oldest minor still supported by Google's release schedule."
+    ),
+    cypher_query=f"""
+    MATCH (g:GKECluster)
+    WITH g,
+         CASE
+             WHEN g.current_master_version IS NULL
+                  OR size(split(toString(g.current_master_version), '.')) < 2 THEN NULL
+             ELSE toInteger(split(split(toString(g.current_master_version), '.')[1], '-')[0])
+         END AS kubernetes_minor
+    WHERE kubernetes_minor IS NOT NULL
+      AND kubernetes_minor < {_OLDEST_SUPPORTED_GKE_KUBERNETES_MINOR}
+    RETURN g.id AS asset_id,
+           g.name AS asset_name,
+           'GKECluster' AS asset_type,
+           'kubernetes' AS software_name,
+           toString(g.current_master_version) AS software_version,
+           1 AS software_major,
+           kubernetes_minor AS software_minor,
+           g.location AS location,
+           'provider' AS support_basis,
+           'eol' AS support_status
+    ORDER BY asset_name
+    """,
+    cypher_visual_query=f"""
+    MATCH project_path=(p:GCPProject)-[:RESOURCE]->(g:GKECluster)
+    WITH project_path, g,
+         CASE
+             WHEN g.current_master_version IS NULL
+                  OR size(split(toString(g.current_master_version), '.')) < 2 THEN NULL
+             ELSE toInteger(split(split(toString(g.current_master_version), '.')[1], '-')[0])
+         END AS kubernetes_minor
+    WHERE kubernetes_minor IS NOT NULL
+      AND kubernetes_minor < {_OLDEST_SUPPORTED_GKE_KUBERNETES_MINOR}
+    RETURN g AS cluster, project_path
+    """,
+    cypher_count_query="""
+    MATCH (g:GKECluster)
+    RETURN COUNT(g) AS count
+    """,
+    asset_id_field="asset_id",
+    module=Module.GCP,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+_aks_cluster_kubernetes_version_eol = Fact(
+    id="aks_cluster_kubernetes_version_eol",
+    name="AKS clusters running end-of-life Kubernetes versions",
+    description=(
+        "Detects AKS clusters whose kubernetes_version runs a minor older "
+        f"than {_OLDEST_SUPPORTED_AKS_KUBERNETES_MINOR}, the oldest minor "
+        "still supported by Microsoft's AKS supported versions policy."
+    ),
+    cypher_query=f"""
+    MATCH (a:AzureKubernetesCluster)
+    WITH a,
+         CASE
+             WHEN a.kubernetes_version IS NULL
+                  OR size(split(toString(a.kubernetes_version), '.')) < 2 THEN NULL
+             ELSE toInteger(split(split(toString(a.kubernetes_version), '.')[1], '-')[0])
+         END AS kubernetes_minor
+    WHERE kubernetes_minor IS NOT NULL
+      AND kubernetes_minor < {_OLDEST_SUPPORTED_AKS_KUBERNETES_MINOR}
+    RETURN a.id AS asset_id,
+           a.name AS asset_name,
+           'AzureKubernetesCluster' AS asset_type,
+           'kubernetes' AS software_name,
+           toString(a.kubernetes_version) AS software_version,
+           1 AS software_major,
+           kubernetes_minor AS software_minor,
+           a.location AS location,
+           'provider' AS support_basis,
+           'eol' AS support_status
+    ORDER BY asset_name
+    """,
+    cypher_visual_query=f"""
+    MATCH sub_path=(s:AzureSubscription)-[:RESOURCE]->(a:AzureKubernetesCluster)
+    WITH sub_path, a,
+         CASE
+             WHEN a.kubernetes_version IS NULL
+                  OR size(split(toString(a.kubernetes_version), '.')) < 2 THEN NULL
+             ELSE toInteger(split(split(toString(a.kubernetes_version), '.')[1], '-')[0])
+         END AS kubernetes_minor
+    WHERE kubernetes_minor IS NOT NULL
+      AND kubernetes_minor < {_OLDEST_SUPPORTED_AKS_KUBERNETES_MINOR}
+    RETURN a AS cluster, sub_path
+    """,
+    cypher_count_query="""
+    MATCH (a:AzureKubernetesCluster)
+    RETURN COUNT(a) AS count
+    """,
+    asset_id_field="asset_id",
+    module=Module.AZURE,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
 
 _kubernetes_cluster_kubernetes_version_eol = Fact(
     id="kubernetes_cluster_kubernetes_version_eol",
@@ -238,6 +352,8 @@ eol_software = Rule(
     output_model=EOLSoftwareOutput,
     facts=(
         _eks_cluster_kubernetes_version_eol,
+        _gke_cluster_kubernetes_version_eol,
+        _aks_cluster_kubernetes_version_eol,
         _kubernetes_cluster_kubernetes_version_eol,
         _ec2_instance_amazon_linux_2_eol,
     ),

--- a/cartography/rules/data/rules/eol_software.py
+++ b/cartography/rules/data/rules/eol_software.py
@@ -177,11 +177,16 @@ _gke_cluster_kubernetes_version_eol = Fact(
 
 _aks_cluster_kubernetes_version_eol = Fact(
     id="aks_cluster_kubernetes_version_eol",
-    name="AKS clusters running end-of-life Kubernetes versions",
+    name="AKS clusters outside Microsoft's standard-support window",
     description=(
         "Detects AKS clusters whose kubernetes_version runs a minor older "
         f"than {_OLDEST_SUPPORTED_AKS_KUBERNETES_MINOR}, the oldest minor "
-        "still supported by Microsoft's AKS supported versions policy."
+        "still in Microsoft's standard AKS support window. Microsoft also "
+        "offers a paid Long-Term Support (LTS) tier on selected minors "
+        "(e.g. 1.32 LTS to March 2027). The current AKS data model does "
+        "not expose an LTS / supportTier flag, so clusters enrolled in "
+        "LTS may show up here as a false positive: treat the finding as "
+        "'standard-support EOL' rather than 'unsupported by the provider'."
     ),
     cypher_query=f"""
     MATCH (a:AzureKubernetesCluster)
@@ -202,7 +207,7 @@ _aks_cluster_kubernetes_version_eol = Fact(
            kubernetes_minor AS software_minor,
            a.location AS location,
            'provider' AS support_basis,
-           'eol' AS support_status
+           'standard-support-eol' AS support_status
     ORDER BY asset_name
     """,
     cypher_visual_query=f"""

--- a/cartography/rules/data/rules/eol_software.py
+++ b/cartography/rules/data/rules/eol_software.py
@@ -6,7 +6,10 @@ from cartography.rules.spec.model import Rule
 from cartography.rules.spec.model import RuleReference
 
 _OLDEST_SUPPORTED_UPSTREAM_KUBERNETES_MINOR = 33
-_OLDEST_SUPPORTED_EKS_KUBERNETES_MINOR = 29
+# AWS EKS supports 1.35 / 1.34 / 1.33 in standard support and 1.32 / 1.31 /
+# 1.30 in extended support as of 2026-05; 1.29 is no longer covered.
+# https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
+_OLDEST_SUPPORTED_EKS_KUBERNETES_MINOR = 30
 _OLDEST_SUPPORTED_GKE_KUBERNETES_MINOR = 30
 # Microsoft AKS supported versions table starts at 1.33 as of 2026-05; 1.32
 # reached community EOL in March 2026. See:

--- a/cartography/rules/data/rules/eol_software.py
+++ b/cartography/rules/data/rules/eol_software.py
@@ -79,9 +79,10 @@ _eks_cluster_kubernetes_version_eol = Fact(
     id="eks_cluster_kubernetes_version_eol",
     name="EKS clusters running end-of-life Kubernetes versions",
     description=(
-        "Detects EKS clusters running Kubernetes minor versions that are no longer "
-        "supported by Amazon EKS. As of 2026-03-10, EKS-supported Kubernetes "
-        "minors are 1.34, 1.33, 1.32, 1.31, 1.30, and 1.29."
+        "Detects EKS clusters running Kubernetes minor versions that are no "
+        "longer supported by Amazon EKS. As of 2026-05, EKS standard support "
+        "covers 1.35 / 1.34 / 1.33 and extended support covers 1.32 / 1.31 / "
+        "1.30; 1.29 and earlier are EOL."
     ),
     cypher_query=f"""
     MATCH (e:EKSCluster)

--- a/cartography/rules/data/rules/identity_administration_privileges.py
+++ b/cartography/rules/data/rules/identity_administration_privileges.py
@@ -183,8 +183,17 @@ _azure_account_manipulation_permissions = Fact(
          [a IN coalesce(perm.actions, [])
             WHERE a IN patterns OR a = 'Microsoft.Authorization/*' OR a = '*'] AS matched
     WHERE size(matched) > 0
-      AND NOT ANY(na IN coalesce(perm.not_actions, [])
-                  WHERE na = '*' OR na IN matched)
+      // Shadow matched actions if a not_action equals '*', equals one of
+      // them, or is a trailing-wildcard prefix. Inner wildcards
+      // (e.g. Microsoft.Authorization/*/write) are not currently expanded.
+      AND NOT ANY(na IN coalesce(perm.not_actions, []) WHERE
+            na = '*'
+            OR na IN matched
+            OR (
+              na ENDS WITH '*'
+              AND ANY(a IN matched WHERE a STARTS WITH split(na, '*')[0])
+            )
+          )
     RETURN DISTINCT
         sub.id AS account_id,
         sub.id AS account,

--- a/cartography/rules/data/rules/identity_administration_privileges.py
+++ b/cartography/rules/data/rules/identity_administration_privileges.py
@@ -233,13 +233,22 @@ _azure_account_manipulation_permissions = Fact(
     MATCH p3=(principal)-[:HAS_ROLE_ASSIGNMENT]->(ra)
     WHERE any(label IN labels(principal)
               WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal'])
-      AND any(a IN coalesce(perm.actions, []) WHERE
-        a IN [
-          'Microsoft.Authorization/roleAssignments/write',
-          'Microsoft.Authorization/roleDefinitions/write',
-          'Microsoft.Authorization/*/write',
-          'Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action'
-        ] OR a = 'Microsoft.Authorization/*' OR a = '*')
+      // Mirror the finding: at least one searched pattern is granted by
+      // actions and is NOT shadowed by not_actions (Contributor-style
+      // not_actions like `Microsoft.Authorization/*/Write` correctly drop
+      // the matching patterns from the visual too).
+      AND ANY(p IN [
+            'Microsoft.Authorization/roleAssignments/write',
+            'Microsoft.Authorization/roleAssignments/delete',
+            'Microsoft.Authorization/roleDefinitions/write',
+            'Microsoft.Authorization/roleDefinitions/delete',
+            'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action'
+        ]
+        WHERE ANY(a IN coalesce(perm.actions, []) WHERE
+                  toLower(p) =~ replace(replace(toLower(a), '.', '[.]'), '*', '.*'))
+          AND NOT ANY(na IN coalesce(perm.not_actions, []) WHERE
+                  toLower(p) =~ replace(replace(toLower(na), '.', '[.]'), '*', '.*'))
+      )
     RETURN *
     """,
     cypher_count_query="""

--- a/cartography/rules/data/rules/identity_administration_privileges.py
+++ b/cartography/rules/data/rules/identity_administration_privileges.py
@@ -82,6 +82,148 @@ _aws_account_manipulation_permissions = Fact(
 )
 
 
+# GCP
+_gcp_account_manipulation_permissions = Fact(
+    id="gcp_account_manipulation_permissions",
+    name="GCP Principals with Identity Administration Permissions",
+    description=(
+        "GCP principals (service accounts, users, groups) bound to a role "
+        "that grants permissions to create, update, or impersonate IAM "
+        "identities. Includes role wildcards (`iam.*`, `*`) and the most "
+        "common identity-administration permissions: "
+        "iam.serviceAccounts.create / actAs / setIamPolicy / "
+        "iam.serviceAccountKeys.create / iam.roles.create / iam.roles.update."
+    ),
+    cypher_query="""
+    MATCH (project:GCPProject)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH (binding)-[:GRANTS_ROLE]->(role:GCPRole)
+    WITH project, principal, role,
+        [
+            'iam.serviceAccounts.create',
+            'iam.serviceAccounts.actAs',
+            'iam.serviceAccounts.setIamPolicy',
+            'iam.serviceAccounts.update',
+            'iam.serviceAccountKeys.create',
+            'iam.roles.create',
+            'iam.roles.update',
+            'resourcemanager.projects.setIamPolicy'
+        ] AS patterns
+    WITH project, principal, role, patterns,
+         [perm IN coalesce(role.permissions, [])
+            WHERE perm IN patterns OR perm = 'iam.*' OR perm = '*'] AS matched
+    WHERE size(matched) > 0
+    RETURN DISTINCT
+        project.id AS account_id,
+        project.id AS account,
+        coalesce(principal.email, principal.id) AS principal_name,
+        principal.id AS principal_identifier,
+        [label IN labels(principal) WHERE label <> 'GCPPrincipal'][0] AS principal_type,
+        role.name AS policy_name,
+        matched AS actions,
+        [project.id] AS resources
+    ORDER BY account, principal_name
+    """,
+    cypher_visual_query="""
+    MATCH p1=(project:GCPProject)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH p2=(binding)-[:GRANTS_ROLE]->(role:GCPRole)
+    WHERE ANY(perm IN coalesce(role.permissions, []) WHERE
+        perm IN [
+            'iam.serviceAccounts.create',
+            'iam.serviceAccounts.actAs',
+            'iam.serviceAccounts.setIamPolicy',
+            'iam.serviceAccounts.update',
+            'iam.serviceAccountKeys.create',
+            'iam.roles.create',
+            'iam.roles.update',
+            'resourcemanager.projects.setIamPolicy'
+        ]
+        OR perm = 'iam.*' OR perm = '*'
+    )
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (principal:GCPPrincipal)
+    RETURN COUNT(principal) AS count
+    """,
+    asset_id_field="principal_identifier",
+    module=Module.GCP,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+# Azure
+_azure_account_manipulation_permissions = Fact(
+    id="azure_account_manipulation_permissions",
+    name="Azure Principals with Identity Administration Permissions",
+    description=(
+        "Entra principals (users, groups, service principals) holding a role "
+        "assignment whose role definition grants permissions to manage role "
+        "assignments, role definitions, or directory-level identities. "
+        "Matches `Microsoft.Authorization/*/write`, "
+        "`Microsoft.Authorization/roleAssignments/write`, "
+        "`Microsoft.Authorization/roleDefinitions/write`, "
+        "`Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action`, "
+        "and the broader `*` wildcard. Excludes assignments shadowed by "
+        "matching `not_actions`."
+    ),
+    cypher_query="""
+    MATCH (sub:AzureSubscription)-[:RESOURCE]->(ra:AzureRoleAssignment)
+    MATCH (ra)-[:ROLE_ASSIGNED]->(rd:AzureRoleDefinition)-[:HAS_PERMISSIONS]->(perm:AzurePermissions)
+    MATCH (principal)-[:HAS_ROLE_ASSIGNMENT]->(ra)
+    WHERE any(label IN labels(principal)
+              WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal'])
+    WITH sub, ra, rd, perm, principal,
+        [
+            'Microsoft.Authorization/roleAssignments/write',
+            'Microsoft.Authorization/roleDefinitions/write',
+            'Microsoft.Authorization/*/write',
+            'Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action'
+        ] AS patterns
+    WITH sub, ra, rd, perm, principal, patterns,
+         [a IN coalesce(perm.actions, [])
+            WHERE a IN patterns OR a = 'Microsoft.Authorization/*' OR a = '*'] AS matched
+    WHERE size(matched) > 0
+      AND NOT ANY(na IN coalesce(perm.not_actions, [])
+                  WHERE na = '*' OR na IN matched)
+    RETURN DISTINCT
+        sub.id AS account_id,
+        sub.id AS account,
+        coalesce(principal.user_principal_name,
+                 principal.display_name,
+                 principal.id) AS principal_name,
+        principal.id AS principal_identifier,
+        [label IN labels(principal)
+            WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal']][0] AS principal_type,
+        rd.role_name AS policy_name,
+        matched AS actions,
+        [ra.scope] AS resources
+    ORDER BY account, principal_name
+    """,
+    cypher_visual_query="""
+    MATCH p1=(sub:AzureSubscription)-[:RESOURCE]->(ra:AzureRoleAssignment)
+    MATCH p2=(ra)-[:ROLE_ASSIGNED]->(rd:AzureRoleDefinition)-[:HAS_PERMISSIONS]->(perm:AzurePermissions)
+    MATCH p3=(principal)-[:HAS_ROLE_ASSIGNMENT]->(ra)
+    WHERE any(label IN labels(principal)
+              WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal'])
+      AND any(a IN coalesce(perm.actions, []) WHERE
+        a IN [
+          'Microsoft.Authorization/roleAssignments/write',
+          'Microsoft.Authorization/roleDefinitions/write',
+          'Microsoft.Authorization/*/write',
+          'Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action'
+        ] OR a = 'Microsoft.Authorization/*' OR a = '*')
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (ra:AzureRoleAssignment)
+    RETURN COUNT(ra) AS count
+    """,
+    asset_id_field="principal_identifier",
+    module=Module.AZURE,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
 # Rule
 class IdentityAdministrationPrivileges(Finding):
     principal_name: str | None = None
@@ -102,7 +244,11 @@ identity_administration_privileges = Rule(
         "(users/roles/groups) and their bindings—classic escalation surface."
     ),
     output_model=IdentityAdministrationPrivileges,
-    facts=(_aws_account_manipulation_permissions,),
+    facts=(
+        _aws_account_manipulation_permissions,
+        _azure_account_manipulation_permissions,
+        _gcp_account_manipulation_permissions,
+    ),
     tags=(
         "iam",
         "stride:elevation_of_privilege",

--- a/cartography/rules/data/rules/identity_administration_privileges.py
+++ b/cartography/rules/data/rules/identity_administration_privileges.py
@@ -98,7 +98,7 @@ _gcp_account_manipulation_permissions = Fact(
     MATCH (binding:GCPPolicyBinding)-[:APPLIES_TO]->(scope)
     WHERE any(label IN labels(scope)
               WHERE label IN ['GCPProject', 'GCPFolder', 'GCPOrganization'])
-    MATCH (binding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH (principal:GCPPrincipal)-[:HAS_ALLOW_POLICY]->(binding)
     MATCH (binding)-[:GRANTS_ROLE]->(role:GCPRole)
     WITH scope, principal, role,
         [
@@ -129,7 +129,7 @@ _gcp_account_manipulation_permissions = Fact(
     ORDER BY account, principal_name
     """,
     cypher_visual_query="""
-    MATCH p1=(scope)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH p1=(principal:GCPPrincipal)-[:HAS_ALLOW_POLICY]->(binding:GCPPolicyBinding)-[:APPLIES_TO]->(scope)
     WHERE any(label IN labels(scope)
               WHERE label IN ['GCPProject', 'GCPFolder', 'GCPOrganization'])
     MATCH p2=(binding)-[:GRANTS_ROLE]->(role:GCPRole)

--- a/cartography/rules/data/rules/identity_administration_privileges.py
+++ b/cartography/rules/data/rules/identity_administration_privileges.py
@@ -95,9 +95,12 @@ _gcp_account_manipulation_permissions = Fact(
         "iam.serviceAccountKeys.create / iam.roles.create / iam.roles.update."
     ),
     cypher_query="""
-    MATCH (project:GCPProject)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH (binding:GCPPolicyBinding)-[:APPLIES_TO]->(scope)
+    WHERE any(label IN labels(scope)
+              WHERE label IN ['GCPProject', 'GCPFolder', 'GCPOrganization'])
+    MATCH (binding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
     MATCH (binding)-[:GRANTS_ROLE]->(role:GCPRole)
-    WITH project, principal, role,
+    WITH scope, principal, role,
         [
             'iam.serviceAccounts.create',
             'iam.serviceAccounts.actAs',
@@ -106,25 +109,29 @@ _gcp_account_manipulation_permissions = Fact(
             'iam.serviceAccountKeys.create',
             'iam.roles.create',
             'iam.roles.update',
-            'resourcemanager.projects.setIamPolicy'
+            'resourcemanager.projects.setIamPolicy',
+            'resourcemanager.folders.setIamPolicy',
+            'resourcemanager.organizations.setIamPolicy'
         ] AS patterns
-    WITH project, principal, role, patterns,
+    WITH scope, principal, role, patterns,
          [perm IN coalesce(role.permissions, [])
             WHERE perm IN patterns OR perm = 'iam.*' OR perm = '*'] AS matched
     WHERE size(matched) > 0
     RETURN DISTINCT
-        project.id AS account_id,
-        project.id AS account,
+        scope.id AS account_id,
+        scope.id AS account,
         coalesce(principal.email, principal.id) AS principal_name,
         principal.id AS principal_identifier,
         [label IN labels(principal) WHERE label <> 'GCPPrincipal'][0] AS principal_type,
         role.name AS policy_name,
         matched AS actions,
-        [project.id] AS resources
+        [scope.id] AS resources
     ORDER BY account, principal_name
     """,
     cypher_visual_query="""
-    MATCH p1=(project:GCPProject)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH p1=(scope)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    WHERE any(label IN labels(scope)
+              WHERE label IN ['GCPProject', 'GCPFolder', 'GCPOrganization'])
     MATCH p2=(binding)-[:GRANTS_ROLE]->(role:GCPRole)
     WHERE ANY(perm IN coalesce(role.permissions, []) WHERE
         perm IN [
@@ -135,7 +142,9 @@ _gcp_account_manipulation_permissions = Fact(
             'iam.serviceAccountKeys.create',
             'iam.roles.create',
             'iam.roles.update',
-            'resourcemanager.projects.setIamPolicy'
+            'resourcemanager.projects.setIamPolicy',
+            'resourcemanager.folders.setIamPolicy',
+            'resourcemanager.organizations.setIamPolicy'
         ]
         OR perm = 'iam.*' OR perm = '*'
     )
@@ -172,28 +181,40 @@ _azure_account_manipulation_permissions = Fact(
     MATCH (principal)-[:HAS_ROLE_ASSIGNMENT]->(ra)
     WHERE any(label IN labels(principal)
               WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal'])
+    // Expand each searched pattern through the role's actions list (handles
+    // bare `*` and trailing-wildcard provider/namespace grants like
+    // `Microsoft.Authorization/*`), then subtract any pattern shadowed by
+    // not_actions. This makes roles like Contributor (actions=['*'],
+    // not_actions=['Microsoft.Authorization/*/Write', ...]) correctly drop
+    // the role-assignment / role-definition patterns.
     WITH sub, ra, rd, perm, principal,
+         coalesce(perm.actions, []) AS role_actions,
+         coalesce(perm.not_actions, []) AS role_not_actions,
         [
             'Microsoft.Authorization/roleAssignments/write',
             'Microsoft.Authorization/roleDefinitions/write',
             'Microsoft.Authorization/*/write',
             'Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action'
         ] AS patterns
-    WITH sub, ra, rd, perm, principal, patterns,
-         [a IN coalesce(perm.actions, [])
-            WHERE a IN patterns OR a = 'Microsoft.Authorization/*' OR a = '*'] AS matched
-    WHERE size(matched) > 0
-      // Shadow matched actions if a not_action equals '*', equals one of
-      // them, or is a trailing-wildcard prefix. Inner wildcards
-      // (e.g. Microsoft.Authorization/*/write) are not currently expanded.
-      AND NOT ANY(na IN coalesce(perm.not_actions, []) WHERE
-            na = '*'
-            OR na IN matched
-            OR (
-              na ENDS WITH '*'
-              AND ANY(a IN matched WHERE a STARTS WITH split(na, '*')[0])
+    WITH sub, ra, rd, perm, principal, role_not_actions,
+        [
+            p IN patterns
+            WHERE ANY(a IN role_actions WHERE
+                a = '*'
+                OR a = p
+                OR (a ENDS WITH '*' AND p STARTS WITH split(a, '*')[0])
             )
-          )
+        ] AS granted
+    WITH sub, ra, rd, perm, principal,
+        [
+            p IN granted
+            WHERE NOT ANY(na IN role_not_actions WHERE
+                na = '*'
+                OR na = p
+                OR (na ENDS WITH '*' AND p STARTS WITH split(na, '*')[0])
+            )
+        ] AS matched
+    WHERE size(matched) > 0
     RETURN DISTINCT
         sub.id AS account_id,
         sub.id AS account,

--- a/cartography/rules/data/rules/identity_administration_privileges.py
+++ b/cartography/rules/data/rules/identity_administration_privileges.py
@@ -115,14 +115,22 @@ _gcp_account_manipulation_permissions = Fact(
         ] AS patterns
     WITH scope, principal, role, patterns,
          [perm IN coalesce(role.permissions, [])
-            WHERE perm IN patterns OR perm = 'iam.*' OR perm = '*'] AS matched
+            WHERE perm IN patterns
+               OR perm = 'iam.*'
+               OR perm = 'resourcemanager.*'
+               OR perm = '*'] AS matched
     WHERE size(matched) > 0
     RETURN DISTINCT
         scope.id AS account_id,
         scope.id AS account,
         coalesce(principal.email, principal.id) AS principal_name,
         principal.id AS principal_identifier,
-        [label IN labels(principal) WHERE label <> 'GCPPrincipal'][0] AS principal_type,
+        coalesce(
+            head([l IN ['GCPServiceAccount', 'GoogleWorkspaceUser', 'GoogleWorkspaceGroup']
+                  WHERE l IN labels(principal)]),
+            head([l IN ['ServiceAccount', 'UserAccount', 'UserGroup']
+                  WHERE l IN labels(principal)])
+        ) AS principal_type,
         role.name AS policy_name,
         matched AS actions,
         [scope.id] AS resources
@@ -146,7 +154,9 @@ _gcp_account_manipulation_permissions = Fact(
             'resourcemanager.folders.setIamPolicy',
             'resourcemanager.organizations.setIamPolicy'
         ]
-        OR perm = 'iam.*' OR perm = '*'
+        OR perm = 'iam.*'
+        OR perm = 'resourcemanager.*'
+        OR perm = '*'
     )
     RETURN *
     """,

--- a/cartography/rules/data/rules/identity_administration_privileges.py
+++ b/cartography/rules/data/rules/identity_administration_privileges.py
@@ -196,7 +196,7 @@ _azure_account_manipulation_permissions = Fact(
             'Microsoft.Authorization/roleAssignments/delete',
             'Microsoft.Authorization/roleDefinitions/write',
             'Microsoft.Authorization/roleDefinitions/delete',
-            'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action'
+            'Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action'
         ] AS patterns
     WITH sub, ra, rd, perm, principal, role_not_actions,
         [
@@ -242,7 +242,7 @@ _azure_account_manipulation_permissions = Fact(
             'Microsoft.Authorization/roleAssignments/delete',
             'Microsoft.Authorization/roleDefinitions/write',
             'Microsoft.Authorization/roleDefinitions/delete',
-            'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action'
+            'Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action'
         ]
         WHERE ANY(a IN coalesce(perm.actions, []) WHERE
                   toLower(p) =~ replace(replace(toLower(a), '.', '[.]'), '*', '.*'))

--- a/cartography/rules/data/rules/identity_administration_privileges.py
+++ b/cartography/rules/data/rules/identity_administration_privileges.py
@@ -181,37 +181,35 @@ _azure_account_manipulation_permissions = Fact(
     MATCH (principal)-[:HAS_ROLE_ASSIGNMENT]->(ra)
     WHERE any(label IN labels(principal)
               WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal'])
-    // Expand each searched pattern through the role's actions list (handles
-    // bare `*` and trailing-wildcard provider/namespace grants like
-    // `Microsoft.Authorization/*`), then subtract any pattern shadowed by
-    // not_actions. This makes roles like Contributor (actions=['*'],
-    // not_actions=['Microsoft.Authorization/*/Write', ...]) correctly drop
-    // the role-assignment / role-definition patterns.
+    // For each literal RBAC pattern, treat each action / not_action as a
+    // case-insensitive glob: replace `.` with the regex char class `[.]`
+    // (so dots are literal), then `*` with `.*`. A `*` anywhere in the
+    // entry now correctly matches. This makes the built-in Contributor
+    // role (actions=['*'], not_actions=['Microsoft.Authorization/*/Write',
+    // 'Microsoft.Authorization/*/Delete', ...]) drop the role-assignment
+    // / role-definition / managed-identity patterns rather than flag.
     WITH sub, ra, rd, perm, principal,
          coalesce(perm.actions, []) AS role_actions,
          coalesce(perm.not_actions, []) AS role_not_actions,
         [
             'Microsoft.Authorization/roleAssignments/write',
+            'Microsoft.Authorization/roleAssignments/delete',
             'Microsoft.Authorization/roleDefinitions/write',
-            'Microsoft.Authorization/*/write',
-            'Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action'
+            'Microsoft.Authorization/roleDefinitions/delete',
+            'Microsoft.ManagedIdentity/userAssignedIdentities/assign/action'
         ] AS patterns
     WITH sub, ra, rd, perm, principal, role_not_actions,
         [
             p IN patterns
             WHERE ANY(a IN role_actions WHERE
-                a = '*'
-                OR a = p
-                OR (a ENDS WITH '*' AND p STARTS WITH split(a, '*')[0])
+                toLower(p) =~ replace(replace(toLower(a), '.', '[.]'), '*', '.*')
             )
         ] AS granted
     WITH sub, ra, rd, perm, principal,
         [
             p IN granted
             WHERE NOT ANY(na IN role_not_actions WHERE
-                na = '*'
-                OR na = p
-                OR (na ENDS WITH '*' AND p STARTS WITH split(na, '*')[0])
+                toLower(p) =~ replace(replace(toLower(na), '.', '[.]'), '*', '.*')
             )
         ] AS matched
     WHERE size(matched) > 0

--- a/cartography/rules/data/rules/mfa_missing.py
+++ b/cartography/rules/data/rules/mfa_missing.py
@@ -5,6 +5,54 @@ from cartography.rules.spec.model import Module
 from cartography.rules.spec.model import Rule
 
 # Facts
+_missing_mfa_ontology = Fact(
+    id="missing-mfa-ontology",
+    name="UserAccount nodes with MFA explicitly disabled",
+    description=(
+        "Active user accounts whose `_ont_has_mfa` ontology field is "
+        "explicitly false. Built on the cross-cloud `UserAccount` "
+        "semantic label so it covers every provider that maps the "
+        "`has_mfa` ontology field, currently: Cloudflare, Slack, "
+        "GitHub, GSuite / Google Workspace, JumpCloud, Keycloak, "
+        "LastPass, OCI, Scaleway, Sentry. Providers that do not "
+        "expose an MFA flag are intentionally skipped (NULL means "
+        "unknown, not missing). AWS uses a separate fact since it "
+        "models MFA via the `:MFA_DEVICE` edge instead of an ontology "
+        "boolean."
+    ),
+    module=Module.CROSS_CLOUD,
+    cypher_query="""
+    MATCH (a:UserAccount)
+    WHERE a._ont_has_mfa = false
+      AND COALESCE(a._ont_active, true)
+      AND NOT COALESCE(a._ont_inactive, false)
+    RETURN
+        a.id AS id,
+        a._ont_email AS email,
+        a._ont_firstname AS firstname,
+        a._ont_lastname AS lastname,
+        a._ont_source AS status
+    ORDER BY id
+    """,
+    cypher_visual_query="""
+    MATCH (a:UserAccount)
+    WHERE a._ont_has_mfa = false
+      AND COALESCE(a._ont_active, true)
+      AND NOT COALESCE(a._ont_inactive, false)
+    RETURN a
+    """,
+    cypher_count_query="""
+    MATCH (a:UserAccount)
+    WHERE a._ont_has_mfa IS NOT NULL
+      AND COALESCE(a._ont_active, true)
+      AND NOT COALESCE(a._ont_inactive, false)
+    RETURN COUNT(a) AS count
+    """,
+    asset_id_field="id",
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
 _missing_mfa_aws = Fact(
     id="missing-mfa-aws",
     name="AWS IAM users without an MFA device",
@@ -15,7 +63,9 @@ _missing_mfa_aws = Fact(
         "is surfaced via the `firstname` field so callers can prioritise "
         "users who have actually signed in via the console. The string "
         "`passwordlastused` is left empty rather than NULL by the AWS "
-        "intel transform, so the typed `_dt` field is the reliable signal."
+        "intel transform, so the typed `_dt` field is the reliable signal. "
+        "AWS is handled outside the cross-cloud ontology fact because the "
+        "AWSUser ontology mapping does not carry an MFA boolean."
     ),
     module=Module.AWS,
     cypher_query="""
@@ -45,29 +95,6 @@ _missing_mfa_aws = Fact(
 )
 
 
-_missing_mfa_cloudflare = Fact(
-    id="missing-mfa-cloudflare",
-    name="Cloudflare members with disabled MFA",
-    description="Finds Cloudflare member accounts that have Multi-Factor Authentication disabled.",
-    module=Module.CLOUDFLARE,
-    cypher_query="""
-    MATCH (m:CloudflareMember)
-    WHERE m.two_factor_authentication_enabled = false
-    RETURN m.id AS id, m.email AS email, m.firstname AS firstname, m.lastname AS lastname, m.status AS status
-    """,
-    cypher_visual_query="""
-    MATCH (m:CloudflareMember)
-    WHERE m.two_factor_authentication_enabled = false
-    RETURN m
-    """,
-    cypher_count_query="""
-    MATCH (m:CloudflareMember)
-    RETURN COUNT(m) AS count
-    """,
-    maturity=Maturity.EXPERIMENTAL,
-)
-
-
 # Rule
 class MFARuleOutput(Finding):
     email: str | None = None
@@ -80,13 +107,17 @@ class MFARuleOutput(Finding):
 missing_mfa_rule = Rule(
     id="mfa-missing",
     name="User accounts missing MFA",
-    description="Detects user accounts that do not have Multi-Factor Authentication enabled.",
+    description=(
+        "Detects user accounts that do not have Multi-Factor Authentication "
+        "enabled. The cross-cloud ontology fact covers any provider that "
+        "exposes the `has_mfa` UserAccount ontology field; AWS is handled "
+        "separately via the `:MFA_DEVICE` edge."
+    ),
     output_model=MFARuleOutput,
     tags=("identity",),
     facts=(
-        # TODO: _missing_mfa_slack,
         _missing_mfa_aws,
-        _missing_mfa_cloudflare,
+        _missing_mfa_ontology,
     ),
-    version="0.1.0",
+    version="0.2.0",
 )

--- a/cartography/rules/data/rules/mfa_missing.py
+++ b/cartography/rules/data/rules/mfa_missing.py
@@ -5,6 +5,44 @@ from cartography.rules.spec.model import Module
 from cartography.rules.spec.model import Rule
 
 # Facts
+_missing_mfa_aws = Fact(
+    id="missing-mfa-aws",
+    name="AWS IAM users without an MFA device",
+    description=(
+        "AWS IAM users that are not associated with any MFA device. The "
+        "check looks for the absence of a `:MFA_DEVICE` relationship from "
+        "an AWSMfaDevice. Console access (passwordlastused IS NOT NULL) is "
+        "surfaced via the `firstname` field so callers can prioritise "
+        "users who have actually signed in via the console."
+    ),
+    module=Module.AWS,
+    cypher_query="""
+    MATCH (account:AWSAccount)-[:RESOURCE]->(user:AWSUser)
+    WHERE NOT (user)<-[:MFA_DEVICE]-(:AWSMfaDevice)
+    RETURN
+        user.arn AS id,
+        user.name AS email,
+        CASE WHEN user.passwordlastused IS NOT NULL
+             THEN 'console-active'
+             ELSE 'programmatic-only' END AS firstname,
+        account.name AS lastname,
+        'no-mfa' AS status
+    ORDER BY id
+    """,
+    cypher_visual_query="""
+    MATCH p=(account:AWSAccount)-[:RESOURCE]->(user:AWSUser)
+    WHERE NOT (user)<-[:MFA_DEVICE]-(:AWSMfaDevice)
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (user:AWSUser)
+    RETURN COUNT(user) AS count
+    """,
+    asset_id_field="id",
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
 _missing_mfa_cloudflare = Fact(
     id="missing-mfa-cloudflare",
     name="Cloudflare members with disabled MFA",
@@ -34,6 +72,7 @@ class MFARuleOutput(Finding):
     id: str | None = None
     firstname: str | None = None
     lastname: str | None = None
+    status: str | None = None
 
 
 missing_mfa_rule = Rule(
@@ -44,6 +83,7 @@ missing_mfa_rule = Rule(
     tags=("identity",),
     facts=(
         # TODO: _missing_mfa_slack,
+        _missing_mfa_aws,
         _missing_mfa_cloudflare,
     ),
     version="0.1.0",

--- a/cartography/rules/data/rules/mfa_missing.py
+++ b/cartography/rules/data/rules/mfa_missing.py
@@ -11,9 +11,11 @@ _missing_mfa_aws = Fact(
     description=(
         "AWS IAM users that are not associated with any MFA device. The "
         "check looks for the absence of a `:MFA_DEVICE` relationship from "
-        "an AWSMfaDevice. Console access (passwordlastused IS NOT NULL) is "
-        "surfaced via the `firstname` field so callers can prioritise "
-        "users who have actually signed in via the console."
+        "an AWSMfaDevice. Console access (passwordlastused_dt IS NOT NULL) "
+        "is surfaced via the `firstname` field so callers can prioritise "
+        "users who have actually signed in via the console. The string "
+        "`passwordlastused` is left empty rather than NULL by the AWS "
+        "intel transform, so the typed `_dt` field is the reliable signal."
     ),
     module=Module.AWS,
     cypher_query="""
@@ -22,7 +24,7 @@ _missing_mfa_aws = Fact(
     RETURN
         user.arn AS id,
         user.name AS email,
-        CASE WHEN user.passwordlastused IS NOT NULL
+        CASE WHEN user.passwordlastused_dt IS NOT NULL
              THEN 'console-active'
              ELSE 'programmatic-only' END AS firstname,
         account.name AS lastname,

--- a/cartography/rules/data/rules/mfa_missing.py
+++ b/cartography/rules/data/rules/mfa_missing.py
@@ -70,7 +70,7 @@ _missing_mfa_aws = Fact(
     module=Module.AWS,
     cypher_query="""
     MATCH (account:AWSAccount)-[:RESOURCE]->(user:AWSUser)
-    WHERE NOT (user)<-[:MFA_DEVICE]-(:AWSMfaDevice)
+    WHERE NOT (user)-[:MFA_DEVICE]->(:AWSMfaDevice)
     RETURN
         user.arn AS id,
         user.name AS email,
@@ -83,7 +83,7 @@ _missing_mfa_aws = Fact(
     """,
     cypher_visual_query="""
     MATCH p=(account:AWSAccount)-[:RESOURCE]->(user:AWSUser)
-    WHERE NOT (user)<-[:MFA_DEVICE]-(:AWSMfaDevice)
+    WHERE NOT (user)-[:MFA_DEVICE]->(:AWSMfaDevice)
     RETURN *
     """,
     cypher_count_query="""

--- a/cartography/rules/data/rules/policy_administration_privileges.py
+++ b/cartography/rules/data/rules/policy_administration_privileges.py
@@ -86,6 +86,139 @@ _aws_policy_manipulation_capabilities = Fact(
 )
 
 
+# GCP
+_gcp_policy_manipulation_capabilities = Fact(
+    id="gcp_policy_manipulation_capabilities",
+    name="GCP Principals with Policy Administration Permissions",
+    description=(
+        "GCP principals bound to a role that grants `setIamPolicy` on a "
+        "project, folder, or organization, or that grants role / "
+        "permission management. Indirect privilege escalation surface."
+    ),
+    cypher_query="""
+    MATCH (project:GCPProject)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH (binding)-[:GRANTS_ROLE]->(role:GCPRole)
+    WITH project, principal, role,
+        [
+            'resourcemanager.projects.setIamPolicy',
+            'resourcemanager.folders.setIamPolicy',
+            'resourcemanager.organizations.setIamPolicy',
+            'iam.roles.create',
+            'iam.roles.update',
+            'iam.roles.delete'
+        ] AS patterns
+    WITH project, principal, role, patterns,
+         [perm IN coalesce(role.permissions, [])
+            WHERE perm IN patterns OR perm = 'iam.*' OR perm = 'resourcemanager.*' OR perm = '*'] AS matched
+    WHERE size(matched) > 0
+    UNWIND matched AS action
+    RETURN DISTINCT
+        project.id AS account,
+        project.id AS account_id,
+        coalesce(principal.email, principal.id) AS principal_name,
+        principal.id AS principal_identifier,
+        [label IN labels(principal) WHERE label <> 'GCPPrincipal'][0] AS principal_type,
+        role.name AS policy_name,
+        action,
+        project.id AS resource
+    ORDER BY account, principal_name, action
+    """,
+    cypher_visual_query="""
+    MATCH p1=(project:GCPProject)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH p2=(binding)-[:GRANTS_ROLE]->(role:GCPRole)
+    WHERE ANY(perm IN coalesce(role.permissions, []) WHERE
+        perm IN [
+            'resourcemanager.projects.setIamPolicy',
+            'resourcemanager.folders.setIamPolicy',
+            'resourcemanager.organizations.setIamPolicy',
+            'iam.roles.create',
+            'iam.roles.update',
+            'iam.roles.delete'
+        ]
+        OR perm = 'iam.*' OR perm = 'resourcemanager.*' OR perm = '*'
+    )
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (principal:GCPPrincipal)
+    RETURN COUNT(principal) AS count
+    """,
+    asset_id_field="principal_identifier",
+    module=Module.GCP,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+# Azure
+_azure_policy_manipulation_capabilities = Fact(
+    id="azure_policy_manipulation_capabilities",
+    name="Azure Principals with Policy Administration Permissions",
+    description=(
+        "Entra principals holding a role assignment whose role definition "
+        "grants permissions to manage role definitions or write at the "
+        "Microsoft.Authorization scope. Indirect privilege escalation "
+        "surface (creating roles, granting them, etc.)."
+    ),
+    cypher_query="""
+    MATCH (sub:AzureSubscription)-[:RESOURCE]->(ra:AzureRoleAssignment)
+    MATCH (ra)-[:ROLE_ASSIGNED]->(rd:AzureRoleDefinition)-[:HAS_PERMISSIONS]->(perm:AzurePermissions)
+    MATCH (principal)-[:HAS_ROLE_ASSIGNMENT]->(ra)
+    WHERE any(label IN labels(principal)
+              WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal'])
+    WITH sub, ra, rd, perm, principal,
+        [
+            'Microsoft.Authorization/roleDefinitions/write',
+            'Microsoft.Authorization/roleDefinitions/delete',
+            'Microsoft.Authorization/policyDefinitions/write',
+            'Microsoft.Authorization/policyAssignments/write',
+            'Microsoft.Authorization/*/write'
+        ] AS patterns
+    WITH sub, ra, rd, perm, principal, patterns,
+         [a IN coalesce(perm.actions, [])
+            WHERE a IN patterns OR a = 'Microsoft.Authorization/*' OR a = '*'] AS matched
+    WHERE size(matched) > 0
+      AND NOT ANY(na IN coalesce(perm.not_actions, []) WHERE na = '*' OR na IN matched)
+    UNWIND matched AS action
+    RETURN DISTINCT
+        sub.id AS account,
+        sub.id AS account_id,
+        coalesce(principal.user_principal_name,
+                 principal.display_name,
+                 principal.id) AS principal_name,
+        principal.id AS principal_identifier,
+        [label IN labels(principal)
+            WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal']][0] AS principal_type,
+        rd.role_name AS policy_name,
+        action,
+        ra.scope AS resource
+    ORDER BY account, principal_name, action
+    """,
+    cypher_visual_query="""
+    MATCH p1=(sub:AzureSubscription)-[:RESOURCE]->(ra:AzureRoleAssignment)
+    MATCH p2=(ra)-[:ROLE_ASSIGNED]->(rd:AzureRoleDefinition)-[:HAS_PERMISSIONS]->(perm:AzurePermissions)
+    MATCH p3=(principal)-[:HAS_ROLE_ASSIGNMENT]->(ra)
+    WHERE any(label IN labels(principal)
+              WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal'])
+      AND any(a IN coalesce(perm.actions, []) WHERE
+        a IN [
+          'Microsoft.Authorization/roleDefinitions/write',
+          'Microsoft.Authorization/roleDefinitions/delete',
+          'Microsoft.Authorization/policyDefinitions/write',
+          'Microsoft.Authorization/policyAssignments/write',
+          'Microsoft.Authorization/*/write'
+        ] OR a = 'Microsoft.Authorization/*' OR a = '*')
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (ra:AzureRoleAssignment)
+    RETURN COUNT(ra) AS count
+    """,
+    asset_id_field="principal_identifier",
+    module=Module.AZURE,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
 # Findings
 class PolicyAdministrationPrivileges(Finding):
     principal_name: str | None = None
@@ -106,7 +239,11 @@ policy_administration_privileges = Rule(
         "indirect privilege escalation."
     ),
     output_model=PolicyAdministrationPrivileges,
-    facts=(_aws_policy_manipulation_capabilities,),
+    facts=(
+        _aws_policy_manipulation_capabilities,
+        _azure_policy_manipulation_capabilities,
+        _gcp_policy_manipulation_capabilities,
+    ),
     tags=(
         "iam",
         "stride:elevation_of_privilege",

--- a/cartography/rules/data/rules/policy_administration_privileges.py
+++ b/cartography/rules/data/rules/policy_administration_privileges.py
@@ -170,10 +170,11 @@ _azure_policy_manipulation_capabilities = Fact(
     MATCH (principal)-[:HAS_ROLE_ASSIGNMENT]->(ra)
     WHERE any(label IN labels(principal)
               WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal'])
-    // Expand each searched pattern through the role's actions, then subtract
-    // any pattern shadowed by not_actions, so wildcards like `*` and
-    // `Microsoft.Authorization/*` interact correctly with not_actions like
-    // `Microsoft.Authorization/*/Write` (built-in Contributor pattern).
+    // Treat each action / not_action as a case-insensitive glob: `.` is
+    // escaped to the regex char class `[.]`, `*` becomes `.*`. A `*`
+    // anywhere now correctly matches; built-in Contributor with
+    // not_actions like `Microsoft.Authorization/*/Write` drops the
+    // matching patterns instead of letting them flag.
     WITH sub, ra, rd, perm, principal,
          coalesce(perm.actions, []) AS role_actions,
          coalesce(perm.not_actions, []) AS role_not_actions,
@@ -181,25 +182,20 @@ _azure_policy_manipulation_capabilities = Fact(
             'Microsoft.Authorization/roleDefinitions/write',
             'Microsoft.Authorization/roleDefinitions/delete',
             'Microsoft.Authorization/policyDefinitions/write',
-            'Microsoft.Authorization/policyAssignments/write',
-            'Microsoft.Authorization/*/write'
+            'Microsoft.Authorization/policyAssignments/write'
         ] AS patterns
     WITH sub, ra, rd, perm, principal, role_not_actions,
         [
             p IN patterns
             WHERE ANY(a IN role_actions WHERE
-                a = '*'
-                OR a = p
-                OR (a ENDS WITH '*' AND p STARTS WITH split(a, '*')[0])
+                toLower(p) =~ replace(replace(toLower(a), '.', '[.]'), '*', '.*')
             )
         ] AS granted
     WITH sub, ra, rd, perm, principal,
         [
             p IN granted
             WHERE NOT ANY(na IN role_not_actions WHERE
-                na = '*'
-                OR na = p
-                OR (na ENDS WITH '*' AND p STARTS WITH split(na, '*')[0])
+                toLower(p) =~ replace(replace(toLower(na), '.', '[.]'), '*', '.*')
             )
         ] AS matched
     WHERE size(matched) > 0

--- a/cartography/rules/data/rules/policy_administration_privileges.py
+++ b/cartography/rules/data/rules/policy_administration_privileges.py
@@ -96,9 +96,12 @@ _gcp_policy_manipulation_capabilities = Fact(
         "permission management. Indirect privilege escalation surface."
     ),
     cypher_query="""
-    MATCH (project:GCPProject)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH (binding:GCPPolicyBinding)-[:APPLIES_TO]->(scope)
+    WHERE any(label IN labels(scope)
+              WHERE label IN ['GCPProject', 'GCPFolder', 'GCPOrganization'])
+    MATCH (binding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
     MATCH (binding)-[:GRANTS_ROLE]->(role:GCPRole)
-    WITH project, principal, role,
+    WITH scope, principal, role,
         [
             'resourcemanager.projects.setIamPolicy',
             'resourcemanager.folders.setIamPolicy',
@@ -107,24 +110,26 @@ _gcp_policy_manipulation_capabilities = Fact(
             'iam.roles.update',
             'iam.roles.delete'
         ] AS patterns
-    WITH project, principal, role, patterns,
+    WITH scope, principal, role, patterns,
          [perm IN coalesce(role.permissions, [])
             WHERE perm IN patterns OR perm = 'iam.*' OR perm = 'resourcemanager.*' OR perm = '*'] AS matched
     WHERE size(matched) > 0
     UNWIND matched AS action
     RETURN DISTINCT
-        project.id AS account,
-        project.id AS account_id,
+        scope.id AS account,
+        scope.id AS account_id,
         coalesce(principal.email, principal.id) AS principal_name,
         principal.id AS principal_identifier,
         [label IN labels(principal) WHERE label <> 'GCPPrincipal'][0] AS principal_type,
         role.name AS policy_name,
         action,
-        project.id AS resource
+        scope.id AS resource
     ORDER BY account, principal_name, action
     """,
     cypher_visual_query="""
-    MATCH p1=(project:GCPProject)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH p1=(scope)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    WHERE any(label IN labels(scope)
+              WHERE label IN ['GCPProject', 'GCPFolder', 'GCPOrganization'])
     MATCH p2=(binding)-[:GRANTS_ROLE]->(role:GCPRole)
     WHERE ANY(perm IN coalesce(role.permissions, []) WHERE
         perm IN [
@@ -165,7 +170,13 @@ _azure_policy_manipulation_capabilities = Fact(
     MATCH (principal)-[:HAS_ROLE_ASSIGNMENT]->(ra)
     WHERE any(label IN labels(principal)
               WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal'])
+    // Expand each searched pattern through the role's actions, then subtract
+    // any pattern shadowed by not_actions, so wildcards like `*` and
+    // `Microsoft.Authorization/*` interact correctly with not_actions like
+    // `Microsoft.Authorization/*/Write` (built-in Contributor pattern).
     WITH sub, ra, rd, perm, principal,
+         coalesce(perm.actions, []) AS role_actions,
+         coalesce(perm.not_actions, []) AS role_not_actions,
         [
             'Microsoft.Authorization/roleDefinitions/write',
             'Microsoft.Authorization/roleDefinitions/delete',
@@ -173,21 +184,25 @@ _azure_policy_manipulation_capabilities = Fact(
             'Microsoft.Authorization/policyAssignments/write',
             'Microsoft.Authorization/*/write'
         ] AS patterns
-    WITH sub, ra, rd, perm, principal, patterns,
-         [a IN coalesce(perm.actions, [])
-            WHERE a IN patterns OR a = 'Microsoft.Authorization/*' OR a = '*'] AS matched
-    WHERE size(matched) > 0
-      // Shadow matched actions if a not_action equals '*', equals one of
-      // them, or is a trailing-wildcard prefix. Inner wildcards
-      // (e.g. Microsoft.Authorization/*/write) are not currently expanded.
-      AND NOT ANY(na IN coalesce(perm.not_actions, []) WHERE
-            na = '*'
-            OR na IN matched
-            OR (
-              na ENDS WITH '*'
-              AND ANY(a IN matched WHERE a STARTS WITH split(na, '*')[0])
+    WITH sub, ra, rd, perm, principal, role_not_actions,
+        [
+            p IN patterns
+            WHERE ANY(a IN role_actions WHERE
+                a = '*'
+                OR a = p
+                OR (a ENDS WITH '*' AND p STARTS WITH split(a, '*')[0])
             )
-          )
+        ] AS granted
+    WITH sub, ra, rd, perm, principal,
+        [
+            p IN granted
+            WHERE NOT ANY(na IN role_not_actions WHERE
+                na = '*'
+                OR na = p
+                OR (na ENDS WITH '*' AND p STARTS WITH split(na, '*')[0])
+            )
+        ] AS matched
+    WHERE size(matched) > 0
     UNWIND matched AS action
     RETURN DISTINCT
         sub.id AS account,

--- a/cartography/rules/data/rules/policy_administration_privileges.py
+++ b/cartography/rules/data/rules/policy_administration_privileges.py
@@ -177,7 +177,17 @@ _azure_policy_manipulation_capabilities = Fact(
          [a IN coalesce(perm.actions, [])
             WHERE a IN patterns OR a = 'Microsoft.Authorization/*' OR a = '*'] AS matched
     WHERE size(matched) > 0
-      AND NOT ANY(na IN coalesce(perm.not_actions, []) WHERE na = '*' OR na IN matched)
+      // Shadow matched actions if a not_action equals '*', equals one of
+      // them, or is a trailing-wildcard prefix. Inner wildcards
+      // (e.g. Microsoft.Authorization/*/write) are not currently expanded.
+      AND NOT ANY(na IN coalesce(perm.not_actions, []) WHERE
+            na = '*'
+            OR na IN matched
+            OR (
+              na ENDS WITH '*'
+              AND ANY(a IN matched WHERE a STARTS WITH split(na, '*')[0])
+            )
+          )
     UNWIND matched AS action
     RETURN DISTINCT
         sub.id AS account,

--- a/cartography/rules/data/rules/policy_administration_privileges.py
+++ b/cartography/rules/data/rules/policy_administration_privileges.py
@@ -120,7 +120,12 @@ _gcp_policy_manipulation_capabilities = Fact(
         scope.id AS account_id,
         coalesce(principal.email, principal.id) AS principal_name,
         principal.id AS principal_identifier,
-        [label IN labels(principal) WHERE label <> 'GCPPrincipal'][0] AS principal_type,
+        coalesce(
+            head([l IN ['GCPServiceAccount', 'GoogleWorkspaceUser', 'GoogleWorkspaceGroup']
+                  WHERE l IN labels(principal)]),
+            head([l IN ['ServiceAccount', 'UserAccount', 'UserGroup']
+                  WHERE l IN labels(principal)])
+        ) AS principal_type,
         role.name AS policy_name,
         action,
         scope.id AS resource

--- a/cartography/rules/data/rules/policy_administration_privileges.py
+++ b/cartography/rules/data/rules/policy_administration_privileges.py
@@ -99,7 +99,7 @@ _gcp_policy_manipulation_capabilities = Fact(
     MATCH (binding:GCPPolicyBinding)-[:APPLIES_TO]->(scope)
     WHERE any(label IN labels(scope)
               WHERE label IN ['GCPProject', 'GCPFolder', 'GCPOrganization'])
-    MATCH (binding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH (principal:GCPPrincipal)-[:HAS_ALLOW_POLICY]->(binding)
     MATCH (binding)-[:GRANTS_ROLE]->(role:GCPRole)
     WITH scope, principal, role,
         [
@@ -127,7 +127,7 @@ _gcp_policy_manipulation_capabilities = Fact(
     ORDER BY account, principal_name, action
     """,
     cypher_visual_query="""
-    MATCH p1=(scope)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)-[:HAS_ALLOW_POLICY]->(principal:GCPPrincipal)
+    MATCH p1=(principal:GCPPrincipal)-[:HAS_ALLOW_POLICY]->(binding:GCPPolicyBinding)-[:APPLIES_TO]->(scope)
     WHERE any(label IN labels(scope)
               WHERE label IN ['GCPProject', 'GCPFolder', 'GCPOrganization'])
     MATCH p2=(binding)-[:GRANTS_ROLE]->(role:GCPRole)

--- a/cartography/rules/data/rules/policy_administration_privileges.py
+++ b/cartography/rules/data/rules/policy_administration_privileges.py
@@ -220,14 +220,19 @@ _azure_policy_manipulation_capabilities = Fact(
     MATCH p3=(principal)-[:HAS_ROLE_ASSIGNMENT]->(ra)
     WHERE any(label IN labels(principal)
               WHERE label IN ['EntraUser', 'EntraGroup', 'EntraServicePrincipal'])
-      AND any(a IN coalesce(perm.actions, []) WHERE
-        a IN [
-          'Microsoft.Authorization/roleDefinitions/write',
-          'Microsoft.Authorization/roleDefinitions/delete',
-          'Microsoft.Authorization/policyDefinitions/write',
-          'Microsoft.Authorization/policyAssignments/write',
-          'Microsoft.Authorization/*/write'
-        ] OR a = 'Microsoft.Authorization/*' OR a = '*')
+      // Mirror the finding query: at least one searched pattern is granted
+      // by actions AND not shadowed by not_actions.
+      AND ANY(p IN [
+            'Microsoft.Authorization/roleDefinitions/write',
+            'Microsoft.Authorization/roleDefinitions/delete',
+            'Microsoft.Authorization/policyDefinitions/write',
+            'Microsoft.Authorization/policyAssignments/write'
+        ]
+        WHERE ANY(a IN coalesce(perm.actions, []) WHERE
+                  toLower(p) =~ replace(replace(toLower(a), '.', '[.]'), '*', '.*'))
+          AND NOT ANY(na IN coalesce(perm.not_actions, []) WHERE
+                  toLower(p) =~ replace(replace(toLower(na), '.', '[.]'), '*', '.*'))
+      )
     RETURN *
     """,
     cypher_count_query="""

--- a/cartography/rules/data/rules/workload_identity_admin_capabilities.py
+++ b/cartography/rules/data/rules/workload_identity_admin_capabilities.py
@@ -48,7 +48,7 @@ _aws_service_account_manipulation_via_ec2 = Fact(
             ] AS effective_actions
         WHERE size(effective_actions) > 0
         // Step 4: Optional internet exposure context
-        OPTIONAL MATCH (ec2 {exposed_internet: True})
+        OPTIONAL MATCH (ec2 {exposed_internet: true})
             -[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)
             <-[:MEMBER_OF_EC2_SECURITY_GROUP]-(ip:AWSIpPermissionInbound)
         UNWIND effective_actions AS action

--- a/cartography/rules/data/rules/workload_identity_admin_capabilities.py
+++ b/cartography/rules/data/rules/workload_identity_admin_capabilities.py
@@ -180,12 +180,12 @@ _gcp_service_account_manipulation_via_gce = Fact(
     name="GCE Instances Bound to a Broad-Scope Service Account",
     description=(
         "GCE instances attached to the default Compute Engine service "
-        "account, or to any service account with a permissive OAuth scope "
-        "(`cloud-platform`, `iam`, or `iam.admin`). A workload with these "
-        "scopes can call effectively any GCP API granted to the SA, "
-        "creating an identity-admin blast radius if compromised. "
-        "The deeper variant (instance to SA permissions) requires an "
-        "explicit `:HAS_SERVICE_ACCOUNT` edge that is not yet modeled."
+        "account, or to a service account configured with the full "
+        "cloud-platform or iam OAuth scope. The scope check is exact to "
+        "avoid matching read-only variants like cloud-platform.read-only "
+        "or iam.readonly. The deeper variant (instance to SA permissions) "
+        "requires an explicit :HAS_SERVICE_ACCOUNT edge that is not yet "
+        "modeled."
     ),
     cypher_query="""
     MATCH (project:GCPProject)-[:RESOURCE]->(instance:GCPInstance)
@@ -193,8 +193,10 @@ _gcp_service_account_manipulation_via_gce = Fact(
       AND (
         instance.service_account_email ENDS WITH '-compute@developer.gserviceaccount.com'
         OR ANY(scope IN coalesce(instance.service_account_scopes, [])
-               WHERE scope CONTAINS 'cloud-platform'
-                  OR scope CONTAINS '/auth/iam')
+               WHERE scope IN [
+                   'https://www.googleapis.com/auth/cloud-platform',
+                   'https://www.googleapis.com/auth/iam'
+               ])
       )
     OPTIONAL MATCH (instance)<-[:NETWORK_INTERFACE]-(nic:GCPNetworkInterface)
     OPTIONAL MATCH (nic)<-[:RESOURCE]-(ac:GCPNicAccessConfig)
@@ -218,8 +220,10 @@ _gcp_service_account_manipulation_via_gce = Fact(
       AND (
         instance.service_account_email ENDS WITH '-compute@developer.gserviceaccount.com'
         OR ANY(scope IN coalesce(instance.service_account_scopes, [])
-               WHERE scope CONTAINS 'cloud-platform'
-                  OR scope CONTAINS '/auth/iam')
+               WHERE scope IN [
+                   'https://www.googleapis.com/auth/cloud-platform',
+                   'https://www.googleapis.com/auth/iam'
+               ])
       )
     OPTIONAL MATCH p2=(instance)<-[:NETWORK_INTERFACE]-(nic:GCPNetworkInterface)<-[:RESOURCE]-(ac:GCPNicAccessConfig)
     RETURN *

--- a/cartography/rules/data/rules/workload_identity_admin_capabilities.py
+++ b/cartography/rules/data/rules/workload_identity_admin_capabilities.py
@@ -174,6 +174,66 @@ _aws_service_account_manipulation_via_lambda = Fact(
 )
 
 
+# GCP
+_gcp_service_account_manipulation_via_gce = Fact(
+    id="gcp_service_account_manipulation_via_gce",
+    name="GCE Instances Bound to a Broad-Scope Service Account",
+    description=(
+        "GCE instances attached to the default Compute Engine service "
+        "account, or to any service account with a permissive OAuth scope "
+        "(`cloud-platform`, `iam`, or `iam.admin`). A workload with these "
+        "scopes can call effectively any GCP API granted to the SA, "
+        "creating an identity-admin blast radius if compromised. "
+        "The deeper variant (instance to SA permissions) requires an "
+        "explicit `:HAS_SERVICE_ACCOUNT` edge that is not yet modeled."
+    ),
+    cypher_query="""
+    MATCH (project:GCPProject)-[:RESOURCE]->(instance:GCPInstance)
+    WHERE instance.service_account_email IS NOT NULL
+      AND (
+        instance.service_account_email ENDS WITH '-compute@developer.gserviceaccount.com'
+        OR ANY(scope IN coalesce(instance.service_account_scopes, [])
+               WHERE scope CONTAINS 'cloud-platform'
+                  OR scope CONTAINS '/auth/iam')
+      )
+    OPTIONAL MATCH (instance)<-[:NETWORK_INTERFACE]-(nic:GCPNetworkInterface)
+    OPTIONAL MATCH (nic)<-[:RESOURCE]-(ac:GCPNicAccessConfig)
+    WHERE ac.type = 'ONE_TO_ONE_NAT'
+      AND ac.public_ip IS NOT NULL
+    WITH project, instance, head(collect(ac.public_ip)) AS public_ip
+    RETURN DISTINCT
+        instance.id AS workload_id,
+        instance.name AS workload_name,
+        project.id AS account,
+        project.id AS account_id,
+        instance.service_account_email AS role_name,
+        coalesce(instance.service_account_scopes, []) AS actions,
+        public_ip IS NOT NULL AS internet_accessible,
+        public_ip AS public_ip_address
+    ORDER BY account, workload_id
+    """,
+    cypher_visual_query="""
+    MATCH p1=(project:GCPProject)-[:RESOURCE]->(instance:GCPInstance)
+    WHERE instance.service_account_email IS NOT NULL
+      AND (
+        instance.service_account_email ENDS WITH '-compute@developer.gserviceaccount.com'
+        OR ANY(scope IN coalesce(instance.service_account_scopes, [])
+               WHERE scope CONTAINS 'cloud-platform'
+                  OR scope CONTAINS '/auth/iam')
+      )
+    OPTIONAL MATCH p2=(instance)<-[:NETWORK_INTERFACE]-(nic:GCPNetworkInterface)<-[:RESOURCE]-(ac:GCPNicAccessConfig)
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (instance:GCPInstance)
+    RETURN COUNT(instance) AS count
+    """,
+    asset_id_field="workload_id",
+    module=Module.GCP,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
 # Rule
 class WorkloadIdentityAdminCapabilities(Finding):
     workload_name: str | None = None
@@ -197,6 +257,7 @@ workload_identity_admin_capabilities = Rule(
     facts=(
         _aws_service_account_manipulation_via_ec2,
         _aws_service_account_manipulation_via_lambda,
+        _gcp_service_account_manipulation_via_gce,
     ),
     tags=(
         "iam",

--- a/cartography/rules/data/rules/workload_identity_admin_capabilities.py
+++ b/cartography/rules/data/rules/workload_identity_admin_capabilities.py
@@ -174,70 +174,6 @@ _aws_service_account_manipulation_via_lambda = Fact(
 )
 
 
-# GCP
-_gcp_service_account_manipulation_via_gce = Fact(
-    id="gcp_service_account_manipulation_via_gce",
-    name="GCE Instances Bound to a Broad-Scope Service Account",
-    description=(
-        "GCE instances attached to the default Compute Engine service "
-        "account, or to a service account configured with the full "
-        "cloud-platform or iam OAuth scope. The scope check is exact to "
-        "avoid matching read-only variants like cloud-platform.read-only "
-        "or iam.readonly. The deeper variant (instance to SA permissions) "
-        "requires an explicit :HAS_SERVICE_ACCOUNT edge that is not yet "
-        "modeled."
-    ),
-    cypher_query="""
-    MATCH (project:GCPProject)-[:RESOURCE]->(instance:GCPInstance)
-    WHERE instance.service_account_email IS NOT NULL
-      AND (
-        instance.service_account_email ENDS WITH '-compute@developer.gserviceaccount.com'
-        OR ANY(scope IN coalesce(instance.service_account_scopes, [])
-               WHERE scope IN [
-                   'https://www.googleapis.com/auth/cloud-platform',
-                   'https://www.googleapis.com/auth/iam'
-               ])
-      )
-    OPTIONAL MATCH (instance)<-[:NETWORK_INTERFACE]-(nic:GCPNetworkInterface)
-    OPTIONAL MATCH (nic)<-[:RESOURCE]-(ac:GCPNicAccessConfig)
-    WHERE ac.type = 'ONE_TO_ONE_NAT'
-      AND ac.public_ip IS NOT NULL
-    WITH project, instance, head(collect(ac.public_ip)) AS public_ip
-    RETURN DISTINCT
-        instance.id AS workload_id,
-        instance.name AS workload_name,
-        project.id AS account,
-        project.id AS account_id,
-        instance.service_account_email AS role_name,
-        coalesce(instance.service_account_scopes, []) AS actions,
-        public_ip IS NOT NULL AS internet_accessible,
-        public_ip AS public_ip_address
-    ORDER BY account, workload_id
-    """,
-    cypher_visual_query="""
-    MATCH p1=(project:GCPProject)-[:RESOURCE]->(instance:GCPInstance)
-    WHERE instance.service_account_email IS NOT NULL
-      AND (
-        instance.service_account_email ENDS WITH '-compute@developer.gserviceaccount.com'
-        OR ANY(scope IN coalesce(instance.service_account_scopes, [])
-               WHERE scope IN [
-                   'https://www.googleapis.com/auth/cloud-platform',
-                   'https://www.googleapis.com/auth/iam'
-               ])
-      )
-    OPTIONAL MATCH p2=(instance)<-[:NETWORK_INTERFACE]-(nic:GCPNetworkInterface)<-[:RESOURCE]-(ac:GCPNicAccessConfig)
-    RETURN *
-    """,
-    cypher_count_query="""
-    MATCH (instance:GCPInstance)
-    RETURN COUNT(instance) AS count
-    """,
-    asset_id_field="workload_id",
-    module=Module.GCP,
-    maturity=Maturity.EXPERIMENTAL,
-)
-
-
 # Rule
 class WorkloadIdentityAdminCapabilities(Finding):
     workload_name: str | None = None
@@ -261,7 +197,6 @@ workload_identity_admin_capabilities = Rule(
     facts=(
         _aws_service_account_manipulation_via_ec2,
         _aws_service_account_manipulation_via_lambda,
-        _gcp_service_account_manipulation_via_gce,
     ),
     tags=(
         "iam",

--- a/docs/root/usage/rules.md
+++ b/docs/root/usage/rules.md
@@ -15,7 +15,7 @@ The rules system uses a simple two-level hierarchy:
 
 ```
 Rule (e.g., mfa-missing, object_storage_public)
-  └─ Fact (e.g., aws_s3_public, missing-mfa-cloudflare)
+  └─ Fact (e.g., aws_s3_public, missing-mfa-ontology)
 ```
 
 **Rules** represent security issues or attack surfaces you want to detect (e.g., "Public Object Storage exposed on internet").
@@ -304,8 +304,8 @@ Output shows all rules with their IDs, names, and fact counts:
 ```
 Available rules:
   - compute_instance_exposed (3 facts)
-  - database_instance_exposed (2 facts)
-  - mfa-missing (1 fact)
+  - database_instance_exposed (4 facts)
+  - mfa-missing (2 facts)
   - object_storage_public (2 facts)
   ...
 ```
@@ -320,18 +320,21 @@ Output shows rule metadata and all associated facts:
 Rule: mfa-missing
 Name: User accounts missing MFA
 Description: Detects user accounts without multi-factor authentication
-Facts: 1
-Version: 0.1.0
+Facts: 2
+Version: 0.2.0
 
 Facts:
-  1. missing-mfa-cloudflare (Cloudflare)
-     Finds Cloudflare member accounts that have MFA disabled
-     Maturity: STABLE
+  1. missing-mfa-aws (AWS)
+     AWS IAM users that are not associated with any MFA device
+     Maturity: EXPERIMENTAL
+  2. missing-mfa-ontology (Cross-cloud)
+     Active UserAccount nodes whose `_ont_has_mfa` is explicitly false
+     Maturity: EXPERIMENTAL
 ```
 
 #### See details of a specific fact
 ```bash
-cartography-rules list mfa-missing missing-mfa-cloudflare
+cartography-rules list mfa-missing missing-mfa-ontology
 ```
 
 ### `run`

--- a/tests/integration/rules/test_mfa_missing.py
+++ b/tests/integration/rules/test_mfa_missing.py
@@ -1,0 +1,95 @@
+from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.rules.data.rules.mfa_missing import missing_mfa_rule
+
+
+def _reset_graph(neo4j_session) -> None:
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+
+
+def _get_fact(fact_id: str):
+    return next(fact for fact in missing_mfa_rule.facts if fact.id == fact_id)
+
+
+def test_aws_mfa_fact_skips_users_with_a_device(neo4j_session) -> None:
+    """
+    The `:MFA_DEVICE` edge is modeled as `(AWSUser)-[:MFA_DEVICE]->(AWSMfaDevice)`
+    (`AWSMfaDeviceToAWSUserRel` carries `LinkDirection.INWARD`). The fact
+    must check that direction; an inverted predicate would flag every
+    AWS user as missing MFA.
+    """
+    _reset_graph(neo4j_session)
+    neo4j_session.run(
+        """
+        CREATE (a:AWSAccount {id: '111111111111', name: 'acme'})
+        CREATE (u_with:AWSUser {
+            arn: 'arn:aws:iam::111111111111:user/with-mfa',
+            name: 'with-mfa'
+        })
+        CREATE (u_without:AWSUser {
+            arn: 'arn:aws:iam::111111111111:user/without-mfa',
+            name: 'without-mfa'
+        })
+        CREATE (mfa:AWSMfaDevice {
+            id: 'arn:aws:iam::111111111111:mfa/with-mfa',
+            serialnumber: 'arn:aws:iam::111111111111:mfa/with-mfa'
+        })
+        MERGE (a)-[:RESOURCE]->(u_with)
+        MERGE (a)-[:RESOURCE]->(u_without)
+        MERGE (u_with)-[:MFA_DEVICE]->(mfa)
+        """
+    )
+
+    findings = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        _get_fact("missing-mfa-aws").cypher_query,
+    )
+
+    ids = [row["id"] for row in findings]
+    assert ids == ["arn:aws:iam::111111111111:user/without-mfa"]
+
+
+def test_ontology_mfa_fact_returns_users_with_explicit_false(neo4j_session) -> None:
+    """
+    The cross-cloud fact looks for `_ont_has_mfa = false` on UserAccount
+    nodes. NULL means unknown, not missing, so users without the field
+    must NOT appear in findings.
+    """
+    _reset_graph(neo4j_session)
+    neo4j_session.run(
+        """
+        CREATE (no_mfa:UserAccount {
+            id: 'cloudflare-no-mfa',
+            _ont_email: 'no-mfa@example.com',
+            _ont_has_mfa: false,
+            _ont_active: true,
+            _ont_source: 'cloudflare'
+        })
+        CREATE (yes_mfa:UserAccount {
+            id: 'cloudflare-yes-mfa',
+            _ont_email: 'yes-mfa@example.com',
+            _ont_has_mfa: true,
+            _ont_active: true,
+            _ont_source: 'cloudflare'
+        })
+        CREATE (unknown_mfa:UserAccount {
+            id: 'okta-unknown-mfa',
+            _ont_email: 'unknown@example.com',
+            _ont_active: true,
+            _ont_source: 'okta'
+        })
+        CREATE (inactive:UserAccount {
+            id: 'gh-inactive',
+            _ont_email: 'inactive@example.com',
+            _ont_has_mfa: false,
+            _ont_active: false,
+            _ont_source: 'github'
+        })
+        """
+    )
+
+    findings = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        _get_fact("missing-mfa-ontology").cypher_query,
+    )
+
+    assert [row["id"] for row in findings] == ["cloudflare-no-mfa"]

--- a/tests/unit/rules/test_azure_rbac_wildcards.py
+++ b/tests/unit/rules/test_azure_rbac_wildcards.py
@@ -32,13 +32,16 @@ def _glob_matches(pattern: str, wildcard: str) -> bool:
     return re.fullmatch(_to_regex(wildcard), pattern.lower()) is not None
 
 
-# Pattern lists the facts search for (literal Azure RBAC actions only).
+# Pattern lists the facts search for. Most are literal Azure RBAC
+# actions, but Microsoft documents the managed-identity assign action
+# with a `*` segment for the identity name (Managed Identity Operator
+# carries it verbatim), so the search pattern needs to match that form.
 IDENTITY_PATTERNS = [
     "Microsoft.Authorization/roleAssignments/write",
     "Microsoft.Authorization/roleAssignments/delete",
     "Microsoft.Authorization/roleDefinitions/write",
     "Microsoft.Authorization/roleDefinitions/delete",
-    "Microsoft.ManagedIdentity/userAssignedIdentities/assign/action",
+    "Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action",
 ]
 
 
@@ -73,13 +76,40 @@ def test_contributor_role_does_not_grant_role_definitions_write() -> None:
     assert _shadow(pattern, CONTRIBUTOR_ACTIONS, CONTRIBUTOR_NOT_ACTIONS) is False
 
 
-def test_contributor_role_does_not_grant_managed_identity_assign() -> None:
-    # Contributor's not_actions don't shadow this one, but the Contributor
-    # role does grant `Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action`
-    # via `*`. We expect this to surface (since Contributor really can attach
-    # UAMIs), so the test asserts the positive direction: granted, not shadowed.
-    pattern = "Microsoft.ManagedIdentity/userAssignedIdentities/assign/action"
+def test_contributor_role_grants_managed_identity_assign() -> None:
+    # Contributor's not_actions don't shadow managed-identity assign, and
+    # the role's `*` should match the wildcard pattern.
+    pattern = "Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action"
     assert _shadow(pattern, CONTRIBUTOR_ACTIONS, CONTRIBUTOR_NOT_ACTIONS) is True
+
+
+def test_managed_identity_operator_role_grants_managed_identity_assign() -> None:
+    """
+    Microsoft documents Managed Identity Operator with the action verbatim
+    as `Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action`,
+    plus `.../*/read`. With a literal `.../assign/action` pattern (no `*/`
+    segment) this role would silently miss the rule; assert that the
+    wildcard pattern matches it.
+    """
+    pattern = "Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action"
+    operator_actions = [
+        "Microsoft.ManagedIdentity/userAssignedIdentities/*/read",
+        "Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action",
+    ]
+    assert _shadow(pattern, operator_actions, []) is True
+
+
+def test_managed_identity_operator_does_not_grant_role_assignment_write() -> None:
+    """Negative control: MIO must not flag the role-assignment patterns."""
+    operator_actions = [
+        "Microsoft.ManagedIdentity/userAssignedIdentities/*/read",
+        "Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action",
+    ]
+    for pattern in (
+        "Microsoft.Authorization/roleAssignments/write",
+        "Microsoft.Authorization/roleDefinitions/write",
+    ):
+        assert _shadow(pattern, operator_actions, []) is False
 
 
 def test_owner_role_grants_role_assignment_write() -> None:

--- a/tests/unit/rules/test_azure_rbac_wildcards.py
+++ b/tests/unit/rules/test_azure_rbac_wildcards.py
@@ -65,16 +65,12 @@ def _shadow(pattern: str, actions: list[str], not_actions: list[str]) -> bool:
 def test_contributor_role_does_not_grant_role_assignment_write() -> None:
     # Contributor: actions=['*'], not_actions cover Microsoft.Authorization/*/Write
     pattern = "Microsoft.Authorization/roleAssignments/write"
-    assert (
-        _shadow(pattern, CONTRIBUTOR_ACTIONS, CONTRIBUTOR_NOT_ACTIONS) is False
-    )
+    assert _shadow(pattern, CONTRIBUTOR_ACTIONS, CONTRIBUTOR_NOT_ACTIONS) is False
 
 
 def test_contributor_role_does_not_grant_role_definitions_write() -> None:
     pattern = "Microsoft.Authorization/roleDefinitions/write"
-    assert (
-        _shadow(pattern, CONTRIBUTOR_ACTIONS, CONTRIBUTOR_NOT_ACTIONS) is False
-    )
+    assert _shadow(pattern, CONTRIBUTOR_ACTIONS, CONTRIBUTOR_NOT_ACTIONS) is False
 
 
 def test_contributor_role_does_not_grant_managed_identity_assign() -> None:
@@ -111,9 +107,7 @@ def test_facts_use_regex_wildcard_expansion() -> None:
     the regex-based wildcard expansion. If someone reverts to plain
     string equality, this test will fail.
     """
-    expected_snippet = (
-        "replace(replace(toLower(a), '.', '[.]'), '*', '.*')"
-    )
+    expected_snippet = "replace(replace(toLower(a), '.', '[.]'), '*', '.*')"
     for rule in (
         identity_administration_privileges,
         policy_administration_privileges,

--- a/tests/unit/rules/test_azure_rbac_wildcards.py
+++ b/tests/unit/rules/test_azure_rbac_wildcards.py
@@ -1,0 +1,127 @@
+"""
+Logic-level regression tests for the Azure RBAC wildcard expansion used in
+the new Azure facts under `identity_administration_privileges`,
+`policy_administration_privileges`, and `delegation_boundary_modifiable`.
+
+The Cypher implementation builds a case-insensitive regex from each
+action / not_action via `replace(replace(toLower(x), '.', '[.]'), '*', '.*')`
+and matches it against the literal pattern with `=~`. This mirrors that
+formula in Python so we can assert the Contributor regression case directly.
+"""
+
+import re
+
+from cartography.rules.data.rules.delegation_boundary_modifiable import (
+    delegation_boundary_modifiable,
+)
+from cartography.rules.data.rules.identity_administration_privileges import (
+    identity_administration_privileges,
+)
+from cartography.rules.data.rules.policy_administration_privileges import (
+    policy_administration_privileges,
+)
+
+
+def _to_regex(action_or_not_action: str) -> str:
+    """Mirror of the Cypher transform applied in the Azure RBAC facts."""
+    return action_or_not_action.lower().replace(".", "[.]").replace("*", ".*")
+
+
+def _glob_matches(pattern: str, wildcard: str) -> bool:
+    """True iff Azure RBAC `wildcard` (with optional `*`) covers `pattern`."""
+    return re.fullmatch(_to_regex(wildcard), pattern.lower()) is not None
+
+
+# Pattern lists the facts search for (literal Azure RBAC actions only).
+IDENTITY_PATTERNS = [
+    "Microsoft.Authorization/roleAssignments/write",
+    "Microsoft.Authorization/roleAssignments/delete",
+    "Microsoft.Authorization/roleDefinitions/write",
+    "Microsoft.Authorization/roleDefinitions/delete",
+    "Microsoft.ManagedIdentity/userAssignedIdentities/assign/action",
+]
+
+
+# A subset of the documented Contributor not_actions, which include
+# inner-wildcard entries (`Microsoft.Authorization/*/Write` etc.).
+CONTRIBUTOR_ACTIONS = ["*"]
+CONTRIBUTOR_NOT_ACTIONS = [
+    "Microsoft.Authorization/*/Write",
+    "Microsoft.Authorization/*/Delete",
+    "Microsoft.Authorization/elevateAccess/Action",
+    "Microsoft.Blueprint/blueprintAssignments/write",
+    "Microsoft.Blueprint/blueprintAssignments/delete",
+    "Microsoft.Compute/galleries/share/action",
+]
+
+
+def _shadow(pattern: str, actions: list[str], not_actions: list[str]) -> bool:
+    """True iff the role grants `pattern` after subtracting not_actions."""
+    granted = any(_glob_matches(pattern, a) for a in actions)
+    shadowed = any(_glob_matches(pattern, na) for na in not_actions)
+    return granted and not shadowed
+
+
+def test_contributor_role_does_not_grant_role_assignment_write() -> None:
+    # Contributor: actions=['*'], not_actions cover Microsoft.Authorization/*/Write
+    pattern = "Microsoft.Authorization/roleAssignments/write"
+    assert (
+        _shadow(pattern, CONTRIBUTOR_ACTIONS, CONTRIBUTOR_NOT_ACTIONS) is False
+    )
+
+
+def test_contributor_role_does_not_grant_role_definitions_write() -> None:
+    pattern = "Microsoft.Authorization/roleDefinitions/write"
+    assert (
+        _shadow(pattern, CONTRIBUTOR_ACTIONS, CONTRIBUTOR_NOT_ACTIONS) is False
+    )
+
+
+def test_contributor_role_does_not_grant_managed_identity_assign() -> None:
+    # Contributor's not_actions don't shadow this one, but the Contributor
+    # role does grant `Microsoft.ManagedIdentity/userAssignedIdentities/*/assign/action`
+    # via `*`. We expect this to surface (since Contributor really can attach
+    # UAMIs), so the test asserts the positive direction: granted, not shadowed.
+    pattern = "Microsoft.ManagedIdentity/userAssignedIdentities/assign/action"
+    assert _shadow(pattern, CONTRIBUTOR_ACTIONS, CONTRIBUTOR_NOT_ACTIONS) is True
+
+
+def test_owner_role_grants_role_assignment_write() -> None:
+    # Owner: actions=['*'], no not_actions blocking auth writes.
+    pattern = "Microsoft.Authorization/roleAssignments/write"
+    assert _shadow(pattern, ["*"], []) is True
+
+
+def test_user_access_administrator_grants_role_assignment_write() -> None:
+    # actions=['Microsoft.Authorization/*'], no not_actions
+    pattern = "Microsoft.Authorization/roleAssignments/write"
+    assert _shadow(pattern, ["Microsoft.Authorization/*"], []) is True
+
+
+def test_case_insensitive_match() -> None:
+    # The regex transform lower-cases both sides.
+    pattern = "Microsoft.Authorization/RoleAssignments/Write"
+    actions = ["MICROSOFT.AUTHORIZATION/*"]
+    assert _shadow(pattern, actions, []) is True
+
+
+def test_facts_use_regex_wildcard_expansion() -> None:
+    """
+    Sanity-check that the Cypher queries in the three Azure facts contain
+    the regex-based wildcard expansion. If someone reverts to plain
+    string equality, this test will fail.
+    """
+    expected_snippet = (
+        "replace(replace(toLower(a), '.', '[.]'), '*', '.*')"
+    )
+    for rule in (
+        identity_administration_privileges,
+        policy_administration_privileges,
+        delegation_boundary_modifiable,
+    ):
+        azure_facts = [f for f in rule.facts if f.id.startswith("azure_")]
+        assert azure_facts, f"no Azure facts in {rule.id}"
+        for fact in azure_facts:
+            assert (
+                expected_snippet in fact.cypher_query
+            ), f"{fact.id} no longer expands actions via regex"

--- a/tests/unit/rules/test_eol_software.py
+++ b/tests/unit/rules/test_eol_software.py
@@ -21,3 +21,28 @@ def test_eol_software_fact_modules() -> None:
 
 def test_eol_software_facts_are_experimental() -> None:
     assert all(fact.maturity == Maturity.EXPERIMENTAL for fact in eol_software.facts)
+
+
+def test_eks_fact_flags_kubernetes_1_29() -> None:
+    """
+    EKS no longer supports 1.29 (extended support covers 1.30 / 1.31 / 1.32).
+    The fact's threshold must be at least 30 so 1.29 clusters are flagged.
+    """
+    fact = next(
+        f for f in eol_software.facts if f.id == "eks_cluster_kubernetes_version_eol"
+    )
+    # The cypher hard-codes the threshold via the constant interpolation;
+    # asserting the literal `< 30` keeps us aligned with the AWS EKS docs.
+    assert "kubernetes_minor < 30" in fact.cypher_query
+
+
+def test_aks_fact_flags_kubernetes_1_32_standard_support() -> None:
+    """
+    Microsoft's AKS standard-support window starts at 1.33 as of 2026-05;
+    1.32 reached community EOL in March 2026. The fact's threshold must
+    be at least 33 so 1.30 / 1.31 / 1.32 are surfaced.
+    """
+    fact = next(
+        f for f in eol_software.facts if f.id == "aks_cluster_kubernetes_version_eol"
+    )
+    assert "kubernetes_minor < 33" in fact.cypher_query

--- a/tests/unit/rules/test_eol_software.py
+++ b/tests/unit/rules/test_eol_software.py
@@ -10,13 +10,13 @@ def test_eol_software_rule_registered() -> None:
 
 def test_eol_software_rule_shape() -> None:
     assert eol_software.name == "End-of-Life Software"
-    assert len(eol_software.facts) == 3
+    assert len(eol_software.facts) == 5
     assert len(eol_software.references) >= 5
 
 
 def test_eol_software_fact_modules() -> None:
     modules = {fact.module for fact in eol_software.facts}
-    assert modules == {Module.AWS, Module.KUBERNETES}
+    assert modules == {Module.AWS, Module.AZURE, Module.GCP, Module.KUBERNETES}
 
 
 def test_eol_software_facts_are_experimental() -> None:


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

### Summary

Adds the missing per-provider Facts to the cross-cloud, non-framework rule files so AWS / GCP / Azure coverage is symmetric for the highest-impact detections. **No model changes in this PR**; everything leans on the data already ingested via [#2755](https://github.com/cartography-cncf/cartography/pull/2755) and [#2756](https://github.com/cartography-cncf/cartography/pull/2756).

| Rule file | New Fact(s) | Backed by |
|---|---|---|
| `compute_instance_exposed.py` | `azure_vm_internet_exposed` | NIC + Public IP, NIC- or subnet-level NSG, `IpPermissionInbound` rule with `*` / `Internet` / `0.0.0.0/0` source over management ports |
| `database_instance_exposed.py` | `azure_sql_internet_exposed`, `azure_sql_allow_azure_services`, `azure_cosmosdb_public_access` | `AzureSQLServer.public_network_access` + `AzureSQLServerFirewallRule`; existing `AzureCosmosDBAccount.publicnetworkaccess` |
| `identity_administration_privileges.py` | `gcp_account_manipulation_permissions`, `azure_account_manipulation_permissions` | `GCPRole.permissions`; `AzurePermissions.actions` / `not_actions` |
| `policy_administration_privileges.py` | `gcp_policy_manipulation_capabilities`, `azure_policy_manipulation_capabilities` | same as above |
| `delegation_boundary_modifiable.py` | `gcp_trust_relationship_manipulation`, `azure_trust_relationship_manipulation` | same as above; Azure analog uses `Microsoft.ManagedIdentity/.../assign/action` plus `Microsoft.Authorization/roleAssignments/write` |
| `eol_software.py` | `gke_cluster_kubernetes_version_eol`, `aks_cluster_kubernetes_version_eol` | `GKECluster.current_master_version`, `AzureKubernetesCluster.kubernetes_version` |
| `workload_identity_admin_capabilities.py` | `gcp_service_account_manipulation_via_gce` | `GCPInstance.service_account_email` / `service_account_scopes` from #2755 |
| `mfa_missing.py` | `missing-mfa-aws` | `AWSMfaDevice` (absence of `:MFA_DEVICE`) |

### Notable design choices

- **Azure SQL exposure split into two Facts** so downstream consumers can flag them as different exposure classes. Per Microsoft docs, the special `start_ip = end_ip = 0.0.0.0` row only allows Azure-hosted services / resources, not arbitrary public IPs. Lumping it with true public-internet exposure would generate false positives in any rule that relies on this Fact. This was [explicitly raised by @kunaals](https://github.com/cartography-cncf/cartography/pull/2756#discussion_r3191645645) when reviewing #2756.
- **GCE workload-identity Fact is intentionally flat.** It uses the new `service_account_email` and `service_account_scopes` string properties to flag the default Compute Engine SA or any SA with `cloud-platform` / `iam` scopes. The deeper "instance to GCPRole.permissions" chain still waits on a `:HAS_SERVICE_ACCOUNT` edge between `GCPInstance` and `GCPServiceAccount`, which is out of scope for this PR.
- **AWS MFA Fact reuses the existing Cloudflare-shaped `Finding`** (`email`, `id`, `firstname`, `lastname`, `status`) and overloads `firstname` to surface `console-active` vs `programmatic-only`, so callers can de-prioritise non-interactive users. A small `status` field was added to the Finding.
- **GKE / AKS oldest-supported minors** are tracked as constants at the top of `eol_software.py` so they can be bumped as Google / Microsoft drop versions, matching the pattern used for EKS.

### Out of scope (tracked separately)

- Azure VM managed-identity admin Fact in `workload_identity_admin_capabilities` (waits on `AzureManagedIdentity` modeling).
- GCP "instance to permissions" deep Fact in `workload_identity_admin_capabilities` (waits on `:HAS_SERVICE_ACCOUNT` edge).
- Okta / Entra / Workspace MFA Facts in `mfa_missing` (waits on per-IdP MFA modeling; current Entra / Okta / Workspace user models do not carry per-user MFA flags).
- GitLab / Bitbucket variants of `unpinned_github_actions` and `malicious_npm_dependencies_*`.
- GCP SCC / Azure Defender variants of `cloud_security_product_deactivated`.

### Related issues or links

Builds directly on [#2755](https://github.com/cartography-cncf/cartography/pull/2755) (CIS GCP / Workspace / K8s coverage + GCP model additions) and [#2756](https://github.com/cartography-cncf/cartography/pull/2756) (Azure VM NSG rules and SQL Server firewall rules).

### How was this tested?

- `make test_lint` passes locally (isort, black, flake8, pyupgrade, mypy).
- `pytest tests/unit` (1873 tests) passes locally.
- Updated `tests/unit/rules/test_eol_software.py` to assert the new fact count and the AWS / AZURE / GCP / KUBERNETES module coverage. The other rule files have no per-rule unit tests today; structural validation (Pydantic Finding fields, Fact dataclass instantiation, Rule registration in `RULES`) is covered by the generic rule unit tests.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit tests.

#### If you are adding or modifying a synced entity
- [x] N/A: no intel module changes; this is a rules-only PR.

#### If you are changing a node or relationship
- [x] N/A: no schema changes.

#### If you are implementing a new intel module
- [x] N/A.

### Notes for reviewers

- Each new Fact is `Maturity.EXPERIMENTAL` to match the existing AWS / GCP entries in the same files.
- The Azure RBAC Facts respect `not_actions` (a permissive `*` in `not_actions` shadows the matched allow), but they do not currently account for higher-priority deny role assignments at narrower scopes; this mirrors the AWS Facts' simplifications around explicit Deny statements.
- The Azure VM exposure Fact intentionally does not currently model effective-rule precedence (a higher-priority Deny shadowing the Allow); flagged in the Fact description, same posture as the existing GCP Fact.