### PR TITLE
chore(ci): harden publish workflow against cache drift

### DIFF
--- a/.github/workflows/publish-to-ghcr-and-pypi.yml
+++ b/.github/workflows/publish-to-ghcr-and-pypi.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.10"
+          python-version: "3.13"
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
@@ -50,12 +50,12 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install uv
+        # No cache on the release publish job: rebuild deps from scratch so the
+        # uploaded artifact is reproducible from a clean state and not derived
+        # from a previously saved cache entry.
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: "uv.lock"
       - name: Build a binary wheel and a source tarball
-        run: uv build
+        run: uv build --frozen
       - name: Publish distribution 📦 to PyPI
         if: github.event_name == 'release'
         # --check-url checks if files already exist on PyPI before uploading.


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Three small drifts in `.github/workflows/publish-to-ghcr-and-pypi.yml` that surfaced during a cache-poisoning audit of CI:

1. **Align coverage-artifact to Python 3.13.** The job was pinned to 3.10 while every other job in the repo uses 3.13. The mismatch produces a separate uv cache silo and tests coverage on a runtime that does not match the release target.
2. **Disable uv cache on the PyPI publish job.** The release publish path should rebuild dependencies from a clean state rather than reuse a cache entry that was populated on a previous run; this keeps the uploaded wheel/sdist reproducible and shrinks the cache-poisoning surface for release artifacts.
3. **Pass `--frozen` to `uv build`.** Ensures that if `uv.lock` has drifted from `pyproject.toml`, the release build fails fast instead of silently re-resolving dependencies into the published artifact.

No functional change to test_suite.yml or to the docker publish job.


### Related issues or links

- Fixes #


### How was this tested?

Static change to workflow YAML. The Test Suite workflow will exercise the unchanged paths on this PR. The publish workflow only runs on `release: created` / `workflow_dispatch`, so it will be exercised at the next release cut.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

CI-only change with no runtime behavior to test; the workflow itself is the proof of correctness once it next runs at release time.


### Notes for reviewers

Focus areas:
- Is dropping the uv cache on the publish job acceptable given it runs only on release (so the cache hit rate is very low anyway)?
- Is bumping the coverage job to 3.13 the right call, or do we want to keep coverage measured against the lowest supported Python? If the latter, the right fix is the inverse (align the rest of CI to 3.10, or matrix it), but 3.13 matches the docker image and the rest of the publish workflow today.