### PR TITLE
fix(analysis): MERGE before DELETE-stale to remove read window in 10 analysis jobs

### DIFF
--- a/.agents/skills/analysis-jobs/SKILL.md
+++ b/.agents/skills/analysis-jobs/SKILL.md
@@ -28,6 +28,9 @@ Use them when you need to:
 2. **Use iterative queries for large datasets.** They must return `COUNT(*) AS TotalCompleted`.
 3. **Document each query** with `__comment__`.
 4. **Clean up stale data** that the analysis job creates (don't leave orphan edges between syncs).
+5. **Order statements correctly to avoid read windows.**
+    - **Properties:** clean up first (`REMOVE n.attr`), then SET. Cleanup of attributes can usually run in a single transaction.
+    - **Relationships:** MERGE first, then DELETE stale (`WHERE r.lastupdated <> $UPDATE_TAG`). Iterative DELETE commits per batch, so a leading DELETE of relationships exposes a graph with those edges missing to concurrent readers until the MERGE finishes. MERGE is idempotent and bumps `r.lastupdated`, so the trailing DELETE only targets edges that genuinely no longer have a current basis. Canonical example: `cartography/data/jobs/analysis/aws_lambda_ecr.json`.
 
 ## Instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Procedures for building and extending Cartography intel modules ship as Claude s
 - **Sync Pattern**: `get()` -> `transform()` -> `load()` -> `cleanup()` -> `analysis` (optional)
 - **Data Model**: Declarative schema using `CartographyNodeSchema` and `CartographyRelSchema`
 - **Update Tag**: Timestamp used for cleanup jobs to remove stale data
-- **Analysis Jobs**: Post-ingestion queries that enrich the graph (e.g., internet exposure, permission inheritance)
+- **Analysis Jobs**: Post-ingestion queries that enrich the graph (e.g., internet exposure, permission inheritance). When a job manages relationships, put `MERGE` statements before the stale-edge `DELETE`; iterative deletion exposes a window where concurrent readers see those edges missing. See the `analysis-jobs` skill.
 
 **Critical Files to Know:**
 - `cartography/config.py` - Configuration object definitions

--- a/cartography/data/jobs/analysis/aibom_runs_on_container_analysis.json
+++ b/cartography/data/jobs/analysis/aibom_runs_on_container_analysis.json
@@ -2,15 +2,15 @@
   "name": "AIBOMSource RUNS_ON Container analysis",
   "statements": [
     {
-      "__comment": "Cleanup: remove stale RUNS_ON edges from AIBOMSource to Container from previous runs.",
-      "query": "MATCH (:AIBOMSource)-[r:RUNS_ON]->(:Container) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r RETURN COUNT(*) AS TotalCompleted",
-      "iterative": true,
-      "iterationsize": 1000
-    },
-    {
       "__comment": "Create RUNS_ON by joining AIBOMSource's SCANNED_IMAGE with the Container's RESOLVED_IMAGE on the same concrete Image. RESOLVED_IMAGE is created by resolved_image_analysis.json (which runs first) and already handles architecture matching and manifest list resolution.",
       "query": "MATCH (a:AIBOMSource)-[:SCANNED_IMAGE]->(i:Image)<-[:RESOLVED_IMAGE]-(c:Container) MERGE (a)-[r:RUNS_ON]->(c) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
+    },
+    {
+      "__comment": "Cleanup: remove stale RUNS_ON edges from AIBOMSource to Container from previous runs. Runs after the MERGE so concurrent readers never observe a missing edge.",
+      "query": "MATCH (:AIBOMSource)-[r:RUNS_ON]->(:Container) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r RETURN COUNT(*) AS TotalCompleted",
+      "iterative": true,
+      "iterationsize": 1000
     }
   ]
 }

