### PR TITLE
feat(gitlab): map GitLabDependency to packages ontology

### DIFF
--- a/cartography/intel/gitlab/dependencies.py
+++ b/cartography/intel/gitlab/dependencies.py
@@ -18,6 +18,7 @@ from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.gitlab.util import check_rate_limit_remaining
 from cartography.intel.gitlab.util import make_request_with_retry
+from cartography.intel.trivy.util import make_normalized_package_id
 from cartography.models.gitlab.dependencies import GitLabDependencySchema
 from cartography.util import timeit
 
@@ -431,9 +432,10 @@ def _parse_cyclonedx_sbom(
 
         # Extract package manager from purl (Package URL)
         # Example: "pkg:npm/express@4.18.2" -> package_manager = "npm"
-        purl = component.get("purl", "")
+        purl = component.get("purl", "") or None
         package_manager = "unknown"
-        if purl.startswith("pkg:"):
+        pkg_type = None
+        if purl and purl.startswith("pkg:"):
             # purl format: pkg:<type>/<name>@<version>
             parts = purl.split("/")
             if len(parts) >= 1:
@@ -445,6 +447,8 @@ def _parse_cyclonedx_sbom(
             "version": version,
             "package_manager": package_manager,
             "manifest_path": manifest_path,
+            "purl": purl,
+            "type": pkg_type,
         }
 
         # Add manifest_id if we found a matching DependencyFile
@@ -472,10 +476,19 @@ def transform_dependencies(
         version = dep.get("version", "")
         package_manager = dep.get("package_manager", "unknown")
         manifest_id = dep.get("manifest_id")
+        purl = dep.get("purl")
+        pkg_type = dep.get("type")
 
         # Construct unique ID: project_url:package_manager:name@version
         # Example: "https://gitlab.com/group/project:npm:express@4.18.2"
         dep_id = f"{project_url}:{package_manager}:{name}@{version}"
+
+        normalized_id = make_normalized_package_id(
+            purl=purl,
+            name=name,
+            version=version,
+            pkg_type=pkg_type,
+        )
 
         transformed_dep = {
             "id": dep_id,
@@ -485,6 +498,9 @@ def transform_dependencies(
             "project_id": project_id,
             "project_url": project_url,
             "gitlab_url": gitlab_url,
+            "purl": purl,
+            "type": pkg_type,
+            "normalized_id": normalized_id,
         }
 
         if manifest_id:

--- a/cartography/models/gitlab/dependencies.py
+++ b/cartography/models/gitlab/dependencies.py
@@ -32,6 +32,9 @@ class GitLabDependencyNodeProperties(CartographyNodeProperties):
     )  # npm, pip, bundler, maven, etc.
     project_id: PropertyRef = PropertyRef("project_id")
     gitlab_url: PropertyRef = PropertyRef("gitlab_url", extra_index=True)
+    type: PropertyRef = PropertyRef("type")
+    purl: PropertyRef = PropertyRef("purl")
+    normalized_id: PropertyRef = PropertyRef("normalized_id", extra_index=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 

--- a/cartography/models/ontology/mapping/data/packages.py
+++ b/cartography/models/ontology/mapping/data/packages.py
@@ -42,7 +42,28 @@ syft_mapping = OntologyMapping(
     ],
 )
 
+gitlab_mapping = OntologyMapping(
+    module_name="gitlab",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="GitLabDependency",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="normalized_id",
+                    node_field="normalized_id",
+                    required=True,
+                ),
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(ontology_field="version", node_field="version"),
+                OntologyFieldMapping(ontology_field="type", node_field="type"),
+                OntologyFieldMapping(ontology_field="purl", node_field="purl"),
+            ],
+        ),
+    ],
+)
+
 PACKAGES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "trivy": trivy_mapping,
     "syft": syft_mapping,
+    "gitlab": gitlab_mapping,
 }

--- a/cartography/models/ontology/package.py
+++ b/cartography/models/ontology/package.py
@@ -63,6 +63,18 @@ class PackageToSocketDevDependencyRel(CartographyRelSchema):
     properties: PackageToNodeRelProperties = PackageToNodeRelProperties()
 
 
