### PR TITLE
fix(ontology): drop deprecated _ont_ indexes from pre-opt-out graphs

### DIFF
--- a/cartography/intel/ontology/__init__.py
+++ b/cartography/intel/ontology/__init__.py
@@ -9,6 +9,9 @@ import cartography.intel.ontology.packages
 import cartography.intel.ontology.publicips
 import cartography.intel.ontology.users
 from cartography.config import Config
+from cartography.intel.ontology.deprecated_indexes import (
+    drop_deprecated_ontology_indexes,
+)
 from cartography.util import run_analysis_job
 from cartography.util import timeit
 
@@ -20,6 +23,10 @@ def run(neo4j_session: neo4j.Session, config: Config) -> None:
     common_job_parameters = {
         "UPDATE_TAG": config.update_tag,
     }
+
+    # DEPRECATED: drop _ont_ RANGE indexes left over from before the indexed=False opt-out (#2845)
+    # on graphs synced with older cartography versions. Remove in v1.0.0.
+    drop_deprecated_ontology_indexes(neo4j_session)
 
     # Get source of truth from config
     if config.ontology_users_source:

--- a/cartography/intel/ontology/deprecated_indexes.py
+++ b/cartography/intel/ontology/deprecated_indexes.py
@@ -1,0 +1,53 @@
+"""DEPRECATED: temporary backward-compatibility cleanup. Remove this whole module in v1.0.0.
+
+Before #2845, cartography created a RANGE index on the `_ont_<field>` of every semantic label,
+including unbounded text/list fields (`description`, `references`, `problem_types`) whose values can
+exceed Neo4j's ~8 KB RANGE index value limit and crash the sync. #2845 added an `indexed=False`
+opt-out so those indexes are no longer created, but graphs synced before that change still carry
+them. This module drops those deprecated indexes if they exist.
+"""
+
+import logging
+
+import neo4j
+
+from cartography.models.ontology.mapping import get_deprecated_ontology_index_properties
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def drop_deprecated_ontology_indexes(neo4j_session: neo4j.Session) -> None:
+    """DEPRECATED: drop RANGE indexes on `_ont_` fields that the `indexed=False` opt-out (#2845)
+    no longer creates. Only needed for graphs synced before that change; remove in v1.0.0.
+    """
+    deprecated_props = get_deprecated_ontology_index_properties()
+    if not deprecated_props:
+        return
+    # SHOW INDEXES is NOT an existence check we could skip with try/except: cartography creates these
+    # indexes unnamed, so this is the only way to recover Neo4j's auto-generated names. `DROP INDEX`
+    # accepts only a literal name (no `DROP INDEX FOR (n:Label) ON (n.prop)` form exists), so the two
+    # queries are incompressible without re-introducing APOC.
+    # type = 'RANGE' is required: cartography only ever created RANGE indexes on these properties,
+    # and SHOW INDEXES also returns TEXT/POINT/etc. indexes. Without this filter we would drop an
+    # operator-managed TEXT (or future non-RANGE) index on the same property.
+    rows = neo4j_session.run(
+        """
+        SHOW INDEXES YIELD name, labelsOrTypes, properties, entityType, type
+        WHERE entityType = 'NODE' AND type = 'RANGE'
+          AND size(properties) = 1 AND properties[0] IN $props
+        RETURN name
+        """,
+        props=list(deprecated_props),
+    )
+    names = [row["name"] for row in rows]
+    for name in names:
+        escaped = name.replace("`", "``")
+        # IF EXISTS only tolerates an index vanishing between SHOW and DROP (race); it does not
+        # replace the SHOW above.
+        neo4j_session.run(f"DROP INDEX `{escaped}` IF EXISTS")
+    if names:
+        logger.info(
+            "Dropped %d deprecated ontology _ont_ index(es): %s", len(names), names
+        )

--- a/cartography/models/ontology/mapping/__init__.py
+++ b/cartography/models/ontology/mapping/__init__.py
@@ -174,3 +174,24 @@ def get_semantic_label_mapping_from_node_schema(
                     )
                     return mapping_node
     return None
+
+
+def get_deprecated_ontology_index_properties() -> set[str]:
+    """DEPRECATED: temporary backward-compatibility helper. Remove in v1.0.0.
+
+    Returns the set of `_ont_<field>` property names whose RANGE index was removed by the
+    `indexed=False` opt-out (#2845). Graphs synced before that change still carry these indexes
+    on their semantic labels; this set is used to drop them. Driven entirely by the data model:
+    any field flagged `indexed=False` is picked up automatically.
+    """
+    props: set[str] = set()
+    for module_mappings in (
+        *SEMANTIC_LABELS_MAPPING.values(),
+        *ONTOLOGY_NODES_MAPPING.values(),
+    ):
+        for ontology_mapping in module_mappings.values():
+            for node in ontology_mapping.nodes:
+                for mapping_field in node.fields:
+                    if not mapping_field.indexed:
+                        props.add(f"_ont_{mapping_field.ontology_field}")
+    return props