--- a/cartography/data/jobs/analysis/aws_ec2_keypair_analysis.json
+++ b/cartography/data/jobs/analysis/aws_ec2_keypair_analysis.json
@@ -12,11 +12,6 @@
             "iterative": false
         },
         {
-            "__comment__": "Delete stale relationships between EC2KeyPairs",
-            "query": "MATCH (k1:EC2KeyPair)-[r:MATCHING_FINGERPRINT]->(k2:EC2KeyPair) WHERE r.lastupdated <> $UPDATE_TAG DELETE (r) return COUNT(*) as TotalCompleted",
-            "iterative": false
-        },
-        {
             "__comment__": "Set EC2KeyPairs with MD5 hash keyfingerprints (47 characters, instead of 59 characters) as user_uploaded = True",
             "query": "MATCH (k:EC2KeyPair) WHERE size(k.keyfingerprint) = 47 SET k.user_uploaded = True",
             "iterative": false
@@ -24,6 +19,11 @@
         {
             "__comment__": "Attach EC2KeyPairs with matching fingerprints to each other and set duplicate_keyfingerprint = True. Use id(k1) < id(k2) to avoid Cartesian product warning and ensure O(1) comparison.",
             "query": "MATCH (k1:EC2KeyPair) MATCH (k2:EC2KeyPair) WHERE id(k1) < id(k2) AND k1.keyfingerprint = k2.keyfingerprint SET k1.duplicate_keyfingerprint = True, k2.duplicate_keyfingerprint = True MERGE (k1)-[r:MATCHING_FINGERPRINT]-(k2) ON CREATE SET r.firstseen = $UPDATE_TAG SET r.lastupdated = $UPDATE_TAG RETURN COUNT(*) as TotalCompleted",
+            "iterative": false
+        },
+        {
+            "__comment__": "Delete stale MATCHING_FINGERPRINT relationships from previous runs. Runs after the MERGE so concurrent readers never observe a missing edge.",
+            "query": "MATCH (k1:EC2KeyPair)-[r:MATCHING_FINGERPRINT]->(k2:EC2KeyPair) WHERE r.lastupdated <> $UPDATE_TAG DELETE (r) return COUNT(*) as TotalCompleted",
             "iterative": false
         }
     ]

--- a/cartography/data/jobs/analysis/ontology_dnsrecords_linking.json
+++ b/cartography/data/jobs/analysis/ontology_dnsrecords_linking.json
@@ -2,12 +2,6 @@
   "name": "Ontology - DNSRecords relationship linking",
   "statements": [
     {
-      "__comment": "Cleanup: remove stale analysis-created DNS_POINTS_TO edges from DNSRecord nodes",
-      "query": "MATCH (:DNSRecord)-[r:DNS_POINTS_TO]->() WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r RETURN COUNT(*) AS TotalCompleted",
-      "iterative": true,
-      "iterationsize": 1000
-    },
-    {
       "__comment": "Link DNSRecord to KubernetesIngress where the record name matches an ingress host",
       "query": "MATCH (dns:DNSRecord) WHERE dns.lastupdated = $UPDATE_TAG AND dns._ont_name IS NOT NULL WITH dns MATCH (ing:KubernetesIngress) WHERE dns._ont_name IN ing.host_names MERGE (dns)-[r:DNS_POINTS_TO]->(ing) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
@@ -81,6 +75,12 @@
       "__comment": "Link GCPRecordSet to AzureFunctionApp via UNWIND on list-valued data",
       "query": "MATCH (dns:GCPRecordSet) WHERE dns.lastupdated = $UPDATE_TAG AND dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (func:AzureFunctionApp) WHERE toLower(val) = toLower(func.default_host_name) MERGE (dns)-[r:DNS_POINTS_TO]->(func) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
+    },
+    {
+      "__comment": "Cleanup: remove stale analysis-created DNS_POINTS_TO edges from DNSRecord nodes. Runs after all MERGE statements so concurrent readers never observe a missing edge.",
+      "query": "MATCH (:DNSRecord)-[r:DNS_POINTS_TO]->() WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r RETURN COUNT(*) AS TotalCompleted",
+      "iterative": true,
+      "iterationsize": 1000
     }
   ]
 }

