### PR TITLE
feat(spacelift): link stacks to assumed AWS IAM roles

### DIFF
--- a/cartography/intel/spacelift/stacks.py
+++ b/cartography/intel/spacelift/stacks.py
@@ -25,6 +25,11 @@ query {
         branch
         projectRoot
         space
+        integrations {
+            aws {
+                assumedRoleArn
+            }
+        }
     }
 }
 """
@@ -48,6 +53,12 @@ def transform_stacks(
     result: list[dict[str, Any]] = []
 
     for stack in stacks_data:
+        # The IAM role a stack assumes at runtime comes from its AWS integration.
+        # integrations or integrations.aws may be absent when no AWS integration is set.
+        integrations = stack.get("integrations") or {}
+        aws_integration = integrations.get("aws") or {}
+        aws_role_arn = aws_integration.get("assumedRoleArn")
+
         transformed_stack = {
             "id": stack["id"],
             "name": stack.get("name"),
@@ -59,6 +70,7 @@ def transform_stacks(
             "project_root": stack.get("projectRoot"),
             "space_id": stack.get("space"),
             "spacelift_account_id": account_id,
+            "aws_role_arn": aws_role_arn,
         }
 
         result.append(transformed_stack)

--- a/cartography/models/spacelift/stack.py
+++ b/cartography/models/spacelift/stack.py
@@ -28,6 +28,9 @@ class SpaceliftStackNodeProperties(CartographyNodeProperties):
     project_root: PropertyRef = PropertyRef("project_root")  # Directory in repo
     space_id: PropertyRef = PropertyRef("space_id")
     spacelift_account_id: PropertyRef = PropertyRef("spacelift_account_id")
+    aws_role_arn: PropertyRef = PropertyRef(
+        "aws_role_arn"
+    )  # IAM role assumed at runtime
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -82,6 +85,33 @@ class SpaceliftStackToSpaceRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class SpaceliftStackToAWSRoleRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class SpaceliftStackToAWSRoleRel(CartographyRelSchema):
+    """
+    ASSUMES relationship from a Stack to the AWS IAM role it assumes at runtime.
+    (:SpaceliftStack)-[:ASSUMES]->(:AWSRole)
+
+    The role ARN comes from the stack's AWS integration (integrations.aws.assumedRoleArn).
+    Only matches AWSRole nodes already present in the graph; stacks without an assumed
+    role (null ARN) match nothing and get no edge.
+    """
+
+    target_node_label: str = "AWSRole"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("aws_role_arn")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "ASSUMES"
+    properties: SpaceliftStackToAWSRoleRelProperties = (
+        SpaceliftStackToAWSRoleRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class SpaceliftStackSchema(CartographyNodeSchema):
     """
     Schema for a Spacelift Stack node.
@@ -94,5 +124,6 @@ class SpaceliftStackSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             SpaceliftStackToSpaceRel(),
+            SpaceliftStackToAWSRoleRel(),
         ],
     )

--- a/docs/root/modules/spacelift/schema.md
+++ b/docs/root/modules/spacelift/schema.md
@@ -16,6 +16,7 @@ St -- CONTAINS --> St2(SpaceliftStack)
 WP -- CONTAINS --> W2(SpaceliftWorker)
 
 St -- GENERATES --> R
+St -- ASSUMES --> Role(AWSRole)
 U -- TRIGGERED --> R
 W -- EXECUTES --> R
 C -- COMMITTED --> R
@@ -151,6 +152,7 @@ Representation of the fundamental building block of Spacelift infrastructure man
 | project_root | Directory in repo containing infrastructure code |
 | space_id | ID of the space this stack belongs to |
 | spacelift_account_id | ID of the Spacelift account this stack belongs to |
+| aws_role_arn | ARN of the AWS IAM role the stack assumes at runtime (from its AWS integration), if any |
 
 #### Relationships
 
@@ -170,6 +172,12 @@ Representation of the fundamental building block of Spacelift infrastructure man
 
     ```
     (SpaceliftStack)-[GENERATED]->(SpaceliftRun)
+    ```
+
+- SpaceliftStacks assume an AWS IAM role at runtime:
+
+    ```
+    (SpaceliftStack)-[ASSUMES]->(AWSRole)
     ```
 
 ### SpaceliftWorkerPool

