### PR TITLE
fix(okta): skip groups deleted during sync when listing members

### DIFF
--- a/cartography/intel/okta/groups.py
+++ b/cartography/intel/okta/groups.py
@@ -18,15 +18,18 @@ from cartography.intel.okta.sync_state import OktaSyncState
 from cartography.intel.okta.utils import check_rate_limit
 from cartography.intel.okta.utils import create_api_client
 from cartography.intel.okta.utils import is_last_page
+from cartography.intel.okta.utils import is_resource_not_found_error
+from cartography.intel.okta.utils import OKTA_RESOURCE_NOT_FOUND_ERROR_CODE
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 OKTA_GROUP_MEMBER_REQUEST_ATTEMPTS = 3
 OKTA_GROUP_MEMBER_RETRY_DELAY_SECONDS = 1
-# Okta error code returned when a resource (e.g. a group) no longer exists.
-# https://developer.okta.com/docs/reference/error-codes/#E0000007
-OKTA_RESOURCE_NOT_FOUND_ERROR_CODE = "E0000007"
+
+# Re-exported for backwards compatibility; the canonical definition lives in
+# cartography.intel.okta.utils.
+__all__ = ["OKTA_RESOURCE_NOT_FOUND_ERROR_CODE"]
 
 
 @timeit
@@ -331,7 +334,7 @@ def sync_okta_group_membership(
             # A group can be deleted between listing groups and fetching its
             # members, in which case Okta returns a "resource not found" error.
             # Skip the group instead of failing the whole sync.
-            if e.error_code == OKTA_RESOURCE_NOT_FOUND_ERROR_CODE:
+            if is_resource_not_found_error(e):
                 logger.warning(
                     "Okta group %s no longer exists (likely deleted during the "
                     "sync); skipping its membership.",

--- a/cartography/intel/okta/groups.py
+++ b/cartography/intel/okta/groups.py
@@ -19,17 +19,12 @@ from cartography.intel.okta.utils import check_rate_limit
 from cartography.intel.okta.utils import create_api_client
 from cartography.intel.okta.utils import is_last_page
 from cartography.intel.okta.utils import is_resource_not_found_error
-from cartography.intel.okta.utils import OKTA_RESOURCE_NOT_FOUND_ERROR_CODE
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 OKTA_GROUP_MEMBER_REQUEST_ATTEMPTS = 3
 OKTA_GROUP_MEMBER_RETRY_DELAY_SECONDS = 1
-
-# Re-exported for backwards compatibility; the canonical definition lives in
-# cartography.intel.okta.utils.
-__all__ = ["OKTA_RESOURCE_NOT_FOUND_ERROR_CODE"]
 
 
 @timeit

--- a/cartography/intel/okta/groups.py
+++ b/cartography/intel/okta/groups.py
@@ -24,6 +24,9 @@ logger = logging.getLogger(__name__)
 
 OKTA_GROUP_MEMBER_REQUEST_ATTEMPTS = 3
 OKTA_GROUP_MEMBER_RETRY_DELAY_SECONDS = 1
+# Okta error code returned when a resource (e.g. a group) no longer exists.
+# https://developer.okta.com/docs/reference/error-codes/#E0000007
+OKTA_RESOURCE_NOT_FOUND_ERROR_CODE = "E0000007"
 
 
 @timeit
@@ -322,7 +325,20 @@ def sync_okta_group_membership(
 
     for group_info in group_list_info:
         group_id = group_info["id"]
-        members_data: List[Dict] = get_okta_group_members(api_client, group_id)
+        try:
+            members_data: List[Dict] = get_okta_group_members(api_client, group_id)
+        except OktaError as e:
+            # A group can be deleted between listing groups and fetching its
+            # members, in which case Okta returns a "resource not found" error.
+            # Skip the group instead of failing the whole sync.
+            if e.error_code == OKTA_RESOURCE_NOT_FOUND_ERROR_CODE:
+                logger.warning(
+                    "Okta group %s no longer exists (likely deleted during the "
+                    "sync); skipping its membership.",
+                    group_id,
+                )
+                continue
+            raise
         transformed_member_data: List[Dict] = transform_okta_group_member_list(
             members_data,
         )

--- a/cartography/intel/okta/roles.py
+++ b/cartography/intel/okta/roles.py
@@ -6,11 +6,13 @@ from typing import List
 
 import neo4j
 from okta.framework.ApiClient import ApiClient
+from okta.framework.OktaError import OktaError
 
 from cartography.client.core.tx import run_write_query
 from cartography.intel.okta.sync_state import OktaSyncState
 from cartography.intel.okta.utils import check_rate_limit
 from cartography.intel.okta.utils import create_api_client
+from cartography.intel.okta.utils import is_resource_not_found_error
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -199,14 +201,38 @@ def sync_roles(
 
     if sync_state.users:
         for user_id in sync_state.users:
-            user_roles_data = _get_user_roles(api_client, user_id, okta_org_id)
+            try:
+                user_roles_data = _get_user_roles(api_client, user_id, okta_org_id)
+            except OktaError as e:
+                # A user can be deleted between listing users and fetching its
+                # roles. Skip it instead of failing the whole sync.
+                if is_resource_not_found_error(e):
+                    logger.warning(
+                        "Okta user %s no longer exists (likely deleted during "
+                        "the sync); skipping its roles.",
+                        user_id,
+                    )
+                    continue
+                raise
             user_roles = transform_user_roles_data(user_roles_data, okta_org_id)
             if len(user_roles) > 0:
                 _load_user_role(neo4j_session, user_id, user_roles, okta_update_tag)
 
     if sync_state.groups:
         for group_id in sync_state.groups:
-            group_roles_data = _get_group_roles(api_client, group_id, okta_org_id)
+            try:
+                group_roles_data = _get_group_roles(api_client, group_id, okta_org_id)
+            except OktaError as e:
+                # A group can be deleted between listing groups and fetching its
+                # roles. Skip it instead of failing the whole sync.
+                if is_resource_not_found_error(e):
+                    logger.warning(
+                        "Okta group %s no longer exists (likely deleted during "
+                        "the sync); skipping its roles.",
+                        group_id,
+                    )
+                    continue
+                raise
             group_roles = transform_group_roles_data(group_roles_data, okta_org_id)
             if len(group_roles) > 0:
                 _load_group_role(neo4j_session, group_id, group_roles, okta_update_tag)

--- a/cartography/intel/okta/utils.py
+++ b/cartography/intel/okta/utils.py
@@ -4,9 +4,24 @@ import time
 
 from okta.framework import PagedResults
 from okta.framework.ApiClient import ApiClient
+from okta.framework.OktaError import OktaError
 from requests import Response
 
 logger = logging.getLogger(__name__)
+
+# Okta error code returned when a resource (e.g. a group or user) no longer
+# exists. A resource can be deleted between the moment we list it and the
+# moment we fetch a follow-up sub-resource for it.
+# https://developer.okta.com/docs/reference/error-codes/#E0000007
+OKTA_RESOURCE_NOT_FOUND_ERROR_CODE = "E0000007"
+
+
+def is_resource_not_found_error(error: OktaError) -> bool:
+    """
+    Return True if the Okta error indicates the requested resource no longer
+    exists (HTTP 404, errorCode E0000007).
+    """
+    return error.error_code == OKTA_RESOURCE_NOT_FOUND_ERROR_CODE
 
 
 def is_last_page(response: PagedResults) -> bool:

--- a/tests/unit/cartography/intel/okta/test_admin_roles.py
+++ b/tests/unit/cartography/intel/okta/test_admin_roles.py
@@ -1,5 +1,13 @@
+from unittest import mock
+
+import pytest
+from okta.framework.OktaError import OktaError
+
+from cartography.intel.okta.roles import sync_roles
 from cartography.intel.okta.roles import transform_group_roles_data
 from cartography.intel.okta.roles import transform_user_roles_data
+from cartography.intel.okta.sync_state import OktaSyncState
+from cartography.intel.okta.utils import OKTA_RESOURCE_NOT_FOUND_ERROR_CODE
 from tests.data.okta.adminroles import LIST_ASSIGNED_GROUP_ROLE_RESPONSE
 from tests.data.okta.adminroles import LIST_ASSIGNED_USER_ROLE_RESPONSE
 
@@ -22,6 +30,70 @@ def test_transform_user_roles():
     ]
 
     assert result == expected
+
+
+@mock.patch("cartography.intel.okta.roles.create_api_client")
+@mock.patch("cartography.intel.okta.roles._load_group_role")
+@mock.patch("cartography.intel.okta.roles._get_group_roles")
+def test_sync_roles_skips_deleted_group(
+    mock_get_group_roles: mock.MagicMock,
+    mock_load_group_role: mock.MagicMock,
+    mock_create_api_client: mock.MagicMock,
+) -> None:
+    """
+    A group deleted between listing and role fetch returns a "resource not
+    found" OktaError; that group is skipped and the role sync continues.
+    """
+    sync_state = OktaSyncState(user=None, groups=["deleted-group", "live-group"])
+    mock_get_group_roles.side_effect = [
+        OktaError({"errorCode": OKTA_RESOURCE_NOT_FOUND_ERROR_CODE}),
+        LIST_ASSIGNED_GROUP_ROLE_RESPONSE,
+    ]
+
+    sync_roles(mock.MagicMock(), "example_org", 1, "fake-key", sync_state)
+
+    mock_load_group_role.assert_called_once()
+    assert mock_load_group_role.call_args.args[1] == "live-group"
+
+
+@mock.patch("cartography.intel.okta.roles.create_api_client")
+@mock.patch("cartography.intel.okta.roles._load_user_role")
+@mock.patch("cartography.intel.okta.roles._get_user_roles")
+def test_sync_roles_skips_deleted_user(
+    mock_get_user_roles: mock.MagicMock,
+    mock_load_user_role: mock.MagicMock,
+    mock_create_api_client: mock.MagicMock,
+) -> None:
+    """
+    A user deleted between listing and role fetch returns a "resource not
+    found" OktaError; that user is skipped and the role sync continues.
+    """
+    sync_state = OktaSyncState(user=["deleted-user", "live-user"], groups=None)
+    mock_get_user_roles.side_effect = [
+        OktaError({"errorCode": OKTA_RESOURCE_NOT_FOUND_ERROR_CODE}),
+        LIST_ASSIGNED_USER_ROLE_RESPONSE,
+    ]
+
+    sync_roles(mock.MagicMock(), "example_org", 1, "fake-key", sync_state)
+
+    mock_load_user_role.assert_called_once()
+    assert mock_load_user_role.call_args.args[1] == "live-user"
+
+
+@mock.patch("cartography.intel.okta.roles.create_api_client")
+@mock.patch("cartography.intel.okta.roles._get_group_roles")
+def test_sync_roles_reraises_other_okta_errors(
+    mock_get_group_roles: mock.MagicMock,
+    mock_create_api_client: mock.MagicMock,
+) -> None:
+    """
+    OktaErrors other than "resource not found" must still propagate.
+    """
+    sync_state = OktaSyncState(user=None, groups=["group-001"])
+    mock_get_group_roles.side_effect = OktaError({"errorCode": "E0000011"})
+
+    with pytest.raises(OktaError):
+        sync_roles(mock.MagicMock(), "example_org", 1, "fake-key", sync_state)
 
 
 def test_transform_group_roles():

--- a/tests/unit/cartography/intel/okta/test_group.py
+++ b/tests/unit/cartography/intel/okta/test_group.py
@@ -4,8 +4,11 @@ from typing import List
 from unittest import mock
 
 import pytest
+from okta.framework.OktaError import OktaError
 
 from cartography.intel.okta.groups import get_okta_group_members
+from cartography.intel.okta.groups import OKTA_RESOURCE_NOT_FOUND_ERROR_CODE
+from cartography.intel.okta.groups import sync_okta_group_membership
 from cartography.intel.okta.groups import transform_okta_group
 from cartography.intel.okta.groups import transform_okta_group_member_list
 from tests.data.okta.groups import create_test_group
@@ -152,3 +155,43 @@ def test_get_okta_group_members_raises_on_malformed_next_link() -> None:
 
     api_client.get_path.assert_called_once()
     api_client.get.assert_not_called()
+
+
+@mock.patch("cartography.intel.okta.groups.load_okta_group_members")
+@mock.patch("cartography.intel.okta.groups.get_okta_group_members")
+def test_sync_okta_group_membership_skips_deleted_group(
+    mock_get_members: mock.MagicMock,
+    mock_load_members: mock.MagicMock,
+) -> None:
+    """
+    A group deleted between listing and membership fetch returns a "resource not
+    found" OktaError; that group is skipped and the sync continues.
+    """
+    neo4j_session = mock.MagicMock()
+    api_client = mock.MagicMock()
+    group_list_info = [{"id": "deleted-group"}, {"id": "live-group"}]
+    mock_get_members.side_effect = [
+        OktaError({"errorCode": OKTA_RESOURCE_NOT_FOUND_ERROR_CODE}),
+        GROUP_MEMBERS_SAMPLE_DATA,
+    ]
+
+    sync_okta_group_membership(neo4j_session, api_client, group_list_info, 1)
+
+    # Only the live group is loaded; the deleted one is skipped.
+    mock_load_members.assert_called_once()
+    assert mock_load_members.call_args.args[1] == "live-group"
+
+
+@mock.patch("cartography.intel.okta.groups.get_okta_group_members")
+def test_sync_okta_group_membership_reraises_other_okta_errors(
+    mock_get_members: mock.MagicMock,
+) -> None:
+    """
+    OktaErrors other than "resource not found" must still propagate.
+    """
+    neo4j_session = mock.MagicMock()
+    api_client = mock.MagicMock()
+    mock_get_members.side_effect = OktaError({"errorCode": "E0000011"})
+
+    with pytest.raises(OktaError):
+        sync_okta_group_membership(neo4j_session, api_client, [{"id": "group-001"}], 1)

--- a/tests/unit/cartography/intel/okta/test_group.py
+++ b/tests/unit/cartography/intel/okta/test_group.py
@@ -7,10 +7,10 @@ import pytest
 from okta.framework.OktaError import OktaError
 
 from cartography.intel.okta.groups import get_okta_group_members
-from cartography.intel.okta.groups import OKTA_RESOURCE_NOT_FOUND_ERROR_CODE
 from cartography.intel.okta.groups import sync_okta_group_membership
 from cartography.intel.okta.groups import transform_okta_group
 from cartography.intel.okta.groups import transform_okta_group_member_list
+from cartography.intel.okta.utils import OKTA_RESOURCE_NOT_FOUND_ERROR_CODE
 from tests.data.okta.groups import create_test_group
 from tests.data.okta.groups import GROUP_MEMBERS_SAMPLE_DATA
 


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary

A group can be deleted in Okta between the moment we list all groups and the moment we fetch each group's members. When that happens, the `/{group_id}/users` endpoint returns an HTTP 404 (`OktaError`, errorCode `E0000007`, "Resource not found"). Previously this exception propagated all the way up and aborted the entire Okta sync, even though every other group synced fine.

This change catches that specific not-found error when listing a group's members, logs a warning, and continues with the remaining groups. Any other `OktaError` (including rate limiting, which the SDK already retries internally and surfaces with a different error code) still propagates unchanged, so genuine failures are not masked.

### Related issues or links

N/A

### How was this tested?

New unit tests in `tests/unit/cartography/intel/okta/test_group.py`:
- `test_sync_okta_group_membership_skips_deleted_group`: a group returning `E0000007` is skipped and the sync continues to the next group.
- `test_sync_okta_group_membership_reraises_other_okta_errors`: any other `OktaError` still propagates.

`make test_lint` passes locally and the full okta group unit suite is green.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective.

#### Proof of functionality
- [x] New or updated unit/integration tests.