--- a/cartography/data/jobs/analysis/resolved_image_analysis.json
+++ b/cartography/data/jobs/analysis/resolved_image_analysis.json
@@ -2,12 +2,6 @@
   "name": "Container/Function RESOLVED_IMAGE analysis",
   "statements": [
     {
-      "__comment": "Cleanup: remove stale RESOLVED_IMAGE edges on :Container from previous runs.",
-      "query": "MATCH (:Container)-[r:RESOLVED_IMAGE]->(:Image) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r RETURN COUNT(*) AS TotalCompleted",
-      "iterative": true,
-      "iterationsize": 1000
-    },
-    {
       "__comment": "Create RESOLVED_IMAGE by traversing the existing HAS_IMAGE edge from Container to Image. Excludes :ImageManifestList to guarantee the target is a deterministic single-platform image. HAS_IMAGE is created at ingest time by matching container runtime digest to image digest, so its existence is already a deterministic digest-level identification.",
       "query": "MATCH (c:Container)-[:HAS_IMAGE]->(i:Image) WHERE NOT i:ImageManifestList MERGE (c)-[r:RESOLVED_IMAGE]->(i) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
@@ -18,12 +12,6 @@
       "iterative": false
     },
     {
-      "__comment": "Cleanup: remove stale RESOLVED_IMAGE edges on :Function from previous runs.",
-      "query": "MATCH (:Function)-[r:RESOLVED_IMAGE]->(:Image) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r RETURN COUNT(*) AS TotalCompleted",
-      "iterative": true,
-      "iterationsize": 1000
-    },
-    {
       "__comment": "Create RESOLVED_IMAGE on :Function via direct HAS_IMAGE (covers container-deployed AWSLambda and AzureFunctionApp, which carry HAS_IMAGE on the node itself). Cloud Run Jobs flow through the :Container path via GCPCloudRunContainer instead.",
       "query": "MATCH (f:Function)-[:HAS_IMAGE]->(i:Image) WHERE NOT i:ImageManifestList MERGE (f)-[r:RESOLVED_IMAGE]->(i) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
@@ -32,6 +20,18 @@
       "__comment": "Create RESOLVED_IMAGE on :Function whose direct HAS_IMAGE points at an ImageManifestList. Architecture-match via the Function's own architecture_normalized with a single-candidate determinism guard.",
       "query": "MATCH (f:Function)-[:HAS_IMAGE]->(:ImageManifestList)-[:CONTAINS_IMAGE]->(i:Image) WHERE f.architecture_normalized IS NOT NULL AND i._ont_architecture = f.architecture_normalized WITH f, collect(DISTINCT i) AS candidates WHERE size(candidates) = 1 WITH f, candidates[0] AS img MERGE (f)-[r:RESOLVED_IMAGE]->(img) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
+    },
+    {
+      "__comment": "Cleanup: remove stale RESOLVED_IMAGE edges on :Container from previous runs. Runs after the MERGE statements so concurrent readers never observe a missing edge.",
+      "query": "MATCH (:Container)-[r:RESOLVED_IMAGE]->(:Image) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r RETURN COUNT(*) AS TotalCompleted",
+      "iterative": true,
+      "iterationsize": 1000
+    },
+    {
+      "__comment": "Cleanup: remove stale RESOLVED_IMAGE edges on :Function from previous runs. Runs after the MERGE statements so concurrent readers never observe a missing edge.",
+      "query": "MATCH (:Function)-[r:RESOLVED_IMAGE]->(:Image) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r RETURN COUNT(*) AS TotalCompleted",
+      "iterative": true,
+      "iterationsize": 1000
     }
   ]
 }

