### PR TITLE
feat(aibom): link detections to GitHub/GitLab code repositories

### DIFF
--- a/cartography/intel/aibom/__init__.py
+++ b/cartography/intel/aibom/__init__.py
@@ -41,6 +41,25 @@ def _image_digest_exists(neo4j_session: Session, digest: str) -> bool:
     return result is not None
 
 
+def _code_repository_uri_exists(neo4j_session: Session, uri: str) -> bool:
+    """
+    Return True when the URI matches an existing GitHubRepository.url or
+    GitLabProject.web_url node already present in the graph.
+    """
+    result = neo4j_session.execute_read(
+        read_single_value_tx,
+        """
+        OPTIONAL MATCH (gh:GitHubRepository {url: $uri})
+        WITH gh
+        OPTIONAL MATCH (gl:GitLabProject {web_url: $uri})
+        RETURN (gh IS NOT NULL OR gl IS NOT NULL) AS resolved
+        LIMIT 1
+        """,
+        uri=uri,
+    )
+    return bool(result)
+
+
 def prepare_aibom_report_for_ingestion(
     neo4j_session: Session,
     document: dict[str, Any],
@@ -48,8 +67,11 @@ def prepare_aibom_report_for_ingestion(
 ) -> dict[str, Any]:
     """
     Perform the GET/preparation step for an AIBOM report:
-    validate the raw document at a high level, extract source keys, require
-    digest-qualified anchors, and verify they resolve to concrete :Image nodes.
+    validate the raw document at a high level, extract source keys, and verify
+    that every anchor resolves to an existing target node. Digest-qualified
+    source keys must resolve to concrete :Image nodes; any other source key is
+    treated as a code-repository URI and must resolve to an existing
+    GitHubRepository or GitLabProject.
     """
     sources = document["aibom_analysis"]["sources"]
     source_keys = tuple(sources)
@@ -58,30 +80,28 @@ def prepare_aibom_report_for_ingestion(
             f"AIBOM report at {source} did not contain any sources",
         )
 
-    invalid_source_keys = [
-        source_key
-        for source_key in source_keys
-        if _extract_digest_from_source_key(source_key) is None
-    ]
-    if invalid_source_keys:
-        raise ValueError(
-            "AIBOM report "
-            f"{source} contained non-digest-qualified source keys: "
-            f"{', '.join(sorted(invalid_source_keys))}",
-        )
+    missing_digests: list[str] = []
+    unresolved_repository_uris: list[str] = []
+    for source_key in source_keys:
+        digest = _extract_digest_from_source_key(source_key)
+        if digest is not None:
+            if not _image_digest_exists(neo4j_session, digest):
+                missing_digests.append(digest)
+        elif not _code_repository_uri_exists(neo4j_session, source_key):
+            unresolved_repository_uris.append(source_key)
 
-    image_digests = tuple(source_key.partition("@")[2] for source_key in source_keys)
-
-    missing_digests = [
-        digest
-        for digest in image_digests
-        if not _image_digest_exists(neo4j_session, digest)
-    ]
     if missing_digests:
         raise ValueError(
             "AIBOM report "
             f"{source} did not resolve to concrete :Image nodes for digests: "
             f"{', '.join(sorted(set(missing_digests)))}",
+        )
+    if unresolved_repository_uris:
+        raise ValueError(
+            "AIBOM report "
+            f"{source} did not resolve to existing GitHubRepository or "
+            "GitLabProject nodes for source keys: "
+            f"{', '.join(sorted(set(unresolved_repository_uris)))}",
         )
 
     return document

--- a/cartography/intel/aibom/transform.py
+++ b/cartography/intel/aibom/transform.py
@@ -18,6 +18,23 @@ def _stable_hash(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
+def _classify_source_key(source_key: str) -> tuple[list[str], list[str]]:
+    """
+    Classify a source key into image-digest and code-repository anchors.
+
+    Image source keys are digest-qualified (``<uri>@sha256:<hex>``); their
+    digest drives the :Image match and no repository URI is emitted. Any other
+    source key is treated as a code repository URI used to match an existing
+    GitHubRepository (by url) or GitLabProject (by web_url). The same URI is
+    offered to both matchers; only the node type that actually exists in the
+    graph gets a DETECTED_IN edge.
+    """
+    _, sep, remainder = source_key.partition("@")
+    if sep and remainder.startswith("sha256:"):
+        return [remainder], []
+    return [], [source_key]
+
+
 def _as_str(value: Any) -> str | None:
     if isinstance(value, str):
         cleaned = value.strip()
@@ -83,8 +100,7 @@ def _build_component_payload(
     component_type: str,
     component: dict[str, Any],
 ) -> dict[str, Any]:
-    digest = source_key.partition("@")[2]
-    manifest_digests = [digest] if digest else []
+    manifest_digests, repo_uris = _classify_source_key(source_key)
     normalized_component_type = (
         _as_str(component.get("component_type")) or component_type
     )
@@ -137,6 +153,8 @@ def _build_component_payload(
         "decision_justification": _as_str(decision_annotation.get("justification")),
         "metadata_json": _json_dumps(component_metadata),
         "manifest_digests": manifest_digests,
+        "github_repo_urls": repo_uris,
+        "gitlab_project_urls": repo_uris,
         "uses_model_component_ids": [],
         "uses_tool_component_ids": [],
         "exposes_tool_component_ids": [],
@@ -183,8 +201,7 @@ def _build_source_payload(
 
     total_relationships = len(source_relationships)
 
-    digest = source_key.partition("@")[2]
-    manifest_digests = [digest] if digest else []
+    manifest_digests, repo_uris = _classify_source_key(source_key)
     image_uri = _as_str(source_data.get("source_name")) or source_key
     report_component_type_names, report_component_type_counts = _flatten_count_map(
         report_component_types,
@@ -198,6 +215,8 @@ def _build_source_payload(
         "image_uri": image_uri,
         "manifest_digests": manifest_digests,
         "image_matched": bool(manifest_digests),
+        "github_repo_urls": repo_uris,
+        "gitlab_project_urls": repo_uris,
         "report_location": report_location,
         "run_id": _as_str(report_metadata.get("run_id")),
         "analyzer_version": _as_str(report_metadata.get("analyzer_version")),

--- a/cartography/models/aibom/component.py
+++ b/cartography/models/aibom/component.py
@@ -77,6 +77,32 @@ class AIBOMComponentDetectedInRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class AIBOMComponentDetectedInGitHubRel(CartographyRelSchema):
+    target_node_label: str = "GitHubRepository"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"url": PropertyRef("github_repo_urls", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "DETECTED_IN"
+    properties: AIBOMComponentDetectedInRelProperties = (
+        AIBOMComponentDetectedInRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AIBOMComponentDetectedInGitLabRel(CartographyRelSchema):
+    target_node_label: str = "GitLabProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"web_url": PropertyRef("gitlab_project_urls", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "DETECTED_IN"
+    properties: AIBOMComponentDetectedInRelProperties = (
+        AIBOMComponentDetectedInRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class AIBOMComponentToComponentRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
@@ -157,6 +183,8 @@ class AIBOMComponentSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             AIBOMComponentDetectedInRel(),
+            AIBOMComponentDetectedInGitHubRel(),
+            AIBOMComponentDetectedInGitLabRel(),
             AIBOMComponentUsesModelRel(),
             AIBOMComponentUsesToolRel(),
             AIBOMComponentExposesToolRel(),

--- a/cartography/models/aibom/source.py
+++ b/cartography/models/aibom/source.py
@@ -85,6 +85,28 @@ class AIBOMSourceToImageRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class AIBOMSourceToGitHubRepoRel(CartographyRelSchema):
+    target_node_label: str = "GitHubRepository"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"url": PropertyRef("github_repo_urls", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "SCANNED_REPOSITORY"
+    properties: AIBOMSourceToImageRelProperties = AIBOMSourceToImageRelProperties()
+
+
+@dataclass(frozen=True)
+class AIBOMSourceToGitLabProjectRel(CartographyRelSchema):
+    target_node_label: str = "GitLabProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"web_url": PropertyRef("gitlab_project_urls", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "SCANNED_REPOSITORY"
+    properties: AIBOMSourceToImageRelProperties = AIBOMSourceToImageRelProperties()
+
+
+@dataclass(frozen=True)
 class AIBOMSourceToComponentRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
@@ -111,6 +133,8 @@ class AIBOMSourceSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             AIBOMSourceToImageRel(),
+            AIBOMSourceToGitHubRepoRel(),
+            AIBOMSourceToGitLabProjectRel(),
             AIBOMSourceToComponentRel(),
         ],
     )

--- a/docs/root/modules/aibom/schema.md
+++ b/docs/root/modules/aibom/schema.md
@@ -1,8 +1,9 @@
 ## AIBOM Schema
 
 The AIBOM module now ingests raw AIBOM `1.0.0rc4` reports directly and loads
-them into a source/component graph model that is anchored to a concrete
-ontology `:Image` node.
+them into a source/component graph model that is anchored either to a concrete
+ontology `:Image` node (for container-image scans) or to a code repository
+(`:GitHubRepository` / `:GitLabProject`) for source-code scans.
 
 - `AIBOMSource` is the primary scanned-target node.
 - `AIBOMComponent` represents one detected component occurrence within that
@@ -78,6 +79,14 @@ scanned artifact.
     (:AIBOMSource)-[:SCANNED_IMAGE]->(:Image)
     ```
 
+- A source built from a code-repository scan points to the repository it
+  scanned. Only the matching repository type present in the graph is linked.
+
+    ```
+    (:AIBOMSource)-[:SCANNED_REPOSITORY]->(:GitHubRepository)
+    (:AIBOMSource)-[:SCANNED_REPOSITORY]->(:GitLabProject)
+    ```
+
 - A source contains component occurrences.
 
     ```
@@ -144,6 +153,16 @@ Representation of one detected AI component occurrence within a source.
     (:AIBOMComponent)-[:DETECTED_IN]->(:Image)
     ```
 
+- For source-code scans, a component occurrence is detected in the code
+  repository resolved for the source. Only the matching repository type present
+  in the graph is linked: the resolved URI is matched against
+  `GitHubRepository.url` and `GitLabProject.web_url`.
+
+    ```
+    (:AIBOMComponent)-[:DETECTED_IN]->(:GitHubRepository)
+    (:AIBOMComponent)-[:DETECTED_IN]->(:GitLabProject)
+    ```
+
 - Report-defined component-to-component relationships are loaded between
   `AIBOMComponent` nodes when both endpoints resolve successfully within the
   same scanned source. During transform, the source component payload owns the
@@ -170,17 +189,20 @@ Representation of one detected AI component occurrence within a source.
 
 ### Linking constraints
 
-- AIBOM ingestion is anchored to a concrete digest-qualified source key such as
-  `repo@sha256:...`.
+- Each AIBOM source key is anchored to an existing target node before the
+  report is ingested:
+    - Digest-qualified source keys such as `repo@sha256:...` must resolve to a
+      concrete `(:Image {_ont_digest: ...})` node.
+    - Any other source key is treated as a code-repository URI and must resolve
+      to an existing `(:GitHubRepository {url: ...})` or
+      `(:GitLabProject {web_url: ...})` node.
 - `aibom_analysis.sources` must be non-empty. Empty source maps are treated as
   malformed input and fail AIBOM sync.
-- Cartography verifies that the digest resolves to an existing concrete
-  `:Image` node before the report is ingested.
 - `:ImageManifestList` and `:ImageTag` are not valid primary anchors for this
   ingestion flow.
-- If any source key is not digest-qualified, or if the exact digest does not
-  already exist as `(:Image {_ont_digest: ...})`, Cartography raises an error
-  and fails the AIBOM sync run rather than partially loading data.
+- If any source key fails to resolve to its expected target node, Cartography
+  raises an error and fails the AIBOM sync run rather than partially loading
+  data.
 
 ### Example queries
 

--- a/tests/data/aibom/aibom_sample.py
+++ b/tests/data/aibom/aibom_sample.py
@@ -1,3 +1,6 @@
+import copy
+from typing import Any
+
 import tests.data.aws.ecr
 
 TEST_REPOSITORY_URI = "205930638578.dkr.ecr.us-east-1.amazonaws.com/subimage-backend"
@@ -1003,3 +1006,21 @@ AIBOM_REPORT = {
         "errors": [],
     },
 }
+
+# Code-repository anchors used by the GitHub/GitLab linking tests. AIBOM source
+# keys for repository scans are plain repo URLs with no `@sha256:` digest.
+TEST_GITHUB_REPO_URL = "https://github.com/example-org/example-repo"
+TEST_GITLAB_PROJECT_URL = "https://gitlab.com/example-group/example-project"
+
+
+def build_repo_anchored_report(source_key: str) -> dict[str, Any]:
+    """
+    Return a copy of ``AIBOM_REPORT`` re-anchored on a code-repository source
+    key (a plain repo URL) instead of the digest-qualified image source key.
+    """
+    report: dict[str, Any] = copy.deepcopy(AIBOM_REPORT)
+    sources: dict[str, Any] = report["aibom_analysis"]["sources"]
+    source_data = sources.pop(TEST_SOURCE_KEY)
+    source_data["source_name"] = source_key
+    sources[source_key] = source_data
+    return report

--- a/tests/integration/cartography/intel/aibom/test_aibom.py
+++ b/tests/integration/cartography/intel/aibom/test_aibom.py
@@ -11,6 +11,9 @@ from cartography.intel.aibom import sync_aibom_from_report_reader
 from cartography.intel.common.object_store import LocalReportReader
 from cartography.intel.common.object_store import ReportRef
 from tests.data.aibom.aibom_sample import AIBOM_REPORT
+from tests.data.aibom.aibom_sample import build_repo_anchored_report
+from tests.data.aibom.aibom_sample import TEST_GITHUB_REPO_URL
+from tests.data.aibom.aibom_sample import TEST_GITLAB_PROJECT_URL
 from tests.data.aibom.aibom_sample import TEST_SOURCE_KEY
 from tests.integration.cartography.intel.aws.common import create_test_account
 from tests.integration.util import check_nodes
@@ -80,6 +83,31 @@ def _seed_single_platform_graph(neo4j_session) -> None:
             TEST_UPDATE_TAG,
             {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
         )
+
+
+def _seed_github_repository(neo4j_session) -> None:
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (r:GitHubRepository {id: $url})
+        SET r.url = $url, r.lastupdated = $update_tag
+        """,
+        url=TEST_GITHUB_REPO_URL,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+
+def _seed_gitlab_project(neo4j_session) -> None:
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (p:GitLabProject {id: $id})
+        SET p.web_url = $web_url, p.lastupdated = $update_tag
+        """,
+        id="42",
+        web_url=TEST_GITLAB_PROJECT_URL,
+        update_tag=TEST_UPDATE_TAG,
+    )
 
 
 def _build_report_without_component(
@@ -372,3 +400,139 @@ def test_sync_aibom_skips_ambiguous_type_name_relationship_endpoints(
         )
         == set()
     )
+
+
+@patch(
+    "builtins.open",
+    new_callable=mock_open,
+    read_data=json.dumps(build_repo_anchored_report(TEST_GITHUB_REPO_URL)).encode(
+        "utf-8"
+    ),
+)
+@patch(
+    "cartography.intel.common.object_store.LocalReportReader.list_reports",
+    return_value=[ReportRef(uri="/tmp/aibom.json", name="aibom.json")],
+)
+def test_sync_aibom_links_components_to_github_repository(
+    mock_json_files,
+    mock_file_open,
+    neo4j_session,
+):
+    # Arrange
+    _seed_github_repository(neo4j_session)
+
+    # Act
+    sync_aibom_from_report_reader(
+        neo4j_session,
+        LocalReportReader("/tmp"),
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    # Assert
+    assert check_nodes(
+        neo4j_session,
+        "AIBOMSource",
+        ["source_key"],
+    ) == {
+        (TEST_GITHUB_REPO_URL,),
+    }
+
+    component_nodes = check_nodes(
+        neo4j_session,
+        "AIBOMComponent",
+        ["name"],
+    )
+    assert component_nodes is not None
+    assert len(component_nodes) > 0
+
+    assert check_rels(
+        neo4j_session,
+        "AIBOMSource",
+        "source_key",
+        "GitHubRepository",
+        "url",
+        "SCANNED_REPOSITORY",
+        rel_direction_right=True,
+    ) == {
+        (TEST_GITHUB_REPO_URL, TEST_GITHUB_REPO_URL),
+    }
+
+    detected_in_rels = check_rels(
+        neo4j_session,
+        "AIBOMComponent",
+        "name",
+        "GitHubRepository",
+        "url",
+        "DETECTED_IN",
+        rel_direction_right=True,
+    )
+    assert len(detected_in_rels) == len(component_nodes)
+
+
+@patch(
+    "builtins.open",
+    new_callable=mock_open,
+    read_data=json.dumps(build_repo_anchored_report(TEST_GITLAB_PROJECT_URL)).encode(
+        "utf-8"
+    ),
+)
+@patch(
+    "cartography.intel.common.object_store.LocalReportReader.list_reports",
+    return_value=[ReportRef(uri="/tmp/aibom.json", name="aibom.json")],
+)
+def test_sync_aibom_links_components_to_gitlab_project(
+    mock_json_files,
+    mock_file_open,
+    neo4j_session,
+):
+    # Arrange
+    _seed_gitlab_project(neo4j_session)
+
+    # Act
+    sync_aibom_from_report_reader(
+        neo4j_session,
+        LocalReportReader("/tmp"),
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    # Assert
+    assert check_nodes(
+        neo4j_session,
+        "AIBOMSource",
+        ["source_key"],
+    ) == {
+        (TEST_GITLAB_PROJECT_URL,),
+    }
+
+    component_nodes = check_nodes(
+        neo4j_session,
+        "AIBOMComponent",
+        ["name"],
+    )
+    assert component_nodes is not None
+    assert len(component_nodes) > 0
+
+    assert check_rels(
+        neo4j_session,
+        "AIBOMSource",
+        "source_key",
+        "GitLabProject",
+        "web_url",
+        "SCANNED_REPOSITORY",
+        rel_direction_right=True,
+    ) == {
+        (TEST_GITLAB_PROJECT_URL, TEST_GITLAB_PROJECT_URL),
+    }
+
+    detected_in_rels = check_rels(
+        neo4j_session,
+        "AIBOMComponent",
+        "name",
+        "GitLabProject",
+        "web_url",
+        "DETECTED_IN",
+        rel_direction_right=True,
+    )
+    assert len(detected_in_rels) == len(component_nodes)

--- a/tests/unit/cartography/intel/aibom/test_init.py
+++ b/tests/unit/cartography/intel/aibom/test_init.py
@@ -90,26 +90,56 @@ def test_prepare_aibom_report_for_ingestion_raises_when_image_digest_missing() -
             )
 
 
-def test_prepare_aibom_report_for_ingestion_raises_for_mixed_digest_and_non_digest_source_keys() -> (
+def test_prepare_aibom_report_for_ingestion_returns_document_for_code_repository_match() -> (
     None
 ):
     # Arrange
     neo4j_session = MagicMock()
     document: dict[str, Any] = copy.deepcopy(AIBOM_REPORT)
-    document["aibom_analysis"]["sources"]["repo:latest"] = copy.deepcopy(
-        document["aibom_analysis"]["sources"][TEST_SOURCE_KEY],
-    )
+    sources = document["aibom_analysis"]["sources"]
+    sources["https://github.com/example/repo"] = sources.pop(TEST_SOURCE_KEY)
 
-    # Act and assert
-    with pytest.raises(
-        ValueError,
-        match="contained non-digest-qualified source keys: repo:latest",
+    with patch(
+        "cartography.intel.aibom._code_repository_uri_exists",
+        return_value=True,
     ):
-        prepare_aibom_report_for_ingestion(
+        # Act
+        prepared_report = prepare_aibom_report_for_ingestion(
             neo4j_session,
             document,
             "/tmp/aibom.json",
         )
+
+    # Assert
+    assert prepared_report == document
+
+
+def test_prepare_aibom_report_for_ingestion_raises_when_code_repository_missing() -> (
+    None
+):
+    # Arrange
+    neo4j_session = MagicMock()
+    document: dict[str, Any] = copy.deepcopy(AIBOM_REPORT)
+    sources = document["aibom_analysis"]["sources"]
+    sources["https://github.com/example/repo"] = sources.pop(TEST_SOURCE_KEY)
+
+    with patch(
+        "cartography.intel.aibom._code_repository_uri_exists",
+        return_value=False,
+    ):
+        # Act and assert
+        with pytest.raises(
+            ValueError,
+            match=(
+                "did not resolve to existing GitHubRepository or GitLabProject "
+                "nodes for source keys: https://github.com/example/repo"
+            ),
+        ):
+            prepare_aibom_report_for_ingestion(
+                neo4j_session,
+                document,
+                "/tmp/aibom.json",
+            )
 
 
 def test_prepare_aibom_report_for_ingestion_raises_when_sources_are_empty() -> None:


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
The AIBOM module previously could only anchor detections to digest-qualified image source keys that resolved to a concrete `:Image` node. That excluded users who scan source code repositories directly or use non-ECR registries.

This PR adds support for anchoring AIBOM detections to code repositories already in the graph:

- `(:AIBOMComponent)-[:DETECTED_IN]->(:GitHubRepository)`
- `(:AIBOMComponent)-[:DETECTED_IN]->(:GitLabProject)`
- `(:AIBOMSource)-[:SCANNED_REPOSITORY]->(:GitHubRepository | :GitLabProject)`

A source key is now classified by shape. Digest-qualified keys (`<uri>@sha256:<hex>`) resolve to `:Image` as before. Any other source key is treated as a code-repository URI and matched against an existing `GitHubRepository.url` or `GitLabProject.web_url`. The same URI is offered to both matchers, so only the repository type actually present in the graph receives an edge.

Report validation now accepts repo-anchored source keys and fails clearly when a key resolves to neither a concrete image nor a known repository, preserving the all-or-nothing ingestion contract.

Note on the matcher field: the issue suggested matching `GitLabProject.id`, but that is the stable numeric project ID and can never equal a repo URL. This PR matches `GitLabProject.web_url` instead, consistent with the existing GitLab `PACKAGED_FROM` matchlinks and the `CodeRepository` ontology mapping (which maps `url` to `web_url`).


### Related issues or links

- Closes #2477


### How was this tested?
- `make test_lint` passes locally (black, flake8, mypy, isort).
- Full unit suite passes (`uv run pytest tests/unit`, 2623 passed).
- AIBOM unit and integration suites pass, including two new integration tests that seed a `GitHubRepository` / `GitLabProject` node and assert `DETECTED_IN` and `SCANNED_REPOSITORY` edges are created from a repo-anchored report.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).


### Notes for reviewers
The same resolved URI is intentionally written to both `github_repo_urls` and `gitlab_project_urls` payload fields; the `one_to_many` matchers only create an edge to nodes that exist, so there is no risk of cross-linking a GitHub URL to a GitLab project or vice versa.