### PR TITLE
feat(rules): detect IAM roles trusting unsynced AWS accounts

### DIFF
--- a/cartography/rules/data/rules/__init__.py
+++ b/cartography/rules/data/rules/__init__.py
@@ -204,6 +204,9 @@ from cartography.rules.data.rules.device_security_posture_gaps import (
 )
 from cartography.rules.data.rules.eol_software import eol_software
 from cartography.rules.data.rules.guardduty_active_threat import guardduty_active_threat
+from cartography.rules.data.rules.iam_role_external_account_trust import (
+    iam_role_external_account_trust,
+)
 from cartography.rules.data.rules.identity_administration_privileges import (
     identity_administration_privileges,
 )
@@ -298,6 +301,7 @@ RULES = {
     delegation_boundary_modifiable.id: delegation_boundary_modifiable,
     device_security_posture_gaps.id: device_security_posture_gaps,
     eol_software.id: eol_software,
+    iam_role_external_account_trust.id: iam_role_external_account_trust,
     identity_administration_privileges.id: identity_administration_privileges,
     identity_mfa_gaps.id: identity_mfa_gaps,
     inactive_user_active_accounts.id: inactive_user_active_accounts,

--- a/cartography/rules/data/rules/iam_role_external_account_trust.py
+++ b/cartography/rules/data/rules/iam_role_external_account_trust.py
@@ -1,0 +1,78 @@
+from cartography.rules.spec.model import Fact
+from cartography.rules.spec.model import Finding
+from cartography.rules.spec.model import Maturity
+from cartography.rules.spec.model import Module
+from cartography.rules.spec.model import Rule
+
+_aws_role_external_account_trust = Fact(
+    id="aws-role-external-account-trust",
+    name="IAM roles trusting AWS accounts not synced by Cartography",
+    description=(
+        "AWS IAM roles in a synced account whose trust policy allows assumption "
+        "by a principal belonging to an AWS account that Cartography does not "
+        "sync. Accounts actually in the sync scope carry `inscope = true`; stub "
+        "accounts materialized from trust-policy parsing do not, so anything "
+        "without it is treated as external. "
+        "Scope note: this covers account-wide trusts (`arn:aws:iam::<acct>:root`), "
+        "for which the sync materializes a stub external AWSAccount and root "
+        "AWSPrincipal linked by `[:RESOURCE]`. Trusts toward a named principal in "
+        "an unsynced account (e.g. `:role/X`, `:user/Y`) are not surfaced because "
+        "the sync does not materialize that principal or its owning account."
+    ),
+    cypher_query="""
+    MATCH (a:AWSAccount {inscope: true})-[:RESOURCE]->(role:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(p:AWSPrincipal)
+    MATCH (ext:AWSAccount)-[:RESOURCE]->(p)
+    WHERE coalesce(ext.inscope, false) <> true
+    RETURN
+        role.arn AS role_arn,
+        role.name AS role_name,
+        a.id AS account_id,
+        ext.id AS external_account_id,
+        p.arn AS trusted_principal_arn
+    ORDER BY account_id, role_arn, external_account_id
+    """,
+    cypher_visual_query="""
+    MATCH p1 = (a:AWSAccount {inscope: true})-[:RESOURCE]->(role:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(p:AWSPrincipal)
+    MATCH p2 = (ext:AWSAccount)-[:RESOURCE]->(p)
+    WHERE coalesce(ext.inscope, false) <> true
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (:AWSAccount {inscope: true})-[:RESOURCE]->(role:AWSRole)
+    RETURN COUNT(role) AS count
+    """,
+    asset_id_field="role_arn",
+    identity_fields=("role_arn", "trusted_principal_arn"),
+    module=Module.AWS,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
+class IamRoleExternalAccountTrust(Finding):
+    role_arn: str | None = None
+    role_name: str | None = None
+    account_id: str | None = None
+    external_account_id: str | None = None
+    trusted_principal_arn: str | None = None
+
+
+iam_role_external_account_trust = Rule(
+    id="iam_role_external_account_trust",
+    name="IAM Role External Account Trust",
+    description=(
+        "Detects IAM roles in synced accounts that trust principals from AWS "
+        "accounts outside the sync perimeter. Such external trusts are a silent "
+        "lateral-movement and persistence vector, often left over from one-off "
+        "integrations or audits."
+    ),
+    output_model=IamRoleExternalAccountTrust,
+    facts=(_aws_role_external_account_trust,),
+    tags=(
+        "iam",
+        "attack_surface",
+        "aws",
+        "stride:elevation_of_privilege",
+        "stride:spoofing",
+    ),
+    version="0.1.0",
+)

--- a/tests/integration/rules/test_iam_role_external_account_trust.py
+++ b/tests/integration/rules/test_iam_role_external_account_trust.py
@@ -1,0 +1,65 @@
+from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.rules.data.rules.iam_role_external_account_trust import (
+    iam_role_external_account_trust,
+)
+
+
+def _reset_graph(neo4j_session) -> None:
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+
+
+def _get_fact():
+    return iam_role_external_account_trust.facts[0]
+
+
+def test_flags_roles_trusting_unsynced_accounts(neo4j_session) -> None:
+    """
+    A role in a synced account (`inscope = true`) trusting a principal owned by an
+    account that Cartography does not sync must be flagged. Trusts toward principals
+    in another in-scope account, or with no owning account, must not.
+    """
+    _reset_graph(neo4j_session)
+    neo4j_session.run(
+        """
+        CREATE (synced:AWSAccount {id: '111111111111', name: 'prod', inscope: true})
+        CREATE (synced2:AWSAccount {id: '222222222222', name: 'staging', inscope: true})
+        CREATE (external:AWSAccount {id: '999999999999'})
+
+        CREATE (role_external:AWSRole {
+            arn: 'arn:aws:iam::111111111111:role/trusts-external',
+            name: 'trusts-external'
+        })
+        CREATE (role_internal:AWSRole {
+            arn: 'arn:aws:iam::111111111111:role/trusts-internal',
+            name: 'trusts-internal'
+        })
+
+        CREATE (ext_principal:AWSPrincipal {arn: 'arn:aws:iam::999999999999:root'})
+        CREATE (int_principal:AWSPrincipal {arn: 'arn:aws:iam::222222222222:root'})
+
+        MERGE (synced)-[:RESOURCE]->(role_external)
+        MERGE (synced)-[:RESOURCE]->(role_internal)
+        MERGE (external)-[:RESOURCE]->(ext_principal)
+        MERGE (synced2)-[:RESOURCE]->(int_principal)
+        MERGE (role_external)-[:TRUSTS_AWS_PRINCIPAL]->(ext_principal)
+        MERGE (role_internal)-[:TRUSTS_AWS_PRINCIPAL]->(int_principal)
+        """
+    )
+
+    findings = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        _get_fact().cypher_query,
+    )
+
+    assert findings == [
+        {
+            "role_arn": "arn:aws:iam::111111111111:role/trusts-external",
+            "role_name": "trusts-external",
+            "account_id": "111111111111",
+            "external_account_id": "999999999999",
+            "trusted_principal_arn": "arn:aws:iam::999999999999:root",
+        }
+    ]
+
+    visual_rows = list(neo4j_session.run(_get_fact().cypher_visual_query))
+    assert len(visual_rows) == 1


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary
Adds a security rule `iam_role_external_account_trust` that flags `AWSRole` nodes in synced accounts whose trust policy allows assumption by an `AWSPrincipal` belonging to an AWS account that Cartography does not sync (external trust).

Detection keys off `AWSAccount.inscope` rather than parsing the account id out of the principal ARN: accounts actually in the sync scope carry `inscope = true`, while stub accounts materialized from trust-policy parsing do not. Anything without `inscope` is therefore treated as external, which is robust to multi-account-in-scope setups.

The sync already materializes `(:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal)` and stub external `AWSAccount` / root-principal nodes, so this is a rule-only change with no datamodel or intel work.

Output fields: role arn/name, role account id, external (unsynced) account id, trusted principal arn.

Scope note: this covers account-wide trusts (`arn:aws:iam::<acct>:root`), for which the sync materializes a stub external `AWSAccount` and root `AWSPrincipal` linked by `[:RESOURCE]`. Trusts toward a named principal in an unsynced account (e.g. `:role/X`, `:user/Y`) are not surfaced today because the sync does not materialize that principal or its owning account; that is a separate intel-level follow-up.

### Related issues or links
- Closes #2878

### How was this tested?
- New integration test `tests/integration/rules/test_iam_role_external_account_trust.py` verifying a role trusting an unsynced account is flagged while an in-scope cross-account trust is not (run against Neo4j, passing).
- Unit rule suites (`test_model.py`, `test_identity_fields.py`) pass with the new rule registered.
- `pre-commit` (black, isort, flake8, mypy, pyupgrade) passes on the changed files.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally.
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)