--- a/cartography/data/jobs/scoped_analysis/aws_lb_container_exposure.json
+++ b/cartography/data/jobs/scoped_analysis/aws_lb_container_exposure.json
@@ -2,14 +2,14 @@
   "name": "AWS LoadBalancer to ECS Container direct relationship",
   "statements": [
     {
-      "__comment": "Cleanup: Remove stale EXPOSE relationships between LBs and containers for this account",
-      "query": "MATCH (aa:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(lb:AWSLoadBalancerV2)-[r:EXPOSE]->(:ECSContainer) WHERE r.lastupdated <> $UPDATE_TAG DELETE r",
-      "iterative": true
-    },
-    {
       "__comment": "Create: EXPOSE relationships for private containers behind internet-facing load balancers",
       "query": "MATCH (aa:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(lb:AWSLoadBalancerV2 {scheme: 'internet-facing'})-[:EXPOSE]->(ip:EC2PrivateIp)<-[:PRIVATE_IP_ADDRESS]-(ni:NetworkInterface)<-[:NETWORK_INTERFACE]-(task:ECSTask)-[:HAS_CONTAINER]->(c:ECSContainer) WHERE ip.public_ip IS NULL MERGE (lb)-[r:EXPOSE]->(c) SET r.lastupdated = $UPDATE_TAG, r.exposure_type = 'via_lb_only'",
       "iterative": false
+    },
+    {
+      "__comment": "Cleanup: Remove stale EXPOSE relationships between LBs and containers for this account. Runs after the MERGE so concurrent readers never observe a missing edge.",
+      "query": "MATCH (aa:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(lb:AWSLoadBalancerV2)-[r:EXPOSE]->(:ECSContainer) WHERE r.lastupdated <> $UPDATE_TAG DELETE r",
+      "iterative": true
     }
   ]
 }

--- a/cartography/data/jobs/scoped_analysis/aws_lb_nacl_direct.json
+++ b/cartography/data/jobs/scoped_analysis/aws_lb_nacl_direct.json
@@ -2,14 +2,14 @@
   "name": "AWS LoadBalancer to NACL direct relationship",
   "statements": [
     {
-      "__comment": "Cleanup: Remove stale PROTECTS relationships between NACLs and LBs for this account",
-      "query": "MATCH (aa:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(lb:AWSLoadBalancerV2)<-[r:PROTECTS]-(:EC2NetworkAcl) WHERE r.lastupdated <> $UPDATE_TAG DELETE r",
-      "iterative": true
-    },
-    {
       "__comment": "Create: PROTECTS relationships via subnet traversal",
       "query": "MATCH (aa:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(lb:AWSLoadBalancerV2)-[:SUBNET]->(subnet:EC2Subnet)<-[:PART_OF_SUBNET]-(nacl:EC2NetworkAcl) MERGE (nacl)-[r:PROTECTS]->(lb) SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
+    },
+    {
+      "__comment": "Cleanup: Remove stale PROTECTS relationships between NACLs and LBs for this account. Runs after the MERGE so concurrent readers never observe a missing edge.",
+      "query": "MATCH (aa:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(lb:AWSLoadBalancerV2)<-[r:PROTECTS]-(:EC2NetworkAcl) WHERE r.lastupdated <> $UPDATE_TAG DELETE r",
+      "iterative": true
     }
   ]
 }