--- a/tests/integration/cartography/intel/ontology/test_deprecated_indexes.py
+++ b/tests/integration/cartography/intel/ontology/test_deprecated_indexes.py
@@ -2,6 +2,11 @@ from cartography.intel.ontology.deprecated_indexes import (
     drop_deprecated_ontology_indexes,
 )
 
+# Properties this test creates indexes on. The integration Neo4j is shared across test modules and
+# only nodes (not indexes) are wiped between them, so we drop these before and after to stay
+# hermetic and to avoid EquivalentSchemaRuleAlreadyExists on CREATE.
+TEST_PROPERTIES = ("_ont_references", "_ont_description", "_ont_cve_id", "_ont_source")
+
 
 def _index_names_on_property(neo4j_session, prop: str) -> set[str]:
     rows = neo4j_session.run(
@@ -15,43 +20,54 @@ def _index_names_on_property(neo4j_session, prop: str) -> set[str]:
     return {row["name"] for row in rows}
 
 
-def test_drop_deprecated_ontology_indexes(neo4j_session):
-    """Deprecated _ont_ indexes are dropped; non-deprecated ones survive (#2845, remove in v1.0.0)."""
-    # Deprecated indexes: RANGE indexes (cartography's default) on semantic labels for unbounded
-    # fields that #2845 opted out.
-    neo4j_session.run("CREATE INDEX FOR (n:CVE) ON (n._ont_references)")
-    neo4j_session.run("CREATE INDEX FOR (n:Risk) ON (n._ont_description)")
-    # Indexes that must be kept: still created by the data model.
-    neo4j_session.run("CREATE INDEX FOR (n:CVE) ON (n._ont_cve_id)")
-    neo4j_session.run("CREATE INDEX FOR (n:CVE) ON (n._ont_source)")
-    # An operator-managed non-RANGE index on a deprecated property must survive: we only drop the
-    # RANGE indexes cartography itself created, never TEXT/POINT/etc.
-    neo4j_session.run(
-        "CREATE TEXT INDEX op_text_ont_references FOR (n:CVE) ON (n._ont_references)"
-    )
-
-    assert _index_names_on_property(neo4j_session, "_ont_references")
-    assert _index_names_on_property(neo4j_session, "_ont_description")
-
-    drop_deprecated_ontology_indexes(neo4j_session)
-
-    # Deprecated RANGE indexes are gone, but the operator-managed TEXT index survives.
-    assert _index_names_on_property(neo4j_session, "_ont_references") == {
-        "op_text_ont_references"
-    }
-    assert _index_names_on_property(neo4j_session, "_ont_description") == set()
-    # Non-deprecated indexes survive.
-    assert _index_names_on_property(neo4j_session, "_ont_cve_id")
-    assert _index_names_on_property(neo4j_session, "_ont_source")
-
-    # Idempotent: a second run with nothing left to drop is a no-op.
-    drop_deprecated_ontology_indexes(neo4j_session)
-    assert _index_names_on_property(neo4j_session, "_ont_cve_id")
-    assert _index_names_on_property(neo4j_session, "_ont_references") == {
-        "op_text_ont_references"
-    }
-
-    # Clean up the indexes we created so we don't leak schema into other tests.
-    for prop in ("_ont_cve_id", "_ont_source", "_ont_references"):
+def _drop_all_indexes_on_properties(neo4j_session, properties) -> None:
+    for prop in properties:
         for name in _index_names_on_property(neo4j_session, prop):
             neo4j_session.run(f"DROP INDEX `{name}` IF EXISTS")
+
+
+def test_drop_deprecated_ontology_indexes(neo4j_session):
+    """Deprecated _ont_ indexes are dropped; non-deprecated ones survive (#2845, remove in v1.0.0)."""
+    _drop_all_indexes_on_properties(neo4j_session, TEST_PROPERTIES)
+    try:
+        # Deprecated indexes: RANGE indexes (cartography's default) on semantic labels for unbounded
+        # fields that #2845 opted out.
+        neo4j_session.run(
+            "CREATE INDEX IF NOT EXISTS FOR (n:CVE) ON (n._ont_references)"
+        )
+        neo4j_session.run(
+            "CREATE INDEX IF NOT EXISTS FOR (n:Risk) ON (n._ont_description)"
+        )
+        # Indexes that must be kept: still created by the data model.
+        neo4j_session.run("CREATE INDEX IF NOT EXISTS FOR (n:CVE) ON (n._ont_cve_id)")
+        neo4j_session.run("CREATE INDEX IF NOT EXISTS FOR (n:CVE) ON (n._ont_source)")
+        # An operator-managed non-RANGE index on a deprecated property must survive: we only drop the
+        # RANGE indexes cartography itself created, never TEXT/POINT/etc.
+        neo4j_session.run(
+            "CREATE TEXT INDEX op_text_ont_references IF NOT EXISTS "
+            "FOR (n:CVE) ON (n._ont_references)"
+        )
+
+        assert _index_names_on_property(neo4j_session, "_ont_references")
+        assert _index_names_on_property(neo4j_session, "_ont_description")
+
+        drop_deprecated_ontology_indexes(neo4j_session)
+
+        # Deprecated RANGE indexes are gone, but the operator-managed TEXT index survives.
+        assert _index_names_on_property(neo4j_session, "_ont_references") == {
+            "op_text_ont_references"
+        }
+        assert _index_names_on_property(neo4j_session, "_ont_description") == set()
+        # Non-deprecated indexes survive.
+        assert _index_names_on_property(neo4j_session, "_ont_cve_id")
+        assert _index_names_on_property(neo4j_session, "_ont_source")
+
+        # Idempotent: a second run with nothing left to drop is a no-op.
+        drop_deprecated_ontology_indexes(neo4j_session)
+        assert _index_names_on_property(neo4j_session, "_ont_cve_id")
+        assert _index_names_on_property(neo4j_session, "_ont_references") == {
+            "op_text_ont_references"
+        }
+    finally:
+        # Don't leak schema into other test modules sharing this Neo4j instance.
+        _drop_all_indexes_on_properties(neo4j_session, TEST_PROPERTIES)

--- a/tests/integration/cartography/intel/ontology/test_deprecated_indexes.py
+++ b/tests/integration/cartography/intel/ontology/test_deprecated_indexes.py
@@ -1,0 +1,57 @@
+from cartography.intel.ontology.deprecated_indexes import (
+    drop_deprecated_ontology_indexes,
+)
+
+
+def _index_names_on_property(neo4j_session, prop: str) -> set[str]:
+    rows = neo4j_session.run(
+        """
+        SHOW INDEXES YIELD name, properties, entityType
+        WHERE entityType = 'NODE' AND size(properties) = 1 AND properties[0] = $prop
+        RETURN name
+        """,
+        prop=prop,
+    )
+    return {row["name"] for row in rows}
+
+
+def test_drop_deprecated_ontology_indexes(neo4j_session):
+    """Deprecated _ont_ indexes are dropped; non-deprecated ones survive (#2845, remove in v1.0.0)."""
+    # Deprecated indexes: RANGE indexes (cartography's default) on semantic labels for unbounded
+    # fields that #2845 opted out.
+    neo4j_session.run("CREATE INDEX FOR (n:CVE) ON (n._ont_references)")
+    neo4j_session.run("CREATE INDEX FOR (n:Risk) ON (n._ont_description)")
+    # Indexes that must be kept: still created by the data model.
+    neo4j_session.run("CREATE INDEX FOR (n:CVE) ON (n._ont_cve_id)")
+    neo4j_session.run("CREATE INDEX FOR (n:CVE) ON (n._ont_source)")
+    # An operator-managed non-RANGE index on a deprecated property must survive: we only drop the
+    # RANGE indexes cartography itself created, never TEXT/POINT/etc.
+    neo4j_session.run(
+        "CREATE TEXT INDEX op_text_ont_references FOR (n:CVE) ON (n._ont_references)"
+    )
+
+    assert _index_names_on_property(neo4j_session, "_ont_references")
+    assert _index_names_on_property(neo4j_session, "_ont_description")
+
+    drop_deprecated_ontology_indexes(neo4j_session)
+
+    # Deprecated RANGE indexes are gone, but the operator-managed TEXT index survives.
+    assert _index_names_on_property(neo4j_session, "_ont_references") == {
+        "op_text_ont_references"
+    }
+    assert _index_names_on_property(neo4j_session, "_ont_description") == set()
+    # Non-deprecated indexes survive.
+    assert _index_names_on_property(neo4j_session, "_ont_cve_id")
+    assert _index_names_on_property(neo4j_session, "_ont_source")
+
+    # Idempotent: a second run with nothing left to drop is a no-op.
+    drop_deprecated_ontology_indexes(neo4j_session)
+    assert _index_names_on_property(neo4j_session, "_ont_cve_id")
+    assert _index_names_on_property(neo4j_session, "_ont_references") == {
+        "op_text_ont_references"
+    }
+
+    # Clean up the indexes we created so we don't leak schema into other tests.
+    for prop in ("_ont_cve_id", "_ont_source", "_ont_references"):
+        for name in _index_names_on_property(neo4j_session, prop):
+            neo4j_session.run(f"DROP INDEX `{name}` IF EXISTS")

--- a/tests/unit/cartography/intel/ontology/test_ontology_mapping.py
+++ b/tests/unit/cartography/intel/ontology/test_ontology_mapping.py
@@ -3,6 +3,7 @@ from typing import Type
 
 import cartography.models
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.ontology.mapping import get_deprecated_ontology_index_properties
 from cartography.models.ontology.mapping import ONTOLOGY_MODELS
 from cartography.models.ontology.mapping import ONTOLOGY_NODES_MAPPING
 from cartography.models.ontology.mapping import SEMANTIC_LABELS_MAPPING
@@ -195,6 +196,29 @@ def test_ontology_mapping_prefix_usage():
                         f"Mapping field '{mapping_field.node_field}' in node '{node.node_label}' of module '{module_name}' "
                         "should not use ontology fields starting with '_ont_' (prefix are added automatically)."
                     )
