### PR TITLE
fix(gcp): reduce policy binding write pressure

### DIFF
--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -526,6 +526,9 @@ def _cleanup_applies_to_relationships(
     project_id: str,
     update_tag: int,
 ) -> None:
+    # APPLIES_TO can point at several resource labels. Clean up by relationship
+    # scope directly instead of running the same stale-edge cleanup once per
+    # possible target label.
     GraphStatement(
         """
         MATCH (:GCPPolicyBinding)-[r:APPLIES_TO]->()

--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -3,6 +3,7 @@ import logging
 import time
 from dataclasses import dataclass
 from enum import Enum
+from threading import BoundedSemaphore
 from threading import Lock
 from typing import Any
 
@@ -22,6 +23,7 @@ from google.protobuf.json_format import MessageToDict
 from cartography.client.core.tx import load
 from cartography.client.core.tx import load_matchlinks
 from cartography.graph.job import GraphJob
+from cartography.graph.statement import GraphStatement
 from cartography.intel.gcp.permission_relationships import (
     build_principals_from_policy_bindings,
 )
@@ -218,8 +220,14 @@ CAI_POLICY_BINDINGS_MIN_INTERVAL_SECONDS = {
     "batch_get_effective_iam_policies": 0.75,
     "search_all_iam_policies": 0.20,
 }
+GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE = 1000
+GCP_POLICY_BINDINGS_CLEANUP_ITERATION_SIZE = 1000
+GCP_POLICY_BINDINGS_GRAPH_CONCURRENCY = 4
 _CAI_POLICY_BINDINGS_THROTTLE_LOCK = Lock()
 _CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION: dict[str, float] = {}
+_GCP_POLICY_BINDINGS_GRAPH_SEMAPHORE = BoundedSemaphore(
+    GCP_POLICY_BINDINGS_GRAPH_CONCURRENCY
+)
 
 
 def _wait_for_cai_policy_bindings_slot(operation: str) -> None:
@@ -496,6 +504,7 @@ def load_bindings(
         neo4j_session,
         GCPPolicyBindingSchema(),
         bindings,
+        batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
         lastupdated=update_tag,
         PROJECT_ID=project_id,
     )
@@ -505,10 +514,36 @@ def load_bindings(
             neo4j_session,
             GCPPolicyBindingAppliesToMatchLink(target_node_label=target_label),
             links,
+            batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
             lastupdated=update_tag,
             _sub_resource_label="GCPProject",
             _sub_resource_id=project_id,
         )
+
+
+def _cleanup_applies_to_relationships(
+    neo4j_session: neo4j.Session,
+    project_id: str,
+    update_tag: int,
+) -> None:
+    GraphStatement(
+        """
+        MATCH (:GCPPolicyBinding)-[r:APPLIES_TO]->()
+        WHERE r.lastupdated <> $UPDATE_TAG
+            AND r._sub_resource_label = $_sub_resource_label
+            AND r._sub_resource_id = $_sub_resource_id
+        WITH r LIMIT $LIMIT_SIZE
+        DELETE r;
+        """,
+        parameters={
+            "UPDATE_TAG": update_tag,
+            "_sub_resource_label": "GCPProject",
+            "_sub_resource_id": project_id,
+        },
+        iterative=True,
+        iterationsize=GCP_POLICY_BINDINGS_CLEANUP_ITERATION_SIZE,
+        parent_job_name="APPLIES_TO",
+    ).run(neo4j_session)
 
 
 @timeit
@@ -521,20 +556,12 @@ def cleanup(
     GraphJob.from_node_schema(
         GCPPolicyBindingSchema(),
         common_job_parameters,
+        iterationsize=GCP_POLICY_BINDINGS_CLEANUP_ITERATION_SIZE,
     ).run(neo4j_session)
 
     project_id = common_job_parameters["PROJECT_ID"]
     update_tag = common_job_parameters["UPDATE_TAG"]
-    # Run a matchlink cleanup for every target label we know how to map. This
-    # clears stale APPLIES_TO edges even if no binding in this sync targeted
-    # that label.
-    for target_label in {mapping.label for mapping in _FULL_NAME_MAPPINGS}:
-        GraphJob.from_matchlink(
-            GCPPolicyBindingAppliesToMatchLink(target_node_label=target_label),
-            "GCPProject",
-            project_id,
-            update_tag,
-        ).run(neo4j_session)
+    _cleanup_applies_to_relationships(neo4j_session, project_id, update_tag)
 
 
 @timeit
@@ -619,8 +646,9 @@ def sync(
         project_id,
     )
 
-    load_bindings(neo4j_session, transformed_bindings_data, project_id, update_tag)
-    cleanup(neo4j_session, common_job_parameters)
+    with _GCP_POLICY_BINDINGS_GRAPH_SEMAPHORE:
+        load_bindings(neo4j_session, transformed_bindings_data, project_id, update_tag)
+        cleanup(neo4j_session, common_job_parameters)
     return PolicyBindingsSyncResult(
         PolicyBindingsSyncStatus.SUCCESS,
         permission_context,

--- a/tests/unit/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/unit/cartography/intel/gcp/test_policy_bindings.py
@@ -221,6 +221,101 @@ def test_get_policy_bindings_passes_custom_retry_to_cai_rpcs(
     assert mock_wait_for_slot.call_count == 2
 
 
+@patch.object(policy_bindings, "load_matchlinks")
+@patch.object(policy_bindings, "load")
+def test_load_bindings_uses_policy_binding_batch_size(mock_load, mock_load_matchlinks):
+    bindings = [
+        {
+            "id": "binding-1",
+            "resource": "//storage.googleapis.com/buckets/test-bucket",
+        },
+    ]
+
+    policy_bindings.load_bindings(
+        MagicMock(),
+        bindings,
+        TEST_PROJECT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+    assert (
+        mock_load.call_args.kwargs["batch_size"]
+        == policy_bindings.GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE
+    )
+    assert (
+        mock_load_matchlinks.call_args.kwargs["batch_size"]
+        == policy_bindings.GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE
+    )
+
+
+@patch.object(policy_bindings, "GraphStatement")
+@patch("cartography.intel.gcp.policy_bindings.GraphJob.from_node_schema")
+def test_cleanup_uses_one_generic_applies_to_cleanup(
+    mock_from_node_schema,
+    mock_graph_statement,
+):
+    neo4j_session = MagicMock()
+    cleanup_job = MagicMock()
+    mock_from_node_schema.return_value = cleanup_job
+    applies_to_cleanup = MagicMock()
+    mock_graph_statement.return_value = applies_to_cleanup
+
+    policy_bindings.cleanup(neo4j_session, COMMON_JOB_PARAMS)
+
+    assert (
+        mock_from_node_schema.call_args.kwargs["iterationsize"]
+        == policy_bindings.GCP_POLICY_BINDINGS_CLEANUP_ITERATION_SIZE
+    )
+    cleanup_job.run.assert_called_once_with(neo4j_session)
+    mock_graph_statement.assert_called_once()
+    query = mock_graph_statement.call_args.args[0]
+    assert "MATCH (:GCPPolicyBinding)-[r:APPLIES_TO]->()" in query
+    assert "r._sub_resource_id = $_sub_resource_id" in query
+    assert (
+        mock_graph_statement.call_args.kwargs["iterationsize"]
+        == policy_bindings.GCP_POLICY_BINDINGS_CLEANUP_ITERATION_SIZE
+    )
+    applies_to_cleanup.run.assert_called_once_with(neo4j_session)
+
+
+@patch.object(policy_bindings, "cleanup")
+@patch.object(policy_bindings, "load_bindings")
+@patch.object(policy_bindings, "build_principals_from_policy_bindings")
+@patch.object(policy_bindings, "transform_bindings")
+@patch.object(policy_bindings, "get_policy_bindings")
+def test_sync_limits_policy_binding_graph_writes(
+    mock_get_policy_bindings,
+    mock_transform_bindings,
+    mock_build_principals,
+    mock_load_bindings,
+    mock_cleanup,
+):
+    graph_semaphore = MagicMock()
+    mock_get_policy_bindings.return_value = {"policy_results": []}
+    mock_transform_bindings.return_value = [{"id": "binding-1"}]
+    mock_build_principals.return_value = {}
+
+    with patch.object(
+        policy_bindings,
+        "_GCP_POLICY_BINDINGS_GRAPH_SEMAPHORE",
+        graph_semaphore,
+    ):
+        result = policy_bindings.sync(
+            MagicMock(),
+            TEST_PROJECT_ID,
+            TEST_UPDATE_TAG,
+            COMMON_JOB_PARAMS,
+            MagicMock(),
+            {},
+        )
+
+    assert result.status == policy_bindings.PolicyBindingsSyncStatus.SUCCESS
+    graph_semaphore.__enter__.assert_called_once()
+    graph_semaphore.__exit__.assert_called_once()
+    mock_load_bindings.assert_called_once()
+    mock_cleanup.assert_called_once()
+
+
 @patch.object(policy_bindings, "cleanup")
 @patch.object(policy_bindings, "load_bindings")
 @patch.object(


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
Reduces Neo4j write pressure from GCP policy binding syncs when multiple projects are processed concurrently.

This keeps the existing GCPPolicyBinding and APPLIES_TO graph model intact while making the write-heavy phase less bursty:
- limits concurrent policy binding graph load/cleanup work within a process
- uses smaller batches for policy binding node and APPLIES_TO relationship writes
- replaces per-target-label APPLIES_TO cleanup with one scoped relationship cleanup query

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity



### Notes for reviewers
This intentionally avoids changing GCPPolicyBinding identity or APPLIES_TO semantics. The goal is to reduce concurrent write contention while preserving existing traversals and cleanup scope.
