### PR TITLE
fix(aws): skip org cleanup when account state is unavailable

### DIFF
--- a/cartography/intel/aws/organizations.py
+++ b/cartography/intel/aws/organizations.py
@@ -148,6 +148,10 @@ def _get_account_state(account: dict[str, Any]) -> str | None:
     return account.get("State") or account.get("Status")
 
 
+def _has_account_state_signal(account: dict[str, Any]) -> bool:
+    return _get_account_state(account) is not None
+
+
 def _is_active_account(account: dict[str, Any]) -> bool:
     return _get_account_state(account) == "ACTIVE"
 
@@ -644,6 +648,17 @@ def sync_aws_organization(
             exc_info=True,
         )
         return result
+
+    if not all(_has_account_state_signal(account) for account in raw_accounts):
+        logger.warning(
+            "Unable to determine state for all accounts in AWS Organization %s; skipping AWS Organizations sync.",
+            organization_id,
+        )
+        return AWSOrganizationSyncResult(
+            current_aws_account_id,
+            AWSOrganizationSyncStatus.INCOMPLETE,
+            organization_id=organization_id,
+        )
 
     organization_accounts = transform_aws_organization_accounts(
         raw_accounts,

--- a/tests/unit/cartography/intel/aws/test_organizations.py
+++ b/tests/unit/cartography/intel/aws/test_organizations.py
@@ -394,3 +394,50 @@ def test_sync_aws_organization_returns_incomplete_result_for_hierarchy_error():
     assert result.status == AWSOrganizationSyncStatus.INCOMPLETE
     assert result.organization_id == "o-exampleorgid"
     assert result.error_code == "ThrottlingException"
+
+
+def test_sync_aws_organization_returns_incomplete_when_account_state_is_unknown():
+    # Arrange
+    class FakeClient:
+        def describe_organization(self):
+            return {"Organization": TEST_ORGANIZATION}
+
+    account_without_state_or_status = {
+        key: value
+        for key, value in TEST_ORGANIZATION_ACCOUNTS[0].items()
+        if key not in {"State", "Status"}
+    }
+
+    with (
+        mock.patch.object(
+            cartography.intel.aws.organizations,
+            "get_aws_organization_hierarchy",
+            return_value=(
+                [TEST_ORGANIZATION_ROOTS[0]],
+                [],
+                [account_without_state_or_status],
+            ),
+        ),
+        mock.patch.object(
+            cartography.intel.aws.organizations,
+            "load_aws_account_nodes_from_organization",
+        ) as mock_load_accounts,
+        mock.patch.object(
+            cartography.intel.aws.organizations,
+            "cleanup_aws_organization_hierarchy",
+        ) as mock_cleanup,
+    ):
+        # Act
+        result = cartography.intel.aws.organizations.sync_aws_organization(
+            mock.Mock(),
+            FakeClient(),
+            "111111111111",
+            1,
+            {"UPDATE_TAG": 1},
+        )
+
+    # Assert
+    assert result.status == AWSOrganizationSyncStatus.INCOMPLETE
+    assert result.organization_id == "o-exampleorgid"
+    mock_load_accounts.assert_not_called()
+    mock_cleanup.assert_not_called()


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary

AWS Organizations cleanup should only run after Cartography can determine current account placement safely. This adds a defensive check that treats a hierarchy response as incomplete if an account has neither the current `State` field nor the legacy `Status` field.

That prevents stale SDK/service-model combinations from turning unknown account state into destructive hierarchy cleanup.


### Related issues or links

- Follow-up to #2780


### Breaking changes

None.


### How was this tested?

- Added basic tests to catch this case


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

This does not move cleanup into an analysis job. The guard stays in the Organizations sync path so cleanup remains coupled to complete, trustworthy hierarchy enumeration.
