### PR TITLE
feat(ontology): reconcile K8s workload identity edges at ontology stage

### DIFF
--- a/cartography/data/jobs/analysis/kubernetes_aws_role_irsa_linking.json
+++ b/cartography/data/jobs/analysis/kubernetes_aws_role_irsa_linking.json
@@ -1,0 +1,16 @@
+{
+  "name": "Kubernetes ServiceAccount to AWS Role linking (IRSA)",
+  "statements": [
+    {
+      "__comment": "IAM Roles for Service Accounts (IRSA): when a KubernetesServiceAccount carries the eks.amazonaws.com/role-arn annotation pointing at an AWSRole, reconcile the ASSUMES_ROLE edge. The same edge is created by the K8s ServiceAccount schema matchlink at K8s sync time, but this job ensures the edge also exists when AWS IAM syncs after Kubernetes.",
+      "query": "MATCH (ksa:KubernetesServiceAccount) WHERE ksa.aws_role_arn IS NOT NULL MATCH (role:AWSRole {arn: ksa.aws_role_arn}) MERGE (ksa)-[r:ASSUMES_ROLE]->(role) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "iterative": false
+    },
+    {
+      "__comment": "Delete stale ASSUMES_ROLE edges that no longer match a current KubernetesServiceAccount.aws_role_arn.",
+      "query": "MATCH (:KubernetesServiceAccount)-[r:ASSUMES_ROLE]->(:AWSRole) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r RETURN COUNT(*) AS TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    }
+  ]
+}

--- a/cartography/data/jobs/analysis/kubernetes_gcp_service_account_workload_identity_linking.json
+++ b/cartography/data/jobs/analysis/kubernetes_gcp_service_account_workload_identity_linking.json
@@ -1,0 +1,16 @@
+{
+  "name": "Kubernetes ServiceAccount to GCP ServiceAccount linking (GKE Workload Identity)",
+  "statements": [
+    {
+      "__comment": "GKE Workload Identity: when a KubernetesServiceAccount carries the iam.gke.io/gcp-service-account annotation pointing at a GCPServiceAccount email, reconcile the WORKLOAD_IDENTITY_BINDING edge. The same edge is created by the K8s ServiceAccount schema matchlink at K8s sync time, but this job ensures the edge also exists when GCP IAM syncs after Kubernetes.",
+      "query": "MATCH (ksa:KubernetesServiceAccount) WHERE ksa.gcp_service_account IS NOT NULL MATCH (gsa:GCPServiceAccount {email: ksa.gcp_service_account}) MERGE (ksa)-[r:WORKLOAD_IDENTITY_BINDING]->(gsa) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "iterative": false
+    },
+    {
+      "__comment": "Delete stale WORKLOAD_IDENTITY_BINDING edges that no longer match a current KubernetesServiceAccount.gcp_service_account.",
+      "query": "MATCH (:KubernetesServiceAccount)-[r:WORKLOAD_IDENTITY_BINDING]->(:GCPServiceAccount) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r RETURN COUNT(*) AS TotalCompleted",
+      "iterative": true,
+      "iterationsize": 100
+    }
+  ]
+}

--- a/cartography/intel/ontology/__init__.py
+++ b/cartography/intel/ontology/__init__.py
@@ -81,3 +81,20 @@ def run(neo4j_session: neo4j.Session, config: Config) -> None:
         neo4j_session,
         common_job_parameters,
     )
+    # Reconcile IRSA edges: (:KubernetesServiceAccount)-[:ASSUMES_ROLE]->(:AWSRole).
+    # The K8s ServiceAccount schema creates this edge at K8s sync time, but only if the AWSRole
+    # already exists at that moment. Running at the ontology stage guarantees the edge regardless
+    # of which module synced last.
+    run_analysis_job(
+        "kubernetes_aws_role_irsa_linking.json",
+        neo4j_session,
+        common_job_parameters,
+    )
+    # Reconcile GKE Workload Identity edges:
+    # (:KubernetesServiceAccount)-[:WORKLOAD_IDENTITY_BINDING]->(:GCPServiceAccount).
+    # Same rationale as the IRSA job above.
+    run_analysis_job(
+        "kubernetes_gcp_service_account_workload_identity_linking.json",
+        neo4j_session,
+        common_job_parameters,
+    )

