### PR TITLE
feat(ontology): add Subnet, VirtualNetwork and Snapshot semantic labels

### DIFF
--- a/cartography/models/aws/ec2/auto_scaling_groups.py
+++ b/cartography/models/aws/ec2/auto_scaling_groups.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -146,6 +147,7 @@ class EC2SubnetAutoScalingGroupSchema(CartographyNodeSchema):
     properties: EC2SubnetAutoScalingGroupNodeProperties = (
         EC2SubnetAutoScalingGroupNodeProperties()
     )
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Subnet"])
     sub_resource_relationship: EC2SubnetToAWSAccountRel = EC2SubnetToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [

--- a/cartography/models/aws/ec2/snapshots.py
+++ b/cartography/models/aws/ec2/snapshots.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -56,5 +57,6 @@ class EBSSnapshotToAWSAccountRel(CartographyRelSchema):
 class EBSSnapshotSchema(CartographyNodeSchema):
     label: str = "EBSSnapshot"
     properties: EBSSnapshotNodeProperties = EBSSnapshotNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Snapshot"])
     sub_resource_relationship: EBSSnapshotToAWSAccountRel = EBSSnapshotToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships([])

--- a/cartography/models/aws/ec2/subnet_instance.py
+++ b/cartography/models/aws/ec2/subnet_instance.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -66,6 +67,7 @@ class EC2SubnetInstanceSchema(CartographyNodeSchema):
 
     label: str = "EC2Subnet"
     properties: EC2SubnetInstanceNodeProperties = EC2SubnetInstanceNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Subnet"])
     sub_resource_relationship: EC2SubnetToAWSAccountRel = EC2SubnetToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [

--- a/cartography/models/aws/ec2/subnet_networkinterface.py
+++ b/cartography/models/aws/ec2/subnet_networkinterface.py
@@ -5,6 +5,7 @@ from cartography.models.aws.ec2.subnet_instance import EC2SubnetToEC2InstanceRel
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -87,6 +88,7 @@ class EC2SubnetNetworkInterfaceSchema(CartographyNodeSchema):
     properties: EC2SubnetNetworkInterfaceNodeProperties = (
         EC2SubnetNetworkInterfaceNodeProperties()
     )
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Subnet"])
     sub_resource_relationship: EC2SubnetToAWSAccountRel = EC2SubnetToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [

--- a/cartography/models/aws/ec2/subnet_vpc_endpoint.py
+++ b/cartography/models/aws/ec2/subnet_vpc_endpoint.py
@@ -4,6 +4,7 @@ from cartography.models.aws.ec2.subnet_instance import EC2SubnetToAWSAccountRel
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -50,6 +51,7 @@ class EC2SubnetVPCEndpointSchema(CartographyNodeSchema):
     properties: EC2SubnetVPCEndpointNodeProperties = (
         EC2SubnetVPCEndpointNodeProperties()
     )
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Subnet"])
     sub_resource_relationship: EC2SubnetToAWSAccountRel = EC2SubnetToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [

--- a/cartography/models/aws/ec2/subnets.py
+++ b/cartography/models/aws/ec2/subnets.py
@@ -4,6 +4,7 @@ from cartography.models.aws.ec2.auto_scaling_groups import EC2SubnetToAWSAccount
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -57,6 +58,7 @@ class EC2SubnetToVpcRel(CartographyRelSchema):
 class EC2SubnetSchema(CartographyNodeSchema):
     label: str = "EC2Subnet"
     properties: EC2SubnetNodeProperties = EC2SubnetNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Subnet"])
     sub_resource_relationship: EC2SubnetToAWSAccountRel = EC2SubnetToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [

--- a/cartography/models/aws/ec2/vpc.py
+++ b/cartography/models/aws/ec2/vpc.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -43,4 +44,5 @@ class VPCToAWSAccountRel(CartographyRelSchema):
 class AWSVpcSchema(CartographyNodeSchema):
     label: str = "AWSVpc"
     properties: VPCNodeProperties = VPCNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["VirtualNetwork"])
     sub_resource_relationship: VPCToAWSAccountRel = VPCToAWSAccountRel()

--- a/cartography/models/aws/rds/snapshot.py
+++ b/cartography/models/aws/rds/snapshot.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -101,6 +102,7 @@ class RDSSnapshotToRDSInstanceRel(CartographyRelSchema):
 class RDSSnapshotSchema(CartographyNodeSchema):
     label: str = "RDSSnapshot"
     properties: RDSSnapshotNodeProperties = RDSSnapshotNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Snapshot"])
     sub_resource_relationship: RDSSnapshotToAWSAccountRel = RDSSnapshotToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [

--- a/cartography/models/azure/subnet.py
+++ b/cartography/models/azure/subnet.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -91,6 +92,7 @@ class AzureSubnetToSubscriptionRel(CartographyRelSchema):
 class AzureSubnetSchema(CartographyNodeSchema):
     label: str = "AzureSubnet"
     properties: AzureSubnetProperties = AzureSubnetProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Subnet"])
     sub_resource_relationship: AzureSubnetToSubscriptionRel = (
         AzureSubnetToSubscriptionRel()
     )

--- a/cartography/models/azure/virtual_network.py
+++ b/cartography/models/azure/virtual_network.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -44,6 +45,7 @@ class AzureVirtualNetworkToSubscriptionRel(CartographyRelSchema):
 class AzureVirtualNetworkSchema(CartographyNodeSchema):
     label: str = "AzureVirtualNetwork"
     properties: AzureVirtualNetworkProperties = AzureVirtualNetworkProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["VirtualNetwork"])
     sub_resource_relationship: AzureVirtualNetworkToSubscriptionRel = (
         AzureVirtualNetworkToSubscriptionRel()
     )

--- a/cartography/models/azure/vm/snapshot.py
+++ b/cartography/models/azure/vm/snapshot.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -51,6 +52,7 @@ class AzureSnapshotToSubscriptionRel(CartographyRelSchema):
 class AzureSnapshotSchema(CartographyNodeSchema):
     label: str = "AzureSnapshot"
     properties: AzureSnapshotProperties = AzureSnapshotProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Snapshot"])
     sub_resource_relationship: AzureSnapshotToSubscriptionRel = (
         AzureSnapshotToSubscriptionRel()
     )

--- a/cartography/models/gcp/compute/subnet.py
+++ b/cartography/models/gcp/compute/subnet.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -74,6 +75,7 @@ class GCPSubnetToVpcRel(CartographyRelSchema):
 class GCPSubnetSchema(CartographyNodeSchema):
     label: str = "GCPSubnet"
     properties: GCPSubnetNodeProperties = GCPSubnetNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Subnet"])
     sub_resource_relationship: GCPSubnetToProjectRel = GCPSubnetToProjectRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [

--- a/cartography/models/gcp/compute/subnet_stub.py
+++ b/cartography/models/gcp/compute/subnet_stub.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -52,4 +53,5 @@ class GCPSubnetStubSchema(CartographyNodeSchema):
 
     label: str = "GCPSubnet"
     properties: GCPSubnetStubNodeProperties = GCPSubnetStubNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Subnet"])
     sub_resource_relationship: GCPSubnetStubToProjectRel = GCPSubnetStubToProjectRel()

--- a/cartography/models/gcp/compute/subnet_stub.py
+++ b/cartography/models/gcp/compute/subnet_stub.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
-from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -53,5 +52,9 @@ class GCPSubnetStubSchema(CartographyNodeSchema):
 
     label: str = "GCPSubnet"
     properties: GCPSubnetStubNodeProperties = GCPSubnetStubNodeProperties()
-    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Subnet"])
+    # Deliberately no `Subnet` semantic label here: stubs only carry partial_uri
+    # and would surface in cross-cloud `(:Subnet)` queries with a null _ont_name
+    # (the GCP mapping resolves the ontology name from the `name` field, which the
+    # stub lacks). The full GCPSubnetSchema attaches the Subnet label and _ont_*
+    # fields once the real subnet data is synced.
     sub_resource_relationship: GCPSubnetStubToProjectRel = GCPSubnetStubToProjectRel()

--- a/cartography/models/gcp/compute/vpc.py
+++ b/cartography/models/gcp/compute/vpc.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -47,4 +48,5 @@ class GCPVpcToProjectRel(CartographyRelSchema):
 class GCPVpcSchema(CartographyNodeSchema):
     label: str = "GCPVpc"
     properties: GCPVpcNodeProperties = GCPVpcNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["VirtualNetwork"])
     sub_resource_relationship: GCPVpcToProjectRel = GCPVpcToProjectRel()

--- a/cartography/models/ontology/mapping/__init__.py
+++ b/cartography/models/ontology/mapping/__init__.py
@@ -88,6 +88,7 @@ from cartography.models.ontology.mapping.data.useraccounts import (
     USERACCOUNTS_ONTOLOGY_MAPPING,
 )
 from cartography.models.ontology.mapping.data.users import USERS_ONTOLOGY_MAPPING
+from cartography.models.ontology.mapping.data.vpcs import VPCS_ONTOLOGY_MAPPING
 from cartography.models.ontology.mapping.specs import OntologyMapping
 from cartography.models.ontology.mapping.specs import OntologyNodeMapping
 from cartography.models.ontology.package import PackageSchema
@@ -138,6 +139,7 @@ SEMANTIC_LABELS_MAPPING: dict[str, dict[str, OntologyMapping]] = {
     "secrets": SECRETS_ONTOLOGY_MAPPING,
     "securityissues": SECURITY_ISSUES_ONTOLOGY_MAPPING,
     "subnets": SUBNETS_ONTOLOGY_MAPPING,
+    "vpcs": VPCS_ONTOLOGY_MAPPING,
     "thirdpartyapps": THIRDPARTYAPPS_ONTOLOGY_MAPPING,
     "tenants": TENANTS_ONTOLOGY_MAPPING,
     "serviceaccounts": SERVICEACCOUNTS_ONTOLOGY_MAPPING,

--- a/cartography/models/ontology/mapping/__init__.py
+++ b/cartography/models/ontology/mapping/__init__.py
@@ -79,6 +79,7 @@ from cartography.models.ontology.mapping.data.security_issues import (
 from cartography.models.ontology.mapping.data.serviceaccounts import (
     SERVICEACCOUNTS_ONTOLOGY_MAPPING,
 )
+from cartography.models.ontology.mapping.data.subnets import SUBNETS_ONTOLOGY_MAPPING
 from cartography.models.ontology.mapping.data.tenants import TENANTS_ONTOLOGY_MAPPING
 from cartography.models.ontology.mapping.data.thirdpartyapps import (
     THIRDPARTYAPPS_ONTOLOGY_MAPPING,
@@ -136,6 +137,7 @@ SEMANTIC_LABELS_MAPPING: dict[str, dict[str, OntologyMapping]] = {
     "roles": ROLES_ONTOLOGY_MAPPING,
     "secrets": SECRETS_ONTOLOGY_MAPPING,
     "securityissues": SECURITY_ISSUES_ONTOLOGY_MAPPING,
+    "subnets": SUBNETS_ONTOLOGY_MAPPING,
     "thirdpartyapps": THIRDPARTYAPPS_ONTOLOGY_MAPPING,
     "tenants": TENANTS_ONTOLOGY_MAPPING,
     "serviceaccounts": SERVICEACCOUNTS_ONTOLOGY_MAPPING,

--- a/cartography/models/ontology/mapping/__init__.py
+++ b/cartography/models/ontology/mapping/__init__.py
@@ -79,6 +79,9 @@ from cartography.models.ontology.mapping.data.security_issues import (
 from cartography.models.ontology.mapping.data.serviceaccounts import (
     SERVICEACCOUNTS_ONTOLOGY_MAPPING,
 )
+from cartography.models.ontology.mapping.data.snapshots import (
+    SNAPSHOTS_ONTOLOGY_MAPPING,
+)
 from cartography.models.ontology.mapping.data.subnets import SUBNETS_ONTOLOGY_MAPPING
 from cartography.models.ontology.mapping.data.tenants import TENANTS_ONTOLOGY_MAPPING
 from cartography.models.ontology.mapping.data.thirdpartyapps import (
@@ -138,6 +141,7 @@ SEMANTIC_LABELS_MAPPING: dict[str, dict[str, OntologyMapping]] = {
     "roles": ROLES_ONTOLOGY_MAPPING,
     "secrets": SECRETS_ONTOLOGY_MAPPING,
     "securityissues": SECURITY_ISSUES_ONTOLOGY_MAPPING,
+    "snapshots": SNAPSHOTS_ONTOLOGY_MAPPING,
     "subnets": SUBNETS_ONTOLOGY_MAPPING,
     "vpcs": VPCS_ONTOLOGY_MAPPING,
     "thirdpartyapps": THIRDPARTYAPPS_ONTOLOGY_MAPPING,

--- a/cartography/models/ontology/mapping/data/snapshots.py
+++ b/cartography/models/ontology/mapping/data/snapshots.py
@@ -1,0 +1,114 @@
+from cartography.models.ontology.mapping.specs import OntologyFieldMapping
+from cartography.models.ontology.mapping.specs import OntologyMapping
+from cartography.models.ontology.mapping.specs import OntologyNodeMapping
+
+# Snapshot fields:
+# _ont_name - The name/identifier of the snapshot
+# _ont_encrypted - Whether the snapshot is encrypted at rest
+# _ont_public - Whether the snapshot is publicly shared (a known attack vector)
+# _ont_source_id - The source volume/database the snapshot was taken from
+# _ont_created_at - When the snapshot was created
+# _ont_region - The region/zone where the snapshot lives
+
+aws_ebs_mapping = OntologyMapping(
+    module_name="aws",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="EBSSnapshot",
+            fields=[
+                # EBS snapshots have no display name; the SnapshotId (`id`) is the
+                # canonical identifier.
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="id", required=True
+                ),
+                OntologyFieldMapping(
+                    ontology_field="encrypted", node_field="encrypted"
+                ),
+                OntologyFieldMapping(ontology_field="public", node_field="ispublic"),
+                OntologyFieldMapping(ontology_field="source_id", node_field="volumeid"),
+                OntologyFieldMapping(
+                    ontology_field="created_at", node_field="starttime"
+                ),
+                OntologyFieldMapping(ontology_field="region", node_field="region"),
+            ],
+        ),
+        OntologyNodeMapping(
+            node_label="RDSSnapshot",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name",
+                    node_field="db_snapshot_identifier",
+                    required=True,
+                ),
+                OntologyFieldMapping(
+                    ontology_field="encrypted", node_field="encrypted"
+                ),
+                OntologyFieldMapping(ontology_field="public", node_field="ispublic"),
+                # The source of an RDS snapshot is the database instance it was
+                # taken from.
+                OntologyFieldMapping(
+                    ontology_field="source_id", node_field="db_instance_identifier"
+                ),
+                OntologyFieldMapping(
+                    ontology_field="created_at", node_field="snapshot_create_time"
+                ),
+                OntologyFieldMapping(ontology_field="region", node_field="region"),
+            ],
+        ),
+    ],
+)
+
+azure_mapping = OntologyMapping(
+    module_name="azure",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="AzureSnapshot",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                # _ont_encrypted: not mapped. The `encryption` field on AzureSnapshot
+                # is `encryption_settings_collection.enabled`, the legacy Azure Disk
+                # Encryption (ADE) flag. Azure snapshots are encrypted at rest by
+                # default via SSE regardless of that flag, so mapping it would make
+                # most snapshots look unencrypted in cross-cloud posture queries.
+                # _ont_public: not mapped. Azure snapshots do not expose a public
+                # sharing flag; access is governed by network_access_policy.
+                # _ont_source_id: not mapped. The source disk is not stored on the
+                # snapshot node.
+                # _ont_created_at: not mapped. No creation timestamp is captured.
+                OntologyFieldMapping(ontology_field="region", node_field="location"),
+            ],
+        ),
+    ],
+)
+
+scaleway_mapping = OntologyMapping(
+    module_name="scaleway",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="ScalewayVolumeSnapshot",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                # _ont_encrypted: Scaleway volume snapshots do not expose encryption
+                # posture in the API.
+                # _ont_public: Scaleway volume snapshots do not expose a public
+                # sharing flag.
+                # _ont_source_id: the source volume is only available through the
+                # HAS relationship, not as a property on the snapshot node.
+                OntologyFieldMapping(
+                    ontology_field="created_at", node_field="creation_date"
+                ),
+                OntologyFieldMapping(ontology_field="region", node_field="zone"),
+            ],
+        ),
+    ],
+)
+
+SNAPSHOTS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
+    "aws": aws_ebs_mapping,
+    "azure": azure_mapping,
+    "scaleway": scaleway_mapping,
+}

