### PR TITLE
fix(gcp): scope inherited policy binding writes

### DIFF
--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -151,11 +151,11 @@ def _sync_project_resources(
     :return: True if policy bindings were requested and every project synced them successfully.
     """
     logger.info("Syncing resources for %d GCP projects.", len(projects))
-    policy_bindings_requested_for_run = (
+    policy_bindings_requested = (
         requested_syncs is None or "policy_bindings" in requested_syncs
     )
     policy_bindings_all_projects_succeeded = (
-        policy_bindings_requested_for_run and len(projects) > 0
+        policy_bindings_requested and len(projects) > 0
     )
 
     # Cloud Asset Inventory (CAI) clients are lazily initialized and reused across all projects.
@@ -635,7 +635,6 @@ def _sync_project_resources(
         # Policy bindings sync uses CAI gRPC client.
         # Runs after all resource modules so that APPLIES_TO matchlinks can find
         # target nodes (secretsmanager, artifact_registry, cloud_run, etc.).
-        policy_bindings_requested = policy_bindings_requested_for_run
         if policy_bindings_requested:
             if policy_bindings_permission_ok is False:
                 policy_bindings_status = (
@@ -925,7 +924,7 @@ def start_gcp_ingestion(
         policy_bindings_requested = (
             requested_syncs is None or "policy_bindings" in requested_syncs
         )
-        if policy_bindings_all_projects_succeeded and policy_bindings_requested:
+        if policy_bindings_all_projects_succeeded:
             policy_bindings.cleanup_inherited_policy_bindings(
                 neo4j_session,
                 common_job_parameters,

--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -3,6 +3,7 @@ import logging
 from collections import namedtuple
 from typing import Dict
 from typing import List
+from typing import NamedTuple
 from typing import Optional
 from typing import Set
 
@@ -94,6 +95,10 @@ service_names = Services(
 )
 
 
+class GCPProjectResourcesSyncResult(NamedTuple):
+    policy_bindings_cleanup_safe: bool
+
+
 def _services_enabled_on_project(serviceusage: Resource, project_id: str) -> Set:
     """
     Return a list of all Google API services that are enabled on the given project ID.
@@ -139,7 +144,7 @@ def _sync_project_resources(
     credentials: GoogleCredentials,
     requested_syncs: Set[str] | None = None,
     org_role_permissions_by_name: dict[str, list[str]] | None = None,
-) -> bool:
+) -> GCPProjectResourcesSyncResult:
     """
     Syncs GCP service-specific resources (Compute, Storage, GKE, DNS, IAM) for each project.
     :param neo4j_session: The Neo4j session
@@ -148,15 +153,13 @@ def _sync_project_resources(
     :param common_job_parameters: Other parameters sent to Neo4j
     :param credentials: GCP credentials to use for API calls.
     :param requested_syncs: Optional set of resource names to sync. If None, all resources are synced.
-    :return: True if policy bindings were requested and every project synced them successfully.
+    :return: Summary of project resource sync state needed by org-scoped follow-up cleanup.
     """
     logger.info("Syncing resources for %d GCP projects.", len(projects))
     policy_bindings_requested = (
         requested_syncs is None or "policy_bindings" in requested_syncs
     )
-    policy_bindings_all_projects_succeeded = (
-        policy_bindings_requested and len(projects) > 0
-    )
+    policy_bindings_cleanup_safe = policy_bindings_requested and len(projects) > 0
 
     # Cloud Asset Inventory (CAI) clients are lazily initialized and reused across all projects.
     # CAI is used for:
@@ -697,7 +700,7 @@ def _sync_project_resources(
                 policy_bindings_status
                 != policy_bindings.PolicyBindingsSyncStatus.SUCCESS
             ):
