### PR TITLE
fix(okta): retry non-json group member errors

### DIFF
--- a/cartography/intel/okta/groups.py
+++ b/cartography/intel/okta/groups.py
@@ -56,11 +56,7 @@ def _get_okta_groups(api_client: ApiClient) -> List[str]:
         check_rate_limit(paged_response)
 
         if not is_last_page(paged_response):
-            next_link = paged_response.links.get("next")
-            if next_link is None:
-                next_url = None
-            else:
-                next_url = next_link.get("url")
+            next_url = _get_next_url(paged_response)
         else:
             break
 
@@ -86,15 +82,18 @@ def get_okta_group_members(api_client: ApiClient, group_id: str) -> List[Dict]:
         check_rate_limit(paged_response)
 
         if not is_last_page(paged_response):
-            next_link = paged_response.links.get("next")
-            if next_link is None:
-                next_url = None
-            else:
-                next_url = next_link.get("url")
+            next_url = _get_next_url(paged_response)
         else:
             break
 
     return member_list
+
+
+def _get_next_url(paged_response: Response) -> str:
+    next_link = paged_response.links.get("next")
+    if not isinstance(next_link, dict) or not next_link.get("url"):
+        raise ValueError("Okta paginated response was missing a next URL.")
+    return str(next_link["url"])
 
 
 def _get_okta_group_members_page(

--- a/cartography/intel/okta/groups.py
+++ b/cartography/intel/okta/groups.py
@@ -1,6 +1,7 @@
 # Okta intel module - Group
 import json
 import logging
+import time
 from typing import Dict
 from typing import List
 from typing import Tuple
@@ -10,6 +11,7 @@ from okta.framework.ApiClient import ApiClient
 from okta.framework.OktaError import OktaError
 from okta.framework.PagedResults import PagedResults
 from okta.models.usergroup import UserGroup
+from requests import Response
 
 from cartography.client.core.tx import run_write_query
 from cartography.intel.okta.sync_state import OktaSyncState
@@ -19,6 +21,9 @@ from cartography.intel.okta.utils import is_last_page
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
+
+OKTA_GROUP_MEMBER_REQUEST_ATTEMPTS = 3
+OKTA_GROUP_MEMBER_RETRY_DELAY_SECONDS = 1
 
 
 @timeit
@@ -51,7 +56,11 @@ def _get_okta_groups(api_client: ApiClient) -> List[str]:
         check_rate_limit(paged_response)
 
         if not is_last_page(paged_response):
-            next_url = paged_response.links.get("next").get("url")
+            next_link = paged_response.links.get("next")
+            if next_link is None:
+                next_url = None
+            else:
+                next_url = next_link.get("url")
         else:
             break
 
@@ -70,29 +79,58 @@ def get_okta_group_members(api_client: ApiClient, group_id: str) -> List[Dict]:
     next_url = None
 
     while True:
-        try:
-            # https://developer.okta.com/docs/reference/api/groups/#list-group-members
-            if next_url:
-                paged_response = api_client.get(next_url)
-            else:
-                params = {
-                    "limit": 1000,
-                }
-                paged_response = api_client.get_path(f"/{group_id}/users", params)
-        except OktaError:
-            logger.error(f"OktaError while listing members of group {group_id}")
-            raise
+        paged_response = _get_okta_group_members_page(api_client, group_id, next_url)
 
         member_list.extend(json.loads(paged_response.text))
 
         check_rate_limit(paged_response)
 
         if not is_last_page(paged_response):
-            next_url = paged_response.links.get("next").get("url")
+            next_link = paged_response.links.get("next")
+            if next_link is None:
+                next_url = None
+            else:
+                next_url = next_link.get("url")
         else:
             break
 
     return member_list
+
+
+def _get_okta_group_members_page(
+    api_client: ApiClient,
+    group_id: str,
+    next_url: str | None,
+) -> Response:
+    for attempt in range(1, OKTA_GROUP_MEMBER_REQUEST_ATTEMPTS + 1):
+        try:
+            # https://developer.okta.com/docs/reference/api/groups/#list-group-members
+            if next_url:
+                return api_client.get(next_url)
+            params = {
+                "limit": 1000,
+            }
+            return api_client.get_path(f"/{group_id}/users", params)
+        except json.JSONDecodeError:
+            if attempt == OKTA_GROUP_MEMBER_REQUEST_ATTEMPTS:
+                logger.exception(
+                    "Okta returned a non-JSON error response while listing members of group %s after %d attempts.",
+                    group_id,
+                    attempt,
+                )
+                raise
+            logger.warning(
+                "Okta returned a non-JSON error response while listing members of group %s. Retrying request (%d/%d).",
+                group_id,
+                attempt + 1,
+                OKTA_GROUP_MEMBER_REQUEST_ATTEMPTS,
+            )
+            time.sleep(OKTA_GROUP_MEMBER_RETRY_DELAY_SECONDS)
+        except OktaError:
+            logger.error("OktaError while listing members of group %s", group_id)
+            raise
+
+    raise RuntimeError("Unexpected Okta group member retry state.")
 
 
 @timeit

--- a/tests/unit/cartography/intel/okta/test_group.py
+++ b/tests/unit/cartography/intel/okta/test_group.py
@@ -1,10 +1,22 @@
+import json
 from typing import Dict
 from typing import List
+from unittest import mock
 
+import pytest
+
+from cartography.intel.okta.groups import get_okta_group_members
 from cartography.intel.okta.groups import transform_okta_group
 from cartography.intel.okta.groups import transform_okta_group_member_list
 from tests.data.okta.groups import create_test_group
 from tests.data.okta.groups import GROUP_MEMBERS_SAMPLE_DATA
+
+
+class _Response:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.headers: dict[str, str] = {}
+        self.links: dict[str, dict[str, str]] = {}
 
 
 def test_group_transform_with_all_values():
@@ -95,3 +107,35 @@ def test_group_member_list_transform():
     assert ("Clarkson", "OKTA_USER_ID_1") in last_names
     assert ("Hammond", "OKTA_USER_ID_3") in last_names
     assert ("May", "OKTA_USER_ID_2") in last_names
+
+
+@mock.patch("cartography.intel.okta.groups.time.sleep", return_value=None)
+def test_get_okta_group_members_retries_non_json_sdk_error(
+    mock_sleep: mock.MagicMock,
+) -> None:
+    api_client = mock.MagicMock()
+    response = _Response(json.dumps(GROUP_MEMBERS_SAMPLE_DATA))
+    api_client.get_path.side_effect = [
+        json.JSONDecodeError("Expecting value", "", 0),
+        response,
+    ]
+
+    result = get_okta_group_members(api_client, "group-001")
+
+    assert result == GROUP_MEMBERS_SAMPLE_DATA
+    assert api_client.get_path.call_count == 2
+    mock_sleep.assert_called_once_with(1)
+
+
+@mock.patch("cartography.intel.okta.groups.time.sleep", return_value=None)
+def test_get_okta_group_members_raises_after_non_json_sdk_retries(
+    mock_sleep: mock.MagicMock,
+) -> None:
+    api_client = mock.MagicMock()
+    api_client.get_path.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+
+    with pytest.raises(json.JSONDecodeError):
+        get_okta_group_members(api_client, "group-001")
+
+    assert api_client.get_path.call_count == 3
+    assert mock_sleep.call_count == 2

--- a/tests/unit/cartography/intel/okta/test_group.py
+++ b/tests/unit/cartography/intel/okta/test_group.py
@@ -139,3 +139,16 @@ def test_get_okta_group_members_raises_after_non_json_sdk_retries(
 
     assert api_client.get_path.call_count == 3
     assert mock_sleep.call_count == 2
+
+
+def test_get_okta_group_members_raises_on_malformed_next_link() -> None:
+    api_client = mock.MagicMock()
+    response = _Response(json.dumps(GROUP_MEMBERS_SAMPLE_DATA))
+    response.links = {"next": {}}
+    api_client.get_path.return_value = response
+
+    with pytest.raises(ValueError, match="missing a next URL"):
+        get_okta_group_members(api_client, "group-001")
+
+    api_client.get_path.assert_called_once()
+    api_client.get.assert_not_called()


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
Adds a bounded retry around Okta group-member page requests when the legacy Okta SDK raises `JSONDecodeError` while trying to parse a non-JSON error response body.

This keeps transient Okta/proxy/rate-limit edge responses from failing group membership sync immediately and preserves the existing `OktaError` behavior for normal JSON error responses.

### Related issues or links
N/A

### Breaking changes
None.

### How was this tested?
- New unit tests

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).

### Notes for reviewers
This is scoped to the group-member pagination call path where the legacy SDK can mask an upstream HTTP error as `JSONDecodeError` when the error body is empty or non-JSON.