### PR TITLE
Add public_snapshots rule: detect publicly shared EBS/RDS snapshots and AMIs

### DIFF
--- a/cartography/rules/data/rules/__init__.py
+++ b/cartography/rules/data/rules/__init__.py
@@ -230,6 +230,7 @@ from cartography.rules.data.rules.object_storage_public import object_storage_pu
 from cartography.rules.data.rules.policy_administration_privileges import (
     policy_administration_privileges,
 )
+from cartography.rules.data.rules.public_snapshots import public_snapshots
 from cartography.rules.data.rules.serverless_workload_exposed import (
     serverless_workload_exposed,
 )
@@ -305,6 +306,7 @@ RULES = {
     missing_mfa_rule.id: missing_mfa_rule,
     object_storage_public.id: object_storage_public,
     policy_administration_privileges.id: policy_administration_privileges,
+    public_snapshots.id: public_snapshots,
     tailscale_tailnet_approval_disabled.id: tailscale_tailnet_approval_disabled,
     tailscale_network_flow_logging_disabled.id: tailscale_network_flow_logging_disabled,
     tailscale_device_auto_updates_disabled.id: tailscale_device_auto_updates_disabled,

--- a/cartography/rules/data/rules/public_snapshots.py
+++ b/cartography/rules/data/rules/public_snapshots.py
@@ -80,6 +80,44 @@ _aws_rds_snapshot_public = Fact(
 )
 
 
+_aws_ami_public = Fact(
+    id="aws_ami_public",
+    name="Publicly Shared AMIs",
+    description=(
+        "AWS AMIs (machine images) shared publicly. A public AMI can be "
+        "launched by any AWS account, exposing the full contents of every "
+        "disk baked into the image (including any secrets or data left on "
+        "the root volume)."
+    ),
+    cypher_query="""
+    MATCH (a:AWSAccount)-[:RESOURCE]->(i:EC2Image)
+    WHERE i.ispublic = true
+    RETURN
+        i.id AS id,
+        i.imageid AS arn,
+        i.name AS source_identifier,
+        null AS encrypted,
+        i.region AS region,
+        a.id AS account_id,
+        a.name AS account,
+        'EC2Image' AS resource_type
+    """,
+    cypher_visual_query="""
+    MATCH p=(a:AWSAccount)-[:RESOURCE]->(i:EC2Image)
+    WHERE i.ispublic = true
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (i:EC2Image)
+    RETURN COUNT(i) AS count
+    """,
+    asset_id_field="id",
+    identity_fields=("id",),
+    module=Module.AWS,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
 # Rule
 class PublicSnapshots(Finding):
     id: str | None = None
@@ -96,14 +134,16 @@ public_snapshots = Rule(
     id="public_snapshots",
     name="Publicly Accessible Snapshots",
     description=(
-        "EBS and RDS snapshots shared publicly, allowing any AWS account to "
-        "copy or restore an entire volume or database. This is a classic "
-        "data-exfiltration path that bypasses bucket and network controls."
+        "EBS snapshots, RDS snapshots, and AMIs shared publicly, allowing any "
+        "AWS account to copy or restore an entire volume, database, or machine "
+        "image. This is a classic data-exfiltration path that bypasses bucket "
+        "and network controls."
     ),
     output_model=PublicSnapshots,
     facts=(
         _aws_ebs_snapshot_public,
         _aws_rds_snapshot_public,
+        _aws_ami_public,
     ),
     tags=(
         "infrastructure",

--- a/cartography/rules/data/rules/public_snapshots.py
+++ b/cartography/rules/data/rules/public_snapshots.py
@@ -1,0 +1,116 @@
+from cartography.rules.data.frameworks.iso27001 import iso27001_annex_a
+from cartography.rules.spec.model import Fact
+from cartography.rules.spec.model import Finding
+from cartography.rules.spec.model import Maturity
+from cartography.rules.spec.model import Module
+from cartography.rules.spec.model import Rule
+
+# AWS Facts
+_aws_ebs_snapshot_public = Fact(
+    id="aws_ebs_snapshot_public",
+    name="Publicly Shared EBS Snapshots",
+    description=(
+        "AWS EBS snapshots shared publicly. A public snapshot can be copied "
+        "or restored into a volume by any AWS account, exposing the full "
+        "contents of the source volume to anyone."
+    ),
+    cypher_query="""
+    MATCH (a:AWSAccount)-[:RESOURCE]->(s:EBSSnapshot)
+    WHERE s.ispublic = true
+    RETURN
+        s.id AS id,
+        s.id AS arn,
+        s.volumeid AS source_identifier,
+        s.encrypted AS encrypted,
+        s.region AS region,
+        a.id AS account_id,
+        a.name AS account,
+        'EBSSnapshot' AS resource_type
+    """,
+    cypher_visual_query="""
+    MATCH p=(a:AWSAccount)-[:RESOURCE]->(s:EBSSnapshot)
+    WHERE s.ispublic = true
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (s:EBSSnapshot)
+    RETURN COUNT(s) AS count
+    """,
+    asset_id_field="id",
+    identity_fields=("id",),
+    module=Module.AWS,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+_aws_rds_snapshot_public = Fact(
+    id="aws_rds_snapshot_public",
+    name="Publicly Shared RDS Snapshots",
+    description=(
+        "AWS RDS snapshots shared publicly. A public snapshot can be copied "
+        "or restored into a database by any AWS account, exposing the full "
+        "contents of the source database to anyone."
+    ),
+    cypher_query="""
+    MATCH (a:AWSAccount)-[:RESOURCE]->(s:RDSSnapshot)
+    WHERE s.ispublic = true
+    RETURN
+        s.db_snapshot_identifier AS id,
+        s.arn AS arn,
+        s.db_instance_identifier AS source_identifier,
+        s.encrypted AS encrypted,
+        s.region AS region,
+        a.id AS account_id,
+        a.name AS account,
+        'RDSSnapshot' AS resource_type
+    """,
+    cypher_visual_query="""
+    MATCH p=(a:AWSAccount)-[:RESOURCE]->(s:RDSSnapshot)
+    WHERE s.ispublic = true
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (s:RDSSnapshot)
+    RETURN COUNT(s) AS count
+    """,
+    asset_id_field="arn",
+    identity_fields=("arn",),
+    module=Module.AWS,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+# Rule
+class PublicSnapshots(Finding):
+    id: str | None = None
+    arn: str | None = None
+    source_identifier: str | None = None
+    encrypted: bool | None = None
+    region: str | None = None
+    account_id: str | None = None
+    account: str | None = None
+    resource_type: str | None = None
+
+
+public_snapshots = Rule(
+    id="public_snapshots",
+    name="Publicly Accessible Snapshots",
+    description=(
+        "EBS and RDS snapshots shared publicly, allowing any AWS account to "
+        "copy or restore an entire volume or database. This is a classic "
+        "data-exfiltration path that bypasses bucket and network controls."
+    ),
+    output_model=PublicSnapshots,
+    facts=(
+        _aws_ebs_snapshot_public,
+        _aws_rds_snapshot_public,
+    ),
+    tags=(
+        "infrastructure",
+        "data",
+        "attack_surface",
+        "stride:information_disclosure",
+    ),
+    version="0.1.0",
+    frameworks=(iso27001_annex_a("8.3"),),
+)

--- a/cartography/rules/data/rules/public_snapshots.py
+++ b/cartography/rules/data/rules/public_snapshots.py
@@ -84,14 +84,19 @@ _aws_ami_public = Fact(
     id="aws_ami_public",
     name="Publicly Shared AMIs",
     description=(
-        "AWS AMIs (machine images) shared publicly. A public AMI can be "
-        "launched by any AWS account, exposing the full contents of every "
-        "disk baked into the image (including any secrets or data left on "
-        "the root volume)."
+        "AWS AMIs (machine images) owned by the account and shared publicly. "
+        "A public AMI can be launched by any AWS account, exposing the full "
+        "contents of every disk baked into the image (including any secrets "
+        "or data left on the root volume). The ownership filter (i.owner = "
+        "a.id) is required because EC2 image ingestion also attaches "
+        "third-party public AMIs referenced by instances/launch templates to "
+        "the syncing account; those are in use, not owned, and must not be "
+        "flagged."
     ),
     cypher_query="""
     MATCH (a:AWSAccount)-[:RESOURCE]->(i:EC2Image)
     WHERE i.ispublic = true
+      AND i.owner = a.id
     RETURN
         i.id AS id,
         i.imageid AS arn,
@@ -105,10 +110,12 @@ _aws_ami_public = Fact(
     cypher_visual_query="""
     MATCH p=(a:AWSAccount)-[:RESOURCE]->(i:EC2Image)
     WHERE i.ispublic = true
+      AND i.owner = a.id
     RETURN *
     """,
     cypher_count_query="""
-    MATCH (i:EC2Image)
+    MATCH (a:AWSAccount)-[:RESOURCE]->(i:EC2Image)
+    WHERE i.owner = a.id
     RETURN COUNT(i) AS count
     """,
     asset_id_field="id",


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary

Adds a new security rule `public_snapshots` under `cartography/rules/data/rules/` that flags AWS resources shared publicly (restorable, copyable, or launchable by any AWS account). A public snapshot or image lets any AWS principal copy an entire volume or database, or launch a full machine image, a classic data-exfiltration path that bypasses bucket and network controls.

The rule is composed of three AWS Facts, consistent with the existing "one concept, provider-specific Facts" pattern:

- `aws_ebs_snapshot_public` — `(:AWSAccount)-[:RESOURCE]->(:EBSSnapshot) WHERE s.ispublic = true`
- `aws_rds_snapshot_public` — `(:AWSAccount)-[:RESOURCE]->(:RDSSnapshot) WHERE s.ispublic = true`
- `aws_ami_public` — `(:AWSAccount)-[:RESOURCE]->(:EC2Image) WHERE i.ispublic = true AND i.owner = a.id`

All three properties (`ispublic`) are already populated during sync, so this is a rule-only change with no datamodel or intel work.

The AMI fact filters on `i.owner = a.id` on purpose: EC2 image ingestion also attaches third-party public AMIs (referenced by instances/launch templates) to the syncing account via the same `RESOURCE` edge, so without the ownership filter an account would be flagged for AMIs it merely *uses*. EBS (`OwnerIds=["self"]`) and RDS (owned-only default) ingestion are not affected.

### Related issues or links

- Closes #2876

### How was this tested?

- `make test_lint` passes locally (black, isort, flake8, mypy, pyupgrade clean on the changed files).
- `tests/unit/rules/` passes (1159 tests), including the parametrized identity-field and model validation that runs against every registered rule.
- `cartography-rules list public_snapshots` renders the rule with its three Facts.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests. (Covered by the parametrized rule-registry validation suite, which now exercises the new rule and its facts.)

### Notes for reviewers

The issue scoped this to EBS + RDS snapshots. AMIs were added because they carry identical `ispublic` data-exposure semantics with no extra datamodel work; the ownership filter is the one subtlety worth a close look.
