### PR TITLE
fix(docs): pull request template linter command

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,7 +33,7 @@
 
 #### General
 - [ ] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
-- [ ] The linter passes locally (`make lint`).
+- [ ] The linter passes locally (`make test_lint`).
 - [ ] I have added/updated tests that prove my fix is effective or my feature works.
 
 #### Proof of functionality


### PR DESCRIPTION
`make lint` is not valid. The correct command is `make test_lint`.