--- a/cartography/data/jobs/scoped_analysis/azure_firewall_lb_protection.json
+++ b/cartography/data/jobs/scoped_analysis/azure_firewall_lb_protection.json
@@ -2,13 +2,13 @@
   "name": "Azure Firewall PROTECTS LB relationships",
   "statements": [
     {
-      "__comment": "Cleanup stale PROTECTS rels from Firewalls to LBs in this subscription",
-      "query": "MATCH (s:AzureSubscription{id: $AZURE_SUBSCRIPTION_ID})-[:RESOURCE]->(fw:AzureFirewall)-[r:PROTECTS]->(:AzureLoadBalancer) WHERE r.lastupdated <> $UPDATE_TAG DELETE r",
+      "__comment": "Create PROTECTS rels from Firewalls to LBs via VNet traversal. This is topology-based and does not validate effective route path or firewall rule evaluation.",
+      "query": "MATCH (s:AzureSubscription{id: $AZURE_SUBSCRIPTION_ID})-[:RESOURCE]->(fw:AzureFirewall)-[:MEMBER_OF]->(vnet:AzureVirtualNetwork)-[:CONTAINS]->(subnet:AzureSubnet)<-[:ATTACHED_TO]-(nic:AzureNetworkInterface)<-[:ROUTES_TO]-(:AzureLoadBalancerBackendPool)<-[:CONTAINS]-(lb:AzureLoadBalancer) MERGE (fw)-[r:PROTECTS]->(lb) SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
-      "__comment": "Create PROTECTS rels from Firewalls to LBs via VNet traversal. This is topology-based and does not validate effective route path or firewall rule evaluation.",
-      "query": "MATCH (s:AzureSubscription{id: $AZURE_SUBSCRIPTION_ID})-[:RESOURCE]->(fw:AzureFirewall)-[:MEMBER_OF]->(vnet:AzureVirtualNetwork)-[:CONTAINS]->(subnet:AzureSubnet)<-[:ATTACHED_TO]-(nic:AzureNetworkInterface)<-[:ROUTES_TO]-(:AzureLoadBalancerBackendPool)<-[:CONTAINS]-(lb:AzureLoadBalancer) MERGE (fw)-[r:PROTECTS]->(lb) SET r.lastupdated = $UPDATE_TAG",
+      "__comment": "Cleanup stale PROTECTS rels from Firewalls to LBs in this subscription. Runs after the MERGE so concurrent readers never observe a missing edge.",
+      "query": "MATCH (s:AzureSubscription{id: $AZURE_SUBSCRIPTION_ID})-[:RESOURCE]->(fw:AzureFirewall)-[r:PROTECTS]->(:AzureLoadBalancer) WHERE r.lastupdated <> $UPDATE_TAG DELETE r",
       "iterative": false
     }
   ]

--- a/cartography/data/jobs/scoped_analysis/azure_lb_exposure.json
+++ b/cartography/data/jobs/scoped_analysis/azure_lb_exposure.json
@@ -2,13 +2,13 @@
   "name": "Azure LB EXPOSE relationships",
   "statements": [
     {
-      "__comment": "Cleanup stale EXPOSE rels from LBs in this subscription",
-      "query": "MATCH (s:AzureSubscription{id: $AZURE_SUBSCRIPTION_ID})-[:RESOURCE]->(lb:AzureLoadBalancer)-[r:EXPOSE]->() WHERE r.lastupdated <> $UPDATE_TAG DELETE r",
+      "__comment": "Create EXPOSE rels from exposed LBs to private VMs behind them",
+      "query": "MATCH (s:AzureSubscription{id: $AZURE_SUBSCRIPTION_ID})-[:RESOURCE]->(lb:AzureLoadBalancer{exposed_internet: true})-[:CONTAINS]->(:AzureLoadBalancerBackendPool)-[:ROUTES_TO]->(nic:AzureNetworkInterface)-[:ATTACHED_TO]->(vm:AzureVirtualMachine) WHERE NOT (nic)-[:ASSOCIATED_WITH]->(:AzurePublicIPAddress) MERGE (lb)-[r:EXPOSE]->(vm) SET r.lastupdated = $UPDATE_TAG, r.exposure_type = 'via_lb_only'",
       "iterative": false
     },
     {
-      "__comment": "Create EXPOSE rels from exposed LBs to private VMs behind them",
-      "query": "MATCH (s:AzureSubscription{id: $AZURE_SUBSCRIPTION_ID})-[:RESOURCE]->(lb:AzureLoadBalancer{exposed_internet: true})-[:CONTAINS]->(:AzureLoadBalancerBackendPool)-[:ROUTES_TO]->(nic:AzureNetworkInterface)-[:ATTACHED_TO]->(vm:AzureVirtualMachine) WHERE NOT (nic)-[:ASSOCIATED_WITH]->(:AzurePublicIPAddress) MERGE (lb)-[r:EXPOSE]->(vm) SET r.lastupdated = $UPDATE_TAG, r.exposure_type = 'via_lb_only'",
+      "__comment": "Cleanup stale EXPOSE rels from LBs in this subscription. Runs after the MERGE so concurrent readers never observe a missing edge.",
+      "query": "MATCH (s:AzureSubscription{id: $AZURE_SUBSCRIPTION_ID})-[:RESOURCE]->(lb:AzureLoadBalancer)-[r:EXPOSE]->() WHERE r.lastupdated <> $UPDATE_TAG DELETE r",
       "iterative": false
     }
   ]