+# (:Package)-[:DETECTED_AS]->(:GitLabDependency)
+@dataclass(frozen=True)
+class PackageToGitLabDependencyRel(CartographyRelSchema):
+    target_node_label: str = "GitLabDependency"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"normalized_id": PropertyRef("normalized_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "DETECTED_AS"
+    properties: PackageToNodeRelProperties = PackageToNodeRelProperties()
+
+
 @dataclass(frozen=True)
 class PackageToOntologyImageRel(CartographyRelSchema):
     """
@@ -129,6 +141,7 @@ class PackageSchema(CartographyNodeSchema):
             PackageToTrivyPackageRel(),
             PackageToSyftPackageRel(),
             PackageToSocketDevDependencyRel(),
+            PackageToGitLabDependencyRel(),
             PackageToOntologyImageRel(),
             PackageToTrivyFixRel(),
             PackageToPackageDependsOnRel(),

--- a/docs/root/modules/gitlab/schema.md
+++ b/docs/root/modules/gitlab/schema.md
@@ -350,6 +350,9 @@ Representation of a software dependency from GitLab's dependency scanning artifa
 | **name** | Name of the dependency |
 | **version** | Version of the dependency |
 | **package_manager** | Package manager (npm, pip, maven, etc.) |
+| type | Package type derived from the PURL (e.g., `npm`, `pypi`, `maven`) |
+| purl | Package URL (e.g., `pkg:npm/express@4.18.2`) |
+| **normalized_id** | Normalized ID for cross-tool matching (format: `{type}\|{namespace/}{name}\|{version}`). Indexed. |
 
 #### Relationships
 
@@ -363,6 +366,12 @@ Representation of a software dependency from GitLab's dependency scanning artifa
 
     ```
     (GitLabDependencyFile)-[HAS_DEP]->(GitLabDependency)
+    ```
+
+- A canonical Package (ontology) is detected as a GitLabDependency.
+
+    ```
+    (Package)-[DETECTED_AS]->(GitLabDependency)
     ```
 
 ### GitLabContainerRepository

--- a/tests/data/gitlab/dependencies.py
+++ b/tests/data/gitlab/dependencies.py
@@ -7,6 +7,8 @@ GET_GITLAB_DEPENDENCIES_RESPONSE = [
         "version": "4.18.2",
         "package_manager": "npm",
         "manifest_path": "package.json",
+        "purl": "pkg:npm/express@4.18.2",
+        "type": "npm",
         "manifest_id": "https://gitlab.example.com/myorg/awesome-project/blob/package.json",
     },
     {
@@ -14,6 +16,8 @@ GET_GITLAB_DEPENDENCIES_RESPONSE = [
         "version": "4.17.21",
         "package_manager": "npm",
         "manifest_path": "package.json",
+        "purl": "pkg:npm/lodash@4.17.21",
+        "type": "npm",
         "manifest_id": "https://gitlab.example.com/myorg/awesome-project/blob/package.json",
     },
     {
@@ -21,12 +25,16 @@ GET_GITLAB_DEPENDENCIES_RESPONSE = [
         "version": "2.31.0",
         "package_manager": "pypi",
         "manifest_path": "backend/requirements.txt",
+        "purl": "pkg:pypi/requests@2.31.0",
+        "type": "pypi",
     },
     {
         "name": "gin",
         "version": "1.9.1",
         "package_manager": "golang",
         "manifest_path": "services/api/go.mod",
+        "purl": "pkg:golang/gin@1.9.1",
+        "type": "golang",
     },
 ]
 
@@ -43,6 +51,9 @@ TRANSFORMED_DEPENDENCIES = [
         "package_manager": "npm",
         "project_id": TEST_PROJECT_ID,
         "gitlab_url": TEST_GITLAB_URL,
+        "purl": "pkg:npm/express@4.18.2",
+        "type": "npm",
+        "normalized_id": "npm|express|4.18.2",
         "manifest_id": "https://gitlab.example.com/myorg/awesome-project/blob/package.json",
     },
     {
@@ -52,6 +63,9 @@ TRANSFORMED_DEPENDENCIES = [
         "package_manager": "npm",
         "project_id": TEST_PROJECT_ID,
         "gitlab_url": TEST_GITLAB_URL,
+        "purl": "pkg:npm/lodash@4.17.21",
+        "type": "npm",
+        "normalized_id": "npm|lodash|4.17.21",
         "manifest_id": "https://gitlab.example.com/myorg/awesome-project/blob/package.json",
     },
     {
@@ -61,6 +75,9 @@ TRANSFORMED_DEPENDENCIES = [
         "package_manager": "pypi",
         "project_id": TEST_PROJECT_ID,
         "gitlab_url": TEST_GITLAB_URL,
+        "purl": "pkg:pypi/requests@2.31.0",
+        "type": "pypi",
+        "normalized_id": "pypi|requests|2.31.0",
     },
     {
         "id": "https://gitlab.example.com/myorg/awesome-project:golang:gin@1.9.1",
@@ -69,5 +86,8 @@ TRANSFORMED_DEPENDENCIES = [
         "package_manager": "golang",
         "project_id": TEST_PROJECT_ID,
         "gitlab_url": TEST_GITLAB_URL,
+        "purl": "pkg:golang/gin@1.9.1",
+        "type": "golang",
+        "normalized_id": "golang|gin|1.9.1",
     },
 ]

--- a/tests/integration/cartography/intel/ontology/test_packages.py
+++ b/tests/integration/cartography/intel/ontology/test_packages.py
@@ -48,6 +48,18 @@ def _setup_trivy_graph(neo4j_session):
     )
 
 
+def _setup_gitlab_graph(neo4j_session):
+    """Create a GitLabDependency node so the Package ontology link can resolve."""
+    neo4j_session.run(
+        """
+        MERGE (d:GitLabDependency {id: 'gitlab-dep-1'})
+        SET d.normalized_id = 'npm|body-parser|1.20.2',
+            d.name = 'body-parser', d.version = '1.20.2',
+            d.type = 'npm', d.purl = 'pkg:npm/body-parser@1.20.2'
+        """,
+    )
+
+
 def _setup_syft_graph(neo4j_session):
     """Create SyftPackage nodes with DEPENDS_ON relationships for testing."""
     neo4j_session.run(
@@ -102,6 +114,7 @@ def test_load_ontology_packages(_mock_get_source_nodes, neo4j_session):
     # Arrange
     _setup_trivy_graph(neo4j_session)
     _setup_syft_graph(neo4j_session)
+    _setup_gitlab_graph(neo4j_session)
 
     # Act
     cartography.intel.ontology.packages.sync(
@@ -160,6 +173,21 @@ def test_load_ontology_packages(_mock_get_source_nodes, neo4j_session):
         rel_direction_right=True,
     )
     assert actual_syft_rels == expected_syft_rels
+
+    # Assert - Check DETECTED_AS relationships to GitLabDependency
+    expected_gitlab_rels = {
+        ("npm|body-parser|1.20.2", "npm|body-parser|1.20.2"),
+    }
+    actual_gitlab_rels = check_rels(
+        neo4j_session,
+        "Package",
+        "id",
+        "GitLabDependency",
+        "normalized_id",
+        "DETECTED_AS",
+        rel_direction_right=True,
+    )
+    assert actual_gitlab_rels == expected_gitlab_rels
 
     # Assert - Check DEPLOYED propagated to Package -> ontology Image
     expected_deployed_image = {

--- a/tests/unit/cartography/intel/gitlab/test_dependencies.py
+++ b/tests/unit/cartography/intel/gitlab/test_dependencies.py
@@ -16,6 +16,7 @@ from cartography.intel.gitlab.dependencies import (
 )
 from cartography.intel.gitlab.dependencies import DEFAULT_DEPENDENCY_SCAN_JOB_NAME
 from cartography.intel.gitlab.dependencies import get_dependencies
+from cartography.intel.gitlab.dependencies import transform_dependencies
 
 
 def _build_artifacts_zip(files: dict[str, dict | bytes]) -> bytes:
@@ -267,6 +268,58 @@ def test_parse_cyclonedx_sbom_extracts_package_manager_from_purl():
     assert result[1]["package_manager"] == "pypi"
     assert result[2]["package_manager"] == "unknown"
 
+    # Assert: raw purl and derived type are preserved for canonical PURL plumbing
+    assert result[0]["purl"] == "pkg:npm/express@4.18.2"
+    assert result[0]["type"] == "npm"
+    assert result[1]["purl"] == "pkg:pypi/requests@2.31.0"
+    assert result[1]["type"] == "pypi"
+    assert result[2]["purl"] is None
+    assert result[2]["type"] is None
+
+
+def test_transform_dependencies_emits_canonical_purl_fields():
+    """
+    transform_dependencies must propagate purl/type from the parser and compute
+    normalized_id via make_normalized_package_id so the ontology Package node
+    can match (:Package)-[:DETECTED_AS]->(:GitLabDependency).
+    """
+    raw = [
+        {
+            "name": "express",
+            "version": "4.18.2",
+            "package_manager": "npm",
+            "purl": "pkg:npm/express@4.18.2",
+            "type": "npm",
+            "manifest_id": "manifest-1",
+        },
+        {
+            # No purl: normalized_id must fall back gracefully on name+version+type.
+            "name": "mystery",
+            "version": "0.0.1",
+            "package_manager": "unknown",
+            "purl": None,
+            "type": None,
+        },
+    ]
+
+    transformed = transform_dependencies(
+        raw_dependencies=raw,
+        project_id=42,
+        project_url="https://gitlab.example.com/g/p",
+        gitlab_url="https://gitlab.example.com",
+    )
+
+    assert transformed[0]["purl"] == "pkg:npm/express@4.18.2"
+    assert transformed[0]["type"] == "npm"
+    assert transformed[0]["normalized_id"] == "npm|express|4.18.2"
+    assert transformed[0]["manifest_id"] == "manifest-1"
+
+    # Missing PURL and missing type: normalized_id falls back to None per
+    # make_normalized_package_id's contract.
+    assert transformed[1]["purl"] is None
+    assert transformed[1]["type"] is None
+    assert transformed[1]["normalized_id"] is None
+
 
 def test_parse_cyclonedx_sbom_skips_components_without_name():
     """
@@ -414,6 +467,8 @@ def test_get_dependencies_uses_selected_job_id_for_artifacts(
             "version": "4.18.2",
             "package_manager": "npm",
             "manifest_path": "package.json",
+            "purl": "pkg:npm/express@4.18.2",
+            "type": "npm",
             "manifest_id": "https://gitlab.example.com/group/project/-/blob/main/package.json",
         },
     ]
