### PR TITLE
feat(gcp): derive GAR parent image lineage

### DIFF
--- a/cartography/intel/gcp/artifact_registry/supply_chain.py
+++ b/cartography/intel/gcp/artifact_registry/supply_chain.py
@@ -28,6 +28,9 @@ from cartography.intel.supply_chain import extract_layers_from_oci_config
 from cartography.intel.supply_chain import extract_provenance_from_oci_config
 from cartography.intel.supply_chain import normalize_vcs_url
 from cartography.models.gcp.artifact_registry.image import (
+    GCPArtifactRegistryImageBuiltFromMatchLink,
+)
+from cartography.models.gcp.artifact_registry.image import (
     GCPArtifactRegistryImageProvenanceSchema,
 )
 from cartography.models.gcp.artifact_registry.image_layer import (
@@ -336,6 +339,30 @@ def _digest_value_from_oci_purl(locator: str) -> str | None:
     return digest_part.split("?", 1)[0].split("#", 1)[0]
 
 
+def _image_digest_from_purl(locator: str) -> str | None:
+    if not locator.startswith(("pkg:oci/", "pkg:docker/")):
+        return None
+    _, separator, digest_part = locator.partition("@sha256:")
+    if not separator:
+        return None
+    digest_value = digest_part.split("?", 1)[0].split("#", 1)[0]
+    return f"sha256:{digest_value}" if digest_value else None
+
+
+def _image_purl_from_spdx_package(package: dict[str, Any]) -> str | None:
+    for external_ref in package.get("externalRefs") or []:
+        if not isinstance(external_ref, dict):
+            continue
+        if external_ref.get("referenceType") != "purl":
+            continue
+        locator = external_ref.get("referenceLocator")
+        if not isinstance(locator, str):
+            continue
+        if _image_digest_from_purl(locator):
+            return locator
+    return None
+
+
 def _spdx_package_matches_subject_digest(
     package: dict[str, Any],
     subject_digest: str,
@@ -364,6 +391,77 @@ def _spdx_package_matches_subject_digest(
     if not oci_digest_values:
         return None
     return subject_digest_value in oci_digest_values
+
+
+def _extract_parent_image_from_spdx_sbom(
+    sbom: dict[str, Any],
+    subject_digest: str | None,
+) -> dict[str, str]:
+    if not subject_digest:
+        return {}
+
+    described_ids = {
+        spdx_id
+        for spdx_id in sbom.get("documentDescribes") or []
+        if isinstance(spdx_id, str)
+    }
+    if not described_ids:
+        return {}
+
+    packages = [
+        package for package in sbom.get("packages") or [] if isinstance(package, dict)
+    ]
+    packages_by_id = {
+        spdx_id: package
+        for package in packages
+        if isinstance(spdx_id := package.get("SPDXID"), str)
+    }
+    subject_package_ids = {
+        spdx_id
+        for spdx_id in described_ids
+        if (package := packages_by_id.get(spdx_id)) is not None
+        if _spdx_package_matches_subject_digest(package, subject_digest) is True
+    }
+    if not subject_package_ids:
+        return {}
+
+    relationships = [
+        relationship
+        for relationship in sbom.get("relationships") or []
+        if isinstance(relationship, dict)
+        and relationship.get("spdxElementId") in subject_package_ids
+    ]
+    for relationship_type in ("DESCENDANT_OF", "VARIANT_OF"):
+        parent_candidates: dict[str, str] = {}
+        for relationship in relationships:
+            if relationship.get("relationshipType") != relationship_type:
+                continue
+            related_package_id = relationship.get("relatedSpdxElement")
+            if not isinstance(related_package_id, str):
+                continue
+            related_package = packages_by_id.get(related_package_id)
+            if related_package is None:
+                continue
+            parent_image_uri = _image_purl_from_spdx_package(related_package)
+            if parent_image_uri is None:
+                continue
+            parent_image_digest = _image_digest_from_purl(parent_image_uri)
+            if parent_image_digest is None or parent_image_digest == subject_digest:
+                continue
+            parent_candidates[parent_image_digest] = parent_image_uri
+
+        if len(parent_candidates) == 1:
+            parent_image_digest, parent_image_uri = next(
+                iter(parent_candidates.items())
+            )
+            return {
+                "parent_image_uri": parent_image_uri,
+                "parent_image_digest": parent_image_digest,
+            }
+        if len(parent_candidates) > 1:
+            return {}
+
+    return {}
 
 
 def _repo_urls_from_contained_spdx_packages(
@@ -554,6 +652,12 @@ async def _fetch_spdx_layer_provenance(
             subject_digest=subject_digest,
             expected_source_uri=expected_source_uri,
         )
+        provenance.update(
+            _extract_parent_image_from_spdx_sbom(
+                blob,
+                subject_digest=subject_digest,
+            )
+        )
         if provenance:
             return provenance
 
@@ -690,7 +794,7 @@ async def _process_single_image(
             same_path_sbom_artifacts.append(sbom_artifact)
 
     if (
-        not provenance.get("source_uri")
+        (not provenance.get("source_uri") or not provenance.get("parent_image_digest"))
         and same_path_sbom_artifacts
         and subject_digest_str
     ):
@@ -710,9 +814,14 @@ async def _process_single_image(
             )
             sbom_provenance = {}
             fetch_failed = True
-        provenance.update(sbom_provenance)
+        for key, value in sbom_provenance.items():
+            provenance.setdefault(key, value)
 
-    if not provenance.get("source_uri") and sbom_artifacts and subject_digest_str:
+    if (
+        (not provenance.get("source_uri") or not provenance.get("parent_image_digest"))
+        and sbom_artifacts
+        and subject_digest_str
+    ):
         for sbom_artifact in sbom_artifacts:
             sbom_parsed = parse_docker_image_uri(sbom_artifact.get("uri", ""))
             if not sbom_parsed:
@@ -737,14 +846,20 @@ async def _process_single_image(
                 )
                 sbom_provenance = {}
                 fetch_failed = True
-            provenance.update(sbom_provenance)
-            if provenance.get("source_uri"):
+            for key, value in sbom_provenance.items():
+                provenance.setdefault(key, value)
+            if provenance.get("source_uri") and provenance.get("parent_image_digest"):
                 break
 
     diff_ids, layer_history = extract_layers_from_oci_config(config)
     has_platform = any(value is not None for value in (architecture, os_name, variant))
 
-    if not provenance.get("source_uri") and not diff_ids and not has_platform:
+    if (
+        not provenance.get("source_uri")
+        and not provenance.get("parent_image_digest")
+        and not diff_ids
+        and not has_platform
+    ):
         return None, fetch_failed
 
     digest = subject_digest_str
@@ -768,6 +883,10 @@ async def _process_single_image(
         result["source_revision"] = provenance["source_revision"]
     if provenance.get("source_file"):
         result["source_file"] = provenance["source_file"]
+    if provenance.get("parent_image_uri"):
+        result["parent_image_uri"] = provenance["parent_image_uri"]
+    if provenance.get("parent_image_digest"):
+        result["parent_image_digest"] = provenance["parent_image_digest"]
     if diff_ids:
         result["layer_diff_ids"] = diff_ids
         result["layer_history"] = layer_history
@@ -902,6 +1021,8 @@ PROVENANCE_SOURCE_FIELDS = (
     "source_uri",
     "source_revision",
     "source_file",
+    "parent_image_uri",
+    "parent_image_digest",
 )
 
 PROVENANCE_FIELDS = (
@@ -937,6 +1058,8 @@ def _merge_existing_image_provenance(
             img.source_uri AS source_uri,
             img.source_revision AS source_revision,
             img.source_file AS source_file,
+            img.parent_image_uri AS parent_image_uri,
+            img.parent_image_digest AS parent_image_digest,
             img.layer_diff_ids AS layer_diff_ids
         """,
         digests=digests,
@@ -961,9 +1084,9 @@ def _merge_existing_image_provenance(
             value = update.get(field)
             if value is not None:
                 merged[field] = value
-        # Source fields are digest-level provenance. Keep existing non-null values
-        # so a later ref without equivalent source metadata does not erase or
-        # replace a source discovered through another ref for the same digest.
+        # These fields are digest-level provenance. Keep existing non-null values
+        # so a later ref without equivalent metadata does not erase or replace
+        # provenance discovered through another ref for the same digest.
         for field in PROVENANCE_SOURCE_FIELDS:
             value = update.get(field)
             if merged.get(field) is None and value is not None:
@@ -996,6 +1119,30 @@ def load_image_provenance(
         ),
         lastupdated=update_tag,
         PROJECT_ID=project_id,
+    )
+    parent_updates = [
+        {
+            **update,
+            "from_sbom": True,
+            "confidence": "explicit",
+        }
+        for update in merged_updates
+        if update.get("parent_image_digest")
+        and update.get("parent_image_uri")
+        and update.get("parent_image_digest") != update.get("digest")
+    ]
+    load_matchlinks_with_progress(
+        neo4j_session,
+        GCPArtifactRegistryImageBuiltFromMatchLink(),
+        parent_updates,
+        batch_size=ARTIFACT_REGISTRY_LOAD_BATCH_SIZE,
+        progress_description=(
+            f"Artifact Registry image BUILT_FROM relationships for project {project_id}"
+        ),
+        lastupdated=update_tag,
+        PROJECT_ID=project_id,
+        _sub_resource_label="GCPProject",
+        _sub_resource_id=project_id,
     )
 
 
@@ -1076,6 +1223,8 @@ def sync(
                 "source_uri": e.get("source_uri"),
                 "source_revision": e.get("source_revision"),
                 "source_file": e.get("source_file"),
+                "parent_image_uri": e.get("parent_image_uri"),
+                "parent_image_digest": e.get("parent_image_digest"),
                 "layer_diff_ids": e.get("layer_diff_ids"),
                 "architecture": e.get("architecture"),
                 "os": e.get("os"),
@@ -1122,23 +1271,32 @@ def sync(
             GCPArtifactRegistryImageLayerSchema(),
             cleanup_params,
         ).run(neo4j_session)
-        # The split write path attaches this relationship with a MatchLink, so
-        # clean it explicitly after node cleanup has used the project RESOURCE
-        # edge to scope stale node deletion.
+        # The split write path attaches these relationships with MatchLinks, so
+        # clean them explicitly after node cleanup has used project RESOURCE
+        # edges to scope stale layer-node deletion.
         GraphJob.from_matchlink(
             GCPArtifactRegistryProjectToImageLayerRel(),
             "GCPProject",
             project_id,
             update_tag,
         ).run(neo4j_session)
+        GraphJob.from_matchlink(
+            GCPArtifactRegistryImageBuiltFromMatchLink(),
+            "GCPProject",
+            project_id,
+            update_tag,
+        ).run(neo4j_session)
 
     provenance_count = sum(1 for e in enrichments if e.get("source_uri"))
+    parent_count = sum(1 for e in enrichments if e.get("parent_image_digest"))
     layer_count = sum(1 for e in enrichments if e.get("layer_diff_ids"))
     logger.info(
         "Completed supply chain sync for GCP project %s: "
-        "%d images with provenance, %d with layer data, %d unique layers",
+        "%d images with source provenance, %d with parent image lineage, "
+        "%d with layer data, %d unique layers",
         project_id,
         provenance_count,
+        parent_count,
         layer_count,
         len(layer_dicts),
     )

--- a/cartography/intel/gcp/artifact_registry/supply_chain.py
+++ b/cartography/intel/gcp/artifact_registry/supply_chain.py
@@ -464,6 +464,10 @@ def _extract_parent_image_from_spdx_sbom(
     return {}
 
 
+def _needs_more_spdx_provenance(provenance: dict[str, Any]) -> bool:
+    return not provenance.get("source_uri") or not provenance.get("parent_image_digest")
+
+
 def _repo_urls_from_contained_spdx_packages(
     relationships: list[dict[str, Any]],
     packages_by_id: dict[str, dict[str, Any]],
@@ -794,7 +798,7 @@ async def _process_single_image(
             same_path_sbom_artifacts.append(sbom_artifact)
 
     if (
-        (not provenance.get("source_uri") or not provenance.get("parent_image_digest"))
+        _needs_more_spdx_provenance(provenance)
         and same_path_sbom_artifacts
         and subject_digest_str
     ):
@@ -818,7 +822,7 @@ async def _process_single_image(
             provenance.setdefault(key, value)
 
     if (
-        (not provenance.get("source_uri") or not provenance.get("parent_image_digest"))
+        _needs_more_spdx_provenance(provenance)
         and sbom_artifacts
         and subject_digest_str
     ):
@@ -848,7 +852,7 @@ async def _process_single_image(
                 fetch_failed = True
             for key, value in sbom_provenance.items():
                 provenance.setdefault(key, value)
-            if provenance.get("source_uri") and provenance.get("parent_image_digest"):
+            if not _needs_more_spdx_provenance(provenance):
                 break
 
     diff_ids, layer_history = extract_layers_from_oci_config(config)
@@ -877,16 +881,9 @@ async def _process_single_image(
         result["os"] = os_name
     if variant is not None:
         result["variant"] = variant
-    if provenance.get("source_uri"):
-        result["source_uri"] = provenance["source_uri"]
-    if provenance.get("source_revision"):
-        result["source_revision"] = provenance["source_revision"]
-    if provenance.get("source_file"):
-        result["source_file"] = provenance["source_file"]
-    if provenance.get("parent_image_uri"):
-        result["parent_image_uri"] = provenance["parent_image_uri"]
-    if provenance.get("parent_image_digest"):
-        result["parent_image_digest"] = provenance["parent_image_digest"]
+    for field in PROVENANCE_SOURCE_FIELDS:
+        if provenance.get(field):
+            result[field] = provenance[field]
     if diff_ids:
         result["layer_diff_ids"] = diff_ids
         result["layer_history"] = layer_history

--- a/cartography/models/gcp/artifact_registry/image.py
+++ b/cartography/models/gcp/artifact_registry/image.py
@@ -52,6 +52,8 @@ class GCPArtifactRegistryImageProvenanceNodeProperties(CartographyNodeProperties
     source_uri: PropertyRef = PropertyRef("source_uri", extra_index=True)
     source_revision: PropertyRef = PropertyRef("source_revision")
     source_file: PropertyRef = PropertyRef("source_file")
+    parent_image_uri: PropertyRef = PropertyRef("parent_image_uri")
+    parent_image_digest: PropertyRef = PropertyRef("parent_image_digest")
     layer_diff_ids: PropertyRef = PropertyRef("layer_diff_ids")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
@@ -81,6 +83,35 @@ class GCPArtifactRegistryImageMatchLinkProperties(CartographyRelProperties):
         "_sub_resource_label", set_in_kwargs=True
     )
     _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPArtifactRegistryImageBuiltFromRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    parent_image_uri: PropertyRef = PropertyRef("parent_image_uri")
+    from_sbom: PropertyRef = PropertyRef("from_sbom")
+    confidence: PropertyRef = PropertyRef("confidence")
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label", set_in_kwargs=True
+    )
+    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPArtifactRegistryImageBuiltFromMatchLink(CartographyRelSchema):
+    source_node_label: str = "GCPArtifactRegistryImage"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"digest": PropertyRef("digest")}
+    )
+    target_node_label: str = "GCPArtifactRegistryImage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"digest": PropertyRef("parent_image_digest")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "BUILT_FROM"
+    properties: GCPArtifactRegistryImageBuiltFromRelProperties = (
+        GCPArtifactRegistryImageBuiltFromRelProperties()
+    )
 
 
 @dataclass(frozen=True)

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -1782,6 +1782,8 @@ Representation of digest-scoped GCP Artifact Registry image content. Multiple `G
 | source_uri | Source repository URL extracted from OCI image config provenance (e.g., `https://github.com/org/repo`) |
 | source_revision | Git commit hash from build provenance |
 | source_file | Dockerfile path from build provenance |
+| parent_image_uri | Parent/base image URI extracted from digest-verified SPDX SBOM image relationships |
+| parent_image_digest | Parent/base image digest extracted from digest-verified SPDX SBOM image relationships |
 | layer_diff_ids | Ordered list of layer diff IDs from the OCI image config |
 | firstseen | Timestamp of when a sync job first discovered this node |
 | lastupdated | Timestamp of the last time the node was updated |
@@ -1791,6 +1793,11 @@ Representation of digest-scoped GCP Artifact Registry image content. Multiple `G
 - Manifest-list/index GCPArtifactRegistryImages contain platform-specific child images.
     ```
     (GCPArtifactRegistryImage:ImageManifestList)-[:CONTAINS_IMAGE]->(GCPArtifactRegistryImage:Image)
+    ```
+
+- GCPArtifactRegistryImages can point to a parent/base image when SPDX SBOM relationships identify another loaded GAR image digest.
+    ```
+    (GCPArtifactRegistryImage)-[:BUILT_FROM]->(GCPArtifactRegistryImage)
     ```
 
 - TrivyImageFindings affect GCPArtifactRegistryImages.

--- a/tests/data/gcp/artifact_registry.py
+++ b/tests/data/gcp/artifact_registry.py
@@ -6,6 +6,17 @@ MOCK_SUPPLY_CHAIN_IMAGE_DIGEST = (
     "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 )
 MOCK_SUPPLY_CHAIN_IMAGE_DIGEST_HEX = MOCK_SUPPLY_CHAIN_IMAGE_DIGEST.split(":", 1)[1]
+MOCK_SUPPLY_CHAIN_PARENT_IMAGE_DIGEST = (
+    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+MOCK_SUPPLY_CHAIN_PARENT_IMAGE_DIGEST_HEX = MOCK_SUPPLY_CHAIN_PARENT_IMAGE_DIGEST.split(
+    ":", 1
+)[1]
+MOCK_SUPPLY_CHAIN_PARENT_IMAGE_URI = (
+    "pkg:oci/base-image@sha256:"
+    f"{MOCK_SUPPLY_CHAIN_PARENT_IMAGE_DIGEST_HEX}"
+    "?repository_url=registry.example.test/base-image"
+)
 MOCK_SUPPLY_CHAIN_IMAGE_URI = (
     "us-central1-docker.pkg.dev/test-project/docker-repo/widgets-api"
     f"@{MOCK_SUPPLY_CHAIN_IMAGE_DIGEST}"
@@ -276,6 +287,61 @@ def mock_ko_spdx_sbom(image_digest=MOCK_SUPPLY_CHAIN_IMAGE_DIGEST):
                 "relatedSpdxElement": (
                     "SPDXRef-Package-github.com.example.dependency-v1.0.0"
                 ),
+            },
+        ],
+    }
+
+
+def mock_spdx_parent_image_sbom(
+    image_digest=MOCK_SUPPLY_CHAIN_IMAGE_DIGEST,
+    parent_image_digest=MOCK_SUPPLY_CHAIN_PARENT_IMAGE_DIGEST,
+    relationship_type="DESCENDANT_OF",
+):
+    image_package_id = "SPDXRef-Package-subject-image"
+    parent_package_id = "SPDXRef-Package-parent-image"
+    parent_digest_value = parent_image_digest.split(":", 1)[1]
+    return {
+        "spdxVersion": "SPDX-2.3",
+        "name": f"sbom-{image_digest}",
+        "documentNamespace": f"https://example.test/sbom/{image_digest}",
+        "documentDescribes": [image_package_id],
+        "packages": [
+            {
+                "name": image_digest,
+                "SPDXID": image_package_id,
+                "downloadLocation": "NOASSERTION",
+                "externalRefs": [
+                    {
+                        "referenceCategory": "PACKAGE-MANAGER",
+                        "referenceType": "purl",
+                        "referenceLocator": (
+                            "pkg:oci/image@sha256:" f"{image_digest.split(':', 1)[1]}"
+                        ),
+                    },
+                ],
+            },
+            {
+                "name": "registry.example.test/base-image",
+                "SPDXID": parent_package_id,
+                "downloadLocation": "NOASSERTION",
+                "externalRefs": [
+                    {
+                        "referenceCategory": "PACKAGE-MANAGER",
+                        "referenceType": "purl",
+                        "referenceLocator": (
+                            "pkg:oci/base-image@sha256:"
+                            f"{parent_digest_value}"
+                            "?repository_url=registry.example.test/base-image"
+                        ),
+                    },
+                ],
+            },
+        ],
+        "relationships": [
+            {
+                "spdxElementId": image_package_id,
+                "relationshipType": relationship_type,
+                "relatedSpdxElement": parent_package_id,
             },
         ],
     }

--- a/tests/integration/cartography/intel/gcp/test_artifact_registry.py
+++ b/tests/integration/cartography/intel/gcp/test_artifact_registry.py
@@ -1164,7 +1164,9 @@ def test_load_image_provenance_stores_parent_without_missing_parent_edge(
         RETURN
             child.parent_image_uri AS parent_image_uri,
             child.parent_image_digest AS parent_image_digest,
-            exists((child)-[:BUILT_FROM]->(:GCPArtifactRegistryImage)) AS has_edge
+            EXISTS {
+                (child)-[:BUILT_FROM]->(:GCPArtifactRegistryImage)
+            } AS has_edge
         """,
         child_digest=child["digest"],
     ).single()

--- a/tests/integration/cartography/intel/gcp/test_artifact_registry.py
+++ b/tests/integration/cartography/intel/gcp/test_artifact_registry.py
@@ -30,6 +30,9 @@ from cartography.intel.gcp.artifact_registry.util import (
 )
 from cartography.intel.supply_chain import get_unmatched_gcp_images_with_history
 from cartography.models.gcp.artifact_registry.image import (
+    GCPArtifactRegistryImageBuiltFromMatchLink,
+)
+from cartography.models.gcp.artifact_registry.image import (
     GCPArtifactRegistryImageContainsImageMatchLink,
 )
 from cartography.models.gcp.artifact_registry.image import (
@@ -997,6 +1000,8 @@ def test_load_image_provenance_preserves_source_and_updates_metadata(
                 "source_uri": "https://github.com/foo/bar",
                 "source_revision": "revision-1",
                 "source_file": "Dockerfile",
+                "parent_image_uri": "pkg:oci/base@sha256:1111",
+                "parent_image_digest": "sha256:1111",
                 "layer_diff_ids": ["sha256:layer-1"],
             },
         ],
@@ -1018,6 +1023,8 @@ def test_load_image_provenance_preserves_source_and_updates_metadata(
                 "source_uri": "https://github.com/other/repo",
                 "source_revision": "revision-2",
                 "source_file": "other/Dockerfile",
+                "parent_image_uri": "pkg:oci/other-base@sha256:2222",
+                "parent_image_digest": "sha256:2222",
                 "layer_diff_ids": ["sha256:layer-2"],
             },
         ],
@@ -1032,6 +1039,8 @@ def test_load_image_provenance_preserves_source_and_updates_metadata(
             image.source_uri AS source_uri,
             image.source_revision AS source_revision,
             image.source_file AS source_file,
+            image.parent_image_uri AS parent_image_uri,
+            image.parent_image_digest AS parent_image_digest,
             image.layer_diff_ids AS layer_diff_ids,
             image.architecture AS architecture,
             image.os AS os,
@@ -1047,6 +1056,8 @@ def test_load_image_provenance_preserves_source_and_updates_metadata(
     assert result["source_uri"] == "https://github.com/foo/bar"
     assert result["source_revision"] == "revision-1"
     assert result["source_file"] == "Dockerfile"
+    assert result["parent_image_uri"] == "pkg:oci/base@sha256:1111"
+    assert result["parent_image_digest"] == "sha256:1111"
     assert result["layer_diff_ids"] == ["sha256:layer-2"]
     assert result["architecture"] == "arm64"
     assert result["os"] == "linux"
@@ -1055,6 +1066,187 @@ def test_load_image_provenance_preserves_source_and_updates_metadata(
     assert result["ont_os"] == "linux"
     assert result["ont_variant"] == "v9"
     assert result["lastupdated"] == TEST_UPDATE_TAG + 1
+
+
+def test_load_image_provenance_creates_parent_image_lineage(neo4j_session):
+    project_id = "test-gar-parent-lineage-project"
+    repo_id = f"projects/{project_id}/locations/us-central1/repositories/docker-repo"
+    _clear_gar_project(neo4j_session, project_id)
+    _create_gar_project_and_repositories(neo4j_session, project_id, [repo_id])
+
+    child = _make_docker_image(repo_id, 12001)
+    parent = _make_docker_image(repo_id, 12002)
+    load_docker_images(neo4j_session, [child, parent], project_id, TEST_UPDATE_TAG)
+
+    load_image_provenance(
+        neo4j_session,
+        [
+            {
+                "digest": child["digest"],
+                "type": "image",
+                "media_type": TEST_SINGLE_IMAGE_MEDIA_TYPE,
+                "parent_image_uri": f"pkg:oci/base@{parent['digest']}",
+                "parent_image_digest": parent["digest"],
+            },
+        ],
+        project_id,
+        TEST_UPDATE_TAG,
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "GCPArtifactRegistryImage",
+        "id",
+        "GCPArtifactRegistryImage",
+        "id",
+        "BUILT_FROM",
+    ) >= {
+        (child["digest"], parent["digest"]),
+    }
+    result = neo4j_session.run(
+        """
+        MATCH (child:GCPArtifactRegistryImage {id: $child_digest})
+        -[built:BUILT_FROM]->
+        (parent:GCPArtifactRegistryImage {id: $parent_digest})
+        RETURN
+            child.parent_image_uri AS parent_image_uri,
+            child.parent_image_digest AS parent_image_digest,
+            built.parent_image_uri AS rel_parent_image_uri,
+            built.from_sbom AS from_sbom,
+            built.confidence AS confidence,
+            built._sub_resource_label AS sub_resource_label,
+            built._sub_resource_id AS sub_resource_id
+        """,
+        child_digest=child["digest"],
+        parent_digest=parent["digest"],
+    ).single()
+    assert result["parent_image_uri"] == f"pkg:oci/base@{parent['digest']}"
+    assert result["parent_image_digest"] == parent["digest"]
+    assert result["rel_parent_image_uri"] == f"pkg:oci/base@{parent['digest']}"
+    assert result["from_sbom"] is True
+    assert result["confidence"] == "explicit"
+    assert result["sub_resource_label"] == "GCPProject"
+    assert result["sub_resource_id"] == project_id
+
+
+def test_load_image_provenance_stores_parent_without_missing_parent_edge(
+    neo4j_session,
+):
+    project_id = "test-gar-parent-lineage-missing-parent-project"
+    repo_id = f"projects/{project_id}/locations/us-central1/repositories/docker-repo"
+    _clear_gar_project(neo4j_session, project_id)
+    _create_gar_project_and_repositories(neo4j_session, project_id, [repo_id])
+
+    child = _make_docker_image(repo_id, 12101)
+    parent_digest = (
+        "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    )
+    load_docker_images(neo4j_session, [child], project_id, TEST_UPDATE_TAG)
+
+    load_image_provenance(
+        neo4j_session,
+        [
+            {
+                "digest": child["digest"],
+                "type": "image",
+                "media_type": TEST_SINGLE_IMAGE_MEDIA_TYPE,
+                "parent_image_uri": f"pkg:oci/base@{parent_digest}",
+                "parent_image_digest": parent_digest,
+            },
+        ],
+        project_id,
+        TEST_UPDATE_TAG,
+    )
+
+    result = neo4j_session.run(
+        """
+        MATCH (child:GCPArtifactRegistryImage {id: $child_digest})
+        RETURN
+            child.parent_image_uri AS parent_image_uri,
+            child.parent_image_digest AS parent_image_digest,
+            exists((child)-[:BUILT_FROM]->(:GCPArtifactRegistryImage)) AS has_edge
+        """,
+        child_digest=child["digest"],
+    ).single()
+    assert result["parent_image_uri"] == f"pkg:oci/base@{parent_digest}"
+    assert result["parent_image_digest"] == parent_digest
+    assert result["has_edge"] is False
+
+
+def test_gcp_artifact_registry_built_from_cleanup_removes_stale_edges(
+    neo4j_session,
+):
+    project_id = "test-gar-parent-lineage-cleanup-project"
+    repo_id = f"projects/{project_id}/locations/us-central1/repositories/docker-repo"
+    _clear_gar_project(neo4j_session, project_id)
+    _create_gar_project_and_repositories(neo4j_session, project_id, [repo_id])
+
+    child = _make_docker_image(repo_id, 12201)
+    current_parent = _make_docker_image(repo_id, 12202)
+    stale_parent = _make_docker_image(repo_id, 12203)
+    load_docker_images(
+        neo4j_session,
+        [child, current_parent, stale_parent],
+        project_id,
+        TEST_UPDATE_TAG,
+    )
+    neo4j_session.run(
+        """
+        MATCH (child:GCPArtifactRegistryImage {id: $child_digest})
+        MATCH (stale_parent:GCPArtifactRegistryImage {id: $stale_parent_digest})
+        MERGE (child)-[built:BUILT_FROM]->(stale_parent)
+        SET built.lastupdated = $stale_update_tag,
+            built._sub_resource_label = 'GCPProject',
+            built._sub_resource_id = $project_id
+        """,
+        child_digest=child["digest"],
+        stale_parent_digest=stale_parent["digest"],
+        stale_update_tag=TEST_UPDATE_TAG - 1,
+        project_id=project_id,
+    )
+
+    load_image_provenance(
+        neo4j_session,
+        [
+            {
+                "digest": child["digest"],
+                "type": "image",
+                "media_type": TEST_SINGLE_IMAGE_MEDIA_TYPE,
+                "parent_image_uri": f"pkg:oci/base@{current_parent['digest']}",
+                "parent_image_digest": current_parent["digest"],
+            },
+        ],
+        project_id,
+        TEST_UPDATE_TAG,
+    )
+    GraphJob.from_matchlink(
+        GCPArtifactRegistryImageBuiltFromMatchLink(),
+        "GCPProject",
+        project_id,
+        TEST_UPDATE_TAG,
+    ).run(neo4j_session)
+
+    assert check_rels(
+        neo4j_session,
+        "GCPArtifactRegistryImage",
+        "id",
+        "GCPArtifactRegistryImage",
+        "id",
+        "BUILT_FROM",
+    ) >= {
+        (child["digest"], current_parent["digest"]),
+    }
+    stale_count = neo4j_session.run(
+        """
+        MATCH (:GCPArtifactRegistryImage {id: $child_digest})
+        -[:BUILT_FROM]->
+        (:GCPArtifactRegistryImage {id: $stale_parent_digest})
+        RETURN count(*) AS count
+        """,
+        child_digest=child["digest"],
+        stale_parent_digest=stale_parent["digest"],
+    ).single()["count"]
+    assert stale_count == 0
 
 
 def test_get_unmatched_gcp_images_with_history_uses_parent_ref_for_platform_child(

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_supply_chain.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_supply_chain.py
@@ -343,6 +343,65 @@ def test_extract_parent_image_from_spdx_sbom_rejects_ambiguous_parents():
     assert provenance == {}
 
 
+def test_extract_parent_image_from_spdx_sbom_rejects_ambiguous_descendant_even_with_variant():
+    sbom = mock_spdx_parent_image_sbom(MOCK_SUPPLY_CHAIN_IMAGE_DIGEST)
+    sbom["packages"].extend(
+        [
+            {
+                "name": "registry.example.test/other-base",
+                "SPDXID": "SPDXRef-Package-other-parent",
+                "downloadLocation": "NOASSERTION",
+                "externalRefs": [
+                    {
+                        "referenceCategory": "PACKAGE-MANAGER",
+                        "referenceType": "purl",
+                        "referenceLocator": (
+                            "pkg:docker/other-base@sha256:"
+                            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                        ),
+                    },
+                ],
+            },
+            {
+                "name": "registry.example.test/variant-base",
+                "SPDXID": "SPDXRef-Package-variant-parent",
+                "downloadLocation": "NOASSERTION",
+                "externalRefs": [
+                    {
+                        "referenceCategory": "PACKAGE-MANAGER",
+                        "referenceType": "purl",
+                        "referenceLocator": (
+                            "pkg:oci/variant-base@sha256:"
+                            "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                        ),
+                    },
+                ],
+            },
+        ],
+    )
+    sbom["relationships"].extend(
+        [
+            {
+                "spdxElementId": "SPDXRef-Package-subject-image",
+                "relationshipType": "DESCENDANT_OF",
+                "relatedSpdxElement": "SPDXRef-Package-other-parent",
+            },
+            {
+                "spdxElementId": "SPDXRef-Package-subject-image",
+                "relationshipType": "VARIANT_OF",
+                "relatedSpdxElement": "SPDXRef-Package-variant-parent",
+            },
+        ],
+    )
+
+    provenance = _extract_parent_image_from_spdx_sbom(
+        sbom,
+        MOCK_SUPPLY_CHAIN_IMAGE_DIGEST,
+    )
+
+    assert provenance == {}
+
+
 # ---------------------------------------------------------------------------
 # Layer history alignment
 # ---------------------------------------------------------------------------
@@ -889,6 +948,64 @@ async def test_process_single_image_extracts_parent_from_spdx_sbom():
     assert result["parent_image_uri"] == MOCK_SUPPLY_CHAIN_PARENT_IMAGE_URI
     assert result["parent_image_digest"] == MOCK_SUPPLY_CHAIN_PARENT_IMAGE_DIGEST
     assert "source_uri" not in result
+
+
+@pytest.mark.asyncio
+async def test_process_single_image_returns_parent_only_spdx_provenance():
+    client = _FakeClient(
+        {
+            MOCK_SUPPLY_CHAIN_IMAGE_MANIFEST_URL: _FakeResponse(
+                200,
+                json_body=MOCK_SINGLE_IMAGE_MANIFEST,
+                headers={"Docker-Content-Digest": MOCK_SUPPLY_CHAIN_IMAGE_DIGEST},
+            ),
+            MOCK_SUPPLY_CHAIN_IMAGE_CONFIG_URL: _FakeResponse(
+                200,
+                json_body={"config": {"Labels": {}}},
+            ),
+            MOCK_SUPPLY_CHAIN_IMAGE_REFERRERS_URL: _FakeResponse(
+                200,
+                json_body={"manifests": []},
+            ),
+            MOCK_SUPPLY_CHAIN_DIGEST_SBOM_MANIFEST_URL: _FakeResponse(
+                200,
+                json_body=MOCK_SPDX_SBOM_MANIFEST,
+            ),
+            MOCK_SUPPLY_CHAIN_DIGEST_SBOM_BLOB_URL: _FakeResponse(
+                200,
+                json_body=mock_spdx_parent_image_sbom(MOCK_SUPPLY_CHAIN_IMAGE_DIGEST),
+            ),
+        },
+    )
+
+    result, fetch_failed = await _process_single_image(
+        client,
+        _fake_token_manager(),
+        {
+            "name": MOCK_SUPPLY_CHAIN_IMAGE_ARTIFACT_NAME,
+            "uri": MOCK_SUPPLY_CHAIN_IMAGE_URI,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        },
+        {
+            MOCK_SUPPLY_CHAIN_IMAGE_DIGEST: [
+                {
+                    "uri": MOCK_SUPPLY_CHAIN_IMAGE_URI,
+                    "tags": [
+                        f"sha256-{MOCK_SUPPLY_CHAIN_IMAGE_DIGEST_HEX}.sbom",
+                    ],
+                }
+            ]
+        },
+    )
+
+    assert fetch_failed is False
+    assert result == {
+        "digest": MOCK_SUPPLY_CHAIN_IMAGE_DIGEST,
+        "type": "image",
+        "media_type": "application/vnd.oci.image.manifest.v1+json",
+        "parent_image_uri": MOCK_SUPPLY_CHAIN_PARENT_IMAGE_URI,
+        "parent_image_digest": MOCK_SUPPLY_CHAIN_PARENT_IMAGE_DIGEST,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_supply_chain.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_supply_chain.py
@@ -7,6 +7,9 @@ import pytest
 from cartography.intel.gcp.artifact_registry import supply_chain
 from cartography.intel.gcp.artifact_registry.supply_chain import _build_layer_dicts
 from cartography.intel.gcp.artifact_registry.supply_chain import (
+    _extract_parent_image_from_spdx_sbom,
+)
+from cartography.intel.gcp.artifact_registry.supply_chain import (
     _extract_source_from_spdx_sbom,
 )
 from cartography.intel.gcp.artifact_registry.supply_chain import (
@@ -22,6 +25,7 @@ from tests.data.gcp.artifact_registry import mock_ko_spdx_sbom
 from tests.data.gcp.artifact_registry import MOCK_SINGLE_IMAGE_CONFIG
 from tests.data.gcp.artifact_registry import mock_single_image_config_without_labels
 from tests.data.gcp.artifact_registry import MOCK_SINGLE_IMAGE_MANIFEST
+from tests.data.gcp.artifact_registry import mock_spdx_parent_image_sbom
 from tests.data.gcp.artifact_registry import mock_spdx_sbom
 from tests.data.gcp.artifact_registry import MOCK_SPDX_SBOM_MANIFEST
 from tests.data.gcp.artifact_registry import MOCK_SUPPLY_CHAIN_DIGEST_SBOM_BLOB_URL
@@ -34,6 +38,8 @@ from tests.data.gcp.artifact_registry import MOCK_SUPPLY_CHAIN_IMAGE_MANIFEST_UR
 from tests.data.gcp.artifact_registry import MOCK_SUPPLY_CHAIN_IMAGE_REFERRERS_URL
 from tests.data.gcp.artifact_registry import MOCK_SUPPLY_CHAIN_IMAGE_URI
 from tests.data.gcp.artifact_registry import MOCK_SUPPLY_CHAIN_MISSING_SBOM_URI
+from tests.data.gcp.artifact_registry import MOCK_SUPPLY_CHAIN_PARENT_IMAGE_DIGEST
+from tests.data.gcp.artifact_registry import MOCK_SUPPLY_CHAIN_PARENT_IMAGE_URI
 from tests.data.gcp.artifact_registry import MOCK_SUPPLY_CHAIN_SBOM_BLOB_URL
 from tests.data.gcp.artifact_registry import MOCK_SUPPLY_CHAIN_SBOM_MANIFEST_URL
 from tests.data.gcp.artifact_registry import MOCK_SUPPLY_CHAIN_SBOM_URI
@@ -205,6 +211,138 @@ def test_extract_source_from_spdx_sbom_accepts_generic_document_identity():
     assert provenance == {"source_uri": "https://github.com/example/widgets"}
 
 
+def test_extract_parent_image_from_spdx_sbom_reads_descendant_relationship():
+    provenance = _extract_parent_image_from_spdx_sbom(
+        mock_spdx_parent_image_sbom(MOCK_SUPPLY_CHAIN_IMAGE_DIGEST),
+        MOCK_SUPPLY_CHAIN_IMAGE_DIGEST,
+    )
+
+    assert provenance == {
+        "parent_image_uri": MOCK_SUPPLY_CHAIN_PARENT_IMAGE_URI,
+        "parent_image_digest": MOCK_SUPPLY_CHAIN_PARENT_IMAGE_DIGEST,
+    }
+
+
+def test_extract_parent_image_from_spdx_sbom_falls_back_to_variant_relationship():
+    provenance = _extract_parent_image_from_spdx_sbom(
+        mock_spdx_parent_image_sbom(
+            MOCK_SUPPLY_CHAIN_IMAGE_DIGEST,
+            relationship_type="VARIANT_OF",
+        ),
+        MOCK_SUPPLY_CHAIN_IMAGE_DIGEST,
+    )
+
+    assert provenance["parent_image_digest"] == MOCK_SUPPLY_CHAIN_PARENT_IMAGE_DIGEST
+
+
+def test_extract_parent_image_from_spdx_sbom_prefers_descendant_relationship():
+    sbom = mock_spdx_parent_image_sbom(
+        MOCK_SUPPLY_CHAIN_IMAGE_DIGEST,
+        relationship_type="DESCENDANT_OF",
+    )
+    sbom["packages"].append(
+        {
+            "name": "registry.example.test/variant-parent",
+            "SPDXID": "SPDXRef-Package-variant-parent",
+            "downloadLocation": "NOASSERTION",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": (
+                        "pkg:oci/variant-parent@sha256:"
+                        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    ),
+                },
+            ],
+        }
+    )
+    sbom["relationships"].append(
+        {
+            "spdxElementId": "SPDXRef-Package-subject-image",
+            "relationshipType": "VARIANT_OF",
+            "relatedSpdxElement": "SPDXRef-Package-variant-parent",
+        }
+    )
+
+    provenance = _extract_parent_image_from_spdx_sbom(
+        sbom,
+        MOCK_SUPPLY_CHAIN_IMAGE_DIGEST,
+    )
+
+    assert provenance["parent_image_digest"] == MOCK_SUPPLY_CHAIN_PARENT_IMAGE_DIGEST
+
+
+def test_extract_parent_image_from_spdx_sbom_rejects_subject_mismatch():
+    provenance = _extract_parent_image_from_spdx_sbom(
+        mock_spdx_parent_image_sbom(MOCK_SUPPLY_CHAIN_IMAGE_DIGEST),
+        "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    )
+
+    assert provenance == {}
+
+
+def test_extract_parent_image_from_spdx_sbom_rejects_non_image_package():
+    sbom = mock_spdx_parent_image_sbom(MOCK_SUPPLY_CHAIN_IMAGE_DIGEST)
+    sbom["packages"][1]["externalRefs"][0][
+        "referenceLocator"
+    ] = "pkg:golang/github.com/example/base@v1.0.0"
+
+    provenance = _extract_parent_image_from_spdx_sbom(
+        sbom,
+        MOCK_SUPPLY_CHAIN_IMAGE_DIGEST,
+    )
+
+    assert provenance == {}
+
+
+def test_extract_parent_image_from_spdx_sbom_rejects_self_reference():
+    provenance = _extract_parent_image_from_spdx_sbom(
+        mock_spdx_parent_image_sbom(
+            MOCK_SUPPLY_CHAIN_IMAGE_DIGEST,
+            parent_image_digest=MOCK_SUPPLY_CHAIN_IMAGE_DIGEST,
+        ),
+        MOCK_SUPPLY_CHAIN_IMAGE_DIGEST,
+    )
+
+    assert provenance == {}
+
+
+def test_extract_parent_image_from_spdx_sbom_rejects_ambiguous_parents():
+    sbom = mock_spdx_parent_image_sbom(MOCK_SUPPLY_CHAIN_IMAGE_DIGEST)
+    sbom["packages"].append(
+        {
+            "name": "registry.example.test/other-base",
+            "SPDXID": "SPDXRef-Package-other-parent",
+            "downloadLocation": "NOASSERTION",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": (
+                        "pkg:docker/other-base@sha256:"
+                        "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                    ),
+                },
+            ],
+        }
+    )
+    sbom["relationships"].append(
+        {
+            "spdxElementId": "SPDXRef-Package-subject-image",
+            "relationshipType": "DESCENDANT_OF",
+            "relatedSpdxElement": "SPDXRef-Package-other-parent",
+        }
+    )
+
+    provenance = _extract_parent_image_from_spdx_sbom(
+        sbom,
+        MOCK_SUPPLY_CHAIN_IMAGE_DIGEST,
+    )
+
+    assert provenance == {}
+
+
 # ---------------------------------------------------------------------------
 # Layer history alignment
 # ---------------------------------------------------------------------------
@@ -372,6 +510,8 @@ def test_sync_loads_provenance_and_layers_with_split_phases(patched_sync):
                 "source_uri": "https://github.com/foo/bar",
                 "source_revision": "deadbeef",
                 "source_file": "Dockerfile",
+                "parent_image_uri": None,
+                "parent_image_digest": None,
                 "layer_diff_ids": ["sha256:a", "sha256:b"],
                 "architecture": None,
                 "os": None,
@@ -386,6 +526,8 @@ def test_sync_loads_provenance_and_layers_with_split_phases(patched_sync):
                 "source_uri": None,
                 "source_revision": None,
                 "source_file": None,
+                "parent_image_uri": None,
+                "parent_image_digest": None,
                 "layer_diff_ids": ["sha256:a"],
                 "architecture": None,
                 "os": None,
@@ -409,10 +551,16 @@ def test_sync_loads_provenance_and_layers_with_split_phases(patched_sync):
 
 def test_load_image_provenance_preserves_existing_values(monkeypatch):
     load_nodes_without_relationships = MagicMock()
+    load_matchlinks_with_progress = MagicMock()
     monkeypatch.setattr(
         supply_chain,
         "load_nodes_without_relationships",
         load_nodes_without_relationships,
+    )
+    monkeypatch.setattr(
+        supply_chain,
+        "load_matchlinks_with_progress",
+        load_matchlinks_with_progress,
     )
     neo4j_session = MagicMock()
     neo4j_session.execute_read.return_value = [
@@ -428,6 +576,8 @@ def test_load_image_provenance_preserves_existing_values(monkeypatch):
             "source_uri": "https://github.com/foo/bar",
             "source_revision": "deadbeef",
             "source_file": "Dockerfile",
+            "parent_image_uri": "pkg:oci/base@sha256:parent",
+            "parent_image_digest": "sha256:parent",
             "layer_diff_ids": ["sha256:a"],
         },
     ]
@@ -444,6 +594,8 @@ def test_load_image_provenance_preserves_existing_values(monkeypatch):
             "source_uri": None,
             "source_revision": None,
             "source_file": None,
+            "parent_image_uri": None,
+            "parent_image_digest": None,
             "layer_diff_ids": None,
         },
     ]
@@ -468,9 +620,12 @@ def test_load_image_provenance_preserves_existing_values(monkeypatch):
             "source_uri": "https://github.com/foo/bar",
             "source_revision": "deadbeef",
             "source_file": "Dockerfile",
+            "parent_image_uri": "pkg:oci/base@sha256:parent",
+            "parent_image_digest": "sha256:parent",
             "layer_diff_ids": ["sha256:a"],
         },
     ]
+    load_matchlinks_with_progress.assert_called_once()
     assert "provenance updates" in call.kwargs["progress_description"]
     assert call.kwargs["lastupdated"] == 1
     assert call.kwargs["PROJECT_ID"] == "proj"
@@ -529,7 +684,7 @@ def test_sync_runs_cleanup_when_safe_and_no_failures(patched_sync):
         cleanup_safe=True,
     )
 
-    assert len(cleanup_runs) == 2
+    assert len(cleanup_runs) == 3
 
 
 def test_sync_skips_cleanup_when_fetch_failures(patched_sync):
@@ -679,6 +834,110 @@ async def test_process_single_image_falls_back_to_digest_specific_spdx_sbom():
         "sha256:2222222222222222222222222222222222222222222222222222222222222222",
     ]
     assert MOCK_SUPPLY_CHAIN_DIGEST_SBOM_MANIFEST_URL in client.calls
+
+
+@pytest.mark.asyncio
+async def test_process_single_image_extracts_parent_from_spdx_sbom():
+    client = _FakeClient(
+        {
+            MOCK_SUPPLY_CHAIN_IMAGE_MANIFEST_URL: _FakeResponse(
+                200,
+                json_body=MOCK_SINGLE_IMAGE_MANIFEST,
+                headers={"Docker-Content-Digest": MOCK_SUPPLY_CHAIN_IMAGE_DIGEST},
+            ),
+            MOCK_SUPPLY_CHAIN_IMAGE_CONFIG_URL: _FakeResponse(
+                200,
+                json_body=mock_single_image_config_without_labels(),
+            ),
+            MOCK_SUPPLY_CHAIN_IMAGE_REFERRERS_URL: _FakeResponse(
+                200,
+                json_body={"manifests": []},
+            ),
+            MOCK_SUPPLY_CHAIN_DIGEST_SBOM_MANIFEST_URL: _FakeResponse(
+                200,
+                json_body=MOCK_SPDX_SBOM_MANIFEST,
+            ),
+            MOCK_SUPPLY_CHAIN_DIGEST_SBOM_BLOB_URL: _FakeResponse(
+                200,
+                json_body=mock_spdx_parent_image_sbom(MOCK_SUPPLY_CHAIN_IMAGE_DIGEST),
+            ),
+        },
+    )
+
+    result, fetch_failed = await _process_single_image(
+        client,
+        _fake_token_manager(),
+        {
+            "name": MOCK_SUPPLY_CHAIN_IMAGE_ARTIFACT_NAME,
+            "uri": MOCK_SUPPLY_CHAIN_IMAGE_URI,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        },
+        {
+            MOCK_SUPPLY_CHAIN_IMAGE_DIGEST: [
+                {
+                    "uri": MOCK_SUPPLY_CHAIN_IMAGE_URI,
+                    "tags": [
+                        f"sha256-{MOCK_SUPPLY_CHAIN_IMAGE_DIGEST_HEX}.sbom",
+                    ],
+                }
+            ]
+        },
+    )
+
+    assert fetch_failed is False
+    assert result["digest"] == MOCK_SUPPLY_CHAIN_IMAGE_DIGEST
+    assert result["parent_image_uri"] == MOCK_SUPPLY_CHAIN_PARENT_IMAGE_URI
+    assert result["parent_image_digest"] == MOCK_SUPPLY_CHAIN_PARENT_IMAGE_DIGEST
+    assert "source_uri" not in result
+
+
+@pytest.mark.asyncio
+async def test_process_single_image_fetches_spdx_parent_when_config_has_source():
+    client = _FakeClient(
+        {
+            MOCK_SUPPLY_CHAIN_IMAGE_MANIFEST_URL: _FakeResponse(
+                200,
+                json_body=MOCK_SINGLE_IMAGE_MANIFEST,
+                headers={"Docker-Content-Digest": MOCK_SUPPLY_CHAIN_IMAGE_DIGEST},
+            ),
+            MOCK_SUPPLY_CHAIN_IMAGE_CONFIG_URL: _FakeResponse(
+                200,
+                json_body=MOCK_SINGLE_IMAGE_CONFIG,
+            ),
+            MOCK_SUPPLY_CHAIN_DIGEST_SBOM_MANIFEST_URL: _FakeResponse(
+                200,
+                json_body=MOCK_SPDX_SBOM_MANIFEST,
+            ),
+            MOCK_SUPPLY_CHAIN_DIGEST_SBOM_BLOB_URL: _FakeResponse(
+                200,
+                json_body=mock_spdx_parent_image_sbom(MOCK_SUPPLY_CHAIN_IMAGE_DIGEST),
+            ),
+        },
+    )
+
+    result, fetch_failed = await _process_single_image(
+        client,
+        _fake_token_manager(),
+        {
+            "name": MOCK_SUPPLY_CHAIN_IMAGE_ARTIFACT_NAME,
+            "uri": MOCK_SUPPLY_CHAIN_IMAGE_URI,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        },
+        {
+            MOCK_SUPPLY_CHAIN_IMAGE_DIGEST: [
+                {
+                    "uri": MOCK_SUPPLY_CHAIN_IMAGE_URI,
+                    "tags": [
+                        f"sha256-{MOCK_SUPPLY_CHAIN_IMAGE_DIGEST_HEX}.sbom",
+                    ],
+                }
+            ]
+        },
+    )
+
+    assert fetch_failed is False
+    assert result["source_uri"] == "https://github.com/example/widgets"
+    assert result["parent_image_digest"] == MOCK_SUPPLY_CHAIN_PARENT_IMAGE_DIGEST
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update


### Summary
Adds GCP Artifact Registry parent/base image lineage from digest-verified SPDX SBOMs.

This keeps the GAR image model aligned with the existing ECR-style shape: parent URI and digest are stored on `GCPArtifactRegistryImage`, and `BUILT_FROM` is created only when the parent digest is already represented by another GAR image node.


### How was this tested?

- Updated integration and unit tests


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

<img width="1206" height="566" alt="Screenshot 2026-05-07 at 6 18 41 PM" src="https://github.com/user-attachments/assets/6986167e-16ac-4d0e-9dec-616282e76f94" />




### Notes for reviewers

This intentionally does not create external image nodes. If an SPDX SBOM references a parent image digest that has not been loaded as a GAR image, Cartography preserves `parent_image_uri` and `parent_image_digest` on the child image but does not create `BUILT_FROM` until the parent digest exists in the graph.