--- a/cartography/models/ontology/mapping/data/subnets.py
+++ b/cartography/models/ontology/mapping/data/subnets.py
@@ -1,0 +1,85 @@
+from cartography.models.ontology.mapping.specs import OntologyFieldMapping
+from cartography.models.ontology.mapping.specs import OntologyMapping
+from cartography.models.ontology.mapping.specs import OntologyNodeMapping
+
+# Subnet fields:
+# _ont_name - The name/identifier of the subnet
+# _ont_cidr_block - The IP range (CIDR) of the subnet
+# _ont_availability_zone - The availability zone the subnet lives in (when applicable)
+# _ont_region - The region/zone where the subnet lives
+#
+# _ont_is_public is intentionally not mapped: no provider stores a faithful
+# public/private flag on the subnet itself. Whether a subnet is public depends
+# on its route table (an internet-gateway default route on AWS) or its NSG/route
+# configuration (Azure), which requires a separate analysis pass to determine.
+
+aws_mapping = OntologyMapping(
+    module_name="aws",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="EC2Subnet",
+            fields=[
+                # EC2 subnets have no display name; the SubnetId (`id`) is the
+                # canonical identifier (the `name` property holds the CIDR block).
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="id", required=True
+                ),
+                OntologyFieldMapping(
+                    ontology_field="cidr_block", node_field="cidr_block"
+                ),
+                OntologyFieldMapping(
+                    ontology_field="availability_zone",
+                    node_field="availability_zone",
+                ),
+                OntologyFieldMapping(ontology_field="region", node_field="region"),
+            ],
+        ),
+    ],
+)
+
+gcp_mapping = OntologyMapping(
+    module_name="gcp",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="GCPSubnet",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                OntologyFieldMapping(
+                    ontology_field="cidr_block", node_field="ip_cidr_range"
+                ),
+                # _ont_availability_zone: not mapped. GCP subnets are regional, not
+                # zonal, so there is no availability zone to expose.
+                OntologyFieldMapping(ontology_field="region", node_field="region"),
+            ],
+        ),
+    ],
+)
+
+azure_mapping = OntologyMapping(
+    module_name="azure",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="AzureSubnet",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                OntologyFieldMapping(
+                    ontology_field="cidr_block", node_field="address_prefix"
+                ),
+                # _ont_availability_zone: not mapped. Azure subnets are not
+                # zone-scoped.
+                # _ont_region: not mapped. The region/location is stored on the
+                # parent AzureVirtualNetwork, not on the subnet node.
+            ],
+        ),
+    ],
+)
+
+SUBNETS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
+    "aws": aws_mapping,
+    "gcp": gcp_mapping,
+    "azure": azure_mapping,
+}