--- a/cartography/data/jobs/scoped_analysis/gcp_lb_exposure.json
+++ b/cartography/data/jobs/scoped_analysis/gcp_lb_exposure.json
@@ -3,15 +3,15 @@
   "__comment__": "This job only creates EXPOSE relationships for graph traversal. Node-level exposed_internet properties are computed in gcp_compute_exposure.json.",
   "statements": [
     {
-      "__comment__": "Cleanup: Remove stale EXPOSE relationships between BackendServices and Instances for this project",
-      "query": "MATCH (p:GCPProject{id: $PROJECT_ID})-[:RESOURCE]->(bs:GCPBackendService)-[r:EXPOSE]->(:GCPInstance) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r",
-      "iterative": true,
-      "iterationsize": 1000
-    },
-    {
       "__comment__": "Create: EXPOSE relationships from external BackendServices to Instances behind them",
       "query": "MATCH (p:GCPProject{id: $PROJECT_ID})-[:RESOURCE]->(bs:GCPBackendService)-[:ROUTES_TO]->(ig:GCPInstanceGroup)-[:HAS_MEMBER]->(i:GCPInstance) WHERE bs.load_balancing_scheme = 'EXTERNAL' OR bs.load_balancing_scheme = 'EXTERNAL_MANAGED' MERGE (bs)-[r:EXPOSE]->(i) SET r.lastupdated = $UPDATE_TAG, r.exposure_type = 'gcp_lb'",
       "iterative": false
+    },
+    {
+      "__comment__": "Cleanup: Remove stale EXPOSE relationships between BackendServices and Instances for this project. Runs after the MERGE so concurrent readers never observe a missing edge.",
+      "query": "MATCH (p:GCPProject{id: $PROJECT_ID})-[:RESOURCE]->(bs:GCPBackendService)-[r:EXPOSE]->(:GCPInstance) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r",
+      "iterative": true,
+      "iterationsize": 1000
     }
   ]
 }

