### PR TITLE
fix(ontology): skip RANGE index on unbounded semantic-label fields

### DIFF
--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -1457,6 +1457,8 @@ def build_create_index_queries(node_schema: CartographyNodeSchema) -> list[str]:
                 ),
             )
             for mapping_field in ontology_mapping.fields:
+                if not mapping_field.indexed:
+                    continue
                 result.append(
                     index_template.safe_substitute(
                         TargetNodeLabel=label_name,

--- a/cartography/models/ontology/mapping/data/coderepositories.py
+++ b/cartography/models/ontology/mapping/data/coderepositories.py
@@ -21,7 +21,9 @@ github_mapping = OntologyMapping(
                 OntologyFieldMapping(ontology_field="name", node_field="name"),
                 OntologyFieldMapping(ontology_field="fullname", node_field="fullname"),
                 OntologyFieldMapping(
-                    ontology_field="description", node_field="description"
+                    ontology_field="description",
+                    node_field="description",
+                    indexed=False,
                 ),
                 OntologyFieldMapping(ontology_field="url", node_field="url"),
                 OntologyFieldMapping(
@@ -49,7 +51,9 @@ gitlab_mapping = OntologyMapping(
                     ontology_field="fullname", node_field="path_with_namespace"
                 ),
                 OntologyFieldMapping(
-                    ontology_field="description", node_field="description"
+                    ontology_field="description",
+                    node_field="description",
+                    indexed=False,
                 ),
                 OntologyFieldMapping(ontology_field="url", node_field="web_url"),
                 OntologyFieldMapping(

--- a/cartography/models/ontology/mapping/data/cves.py
+++ b/cartography/models/ontology/mapping/data/cves.py
@@ -36,14 +36,17 @@ cve_mapping = OntologyMapping(
                 OntologyFieldMapping(
                     ontology_field="description",
                     node_field="description",
+                    indexed=False,
                 ),
                 OntologyFieldMapping(
                     ontology_field="references",
                     node_field="references",
+                    indexed=False,
                 ),
                 OntologyFieldMapping(
                     ontology_field="problem_types",
                     node_field="problem_types",
+                    indexed=False,
                 ),
                 OntologyFieldMapping(
                     ontology_field="vector_string",
@@ -121,14 +124,17 @@ trivy_mapping = OntologyMapping(
                 OntologyFieldMapping(
                     ontology_field="description",
                     node_field="description",
+                    indexed=False,
                 ),
                 OntologyFieldMapping(
                     ontology_field="references",
                     node_field="references",
+                    indexed=False,
                 ),
                 OntologyFieldMapping(
                     ontology_field="problem_types",
                     node_field="cwe_ids",
+                    indexed=False,
                 ),
                 OntologyFieldMapping(
                     ontology_field="vector_string",
@@ -169,6 +175,7 @@ ubuntu_mapping = OntologyMapping(
                 OntologyFieldMapping(
                     ontology_field="description",
                     node_field="description",
+                    indexed=False,
                 ),
                 OntologyFieldMapping(
                     ontology_field="attack_vector",
@@ -245,14 +252,17 @@ github_mapping = OntologyMapping(
                 OntologyFieldMapping(
                     ontology_field="description",
                     node_field="advisory_description",
+                    indexed=False,
                 ),
                 OntologyFieldMapping(
                     ontology_field="references",
                     node_field="references",
+                    indexed=False,
                 ),
                 OntologyFieldMapping(
                     ontology_field="problem_types",
                     node_field="cwe_ids",
+                    indexed=False,
                 ),
                 OntologyFieldMapping(
                     ontology_field="vector_string",

--- a/cartography/models/ontology/mapping/data/groups.py
+++ b/cartography/models/ontology/mapping/data/groups.py
@@ -28,7 +28,9 @@ aws_mapping = OntologyMapping(
                     ontology_field="name", node_field="display_name", required=True
                 ),
                 OntologyFieldMapping(
-                    ontology_field="description", node_field="description"
+                    ontology_field="description",
+                    node_field="description",
+                    indexed=False,
                 ),
                 # email: Not available
             ],
@@ -46,7 +48,9 @@ duo_mapping = OntologyMapping(
                 OntologyFieldMapping(
                     ontology_field="name", node_field="name", required=True
                 ),
-                OntologyFieldMapping(ontology_field="description", node_field="desc"),
+                OntologyFieldMapping(
+                    ontology_field="description", node_field="desc", indexed=False
+                ),
                 # email: Not available
             ],
         ),
@@ -64,7 +68,9 @@ entra_mapping = OntologyMapping(
                     ontology_field="name", node_field="display_name", required=True
                 ),
                 OntologyFieldMapping(
-                    ontology_field="description", node_field="description"
+                    ontology_field="description",
+                    node_field="description",
+                    indexed=False,
                 ),
                 OntologyFieldMapping(ontology_field="email", node_field="mail"),
             ],
@@ -83,7 +89,9 @@ github_mapping = OntologyMapping(
                     ontology_field="name", node_field="name", required=True
                 ),
                 OntologyFieldMapping(
-                    ontology_field="description", node_field="description"
+                    ontology_field="description",
+                    node_field="description",
+                    indexed=False,
                 ),
                 # email: Not available
             ],
@@ -102,7 +110,9 @@ gitlab_mapping = OntologyMapping(
                     ontology_field="name", node_field="name", required=True
                 ),
                 OntologyFieldMapping(
-                    ontology_field="description", node_field="description"
+                    ontology_field="description",
+                    node_field="description",
+                    indexed=False,
                 ),
                 # email: Not available
             ],
@@ -121,7 +131,9 @@ googleworkspace_mapping = OntologyMapping(
                     ontology_field="name", node_field="display_name", required=True
                 ),
                 OntologyFieldMapping(
-                    ontology_field="description", node_field="description"
+                    ontology_field="description",
+                    node_field="description",
+                    indexed=False,
                 ),
                 OntologyFieldMapping(ontology_field="email", node_field="email"),
             ],
@@ -140,7 +152,9 @@ gsuite_mapping = OntologyMapping(
                     ontology_field="name", node_field="name", required=True
                 ),
                 OntologyFieldMapping(
-                    ontology_field="description", node_field="description"
+                    ontology_field="description",
+                    node_field="description",
+                    indexed=False,
                 ),
                 OntologyFieldMapping(ontology_field="email", node_field="email"),
             ],
@@ -159,7 +173,9 @@ keycloak_mapping = OntologyMapping(
                     ontology_field="name", node_field="name", required=True
                 ),
                 OntologyFieldMapping(
-                    ontology_field="description", node_field="description"
+                    ontology_field="description",
+                    node_field="description",
+                    indexed=False,
                 ),
                 # email: Not available
             ],
@@ -178,7 +194,9 @@ oci_mapping = OntologyMapping(
                     ontology_field="name", node_field="name", required=True
                 ),
                 OntologyFieldMapping(
-                    ontology_field="description", node_field="description"
+                    ontology_field="description",
+                    node_field="description",
+                    indexed=False,
                 ),
                 # email: Not available
             ],
@@ -197,7 +215,9 @@ okta_mapping = OntologyMapping(
                     ontology_field="name", node_field="name", required=True
                 ),
                 OntologyFieldMapping(
-                    ontology_field="description", node_field="description"
+                    ontology_field="description",
+                    node_field="description",
+                    indexed=False,
                 ),
                 # email: Not available
             ],
@@ -216,7 +236,9 @@ pagerduty_mapping = OntologyMapping(
                     ontology_field="name", node_field="name", required=True
                 ),
                 OntologyFieldMapping(
-                    ontology_field="description", node_field="description"
+                    ontology_field="description",
+                    node_field="description",
+                    indexed=False,
                 ),
                 # email: Not available
             ],
@@ -252,7 +274,9 @@ scaleway_mapping = OntologyMapping(
                     ontology_field="name", node_field="name", required=True
                 ),
                 OntologyFieldMapping(
-                    ontology_field="description", node_field="description"
+                    ontology_field="description",
+                    node_field="description",
+                    indexed=False,
                 ),
                 # email: Not available
             ],
@@ -271,7 +295,9 @@ slack_mapping = OntologyMapping(
                     ontology_field="name", node_field="name", required=True
                 ),
                 OntologyFieldMapping(
-                    ontology_field="description", node_field="description"
+                    ontology_field="description",
+                    node_field="description",
+                    indexed=False,
                 ),
                 # email: Not available
             ],