--- a/cartography/models/ontology/mapping/data/vpcs.py
+++ b/cartography/models/ontology/mapping/data/vpcs.py
@@ -1,0 +1,70 @@
+from cartography.models.ontology.mapping.specs import OntologyFieldMapping
+from cartography.models.ontology.mapping.specs import OntologyMapping
+from cartography.models.ontology.mapping.specs import OntologyNodeMapping
+
+# VirtualNetwork fields:
+# _ont_name - The name/identifier of the virtual network
+# _ont_cidr - The IP range (CIDR) of the virtual network, when the provider
+#             exposes it at the network level
+# _ont_region - The region where the virtual network lives, when applicable
+
+aws_mapping = OntologyMapping(
+    module_name="aws",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="AWSVpc",
+            fields=[
+                # AWS VPCs have no display name; the VpcId (`id`) is the
+                # canonical identifier.
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="id", required=True
+                ),
+                OntologyFieldMapping(
+                    ontology_field="cidr", node_field="primary_cidr_block"
+                ),
+                OntologyFieldMapping(ontology_field="region", node_field="region"),
+            ],
+        ),
+    ],
+)
+
+gcp_mapping = OntologyMapping(
+    module_name="gcp",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="GCPVpc",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                # _ont_cidr: not mapped. GCP VPCs do not carry a CIDR block; the IP
+                # ranges live on the member subnetworks (GCPSubnet.ip_cidr_range).
+                # _ont_region: not mapped. GCP VPCs are global, not regional.
+            ],
+        ),
+    ],
+)
+
+azure_mapping = OntologyMapping(
+    module_name="azure",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="AzureVirtualNetwork",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                # _ont_cidr: not mapped. The address space is not captured on the
+                # AzureVirtualNetwork node; CIDRs live on the member AzureSubnet
+                # (address_prefix).
+                OntologyFieldMapping(ontology_field="region", node_field="location"),
+            ],
+        ),
+    ],
+)
+
+VPCS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
+    "aws": aws_mapping,
+    "gcp": gcp_mapping,
+    "azure": azure_mapping,
+}

