### PR TITLE
feat(aws): add --aws-excluded-syncs to skip individual modules

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -518,6 +518,20 @@ class CLI:
                     hidden=PANEL_AWS not in visible_panels,
                 ),
             ] = None,
+            aws_excluded_syncs: Annotated[
+                str | None,
+                typer.Option(
+                    "--aws-excluded-syncs",
+                    help=(
+                        "Comma-separated list of AWS resources to skip. Subtracted from the "
+                        "effective sync set (either --aws-requested-syncs or, if unset, all "
+                        'modules). Example: "secretsmanager". See cartography.intel.aws.resources '
+                        "for the full list of valid names."
+                    ),
+                    rich_help_panel=PANEL_AWS,
+                    hidden=PANEL_AWS not in visible_panels,
+                ),
+            ] = None,
             aws_guardduty_severity_threshold: Annotated[
                 str | None,
                 typer.Option(
@@ -1971,6 +1985,12 @@ class CLI:
                 )
 
                 parse_and_validate_aws_requested_syncs(aws_requested_syncs)
+            if aws_excluded_syncs:
+                from cartography.intel.aws.util.common import (
+                    parse_and_validate_aws_excluded_syncs,
+                )
+
+                parse_and_validate_aws_excluded_syncs(aws_excluded_syncs)
             if aws_regions:
                 from cartography.intel.aws.util.common import (
                     parse_and_validate_aws_regions,
@@ -2499,6 +2519,7 @@ class CLI:
                 entra_client_id=entra_client_id,
                 entra_client_secret=entra_client_secret,
                 aws_requested_syncs=aws_requested_syncs,
+                aws_excluded_syncs=aws_excluded_syncs,
                 aws_guardduty_severity_threshold=aws_guardduty_severity_threshold,
                 analysis_job_directory=analysis_job_directory,
                 oci_sync_all_profiles=oci_sync_all_profiles,

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -100,6 +100,10 @@ class Config:
     :param entra_client_secret: Client Secret for connecting in a Service Principal Authentication approach. Optional.
     :type aws_requested_syncs: str
     :param aws_requested_syncs: Comma-separated list of AWS resources to sync. Optional.
+    :type aws_excluded_syncs: str
+    :param aws_excluded_syncs: Comma-separated list of AWS resources to skip. Subtracted from the
+        effective sync set (``aws_requested_syncs`` if provided, otherwise the default of all
+        modules). Optional.
     :type aws_guardduty_severity_threshold: str
     :param aws_guardduty_severity_threshold: GuardDuty severity threshold filter. Only findings at or above this
         severity level will be synced. Valid values: LOW, MEDIUM, HIGH, CRITICAL. Optional.
@@ -362,6 +366,7 @@ class Config:
         entra_client_id=None,
         entra_client_secret=None,
         aws_requested_syncs=None,
+        aws_excluded_syncs=None,
         aws_guardduty_severity_threshold=None,
         analysis_job_directory=None,
         oci_sync_all_profiles=None,
@@ -529,6 +534,7 @@ class Config:
         self.entra_client_id = entra_client_id
         self.entra_client_secret = entra_client_secret
         self.aws_requested_syncs = aws_requested_syncs
+        self.aws_excluded_syncs = aws_excluded_syncs
         self.aws_guardduty_severity_threshold = aws_guardduty_severity_threshold
         self.analysis_job_directory = analysis_job_directory
         self.oci_sync_all_profiles = oci_sync_all_profiles

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -15,6 +15,7 @@ import neo4j
 from cartography.config import Config
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.intel.aws.util.common import parse_and_validate_aws_account_ids
+from cartography.intel.aws.util.common import parse_and_validate_aws_excluded_syncs
 from cartography.intel.aws.util.common import parse_and_validate_aws_regions
 from cartography.intel.aws.util.common import parse_and_validate_aws_requested_syncs
 from cartography.stats import get_stats_client
@@ -91,6 +92,7 @@ def _sync_one_account(
     common_job_parameters: Dict[str, Any],
     regions: list[str] | None = None,
     aws_requested_syncs: Iterable[str] = RESOURCE_FUNCTIONS.keys(),
+    aws_excluded_syncs: Iterable[str] = (),
     aioboto3_session: aioboto3.Session | None = None,
 ) -> None:
     if aioboto3_session is None:
@@ -110,6 +112,20 @@ def _sync_one_account(
     )
 
     aws_requested_syncs = _normalize_requested_syncs(aws_requested_syncs)
+
+    # Apply exclusions after normalization so that _normalize_requested_syncs's
+    # backward-compat auto-includes (e.g. pulling in 'ec2:load_balancer_v2:expose'
+    # whenever 'ec2:load_balancer_v2' is requested) cannot silently re-add a
+    # module the caller explicitly asked to skip.
+    excluded_syncs_set = set(aws_excluded_syncs)
+    if excluded_syncs_set:
+        aws_requested_syncs = [
+            s for s in aws_requested_syncs if s not in excluded_syncs_set
+        ]
+        logger.info(
+            "Excluding AWS sync modules per aws_excluded_syncs: %s",
+            ", ".join(sorted(excluded_syncs_set)),
+        )
 
     # Validate that all requested syncs exist
     requested_syncs_set = set(aws_requested_syncs)
@@ -509,6 +525,7 @@ def _sync_multiple_accounts(
     common_job_parameters: Dict[str, Any],
     aws_best_effort_mode: bool,
     aws_requested_syncs: List[str] = [],
+    aws_excluded_syncs: List[str] = [],
     regions: list[str] | None = None,
     organization_account_ids: Iterable[str] | None = None,
     use_explicit_profile: bool = False,
@@ -549,6 +566,7 @@ def _sync_multiple_accounts(
                 common_job_parameters,
                 regions=regions,
                 aws_requested_syncs=aws_requested_syncs,  # Could be replaced later with per-account requested syncs
+                aws_excluded_syncs=aws_excluded_syncs,
                 aioboto3_session=aioboto3_session,
             )
         except Exception as e:
@@ -706,6 +724,12 @@ def start_aws_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
         )
     requested_syncs = _normalize_requested_syncs(requested_syncs)
 
+    excluded_syncs: List[str] = []
+    if getattr(config, "aws_excluded_syncs", None):
+        excluded_syncs = parse_and_validate_aws_excluded_syncs(
+            config.aws_excluded_syncs,
+        )
+
     if config.aws_regions:
         regions = parse_and_validate_aws_regions(config.aws_regions)
     else:
@@ -724,6 +748,7 @@ def start_aws_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
         common_job_parameters,
         config.aws_best_effort_mode,
         requested_syncs,
+        aws_excluded_syncs=excluded_syncs,
         regions=regions,
         organization_account_ids=organization_account_ids,
         # Today this flag mirrors aws_sync_all_profiles 1:1; it's named separately so _sync_multiple_accounts
@@ -732,4 +757,5 @@ def start_aws_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     )
 
     if sync_successful:
-        _perform_aws_analysis(requested_syncs, neo4j_session, common_job_parameters)
+        effective_syncs = [s for s in requested_syncs if s not in set(excluded_syncs)]
+        _perform_aws_analysis(effective_syncs, neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/util/common.py
+++ b/cartography/intel/aws/util/common.py
@@ -26,6 +26,25 @@ def parse_and_validate_aws_requested_syncs(aws_requested_syncs: str) -> List[str
     return validated_resources
 
 
+def parse_and_validate_aws_excluded_syncs(aws_excluded_syncs: str) -> List[str]:
+    validated_resources: List[str] = []
+    for resource in aws_excluded_syncs.split(","):
+        resource = resource.strip()
+        if not resource:
+            continue
+        if resource in RESOURCE_FUNCTIONS:
+            validated_resources.append(resource)
+        else:
+            valid_syncs: str = ", ".join(RESOURCE_FUNCTIONS.keys())
+            raise ValueError(
+                f'Error parsing `aws-excluded-syncs`. You specified "{aws_excluded_syncs}". '
+                f"Please check that your string is formatted properly. "
+                f'Example valid input looks like "secretsmanager" or "secretsmanager, sagemaker". '
+                f"Our full list of valid values is: {valid_syncs}.",
+            )
+    return validated_resources
+
+
 def parse_and_validate_aws_regions(aws_regions: str) -> list[str]:
     """
     Parse and validate a comma-separated string of AWS regions.

--- a/docs/root/modules/aws/config.md
+++ b/docs/root/modules/aws/config.md
@@ -158,3 +158,22 @@ cartography --neo4j-uri bolt://localhost:7687 --aws-requested-syncs "ecr,lambda_
 For a complete and up-to-date list of resource identifiers that can be specified with `--aws-requested-syncs`, refer to the `RESOURCE_FUNCTIONS` dictionary in `cartography/cartography/intel/aws/resources.py`.
 
 **Note**: Cartography automatically handles resource dependencies and sync order internally, so you don't need to worry about the order in which you specify resources in the list. Using `--aws-requested-syncs` can significantly reduce sync time and API calls when you only need specific resources.
+
+### Skipping Specific Syncs with `--aws-excluded-syncs`
+
+When you want everything *except* one or two modules, `--aws-excluded-syncs` is more convenient than enumerating an allowlist with `--aws-requested-syncs`. It accepts the same comma-separated resource identifiers and subtracts them from the effective sync set.
+
+Sync everything except SecretsManager:
+```bash
+cartography --neo4j-uri bolt://localhost:7687 --aws-excluded-syncs "secretsmanager"
+```
+
+Both flags can be combined; exclusions are applied after the requested list:
+```bash
+cartography --neo4j-uri bolt://localhost:7687 \
+    --aws-requested-syncs "ec2:instance,s3,iam,secretsmanager" \
+    --aws-excluded-syncs "secretsmanager"
+# Effective set: ec2:instance, s3, iam
+```
+
+Unknown names raise an error at startup, matching `--aws-requested-syncs` behavior.

--- a/tests/integration/cartography/intel/aws/test_init.py
+++ b/tests/integration/cartography/intel/aws/test_init.py
@@ -98,6 +98,7 @@ def test_sync_multiple_accounts(
         GRAPH_JOB_PARAMETERS,
         regions=None,
         aws_requested_syncs=[],
+        aws_excluded_syncs=[],
         aioboto3_session=mock_aioboto3_session(profile_name="profile1"),
     )
     mock_sync_one.assert_any_call(
@@ -108,6 +109,7 @@ def test_sync_multiple_accounts(
         GRAPH_JOB_PARAMETERS,
         regions=None,
         aws_requested_syncs=[],
+        aws_excluded_syncs=[],
         aioboto3_session=mock_aioboto3_session(profile_name="profile2"),
     )
     mock_sync_one.assert_any_call(
@@ -118,6 +120,7 @@ def test_sync_multiple_accounts(
         GRAPH_JOB_PARAMETERS,
         regions=None,
         aws_requested_syncs=[],
+        aws_excluded_syncs=[],
         aioboto3_session=mock_aioboto3_session(profile_name="profile3"),
     )
 
@@ -545,6 +548,7 @@ def test_sync_multiple_accounts_single_profile_uses_profile_name(
         GRAPH_JOB_PARAMETERS,
         regions=None,
         aws_requested_syncs=[],
+        aws_excluded_syncs=[],
         aioboto3_session=mock_aioboto3_session(profile_name="spoke1"),
     )
 
@@ -964,6 +968,103 @@ def test_sync_one_account_just_iam_rels_and_tags(
     assert mock_autodiscover.call_count == 1
     assert mock_cleanup.call_count == 0
     assert mock_analysis.call_count == 1
+
+
+@mock.patch("cartography.intel.aws.aioboto3.Session")
+@mock.patch("cartography.intel.aws.boto3.Session")
+@mock.patch.dict(
+    "cartography.intel.aws.RESOURCE_FUNCTIONS", AWS_RESOURCE_FUNCTIONS_STUB
+)
+@mock.patch.object(
+    cartography.intel.aws.resourcegroupstaggingapi, "sync", return_value=None
+)
+@mock.patch("cartography.intel.aws.permission_relationships.sync")
+@mock.patch.object(
+    cartography.intel.aws, "_autodiscover_account_regions", return_value=TEST_REGIONS
+)
+@mock.patch.object(cartography.intel.aws, "run_cleanup_job", return_value=None)
+@mock.patch.object(cartography.intel.aws, "run_scoped_analysis_job", return_value=None)
+def test_sync_one_account_excluded_syncs_skipped(
+    mock_analysis,
+    mock_cleanup,
+    mock_autodiscover,
+    mock_perm_rels,
+    mock_tags,
+    mock_boto3_session,
+    mock_aioboto3_session,
+    neo4j_session,
+):
+    """
+    Modules listed in aws_excluded_syncs must not run, even after
+    _normalize_requested_syncs has had a chance to auto-include them.
+    This is the canonical case: --aws-requested-syncs ec2:load_balancer_v2,iam
+    plus --aws-excluded-syncs ec2:load_balancer_v2:expose. _normalize_requested_syncs
+    would otherwise re-add ':expose', silently overriding the user's exclusion.
+    """
+    # AWS_RESOURCE_FUNCTIONS_STUB is a module-level dict of MagicMocks that
+    # persists `.called` state across tests in this module. Reset before
+    # asserting which modules ran in this test.
+    for stub in AWS_RESOURCE_FUNCTIONS_STUB.values():
+        stub.reset_mock()
+
+    cartography.intel.aws._sync_one_account(
+        neo4j_session,
+        mock_boto3_session(),
+        "1234",
+        TEST_UPDATE_TAG,
+        GRAPH_JOB_PARAMETERS,
+        aws_requested_syncs=["iam", "ec2:load_balancer_v2"],
+        aws_excluded_syncs=["ec2:load_balancer_v2:expose"],
+    )
+
+    AWS_RESOURCE_FUNCTIONS_STUB["iam"].assert_called()
+    AWS_RESOURCE_FUNCTIONS_STUB["ec2:load_balancer_v2"].assert_called()
+    AWS_RESOURCE_FUNCTIONS_STUB["ec2:load_balancer_v2:expose"].assert_not_called()
+
+
+@mock.patch("cartography.intel.aws.aioboto3.Session")
+@mock.patch("cartography.intel.aws.boto3.Session")
+@mock.patch.dict(
+    "cartography.intel.aws.RESOURCE_FUNCTIONS", AWS_RESOURCE_FUNCTIONS_STUB
+)
+@mock.patch.object(
+    cartography.intel.aws.resourcegroupstaggingapi, "sync", return_value=None
+)
+@mock.patch("cartography.intel.aws.permission_relationships.sync")
+@mock.patch.object(
+    cartography.intel.aws, "_autodiscover_account_regions", return_value=TEST_REGIONS
+)
+@mock.patch.object(cartography.intel.aws, "run_cleanup_job", return_value=None)
+@mock.patch.object(cartography.intel.aws, "run_scoped_analysis_job", return_value=None)
+def test_sync_one_account_excluded_syncs_with_no_requested(
+    mock_analysis,
+    mock_cleanup,
+    mock_autodiscover,
+    mock_perm_rels,
+    mock_tags,
+    mock_boto3_session,
+    mock_aioboto3_session,
+    neo4j_session,
+):
+    """
+    Passing only aws_excluded_syncs (no aws_requested_syncs) excludes the named
+    module from the default full-sync set. Excluded module should NOT be invoked;
+    a non-excluded module should be invoked.
+    """
+    for stub in AWS_RESOURCE_FUNCTIONS_STUB.values():
+        stub.reset_mock()
+
+    cartography.intel.aws._sync_one_account(
+        neo4j_session,
+        mock_boto3_session(),
+        "1234",
+        TEST_UPDATE_TAG,
+        GRAPH_JOB_PARAMETERS,
+        aws_excluded_syncs=["secretsmanager"],
+    )
+
+    AWS_RESOURCE_FUNCTIONS_STUB["iam"].assert_called()
+    AWS_RESOURCE_FUNCTIONS_STUB["secretsmanager"].assert_not_called()
 
 
 def test_standardize_aws_sync_kwargs():

--- a/tests/unit/cartography/intel/aws/test_util.py
+++ b/tests/unit/cartography/intel/aws/test_util.py
@@ -1,6 +1,7 @@
 import pytest
 
 from cartography.intel.aws.util.common import parse_and_validate_aws_account_ids
+from cartography.intel.aws.util.common import parse_and_validate_aws_excluded_syncs
 from cartography.intel.aws.util.common import parse_and_validate_aws_regions
 from cartography.intel.aws.util.common import parse_and_validate_aws_requested_syncs
 
@@ -28,6 +29,33 @@ def test_parse_and_validate_requested_syncs():
     absolute_garbage = "#@$@#RDFFHKjsdfkjsd,KDFJHW#@,"
     with pytest.raises(ValueError):
         parse_and_validate_aws_requested_syncs(absolute_garbage)
+
+
+def test_parse_and_validate_excluded_syncs():
+    single = "secretsmanager"
+    assert parse_and_validate_aws_excluded_syncs(single) == ["secretsmanager"]
+
+    multiple = "secretsmanager, sagemaker,inspector"
+    assert parse_and_validate_aws_excluded_syncs(multiple) == [
+        "secretsmanager",
+        "sagemaker",
+        "inspector",
+    ]
+
+    # Empty input and trailing commas are tolerated (unlike requested_syncs,
+    # an empty excluded list is meaningful: "exclude nothing").
+    assert parse_and_validate_aws_excluded_syncs("") == []
+    assert parse_and_validate_aws_excluded_syncs("secretsmanager,,") == [
+        "secretsmanager",
+    ]
+
+    sync_that_does_not_exist = "secretsmanager, thisfuncdoesnotexist"
+    with pytest.raises(ValueError):
+        parse_and_validate_aws_excluded_syncs(sync_that_does_not_exist)
+
+    absolute_garbage = "#@$@#RDFFHKjsdfkjsd,KDFJHW#@,"
+    with pytest.raises(ValueError):
+        parse_and_validate_aws_excluded_syncs(absolute_garbage)
 
 
 def test_parse_and_validate_aws_regions():


### PR DESCRIPTION
## Motivation

When a single AWS module misbehaves (slow, throttled, or temporarily broken upstream), users today must either disable the entire AWS sync or enumerate every other module via `--aws-requested-syncs`. The latter breaks silently when cartography adds a new module in a release — the user's curated allowlist will keep working but quietly stop syncing the newly-added module.

This change adds `--aws-excluded-syncs` as the inverse of `--aws-requested-syncs`. Excluded modules are subtracted from the effective sync set (either `--aws-requested-syncs` if set, or the full `RESOURCE_FUNCTIONS` default). Unknown module names raise a `ValueError` at startup, mirroring the validation behavior of `--aws-requested-syncs`.

### Motivating example

SecretsManager's sync runs a strict serial loop calling `list_secret_version_ids` per secret (`cartography/intel/aws/secretsmanager.py:238`). Under SecretsManager API throttling, each call hits cartography's nested retry/backoff — boto3's internal retries *plus* the `@aws_handle_regions` decorator's `backoff.on_exception(..., max_time=600)` in `cartography/util.py:706` — ballooning to ~3 min/secret. With ~1000 secrets in a single account/region, the module takes days and stalls every later module in the `RESOURCE_FUNCTIONS` sync order.

`--aws-excluded-syncs secretsmanager` is the minimal-disruption workaround until that loop is parallelised, and the same shape of escape hatch should work for any future module that hits comparable pathology.

## Implementation notes

- **Exclusion is applied inside `_sync_one_account` *after* its inner `_normalize_requested_syncs` call.** This is load-bearing: `_normalize_requested_syncs` has a backward-compat auto-include for `ec2:load_balancer_v2:expose` whenever `ec2:load_balancer_v2` is requested. If exclusion were applied earlier (e.g. only in `start_aws_ingestion`), the inner normalize would silently re-add the excluded module. Applying exclusion as the final filter step makes the user's exclusion authoritative.
- `aws_excluded_syncs` is plumbed through `_sync_multiple_accounts` → `_sync_one_account` as a new optional kwarg, so programmatic callers can opt into the same behavior without going through `start_aws_ingestion`.
- `_perform_aws_analysis` receives the post-exclusion list so cross-module analysis jobs whose deps were excluded are correctly skipped via the existing `run_analysis_and_ensure_deps` gating.

## Semantics

When both `--aws-requested-syncs` and `--aws-excluded-syncs` are passed, the effective set is `requested - excluded`:

```bash
cartography --aws-requested-syncs "ec2:instance,s3,iam,secretsmanager" \
            --aws-excluded-syncs  "secretsmanager"
# Effective set: ec2:instance, s3, iam
```

When only `--aws-excluded-syncs` is passed, the effective set is `ALL_MODULES - excluded`.

## Tests

- **Unit**: `parse_and_validate_aws_excluded_syncs` covered for single, multi, empty, trailing-comma, unknown-name, and garbage inputs.
- **Integration**: new tests verify (a) excluded module is not invoked even when normalize would auto-include it (the load-bearing order-of-operations case), and (b) exclusion works without `--aws-requested-syncs` (default-all minus excluded).
- All existing tests continue to pass; the only mechanical adjustments are kwarg additions in `_sync_one_account` call assertions (`aws_excluded_syncs=[]` propagated).
- `pre-commit run --all-files` clean (isort / black / flake8 / pyupgrade / mypy).