### PR TITLE
feat(aws): add ALB mTLS properties to ELBV2Listener

### DIFF
--- a/cartography/intel/aws/ec2/load_balancer_v2s.py
+++ b/cartography/intel/aws/ec2/load_balancer_v2s.py
@@ -226,6 +226,7 @@ def _transform_load_balancer_v2_data(
 
         # Extract listener data
         for listener in lb.get("Listeners", []):
+            mutual_auth = listener.get("MutualAuthentication") or {}
             listener_data.append(
                 {
                     "ListenerArn": listener["ListenerArn"],
@@ -234,6 +235,14 @@ def _transform_load_balancer_v2_data(
                     "SslPolicy": listener.get("SslPolicy"),
                     "TargetGroupArn": listener.get("TargetGroupArn"),
                     "LoadBalancerId": dns_name,
+                    "MutualAuthenticationMode": mutual_auth.get("Mode"),
+                    "TrustStoreArn": mutual_auth.get("TrustStoreArn"),
+                    "IgnoreClientCertificateExpiry": mutual_auth.get(
+                        "IgnoreClientCertificateExpiry"
+                    ),
+                    "AdvertiseTrustStoreCaNames": mutual_auth.get(
+                        "AdvertiseTrustStoreCaNames"
+                    ),
                 }
             )
 

--- a/cartography/intel/aws/ec2/load_balancer_v2s.py
+++ b/cartography/intel/aws/ec2/load_balancer_v2s.py
@@ -176,6 +176,26 @@ def get_loadbalancer_v2_data(boto3_session: boto3.Session, region: str) -> List[
     return elbv2s
 
 
+def _transform_listener(listener: Dict, load_balancer_id: str) -> Dict:
+    """Build the listener dict consumed by ELBV2ListenerSchema."""
+    mutual_auth = listener.get("MutualAuthentication") or {}
+    return {
+        "ListenerArn": listener["ListenerArn"],
+        "Port": listener.get("Port"),
+        "Protocol": listener.get("Protocol"),
+        "SslPolicy": listener.get("SslPolicy"),
+        "TargetGroupArn": listener.get("TargetGroupArn"),
+        "LoadBalancerId": load_balancer_id,
+        "MutualAuthenticationMode": mutual_auth.get("Mode"),
+        "TrustStoreArn": mutual_auth.get("TrustStoreArn"),
+        "IgnoreClientCertificateExpiry": mutual_auth.get(
+            "IgnoreClientCertificateExpiry"
+        ),
+        "TrustStoreAssociationStatus": mutual_auth.get("TrustStoreAssociationStatus"),
+        "AdvertiseTrustStoreCaNames": mutual_auth.get("AdvertiseTrustStoreCaNames"),
+    }
+
+
 def _transform_load_balancer_v2_data(
     data: List[Dict],
 ) -> Tuple[List[Dict], List[Dict], List[Dict], List[Dict]]:
@@ -226,28 +246,7 @@ def _transform_load_balancer_v2_data(
 
         # Extract listener data
         for listener in lb.get("Listeners", []):
-            mutual_auth = listener.get("MutualAuthentication") or {}
-            listener_data.append(
-                {
-                    "ListenerArn": listener["ListenerArn"],
-                    "Port": listener.get("Port"),
-                    "Protocol": listener.get("Protocol"),
-                    "SslPolicy": listener.get("SslPolicy"),
-                    "TargetGroupArn": listener.get("TargetGroupArn"),
-                    "LoadBalancerId": dns_name,
-                    "MutualAuthenticationMode": mutual_auth.get("Mode"),
-                    "TrustStoreArn": mutual_auth.get("TrustStoreArn"),
-                    "IgnoreClientCertificateExpiry": mutual_auth.get(
-                        "IgnoreClientCertificateExpiry"
-                    ),
-                    "TrustStoreAssociationStatus": mutual_auth.get(
-                        "TrustStoreAssociationStatus"
-                    ),
-                    "AdvertiseTrustStoreCaNames": mutual_auth.get(
-                        "AdvertiseTrustStoreCaNames"
-                    ),
-                }
-            )
+            listener_data.append(_transform_listener(listener, dns_name))
 
         # Extract target group nodes and target relationships
         for target_group in lb.get("TargetGroups", []):
@@ -408,17 +407,8 @@ def load_load_balancer_v2_listeners(
     aws_account_id: str,
 ) -> None:
     """Load ELBV2Listener nodes and their relationships to LoadBalancerV2."""
-    # Transform listener data to include the load balancer id
     transformed_data = [
-        {
-            "ListenerArn": listener["ListenerArn"],
-            "Port": listener.get("Port"),
-            "Protocol": listener.get("Protocol"),
-            "SslPolicy": listener.get("SslPolicy"),
-            "TargetGroupArn": listener.get("TargetGroupArn"),
-            "LoadBalancerId": load_balancer_id,
-        }
-        for listener in listener_data
+        _transform_listener(listener, load_balancer_id) for listener in listener_data
     ]
     load(
         neo4j_session,

--- a/cartography/intel/aws/ec2/load_balancer_v2s.py
+++ b/cartography/intel/aws/ec2/load_balancer_v2s.py
@@ -240,6 +240,9 @@ def _transform_load_balancer_v2_data(
                     "IgnoreClientCertificateExpiry": mutual_auth.get(
                         "IgnoreClientCertificateExpiry"
                     ),
+                    "TrustStoreAssociationStatus": mutual_auth.get(
+                        "TrustStoreAssociationStatus"
+                    ),
                     "AdvertiseTrustStoreCaNames": mutual_auth.get(
                         "AdvertiseTrustStoreCaNames"
                     ),

--- a/cartography/models/aws/ec2/loadbalancerv2.py
+++ b/cartography/models/aws/ec2/loadbalancerv2.py
@@ -321,6 +321,9 @@ class ELBV2ListenerNodeProperties(CartographyNodeProperties):
     ignore_client_certificate_expiry: PropertyRef = PropertyRef(
         "IgnoreClientCertificateExpiry"
     )
+    trust_store_association_status: PropertyRef = PropertyRef(
+        "TrustStoreAssociationStatus"
+    )
     advertise_trust_store_ca_names: PropertyRef = PropertyRef(
         "AdvertiseTrustStoreCaNames"
     )

--- a/cartography/models/aws/ec2/loadbalancerv2.py
+++ b/cartography/models/aws/ec2/loadbalancerv2.py
@@ -316,6 +316,14 @@ class ELBV2ListenerNodeProperties(CartographyNodeProperties):
     protocol: PropertyRef = PropertyRef("Protocol")
     ssl_policy: PropertyRef = PropertyRef("SslPolicy")
     targetgrouparn: PropertyRef = PropertyRef("TargetGroupArn")
+    mutual_authentication_mode: PropertyRef = PropertyRef("MutualAuthenticationMode")
+    trust_store_arn: PropertyRef = PropertyRef("TrustStoreArn")
+    ignore_client_certificate_expiry: PropertyRef = PropertyRef(
+        "IgnoreClientCertificateExpiry"
+    )
+    advertise_trust_store_ca_names: PropertyRef = PropertyRef(
+        "AdvertiseTrustStoreCaNames"
+    )
 
 
 @dataclass(frozen=True)

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -3016,6 +3016,10 @@ Representation of an AWS Elastic Load Balancer V2 [Listener](https://docs.aws.am
 | ssl\_policy | Only set for HTTPS or TLS listener. The security policy that defines which protocols and ciphers are supported. |
 | targetgrouparn | The ARN of the Target Group, if the Action type is `forward`. |
 | arn | The ARN of the ELBV2Listener |
+| mutual\_authentication\_mode | Mutual TLS authentication mode on the listener. One of `off`, `verify`, `passthrough`. Null when mTLS is not configured. |
+| trust\_store\_arn | The ARN of the trust store used for mutual TLS, when `mutual_authentication_mode` is `verify`. |
+| ignore\_client\_certificate\_expiry | Whether expired client certificates are accepted (boolean). Only meaningful when `mutual_authentication_mode` is `verify`. |
+| advertise\_trust\_store\_ca\_names | Whether the listener advertises trust store CA names during the TLS handshake. One of `on`, `off`. |
 
 #### Relationships
 

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -3019,6 +3019,7 @@ Representation of an AWS Elastic Load Balancer V2 [Listener](https://docs.aws.am
 | mutual\_authentication\_mode | Mutual TLS authentication mode on the listener. One of `off`, `verify`, `passthrough`. Null when mTLS is not configured. |
 | trust\_store\_arn | The ARN of the trust store used for mutual TLS, when `mutual_authentication_mode` is `verify`. |
 | ignore\_client\_certificate\_expiry | Whether expired client certificates are accepted (boolean). Only meaningful when `mutual_authentication_mode` is `verify`. |
+| trust\_store\_association\_status | State of the trust store association on the listener. One of `active`, `removed`. |
 | advertise\_trust\_store\_ca\_names | Whether the listener advertises trust store CA names during the TLS handshake. One of `on`, `off`. |
 
 #### Relationships

--- a/tests/data/aws/ec2/load_balancer_v2s.py
+++ b/tests/data/aws/ec2/load_balancer_v2s.py
@@ -30,6 +30,12 @@ GET_LOAD_BALANCER_V2_DATA = [
                 "Port": 443,
                 "Protocol": "HTTPS",
                 "SslPolicy": "ELBSecurityPolicy-2016-08",
+                "MutualAuthentication": {
+                    "Mode": "verify",
+                    "TrustStoreArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:truststore/test-ts/1111222233334444",
+                    "IgnoreClientCertificateExpiry": False,
+                    "AdvertiseTrustStoreCaNames": "on",
+                },
             },
             {
                 "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:listener/app/test-alb/1234567890123456/1234567890abcdef",

--- a/tests/data/aws/ec2/load_balancer_v2s.py
+++ b/tests/data/aws/ec2/load_balancer_v2s.py
@@ -34,6 +34,7 @@ GET_LOAD_BALANCER_V2_DATA = [
                     "Mode": "verify",
                     "TrustStoreArn": "arn:aws:elasticloadbalancing:us-east-1:000000000000:truststore/test-ts/1111222233334444",
                     "IgnoreClientCertificateExpiry": False,
+                    "TrustStoreAssociationStatus": "active",
                     "AdvertiseTrustStoreCaNames": "on",
                 },
             },

--- a/tests/integration/cartography/intel/aws/ec2/test_load_balancer_v2s.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_load_balancer_v2s.py
@@ -107,26 +107,46 @@ def test_sync_load_balancer_v2s(mock_get_loadbalancer_v2_data, neo4j_session):
         (TEST_ACCOUNT_ID, "test-nlb-abcdef0123.us-east-1.elb.amazonaws.com"),
     }
 
-    # Assert - ELBV2Listener nodes exist
+    # Assert - ELBV2Listener nodes exist with mTLS fields
     assert check_nodes(
         neo4j_session,
         "ELBV2Listener",
-        ["id", "port", "protocol"],
+        [
+            "id",
+            "port",
+            "protocol",
+            "mutual_authentication_mode",
+            "trust_store_arn",
+            "ignore_client_certificate_expiry",
+            "advertise_trust_store_ca_names",
+        ],
     ) == {
         (
             "arn:aws:elasticloadbalancing:us-east-1:000000000000:listener/app/test-alb/1234567890123456/abcdef1234567890",
             443,
             "HTTPS",
+            "verify",
+            "arn:aws:elasticloadbalancing:us-east-1:000000000000:truststore/test-ts/1111222233334444",
+            False,
+            "on",
         ),
         (
             "arn:aws:elasticloadbalancing:us-east-1:000000000000:listener/app/test-alb/1234567890123456/1234567890abcdef",
             80,
             "HTTP",
+            None,
+            None,
+            None,
+            None,
         ),
         (
             "arn:aws:elasticloadbalancing:us-east-1:000000000000:listener/net/test-nlb/abcdef0123456789/fedcba9876543210",
             443,
             "TLS",
+            None,
+            None,
+            None,
+            None,
         ),
     }
 

--- a/tests/integration/cartography/intel/aws/ec2/test_load_balancer_v2s.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_load_balancer_v2s.py
@@ -118,6 +118,7 @@ def test_sync_load_balancer_v2s(mock_get_loadbalancer_v2_data, neo4j_session):
             "mutual_authentication_mode",
             "trust_store_arn",
             "ignore_client_certificate_expiry",
+            "trust_store_association_status",
             "advertise_trust_store_ca_names",
         ],
     ) == {
@@ -128,6 +129,7 @@ def test_sync_load_balancer_v2s(mock_get_loadbalancer_v2_data, neo4j_session):
             "verify",
             "arn:aws:elasticloadbalancing:us-east-1:000000000000:truststore/test-ts/1111222233334444",
             False,
+            "active",
             "on",
         ),
         (
@@ -138,11 +140,13 @@ def test_sync_load_balancer_v2s(mock_get_loadbalancer_v2_data, neo4j_session):
             None,
             None,
             None,
+            None,
         ),
         (
             "arn:aws:elasticloadbalancing:us-east-1:000000000000:listener/net/test-nlb/abcdef0123456789/fedcba9876543210",
             443,
             "TLS",
+            None,
             None,
             None,
             None,


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary

ALB / NLB listener nodes in Cartography currently expose only `port`, `protocol`, `ssl_policy`, and `targetgrouparn`. They do not surface the `MutualAuthentication` block that AWS returns from `DescribeListeners`, so there is no way to query whether mutual TLS is enforced on a listener.

This PR adds four additive properties to the existing `ELBV2Listener` node, populated from the listener's `MutualAuthentication` object:

| AWS field                       | Node property                      |
| ------------------------------- | ---------------------------------- |
| `Mode`                          | `mutual_authentication_mode`       |
| `TrustStoreArn`                 | `trust_store_arn`                  |
| `IgnoreClientCertificateExpiry` | `ignore_client_certificate_expiry` |
| `AdvertiseTrustStoreCaNames`    | `advertise_trust_store_ca_names`   |

Listeners without `MutualAuthentication` get `null` for all four, mirroring the existing behavior of `ssl_policy` and `targetgrouparn` on plain HTTP listeners. No new node, no new relationship, no migration.

### Related issues or links

(none)

### How was this tested?

- Extended the existing `tests/data/aws/ec2/load_balancer_v2s.py` fixture so the HTTPS test listener carries a `MutualAuthentication` block; HTTP and TLS listeners stay bare to cover the "no mTLS" path.
- Extended the existing `check_nodes(..., "ELBV2Listener", [...])` assertion in `tests/integration/cartography/intel/aws/ec2/test_load_balancer_v2s.py` to check the four new properties on all three test listeners.
- `make test_lint` passes.
- `uv run pytest tests/integration/cartography/intel/aws/ec2/test_load_balancer_v2s.py` passes (4/4).

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the schema documentation.
- [ ] Updated the schema README. (No new node or relationship; only additive properties on an existing node, table-only.)

### Test plan

- [x] `make test_lint` passes
- [x] `pytest tests/integration/cartography/intel/aws/ec2/test_load_balancer_v2s.py` passes
- [ ] Against a synced dev DB, `MATCH (l:ELBV2Listener) WHERE l.mutual_authentication_mode IS NOT NULL RETURN l` returns listeners with mTLS enabled