--- a/cartography/models/ontology/mapping/specs.py
+++ b/cartography/models/ontology/mapping/specs.py
@@ -13,6 +13,9 @@ class OntologyFieldMapping:
         required: Whether this field is required to create an ontology node or not.
         special_handling: Any special handling required for this field (e.g., "invert_boolean").
         extra: Additional info that may be relevant for this mapping (only used for specific special_handling).
+        indexed: Whether to create a RANGE index on the resulting `_ont_<field>` for each semantic label.
+          Set to False for unbounded text/list fields (e.g. references, description) whose values can
+          exceed Neo4j's index value limit (~8 KB).
 
     Available special_handling options:
         - "invert_boolean": Inverts the boolean value of the field (e.g., True becomes False and vice versa).
@@ -35,6 +38,7 @@ class OntologyFieldMapping:
     required: bool = False
     special_handling: str | None = None
     extra: dict[str, Any] = field(default_factory=dict)
+    indexed: bool = True
 
 
 @dataclass(frozen=True)

--- a/tests/unit/cartography/graph/test_querybuilder_indexcreation.py
+++ b/tests/unit/cartography/graph/test_querybuilder_indexcreation.py
@@ -1,6 +1,7 @@
 from cartography.graph.querybuilder import build_create_index_queries
 from cartography.models.aws.dynamodb.tables import DynamoDBTableSchema
 from cartography.models.aws.emr import EMRClusterSchema