--- a/cartography/data/jobs/scoped_analysis/k8s_lb_exposure.json
+++ b/cartography/data/jobs/scoped_analysis/k8s_lb_exposure.json
@@ -2,16 +2,6 @@
   "name": "Kubernetes LoadBalancer to compute EXPOSE relationships",
   "statements": [
     {
-      "__comment": "Cleanup: Remove stale EXPOSE relationships between LBs and KubernetesPods for this cluster",
-      "query": "MATCH (cluster:KubernetesCluster{id: $CLUSTER_ID})-[:RESOURCE]->(pod:KubernetesPod)<-[r:EXPOSE]-(:AWSLoadBalancerV2) WHERE r.lastupdated <> $UPDATE_TAG DELETE r",
-      "iterative": true
-    },
-    {
-      "__comment": "Cleanup: Remove stale EXPOSE relationships between LBs and KubernetesContainers for this cluster",
-      "query": "MATCH (cluster:KubernetesCluster{id: $CLUSTER_ID})-[:RESOURCE]->(c:KubernetesContainer)<-[r:EXPOSE]-(:AWSLoadBalancerV2) WHERE r.lastupdated <> $UPDATE_TAG DELETE r",
-      "iterative": true
-    },
-    {
       "__comment": "Create: EXPOSE from internet-facing LB to Pod via Service type=LoadBalancer. Includes NLB fallback when aws_ec2_asset_exposure has not run.",
       "query": "MATCH (cluster:KubernetesCluster{id: $CLUSTER_ID})-[:RESOURCE]->(svc:KubernetesService)-[:USES_LOAD_BALANCER]->(lb:AWSLoadBalancerV2) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (svc)-[:TARGETS]->(pod:KubernetesPod) MERGE (lb)-[r:EXPOSE]->(pod) SET r.lastupdated = $UPDATE_TAG, r.exposure_type = 'via_lb_only'",
       "iterative": false
@@ -30,6 +20,16 @@
       "__comment": "Create: EXPOSE from internet-facing LB to Container via Ingress",
       "query": "MATCH (cluster:KubernetesCluster{id: $CLUSTER_ID})-[:RESOURCE]->(ing:KubernetesIngress)-[:USES_LOAD_BALANCER]->(lb:AWSLoadBalancerV2) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (ing)-[:TARGETS]->(svc:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer) MERGE (lb)-[r:EXPOSE]->(c) SET r.lastupdated = $UPDATE_TAG, r.exposure_type = 'via_lb_only'",
       "iterative": false
+    },
+    {
+      "__comment": "Cleanup: Remove stale EXPOSE relationships between LBs and KubernetesPods for this cluster. Runs after the MERGE statements so concurrent readers never observe a missing edge.",
+      "query": "MATCH (cluster:KubernetesCluster{id: $CLUSTER_ID})-[:RESOURCE]->(pod:KubernetesPod)<-[r:EXPOSE]-(:AWSLoadBalancerV2) WHERE r.lastupdated <> $UPDATE_TAG DELETE r",
+      "iterative": true
+    },
+    {
+      "__comment": "Cleanup: Remove stale EXPOSE relationships between LBs and KubernetesContainers for this cluster. Runs after the MERGE statements so concurrent readers never observe a missing edge.",
+      "query": "MATCH (cluster:KubernetesCluster{id: $CLUSTER_ID})-[:RESOURCE]->(c:KubernetesContainer)<-[r:EXPOSE]-(:AWSLoadBalancerV2) WHERE r.lastupdated <> $UPDATE_TAG DELETE r",
+      "iterative": true
     }
   ]
 }

--- a/docs/root/dev/writing-analysis-jobs.md
+++ b/docs/root/dev/writing-analysis-jobs.md
@@ -77,8 +77,11 @@ Kinda neat, right?
 ### The skeleton of an Analysis Job
 Now that we know what we want to do on a sync, how should we structure the Analysis Job?  Here is the basic skeleton that we recommend.
 
-#### Clean up first, then update
-In general, the first statement(s) should be a "clean-up phase" that removes custom attributes or relationships that you may have added in a previous run. This ensures that whatever labels you add on this current run will be up to date and not stale. Next, the statements after the clean-up phase will perform the matching and attribute updates as described in the previous section.
+#### Clean up first, then update (properties)
+For analysis jobs that **set custom attributes on nodes**, the first statement(s) should be a "clean-up phase" that removes the custom attributes you may have added in a previous run. This ensures that whatever labels you add on this current run will be up to date and not stale. Next, the statements after the clean-up phase will perform the matching and attribute updates as described in the previous section.
+
+#### MERGE first, then clean up (relationships)
+For analysis jobs that **create or update relationships**, invert the order: run the `MERGE` statements first, then `DELETE` any edge whose `r.lastupdated <> $UPDATE_TAG` at the end. Iterative `DELETE` statements commit per batch, so a leading `DELETE` of relationships creates a visible window during which concurrent readers observe the graph with those edges missing or partially deleted. `MERGE` is idempotent and bumps `r.lastupdated` on every still-valid edge, so the trailing `DELETE` only removes edges that genuinely no longer have a current basis. See `cartography/data/jobs/analysis/aws_lambda_ecr.json` for the canonical ordering.
 
 **Here's our final result:**
 


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):

### Summary

Several analysis jobs under `cartography/data/jobs/analysis/` and `cartography/data/jobs/scoped_analysis/` ran their iterative `DELETE r WHERE r.lastupdated <> $UPDATE_TAG` statement **before** the `MERGE` statements that recreate the relationships. At sync start, every existing edge has `lastupdated != $UPDATE_TAG` (the tag was just bumped), so the DELETE wiped the full set. Because the DELETE statement is iterative and commits per batch, concurrent reader sessions observed a graph where the relationship was partially or fully missing until the MERGE finished. Multi-hop queries traversing those edges returned incomplete results during a sync run and resolved themselves once the run completed.