-                policy_bindings_all_projects_succeeded = False
+                policy_bindings_cleanup_safe = False
 
         permission_relationships_requested = (
             requested_syncs is None or "permission_relationships" in requested_syncs
@@ -773,7 +776,9 @@ def _sync_project_resources(
 
         del common_job_parameters["PROJECT_ID"]
 
-    return policy_bindings_all_projects_succeeded
+    return GCPProjectResourcesSyncResult(
+        policy_bindings_cleanup_safe=policy_bindings_cleanup_safe,
+    )
 
 
 @timeit
@@ -911,7 +916,7 @@ def start_gcp_ingestion(
             org_role_permissions_by_name = {}
 
         # Ingest per-project resources (these run their own cleanup immediately since they're leaf nodes)
-        policy_bindings_all_projects_succeeded = _sync_project_resources(
+        project_resources_result = _sync_project_resources(
             neo4j_session,
             projects,
             config.update_tag,
@@ -924,7 +929,7 @@ def start_gcp_ingestion(
         policy_bindings_requested = (
             requested_syncs is None or "policy_bindings" in requested_syncs
         )
-        if policy_bindings_all_projects_succeeded:
+        if project_resources_result.policy_bindings_cleanup_safe:
             policy_bindings.cleanup_inherited_policy_bindings(
                 neo4j_session,
                 common_job_parameters,

--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -97,6 +97,7 @@ service_names = Services(
 
 class GCPProjectResourcesSyncResult(NamedTuple):
     policy_bindings_cleanup_safe: bool
+    policy_bindings_cleanup_skip_reason: str | None = None
 
 
 def _services_enabled_on_project(serviceusage: Resource, project_id: str) -> Set:
@@ -160,6 +161,9 @@ def _sync_project_resources(
         requested_syncs is None or "policy_bindings" in requested_syncs
     )
     policy_bindings_cleanup_safe = policy_bindings_requested and len(projects) > 0
+    policy_bindings_cleanup_skip_reason = (
+        "no_projects" if policy_bindings_requested and not projects else None
+    )
 
     # Cloud Asset Inventory (CAI) clients are lazily initialized and reused across all projects.
     # CAI is used for:
@@ -701,6 +705,7 @@ def _sync_project_resources(
                 != policy_bindings.PolicyBindingsSyncStatus.SUCCESS
             ):
                 policy_bindings_cleanup_safe = False
+                policy_bindings_cleanup_skip_reason = "project_sync_incomplete"
 
         permission_relationships_requested = (
             requested_syncs is None or "permission_relationships" in requested_syncs
@@ -778,6 +783,7 @@ def _sync_project_resources(
 
     return GCPProjectResourcesSyncResult(
         policy_bindings_cleanup_safe=policy_bindings_cleanup_safe,
+        policy_bindings_cleanup_skip_reason=policy_bindings_cleanup_skip_reason,
     )
 
 
@@ -936,12 +942,23 @@ def start_gcp_ingestion(
                 [folder["name"] for folder in folders if folder.get("name")],
             )
         elif policy_bindings_requested:
-            logger.warning(
-                "Skipping inherited GCP policy bindings cleanup for %s because "
-                "not every project policy bindings sync succeeded. Preserving "
-                "existing inherited policy bindings.",
-                org_resource_name,
-            )
+            if (
+                project_resources_result.policy_bindings_cleanup_skip_reason
+                == "no_projects"
+            ):
+                logger.info(
+                    "Skipping inherited GCP policy bindings cleanup for %s because "
+                    "no GCP projects were discovered. Preserving existing inherited "
+                    "policy bindings.",
+                    org_resource_name,
+                )
+            else:
+                logger.warning(
+                    "Skipping inherited GCP policy bindings cleanup for %s because "
+                    "not every project policy bindings sync succeeded. Preserving "
+                    "existing inherited policy bindings.",
+                    org_resource_name,
+                )
 
         # Clean up org-level roles for this org (after all project resources have been synced)
         if (

--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -139,7 +139,7 @@ def _sync_project_resources(
     credentials: GoogleCredentials,
     requested_syncs: Set[str] | None = None,
     org_role_permissions_by_name: dict[str, list[str]] | None = None,
-) -> None:
+) -> bool:
     """
     Syncs GCP service-specific resources (Compute, Storage, GKE, DNS, IAM) for each project.
     :param neo4j_session: The Neo4j session
@@ -148,9 +148,15 @@ def _sync_project_resources(
     :param common_job_parameters: Other parameters sent to Neo4j
     :param credentials: GCP credentials to use for API calls.
     :param requested_syncs: Optional set of resource names to sync. If None, all resources are synced.
-    :return: Nothing
+    :return: True if policy bindings were requested and every project synced them successfully.
     """
     logger.info("Syncing resources for %d GCP projects.", len(projects))
+    policy_bindings_requested_for_run = (
+        requested_syncs is None or "policy_bindings" in requested_syncs
+    )
+    policy_bindings_all_projects_succeeded = (
+        policy_bindings_requested_for_run and len(projects) > 0
+    )
 
     # Cloud Asset Inventory (CAI) clients are lazily initialized and reused across all projects.
     # CAI is used for:
@@ -629,9 +635,7 @@ def _sync_project_resources(
         # Policy bindings sync uses CAI gRPC client.
         # Runs after all resource modules so that APPLIES_TO matchlinks can find
         # target nodes (secretsmanager, artifact_registry, cloud_run, etc.).
-        policy_bindings_requested = (
-            requested_syncs is None or "policy_bindings" in requested_syncs
-        )
+        policy_bindings_requested = policy_bindings_requested_for_run
         if policy_bindings_requested:
             if policy_bindings_permission_ok is False:
                 policy_bindings_status = (
@@ -690,6 +694,11 @@ def _sync_project_resources(
                     == policy_bindings.PolicyBindingsSyncStatus.SKIPPED_PERMISSION_DENIED
                 ):
                     policy_bindings_permission_ok = False
+            if (
+                policy_bindings_status
+                != policy_bindings.PolicyBindingsSyncStatus.SUCCESS
+            ):
+                policy_bindings_all_projects_succeeded = False
 
         permission_relationships_requested = (
             requested_syncs is None or "permission_relationships" in requested_syncs
@@ -764,6 +773,8 @@ def _sync_project_resources(
             )
 
         del common_job_parameters["PROJECT_ID"]
+
+    return policy_bindings_all_projects_succeeded
 
 
 @timeit
@@ -901,7 +912,7 @@ def start_gcp_ingestion(
             org_role_permissions_by_name = {}
 
         # Ingest per-project resources (these run their own cleanup immediately since they're leaf nodes)
-        _sync_project_resources(
+        policy_bindings_all_projects_succeeded = _sync_project_resources(
             neo4j_session,
             projects,
             config.update_tag,
@@ -910,6 +921,23 @@ def start_gcp_ingestion(
             requested_syncs=requested_syncs,
             org_role_permissions_by_name=org_role_permissions_by_name,
         )
+
+        policy_bindings_requested = (
+            requested_syncs is None or "policy_bindings" in requested_syncs
+        )
+        if policy_bindings_all_projects_succeeded and policy_bindings_requested:
+            policy_bindings.cleanup_inherited_policy_bindings(
+                neo4j_session,
+                common_job_parameters,
+                [folder["name"] for folder in folders if folder.get("name")],
+            )
+        elif policy_bindings_requested:
+            logger.warning(
+                "Skipping inherited GCP policy bindings cleanup for %s because "
+                "not every project policy bindings sync succeeded. Preserving "
+                "existing inherited policy bindings.",
+                org_resource_name,
+            )
 
         # Clean up org-level roles for this org (after all project resources have been synced)
         if (

--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -164,6 +164,7 @@ def _sync_project_resources(
     policy_bindings_cleanup_skip_reason = (
         "no_projects" if policy_bindings_requested and not projects else None
     )
+    inherited_binding_claim_state = policy_bindings.InheritedPolicyBindingClaimState()
 
     # Cloud Asset Inventory (CAI) clients are lazily initialized and reused across all projects.
     # CAI is used for:
@@ -690,6 +691,7 @@ def _sync_project_resources(
                     common_job_parameters,
                     cai_grpc_client,
                     role_permissions_by_name,
+                    inherited_binding_claim_state,
                 )
                 policy_bindings_status = policy_bindings_result.status
                 permission_context = policy_bindings_result.permission_context

--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -667,9 +667,6 @@ def load_bindings(
     project_id: str,
     update_tag: int,
 ) -> None:
-    if not bindings:
-        return
-
     load(
         neo4j_session,
         GCPPolicyBindingSchema(),
@@ -697,9 +694,6 @@ def _load_organization_bindings(
     org_resource_name: str,
     update_tag: int,
 ) -> None:
-    if not bindings:
-        return
-
     load(
         neo4j_session,
         GCPOrganizationPolicyBindingSchema(),
@@ -727,9 +721,6 @@ def _load_folder_bindings(
     folder_id: str,
     update_tag: int,
 ) -> None:
-    if not bindings:
-        return
-
     load(
         neo4j_session,
         GCPFolderPolicyBindingSchema(),

--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -6,6 +6,7 @@ from enum import Enum
 from threading import BoundedSemaphore
 from threading import Lock
 from typing import Any
+from typing import TypeAlias
 
 import neo4j
 from google.api_core.exceptions import DeadlineExceeded
@@ -60,6 +61,8 @@ class _FullNameMapping:
       SearchAllIamPolicies for direct child-resource policies. Resource Manager
       scopes are fetched through BatchGetEffectiveIamPolicies instead, so they
       do not need a search asset type here.
+    - ``additional_asset_types``: Extra Cloud Asset asset types that use the
+      same full-name shape and Cartography node label.
     """
 
     service_prefix: str
@@ -67,6 +70,7 @@ class _FullNameMapping:
     label: str
     id_mode: str
     asset_type: str | None = None
+    additional_asset_types: tuple[str, ...] = ()
 
 
 # Order matters within a given service_prefix: more specific mappings first so
@@ -175,6 +179,8 @@ _FULL_NAME_MAPPINGS: list[_FullNameMapping] = [
         "functions",
         "GCPCloudFunction",
         "full_path",
+        "cloudfunctions.googleapis.com/Function",
+        ("cloudfunctions.googleapis.com/CloudFunction",),
     ),
     # Compute — node id is the "partial URI" (``projects/.../{kind}/{name}``),
     # which matches the path left after stripping the service prefix.
@@ -270,9 +276,12 @@ def _parse_full_resource_name(full_name: str) -> tuple[str | None, str | None]:
 
 def _search_asset_types_from_full_name_mappings() -> list[str]:
     return [
-        mapping.asset_type
+        asset_type
         for mapping in _FULL_NAME_MAPPINGS
-        if mapping.asset_type is not None
+        for asset_type in (
+            ((mapping.asset_type,) if mapping.asset_type is not None else ())
+            + mapping.additional_asset_types
+        )
     ]
 
 
@@ -318,7 +327,7 @@ _GCP_POLICY_BINDINGS_GRAPH_SEMAPHORE = BoundedSemaphore(
 _INHERITED_POLICY_BINDINGS_LOCK = Lock()
 _INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG: int | None = None
 _INHERITED_POLICY_BINDINGS_SEEN: set[tuple[str, str, str]] = set()
-PolicyBindingSchema = (
+PolicyBindingSchema: TypeAlias = (
     GCPPolicyBindingSchema
     | GCPOrganizationPolicyBindingSchema
     | GCPFolderPolicyBindingSchema

--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -2,11 +2,11 @@ import hashlib
 import logging
 import time
 from dataclasses import dataclass
+from dataclasses import field
 from enum import Enum
 from threading import BoundedSemaphore
 from threading import Lock
 from typing import Any
-from typing import TypeAlias
 
 import neo4j
 from google.api_core.exceptions import DeadlineExceeded
@@ -29,12 +29,14 @@ from cartography.intel.gcp.permission_relationships import (
     build_principals_from_policy_bindings,
 )
 from cartography.intel.gcp.permission_relationships import GCPPrincipalPermissionContext
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import MatchLinkSubResource
 from cartography.models.gcp.policy_bindings import GCPFolderPolicyBindingSchema
 from cartography.models.gcp.policy_bindings import GCPOrganizationPolicyBindingSchema
+from cartography.models.gcp.policy_bindings import GCPPolicyBindingAppliesToMatchLink
 from cartography.models.gcp.policy_bindings import GCPPolicyBindingSchema
-from cartography.models.gcp.policy_bindings import (
-    make_policy_binding_applies_to_matchlink,
-)
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -324,16 +326,12 @@ _CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION: dict[str, float] = {}
 _GCP_POLICY_BINDINGS_GRAPH_SEMAPHORE = BoundedSemaphore(
     GCP_POLICY_BINDINGS_GRAPH_CONCURRENCY
 )
-_INHERITED_POLICY_BINDINGS_LOCK = Lock()
-_INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG: int | None = None
-# Deduplicate inherited binding graph writes within one Cartography update tag.
-# Scope keys include the owning org/folder id, so different owners do not collide.
-_INHERITED_POLICY_BINDINGS_SEEN: set[tuple[str, str, str]] = set()
-PolicyBindingSchema: TypeAlias = (
-    GCPPolicyBindingSchema
-    | GCPOrganizationPolicyBindingSchema
-    | GCPFolderPolicyBindingSchema
-)
+
+
+@dataclass
+class InheritedPolicyBindingClaimState:
+    lock: Lock = field(default_factory=Lock)
+    seen: set[tuple[str, str, str]] = field(default_factory=set)
 
 
 def _wait_for_cai_policy_bindings_slot(operation: str) -> None:
@@ -629,79 +627,37 @@ def _split_bindings_by_graph_scope(
 
 def _claim_inherited_bindings_for_graph(
     inherited_bindings: dict[tuple[str, str], list[dict[str, Any]]],
-    update_tag: int,
+    claim_state: InheritedPolicyBindingClaimState,
 ) -> dict[tuple[str, str], list[dict[str, Any]]]:
-    global _INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG
-
     claimed: dict[tuple[str, str], list[dict[str, Any]]] = {}
-    with _INHERITED_POLICY_BINDINGS_LOCK:
-        if _INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG != update_tag:
-            _INHERITED_POLICY_BINDINGS_SEEN.clear()
-            _INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG = update_tag
-
+    with claim_state.lock:
         for scope, bindings in inherited_bindings.items():
             owner_label, owner_id = scope
             for binding in bindings:
                 seen_key = (owner_label, owner_id, binding["id"])
-                if seen_key in _INHERITED_POLICY_BINDINGS_SEEN:
+                if seen_key in claim_state.seen:
                     continue
-                _INHERITED_POLICY_BINDINGS_SEEN.add(seen_key)
+                claim_state.seen.add(seen_key)
                 claimed.setdefault(scope, []).append(binding)
 
     return claimed
 
 
-def _get_policy_binding_schema_for_scope(
+def make_policy_binding_applies_to_matchlink(
+    target_node_label: str,
     owner_label: str,
-) -> PolicyBindingSchema:
-    if owner_label == "GCPProject":
-        return GCPPolicyBindingSchema()
-    if owner_label == "GCPOrganization":
-        return GCPOrganizationPolicyBindingSchema()
-    if owner_label == "GCPFolder":
-        return GCPFolderPolicyBindingSchema()
-    raise ValueError(f"Unsupported GCP policy binding owner label: {owner_label}")
-
-
-def _get_policy_binding_scope_kwargs(owner_label: str, owner_id: str) -> dict[str, str]:
-    if owner_label == "GCPProject":
-        return {"PROJECT_ID": owner_id}
-    if owner_label == "GCPOrganization":
-        return {"ORG_RESOURCE_NAME": owner_id}
-    if owner_label == "GCPFolder":
-        return {"FOLDER_ID": owner_id}
-    raise ValueError(f"Unsupported GCP policy binding owner label: {owner_label}")
-
-
-def _load_bindings_for_scope(
-    neo4j_session: neo4j.Session,
-    bindings: list[dict[str, Any]],
-    owner_label: str,
-    owner_id: str,
-    update_tag: int,
-) -> None:
-    if not bindings:
-        return
-
-    load(
-        neo4j_session,
-        _get_policy_binding_schema_for_scope(owner_label),
-        bindings,
-        batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
-        lastupdated=update_tag,
-        **_get_policy_binding_scope_kwargs(owner_label, owner_id),
+) -> GCPPolicyBindingAppliesToMatchLink:
+    return GCPPolicyBindingAppliesToMatchLink(
+        target_node_label=target_node_label,
+        source_node_sub_resource=MatchLinkSubResource(
+            target_node_label=owner_label,
+            target_node_matcher=make_target_node_matcher(
+                {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
+            ),
+            direction=LinkDirection.INWARD,
+            rel_label="RESOURCE",
+        ),
     )
-
-    for target_label, links in _group_applies_to_links(bindings).items():
-        load_matchlinks(
-            neo4j_session,
-            make_policy_binding_applies_to_matchlink(target_label, owner_label),
-            links,
-            batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
-            lastupdated=update_tag,
-            _sub_resource_label=owner_label,
-            _sub_resource_id=owner_id,
-        )
 
 
 @timeit
@@ -711,13 +667,88 @@ def load_bindings(
     project_id: str,
     update_tag: int,
 ) -> None:
-    _load_bindings_for_scope(
+    if not bindings:
+        return
+
+    load(
         neo4j_session,
+        GCPPolicyBindingSchema(),
         bindings,
-        "GCPProject",
-        project_id,
-        update_tag,
+        batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
+        lastupdated=update_tag,
+        PROJECT_ID=project_id,
     )
+
+    for target_label, links in _group_applies_to_links(bindings).items():
+        load_matchlinks(
+            neo4j_session,
+            make_policy_binding_applies_to_matchlink(target_label, "GCPProject"),
+            links,
+            batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
+            lastupdated=update_tag,
+            _sub_resource_label="GCPProject",
+            _sub_resource_id=project_id,
+        )
+
+
+def _load_organization_bindings(
+    neo4j_session: neo4j.Session,
+    bindings: list[dict[str, Any]],
+    org_resource_name: str,
+    update_tag: int,
+) -> None:
+    if not bindings:
+        return
+
+    load(
+        neo4j_session,
+        GCPOrganizationPolicyBindingSchema(),
+        bindings,
+        batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
+        lastupdated=update_tag,
+        ORG_RESOURCE_NAME=org_resource_name,
+    )
+
+    for target_label, links in _group_applies_to_links(bindings).items():
+        load_matchlinks(
+            neo4j_session,
+            make_policy_binding_applies_to_matchlink(target_label, "GCPOrganization"),
+            links,
+            batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
+            lastupdated=update_tag,
+            _sub_resource_label="GCPOrganization",
+            _sub_resource_id=org_resource_name,
+        )
+
+
+def _load_folder_bindings(
+    neo4j_session: neo4j.Session,
+    bindings: list[dict[str, Any]],
+    folder_id: str,
+    update_tag: int,
+) -> None:
+    if not bindings:
+        return
+
+    load(
+        neo4j_session,
+        GCPFolderPolicyBindingSchema(),
+        bindings,
+        batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
+        lastupdated=update_tag,
+        FOLDER_ID=folder_id,
+    )
+
+    for target_label, links in _group_applies_to_links(bindings).items():
+        load_matchlinks(
+            neo4j_session,
+            make_policy_binding_applies_to_matchlink(target_label, "GCPFolder"),
+            links,
+            batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
+            lastupdated=update_tag,
+            _sub_resource_label="GCPFolder",
+            _sub_resource_id=folder_id,
+        )
 
 
 @timeit
@@ -728,13 +759,24 @@ def load_inherited_bindings(
 ) -> int:
     loaded_count = 0
     for (owner_label, owner_id), bindings in inherited_bindings.items():
-        _load_bindings_for_scope(
-            neo4j_session,
-            bindings,
-            owner_label,
-            owner_id,
-            update_tag,
-        )
+        if owner_label == "GCPOrganization":
+            _load_organization_bindings(
+                neo4j_session,
+                bindings,
+                owner_id,
+                update_tag,
+            )
+        elif owner_label == "GCPFolder":
+            _load_folder_bindings(
+                neo4j_session,
+                bindings,
+                owner_id,
+                update_tag,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported inherited GCP policy binding owner label: {owner_label}"
+            )
         loaded_count += len(bindings)
     return loaded_count
 
@@ -842,6 +884,7 @@ def sync(
     common_job_parameters: dict[str, Any],
     client: AssetServiceClient,
     role_permissions_by_name: dict[str, list[str]],
+    inherited_binding_claim_state: InheritedPolicyBindingClaimState | None = None,
 ) -> PolicyBindingsSyncResult:
     """
     Sync GCP IAM policy bindings for a project.
@@ -919,10 +962,13 @@ def sync(
         project_id,
     )
 
+    if inherited_binding_claim_state is None:
+        inherited_binding_claim_state = InheritedPolicyBindingClaimState()
+
     with _GCP_POLICY_BINDINGS_GRAPH_SEMAPHORE:
         inherited_bindings_to_load = _claim_inherited_bindings_for_graph(
             inherited_bindings,
-            update_tag,
+            inherited_binding_claim_state,
         )
         inherited_loaded_count = load_inherited_bindings(
             neo4j_session,

--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -326,6 +326,8 @@ _GCP_POLICY_BINDINGS_GRAPH_SEMAPHORE = BoundedSemaphore(
 )
 _INHERITED_POLICY_BINDINGS_LOCK = Lock()
 _INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG: int | None = None
+# Deduplicate inherited binding graph writes within one Cartography update tag.
+# Scope keys include the owning org/folder id, so different owners do not collide.
 _INHERITED_POLICY_BINDINGS_SEEN: set[tuple[str, str, str]] = set()
 PolicyBindingSchema: TypeAlias = (
     GCPPolicyBindingSchema
@@ -773,6 +775,9 @@ def cleanup(
 ) -> None:
     logger.debug("Running GCP policy bindings cleanup job")
 
+    # During migration, project cleanup also removes stale project-owned
+    # RESOURCE edges for inherited org/folder bindings that are now owned by
+    # their real scope.
     GraphJob.from_node_schema(
         GCPPolicyBindingSchema(),
         common_job_parameters,

--- a/cartography/intel/gcp/policy_bindings.py
+++ b/cartography/intel/gcp/policy_bindings.py
@@ -28,8 +28,12 @@ from cartography.intel.gcp.permission_relationships import (
     build_principals_from_policy_bindings,
 )
 from cartography.intel.gcp.permission_relationships import GCPPrincipalPermissionContext
-from cartography.models.gcp.policy_bindings import GCPPolicyBindingAppliesToMatchLink
+from cartography.models.gcp.policy_bindings import GCPFolderPolicyBindingSchema
+from cartography.models.gcp.policy_bindings import GCPOrganizationPolicyBindingSchema
 from cartography.models.gcp.policy_bindings import GCPPolicyBindingSchema
+from cartography.models.gcp.policy_bindings import (
+    make_policy_binding_applies_to_matchlink,
+)
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -50,12 +54,19 @@ class _FullNameMapping:
         * ``"type_prefixed"``  — ``"{marker}/{name}"`` (GCPFolder, GCPOrganization).
         * ``"full_path"``      — the whole path up to and including the name
           (KMS, Secrets, Artifact Registry, Cloud Run, Compute).
+        * ``"bigquery_dataset"`` — ``"{project_id}:{dataset_id}"``.
+        * ``"bigquery_table"`` — ``"{project_id}:{dataset_id}.{table_id}"``.
+    - ``asset_type``: Cloud Asset asset type to request from
+      SearchAllIamPolicies for direct child-resource policies. Resource Manager
+      scopes are fetched through BatchGetEffectiveIamPolicies instead, so they
+      do not need a search asset type here.
     """
 
     service_prefix: str
     marker: str
     label: str
     id_mode: str
+    asset_type: str | None = None
 
 
 # Order matters within a given service_prefix: more specific mappings first so
@@ -87,6 +98,22 @@ _FULL_NAME_MAPPINGS: list[_FullNameMapping] = [
         "buckets",
         "GCPBucket",
         "last_segment",
+        "storage.googleapis.com/Bucket",
+    ),
+    # BigQuery — table wins over dataset (nested).
+    _FullNameMapping(
+        "//bigquery.googleapis.com/",
+        "tables",
+        "GCPBigQueryTable",
+        "bigquery_table",
+        "bigquery.googleapis.com/Table",
+    ),
+    _FullNameMapping(
+        "//bigquery.googleapis.com/",
+        "datasets",
+        "GCPBigQueryDataset",
+        "bigquery_dataset",
+        "bigquery.googleapis.com/Dataset",
     ),
     # KMS — cryptoKey wins over keyRing (nested).
     _FullNameMapping(
@@ -94,12 +121,14 @@ _FULL_NAME_MAPPINGS: list[_FullNameMapping] = [
         "cryptoKeys",
         "GCPCryptoKey",
         "full_path",
+        "cloudkms.googleapis.com/CryptoKey",
     ),
     _FullNameMapping(
         "//cloudkms.googleapis.com/",
         "keyRings",
         "GCPKeyRing",
         "full_path",
+        "cloudkms.googleapis.com/KeyRing",
     ),
     # Secret Manager — version wins over secret (nested).
     _FullNameMapping(
@@ -107,12 +136,14 @@ _FULL_NAME_MAPPINGS: list[_FullNameMapping] = [
         "versions",
         "GCPSecretManagerSecretVersion",
         "full_path",
+        "secretmanager.googleapis.com/SecretVersion",
     ),
     _FullNameMapping(
         "//secretmanager.googleapis.com/",
         "secrets",
         "GCPSecretManagerSecret",
         "full_path",
+        "secretmanager.googleapis.com/Secret",
     ),
     # Artifact Registry.
     _FullNameMapping(
@@ -120,6 +151,7 @@ _FULL_NAME_MAPPINGS: list[_FullNameMapping] = [
         "repositories",
         "GCPArtifactRegistryRepository",
         "full_path",
+        "artifactregistry.googleapis.com/Repository",
     ),
     # Cloud Run services.
     _FullNameMapping(
@@ -127,6 +159,15 @@ _FULL_NAME_MAPPINGS: list[_FullNameMapping] = [
         "services",
         "GCPCloudRunService",
         "full_path",
+        "run.googleapis.com/Service",
+    ),
+    # IAM service accounts.
+    _FullNameMapping(
+        "//iam.googleapis.com/",
+        "serviceAccounts",
+        "GCPServiceAccount",
+        "last_segment",
+        "iam.googleapis.com/ServiceAccount",
     ),
     # Compute — node id is the "partial URI" (``projects/.../{kind}/{name}``),
     # which matches the path left after stripping the service prefix.
@@ -135,26 +176,49 @@ _FULL_NAME_MAPPINGS: list[_FullNameMapping] = [
         "instances",
         "GCPInstance",
         "full_path",
+        "compute.googleapis.com/Instance",
     ),
     _FullNameMapping(
         "//compute.googleapis.com/",
         "networks",
         "GCPVpc",
         "full_path",
+        "compute.googleapis.com/Network",
     ),
     _FullNameMapping(
         "//compute.googleapis.com/",
         "subnetworks",
         "GCPSubnet",
         "full_path",
+        "compute.googleapis.com/Subnetwork",
     ),
     _FullNameMapping(
         "//compute.googleapis.com/",
         "firewalls",
         "GCPFirewall",
         "full_path",
+        "compute.googleapis.com/Firewall",
     ),
 ]
+
+
+def _bigquery_resource_id(parts: list[str], table: bool) -> str | None:
+    try:
+        project_id = parts[parts.index("projects") + 1]
+        dataset_id = parts[parts.index("datasets") + 1]
+    except (IndexError, ValueError):
+        return None
+    if not project_id or not dataset_id:
+        return None
+    if not table:
+        return f"{project_id}:{dataset_id}"
+    try:
+        table_id = parts[parts.index("tables") + 1]
+    except (IndexError, ValueError):
+        return None
+    if not table_id:
+        return None
+    return f"{project_id}:{dataset_id}.{table_id}"
 
 
 def _parse_full_resource_name(full_name: str) -> tuple[str | None, str | None]:
@@ -181,6 +245,10 @@ def _parse_full_resource_name(full_name: str) -> tuple[str | None, str | None]:
         name_segment = parts[marker_idx + 1]
         if not name_segment:
             continue
+        if mapping.id_mode == "bigquery_dataset":
+            return mapping.label, _bigquery_resource_id(parts, table=False)
+        if mapping.id_mode == "bigquery_table":
+            return mapping.label, _bigquery_resource_id(parts, table=True)
         if mapping.id_mode == "last_segment":
             return mapping.label, name_segment
         if mapping.id_mode == "type_prefixed":
@@ -191,6 +259,14 @@ def _parse_full_resource_name(full_name: str) -> tuple[str | None, str | None]:
         # mapping order defined above.
         return mapping.label, "/".join(parts[: marker_idx + 2])
     return None, None
+
+
+def _search_asset_types_from_full_name_mappings() -> list[str]:
+    return [
+        mapping.asset_type
+        for mapping in _FULL_NAME_MAPPINGS
+        if mapping.asset_type is not None
+    ]
 
 
 class PolicyBindingsSyncStatus(str, Enum):
@@ -223,10 +299,22 @@ CAI_POLICY_BINDINGS_MIN_INTERVAL_SECONDS = {
 GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE = 1000
 GCP_POLICY_BINDINGS_CLEANUP_ITERATION_SIZE = 1000
 GCP_POLICY_BINDINGS_GRAPH_CONCURRENCY = 4
+# Without this filter, Cloud Asset can return direct IAM policies for very high
+# cardinality child resources such as Artifact Registry Docker images. Those
+# bindings are not useful to Cartography today and can dominate graph writes.
+GCP_POLICY_BINDINGS_SEARCH_ASSET_TYPES = _search_asset_types_from_full_name_mappings()
 _CAI_POLICY_BINDINGS_THROTTLE_LOCK = Lock()
 _CAI_POLICY_BINDINGS_LAST_CALL_BY_OPERATION: dict[str, float] = {}
 _GCP_POLICY_BINDINGS_GRAPH_SEMAPHORE = BoundedSemaphore(
     GCP_POLICY_BINDINGS_GRAPH_CONCURRENCY
+)
+_INHERITED_POLICY_BINDINGS_LOCK = Lock()
+_INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG: int | None = None
+_INHERITED_POLICY_BINDINGS_SEEN: set[tuple[str, str, str]] = set()
+PolicyBindingSchema = (
+    GCPPolicyBindingSchema
+    | GCPOrganizationPolicyBindingSchema
+    | GCPFolderPolicyBindingSchema
 )
 
 
@@ -330,7 +418,7 @@ def get_policy_bindings(
     # Fetch direct policy bindings for all child resources using search_all_iam_policies (project scope - no inheritance)
     search_request = SearchAllIamPoliciesRequest(
         scope=f"projects/{project_id}",
-        asset_types=[],
+        asset_types=GCP_POLICY_BINDINGS_SEARCH_ASSET_TYPES,
     )
     search_retry = build_cai_policy_bindings_retry(
         project_id,
@@ -493,6 +581,111 @@ def _group_applies_to_links(
     return grouped
 
 
+def _get_inherited_binding_scope(
+    binding: dict[str, Any],
+) -> tuple[str, str] | None:
+    if binding.get("resource_type") not in ("organization", "folder"):
+        return None
+
+    label, resource_id = _parse_full_resource_name(binding["resource"])
+    if label not in ("GCPOrganization", "GCPFolder") or resource_id is None:
+        return None
+    return label, resource_id
+
+
+def _split_bindings_by_graph_scope(
+    bindings: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[tuple[str, str], list[dict[str, Any]]]]:
+    direct_bindings: list[dict[str, Any]] = []
+    inherited_bindings: dict[tuple[str, str], list[dict[str, Any]]] = {}
+
+    for binding in bindings:
+        inherited_scope = _get_inherited_binding_scope(binding)
+        if inherited_scope is None:
+            direct_bindings.append(binding)
+            continue
+        inherited_bindings.setdefault(inherited_scope, []).append(binding)
+
+    return direct_bindings, inherited_bindings
+
+
+def _claim_inherited_bindings_for_graph(
+    inherited_bindings: dict[tuple[str, str], list[dict[str, Any]]],
+    update_tag: int,
+) -> dict[tuple[str, str], list[dict[str, Any]]]:
+    global _INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG
+
+    claimed: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    with _INHERITED_POLICY_BINDINGS_LOCK:
+        if _INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG != update_tag:
+            _INHERITED_POLICY_BINDINGS_SEEN.clear()
+            _INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG = update_tag
+
+        for scope, bindings in inherited_bindings.items():
+            owner_label, owner_id = scope
+            for binding in bindings:
+                seen_key = (owner_label, owner_id, binding["id"])
+                if seen_key in _INHERITED_POLICY_BINDINGS_SEEN:
+                    continue
+                _INHERITED_POLICY_BINDINGS_SEEN.add(seen_key)
+                claimed.setdefault(scope, []).append(binding)
+
+    return claimed
+
+
+def _get_policy_binding_schema_for_scope(
+    owner_label: str,
+) -> PolicyBindingSchema:
+    if owner_label == "GCPProject":
+        return GCPPolicyBindingSchema()
+    if owner_label == "GCPOrganization":
+        return GCPOrganizationPolicyBindingSchema()
+    if owner_label == "GCPFolder":
+        return GCPFolderPolicyBindingSchema()
+    raise ValueError(f"Unsupported GCP policy binding owner label: {owner_label}")
+
+
+def _get_policy_binding_scope_kwargs(owner_label: str, owner_id: str) -> dict[str, str]:
+    if owner_label == "GCPProject":
+        return {"PROJECT_ID": owner_id}
+    if owner_label == "GCPOrganization":
+        return {"ORG_RESOURCE_NAME": owner_id}
+    if owner_label == "GCPFolder":
+        return {"FOLDER_ID": owner_id}
+    raise ValueError(f"Unsupported GCP policy binding owner label: {owner_label}")
+
+
+def _load_bindings_for_scope(
+    neo4j_session: neo4j.Session,
+    bindings: list[dict[str, Any]],
+    owner_label: str,
+    owner_id: str,
+    update_tag: int,
+) -> None:
+    if not bindings:
+        return
+
+    load(
+        neo4j_session,
+        _get_policy_binding_schema_for_scope(owner_label),
+        bindings,
+        batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
+        lastupdated=update_tag,
+        **_get_policy_binding_scope_kwargs(owner_label, owner_id),
+    )
+
+    for target_label, links in _group_applies_to_links(bindings).items():
+        load_matchlinks(
+            neo4j_session,
+            make_policy_binding_applies_to_matchlink(target_label, owner_label),
+            links,
+            batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
+            lastupdated=update_tag,
+            _sub_resource_label=owner_label,
+            _sub_resource_id=owner_id,
+        )
+
+
 @timeit
 def load_bindings(
     neo4j_session: neo4j.Session,
@@ -500,30 +693,38 @@ def load_bindings(
     project_id: str,
     update_tag: int,
 ) -> None:
-    load(
+    _load_bindings_for_scope(
         neo4j_session,
-        GCPPolicyBindingSchema(),
         bindings,
-        batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
-        lastupdated=update_tag,
-        PROJECT_ID=project_id,
+        "GCPProject",
+        project_id,
+        update_tag,
     )
 
-    for target_label, links in _group_applies_to_links(bindings).items():
-        load_matchlinks(
+
+@timeit
+def load_inherited_bindings(
+    neo4j_session: neo4j.Session,
+    inherited_bindings: dict[tuple[str, str], list[dict[str, Any]]],
+    update_tag: int,
+) -> int:
+    loaded_count = 0
+    for (owner_label, owner_id), bindings in inherited_bindings.items():
+        _load_bindings_for_scope(
             neo4j_session,
-            GCPPolicyBindingAppliesToMatchLink(target_node_label=target_label),
-            links,
-            batch_size=GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE,
-            lastupdated=update_tag,
-            _sub_resource_label="GCPProject",
-            _sub_resource_id=project_id,
+            bindings,
+            owner_label,
+            owner_id,
+            update_tag,
         )
+        loaded_count += len(bindings)
+    return loaded_count
 
 
 def _cleanup_applies_to_relationships(
     neo4j_session: neo4j.Session,
-    project_id: str,
+    sub_resource_label: str,
+    sub_resource_id: str,
     update_tag: int,
 ) -> None:
     # APPLIES_TO can point at several resource labels. Clean up by relationship
@@ -540,8 +741,8 @@ def _cleanup_applies_to_relationships(
         """,
         parameters={
             "UPDATE_TAG": update_tag,
-            "_sub_resource_label": "GCPProject",
-            "_sub_resource_id": project_id,
+            "_sub_resource_label": sub_resource_label,
+            "_sub_resource_id": sub_resource_id,
         },
         iterative=True,
         iterationsize=GCP_POLICY_BINDINGS_CLEANUP_ITERATION_SIZE,
@@ -564,7 +765,52 @@ def cleanup(
 
     project_id = common_job_parameters["PROJECT_ID"]
     update_tag = common_job_parameters["UPDATE_TAG"]
-    _cleanup_applies_to_relationships(neo4j_session, project_id, update_tag)
+    _cleanup_applies_to_relationships(
+        neo4j_session,
+        "GCPProject",
+        project_id,
+        update_tag,
+    )
+
+
+@timeit
+def cleanup_inherited_policy_bindings(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+    folder_ids: list[str],
+) -> None:
+    logger.debug("Running inherited GCP policy bindings cleanup job")
+    org_resource_name = common_job_parameters["ORG_RESOURCE_NAME"]
+    update_tag = common_job_parameters["UPDATE_TAG"]
+
+    GraphJob.from_node_schema(
+        GCPOrganizationPolicyBindingSchema(),
+        common_job_parameters,
+        iterationsize=GCP_POLICY_BINDINGS_CLEANUP_ITERATION_SIZE,
+    ).run(neo4j_session)
+    _cleanup_applies_to_relationships(
+        neo4j_session,
+        "GCPOrganization",
+        org_resource_name,
+        update_tag,
+    )
+
+    for folder_id in folder_ids:
+        folder_job_parameters = {
+            **common_job_parameters,
+            "FOLDER_ID": folder_id,
+        }
+        GraphJob.from_node_schema(
+            GCPFolderPolicyBindingSchema(),
+            folder_job_parameters,
+            iterationsize=GCP_POLICY_BINDINGS_CLEANUP_ITERATION_SIZE,
+        ).run(neo4j_session)
+        _cleanup_applies_to_relationships(
+            neo4j_session,
+            "GCPFolder",
+            folder_id,
+            update_tag,
+        )
 
 
 @timeit
@@ -643,6 +889,9 @@ def sync(
         )
 
     transformed_bindings_data = transform_bindings(bindings_data)
+    direct_bindings, inherited_bindings = _split_bindings_by_graph_scope(
+        transformed_bindings_data
+    )
     permission_context = build_principals_from_policy_bindings(
         transformed_bindings_data,
         role_permissions_by_name,
@@ -650,8 +899,30 @@ def sync(
     )
 
     with _GCP_POLICY_BINDINGS_GRAPH_SEMAPHORE:
-        load_bindings(neo4j_session, transformed_bindings_data, project_id, update_tag)
+        inherited_bindings_to_load = _claim_inherited_bindings_for_graph(
+            inherited_bindings,
+            update_tag,
+        )
+        inherited_loaded_count = load_inherited_bindings(
+            neo4j_session,
+            inherited_bindings_to_load,
+            update_tag,
+        )
+        load_bindings(neo4j_session, direct_bindings, project_id, update_tag)
         cleanup(neo4j_session, common_job_parameters)
+    logger.info(
+        "Synced GCP policy bindings for project '%s': policy_results=%d, "
+        "transformed_bindings=%d, direct_graph_bindings=%d, "
+        "inherited_bindings=%d, newly_loaded_inherited_bindings=%d, "
+        "permission_principals=%d",
+        project_id,
+        len(bindings_data["policy_results"]),
+        len(transformed_bindings_data),
+        len(direct_bindings),
+        sum(len(bindings) for bindings in inherited_bindings.values()),
+        inherited_loaded_count,
+        len(permission_context),
+    )
     return PolicyBindingsSyncResult(
         PolicyBindingsSyncStatus.SUCCESS,
         permission_context,

--- a/cartography/models/gcp/policy_bindings.py
+++ b/cartography/models/gcp/policy_bindings.py
@@ -29,7 +29,7 @@ class GCPPolicyBindingNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class GCPPolicyBindingToProjectRelProperties(CartographyRelProperties):
+class GCPPolicyBindingResourceRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -41,8 +41,8 @@ class GCPPolicyBindingToProjectRel(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: GCPPolicyBindingToProjectRelProperties = (
-        GCPPolicyBindingToProjectRelProperties()
+    properties: GCPPolicyBindingResourceRelProperties = (
+        GCPPolicyBindingResourceRelProperties()
     )
 
 
@@ -54,8 +54,8 @@ class GCPPolicyBindingToOrganizationRel(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: GCPPolicyBindingToProjectRelProperties = (
-        GCPPolicyBindingToProjectRelProperties()
+    properties: GCPPolicyBindingResourceRelProperties = (
+        GCPPolicyBindingResourceRelProperties()
     )
 
 
@@ -67,8 +67,8 @@ class GCPPolicyBindingToFolderRel(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RESOURCE"
-    properties: GCPPolicyBindingToProjectRelProperties = (
-        GCPPolicyBindingToProjectRelProperties()
+    properties: GCPPolicyBindingResourceRelProperties = (
+        GCPPolicyBindingResourceRelProperties()
     )
 
 
@@ -198,12 +198,12 @@ class GCPPolicyBindingAppliesToMatchLink(CartographyRelSchema):
 
 def make_policy_binding_applies_to_matchlink(
     target_node_label: str,
-    source_node_label: str,
+    owner_label: str,
 ) -> GCPPolicyBindingAppliesToMatchLink:
     return GCPPolicyBindingAppliesToMatchLink(
         target_node_label=target_node_label,
         source_node_sub_resource=MatchLinkSubResource(
-            target_node_label=source_node_label,
+            target_node_label=owner_label,
             target_node_matcher=make_target_node_matcher(
                 {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
             ),

--- a/cartography/models/gcp/policy_bindings.py
+++ b/cartography/models/gcp/policy_bindings.py
@@ -47,6 +47,32 @@ class GCPPolicyBindingToProjectRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class GCPPolicyBindingToOrganizationRel(CartographyRelSchema):
+    target_node_label: str = "GCPOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ORG_RESOURCE_NAME", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPPolicyBindingToProjectRelProperties = (
+        GCPPolicyBindingToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GCPPolicyBindingToFolderRel(CartographyRelSchema):
+    target_node_label: str = "GCPFolder"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("FOLDER_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPPolicyBindingToProjectRelProperties = (
+        GCPPolicyBindingToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class GCPPolicyBindingToPrincipalRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
@@ -98,6 +124,36 @@ class GCPPolicyBindingSchema(CartographyNodeSchema):
 
 
 @dataclass(frozen=True)
+class GCPOrganizationPolicyBindingSchema(CartographyNodeSchema):
+    label: str = "GCPPolicyBinding"
+    properties: GCPPolicyBindingNodeProperties = GCPPolicyBindingNodeProperties()
+    sub_resource_relationship: GCPPolicyBindingToOrganizationRel = (
+        GCPPolicyBindingToOrganizationRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            GCPPolicyBindingToPrincipalRel(),
+            GCPPolicyBindingToRoleRel(),
+        ]
+    )
+
+
+@dataclass(frozen=True)
+class GCPFolderPolicyBindingSchema(CartographyNodeSchema):
+    label: str = "GCPPolicyBinding"
+    properties: GCPPolicyBindingNodeProperties = GCPPolicyBindingNodeProperties()
+    sub_resource_relationship: GCPPolicyBindingToFolderRel = (
+        GCPPolicyBindingToFolderRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            GCPPolicyBindingToPrincipalRel(),
+            GCPPolicyBindingToRoleRel(),
+        ]
+    )
+
+
+@dataclass(frozen=True)
 class GCPPolicyBindingAppliesToRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
     _sub_resource_label: PropertyRef = PropertyRef(
@@ -137,4 +193,21 @@ class GCPPolicyBindingAppliesToMatchLink(CartographyRelSchema):
         ),
         direction=LinkDirection.INWARD,
         rel_label="RESOURCE",
+    )
+
+
+def make_policy_binding_applies_to_matchlink(
+    target_node_label: str,
+    source_node_label: str,
+) -> GCPPolicyBindingAppliesToMatchLink:
+    return GCPPolicyBindingAppliesToMatchLink(
+        target_node_label=target_node_label,
+        source_node_sub_resource=MatchLinkSubResource(
+            target_node_label=source_node_label,
+            target_node_matcher=make_target_node_matcher(
+                {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
+            ),
+            direction=LinkDirection.INWARD,
+            rel_label="RESOURCE",
+        ),
     )

--- a/cartography/models/gcp/policy_bindings.py
+++ b/cartography/models/gcp/policy_bindings.py
@@ -194,20 +194,3 @@ class GCPPolicyBindingAppliesToMatchLink(CartographyRelSchema):
         direction=LinkDirection.INWARD,
         rel_label="RESOURCE",
     )
-
-
-def make_policy_binding_applies_to_matchlink(
-    target_node_label: str,
-    owner_label: str,
-) -> GCPPolicyBindingAppliesToMatchLink:
-    return GCPPolicyBindingAppliesToMatchLink(
-        target_node_label=target_node_label,
-        source_node_sub_resource=MatchLinkSubResource(
-            target_node_label=owner_label,
-            target_node_matcher=make_target_node_matcher(
-                {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
-            ),
-            direction=LinkDirection.INWARD,
-            rel_label="RESOURCE",
-        ),
-    )

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -966,7 +966,11 @@ Representation of a GCP [IAM Policy Binding](https://cloud.google.com/iam/docs/r
 - GCPPolicyBindings are resources of the scope where the binding is attached.
   Project and child-resource bindings are owned by GCPProjects. Inherited
   organization and folder bindings are owned by GCPOrganizations and GCPFolders,
-  respectively.
+  respectively. In earlier versions, inherited organization and folder bindings
+  were repeatedly attached to each project that observed them. Downstream queries
+  that need inherited bindings should traverse the binding's real owner scope or
+  its `APPLIES_TO` edge instead of assuming every inherited binding is
+  project-owned.
 
     ```
     (GCPProject)-[:RESOURCE]->(GCPPolicyBinding)

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -963,10 +963,15 @@ Representation of a GCP [IAM Policy Binding](https://cloud.google.com/iam/docs/r
 
 #### Relationships
 
-- GCPPolicyBindings are resources of GCPProjects.
+- GCPPolicyBindings are resources of the scope where the binding is attached.
+  Project and child-resource bindings are owned by GCPProjects. Inherited
+  organization and folder bindings are owned by GCPOrganizations and GCPFolders,
+  respectively.
 
     ```
     (GCPProject)-[:RESOURCE]->(GCPPolicyBinding)
+    (GCPOrganization)-[:RESOURCE]->(GCPPolicyBinding)
+    (GCPFolder)-[:RESOURCE]->(GCPPolicyBinding)
     ```
 
 - GCPPrincipals have allow policies that grant them access.

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -966,11 +966,8 @@ Representation of a GCP [IAM Policy Binding](https://cloud.google.com/iam/docs/r
 - GCPPolicyBindings are resources of the scope where the binding is attached.
   Project and child-resource bindings are owned by GCPProjects. Inherited
   organization and folder bindings are owned by GCPOrganizations and GCPFolders,
-  respectively. In earlier versions, inherited organization and folder bindings
-  were repeatedly attached to each project that observed them. Downstream queries
-  that need inherited bindings should traverse the binding's real owner scope or
-  its `APPLIES_TO` edge instead of assuming every inherited binding is
-  project-owned.
+  respectively. Queries that need inherited bindings should traverse the
+  binding's owner scope or its `APPLIES_TO` edge.
 
     ```
     (GCPProject)-[:RESOURCE]->(GCPPolicyBinding)

--- a/tests/data/gcp/policy_bindings.py
+++ b/tests/data/gcp/policy_bindings.py
@@ -301,3 +301,49 @@ MOCK_POLICY_BINDINGS_RESPONSE = {
         },
     ],
 }
+
+MOCK_INHERITED_POLICY_BINDINGS_RESPONSE = {
+    "project_id": "project-abc",
+    "organization": "organizations/1337",
+    "policy_results": [
+        {
+            "full_resource_name": "//cloudresourcemanager.googleapis.com/organizations/1337",
+            "policies": [
+                {
+                    "attached_resource": "//cloudresourcemanager.googleapis.com/organizations/1337",
+                    "policy": {
+                        "bindings": [
+                            {
+                                "role": "roles/viewer",
+                                "members": ["user:alice@example.com"],
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+        {
+            "full_resource_name": "//cloudresourcemanager.googleapis.com/folders/1414",
+            "policies": [
+                {
+                    "attached_resource": "//cloudresourcemanager.googleapis.com/folders/1414",
+                    "policy": {
+                        "bindings": [
+                            {
+                                "role": "roles/viewer",
+                                "members": ["user:alice@example.com"],
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    ],
+}
+
+INHERITED_ORG_BINDING_ID = (
+    "//cloudresourcemanager.googleapis.com/organizations/1337_roles/viewer"
+)
+INHERITED_FOLDER_BINDING_ID = (
+    "//cloudresourcemanager.googleapis.com/folders/1414_roles/viewer"
+)

--- a/tests/integration/cartography/intel/gcp/test_cascade_delete.py
+++ b/tests/integration/cartography/intel/gcp/test_cascade_delete.py
@@ -28,6 +28,9 @@ TEST_UPDATE_TAG = 123456789
 TEST_UPDATE_TAG_V2 = 123456790
 TEST_ORG_ID = "organizations/1337"
 TEST_PROJECT_ID = "test-project-cascade"
+SKIPPED_PROJECT_RESOURCES_RESULT = cartography.intel.gcp.GCPProjectResourcesSyncResult(
+    policy_bindings_cleanup_safe=False,
+)
 
 
 class TestProjectCascadeDelete:
@@ -286,7 +289,7 @@ class TestCascadeDeleteIntegration:
     @patch.object(
         cartography.intel.gcp,
         "_sync_project_resources",
-        return_value=None,
+        return_value=SKIPPED_PROJECT_RESOURCES_RESULT,
     )
     @patch.object(
         cartography.intel.gcp.crm.projects,

--- a/tests/integration/cartography/intel/gcp/test_crm_deferred_cleanup.py
+++ b/tests/integration/cartography/intel/gcp/test_crm_deferred_cleanup.py
@@ -21,6 +21,9 @@ from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
 TEST_UPDATE_TAG_V2 = 123456790  # For simulating a second sync
+SKIPPED_PROJECT_RESOURCES_RESULT = cartography.intel.gcp.GCPProjectResourcesSyncResult(
+    policy_bindings_cleanup_safe=False,
+)
 
 
 def _make_fake_credentials():
@@ -39,7 +42,7 @@ def _make_fake_credentials():
 @patch.object(
     cartography.intel.gcp,
     "_sync_project_resources",
-    return_value=None,  # Skip project resource sync for these tests
+    return_value=SKIPPED_PROJECT_RESOURCES_RESULT,  # Skip project resource sync for these tests
 )
 @patch.object(
     cartography.intel.gcp.crm.projects,
@@ -143,7 +146,7 @@ def test_deferred_cleanup_order(
 @patch.object(
     cartography.intel.gcp,
     "_sync_project_resources",
-    return_value=None,
+    return_value=SKIPPED_PROJECT_RESOURCES_RESULT,
 )
 @patch.object(
     cartography.intel.gcp.crm.projects,
@@ -241,7 +244,7 @@ def test_org_deletion_cleanup(
 @patch.object(
     cartography.intel.gcp,
     "_sync_project_resources",
-    return_value=None,
+    return_value=SKIPPED_PROJECT_RESOURCES_RESULT,
 )
 @patch.object(
     cartography.intel.gcp.crm.projects,
@@ -323,7 +326,7 @@ def test_partial_deletion_cleanup(
 @patch.object(
     cartography.intel.gcp,
     "_sync_project_resources",
-    return_value=None,  # Skip project resource sync for these tests
+    return_value=SKIPPED_PROJECT_RESOURCES_RESULT,  # Skip project resource sync for these tests
 )
 @patch.object(
     cartography.intel.gcp.iam,

--- a/tests/integration/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/integration/cartography/intel/gcp/test_policy_bindings.py
@@ -227,7 +227,7 @@ def test_sync_gcp_policy_bindings(
     """
     Test that GCP policy bindings sync creates the expected nodes and relationships.
     """
-    # ARRANGE
+    # Arrange
     _create_test_project(neo4j_session)
     _create_test_organization(neo4j_session)
     _create_test_bucket(neo4j_session)
@@ -270,7 +270,7 @@ def test_sync_gcp_policy_bindings(
         tests.data.gcp.policy_bindings.MOCK_IAM_ROLES
     )
 
-    # ACT
+    # Act
     cartography.intel.gcp.policy_bindings.sync(
         neo4j_session,
         TEST_PROJECT_ID,
@@ -280,7 +280,7 @@ def test_sync_gcp_policy_bindings(
         role_permissions_by_name,
     )
 
-    # ASSERT
+    # Assert
     # Check GCP policy binding nodes
     assert check_nodes(
         neo4j_session, "GCPPolicyBinding", ["id", "role", "resource_type"]
@@ -755,11 +755,11 @@ def test_sync_gcp_policy_bindings_permission_denied(
     When the user lacks org-level cloudasset.viewer role, sync should return a
     skipped status and not raise an exception.
     """
-    # ARRANGE
+    # Arrange
     _create_test_project(neo4j_session)
     mock_asset_client = MagicMock()
 
-    # ACT
+    # Act
     result = cartography.intel.gcp.policy_bindings.sync(
         neo4j_session,
         TEST_PROJECT_ID,
@@ -769,7 +769,7 @@ def test_sync_gcp_policy_bindings_permission_denied(
         {},
     )
 
-    # ASSERT - sync should return a skipped status and not raise an exception
+    # Assert - sync should return a skipped status and not raise an exception
     assert (
         result.status
         == cartography.intel.gcp.policy_bindings.PolicyBindingsSyncStatus.SKIPPED_PERMISSION_DENIED

--- a/tests/integration/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/integration/cartography/intel/gcp/test_policy_bindings.py
@@ -3,10 +3,14 @@ from unittest.mock import patch
 
 from google.api_core.exceptions import PermissionDenied
 
+import cartography.intel.gcp.crm.folders
+import cartography.intel.gcp.crm.orgs
+import cartography.intel.gcp.crm.projects
 import cartography.intel.gcp.iam
 import cartography.intel.gcp.policy_bindings
 import cartography.intel.gsuite.groups
 import cartography.intel.gsuite.users
+import tests.data.gcp.crm
 import tests.data.gcp.policy_bindings
 from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
@@ -22,6 +26,8 @@ GSUITE_COMMON_PARAMS = {
     **COMMON_JOB_PARAMS,
     "CUSTOMER_ID": "customer-123",
 }
+INHERITED_ORG_BINDING_ID = tests.data.gcp.policy_bindings.INHERITED_ORG_BINDING_ID
+INHERITED_FOLDER_BINDING_ID = tests.data.gcp.policy_bindings.INHERITED_FOLDER_BINDING_ID
 
 
 def _create_test_project(neo4j_session):
@@ -60,6 +66,110 @@ def _create_test_bucket(neo4j_session):
         """,
         bucket_id="test-bucket",
         update_tag=TEST_UPDATE_TAG,
+    )
+
+
+def _sync_test_resource_hierarchy(neo4j_session):
+    with (
+        patch.object(
+            cartography.intel.gcp.crm.orgs,
+            "get_gcp_organizations",
+            return_value=tests.data.gcp.crm.GCP_ORGANIZATIONS,
+        ),
+        patch.object(
+            cartography.intel.gcp.crm.folders,
+            "get_gcp_folders",
+            return_value=tests.data.gcp.crm.GCP_FOLDERS,
+        ),
+        patch.object(
+            cartography.intel.gcp.crm.projects,
+            "get_gcp_projects",
+            return_value=tests.data.gcp.crm.GCP_PROJECTS,
+        ),
+    ):
+        cartography.intel.gcp.crm.orgs.sync_gcp_organizations(
+            neo4j_session,
+            TEST_UPDATE_TAG,
+            COMMON_JOB_PARAMS,
+        )
+        folders = cartography.intel.gcp.crm.folders.sync_gcp_folders(
+            neo4j_session,
+            TEST_UPDATE_TAG,
+            COMMON_JOB_PARAMS,
+            COMMON_JOB_PARAMS["ORG_RESOURCE_NAME"],
+        )
+        cartography.intel.gcp.crm.projects.sync_gcp_projects(
+            neo4j_session,
+            COMMON_JOB_PARAMS["ORG_RESOURCE_NAME"],
+            folders,
+            TEST_UPDATE_TAG,
+            COMMON_JOB_PARAMS,
+        )
+        return folders
+
+
+def _sync_test_principal_and_role(neo4j_session):
+    viewer_role = [
+        role
+        for role in tests.data.gcp.policy_bindings.MOCK_IAM_ROLES
+        if role["name"] == "roles/viewer"
+    ]
+    with (
+        patch.object(
+            cartography.intel.gcp.iam,
+            "get_gcp_predefined_roles",
+            return_value=viewer_role,
+        ),
+        patch.object(
+            cartography.intel.gcp.iam,
+            "get_gcp_org_roles",
+            return_value=[],
+        ),
+        patch.object(
+            cartography.intel.gsuite.users,
+            "get_all_users",
+            return_value=tests.data.gcp.policy_bindings.MOCK_GSUITE_USERS,
+        ),
+    ):
+        cartography.intel.gcp.iam.sync_org_iam(
+            neo4j_session,
+            MagicMock(),
+            COMMON_JOB_PARAMS["ORG_RESOURCE_NAME"],
+            TEST_UPDATE_TAG,
+            COMMON_JOB_PARAMS,
+        )
+        cartography.intel.gsuite.users.sync_gsuite_users(
+            neo4j_session,
+            MagicMock(),
+            TEST_UPDATE_TAG,
+            GSUITE_COMMON_PARAMS,
+        )
+
+
+def _reset_inherited_policy_binding_test_scope(neo4j_session):
+    neo4j_session.run(
+        """
+        MATCH (n)
+        WHERE
+            (n:GCPProject AND n.id = $project_id)
+            OR (n:GCPOrganization AND n.id = $org_id)
+            OR (n:GCPFolder AND n.id = $folder_id)
+            OR (n:GCPPrincipal AND n.email = $email)
+            OR (n:GCPRole AND n.name = $role)
+            OR (n:GCPPolicyBinding AND n.id IN $binding_ids)
+        DETACH DELETE n
+        """,
+        project_id=TEST_PROJECT_ID,
+        org_id=COMMON_JOB_PARAMS["ORG_RESOURCE_NAME"],
+        folder_id="folders/1414",
+        email="alice@example.com",
+        role="roles/viewer",
+        binding_ids=[
+            INHERITED_ORG_BINDING_ID,
+            INHERITED_FOLDER_BINDING_ID,
+            "old-org-binding",
+            "old-folder-binding",
+        ],
     )
 
 
@@ -400,6 +510,233 @@ def test_sync_gcp_policy_bindings(
     ).single()
     assert bucket_binding["is_public"] is True
     assert sorted(bucket_binding["members"]) == ["alice@example.com"]
+
+
+@patch.object(
+    cartography.intel.gcp.policy_bindings,
+    "get_policy_bindings",
+    return_value=tests.data.gcp.policy_bindings.MOCK_INHERITED_POLICY_BINDINGS_RESPONSE,
+)
+def test_sync_gcp_inherited_policy_bindings_are_owned_by_scope(
+    mock_get_policy_bindings,
+    neo4j_session,
+):
+    # Arrange
+    _reset_inherited_policy_binding_test_scope(neo4j_session)
+    _sync_test_resource_hierarchy(neo4j_session)
+    _sync_test_principal_and_role(neo4j_session)
+
+    # Act
+    result = cartography.intel.gcp.policy_bindings.sync(
+        neo4j_session,
+        TEST_PROJECT_ID,
+        TEST_UPDATE_TAG,
+        COMMON_JOB_PARAMS,
+        MagicMock(),
+        {"roles/viewer": ["storage.objects.get"]},
+    )
+
+    # Assert
+    assert (
+        result.status
+        == cartography.intel.gcp.policy_bindings.PolicyBindingsSyncStatus.SUCCESS
+    )
+    inherited_nodes = {
+        tuple(row)
+        for row in neo4j_session.run(
+            """
+            MATCH (binding:GCPPolicyBinding)
+            WHERE binding.id IN $binding_ids
+            RETURN binding.id, binding.role, binding.resource_type
+            """,
+            binding_ids=[INHERITED_ORG_BINDING_ID, INHERITED_FOLDER_BINDING_ID],
+        )
+    }
+    assert inherited_nodes == {
+        (
+            INHERITED_ORG_BINDING_ID,
+            "roles/viewer",
+            "organization",
+        ),
+        (
+            INHERITED_FOLDER_BINDING_ID,
+            "roles/viewer",
+            "folder",
+        ),
+    }
+    assert check_rels(
+        neo4j_session,
+        "GCPOrganization",
+        "id",
+        "GCPPolicyBinding",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (
+            "organizations/1337",
+            INHERITED_ORG_BINDING_ID,
+        ),
+    }
+    assert check_rels(
+        neo4j_session,
+        "GCPFolder",
+        "id",
+        "GCPPolicyBinding",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (
+            "folders/1414",
+            INHERITED_FOLDER_BINDING_ID,
+        ),
+    }
+    inherited_project_resource_edges = neo4j_session.run(
+        """
+        MATCH (:GCPProject)-[:RESOURCE]->(binding:GCPPolicyBinding)
+        WHERE binding.id IN $binding_ids
+        RETURN count(binding) AS count
+        """,
+        binding_ids=[INHERITED_ORG_BINDING_ID, INHERITED_FOLDER_BINDING_ID],
+    ).single()["count"]
+    assert inherited_project_resource_edges == 0
+    has_allow_policy_rels = {
+        tuple(row)
+        for row in neo4j_session.run(
+            """
+            MATCH (principal:GCPPrincipal)-[:HAS_ALLOW_POLICY]->(
+                binding:GCPPolicyBinding
+            )
+            WHERE binding.id IN $binding_ids
+            RETURN principal.email, binding.id
+            """,
+            binding_ids=[INHERITED_ORG_BINDING_ID, INHERITED_FOLDER_BINDING_ID],
+        )
+    }
+    assert has_allow_policy_rels == {
+        (
+            "alice@example.com",
+            INHERITED_ORG_BINDING_ID,
+        ),
+        (
+            "alice@example.com",
+            INHERITED_FOLDER_BINDING_ID,
+        ),
+    }
+    grants_role_rels = {
+        tuple(row)
+        for row in neo4j_session.run(
+            """
+            MATCH (binding:GCPPolicyBinding)-[:GRANTS_ROLE]->(role:GCPRole)
+            WHERE binding.id IN $binding_ids
+            RETURN binding.id, role.name
+            """,
+            binding_ids=[INHERITED_ORG_BINDING_ID, INHERITED_FOLDER_BINDING_ID],
+        )
+    }
+    assert grants_role_rels == {
+        (
+            INHERITED_ORG_BINDING_ID,
+            "roles/viewer",
+        ),
+        (
+            INHERITED_FOLDER_BINDING_ID,
+            "roles/viewer",
+        ),
+    }
+    assert check_rels(
+        neo4j_session,
+        "GCPPolicyBinding",
+        "id",
+        "GCPOrganization",
+        "id",
+        "APPLIES_TO",
+        rel_direction_right=True,
+    ) == {
+        (
+            INHERITED_ORG_BINDING_ID,
+            "organizations/1337",
+        ),
+    }
+    assert check_rels(
+        neo4j_session,
+        "GCPPolicyBinding",
+        "id",
+        "GCPFolder",
+        "id",
+        "APPLIES_TO",
+        rel_direction_right=True,
+    ) == {
+        (
+            INHERITED_FOLDER_BINDING_ID,
+            "folders/1414",
+        ),
+    }
+
+
+def test_cleanup_gcp_inherited_policy_bindings(neo4j_session):
+    # Arrange
+    _reset_inherited_policy_binding_test_scope(neo4j_session)
+    folders = _sync_test_resource_hierarchy(neo4j_session)
+    _sync_test_principal_and_role(neo4j_session)
+    neo4j_session.run(
+        """
+        MATCH (org:GCPOrganization {id: $org_id})
+        MATCH (folder:GCPFolder {id: $folder_id})
+        MATCH (principal:GCPPrincipal {email: $email})
+        MATCH (role:GCPRole {name: $role})
+        MERGE (org_binding:GCPPolicyBinding {id: $org_binding_id})
+        SET org_binding.lastupdated = $old_update_tag
+        MERGE (folder_binding:GCPPolicyBinding {id: $folder_binding_id})
+        SET folder_binding.lastupdated = $old_update_tag
+        MERGE (org)-[org_resource:RESOURCE]->(org_binding)
+        SET org_resource.lastupdated = $old_update_tag
+        MERGE (folder)-[folder_resource:RESOURCE]->(folder_binding)
+        SET folder_resource.lastupdated = $old_update_tag
+        MERGE (principal)-[org_policy:HAS_ALLOW_POLICY]->(org_binding)
+        SET org_policy.lastupdated = $old_update_tag
+        MERGE (principal)-[folder_policy:HAS_ALLOW_POLICY]->(folder_binding)
+        SET folder_policy.lastupdated = $old_update_tag
+        MERGE (org_binding)-[org_role:GRANTS_ROLE]->(role)
+        SET org_role.lastupdated = $old_update_tag
+        MERGE (folder_binding)-[folder_role:GRANTS_ROLE]->(role)
+        SET folder_role.lastupdated = $old_update_tag
+        MERGE (org_binding)-[org_applies:APPLIES_TO]->(org)
+        SET org_applies.lastupdated = $old_update_tag,
+            org_applies._sub_resource_label = "GCPOrganization",
+            org_applies._sub_resource_id = $org_id
+        MERGE (folder_binding)-[folder_applies:APPLIES_TO]->(folder)
+        SET folder_applies.lastupdated = $old_update_tag,
+            folder_applies._sub_resource_label = "GCPFolder",
+            folder_applies._sub_resource_id = $folder_id
+        """,
+        org_id=COMMON_JOB_PARAMS["ORG_RESOURCE_NAME"],
+        folder_id="folders/1414",
+        email="alice@example.com",
+        role="roles/viewer",
+        old_update_tag=TEST_UPDATE_TAG - 1,
+        org_binding_id="old-org-binding",
+        folder_binding_id="old-folder-binding",
+    )
+
+    # Act
+    cartography.intel.gcp.policy_bindings.cleanup_inherited_policy_bindings(
+        neo4j_session,
+        COMMON_JOB_PARAMS,
+        [folder["name"] for folder in folders if folder.get("name")],
+    )
+
+    # Assert
+    stale_nodes = neo4j_session.run(
+        """
+        MATCH (binding:GCPPolicyBinding)
+        WHERE binding.id IN $binding_ids
+        RETURN count(binding) AS count
+        """,
+        binding_ids=["old-org-binding", "old-folder-binding"],
+    ).single()["count"]
+    assert stale_nodes == 0
 
 
 @patch.object(

--- a/tests/integration/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/integration/cartography/intel/gcp/test_policy_bindings.py
@@ -17,6 +17,14 @@ from tests.integration.util import check_rels
 
 TEST_PROJECT_ID = "project-abc"
 TEST_UPDATE_TAG = 123456789
+TEST_FOLDER_ID = tests.data.gcp.crm.GCP_FOLDERS[0]["name"]
+TEST_POLICY_BINDING_GSUITE_USERS = tests.data.gcp.policy_bindings.MOCK_GSUITE_USERS[0][
+    "users"
+]
+TEST_POLICY_BINDING_PRINCIPAL_EMAIL = TEST_POLICY_BINDING_GSUITE_USERS[0][
+    "primaryEmail"
+]
+TEST_VIEWER_ROLE = "roles/viewer"
 COMMON_JOB_PARAMS = {
     "UPDATE_TAG": TEST_UPDATE_TAG,
     "ORG_RESOURCE_NAME": "organizations/1337",
@@ -28,6 +36,8 @@ GSUITE_COMMON_PARAMS = {
 }
 INHERITED_ORG_BINDING_ID = tests.data.gcp.policy_bindings.INHERITED_ORG_BINDING_ID
 INHERITED_FOLDER_BINDING_ID = tests.data.gcp.policy_bindings.INHERITED_FOLDER_BINDING_ID
+STALE_INHERITED_ORG_BINDING_ID = "old-org-binding"
+STALE_INHERITED_FOLDER_BINDING_ID = "old-folder-binding"
 
 
 def _create_test_project(neo4j_session):
@@ -112,7 +122,7 @@ def _sync_test_principal_and_role(neo4j_session):
     viewer_role = [
         role
         for role in tests.data.gcp.policy_bindings.MOCK_IAM_ROLES
-        if role["name"] == "roles/viewer"
+        if role["name"] == TEST_VIEWER_ROLE
     ]
     with (
         patch.object(
@@ -161,15 +171,57 @@ def _reset_inherited_policy_binding_test_scope(neo4j_session):
         """,
         project_id=TEST_PROJECT_ID,
         org_id=COMMON_JOB_PARAMS["ORG_RESOURCE_NAME"],
-        folder_id="folders/1414",
-        email="alice@example.com",
-        role="roles/viewer",
+        folder_id=TEST_FOLDER_ID,
+        email=TEST_POLICY_BINDING_PRINCIPAL_EMAIL,
+        role=TEST_VIEWER_ROLE,
         binding_ids=[
             INHERITED_ORG_BINDING_ID,
             INHERITED_FOLDER_BINDING_ID,
-            "old-org-binding",
-            "old-folder-binding",
+            STALE_INHERITED_ORG_BINDING_ID,
+            STALE_INHERITED_FOLDER_BINDING_ID,
         ],
+    )
+
+
+def _seed_stale_inherited_policy_bindings(neo4j_session):
+    neo4j_session.run(
+        """
+        MATCH (org:GCPOrganization {id: $org_id})
+        MATCH (folder:GCPFolder {id: $folder_id})
+        MATCH (principal:GCPPrincipal {email: $email})
+        MATCH (role:GCPRole {name: $role})
+        MERGE (org_binding:GCPPolicyBinding {id: $org_binding_id})
+        SET org_binding.lastupdated = $old_update_tag
+        MERGE (folder_binding:GCPPolicyBinding {id: $folder_binding_id})
+        SET folder_binding.lastupdated = $old_update_tag
+        MERGE (org)-[org_resource:RESOURCE]->(org_binding)
+        SET org_resource.lastupdated = $old_update_tag
+        MERGE (folder)-[folder_resource:RESOURCE]->(folder_binding)
+        SET folder_resource.lastupdated = $old_update_tag
+        MERGE (principal)-[org_policy:HAS_ALLOW_POLICY]->(org_binding)
+        SET org_policy.lastupdated = $old_update_tag
+        MERGE (principal)-[folder_policy:HAS_ALLOW_POLICY]->(folder_binding)
+        SET folder_policy.lastupdated = $old_update_tag
+        MERGE (org_binding)-[org_role:GRANTS_ROLE]->(role)
+        SET org_role.lastupdated = $old_update_tag
+        MERGE (folder_binding)-[folder_role:GRANTS_ROLE]->(role)
+        SET folder_role.lastupdated = $old_update_tag
+        MERGE (org_binding)-[org_applies:APPLIES_TO]->(org)
+        SET org_applies.lastupdated = $old_update_tag,
+            org_applies._sub_resource_label = "GCPOrganization",
+            org_applies._sub_resource_id = $org_id
+        MERGE (folder_binding)-[folder_applies:APPLIES_TO]->(folder)
+        SET folder_applies.lastupdated = $old_update_tag,
+            folder_applies._sub_resource_label = "GCPFolder",
+            folder_applies._sub_resource_id = $folder_id
+        """,
+        org_id=COMMON_JOB_PARAMS["ORG_RESOURCE_NAME"],
+        folder_id=TEST_FOLDER_ID,
+        email=TEST_POLICY_BINDING_PRINCIPAL_EMAIL,
+        role=TEST_VIEWER_ROLE,
+        old_update_tag=TEST_UPDATE_TAG - 1,
+        org_binding_id=STALE_INHERITED_ORG_BINDING_ID,
+        folder_binding_id=STALE_INHERITED_FOLDER_BINDING_ID,
     )
 
 
@@ -533,7 +585,7 @@ def test_sync_gcp_inherited_policy_bindings_are_owned_by_scope(
         TEST_UPDATE_TAG,
         COMMON_JOB_PARAMS,
         MagicMock(),
-        {"roles/viewer": ["storage.objects.get"]},
+        {TEST_VIEWER_ROLE: ["storage.objects.get"]},
     )
 
     # Assert
@@ -555,12 +607,12 @@ def test_sync_gcp_inherited_policy_bindings_are_owned_by_scope(
     assert inherited_nodes == {
         (
             INHERITED_ORG_BINDING_ID,
-            "roles/viewer",
+            TEST_VIEWER_ROLE,
             "organization",
         ),
         (
             INHERITED_FOLDER_BINDING_ID,
-            "roles/viewer",
+            TEST_VIEWER_ROLE,
             "folder",
         ),
     }
@@ -588,7 +640,7 @@ def test_sync_gcp_inherited_policy_bindings_are_owned_by_scope(
         rel_direction_right=True,
     ) == {
         (
-            "folders/1414",
+            TEST_FOLDER_ID,
             INHERITED_FOLDER_BINDING_ID,
         ),
     }
@@ -616,11 +668,11 @@ def test_sync_gcp_inherited_policy_bindings_are_owned_by_scope(
     }
     assert has_allow_policy_rels == {
         (
-            "alice@example.com",
+            TEST_POLICY_BINDING_PRINCIPAL_EMAIL,
             INHERITED_ORG_BINDING_ID,
         ),
         (
-            "alice@example.com",
+            TEST_POLICY_BINDING_PRINCIPAL_EMAIL,
             INHERITED_FOLDER_BINDING_ID,
         ),
     }
@@ -638,11 +690,11 @@ def test_sync_gcp_inherited_policy_bindings_are_owned_by_scope(
     assert grants_role_rels == {
         (
             INHERITED_ORG_BINDING_ID,
-            "roles/viewer",
+            TEST_VIEWER_ROLE,
         ),
         (
             INHERITED_FOLDER_BINDING_ID,
-            "roles/viewer",
+            TEST_VIEWER_ROLE,
         ),
     }
     assert check_rels(
@@ -670,7 +722,7 @@ def test_sync_gcp_inherited_policy_bindings_are_owned_by_scope(
     ) == {
         (
             INHERITED_FOLDER_BINDING_ID,
-            "folders/1414",
+            TEST_FOLDER_ID,
         ),
     }
 
@@ -680,45 +732,7 @@ def test_cleanup_gcp_inherited_policy_bindings(neo4j_session):
     _reset_inherited_policy_binding_test_scope(neo4j_session)
     folders = _sync_test_resource_hierarchy(neo4j_session)
     _sync_test_principal_and_role(neo4j_session)
-    neo4j_session.run(
-        """
-        MATCH (org:GCPOrganization {id: $org_id})
-        MATCH (folder:GCPFolder {id: $folder_id})
-        MATCH (principal:GCPPrincipal {email: $email})
-        MATCH (role:GCPRole {name: $role})
-        MERGE (org_binding:GCPPolicyBinding {id: $org_binding_id})
-        SET org_binding.lastupdated = $old_update_tag
-        MERGE (folder_binding:GCPPolicyBinding {id: $folder_binding_id})
-        SET folder_binding.lastupdated = $old_update_tag
-        MERGE (org)-[org_resource:RESOURCE]->(org_binding)
-        SET org_resource.lastupdated = $old_update_tag
-        MERGE (folder)-[folder_resource:RESOURCE]->(folder_binding)
-        SET folder_resource.lastupdated = $old_update_tag
-        MERGE (principal)-[org_policy:HAS_ALLOW_POLICY]->(org_binding)
-        SET org_policy.lastupdated = $old_update_tag
-        MERGE (principal)-[folder_policy:HAS_ALLOW_POLICY]->(folder_binding)
-        SET folder_policy.lastupdated = $old_update_tag
-        MERGE (org_binding)-[org_role:GRANTS_ROLE]->(role)
-        SET org_role.lastupdated = $old_update_tag
-        MERGE (folder_binding)-[folder_role:GRANTS_ROLE]->(role)
-        SET folder_role.lastupdated = $old_update_tag
-        MERGE (org_binding)-[org_applies:APPLIES_TO]->(org)
-        SET org_applies.lastupdated = $old_update_tag,
-            org_applies._sub_resource_label = "GCPOrganization",
-            org_applies._sub_resource_id = $org_id
-        MERGE (folder_binding)-[folder_applies:APPLIES_TO]->(folder)
-        SET folder_applies.lastupdated = $old_update_tag,
-            folder_applies._sub_resource_label = "GCPFolder",
-            folder_applies._sub_resource_id = $folder_id
-        """,
-        org_id=COMMON_JOB_PARAMS["ORG_RESOURCE_NAME"],
-        folder_id="folders/1414",
-        email="alice@example.com",
-        role="roles/viewer",
-        old_update_tag=TEST_UPDATE_TAG - 1,
-        org_binding_id="old-org-binding",
-        folder_binding_id="old-folder-binding",
-    )
+    _seed_stale_inherited_policy_bindings(neo4j_session)
 
     # Act
     cartography.intel.gcp.policy_bindings.cleanup_inherited_policy_bindings(
@@ -734,7 +748,10 @@ def test_cleanup_gcp_inherited_policy_bindings(neo4j_session):
         WHERE binding.id IN $binding_ids
         RETURN count(binding) AS count
         """,
-        binding_ids=["old-org-binding", "old-folder-binding"],
+        binding_ids=[
+            STALE_INHERITED_ORG_BINDING_ID,
+            STALE_INHERITED_FOLDER_BINDING_ID,
+        ],
     ).single()["count"]
     assert stale_nodes == 0
 

--- a/tests/integration/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/integration/cartography/intel/gcp/test_policy_bindings.py
@@ -769,7 +769,8 @@ def test_sync_gcp_policy_bindings_permission_denied(
         {},
     )
 
-    # Assert - sync should return a skipped status and not raise an exception
+    # Assert
+    # Sync should return a skipped status and not raise an exception.
     assert (
         result.status
         == cartography.intel.gcp.policy_bindings.PolicyBindingsSyncStatus.SKIPPED_PERMISSION_DENIED

--- a/tests/unit/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/unit/cartography/intel/gcp/test_policy_bindings.py
@@ -46,6 +46,16 @@ COMMON_JOB_PARAMS = {
             "//storage.googleapis.com/buckets/test-bucket/objects/foo.txt",
             ("GCPBucket", "test-bucket"),
         ),
+        # BigQuery dataset
+        (
+            "//bigquery.googleapis.com/projects/project-abc/datasets/dataset_a",
+            ("GCPBigQueryDataset", "project-abc:dataset_a"),
+        ),
+        # BigQuery table
+        (
+            "//bigquery.googleapis.com/projects/project-abc/datasets/dataset_a/tables/events",
+            ("GCPBigQueryTable", "project-abc:dataset_a.events"),
+        ),
         # KMS — cryptoKey wins over keyRing
         (
             "//cloudkms.googleapis.com/projects/p/locations/us/keyRings/r/cryptoKeys/k",
@@ -90,6 +100,11 @@ COMMON_JOB_PARAMS = {
                 "projects/p/locations/us-central1/services/svc",
             ),
         ),
+        # Service Account
+        (
+            "//iam.googleapis.com/projects/project-abc/serviceAccounts/sa@project-abc.iam.gserviceaccount.com",
+            ("GCPServiceAccount", "sa@project-abc.iam.gserviceaccount.com"),
+        ),
         # Compute — instance (partial_uri format)
         (
             "//compute.googleapis.com/projects/p/zones/us-central1-a/instances/vm1",
@@ -112,7 +127,7 @@ COMMON_JOB_PARAMS = {
         ),
         # Unknown service
         (
-            "//bigquery.googleapis.com/projects/p/datasets/d",
+            "//pubsub.googleapis.com/projects/p/topics/t",
             (None, None),
         ),
         # Empty suffix
@@ -129,6 +144,22 @@ COMMON_JOB_PARAMS = {
 )
 def test_parse_full_resource_name(full_name, expected):
     assert _parse_full_resource_name(full_name) == expected
+
+
+def test_policy_bindings_search_asset_types_come_from_full_name_mappings():
+    assert policy_bindings.GCP_POLICY_BINDINGS_SEARCH_ASSET_TYPES == [
+        mapping.asset_type
+        for mapping in policy_bindings._FULL_NAME_MAPPINGS
+        if mapping.asset_type is not None
+    ]
+    assert (
+        "artifactregistry.googleapis.com/Repository"
+        in policy_bindings.GCP_POLICY_BINDINGS_SEARCH_ASSET_TYPES
+    )
+    assert (
+        "artifactregistry.googleapis.com/DockerImage"
+        not in policy_bindings.GCP_POLICY_BINDINGS_SEARCH_ASSET_TYPES
+    )
 
 
 def test_wait_for_cai_policy_bindings_slot_reserves_per_operation_slots():
@@ -218,7 +249,86 @@ def test_get_policy_bindings_passes_custom_retry_to_cai_rpcs(
         client.search_all_iam_policies.call_args.kwargs["timeout"]
         == policy_bindings.CAI_POLICY_BINDINGS_SEARCH_TIMEOUT
     )
+    search_request = client.search_all_iam_policies.call_args.kwargs["request"]
+    assert (
+        list(search_request.asset_types)
+        == policy_bindings.GCP_POLICY_BINDINGS_SEARCH_ASSET_TYPES
+    )
+    assert "artifactregistry.googleapis.com/Repository" in search_request.asset_types
+    assert (
+        "artifactregistry.googleapis.com/DockerImage" not in search_request.asset_types
+    )
     assert mock_wait_for_slot.call_count == 2
+
+
+def test_split_bindings_by_graph_scope_keeps_inherited_separate():
+    direct_project = {
+        "id": "project-binding",
+        "resource": "//cloudresourcemanager.googleapis.com/projects/project-abc",
+        "resource_type": "project",
+    }
+    direct_resource = {
+        "id": "bucket-binding",
+        "resource": "//storage.googleapis.com/buckets/test-bucket",
+        "resource_type": "resource",
+    }
+    inherited_org = {
+        "id": "org-binding",
+        "resource": "//cloudresourcemanager.googleapis.com/organizations/1337",
+        "resource_type": "organization",
+    }
+    inherited_folder = {
+        "id": "folder-binding",
+        "resource": "//cloudresourcemanager.googleapis.com/folders/1414",
+        "resource_type": "folder",
+    }
+
+    direct, inherited = policy_bindings._split_bindings_by_graph_scope(
+        [direct_project, direct_resource, inherited_org, inherited_folder]
+    )
+
+    assert direct == [direct_project, direct_resource]
+    assert inherited == {
+        ("GCPOrganization", "organizations/1337"): [inherited_org],
+        ("GCPFolder", "folders/1414"): [inherited_folder],
+    }
+
+
+def test_claim_inherited_bindings_for_graph_dedupes_per_update_tag():
+    original_update_tag = policy_bindings._INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG
+    original_seen = policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.copy()
+    policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.clear()
+    policy_bindings._INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG = None
+    inherited = {
+        ("GCPOrganization", "organizations/1337"): [
+            {
+                "id": "org-binding",
+                "resource": "//cloudresourcemanager.googleapis.com/organizations/1337",
+                "resource_type": "organization",
+            },
+        ],
+    }
+    try:
+        first_claim = policy_bindings._claim_inherited_bindings_for_graph(
+            inherited,
+            TEST_UPDATE_TAG,
+        )
+        second_claim = policy_bindings._claim_inherited_bindings_for_graph(
+            inherited,
+            TEST_UPDATE_TAG,
+        )
+        next_run_claim = policy_bindings._claim_inherited_bindings_for_graph(
+            inherited,
+            TEST_UPDATE_TAG + 1,
+        )
+
+        assert first_claim == inherited
+        assert second_claim == {}
+        assert next_run_claim == inherited
+    finally:
+        policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.clear()
+        policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.update(original_seen)
+        policy_bindings._INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG = original_update_tag
 
 
 @patch.object(policy_bindings, "load_matchlinks")
@@ -245,6 +355,53 @@ def test_load_bindings_uses_policy_binding_batch_size(mock_load, mock_load_match
     assert (
         mock_load_matchlinks.call_args.kwargs["batch_size"]
         == policy_bindings.GCP_POLICY_BINDINGS_GRAPH_BATCH_SIZE
+    )
+
+
+@patch.object(policy_bindings, "load_matchlinks")
+@patch.object(policy_bindings, "load")
+def test_load_inherited_bindings_uses_owner_scope(mock_load, mock_load_matchlinks):
+    inherited = {
+        ("GCPOrganization", "organizations/1337"): [
+            {
+                "id": "org-binding",
+                "resource": "//cloudresourcemanager.googleapis.com/organizations/1337",
+                "resource_type": "organization",
+            },
+        ],
+        ("GCPFolder", "folders/1414"): [
+            {
+                "id": "folder-binding",
+                "resource": "//cloudresourcemanager.googleapis.com/folders/1414",
+                "resource_type": "folder",
+            },
+        ],
+    }
+
+    loaded_count = policy_bindings.load_inherited_bindings(
+        MagicMock(),
+        inherited,
+        TEST_UPDATE_TAG,
+    )
+
+    assert loaded_count == 2
+    assert mock_load.call_count == 2
+    assert mock_load.call_args_list[0].kwargs["ORG_RESOURCE_NAME"] == (
+        "organizations/1337"
+    )
+    assert mock_load.call_args_list[1].kwargs["FOLDER_ID"] == "folders/1414"
+    assert mock_load_matchlinks.call_count == 2
+    assert mock_load_matchlinks.call_args_list[0].kwargs["_sub_resource_label"] == (
+        "GCPOrganization"
+    )
+    assert mock_load_matchlinks.call_args_list[0].kwargs["_sub_resource_id"] == (
+        "organizations/1337"
+    )
+    assert mock_load_matchlinks.call_args_list[1].kwargs["_sub_resource_label"] == (
+        "GCPFolder"
+    )
+    assert mock_load_matchlinks.call_args_list[1].kwargs["_sub_resource_id"] == (
+        "folders/1414"
     )
 
 
@@ -278,8 +435,49 @@ def test_cleanup_uses_one_generic_applies_to_cleanup(
     applies_to_cleanup.run.assert_called_once_with(neo4j_session)
 
 
+@patch.object(policy_bindings, "GraphStatement")
+@patch("cartography.intel.gcp.policy_bindings.GraphJob.from_node_schema")
+def test_cleanup_inherited_policy_bindings_cleans_org_and_folders(
+    mock_from_node_schema,
+    mock_graph_statement,
+):
+    neo4j_session = MagicMock()
+    mock_from_node_schema.return_value = MagicMock()
+    mock_graph_statement.return_value = MagicMock()
+
+    policy_bindings.cleanup_inherited_policy_bindings(
+        neo4j_session,
+        COMMON_JOB_PARAMS,
+        ["folders/1414"],
+    )
+
+    assert mock_from_node_schema.call_count == 2
+    assert mock_graph_statement.call_count == 2
+    assert (
+        mock_graph_statement.call_args_list[0].kwargs["parameters"][
+            "_sub_resource_label"
+        ]
+        == "GCPOrganization"
+    )
+    assert (
+        mock_graph_statement.call_args_list[0].kwargs["parameters"]["_sub_resource_id"]
+        == "organizations/1337"
+    )
+    assert (
+        mock_graph_statement.call_args_list[1].kwargs["parameters"][
+            "_sub_resource_label"
+        ]
+        == "GCPFolder"
+    )
+    assert (
+        mock_graph_statement.call_args_list[1].kwargs["parameters"]["_sub_resource_id"]
+        == "folders/1414"
+    )
+
+
 @patch.object(policy_bindings, "cleanup")
 @patch.object(policy_bindings, "load_bindings")
+@patch.object(policy_bindings, "load_inherited_bindings", return_value=1)
 @patch.object(policy_bindings, "build_principals_from_policy_bindings")
 @patch.object(policy_bindings, "transform_bindings")
 @patch.object(policy_bindings, "get_policy_bindings")
@@ -287,6 +485,7 @@ def test_sync_limits_policy_binding_graph_writes(
     mock_get_policy_bindings,
     mock_transform_bindings,
     mock_build_principals,
+    mock_load_inherited_bindings,
     mock_load_bindings,
     mock_cleanup,
 ):
@@ -313,6 +512,7 @@ def test_sync_limits_policy_binding_graph_writes(
     graph_semaphore.__enter__.assert_called_once()
     graph_semaphore.__exit__.assert_called_once()
     mock_load_bindings.assert_called_once()
+    mock_load_inherited_bindings.assert_called_once()
     mock_cleanup.assert_called_once()
 
 
@@ -377,7 +577,7 @@ def test_sync_project_resources_skips_permission_relationships_after_policy_bind
     mock_build_client.return_value = MagicMock()
     mock_build_asset_client.return_value = MagicMock()
 
-    cartography.intel.gcp._sync_project_resources(
+    result = cartography.intel.gcp._sync_project_resources(
         neo4j_session=MagicMock(),
         projects=[{"projectId": TEST_PROJECT_ID}],
         gcp_update_tag=TEST_UPDATE_TAG,
@@ -389,6 +589,99 @@ def test_sync_project_resources_skips_permission_relationships_after_policy_bind
     assert mock_services_enabled.call_count == 2
     mock_policy_bindings_sync.assert_called_once()
     mock_permission_relationships_sync.assert_not_called()
+    assert result is False
+
+
+@patch("cartography.intel.gcp.build_asset_client")
+@patch("cartography.intel.gcp.build_client")
+@patch(
+    "cartography.intel.gcp.policy_bindings.sync",
+    side_effect=[
+        policy_bindings.PolicyBindingsSyncResult(
+            policy_bindings.PolicyBindingsSyncStatus.SUCCESS,
+            {},
+        ),
+        policy_bindings.PolicyBindingsSyncResult(
+            policy_bindings.PolicyBindingsSyncStatus.SKIPPED_RATE_LIMIT,
+            {},
+        ),
+    ],
+)
+@patch(
+    "cartography.intel.gcp._services_enabled_on_project",
+    side_effect=[
+        set(),
+        {cartography.intel.gcp.service_names.cai},
+        set(),
+    ],
+)
+def test_sync_project_resources_reports_policy_bindings_partial_failure(
+    mock_services_enabled,
+    mock_policy_bindings_sync,
+    mock_build_client,
+    mock_build_asset_client,
+):
+    mock_build_client.return_value = MagicMock()
+    mock_build_asset_client.return_value = MagicMock()
+
+    result = cartography.intel.gcp._sync_project_resources(
+        neo4j_session=MagicMock(),
+        projects=[
+            {"projectId": TEST_PROJECT_ID},
+            {"projectId": "project-def"},
+        ],
+        gcp_update_tag=TEST_UPDATE_TAG,
+        common_job_parameters=COMMON_JOB_PARAMS.copy(),
+        credentials=MagicMock(),
+        requested_syncs={"policy_bindings"},
+    )
+
+    assert mock_services_enabled.call_count == 3
+    assert mock_policy_bindings_sync.call_count == 2
+    assert result is False
+
+
+@patch("cartography.intel.gcp.build_asset_client")
+@patch("cartography.intel.gcp.build_client")
+@patch(
+    "cartography.intel.gcp.policy_bindings.sync",
+    return_value=policy_bindings.PolicyBindingsSyncResult(
+        policy_bindings.PolicyBindingsSyncStatus.SUCCESS,
+        {},
+    ),
+)
+@patch(
+    "cartography.intel.gcp._services_enabled_on_project",
+    side_effect=[
+        set(),
+        {cartography.intel.gcp.service_names.cai},
+        set(),
+    ],
+)
+def test_sync_project_resources_reports_policy_bindings_full_success(
+    mock_services_enabled,
+    mock_policy_bindings_sync,
+    mock_build_client,
+    mock_build_asset_client,
+):
+    mock_build_client.return_value = MagicMock()
+    mock_build_asset_client.return_value = MagicMock()
+
+    result = cartography.intel.gcp._sync_project_resources(
+        neo4j_session=MagicMock(),
+        projects=[
+            {"projectId": TEST_PROJECT_ID},
+            {"projectId": "project-def"},
+        ],
+        gcp_update_tag=TEST_UPDATE_TAG,
+        common_job_parameters=COMMON_JOB_PARAMS.copy(),
+        credentials=MagicMock(),
+        requested_syncs={"policy_bindings"},
+    )
+
+    assert mock_services_enabled.call_count == 3
+    assert mock_policy_bindings_sync.call_count == 2
+    assert result is True
 
 
 @patch("cartography.intel.gcp.build_asset_client")
@@ -409,7 +702,7 @@ def test_sync_project_resources_skips_permission_relationships_when_cai_api_disa
     mock_build_client.return_value = MagicMock()
     mock_build_asset_client.return_value = MagicMock()
 
-    cartography.intel.gcp._sync_project_resources(
+    result = cartography.intel.gcp._sync_project_resources(
         neo4j_session=MagicMock(),
         projects=[{"projectId": TEST_PROJECT_ID}],
         gcp_update_tag=TEST_UPDATE_TAG,
@@ -421,3 +714,4 @@ def test_sync_project_resources_skips_permission_relationships_when_cai_api_disa
     assert mock_services_enabled.call_count == 2
     mock_policy_bindings_sync.assert_not_called()
     mock_permission_relationships_sync.assert_not_called()
+    assert result is False

--- a/tests/unit/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/unit/cartography/intel/gcp/test_policy_bindings.py
@@ -619,7 +619,7 @@ def test_sync_project_resources_skips_permission_relationships_after_policy_bind
     assert mock_services_enabled.call_count == 2
     mock_policy_bindings_sync.assert_called_once()
     mock_permission_relationships_sync.assert_not_called()
-    assert result is False
+    assert result.policy_bindings_cleanup_safe is False
 
 
 @patch("cartography.intel.gcp.build_asset_client")
@@ -668,7 +668,7 @@ def test_sync_project_resources_reports_policy_bindings_partial_failure(
 
     assert mock_services_enabled.call_count == 3
     assert mock_policy_bindings_sync.call_count == 2
-    assert result is False
+    assert result.policy_bindings_cleanup_safe is False
 
 
 @patch("cartography.intel.gcp.build_asset_client")
@@ -711,7 +711,7 @@ def test_sync_project_resources_reports_policy_bindings_full_success(
 
     assert mock_services_enabled.call_count == 3
     assert mock_policy_bindings_sync.call_count == 2
-    assert result is True
+    assert result.policy_bindings_cleanup_safe is True
 
 
 @patch("cartography.intel.gcp.build_asset_client")
@@ -744,4 +744,4 @@ def test_sync_project_resources_skips_permission_relationships_when_cai_api_disa
     assert mock_services_enabled.call_count == 2
     mock_policy_bindings_sync.assert_not_called()
     mock_permission_relationships_sync.assert_not_called()
-    assert result is False
+    assert result.policy_bindings_cleanup_safe is False

--- a/tests/unit/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/unit/cartography/intel/gcp/test_policy_bindings.py
@@ -20,20 +20,6 @@ COMMON_JOB_PARAMS = {
 }
 
 
-@pytest.fixture(autouse=True)
-def reset_inherited_policy_binding_claims():
-    original_update_tag = policy_bindings._INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG
-    original_seen = policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.copy()
-    policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.clear()
-    policy_bindings._INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG = None
-    try:
-        yield
-    finally:
-        policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.clear()
-        policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.update(original_seen)
-        policy_bindings._INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG = original_update_tag
-
-
 @pytest.mark.parametrize(
     "full_name, expected",
     [
@@ -324,11 +310,7 @@ def test_split_bindings_by_graph_scope_keeps_inherited_separate():
     }
 
 
-def test_claim_inherited_bindings_for_graph_dedupes_per_update_tag():
-    original_update_tag = policy_bindings._INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG
-    original_seen = policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.copy()
-    policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.clear()
-    policy_bindings._INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG = None
+def test_claim_inherited_bindings_for_graph_dedupes_per_claim_state():
     inherited = {
         ("GCPOrganization", "organizations/1337"): [
             {
@@ -338,27 +320,24 @@ def test_claim_inherited_bindings_for_graph_dedupes_per_update_tag():
             },
         ],
     }
-    try:
-        first_claim = policy_bindings._claim_inherited_bindings_for_graph(
-            inherited,
-            TEST_UPDATE_TAG,
-        )
-        second_claim = policy_bindings._claim_inherited_bindings_for_graph(
-            inherited,
-            TEST_UPDATE_TAG,
-        )
-        next_run_claim = policy_bindings._claim_inherited_bindings_for_graph(
-            inherited,
-            TEST_UPDATE_TAG + 1,
-        )
+    claim_state = policy_bindings.InheritedPolicyBindingClaimState()
 
-        assert first_claim == inherited
-        assert second_claim == {}
-        assert next_run_claim == inherited
-    finally:
-        policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.clear()
-        policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.update(original_seen)
-        policy_bindings._INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG = original_update_tag
+    first_claim = policy_bindings._claim_inherited_bindings_for_graph(
+        inherited,
+        claim_state,
+    )
+    second_claim = policy_bindings._claim_inherited_bindings_for_graph(
+        inherited,
+        claim_state,
+    )
+    next_run_claim = policy_bindings._claim_inherited_bindings_for_graph(
+        inherited,
+        policy_bindings.InheritedPolicyBindingClaimState(),
+    )
+
+    assert first_claim == inherited
+    assert second_claim == {}
+    assert next_run_claim == inherited
 
 
 @patch.object(policy_bindings, "load_matchlinks")

--- a/tests/unit/cartography/intel/gcp/test_policy_bindings.py
+++ b/tests/unit/cartography/intel/gcp/test_policy_bindings.py
@@ -20,6 +20,20 @@ COMMON_JOB_PARAMS = {
 }
 
 
+@pytest.fixture(autouse=True)
+def reset_inherited_policy_binding_claims():
+    original_update_tag = policy_bindings._INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG
+    original_seen = policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.copy()
+    policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.clear()
+    policy_bindings._INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG = None
+    try:
+        yield
+    finally:
+        policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.clear()
+        policy_bindings._INHERITED_POLICY_BINDINGS_SEEN.update(original_seen)
+        policy_bindings._INHERITED_POLICY_BINDINGS_SEEN_UPDATE_TAG = original_update_tag
+
+
 @pytest.mark.parametrize(
     "full_name, expected",
     [
@@ -105,6 +119,11 @@ COMMON_JOB_PARAMS = {
             "//iam.googleapis.com/projects/project-abc/serviceAccounts/sa@project-abc.iam.gserviceaccount.com",
             ("GCPServiceAccount", "sa@project-abc.iam.gserviceaccount.com"),
         ),
+        # Cloud Functions
+        (
+            "//cloudfunctions.googleapis.com/projects/p/locations/us-central1/functions/fn",
+            ("GCPCloudFunction", "projects/p/locations/us-central1/functions/fn"),
+        ),
         # Compute — instance (partial_uri format)
         (
             "//compute.googleapis.com/projects/p/zones/us-central1-a/instances/vm1",
@@ -148,12 +167,23 @@ def test_parse_full_resource_name(full_name, expected):
 
 def test_policy_bindings_search_asset_types_come_from_full_name_mappings():
     assert policy_bindings.GCP_POLICY_BINDINGS_SEARCH_ASSET_TYPES == [
-        mapping.asset_type
+        asset_type
         for mapping in policy_bindings._FULL_NAME_MAPPINGS
-        if mapping.asset_type is not None
+        for asset_type in (
+            ((mapping.asset_type,) if mapping.asset_type is not None else ())
+            + mapping.additional_asset_types
+        )
     ]
     assert (
         "artifactregistry.googleapis.com/Repository"
+        in policy_bindings.GCP_POLICY_BINDINGS_SEARCH_ASSET_TYPES
+    )
+    assert (
+        "cloudfunctions.googleapis.com/Function"
+        in policy_bindings.GCP_POLICY_BINDINGS_SEARCH_ASSET_TYPES
+    )
+    assert (
+        "cloudfunctions.googleapis.com/CloudFunction"
         in policy_bindings.GCP_POLICY_BINDINGS_SEARCH_ASSET_TYPES
     )
     assert (


### PR DESCRIPTION
### Type of change
- [x] Bug fix (fixes excessive inherited GCP policy binding writes)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update


### Summary

Materialize inherited GCP IAM policy bindings at their real organization or folder scope instead of repeatedly writing the same inherited binding as a project-owned resource for every project that sees it in its effective policy response.

This keeps direct project and child-resource policy bindings project-owned, preserves the policy-binding relationships to principals, roles, and bound resources, and still uses the full effective policy context for derived permission relationships.

### Breaking changes

Inherited organization and folder policy bindings are now owned by `GCPOrganization` or `GCPFolder` instead of being repeatedly attached to every project.

Queries that only traverse `MATCH (p:GCPProject)-[:RESOURCE]->(b:GCPPolicyBinding)` will no longer see inherited organization or folder bindings as project-owned rows. To include inherited bindings, traverse the binding owner scope (`GCPOrganization` / `GCPFolder`) or the binding `APPLIES_TO` relationship. Direct project and child-resource policy binding ownership remains unchanged.


### How was this tested?
- Tested against real GCP environment


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.
 
<img width="1017" height="897" alt="Screenshot 2026-05-09 at 9 34 08 AM" src="https://github.com/user-attachments/assets/9f6f9f5e-a1e0-45c7-af40-67d1a071ab86" />


#### If you are adding or modifying a synced entity
- [x] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
```
INFO:cartography.intel.gcp.policy_bindings:Synced GCP policy bindings for project '<project-1>': policy_results=2, transformed_bindings=39, direct_graph_bindings=13, inherited_bindings=26, newly_loaded_inherited_bindings=26, permission_principals=19
INFO:cartography.intel.gcp.policy_bindings:Synced GCP policy bindings for project '<project-2>': policy_results=1, transformed_bindings=24, direct_graph_bindings=1, inherited_bindings=23, newly_loaded_inherited_bindings=0, permission_principals=11
INFO:cartography.intel.gcp.policy_bindings:Synced GCP policy bindings for project '<project-3>': policy_results=1, transformed_bindings=24, direct_graph_bindings=1, inherited_bindings=23, newly_loaded_inherited_bindings=0, permission_principals=11
INFO:cartography.intel.gcp.policy_bindings:Synced GCP policy bindings for project '<project-4>': policy_results=1, transformed_bindings=24, direct_graph_bindings=1, inherited_bindings=23, newly_loaded_inherited_bindings=0, permission_principals=11
INFO:cartography.intel.gcp.policy_bindings:Synced GCP policy bindings for project '<project-5>': policy_results=1, transformed_bindings=33, direct_graph_bindings=10, inherited_bindings=23, newly_loaded_inherited_bindings=0, permission_principals=18
INFO:cartography.intel.gcp.policy_bindings:Synced GCP policy bindings for project '<project-6>': policy_results=1, transformed_bindings=32, direct_graph_bindings=9, inherited_bindings=23, newly_loaded_inherited_bindings=0, permission_principals=18
INFO:cartography.intel.gcp.policy_bindings:Synced GCP policy bindings for project '<project-7>': policy_results=1, transformed_bindings=24, direct_graph_bindings=1, inherited_bindings=23, newly_loaded_inherited_bindings=0, permission_principals=11
INFO:cartography.intel.gcp.policy_bindings:Synced GCP policy bindings for project '<project-8>': policy_results=1, transformed_bindings=24, direct_graph_bindings=1, inherited_bindings=23, newly_loaded_inherited_bindings=0, permission_principals=11
```

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [x] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [x] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

This is a follow-up to reduce write amplification for inherited GCP IAM policy bindings. The full effective policy response is still used for permission evaluation; only graph ownership of inherited bindings changes to the actual organization or folder scope.