--- a/cartography/models/scaleway/storage/snapshot.py
+++ b/cartography/models/scaleway/storage/snapshot.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -70,6 +71,7 @@ class ScalewayVolumeSnapshotSchema(CartographyNodeSchema):
     properties: ScalewayVolumeSnapshotNodeProperties = (
         ScalewayVolumeSnapshotNodeProperties()
     )
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Snapshot"])
     sub_resource_relationship: ScalewayVolumeSnapshotToProjectRel = (
         ScalewayVolumeSnapshotToProjectRel()
     )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1267,6 +1267,8 @@ Representation of an [AWS Transit Gateway Attachment](https://docs.aws.amazon.co
 Representation of an [AWS CidrBlock used in VPC configuration](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_VpcCidrBlockAssociation.html).
 More information on https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-vpcs.html
 
+> **Ontology Mapping**: This node has the extra label `VirtualNetwork` and normalized `_ont_*` properties to enable cross-platform queries for virtual networks across different systems (e.g., GCPVpc, AzureVirtualNetwork).
+
 | Field | Description |
 |-------|-------------|
 |firstseen| Timestamp of when a sync job discovered this node|

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -2436,6 +2436,8 @@ Representation of an AWS EC2 [Security Group](https://docs.aws.amazon.com/AWSEC2
 
 Representation of an AWS EC2 [Subnet](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Subnet.html).
 
+> **Ontology Mapping**: This node has the extra label `Subnet` and normalized `_ont_*` properties to enable cross-platform queries for network subnets across different systems (e.g., GCPSubnet, AzureSubnet).
+
 | Field | Description |
 |-------|-------------|
 | firstseen| Timestamp of when a sync job first discovered this node  |

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -3833,6 +3833,8 @@ Representation of an AWS Relational Database Service [DBInstance](https://docs.a
 
 Representation of an AWS Relational Database Service [DBSnapshot](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DBSnapshot.html).
 
+> **Ontology Mapping**: This node has the extra label `Snapshot` and normalized `_ont_*` properties to enable cross-platform queries for volume/database snapshots across different systems (e.g., EBSSnapshot, AzureSnapshot, ScalewayVolumeSnapshot).
+
 | Field | Description |
 |-------|-------------|
 | firstseen| Timestamp of when a sync job first discovered this node  |
@@ -4713,6 +4715,8 @@ Representation of an AWS [EBS Volume](https://docs.aws.amazon.com/AWSEC2/latest/
 ### EBSSnapshot
 
 Representation of an AWS [EBS Snapshot](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSSnapshots.html).
+
+> **Ontology Mapping**: This node has the extra label `Snapshot` and normalized `_ont_*` properties to enable cross-platform queries for volume/database snapshots across different systems (e.g., RDSSnapshot, AzureSnapshot, ScalewayVolumeSnapshot).
 
 | Field | Description |
 |-------|-------------|

--- a/docs/root/modules/azure/schema.md
+++ b/docs/root/modules/azure/schema.md
@@ -371,6 +371,8 @@ Representation of an [Azure Disk](https://docs.microsoft.com/en-us/rest/api/comp
 
 Representation of an [Azure Snapshot](https://docs.microsoft.com/en-us/rest/api/compute/snapshots).
 
+> **Ontology Mapping**: This node has the extra label `Snapshot` and normalized `_ont_*` properties to enable cross-platform queries for volume/database snapshots across different systems (e.g., EBSSnapshot, RDSSnapshot, ScalewayVolumeSnapshot).
+
 | Field | Description |
 |-------|-------------|
 |firstseen| Timestamp of when a sync job discovered this node|

--- a/docs/root/modules/azure/schema.md
+++ b/docs/root/modules/azure/schema.md
@@ -2345,6 +2345,8 @@ Representation of an [Azure Virtual Network](https://learn.microsoft.com/en-us/r
 
 Representation of a [Subnet within an Azure Virtual Network](https://learn.microsoft.com/en-us/rest/api/virtualnetwork/subnets/get).
 
+> **Ontology Mapping**: This node has the extra label `Subnet` and normalized `_ont_*` properties to enable cross-platform queries for network subnets across different systems (e.g., EC2Subnet, GCPSubnet).
+
 | Field          | Description                                         |
 | -------------- | --------------------------------------------------- |
 | firstseen      | Timestamp of when a sync job discovered this node   |

--- a/docs/root/modules/azure/schema.md
+++ b/docs/root/modules/azure/schema.md
@@ -2315,6 +2315,8 @@ Representation of a key-value tag applied to an Azure resource. Tags with the sa
 
 Representation of an [Azure Virtual Network](https://learn.microsoft.com/en-us/rest/api/virtualnetwork/virtual-networks/get).
 
+> **Ontology Mapping**: This node has the extra label `VirtualNetwork` and normalized `_ont_*` properties to enable cross-platform queries for virtual networks across different systems (e.g., AWSVpc, GCPVpc).
+
 | Field                | Description                                                       |
 | -------------------- | ----------------------------------------------------------------- |
 | firstseen            | Timestamp of when a sync job discovered this node                 |

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -532,6 +532,8 @@ Representation of a GCP [Resource Record Set](https://cloud.google.com/dns/docs/
 
 Representation of a GCP [Subnetwork](https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks).
 
+> **Ontology Mapping**: This node has the extra label `Subnet` and normalized `_ont_*` properties to enable cross-platform queries for network subnets across different systems (e.g., EC2Subnet, AzureSubnet).
+
 | Field                    | Description                                                                                                                                                                                        |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | firstseen                | Timestamp of when a sync job first discovered this node                                                                                                                                            |

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -394,6 +394,8 @@ Representation of a Tag defined on a GCP Instance or GCP Firewall.  Tags are def
 
 Representation of a GCP [VPC](https://cloud.google.com/compute/docs/reference/rest/v1/networks/).  In GCP documentation this is also known simply as a "Network" object.
 
+> **Ontology Mapping**: This node has the extra label `VirtualNetwork` and normalized `_ont_*` properties to enable cross-platform queries for virtual networks across different systems (e.g., AWSVpc, AzureVirtualNetwork).
+
 | Field                      | Description |
 | -------------------------- | ----------- |
 | firstseen                  | Timestamp of when a sync job first discovered this node |

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -630,6 +630,24 @@ as opposed to object storage (S3-like) or network file storage (EFS-like).
 | _ont_state | The lifecycle state of the volume (e.g., `available`, `in-use`). |
 
 
+### Snapshot
+
+```{note}
+Snapshot is a semantic label.
+```
+
+A snapshot represents a point-in-time copy of a volume or database. It generalizes AWS EBS/RDS snapshots, Azure snapshots, and Scaleway volume snapshots. Publicly shared snapshots are a known data-exfiltration vector.
+
+| Field | Description |
+|-------|-------------|
+| _ont_name | The name/identifier of the snapshot (REQUIRED). For AWS EBS this is the SnapshotId. |
+| _ont_encrypted | Whether the snapshot is encrypted at rest. Populated for AWS EBS/RDS snapshots only. **Absence is not `false`**: it means "unknown / not modeled" for that provider, not "unencrypted". Azure exposes only the legacy Azure Disk Encryption flag (snapshots are encrypted at rest by default via SSE), and Scaleway does not expose encryption posture, so the field is left unset for both. Do not write `coalesce(s._ont_encrypted, false) = false` to find unencrypted snapshots; filter on `s._ont_encrypted = false` instead. |
+| _ont_public | Whether the snapshot is publicly shared. Populated for AWS EBS/RDS snapshots only. **Absence is not `false`**: Azure and Scaleway do not expose a public-sharing flag on the snapshot node, so the field is left unset (state unknown, not "private"). |
+| _ont_source_id | The source volume (AWS EBS), database instance (AWS RDS) the snapshot was taken from. Not populated for Azure (no source on the node) or Scaleway (the source volume is only linked via the `HAS` relationship). |
+| _ont_created_at | When the snapshot was created. Not populated for Azure (no creation timestamp captured). |
+| _ont_region | The region/zone where the snapshot lives. |
+
+
 ### IdentityProvider
 
 ```{note}
@@ -864,6 +882,43 @@ If field `ip_version` is null, it should not be considered as `4` or `6`, only a
     ```
     (:PublicIP)-[:POINTS_TO]->(:ComputeInstance)
     ```
+
+
+### Subnet
+
+```{note}
+Subnet is a semantic label.
+```
+
+A subnet represents an IP subnetwork within a virtual network. It generalizes AWS EC2 subnets, GCP subnetworks, and Azure subnets.
+
+| Field | Description |
+|-------|-------------|
+| _ont_name | The name/identifier of the subnet (REQUIRED). For AWS this is the SubnetId (EC2 subnets have no display name). |
+| _ont_cidr_block | The IP range (CIDR) of the subnet. |
+| _ont_availability_zone | The availability zone of the subnet. AWS only: GCP subnets are regional and Azure subnets are not zone-scoped, so the field is left unset for those providers. |
+| _ont_region | The region/zone where the subnet lives. Not populated for Azure subnets: the region lives on the parent `AzureVirtualNetwork`. A region-scoped cross-cloud query like `MATCH (s:Subnet) WHERE s._ont_region = $region` will silently drop Azure subnets; traverse through `AzureVirtualNetwork` to filter those by region. |
+
+`_ont_is_public` is intentionally not modeled: no provider exposes a faithful public/private flag on the subnet node (it depends on route-table/internet-gateway analysis on AWS, and route/NSG configuration on Azure).
+
+```{note}
+Several AWS sync paths (instances, network interfaces, VPC endpoints, auto scaling groups) create partial `EC2Subnet` nodes that know only the subnet id and sometimes the region. These nodes carry the `Subnet` label with `_ont_name` and `_ont_source` set, but may have a null `_ont_cidr_block` / `_ont_availability_zone` until a full subnet sync enriches them. `(:Subnet)` queries that rely on CIDR/AZ should treat absence as "not yet known", not as a real value. GCP subnet stub nodes are deliberately left unlabeled because they lack even a name.
+```
+
+
+### VirtualNetwork
+
+```{note}
+VirtualNetwork is a semantic label.
+```
+
+A virtual network represents an isolated virtual network environment that defines the network boundary for cloud resources. It generalizes AWS VPCs, GCP VPCs, and Azure virtual networks.
+
+| Field | Description |
+|-------|-------------|
+| _ont_name | The name/identifier of the virtual network (REQUIRED). For AWS this is the VpcId (VPCs have no display name). |
+| _ont_cidr | The IP range (CIDR) of the virtual network. AWS only: GCP VPCs keep CIDRs on their subnets, and Azure stores the address space on subnets rather than the virtual network, so the field is left unset for those providers. |
+| _ont_region | The region where the virtual network lives. Not populated for GCP (VPCs are global). |
 
 
 ### Package

--- a/docs/root/modules/scaleway/schema.md
+++ b/docs/root/modules/scaleway/schema.md
@@ -346,6 +346,8 @@ Volumes are storage space used by your Instances. You can attach several volumes
 
 A snapshot takes a picture of a volume at one specific point in time. For a complete backup of your Instance, you can create an image.
 
+> **Ontology Mapping**: This node has the extra label `Snapshot` and normalized `_ont_*` properties to enable cross-platform queries for volume/database snapshots across different systems (e.g., EBSSnapshot, RDSSnapshot, AzureSnapshot).
+
 | Field           | Description                                  |
 |-----------------|----------------------------------------------|
 | id              | Snapshot ID.                                 |

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_snapshots.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_snapshots.py
@@ -364,3 +364,48 @@ def test_sync_ebs_snapshots_with_snapshots_in_use(mock_get_snapshots, neo4j_sess
         )
         == expected_created_from_relationships
     )
+
+
+@patch.object(
+    cartography.intel.aws.ec2.snapshots,
+    "get_snapshots",
+    return_value=tests.data.aws.ec2.snapshots.DESCRIBE_SNAPSHOTS,
+)
+@patch.object(
+    cartography.intel.aws.ec2.snapshots,
+    "get_snapshots_in_use",
+    return_value=[],
+)
+def test_snapshot_ontology_labels(
+    mock_get_snapshots_in_use, mock_get_snapshots, neo4j_session
+):
+    # Arrange / Act
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    cartography.intel.aws.ec2.snapshots.sync_ebs_snapshots(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+
+    # Assert: every EBSSnapshot carries the Snapshot semantic label with
+    # normalized _ont_* properties populated.
+    assert check_nodes(
+        neo4j_session,
+        "Snapshot",
+        [
+            "_ont_name",
+            "_ont_public",
+            "_ont_encrypted",
+            "_ont_source_id",
+            "_ont_region",
+            "_ont_source",
+        ],
+    ) == {
+        ("sn-01", True, True, "vol-0df", TEST_REGION, "aws"),
+        ("sn-02", False, True, "vol-03", TEST_REGION, "aws"),
+    }

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_subnets.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_subnets.py
@@ -277,3 +277,28 @@ def test_sync_subnets(mock_get_subnets, neo4j_session):
         "available",
         251,
     ) in all_subnet_props
+
+
+def test_subnet_ontology_labels(neo4j_session):
+    # Arrange / Act
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    data = tests.data.aws.ec2.subnets.DESCRIBE_SUBNETS
+    cartography.intel.aws.ec2.subnets.load_subnets(
+        neo4j_session,
+        data,
+        TEST_REGION,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+    # Assert: every EC2Subnet carries the Subnet semantic label with normalized
+    # _ont_* properties populated.
+    assert check_nodes(
+        neo4j_session,
+        "Subnet",
+        ["_ont_name", "_ont_cidr_block", "_ont_region", "_ont_source"],
+    ) == {
+        ("subnet-020b2f3928f190ce8", "10.1.2.0/24", TEST_REGION, "aws"),
+        ("subnet-0773409557644dca4", "10.1.1.0/24", TEST_REGION, "aws"),
+        ("subnet-0fa9c8fa7cb241479", "10.2.1.0/24", TEST_REGION, "aws"),
+    }

--- a/tests/integration/cartography/intel/aws/ec2/test_vpc.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_vpc.py
@@ -468,3 +468,38 @@ def test_sync_vpc(
             "vpc-0015dc961e537676a|10.0.0.0/16",
         ),  # Accepter CIDR block for VPC peering
     }
+
+
+@patch.object(
+    cartography.intel.aws.ec2.vpc,
+    "get_ec2_vpcs",
+    return_value=TEST_VPCS,
+)
+def test_vpc_ontology_labels(mock_get_vpcs, neo4j_session):
+    # Arrange / Act
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    sync_vpc(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+
+    # Assert: every AWSVpc carries the VirtualNetwork semantic label with
+    # normalized _ont_* properties populated.
+    assert check_nodes(
+        neo4j_session,
+        "VirtualNetwork",
+        ["_ont_name", "_ont_cidr", "_ont_region", "_ont_source"],
+    ) == {
+        ("vpc-038cf", "172.31.0.0/16", TEST_REGION, "aws"),
+        ("vpc-0f510", "10.1.0.0/16", TEST_REGION, "aws"),
+        ("vpc-0a1b2", "2001:db8::/32", TEST_REGION, "aws"),
+        ("vpc-05326141848d1c681", "10.0.0.0/16", TEST_REGION, "aws"),
+        ("vpc-0767", "192.168.0.0/16", TEST_REGION, "aws"),
+        ("vpc-025873e026b9e8ee6", "172.16.0.0/16", TEST_REGION, "aws"),
+    }

--- a/tests/integration/cartography/intel/aws/test_rds.py
+++ b/tests/integration/cartography/intel/aws/test_rds.py
@@ -237,6 +237,30 @@ def test_load_rds_snapshots_basic(neo4j_session):
     }
     assert actual_snapshots == expected_snapshots
 
+    # Assert - Snapshot semantic label + normalized _ont_* fields for RDS
+    # snapshots (full set: name, encrypted, public, source_id, region).
+    assert check_nodes(
+        neo4j_session,
+        "Snapshot",
+        [
+            "_ont_name",
+            "_ont_encrypted",
+            "_ont_public",
+            "_ont_source_id",
+            "_ont_region",
+            "_ont_source",
+        ],
+    ) == {
+        (
+            "some-db-snapshot-identifier",
+            True,
+            True,
+            "some-prod-db-iad-0",
+            "us-east1",
+            "aws",
+        ),
+    }
+
     query = """MATCH(rdsInstance:RDSInstance)-[:IS_SNAPSHOT_SOURCE]-(rdsSnapshot:RDSSnapshot)
                RETURN rdsInstance.id, rdsSnapshot.id"""
     results = neo4j_session.run(query)

--- a/tests/integration/cartography/intel/azure/test_compute.py
+++ b/tests/integration/cartography/intel/azure/test_compute.py
@@ -97,6 +97,18 @@ def test_sync_compute_resources(
         check_nodes(neo4j_session, "AzureSnapshot", ["id"]) == expected_snapshot_nodes
     )
 
+    # Assert - Snapshot semantic label + normalized _ont_* fields. Azure exposes
+    # only name + region on the snapshot node; encrypted/public/source_id/
+    # created_at are intentionally unset (see the snapshots ontology mapping).
+    assert check_nodes(
+        neo4j_session,
+        "Snapshot",
+        ["_ont_name", "_ont_region", "_ont_source"],
+    ) == {
+        ("ss0", "West US", "azure"),
+        ("ss1", "West US", "azure"),
+    }
+
     # Assert - Check VM-to-subscription relationships
     expected_vm_rels = {
         (

--- a/tests/integration/cartography/intel/azure/test_network.py
+++ b/tests/integration/cartography/intel/azure/test_network.py
@@ -80,6 +80,28 @@ def test_sync_network(
     expected_subnets = {(s["id"],) for s in MOCK_SUBNETS}
     assert check_nodes(neo4j_session, "AzureSubnet", ["id"]) == expected_subnets
 
+    # Assert - Subnet semantic label + normalized _ont_* fields. Azure subnets
+    # carry name + cidr_block; the region lives on the parent VNet, so
+    # _ont_region is intentionally unset here.
+    assert check_nodes(
+        neo4j_session,
+        "Subnet",
+        ["_ont_name", "_ont_cidr_block", "_ont_source"],
+    ) == {
+        ("subnet-with-nsg", "10.0.1.0/24", "azure"),
+        ("subnet-without-nsg", "10.0.2.0/24", "azure"),
+    }
+
+    # Assert - VirtualNetwork semantic label + normalized _ont_* fields. Azure
+    # stores the address space on subnets, so _ont_cidr is intentionally unset.
+    assert check_nodes(
+        neo4j_session,
+        "VirtualNetwork",
+        ["_ont_name", "_ont_region", "_ont_source"],
+    ) == {
+        ("my-test-vnet", "eastus", "azure"),
+    }
+
     # Assert Relationships
     vnet_id = MOCK_VNETS[0]["id"]
     nsg_id = MOCK_NSGS[0]["id"]

--- a/tests/integration/cartography/intel/gcp/test_compute.py
+++ b/tests/integration/cartography/intel/gcp/test_compute.py
@@ -97,6 +97,17 @@ def test_sync_gcp_vpcs(mock_get_vpcs, neo4j_session):
         ),
     }
 
+    # Assert - VirtualNetwork semantic label + normalized _ont_* fields.
+    # GCP VPCs are global and keep CIDRs on subnets, so _ont_cidr/_ont_region
+    # are intentionally unset.
+    assert check_nodes(
+        neo4j_session,
+        "VirtualNetwork",
+        ["_ont_name", "_ont_source"],
+    ) == {
+        ("default", "gcp"),
+    }
+
     # Assert - Project to VPC relationship created
     assert check_rels(
         neo4j_session,
@@ -171,6 +182,15 @@ def test_sync_gcp_subnets(mock_get_vpcs, mock_get_subnets, neo4j_session):
         ),
     }
 
+    # Assert - Subnet semantic label + normalized _ont_* fields
+    assert check_nodes(
+        neo4j_session,
+        "Subnet",
+        ["_ont_name", "_ont_cidr_block", "_ont_region", "_ont_source"],
+    ) == {
+        ("default", "10.0.0.0/20", "europe-west2", "gcp"),
+    }
+
     # Assert - VPC to Subnet relationship created
     assert check_rels(
         neo4j_session,
@@ -186,6 +206,40 @@ def test_sync_gcp_subnets(mock_get_vpcs, mock_get_subnets, neo4j_session):
             "projects/project-abc/regions/europe-west2/subnetworks/default",
         ),
     }
+
+
+@patch.object(
+    cartography.intel.gcp.compute,
+    "get_gcp_instance_responses",
+    return_value=[tests.data.gcp.compute.GCP_LIST_INSTANCES_RESPONSE],
+)
+def test_gcp_subnet_stub_not_labeled_subnet(mock_get_instances, neo4j_session):
+    """Regression: GCP subnet stubs created by the instance path only know
+    partial_uri, so they must NOT carry the Subnet semantic label. Otherwise
+    cross-cloud (:Subnet) queries would return nameless GCP subnet nodes (no
+    _ont_name/_ont_cidr_block/_ont_region) until a full subnet sync runs."""
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "PROJECT_ID": TEST_PROJECT_ID,
+    }
+    _create_test_project(neo4j_session, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+
+    # Act - sync instances only; this creates GCPSubnet stub nodes without full
+    # subnet data.
+    cartography.intel.gcp.compute.sync_gcp_instances(
+        neo4j_session,
+        MagicMock(),
+        TEST_PROJECT_ID,
+        None,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    # Assert - stub subnet nodes exist, but none carry the Subnet label.
+    assert check_nodes(neo4j_session, "GCPSubnet", ["id"]) != set()
+    assert check_nodes(neo4j_session, "Subnet", ["id"]) == set()
 
 
 @patch.object(

--- a/tests/integration/cartography/intel/scaleway/test_storage.py
+++ b/tests/integration/cartography/intel/scaleway/test_storage.py
@@ -120,6 +120,17 @@ def test_load_scaleway_snapshots(_mock_get, neo4j_session):
         == expected_nodes
     )
 
+    # Assert - Snapshot semantic label + normalized _ont_* fields. Scaleway
+    # exposes name + region (zone) + created_at; encrypted/public/source_id are
+    # intentionally unset (the source volume is linked via the HAS relationship).
+    assert check_nodes(
+        neo4j_session,
+        "Snapshot",
+        ["_ont_name", "_ont_region", "_ont_source"],
+    ) == {
+        ("image-gateway_snap_0", "fr-par-1", "scaleway"),
+    }
+
     # Assert Project exists
     assert check_nodes(neo4j_session, "ScalewayProject", ["id"]) == {(TEST_PROJECT_ID,)}
 


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary
Adds three new cross-provider ontology **semantic-label categories** so network and storage-snapshot resources become queryable through the abstract ontology layer, regardless of provider:

- **`Subnet`** — `EC2Subnet` (AWS), `GCPSubnet` (GCP), `AzureSubnet` (Azure). Normalized `_ont_*`: `name`, `cidr_block`, `availability_zone`, `region` (where the provider exposes them).
- **`VirtualNetwork`** — `AWSVpc`, `GCPVpc`, `AzureVirtualNetwork`. Normalized `_ont_*`: `name`, `cidr`, `region`.
- **`Snapshot`** — `EBSSnapshot`, `RDSSnapshot` (AWS), `AzureSnapshot`, `ScalewayVolumeSnapshot`. Normalized `_ont_*`: `name`, `encrypted`, `public`, `source_id`, `created_at`, `region`.

Each category adds a mapping under `cartography/models/ontology/mapping/data/`, registers it in `SEMANTIC_LABELS_MAPPING`, and attaches `ExtraNodeLabels` to every source schema class that shares the label (including the composite/stub schemas, e.g. all `EC2Subnet` variants).

Fields are only mapped where the provider actually exposes them; gaps are documented inline rather than approximated. Notably:
- `Subnet._ont_is_public` is **not** mapped: no provider stores a faithful public/private flag on the subnet node (it requires route-table/IGW or NSG analysis).
- `VirtualNetwork._ont_cidr` is omitted for GCP (CIDRs live on subnets) and Azure (address space stored on subnets); `region` is omitted for GCP (VPCs are global).
- `Snapshot._ont_encrypted` is skipped for Azure (the available field is the legacy ADE flag, which would mislabel SSE-encrypted snapshots as unencrypted, mirroring the existing `AzureDisk` treatment in `blockstorage`); Azure/Scaleway also lack public/source/created_at on the snapshot node.

The constraint mechanism and CI guard already exist (`constraints.py`, `test_ontology_rel_constraints.py`), and semantic-label categories are exempt from the canonical-node id requirement, so no foundation changes were needed.

### Related issues or links

N/A

### Breaking changes

None. This only adds extra Neo4j labels and `_ont_*` properties to existing nodes.

### How was this tested?
- Unit: `pytest tests/unit/cartography/intel/ontology/ tests/unit/cartography/graph/test_ontology_rel_constraints.py`
- Integration (against a local Neo4j): new `_ont_*`/label assertions plus the full touched suites:
  `pytest tests/integration/cartography/intel/aws/ec2/test_ec2_subnets.py tests/integration/cartography/intel/aws/ec2/test_vpc.py tests/integration/cartography/intel/aws/ec2/test_ec2_snapshots.py tests/integration/cartography/intel/aws/test_rds.py tests/integration/cartography/intel/gcp/test_compute.py`
- `pre-commit` (isort/black/flake8/mypy) passes on all changed files.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally.
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the schema documentation.

### Notes for reviewers
- The semantic label is attached via `ExtraNodeLabels` on **every** schema class that shares a node label (the composite/stub pattern). The querybuilder looks up the ontology mapping by `node_schema.label` and skips mapped fields a given schema does not define, so partial/stub writers never null-clobber `_ont_*` set by the full writer.
- `GCPSubnetStubSchema` deliberately does **not** carry the `Subnet` label: it only holds `partial_uri`, so it would otherwise surface in `(:Subnet)` queries with a null `_ont_name`. The full `GCPSubnetSchema` attaches the label once real subnet data syncs. AWS stubs are unaffected because their ontology name resolves from `id` (always present).