+
+
+def test_get_deprecated_ontology_index_properties():
+    # DEPRECATED helper (#2845, remove in v1.0.0): it must return exactly the `_ont_<field>`
+    # property names whose RANGE index was opted out via `indexed=False` in the data model.
+    expected: set[str] = set()
+    for mappings in ALL_MAPPINGS.values():
+        for mapping in mappings.values():
+            for node in mapping.nodes:
+                for mapping_field in node.fields:
+                    if not mapping_field.indexed:
+                        expected.add(f"_ont_{mapping_field.ontology_field}")
+
+    result = get_deprecated_ontology_index_properties()
+
+    assert result == expected
+    # Sanity check the fields that #2845 actually opted out, so a regression in the data model
+    # (re-enabling an index on an unbounded field) is caught here.
+    assert {"_ont_description", "_ont_references", "_ont_problem_types"}.issubset(
+        result
+    )
+    # All deprecated properties must carry the ontology `_ont_` namespace prefix.
+    assert all(prop.startswith("_ont_") for prop in result)
 
 
 def test_ontology_mapping_or_boolean_fields():


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
PR #2845 added an `indexed=False` opt-out so cartography no longer creates RANGE indexes on unbounded `_ont_` fields (`description`, `references`, `problem_types`) whose values can exceed Neo4j's ~8 KB RANGE index value limit and crash the sync with `Property value is too large to index`.

