### PR TITLE
feat(github): support explicit PAT config keys

### DIFF
--- a/cartography/intel/github/app_auth.py
+++ b/cartography/intel/github/app_auth.py
@@ -21,7 +21,10 @@ logger = logging.getLogger(__name__)
 # Installation tokens are valid for 1 hour; refresh 5 minutes before expiry
 _TOKEN_REFRESH_BUFFER_SECONDS = 300
 _JWT_EXPIRATION_SECONDS = 600  # 10 minutes (GitHub max)
+_JWT_IAT_CLOCK_DRIFT_SECONDS = 60
 _TIMEOUT = (60, 60)
+_PAT_FIELDS = ("token", "classic_pat", "fine_grained_pat")
+_APP_REQUIRED_FIELDS = ("client_id", "private_key", "installation_id")
 
 
 class GitHubCredential:
@@ -75,9 +78,10 @@ class AppCredential(GitHubCredential):
 
     def _create_jwt(self) -> str:
         now = int(time.time())
+        issued_at = now - _JWT_IAT_CLOCK_DRIFT_SECONDS
         payload = {
-            "iat": now,
-            "exp": now + _JWT_EXPIRATION_SECONDS,
+            "iat": issued_at,
+            "exp": issued_at + _JWT_EXPIRATION_SECONDS,
             "iss": self._client_id,
         }
         encoded: str = jwt.encode(payload, self._private_key, algorithm="RS256")
@@ -107,16 +111,43 @@ def make_credential(auth_data: dict[str, Any]) -> GitHubCredential:
     """
     Create the appropriate credential from a GitHub config entry.
 
-    PAT config: {"token": "ghp_xxx", "url": "...", "name": "..."}
+    PAT config (classic or fine-grained):
+    - {"token": "ghp_xxx", "url": "...", "name": "..."}
+    - {"classic_pat": "ghp_xxx", "url": "...", "name": "..."}
+    - {"fine_grained_pat": "github_pat_xxx", "url": "...", "name": "..."}
     App config: {"client_id": "...", "private_key": "...", "installation_id": "...", "url": "...", "name": "..."}
     """
-    if "token" in auth_data:
-        return PatCredential(auth_data["token"])
-    if "client_id" in auth_data:
-        missing = [k for k in ("private_key", "installation_id") if k not in auth_data]
+    present_pat_fields = [field for field in _PAT_FIELDS if field in auth_data]
+    present_app_fields = [field for field in _APP_REQUIRED_FIELDS if field in auth_data]
+
+    if len(present_pat_fields) > 1:
+        raise ValueError(
+            "GitHub config entry must contain only one PAT key; found: "
+            f"{', '.join(sorted(present_pat_fields))}",
+        )
+
+    if present_pat_fields and present_app_fields:
+        raise ValueError(
+            "GitHub config entry must use either PAT auth or GitHub App auth, "
+            "not both; found PAT key "
+            f"'{present_pat_fields[0]}' and GitHub App keys: "
+            f"{', '.join(sorted(present_app_fields))}",
+        )
+
+    if present_pat_fields:
+        field = present_pat_fields[0]
+        token = auth_data.get(field)
+        if not token:
+            raise ValueError(
+                f"GitHub PAT config key '{field}' must contain a non-empty token value",
+            )
+        return PatCredential(token)
+
+    if present_app_fields:
+        missing = [k for k in _APP_REQUIRED_FIELDS if k not in auth_data]
         if missing:
             raise ValueError(
-                f"GitHub App config with 'client_id' is missing required keys: {', '.join(missing)}",
+                f"GitHub App config is missing required keys: {', '.join(missing)}",
             )
         api_base_url = _get_rest_api_base_url(auth_data["url"])
         return AppCredential(
@@ -126,6 +157,7 @@ def make_credential(auth_data: dict[str, Any]) -> GitHubCredential:
             api_base_url=api_base_url,
         )
     raise ValueError(
-        "GitHub config entry must contain either 'token' (PAT) or "
+        "GitHub config entry must contain either one of "
+        "'token' / 'classic_pat' / 'fine_grained_pat' (PAT) or "
         "'client_id' + 'private_key' + 'installation_id' (GitHub App)",
     )