--- a/tests/data/spacelift/spacelift_data.py
+++ b/tests/data/spacelift/spacelift_data.py
@@ -44,6 +44,11 @@ STACKS_DATA = {
                 "branch": "main",
                 "projectRoot": "/terraform/prod",
                 "space": "root-space",
+                "integrations": {
+                    "aws": {
+                        "assumedRoleArn": "arn:aws:iam::000000000000:role/SpaceLift-Administrator-Access",
+                    },
+                },
             },
             {
                 "id": "stack-2",
@@ -55,6 +60,12 @@ STACKS_DATA = {
                 "branch": "staging",
                 "projectRoot": "/terraform/staging",
                 "space": "child-space-1",
+                # No AWS integration: assumedRoleArn is null, so no ASSUMES edge.
+                "integrations": {
+                    "aws": {
+                        "assumedRoleArn": None,
+                    },
+                },
             },
         ],
     },

--- a/tests/integration/cartography/intel/spacelift/test_spacelift.py
+++ b/tests/integration/cartography/intel/spacelift/test_spacelift.py
@@ -25,6 +25,7 @@ TEST_API_ENDPOINT = "https://fake.spacelift.io/graphql"
 TEST_ACCOUNT_ID = "test-account-123"
 TEST_AWS_ACCOUNT_ID = "000000000000"
 TEST_AWS_REGION = "us-east-1"
+TEST_AWS_ROLE_ARN = "arn:aws:iam::000000000000:role/SpaceLift-Administrator-Access"
 
 
 @patch.object(
@@ -116,6 +117,17 @@ def test_spacelift_end_to_end(
     actual_ec2_nodes = check_nodes(neo4j_session, "EC2Instance", ["id", "instanceid"])
     assert actual_ec2_nodes is not None
     assert expected_ec2_nodes == actual_ec2_nodes
+
+    # Seed an AWSRole node (normally created by the AWS IAM sync) so the
+    # SpaceliftStack-[:ASSUMES]->AWSRole relationship can be matched.
+    neo4j_session.run(
+        """
+        MERGE (r:AWSRole {arn: $arn})
+        SET r.id = $arn, r.lastupdated = $update_tag
+        """,
+        arn=TEST_AWS_ROLE_ARN,
+        update_tag=TEST_UPDATE_TAG,
+    )
 
     common_job_parameters = {
         "UPDATE_TAG": TEST_UPDATE_TAG,
@@ -302,3 +314,19 @@ def test_spacelift_end_to_end(
     )
     assert actual_pool_worker_relationships is not None
     assert expected_pool_worker_relationships == actual_pool_worker_relationships
+
+    # Check that Stack-[:ASSUMES]->AWSRole relationships were created.
+    # Only stack-1 has an assumed role ARN; stack-2's is null, so it gets no edge.
+    expected_stack_role_relationships = {
+        ("stack-1", TEST_AWS_ROLE_ARN),
+    }
+    actual_stack_role_relationships = check_rels(
+        neo4j_session,
+        "SpaceliftStack",
+        "id",
+        "AWSRole",
+        "arn",
+        "ASSUMES",
+    )
+    assert actual_stack_role_relationships is not None
+    assert expected_stack_role_relationships == actual_stack_role_relationships


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary

`SpaceliftStack` nodes had no relationship to the AWS IAM role they assume at runtime, so Spacelift to AWS attack paths could not be built automatically even when the relevant roles were present in the graph.

This change resolves and links the IAM role each Spacelift stack assumes:

- Extends the stacks GraphQL query to fetch `integrations { aws { assumedRoleArn } }`.
- Adds an `aws_role_arn` property to `SpaceliftStack`.
- Adds a `(:SpaceliftStack)-[:ASSUMES]->(:AWSRole)` relationship, matched against `AWSRole` nodes already in the graph. Stacks without an AWS integration (null ARN) get no edge.

### How was this tested?

- Updated the end-to-end Spacelift integration test to seed an `AWSRole` node and assert that the `ASSUMES` edge is created for a stack with an assumed-role ARN, and that a stack with a null ARN gets no edge.
- Ran the integration test locally against Neo4j 5: passing.
- `make test_lint` equivalent (`pre-commit`) passes locally (isort, black, flake8, mypy, pyupgrade).

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the schema documentation.

### Notes for reviewers

Scoped to the stack-level AWS integration field `integrations.aws.assumedRoleArn` (a single assumed role per stack). Modern auto-attached cloud integrations, which model role ARNs on separate AWS integration entities, are intentionally out of scope and could be a follow-up.
