### PR TITLE
Add ingress-nginx retirement coverage to EOL software rule

### DIFF
--- a/cartography/rules/data/rules/eol_software.py
+++ b/cartography/rules/data/rules/eol_software.py
@@ -94,7 +94,16 @@ def _build_kubernetes_ingress_nginx_eol_query(
 ) -> str:
     return f"""
     MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
-    MATCH (pod)-[:CONTAINS|WORKLOAD_PARENT]-(container:KubernetesContainer)
+    CALL {{
+        WITH pod
+        MATCH (container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod)
+        RETURN container
+        UNION
+        WITH pod
+        MATCH (pod)-[:CONTAINS]->(container:KubernetesContainer)
+        RETURN container
+    }}
+    WITH DISTINCT cluster, pod, container
     WITH cluster, pod, container,
          replace(toLower(coalesce(pod.labels, '')), ' ', '') AS labels_compacted,
          toLower(coalesce(container.image, '')) AS image
@@ -402,8 +411,21 @@ _kubernetes_ingress_nginx_controller_eol = Fact(
     ),
     cypher_query=_build_kubernetes_ingress_nginx_eol_query(),
     cypher_visual_query=f"""
-    MATCH controller_path=(cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
-          -[:CONTAINS|WORKLOAD_PARENT]-(container:KubernetesContainer)
+    MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
+    CALL {{
+        WITH pod
+        MATCH (container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod)
+        RETURN container
+        UNION
+        WITH pod
+        MATCH (pod)-[:CONTAINS]->(container:KubernetesContainer)
+        RETURN container
+    }}
+    WITH DISTINCT cluster, pod, container
+    OPTIONAL MATCH workload_parent_path=(container)-[:WORKLOAD_PARENT]->(pod)
+    OPTIONAL MATCH legacy_contains_path=(pod)-[:CONTAINS]->(container)
+    WITH cluster, pod, container,
+         coalesce(workload_parent_path, legacy_contains_path) AS controller_path
     WITH controller_path, cluster, pod, container,
          replace(toLower(coalesce(pod.labels, '')), ' ', '') AS labels_compacted,
          toLower(coalesce(container.image, '')) AS image
@@ -418,7 +440,16 @@ _kubernetes_ingress_nginx_controller_eol = Fact(
     """,
     cypher_count_query=f"""
     MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
-    MATCH (pod)-[:CONTAINS|WORKLOAD_PARENT]-(container:KubernetesContainer)
+    CALL {{
+        WITH pod
+        MATCH (container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod)
+        RETURN container
+        UNION
+        WITH pod
+        MATCH (pod)-[:CONTAINS]->(container:KubernetesContainer)
+        RETURN container
+    }}
+    WITH DISTINCT cluster, pod, container
     WITH cluster, pod, container,
          replace(toLower(coalesce(pod.labels, '')), ' ', '') AS labels_compacted,
          toLower(coalesce(container.image, '')) AS image

--- a/cartography/rules/data/rules/eol_software.py
+++ b/cartography/rules/data/rules/eol_software.py
@@ -94,7 +94,7 @@ def _build_kubernetes_ingress_nginx_eol_query(
 ) -> str:
     return f"""
     MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
-          <-[:WORKLOAD_PARENT]-(container:KubernetesContainer)
+    MATCH (pod)-[:CONTAINS|WORKLOAD_PARENT]-(container:KubernetesContainer)
     WITH cluster, pod, container,
          replace(toLower(coalesce(pod.labels, '')), ' ', '') AS labels_compacted,
          toLower(coalesce(container.image, '')) AS image
@@ -403,7 +403,7 @@ _kubernetes_ingress_nginx_controller_eol = Fact(
     cypher_query=_build_kubernetes_ingress_nginx_eol_query(),
     cypher_visual_query=f"""
     MATCH controller_path=(cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
-          <-[:WORKLOAD_PARENT]-(container:KubernetesContainer)
+          -[:CONTAINS|WORKLOAD_PARENT]-(container:KubernetesContainer)
     WITH controller_path, cluster, pod, container,
          replace(toLower(coalesce(pod.labels, '')), ' ', '') AS labels_compacted,
          toLower(coalesce(container.image, '')) AS image
@@ -418,7 +418,7 @@ _kubernetes_ingress_nginx_controller_eol = Fact(
     """,
     cypher_count_query=f"""
     MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
-          <-[:WORKLOAD_PARENT]-(container:KubernetesContainer)
+    MATCH (pod)-[:CONTAINS|WORKLOAD_PARENT]-(container:KubernetesContainer)
     WITH cluster, pod, container,
          replace(toLower(coalesce(pod.labels, '')), ' ', '') AS labels_compacted,
          toLower(coalesce(container.image, '')) AS image

--- a/cartography/rules/data/rules/eol_software.py
+++ b/cartography/rules/data/rules/eol_software.py
@@ -400,10 +400,9 @@ _kubernetes_ingress_nginx_controller_eol = Fact(
     id="kubernetes_ingress_nginx_controller_eol",
     name="Kubernetes clusters running retired ingress-nginx controllers",
     description=(
-        "Detects Kubernetes ingress-nginx controller workloads after the "
-        "upstream ingress-nginx project retirement date. The project was "
-        "retired in March 2026 and no longer receives bug fixes or security "
-        "updates."
+        "Detects deployed Kubernetes ingress-nginx controller workloads now "
+        "that the upstream ingress-nginx project has been retired and no "
+        "longer receives bug fixes or security updates."
     ),
     cypher_query=_build_kubernetes_ingress_nginx_eol_query(),
     cypher_visual_query="""
@@ -540,8 +539,8 @@ eol_software = Rule(
         "Kubernetes support window and EKS clusters using the Amazon EKS "
         "provider lifecycle. It also flags EC2 instances that AWS SSM reports "
         "as running Amazon Linux 2 after the vendor end-of-life date and "
-        "Kubernetes ingress-nginx controllers after the upstream project "
-        "retirement date."
+        "deployed Kubernetes ingress-nginx controllers now that the upstream "
+        "project has been retired."
     ),
     output_model=EOLSoftwareOutput,
     facts=(

--- a/cartography/rules/data/rules/eol_software.py
+++ b/cartography/rules/data/rules/eol_software.py
@@ -17,6 +17,7 @@ _OLDEST_SUPPORTED_GKE_KUBERNETES_MINOR = 30
 # https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions
 _OLDEST_SUPPORTED_AKS_KUBERNETES_MINOR = 33
 _AMAZON_LINUX_2_EOL_DATE = "2026-06-30"
+_INGRESS_NGINX_EOL_DATE = "2026-03-24"
 
 EOL_SOFTWARE_REFERENCES = [
     RuleReference(
@@ -51,6 +52,18 @@ EOL_SOFTWARE_REFERENCES = [
         text="AWS Systems Manager InstanceInformation API",
         url="https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_InstanceInformation.html",
     ),
+    RuleReference(
+        text="Ingress NGINX Retirement",
+        url="https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/",
+    ),
+    RuleReference(
+        text="Ingress NGINX retirement statement",
+        url="https://kubernetes.io/blog/2026/01/29/ingress-nginx-statement/",
+    ),
+    RuleReference(
+        text="kubernetes/ingress-nginx archived repository",
+        url="https://github.com/kubernetes/ingress-nginx",
+    ),
 ]
 
 
@@ -73,6 +86,74 @@ def _build_ec2_instance_amazon_linux_2_eol_query(
            'vendor' AS support_basis,
            'eol' AS support_status
     ORDER BY asset_name
+    """
+
+
+def _build_kubernetes_ingress_nginx_eol_query(
+    current_date_expression: str = "date()",
+) -> str:
+    return f"""
+    MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
+          <-[:WORKLOAD_PARENT]-(container:KubernetesContainer)
+    WITH cluster, pod, container,
+         replace(toLower(coalesce(pod.labels, '')), ' ', '') AS labels_compacted,
+         toLower(coalesce(container.image, '')) AS image
+    WITH cluster, pod, container, labels_compacted, image,
+         labels_compacted CONTAINS '"app.kubernetes.io/name":"ingress-nginx"'
+             AND labels_compacted CONTAINS '"app.kubernetes.io/component":"controller"'
+             AS has_controller_labels,
+         image CONTAINS '/ingress-nginx/controller:' AS has_controller_image
+    WHERE {current_date_expression} > date('{_INGRESS_NGINX_EOL_DATE}')
+      AND (has_controller_labels OR has_controller_image)
+    WITH cluster, pod, container, labels_compacted, image,
+         CASE
+             WHEN labels_compacted CONTAINS '"app.kubernetes.io/instance":"'
+             THEN split(split(labels_compacted, '"app.kubernetes.io/instance":"')[1], '"')[0]
+             ELSE 'ingress-nginx'
+         END AS controller_instance,
+         CASE
+             WHEN labels_compacted CONTAINS '"app.kubernetes.io/version":"'
+             THEN split(split(labels_compacted, '"app.kubernetes.io/version":"')[1], '"')[0]
+             WHEN image CONTAINS '/ingress-nginx/controller:'
+             THEN split(split(image, '/ingress-nginx/controller:')[1], '@')[0]
+             ELSE NULL
+         END AS software_version_raw
+    WITH cluster, pod, container, controller_instance,
+         CASE
+             WHEN software_version_raw STARTS WITH 'v'
+             THEN substring(software_version_raw, 1)
+             ELSE software_version_raw
+         END AS software_version
+    WITH cluster,
+         coalesce(pod.namespace, container.namespace, 'default') AS namespace,
+         controller_instance,
+         software_version,
+         CASE
+             WHEN software_version IS NULL OR size(split(software_version, '.')) < 1 THEN NULL
+             ELSE toInteger(split(software_version, '.')[0])
+         END AS software_major,
+         CASE
+             WHEN software_version IS NULL OR size(split(software_version, '.')) < 2 THEN NULL
+             ELSE toInteger(split(split(software_version, '.')[1], '-')[0])
+         END AS software_minor
+    WITH DISTINCT cluster, namespace, controller_instance,
+                  software_version, software_major, software_minor
+    RETURN coalesce(cluster.id, cluster.name, 'unknown-cluster')
+               + '/namespaces/' + namespace
+               + '/ingress-controllers/' + controller_instance
+               + '/' + coalesce(software_version, 'unknown') AS asset_id,
+           coalesce(cluster.name, cluster.id, 'unknown-cluster')
+               + '/' + namespace
+               + '/' + controller_instance AS asset_name,
+           'KubernetesIngressController' AS asset_type,
+           'ingress-nginx' AS software_name,
+           software_version AS software_version,
+           software_major AS software_major,
+           software_minor AS software_minor,
+           NULL AS location,
+           'upstream' AS support_basis,
+           'eol' AS support_status
+    ORDER BY asset_name, software_version
     """
 
 
@@ -309,6 +390,78 @@ _kubernetes_cluster_kubernetes_version_eol = Fact(
     maturity=Maturity.EXPERIMENTAL,
 )
 
+
+_kubernetes_ingress_nginx_controller_eol = Fact(
+    id="kubernetes_ingress_nginx_controller_eol",
+    name="Kubernetes clusters running retired ingress-nginx controllers",
+    description=(
+        "Detects Kubernetes ingress-nginx controller workloads after the "
+        "upstream ingress-nginx project retirement date. The project was "
+        "retired in March 2026 and no longer receives bug fixes or security "
+        "updates."
+    ),
+    cypher_query=_build_kubernetes_ingress_nginx_eol_query(),
+    cypher_visual_query=f"""
+    MATCH controller_path=(cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
+          <-[:WORKLOAD_PARENT]-(container:KubernetesContainer)
+    WITH controller_path, cluster, pod, container,
+         replace(toLower(coalesce(pod.labels, '')), ' ', '') AS labels_compacted,
+         toLower(coalesce(container.image, '')) AS image
+    WITH controller_path, cluster, pod, container, labels_compacted, image,
+         labels_compacted CONTAINS '"app.kubernetes.io/name":"ingress-nginx"'
+             AND labels_compacted CONTAINS '"app.kubernetes.io/component":"controller"'
+             AS has_controller_labels,
+         image CONTAINS '/ingress-nginx/controller:' AS has_controller_image
+    WHERE date() > date('{_INGRESS_NGINX_EOL_DATE}')
+      AND (has_controller_labels OR has_controller_image)
+    RETURN cluster, pod, container, controller_path
+    """,
+    cypher_count_query=f"""
+    MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
+          <-[:WORKLOAD_PARENT]-(container:KubernetesContainer)
+    WITH cluster, pod, container,
+         replace(toLower(coalesce(pod.labels, '')), ' ', '') AS labels_compacted,
+         toLower(coalesce(container.image, '')) AS image
+    WITH cluster, pod, container, labels_compacted, image,
+         labels_compacted CONTAINS '"app.kubernetes.io/name":"ingress-nginx"'
+             AND labels_compacted CONTAINS '"app.kubernetes.io/component":"controller"'
+             AS has_controller_labels,
+         image CONTAINS '/ingress-nginx/controller:' AS has_controller_image
+    WHERE date() > date('{_INGRESS_NGINX_EOL_DATE}')
+      AND (has_controller_labels OR has_controller_image)
+    WITH cluster, pod, container, labels_compacted, image,
+         CASE
+             WHEN labels_compacted CONTAINS '"app.kubernetes.io/instance":"'
+             THEN split(split(labels_compacted, '"app.kubernetes.io/instance":"')[1], '"')[0]
+             ELSE 'ingress-nginx'
+         END AS controller_instance,
+         CASE
+             WHEN labels_compacted CONTAINS '"app.kubernetes.io/version":"'
+             THEN split(split(labels_compacted, '"app.kubernetes.io/version":"')[1], '"')[0]
+             WHEN image CONTAINS '/ingress-nginx/controller:'
+             THEN split(split(image, '/ingress-nginx/controller:')[1], '@')[0]
+             ELSE NULL
+         END AS software_version_raw
+    WITH DISTINCT coalesce(cluster.id, cluster.name, 'unknown-cluster')
+             + '/namespaces/' + coalesce(pod.namespace, container.namespace, 'default')
+             + '/ingress-controllers/' + controller_instance
+             + '/'
+             + coalesce(
+                 CASE
+                     WHEN software_version_raw STARTS WITH 'v'
+                     THEN substring(software_version_raw, 1)
+                     ELSE software_version_raw
+                 END,
+                 'unknown'
+             ) AS asset_id
+    RETURN COUNT(asset_id) AS count
+    """,
+    asset_id_field="asset_id",
+    module=Module.KUBERNETES,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
 _ec2_instance_amazon_linux_2_eol = Fact(
     id="ec2_instance_amazon_linux_2_eol",
     name="EC2 instances running end-of-life Amazon Linux 2",
@@ -360,7 +513,9 @@ eol_software = Rule(
         "The initial coverage flags raw Kubernetes clusters using the upstream "
         "Kubernetes support window and EKS clusters using the Amazon EKS "
         "provider lifecycle. It also flags EC2 instances that AWS SSM reports "
-        "as running Amazon Linux 2 after the vendor end-of-life date."
+        "as running Amazon Linux 2 after the vendor end-of-life date and "
+        "Kubernetes ingress-nginx controllers after the upstream project "
+        "retirement date."
     ),
     output_model=EOLSoftwareOutput,
     facts=(
@@ -368,6 +523,7 @@ eol_software = Rule(
         _gke_cluster_kubernetes_version_eol,
         _aks_cluster_kubernetes_version_eol,
         _kubernetes_cluster_kubernetes_version_eol,
+        _kubernetes_ingress_nginx_controller_eol,
         _ec2_instance_amazon_linux_2_eol,
     ),
     tags=(
@@ -378,7 +534,7 @@ eol_software = Rule(
         "lifecycle",
         "compliance",
     ),
-    version="0.2.0",
+    version="0.3.0",
     references=EOL_SOFTWARE_REFERENCES,
     frameworks=(iso27001_annex_a("8.8"),),
 )

--- a/cartography/rules/data/rules/eol_software.py
+++ b/cartography/rules/data/rules/eol_software.py
@@ -411,7 +411,7 @@ _kubernetes_ingress_nginx_controller_eol = Fact(
     ),
     cypher_query=_build_kubernetes_ingress_nginx_eol_query(),
     cypher_visual_query=f"""
-    MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
+    MATCH resource_path=(cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
     CALL {{
         WITH pod
         MATCH (container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod)
@@ -421,22 +421,23 @@ _kubernetes_ingress_nginx_controller_eol = Fact(
         MATCH (pod)-[:CONTAINS]->(container:KubernetesContainer)
         RETURN container
     }}
-    WITH DISTINCT cluster, pod, container
+    WITH DISTINCT resource_path, cluster, pod, container
     OPTIONAL MATCH workload_parent_path=(container)-[:WORKLOAD_PARENT]->(pod)
     OPTIONAL MATCH legacy_contains_path=(pod)-[:CONTAINS]->(container)
     WITH cluster, pod, container,
+         resource_path,
          coalesce(workload_parent_path, legacy_contains_path) AS controller_path
-    WITH controller_path, cluster, pod, container,
+    WITH resource_path, controller_path, cluster, pod, container,
          replace(toLower(coalesce(pod.labels, '')), ' ', '') AS labels_compacted,
          toLower(coalesce(container.image, '')) AS image
-    WITH controller_path, cluster, pod, container, labels_compacted, image,
+    WITH resource_path, controller_path, cluster, pod, container, labels_compacted, image,
          labels_compacted CONTAINS '"app.kubernetes.io/name":"ingress-nginx"'
              AND labels_compacted CONTAINS '"app.kubernetes.io/component":"controller"'
              AS has_controller_labels,
          image CONTAINS '/ingress-nginx/controller:' AS has_controller_image
     WHERE date() > date('{_INGRESS_NGINX_EOL_DATE}')
       AND (has_controller_labels OR has_controller_image)
-    RETURN cluster, pod, container, controller_path
+    RETURN cluster, pod, container, resource_path, controller_path
     """,
     cypher_count_query=f"""
     MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)

--- a/cartography/rules/data/rules/eol_software.py
+++ b/cartography/rules/data/rules/eol_software.py
@@ -17,7 +17,6 @@ _OLDEST_SUPPORTED_GKE_KUBERNETES_MINOR = 30
 # https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions
 _OLDEST_SUPPORTED_AKS_KUBERNETES_MINOR = 33
 _AMAZON_LINUX_2_EOL_DATE = "2026-06-30"
-_INGRESS_NGINX_EOL_DATE = "2026-03-24"
 
 EOL_SOFTWARE_REFERENCES = [
     RuleReference(
@@ -89,12 +88,10 @@ def _build_ec2_instance_amazon_linux_2_eol_query(
     """
 
 
-def _build_kubernetes_ingress_nginx_eol_query(
-    current_date_expression: str = "date()",
-) -> str:
-    return f"""
+def _build_kubernetes_ingress_nginx_eol_query() -> str:
+    return """
     MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
-    CALL {{
+    CALL {
         WITH pod
         MATCH (container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod)
         RETURN container
@@ -102,7 +99,7 @@ def _build_kubernetes_ingress_nginx_eol_query(
         WITH pod
         MATCH (pod)-[:CONTAINS]->(container:KubernetesContainer)
         RETURN container
-    }}
+    }
     WITH DISTINCT cluster, pod, container
     WITH cluster, pod, container,
          replace(toLower(coalesce(pod.labels, '')), ' ', '') AS labels_compacted,
@@ -112,8 +109,7 @@ def _build_kubernetes_ingress_nginx_eol_query(
              AND labels_compacted CONTAINS '"app.kubernetes.io/component":"controller"'
              AS has_controller_labels,
          image CONTAINS '/ingress-nginx/controller:' AS has_controller_image
-    WHERE {current_date_expression} > date('{_INGRESS_NGINX_EOL_DATE}')
-      AND (has_controller_labels OR has_controller_image)
+    WHERE has_controller_labels OR has_controller_image
     WITH cluster, pod, container, labels_compacted, image,
          CASE
              WHEN labels_compacted CONTAINS '"app.kubernetes.io/instance":"'
@@ -410,9 +406,9 @@ _kubernetes_ingress_nginx_controller_eol = Fact(
         "updates."
     ),
     cypher_query=_build_kubernetes_ingress_nginx_eol_query(),
-    cypher_visual_query=f"""
+    cypher_visual_query="""
     MATCH resource_path=(cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
-    CALL {{
+    CALL {
         WITH pod
         MATCH (container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod)
         RETURN container
@@ -420,7 +416,7 @@ _kubernetes_ingress_nginx_controller_eol = Fact(
         WITH pod
         MATCH (pod)-[:CONTAINS]->(container:KubernetesContainer)
         RETURN container
-    }}
+    }
     WITH DISTINCT resource_path, cluster, pod, container
     OPTIONAL MATCH workload_parent_path=(container)-[:WORKLOAD_PARENT]->(pod)
     OPTIONAL MATCH legacy_contains_path=(pod)-[:CONTAINS]->(container)
@@ -435,13 +431,12 @@ _kubernetes_ingress_nginx_controller_eol = Fact(
              AND labels_compacted CONTAINS '"app.kubernetes.io/component":"controller"'
              AS has_controller_labels,
          image CONTAINS '/ingress-nginx/controller:' AS has_controller_image
-    WHERE date() > date('{_INGRESS_NGINX_EOL_DATE}')
-      AND (has_controller_labels OR has_controller_image)
+    WHERE has_controller_labels OR has_controller_image
     RETURN cluster, pod, container, resource_path, controller_path
     """,
-    cypher_count_query=f"""
+    cypher_count_query="""
     MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
-    CALL {{
+    CALL {
         WITH pod
         MATCH (container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod)
         RETURN container
@@ -449,7 +444,7 @@ _kubernetes_ingress_nginx_controller_eol = Fact(
         WITH pod
         MATCH (pod)-[:CONTAINS]->(container:KubernetesContainer)
         RETURN container
-    }}
+    }
     WITH DISTINCT cluster, pod, container
     WITH cluster, pod, container,
          replace(toLower(coalesce(pod.labels, '')), ' ', '') AS labels_compacted,
@@ -459,8 +454,7 @@ _kubernetes_ingress_nginx_controller_eol = Fact(
              AND labels_compacted CONTAINS '"app.kubernetes.io/component":"controller"'
              AS has_controller_labels,
          image CONTAINS '/ingress-nginx/controller:' AS has_controller_image
-    WHERE date() > date('{_INGRESS_NGINX_EOL_DATE}')
-      AND (has_controller_labels OR has_controller_image)
+    WHERE has_controller_labels OR has_controller_image
     WITH cluster, pod, container, labels_compacted, image,
          CASE
              WHEN labels_compacted CONTAINS '"app.kubernetes.io/instance":"'

--- a/tests/integration/rules/test_eol_software.py
+++ b/tests/integration/rules/test_eol_software.py
@@ -220,7 +220,7 @@ def test_ingress_nginx_fact_collapses_controller_replicas(neo4j_session) -> None
     # Act
     findings = neo4j_session.execute_read(
         read_list_of_dicts_tx,
-        _build_kubernetes_ingress_nginx_eol_query("date('2026-03-25')"),
+        _build_kubernetes_ingress_nginx_eol_query(),
     )
 
     # Assert
@@ -238,21 +238,6 @@ def test_ingress_nginx_fact_collapses_controller_replicas(neo4j_session) -> None
             "support_status": "eol",
         }
     ]
-
-
-def test_ingress_nginx_fact_ignores_controllers_before_eol(neo4j_session) -> None:
-    # Arrange
-    _reset_graph(neo4j_session)
-    _seed_ingress_nginx_controller_graph(neo4j_session)
-
-    # Act
-    findings = neo4j_session.execute_read(
-        read_list_of_dicts_tx,
-        _build_kubernetes_ingress_nginx_eol_query("date('2026-03-23')"),
-    )
-
-    # Assert
-    assert findings == []
 
 
 def test_ingress_nginx_fact_ignores_non_controller_images(neo4j_session) -> None:
@@ -303,7 +288,7 @@ def test_ingress_nginx_fact_ignores_non_controller_images(neo4j_session) -> None
     # Act
     findings = neo4j_session.execute_read(
         read_list_of_dicts_tx,
-        _build_kubernetes_ingress_nginx_eol_query("date('2026-03-25')"),
+        _build_kubernetes_ingress_nginx_eol_query(),
     )
 
     # Assert

--- a/tests/integration/rules/test_eol_software.py
+++ b/tests/integration/rules/test_eol_software.py
@@ -333,6 +333,7 @@ def test_ingress_nginx_visual_query_returns_controller_context(
     assert record["container"]["image"].startswith(
         "registry.k8s.io/ingress-nginx/controller:v1.12.0",
     )
+    assert record["resource_path"] is not None
     assert record["controller_path"] is not None
 
 

--- a/tests/integration/rules/test_eol_software.py
+++ b/tests/integration/rules/test_eol_software.py
@@ -54,6 +54,7 @@ def _seed_ingress_nginx_controller_graph(neo4j_session) -> None:
         CREATE (cluster)-[:RESOURCE]->(pod_1)
         CREATE (cluster)-[:RESOURCE]->(pod_2)
         CREATE (container_1)-[:WORKLOAD_PARENT]->(pod_1)
+        CREATE (pod_1)-[:CONTAINS]->(container_1)
         CREATE (pod_2)-[:CONTAINS]->(container_2)
         """
     )
@@ -325,6 +326,7 @@ def test_ingress_nginx_visual_query_returns_controller_context(
 
     # Assert
     assert records
+    assert len(records) == 2
     record = records[0]
     assert record["cluster"]["name"] == "cluster-1"
     assert record["pod"]["namespace"] == "ingress-nginx"

--- a/tests/integration/rules/test_eol_software.py
+++ b/tests/integration/rules/test_eol_software.py
@@ -54,7 +54,7 @@ def _seed_ingress_nginx_controller_graph(neo4j_session) -> None:
         CREATE (cluster)-[:RESOURCE]->(pod_1)
         CREATE (cluster)-[:RESOURCE]->(pod_2)
         CREATE (container_1)-[:WORKLOAD_PARENT]->(pod_1)
-        CREATE (container_2)-[:WORKLOAD_PARENT]->(pod_2)
+        CREATE (pod_2)-[:CONTAINS]->(container_2)
         """
     )
     result.consume()

--- a/tests/integration/rules/test_eol_software.py
+++ b/tests/integration/rules/test_eol_software.py
@@ -2,6 +2,9 @@ from cartography.client.core.tx import read_list_of_dicts_tx
 from cartography.rules.data.rules.eol_software import (
     _build_ec2_instance_amazon_linux_2_eol_query,
 )
+from cartography.rules.data.rules.eol_software import (
+    _build_kubernetes_ingress_nginx_eol_query,
+)
 from cartography.rules.data.rules.eol_software import eol_software
 
 
@@ -11,6 +14,50 @@ def _reset_graph(neo4j_session) -> None:
 
 def _get_fact(fact_id: str):
     return next(fact for fact in eol_software.facts if fact.id == fact_id)
+
+
+def _seed_ingress_nginx_controller_graph(neo4j_session) -> None:
+    result = neo4j_session.run(
+        """
+        CREATE (cluster:KubernetesCluster {
+            id: 'cluster-1',
+            name: 'cluster-1'
+        })
+        CREATE (pod_1:KubernetesPod {
+            id: 'pod-controller-1',
+            name: 'ingress-nginx-controller-abcde',
+            namespace: 'ingress-nginx',
+            cluster_name: 'cluster-1',
+            labels: '{"app.kubernetes.io/name":"ingress-nginx","app.kubernetes.io/component":"controller","app.kubernetes.io/instance":"ingress-nginx","app.kubernetes.io/version":"1.12.0","helm.sh/chart":"ingress-nginx-4.12.0"}'
+        })
+        CREATE (pod_2:KubernetesPod {
+            id: 'pod-controller-2',
+            name: 'ingress-nginx-controller-fghij',
+            namespace: 'ingress-nginx',
+            cluster_name: 'cluster-1',
+            labels: '{"app.kubernetes.io/name":"ingress-nginx","app.kubernetes.io/component":"controller","app.kubernetes.io/instance":"ingress-nginx","app.kubernetes.io/version":"1.12.0","helm.sh/chart":"ingress-nginx-4.12.0"}'
+        })
+        CREATE (container_1:KubernetesContainer {
+            id: 'container-controller-1',
+            name: 'controller',
+            namespace: 'ingress-nginx',
+            cluster_name: 'cluster-1',
+            image: 'registry.k8s.io/ingress-nginx/controller:v1.12.0@sha256:abc'
+        })
+        CREATE (container_2:KubernetesContainer {
+            id: 'container-controller-2',
+            name: 'controller',
+            namespace: 'ingress-nginx',
+            cluster_name: 'cluster-1',
+            image: 'registry.k8s.io/ingress-nginx/controller:v1.12.0@sha256:def'
+        })
+        CREATE (cluster)-[:RESOURCE]->(pod_1)
+        CREATE (cluster)-[:RESOURCE]->(pod_2)
+        CREATE (container_1)-[:WORKLOAD_PARENT]->(pod_1)
+        CREATE (container_2)-[:WORKLOAD_PARENT]->(pod_2)
+        """
+    )
+    result.consume()
 
 
 def test_eks_fact_returns_provider_lifecycle_finding(neo4j_session) -> None:
@@ -162,6 +209,129 @@ def test_kubernetes_visual_query_returns_workload_context(neo4j_session) -> None
     assert record["cluster"]["name"] == "kube-1"
     assert record["workload_path"] is not None
     assert record["resource_path"] is not None
+
+
+def test_ingress_nginx_fact_collapses_controller_replicas(neo4j_session) -> None:
+    # Arrange
+    _reset_graph(neo4j_session)
+    _seed_ingress_nginx_controller_graph(neo4j_session)
+
+    # Act
+    findings = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        _build_kubernetes_ingress_nginx_eol_query("date('2026-03-25')"),
+    )
+
+    # Assert
+    assert findings == [
+        {
+            "asset_id": "cluster-1/namespaces/ingress-nginx/ingress-controllers/ingress-nginx/1.12.0",
+            "asset_name": "cluster-1/ingress-nginx/ingress-nginx",
+            "asset_type": "KubernetesIngressController",
+            "software_name": "ingress-nginx",
+            "software_version": "1.12.0",
+            "software_major": 1,
+            "software_minor": 12,
+            "location": None,
+            "support_basis": "upstream",
+            "support_status": "eol",
+        }
+    ]
+
+
+def test_ingress_nginx_fact_ignores_controllers_before_eol(neo4j_session) -> None:
+    # Arrange
+    _reset_graph(neo4j_session)
+    _seed_ingress_nginx_controller_graph(neo4j_session)
+
+    # Act
+    findings = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        _build_kubernetes_ingress_nginx_eol_query("date('2026-03-23')"),
+    )
+
+    # Assert
+    assert findings == []
+
+
+def test_ingress_nginx_fact_ignores_non_controller_images(neo4j_session) -> None:
+    # Arrange
+    _reset_graph(neo4j_session)
+    result = neo4j_session.run(
+        """
+        CREATE (cluster:KubernetesCluster {
+            id: 'cluster-1',
+            name: 'cluster-1'
+        })
+        CREATE (admission_pod:KubernetesPod {
+            id: 'pod-admission',
+            name: 'ingress-nginx-admission-create',
+            namespace: 'ingress-nginx',
+            cluster_name: 'cluster-1',
+            labels: '{"app.kubernetes.io/name":"ingress-nginx","app.kubernetes.io/component":"admission-webhook","app.kubernetes.io/instance":"ingress-nginx"}'
+        })
+        CREATE (nginx_pod:KubernetesPod {
+            id: 'pod-nginx',
+            name: 'nginx',
+            namespace: 'default',
+            cluster_name: 'cluster-1',
+            labels: '{"app.kubernetes.io/name":"nginx","app.kubernetes.io/component":"server"}'
+        })
+        CREATE (admission_container:KubernetesContainer {
+            id: 'container-admission',
+            name: 'create',
+            namespace: 'ingress-nginx',
+            cluster_name: 'cluster-1',
+            image: 'registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.5.2'
+        })
+        CREATE (nginx_container:KubernetesContainer {
+            id: 'container-nginx',
+            name: 'nginx',
+            namespace: 'default',
+            cluster_name: 'cluster-1',
+            image: 'docker.io/library/nginx:1.25'
+        })
+        CREATE (cluster)-[:RESOURCE]->(admission_pod)
+        CREATE (cluster)-[:RESOURCE]->(nginx_pod)
+        CREATE (admission_container)-[:WORKLOAD_PARENT]->(admission_pod)
+        CREATE (nginx_container)-[:WORKLOAD_PARENT]->(nginx_pod)
+        """
+    )
+    result.consume()
+
+    # Act
+    findings = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        _build_kubernetes_ingress_nginx_eol_query("date('2026-03-25')"),
+    )
+
+    # Assert
+    assert findings == []
+
+
+def test_ingress_nginx_visual_query_returns_controller_context(
+    neo4j_session,
+) -> None:
+    # Arrange
+    _reset_graph(neo4j_session)
+    _seed_ingress_nginx_controller_graph(neo4j_session)
+
+    # Act
+    records = list(
+        neo4j_session.run(
+            _get_fact("kubernetes_ingress_nginx_controller_eol").cypher_visual_query,
+        )
+    )
+
+    # Assert
+    assert records
+    record = records[0]
+    assert record["cluster"]["name"] == "cluster-1"
+    assert record["pod"]["namespace"] == "ingress-nginx"
+    assert record["container"]["image"].startswith(
+        "registry.k8s.io/ingress-nginx/controller:v1.12.0",
+    )
+    assert record["controller_path"] is not None
 
 
 def test_ec2_fact_flags_amazon_linux_2_after_eol(neo4j_session) -> None:

--- a/tests/unit/rules/test_eol_software.py
+++ b/tests/unit/rules/test_eol_software.py
@@ -48,7 +48,7 @@ def test_aks_fact_flags_kubernetes_1_32_standard_support() -> None:
     assert "kubernetes_minor < 33" in fact.cypher_query
 
 
-def test_ingress_nginx_fact_uses_retirement_date() -> None:
+def test_ingress_nginx_fact_is_kubernetes_experimental() -> None:
     fact = next(
         f
         for f in eol_software.facts
@@ -56,5 +56,4 @@ def test_ingress_nginx_fact_uses_retirement_date() -> None:
     )
 
     assert fact.maturity == Maturity.EXPERIMENTAL
-    assert "2026-03-24" in fact.cypher_query
     assert fact.module == Module.KUBERNETES

--- a/tests/unit/rules/test_eol_software.py
+++ b/tests/unit/rules/test_eol_software.py
@@ -10,7 +10,7 @@ def test_eol_software_rule_registered() -> None:
 
 def test_eol_software_rule_shape() -> None:
     assert eol_software.name == "End-of-Life Software"
-    assert len(eol_software.facts) == 5
+    assert len(eol_software.facts) == 6
     assert len(eol_software.references) >= 5
 
 
@@ -46,3 +46,15 @@ def test_aks_fact_flags_kubernetes_1_32_standard_support() -> None:
         f for f in eol_software.facts if f.id == "aks_cluster_kubernetes_version_eol"
     )
     assert "kubernetes_minor < 33" in fact.cypher_query
+
+
+def test_ingress_nginx_fact_uses_retirement_date() -> None:
+    fact = next(
+        f
+        for f in eol_software.facts
+        if f.id == "kubernetes_ingress_nginx_controller_eol"
+    )
+
+    assert fact.maturity == Maturity.EXPERIMENTAL
+    assert "2026-03-24" in fact.cypher_query
+    assert fact.module == Module.KUBERNETES


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary
Adds an experimental `eol_software` fact for deployed Kubernetes ingress-nginx controller workloads now that the upstream project has been retired.

The Kubernetes project announced that ingress-nginx would be retired in March 2026, with no further releases, bug fixes, or security updates after retirement. Cartography already stores Kubernetes pod labels, container images, and pod/container/cluster relationships, so this rule can surface deployed ingress-nginx controllers as end-of-life software without adding new synced entities.


### Related issues or links
- https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/
- https://kubernetes.io/blog/2026/01/29/ingress-nginx-statement/
- https://github.com/kubernetes/ingress-nginx


### Breaking changes
None.


### How was this tested?
- `uv run pytest tests/unit/rules/test_eol_software.py tests/integration/rules/test_eol_software.py -v`
- `make test_lint`


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Not applicable; this PR only adds a rule fact and does not add or modify synced entities.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules). Not applicable; this PR does not add or modify graph schema.
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md). Not applicable; this PR does not add or modify graph schema.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node). Not applicable; this PR does not add a new intel module.


### Notes for reviewers
The fact matches controller workloads using ingress-nginx pod labels or the official controller image path, then groups by cluster, namespace, controller instance, and controller version so replicated controllers produce one finding per deployed controller version.