@@ -502,6 +557,8 @@ def test_get_dependencies_paginates_jobs_and_prefers_default_branch(mocker) -> N
             "version": "2.31.0",
             "package_manager": "pypi",
             "manifest_path": "requirements.txt",
+            "purl": "pkg:pypi/requests@2.31.0",
+            "type": "pypi",
             "manifest_id": "https://gitlab.example.com/group/project/-/blob/main/requirements.txt",
         },
     ]
@@ -581,6 +638,8 @@ def test_get_dependencies_parses_gzipped_cyclonedx_from_archive(mocker) -> None:
             "version": "2.2.1",
             "package_manager": "pypi",
             "manifest_path": "requirements.txt",
+            "purl": "pkg:pypi/urllib3@2.2.1",
+            "type": "pypi",
             "manifest_id": "https://gitlab.example.com/group/project/-/blob/main/requirements.txt",
         },
     ]
@@ -650,6 +709,8 @@ def test_get_dependencies_parses_direct_gzipped_cyclonedx_response(mocker) -> No
             "version": "2.2.1",
             "package_manager": "pypi",
             "manifest_path": "requirements.txt",
+            "purl": "pkg:pypi/urllib3@2.2.1",
+            "type": "pypi",
             "manifest_id": "https://gitlab.example.com/group/project/-/blob/main/requirements.txt",
         },
     ]