The codebase already supported the safe ordering: `aws_lambda_ecr.json`, `gcp_compute_instance_vpc_analysis.json`, `gsuite_human_link.json`, `intune_compliance_policy_device.json` all MERGE-first then DELETE-stale. This PR reorders the rest to match and documents the convention so it does not regress.

The fix is purely a statement reorder. Steady-state behavior is unchanged because `MERGE` is idempotent and bumps `r.lastupdated` on every still-valid edge, so the trailing `DELETE` only targets edges that genuinely no longer have a current basis.

**Jobs reordered (10):**

`analysis/`
- `resolved_image_analysis.json` (Container/Function `RESOLVED_IMAGE` Image)
- `aibom_runs_on_container_analysis.json` (AIBOMSource `RUNS_ON` Container)
- `ontology_dnsrecords_linking.json` (DNSRecord `DNS_POINTS_TO` *)
- `aws_ec2_keypair_analysis.json` (EC2KeyPair `MATCHING_FINGERPRINT` EC2KeyPair)

`scoped_analysis/`
- `aws_lb_container_exposure.json` (LB `EXPOSE` ECSContainer)
- `aws_lb_nacl_direct.json` (NACL `PROTECTS` LB)
- `k8s_lb_exposure.json` (LB `EXPOSE` Pod/Container)
- `gcp_lb_exposure.json` (BackendService `EXPOSE` Instance)
- `azure_lb_exposure.json` (LB `EXPOSE` VM)
- `azure_firewall_lb_protection.json` (Firewall `PROTECTS` LB)

**Docs updated:**
- `docs/root/dev/writing-analysis-jobs.md`: split the cleanup-ordering guidance into properties (clean first) vs relationships (MERGE first, DELETE last).
- `.agents/skills/analysis-jobs/SKILL.md`: added a Critical rule with the canonical example.
- `AGENTS.md`: one-liner under the Analysis Jobs concept.

### Related issues or links

N/A

### How was this tested?

`make test_lint` passes.

Targeted integration suites covering the affected jobs all pass (37 tests):

```
pytest tests/integration/cartography/data/jobs/test_syntax.py \
       tests/integration/cartography/intel/ontology/test_resolved_images.py \
       tests/integration/cartography/intel/aibom/test_aibom.py \
       tests/integration/cartography/intel/aws/ec2/test_ec2_key_pairs.py \
       tests/integration/cartography/intel/vercel/test_dnsrecords.py \
       tests/integration/cartography/intel/cloudflare/test_dnsrecords.py \
       tests/integration/cartography/intel/kubernetes/test_exposure.py \
       tests/integration/cartography/intel/azure/test_compute_exposure.py \
       tests/integration/cartography/intel/gcp/test_compute_exposure.py \
       tests/integration/cartography/intel/microsoft/intune/test_intune.py
```

These tests assert the post-sync graph state, which is unchanged by the reorder. The read window itself is a transactional-visibility property that a single test session cannot observe deterministically, so no new tests are added.

Manual mid-sync probe to confirm the original bug (against a populated test database):

```
MATCH (:Container)-[r:RESOLVED_IMAGE]->(:Image) RETURN count(r)
```

Sampled every few seconds during a sync run. Before the fix: count drops sharply (often to zero) at the start of `resolved_image_analysis.json`. After the fix: count stays steady, climbing only as new edges are added.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

### Notes for reviewers

No new tests were added because all four jobs already have integration coverage that asserts the post-state graph. The bug fixed here is transactional-visibility-only and is not reproducible with a single Neo4j session. If a guardrail is desired (e.g. a lint over `cartography/data/jobs/analysis/*.json` and `cartography/data/jobs/scoped_analysis/*.json` that forbids `DELETE r ... WHERE r.lastupdated <> $UPDATE_TAG` followed by a `MERGE` on the same relationship), I am happy to follow up in a separate PR.