### PR TITLE
fix: bump docker-compose Neo4j image to 5-community

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 # functionality that you can extend on your own.
 services:
   neo4j:
-    image: neo4j:5.15.0-community
+    image: neo4j:5-community
     restart: unless-stopped
     ports:
       - 7474:7474

--- a/docs/root/install.md
+++ b/docs/root/install.md
@@ -193,7 +193,7 @@ Do this if you prefer to install and manage all the dependencies yourself. Carto
 
     Older versions of Python (3.10-3.12) may work but are not tested. Python 3.10 support will be removed in October 2026.
 
-1. **Run Neo4j graph database version 5.x or higher.**
+1. **Run Neo4j graph database version 5.23 or higher.** Cartography emits scoped subqueries (`CALL (var) { ... }`) that earlier 5.x releases do not support.
 
     1. We recommend running Neo4j as a Docker container so that you save time and don't need to install Java. Run `docker run --publish=7474:7474 --publish=7687:7687 -v data:/data --env=NEO4J_AUTH=none neo4j:5-community`.
 
@@ -203,7 +203,7 @@ Do this if you prefer to install and manage all the dependencies yourself. Carto
 
             ⚠️ Make sure you have the `JAVA_HOME` environment variable set. The following works for Mac OS: `export JAVA_HOME=$(/usr/libexec/java_home)`
 
-        1. Go to the [Neo4j download page](https://neo4j.com/download-center/#community), and download Neo4j Community Edition 5.\*.
+        1. Go to the [Neo4j download page](https://neo4j.com/download-center/#community), and download Neo4j Community Edition 5.23 or higher.
 
         1. [Install](https://neo4j.com/docs/operations-manual/current/installation/) Neo4j.
 


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary
The Neo4j image pinned in `docker-compose.yml` (`5.15.0-community`) does not support the scoped subquery syntax `CALL (var) { ... }` emitted by `cartography/graph/querybuilder.py` and `cartography/graph/cleanupbuilder.py`. That syntax requires Neo4j 5.23+. As a result, anyone running a sync via `docker compose` hits:

```
Invalid input '(': expected "{" (line 26, column 14)
"        CALL (i, item) {"
```

Two changes:
1. Bump `docker-compose.yml` to the rolling `neo4j:5-community` tag, matching what CI (`.github/workflows/test_suite.yml`) and the install docs already use.
2. Make the Neo4j minimum version explicit in `docs/root/install.md`. The doc previously said "version 5.x or higher", which is inaccurate: 5.0–5.22 will fail with the same syntax error. State 5.23 as the minimum and explain why.


### Related issues or links

- Fixes #2766


### How was this tested?
- Confirmed via `grep` that the `CALL (var) { ... }` syntax is emitted in `cartography/graph/querybuilder.py:939` and `cartography/graph/cleanupbuilder.py:327`, which is unsupported on 5.15 and supported from 5.23 onward.
- The CI test suite already runs against `neo4j:5-community`, so this aligns the local docker-compose environment with the tested configuration.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.


### Notes for reviewers
Two small changes: a docker-compose image tag and two lines of install-guide wording. No code or schema changes.