@@ -714,6 +775,8 @@ def test_get_dependencies_downloads_raw_cyclonedx_artifact_when_archive_has_no_s
             "version": "2.2.1",
             "package_manager": "pypi",
             "manifest_path": "",
+            "purl": "pkg:pypi/urllib3@2.2.1",
+            "type": "pypi",
         },
     ]
     assert (


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

### Summary

Maps `GitLabDependency` into the `Package` ontology so that GitLab dependency-scanning data is queryable alongside Trivy and Syft results.

To do that this PR plumbs the canonical PURL fields through the GitLab dependency ingestion path:

- `GitLabDependencyNodeProperties` now carries `type`, `purl`, and (indexed) `normalized_id`.
- The CycloneDX SBOM parser preserves the raw `purl` and the derived `type` instead of dropping them after computing `package_manager`.
- `transform_dependencies` computes `normalized_id` via the shared `cartography.intel.trivy.util.make_normalized_package_id` helper so cross-tool matching works the same way it does for Trivy and Syft.
- Adds `PackageToGitLabDependencyRel` and registers a `gitlab` entry in `PACKAGES_ONTOLOGY_MAPPING`, so the ontology load creates `(:Package)-[:DETECTED_AS]->(:GitLabDependency)` edges.
- Updates the GitLab schema docs to document the new node properties and the new ontology relationship.

### How was this tested?

- `make test_lint`
- `uv run --frozen pytest tests/unit/cartography/intel/gitlab/test_dependencies.py` (17 passed, including new `test_transform_dependencies_emits_canonical_purl_fields` and extended `test_parse_cyclonedx_sbom_extracts_package_manager_from_purl` assertions)
- `uv run --frozen pytest tests/integration/cartography/intel/gitlab/ tests/integration/cartography/intel/ontology/` (71 passed, including a new GitLab branch in `test_load_ontology_packages` that asserts the `Package -[DETECTED_AS]-> GitLabDependency` edge is created)

### Test plan

- [x] Unit: parser preserves `purl` / `type`, including the `purl is None` fallback.
- [x] Unit: `transform_dependencies` emits `normalized_id` for a PURL-bearing dep and falls back to `None` when no PURL/type is available.
- [x] Integration: after `ontology.packages.sync` runs, `(:Package)-[:DETECTED_AS]->(:GitLabDependency)` exists for a dependency whose `normalized_id` matches.
- [x] Lint: `make test_lint` passes.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the schema documentation.