### PR TITLE
fix (rules): Fix CIS AWS IAM datetime casts

### DIFF
--- a/cartography/rules/data/rules/cis_aws_iam.py
+++ b/cartography/rules/data/rules/cis_aws_iam.py
@@ -66,13 +66,13 @@ _aws_access_key_not_rotated = Fact(
     MATCH (a:AWSAccount)-[:RESOURCE]->(user:AWSUser)-[:AWS_ACCESS_KEY]->(key:AccountAccessKey)
     WHERE key.status = 'Active'
       AND key.createdate_dt IS NOT NULL
-      AND date(key.createdate_dt) < date() - duration('P90D')
+      AND date(datetime(key.createdate_dt)) < date() - duration('P90D')
     RETURN
         key.accesskeyid AS access_key_id,
         user.name AS user_name,
         user.arn AS user_arn,
         key.createdate_dt AS key_create_date,
-        duration.inDays(date(key.createdate_dt), date()).days AS days_since_rotation,
+        duration.inDays(date(datetime(key.createdate_dt)), date()).days AS days_since_rotation,
         a.id AS account_id,
         a.name AS account
     """,
@@ -80,7 +80,7 @@ _aws_access_key_not_rotated = Fact(
     MATCH p=(a:AWSAccount)-[:RESOURCE]->(user:AWSUser)-[:AWS_ACCESS_KEY]->(key:AccountAccessKey)
     WHERE key.status = 'Active'
       AND key.createdate_dt IS NOT NULL
-      AND date(key.createdate_dt) < date() - duration('P90D')
+      AND date(datetime(key.createdate_dt)) < date() - duration('P90D')
     RETURN *
     """,
     cypher_count_query="""
@@ -138,9 +138,9 @@ _aws_unused_credentials = Fact(
     MATCH (a:AWSAccount)-[:RESOURCE]->(user:AWSUser)-[:AWS_ACCESS_KEY]->(key:AccountAccessKey)
     WHERE key.status = 'Active'
     WITH a, user, key
-    WHERE (key.lastuseddate_dt IS NOT NULL AND date(key.lastuseddate_dt) < date() - duration('P45D'))
+    WHERE (key.lastuseddate_dt IS NOT NULL AND date(datetime(key.lastuseddate_dt)) < date() - duration('P45D'))
        OR (key.lastuseddate_dt IS NULL AND key.createdate_dt IS NOT NULL
-           AND date(key.createdate_dt) < date() - duration('P45D'))
+           AND date(datetime(key.createdate_dt)) < date() - duration('P45D'))
     RETURN
         key.accesskeyid AS access_key_id,
         user.name AS user_name,
@@ -154,9 +154,9 @@ _aws_unused_credentials = Fact(
     MATCH p=(a:AWSAccount)-[:RESOURCE]->(user:AWSUser)-[:AWS_ACCESS_KEY]->(key:AccountAccessKey)
     WHERE key.status = 'Active'
     WITH p, a, user, key
-    WHERE (key.lastuseddate_dt IS NOT NULL AND date(key.lastuseddate_dt) < date() - duration('P45D'))
+    WHERE (key.lastuseddate_dt IS NOT NULL AND date(datetime(key.lastuseddate_dt)) < date() - duration('P45D'))
        OR (key.lastuseddate_dt IS NULL AND key.createdate_dt IS NOT NULL
-           AND date(key.createdate_dt) < date() - duration('P45D'))
+           AND date(datetime(key.createdate_dt)) < date() - duration('P45D'))
     RETURN *
     """,
     cypher_count_query="""

--- a/tests/integration/rules/test_cis_aws_iam.py
+++ b/tests/integration/rules/test_cis_aws_iam.py
@@ -1,0 +1,85 @@
+from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_11_unused_credentials
+from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_13_access_key_not_rotated
+
+
+def _reset_graph(neo4j_session) -> None:
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+
+
+def _get_fact(rule):
+    return rule.facts[0]
+
+
+def test_access_key_rules_parse_iso_datetime_strings_with_z(neo4j_session) -> None:
+    # Arrange
+    _reset_graph(neo4j_session)
+    neo4j_session.run(
+        """
+        CREATE (a:AWSAccount {id: '111111111111', name: 'prod'})
+        CREATE (rotated_user:AWSUser {
+            arn: 'arn:aws:iam::111111111111:user/old-rotation',
+            name: 'old-rotation'
+        })
+        CREATE (used_user:AWSUser {
+            arn: 'arn:aws:iam::111111111111:user/old-last-used',
+            name: 'old-last-used'
+        })
+        CREATE (never_used_user:AWSUser {
+            arn: 'arn:aws:iam::111111111111:user/never-used',
+            name: 'never-used'
+        })
+        CREATE (rotated_key:AccountAccessKey {
+            accesskeyid: 'AKIAOLDROTATION',
+            status: 'Active',
+            createdate_dt: '2020-02-17T22:57:02Z',
+            lastuseddate_dt: '2999-02-17T22:57:02Z'
+        })
+        CREATE (used_key:AccountAccessKey {
+            accesskeyid: 'AKIAOLDLASTUSED',
+            status: 'Active',
+            createdate_dt: '2020-02-17T22:57:02Z',
+            lastuseddate_dt: '2020-03-17T22:57:02Z'
+        })
+        CREATE (never_used_key:AccountAccessKey {
+            accesskeyid: 'AKIANEVERUSED',
+            status: 'Active',
+            createdate_dt: '2020-04-17T22:57:02Z'
+        })
+        MERGE (a)-[:RESOURCE]->(rotated_user)
+        MERGE (a)-[:RESOURCE]->(used_user)
+        MERGE (a)-[:RESOURCE]->(never_used_user)
+        MERGE (rotated_user)-[:AWS_ACCESS_KEY]->(rotated_key)
+        MERGE (used_user)-[:AWS_ACCESS_KEY]->(used_key)
+        MERGE (never_used_user)-[:AWS_ACCESS_KEY]->(never_used_key)
+        """
+    )
+
+    rotation_fact = _get_fact(cis_aws_2_13_access_key_not_rotated)
+    unused_fact = _get_fact(cis_aws_2_11_unused_credentials)
+
+    # Act
+    rotation_findings = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        rotation_fact.cypher_query,
+    )
+    unused_findings = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        unused_fact.cypher_query,
+    )
+    rotation_visual_rows = list(neo4j_session.run(rotation_fact.cypher_visual_query))
+    unused_visual_rows = list(neo4j_session.run(unused_fact.cypher_visual_query))
+
+    # Assert
+    assert {row["access_key_id"] for row in rotation_findings} == {
+        "AKIAOLDROTATION",
+        "AKIAOLDLASTUSED",
+        "AKIANEVERUSED",
+    }
+    assert all(row["days_since_rotation"] > 90 for row in rotation_findings)
+    assert {row["access_key_id"] for row in unused_findings} == {
+        "AKIAOLDLASTUSED",
+        "AKIANEVERUSED",
+    }
+    assert len(rotation_visual_rows) == 3
+    assert len(unused_visual_rows) == 2

--- a/tests/unit/rules/test_cis_aws.py
+++ b/tests/unit/rules/test_cis_aws.py
@@ -134,6 +134,26 @@ class TestCisAwsFactMetadata:
             assert "COUNT" in fact.cypher_count_query
             assert "AS count" in fact.cypher_count_query
 
+    def test_access_key_date_filters_parse_iso_datetime_strings(self):
+        access_key_rules = (
+            cis_aws_2_11_unused_credentials,
+            cis_aws_2_13_access_key_not_rotated,
+        )
+
+        for rule in access_key_rules:
+            fact = rule.facts[0]
+            query_text = f"{fact.cypher_query}\n{fact.cypher_visual_query}"
+            assert "date(key.createdate_dt)" not in query_text
+            assert "date(key.lastuseddate_dt)" not in query_text
+            assert "date(datetime(key.createdate_dt))" in query_text
+
+        unused_credentials_fact = cis_aws_2_11_unused_credentials.facts[0]
+        unused_credentials_query_text = (
+            f"{unused_credentials_fact.cypher_query}\n"
+            f"{unused_credentials_fact.cypher_visual_query}"
+        )
+        assert "date(datetime(key.lastuseddate_dt))" in unused_credentials_query_text
+
 
 class TestCisAwsRuleRegistration:
     """Test that all CIS AWS rules are registered."""


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
Fixes the CIS AWS IAM access-key rules so Neo4j can evaluate ISO datetime strings stored on `AccountAccessKey.createdate_dt` and `AccountAccessKey.lastuseddate_dt`.

Neo4j rejects values like `2026-02-17T22:57:02Z` when passed directly to `date(...)`. The affected rule queries now parse the value with `datetime(...)` first and then cast to `date(...)`, including the `duration.inDays(...)` calculation used for key rotation age.

### Breaking changes
None.


### How was this tested?
- Tested on local env


### Checklist

#### General
- [ ] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
This only changes rule query casting for existing access-key datetime properties. No schema, sync, or relationship behavior is changed.