--- a/docs/root/modules/kubernetes/schema.md
+++ b/docs/root/modules/kubernetes/schema.md
@@ -446,12 +446,12 @@ Representation of a [Kubernetes ServiceAccount.](https://kubernetes.io/docs/conc
     (:KubernetesPod)-[:USES_SERVICE_ACCOUNT]->(:KubernetesServiceAccount)
     ```
 
-- `KubernetesServiceAccount` can assume an `AWSRole` via IRSA when annotated with `eks.amazonaws.com/role-arn`.
+- `KubernetesServiceAccount` can assume an `AWSRole` via IRSA when annotated with `eks.amazonaws.com/role-arn`. This edge is also reconciled at the ontology stage by `kubernetes_aws_role_irsa_linking.json`, so it exists even when AWS IAM syncs after Kubernetes.
     ```
     (:KubernetesServiceAccount)-[:ASSUMES_ROLE]->(:AWSRole)
     ```
 
-- `KubernetesServiceAccount` impersonates a `GCPServiceAccount` via GKE Workload Identity when annotated with `iam.gke.io/gcp-service-account`.
+- `KubernetesServiceAccount` impersonates a `GCPServiceAccount` via GKE Workload Identity when annotated with `iam.gke.io/gcp-service-account`. This edge is also reconciled at the ontology stage by `kubernetes_gcp_service_account_workload_identity_linking.json`, so it exists even when GCP IAM syncs after Kubernetes.
     ```
     (:KubernetesServiceAccount)-[:WORKLOAD_IDENTITY_BINDING]->(:GCPServiceAccount)
     ```


### PR DESCRIPTION
### Type of change

- [x] New feature (non-breaking change that adds functionality)

### Summary

Adds two cross-cloud analysis jobs that re-MERGE Kubernetes workload identity edges at the ontology stage:

- `kubernetes_aws_role_irsa_linking.json` reconciles `(:KubernetesServiceAccount)-[:ASSUMES_ROLE]->(:AWSRole)` (IRSA, matched on `aws_role_arn` ↔ `arn`).
- `kubernetes_gcp_service_account_workload_identity_linking.json` reconciles `(:KubernetesServiceAccount)-[:WORKLOAD_IDENTITY_BINDING]->(:GCPServiceAccount)` (GKE Workload Identity, matched on `gcp_service_account` ↔ `email`).

Both edges are already declared as schema matchlinks on the K8s `ServiceAccount` schema, but they only fire when the K8s sync runs. If AWS IAM or GCP IAM syncs after Kubernetes, the cloud roles exist but the edges are never created until the next K8s sync. Running these jobs at the ontology stage (after every provider has synced) guarantees the edges regardless of sync order.

Each job follows the existing `gsuite_human_link.json` pattern: one `MATCH ... MERGE ... SET r.lastupdated = $UPDATE_TAG` statement plus one iterative cleanup statement that deletes edges with `r.lastupdated <> $UPDATE_TAG`.

### How was this tested?

- `make test_lint` passes.
- `pytest tests/integration/cartography/data/jobs/test_syntax.py` passes; the existing `test_analysis_jobs_cypher_syntax` auto-discovers and validates the two new JSON jobs.
- Manual verification against a local Neo4j: seeded a `KubernetesServiceAccount` with `aws_role_arn` plus a matching `AWSRole` (and equivalently `gcp_service_account` plus matching `GCPServiceAccount`), ran the jobs, confirmed `ASSUMES_ROLE` / `WORKLOAD_IDENTITY_BINDING` edges exist with a fresh `lastupdated`; flipped `lastupdated` to a stale value and confirmed the iterative cleanup deleted them.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests (existing `test_analysis_jobs_cypher_syntax` auto-covers the new jobs).

#### If you are changing a node or relationship
- [x] Updated the schema documentation (`docs/root/modules/kubernetes/schema.md`).

### Test plan

- [ ] Run a full sync where AWS IAM and Kubernetes are enabled in either order; confirm `(:KubernetesServiceAccount)-[:ASSUMES_ROLE]->(:AWSRole)` exists after the ontology stage finishes.
- [ ] Run the same with GCP IAM and Kubernetes; confirm `(:KubernetesServiceAccount)-[:WORKLOAD_IDENTITY_BINDING]->(:GCPServiceAccount)` exists.
- [ ] Remove a Kubernetes ServiceAccount's `aws_role_arn` annotation and re-sync; confirm the stale `ASSUMES_ROLE` edge is cleaned up after the next ontology run.