### PR TITLE
fix(rules): correct invalid Cypher syntax in CIS GCP rules

### DIFF
--- a/cartography/rules/data/rules/cis_4_0_gcp.py
+++ b/cartography/rules/data/rules/cis_4_0_gcp.py
@@ -1183,7 +1183,7 @@ _gcp_cloudsql_mysql_skip_show_database = _make_cloudsql_flag_fact(
     "GCP Cloud SQL MySQL instances without skip_show_database=on",
     "Detects MySQL Cloud SQL instances where skip_show_database is not set to on.",
     "MYSQL",
-    'coalesce(instance.database_flags, \'\') !~ \'.*\\"name\\": \\"skip_show_database\\", \\"value\\": \\"on\\".*\'',
+    'NOT (coalesce(instance.database_flags, \'\') =~ \'.*\\"name\\": \\"skip_show_database\\", \\"value\\": \\"on\\".*\')',
 )
 cis_gcp_6_1_2_cloudsql_mysql_skip_show_database = _make_cloudsql_flag_rule(
     "cis_gcp_6_1_2_cloudsql_mysql_skip_show_database",
@@ -1198,7 +1198,7 @@ _gcp_cloudsql_mysql_local_infile = _make_cloudsql_flag_fact(
     "GCP Cloud SQL MySQL instances without local_infile=off",
     "Detects MySQL Cloud SQL instances where local_infile is not set to off.",
     "MYSQL",
-    'coalesce(instance.database_flags, \'\') !~ \'.*\\"name\\": \\"local_infile\\", \\"value\\": \\"off\\".*\'',
+    'NOT (coalesce(instance.database_flags, \'\') =~ \'.*\\"name\\": \\"local_infile\\", \\"value\\": \\"off\\".*\')',
 )
 cis_gcp_6_1_3_cloudsql_mysql_local_infile = _make_cloudsql_flag_rule(
     "cis_gcp_6_1_3_cloudsql_mysql_local_infile",
@@ -1228,7 +1228,7 @@ _gcp_cloudsql_postgres_log_connections = _make_cloudsql_flag_fact(
     "GCP Cloud SQL PostgreSQL instances without log_connections=on",
     "Detects PostgreSQL Cloud SQL instances where log_connections is not set to on.",
     "POSTGRES",
-    'coalesce(instance.database_flags, \'\') !~ \'.*\\"name\\": \\"log_connections\\", \\"value\\": \\"on\\".*\'',
+    'NOT (coalesce(instance.database_flags, \'\') =~ \'.*\\"name\\": \\"log_connections\\", \\"value\\": \\"on\\".*\')',
 )
 cis_gcp_6_2_2_cloudsql_postgres_log_connections = _make_cloudsql_flag_rule(
     "cis_gcp_6_2_2_cloudsql_postgres_log_connections",
@@ -1243,7 +1243,7 @@ _gcp_cloudsql_postgres_log_disconnections = _make_cloudsql_flag_fact(
     "GCP Cloud SQL PostgreSQL instances without log_disconnections=on",
     "Detects PostgreSQL Cloud SQL instances where log_disconnections is not set to on.",
     "POSTGRES",
-    'coalesce(instance.database_flags, \'\') !~ \'.*\\"name\\": \\"log_disconnections\\", \\"value\\": \\"on\\".*\'',
+    'NOT (coalesce(instance.database_flags, \'\') =~ \'.*\\"name\\": \\"log_disconnections\\", \\"value\\": \\"on\\".*\')',
 )
 cis_gcp_6_2_3_cloudsql_postgres_log_disconnections = _make_cloudsql_flag_rule(
     "cis_gcp_6_2_3_cloudsql_postgres_log_disconnections",
@@ -1303,7 +1303,7 @@ _gcp_cloudsql_postgres_enable_pgaudit = _make_cloudsql_flag_fact(
     "GCP Cloud SQL PostgreSQL instances without cloudsql.enable_pgaudit=on",
     "Detects PostgreSQL Cloud SQL instances where cloudsql.enable_pgaudit is not set to on.",
     "POSTGRES",
-    'coalesce(instance.database_flags, \'\') !~ \'.*\\"name\\": \\"cloudsql.enable_pgaudit\\", \\"value\\": \\"on\\".*\'',
+    'NOT (coalesce(instance.database_flags, \'\') =~ \'.*\\"name\\": \\"cloudsql.enable_pgaudit\\", \\"value\\": \\"on\\".*\')',
 )
 cis_gcp_6_2_8_cloudsql_postgres_enable_pgaudit = _make_cloudsql_flag_rule(
     "cis_gcp_6_2_8_cloudsql_postgres_enable_pgaudit",
@@ -1378,7 +1378,7 @@ _gcp_cloudsql_sqlserver_remote_access = _make_cloudsql_flag_fact(
     "GCP Cloud SQL SQL Server instances without remote access=off",
     "Detects SQL Server Cloud SQL instances where remote access is not set to off.",
     "SQLSERVER",
-    'coalesce(instance.database_flags, \'\') !~ \'.*\\"name\\": \\"remote access\\", \\"value\\": \\"off\\".*\'',
+    'NOT (coalesce(instance.database_flags, \'\') =~ \'.*\\"name\\": \\"remote access\\", \\"value\\": \\"off\\".*\')',
 )
 cis_gcp_6_3_5_cloudsql_sqlserver_remote_access = _make_cloudsql_flag_rule(
     "cis_gcp_6_3_5_cloudsql_sqlserver_remote_access",
@@ -1393,7 +1393,7 @@ _gcp_cloudsql_sqlserver_trace_3625 = _make_cloudsql_flag_fact(
     "GCP Cloud SQL SQL Server instances without trace flag 3625=on",
     "Detects SQL Server Cloud SQL instances where trace flag 3625 is not set to on.",
     "SQLSERVER",
-    'coalesce(instance.database_flags, \'\') !~ \'.*\\"name\\": \\"3625\\", \\"value\\": \\"on\\".*\'',
+    'NOT (coalesce(instance.database_flags, \'\') =~ \'.*\\"name\\": \\"3625\\", \\"value\\": \\"on\\".*\')',
 )
 cis_gcp_6_3_6_cloudsql_sqlserver_trace_3625 = _make_cloudsql_flag_rule(
     "cis_gcp_6_3_6_cloudsql_sqlserver_trace_3625",
@@ -1835,7 +1835,7 @@ _gcp_instance_project_wide_ssh_keys = Fact(
           AND toLower(coalesce(project.compute_project_enable_oslogin, '')) = 'true'
         )
       )
-      AND toLower(coalesce(instance.block_project_ssh_keys, 'false')) NOT IN ['true', '1']
+      AND NOT toLower(coalesce(instance.block_project_ssh_keys, 'false')) IN ['true', '1']
     RETURN
         instance.instancename AS instance_name,
         instance.id AS instance_id,
@@ -1856,7 +1856,7 @@ _gcp_instance_project_wide_ssh_keys = Fact(
           AND toLower(coalesce(project.compute_project_enable_oslogin, '')) = 'true'
         )
       )
-      AND toLower(coalesce(instance.block_project_ssh_keys, 'false')) NOT IN ['true', '1']
+      AND NOT toLower(coalesce(instance.block_project_ssh_keys, 'false')) IN ['true', '1']
     RETURN *
     """,
     cypher_count_query="""


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Eight CIS GCP rules in `cis_4_0_gcp.py` emit Cypher that Neo4j 5 rejects at parse time, so they never produce findings (the rules look "clean" in any compliance framework that references them). Two distinct bug classes, both string-literal issues:

1. **`expr !~ 'pattern'` is not valid Cypher.** Seven Cloud SQL database-flag predicates used `coalesce(instance.database_flags, '') !~ '...'`. Rewrote each to `NOT (coalesce(instance.database_flags, '') =~ '...')`.
2. **`expr NOT IN [...]` is not valid Cypher.** Two occurrences in `_gcp_instance_project_wide_ssh_keys` (one in `cypher_query`, one in `cypher_visual_query`) used `toLower(...) NOT IN ['true', '1']`. Fixed to `NOT toLower(...) IN ['true', '1']`.

Affected rules:
- `cis_gcp_4_3_block_project_wide_ssh_keys`
- `cis_gcp_6_1_2_cloudsql_mysql_skip_show_database`
- `cis_gcp_6_1_3_cloudsql_mysql_local_infile`
- `cis_gcp_6_2_2_cloudsql_postgres_log_connections`
- `cis_gcp_6_2_3_cloudsql_postgres_log_disconnections`
- `cis_gcp_6_2_8_cloudsql_postgres_enable_pgaudit`
- `cis_gcp_6_3_5_cloudsql_sqlserver_remote_access`
- `cis_gcp_6_3_6_cloudsql_sqlserver_trace_3625`

I also audited every other Cypher string under `cartography/rules/data/rules/` for the same and related patterns (negated regex, misplaced `NOT IN`/`NOT CONTAINS`/`NOT STARTS WITH`, deprecated `HAS()` / `LENGTH()`, removed `START` clause, bare pattern expressions in `WHERE`); no other occurrences.


### Related issues or links



### How was this tested?

- `make test_lint` passes.
- `pytest tests/unit/rules/test_cis_4_0_gcp.py` passes (3/3).
- Verified `grep -rn '!~' cartography/rules/` and `grep -rnE '\) NOT IN \[' cartography/rules/` return no hits.
- Spot-checked the rewritten queries against Neo4j 5 with `EXPLAIN` (no `SyntaxError`).


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

### Notes for reviewers

No new tests in this PR: the change is purely a Cypher-syntax fix in string literals, and the existing unit tests in `tests/unit/rules/test_cis_4_0_gcp.py` already exercise rule registration and parsing for all eight rules. A parser-level smoke test that runs `EXPLAIN` against a live Neo4j for every rule would be valuable but is out of scope here (no existing test in this suite runs Cypher).