--- a/docs/root/modules/github/config.md
+++ b/docs/root/modules/github/config.md
@@ -109,13 +109,13 @@ Cartography accepts GitHub credentials as a base64-encoded JSON configuration. T
     config = {
         "organization": [
             {
-                "token": "ghp_your_token_here",
+                "fine_grained_pat": "github_pat_your_token_here",
                 "url": "https://api.github.com/graphql",
                 "name": "your-org-name",
             },
             # Optional: Add additional orgs or GitHub Enterprise instances
             # {
-            #     "token": "ghp_enterprise_token",
+            #     "classic_pat": "ghp_enterprise_token",
             #     "url": "https://github.example.com/api/graphql",
             #     "name": "enterprise-org-name",
             # },
@@ -126,6 +126,8 @@ Cartography accepts GitHub credentials as a base64-encoded JSON configuration. T
     encoded = base64.b64encode(json.dumps(config).encode()).decode()
     print(encoded)
     ```
+
+Use `fine_grained_pat` for fine-grained PATs and `classic_pat` for classic PATs. The generic `token` key remains supported for backward compatibility.
 
 For **GitHub App authentication**, use this format instead:
 
@@ -170,7 +172,7 @@ For GitHub Enterprise, use the same token scopes/permissions as above. Set the `
 
 ```python
 {
-    "token": "your_enterprise_token",
+    "classic_pat": "your_enterprise_token",
     "url": "https://github.your-company.com/api/graphql",
     "name": "your-enterprise-org",
 }

--- a/tests/data/github/auth.py
+++ b/tests/data/github/auth.py
@@ -1,0 +1,60 @@
+from copy import deepcopy
+from typing import Any
+from typing import cast
+
+from tests.data.github.users import GITHUB_ENTERPRISE_OWNER_DATA
+from tests.data.github.users import GITHUB_ORG_DATA
+from tests.data.github.users import GITHUB_USER_DATA
+
+CLASSIC_PAT_FIXTURE = "ghp_fixture"
+FINE_GRAINED_PAT_FIXTURE = "github_pat_fixture"
+GENERIC_PAT_FIXTURE = "pat_fixture"
+
+PAT_CONFIG_BY_KEY = {
+    "token": GENERIC_PAT_FIXTURE,
+    "classic_pat": CLASSIC_PAT_FIXTURE,
+    "fine_grained_pat": FINE_GRAINED_PAT_FIXTURE,
+}
+
+GITHUB_RATE_LIMIT_OK = {
+    "resources": {
+        "graphql": {
+            "limit": 5000,
+            "remaining": 5000,
+            "reset": 4102444800,
+            "used": 0,
+            "resource": "graphql",
+        },
+    },
+}
+
+
+def build_graphql_page(
+    resource_type: str, edges: list[dict[str, Any]]
+) -> dict[str, Any]:
+    return {
+        "data": {
+            "organization": {
+                "url": GITHUB_ORG_DATA["url"],
+                "login": GITHUB_ORG_DATA["login"],
+                resource_type: {
+                    "nodes": [],
+                    "edges": deepcopy(edges),
+                    "pageInfo": {
+                        "endCursor": None,
+                        "hasNextPage": False,
+                    },
+                },
+            },
+        },
+    }
+
+
+GITHUB_USERS_GRAPHQL_RESPONSE = build_graphql_page(
+    "membersWithRole",
+    cast(list[dict[str, Any]], GITHUB_USER_DATA[0]),
+)
+GITHUB_ENTERPRISE_OWNERS_GRAPHQL_RESPONSE = build_graphql_page(
+    "enterpriseOwners",
+    cast(list[dict[str, Any]], GITHUB_ENTERPRISE_OWNER_DATA[0]),
+)

--- a/tests/integration/cartography/intel/github/test_users.py
+++ b/tests/integration/cartography/intel/github/test_users.py
@@ -1,7 +1,13 @@
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import cartography.intel.github.users
+from cartography.intel.github.app_auth import PatCredential
 from cartography.models.github.users import GitHubOrganizationUserSchema
+from tests.data.github.auth import GENERIC_PAT_FIXTURE
+from tests.data.github.auth import GITHUB_ENTERPRISE_OWNERS_GRAPHQL_RESPONSE
+from tests.data.github.auth import GITHUB_RATE_LIMIT_OK
+from tests.data.github.auth import GITHUB_USERS_GRAPHQL_RESPONSE
 from tests.data.github.users import GITHUB_ENTERPRISE_OWNER_DATA
 from tests.data.github.users import GITHUB_ORG_DATA
 from tests.data.github.users import GITHUB_USER_DATA
@@ -141,6 +147,56 @@ def test_sync(mock_owners, mock_users, neo4j_session):
     assert actual_emails == expected_emails
 
 
+@patch("cartography.intel.github.util.requests.post")
+@patch("cartography.intel.github.util.requests.get")
+def test_sync_accepts_pat_credential_through_real_fetch_path(
+    mock_get,
+    mock_post,
+    neo4j_session,
+):
+    # Arrange
+    mock_get.return_value.json.return_value = GITHUB_RATE_LIMIT_OK
+    mock_post.side_effect = [
+        _mock_response(GITHUB_USERS_GRAPHQL_RESPONSE),
+        _mock_response(GITHUB_ENTERPRISE_OWNERS_GRAPHQL_RESPONSE),
+    ]
+
+    # Act
+    cartography.intel.github.users.sync(
+        neo4j_session,
+        TEST_JOB_PARAMS,
+        PatCredential(GENERIC_PAT_FIXTURE),
+        "https://api.github.com/graphql",
+        TEST_GITHUB_ORG,
+    )
+
+    # Assert
+    assert mock_post.call_count == 2
+    assert all(
+        call.kwargs["headers"]["Authorization"] == f"Bearer {GENERIC_PAT_FIXTURE}"
+        for call in mock_post.call_args_list
+    )
+    assert check_nodes(neo4j_session, "GitHubUser", ["id"]) == {
+        ("https://github.com/hjsimpson",),
+        ("https://github.com/lmsimpson",),
+        ("https://github.com/mbsimpson",),
+        ("https://github.com/kbroflovski",),
+    }
+    assert check_rels(
+        neo4j_session,
+        "GitHubUser",
+        "id",
+        "GitHubOrganization",
+        "id",
+        "MEMBER_OF",
+        rel_direction_right=True,
+    ) == {
+        ("https://github.com/hjsimpson", "https://github.com/simpsoncorp"),
+        ("https://github.com/lmsimpson", "https://github.com/simpsoncorp"),
+        ("https://github.com/mbsimpson", "https://github.com/simpsoncorp"),
+    }
+
+
 @patch.object(
     cartography.intel.github.users,
     "get_users",
@@ -194,3 +250,9 @@ def test_sync_with_cleanups(mock_owners, mock_users, neo4j_session):
     ) == {
         ("https://github.com/hjsimpson", "https://github.com/simpsoncorp"),
     }
+
+
+def _mock_response(payload):
+    response = MagicMock()
+    response.json.return_value = payload
+    return response

--- a/tests/unit/cartography/intel/github/test_app_auth.py
+++ b/tests/unit/cartography/intel/github/test_app_auth.py
@@ -6,6 +6,7 @@ import pytest
 from cartography.intel.github.app_auth import AppCredential
 from cartography.intel.github.app_auth import make_credential
 from cartography.intel.github.app_auth import PatCredential
+from tests.data.github.auth import PAT_CONFIG_BY_KEY
 
 
 def test_pat_get_token_returns_static_token() -> None:
@@ -128,7 +129,9 @@ def test_app_github_enterprise_url(
 
 
 @patch("cartography.intel.github.app_auth.jwt.encode")
-def test_app_jwt_payload(mock_jwt_encode: MagicMock) -> None:
+@patch("cartography.intel.github.app_auth.time.time")
+def test_app_jwt_payload(mock_time: MagicMock, mock_jwt_encode: MagicMock) -> None:
+    mock_time.return_value = 1000
     mock_jwt_encode.return_value = "fake-jwt"
 
     cred = AppCredential(
@@ -147,21 +150,73 @@ def test_app_jwt_payload(mock_jwt_encode: MagicMock) -> None:
     call_args = mock_jwt_encode.call_args
     payload = call_args[0][0]
     assert payload["iss"] == "Iv1.myclientid"
-    assert "iat" in payload
-    assert "exp" in payload
+    assert payload["iat"] == 940
+    assert payload["exp"] <= 1600
     assert payload["exp"] - payload["iat"] == 600  # 10 minute expiry
     assert call_args[1]["algorithm"] == "RS256"
 
 
 def test_make_credential_pat_config() -> None:
+    for pat_key, pat_value in PAT_CONFIG_BY_KEY.items():
+        auth_data = {
+            pat_key: pat_value,
+            "url": "https://api.github.com/graphql",
+            "name": "my-org",
+        }
+        cred = make_credential(auth_data)
+        assert isinstance(cred, PatCredential)
+        assert cred.get_token() == pat_value
+
+
+def test_make_credential_blank_pat_raises() -> None:
+    for pat_key in PAT_CONFIG_BY_KEY:
+        auth_data = {
+            pat_key: "",
+            "url": "https://api.github.com/graphql",
+            "name": "my-org",
+        }
+        with pytest.raises(ValueError, match=f"'{pat_key}'.*non-empty"):
+            make_credential(auth_data)
+
+
+def test_make_credential_multiple_pat_fields_raises_without_leaking_values() -> None:
     auth_data = {
-        "token": "ghp_abc123",
+        "token": "placeholder-token-value",
+        "classic_pat": "placeholder-classic-value",
         "url": "https://api.github.com/graphql",
         "name": "my-org",
     }
-    cred = make_credential(auth_data)
-    assert isinstance(cred, PatCredential)
-    assert cred.get_token() == "ghp_abc123"
+    with pytest.raises(ValueError, match="only one PAT key") as exc:
+        make_credential(auth_data)
+
+    message = str(exc.value)
+    assert "token" in message
+    assert "classic_pat" in message
+    assert "placeholder-token-value" not in message
+    assert "placeholder-classic-value" not in message
+
+
+def test_make_credential_mixed_pat_and_app_fields_raises_without_leaking_values() -> (
+    None
+):
+    auth_data = {
+        "fine_grained_pat": "placeholder-fine-grained-value",
+        "client_id": "Iv1.abc",
+        "private_key": "placeholder-private-key-value",
+        "installation_id": "12345",
+        "url": "https://api.github.com/graphql",
+        "name": "my-org",
+    }
+    with pytest.raises(ValueError, match="not both") as exc:
+        make_credential(auth_data)
+
+    message = str(exc.value)
+    assert "fine_grained_pat" in message
+    assert "client_id" in message
+    assert "private_key" in message
+    assert "installation_id" in message
+    assert "placeholder-fine-grained-value" not in message
+    assert "placeholder-private-key-value" not in message
 
 
 def test_make_credential_app_config() -> None:
@@ -191,7 +246,7 @@ def test_make_credential_app_config_enterprise() -> None:
 
 def test_make_credential_app_missing_keys_raises() -> None:
     auth_data = {
-        "client_id": "Iv1.abc",
+        "private_key": "fake-key",
         "url": "https://api.github.com/graphql",
         "name": "my-org",
     }


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary
Adds explicit GitHub PAT config keys for classic and fine-grained personal access tokens while keeping the existing `token` key backward-compatible.

This keeps both PAT types represented by the existing `PatCredential` runtime path, rejects ambiguous config entries that mix auth modes or multiple PAT keys, and avoids logging credential values in validation errors. It also backdates GitHub App JWT `iat` by 60 seconds to tolerate small clock drift while preserving GitHub's 10-minute maximum JWT lifetime.


### Related issues or links
N/A


### Breaking changes
None. Existing configs that use `token` continue to work.


### How was this tested?
- `uv run --frozen pytest -q tests/unit/cartography/intel/github/test_app_auth.py tests/unit/cartography/intel/github/test_github.py tests/integration/cartography/intel/github/test_users.py::test_sync_accepts_pat_credential_through_real_fetch_path`
- `make test_unit`
- `make test_lint`
- Read-only live GitHub validation using the new `fine_grained_pat` config key with a local temporary Neo4j database. Redacted local logs retained.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
The new config keys are aliases for readability only; Cartography does not infer token type from token prefixes because GitHub Enterprise and future token formats can vary.