+from cartography.models.trivy.findings import TrivyImageFindingSchema
 from tests.data.graph.querybuilder.sample_models.interesting_asset import (
     InterestingAssetSchema,
 )
@@ -41,6 +42,31 @@ def test_build_create_index_queries_for_emr():
         "CREATE INDEX IF NOT EXISTS FOR (n:ComputeCluster) ON (n._ont_region);",
         "CREATE INDEX IF NOT EXISTS FOR (n:ComputeCluster) ON (n._ont_version);",
     }.issubset(set(result))
+
+
+def test_build_create_index_queries_skips_unindexed_ontology_fields():
+    """
+    Unbounded ontology fields (references, description, problem_types) declare indexed=False
+    so they do not get a RANGE index on the semantic labels. Their `_ont_<field>` values can
+    exceed Neo4j's index value limit (~8 KB) and crash the sync. Bounded fields and _ont_source
+    must still be indexed. TrivyImageFinding carries the "Risk" and "CVE" semantic labels.
+    """
+    result = set(build_create_index_queries(TrivyImageFindingSchema()))
+
+    for label in ("Risk", "CVE"):
+        for field in ("references", "description", "problem_types"):
+            assert (
+                f"CREATE INDEX IF NOT EXISTS FOR (n:{label}) ON (n._ont_{field});"
+                not in result
+            )
+
+    # Bounded ontology fields and _ont_source are still indexed on the semantic labels.
+    assert {
+        "CREATE INDEX IF NOT EXISTS FOR (n:Risk) ON (n._ont_source);",
+        "CREATE INDEX IF NOT EXISTS FOR (n:Risk) ON (n._ont_cve_id);",
+        "CREATE INDEX IF NOT EXISTS FOR (n:CVE) ON (n._ont_source);",
+        "CREATE INDEX IF NOT EXISTS FOR (n:CVE) ON (n._ont_cve_id);",
+    }.issubset(result)
 
 
 def test_build_create_index_queries_for_dynamodb_table_arn():


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

`build_create_index_queries()` creates a RANGE index on **every** ontology field of **every** semantic (extra) label, with no way to opt out. For ontology fields that hold unbounded text or lists (notably `references`, `description`, `problem_types` on CVE/Risk-labeled nodes), the resulting `_ont_<field>` value can exceed Neo4j's RANGE index value limit (~8167 bytes). When that happens, the `load()` write fails and the entire sync aborts:

```
Neo.DatabaseError.Statement.ExecutionFailed
Property value is too large to index, please see index documentation for limitations.
Index( ... type='RANGE', schema=(:Risk {_ont_references}) ), property size: 13846.
```

The failure is not self-recovering: `load()` calls `ensure_indexes()` (re-creating the offending index) and then writes the same oversized value, so every subsequent run re-hits the limit. The bad index must be dropped manually to unblock the affected database.

These indexes are also useless: you never range/equality-match on a list of advisory URLs or a free-text description.

**Fix:** add an `indexed: bool = True` flag to `OntologyFieldMapping` and skip index creation when it is `False`. Default `True` preserves current behavior for every existing mapping. The unbounded fields (`references`, `problem_types`, and all `description` mappings) are opted out. The `_ont_source` index is unaffected.


### Related issues or links

<!-- none -->


### How was this tested?

- Added a unit test (`test_build_create_index_queries_skips_unindexed_ontology_fields`) asserting that a schema carrying the `Risk` and `CVE` semantic labels produces **no** `_ont_references` / `_ont_description` / `_ont_problem_types` indexes, while still emitting `_ont_source` and bounded fields such as `_ont_cve_id`.
- `make test_lint` passes locally (black, flake8, isort, mypy).
- Ran the graph and ontology unit suites: 105 passed.


### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.


### Notes for reviewers

The flag only prevents *future* index creation. Databases that already ran an affected sync will have the oversized index and must drop it to recover:

```cypher
SHOW INDEXES YIELD name, type, entityType, properties
WHERE entityType = 'NODE' AND type = 'RANGE'
  AND any(p IN properties WHERE p IN ['_ont_references','_ont_description','_ont_problem_types'])
RETURN name;
// then, per returned name:
DROP INDEX `<name>` IF EXISTS;
```