### PR TITLE
[codex] Add compound risk security rules

### DIFF
--- a/cartography/rules/data/rules/__init__.py
+++ b/cartography/rules/data/rules/__init__.py
@@ -203,6 +203,9 @@ from cartography.rules.data.rules.device_security_posture_gaps import (
     device_security_posture_gaps,
 )
 from cartography.rules.data.rules.eol_software import eol_software
+from cartography.rules.data.rules.github_actions_privileged_pull_request import (
+    github_actions_privileged_pull_request,
+)
 from cartography.rules.data.rules.guardduty_active_threat import guardduty_active_threat
 from cartography.rules.data.rules.identity_administration_privileges import (
     identity_administration_privileges,
@@ -210,6 +213,9 @@ from cartography.rules.data.rules.identity_administration_privileges import (
 from cartography.rules.data.rules.identity_mfa_gaps import identity_mfa_gaps
 from cartography.rules.data.rules.inactive_user_active_accounts import (
     inactive_user_active_accounts,
+)
+from cartography.rules.data.rules.internet_exposed_database_without_backups import (
+    internet_exposed_database_without_backups,
 )
 from cartography.rules.data.rules.kubernetes_control_plane_exposed import (
     kubernetes_control_plane_exposed,
@@ -229,6 +235,15 @@ from cartography.rules.data.rules.nist_ai_rmf import (
 from cartography.rules.data.rules.object_storage_public import object_storage_public
 from cartography.rules.data.rules.policy_administration_privileges import (
     policy_administration_privileges,
+)
+from cartography.rules.data.rules.privileged_kubernetes_workload_cloud_identity import (
+    privileged_kubernetes_workload_cloud_identity,
+)
+from cartography.rules.data.rules.public_database_snapshot import (
+    public_database_snapshot,
+)
+from cartography.rules.data.rules.public_object_storage_without_recovery import (
+    public_object_storage_without_recovery,
 )
 from cartography.rules.data.rules.serverless_workload_exposed import (
     serverless_workload_exposed,
@@ -301,10 +316,14 @@ RULES = {
     identity_administration_privileges.id: identity_administration_privileges,
     identity_mfa_gaps.id: identity_mfa_gaps,
     inactive_user_active_accounts.id: inactive_user_active_accounts,
+    internet_exposed_database_without_backups.id: internet_exposed_database_without_backups,
     kubernetes_control_plane_exposed.id: kubernetes_control_plane_exposed,
     missing_mfa_rule.id: missing_mfa_rule,
     object_storage_public.id: object_storage_public,
     policy_administration_privileges.id: policy_administration_privileges,
+    privileged_kubernetes_workload_cloud_identity.id: privileged_kubernetes_workload_cloud_identity,
+    public_database_snapshot.id: public_database_snapshot,
+    public_object_storage_without_recovery.id: public_object_storage_without_recovery,
     tailscale_tailnet_approval_disabled.id: tailscale_tailnet_approval_disabled,
     tailscale_network_flow_logging_disabled.id: tailscale_network_flow_logging_disabled,
     tailscale_device_auto_updates_disabled.id: tailscale_device_auto_updates_disabled,
@@ -313,6 +332,7 @@ RULES = {
     unmanaged_accounts.id: unmanaged_accounts,
     workload_identity_admin_capabilities.id: workload_identity_admin_capabilities,
     cloud_security_product_deactivated.id: cloud_security_product_deactivated,
+    github_actions_privileged_pull_request.id: github_actions_privileged_pull_request,
     guardduty_active_threat.id: guardduty_active_threat,
     malicious_npm_dependencies_shai_hulud.id: malicious_npm_dependencies_shai_hulud,
     unpinned_github_actions.id: unpinned_github_actions,

--- a/cartography/rules/data/rules/github_actions_privileged_pull_request.py
+++ b/cartography/rules/data/rules/github_actions_privileged_pull_request.py
@@ -67,7 +67,6 @@ _github_public_pull_request_target_write_token = Fact(
     MATCH (repo:GitHubRepository)-[:HAS_WORKFLOW]->(workflow:GitHubWorkflow)
     WHERE coalesce(repo.private, false) = false
       AND coalesce(repo.archived, false) = false
-      AND 'pull_request_target' IN coalesce(workflow.trigger_events, [])
     RETURN COUNT(workflow) AS count
     """,
     asset_id_field="workflow_id",

--- a/cartography/rules/data/rules/github_actions_privileged_pull_request.py
+++ b/cartography/rules/data/rules/github_actions_privileged_pull_request.py
@@ -1,0 +1,124 @@
+from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
+from cartography.rules.spec.model import Fact
+from cartography.rules.spec.model import Finding
+from cartography.rules.spec.model import Maturity
+from cartography.rules.spec.model import Module
+from cartography.rules.spec.model import Rule
+from cartography.rules.spec.model import RuleReference
+
+_github_public_pull_request_target_write_token = Fact(
+    id="github_public_pull_request_target_write_token",
+    name="Public GitHub workflows using pull_request_target with write token scopes",
+    description=(
+        "Public repositories whose GitHub Actions workflows run on "
+        "pull_request_target and explicitly request write-capable GITHUB_TOKEN "
+        "permissions."
+    ),
+    cypher_query="""
+    MATCH (repo:GitHubRepository)-[:HAS_WORKFLOW]->(workflow:GitHubWorkflow)
+    WHERE coalesce(repo.private, false) = false
+      AND coalesce(repo.archived, false) = false
+      AND 'pull_request_target' IN coalesce(workflow.trigger_events, [])
+    WITH repo, workflow,
+         [scope IN [
+             CASE WHEN workflow.permissions_actions = 'write' THEN 'actions' ELSE null END,
+             CASE WHEN workflow.permissions_contents = 'write' THEN 'contents' ELSE null END,
+             CASE WHEN workflow.permissions_packages = 'write' THEN 'packages' ELSE null END,
+             CASE WHEN workflow.permissions_pull_requests = 'write' THEN 'pull_requests' ELSE null END,
+             CASE WHEN workflow.permissions_issues = 'write' THEN 'issues' ELSE null END,
+             CASE WHEN workflow.permissions_deployments = 'write' THEN 'deployments' ELSE null END,
+             CASE WHEN workflow.permissions_statuses = 'write' THEN 'statuses' ELSE null END,
+             CASE WHEN workflow.permissions_checks = 'write' THEN 'checks' ELSE null END,
+             CASE WHEN workflow.permissions_id_token = 'write' THEN 'id_token' ELSE null END,
+             CASE WHEN workflow.permissions_security_events = 'write' THEN 'security_events' ELSE null END
+         ] WHERE scope IS NOT NULL] AS write_scopes
+    WHERE size(write_scopes) > 0
+    RETURN
+        repo.id AS repo_id,
+        repo.fullname AS repo,
+        repo.defaultbranch AS default_branch,
+        workflow.id AS workflow_id,
+        workflow.name AS workflow_name,
+        workflow.path AS workflow_path,
+        workflow.trigger_events AS trigger_events,
+        write_scopes
+    ORDER BY repo, workflow_path
+    """,
+    cypher_visual_query="""
+    MATCH p=(repo:GitHubRepository)-[:HAS_WORKFLOW]->(workflow:GitHubWorkflow)
+    WHERE coalesce(repo.private, false) = false
+      AND coalesce(repo.archived, false) = false
+      AND 'pull_request_target' IN coalesce(workflow.trigger_events, [])
+      AND (
+          workflow.permissions_actions = 'write'
+          OR workflow.permissions_contents = 'write'
+          OR workflow.permissions_packages = 'write'
+          OR workflow.permissions_pull_requests = 'write'
+          OR workflow.permissions_issues = 'write'
+          OR workflow.permissions_deployments = 'write'
+          OR workflow.permissions_statuses = 'write'
+          OR workflow.permissions_checks = 'write'
+          OR workflow.permissions_id_token = 'write'
+          OR workflow.permissions_security_events = 'write'
+      )
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (repo:GitHubRepository)-[:HAS_WORKFLOW]->(workflow:GitHubWorkflow)
+    WHERE coalesce(repo.private, false) = false
+      AND coalesce(repo.archived, false) = false
+      AND 'pull_request_target' IN coalesce(workflow.trigger_events, [])
+    RETURN COUNT(workflow) AS count
+    """,
+    asset_id_field="workflow_id",
+    module=Module.GITHUB,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+class GitHubActionsPrivilegedPullRequest(Finding):
+    repo_id: str | None = None
+    repo: str | None = None
+    default_branch: str | None = None
+    workflow_id: str | None = None
+    workflow_name: str | None = None
+    workflow_path: str | None = None
+    trigger_events: list[str] | None = None
+    write_scopes: list[str] | None = None
+
+
+github_actions_privileged_pull_request = Rule(
+    id="github_actions_privileged_pull_request",
+    name="GitHub Actions pull_request_target With Write Token",
+    description=(
+        "Public repositories with pull_request_target workflows that request "
+        "write-capable token scopes. This is a supply-chain trust boundary: "
+        "untrusted pull request content can influence a workflow running in "
+        "the base repository security context if the workflow is unsafe."
+    ),
+    output_model=GitHubActionsPrivilegedPullRequest,
+    facts=(_github_public_pull_request_target_write_token,),
+    tags=(
+        "supply_chain",
+        "github",
+        "ci_cd",
+        "stride:tampering",
+        "stride:elevation_of_privilege",
+    ),
+    version="0.1.0",
+    references=[
+        RuleReference(
+            text="GitHub - Security hardening for GitHub Actions",
+            url="https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions",
+        ),
+        RuleReference(
+            text="GitHub - Automatic token authentication",
+            url="https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication",
+        ),
+    ],
+    frameworks=(
+        iso27001_annex_a("8.25"),
+        iso27001_annex_a("8.28"),
+        iso27001_annex_a("8.32"),
+    ),
+)

--- a/cartography/rules/data/rules/internet_exposed_database_without_backups.py
+++ b/cartography/rules/data/rules/internet_exposed_database_without_backups.py
@@ -1,0 +1,167 @@
+from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
+from cartography.rules.spec.model import Fact
+from cartography.rules.spec.model import Finding
+from cartography.rules.spec.model import Maturity
+from cartography.rules.spec.model import Module
+from cartography.rules.spec.model import Rule
+
+_aws_public_rds_without_backups = Fact(
+    id="aws_public_rds_without_backups",
+    name="Internet-exposed RDS instances without backups",
+    description=(
+        "RDS instances that are publicly reachable through a 0.0.0.0/0 "
+        "security-group path and have automated backup retention disabled."
+    ),
+    cypher_query="""
+    MATCH (account:AWSAccount)-[:RESOURCE]->(rds:RDSInstance {publicly_accessible: true})
+    WHERE rds.endpoint_port IS NOT NULL
+      AND coalesce(rds.backup_retention_period, 0) = 0
+    MATCH (rds)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)
+        <-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound)
+    MATCH (rule)<-[:MEMBER_OF_IP_RULE]-(:AWSIpRange {range: '0.0.0.0/0'})
+    WHERE coalesce(rule.protocol, '') IN ['tcp', '-1', 'all']
+      AND (
+        rule.fromport IS NULL
+        OR (
+          coalesce(rule.fromport, 0) <= rds.endpoint_port
+          AND coalesce(rule.toport, rule.fromport, 0) >= rds.endpoint_port
+        )
+      )
+    RETURN DISTINCT
+        rds.id AS id,
+        rds.db_instance_identifier AS name,
+        account.name AS account,
+        account.id AS account_id,
+        rds.region AS region,
+        'aws' AS provider,
+        rds.engine AS engine,
+        rds.endpoint_address AS host,
+        rds.endpoint_port AS port,
+        rds.backup_retention_period AS backup_retention_days,
+        rds.deletion_protection AS deletion_protection
+    ORDER BY account, region, name
+    """,
+    cypher_visual_query="""
+    MATCH p1=(account:AWSAccount)-[:RESOURCE]->(rds:RDSInstance {publicly_accessible: true})
+    MATCH p2=(rds)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)
+        <-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound)
+    MATCH p3=(rule)<-[:MEMBER_OF_IP_RULE]-(:AWSIpRange {range: '0.0.0.0/0'})
+    WHERE rds.endpoint_port IS NOT NULL
+      AND coalesce(rds.backup_retention_period, 0) = 0
+      AND coalesce(rule.protocol, '') IN ['tcp', '-1', 'all']
+      AND (
+        rule.fromport IS NULL
+        OR (
+          coalesce(rule.fromport, 0) <= rds.endpoint_port
+          AND coalesce(rule.toport, rule.fromport, 0) >= rds.endpoint_port
+        )
+      )
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (rds:RDSInstance {publicly_accessible: true})
+    WHERE rds.endpoint_port IS NOT NULL
+    MATCH (rds)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)
+        <-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound)
+    MATCH (rule)<-[:MEMBER_OF_IP_RULE]-(:AWSIpRange {range: '0.0.0.0/0'})
+    WHERE coalesce(rule.protocol, '') IN ['tcp', '-1', 'all']
+      AND (
+        rule.fromport IS NULL
+        OR (
+          coalesce(rule.fromport, 0) <= rds.endpoint_port
+          AND coalesce(rule.toport, rule.fromport, 0) >= rds.endpoint_port
+        )
+      )
+    RETURN COUNT(DISTINCT rds) AS count
+    """,
+    asset_id_field="id",
+    module=Module.AWS,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+_gcp_public_cloudsql_without_backups = Fact(
+    id="gcp_public_cloudsql_without_backups",
+    name="Internet-exposed Cloud SQL instances without backups",
+    description=(
+        "Cloud SQL instances that allow inbound connections from 0.0.0.0/0 "
+        "and have automated backups disabled."
+    ),
+    cypher_query="""
+    MATCH (project:GCPProject)-[:RESOURCE]->(sql:GCPCloudSQLInstance)
+    MATCH (sql)-[:AUTHORIZED_NETWORK]-(net:GCPCloudSQLAuthorizedNetwork)
+    WHERE net.value = '0.0.0.0/0'
+      AND coalesce(sql.backup_enabled, false) = false
+    RETURN DISTINCT
+        sql.id AS id,
+        sql.name AS name,
+        project.id AS account,
+        project.id AS account_id,
+        sql.region AS region,
+        'gcp' AS provider,
+        sql.database_version AS engine,
+        sql.connection_name AS host,
+        null AS port,
+        0 AS backup_retention_days,
+        null AS deletion_protection
+    ORDER BY account, region, name
+    """,
+    cypher_visual_query="""
+    MATCH p=(project:GCPProject)-[:RESOURCE]->(sql:GCPCloudSQLInstance)
+          -[:AUTHORIZED_NETWORK]-(net:GCPCloudSQLAuthorizedNetwork)
+    WHERE net.value = '0.0.0.0/0'
+      AND coalesce(sql.backup_enabled, false) = false
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (sql:GCPCloudSQLInstance)-[:AUTHORIZED_NETWORK]-(net:GCPCloudSQLAuthorizedNetwork)
+    WHERE net.value = '0.0.0.0/0'
+    RETURN COUNT(DISTINCT sql) AS count
+    """,
+    asset_id_field="id",
+    module=Module.GCP,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+class InternetExposedDatabaseWithoutBackups(Finding):
+    id: str | None = None
+    name: str | None = None
+    account: str | None = None
+    account_id: str | None = None
+    region: str | None = None
+    provider: str | None = None
+    engine: str | None = None
+    host: str | None = None
+    port: int | None = None
+    backup_retention_days: int | None = None
+    deletion_protection: bool | None = None
+
+
+internet_exposed_database_without_backups = Rule(
+    id="internet_exposed_database_without_backups",
+    name="Internet-Exposed Databases Without Backups",
+    description=(
+        "Databases reachable from the public internet where the graph also "
+        "shows automated backups are disabled. This combines exposure with "
+        "recovery blast radius rather than reporting backup posture alone."
+    ),
+    output_model=InternetExposedDatabaseWithoutBackups,
+    facts=(
+        _aws_public_rds_without_backups,
+        _gcp_public_cloudsql_without_backups,
+    ),
+    tags=(
+        "data",
+        "database",
+        "attack_surface",
+        "resilience",
+        "stride:information_disclosure",
+        "stride:tampering",
+    ),
+    version="0.1.0",
+    frameworks=(
+        iso27001_annex_a("8.13"),
+        iso27001_annex_a("8.14"),
+        iso27001_annex_a("8.20"),
+    ),
+)

--- a/cartography/rules/data/rules/internet_exposed_database_without_backups.py
+++ b/cartography/rules/data/rules/internet_exposed_database_without_backups.py
@@ -59,20 +59,8 @@ _aws_public_rds_without_backups = Fact(
     RETURN *
     """,
     cypher_count_query="""
-    MATCH (rds:RDSInstance {publicly_accessible: true})
-    WHERE rds.endpoint_port IS NOT NULL
-    MATCH (rds)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg:EC2SecurityGroup)
-        <-[:MEMBER_OF_EC2_SECURITY_GROUP]-(rule:AWSIpPermissionInbound)
-    MATCH (rule)<-[:MEMBER_OF_IP_RULE]-(:AWSIpRange {range: '0.0.0.0/0'})
-    WHERE coalesce(rule.protocol, '') IN ['tcp', '-1', 'all']
-      AND (
-        rule.fromport IS NULL
-        OR (
-          coalesce(rule.fromport, 0) <= rds.endpoint_port
-          AND coalesce(rule.toport, rule.fromport, 0) >= rds.endpoint_port
-        )
-      )
-    RETURN COUNT(DISTINCT rds) AS count
+    MATCH (rds:RDSInstance)
+    RETURN COUNT(rds) AS count
     """,
     asset_id_field="id",
     module=Module.AWS,
@@ -101,7 +89,7 @@ _gcp_public_cloudsql_without_backups = Fact(
         sql.database_version AS engine,
         sql.connection_name AS host,
         null AS port,
-        0 AS backup_retention_days,
+        null AS backup_retention_days,
         null AS deletion_protection
     ORDER BY account, region, name
     """,
@@ -113,9 +101,8 @@ _gcp_public_cloudsql_without_backups = Fact(
     RETURN *
     """,
     cypher_count_query="""
-    MATCH (sql:GCPCloudSQLInstance)-[:AUTHORIZED_NETWORK]-(net:GCPCloudSQLAuthorizedNetwork)
-    WHERE net.value = '0.0.0.0/0'
-    RETURN COUNT(DISTINCT sql) AS count
+    MATCH (sql:GCPCloudSQLInstance)
+    RETURN COUNT(sql) AS count
     """,
     asset_id_field="id",
     module=Module.GCP,

--- a/cartography/rules/data/rules/privileged_kubernetes_workload_cloud_identity.py
+++ b/cartography/rules/data/rules/privileged_kubernetes_workload_cloud_identity.py
@@ -68,10 +68,9 @@ _k8s_privileged_workloads_with_aws_identity = Fact(
     RETURN *
     """,
     cypher_count_query="""
-    MATCH (pod:KubernetesPod)-[:USES_SERVICE_ACCOUNT]->(:KubernetesServiceAccount)
-          -[:ASSUMES_ROLE]->(:AWSRole)
+    MATCH (pod:KubernetesPod)
     WHERE NOT pod.namespace IN ['kube-system', 'kube-public', 'kube-node-lease']
-    RETURN COUNT(DISTINCT pod) AS count
+    RETURN COUNT(pod) AS count
     """,
     asset_id_field="pod_id",
     module=Module.KUBERNETES,
@@ -141,10 +140,9 @@ _k8s_privileged_workloads_with_gcp_identity = Fact(
     RETURN *
     """,
     cypher_count_query="""
-    MATCH (pod:KubernetesPod)-[:USES_SERVICE_ACCOUNT]->(:KubernetesServiceAccount)
-          -[:WORKLOAD_IDENTITY_BINDING]->(:GCPServiceAccount)
+    MATCH (pod:KubernetesPod)
     WHERE NOT pod.namespace IN ['kube-system', 'kube-public', 'kube-node-lease']
-    RETURN COUNT(DISTINCT pod) AS count
+    RETURN COUNT(pod) AS count
     """,
     asset_id_field="pod_id",
     module=Module.KUBERNETES,

--- a/cartography/rules/data/rules/privileged_kubernetes_workload_cloud_identity.py
+++ b/cartography/rules/data/rules/privileged_kubernetes_workload_cloud_identity.py
@@ -1,0 +1,192 @@
+from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
+from cartography.rules.spec.model import Fact
+from cartography.rules.spec.model import Finding
+from cartography.rules.spec.model import Maturity
+from cartography.rules.spec.model import Module
+from cartography.rules.spec.model import Rule
+
+_k8s_privileged_workloads_with_aws_identity = Fact(
+    id="k8s_privileged_workloads_with_aws_identity",
+    name="Privileged Kubernetes workloads bound to AWS roles",
+    description=(
+        "Kubernetes pods with host/privilege indicators whose service account "
+        "can assume an AWS IAM role."
+    ),
+    cypher_query="""
+    MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
+          -[:USES_SERVICE_ACCOUNT]->(sa:KubernetesServiceAccount)
+          -[:ASSUMES_ROLE]->(role:AWSRole)
+    WHERE NOT pod.namespace IN ['kube-system', 'kube-public', 'kube-node-lease']
+    OPTIONAL MATCH (container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod)
+    WITH cluster, pod, sa, role, collect(container) AS containers
+    WITH cluster, pod, sa, role,
+         [reason IN [
+             CASE WHEN coalesce(pod.host_pid, false) THEN 'host_pid' ELSE null END,
+             CASE WHEN coalesce(pod.host_ipc, false) THEN 'host_ipc' ELSE null END,
+             CASE WHEN coalesce(pod.host_network, false) THEN 'host_network' ELSE null END,
+             CASE WHEN size(coalesce(pod.host_path_volume_paths, [])) > 0 THEN 'host_path_volume' ELSE null END
+         ] WHERE reason IS NOT NULL]
+         + reduce(container_reasons = [], c IN containers |
+             container_reasons + [reason IN [
+                 CASE WHEN coalesce(c.allow_privilege_escalation, false) THEN 'allow_privilege_escalation' ELSE null END,
+                 CASE WHEN 'SYS_ADMIN' IN coalesce(c.added_capabilities, []) THEN 'cap_sys_admin' ELSE null END,
+                 CASE WHEN 'NET_ADMIN' IN coalesce(c.added_capabilities, []) THEN 'cap_net_admin' ELSE null END,
+                 CASE WHEN size(coalesce(c.host_ports, [])) > 0 THEN 'host_ports' ELSE null END
+             ] WHERE reason IS NOT NULL]
+         ) AS privilege_reasons
+    WHERE size(privilege_reasons) > 0
+    RETURN DISTINCT
+        pod.id AS pod_id,
+        pod.name AS pod_name,
+        pod.namespace AS namespace,
+        cluster.name AS cluster_name,
+        sa.name AS service_account,
+        role.arn AS cloud_identity,
+        'aws' AS cloud_provider,
+        privilege_reasons
+    ORDER BY cluster_name, namespace, pod_name, cloud_identity
+    """,
+    cypher_visual_query="""
+    MATCH p=(cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
+          -[:USES_SERVICE_ACCOUNT]->(sa:KubernetesServiceAccount)
+          -[:ASSUMES_ROLE]->(role:AWSRole)
+    WHERE NOT pod.namespace IN ['kube-system', 'kube-public', 'kube-node-lease']
+      AND (
+       coalesce(pod.host_pid, false)
+       OR coalesce(pod.host_ipc, false)
+       OR coalesce(pod.host_network, false)
+       OR size(coalesce(pod.host_path_volume_paths, [])) > 0
+       OR EXISTS {
+           MATCH (container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod)
+           WHERE coalesce(container.allow_privilege_escalation, false)
+              OR 'SYS_ADMIN' IN coalesce(container.added_capabilities, [])
+              OR 'NET_ADMIN' IN coalesce(container.added_capabilities, [])
+              OR size(coalesce(container.host_ports, [])) > 0
+       }
+      )
+    OPTIONAL MATCH p2=(container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod)
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (pod:KubernetesPod)-[:USES_SERVICE_ACCOUNT]->(:KubernetesServiceAccount)
+          -[:ASSUMES_ROLE]->(:AWSRole)
+    WHERE NOT pod.namespace IN ['kube-system', 'kube-public', 'kube-node-lease']
+    RETURN COUNT(DISTINCT pod) AS count
+    """,
+    asset_id_field="pod_id",
+    module=Module.KUBERNETES,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+_k8s_privileged_workloads_with_gcp_identity = Fact(
+    id="k8s_privileged_workloads_with_gcp_identity",
+    name="Privileged Kubernetes workloads bound to GCP service accounts",
+    description=(
+        "Kubernetes pods with host/privilege indicators whose service account "
+        "can impersonate a GCP service account through Workload Identity."
+    ),
+    cypher_query="""
+    MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
+          -[:USES_SERVICE_ACCOUNT]->(sa:KubernetesServiceAccount)
+          -[:WORKLOAD_IDENTITY_BINDING]->(gsa:GCPServiceAccount)
+    WHERE NOT pod.namespace IN ['kube-system', 'kube-public', 'kube-node-lease']
+    OPTIONAL MATCH (container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod)
+    WITH cluster, pod, sa, gsa, collect(container) AS containers
+    WITH cluster, pod, sa, gsa,
+         [reason IN [
+             CASE WHEN coalesce(pod.host_pid, false) THEN 'host_pid' ELSE null END,
+             CASE WHEN coalesce(pod.host_ipc, false) THEN 'host_ipc' ELSE null END,
+             CASE WHEN coalesce(pod.host_network, false) THEN 'host_network' ELSE null END,
+             CASE WHEN size(coalesce(pod.host_path_volume_paths, [])) > 0 THEN 'host_path_volume' ELSE null END
+         ] WHERE reason IS NOT NULL]
+         + reduce(container_reasons = [], c IN containers |
+             container_reasons + [reason IN [
+                 CASE WHEN coalesce(c.allow_privilege_escalation, false) THEN 'allow_privilege_escalation' ELSE null END,
+                 CASE WHEN 'SYS_ADMIN' IN coalesce(c.added_capabilities, []) THEN 'cap_sys_admin' ELSE null END,
+                 CASE WHEN 'NET_ADMIN' IN coalesce(c.added_capabilities, []) THEN 'cap_net_admin' ELSE null END,
+                 CASE WHEN size(coalesce(c.host_ports, [])) > 0 THEN 'host_ports' ELSE null END
+             ] WHERE reason IS NOT NULL]
+         ) AS privilege_reasons
+    WHERE size(privilege_reasons) > 0
+    RETURN DISTINCT
+        pod.id AS pod_id,
+        pod.name AS pod_name,
+        pod.namespace AS namespace,
+        cluster.name AS cluster_name,
+        sa.name AS service_account,
+        coalesce(gsa.email, gsa.id) AS cloud_identity,
+        'gcp' AS cloud_provider,
+        privilege_reasons
+    ORDER BY cluster_name, namespace, pod_name, cloud_identity
+    """,
+    cypher_visual_query="""
+    MATCH p=(cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
+          -[:USES_SERVICE_ACCOUNT]->(sa:KubernetesServiceAccount)
+          -[:WORKLOAD_IDENTITY_BINDING]->(gsa:GCPServiceAccount)
+    WHERE NOT pod.namespace IN ['kube-system', 'kube-public', 'kube-node-lease']
+      AND (
+       coalesce(pod.host_pid, false)
+       OR coalesce(pod.host_ipc, false)
+       OR coalesce(pod.host_network, false)
+       OR size(coalesce(pod.host_path_volume_paths, [])) > 0
+       OR EXISTS {
+           MATCH (container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod)
+           WHERE coalesce(container.allow_privilege_escalation, false)
+              OR 'SYS_ADMIN' IN coalesce(container.added_capabilities, [])
+              OR 'NET_ADMIN' IN coalesce(container.added_capabilities, [])
+              OR size(coalesce(container.host_ports, [])) > 0
+       }
+      )
+    OPTIONAL MATCH p2=(container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod)
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (pod:KubernetesPod)-[:USES_SERVICE_ACCOUNT]->(:KubernetesServiceAccount)
+          -[:WORKLOAD_IDENTITY_BINDING]->(:GCPServiceAccount)
+    WHERE NOT pod.namespace IN ['kube-system', 'kube-public', 'kube-node-lease']
+    RETURN COUNT(DISTINCT pod) AS count
+    """,
+    asset_id_field="pod_id",
+    module=Module.KUBERNETES,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+class PrivilegedKubernetesWorkloadCloudIdentity(Finding):
+    pod_id: str | None = None
+    pod_name: str | None = None
+    namespace: str | None = None
+    cluster_name: str | None = None
+    service_account: str | None = None
+    cloud_identity: str | None = None
+    cloud_provider: str | None = None
+    privilege_reasons: list[str] | None = None
+
+
+privileged_kubernetes_workload_cloud_identity = Rule(
+    id="privileged_kubernetes_workload_cloud_identity",
+    name="Privileged Kubernetes Workload With Cloud Identity",
+    description=(
+        "Kubernetes workloads that combine host-level or privilege-escalation "
+        "settings with a bound cloud identity outside standard Kubernetes "
+        "system namespaces. This is a graph-backed compound risk because a pod "
+        "escape or workload compromise can become cloud control-plane access."
+    ),
+    output_model=PrivilegedKubernetesWorkloadCloudIdentity,
+    facts=(
+        _k8s_privileged_workloads_with_aws_identity,
+        _k8s_privileged_workloads_with_gcp_identity,
+    ),
+    tags=(
+        "kubernetes",
+        "iam",
+        "attack_surface",
+        "stride:elevation_of_privilege",
+        "stride:spoofing",
+    ),
+    version="0.1.0",
+    frameworks=(
+        iso27001_annex_a("5.18"),
+        iso27001_annex_a("8.9"),
+    ),
+)

--- a/cartography/rules/data/rules/public_database_snapshot.py
+++ b/cartography/rules/data/rules/public_database_snapshot.py
@@ -1,0 +1,82 @@
+from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
+from cartography.rules.spec.model import Fact
+from cartography.rules.spec.model import Finding
+from cartography.rules.spec.model import Maturity
+from cartography.rules.spec.model import Module
+from cartography.rules.spec.model import Rule
+
+_aws_public_rds_snapshots = Fact(
+    id="aws_public_rds_snapshots",
+    name="Public AWS RDS snapshots",
+    description=(
+        "RDS DB snapshots marked public. Public database snapshots can expose "
+        "database contents outside the account even when the source database is "
+        "private."
+    ),
+    cypher_query="""
+    MATCH (account:AWSAccount)-[:RESOURCE]->(snapshot:RDSSnapshot)
+    WHERE coalesce(snapshot.ispublic, false) = true
+    RETURN
+        snapshot.arn AS snapshot_id,
+        snapshot.db_snapshot_identifier AS snapshot_name,
+        account.name AS account,
+        account.id AS account_id,
+        snapshot.region AS region,
+        snapshot.engine AS engine,
+        snapshot.encrypted AS encrypted,
+        snapshot.snapshot_type AS snapshot_type,
+        snapshot.db_instance_identifier AS source_database,
+        snapshot.snapshot_create_time AS created_at
+    ORDER BY account, region, snapshot_name
+    """,
+    cypher_visual_query="""
+    MATCH p=(account:AWSAccount)-[:RESOURCE]->(snapshot:RDSSnapshot)
+    WHERE coalesce(snapshot.ispublic, false) = true
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (snapshot:RDSSnapshot)
+    RETURN COUNT(snapshot) AS count
+    """,
+    asset_id_field="snapshot_id",
+    module=Module.AWS,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+class PublicDatabaseSnapshot(Finding):
+    snapshot_id: str | None = None
+    snapshot_name: str | None = None
+    account: str | None = None
+    account_id: str | None = None
+    region: str | None = None
+    engine: str | None = None
+    encrypted: bool | None = None
+    snapshot_type: str | None = None
+    source_database: str | None = None
+    created_at: str | None = None
+
+
+public_database_snapshot = Rule(
+    id="public_database_snapshot",
+    name="Public Database Snapshots",
+    description=(
+        "Database snapshots shared publicly. These are high-signal exposure "
+        "findings because the snapshot can contain production data independent "
+        "of the live database network posture."
+    ),
+    output_model=PublicDatabaseSnapshot,
+    facts=(_aws_public_rds_snapshots,),
+    tags=(
+        "data",
+        "database",
+        "backup",
+        "attack_surface",
+        "stride:information_disclosure",
+    ),
+    version="0.1.0",
+    frameworks=(
+        iso27001_annex_a("8.3"),
+        iso27001_annex_a("8.12"),
+    ),
+)

--- a/cartography/rules/data/rules/public_object_storage_without_recovery.py
+++ b/cartography/rules/data/rules/public_object_storage_without_recovery.py
@@ -22,7 +22,7 @@ _aws_public_s3_without_versioning = Fact(
         OR EXISTS {
             MATCH (bucket)-[:POLICY_STATEMENT]->(stmt:S3PolicyStatement)
             WHERE stmt.effect = 'Allow'
-              AND (stmt.principal = '*' OR stmt.principal CONTAINS 'AllUsers')
+              AND stmt.principal IN ['*', '"*"']
         }
       )
     OPTIONAL MATCH (account:AWSAccount)-[:RESOURCE]->(bucket)
@@ -46,7 +46,7 @@ _aws_public_s3_without_versioning = Fact(
         OR EXISTS {
             MATCH (bucket)-[:POLICY_STATEMENT]->(stmt:S3PolicyStatement)
             WHERE stmt.effect = 'Allow'
-              AND (stmt.principal = '*' OR stmt.principal CONTAINS 'AllUsers')
+              AND stmt.principal IN ['*', '"*"']
         }
       )
     OPTIONAL MATCH p2=(account:AWSAccount)-[:RESOURCE]->(bucket)
@@ -55,13 +55,6 @@ _aws_public_s3_without_versioning = Fact(
     """,
     cypher_count_query="""
     MATCH (bucket:S3Bucket)
-    WHERE bucket.anonymous_access = true
-       OR (bucket.anonymous_actions IS NOT NULL AND size(bucket.anonymous_actions) > 0)
-       OR EXISTS {
-           MATCH (bucket)-[:POLICY_STATEMENT]->(stmt:S3PolicyStatement)
-           WHERE stmt.effect = 'Allow'
-             AND (stmt.principal = '*' OR stmt.principal CONTAINS 'AllUsers')
-       }
     RETURN COUNT(bucket) AS count
     """,
     asset_id_field="id",
@@ -108,12 +101,6 @@ _gcp_public_bucket_without_versioning = Fact(
     """,
     cypher_count_query="""
     MATCH (bucket:GCPBucket)
-    WHERE coalesce(bucket.iam_config_public_access_prevention, '') <> 'enforced'
-      AND EXISTS {
-          MATCH (bucket)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)
-          WHERE binding.is_public = true
-            AND coalesce(binding.has_condition, false) = false
-      }
     RETURN COUNT(bucket) AS count
     """,
     asset_id_field="id",
@@ -138,9 +125,10 @@ _azure_public_blob_without_retention = Fact(
     RETURN
         container.id AS id,
         container.name AS name,
-        coalesce(account.name, subscription.id) AS account,
+        subscription.id AS account,
         subscription.id AS account_id,
         account.location AS region,
+        account.name AS storage_account,
         'azure' AS provider,
         'no_retention_or_immutability' AS recovery_gap,
         toString(container.remaining_retention_days) AS recovery_status
@@ -157,7 +145,6 @@ _azure_public_blob_without_retention = Fact(
     """,
     cypher_count_query="""
     MATCH (container:AzureStorageBlobContainer)
-    WHERE container.public_access IN ['Container', 'Blob']
     RETURN COUNT(container) AS count
     """,
     asset_id_field="id",
@@ -172,6 +159,7 @@ class PublicObjectStorageWithoutRecovery(Finding):
     account: str | None = None
     account_id: str | None = None
     region: str | None = None
+    storage_account: str | None = None
     provider: str | None = None
     recovery_gap: str | None = None
     recovery_status: str | None = None

--- a/cartography/rules/data/rules/public_object_storage_without_recovery.py
+++ b/cartography/rules/data/rules/public_object_storage_without_recovery.py
@@ -1,0 +1,208 @@
+from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
+from cartography.rules.spec.model import Fact
+from cartography.rules.spec.model import Finding
+from cartography.rules.spec.model import Maturity
+from cartography.rules.spec.model import Module
+from cartography.rules.spec.model import Rule
+
+_aws_public_s3_without_versioning = Fact(
+    id="aws_public_s3_without_versioning",
+    name="Public S3 buckets without versioning",
+    description=(
+        "S3 buckets with public access evidence and versioning not enabled. "
+        "Public write, overwrite, or delete exposure is more damaging when "
+        "object recovery controls are absent."
+    ),
+    cypher_query="""
+    MATCH (bucket:S3Bucket)
+    WHERE coalesce(bucket.versioning_status, '') <> 'Enabled'
+      AND (
+        bucket.anonymous_access = true
+        OR (bucket.anonymous_actions IS NOT NULL AND size(bucket.anonymous_actions) > 0)
+        OR EXISTS {
+            MATCH (bucket)-[:POLICY_STATEMENT]->(stmt:S3PolicyStatement)
+            WHERE stmt.effect = 'Allow'
+              AND (stmt.principal = '*' OR stmt.principal CONTAINS 'AllUsers')
+        }
+      )
+    OPTIONAL MATCH (account:AWSAccount)-[:RESOURCE]->(bucket)
+    RETURN
+        bucket.id AS id,
+        bucket.name AS name,
+        account.name AS account,
+        account.id AS account_id,
+        bucket.region AS region,
+        'aws' AS provider,
+        'versioning_disabled' AS recovery_gap,
+        bucket.versioning_status AS recovery_status
+    ORDER BY account, region, name
+    """,
+    cypher_visual_query="""
+    MATCH (bucket:S3Bucket)
+    WHERE coalesce(bucket.versioning_status, '') <> 'Enabled'
+      AND (
+        bucket.anonymous_access = true
+        OR (bucket.anonymous_actions IS NOT NULL AND size(bucket.anonymous_actions) > 0)
+        OR EXISTS {
+            MATCH (bucket)-[:POLICY_STATEMENT]->(stmt:S3PolicyStatement)
+            WHERE stmt.effect = 'Allow'
+              AND (stmt.principal = '*' OR stmt.principal CONTAINS 'AllUsers')
+        }
+      )
+    OPTIONAL MATCH p2=(account:AWSAccount)-[:RESOURCE]->(bucket)
+    OPTIONAL MATCH p3=(bucket)-[:POLICY_STATEMENT]->(:S3PolicyStatement)
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (bucket:S3Bucket)
+    WHERE bucket.anonymous_access = true
+       OR (bucket.anonymous_actions IS NOT NULL AND size(bucket.anonymous_actions) > 0)
+       OR EXISTS {
+           MATCH (bucket)-[:POLICY_STATEMENT]->(stmt:S3PolicyStatement)
+           WHERE stmt.effect = 'Allow'
+             AND (stmt.principal = '*' OR stmt.principal CONTAINS 'AllUsers')
+       }
+    RETURN COUNT(bucket) AS count
+    """,
+    asset_id_field="id",
+    module=Module.AWS,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+_gcp_public_bucket_without_versioning = Fact(
+    id="gcp_public_bucket_without_versioning",
+    name="Public GCS buckets without versioning",
+    description=(
+        "GCS buckets with unconditional public IAM bindings and object "
+        "versioning disabled."
+    ),
+    cypher_query="""
+    MATCH (bucket:GCPBucket)
+    WHERE coalesce(bucket.iam_config_public_access_prevention, '') <> 'enforced'
+      AND coalesce(bucket.versioning_enabled, false) = false
+      AND EXISTS {
+          MATCH (bucket)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)
+          WHERE binding.is_public = true
+            AND coalesce(binding.has_condition, false) = false
+      }
+    OPTIONAL MATCH (project:GCPProject)-[:RESOURCE]->(bucket)
+    RETURN
+        bucket.id AS id,
+        bucket.id AS name,
+        project.id AS account,
+        project.id AS account_id,
+        bucket.location AS region,
+        'gcp' AS provider,
+        'versioning_disabled' AS recovery_gap,
+        toString(bucket.versioning_enabled) AS recovery_status
+    ORDER BY account, region, name
+    """,
+    cypher_visual_query="""
+    MATCH p=(bucket:GCPBucket)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)
+    WHERE coalesce(bucket.iam_config_public_access_prevention, '') <> 'enforced'
+      AND coalesce(bucket.versioning_enabled, false) = false
+      AND binding.is_public = true
+      AND coalesce(binding.has_condition, false) = false
+    OPTIONAL MATCH p2=(project:GCPProject)-[:RESOURCE]->(bucket)
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (bucket:GCPBucket)
+    WHERE coalesce(bucket.iam_config_public_access_prevention, '') <> 'enforced'
+      AND EXISTS {
+          MATCH (bucket)<-[:APPLIES_TO]-(binding:GCPPolicyBinding)
+          WHERE binding.is_public = true
+            AND coalesce(binding.has_condition, false) = false
+      }
+    RETURN COUNT(bucket) AS count
+    """,
+    asset_id_field="id",
+    module=Module.GCP,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+_azure_public_blob_without_retention = Fact(
+    id="azure_public_blob_without_retention",
+    name="Public Azure blob containers without retention controls",
+    description=(
+        "Azure blob containers with public blob/container access and no "
+        "container-level retention, immutability policy, or legal hold signal."
+    ),
+    cypher_query="""
+    MATCH (subscription:AzureSubscription)-[:RESOURCE]->(container:AzureStorageBlobContainer)
+    WHERE container.public_access IN ['Container', 'Blob']
+      AND coalesce(container.remaining_retention_days, 0) <= 0
+      AND coalesce(container.has_immutability_policy, false) = false
+      AND coalesce(container.has_legal_hold, false) = false
+    OPTIONAL MATCH (account:AzureStorageAccount)-[:USES]->(:AzureStorageBlobService)-[:CONTAINS]->(container)
+    RETURN
+        container.id AS id,
+        container.name AS name,
+        coalesce(account.name, subscription.id) AS account,
+        subscription.id AS account_id,
+        account.location AS region,
+        'azure' AS provider,
+        'no_retention_or_immutability' AS recovery_gap,
+        toString(container.remaining_retention_days) AS recovery_status
+    ORDER BY account, region, name
+    """,
+    cypher_visual_query="""
+    MATCH p=(subscription:AzureSubscription)-[:RESOURCE]->(container:AzureStorageBlobContainer)
+    WHERE container.public_access IN ['Container', 'Blob']
+      AND coalesce(container.remaining_retention_days, 0) <= 0
+      AND coalesce(container.has_immutability_policy, false) = false
+      AND coalesce(container.has_legal_hold, false) = false
+    OPTIONAL MATCH p2=(account:AzureStorageAccount)-[:USES]->(:AzureStorageBlobService)-[:CONTAINS]->(container)
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (container:AzureStorageBlobContainer)
+    WHERE container.public_access IN ['Container', 'Blob']
+    RETURN COUNT(container) AS count
+    """,
+    asset_id_field="id",
+    module=Module.AZURE,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+class PublicObjectStorageWithoutRecovery(Finding):
+    id: str | None = None
+    name: str | None = None
+    account: str | None = None
+    account_id: str | None = None
+    region: str | None = None
+    provider: str | None = None
+    recovery_gap: str | None = None
+    recovery_status: str | None = None
+
+
+public_object_storage_without_recovery = Rule(
+    id="public_object_storage_without_recovery",
+    name="Public Object Storage Without Recovery Controls",
+    description=(
+        "Public object storage locations that lack versioning, retention, "
+        "immutability, or similar recovery controls available in the current "
+        "graph. These findings combine exposure with tamper/recovery impact."
+    ),
+    output_model=PublicObjectStorageWithoutRecovery,
+    facts=(
+        _aws_public_s3_without_versioning,
+        _azure_public_blob_without_retention,
+        _gcp_public_bucket_without_versioning,
+    ),
+    tags=(
+        "data",
+        "storage",
+        "attack_surface",
+        "resilience",
+        "stride:information_disclosure",
+        "stride:tampering",
+    ),
+    version="0.1.0",
+    frameworks=(
+        iso27001_annex_a("8.3"),
+        iso27001_annex_a("8.10"),
+        iso27001_annex_a("8.13"),
+    ),
+)

--- a/tests/integration/rules/test_cspm_compound_risks.py
+++ b/tests/integration/rules/test_cspm_compound_risks.py
@@ -1,0 +1,352 @@
+from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.rules.data.rules.github_actions_privileged_pull_request import (
+    github_actions_privileged_pull_request,
+)
+from cartography.rules.data.rules.internet_exposed_database_without_backups import (
+    internet_exposed_database_without_backups,
+)
+from cartography.rules.data.rules.privileged_kubernetes_workload_cloud_identity import (
+    privileged_kubernetes_workload_cloud_identity,
+)
+from cartography.rules.data.rules.public_object_storage_without_recovery import (
+    public_object_storage_without_recovery,
+)
+from cartography.rules.spec.model import Fact
+from cartography.rules.spec.model import Rule
+
+
+def _reset_graph(neo4j_session) -> None:
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+
+
+def _get_fact(rule: Rule, fact_id: str) -> Fact:
+    return next(fact for fact in rule.facts if fact.id == fact_id)
+
+
+def _run_query(neo4j_session, fact: Fact) -> list[dict]:
+    return neo4j_session.execute_read(read_list_of_dicts_tx, fact.cypher_query)
+
+
+def _run_count_query(neo4j_session, fact: Fact) -> int:
+    rows = neo4j_session.execute_read(read_list_of_dicts_tx, fact.cypher_count_query)
+    return rows[0]["count"]
+
+
+def test_public_s3_without_versioning_matches_json_serialized_public_principal(
+    neo4j_session,
+) -> None:
+    # Arrange
+    _reset_graph(neo4j_session)
+    fact = _get_fact(
+        public_object_storage_without_recovery,
+        "aws_public_s3_without_versioning",
+    )
+    neo4j_session.run(
+        """
+        CREATE (account:AWSAccount {id: 'aws-account-1', name: 'test-account'})
+        CREATE (public_bucket:S3Bucket {
+            id: 'bucket-public-policy',
+            name: 'bucket-public-policy',
+            versioning_status: 'Suspended',
+            anonymous_access: false,
+            region: 'us-east-1'
+        })
+        CREATE (versioned_bucket:S3Bucket {
+            id: 'bucket-versioned',
+            name: 'bucket-versioned',
+            versioning_status: 'Enabled',
+            anonymous_access: true,
+            region: 'us-east-1'
+        })
+        CREATE (stmt:S3PolicyStatement {
+            id: 'bucket-public-policy/policy_statement/1/public',
+            effect: 'Allow',
+            principal: '"*"'
+        })
+        CREATE (account)-[:RESOURCE]->(public_bucket)
+        CREATE (account)-[:RESOURCE]->(versioned_bucket)
+        CREATE (public_bucket)-[:POLICY_STATEMENT]->(stmt)
+        """
+    )
+
+    # Act
+    findings = _run_query(neo4j_session, fact)
+
+    # Assert
+    assert findings == [
+        {
+            "id": "bucket-public-policy",
+            "name": "bucket-public-policy",
+            "account": "test-account",
+            "account_id": "aws-account-1",
+            "region": "us-east-1",
+            "provider": "aws",
+            "recovery_gap": "versioning_disabled",
+            "recovery_status": "Suspended",
+        }
+    ]
+    assert _run_count_query(neo4j_session, fact) == 2
+
+
+def test_public_azure_blob_without_retention_keeps_account_fields_consistent(
+    neo4j_session,
+) -> None:
+    # Arrange
+    _reset_graph(neo4j_session)
+    fact = _get_fact(
+        public_object_storage_without_recovery,
+        "azure_public_blob_without_retention",
+    )
+    neo4j_session.run(
+        """
+        CREATE (subscription:AzureSubscription {id: 'sub-1'})
+        CREATE (account:AzureStorageAccount {
+            id: 'storage-account-1',
+            name: 'storage-account-1',
+            location: 'eastus'
+        })
+        CREATE (service:AzureStorageBlobService {id: 'blob-service-1'})
+        CREATE (container:AzureStorageBlobContainer {
+            id: 'container-1',
+            name: 'container-1',
+            public_access: 'Container',
+            remaining_retention_days: 0,
+            has_immutability_policy: false,
+            has_legal_hold: false
+        })
+        CREATE (subscription)-[:RESOURCE]->(container)
+        CREATE (subscription)-[:RESOURCE]->(account)
+        CREATE (account)-[:USES]->(service)
+        CREATE (service)-[:CONTAINS]->(container)
+        """
+    )
+
+    # Act
+    findings = _run_query(neo4j_session, fact)
+
+    # Assert
+    assert findings == [
+        {
+            "id": "container-1",
+            "name": "container-1",
+            "account": "sub-1",
+            "account_id": "sub-1",
+            "region": "eastus",
+            "storage_account": "storage-account-1",
+            "provider": "azure",
+            "recovery_gap": "no_retention_or_immutability",
+            "recovery_status": "0",
+        }
+    ]
+    assert _run_count_query(neo4j_session, fact) == 1
+
+
+def test_internet_exposed_rds_without_backups_requires_backup_disabled(
+    neo4j_session,
+) -> None:
+    # Arrange
+    _reset_graph(neo4j_session)
+    fact = _get_fact(
+        internet_exposed_database_without_backups,
+        "aws_public_rds_without_backups",
+    )
+    neo4j_session.run(
+        """
+        CREATE (account:AWSAccount {id: 'aws-account-1', name: 'test-account'})
+        CREATE (rds_without_backups:RDSInstance {
+            id: 'rds-no-backups',
+            db_instance_identifier: 'rds-no-backups',
+            publicly_accessible: true,
+            endpoint_port: 5432,
+            endpoint_address: 'rds-no-backups.example.test',
+            backup_retention_period: 0,
+            deletion_protection: false,
+            engine: 'postgres',
+            region: 'us-east-1'
+        })
+        CREATE (rds_with_backups:RDSInstance {
+            id: 'rds-with-backups',
+            db_instance_identifier: 'rds-with-backups',
+            publicly_accessible: true,
+            endpoint_port: 5432,
+            endpoint_address: 'rds-with-backups.example.test',
+            backup_retention_period: 7,
+            deletion_protection: true,
+            engine: 'postgres',
+            region: 'us-east-1'
+        })
+        CREATE (sg:EC2SecurityGroup {id: 'sg-public'})
+        CREATE (rule:AWSIpPermissionInbound {
+            id: 'rule-public-postgres',
+            protocol: 'tcp',
+            fromport: 5432,
+            toport: 5432
+        })
+        CREATE (range:AWSIpRange {id: '0.0.0.0/0', range: '0.0.0.0/0'})
+        CREATE (account)-[:RESOURCE]->(rds_without_backups)
+        CREATE (account)-[:RESOURCE]->(rds_with_backups)
+        CREATE (rds_without_backups)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg)
+        CREATE (rds_with_backups)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg)
+        CREATE (rule)-[:MEMBER_OF_EC2_SECURITY_GROUP]->(sg)
+        CREATE (range)-[:MEMBER_OF_IP_RULE]->(rule)
+        """
+    )
+
+    # Act
+    findings = _run_query(neo4j_session, fact)
+
+    # Assert
+    assert [finding["id"] for finding in findings] == ["rds-no-backups"]
+    assert _run_count_query(neo4j_session, fact) == 2
+
+
+def test_internet_exposed_cloudsql_without_backups_uses_null_retention(
+    neo4j_session,
+) -> None:
+    # Arrange
+    _reset_graph(neo4j_session)
+    fact = _get_fact(
+        internet_exposed_database_without_backups,
+        "gcp_public_cloudsql_without_backups",
+    )
+    neo4j_session.run(
+        """
+        CREATE (project:GCPProject {id: 'project-1'})
+        CREATE (sql:GCPCloudSQLInstance {
+            id: 'sql-1',
+            name: 'sql-1',
+            database_version: 'POSTGRES_15',
+            connection_name: 'project-1:us-central1:sql-1',
+            region: 'us-central1',
+            backup_enabled: false
+        })
+        CREATE (network:GCPCloudSQLAuthorizedNetwork {
+            id: 'network-1',
+            value: '0.0.0.0/0'
+        })
+        CREATE (project)-[:RESOURCE]->(sql)
+        CREATE (sql)-[:AUTHORIZED_NETWORK]->(network)
+        """
+    )
+
+    # Act
+    findings = _run_query(neo4j_session, fact)
+
+    # Assert
+    assert findings[0]["backup_retention_days"] is None
+    assert _run_count_query(neo4j_session, fact) == 1
+
+
+def test_privileged_kubernetes_workload_cloud_identity_ignores_system_namespace(
+    neo4j_session,
+) -> None:
+    # Arrange
+    _reset_graph(neo4j_session)
+    fact = _get_fact(
+        privileged_kubernetes_workload_cloud_identity,
+        "k8s_privileged_workloads_with_aws_identity",
+    )
+    neo4j_session.run(
+        """
+        CREATE (cluster:KubernetesCluster {id: 'cluster-1', name: 'cluster-1'})
+        CREATE (role:AWSRole {
+            id: 'role-1',
+            arn: 'arn:aws:iam::aws-account-1:role/test-role'
+        })
+        CREATE (sa:KubernetesServiceAccount {
+            id: 'sa-default',
+            name: 'workload',
+            namespace: 'default'
+        })
+        CREATE (system_sa:KubernetesServiceAccount {
+            id: 'sa-system',
+            name: 'system-workload',
+            namespace: 'kube-system'
+        })
+        CREATE (pod:KubernetesPod {
+            id: 'pod-default',
+            name: 'pod-default',
+            namespace: 'default',
+            host_network: true
+        })
+        CREATE (system_pod:KubernetesPod {
+            id: 'pod-system',
+            name: 'pod-system',
+            namespace: 'kube-system',
+            host_network: true
+        })
+        CREATE (cluster)-[:RESOURCE]->(pod)
+        CREATE (cluster)-[:RESOURCE]->(system_pod)
+        CREATE (pod)-[:USES_SERVICE_ACCOUNT]->(sa)
+        CREATE (system_pod)-[:USES_SERVICE_ACCOUNT]->(system_sa)
+        CREATE (sa)-[:ASSUMES_ROLE]->(role)
+        CREATE (system_sa)-[:ASSUMES_ROLE]->(role)
+        """
+    )
+
+    # Act
+    findings = _run_query(neo4j_session, fact)
+
+    # Assert
+    assert [finding["pod_id"] for finding in findings] == ["pod-default"]
+    assert _run_count_query(neo4j_session, fact) == 1
+
+
+def test_github_actions_pr_target_write_token_counts_public_workflows(
+    neo4j_session,
+) -> None:
+    # Arrange
+    _reset_graph(neo4j_session)
+    fact = _get_fact(
+        github_actions_privileged_pull_request,
+        "github_public_pull_request_target_write_token",
+    )
+    neo4j_session.run(
+        """
+        CREATE (repo:GitHubRepository {
+            id: 'repo-public',
+            fullname: 'org/repo-public',
+            defaultbranch: 'main',
+            private: false,
+            archived: false
+        })
+        CREATE (private_repo:GitHubRepository {
+            id: 'repo-private',
+            fullname: 'org/repo-private',
+            defaultbranch: 'main',
+            private: true,
+            archived: false
+        })
+        CREATE (pr_target:GitHubWorkflow {
+            id: 'workflow-pr-target',
+            name: 'pr-target',
+            path: '.github/workflows/pr-target.yml',
+            trigger_events: ['pull_request_target'],
+            permissions_contents: 'write'
+        })
+        CREATE (push_workflow:GitHubWorkflow {
+            id: 'workflow-push',
+            name: 'push',
+            path: '.github/workflows/push.yml',
+            trigger_events: ['push'],
+            permissions_contents: 'write'
+        })
+        CREATE (private_workflow:GitHubWorkflow {
+            id: 'workflow-private',
+            name: 'private',
+            path: '.github/workflows/private.yml',
+            trigger_events: ['pull_request_target'],
+            permissions_contents: 'write'
+        })
+        CREATE (repo)-[:HAS_WORKFLOW]->(pr_target)
+        CREATE (repo)-[:HAS_WORKFLOW]->(push_workflow)
+        CREATE (private_repo)-[:HAS_WORKFLOW]->(private_workflow)
+        """
+    )
+
+    # Act
+    findings = _run_query(neo4j_session, fact)
+
+    # Assert
+    assert [finding["workflow_id"] for finding in findings] == ["workflow-pr-target"]
+    assert _run_count_query(neo4j_session, fact) == 2

--- a/tests/unit/rules/test_cspm_compound_risks.py
+++ b/tests/unit/rules/test_cspm_compound_risks.py
@@ -1,0 +1,105 @@
+from cartography.rules.data.rules import RULES
+from cartography.rules.data.rules.github_actions_privileged_pull_request import (
+    github_actions_privileged_pull_request,
+)
+from cartography.rules.data.rules.internet_exposed_database_without_backups import (
+    internet_exposed_database_without_backups,
+)
+from cartography.rules.data.rules.privileged_kubernetes_workload_cloud_identity import (
+    privileged_kubernetes_workload_cloud_identity,
+)
+from cartography.rules.data.rules.public_database_snapshot import (
+    public_database_snapshot,
+)
+from cartography.rules.data.rules.public_object_storage_without_recovery import (
+    public_object_storage_without_recovery,
+)
+from cartography.rules.spec.model import Maturity
+from cartography.rules.spec.model import Module
+
+NEW_CSPM_RULES = [
+    public_database_snapshot,
+    public_object_storage_without_recovery,
+    internet_exposed_database_without_backups,
+    privileged_kubernetes_workload_cloud_identity,
+    github_actions_privileged_pull_request,
+]
+
+
+def test_new_cspm_rules_are_registered() -> None:
+    for rule in NEW_CSPM_RULES:
+        assert RULES[rule.id] is rule
+
+
+def test_new_cspm_rules_are_experimental() -> None:
+    for rule in NEW_CSPM_RULES:
+        assert all(fact.maturity == Maturity.EXPERIMENTAL for fact in rule.facts)
+
+
+def test_public_database_snapshot_shape() -> None:
+    assert public_database_snapshot.id == "public_database_snapshot"
+    assert {fact.module for fact in public_database_snapshot.facts} == {Module.AWS}
+    assert public_database_snapshot.facts[0].asset_id_field == "snapshot_id"
+    assert "RDSSnapshot" in public_database_snapshot.facts[0].cypher_query
+    assert "ispublic" in public_database_snapshot.facts[0].cypher_query
+
+
+def test_public_object_storage_without_recovery_modules() -> None:
+    assert public_object_storage_without_recovery.id == (
+        "public_object_storage_without_recovery"
+    )
+    assert {fact.module for fact in public_object_storage_without_recovery.facts} == {
+        Module.AWS,
+        Module.AZURE,
+        Module.GCP,
+    }
+    for fact in public_object_storage_without_recovery.facts:
+        assert fact.asset_id_field == "id"
+
+
+def test_internet_exposed_database_without_backups_modules() -> None:
+    assert internet_exposed_database_without_backups.id == (
+        "internet_exposed_database_without_backups"
+    )
+    assert {
+        fact.module for fact in internet_exposed_database_without_backups.facts
+    } == {
+        Module.AWS,
+        Module.GCP,
+    }
+    assert all(
+        fact.asset_id_field == "id"
+        for fact in internet_exposed_database_without_backups.facts
+    )
+
+
+def test_privileged_kubernetes_workload_cloud_identity_shape() -> None:
+    assert privileged_kubernetes_workload_cloud_identity.id == (
+        "privileged_kubernetes_workload_cloud_identity"
+    )
+    assert {
+        fact.module for fact in privileged_kubernetes_workload_cloud_identity.facts
+    } == {Module.KUBERNETES}
+    query_text = "\n".join(
+        fact.cypher_query
+        for fact in privileged_kubernetes_workload_cloud_identity.facts
+    )
+    assert "ASSUMES_ROLE" in query_text
+    assert "WORKLOAD_IDENTITY_BINDING" in query_text
+    assert "allow_privilege_escalation" in query_text
+    assert "kube-system" in query_text
+
+
+def test_github_actions_privileged_pull_request_shape() -> None:
+    fact = github_actions_privileged_pull_request.facts[0]
+
+    assert github_actions_privileged_pull_request.id == (
+        "github_actions_privileged_pull_request"
+    )
+    assert {fact.module for fact in github_actions_privileged_pull_request.facts} == {
+        Module.GITHUB
+    }
+    assert fact.asset_id_field == "workflow_id"
+    assert "pull_request_target" in fact.cypher_query
+    assert "permissions_contents = 'write'" in fact.cypher_query
+    assert "coalesce(repo.private, false) = false" in fact.cypher_query


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

### Summary
Adds five experimental graph-backed security rules that combine existing Cartography evidence into higher-signal findings:

- public database snapshots
- public object storage without recovery controls
- internet-exposed databases without backups
- privileged Kubernetes workloads bound to cloud identities
- public GitHub `pull_request_target` workflows with write-capable token scopes

These rules use existing graph data and stay within the rules framework; no new intel module, node schema, or relationship schema is added.

### Related issues or links
N/A

### Breaking changes
None.

### How was this tested?
- `python3 -m compileall -q` on the new rule files and focused unit test file.
- `git diff --check` and `git diff --cached --check`.
- Pre-commit hooks during commit: docstring position, merge-conflict check, VCS permalink check, debug statement check, EOF/whitespace fixes, `isort`, `black`, `flake8`, `pyupgrade`, and `mypy` all passed.
- Added focused unit tests for rule registration, maturity, modules, asset ID fields, and key query predicates.

Not run locally:
- `python3 -m pytest tests/unit/rules/test_cspm_compound_risks.py` because `pytest` is not installed in this environment.
- `make test_lint` because `uv` is not installed in this environment.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Not applicable; this PR only adds rules over existing graph data.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules). Not applicable; no schema changes.
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md). Not applicable; no schema changes.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node). Not applicable; no new intel module.

### Notes for reviewers
All new facts are marked `EXPERIMENTAL` because these are new rule predicates and may need tuning against larger graphs before promotion to stable.