That opt-out only stops *creating* new indexes. Graphs synced with older cartography versions still carry these RANGE indexes on their semantic labels (e.g. `:CVE(_ont_references)`, `:Risk(_ont_description)`) and keep hitting the error on every write.

This PR adds a data-model-driven cleanup, run once at the start of the ontology sync, that discovers and drops these leftover indexes if present:

- `get_deprecated_ontology_index_properties()` collects every `_ont_<field>` flagged `indexed=False` across the ontology mappings, so the set stays in sync with the data model automatically.
- `drop_deprecated_ontology_indexes()` resolves the auto-generated index names via `SHOW INDEXES`, then drops them. It filters `type = 'RANGE'` so operator-managed TEXT/POINT (or future non-RANGE) indexes on the same property are left untouched.

A plain Cypher analysis job can't do this: cartography creates these indexes unnamed, `DROP INDEX` requires a literal name (there is no `DROP INDEX FOR (n:Label) ON (n.prop)` form), and the only dynamic-name path is APOC, which is absent from the core and the `neo4j:5-community` test container. Hence a Python function.

Everything is marked deprecated and slated for removal in v1.0.0.

### Related issues or links

N/A

### How was this tested?
- Unit test asserting `get_deprecated_ontology_index_properties()` returns exactly the `indexed=False` properties.
- Integration test against a real `neo4j:5-community` container: creates deprecated RANGE indexes plus kept indexes (`_ont_cve_id`, `_ont_source`) and an operator-managed TEXT index on `_ont_references`, then asserts only the deprecated RANGE indexes are dropped, the TEXT index survives, and a second run is a no-op (idempotent).
- `make test_lint` passes locally.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
