### PR TITLE
Implement CIS AWS IAM rules 2.3, 2.4, 2.15 (resolve stale TODOs)

### DIFF
--- a/cartography/rules/data/rules/__init__.py
+++ b/cartography/rules/data/rules/__init__.py
@@ -76,10 +76,13 @@ from cartography.rules.data.rules.cis_4_0_gcp import cis_gcp_6_7_cloudsql_backup
 from cartography.rules.data.rules.cis_4_0_gcp import cis_gcp_7_1_bigquery_dataset_public
 from cartography.rules.data.rules.cis_4_0_gcp import cis_gcp_7_2_bigquery_table_cmek
 from cartography.rules.data.rules.cis_4_0_gcp import cis_gcp_7_3_bigquery_dataset_cmek
+from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_3_root_access_key
+from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_4_root_mfa
 from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_11_unused_credentials
 from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_12_multiple_access_keys
 from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_13_access_key_not_rotated
 from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_14_user_direct_policies
+from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_15_admin_policy
 from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_18_expired_certificates
 from cartography.rules.data.rules.cis_aws_logging import (
     cis_aws_4_1_cloudtrail_multi_region,
@@ -265,10 +268,13 @@ from cartography.rules.data.rules.workload_identity_admin_capabilities import (
 # Rule registry - all available rules
 RULES = {
     # CIS AWS IAM Rules (Section 2)
+    cis_aws_2_3_root_access_key.id: cis_aws_2_3_root_access_key,
+    cis_aws_2_4_root_mfa.id: cis_aws_2_4_root_mfa,
     cis_aws_2_11_unused_credentials.id: cis_aws_2_11_unused_credentials,
     cis_aws_2_12_multiple_access_keys.id: cis_aws_2_12_multiple_access_keys,
     cis_aws_2_13_access_key_not_rotated.id: cis_aws_2_13_access_key_not_rotated,
     cis_aws_2_14_user_direct_policies.id: cis_aws_2_14_user_direct_policies,
+    cis_aws_2_15_admin_policy.id: cis_aws_2_15_admin_policy,
     cis_aws_2_18_expired_certificates.id: cis_aws_2_18_expired_certificates,
     # CIS AWS Storage Rules (Section 3)
     cis_aws_3_1_2_s3_mfa_delete.id: cis_aws_3_1_2_s3_mfa_delete,

--- a/cartography/rules/data/rules/cis_aws_iam.py
+++ b/cartography/rules/data/rules/cis_aws_iam.py
@@ -454,6 +454,7 @@ cis_aws_2_3_root_access_key = Rule(
     frameworks=(
         cis_aws("2.3"),
         iso27001_annex_a("8.2"),
+        iso27001_annex_a("5.17"),
     ),
 )
 
@@ -517,6 +518,7 @@ cis_aws_2_4_root_mfa = Rule(
     frameworks=(
         cis_aws("2.4"),
         iso27001_annex_a("8.5"),
+        iso27001_annex_a("8.2"),
     ),
 )
 
@@ -607,6 +609,7 @@ cis_aws_2_15_admin_policy = Rule(
     frameworks=(
         cis_aws("2.15"),
         iso27001_annex_a("8.2"),
+        iso27001_annex_a("5.18"),
     ),
 )
 

--- a/cartography/rules/data/rules/cis_aws_iam.py
+++ b/cartography/rules/data/rules/cis_aws_iam.py
@@ -431,6 +431,7 @@ _aws_root_access_key_present = Fact(
     """,
     cypher_count_query="""
     MATCH (a:AWSAccount)
+    WHERE a.account_access_keys_present IS NOT NULL
     RETURN COUNT(a) AS count
     """,
     identity_fields=("account_id",),
@@ -495,6 +496,7 @@ _aws_root_mfa_disabled = Fact(
     """,
     cypher_count_query="""
     MATCH (a:AWSAccount)
+    WHERE a.account_mfa_enabled IS NOT NULL
     RETURN COUNT(a) AS count
     """,
     identity_fields=("account_id",),

--- a/cartography/rules/data/rules/cis_aws_iam.py
+++ b/cartography/rules/data/rules/cis_aws_iam.py
@@ -588,8 +588,8 @@ _aws_admin_policy_attached = Fact(
     RETURN *
     """,
     cypher_count_query="""
-    MATCH (policy:AWSPolicy)
-    RETURN COUNT(policy) AS count
+    MATCH (:AWSPrincipal)-[:POLICY]->(policy:AWSPolicy)
+    RETURN COUNT(DISTINCT policy.id) AS count
     """,
     asset_id_field="policy_id",
     identity_fields=("policy_id", "principal_arn"),

--- a/cartography/rules/data/rules/cis_aws_iam.py
+++ b/cartography/rules/data/rules/cis_aws_iam.py
@@ -563,7 +563,7 @@ _aws_admin_policy_attached = Fact(
         "privilege and should be replaced with scoped permissions."
     ),
     cypher_query="""
-    MATCH (a:AWSAccount)-[:RESOURCE]->(principal:AWSPrincipal)<-[:POLICY]-(policy:AWSPolicy)-[:STATEMENT]->(stmt:AWSPolicyStatement)
+    MATCH (a:AWSAccount)-[:RESOURCE]->(principal:AWSPrincipal)-[:POLICY]->(policy:AWSPolicy)-[:STATEMENT]->(stmt:AWSPolicyStatement)
     WHERE stmt.effect = 'Allow'
       AND any(action IN stmt.action WHERE action = '*' OR action = '*:*')
       AND any(resource IN stmt.resource WHERE resource = '*')
@@ -576,7 +576,7 @@ _aws_admin_policy_attached = Fact(
         a.name AS account
     """,
     cypher_visual_query="""
-    MATCH p=(a:AWSAccount)-[:RESOURCE]->(principal:AWSPrincipal)<-[:POLICY]-(policy:AWSPolicy)-[:STATEMENT]->(stmt:AWSPolicyStatement)
+    MATCH p=(a:AWSAccount)-[:RESOURCE]->(principal:AWSPrincipal)-[:POLICY]->(policy:AWSPolicy)-[:STATEMENT]->(stmt:AWSPolicyStatement)
     WHERE stmt.effect = 'Allow'
       AND any(action IN stmt.action WHERE action = '*' OR action = '*:*')
       AND any(resource IN stmt.resource WHERE resource = '*')

--- a/cartography/rules/data/rules/cis_aws_iam.py
+++ b/cartography/rules/data/rules/cis_aws_iam.py
@@ -394,15 +394,131 @@ cis_aws_2_18_expired_certificates = Rule(
     ),
 )
 
-# =============================================================================
-# TODO: CIS AWS 2.3: No root user account access key exists
-# Missing datamodel or evidence: root account summary or credential report fields such as AccountAccessKeysPresent
-# =============================================================================
 
 # =============================================================================
-# TODO: CIS AWS 2.4: MFA is enabled for the root user account
-# Missing datamodel or evidence: root account summary fields such as AccountMFAEnabled and AccountPasswordPresent
+# CIS AWS 2.3: No root user account access key exists
+# Main node: AWSAccount
 # =============================================================================
+class RootAccessKeyOutput(Finding):
+    """Output model for the root access key check."""
+
+    account_id: str | None = None
+    account: str | None = None
+    account_access_keys_present: int | None = None
+
+
+_aws_root_access_key_present = Fact(
+    id="aws_root_access_key_present",
+    name="AWS account with a root user access key",
+    description=(
+        "Detects AWS accounts whose root user has an access key. Root access keys "
+        "grant unrestricted access to the account and cannot be scoped down, so they "
+        "should be removed entirely. The signal comes from the IAM account summary "
+        "field AccountAccessKeysPresent."
+    ),
+    cypher_query="""
+    MATCH (a:AWSAccount)
+    WHERE a.account_access_keys_present = 1
+    RETURN
+        a.id AS account_id,
+        a.name AS account,
+        a.account_access_keys_present AS account_access_keys_present
+    """,
+    cypher_visual_query="""
+    MATCH p=(a:AWSAccount)
+    WHERE a.account_access_keys_present = 1
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (a:AWSAccount)
+    RETURN COUNT(a) AS count
+    """,
+    identity_fields=("account_id",),
+    module=Module.AWS,
+    maturity=Maturity.STABLE,
+)
+
+cis_aws_2_3_root_access_key = Rule(
+    id="cis_aws_2_3_root_access_key",
+    name="CIS AWS 2.3: No Root User Access Key Exists",
+    description=(
+        "The root user should not have any access keys. Root access keys grant "
+        "unrestricted access to the account and cannot be scoped down, so they "
+        "should be removed entirely."
+    ),
+    output_model=RootAccessKeyOutput,
+    facts=(_aws_root_access_key_present,),
+    tags=("iam", "credentials", "root", "stride:elevation_of_privilege"),
+    version="1.0.0",
+    references=CIS_REFERENCES,
+    frameworks=(
+        cis_aws("2.3"),
+        iso27001_annex_a("8.2"),
+    ),
+)
+
+
+# =============================================================================
+# CIS AWS 2.4: MFA is enabled for the root user account
+# Main node: AWSAccount
+# =============================================================================
+class RootMfaDisabledOutput(Finding):
+    """Output model for the root MFA check."""
+
+    account_id: str | None = None
+    account: str | None = None
+    account_mfa_enabled: int | None = None
+
+
+_aws_root_mfa_disabled = Fact(
+    id="aws_root_mfa_disabled",
+    name="AWS account without MFA enabled for the root user",
+    description=(
+        "Detects AWS accounts where multi-factor authentication is not enabled for "
+        "the root user. The root user has unrestricted access, so it should always be "
+        "protected with MFA. The signal comes from the IAM account summary field "
+        "AccountMFAEnabled."
+    ),
+    cypher_query="""
+    MATCH (a:AWSAccount)
+    WHERE a.account_mfa_enabled = 0
+    RETURN
+        a.id AS account_id,
+        a.name AS account,
+        a.account_mfa_enabled AS account_mfa_enabled
+    """,
+    cypher_visual_query="""
+    MATCH p=(a:AWSAccount)
+    WHERE a.account_mfa_enabled = 0
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (a:AWSAccount)
+    RETURN COUNT(a) AS count
+    """,
+    identity_fields=("account_id",),
+    module=Module.AWS,
+    maturity=Maturity.STABLE,
+)
+
+cis_aws_2_4_root_mfa = Rule(
+    id="cis_aws_2_4_root_mfa",
+    name="CIS AWS 2.4: MFA Enabled For Root User",
+    description=(
+        "Multi-factor authentication should be enabled for the root user. The root "
+        "user has unrestricted access to the account, so it must always be protected "
+        "with an additional authentication factor."
+    ),
+    output_model=RootMfaDisabledOutput,
+    facts=(_aws_root_mfa_disabled,),
+    tags=("iam", "credentials", "root", "stride:spoofing"),
+    version="1.0.0",
+    references=CIS_REFERENCES,
+    frameworks=(
+        cis_aws("2.4"),
+        iso27001_annex_a("8.5"),
+    ),
+)
 
 # =============================================================================
 # TODO: CIS AWS 2.7: IAM password policy requires minimum length of 14 or greater
@@ -419,10 +535,80 @@ cis_aws_2_18_expired_certificates = Rule(
 # Missing datamodel or evidence: credential report fields for password_enabled and mfa_active on IAM users
 # =============================================================================
 
+
 # =============================================================================
-# TODO: CIS AWS 2.15: IAM policies that allow full *:* administrative privileges are not attached
-# Missing datamodel or evidence: parsed policy documents for managed and inline IAM policies, plus attachments to users, groups, and roles
+# CIS AWS 2.15: IAM policies that allow full *:* administrative privileges
+# Main node: AWSPolicy
 # =============================================================================
+class AdminPolicyAttachedOutput(Finding):
+    """Output model for the full administrative privileges check."""
+
+    policy_arn: str | None = None
+    policy_name: str | None = None
+    statement_sid: str | None = None
+    principal_arn: str | None = None
+    account_id: str | None = None
+    account: str | None = None
+
+
+_aws_admin_policy_attached = Fact(
+    id="aws_admin_policy_attached",
+    name="AWS IAM policy granting full administrative privileges",
+    description=(
+        "Detects IAM policies attached to a user, group, or role that grant full "
+        "'*:*' administrative privileges, i.e. an Allow statement whose action "
+        "includes '*' (or '*:*') on resource '*'. Such policies violate least "
+        "privilege and should be replaced with scoped permissions."
+    ),
+    cypher_query="""
+    MATCH (a:AWSAccount)-[:RESOURCE]->(principal:AWSPrincipal)<-[:POLICY]-(policy:AWSPolicy)-[:STATEMENT]->(stmt:AWSPolicyStatement)
+    WHERE stmt.effect = 'Allow'
+      AND any(action IN stmt.action WHERE action = '*' OR action = '*:*')
+      AND any(resource IN stmt.resource WHERE resource = '*')
+    RETURN DISTINCT
+        policy.arn AS policy_arn,
+        policy.name AS policy_name,
+        stmt.sid AS statement_sid,
+        principal.arn AS principal_arn,
+        a.id AS account_id,
+        a.name AS account
+    """,
+    cypher_visual_query="""
+    MATCH p=(a:AWSAccount)-[:RESOURCE]->(principal:AWSPrincipal)<-[:POLICY]-(policy:AWSPolicy)-[:STATEMENT]->(stmt:AWSPolicyStatement)
+    WHERE stmt.effect = 'Allow'
+      AND any(action IN stmt.action WHERE action = '*' OR action = '*:*')
+      AND any(resource IN stmt.resource WHERE resource = '*')
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (policy:AWSPolicy)
+    RETURN COUNT(policy) AS count
+    """,
+    asset_id_field="policy_arn",
+    identity_fields=("policy_arn", "principal_arn"),
+    module=Module.AWS,
+    maturity=Maturity.STABLE,
+)
+
+cis_aws_2_15_admin_policy = Rule(
+    id="cis_aws_2_15_admin_policy",
+    name="CIS AWS 2.15: No Full Administrative Privilege Policies Attached",
+    description=(
+        "IAM policies that allow full '*:*' administrative privileges should not be "
+        "attached to users, groups, or roles. Granting full administrative access "
+        "violates the principle of least privilege and broadens the blast radius of "
+        "a compromised identity."
+    ),
+    output_model=AdminPolicyAttachedOutput,
+    facts=(_aws_admin_policy_attached,),
+    tags=("iam", "policies", "stride:elevation_of_privilege"),
+    version="1.0.0",
+    references=CIS_REFERENCES,
+    frameworks=(
+        cis_aws("2.15"),
+        iso27001_annex_a("8.2"),
+    ),
+)
 
 # =============================================================================
 # TODO: CIS AWS 2.16: A support role has been created to manage incidents with AWS Support

--- a/cartography/rules/data/rules/cis_aws_iam.py
+++ b/cartography/rules/data/rules/cis_aws_iam.py
@@ -545,6 +545,7 @@ cis_aws_2_4_root_mfa = Rule(
 class AdminPolicyAttachedOutput(Finding):
     """Output model for the full administrative privileges check."""
 
+    policy_id: str | None = None
     policy_arn: str | None = None
     policy_name: str | None = None
     statement_sid: str | None = None
@@ -557,10 +558,11 @@ _aws_admin_policy_attached = Fact(
     id="aws_admin_policy_attached",
     name="AWS IAM policy granting full administrative privileges",
     description=(
-        "Detects IAM policies attached to a user, group, or role that grant full "
-        "'*:*' administrative privileges, i.e. an Allow statement whose action "
-        "includes '*' (or '*:*') on resource '*'. Such policies violate least "
-        "privilege and should be replaced with scoped permissions."
+        "Detects managed or inline IAM policies attached to a user, group, or role "
+        "that grant full '*:*' administrative privileges, i.e. an Allow statement "
+        "whose action includes '*' (or '*:*') on resource '*'. Such policies violate "
+        "least privilege and should be replaced with scoped permissions. Inline "
+        "policies have no ARN, so policy.id is used as the stable identifier."
     ),
     cypher_query="""
     MATCH (a:AWSAccount)-[:RESOURCE]->(principal:AWSPrincipal)-[:POLICY]->(policy:AWSPolicy)-[:STATEMENT]->(stmt:AWSPolicyStatement)
@@ -568,6 +570,7 @@ _aws_admin_policy_attached = Fact(
       AND any(action IN stmt.action WHERE action = '*' OR action = '*:*')
       AND any(resource IN stmt.resource WHERE resource = '*')
     RETURN DISTINCT
+        policy.id AS policy_id,
         policy.arn AS policy_arn,
         policy.name AS policy_name,
         stmt.sid AS statement_sid,
@@ -586,8 +589,8 @@ _aws_admin_policy_attached = Fact(
     MATCH (policy:AWSPolicy)
     RETURN COUNT(policy) AS count
     """,
-    asset_id_field="policy_arn",
-    identity_fields=("policy_arn", "principal_arn"),
+    asset_id_field="policy_id",
+    identity_fields=("policy_id", "principal_arn"),
     module=Module.AWS,
     maturity=Maturity.STABLE,
 )

--- a/tests/integration/rules/test_cis_aws_iam.py
+++ b/tests/integration/rules/test_cis_aws_iam.py
@@ -172,6 +172,20 @@ def test_admin_policy_flags_attached_full_admin_policies(neo4j_session) -> None:
             arn: null,
             name: 'AdminInline'
         })
+        // Managed policy nodes are global and survive cleanup even when no longer
+        // attached. An unattached admin policy must not be counted as evaluated.
+        CREATE (orphan_policy:AWSManagedPolicy:AWSPolicy {
+            id: 'arn:aws:iam::aws:policy/OrphanAdmin',
+            arn: 'arn:aws:iam::aws:policy/OrphanAdmin',
+            name: 'OrphanAdmin'
+        })
+        CREATE (orphan_stmt:AWSPolicyStatement {
+            id: 'arn:aws:iam::aws:policy/OrphanAdmin/statement/1',
+            effect: 'Allow',
+            action: ['*'],
+            resource: ['*'],
+            sid: 'OrphanAll'
+        })
         CREATE (admin_stmt:AWSPolicyStatement {
             id: 'arn:aws:iam::aws:policy/AdministratorAccess/statement/1',
             effect: 'Allow',
@@ -201,6 +215,7 @@ def test_admin_policy_flags_attached_full_admin_policies(neo4j_session) -> None:
         MERGE (admin_policy)-[:STATEMENT]->(admin_stmt)
         MERGE (scoped_policy)-[:STATEMENT]->(scoped_stmt)
         MERGE (inline_policy)-[:STATEMENT]->(inline_stmt)
+        MERGE (orphan_policy)-[:STATEMENT]->(orphan_stmt)
         """
     )
     fact = _get_fact(cis_aws_2_15_admin_policy)
@@ -208,6 +223,7 @@ def test_admin_policy_flags_attached_full_admin_policies(neo4j_session) -> None:
     # Act
     findings = neo4j_session.execute_read(read_list_of_dicts_tx, fact.cypher_query)
     visual_rows = list(neo4j_session.run(fact.cypher_visual_query))
+    count_rows = list(neo4j_session.run(fact.cypher_count_query))
 
     # Assert: both the managed and the inline admin policy are flagged, each with
     # a stable, non-null policy_id (the inline policy has no arn).
@@ -221,3 +237,6 @@ def test_admin_policy_flags_attached_full_admin_policies(neo4j_session) -> None:
     )
     assert inline_finding["policy_arn"] is None
     assert len(visual_rows) == 2
+    # Only attached policies are evaluated assets: admin + scoped + inline = 3.
+    # The unattached OrphanAdmin managed policy must be excluded.
+    assert count_rows[0]["count"] == 3

--- a/tests/integration/rules/test_cis_aws_iam.py
+++ b/tests/integration/rules/test_cis_aws_iam.py
@@ -103,10 +103,14 @@ def test_root_access_key_flags_accounts_with_root_keys(neo4j_session) -> None:
     # Act
     findings = neo4j_session.execute_read(read_list_of_dicts_tx, fact.cypher_query)
     visual_rows = list(neo4j_session.run(fact.cypher_visual_query))
+    count_rows = list(neo4j_session.run(fact.cypher_count_query))
 
     # Assert
     assert {row["account_id"] for row in findings} == {"111111111111"}
     assert len(visual_rows) == 1
+    # The 'unknown' account has no IAM summary data, so it must not be counted
+    # as an evaluated asset (otherwise it would be reported as passing).
+    assert count_rows[0]["count"] == 2
 
 
 def test_root_mfa_flags_accounts_without_root_mfa(neo4j_session) -> None:
@@ -124,10 +128,14 @@ def test_root_mfa_flags_accounts_without_root_mfa(neo4j_session) -> None:
     # Act
     findings = neo4j_session.execute_read(read_list_of_dicts_tx, fact.cypher_query)
     visual_rows = list(neo4j_session.run(fact.cypher_visual_query))
+    count_rows = list(neo4j_session.run(fact.cypher_count_query))
 
     # Assert
     assert {row["account_id"] for row in findings} == {"111111111111"}
     assert len(visual_rows) == 1
+    # The 'unknown' account has no IAM summary data, so it must not be counted
+    # as an evaluated asset (otherwise it would be reported as passing).
+    assert count_rows[0]["count"] == 2
 
 
 def test_admin_policy_flags_attached_full_admin_policies(neo4j_session) -> None:

--- a/tests/integration/rules/test_cis_aws_iam.py
+++ b/tests/integration/rules/test_cis_aws_iam.py
@@ -169,8 +169,8 @@ def test_admin_policy_flags_attached_full_admin_policies(neo4j_session) -> None:
         })
         MERGE (a)-[:RESOURCE]->(admin_user)
         MERGE (a)-[:RESOURCE]->(scoped_user)
-        MERGE (admin_user)<-[:POLICY]-(admin_policy)
-        MERGE (scoped_user)<-[:POLICY]-(scoped_policy)
+        MERGE (admin_user)-[:POLICY]->(admin_policy)
+        MERGE (scoped_user)-[:POLICY]->(scoped_policy)
         MERGE (admin_policy)-[:STATEMENT]->(admin_stmt)
         MERGE (scoped_policy)-[:STATEMENT]->(scoped_stmt)
         """

--- a/tests/integration/rules/test_cis_aws_iam.py
+++ b/tests/integration/rules/test_cis_aws_iam.py
@@ -144,6 +144,10 @@ def test_admin_policy_flags_attached_full_admin_policies(neo4j_session) -> None:
             arn: 'arn:aws:iam::111111111111:user/scoped',
             name: 'scoped'
         })
+        CREATE (inline_role:AWSRole:AWSPrincipal {
+            arn: 'arn:aws:iam::111111111111:role/inline-admin',
+            name: 'inline-admin'
+        })
         CREATE (admin_policy:AWSManagedPolicy:AWSPolicy {
             id: 'arn:aws:iam::aws:policy/AdministratorAccess',
             arn: 'arn:aws:iam::aws:policy/AdministratorAccess',
@@ -153,6 +157,12 @@ def test_admin_policy_flags_attached_full_admin_policies(neo4j_session) -> None:
             id: 'arn:aws:iam::111111111111:policy/ReadOnly',
             arn: 'arn:aws:iam::111111111111:policy/ReadOnly',
             name: 'ReadOnly'
+        })
+        // Inline policies are loaded with arn = null; policy.id is the only stable id.
+        CREATE (inline_policy:AWSInlinePolicy:AWSPolicy {
+            id: 'arn:aws:iam::111111111111:role/inline-admin/inline_policy/AdminInline',
+            arn: null,
+            name: 'AdminInline'
         })
         CREATE (admin_stmt:AWSPolicyStatement {
             id: 'arn:aws:iam::aws:policy/AdministratorAccess/statement/1',
@@ -167,12 +177,22 @@ def test_admin_policy_flags_attached_full_admin_policies(neo4j_session) -> None:
             action: ['s3:GetObject'],
             resource: ['*']
         })
+        CREATE (inline_stmt:AWSPolicyStatement {
+            id: 'arn:aws:iam::111111111111:role/inline-admin/inline_policy/AdminInline/statement/1',
+            effect: 'Allow',
+            action: ['*:*'],
+            resource: ['*'],
+            sid: 'InlineAdmin'
+        })
         MERGE (a)-[:RESOURCE]->(admin_user)
         MERGE (a)-[:RESOURCE]->(scoped_user)
+        MERGE (a)-[:RESOURCE]->(inline_role)
         MERGE (admin_user)-[:POLICY]->(admin_policy)
         MERGE (scoped_user)-[:POLICY]->(scoped_policy)
+        MERGE (inline_role)-[:POLICY]->(inline_policy)
         MERGE (admin_policy)-[:STATEMENT]->(admin_stmt)
         MERGE (scoped_policy)-[:STATEMENT]->(scoped_stmt)
+        MERGE (inline_policy)-[:STATEMENT]->(inline_stmt)
         """
     )
     fact = _get_fact(cis_aws_2_15_admin_policy)
@@ -181,8 +201,15 @@ def test_admin_policy_flags_attached_full_admin_policies(neo4j_session) -> None:
     findings = neo4j_session.execute_read(read_list_of_dicts_tx, fact.cypher_query)
     visual_rows = list(neo4j_session.run(fact.cypher_visual_query))
 
-    # Assert
-    assert {row["policy_arn"] for row in findings} == {
+    # Assert: both the managed and the inline admin policy are flagged, each with
+    # a stable, non-null policy_id (the inline policy has no arn).
+    assert {row["policy_id"] for row in findings} == {
         "arn:aws:iam::aws:policy/AdministratorAccess",
+        "arn:aws:iam::111111111111:role/inline-admin/inline_policy/AdminInline",
     }
-    assert len(visual_rows) == 1
+    assert all(row["policy_id"] is not None for row in findings)
+    inline_finding = next(
+        row for row in findings if row["policy_id"].endswith("AdminInline")
+    )
+    assert inline_finding["policy_arn"] is None
+    assert len(visual_rows) == 2

--- a/tests/integration/rules/test_cis_aws_iam.py
+++ b/tests/integration/rules/test_cis_aws_iam.py
@@ -1,6 +1,9 @@
 from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_3_root_access_key
+from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_4_root_mfa
 from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_11_unused_credentials
 from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_13_access_key_not_rotated
+from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_15_admin_policy
 
 
 def _reset_graph(neo4j_session) -> None:
@@ -83,3 +86,103 @@ def test_access_key_rules_parse_iso_datetime_strings_with_z(neo4j_session) -> No
     }
     assert len(rotation_visual_rows) == 3
     assert len(unused_visual_rows) == 2
+
+
+def test_root_access_key_flags_accounts_with_root_keys(neo4j_session) -> None:
+    # Arrange
+    _reset_graph(neo4j_session)
+    neo4j_session.run(
+        """
+        CREATE (:AWSAccount {id: '111111111111', name: 'has-root-key', account_access_keys_present: 1})
+        CREATE (:AWSAccount {id: '222222222222', name: 'no-root-key', account_access_keys_present: 0})
+        CREATE (:AWSAccount {id: '333333333333', name: 'unknown'})
+        """
+    )
+    fact = _get_fact(cis_aws_2_3_root_access_key)
+
+    # Act
+    findings = neo4j_session.execute_read(read_list_of_dicts_tx, fact.cypher_query)
+    visual_rows = list(neo4j_session.run(fact.cypher_visual_query))
+
+    # Assert
+    assert {row["account_id"] for row in findings} == {"111111111111"}
+    assert len(visual_rows) == 1
+
+
+def test_root_mfa_flags_accounts_without_root_mfa(neo4j_session) -> None:
+    # Arrange
+    _reset_graph(neo4j_session)
+    neo4j_session.run(
+        """
+        CREATE (:AWSAccount {id: '111111111111', name: 'mfa-off', account_mfa_enabled: 0})
+        CREATE (:AWSAccount {id: '222222222222', name: 'mfa-on', account_mfa_enabled: 1})
+        CREATE (:AWSAccount {id: '333333333333', name: 'unknown'})
+        """
+    )
+    fact = _get_fact(cis_aws_2_4_root_mfa)
+
+    # Act
+    findings = neo4j_session.execute_read(read_list_of_dicts_tx, fact.cypher_query)
+    visual_rows = list(neo4j_session.run(fact.cypher_visual_query))
+
+    # Assert
+    assert {row["account_id"] for row in findings} == {"111111111111"}
+    assert len(visual_rows) == 1
+
+
+def test_admin_policy_flags_attached_full_admin_policies(neo4j_session) -> None:
+    # Arrange
+    _reset_graph(neo4j_session)
+    neo4j_session.run(
+        """
+        CREATE (a:AWSAccount {id: '111111111111', name: 'prod'})
+        CREATE (admin_user:AWSUser:AWSPrincipal {
+            arn: 'arn:aws:iam::111111111111:user/admin',
+            name: 'admin'
+        })
+        CREATE (scoped_user:AWSUser:AWSPrincipal {
+            arn: 'arn:aws:iam::111111111111:user/scoped',
+            name: 'scoped'
+        })
+        CREATE (admin_policy:AWSManagedPolicy:AWSPolicy {
+            id: 'arn:aws:iam::aws:policy/AdministratorAccess',
+            arn: 'arn:aws:iam::aws:policy/AdministratorAccess',
+            name: 'AdministratorAccess'
+        })
+        CREATE (scoped_policy:AWSManagedPolicy:AWSPolicy {
+            id: 'arn:aws:iam::111111111111:policy/ReadOnly',
+            arn: 'arn:aws:iam::111111111111:policy/ReadOnly',
+            name: 'ReadOnly'
+        })
+        CREATE (admin_stmt:AWSPolicyStatement {
+            id: 'arn:aws:iam::aws:policy/AdministratorAccess/statement/1',
+            effect: 'Allow',
+            action: ['*'],
+            resource: ['*'],
+            sid: 'AdminAll'
+        })
+        CREATE (scoped_stmt:AWSPolicyStatement {
+            id: 'arn:aws:iam::111111111111:policy/ReadOnly/statement/1',
+            effect: 'Allow',
+            action: ['s3:GetObject'],
+            resource: ['*']
+        })
+        MERGE (a)-[:RESOURCE]->(admin_user)
+        MERGE (a)-[:RESOURCE]->(scoped_user)
+        MERGE (admin_user)<-[:POLICY]-(admin_policy)
+        MERGE (scoped_user)<-[:POLICY]-(scoped_policy)
+        MERGE (admin_policy)-[:STATEMENT]->(admin_stmt)
+        MERGE (scoped_policy)-[:STATEMENT]->(scoped_stmt)
+        """
+    )
+    fact = _get_fact(cis_aws_2_15_admin_policy)
+
+    # Act
+    findings = neo4j_session.execute_read(read_list_of_dicts_tx, fact.cypher_query)
+    visual_rows = list(neo4j_session.run(fact.cypher_visual_query))
+
+    # Assert
+    assert {row["policy_arn"] for row in findings} == {
+        "arn:aws:iam::aws:policy/AdministratorAccess",
+    }
+    assert len(visual_rows) == 1

--- a/tests/unit/rules/test_cis_aws.py
+++ b/tests/unit/rules/test_cis_aws.py
@@ -224,13 +224,13 @@ class TestIso27001AwsMappings:
     """Test that batch 1 AWS rules have expected ISO 27001 Annex A mappings."""
 
     EXPECTED_REQUIREMENTS = {
-        "cis_aws_2_3_root_access_key": {"8.2"},
-        "cis_aws_2_4_root_mfa": {"8.5"},
+        "cis_aws_2_3_root_access_key": {"8.2", "5.17"},
+        "cis_aws_2_4_root_mfa": {"8.5", "8.2"},
         "cis_aws_2_11_unused_credentials": {"5.18"},
         "cis_aws_2_12_multiple_access_keys": {"5.17"},
         "cis_aws_2_13_access_key_not_rotated": {"5.17"},
         "cis_aws_2_14_user_direct_policies": {"5.18"},
-        "cis_aws_2_15_admin_policy": {"8.2"},
+        "cis_aws_2_15_admin_policy": {"8.2", "5.18"},
         "cis_aws_2_18_expired_certificates": {"8.24"},
         "cis_aws_3_1_2_s3_mfa_delete": {"8.10"},
         "cis_aws_3_1_4_s3_block_public_access": {"8.3"},

--- a/tests/unit/rules/test_cis_aws.py
+++ b/tests/unit/rules/test_cis_aws.py
@@ -7,10 +7,13 @@ current AWS CIS v6.0.0 requirement numbering used by Cartography.
 
 import pytest
 
+from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_3_root_access_key
+from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_4_root_mfa
 from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_11_unused_credentials
 from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_12_multiple_access_keys
 from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_13_access_key_not_rotated
 from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_14_user_direct_policies
+from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_15_admin_policy
 from cartography.rules.data.rules.cis_aws_iam import cis_aws_2_18_expired_certificates
 from cartography.rules.data.rules.cis_aws_logging import (
     cis_aws_4_1_cloudtrail_multi_region,
@@ -47,10 +50,13 @@ from cartography.rules.spec.model import Maturity
 from cartography.rules.spec.model import Module
 
 ALL_CIS_AWS_RULES = [
+    cis_aws_2_3_root_access_key,
+    cis_aws_2_4_root_mfa,
     cis_aws_2_11_unused_credentials,
     cis_aws_2_12_multiple_access_keys,
     cis_aws_2_13_access_key_not_rotated,
     cis_aws_2_14_user_direct_policies,
+    cis_aws_2_15_admin_policy,
     cis_aws_2_18_expired_certificates,
     cis_aws_3_1_2_s3_mfa_delete,
     cis_aws_3_1_4_s3_block_public_access,
@@ -176,10 +182,13 @@ class TestCisAwsRuleIds:
     """Test that AWS CIS rule ids and framework requirements stay aligned."""
 
     EXPECTED_RULES = {
+        "cis_aws_2_3_root_access_key": "2.3",
+        "cis_aws_2_4_root_mfa": "2.4",
         "cis_aws_2_11_unused_credentials": "2.11",
         "cis_aws_2_12_multiple_access_keys": "2.12",
         "cis_aws_2_13_access_key_not_rotated": "2.13",
         "cis_aws_2_14_user_direct_policies": "2.14",
+        "cis_aws_2_15_admin_policy": "2.15",
         "cis_aws_2_18_expired_certificates": "2.18",
         "cis_aws_3_1_2_s3_mfa_delete": "3.1.2",
         "cis_aws_3_1_4_s3_block_public_access": "3.1.4",
@@ -215,10 +224,13 @@ class TestIso27001AwsMappings:
     """Test that batch 1 AWS rules have expected ISO 27001 Annex A mappings."""
 
     EXPECTED_REQUIREMENTS = {
+        "cis_aws_2_3_root_access_key": {"8.2"},
+        "cis_aws_2_4_root_mfa": {"8.5"},
         "cis_aws_2_11_unused_credentials": {"5.18"},
         "cis_aws_2_12_multiple_access_keys": {"5.17"},
         "cis_aws_2_13_access_key_not_rotated": {"5.17"},
         "cis_aws_2_14_user_direct_policies": {"5.18"},
+        "cis_aws_2_15_admin_policy": {"8.2"},
         "cis_aws_2_18_expired_certificates": {"8.24"},
         "cis_aws_3_1_2_s3_mfa_delete": {"8.10"},
         "cis_aws_3_1_4_s3_block_public_access": {"8.3"},


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
Implements three CIS AWS Foundations Benchmark v6.0.0 IAM controls whose
`TODO: Missing datamodel or evidence` blocks in
`cartography/rules/data/rules/cis_aws_iam.py` were stale: the required data is
already collected. The TODOs are removed and replaced with working rules.

- **CIS AWS 2.3** (no root user access key exists): flags `AWSAccount` nodes where
  `account_access_keys_present = 1` (from the `AWSAccountSummary` composite node).
- **CIS AWS 2.4** (MFA enabled for the root user): flags `AWSAccount` nodes where
  `account_mfa_enabled = 0`.
- **CIS AWS 2.15** (no IAM policy grants full `*:*` admin privileges): flags
  `AWSPolicy` nodes attached to a principal via
  `(:AWSAccount)-[:RESOURCE]->(:AWSPrincipal)-[:POLICY]->(:AWSPolicy)-[:STATEMENT]->(:AWSPolicyStatement)`
  with an `Allow` statement granting action `*`/`*:*` on resource `*`.

Each rule maps to its CIS AWS v6.0.0 requirement plus relevant ISO/IEC 27001:2022
Annex A controls (2.3 -> 8.2, 5.17; 2.4 -> 8.5, 8.2; 2.15 -> 8.2, 5.18).

Implementation notes worth flagging for review:
- **2.15 edge direction**: uses `(:AWSPrincipal)-[:POLICY]->(:AWSPolicy)`, matching
  the IAM ingestion contract (`LinkDirection.INWARD` on the policy schemas).
- **2.15 inline policies**: inline policies are loaded with `arn = null`, so the rule
  returns `policy.id` as the stable identifier (`asset_id_field` / `identity_fields`),
  keeping `policy.arn` for display.
- **Accurate passing counts**: count queries are scoped so non-evaluated assets are not
  reported as passing. 2.3/2.4 count only accounts with observed summary fields
  (`<field> IS NOT NULL`); 2.15 counts only distinct policies actually attached to a
  principal (managed policy nodes are global and survive cleanup).

No new data collection is introduced.


### Related issues or links

- Fixes #2877


### How was this tested?
- `make test_lint` passes locally (pre-commit: black, isort, flake8, mypy, etc.).
- Unit tests updated in `tests/unit/rules/test_cis_aws.py` (rule registration, id
  <-> CIS requirement mapping, ISO 27001 mappings).
- Integration tests added in `tests/integration/rules/test_cis_aws_iam.py` exercising
  each Fact query (and count query) against a seeded Neo4j graph, including:
  - 2.3/2.4: an account lacking IAM summary data is excluded from both findings and
    the evaluated count.
  - 2.15: an attached managed admin policy and an attached inline admin policy
    (`arn = null`) are flagged with a non-null `policy_id`; a scoped policy and an
    unattached managed admin policy are excluded from findings and the count.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
This PR does not add or modify any node or relationship schema; it only adds security
rules that query existing data, so the schema docs are unaffected.
