### PR TITLE
fix(aws): correct AWSTag region handling for tag matching (#1094, #1137)

### DIFF
--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -104,6 +104,9 @@ def get_resource_type_from_arn(arn: str) -> str:
 # id_func: [optional] - EC2 instances and S3 buckets in cartography currently use non-ARNs as their primary identifiers
 # so we need to supply a function pointer to translate the ARN returned by the resourcegroupstaggingapi to the form that
 # cartography uses.
+# region_property: [optional] - the node property holding the resource's region. When present, the tag MATCH is scoped to
+# the synced region so that same-named resources in different regions (e.g. load balancers keyed by name) are not
+# cross-tagged.
 # TODO - we should make EC2 and S3 assets query-able by their full ARN so that we don't need this workaround.
 TAG_RESOURCE_TYPE_MAPPINGS: Dict = {
     "autoscaling:autoScalingGroup": {"label": "AutoScalingGroup", "property": "arn"},
@@ -162,20 +165,27 @@ TAG_RESOURCE_TYPE_MAPPINGS: Dict = {
     "ecs:task-definition": {"label": "ECSTaskDefinition", "property": "id"},
     "eks:cluster": {"label": "EKSCluster", "property": "id"},
     "elasticache:cluster": {"label": "ElasticacheCluster", "property": "arn"},
+    # Match on the classic ELB's own label (AWSLoadBalancer), not the shared
+    # "LoadBalancer" ontology label, which is also attached to AWSLoadBalancerV2
+    # nodes. Otherwise a classic ELB tag would bleed onto an ALB/NLB of the same
+    # name in the same region.
     "elasticloadbalancing:loadbalancer": {
-        "label": "LoadBalancer",
+        "label": "AWSLoadBalancer",
         "property": "name",
         "id_func": get_short_id_from_elb_arn,
+        "region_property": "region",
     },
     "elasticloadbalancing:loadbalancer/app": {
         "label": "AWSLoadBalancerV2",
         "property": "name",
         "id_func": get_short_id_from_lb2_arn,
+        "region_property": "region",
     },
     "elasticloadbalancing:loadbalancer/net": {
         "label": "AWSLoadBalancerV2",
         "property": "name",
         "id_func": get_short_id_from_lb2_arn,
+        "region_property": "region",
     },
     "elasticmapreduce:cluster": {"label": "EMRCluster", "property": "arn"},
     "es:domain": {"label": "ESDomain", "property": "arn"},
@@ -221,20 +231,13 @@ def get_tags(
     return resources
 
 
-def _load_tags_tx(
-    tx: neo4j.Transaction,
-    tag_data: Dict,
-    resource_type: str,
-    region: str,
-    current_aws_account_id: str,
-    aws_update_tag: int,
-) -> None:
-    INGEST_TAG_TEMPLATE = Template(
-        """
+INGEST_TAG_TEMPLATE = Template(
+    """
     UNWIND $TagData as tag_mapping
         UNWIND tag_mapping.Tags as input_tag
             MATCH
             (a:AWSAccount{id:$Account})-[res:RESOURCE]->(resource:$resource_label{$property:tag_mapping.resource_id})
+            $region_filter
             MERGE
             (aws_tag:AWSTag:Tag{id:input_tag.Key + ":" + input_tag.Value})
             ON CREATE SET aws_tag.firstseen = timestamp()
@@ -247,14 +250,41 @@ def _load_tags_tx(
             SET r.lastupdated = $UpdateTag,
             r.firstseen = timestamp()
     """,
+)
+
+
+def _build_ingest_tag_query(resource_type: str) -> str:
+    """Build the tag ingestion Cypher for a resource type.
+
+    Region-scoped resource types (those with a ``region_property`` mapping) get a
+    ``WHERE resource.<prop> = $Region`` predicate so that same-named resources in
+    different regions are not cross-tagged. The injected ``$Region`` is not
+    re-scanned by ``safe_substitute`` and is bound as a normal Cypher parameter.
+    """
+    mapping = TAG_RESOURCE_TYPE_MAPPINGS[resource_type]
+    region_property = mapping.get("region_property")
+    region_filter = (
+        f"WHERE resource.{region_property} = $Region" if region_property else ""
     )
+    return INGEST_TAG_TEMPLATE.safe_substitute(
+        resource_label=mapping["label"],
+        property=mapping["property"],
+        region_filter=region_filter,
+    )
+
+
+def _load_tags_tx(
+    tx: neo4j.Transaction,
+    tag_data: Dict,
+    resource_type: str,
+    region: str,
+    current_aws_account_id: str,
+    aws_update_tag: int,
+) -> None:
     if not tag_data:
         return
 
-    query = INGEST_TAG_TEMPLATE.safe_substitute(
-        resource_label=TAG_RESOURCE_TYPE_MAPPINGS[resource_type]["label"],
-        property=TAG_RESOURCE_TYPE_MAPPINGS[resource_type]["property"],
-    )
+    query = _build_ingest_tag_query(resource_type)
     tx.run(
         query,
         TagData=tag_data,

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -21,9 +21,9 @@ stat_handler = get_stats_client(__name__)
 
 DEFAULT_CLEANUP_BATCH_SIZE = 1000
 
-# IAM is a global service, so its tags are not regional. We use a "global"
-# marker on the AWSTag.region property and fetch IAM tags once per sync rather
-# than once per region.
+# IAM is a global service, so its tags are not regional. We fetch IAM tags once
+# per sync rather than once per region, passing this marker as the region so the
+# IAM path skips the regional resource matching used for regional services.
 GLOBAL_REGION = "global"
 IAM_TAG_RESOURCE_TYPES = frozenset({"iam:role", "iam:user"})
 
@@ -241,8 +241,7 @@ def _load_tags_tx(
 
             SET aws_tag.lastupdated = $UpdateTag,
             aws_tag.key = input_tag.Key,
-            aws_tag.value =  input_tag.Value,
-            aws_tag.region = $Region
+            aws_tag.value =  input_tag.Value
 
             MERGE (resource)-[r:TAGGED]->(aws_tag)
             SET r.lastupdated = $UpdateTag,

--- a/cartography/models/aws/resourcegroupstaggingapi/tag.py
+++ b/cartography/models/aws/resourcegroupstaggingapi/tag.py
@@ -20,7 +20,6 @@ class AWSTagNodeProperties(CartographyNodeProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
     key: PropertyRef = PropertyRef("key", extra_index=True)
     value: PropertyRef = PropertyRef("value")
-    region: PropertyRef = PropertyRef("region", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1320,7 +1320,6 @@ Representation of an AWS [Tag](https://docs.aws.amazon.com/resourcegroupstagging
 | **id** | This tag's unique identifier of the format `{TagKey}:{TagValue}`. We fabricated this ID. |
 | key | One part of a key-value pair that makes up a tag.|
 | value | One part of a key-value pair that makes up a tag. |
-| region | The region where this tag was discovered.|
 
 #### Relationships
 -  AWS VPCs, DB Subnet Groups, EC2 Instances, EC2 SecurityGroups, EC2 Subnets, EC2 Network Interfaces, RDS Instances, S3 Buckets, AWS Roles, AWS Users, and AWS Groups can be tagged with AWSTags.

--- a/tests/data/aws/resourcegroupstaggingapi.py
+++ b/tests/data/aws/resourcegroupstaggingapi.py
@@ -48,3 +48,50 @@ GET_RESOURCES_RESPONSE_UPDATED = [
         ],
     },
 ]
+
+# Two classic load balancers with the SAME name in two different regions. The
+# classic LB tag mapping is keyed by the non-unique `name` property, so without
+# a region predicate the tagging API would cross-tag both LBs (issue #1137).
+SAME_NAME_LB = "my-lb"
+
+LOAD_BALANCERS_US_EAST_1 = [
+    {
+        "id": f"{SAME_NAME_LB}-us-east-1.elb.amazonaws.com",
+        "name": SAME_NAME_LB,
+        "dnsname": f"{SAME_NAME_LB}-us-east-1.elb.amazonaws.com",
+    },
+]
+
+LOAD_BALANCERS_US_WEST_2 = [
+    {
+        "id": f"{SAME_NAME_LB}-us-west-2.elb.amazonaws.com",
+        "name": SAME_NAME_LB,
+        "dnsname": f"{SAME_NAME_LB}-us-west-2.elb.amazonaws.com",
+    },
+]
+
+# Tagging API responses: the us-east-1 LB is tagged env:prod, the same-named
+# us-west-2 LB is tagged env:staging.
+GET_RESOURCES_RESPONSE_LB_US_EAST_1 = [
+    {
+        "ResourceARN": f"arn:aws:elasticloadbalancing:us-east-1:1234:loadbalancer/{SAME_NAME_LB}",
+        "Tags": [
+            {
+                "Key": "env",
+                "Value": "prod",
+            },
+        ],
+    },
+]
+
+GET_RESOURCES_RESPONSE_LB_US_WEST_2 = [
+    {
+        "ResourceARN": f"arn:aws:elasticloadbalancing:us-west-2:1234:loadbalancer/{SAME_NAME_LB}",
+        "Tags": [
+            {
+                "Key": "env",
+                "Value": "staging",
+            },
+        ],
+    },
+]

--- a/tests/integration/cartography/intel/aws/test_resourcegroupstaggingapi.py
+++ b/tests/integration/cartography/intel/aws/test_resourcegroupstaggingapi.py
@@ -5,9 +5,14 @@ from unittest.mock import patch
 import cartography.intel.aws.ec2.instances
 import cartography.intel.aws.resourcegroupstaggingapi as rgta
 from cartography.intel.aws.ec2.instances import sync_ec2_instances
+from cartography.intel.aws.ec2.load_balancers import load_load_balancers
 from cartography.intel.aws.resourcegroupstaggingapi import sync
 from tests.data.aws.ec2.instances import DESCRIBE_INSTANCES
 from tests.data.aws.resourcegroupstaggingapi import GET_RESOURCES_RESPONSE
+from tests.data.aws.resourcegroupstaggingapi import GET_RESOURCES_RESPONSE_LB_US_EAST_1
+from tests.data.aws.resourcegroupstaggingapi import GET_RESOURCES_RESPONSE_LB_US_WEST_2
+from tests.data.aws.resourcegroupstaggingapi import LOAD_BALANCERS_US_EAST_1
+from tests.data.aws.resourcegroupstaggingapi import LOAD_BALANCERS_US_WEST_2
 from tests.integration.cartography.intel.aws.common import create_test_account
 from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
@@ -84,3 +89,69 @@ def test_sync_tags(mock_get_tags, mock_get_instances, neo4j_session):
         "MATCH (n:AWSTag) RETURN keys(n) AS props",
     ).single()["props"]
     assert "region" not in region_props
+
+
+def test_sync_tags_scopes_to_correct_region(neo4j_session):
+    """
+    Regression test for #1137: two load balancers with the same name in two
+    different regions must each be tagged with only their own region's tags.
+    The classic LB tag mapping is keyed by the non-unique `name`, so before the
+    region predicate both LBs were cross-tagged.
+    """
+    # Arrange - account plus two same-named LBs in two regions
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    load_load_balancers(
+        neo4j_session,
+        LOAD_BALANCERS_US_EAST_1,
+        "us-east-1",
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+    load_load_balancers(
+        neo4j_session,
+        LOAD_BALANCERS_US_WEST_2,
+        "us-west-2",
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+    # Act - sync tags for both regions; each region returns its own tag data
+    tag_data_by_region = {
+        "us-east-1": GET_RESOURCES_RESPONSE_LB_US_EAST_1,
+        "us-west-2": GET_RESOURCES_RESPONSE_LB_US_WEST_2,
+    }
+
+    def fake_get_tags(_boto3_session, _resource_types, region):
+        return copy.deepcopy(tag_data_by_region[region])
+
+    test_mapping = {
+        "elasticloadbalancing:loadbalancer": rgta.TAG_RESOURCE_TYPE_MAPPINGS[
+            "elasticloadbalancing:loadbalancer"
+        ],
+    }
+    with patch.object(rgta, "get_tags", side_effect=fake_get_tags):
+        sync(
+            neo4j_session,
+            boto3_session,
+            ["us-east-1", "us-west-2"],
+            TEST_ACCOUNT_ID,
+            TEST_UPDATE_TAG,
+            {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
+            tag_resource_type_mappings=test_mapping,
+        )
+
+    # Assert - each LB is tagged only with its own region's tag, identified by
+    # the region-specific `id`.
+    assert check_rels(
+        neo4j_session,
+        "LoadBalancer",
+        "id",
+        "AWSTag",
+        "id",
+        "TAGGED",
+        rel_direction_right=True,
+    ) == {
+        (LOAD_BALANCERS_US_EAST_1[0]["id"], "env:prod"),
+        (LOAD_BALANCERS_US_WEST_2[0]["id"], "env:staging"),
+    }

--- a/tests/integration/cartography/intel/aws/test_resourcegroupstaggingapi.py
+++ b/tests/integration/cartography/intel/aws/test_resourcegroupstaggingapi.py
@@ -77,3 +77,10 @@ def test_sync_tags(mock_get_tags, mock_get_instances, neo4j_session):
     ) == {
         ("i-01", "TestKey:TestValue"),
     }
+
+    # Assert - AWSTag nodes no longer carry a region property (#1094). The
+    # property is meaningless on a shared Key:Value node and has been dropped.
+    region_props = neo4j_session.run(
+        "MATCH (n:AWSTag) RETURN keys(n) AS props",
+    ).single()["props"]
+    assert "region" not in region_props

--- a/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
+++ b/tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
@@ -61,6 +61,27 @@ def test_group_tag_data_by_resource_type():
     assert len(grouped["s3"]) == 1
 
 
+def test_build_ingest_tag_query_region_scoped():
+    """
+    Load balancer resource types are keyed by a non-unique `name`, so their
+    ingest query must be scoped to the synced region (#1137).
+    """
+    query = rgta._build_ingest_tag_query("elasticloadbalancing:loadbalancer")
+    assert "WHERE resource.region = $Region" in query
+    # The tag node itself no longer stores region (#1094).
+    assert "aws_tag.region" not in query
+
+
+def test_build_ingest_tag_query_not_region_scoped():
+    """
+    ARN/id-keyed resource types (e.g. s3) keep their matching unchanged: no
+    region predicate, no region property on the tag node.
+    """
+    query = rgta._build_ingest_tag_query("s3")
+    assert "WHERE resource.region" not in query
+    assert "aws_tag.region" not in query
+
+
 def test_transform_tags():
     get_resources_response = copy.deepcopy(test_data.GET_RESOURCES_RESPONSE)
     assert "resource_id" not in get_resources_response[0]


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Two long-standing fixes to the AWS Resource Groups Tagging API sync. Both
touch `cartography/intel/aws/resourcegroupstaggingapi.py`.

**#1094: remove the meaningless `region` property from `AWSTag`.** An `AWSTag`
id is `Key:Value`, so the node is shared across every resource carrying that
tag. Its `region` property was therefore meaningless: whichever region's batch
wrote last won, and nothing downstream read it. The property is dropped from
the model and the ingestion template.

**#1137: tag the correct regional resource.** The resource MATCH in the
ingestion query bound only on account plus an identifying property, with no
region predicate. Resource types keyed by a non-unique `name` (the load
balancers) could be cross-tagged across regions. We add an optional
`region_property` to the tag resource-type mappings and, when present, scope the
MATCH to the synced region (`WHERE resource.region = $Region`). Only the three
name-keyed load balancer mappings opt in; every ARN/id-keyed type and the IAM
global path are unchanged.

The classic ELB mapping additionally now matches on its own label
(`AWSLoadBalancer`) instead of the shared `LoadBalancer` ontology label, which
`AWSLoadBalancerV2` nodes also carry. Without this, a classic ELB tag would
bleed onto an ALB/NLB of the same name in the same region.

The earlier per-region `get_role_tags` performance ask from these issues was
already resolved by #2728.


### Related issues or links

- Closes #1094
- Closes #1137


### How was this tested?

- `make test_lint` passes locally.
- Unit tests assert the query built for a load balancer type contains the
  region predicate, while an ARN/id-keyed type (`s3`) does not and neither
  contains `aws_tag.region`.
- An integration regression test loads two same-named classic ELBs in
  `us-east-1` and `us-west-2` and asserts each is tagged only with its own
  region's tag. This test fails on `master` and passes with the fix.
- `test_sync_tags` now also asserts `AWSTag` nodes no longer carry a `region`
  key.

```
pytest tests/unit/cartography/intel/aws/test_resourcegroupstaggingapi.py
pytest tests/integration/cartography/intel/aws/test_resourcegroupstaggingapi.py
```


### Breaking changes

None. No data migration is needed for the dropped `region` property: stale
values already in a graph are harmless and cartography does not migrate
property removals.


### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the schema documentation.
