### PR TITLE
feat(rules): Add compliance_only flag

### DIFF
--- a/cartography/rules/data/rules/cis_4_0_gcp.py
+++ b/cartography/rules/data/rules/cis_4_0_gcp.py
@@ -10,6 +10,7 @@ Facts within a Rule are provider-specific implementations of the same concept.
 
 from cartography.rules.data.frameworks.cis import cis_gcp
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
+from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -91,6 +92,7 @@ cis_gcp_3_1_default_network = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("3.1"),
         iso27001_annex_a("8.20"),
@@ -181,6 +183,7 @@ cis_gcp_3_6_unrestricted_ssh = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("3.6"),
         iso27001_annex_a("8.20"),
@@ -270,6 +273,7 @@ cis_gcp_3_7_unrestricted_rdp = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("3.7"),
         iso27001_annex_a("8.20"),
@@ -344,6 +348,7 @@ cis_gcp_4_9_public_ip = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("4.9"),
         iso27001_annex_a("8.20"),
@@ -430,6 +435,7 @@ cis_gcp_4_11_confidential_compute = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("4.11"),
         iso27001_annex_a("8.24"),
@@ -489,6 +495,7 @@ cis_gcp_3_3_dnssec_enabled = Rule(
     tags=("dns", "dnssec", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("3.3"),
         iso27001_annex_a("8.20"),
@@ -559,6 +566,7 @@ cis_gcp_3_4_dnssec_no_rsasha1_ksk = Rule(
     tags=("dns", "dnssec", "crypto", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("3.4"),
         iso27001_annex_a("8.24"),
@@ -623,6 +631,7 @@ cis_gcp_3_5_dnssec_no_rsasha1_zsk = Rule(
     tags=("dns", "dnssec", "crypto", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("3.5"),
         iso27001_annex_a("8.24"),
@@ -714,6 +723,7 @@ cis_gcp_3_8_vpc_flow_logs = Rule(
     tags=("networking", "subnet", "flow-logs", "logging"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("3.8"),
         iso27001_annex_a("8.15"),
@@ -771,6 +781,7 @@ cis_gcp_6_6_cloudsql_public_ip = Rule(
     tags=("cloudsql", "database", "networking", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("6.6"),
         iso27001_annex_a("8.20"),
@@ -827,6 +838,7 @@ cis_gcp_6_7_cloudsql_backups = Rule(
     tags=("cloudsql", "database", "backup", "resilience"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("6.7"),
         iso27001_annex_a("8.13"),
@@ -883,6 +895,7 @@ cis_gcp_7_1_bigquery_dataset_public = Rule(
     tags=("bigquery", "data-warehouse", "iam", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("7.1"),
         iso27001_annex_a("8.3"),
@@ -939,6 +952,7 @@ cis_gcp_7_2_bigquery_table_cmek = Rule(
     tags=("bigquery", "encryption", "cmek", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("7.2"),
         iso27001_annex_a("8.24"),
@@ -993,6 +1007,7 @@ cis_gcp_7_3_bigquery_dataset_cmek = Rule(
     tags=("bigquery", "encryption", "cmek", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("7.3"),
         iso27001_annex_a("8.24"),
@@ -1053,6 +1068,7 @@ cis_gcp_6_4_cloudsql_ssl_required = Rule(
     tags=("cloudsql", "database", "ssl", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("6.4"),
         iso27001_annex_a("8.24"),
@@ -1109,6 +1125,7 @@ cis_gcp_6_5_cloudsql_authorized_networks = Rule(
     tags=("cloudsql", "database", "networking", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("6.5"),
         iso27001_annex_a("8.20"),
@@ -1181,6 +1198,7 @@ def _make_cloudsql_flag_rule(
         tags=("cloudsql", "database", "configuration"),
         version="1.0.0",
         references=CIS_REFERENCES,
+        catalog_visibility=(Catalog.COMPLIANCE,),
         frameworks=(
             cis_gcp(requirement),
             iso27001_annex_a("8.9"),
@@ -1500,6 +1518,7 @@ cis_gcp_5_2_bucket_uniform_access = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("5.2"),
         iso27001_annex_a("8.3"),
@@ -1742,6 +1761,7 @@ cis_gcp_4_1_default_service_account = Rule(
     tags=("compute", "iam", "service-accounts", "least-privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("4.1"),
         iso27001_annex_a("5.16"),
@@ -1808,6 +1828,7 @@ cis_gcp_4_2_default_service_account_full_api = Rule(
     tags=("compute", "iam", "service-accounts", "least-privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("4.2"),
         iso27001_annex_a("5.18"),
@@ -1889,6 +1910,7 @@ cis_gcp_4_3_block_project_wide_ssh_keys = Rule(
     tags=("compute", "ssh", "oslogin", "remote-access"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("4.3"),
         iso27001_annex_a("8.5"),
@@ -1956,6 +1978,7 @@ cis_gcp_4_4_oslogin_enabled = Rule(
     tags=("compute", "ssh", "oslogin", "iam"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("4.4"),
         iso27001_annex_a("8.5"),
@@ -2021,6 +2044,7 @@ cis_gcp_4_6_ip_forwarding = Rule(
     tags=("compute", "networking", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("4.6"),
         iso27001_annex_a("8.20"),
@@ -2096,6 +2120,7 @@ cis_gcp_4_8_shielded_vm = Rule(
     tags=("compute", "shielded-vm", "integrity"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("4.8"),
         iso27001_annex_a("8.9"),
@@ -2152,6 +2177,7 @@ cis_gcp_4_5_serial_ports_disabled = Rule(
     tags=("compute", "serial-port", "remote-access"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_gcp("4.5"),
         iso27001_annex_a("8.3"),

--- a/cartography/rules/data/rules/cis_4_0_gcp.py
+++ b/cartography/rules/data/rules/cis_4_0_gcp.py
@@ -10,7 +10,6 @@ Facts within a Rule are provider-specific implementations of the same concept.
 
 from cartography.rules.data.frameworks.cis import cis_gcp
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
-from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -93,7 +92,7 @@ cis_gcp_3_1_default_network = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("3.1"),
         iso27001_annex_a("8.20"),
@@ -185,7 +184,7 @@ cis_gcp_3_6_unrestricted_ssh = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("3.6"),
         iso27001_annex_a("8.20"),
@@ -276,7 +275,7 @@ cis_gcp_3_7_unrestricted_rdp = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("3.7"),
         iso27001_annex_a("8.20"),
@@ -352,7 +351,7 @@ cis_gcp_4_9_public_ip = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("4.9"),
         iso27001_annex_a("8.20"),
@@ -440,7 +439,7 @@ cis_gcp_4_11_confidential_compute = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("4.11"),
         iso27001_annex_a("8.24"),
@@ -501,7 +500,7 @@ cis_gcp_3_3_dnssec_enabled = Rule(
     tags=("dns", "dnssec", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("3.3"),
         iso27001_annex_a("8.20"),
@@ -573,7 +572,7 @@ cis_gcp_3_4_dnssec_no_rsasha1_ksk = Rule(
     tags=("dns", "dnssec", "crypto", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("3.4"),
         iso27001_annex_a("8.24"),
@@ -639,7 +638,7 @@ cis_gcp_3_5_dnssec_no_rsasha1_zsk = Rule(
     tags=("dns", "dnssec", "crypto", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("3.5"),
         iso27001_annex_a("8.24"),
@@ -732,7 +731,7 @@ cis_gcp_3_8_vpc_flow_logs = Rule(
     tags=("networking", "subnet", "flow-logs", "logging"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("3.8"),
         iso27001_annex_a("8.15"),
@@ -791,7 +790,7 @@ cis_gcp_6_6_cloudsql_public_ip = Rule(
     tags=("cloudsql", "database", "networking", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("6.6"),
         iso27001_annex_a("8.20"),
@@ -849,7 +848,7 @@ cis_gcp_6_7_cloudsql_backups = Rule(
     tags=("cloudsql", "database", "backup", "resilience"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("6.7"),
         iso27001_annex_a("8.13"),
@@ -907,7 +906,7 @@ cis_gcp_7_1_bigquery_dataset_public = Rule(
     tags=("bigquery", "data-warehouse", "iam", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("7.1"),
         iso27001_annex_a("8.3"),
@@ -965,7 +964,7 @@ cis_gcp_7_2_bigquery_table_cmek = Rule(
     tags=("bigquery", "encryption", "cmek", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("7.2"),
         iso27001_annex_a("8.24"),
@@ -1021,7 +1020,7 @@ cis_gcp_7_3_bigquery_dataset_cmek = Rule(
     tags=("bigquery", "encryption", "cmek", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("7.3"),
         iso27001_annex_a("8.24"),
@@ -1083,7 +1082,7 @@ cis_gcp_6_4_cloudsql_ssl_required = Rule(
     tags=("cloudsql", "database", "ssl", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("6.4"),
         iso27001_annex_a("8.24"),
@@ -1141,7 +1140,7 @@ cis_gcp_6_5_cloudsql_authorized_networks = Rule(
     tags=("cloudsql", "database", "networking", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("6.5"),
         iso27001_annex_a("8.20"),
@@ -1215,7 +1214,7 @@ def _make_cloudsql_flag_rule(
         tags=("cloudsql", "database", "configuration"),
         version="1.0.0",
         references=CIS_REFERENCES,
-        catalog_visibility=(Catalog.COMPLIANCE,),
+        compliance_only=True,
         frameworks=(
             cis_gcp(requirement),
             iso27001_annex_a("8.9"),
@@ -1536,7 +1535,7 @@ cis_gcp_5_2_bucket_uniform_access = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("5.2"),
         iso27001_annex_a("8.3"),
@@ -1780,7 +1779,7 @@ cis_gcp_4_1_default_service_account = Rule(
     tags=("compute", "iam", "service-accounts", "least-privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("4.1"),
         iso27001_annex_a("5.16"),
@@ -1848,7 +1847,7 @@ cis_gcp_4_2_default_service_account_full_api = Rule(
     tags=("compute", "iam", "service-accounts", "least-privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("4.2"),
         iso27001_annex_a("5.18"),
@@ -1931,7 +1930,7 @@ cis_gcp_4_3_block_project_wide_ssh_keys = Rule(
     tags=("compute", "ssh", "oslogin", "remote-access"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("4.3"),
         iso27001_annex_a("8.5"),
@@ -2000,7 +1999,7 @@ cis_gcp_4_4_oslogin_enabled = Rule(
     tags=("compute", "ssh", "oslogin", "iam"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("4.4"),
         iso27001_annex_a("8.5"),
@@ -2067,7 +2066,7 @@ cis_gcp_4_6_ip_forwarding = Rule(
     tags=("compute", "networking", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("4.6"),
         iso27001_annex_a("8.20"),
@@ -2144,7 +2143,7 @@ cis_gcp_4_8_shielded_vm = Rule(
     tags=("compute", "shielded-vm", "integrity"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("4.8"),
         iso27001_annex_a("8.9"),
@@ -2202,7 +2201,7 @@ cis_gcp_4_5_serial_ports_disabled = Rule(
     tags=("compute", "serial-port", "remote-access"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_gcp("4.5"),
         iso27001_annex_a("8.3"),

--- a/cartography/rules/data/rules/cis_4_0_gcp.py
+++ b/cartography/rules/data/rules/cis_4_0_gcp.py
@@ -184,6 +184,7 @@ cis_gcp_3_6_unrestricted_ssh = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_gcp("3.6"),
         iso27001_annex_a("8.20"),
@@ -274,6 +275,7 @@ cis_gcp_3_7_unrestricted_rdp = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_gcp("3.7"),
         iso27001_annex_a("8.20"),
@@ -349,6 +351,7 @@ cis_gcp_4_9_public_ip = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_gcp("4.9"),
         iso27001_annex_a("8.20"),
@@ -787,6 +790,7 @@ cis_gcp_6_6_cloudsql_public_ip = Rule(
     tags=("cloudsql", "database", "networking", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_gcp("6.6"),
         iso27001_annex_a("8.20"),
@@ -902,6 +906,7 @@ cis_gcp_7_1_bigquery_dataset_public = Rule(
     tags=("bigquery", "data-warehouse", "iam", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_gcp("7.1"),
         iso27001_annex_a("8.3"),
@@ -1135,6 +1140,7 @@ cis_gcp_6_5_cloudsql_authorized_networks = Rule(
     tags=("cloudsql", "database", "networking", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_gcp("6.5"),
         iso27001_annex_a("8.20"),
@@ -1208,6 +1214,7 @@ def _make_cloudsql_flag_rule(
         tags=("cloudsql", "database", "configuration"),
         version="1.0.0",
         references=CIS_REFERENCES,
+        compliance_only=True,
         frameworks=(
             cis_gcp(requirement),
             iso27001_annex_a("8.9"),
@@ -1840,6 +1847,7 @@ cis_gcp_4_2_default_service_account_full_api = Rule(
     tags=("compute", "iam", "service-accounts", "least-privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_gcp("4.2"),
         iso27001_annex_a("5.18"),
@@ -2058,6 +2066,7 @@ cis_gcp_4_6_ip_forwarding = Rule(
     tags=("compute", "networking", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_gcp("4.6"),
         iso27001_annex_a("8.20"),

--- a/cartography/rules/data/rules/cis_4_0_gcp.py
+++ b/cartography/rules/data/rules/cis_4_0_gcp.py
@@ -184,7 +184,6 @@ cis_gcp_3_6_unrestricted_ssh = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_gcp("3.6"),
         iso27001_annex_a("8.20"),
@@ -275,7 +274,6 @@ cis_gcp_3_7_unrestricted_rdp = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_gcp("3.7"),
         iso27001_annex_a("8.20"),
@@ -351,7 +349,6 @@ cis_gcp_4_9_public_ip = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_gcp("4.9"),
         iso27001_annex_a("8.20"),
@@ -790,7 +787,6 @@ cis_gcp_6_6_cloudsql_public_ip = Rule(
     tags=("cloudsql", "database", "networking", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_gcp("6.6"),
         iso27001_annex_a("8.20"),
@@ -906,7 +902,6 @@ cis_gcp_7_1_bigquery_dataset_public = Rule(
     tags=("bigquery", "data-warehouse", "iam", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_gcp("7.1"),
         iso27001_annex_a("8.3"),
@@ -1140,7 +1135,6 @@ cis_gcp_6_5_cloudsql_authorized_networks = Rule(
     tags=("cloudsql", "database", "networking", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_gcp("6.5"),
         iso27001_annex_a("8.20"),
@@ -1214,7 +1208,6 @@ def _make_cloudsql_flag_rule(
         tags=("cloudsql", "database", "configuration"),
         version="1.0.0",
         references=CIS_REFERENCES,
-        compliance_only=True,
         frameworks=(
             cis_gcp(requirement),
             iso27001_annex_a("8.9"),
@@ -1847,7 +1840,6 @@ cis_gcp_4_2_default_service_account_full_api = Rule(
     tags=("compute", "iam", "service-accounts", "least-privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_gcp("4.2"),
         iso27001_annex_a("5.18"),
@@ -2066,7 +2058,6 @@ cis_gcp_4_6_ip_forwarding = Rule(
     tags=("compute", "networking", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_gcp("4.6"),
         iso27001_annex_a("8.20"),

--- a/cartography/rules/data/rules/cis_aws_iam.py
+++ b/cartography/rules/data/rules/cis_aws_iam.py
@@ -15,6 +15,7 @@ from pydantic import BeforeValidator
 
 from cartography.rules.data.frameworks.cis import cis_aws
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
+from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -103,6 +104,7 @@ cis_aws_2_13_access_key_not_rotated = Rule(
     tags=("iam", "credentials", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("2.13"),
         iso27001_annex_a("5.17"),
@@ -178,6 +180,7 @@ cis_aws_2_11_unused_credentials = Rule(
     tags=("iam", "credentials", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("2.11"),
         iso27001_annex_a("5.18"),
@@ -243,6 +246,7 @@ cis_aws_2_14_user_direct_policies = Rule(
     tags=("iam", "policies", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("2.14"),
         iso27001_annex_a("5.18"),
@@ -313,6 +317,7 @@ cis_aws_2_12_multiple_access_keys = Rule(
     tags=("iam", "credentials", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("2.12"),
         iso27001_annex_a("5.17"),
@@ -383,6 +388,7 @@ cis_aws_2_18_expired_certificates = Rule(
     tags=("certificates", "acm", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("2.18"),
         iso27001_annex_a("8.24"),

--- a/cartography/rules/data/rules/cis_aws_iam.py
+++ b/cartography/rules/data/rules/cis_aws_iam.py
@@ -15,7 +15,6 @@ from pydantic import BeforeValidator
 
 from cartography.rules.data.frameworks.cis import cis_aws
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
-from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -105,7 +104,7 @@ cis_aws_2_13_access_key_not_rotated = Rule(
     tags=("iam", "credentials", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("2.13"),
         iso27001_annex_a("5.17"),
@@ -182,7 +181,7 @@ cis_aws_2_11_unused_credentials = Rule(
     tags=("iam", "credentials", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("2.11"),
         iso27001_annex_a("5.18"),
@@ -249,7 +248,7 @@ cis_aws_2_14_user_direct_policies = Rule(
     tags=("iam", "policies", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("2.14"),
         iso27001_annex_a("5.18"),
@@ -321,7 +320,7 @@ cis_aws_2_12_multiple_access_keys = Rule(
     tags=("iam", "credentials", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("2.12"),
         iso27001_annex_a("5.17"),
@@ -393,7 +392,7 @@ cis_aws_2_18_expired_certificates = Rule(
     tags=("certificates", "acm", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("2.18"),
         iso27001_annex_a("8.24"),

--- a/cartography/rules/data/rules/cis_aws_logging.py
+++ b/cartography/rules/data/rules/cis_aws_logging.py
@@ -10,6 +10,7 @@ Facts within a Rule are provider-specific implementations of the same concept.
 
 from cartography.rules.data.frameworks.cis import cis_aws
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
+from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -89,6 +90,7 @@ cis_aws_4_1_cloudtrail_multi_region = Rule(
     tags=("logging", "cloudtrail", "stride:repudiation"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("4.1"),
         iso27001_annex_a("8.15"),
@@ -157,6 +159,7 @@ cis_aws_4_2_cloudtrail_log_validation = Rule(
     tags=("logging", "cloudtrail", "stride:repudiation", "stride:tampering"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("4.2"),
         iso27001_annex_a("8.15"),
@@ -228,6 +231,7 @@ cis_aws_4_4_cloudtrail_bucket_access_logging = Rule(
     tags=("logging", "cloudtrail", "s3", "stride:repudiation"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("4.4"),
         iso27001_annex_a("8.15"),
@@ -295,6 +299,7 @@ cis_aws_4_5_cloudtrail_encryption = Rule(
     tags=("logging", "cloudtrail", "encryption", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("4.5"),
         iso27001_annex_a("8.24"),

--- a/cartography/rules/data/rules/cis_aws_logging.py
+++ b/cartography/rules/data/rules/cis_aws_logging.py
@@ -10,7 +10,6 @@ Facts within a Rule are provider-specific implementations of the same concept.
 
 from cartography.rules.data.frameworks.cis import cis_aws
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
-from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -91,7 +90,7 @@ cis_aws_4_1_cloudtrail_multi_region = Rule(
     tags=("logging", "cloudtrail", "stride:repudiation"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("4.1"),
         iso27001_annex_a("8.15"),
@@ -161,7 +160,7 @@ cis_aws_4_2_cloudtrail_log_validation = Rule(
     tags=("logging", "cloudtrail", "stride:repudiation", "stride:tampering"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("4.2"),
         iso27001_annex_a("8.15"),
@@ -234,7 +233,7 @@ cis_aws_4_4_cloudtrail_bucket_access_logging = Rule(
     tags=("logging", "cloudtrail", "s3", "stride:repudiation"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("4.4"),
         iso27001_annex_a("8.15"),
@@ -303,7 +302,7 @@ cis_aws_4_5_cloudtrail_encryption = Rule(
     tags=("logging", "cloudtrail", "encryption", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("4.5"),
         iso27001_annex_a("8.24"),

--- a/cartography/rules/data/rules/cis_aws_networking.py
+++ b/cartography/rules/data/rules/cis_aws_networking.py
@@ -10,7 +10,6 @@ Facts within a Rule are provider-specific implementations of the same concept.
 
 from cartography.rules.data.frameworks.cis import cis_aws
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
-from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -93,7 +92,7 @@ cis_aws_6_1_1_ebs_encryption = Rule(
     tags=("networking", "ebs", "encryption", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("6.1.1"),
         iso27001_annex_a("8.24"),
@@ -196,7 +195,7 @@ cis_aws_6_1_2_cifs_restricted = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("6.1.2"),
         iso27001_annex_a("8.20"),
@@ -302,7 +301,7 @@ cis_aws_6_3_remote_admin_ipv4 = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("6.3"),
         iso27001_annex_a("8.20"),
@@ -408,7 +407,7 @@ cis_aws_6_4_remote_admin_ipv6 = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("6.4"),
         iso27001_annex_a("8.20"),
@@ -499,7 +498,7 @@ cis_aws_6_5_default_sg_traffic = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("6.5"),
         iso27001_annex_a("8.20"),
@@ -575,7 +574,7 @@ cis_aws_6_7_ec2_imdsv2 = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("6.7"),
         iso27001_annex_a("8.9"),

--- a/cartography/rules/data/rules/cis_aws_networking.py
+++ b/cartography/rules/data/rules/cis_aws_networking.py
@@ -195,7 +195,6 @@ cis_aws_6_1_2_cifs_restricted = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_aws("6.1.2"),
         iso27001_annex_a("8.20"),
@@ -301,7 +300,6 @@ cis_aws_6_3_remote_admin_ipv4 = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_aws("6.3"),
         iso27001_annex_a("8.20"),
@@ -407,7 +405,6 @@ cis_aws_6_4_remote_admin_ipv6 = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_aws("6.4"),
         iso27001_annex_a("8.20"),
@@ -498,7 +495,6 @@ cis_aws_6_5_default_sg_traffic = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_aws("6.5"),
         iso27001_annex_a("8.20"),

--- a/cartography/rules/data/rules/cis_aws_networking.py
+++ b/cartography/rules/data/rules/cis_aws_networking.py
@@ -195,6 +195,7 @@ cis_aws_6_1_2_cifs_restricted = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_aws("6.1.2"),
         iso27001_annex_a("8.20"),
@@ -300,6 +301,7 @@ cis_aws_6_3_remote_admin_ipv4 = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_aws("6.3"),
         iso27001_annex_a("8.20"),
@@ -405,6 +407,7 @@ cis_aws_6_4_remote_admin_ipv6 = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_aws("6.4"),
         iso27001_annex_a("8.20"),
@@ -495,6 +498,7 @@ cis_aws_6_5_default_sg_traffic = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_aws("6.5"),
         iso27001_annex_a("8.20"),

--- a/cartography/rules/data/rules/cis_aws_networking.py
+++ b/cartography/rules/data/rules/cis_aws_networking.py
@@ -10,6 +10,7 @@ Facts within a Rule are provider-specific implementations of the same concept.
 
 from cartography.rules.data.frameworks.cis import cis_aws
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
+from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -91,6 +92,7 @@ cis_aws_6_1_1_ebs_encryption = Rule(
     tags=("networking", "ebs", "encryption", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("6.1.1"),
         iso27001_annex_a("8.24"),
@@ -183,6 +185,7 @@ cis_aws_6_1_2_cifs_restricted = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("6.1.2"),
         iso27001_annex_a("8.20"),
@@ -278,6 +281,7 @@ cis_aws_6_3_remote_admin_ipv4 = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("6.3"),
         iso27001_annex_a("8.20"),
@@ -373,6 +377,7 @@ cis_aws_6_4_remote_admin_ipv6 = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("6.4"),
         iso27001_annex_a("8.20"),
@@ -462,6 +467,7 @@ cis_aws_6_5_default_sg_traffic = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("6.5"),
         iso27001_annex_a("8.20"),
@@ -536,6 +542,7 @@ cis_aws_6_7_ec2_imdsv2 = Rule(
     ),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("6.7"),
         iso27001_annex_a("8.9"),

--- a/cartography/rules/data/rules/cis_aws_storage.py
+++ b/cartography/rules/data/rules/cis_aws_storage.py
@@ -10,6 +10,7 @@ Facts within a Rule are provider-specific implementations of the same concept.
 
 from cartography.rules.data.frameworks.cis import cis_aws
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
+from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -94,6 +95,7 @@ cis_aws_3_1_2_s3_mfa_delete = Rule(
     tags=("storage", "s3", "stride:tampering"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("3.1.2"),
         iso27001_annex_a("8.10"),
@@ -171,6 +173,7 @@ cis_aws_3_1_4_s3_block_public_access = Rule(
     tags=("storage", "s3", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("3.1.4"),
         iso27001_annex_a("8.3"),
@@ -243,6 +246,7 @@ cis_aws_3_2_1_rds_encryption = Rule(
     tags=("storage", "rds", "encryption", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_aws("3.2.1"),
         iso27001_annex_a("8.24"),

--- a/cartography/rules/data/rules/cis_aws_storage.py
+++ b/cartography/rules/data/rules/cis_aws_storage.py
@@ -174,7 +174,6 @@ cis_aws_3_1_4_s3_block_public_access = Rule(
     tags=("storage", "s3", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_aws("3.1.4"),
         iso27001_annex_a("8.3"),

--- a/cartography/rules/data/rules/cis_aws_storage.py
+++ b/cartography/rules/data/rules/cis_aws_storage.py
@@ -10,7 +10,6 @@ Facts within a Rule are provider-specific implementations of the same concept.
 
 from cartography.rules.data.frameworks.cis import cis_aws
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
-from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -96,7 +95,7 @@ cis_aws_3_1_2_s3_mfa_delete = Rule(
     tags=("storage", "s3", "stride:tampering"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("3.1.2"),
         iso27001_annex_a("8.10"),
@@ -175,7 +174,7 @@ cis_aws_3_1_4_s3_block_public_access = Rule(
     tags=("storage", "s3", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("3.1.4"),
         iso27001_annex_a("8.3"),
@@ -249,7 +248,7 @@ cis_aws_3_2_1_rds_encryption = Rule(
     tags=("storage", "rds", "encryption", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_aws("3.2.1"),
         iso27001_annex_a("8.24"),

--- a/cartography/rules/data/rules/cis_aws_storage.py
+++ b/cartography/rules/data/rules/cis_aws_storage.py
@@ -174,6 +174,7 @@ cis_aws_3_1_4_s3_block_public_access = Rule(
     tags=("storage", "s3", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_aws("3.1.4"),
         iso27001_annex_a("8.3"),

--- a/cartography/rules/data/rules/cis_google_workspace.py
+++ b/cartography/rules/data/rules/cis_google_workspace.py
@@ -10,7 +10,6 @@ Facts within a Rule are provider-specific implementations of the same concept.
 
 from cartography.rules.data.frameworks.cis import cis_google_workspace
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
-from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -92,7 +91,7 @@ cis_gw_4_1_1_3_user_2sv_not_enforced = Rule(
     tags=("iam", "authentication", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_google_workspace("4.1.1.3"),
         iso27001_annex_a("8.5"),
@@ -174,7 +173,7 @@ cis_gw_4_1_1_1_admin_2sv_not_enforced = Rule(
     tags=("iam", "authentication", "privileged_access", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_google_workspace("4.1.1.1"),
         iso27001_annex_a("8.5"),
@@ -261,7 +260,7 @@ cis_gw_1_1_1_super_admin_count_too_low = Rule(
     tags=("iam", "privileged_access", "resilience"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_google_workspace("1.1.1"),
         iso27001_annex_a("8.2"),
@@ -321,7 +320,7 @@ cis_gw_1_1_2_super_admin_count_too_high = Rule(
     tags=("iam", "privileged_access", "least_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_google_workspace("1.1.2"),
         iso27001_annex_a("8.2"),
@@ -386,7 +385,7 @@ cis_gw_1_1_3_super_admin_used_for_daily_admin = Rule(
     tags=("iam", "privileged_access", "least_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_google_workspace("1.1.3"),
         iso27001_annex_a("8.2"),

--- a/cartography/rules/data/rules/cis_google_workspace.py
+++ b/cartography/rules/data/rules/cis_google_workspace.py
@@ -10,6 +10,7 @@ Facts within a Rule are provider-specific implementations of the same concept.
 
 from cartography.rules.data.frameworks.cis import cis_google_workspace
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
+from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -90,6 +91,7 @@ cis_gw_4_1_1_3_user_2sv_not_enforced = Rule(
     tags=("iam", "authentication", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_google_workspace("4.1.1.3"),
         iso27001_annex_a("8.5"),
@@ -170,6 +172,7 @@ cis_gw_4_1_1_1_admin_2sv_not_enforced = Rule(
     tags=("iam", "authentication", "privileged_access", "stride:spoofing"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_google_workspace("4.1.1.1"),
         iso27001_annex_a("8.5"),
@@ -255,6 +258,7 @@ cis_gw_1_1_1_super_admin_count_too_low = Rule(
     tags=("iam", "privileged_access", "resilience"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_google_workspace("1.1.1"),
         iso27001_annex_a("8.2"),
@@ -313,6 +317,7 @@ cis_gw_1_1_2_super_admin_count_too_high = Rule(
     tags=("iam", "privileged_access", "least_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_google_workspace("1.1.2"),
         iso27001_annex_a("8.2"),
@@ -376,6 +381,7 @@ cis_gw_1_1_3_super_admin_used_for_daily_admin = Rule(
     tags=("iam", "privileged_access", "least_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_google_workspace("1.1.3"),
         iso27001_annex_a("8.2"),

--- a/cartography/rules/data/rules/cis_kubernetes_rbac.py
+++ b/cartography/rules/data/rules/cis_kubernetes_rbac.py
@@ -103,6 +103,7 @@ cis_k8s_5_1_1_cluster_admin_usage = Rule(
     tags=("rbac", "cluster-admin", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.1"),
         iso27001_annex_a("5.18"),
@@ -212,6 +213,7 @@ cis_k8s_5_1_2_secret_access = Rule(
     tags=("rbac", "secrets", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.2"),
         iso27001_annex_a("8.3"),
@@ -329,6 +331,7 @@ cis_k8s_5_1_3_wildcard_roles = Rule(
     tags=("rbac", "wildcard", "least-privilege", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.3"),
         iso27001_annex_a("5.18"),
@@ -435,6 +438,7 @@ cis_k8s_5_1_4_pod_create_access = Rule(
     tags=("rbac", "pods", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.4"),
         iso27001_annex_a("5.18"),
@@ -631,6 +635,7 @@ cis_k8s_5_1_5_default_sa_bindings = Rule(
     tags=("rbac", "service-accounts", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.5"),
         iso27001_annex_a("5.16"),
@@ -743,6 +748,7 @@ cis_k8s_5_1_7_system_masters_group = Rule(
     tags=("rbac", "system-masters", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.7"),
         iso27001_annex_a("8.2"),
@@ -845,6 +851,7 @@ cis_k8s_5_1_8_escalation_permissions = Rule(
     tags=("rbac", "escalation", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.8"),
         iso27001_annex_a("5.18"),
@@ -955,6 +962,7 @@ cis_k8s_5_1_9_pv_create_access = Rule(
     tags=("rbac", "persistent-volumes", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.9"),
         iso27001_annex_a("5.18"),
@@ -1027,6 +1035,7 @@ cis_k8s_5_1_10_node_proxy_access = Rule(
     tags=("rbac", "nodes", "kubelet", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.10"),
         iso27001_annex_a("8.2"),
@@ -1100,6 +1109,7 @@ cis_k8s_5_1_11_csr_approval_access = Rule(
     tags=("rbac", "certificates", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.11"),
         iso27001_annex_a("8.5"),
@@ -1187,6 +1197,7 @@ cis_k8s_5_1_12_webhook_config_access = Rule(
     tags=("rbac", "webhooks", "stride:elevation_of_privilege", "stride:tampering"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.12"),
         iso27001_annex_a("8.9"),
@@ -1260,6 +1271,7 @@ cis_k8s_5_1_13_sa_token_creation = Rule(
     tags=("rbac", "service-accounts", "tokens", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.13"),
         iso27001_annex_a("5.17"),

--- a/cartography/rules/data/rules/cis_kubernetes_rbac.py
+++ b/cartography/rules/data/rules/cis_kubernetes_rbac.py
@@ -10,6 +10,7 @@ Facts within a Rule are provider-specific implementations of the same concept.
 
 from cartography.rules.data.frameworks.cis import cis_kubernetes
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
+from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -100,6 +101,7 @@ cis_k8s_5_1_1_cluster_admin_usage = Rule(
     tags=("rbac", "cluster-admin", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.1.1"),
         iso27001_annex_a("5.18"),
@@ -204,6 +206,7 @@ cis_k8s_5_1_2_secret_access = Rule(
     tags=("rbac", "secrets", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.1.2"),
         iso27001_annex_a("8.3"),
@@ -316,6 +319,7 @@ cis_k8s_5_1_3_wildcard_roles = Rule(
     tags=("rbac", "wildcard", "least-privilege", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.1.3"),
         iso27001_annex_a("5.18"),
@@ -417,6 +421,7 @@ cis_k8s_5_1_4_pod_create_access = Rule(
     tags=("rbac", "pods", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.1.4"),
         iso27001_annex_a("5.18"),
@@ -609,6 +614,7 @@ cis_k8s_5_1_5_default_sa_bindings = Rule(
     tags=("rbac", "service-accounts", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.1.5"),
         iso27001_annex_a("5.16"),
@@ -719,6 +725,7 @@ cis_k8s_5_1_7_system_masters_group = Rule(
     tags=("rbac", "system-masters", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.1.7"),
         iso27001_annex_a("8.2"),
@@ -816,6 +823,7 @@ cis_k8s_5_1_8_escalation_permissions = Rule(
     tags=("rbac", "escalation", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.1.8"),
         iso27001_annex_a("5.18"),
@@ -921,6 +929,7 @@ cis_k8s_5_1_9_pv_create_access = Rule(
     tags=("rbac", "persistent-volumes", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.1.9"),
         iso27001_annex_a("5.18"),
@@ -990,6 +999,7 @@ cis_k8s_5_1_10_node_proxy_access = Rule(
     tags=("rbac", "nodes", "kubelet", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.1.10"),
         iso27001_annex_a("8.2"),
@@ -1060,6 +1070,7 @@ cis_k8s_5_1_11_csr_approval_access = Rule(
     tags=("rbac", "certificates", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.1.11"),
         iso27001_annex_a("8.5"),
@@ -1144,6 +1155,7 @@ cis_k8s_5_1_12_webhook_config_access = Rule(
     tags=("rbac", "webhooks", "stride:elevation_of_privilege", "stride:tampering"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.1.12"),
         iso27001_annex_a("8.9"),
@@ -1214,6 +1226,7 @@ cis_k8s_5_1_13_sa_token_creation = Rule(
     tags=("rbac", "service-accounts", "tokens", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.1.13"),
         iso27001_annex_a("5.17"),

--- a/cartography/rules/data/rules/cis_kubernetes_rbac.py
+++ b/cartography/rules/data/rules/cis_kubernetes_rbac.py
@@ -103,7 +103,6 @@ cis_k8s_5_1_1_cluster_admin_usage = Rule(
     tags=("rbac", "cluster-admin", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.1"),
         iso27001_annex_a("5.18"),
@@ -213,7 +212,6 @@ cis_k8s_5_1_2_secret_access = Rule(
     tags=("rbac", "secrets", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.2"),
         iso27001_annex_a("8.3"),
@@ -331,7 +329,6 @@ cis_k8s_5_1_3_wildcard_roles = Rule(
     tags=("rbac", "wildcard", "least-privilege", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.3"),
         iso27001_annex_a("5.18"),
@@ -438,7 +435,6 @@ cis_k8s_5_1_4_pod_create_access = Rule(
     tags=("rbac", "pods", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.4"),
         iso27001_annex_a("5.18"),
@@ -635,7 +631,6 @@ cis_k8s_5_1_5_default_sa_bindings = Rule(
     tags=("rbac", "service-accounts", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.5"),
         iso27001_annex_a("5.16"),
@@ -748,7 +743,6 @@ cis_k8s_5_1_7_system_masters_group = Rule(
     tags=("rbac", "system-masters", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.7"),
         iso27001_annex_a("8.2"),
@@ -851,7 +845,6 @@ cis_k8s_5_1_8_escalation_permissions = Rule(
     tags=("rbac", "escalation", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.8"),
         iso27001_annex_a("5.18"),
@@ -962,7 +955,6 @@ cis_k8s_5_1_9_pv_create_access = Rule(
     tags=("rbac", "persistent-volumes", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.9"),
         iso27001_annex_a("5.18"),
@@ -1035,7 +1027,6 @@ cis_k8s_5_1_10_node_proxy_access = Rule(
     tags=("rbac", "nodes", "kubelet", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.10"),
         iso27001_annex_a("8.2"),
@@ -1109,7 +1100,6 @@ cis_k8s_5_1_11_csr_approval_access = Rule(
     tags=("rbac", "certificates", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.11"),
         iso27001_annex_a("8.5"),
@@ -1197,7 +1187,6 @@ cis_k8s_5_1_12_webhook_config_access = Rule(
     tags=("rbac", "webhooks", "stride:elevation_of_privilege", "stride:tampering"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.12"),
         iso27001_annex_a("8.9"),
@@ -1271,7 +1260,6 @@ cis_k8s_5_1_13_sa_token_creation = Rule(
     tags=("rbac", "service-accounts", "tokens", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.13"),
         iso27001_annex_a("5.17"),

--- a/cartography/rules/data/rules/cis_kubernetes_rbac.py
+++ b/cartography/rules/data/rules/cis_kubernetes_rbac.py
@@ -10,7 +10,6 @@ Facts within a Rule are provider-specific implementations of the same concept.
 
 from cartography.rules.data.frameworks.cis import cis_kubernetes
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
-from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -104,7 +103,7 @@ cis_k8s_5_1_1_cluster_admin_usage = Rule(
     tags=("rbac", "cluster-admin", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.1"),
         iso27001_annex_a("5.18"),
@@ -214,7 +213,7 @@ cis_k8s_5_1_2_secret_access = Rule(
     tags=("rbac", "secrets", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.2"),
         iso27001_annex_a("8.3"),
@@ -332,7 +331,7 @@ cis_k8s_5_1_3_wildcard_roles = Rule(
     tags=("rbac", "wildcard", "least-privilege", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.3"),
         iso27001_annex_a("5.18"),
@@ -439,7 +438,7 @@ cis_k8s_5_1_4_pod_create_access = Rule(
     tags=("rbac", "pods", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.4"),
         iso27001_annex_a("5.18"),
@@ -636,7 +635,7 @@ cis_k8s_5_1_5_default_sa_bindings = Rule(
     tags=("rbac", "service-accounts", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.5"),
         iso27001_annex_a("5.16"),
@@ -749,7 +748,7 @@ cis_k8s_5_1_7_system_masters_group = Rule(
     tags=("rbac", "system-masters", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.7"),
         iso27001_annex_a("8.2"),
@@ -852,7 +851,7 @@ cis_k8s_5_1_8_escalation_permissions = Rule(
     tags=("rbac", "escalation", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.8"),
         iso27001_annex_a("5.18"),
@@ -963,7 +962,7 @@ cis_k8s_5_1_9_pv_create_access = Rule(
     tags=("rbac", "persistent-volumes", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.9"),
         iso27001_annex_a("5.18"),
@@ -1036,7 +1035,7 @@ cis_k8s_5_1_10_node_proxy_access = Rule(
     tags=("rbac", "nodes", "kubelet", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.10"),
         iso27001_annex_a("8.2"),
@@ -1110,7 +1109,7 @@ cis_k8s_5_1_11_csr_approval_access = Rule(
     tags=("rbac", "certificates", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.11"),
         iso27001_annex_a("8.5"),
@@ -1198,7 +1197,7 @@ cis_k8s_5_1_12_webhook_config_access = Rule(
     tags=("rbac", "webhooks", "stride:elevation_of_privilege", "stride:tampering"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.12"),
         iso27001_annex_a("8.9"),
@@ -1272,7 +1271,7 @@ cis_k8s_5_1_13_sa_token_creation = Rule(
     tags=("rbac", "service-accounts", "tokens", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.13"),
         iso27001_annex_a("5.17"),

--- a/cartography/rules/data/rules/cis_kubernetes_workloads.py
+++ b/cartography/rules/data/rules/cis_kubernetes_workloads.py
@@ -133,6 +133,7 @@ cis_k8s_5_4_1_secrets_in_env_vars = Rule(
     tags=("secrets", "environment-variables", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.4.1"),
         iso27001_annex_a("8.12"),
@@ -252,6 +253,7 @@ cis_k8s_5_1_6_sa_token_mounts = Rule(
     tags=("service-accounts", "tokens", "workloads", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.6"),
         iso27001_annex_a("5.17"),
@@ -309,6 +311,7 @@ cis_k8s_5_2_3_host_pid = Rule(
     tags=("pod-security", "hostpid", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.3"),
         iso27001_annex_a("8.9"),
@@ -360,6 +363,7 @@ cis_k8s_5_2_4_host_ipc = Rule(
     tags=("pod-security", "hostipc", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.4"),
         iso27001_annex_a("8.9"),
@@ -411,6 +415,7 @@ cis_k8s_5_2_5_host_network = Rule(
     tags=("pod-security", "hostnetwork", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.5"),
         iso27001_annex_a("8.9"),
@@ -468,6 +473,7 @@ cis_k8s_5_2_6_allow_privilege_escalation = Rule(
     tags=("pod-security", "privilege-escalation", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.6"),
         iso27001_annex_a("8.9"),
@@ -530,6 +536,7 @@ cis_k8s_5_2_11_host_path_volumes = Rule(
     tags=("pod-security", "hostpath", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.11"),
         iso27001_annex_a("8.9"),
@@ -582,6 +589,7 @@ cis_k8s_5_2_12_host_ports = Rule(
     tags=("pod-security", "hostports", "networking", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.12"),
         iso27001_annex_a("8.9"),

--- a/cartography/rules/data/rules/cis_kubernetes_workloads.py
+++ b/cartography/rules/data/rules/cis_kubernetes_workloads.py
@@ -133,7 +133,6 @@ cis_k8s_5_4_1_secrets_in_env_vars = Rule(
     tags=("secrets", "environment-variables", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.4.1"),
         iso27001_annex_a("8.12"),
@@ -253,7 +252,6 @@ cis_k8s_5_1_6_sa_token_mounts = Rule(
     tags=("service-accounts", "tokens", "workloads", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.6"),
         iso27001_annex_a("5.17"),
@@ -311,7 +309,6 @@ cis_k8s_5_2_3_host_pid = Rule(
     tags=("pod-security", "hostpid", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.3"),
         iso27001_annex_a("8.9"),
@@ -363,7 +360,6 @@ cis_k8s_5_2_4_host_ipc = Rule(
     tags=("pod-security", "hostipc", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.4"),
         iso27001_annex_a("8.9"),
@@ -415,7 +411,6 @@ cis_k8s_5_2_5_host_network = Rule(
     tags=("pod-security", "hostnetwork", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.5"),
         iso27001_annex_a("8.9"),
@@ -473,7 +468,6 @@ cis_k8s_5_2_6_allow_privilege_escalation = Rule(
     tags=("pod-security", "privilege-escalation", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.6"),
         iso27001_annex_a("8.9"),
@@ -536,7 +530,6 @@ cis_k8s_5_2_11_host_path_volumes = Rule(
     tags=("pod-security", "hostpath", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.11"),
         iso27001_annex_a("8.9"),
@@ -589,7 +582,6 @@ cis_k8s_5_2_12_host_ports = Rule(
     tags=("pod-security", "hostports", "networking", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.12"),
         iso27001_annex_a("8.9"),

--- a/cartography/rules/data/rules/cis_kubernetes_workloads.py
+++ b/cartography/rules/data/rules/cis_kubernetes_workloads.py
@@ -12,7 +12,6 @@ import json
 
 from cartography.rules.data.frameworks.cis import cis_kubernetes
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
-from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -134,7 +133,7 @@ cis_k8s_5_4_1_secrets_in_env_vars = Rule(
     tags=("secrets", "environment-variables", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.4.1"),
         iso27001_annex_a("8.12"),
@@ -254,7 +253,7 @@ cis_k8s_5_1_6_sa_token_mounts = Rule(
     tags=("service-accounts", "tokens", "workloads", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.1.6"),
         iso27001_annex_a("5.17"),
@@ -312,7 +311,7 @@ cis_k8s_5_2_3_host_pid = Rule(
     tags=("pod-security", "hostpid", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.3"),
         iso27001_annex_a("8.9"),
@@ -364,7 +363,7 @@ cis_k8s_5_2_4_host_ipc = Rule(
     tags=("pod-security", "hostipc", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.4"),
         iso27001_annex_a("8.9"),
@@ -416,7 +415,7 @@ cis_k8s_5_2_5_host_network = Rule(
     tags=("pod-security", "hostnetwork", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.5"),
         iso27001_annex_a("8.9"),
@@ -474,7 +473,7 @@ cis_k8s_5_2_6_allow_privilege_escalation = Rule(
     tags=("pod-security", "privilege-escalation", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.6"),
         iso27001_annex_a("8.9"),
@@ -537,7 +536,7 @@ cis_k8s_5_2_11_host_path_volumes = Rule(
     tags=("pod-security", "hostpath", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.11"),
         iso27001_annex_a("8.9"),
@@ -590,7 +589,7 @@ cis_k8s_5_2_12_host_ports = Rule(
     tags=("pod-security", "hostports", "networking", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.2.12"),
         iso27001_annex_a("8.9"),
@@ -670,7 +669,7 @@ cis_k8s_5_6_2_runtime_default_seccomp = Rule(
     tags=("pod-security", "seccomp", "runtime-default"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(
         cis_kubernetes("5.6.2"),
         iso27001_annex_a("8.9"),
@@ -743,7 +742,7 @@ cis_k8s_5_6_4_default_namespace = Rule(
     tags=("namespaces", "general-policies", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
-    catalog_visibility=(Catalog.COMPLIANCE,),
+    compliance_only=True,
     frameworks=(cis_kubernetes("5.6.4"),),
 )
 

--- a/cartography/rules/data/rules/cis_kubernetes_workloads.py
+++ b/cartography/rules/data/rules/cis_kubernetes_workloads.py
@@ -12,6 +12,7 @@ import json
 
 from cartography.rules.data.frameworks.cis import cis_kubernetes
 from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
+from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Maturity
@@ -132,6 +133,7 @@ cis_k8s_5_4_1_secrets_in_env_vars = Rule(
     tags=("secrets", "environment-variables", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.4.1"),
         iso27001_annex_a("8.12"),
@@ -250,6 +252,7 @@ cis_k8s_5_1_6_sa_token_mounts = Rule(
     tags=("service-accounts", "tokens", "workloads", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.1.6"),
         iso27001_annex_a("5.17"),
@@ -306,6 +309,7 @@ cis_k8s_5_2_3_host_pid = Rule(
     tags=("pod-security", "hostpid", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.2.3"),
         iso27001_annex_a("8.9"),
@@ -356,6 +360,7 @@ cis_k8s_5_2_4_host_ipc = Rule(
     tags=("pod-security", "hostipc", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.2.4"),
         iso27001_annex_a("8.9"),
@@ -406,6 +411,7 @@ cis_k8s_5_2_5_host_network = Rule(
     tags=("pod-security", "hostnetwork", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.2.5"),
         iso27001_annex_a("8.9"),
@@ -462,6 +468,7 @@ cis_k8s_5_2_6_allow_privilege_escalation = Rule(
     tags=("pod-security", "privilege-escalation", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.2.6"),
         iso27001_annex_a("8.9"),
@@ -523,6 +530,7 @@ cis_k8s_5_2_11_host_path_volumes = Rule(
     tags=("pod-security", "hostpath", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.2.11"),
         iso27001_annex_a("8.9"),
@@ -574,6 +582,7 @@ cis_k8s_5_2_12_host_ports = Rule(
     tags=("pod-security", "hostports", "networking", "stride:elevation_of_privilege"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.2.12"),
         iso27001_annex_a("8.9"),
@@ -652,6 +661,7 @@ cis_k8s_5_6_2_runtime_default_seccomp = Rule(
     tags=("pod-security", "seccomp", "runtime-default"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(
         cis_kubernetes("5.6.2"),
         iso27001_annex_a("8.9"),
@@ -721,6 +731,7 @@ cis_k8s_5_6_4_default_namespace = Rule(
     tags=("namespaces", "general-policies", "stride:information_disclosure"),
     version="1.0.0",
     references=CIS_REFERENCES,
+    catalog_visibility=(Catalog.COMPLIANCE,),
     frameworks=(cis_kubernetes("5.6.4"),),
 )
 

--- a/cartography/rules/data/rules/nist_ai_rmf.py
+++ b/cartography/rules/data/rules/nist_ai_rmf.py
@@ -163,6 +163,7 @@ nist_ai_third_party_app_inventory = Rule(
     tags=("ai", "identity", "compliance", "governance"),
     version="0.1.0",
     references=NIST_REFERENCES,
+    compliance_only=True,
     frameworks=(
         nist_ai_rmf("MAP 1"),
         iso27001_annex_a("5.21"),
@@ -267,6 +268,7 @@ nist_ai_third_party_app_sensitive_scopes = Rule(
     tags=("ai", "identity", "oauth", "compliance"),
     version="0.1.0",
     references=NIST_REFERENCES,
+    compliance_only=True,
     frameworks=(
         nist_ai_rmf("MEASURE 2"),
         nist_ai_rmf("MANAGE 2"),
@@ -398,6 +400,7 @@ nist_ai_admin_ai_app_authorizations = Rule(
     tags=("ai", "identity", "privileged_access", "compliance"),
     version="0.1.0",
     references=NIST_REFERENCES,
+    compliance_only=True,
     frameworks=(
         nist_ai_rmf("GOVERN 5"),
         iso27001_annex_a("5.18"),
@@ -554,6 +557,7 @@ nist_ai_aibom_agent_inventory = Rule(
     tags=("ai", "inventory", "software_supply_chain", "compliance"),
     version="0.1.0",
     references=NIST_REFERENCES,
+    compliance_only=True,
     frameworks=(
         nist_ai_rmf("MAP 1"),
         nist_ai_rmf("GOVERN 1"),
@@ -653,6 +657,7 @@ nist_ai_aibom_coverage_gaps = Rule(
     tags=("ai", "inventory", "provenance", "compliance"),
     version="0.1.0",
     references=NIST_REFERENCES,
+    compliance_only=True,
     frameworks=(
         nist_ai_rmf("MEASURE 2"),
         nist_ai_rmf("MANAGE 2"),
@@ -868,6 +873,7 @@ nist_ai_provider_api_key_hygiene = Rule(
     tags=("ai", "credentials", "governance", "compliance"),
     version="0.1.0",
     references=NIST_REFERENCES,
+    compliance_only=True,
     frameworks=(
         nist_ai_rmf("GOVERN 5"),
         nist_ai_rmf("MANAGE 2"),

--- a/cartography/rules/runners.py
+++ b/cartography/rules/runners.py
@@ -2,8 +2,6 @@
 Framework and Fact execution logic for Cartography rules.
 """
 
-from typing import cast
-
 from neo4j import Driver
 from neo4j import GraphDatabase
 
@@ -11,7 +9,6 @@ from cartography.client.core.tx import read_list_of_dicts_tx
 from cartography.rules.data.rules import RULES
 from cartography.rules.formatters import _format_and_output_results
 from cartography.rules.formatters import _generate_neo4j_browser_url
-from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Framework
 from cartography.rules.spec.model import Maturity
@@ -224,7 +221,7 @@ def _run_single_rule(
         counter=counter,
         rule_tags=rule.tags,
         rule_frameworks=rule.frameworks,
-        rule_catalog_visibility=cast(tuple[Catalog, ...], rule.catalog_visibility),
+        rule_compliance_only=rule.compliance_only,
     )
 
 

--- a/cartography/rules/runners.py
+++ b/cartography/rules/runners.py
@@ -2,6 +2,8 @@
 Framework and Fact execution logic for Cartography rules.
 """
 
+from typing import cast
+
 from neo4j import Driver
 from neo4j import GraphDatabase
 
@@ -9,6 +11,7 @@ from cartography.client.core.tx import read_list_of_dicts_tx
 from cartography.rules.data.rules import RULES
 from cartography.rules.formatters import _format_and_output_results
 from cartography.rules.formatters import _generate_neo4j_browser_url
+from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Framework
 from cartography.rules.spec.model import Maturity
@@ -220,6 +223,7 @@ def _run_single_rule(
         counter=counter,
         rule_tags=rule.tags,
         rule_frameworks=rule.frameworks,
+        rule_catalog_visibility=cast(tuple[Catalog, ...], rule.catalog_visibility),
     )
 
 

--- a/cartography/rules/spec/model.py
+++ b/cartography/rules/spec/model.py
@@ -129,16 +129,6 @@ class Maturity(str, Enum):
     """Stable: Well-tested and reliable for production use."""
 
 
-class Catalog(str, Enum):
-    """Where a Rule should appear in rule and compliance catalogs."""
-
-    RULES = "rules"
-    """Visible in the standalone rule catalog."""
-
-    COMPLIANCE = "compliance"
-    """Visible through compliance framework catalogs."""
-
-
 MODULE_TO_CARTOGRAPHY_INTEL = {
     Module.AIBOM: "aibom",
     Module.AIRBYTE: "airbyte",
@@ -344,33 +334,16 @@ class Rule:
     """References or links to external resources related to the Rule."""
     frameworks: tuple[Framework, ...] = ()
     """Compliance frameworks this rule maps to (e.g., CIS benchmarks)."""
-    catalog_visibility: (
-        tuple[Catalog | str, ...] | list[Catalog | str] | Catalog | str | None
-    ) = None
+    compliance_only: bool = False
     """
-    Controls where this rule appears in catalog views. Defaults to
-    ``(Catalog.RULES, Catalog.COMPLIANCE)`` for framework-mapped rules and
-    ``(Catalog.RULES,)`` for standalone rules.
-    """
+    Whether this rule should only appear in compliance framework contexts.
 
-    def __post_init__(self) -> None:
-        visibility = self.catalog_visibility
-        if visibility is None:
-            visibility = (
-                (Catalog.RULES, Catalog.COMPLIANCE)
-                if self.frameworks
-                else (Catalog.RULES,)
-            )
-        elif isinstance(visibility, Catalog):
-            visibility = (visibility,)
-        elif isinstance(visibility, str):
-            visibility = (Catalog(visibility),)
-        else:
-            visibility = tuple(
-                catalog if isinstance(catalog, Catalog) else Catalog(catalog)
-                for catalog in visibility
-            )
-        object.__setattr__(self, "catalog_visibility", visibility)
+    Set this to ``True`` for framework checklist controls that are primarily
+    hygiene or governance checks rather than immediate threat detections.
+    Framework mappings are preserved either way; this only helps catalog
+    consumers decide whether to show the rule in standalone actionable rule
+    lists.
+    """
 
     @property
     def modules(self) -> set[Module]:

--- a/cartography/rules/spec/model.py
+++ b/cartography/rules/spec/model.py
@@ -129,6 +129,16 @@ class Maturity(str, Enum):
     """Stable: Well-tested and reliable for production use."""
 
 
+class Catalog(str, Enum):
+    """Where a Rule should appear in rule and compliance catalogs."""
+
+    RULES = "rules"
+    """Visible in the standalone rule catalog."""
+
+    COMPLIANCE = "compliance"
+    """Visible through compliance framework catalogs."""
+
+
 MODULE_TO_CARTOGRAPHY_INTEL = {
     Module.AIBOM: "aibom",
     Module.AIRBYTE: "airbyte",
@@ -326,6 +336,33 @@ class Rule:
     """References or links to external resources related to the Rule."""
     frameworks: tuple[Framework, ...] = ()
     """Compliance frameworks this rule maps to (e.g., CIS benchmarks)."""
+    catalog_visibility: (
+        tuple[Catalog | str, ...] | list[Catalog | str] | Catalog | str | None
+    ) = None
+    """
+    Controls where this rule appears in catalog views. Defaults to
+    ``(Catalog.RULES, Catalog.COMPLIANCE)`` for framework-mapped rules and
+    ``(Catalog.RULES,)`` for standalone rules.
+    """
+
+    def __post_init__(self) -> None:
+        visibility = self.catalog_visibility
+        if visibility is None:
+            visibility = (
+                (Catalog.RULES, Catalog.COMPLIANCE)
+                if self.frameworks
+                else (Catalog.RULES,)
+            )
+        elif isinstance(visibility, Catalog):
+            visibility = (visibility,)
+        elif isinstance(visibility, str):
+            visibility = (Catalog(visibility),)
+        else:
+            visibility = tuple(
+                catalog if isinstance(catalog, Catalog) else Catalog(catalog)
+                for catalog in visibility
+            )
+        object.__setattr__(self, "catalog_visibility", visibility)
 
     @property
     def modules(self) -> set[Module]:

--- a/cartography/rules/spec/result.py
+++ b/cartography/rules/spec/result.py
@@ -8,6 +8,7 @@ of rule and fact execution.
 from dataclasses import dataclass
 from dataclasses import field
 
+from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Framework
 
@@ -85,6 +86,7 @@ class RuleResult:
         facts (list[FactResult]): Results from each Fact executed within this Rule.
         rule_tags (tuple[str, ...]): Tags associated with the Rule.
         rule_frameworks (tuple[Framework, ...]): Compliance frameworks this rule maps to.
+        rule_catalog_visibility (tuple[Catalog, ...]): Where this rule appears in catalogs.
     """
 
     rule_id: str
@@ -94,3 +96,4 @@ class RuleResult:
     facts: list[FactResult] = field(default_factory=list)
     rule_tags: tuple[str, ...] = ()
     rule_frameworks: tuple[Framework, ...] = ()
+    rule_catalog_visibility: tuple[Catalog, ...] = (Catalog.RULES,)

--- a/cartography/rules/spec/result.py
+++ b/cartography/rules/spec/result.py
@@ -8,7 +8,6 @@ of rule and fact execution.
 from dataclasses import dataclass
 from dataclasses import field
 
-from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Framework
 
@@ -93,7 +92,7 @@ class RuleResult:
         facts (list[FactResult]): Results from each Fact executed within this Rule.
         rule_tags (tuple[str, ...]): Tags associated with the Rule.
         rule_frameworks (tuple[Framework, ...]): Compliance frameworks this rule maps to.
-        rule_catalog_visibility (tuple[Catalog, ...]): Where this rule appears in catalogs.
+        rule_compliance_only (bool): Whether this rule is primarily a hygiene or governance control that should only appear in compliance framework catalogs.
     """
 
     rule_id: str
@@ -103,4 +102,4 @@ class RuleResult:
     facts: list[FactResult] = field(default_factory=list)
     rule_tags: tuple[str, ...] = ()
     rule_frameworks: tuple[Framework, ...] = ()
-    rule_catalog_visibility: tuple[Catalog, ...] = (Catalog.RULES,)
+    rule_compliance_only: bool = False

--- a/docs/root/usage/rules.md
+++ b/docs/root/usage/rules.md
@@ -73,6 +73,15 @@ Each rule has a semantic version number (e.g., `0.1.0`, `1.0.0`) that helps trac
 
 When a rule's version changes, you can review the changes in the git history to understand what was modified and assess impact on your existing workflows.
 
+### Catalog Visibility
+
+Each rule has `catalog_visibility` metadata that tells consumers which catalog views the rule belongs in:
+
+- `rules`: show in the standalone rule catalog.
+- `compliance`: show through compliance framework pages.
+
+If omitted, standalone rules default to `("rules",)` and framework-mapped rules default to `("rules", "compliance")`. Use `("compliance",)` for framework checklist controls that are not useful as standalone detections.
+
 ### Fact Maturity Levels
 
 Each fact has a maturity level that indicates its stability and production-readiness:

--- a/docs/root/usage/rules.md
+++ b/docs/root/usage/rules.md
@@ -73,14 +73,13 @@ Each rule has a semantic version number (e.g., `0.1.0`, `1.0.0`) that helps trac
 
 When a rule's version changes, you can review the changes in the git history to understand what was modified and assess impact on your existing workflows.
 
-### Catalog Visibility
+### Compliance-Only Rules
 
-Each rule has `catalog_visibility` metadata that tells consumers which catalog views the rule belongs in:
+Each rule has a `compliance_only` flag that tells consumers whether the rule is primarily a compliance framework control rather than a standalone actionable detection.
 
-- `rules`: show in the standalone rule catalog.
-- `compliance`: show through compliance framework pages.
+Set `compliance_only=True` for framework checklist controls that are more about hygiene, governance, or audit posture than immediate threats. Examples include CIS benchmark controls that verify credential rotation, logging configuration, or policy hygiene.
 
-If omitted, standalone rules default to `("rules",)` and framework-mapped rules default to `("rules", "compliance")`. Use `("compliance",)` for framework checklist controls that are not useful as standalone detections.
+Leave `compliance_only=False` for operational detections that should appear in standalone rule catalogs, even if they are also mapped to one or more compliance frameworks. Framework mappings are preserved either way; this flag only helps catalog consumers decide whether to show the rule outside framework-specific pages.
 
 ### Fact Maturity Levels
 

--- a/tests/unit/rules/test_catalog_visibility.py
+++ b/tests/unit/rules/test_catalog_visibility.py
@@ -1,0 +1,101 @@
+from cartography.rules.data.rules import RULES
+from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_11_unused_credentials
+from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_13_access_key_not_rotated
+from cartography.rules.data.rules.guardduty_active_threat import guardduty_active_threat
+from cartography.rules.data.rules.nist_ai_rmf import nist_ai_admin_ai_app_authorizations
+from cartography.rules.data.rules.nist_ai_rmf import nist_ai_aibom_agent_inventory
+from cartography.rules.data.rules.nist_ai_rmf import nist_ai_aibom_coverage_gaps
+from cartography.rules.data.rules.nist_ai_rmf import nist_ai_provider_api_key_hygiene
+from cartography.rules.data.rules.nist_ai_rmf import nist_ai_third_party_app_inventory
+from cartography.rules.data.rules.nist_ai_rmf import (
+    nist_ai_third_party_app_sensitive_scopes,
+)
+from cartography.rules.data.rules.object_storage_public import object_storage_public
+from cartography.rules.data.rules.subimage_coverage import aws_account_not_synced
+from cartography.rules.data.rules.subimage_coverage import container_image_not_found
+from cartography.rules.formatters import to_serializable
+from cartography.rules.runners import get_all_frameworks
+from cartography.rules.spec.model import Catalog
+from cartography.rules.spec.result import CounterResult
+from cartography.rules.spec.result import RuleResult
+
+
+def _serialized_catalog_visibility(rule) -> list[str]:
+    result = RuleResult(
+        rule_id=rule.id,
+        rule_name=rule.name,
+        rule_description=rule.description,
+        counter=CounterResult(),
+        rule_tags=rule.tags,
+        rule_frameworks=rule.frameworks,
+        rule_catalog_visibility=rule.catalog_visibility,
+    )
+    return to_serializable(result)["rule_catalog_visibility"]
+
+
+def test_cis_catalog_rules_are_compliance_only() -> None:
+    cis_rules = {
+        rule_id: rule
+        for rule_id, rule in RULES.items()
+        if rule_id.startswith(("cis_aws_", "cis_gcp_", "cis_k8s_", "cis_gw_"))
+    }
+
+    assert cis_rules
+    for rule in cis_rules.values():
+        assert rule.catalog_visibility == (Catalog.COMPLIANCE,)
+
+    assert _serialized_catalog_visibility(cis_aws_2_11_unused_credentials) == [
+        "compliance"
+    ]
+    assert _serialized_catalog_visibility(cis_aws_2_13_access_key_not_rotated) == [
+        "compliance"
+    ]
+
+
+def test_standalone_operational_rules_serialize_as_rules() -> None:
+    for rule in (
+        guardduty_active_threat,
+        container_image_not_found,
+        aws_account_not_synced,
+    ):
+        assert rule.frameworks == ()
+        assert rule.catalog_visibility == (Catalog.RULES,)
+        assert _serialized_catalog_visibility(rule) == ["rules"]
+
+
+def test_framework_mapped_operational_rules_serialize_as_rules_and_compliance() -> None:
+    assert object_storage_public.frameworks
+    assert object_storage_public.catalog_visibility == (
+        Catalog.RULES,
+        Catalog.COMPLIANCE,
+    )
+    assert _serialized_catalog_visibility(object_storage_public) == [
+        "rules",
+        "compliance",
+    ]
+
+
+def test_nist_ai_rmf_operational_rules_serialize_as_rules_and_compliance() -> None:
+    for rule in (
+        nist_ai_third_party_app_inventory,
+        nist_ai_third_party_app_sensitive_scopes,
+        nist_ai_admin_ai_app_authorizations,
+        nist_ai_aibom_agent_inventory,
+        nist_ai_aibom_coverage_gaps,
+        nist_ai_provider_api_key_hygiene,
+    ):
+        assert rule.has_framework("nist-ai-rmf", revision="1.0")
+        assert rule.catalog_visibility == (Catalog.RULES, Catalog.COMPLIANCE)
+        assert _serialized_catalog_visibility(rule) == ["rules", "compliance"]
+
+
+def test_catalog_visibility_does_not_remove_framework_mappings() -> None:
+    assert cis_aws_2_11_unused_credentials.has_framework("cis", "aws", "6.0.0")
+    assert cis_aws_2_11_unused_credentials.has_framework("27001", revision="2022")
+
+    frameworks = get_all_frameworks()
+    cis_aws_rules = [
+        rule for rule in RULES.values() if rule.has_framework("cis", "aws", "6.0.0")
+    ]
+    assert "cis" in frameworks
+    assert len(cis_aws_rules) == 18

--- a/tests/unit/rules/test_compliance_only.py
+++ b/tests/unit/rules/test_compliance_only.py
@@ -15,12 +15,11 @@ from cartography.rules.data.rules.subimage_coverage import aws_account_not_synce
 from cartography.rules.data.rules.subimage_coverage import container_image_not_found
 from cartography.rules.formatters import to_serializable
 from cartography.rules.runners import get_all_frameworks
-from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.result import CounterResult
 from cartography.rules.spec.result import RuleResult
 
 
-def _serialized_catalog_visibility(rule) -> list[str]:
+def _serialized_compliance_only(rule) -> bool:
     result = RuleResult(
         rule_id=rule.id,
         rule_name=rule.name,
@@ -28,9 +27,9 @@ def _serialized_catalog_visibility(rule) -> list[str]:
         counter=CounterResult(),
         rule_tags=rule.tags,
         rule_frameworks=rule.frameworks,
-        rule_catalog_visibility=rule.catalog_visibility,
+        rule_compliance_only=rule.compliance_only,
     )
-    return to_serializable(result)["rule_catalog_visibility"]
+    return to_serializable(result)["rule_compliance_only"]
 
 
 def test_cis_catalog_rules_are_compliance_only() -> None:
@@ -42,40 +41,30 @@ def test_cis_catalog_rules_are_compliance_only() -> None:
 
     assert cis_rules
     for rule in cis_rules.values():
-        assert rule.catalog_visibility == (Catalog.COMPLIANCE,)
+        assert rule.compliance_only is True
 
-    assert _serialized_catalog_visibility(cis_aws_2_11_unused_credentials) == [
-        "compliance"
-    ]
-    assert _serialized_catalog_visibility(cis_aws_2_13_access_key_not_rotated) == [
-        "compliance"
-    ]
+    assert _serialized_compliance_only(cis_aws_2_11_unused_credentials) is True
+    assert _serialized_compliance_only(cis_aws_2_13_access_key_not_rotated) is True
 
 
-def test_standalone_operational_rules_serialize_as_rules() -> None:
+def test_standalone_operational_rules_are_not_compliance_only() -> None:
     for rule in (
         guardduty_active_threat,
         container_image_not_found,
         aws_account_not_synced,
     ):
         assert rule.frameworks == ()
-        assert rule.catalog_visibility == (Catalog.RULES,)
-        assert _serialized_catalog_visibility(rule) == ["rules"]
+        assert rule.compliance_only is False
+        assert _serialized_compliance_only(rule) is False
 
 
-def test_framework_mapped_operational_rules_serialize_as_rules_and_compliance() -> None:
+def test_framework_mapped_operational_rules_are_not_compliance_only() -> None:
     assert object_storage_public.frameworks
-    assert object_storage_public.catalog_visibility == (
-        Catalog.RULES,
-        Catalog.COMPLIANCE,
-    )
-    assert _serialized_catalog_visibility(object_storage_public) == [
-        "rules",
-        "compliance",
-    ]
+    assert object_storage_public.compliance_only is False
+    assert _serialized_compliance_only(object_storage_public) is False
 
 
-def test_nist_ai_rmf_operational_rules_serialize_as_rules_and_compliance() -> None:
+def test_nist_ai_rmf_operational_rules_are_not_compliance_only() -> None:
     for rule in (
         nist_ai_third_party_app_inventory,
         nist_ai_third_party_app_sensitive_scopes,
@@ -85,11 +74,11 @@ def test_nist_ai_rmf_operational_rules_serialize_as_rules_and_compliance() -> No
         nist_ai_provider_api_key_hygiene,
     ):
         assert rule.has_framework("nist-ai-rmf", revision="1.0")
-        assert rule.catalog_visibility == (Catalog.RULES, Catalog.COMPLIANCE)
-        assert _serialized_catalog_visibility(rule) == ["rules", "compliance"]
+        assert rule.compliance_only is False
+        assert _serialized_compliance_only(rule) is False
 
 
-def test_catalog_visibility_does_not_remove_framework_mappings() -> None:
+def test_compliance_only_does_not_remove_framework_mappings() -> None:
     assert cis_aws_2_11_unused_credentials.has_framework("cis", "aws", "6.0.0")
     assert cis_aws_2_11_unused_credentials.has_framework("27001", revision="2022")
 

--- a/tests/unit/rules/test_compliance_only.py
+++ b/tests/unit/rules/test_compliance_only.py
@@ -7,9 +7,6 @@ from cartography.rules.data.rules.cis_aws_networking import (
 from cartography.rules.data.rules.cis_aws_storage import (
     cis_aws_3_1_4_s3_block_public_access,
 )
-from cartography.rules.data.rules.cis_kubernetes_rbac import (
-    cis_k8s_5_1_8_escalation_permissions,
-)
 from cartography.rules.data.rules.cis_kubernetes_workloads import (
     cis_k8s_5_6_2_runtime_default_seccomp,
 )
@@ -44,25 +41,18 @@ def _serialized_compliance_only(rule) -> bool:
     return to_serializable(result)["rule_compliance_only"]
 
 
-def test_compliance_hygiene_rules_are_compliance_only() -> None:
+def test_framework_prefixed_rules_are_compliance_only() -> None:
     for rule in (
         cis_aws_2_11_unused_credentials,
         cis_aws_2_13_access_key_not_rotated,
         cis_k8s_5_6_2_runtime_default_seccomp,
-    ):
-        assert rule.compliance_only is True
-        assert _serialized_compliance_only(rule) is True
-
-
-def test_framework_mapped_operational_cis_rules_are_not_compliance_only() -> None:
-    for rule in (
         cis_aws_6_3_remote_admin_ipv4,
         cis_aws_3_1_4_s3_block_public_access,
-        cis_k8s_5_1_8_escalation_permissions,
+        nist_ai_provider_api_key_hygiene,
     ):
         assert rule.frameworks
-        assert rule.compliance_only is False
-        assert _serialized_compliance_only(rule) is False
+        assert rule.compliance_only is True
+        assert _serialized_compliance_only(rule) is True
 
 
 def test_standalone_operational_rules_are_not_compliance_only() -> None:
@@ -82,7 +72,16 @@ def test_framework_mapped_operational_rules_are_not_compliance_only() -> None:
     assert _serialized_compliance_only(object_storage_public) is False
 
 
-def test_nist_ai_rmf_operational_rules_are_not_compliance_only() -> None:
+def test_all_framework_prefixed_rules_are_compliance_only() -> None:
+    prefixed_rules = [
+        rule for rule in RULES.values() if rule.id.startswith(("cis_", "nist_ai_"))
+    ]
+
+    assert prefixed_rules
+    assert all(rule.compliance_only for rule in prefixed_rules)
+
+
+def test_nist_ai_rmf_prefixed_rules_are_compliance_only() -> None:
     for rule in (
         nist_ai_third_party_app_inventory,
         nist_ai_third_party_app_sensitive_scopes,
@@ -92,8 +91,8 @@ def test_nist_ai_rmf_operational_rules_are_not_compliance_only() -> None:
         nist_ai_provider_api_key_hygiene,
     ):
         assert rule.has_framework("nist-ai-rmf", revision="1.0")
-        assert rule.compliance_only is False
-        assert _serialized_compliance_only(rule) is False
+        assert rule.compliance_only is True
+        assert _serialized_compliance_only(rule) is True
 
 
 def test_compliance_only_does_not_remove_framework_mappings() -> None:

--- a/tests/unit/rules/test_compliance_only.py
+++ b/tests/unit/rules/test_compliance_only.py
@@ -1,6 +1,18 @@
 from cartography.rules.data.rules import RULES
 from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_11_unused_credentials
 from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_13_access_key_not_rotated
+from cartography.rules.data.rules.cis_aws_networking import (
+    cis_aws_6_3_remote_admin_ipv4,
+)
+from cartography.rules.data.rules.cis_aws_storage import (
+    cis_aws_3_1_4_s3_block_public_access,
+)
+from cartography.rules.data.rules.cis_kubernetes_rbac import (
+    cis_k8s_5_1_8_escalation_permissions,
+)
+from cartography.rules.data.rules.cis_kubernetes_workloads import (
+    cis_k8s_5_6_2_runtime_default_seccomp,
+)
 from cartography.rules.data.rules.guardduty_active_threat import guardduty_active_threat
 from cartography.rules.data.rules.nist_ai_rmf import nist_ai_admin_ai_app_authorizations
 from cartography.rules.data.rules.nist_ai_rmf import nist_ai_aibom_agent_inventory
@@ -32,19 +44,25 @@ def _serialized_compliance_only(rule) -> bool:
     return to_serializable(result)["rule_compliance_only"]
 
 
-def test_cis_catalog_rules_are_compliance_only() -> None:
-    cis_rules = {
-        rule_id: rule
-        for rule_id, rule in RULES.items()
-        if rule_id.startswith(("cis_aws_", "cis_gcp_", "cis_k8s_", "cis_gw_"))
-    }
-
-    assert cis_rules
-    for rule in cis_rules.values():
+def test_compliance_hygiene_rules_are_compliance_only() -> None:
+    for rule in (
+        cis_aws_2_11_unused_credentials,
+        cis_aws_2_13_access_key_not_rotated,
+        cis_k8s_5_6_2_runtime_default_seccomp,
+    ):
         assert rule.compliance_only is True
+        assert _serialized_compliance_only(rule) is True
 
-    assert _serialized_compliance_only(cis_aws_2_11_unused_credentials) is True
-    assert _serialized_compliance_only(cis_aws_2_13_access_key_not_rotated) is True
+
+def test_framework_mapped_operational_cis_rules_are_not_compliance_only() -> None:
+    for rule in (
+        cis_aws_6_3_remote_admin_ipv4,
+        cis_aws_3_1_4_s3_block_public_access,
+        cis_k8s_5_1_8_escalation_permissions,
+    ):
+        assert rule.frameworks
+        assert rule.compliance_only is False
+        assert _serialized_compliance_only(rule) is False
 
 
 def test_standalone_operational_rules_are_not_compliance_only() -> None:
@@ -87,4 +105,4 @@ def test_compliance_only_does_not_remove_framework_mappings() -> None:
         rule for rule in RULES.values() if rule.has_framework("cis", "aws", "6.0.0")
     ]
     assert "cis" in frameworks
-    assert len(cis_aws_rules) == 18
+    assert cis_aws_rules

--- a/tests/unit/rules/test_model.py
+++ b/tests/unit/rules/test_model.py
@@ -1,7 +1,23 @@
+from cartography.rules.spec.model import Catalog
+from cartography.rules.spec.model import Fact
+from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Framework
+from cartography.rules.spec.model import Maturity
 from cartography.rules.spec.model import Module
 from cartography.rules.spec.model import MODULE_TO_CARTOGRAPHY_INTEL
+from cartography.rules.spec.model import Rule
 from cartography.sync import TOP_LEVEL_MODULES
+
+_TEST_FACT = Fact(
+    id="test_fact",
+    name="Test Fact",
+    description="Test fact",
+    module=Module.AWS,
+    maturity=Maturity.STABLE,
+    cypher_query="MATCH (n) RETURN n.id AS id",
+    cypher_visual_query="MATCH (n) RETURN *",
+    cypher_count_query="MATCH (n) RETURN COUNT(n) AS count",
+)
 
 
 def test_framework_normalizes_to_lowercase():
@@ -114,6 +130,72 @@ def test_framework_matches_with_optional_fields():
     assert not fw_no_revision.matches(
         "cis", "aws", "5.0"
     )  # Can't match revision if None
+
+
+def test_rule_catalog_visibility_defaults_to_rules_for_standalone_rule():
+    rule = Rule(
+        id="standalone_rule",
+        name="Standalone Rule",
+        tags=("test",),
+        description="Standalone rule",
+        version="0.1.0",
+        facts=(_TEST_FACT,),
+        output_model=Finding,
+    )
+
+    assert rule.catalog_visibility == (Catalog.RULES,)
+
+
+def test_rule_catalog_visibility_defaults_to_rules_and_compliance_for_framework_mapped_rule():
+    rule = Rule(
+        id="framework_mapped_rule",
+        name="Framework-Mapped Rule",
+        tags=("test",),
+        description="Framework-mapped rule",
+        version="0.1.0",
+        facts=(_TEST_FACT,),
+        output_model=Finding,
+        frameworks=(
+            Framework(
+                name="ISO/IEC 27001",
+                short_name="27001",
+                requirement="8.5",
+                revision="2022",
+            ),
+        ),
+    )
+
+    assert rule.catalog_visibility == (Catalog.RULES, Catalog.COMPLIANCE)
+
+
+def test_rule_catalog_visibility_accepts_string_values():
+    rule = Rule(
+        id="compliance_rule",
+        name="Compliance Rule",
+        tags=("test",),
+        description="Compliance rule",
+        version="0.1.0",
+        facts=(_TEST_FACT,),
+        output_model=Finding,
+        catalog_visibility="compliance",
+    )
+
+    assert rule.catalog_visibility == (Catalog.COMPLIANCE,)
+
+
+def test_rule_catalog_visibility_accepts_list_values():
+    rule = Rule(
+        id="multi_catalog_rule",
+        name="Multi-Catalog Rule",
+        tags=("test",),
+        description="Multi-catalog rule",
+        version="0.1.0",
+        facts=(_TEST_FACT,),
+        output_model=Finding,
+        catalog_visibility=["rules", "compliance"],
+    )
+
+    assert rule.catalog_visibility == (Catalog.RULES, Catalog.COMPLIANCE)
 
 
 def test_all_module_keys_in_mapping_except_cross_cloud():

--- a/tests/unit/rules/test_model.py
+++ b/tests/unit/rules/test_model.py
@@ -1,4 +1,3 @@
-from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Finding
 from cartography.rules.spec.model import Framework
@@ -133,7 +132,7 @@ def test_framework_matches_with_optional_fields():
     )  # Can't match revision if None
 
 
-def test_rule_catalog_visibility_defaults_to_rules_for_standalone_rule():
+def test_rule_compliance_only_defaults_to_false_for_standalone_rule():
     rule = Rule(
         id="standalone_rule",
         name="Standalone Rule",
@@ -144,10 +143,10 @@ def test_rule_catalog_visibility_defaults_to_rules_for_standalone_rule():
         output_model=Finding,
     )
 
-    assert rule.catalog_visibility == (Catalog.RULES,)
+    assert rule.compliance_only is False
 
 
-def test_rule_catalog_visibility_defaults_to_rules_and_compliance_for_framework_mapped_rule():
+def test_rule_compliance_only_defaults_to_false_for_framework_mapped_rule():
     rule = Rule(
         id="framework_mapped_rule",
         name="Framework-Mapped Rule",
@@ -166,10 +165,10 @@ def test_rule_catalog_visibility_defaults_to_rules_and_compliance_for_framework_
         ),
     )
 
-    assert rule.catalog_visibility == (Catalog.RULES, Catalog.COMPLIANCE)
+    assert rule.compliance_only is False
 
 
-def test_rule_catalog_visibility_accepts_string_values():
+def test_rule_compliance_only_can_be_enabled():
     rule = Rule(
         id="compliance_rule",
         name="Compliance Rule",
@@ -178,25 +177,10 @@ def test_rule_catalog_visibility_accepts_string_values():
         version="0.1.0",
         facts=(_TEST_FACT,),
         output_model=Finding,
-        catalog_visibility="compliance",
+        compliance_only=True,
     )
 
-    assert rule.catalog_visibility == (Catalog.COMPLIANCE,)
-
-
-def test_rule_catalog_visibility_accepts_list_values():
-    rule = Rule(
-        id="multi_catalog_rule",
-        name="Multi-Catalog Rule",
-        tags=("test",),
-        description="Multi-catalog rule",
-        version="0.1.0",
-        facts=(_TEST_FACT,),
-        output_model=Finding,
-        catalog_visibility=["rules", "compliance"],
-    )
-
-    assert rule.catalog_visibility == (Catalog.RULES, Catalog.COMPLIANCE)
+    assert rule.compliance_only is True
 
 
 def test_all_module_keys_in_mapping_except_cross_cloud():

--- a/tests/unit/rules/test_model.py
+++ b/tests/unit/rules/test_model.py
@@ -17,6 +17,7 @@ _TEST_FACT = Fact(
     cypher_query="MATCH (n) RETURN n.id AS id",
     cypher_visual_query="MATCH (n) RETURN *",
     cypher_count_query="MATCH (n) RETURN COUNT(n) AS count",
+    identity_fields=("id",),
 )
 
 

--- a/tests/unit/rules/test_runners.py
+++ b/tests/unit/rules/test_runners.py
@@ -10,7 +10,6 @@ from unittest.mock import patch
 
 from cartography.rules.formatters import to_serializable
 from cartography.rules.runners import _run_single_rule
-from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Framework
 from cartography.rules.spec.model import Maturity
@@ -47,7 +46,7 @@ def test_run_single_rule_aggregates_facts_correctly(mock_run_fact):
     mock_rule.facts = (mock_fact1, mock_fact2, mock_fact3)
     mock_rule.tags = ("test",)
     mock_rule.frameworks = ()
-    mock_rule.catalog_visibility = (Catalog.RULES,)
+    mock_rule.compliance_only = False
 
     # Add to RULES dict
     from cartography.rules.runners import RULES
@@ -99,7 +98,7 @@ def test_run_single_rule_aggregates_facts_correctly(mock_run_fact):
     # Verify tags and frameworks are propagated to RuleResult
     assert rule_result.rule_tags == ("test",)
     assert rule_result.rule_frameworks == ()
-    assert rule_result.rule_catalog_visibility == (Catalog.RULES,)
+    assert rule_result.rule_compliance_only is False
 
     assert (
         len(rule_result.facts) == 3
@@ -127,7 +126,7 @@ def test_run_single_rule_with_zero_findings(mock_run_fact):
     mock_rule.facts = (mock_fact,)
     mock_rule.tags = ("test",)
     mock_rule.frameworks = ()
-    mock_rule.catalog_visibility = (Catalog.RULES,)
+    mock_rule.compliance_only = False
 
     # Add to RULES dict
     from cartography.rules.runners import RULES
@@ -160,7 +159,7 @@ def test_run_single_rule_with_zero_findings(mock_run_fact):
     # Verify tags and frameworks are propagated to RuleResult
     assert rule_result.rule_tags == ("test",)
     assert rule_result.rule_frameworks == ()
-    assert rule_result.rule_catalog_visibility == (Catalog.RULES,)
+    assert rule_result.rule_compliance_only is False
 
 
 @patch("cartography.rules.runners._run_fact")
@@ -183,7 +182,7 @@ def test_run_single_rule_with_fact_filter(mock_run_fact):
     mock_rule.facts = (mock_fact1, mock_fact2)
     mock_rule.tags = ("test",)
     mock_rule.frameworks = ()
-    mock_rule.catalog_visibility = (Catalog.RULES,)
+    mock_rule.compliance_only = False
 
     # Add to RULES dict
     from cartography.rules.runners import RULES
@@ -242,7 +241,7 @@ def test_run_single_rule_propagates_frameworks(mock_run_fact):
     mock_rule.facts = (mock_fact,)
     mock_rule.tags = ("iam", "credentials", "stride:spoofing")
     mock_rule.frameworks = (cis_framework,)
-    mock_rule.catalog_visibility = (Catalog.COMPLIANCE,)
+    mock_rule.compliance_only = True
 
     # Add to RULES dict
     from cartography.rules.runners import RULES
@@ -274,5 +273,5 @@ def test_run_single_rule_propagates_frameworks(mock_run_fact):
     assert rule_result.rule_frameworks[0].scope == "aws"
     assert rule_result.rule_frameworks[0].revision == "5.0"
     assert rule_result.rule_frameworks[0].requirement == "1.14"
-    assert rule_result.rule_catalog_visibility == (Catalog.COMPLIANCE,)
-    assert to_serializable(rule_result)["rule_catalog_visibility"] == ["compliance"]
+    assert rule_result.rule_compliance_only is True
+    assert to_serializable(rule_result)["rule_compliance_only"] is True

--- a/tests/unit/rules/test_runners.py
+++ b/tests/unit/rules/test_runners.py
@@ -8,7 +8,9 @@ correctly sums up from facts → findings.
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+from cartography.rules.formatters import to_serializable
 from cartography.rules.runners import _run_single_rule
+from cartography.rules.spec.model import Catalog
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import Framework
 from cartography.rules.spec.model import Maturity
@@ -45,6 +47,7 @@ def test_run_single_rule_aggregates_facts_correctly(mock_run_fact):
     mock_rule.facts = (mock_fact1, mock_fact2, mock_fact3)
     mock_rule.tags = ("test",)
     mock_rule.frameworks = ()
+    mock_rule.catalog_visibility = (Catalog.RULES,)
 
     # Add to RULES dict
     from cartography.rules.runners import RULES
@@ -96,6 +99,7 @@ def test_run_single_rule_aggregates_facts_correctly(mock_run_fact):
     # Verify tags and frameworks are propagated to RuleResult
     assert rule_result.rule_tags == ("test",)
     assert rule_result.rule_frameworks == ()
+    assert rule_result.rule_catalog_visibility == (Catalog.RULES,)
 
     assert (
         len(rule_result.facts) == 3
@@ -123,6 +127,7 @@ def test_run_single_rule_with_zero_findings(mock_run_fact):
     mock_rule.facts = (mock_fact,)
     mock_rule.tags = ("test",)
     mock_rule.frameworks = ()
+    mock_rule.catalog_visibility = (Catalog.RULES,)
 
     # Add to RULES dict
     from cartography.rules.runners import RULES
@@ -155,6 +160,7 @@ def test_run_single_rule_with_zero_findings(mock_run_fact):
     # Verify tags and frameworks are propagated to RuleResult
     assert rule_result.rule_tags == ("test",)
     assert rule_result.rule_frameworks == ()
+    assert rule_result.rule_catalog_visibility == (Catalog.RULES,)
 
 
 @patch("cartography.rules.runners._run_fact")
@@ -177,6 +183,7 @@ def test_run_single_rule_with_fact_filter(mock_run_fact):
     mock_rule.facts = (mock_fact1, mock_fact2)
     mock_rule.tags = ("test",)
     mock_rule.frameworks = ()
+    mock_rule.catalog_visibility = (Catalog.RULES,)
 
     # Add to RULES dict
     from cartography.rules.runners import RULES
@@ -235,6 +242,7 @@ def test_run_single_rule_propagates_frameworks(mock_run_fact):
     mock_rule.facts = (mock_fact,)
     mock_rule.tags = ("iam", "credentials", "stride:spoofing")
     mock_rule.frameworks = (cis_framework,)
+    mock_rule.catalog_visibility = (Catalog.COMPLIANCE,)
 
     # Add to RULES dict
     from cartography.rules.runners import RULES
@@ -266,3 +274,5 @@ def test_run_single_rule_propagates_frameworks(mock_run_fact):
     assert rule_result.rule_frameworks[0].scope == "aws"
     assert rule_result.rule_frameworks[0].revision == "5.0"
     assert rule_result.rule_frameworks[0].requirement == "1.14"
+    assert rule_result.rule_catalog_visibility == (Catalog.COMPLIANCE,)
+    assert to_serializable(rule_result)["rule_catalog_visibility"] == ["compliance"]


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update


### Summary
Adds explicit rule metadata so catalog consumers can distinguish compliance-only hygiene/checklist controls from standalone actionable rules without relying on rule names or framework heuristics.

The new `Rule.compliance_only` flag defaults to `False`. Rules with `compliance_only=False` remain appropriate for standalone rule catalogs, even when they are also mapped to compliance frameworks.

Framework-prefixed rule definitions are marked `compliance_only=True`. This covers rule IDs/names that are authored as specific framework controls, such as `cis_*` rules and `nist_ai_*` / `NIST AI RMF: ...` rules. These are primarily compliance, governance, or hygiene checklist controls and should appear through framework views rather than the general standalone rules catalog.

Regular rule definitions that are mapped into frameworks remain standalone-visible by default. If a framework-prefixed control should become a standalone detection, it can be renamed/generalized into a regular rule and then mapped into the relevant framework.

Rule execution and framework mappings are unchanged. The serialized rule result now includes `rule_compliance_only` alongside the existing rule tags and framework metadata.

### Breaking changes

None.


### How was this tested?

- `uv run --frozen pytest -q tests/unit/rules/test_compliance_only.py tests/unit/rules/test_model.py tests/unit/rules/test_runners.py`
- `make test_lint`
- `make test_unit`


### Checklist

#### General
- [ ] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

This is metadata-only for catalog surfaces. Frameworks still wrap rules the same way, and framework detail pages can continue to use the existing framework mappings. The intended boundary is that framework-prefixed controls are compliance-only, while reusable regular detections can remain visible in standalone catalogs even when mapped to one or more frameworks.
