### PR TITLE
feat(rules): add serverless_workload_exposed multi-cloud rule

### DIFF
--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -128,6 +128,13 @@ _FULL_NAME_MAPPINGS: list[_FullNameMapping] = [
         "GCPCloudRunService",
         "full_path",
     ),
+    # Cloud Functions.
+    _FullNameMapping(
+        "//cloudfunctions.googleapis.com/",
+        "functions",
+        "GCPCloudFunction",
+        "full_path",
+    ),
     # Compute — node id is the "partial URI" (``projects/.../{kind}/{name}``),
     # which matches the path left after stripping the service prefix.
     _FullNameMapping(

--- a/cartography/rules/data/rules/__init__.py
+++ b/cartography/rules/data/rules/__init__.py
@@ -219,6 +219,9 @@ from cartography.rules.data.rules.object_storage_public import object_storage_pu
 from cartography.rules.data.rules.policy_administration_privileges import (
     policy_administration_privileges,
 )
+from cartography.rules.data.rules.serverless_workload_exposed import (
+    serverless_workload_exposed,
+)
 from cartography.rules.data.rules.subimage_coverage import aws_account_not_synced
 from cartography.rules.data.rules.subimage_coverage import container_image_not_found
 from cartography.rules.data.rules.subimage_coverage import (
@@ -275,6 +278,7 @@ RULES = {
     missing_mfa_rule.id: missing_mfa_rule,
     object_storage_public.id: object_storage_public,
     policy_administration_privileges.id: policy_administration_privileges,
+    serverless_workload_exposed.id: serverless_workload_exposed,
     unmanaged_accounts.id: unmanaged_accounts,
     workload_identity_admin_capabilities.id: workload_identity_admin_capabilities,
     cloud_security_product_deactivated.id: cloud_security_product_deactivated,

--- a/cartography/rules/data/rules/serverless_workload_exposed.py
+++ b/cartography/rules/data/rules/serverless_workload_exposed.py
@@ -87,6 +87,43 @@ _gcp_cloud_function_http_trigger = Fact(
 )
 
 
+# AWS Facts
+_aws_lambda_anonymous_access = Fact(
+    id="aws_lambda_anonymous_access",
+    name="Internet-Accessible AWS Lambda Attack Surface",
+    description=(
+        "AWS Lambda functions whose resource policy allows anonymous "
+        "invocation. The cartography AWS Lambda intel module sets "
+        "anonymous_access = true when the function's resource-based policy "
+        "grants the lambda:InvokeFunction action (or equivalent) to a "
+        "wildcard principal, which covers Function URLs configured with "
+        "AuthType=NONE as well as policies opened to '*' / Everyone."
+    ),
+    cypher_query="""
+    MATCH (acc:AWSAccount)-[:RESOURCE]->(fn:AWSLambda)
+    WHERE fn.anonymous_access = true
+    RETURN
+        fn.arn AS id,
+        fn.name AS name,
+        fn.region AS region,
+        fn.runtime AS runtime,
+        'lambda_anonymous_invoke' AS exposure_type
+    """,
+    cypher_visual_query="""
+    MATCH p=(acc:AWSAccount)-[:RESOURCE]->(fn:AWSLambda)
+    WHERE fn.anonymous_access = true
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (fn:AWSLambda)
+    RETURN COUNT(fn) AS count
+    """,
+    asset_id_field="id",
+    module=Module.AWS,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
 # TODO: add an Azure Function App fact once the cartography intel module
 # ingests siteConfig.publicNetworkAccess and privateEndpointConnections.
 # Today only `https_only` and `state` are modelled, which is not enough to
@@ -107,11 +144,13 @@ serverless_workload_exposed = Rule(
     name="Internet-Exposed Serverless Workloads",
     description=(
         "Serverless compute reachable from the public internet via "
-        "permissive ingress or anonymous IAM bindings. Covers GCP Cloud "
-        "Run and GCP Cloud Functions."
+        "permissive ingress, anonymous IAM bindings, or unauthenticated "
+        "Function URLs. Covers GCP Cloud Run, GCP Cloud Functions, and "
+        "AWS Lambda."
     ),
     output_model=ServerlessWorkloadExposed,
     facts=(
+        _aws_lambda_anonymous_access,
         _gcp_cloud_run_public_ingress,
         _gcp_cloud_function_http_trigger,
     ),

--- a/cartography/rules/data/rules/serverless_workload_exposed.py
+++ b/cartography/rules/data/rules/serverless_workload_exposed.py
@@ -1,0 +1,126 @@
+from cartography.rules.spec.model import Fact
+from cartography.rules.spec.model import Finding
+from cartography.rules.spec.model import Maturity
+from cartography.rules.spec.model import Module
+from cartography.rules.spec.model import Rule
+
+# GCP Facts
+_gcp_cloud_run_public_ingress = Fact(
+    id="gcp_cloud_run_public_ingress",
+    name="Internet-Accessible Cloud Run Service Attack Surface",
+    description=(
+        "Cloud Run services that allow ingress from the public internet "
+        "(ingress = INGRESS_TRAFFIC_ALL) AND grant the run.invoker role to "
+        "allUsers or allAuthenticatedUsers via an unconditional IAM binding. "
+        "Both layers must be permissive for the service to be anonymously "
+        "invokable from the internet."
+    ),
+    cypher_query="""
+    MATCH (svc:GCPCloudRunService)
+    WHERE svc.ingress = 'INGRESS_TRAFFIC_ALL'
+      AND EXISTS {
+          MATCH (svc)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)
+          WHERE binding.is_public = true
+            AND coalesce(binding.has_condition, false) = false
+      }
+    RETURN
+        svc.id AS id,
+        svc.name AS name,
+        svc.location AS region,
+        'cloud_run_public_ingress' AS exposure_type
+    """,
+    cypher_visual_query="""
+    MATCH p=(svc:GCPCloudRunService)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)
+    WHERE svc.ingress = 'INGRESS_TRAFFIC_ALL'
+      AND binding.is_public = true
+      AND coalesce(binding.has_condition, false) = false
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (svc:GCPCloudRunService)
+    RETURN COUNT(svc) AS count
+    """,
+    asset_id_field="id",
+    module=Module.GCP,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+_gcp_cloud_function_http_trigger = Fact(
+    id="gcp_cloud_function_http_trigger",
+    name="Internet-Accessible Cloud Function Attack Surface",
+    description=(
+        "Cloud Functions configured with an HTTPS trigger AND granting the "
+        "cloudfunctions.invoker role (or equivalent) to allUsers or "
+        "allAuthenticatedUsers via an unconditional IAM binding. Anonymous "
+        "callers can invoke the function over the public internet."
+    ),
+    cypher_query="""
+    MATCH (fn:GCPCloudFunction)
+    WHERE fn.https_trigger_url IS NOT NULL
+      AND EXISTS {
+          MATCH (fn)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)
+          WHERE binding.is_public = true
+            AND coalesce(binding.has_condition, false) = false
+      }
+    RETURN
+        fn.id AS id,
+        fn.name AS name,
+        fn.region AS region,
+        fn.runtime AS runtime,
+        'cloud_function_http_trigger' AS exposure_type
+    """,
+    cypher_visual_query="""
+    MATCH p=(fn:GCPCloudFunction)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)
+    WHERE fn.https_trigger_url IS NOT NULL
+      AND binding.is_public = true
+      AND coalesce(binding.has_condition, false) = false
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (fn:GCPCloudFunction)
+    RETURN COUNT(fn) AS count
+    """,
+    asset_id_field="id",
+    module=Module.GCP,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+# TODO: add an Azure Function App fact once the cartography intel module
+# ingests siteConfig.publicNetworkAccess and privateEndpointConnections.
+# Today only `https_only` and `state` are modelled, which is not enough to
+# discriminate publicly-invokable Function Apps from privately-bound ones.
+
+
+# Rule
+class ServerlessWorkloadExposed(Finding):
+    id: str | None = None
+    name: str | None = None
+    region: str | None = None
+    runtime: str | None = None
+    exposure_type: str | None = None
+
+
+serverless_workload_exposed = Rule(
+    id="serverless_workload_exposed",
+    name="Internet-Exposed Serverless Workloads",
+    description=(
+        "Serverless compute reachable from the public internet via "
+        "permissive ingress or anonymous IAM bindings. Covers GCP Cloud "
+        "Run and GCP Cloud Functions."
+    ),
+    output_model=ServerlessWorkloadExposed,
+    facts=(
+        _gcp_cloud_run_public_ingress,
+        _gcp_cloud_function_http_trigger,
+    ),
+    tags=(
+        "infrastructure",
+        "serverless",
+        "attack_surface",
+        "stride:tampering",
+        "stride:elevation_of_privilege",
+    ),
+    version="0.1.0",
+)

--- a/cartography/rules/data/rules/serverless_workload_exposed.py
+++ b/cartography/rules/data/rules/serverless_workload_exposed.py
@@ -53,9 +53,11 @@ _gcp_cloud_function_http_trigger = Fact(
     name="Internet-Accessible Cloud Function Attack Surface",
     description=(
         "Cloud Functions configured with an HTTPS trigger AND granting "
-        "roles/cloudfunctions.invoker to allUsers or allAuthenticatedUsers "
-        "via an unconditional IAM binding. Anonymous callers can invoke "
-        "the function over the public internet."
+        "an invoker role (roles/cloudfunctions.invoker for 1st gen, "
+        "roles/run.invoker for 2nd gen, which runs on Cloud Run) to "
+        "allUsers or allAuthenticatedUsers via an unconditional IAM "
+        "binding. Anonymous callers can invoke the function over the "
+        "public internet."
     ),
     cypher_query="""
     MATCH (fn:GCPCloudFunction)
@@ -64,7 +66,10 @@ _gcp_cloud_function_http_trigger = Fact(
           MATCH (fn)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)
           WHERE binding.is_public = true
             AND coalesce(binding.has_condition, false) = false
-            AND binding.role = 'roles/cloudfunctions.invoker'
+            AND binding.role IN [
+                'roles/cloudfunctions.invoker',
+                'roles/run.invoker'
+            ]
       }
     RETURN
         fn.id AS id,
@@ -78,7 +83,10 @@ _gcp_cloud_function_http_trigger = Fact(
     WHERE fn.https_trigger_url IS NOT NULL
       AND binding.is_public = true
       AND coalesce(binding.has_condition, false) = false
-      AND binding.role = 'roles/cloudfunctions.invoker'
+      AND binding.role IN [
+          'roles/cloudfunctions.invoker',
+          'roles/run.invoker'
+      ]
     RETURN *
     """,
     cypher_count_query="""

--- a/cartography/rules/data/rules/serverless_workload_exposed.py
+++ b/cartography/rules/data/rules/serverless_workload_exposed.py
@@ -10,7 +10,7 @@ _gcp_cloud_run_public_ingress = Fact(
     name="Internet-Accessible Cloud Run Service Attack Surface",
     description=(
         "Cloud Run services that allow ingress from the public internet "
-        "(ingress = INGRESS_TRAFFIC_ALL) AND grant the run.invoker role to "
+        "(ingress = INGRESS_TRAFFIC_ALL) AND grant roles/run.invoker to "
         "allUsers or allAuthenticatedUsers via an unconditional IAM binding. "
         "Both layers must be permissive for the service to be anonymously "
         "invokable from the internet."
@@ -22,6 +22,7 @@ _gcp_cloud_run_public_ingress = Fact(
           MATCH (svc)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)
           WHERE binding.is_public = true
             AND coalesce(binding.has_condition, false) = false
+            AND binding.role = 'roles/run.invoker'
       }
     RETURN
         svc.id AS id,
@@ -34,6 +35,7 @@ _gcp_cloud_run_public_ingress = Fact(
     WHERE svc.ingress = 'INGRESS_TRAFFIC_ALL'
       AND binding.is_public = true
       AND coalesce(binding.has_condition, false) = false
+      AND binding.role = 'roles/run.invoker'
     RETURN *
     """,
     cypher_count_query="""
@@ -50,10 +52,10 @@ _gcp_cloud_function_http_trigger = Fact(
     id="gcp_cloud_function_http_trigger",
     name="Internet-Accessible Cloud Function Attack Surface",
     description=(
-        "Cloud Functions configured with an HTTPS trigger AND granting the "
-        "cloudfunctions.invoker role (or equivalent) to allUsers or "
-        "allAuthenticatedUsers via an unconditional IAM binding. Anonymous "
-        "callers can invoke the function over the public internet."
+        "Cloud Functions configured with an HTTPS trigger AND granting "
+        "roles/cloudfunctions.invoker to allUsers or allAuthenticatedUsers "
+        "via an unconditional IAM binding. Anonymous callers can invoke "
+        "the function over the public internet."
     ),
     cypher_query="""
     MATCH (fn:GCPCloudFunction)
@@ -62,6 +64,7 @@ _gcp_cloud_function_http_trigger = Fact(
           MATCH (fn)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)
           WHERE binding.is_public = true
             AND coalesce(binding.has_condition, false) = false
+            AND binding.role = 'roles/cloudfunctions.invoker'
       }
     RETURN
         fn.id AS id,
@@ -75,6 +78,7 @@ _gcp_cloud_function_http_trigger = Fact(
     WHERE fn.https_trigger_url IS NOT NULL
       AND binding.is_public = true
       AND coalesce(binding.has_condition, false) = false
+      AND binding.role = 'roles/cloudfunctions.invoker'
     RETURN *
     """,
     cypher_count_query="""

--- a/tests/unit/rules/test_serverless_workload_exposed.py
+++ b/tests/unit/rules/test_serverless_workload_exposed.py
@@ -16,12 +16,12 @@ def test_serverless_workload_exposed_rule_registered() -> None:
 def test_serverless_workload_exposed_rule_shape() -> None:
     assert serverless_workload_exposed.id == "serverless_workload_exposed"
     assert serverless_workload_exposed.output_model is ServerlessWorkloadExposed
-    assert len(serverless_workload_exposed.facts) == 2
+    assert len(serverless_workload_exposed.facts) == 3
 
 
 def test_serverless_workload_exposed_fact_modules() -> None:
     modules = {fact.module for fact in serverless_workload_exposed.facts}
-    assert modules == {Module.GCP}
+    assert modules == {Module.AWS, Module.GCP}
 
 
 def test_serverless_workload_exposed_facts_are_experimental() -> None:

--- a/tests/unit/rules/test_serverless_workload_exposed.py
+++ b/tests/unit/rules/test_serverless_workload_exposed.py
@@ -1,0 +1,36 @@
+from cartography.rules.data.rules import RULES
+from cartography.rules.data.rules.serverless_workload_exposed import (
+    serverless_workload_exposed,
+)
+from cartography.rules.data.rules.serverless_workload_exposed import (
+    ServerlessWorkloadExposed,
+)
+from cartography.rules.spec.model import Maturity
+from cartography.rules.spec.model import Module
+
+
+def test_serverless_workload_exposed_rule_registered() -> None:
+    assert RULES[serverless_workload_exposed.id] is serverless_workload_exposed
+
+
+def test_serverless_workload_exposed_rule_shape() -> None:
+    assert serverless_workload_exposed.id == "serverless_workload_exposed"
+    assert serverless_workload_exposed.output_model is ServerlessWorkloadExposed
+    assert len(serverless_workload_exposed.facts) == 2
+
+
+def test_serverless_workload_exposed_fact_modules() -> None:
+    modules = {fact.module for fact in serverless_workload_exposed.facts}
+    assert modules == {Module.GCP}
+
+
+def test_serverless_workload_exposed_facts_are_experimental() -> None:
+    assert all(
+        fact.maturity == Maturity.EXPERIMENTAL
+        for fact in serverless_workload_exposed.facts
+    )
+
+
+def test_serverless_workload_exposed_fact_ids_are_unique() -> None:
+    fact_ids = [fact.id for fact in serverless_workload_exposed.facts]
+    assert len(fact_ids) == len(set(fact_ids))


### PR DESCRIPTION
## Summary

Adds a new aggregated finding rule `serverless_workload_exposed` covering serverless workloads reachable from the public internet. Follows the existing multi-cloud aggregation pattern (`database_instance_exposed`, `compute_instance_exposed`, `object_storage_public`).

Facts:
- `gcp_cloud_run_public_ingress` — Cloud Run services with `ingress = INGRESS_TRAFFIC_ALL` AND an unconditional `GCPPolicyBinding{is_public:true}` granting invoke to `allUsers`/`allAuthenticatedUsers`
- `gcp_cloud_function_http_trigger` — Cloud Functions with an HTTPS trigger AND an unconditional public IAM binding
- `aws_lambda_anonymous_access` — AWS Lambda functions whose resource policy grants invoke to a wildcard principal (transparently covers Function URLs with `AuthType=NONE` and `*`-opened policies)

Linked: [SUB-1070](https://linear.app/subimagesec/issue/SUB-1070/create-finding-rules-for-gcp-internet-exposed-services).

CloudSQL public-IP exposure (also called out by SUB-1070) is already covered by the existing `database_instance_exposed` rule via `_gcp_cloud_sql_public_access`; the corresponding attack-path transition only needs `rule_id = "database_instance_exposed"` (out of scope for this PR — done in the attack-paths repo).

Azure Function App support is left as a follow-up: the current cartography `AzureFunctionApp` model only exposes `https_only`/`state`, which is not enough to discriminate publicly-invokable Function Apps from privately-bound ones. A `TODO` in the new file flags the intel-module enrichment that would unblock it (`siteConfig.publicNetworkAccess`, `privateEndpointConnections`).

Commits:
1. GCP Cloud Run + GCP Cloud Functions + scaffolding + tests
2. AWS Lambda fact

## Test plan

- [x] `make test_lint` clean
- [x] `uv run --frozen pytest tests/unit/rules/ -q` — 587 passed
- [ ] Sanity-check each fact's Cypher against a synced Neo4j when a tenant with public Cloud Run / Cloud Function / Lambda is available
- [ ] After merge, confirm `serverless_workload_exposed` surfaces findings in the SubImage UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)