### PR TITLE
Map more GCP policy binding targets

### DIFF
--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -67,7 +67,7 @@ class _FullNameMapping:
 
 
 @dataclass(frozen=True)
-class _ResourceTarget:
+class _AppliesToTarget:
     label: str
     property_name: str
     value: str
@@ -317,25 +317,26 @@ _FULL_NAME_MAPPINGS: list[_FullNameMapping] = [
 def _parse_bigquery_resource_name(
     parts: list[str],
     marker: str,
+    name_segment: str,
     id_mode: str,
 ) -> str | None:
     try:
         project_id = parts[parts.index("projects") + 1]
-        dataset_id = parts[parts.index("datasets") + 1]
     except (ValueError, IndexError):
         return None
 
     if id_mode == "bigquery_dataset":
-        return f"{project_id}:{dataset_id}"
+        return f"{project_id}:{name_segment}"
 
     try:
+        dataset_id = parts[parts.index("datasets") + 1]
         resource_id = parts[parts.index(marker) + 1]
     except (ValueError, IndexError):
         return None
     return f"{project_id}:{dataset_id}.{resource_id}"
 
 
-def _target_from_full_resource_name(full_name: str) -> _ResourceTarget | None:
+def _parse_full_resource_name(full_name: str) -> _AppliesToTarget | None:
     """
     Parse a GCP Cloud Asset full resource name and return the matching
     Cartography node target when the resource type is part of the Cartography
@@ -373,18 +374,14 @@ def _target_from_full_resource_name(full_name: str) -> _ResourceTarget | None:
                 value = f"{mapping.id_prefix}{value}"
         elif mapping.id_mode.startswith("bigquery_"):
             value = _parse_bigquery_resource_name(
-                parts, mapping.marker, mapping.id_mode
+                parts,
+                mapping.marker,
+                name_segment,
+                mapping.id_mode,
             )
         if value:
-            return _ResourceTarget(mapping.label, mapping.target_property, value)
+            return _AppliesToTarget(mapping.label, mapping.target_property, value)
     return None
-
-
-def _parse_full_resource_name(full_name: str) -> tuple[str | None, str | None]:
-    target = _target_from_full_resource_name(full_name)
-    if target is None:
-        return None, None
-    return target.label, target.value
 
 
 class PolicyBindingsSyncStatus(str, Enum):
@@ -671,7 +668,7 @@ def _group_applies_to_links(
     """
     grouped: dict[tuple[str, str], list[dict[str, str]]] = {}
     for binding in bindings:
-        target = _target_from_full_resource_name(binding["resource"])
+        target = _parse_full_resource_name(binding["resource"])
         if target is None:
             continue
         grouped.setdefault((target.label, target.property_name), []).append(

--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -26,6 +26,8 @@ from cartography.intel.gcp.permission_relationships import (
     build_principals_from_policy_bindings,
 )
 from cartography.intel.gcp.permission_relationships import GCPPrincipalPermissionContext
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.relationships import make_target_node_matcher
 from cartography.models.gcp.policy_bindings import GCPPolicyBindingAppliesToMatchLink
 from cartography.models.gcp.policy_bindings import GCPPolicyBindingSchema
 from cartography.util import timeit
@@ -48,12 +50,27 @@ class _FullNameMapping:
         * ``"type_prefixed"``  — ``"{marker}/{name}"`` (GCPFolder, GCPOrganization).
         * ``"full_path"``      — the whole path up to and including the name
           (KMS, Secrets, Artifact Registry, Cloud Run, Compute).
+        * ``"prefixed_full_path"`` — the full path with ``id_prefix`` prepended.
+        * ``"bigquery_dataset"`` / ``"bigquery_child"`` — BigQuery's legacy
+          ``project:dataset`` and ``project:dataset.resource`` node ids.
+    - ``target_property``: the target node property to match on. Most resources
+      use ``id``; a few existing schemas use another indexed canonical field.
+    - ``id_prefix``: prefix for resources whose node id is the API selfLink.
     """
 
     service_prefix: str
     marker: str
     label: str
     id_mode: str
+    target_property: str = "id"
+    id_prefix: str | None = None
+
+
+@dataclass(frozen=True)
+class _ResourceTarget:
+    label: str
+    property_name: str
+    value: str
 
 
 # Order matters within a given service_prefix: more specific mappings first so
@@ -115,23 +132,159 @@ _FULL_NAME_MAPPINGS: list[_FullNameMapping] = [
     # Artifact Registry.
     _FullNameMapping(
         "//artifactregistry.googleapis.com/",
+        "dockerImages",
+        "GCPArtifactRegistryRepositoryImage",
+        "full_path",
+        "resource_name",
+    ),
+    _FullNameMapping(
+        "//artifactregistry.googleapis.com/",
+        "mavenArtifacts",
+        "GCPArtifactRegistryLanguagePackage",
+        "full_path",
+    ),
+    _FullNameMapping(
+        "//artifactregistry.googleapis.com/",
+        "npmPackages",
+        "GCPArtifactRegistryLanguagePackage",
+        "full_path",
+    ),
+    _FullNameMapping(
+        "//artifactregistry.googleapis.com/",
+        "pythonPackages",
+        "GCPArtifactRegistryLanguagePackage",
+        "full_path",
+    ),
+    _FullNameMapping(
+        "//artifactregistry.googleapis.com/",
         "repositories",
         "GCPArtifactRegistryRepository",
         "full_path",
     ),
-    # Cloud Run services.
+    # BigQuery.
+    _FullNameMapping(
+        "//bigquery.googleapis.com/",
+        "tables",
+        "GCPBigQueryTable",
+        "bigquery_child",
+    ),
+    _FullNameMapping(
+        "//bigquery.googleapis.com/",
+        "routines",
+        "GCPBigQueryRoutine",
+        "bigquery_child",
+    ),
+    _FullNameMapping(
+        "//bigquery.googleapis.com/",
+        "datasets",
+        "GCPBigQueryDataset",
+        "bigquery_dataset",
+    ),
+    # Cloud Functions.
+    _FullNameMapping(
+        "//cloudfunctions.googleapis.com/",
+        "functions",
+        "GCPCloudFunction",
+        "full_path",
+    ),
+    # Cloud Run.
+    _FullNameMapping(
+        "//run.googleapis.com/",
+        "executions",
+        "GCPCloudRunExecution",
+        "full_path",
+    ),
+    _FullNameMapping(
+        "//run.googleapis.com/",
+        "jobs",
+        "GCPCloudRunJob",
+        "full_path",
+    ),
+    _FullNameMapping(
+        "//run.googleapis.com/",
+        "revisions",
+        "GCPCloudRunRevision",
+        "full_path",
+    ),
     _FullNameMapping(
         "//run.googleapis.com/",
         "services",
         "GCPCloudRunService",
         "full_path",
     ),
+    # Cloud SQL.
+    _FullNameMapping(
+        "//sqladmin.googleapis.com/",
+        "instances",
+        "GCPCloudSQLInstance",
+        "prefixed_full_path",
+        id_prefix="https://sqladmin.googleapis.com/sql/v1beta4/",
+    ),
+    # GKE.
+    _FullNameMapping(
+        "//container.googleapis.com/",
+        "clusters",
+        "GKECluster",
+        "prefixed_full_path",
+        id_prefix="https://container.googleapis.com/v1/",
+    ),
+    # IAM. Service account keys must precede service accounts.
+    _FullNameMapping(
+        "//iam.googleapis.com/",
+        "keys",
+        "GCPServiceAccountKey",
+        "full_path",
+    ),
+    _FullNameMapping(
+        "//iam.googleapis.com/",
+        "serviceAccounts",
+        "GCPServiceAccount",
+        "last_segment",
+        "email",
+    ),
+    _FullNameMapping(
+        "//iam.googleapis.com/",
+        "roles",
+        "GCPRole",
+        "full_path",
+    ),
+    # Vertex AI.
+    _FullNameMapping(
+        "//aiplatform.googleapis.com/",
+        "models",
+        "GCPVertexAIModel",
+        "full_path",
+    ),
+    _FullNameMapping(
+        "//aiplatform.googleapis.com/",
+        "trainingPipelines",
+        "GCPVertexAITrainingPipeline",
+        "full_path",
+    ),
     # Compute — node id is the "partial URI" (``projects/.../{kind}/{name}``),
     # which matches the path left after stripping the service prefix.
     _FullNameMapping(
         "//compute.googleapis.com/",
+        "backendServices",
+        "GCPBackendService",
+        "full_path",
+    ),
+    _FullNameMapping(
+        "//compute.googleapis.com/",
+        "forwardingRules",
+        "GCPForwardingRule",
+        "full_path",
+    ),
+    _FullNameMapping(
+        "//compute.googleapis.com/",
         "instances",
         "GCPInstance",
+        "full_path",
+    ),
+    _FullNameMapping(
+        "//compute.googleapis.com/",
+        "instanceGroups",
+        "GCPInstanceGroup",
         "full_path",
     ),
     _FullNameMapping(
@@ -148,6 +301,12 @@ _FULL_NAME_MAPPINGS: list[_FullNameMapping] = [
     ),
     _FullNameMapping(
         "//compute.googleapis.com/",
+        "securityPolicies",
+        "GCPCloudArmorPolicy",
+        "full_path",
+    ),
+    _FullNameMapping(
+        "//compute.googleapis.com/",
         "firewalls",
         "GCPFirewall",
         "full_path",
@@ -155,11 +314,32 @@ _FULL_NAME_MAPPINGS: list[_FullNameMapping] = [
 ]
 
 
-def _parse_full_resource_name(full_name: str) -> tuple[str | None, str | None]:
+def _parse_bigquery_resource_name(
+    parts: list[str],
+    marker: str,
+    id_mode: str,
+) -> str | None:
+    try:
+        project_id = parts[parts.index("projects") + 1]
+        dataset_id = parts[parts.index("datasets") + 1]
+    except (ValueError, IndexError):
+        return None
+
+    if id_mode == "bigquery_dataset":
+        return f"{project_id}:{dataset_id}"
+
+    try:
+        resource_id = parts[parts.index(marker) + 1]
+    except (ValueError, IndexError):
+        return None
+    return f"{project_id}:{dataset_id}.{resource_id}"
+
+
+def _target_from_full_resource_name(full_name: str) -> _ResourceTarget | None:
     """
     Parse a GCP Cloud Asset full resource name and return the matching
-    (target_node_label, target_id) pair when the resource type is part of the
-    Cartography ontology, or (None, None) otherwise.
+    Cartography node target when the resource type is part of the Cartography
+    ontology.
 
     Full resource name format: ``//{service}.googleapis.com/{path}``.
     """
@@ -179,16 +359,32 @@ def _parse_full_resource_name(full_name: str) -> tuple[str | None, str | None]:
         name_segment = parts[marker_idx + 1]
         if not name_segment:
             continue
+        value = None
         if mapping.id_mode == "last_segment":
-            return mapping.label, name_segment
-        if mapping.id_mode == "type_prefixed":
-            return mapping.label, f"{mapping.marker}/{name_segment}"
-        # full_path: keep everything up to and including the resource name.
-        # Sub-paths (e.g. a policy on a secret version, or on a cryptoKey
-        # version) resolve to the nearest ancestor in the ontology via the
-        # mapping order defined above.
-        return mapping.label, "/".join(parts[: marker_idx + 2])
-    return None, None
+            value = name_segment
+        elif mapping.id_mode == "type_prefixed":
+            value = f"{mapping.marker}/{name_segment}"
+        elif mapping.id_mode in ("full_path", "prefixed_full_path"):
+            # Keep everything up to and including the resource name. Sub-paths
+            # resolve to the nearest ancestor in the ontology via mapping order.
+            value = "/".join(parts[: marker_idx + 2])
+            if mapping.id_mode == "prefixed_full_path":
+                assert mapping.id_prefix is not None
+                value = f"{mapping.id_prefix}{value}"
+        elif mapping.id_mode.startswith("bigquery_"):
+            value = _parse_bigquery_resource_name(
+                parts, mapping.marker, mapping.id_mode
+            )
+        if value:
+            return _ResourceTarget(mapping.label, mapping.target_property, value)
+    return None
+
+
+def _parse_full_resource_name(full_name: str) -> tuple[str | None, str | None]:
+    target = _target_from_full_resource_name(full_name)
+    if target is None:
+        return None, None
+    return target.label, target.value
 
 
 class PolicyBindingsSyncStatus(str, Enum):
@@ -466,21 +662,20 @@ def transform_bindings(data: dict[str, Any]) -> list[dict[str, Any]]:
 
 def _group_applies_to_links(
     bindings: list[dict[str, Any]],
-) -> dict[str, list[dict[str, str]]]:
+) -> dict[tuple[str, str], list[dict[str, str]]]:
     """
-    Group bindings by the Cartography label of their bound resource so
-    load_matchlinks can be invoked once per target label. Bindings whose
-    resource type is not yet in the ontology are silently dropped here — the
-    binding node is still created by the main load(), just without an
-    APPLIES_TO edge.
+    Group bindings by target label and property so load_matchlinks can be
+    invoked once per target matcher. Bindings whose resource type is not yet in
+    the ontology are silently dropped here — the binding node is still created
+    by the main load(), just without an APPLIES_TO edge.
     """
-    grouped: dict[str, list[dict[str, str]]] = {}
+    grouped: dict[tuple[str, str], list[dict[str, str]]] = {}
     for binding in bindings:
-        label, target_id = _parse_full_resource_name(binding["resource"])
-        if not label or not target_id:
+        target = _target_from_full_resource_name(binding["resource"])
+        if target is None:
             continue
-        grouped.setdefault(label, []).append(
-            {"binding_id": binding["id"], "target_id": target_id},
+        grouped.setdefault((target.label, target.property_name), []).append(
+            {"binding_id": binding["id"], "target_value": target.value},
         )
     return grouped
 
@@ -500,10 +695,17 @@ def load_bindings(
         PROJECT_ID=project_id,
     )
 
-    for target_label, links in _group_applies_to_links(bindings).items():
+    for (target_label, target_property), links in _group_applies_to_links(
+        bindings
+    ).items():
         load_matchlinks(
             neo4j_session,
-            GCPPolicyBindingAppliesToMatchLink(target_node_label=target_label),
+            GCPPolicyBindingAppliesToMatchLink(
+                target_node_label=target_label,
+                target_node_matcher=make_target_node_matcher(
+                    {target_property: PropertyRef("target_value")},
+                ),
+            ),
             links,
             lastupdated=update_tag,
             _sub_resource_label="GCPProject",

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -986,8 +986,14 @@ Representation of a GCP [IAM Policy Binding](https://cloud.google.com/iam/docs/r
   supports `GCPProject`, `GCPFolder`, `GCPOrganization`, `GCPBucket`,
   `GCPKeyRing`, `GCPCryptoKey`, `GCPSecretManagerSecret`,
   `GCPSecretManagerSecretVersion`, `GCPArtifactRegistryRepository`,
-  `GCPCloudRunService`, `GCPInstance`, `GCPVpc`, `GCPSubnet`, and
-  `GCPFirewall` targets.
+  `GCPArtifactRegistryRepositoryImage`, `GCPArtifactRegistryLanguagePackage`,
+  `GCPBigQueryDataset`, `GCPBigQueryTable`, `GCPBigQueryRoutine`,
+  `GCPCloudFunction`, `GCPCloudRunService`, `GCPCloudRunJob`,
+  `GCPCloudRunRevision`, `GCPCloudRunExecution`, `GCPCloudSQLInstance`,
+  `GKECluster`, `GCPServiceAccount`, `GCPServiceAccountKey`, `GCPRole`,
+  `GCPVertexAIModel`, `GCPVertexAITrainingPipeline`, `GCPInstance`,
+  `GCPInstanceGroup`, `GCPBackendService`, `GCPForwardingRule`, `GCPVpc`,
+  `GCPSubnet`, `GCPCloudArmorPolicy`, and `GCPFirewall` targets.
 
     ```
     (GCPPolicyBinding)-[:APPLIES_TO]->(:GCPProject|GCPBucket|GCPCryptoKey|...)

--- a/tests/data/gcp/policy_bindings.py
+++ b/tests/data/gcp/policy_bindings.py
@@ -271,6 +271,30 @@ MOCK_POLICY_BINDINGS_RESPONSE = {
                 },
             ],
         },
+        {
+            "full_resource_name": (
+                "//iam.googleapis.com/projects/project-abc/"
+                "serviceAccounts/sa@project-abc.iam.gserviceaccount.com"
+            ),
+            "policies": [
+                {
+                    "attached_resource": (
+                        "//iam.googleapis.com/projects/project-abc/"
+                        "serviceAccounts/sa@project-abc.iam.gserviceaccount.com"
+                    ),
+                    "policy": {
+                        "bindings": [
+                            {
+                                "role": "roles/viewer",
+                                "members": [
+                                    "user:alice@example.com",
+                                ],
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
         # Resource-scoped binding on a specific BigQuery table. Used by
         # test_sync_gcp_permission_relationships to verify that scope keys
         # disambiguate sibling tables sharing the same leaf name across

--- a/tests/integration/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/integration/cartography/intel/gcp/test_policy_bindings.py
@@ -63,6 +63,19 @@ def _create_test_bucket(neo4j_session):
     )
 
 
+def _create_test_bigquery_table(neo4j_session):
+    """Create a BigQuery table node to verify APPLIES_TO relationship wiring."""
+    neo4j_session.run(
+        """
+        MERGE (table:GCPBigQueryTable{id: $table_id})
+        ON CREATE SET table.firstseen = timestamp()
+        SET table.lastupdated = $update_tag
+        """,
+        table_id="project-abc:dataset_a.events",
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+
 @patch.object(
     cartography.intel.gcp.policy_bindings,
     "get_policy_bindings",
@@ -121,6 +134,7 @@ def test_sync_gcp_policy_bindings(
     _create_test_project(neo4j_session)
     _create_test_organization(neo4j_session)
     _create_test_bucket(neo4j_session)
+    _create_test_bigquery_table(neo4j_session)
     mock_iam_client = MagicMock()
     mock_admin_resource = MagicMock()
     mock_asset_client = MagicMock()
@@ -385,6 +399,22 @@ def test_sync_gcp_policy_bindings(
         (
             "//storage.googleapis.com/buckets/test-bucket_roles/storage.objectViewer",
             "test-bucket",
+        ),
+    }
+
+    # Check GCPPolicyBinding to GCPBigQueryTable APPLIES_TO relationships
+    assert check_rels(
+        neo4j_session,
+        "GCPPolicyBinding",
+        "id",
+        "GCPBigQueryTable",
+        "id",
+        "APPLIES_TO",
+        rel_direction_right=True,
+    ) == {
+        (
+            "//bigquery.googleapis.com/projects/project-abc/datasets/dataset_a/tables/events_roles/bigquery.dataViewer",
+            "project-abc:dataset_a.events",
         ),
     }
 

--- a/tests/integration/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/integration/cartography/intel/gcp/test_policy_bindings.py
@@ -220,6 +220,11 @@ def test_sync_gcp_policy_bindings(
             "resource",
         ),
         (
+            "//iam.googleapis.com/projects/project-abc/serviceAccounts/sa@project-abc.iam.gserviceaccount.com_roles/viewer",
+            "roles/viewer",
+            "resource",
+        ),
+        (
             "//bigquery.googleapis.com/projects/project-abc/datasets/dataset_a/tables/events_roles/bigquery.dataViewer",
             "roles/bigquery.dataViewer",
             "resource",
@@ -262,6 +267,10 @@ def test_sync_gcp_policy_bindings(
         ),
         (
             TEST_PROJECT_ID,
+            "//iam.googleapis.com/projects/project-abc/serviceAccounts/sa@project-abc.iam.gserviceaccount.com_roles/viewer",
+        ),
+        (
+            TEST_PROJECT_ID,
             "//bigquery.googleapis.com/projects/project-abc/datasets/dataset_a/tables/events_roles/bigquery.dataViewer",
         ),
     }
@@ -288,6 +297,10 @@ def test_sync_gcp_policy_bindings(
         (
             "alice@example.com",
             "//storage.googleapis.com/buckets/test-bucket_roles/storage.objectViewer",
+        ),
+        (
+            "alice@example.com",
+            "//iam.googleapis.com/projects/project-abc/serviceAccounts/sa@project-abc.iam.gserviceaccount.com_roles/viewer",
         ),
         (
             "bob@example.com",
@@ -346,6 +359,10 @@ def test_sync_gcp_policy_bindings(
         (
             "//storage.googleapis.com/buckets/test-bucket_roles/storage.objectViewer",
             "roles/storage.objectViewer",
+        ),
+        (
+            "//iam.googleapis.com/projects/project-abc/serviceAccounts/sa@project-abc.iam.gserviceaccount.com_roles/viewer",
+            "roles/viewer",
         ),
         (
             "//bigquery.googleapis.com/projects/project-abc/datasets/dataset_a/tables/events_roles/bigquery.dataViewer",
@@ -415,6 +432,23 @@ def test_sync_gcp_policy_bindings(
         (
             "//bigquery.googleapis.com/projects/project-abc/datasets/dataset_a/tables/events_roles/bigquery.dataViewer",
             "project-abc:dataset_a.events",
+        ),
+    }
+
+    # Check GCPPolicyBinding to GCPServiceAccount APPLIES_TO relationships. This
+    # target matches on email instead of id.
+    assert check_rels(
+        neo4j_session,
+        "GCPPolicyBinding",
+        "id",
+        "GCPServiceAccount",
+        "email",
+        "APPLIES_TO",
+        rel_direction_right=True,
+    ) == {
+        (
+            "//iam.googleapis.com/projects/project-abc/serviceAccounts/sa@project-abc.iam.gserviceaccount.com_roles/viewer",
+            "sa@project-abc.iam.gserviceaccount.com",
         ),
     }
 

--- a/tests/unit/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/unit/cartography/intel/gcp/test_policy_bindings.py
@@ -9,6 +9,7 @@ from google.api_core.exceptions import RetryError
 
 import cartography.intel.gcp
 import cartography.intel.gcp.policy_bindings as policy_bindings
+from cartography.intel.gcp.policy_bindings import _AppliesToTarget
 from cartography.intel.gcp.policy_bindings import _group_applies_to_links
 from cartography.intel.gcp.policy_bindings import _parse_full_resource_name
 
@@ -251,7 +252,20 @@ COMMON_JOB_PARAMS = {
     ],
 )
 def test_parse_full_resource_name(full_name, expected):
-    assert _parse_full_resource_name(full_name) == expected
+    if expected == (None, None):
+        assert _parse_full_resource_name(full_name) is None
+        return
+
+    expected_label, expected_value = expected
+    expected_property = {
+        "GCPArtifactRegistryRepositoryImage": "resource_name",
+        "GCPServiceAccount": "email",
+    }.get(expected_label, "id")
+    assert _parse_full_resource_name(full_name) == _AppliesToTarget(
+        expected_label,
+        expected_property,
+        expected_value,
+    )
 
 
 def test_group_applies_to_links_groups_by_target_matcher():

--- a/tests/unit/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/unit/cartography/intel/gcp/test_policy_bindings.py
@@ -9,6 +9,7 @@ from google.api_core.exceptions import RetryError
 
 import cartography.intel.gcp
 import cartography.intel.gcp.policy_bindings as policy_bindings
+from cartography.intel.gcp.policy_bindings import _group_applies_to_links
 from cartography.intel.gcp.policy_bindings import _parse_full_resource_name
 
 TEST_PROJECT_ID = "project-abc"
@@ -110,9 +111,131 @@ COMMON_JOB_PARAMS = {
             "//compute.googleapis.com/projects/p/global/firewalls/fw-allow-ssh",
             ("GCPFirewall", "projects/p/global/firewalls/fw-allow-ssh"),
         ),
-        # Unknown service
+        # Artifact Registry child resources
+        (
+            "//artifactregistry.googleapis.com/projects/p/locations/us/repositories/r/dockerImages/nginx@sha256:abc123",
+            (
+                "GCPArtifactRegistryRepositoryImage",
+                "projects/p/locations/us/repositories/r/dockerImages/nginx@sha256:abc123",
+            ),
+        ),
+        (
+            "//artifactregistry.googleapis.com/projects/p/locations/us/repositories/r/mavenArtifacts/com.example:app:1.0.0",
+            (
+                "GCPArtifactRegistryLanguagePackage",
+                "projects/p/locations/us/repositories/r/mavenArtifacts/com.example:app:1.0.0",
+            ),
+        ),
+        # BigQuery
         (
             "//bigquery.googleapis.com/projects/p/datasets/d",
+            ("GCPBigQueryDataset", "p:d"),
+        ),
+        (
+            "//bigquery.googleapis.com/projects/p/datasets/d/tables/events",
+            ("GCPBigQueryTable", "p:d.events"),
+        ),
+        (
+            "//bigquery.googleapis.com/projects/p/datasets/d/routines/routine_1",
+            ("GCPBigQueryRoutine", "p:d.routine_1"),
+        ),
+        # Cloud Functions
+        (
+            "//cloudfunctions.googleapis.com/projects/p/locations/us-central1/functions/fn",
+            ("GCPCloudFunction", "projects/p/locations/us-central1/functions/fn"),
+        ),
+        # Cloud Run
+        (
+            "//run.googleapis.com/projects/p/locations/us-central1/jobs/job-1/executions/job-1-abc",
+            (
+                "GCPCloudRunExecution",
+                "projects/p/locations/us-central1/jobs/job-1/executions/job-1-abc",
+            ),
+        ),
+        (
+            "//run.googleapis.com/projects/p/locations/us-central1/jobs/job-1",
+            ("GCPCloudRunJob", "projects/p/locations/us-central1/jobs/job-1"),
+        ),
+        (
+            "//run.googleapis.com/projects/p/locations/us-central1/revisions/rev-1",
+            (
+                "GCPCloudRunRevision",
+                "projects/p/locations/us-central1/revisions/rev-1",
+            ),
+        ),
+        # Cloud SQL
+        (
+            "//sqladmin.googleapis.com/projects/p/instances/sql-1",
+            (
+                "GCPCloudSQLInstance",
+                "https://sqladmin.googleapis.com/sql/v1beta4/projects/p/instances/sql-1",
+            ),
+        ),
+        # GKE
+        (
+            "//container.googleapis.com/projects/p/locations/us-central1/clusters/cluster-1",
+            (
+                "GKECluster",
+                "https://container.googleapis.com/v1/projects/p/locations/us-central1/clusters/cluster-1",
+            ),
+        ),
+        # IAM
+        (
+            "//iam.googleapis.com/projects/p/serviceAccounts/sa@p.iam.gserviceaccount.com/keys/key-1",
+            (
+                "GCPServiceAccountKey",
+                "projects/p/serviceAccounts/sa@p.iam.gserviceaccount.com/keys/key-1",
+            ),
+        ),
+        (
+            "//iam.googleapis.com/projects/p/serviceAccounts/sa@p.iam.gserviceaccount.com",
+            ("GCPServiceAccount", "sa@p.iam.gserviceaccount.com"),
+        ),
+        (
+            "//iam.googleapis.com/projects/p/roles/customRole",
+            ("GCPRole", "projects/p/roles/customRole"),
+        ),
+        # Vertex AI
+        (
+            "//aiplatform.googleapis.com/projects/p/locations/us-central1/models/model-1",
+            (
+                "GCPVertexAIModel",
+                "projects/p/locations/us-central1/models/model-1",
+            ),
+        ),
+        (
+            "//aiplatform.googleapis.com/projects/p/locations/us-central1/trainingPipelines/pipeline-1",
+            (
+                "GCPVertexAITrainingPipeline",
+                "projects/p/locations/us-central1/trainingPipelines/pipeline-1",
+            ),
+        ),
+        # Compute additions
+        (
+            "//compute.googleapis.com/projects/p/global/backendServices/backend-1",
+            ("GCPBackendService", "projects/p/global/backendServices/backend-1"),
+        ),
+        (
+            "//compute.googleapis.com/projects/p/regions/us-central1/forwardingRules/fr-1",
+            (
+                "GCPForwardingRule",
+                "projects/p/regions/us-central1/forwardingRules/fr-1",
+            ),
+        ),
+        (
+            "//compute.googleapis.com/projects/p/zones/us-central1-a/instanceGroups/group-1",
+            (
+                "GCPInstanceGroup",
+                "projects/p/zones/us-central1-a/instanceGroups/group-1",
+            ),
+        ),
+        (
+            "//compute.googleapis.com/projects/p/global/securityPolicies/policy-1",
+            ("GCPCloudArmorPolicy", "projects/p/global/securityPolicies/policy-1"),
+        ),
+        # Unknown service
+        (
+            "//pubsub.googleapis.com/projects/p/topics/topic-1",
             (None, None),
         ),
         # Empty suffix
@@ -129,6 +252,34 @@ COMMON_JOB_PARAMS = {
 )
 def test_parse_full_resource_name(full_name, expected):
     assert _parse_full_resource_name(full_name) == expected
+
+
+def test_group_applies_to_links_groups_by_target_matcher():
+    bindings = [
+        {
+            "id": "sa-binding",
+            "resource": "//iam.googleapis.com/projects/project-abc/serviceAccounts/sa@project-abc.iam.gserviceaccount.com",
+        },
+        {
+            "id": "image-binding",
+            "resource": "//artifactregistry.googleapis.com/projects/project-abc/locations/us/repositories/repo/dockerImages/nginx@sha256:abc123",
+        },
+    ]
+
+    assert _group_applies_to_links(bindings) == {
+        ("GCPServiceAccount", "email"): [
+            {
+                "binding_id": "sa-binding",
+                "target_value": "sa@project-abc.iam.gserviceaccount.com",
+            },
+        ],
+        ("GCPArtifactRegistryRepositoryImage", "resource_name"): [
+            {
+                "binding_id": "image-binding",
+                "target_value": "projects/project-abc/locations/us/repositories/repo/dockerImages/nginx@sha256:abc123",
+            },
+        ],
+    }
 
 
 def test_wait_for_cai_policy_bindings_slot_reserves_per_operation_slots():


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary
Expand GCP policy binding `APPLIES_TO` coverage for existing Cartography resource types whose Cloud Asset Inventory full resource names can be mapped to current node identifiers.

This adds typed targets for additional Artifact Registry, BigQuery, Cloud Functions, Cloud Run, Cloud SQL, GKE, IAM, Vertex AI, and Compute resources. Unsupported or unmodeled resources continue to be ingested as `GCPPolicyBinding` nodes without an `APPLIES_TO` edge.


### Related issues or links
N/A


### Breaking changes
None.


### How was this tested?
- `uv run pytest tests/unit/cartography/intel/gcp/test_policy_bindings.py tests/integration/cartography/intel/gcp/test_policy_bindings.py -q`
- `make test_lint`


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md). N/A: no `docs/schema/README.md` exists in this checkout.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
This changes policy-binding matchlink coverage only. It does not add new GCP resource syncs or change permission relationship evaluation.