### PR TITLE
fix(microsoft): restart expired Graph pagination

### DIFF
--- a/cartography/intel/microsoft/entra/groups.py
+++ b/cartography/intel/microsoft/entra/groups.py
@@ -13,6 +13,9 @@ from msgraph.generated.models.group import Group
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.microsoft.entra.utils import call_with_retries
+from cartography.intel.microsoft.entra.utils import (
+    get_paginated_values_with_expired_page_retry,
+)
 from cartography.models.microsoft.entra.group import EntraGroupSchema
 from cartography.util import timeit
 
@@ -43,19 +46,18 @@ async def get_group_members(
     user_ids: list[str] = []
     group_ids: list[str] = []
     request_builder = client.groups.by_group_id(group_id).members
-    page = await request_builder.get()
-    while page:
-        if page.value:
-            for obj in page.value:
-                if isinstance(obj, DirectoryObject):
-                    odata_type = getattr(obj, "odata_type", "")
-                    if odata_type == "#microsoft.graph.user":
-                        user_ids.append(obj.id)
-                    elif odata_type == "#microsoft.graph.group":
-                        group_ids.append(obj.id)
-        if not page.odata_next_link:
-            break
-        page = await request_builder.with_url(page.odata_next_link).get()
+    members = await get_paginated_values_with_expired_page_retry(
+        request_builder.get,
+        lambda next_link: request_builder.with_url(next_link).get(),
+        f"members for Entra group {group_id}",
+    )
+    for obj in members:
+        if isinstance(obj, DirectoryObject):
+            odata_type = getattr(obj, "odata_type", "")
+            if odata_type == "#microsoft.graph.user":
+                user_ids.append(obj.id)
+            elif odata_type == "#microsoft.graph.group":
+                group_ids.append(obj.id)
     return user_ids, group_ids
 
 
@@ -64,16 +66,15 @@ async def get_group_owners(client: GraphServiceClient, group_id: str) -> list[st
     """Get owner user IDs for a given group."""
     owner_ids: list[str] = []
     request_builder = client.groups.by_group_id(group_id).owners
-    page = await request_builder.get()
-    while page:
-        if page.value:
-            for obj in page.value:
-                odata_type = getattr(obj, "odata_type", "")
-                if odata_type == "#microsoft.graph.user":
-                    owner_ids.append(obj.id)
-        if not page.odata_next_link:
-            break
-        page = await request_builder.with_url(page.odata_next_link).get()
+    owners = await get_paginated_values_with_expired_page_retry(
+        request_builder.get,
+        lambda next_link: request_builder.with_url(next_link).get(),
+        f"owners for Entra group {group_id}",
+    )
+    for obj in owners:
+        odata_type = getattr(obj, "odata_type", "")
+        if odata_type == "#microsoft.graph.user":
+            owner_ids.append(obj.id)
     return owner_ids
 
 
@@ -161,18 +162,40 @@ async def sync_entra_groups(
         # returning a 404 or 410. Skip it and move on.
         try:
             owners = await call_with_retries(get_group_owners, client, group.id)
-            users, subgroups = await call_with_retries(
-                get_group_members, client, group.id
-            )
-        except APIError as e:
-            if e.response_status_code in (404, 410):
+        except Exception as e:
+            if isinstance(e, APIError) and e.response_status_code in (404, 410):
                 logger.warning(
-                    "Group %s (%s) not found (%d); skipping.",
+                    "Group %s (%s) not found (%d) while fetching owners; skipping.",
                     group.id,
                     group.display_name,
                     e.response_status_code,
                 )
                 continue
+            logger.exception(
+                "Failed to fetch owners for Entra group %s (%s).",
+                group.id,
+                group.display_name,
+            )
+            raise
+
+        try:
+            users, subgroups = await call_with_retries(
+                get_group_members, client, group.id
+            )
+        except Exception as e:
+            if isinstance(e, APIError) and e.response_status_code in (404, 410):
+                logger.warning(
+                    "Group %s (%s) not found (%d) while fetching members; skipping.",
+                    group.id,
+                    group.display_name,
+                    e.response_status_code,
+                )
+                continue
+            logger.exception(
+                "Failed to fetch members for Entra group %s (%s).",
+                group.id,
+                group.display_name,
+            )
             raise
 
         groups_batch.append(group)

--- a/cartography/intel/microsoft/entra/utils.py
+++ b/cartography/intel/microsoft/entra/utils.py
@@ -1,9 +1,11 @@
 import logging
 from typing import Any
+from typing import Awaitable
 from typing import Callable
 
 import backoff
 import httpx
+from kiota_abstractions.api_error import APIError
 
 from cartography.helpers import backoff_handler
 
@@ -12,6 +14,8 @@ logger = logging.getLogger(__name__)
 # Transient transport errors that are safe to retry (HTTP/2 resets, connection drops, etc.)
 TRANSIENT_EXCEPTIONS = (httpx.ReadError, httpx.ConnectError, httpx.RemoteProtocolError)
 MAX_RETRIES = 3
+DIRECTORY_EXPIRED_PAGE_TOKEN = "Directory_ExpiredPageToken"
+MAX_EXPIRED_PAGE_TOKEN_RESTARTS = 1
 
 
 async def call_with_retries(
@@ -43,3 +47,69 @@ async def call_with_retries(
         return await func(*args)
 
     return await _inner()
+
+
+def is_directory_expired_page_token_error(error: Exception) -> bool:
+    """
+    Return whether a Microsoft Graph error is an expired pagination token.
+
+    Microsoft Graph returns this as a 400 ODataError. Other 400s, including
+    authorization/configuration problems expressed through Graph, must continue
+    to fail fast.
+    """
+    if not isinstance(error, APIError):
+        return False
+    if error.response_status_code != 400:
+        return False
+
+    graph_error = getattr(error, "error", None)
+    return getattr(graph_error, "code", None) == DIRECTORY_EXPIRED_PAGE_TOKEN
+
+
+async def get_paginated_values_with_expired_page_retry(
+    first_page_getter: Callable[[], Awaitable[Any]],
+    next_page_getter: Callable[[str], Awaitable[Any]],
+    resource_description: str,
+    max_expired_page_token_restarts: int = MAX_EXPIRED_PAGE_TOKEN_RESTARTS,
+) -> list[Any]:
+    """
+    Fetch all values from a Microsoft Graph paginated request.
+
+    If a next-link fails with Directory_ExpiredPageToken, restart the whole
+    request from the first page and discard partial results. Retrying the same
+    expired next-link cannot succeed.
+    """
+    restart_count = 0
+
+    while True:
+        values: list[Any] = []
+
+        try:
+            page = await call_with_retries(first_page_getter)
+
+            while page:
+                if page.value:
+                    values.extend(page.value)
+
+                next_link = page.odata_next_link
+                if not next_link:
+                    return values
+
+                page = await call_with_retries(lambda: next_page_getter(next_link))
+            return values
+        except APIError as e:
+            if (
+                is_directory_expired_page_token_error(e)
+                and restart_count < max_expired_page_token_restarts
+            ):
+                restart_count += 1
+                logger.warning(
+                    "Microsoft Graph pagination token expired for %s; "
+                    "restarting paginated request from the first page "
+                    "(restart %d/%d).",
+                    resource_description,
+                    restart_count,
+                    max_expired_page_token_restarts,
+                )
+                continue
+            raise

--- a/cartography/intel/microsoft/entra/utils.py
+++ b/cartography/intel/microsoft/entra/utils.py
@@ -62,8 +62,10 @@ def is_directory_expired_page_token_error(error: Exception) -> bool:
     if error.response_status_code != 400:
         return False
 
-    graph_error = getattr(error, "error", None)
-    return getattr(graph_error, "code", None) == DIRECTORY_EXPIRED_PAGE_TOKEN
+    graph_error = error.error
+    if graph_error is None:
+        return False
+    return graph_error.code == DIRECTORY_EXPIRED_PAGE_TOKEN
 
 
 async def get_paginated_values_with_expired_page_retry(

--- a/cartography/intel/microsoft/entra/utils.py
+++ b/cartography/intel/microsoft/entra/utils.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 TRANSIENT_EXCEPTIONS = (httpx.ReadError, httpx.ConnectError, httpx.RemoteProtocolError)
 MAX_RETRIES = 3
 DIRECTORY_EXPIRED_PAGE_TOKEN = "Directory_ExpiredPageToken"
-MAX_EXPIRED_PAGE_TOKEN_RESTARTS = 1
+MAX_EXPIRED_PAGE_TOKEN_RESTARTS = 5
 
 
 async def call_with_retries(

--- a/tests/integration/cartography/intel/microsoft/entra/test_groups.py
+++ b/tests/integration/cartography/intel/microsoft/entra/test_groups.py
@@ -172,8 +172,8 @@ async def test_get_group_members_does_not_restart_expired_page_token_forever():
             "11111111-1111-1111-1111-111111111111",
         )
 
-    assert members_builder.first_page_calls == 2
-    assert members_builder.next_page_calls == 2
+    assert members_builder.first_page_calls == 6
+    assert members_builder.next_page_calls == 6
 
 
 @pytest.mark.asyncio

--- a/tests/integration/cartography/intel/microsoft/entra/test_groups.py
+++ b/tests/integration/cartography/intel/microsoft/entra/test_groups.py
@@ -3,8 +3,11 @@ from unittest.mock import patch
 
 import pytest
 from kiota_abstractions.api_error import APIError
+from msgraph.generated.models.o_data_errors.main_error import MainError
+from msgraph.generated.models.o_data_errors.o_data_error import ODataError
 
 import cartography.intel.microsoft.entra.groups
+from cartography.intel.microsoft.entra.groups import get_group_members
 from cartography.intel.microsoft.entra.groups import sync_entra_groups
 from cartography.intel.microsoft.entra.users import load_tenant
 from cartography.intel.microsoft.entra.users import load_users
@@ -21,6 +24,75 @@ from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 1234567890
+
+
+class MockPage:
+    def __init__(self, value, odata_next_link=None):
+        self.value = value
+        self.odata_next_link = odata_next_link
+
+
+def _expired_page_token_error() -> ODataError:
+    error = ODataError()
+    error.response_status_code = 400
+    error.error = MainError()
+    error.error.code = "Directory_ExpiredPageToken"
+    error.error.message = (
+        "The specified page token value has expired and can no longer be "
+        "included in your request."
+    )
+    return error
+
+
+class MockGroupMembersRequestBuilder:
+    def __init__(self, first_page, second_page, recover_on_second_attempt=True):
+        self.first_page = first_page
+        self.second_page = second_page
+        self.recover_on_second_attempt = recover_on_second_attempt
+        self.first_page_calls = 0
+        self.next_page_calls = 0
+        self.expired_token_raised = False
+
+    async def get(self):
+        self.first_page_calls += 1
+        return self.first_page
+
+    def with_url(self, next_link):
+        assert next_link == "next-page"
+        return MockGroupMembersNextPageRequestBuilder(self)
+
+
+class MockGroupMembersNextPageRequestBuilder:
+    def __init__(self, parent):
+        self.parent = parent
+
+    async def get(self):
+        self.parent.next_page_calls += 1
+        if (
+            not self.parent.expired_token_raised
+            or not self.parent.recover_on_second_attempt
+        ):
+            self.parent.expired_token_raised = True
+            raise _expired_page_token_error()
+        return self.parent.second_page
+
+
+class MockGroupsRequestBuilder:
+    def __init__(self, members_builder):
+        self.members_builder = members_builder
+
+    def by_group_id(self, group_id):
+        return MockGroupRequestBuilder(self.members_builder)
+
+
+class MockGroupRequestBuilder:
+    def __init__(self, members_builder):
+        self.members = members_builder
+
+
+class MockGraphClient:
+    def __init__(self, members_builder):
+        self.groups = MockGroupsRequestBuilder(members_builder)
 
 
 def mock_get_group_members_side_effect(
@@ -45,6 +117,79 @@ def mock_get_group_owners_side_effect(client, group_id: str) -> list[str]:
         return ["11dca63b-cb03-4e53-bb75-fa8060285550"]
     else:
         return []
+
+
+@pytest.mark.asyncio
+async def test_get_group_members_restarts_after_expired_page_token():
+    first_page = MockPage(
+        [
+            MOCK_GROUP_MEMBERS["11111111-1111-1111-1111-111111111111"][0],
+        ],
+        "next-page",
+    )
+    second_page = MockPage(
+        [
+            MOCK_GROUP_MEMBERS["11111111-1111-1111-1111-111111111111"][1],
+            MOCK_GROUP_MEMBERS["11111111-1111-1111-1111-111111111111"][2],
+        ],
+    )
+    members_builder = MockGroupMembersRequestBuilder(first_page, second_page)
+    client = MockGraphClient(members_builder)
+
+    user_ids, group_ids = await get_group_members(
+        client,
+        "11111111-1111-1111-1111-111111111111",
+    )
+
+    assert user_ids == [
+        "ae4ac864-4433-4ba6-96a6-20f8cffdadcb",
+        "11dca63b-cb03-4e53-bb75-fa8060285550",
+    ]
+    assert group_ids == ["22222222-2222-2222-2222-222222222222"]
+    assert members_builder.first_page_calls == 2
+    assert members_builder.next_page_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_get_group_members_does_not_restart_expired_page_token_forever():
+    first_page = MockPage(
+        [
+            MOCK_GROUP_MEMBERS["11111111-1111-1111-1111-111111111111"][0],
+        ],
+        "next-page",
+    )
+    second_page = MockPage([])
+    members_builder = MockGroupMembersRequestBuilder(
+        first_page,
+        second_page,
+        recover_on_second_attempt=False,
+    )
+    client = MockGraphClient(members_builder)
+
+    with pytest.raises(ODataError):
+        await get_group_members(
+            client,
+            "11111111-1111-1111-1111-111111111111",
+        )
+
+    assert members_builder.first_page_calls == 2
+    assert members_builder.next_page_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_get_group_members_returns_empty_for_missing_first_page():
+    members_builder = MockGroupMembersRequestBuilder(None, MockPage([]))
+    client = MockGraphClient(members_builder)
+
+    user_ids, group_ids = await get_group_members(
+        client,
+        "11111111-1111-1111-1111-111111111111",
+    )
+
+    assert user_ids == []
+    assert group_ids == []
+    assert members_builder.first_page_calls == 1
+    assert members_builder.next_page_calls == 0
 
 
 async def _mock_get_entra_groups(client):


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)



### Summary
Microsoft Graph can return `Directory_ExpiredPageToken` during paginated reads when an `odata_next_link` expires. This currently bubbles up from Entra group owner/member pagination and fails the Microsoft sync.

This change adds a bounded paginated-read helper that treats only that Graph error as retryable, discards partial page results, and restarts the affected request from the first page instead of retrying the expired next-link. Other Graph errors, including authorization and unrelated bad requests, continue to fail fast.

Group owner/member fetch failures now log the affected group id and display name to make sync failures easier to diagnose.


### Related issues or links

N/A


### Breaking changes

None.


### How was this tested?

- Manual live validation against a large Entra tenant using a temporary local Neo4j database. The run observed repeated `Directory_ExpiredPageToken` responses during group-member pagination, restarted the affected paginated requests, and completed Entra tenant/user/group loading. Raw logs were kept local and redacted before summarizing.


### Checklist

#### General
- [ ] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

The retry is intentionally narrow: it only handles Microsoft Graph `Directory_ExpiredPageToken` responses and restarts the affected paginated request a bounded number of times. Retrying the expired `odata_next_link` directly is avoided because the token is no longer valid.
