### PR TITLE
feat(ontology): canonical HAS_ROLE edge (UserAccount/ServiceAccount -> PermissionRole)

### DIFF
--- a/.agents/skills/promote-ontology-relationship/SKILL.md
+++ b/.agents/skills/promote-ontology-relationship/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: promote-ontology-relationship
+description: Promote provider-specific relationships to a canonical cross-provider ontology edge using the WORKLOAD_PARENT pattern (a parallel CartographyRelSchema with the canonical rel_label, the old edge kept and deprecated, plus a RelConstraint enforced by the CI guard). Use when the user asks to "propagate X->Y relationship to the ontology level", unify/normalise a relationship label across providers, add a canonical ontology edge (HAS_ROLE, MEMBER_OF, ASSUMES, ENCRYPTED_BY, POINTS_TO, ...), add a RelConstraint, or deprecate/rename an ontology relationship label.
+---
+
+# promote-ontology-relationship
+
+Cartography normalises cross-provider edges between two **ontology-labelled** nodes (semantic labels like `UserAccount`, `PermissionRole`, `ServiceAccount`, `ComputePod`, or abstract nodes like `User`, `Device`) under a single canonical relationship label. The canonical label is declared as a `RelConstraint` and enforced by a CI guard.
+
+This is **NOT** done with analysis/linking jobs. It follows the `WORKLOAD_PARENT` precedent (PRs #2735 / #2738): add a parallel canonical edge, keep the old one deprecated for backward compatibility, and add a constraint.
+
+## Mechanism (the WORKLOAD_PARENT pattern)
+
+For each existing **direct** `CartographyRelSchema` edge that connects two ontology-labelled nodes:
+
+1. **Add a new parallel rel class** with `rel_label = "<CANONICAL>"`, same `target_node_label` / matcher / direction as the existing edge, and register it in the node schema's `other_relationships` (both edges MERGE on every sync).
+2. **Keep the old edge** but mark it `# DEPRECATED: replaced by <CANONICAL>, will be removed in v1.0.0`, and add its rel class to `LEGACY_REL_WHITELIST` in [`constraints.py`](../../../cartography/models/ontology/constraints.py).
+3. **Add a `RelConstraint(src, dst, label)`** to `ONTOLOGY_REL_CONSTRAINTS` so the guard enforces the canonical label + direction whenever both endpoints carry the listed ontology labels.
+4. **Whitelist** any other existing edge that shares the same ontology-label pair but carries a *distinct semantic* (reverse direction, or a different concept).
+
+If a provider already uses the chosen canonical label, that edge is already compliant: leave it untouched (no parallel, no deprecation).
+
+## Critical rules
+
+1. **The guard reads labels from the node *schema*** (`label` + `extra_node_labels`, including `ConditionalNodeLabel`), not from the runtime graph. An edge is only constrained when **both** endpoints carry an ontology label in their schema. Edges through intermediate binding nodes (e.g. `GCPPolicyBinding`, `KubernetesRoleBinding`, `AzureRoleAssignment`) are NOT direct and are not affected by a rename.
+2. **Pick the canonical verb to fit the abstraction, not one provider.** The label applies to the abstract semantic pair (e.g. `UserAccount -> PermissionRole`), which spans many providers. Prefer a neutral verb (`HAS_ROLE`, not `ASSUME_ROLE`, when the target generalises IAM roles, permission sets, and SaaS roles). Reserve action verbs (`ASSUMES`) for workload-identity/runtime semantics.
+3. **Backward compatibility is mandatory.** Never rename in place. The old edge keeps being created (whitelisted) until v1.0.0 so existing queries/rules keep working.
+4. **Run the guard test to discover collisions**: do not assume you found every edge by reading code. `test_ontology_rel_constraints.py` will list every offending rel (wrong label or reverse direction). Decide per edge: migrate (parallel + deprecate) or whitelist (distinct semantic).
+5. **Docs: replace the deprecated relation, do not just annotate it.** In the module `schema.md`, the old edge must be **removed entirely** (bullet + cypher block + mermaid line) and replaced by the canonical one. Do NOT keep it with an inline `(DEPRECATED: ...)` marker: that is the mistake the original `WORKLOAD_PARENT` migration made, and it leaves the duplicate documented. The class stays in code (whitelisted) but is no longer advertised. Add the canonical edge to the ontology `schema.md`.
+6. **Decouple internal queries from the deprecated label.** If any analysis job / intel query traverses the old label, switch it to the canonical one (both edges exist, so it is equivalent and survives the v1.0.0 removal).
+7. **One commit per canonical edge.** `--signoff`. No internal ticket or client references in committed text.
+
+## Instructions
+
+### Step 1: Identify the canonical pair and label
+
+Decide the abstract pair and verb, e.g. `UserAccount -[:HAS_ROLE]-> PermissionRole`. Confirm the chosen verb is not already overloaded by a different concept (grep the canonical label across the repo).
+
+### Step 2: Find which provider nodes carry each ontology label
+
+The semantic label is applied via `extra_node_labels` on the node schema (sometimes a `ConditionalNodeLabel`). The ontology mapping files under `cartography/models/ontology/mapping/data/<category>.py` list which provider node labels belong to a category. Build the set of node labels carrying `src` and `dst`.
+
+```bash
+# which schemas declare the semantic labels
+grep -rln '"PermissionRole"' cartography/models/ | grep -v ontology/mapping
+grep -rln '"UserAccount"'    cartography/models/ | grep -v ontology/mapping
+```
+
+### Step 3: Find the direct edges to migrate
+
+For each `dst` node label, find `CartographyRelSchema` classes whose `target_node_label` is that label (or rels defined on the `dst` schema pointing back at a `src` node). A direct edge is one whose **other endpoint also carries an ontology label**. Edges through binding/intermediate nodes are out of scope (they are not direct).
+
+```bash
+grep -rn "target_node_label.*<RoleNodeLabel>" cartography/models/
+```
+
+Classify each direct edge:
+- **Same label as canonical** -> already compliant, leave it.
+- **Different label, canonical direction** -> migrate (Step 4).
+- **Different label, reverse direction, or distinct semantic** -> whitelist (Step 6).
+
+### Step 4: Add the parallel canonical edge
+
+In the provider model file, add a Properties + Rel class mirroring the existing one but with the canonical `rel_label`, and register it in `other_relationships`. Mark the old rel deprecated. Example (AWS SSO user -> permission set):
+
+```python
+@dataclass(frozen=True)
+# DEPRECATED: replaced by the canonical (:UserAccount)-[:HAS_ROLE]->(:PermissionRole)
+# edge (AWSSSOUserToPermissionSetHasRoleRel). Kept for backward compatibility,
+# will be removed in v1.0.0.
+class AWSSSOUserToPermissionSetRel(CartographyRelSchema):
+    target_node_label: str = "AWSPermissionSet"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("AssignedPermissionSets", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_PERMISSION_SET"
+    properties: AWSSSOUserToPermissionSetRelProperties = AWSSSOUserToPermissionSetRelProperties()
+
+
+@dataclass(frozen=True)
+class AWSSSOUserToPermissionSetHasRoleRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# Canonical ontology edge: (:UserAccount)-[:HAS_ROLE]->(:PermissionRole)
+class AWSSSOUserToPermissionSetHasRoleRel(CartographyRelSchema):
+    target_node_label: str = "AWSPermissionSet"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("AssignedPermissionSets", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_ROLE"
+    properties: AWSSSOUserToPermissionSetHasRoleRelProperties = AWSSSOUserToPermissionSetHasRoleRelProperties()
+```
+
+Then add `AWSSSOUserToPermissionSetHasRoleRel()` to the node schema's `OtherRelationships([...])`.
+
+For edges created in a hand-written query (not a schema rel), add a parallel `MERGE` of the canonical edge next to the existing one, keeping both.
+
+### Step 5: Add the constraint
+
+In [`cartography/models/ontology/constraints.py`](../../../cartography/models/ontology/constraints.py), append to `ONTOLOGY_REL_CONSTRAINTS`:
+
+```python
+# A user account is granted a role.
+RelConstraint(src="UserAccount", dst="PermissionRole", label="HAS_ROLE"),
+```
+
+A constraint with no current direct edge is valid governance ("never requires the edge to exist; only constrains the name when both endpoints carry the labels").
+
+### Step 6: Run the guard, then whitelist remaining collisions
+
+```bash
+uv run pytest tests/unit/cartography/graph/test_ontology_rel_constraints.py -q
+```
+
+The guard lists violations as either *wrong label* (canonical direction) or *wrong direction* (reverse). For each:
+- A deprecated edge you are replacing -> add its class to `LEGACY_REL_WHITELIST` with a `# DEPRECATED: replaced by <CANONICAL>` comment.
+- A genuinely different semantic sharing the label pair -> add it to `LEGACY_REL_WHITELIST` with a comment explaining why it is distinct (e.g. `ALLOWED_BY` = "role is assumable by", `MAPS_TO` = identity federation, `ASSUMED_ROLE_WITH_SAML` = runtime event, `ASSUMES_ROLE` = workload identity / IRSA).
+
+Re-run until green. Add the needed imports to `constraints.py` (isort will order them).
+
+### Step 7: Update documentation
+
+**Module `schema.md`** (`docs/root/modules/<provider>/schema.md`): **remove** the deprecated edge and document only the canonical one.
+
+- Delete the relationship bullet, its cypher fenced block, **and** its line in the module's mermaid diagram. Do not leave an inline `(DEPRECATED: ...)` note: the deprecated edge must disappear from the doc entirely.
+- The same edge is usually documented in **both endpoints' sections** (e.g. once under the source node, once under the target node) and sometimes in a catch-all list. Grep every occurrence:
+  ```bash
+  grep -rn "OLD_LABEL\|<SrcNode>.*<DstNode>" docs/root/modules/<provider>/schema.md
+  ```
+- **Do not remove a same-label edge that is a different, non-deprecated relationship.** Cross-check against `LEGACY_REL_WHITELIST`: only the exact `(src, label, dst)` triples you deprecated are removed. Example from the `WORKLOAD_PARENT` cleanup: `(:ECSService)-[:HAS_TASK]->(:ECSTask)` was removed, but `(:ECSContainerInstance)-[:HAS_TASK]->(:ECSTask)` (same `HAS_TASK` label, not deprecated) was kept. Likewise the Kubernetes namespace catch-all kept `CONTAINS` to `Secret`/`Service`/`Role` and only dropped `Pod`/`Container`.
+- Reword surrounding prose/notes to the canonical label.
+
+**Ontology `schema.md`** (`docs/root/modules/ontology/schema.md`): add the edge to the top mermaid diagram (`UA -- HAS_ROLE --> PR`) and to the prose under the `dst` semantic-label section.
+
+### Step 8: Decouple internal queries
+
+Grep the old label across `cartography/` (intel, `data/jobs/`, `rules/`). Any analysis/intel query that traverses the old label should be switched to the canonical one (both exist now). Confirm no rule depends on the old label.
+
+```bash
+grep -rn "OLD_LABEL" cartography/intel cartography/data/jobs cartography/rules
+```
+
+### Step 9: Tests and verification
+
+Add **additive** assertions in the affected integration tests (assert the new canonical edge; keep the old assertion only if you still assert the deprecated edge intentionally).
+
+```bash
+uv run pytest tests/unit/cartography/graph/test_ontology_rel_constraints.py -q
+uv run pytest tests/integration/cartography/intel/<provider>/ -q   # needs Neo4j
+uv run --frozen pre-commit run --files <changed files>
+```
+
+## Reference
+
+- `references/worked-example.md`: the full `HAS_ROLE` migration: every file touched, the collisions the guard surfaced, and how each was resolved.
+
+## Related skills
+
+- `add-relationship`: base `CartographyRelSchema` / `MatchLink` mechanics.
+- `enrich-ontology`: applying the semantic labels (`extra_node_labels`, `_ont_*`) that this skill's constraints operate on.
+- `analysis-jobs`: when an edge must be derived after sync rather than declared on a schema.

--- a/.agents/skills/promote-ontology-relationship/references/worked-example.md
+++ b/.agents/skills/promote-ontology-relationship/references/worked-example.md
@@ -1,0 +1,63 @@
+# Worked example: `HAS_ROLE` (UserAccount/ServiceAccount -> PermissionRole)
+
+This is the real migration that introduced the canonical `HAS_ROLE` edge, done as two commits (the user edge, then the service-account constraint).
+
+## Goal
+
+- `(:UserAccount)-[:HAS_ROLE]->(:PermissionRole)`
+- `(:ServiceAccount)-[:HAS_ROLE]->(:PermissionRole)`
+
+`PermissionRole` is the semantic label on AWS roles/permission sets, Azure role definitions, GCP roles, Keycloak/Cloudflare/OCI/Okta/Kubernetes roles, etc. `HAS_ROLE` was chosen over `ASSUME_ROLE` because the target generalises **permission sets** (static assignment) and SaaS roles, where "assume" is semantically wrong. `ASSUME_ROLE`/`ASSUMES` stays reserved for workload-identity (STS / IRSA).
+
+## Direct edges found (Step 3)
+
+| Provider  | Edge                                                              | Old label            | Action                              |
+| --------- | ----------------------------------------------------------------- | -------------------- | ----------------------------------- |
+| AWS       | `AWSSSOUser -> AWSPermissionSet` (`awsssouser.py`)                | `HAS_PERMISSION_SET` | add parallel `HAS_ROLE`, deprecate  |
+| Keycloak  | `KeycloakUser -> KeycloakRole` (INWARD on `KeycloakRoleToUserRel`)| `ASSUME_ROLE`        | add parallel `HAS_ROLE`, deprecate  |
+| Cloudflare| `CloudflareMember -> CloudflareRole` (`member.py`)                | `HAS_ROLE`           | already compliant: untouched       |
+
+Service-account -> role: no **direct** edge exists (GCP/K8s/Azure go through binding nodes); the constraint is added as forward-looking governance.
+
+The Keycloak group-inherited edge is created in a hand-written query (`cartography/intel/keycloak/inheritance.py` `_ASSUME_ROLE_VIA_GROUP_QUERY`): a parallel `MERGE (u)-[:HAS_ROLE]->(r)` was added next to the existing `ASSUME_ROLE` merge.
+
+## Collisions the guard surfaced (Step 6) and their resolution
+
+Running `test_ontology_rel_constraints.py` after adding the constraints flagged edges sharing the `UserAccount|ServiceAccount` / `PermissionRole` label pair. Each was whitelisted with a reason, because it is a *distinct* semantic, not a static role grant:
+
+| Rel class                          | Label                   | Why whitelisted (not migrated)                                  |
+| ---------------------------------- | ----------------------- | --------------------------------------------------------------- |
+| `AWSSSOUserToPermissionSetRel`     | `HAS_PERMISSION_SET`    | the edge we deprecated                                          |
+| `KeycloakRoleToUserRel`            | `ASSUME_ROLE`           | the edge we deprecated                                          |
+| `CloudflareMemberToCloudflareRoleRel` | `HAS_ROLE`           | (not whitelisted: it IS the canonical edge)                    |
+| `AWSRoleToSSOUserMatchLink`        | `ALLOWED_BY`            | reverse direction; "role is assumable by SSO user", not a grant |
+| `KubernetesUserToAWSRoleRel`       | `MAPS_TO`               | identity-federation mapping, not a grant                        |
+| `AssumedRoleWithSAMLMatchLink`     | `ASSUMED_ROLE_WITH_SAML`| CloudTrail-observed runtime assumption event                    |
+| `KubernetesServiceAccountToAWSRoleRel` | `ASSUMES_ROLE`      | workload-identity (IRSA); reserved for the `ASSUMES` edge        |
+
+Lesson: a constraint catches **every** edge between the two labels, including reverse-direction MatchLinks and unrelated concepts. Read code first, but trust the guard to find the rest.
+
+## Files touched
+
+Commit 1 (`HAS_ROLE` user edge):
+- `cartography/models/ontology/constraints.py`: `RelConstraint(UserAccount, PermissionRole, HAS_ROLE)` + whitelist entries + imports
+- `cartography/models/aws/identitycenter/awsssouser.py`: parallel `HAS_ROLE` rel, deprecate old
+- `cartography/models/keycloak/role.py`: parallel `HAS_ROLE` rel, deprecate old
+- `cartography/intel/keycloak/inheritance.py`: parallel `HAS_ROLE` MERGE in the group-inherited query; **and** switched `_ASSUME_SCOPE_QUERY` to traverse `HAS_ROLE` (decouple from the deprecated label)
+- `docs/root/modules/aws/schema.md`, `docs/root/modules/keycloak/schema.md`, `docs/root/modules/keycloak/analysis.md`: document only `HAS_ROLE` (deprecated edge removed from docs)
+- `docs/root/modules/ontology/schema.md`: `UA -- HAS_ROLE --> PR` + prose
+- `tests/integration/.../aws/test_identitycenter.py`, `tests/integration/.../keycloak/test_roles.py`: additive `HAS_ROLE` assertions
+
+Commit 2 (`HAS_ROLE` service-account constraint):
+- `cartography/models/ontology/constraints.py`: `RelConstraint(ServiceAccount, PermissionRole, HAS_ROLE)` + whitelist `KubernetesServiceAccountToAWSRoleRel`
+- `docs/root/modules/ontology/schema.md`: `SA -- HAS_ROLE --> PR` + prose
+
+## Verification used
+
+```bash
+uv run pytest tests/unit/cartography/graph/test_ontology_rel_constraints.py tests/unit/cartography/test_doc.py -q
+uv run pytest tests/integration/cartography/intel/aws/test_identitycenter.py \
+              tests/integration/cartography/intel/keycloak/ \
+              tests/integration/cartography/intel/cloudflare/test_members.py -q
+uv run --frozen pre-commit run --files <changed files>
+```

--- a/cartography/intel/keycloak/inheritance.py
+++ b/cartography/intel/keycloak/inheritance.py
@@ -28,9 +28,15 @@ _INHERITED_MEMBER_OF_QUERY = """
 _ASSUME_ROLE_VIA_GROUP_QUERY = """
     MATCH (:KeycloakRealm {name: $REALM})-[:RESOURCE]->(u:KeycloakUser)
           -[:MEMBER_OF|INHERITED_MEMBER_OF]->(:KeycloakGroup)-[:GRANTS]->(r:KeycloakRole)
+    // DEPRECATED: ASSUME_ROLE is kept for backward compatibility alongside the
+    // canonical HAS_ROLE edge; will be removed in v1.0.0.
     MERGE (u)-[rel:ASSUME_ROLE]->(r)
     ON CREATE SET rel.firstseen = timestamp()
     SET rel.lastupdated = $UPDATE_TAG
+    // Canonical ontology edge: (:UserAccount)-[:HAS_ROLE]->(:PermissionRole)
+    MERGE (u)-[hr:HAS_ROLE]->(r)
+    ON CREATE SET hr.firstseen = timestamp()
+    SET hr.lastupdated = $UPDATE_TAG
 """
 
 _INDIRECT_GRANTS_QUERY = """
@@ -41,7 +47,7 @@ _INDIRECT_GRANTS_QUERY = """
 
 _ASSUME_SCOPE_QUERY = """
     MATCH (:KeycloakRealm {name: $REALM})-[:RESOURCE]->(u:KeycloakUser)
-          -[:ASSUME_ROLE]->(:KeycloakRole)-[:GRANTS|INDIRECT_GRANTS]->(s:KeycloakScope)
+          -[:HAS_ROLE]->(:KeycloakRole)-[:GRANTS|INDIRECT_GRANTS]->(s:KeycloakScope)
     RETURN DISTINCT u.id AS user_id, s.id AS scope_id
 """
 

--- a/cartography/models/aws/identitycenter/awsssouser.py
+++ b/cartography/models/aws/identitycenter/awsssouser.py
@@ -81,6 +81,9 @@ class AWSSSOUserToPermissionSetRelProperties(CartographyRelProperties):
 
 
 @dataclass(frozen=True)
+# DEPRECATED: replaced by the canonical (:UserAccount)-[:HAS_ROLE]->(:PermissionRole)
+# edge (AWSSSOUserToPermissionSetHasRoleRel). Kept for backward compatibility,
+# will be removed in v1.0.0.
 class AWSSSOUserToPermissionSetRel(CartographyRelSchema):
     target_node_label: str = "AWSPermissionSet"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
@@ -90,6 +93,25 @@ class AWSSSOUserToPermissionSetRel(CartographyRelSchema):
     rel_label: str = "HAS_PERMISSION_SET"
     properties: AWSSSOUserToPermissionSetRelProperties = (
         AWSSSOUserToPermissionSetRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AWSSSOUserToPermissionSetHasRoleRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# Canonical ontology edge: (:UserAccount)-[:HAS_ROLE]->(:PermissionRole)
+class AWSSSOUserToPermissionSetHasRoleRel(CartographyRelSchema):
+    target_node_label: str = "AWSPermissionSet"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("AssignedPermissionSets", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_ROLE"
+    properties: AWSSSOUserToPermissionSetHasRoleRelProperties = (
+        AWSSSOUserToPermissionSetHasRoleRelProperties()
     )
 
 
@@ -106,5 +128,6 @@ class AWSSSOUserSchema(CartographyNodeSchema):
             AWSSSOUserToOktaUserRel(),
             AWSSSOUserToSSOGroupRel(),
             AWSSSOUserToPermissionSetRel(),
+            AWSSSOUserToPermissionSetHasRoleRel(),
         ],
     )

--- a/cartography/models/keycloak/role.py
+++ b/cartography/models/keycloak/role.py
@@ -101,6 +101,9 @@ class KeycloakRoleToUserRelProperties(CartographyRelProperties):
 
 
 @dataclass(frozen=True)
+# DEPRECATED: replaced by the canonical (:UserAccount)-[:HAS_ROLE]->(:PermissionRole)
+# edge (KeycloakRoleToUserHasRoleRel). Kept for backward compatibility, will be
+# removed in v1.0.0.
 # (:KeycloakRole)<-[:ASSUME_ROLE]-(:KeycloakUser)
 class KeycloakRoleToUserRel(CartographyRelSchema):
     target_node_label: str = "KeycloakUser"
@@ -110,6 +113,26 @@ class KeycloakRoleToUserRel(CartographyRelSchema):
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "ASSUME_ROLE"
     properties: KeycloakRoleToUserRelProperties = KeycloakRoleToUserRelProperties()
+
+
+@dataclass(frozen=True)
+class KeycloakRoleToUserHasRoleRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("LASTUPDATED", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# Canonical ontology edge: (:UserAccount)-[:HAS_ROLE]->(:PermissionRole)
+# i.e. (:KeycloakRole)<-[:HAS_ROLE]-(:KeycloakUser)
+class KeycloakRoleToUserHasRoleRel(CartographyRelSchema):
+    target_node_label: str = "KeycloakUser"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("_direct_members", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_ROLE"
+    properties: KeycloakRoleToUserHasRoleRelProperties = (
+        KeycloakRoleToUserHasRoleRelProperties()
+    )
 
 
 @dataclass(frozen=True)
@@ -124,5 +147,6 @@ class KeycloakRoleSchema(CartographyNodeSchema):
             KeycloakRoleToRoleRel(),
             KeycloakRoleToScopeRel(),
             KeycloakRoleToUserRel(),
+            KeycloakRoleToUserHasRoleRel(),
         ],
     )

--- a/cartography/models/ontology/constraints.py
+++ b/cartography/models/ontology/constraints.py
@@ -1,9 +1,18 @@
 from dataclasses import dataclass
 
+from cartography.models.aws.cloudtrail.management_events import (
+    AssumedRoleWithSAMLMatchLink,
+)
 from cartography.models.aws.ecs.containers import ECSContainerToTaskRel
 from cartography.models.aws.ecs.services import ECSServiceToECSClusterRel
 from cartography.models.aws.ecs.services import ECSServiceToECSTaskRel
 from cartography.models.aws.ecs.tasks import ECSTaskToECSClusterRel
+from cartography.models.aws.identitycenter.awspermissionset import (
+    AWSRoleToSSOUserMatchLink,
+)
+from cartography.models.aws.identitycenter.awsssouser import (
+    AWSSSOUserToPermissionSetRel,
+)
 from cartography.models.azure.container_instance import (
     AzureGroupContainerToContainerInstanceRel,
 )
@@ -11,6 +20,7 @@ from cartography.models.gcp.cloudrun.job_container import CloudRunJobToContainer
 from cartography.models.gcp.cloudrun.service_container import (
     CloudRunServiceToContainerRel,
 )
+from cartography.models.keycloak.role import KeycloakRoleToUserRel
 from cartography.models.kubernetes.containers import (
     KubernetesContainerToKubernetesPodRel,
 )
@@ -19,6 +29,7 @@ from cartography.models.kubernetes.namespaces import (
 )
 from cartography.models.kubernetes.pods import KubernetesPodToKubernetesClusterRel
 from cartography.models.kubernetes.pods import KubernetesPodToKubernetesNamespaceRel
+from cartography.models.kubernetes.users import KubernetesUserToAWSRoleRel
 
 
 @dataclass(frozen=True)
@@ -51,6 +62,8 @@ ONTOLOGY_REL_CONSTRAINTS: tuple[RelConstraint, ...] = (
     RelConstraint(
         src="ComputeNamespace", dst="ComputeCluster", label="WORKLOAD_PARENT"
     ),
+    # A user account is granted a role.
+    RelConstraint(src="UserAccount", dst="PermissionRole", label="HAS_ROLE"),
 )
 
 
@@ -73,5 +86,19 @@ LEGACY_REL_WHITELIST: frozenset[type] = frozenset(
         # tenant scoping and the workload chain are reconciled.
         KubernetesNamespaceToKubernetesClusterRel,
         KubernetesPodToKubernetesClusterRel,
+        # DEPRECATED: replaced by HAS_ROLE, will be removed in v1.0.0.
+        AWSSSOUserToPermissionSetRel,
+        KeycloakRoleToUserRel,
+        # ALLOWED_BY is a distinct "this role is assumable by that SSO user"
+        # semantic (PermissionRole->UserAccount), not a role assignment, so it
+        # intentionally runs counter to the HAS_ROLE (UserAccount->PermissionRole)
+        # direction. Whitelisted so the constraint does not flag it.
+        AWSRoleToSSOUserMatchLink,
+        # MAPS_TO is an identity-federation mapping (a Kubernetes user authenticates
+        # as an AWS role/user), not a role grant. Distinct from HAS_ROLE.
+        KubernetesUserToAWSRoleRel,
+        # ASSUMED_ROLE_WITH_SAML records a CloudTrail-observed runtime assumption
+        # event, not a static role assignment. Distinct from HAS_ROLE.
+        AssumedRoleWithSAMLMatchLink,
     }
 )

--- a/cartography/models/ontology/constraints.py
+++ b/cartography/models/ontology/constraints.py
@@ -29,6 +29,9 @@ from cartography.models.kubernetes.namespaces import (
 )
 from cartography.models.kubernetes.pods import KubernetesPodToKubernetesClusterRel
 from cartography.models.kubernetes.pods import KubernetesPodToKubernetesNamespaceRel
+from cartography.models.kubernetes.serviceaccounts import (
+    KubernetesServiceAccountToAWSRoleRel,
+)
 from cartography.models.kubernetes.users import KubernetesUserToAWSRoleRel
 
 
@@ -64,6 +67,10 @@ ONTOLOGY_REL_CONSTRAINTS: tuple[RelConstraint, ...] = (
     ),
     # A user account is granted a role.
     RelConstraint(src="UserAccount", dst="PermissionRole", label="HAS_ROLE"),
+    # A service account (workload identity) is granted a role. No provider
+    # currently wires a direct edge (all go through binding nodes), so this is
+    # forward-looking governance for future modules.
+    RelConstraint(src="ServiceAccount", dst="PermissionRole", label="HAS_ROLE"),
 )
 
 
@@ -100,5 +107,9 @@ LEGACY_REL_WHITELIST: frozenset[type] = frozenset(
         # ASSUMED_ROLE_WITH_SAML records a CloudTrail-observed runtime assumption
         # event, not a static role assignment. Distinct from HAS_ROLE.
         AssumedRoleWithSAMLMatchLink,
+        # ASSUMES_ROLE is workload-identity federation (a Kubernetes service
+        # account assumes an AWS IAM role, IRSA-style). This is the canonical
+        # ASSUMES semantic, not a static role grant. Distinct from HAS_ROLE.
+        KubernetesServiceAccountToAWSRoleRel,
     }
 )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -5751,10 +5751,10 @@ Representation of an AWS SSO User.
 
 - An AWSSSOUser can be assigned to one or more AWSPermissionSets. This includes both direct assignments and assignments inherited through AWSSSOGroup membership.
     ```
-    (:AWSSSOUser)-[:HAS_PERMISSION_SET]->(:AWSPermissionSet)
+    (:AWSSSOUser)-[:HAS_ROLE]->(:AWSPermissionSet)
     ```
     Notes:
-    - The AWS Identity Center API (`list_account_assignments_for_principal`) automatically resolves group memberships server-side, so users receive `HAS_PERMISSION_SET` relationships for permission sets they have access to through groups they belong to. This means if a user is only in a group that has a permission set assignment, the user will still have a direct `HAS_PERMISSION_SET` relationship to that permission set.
+    - The AWS Identity Center API (`list_account_assignments_for_principal`) automatically resolves group memberships server-side, so users receive `HAS_ROLE` relationships for permission sets they have access to through groups they belong to. This means if a user is only in a group that has a permission set assignment, the user will still have a direct `HAS_ROLE` relationship to that permission set.
     - This is a **summary relationship** that does not indicate which specific accounts the user has access to, only that they have been assigned to the permission set. For a user to have access to an AWS account, they must be assigned to a permission set for that specific account. This is captured by the `ALLOWED_BY` relationship.
 
 - AWSSSOUser can assume AWS roles via SAML (recorded from CloudTrail management events).
@@ -5847,10 +5847,10 @@ Representation of an AWS Identity Center Permission Set.
 
 - An AWSSSOUser can be assigned to one or more AWSPermissionSets. This includes both direct assignments and assignments inherited through AWSSSOGroup membership.
     ```
-    (:AWSSSOUser)-[:HAS_PERMISSION_SET]->(:AWSPermissionSet)
+    (:AWSSSOUser)-[:HAS_ROLE]->(:AWSPermissionSet)
     ```
     Notes:
-    - The AWS Identity Center API (`list_account_assignments_for_principal`) automatically resolves group memberships server-side, so users receive `HAS_PERMISSION_SET` relationships for permission sets they have access to through groups they belong to. This means if a user is only in a group that has a permission set assignment, the user will still have a direct `HAS_PERMISSION_SET` relationship to that permission set.
+    - The AWS Identity Center API (`list_account_assignments_for_principal`) automatically resolves group memberships server-side, so users receive `HAS_ROLE` relationships for permission sets they have access to through groups they belong to. This means if a user is only in a group that has a permission set assignment, the user will still have a direct `HAS_ROLE` relationship to that permission set.
     - This is a **summary relationship** that does not indicate which specific accounts the user has access to, only that they have been assigned to the permission set. For a user to have access to an AWS account, they must be assigned to a permission set _for that specific account_. This is captured by the `ALLOWED_BY` relationship.
 
 - An AWSSSOGroup has assigned permission sets. AWSSSOUsers in the group will receive all permission sets that the group is assigned to.

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -5146,16 +5146,6 @@ Representation of an AWS ECS [Service](https://docs.aws.amazon.com/AmazonECS/lat
 
 #### Relationships
 
-- An ECSCluster has ECSService (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
-    ```
-    (:ECSCluster)-[:HAS_SERVICE]->(:ECSService)
-    ```
-
-- An ECSService has ECSTasks (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
-    ```
-    (:ECSService)-[:HAS_TASK]->(:ECSTask)
-    ```
-
 - An ECSService points at its parent cluster via the unified workload chain.
     ```
     (:ECSService)-[:WORKLOAD_PARENT]->(:ECSCluster)
@@ -5305,11 +5295,6 @@ Representation of an AWS ECS [Task](https://docs.aws.amazon.com/AmazonECS/latest
     (:AWSAccount)-[:RESOURCE]->(:ECSTask)
     ```
 
-- ECSClusters have ECSTasks (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
-    ```
-    (:ECSCluster)-[:HAS_TASK]->(:ECSTask)
-    ```
-
 - ECSContainerInstances have ECSTasks
     ```
     (:ECSContainerInstance)-[:HAS_TASK]->(:ECSTask)
@@ -5363,11 +5348,6 @@ Representation of an AWS ECS [Container](https://docs.aws.amazon.com/AmazonECS/l
 | exposed\_internet | Set to `True` if this container is exposed to the internet via an internet-facing load balancer. Set by the `aws_ecs_asset_exposure` [analysis job](https://github.com/cartography-cncf/cartography/blob/master/cartography/data/jobs/analysis/aws_ecs_asset_exposure.json). |
 
 #### Relationships
-
-- ECSTasks have ECSContainers (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
-    ```
-    (:ECSTask)-[:HAS_CONTAINER]->(:ECSContainer)
-    ```
 
 - ECSContainers point at their parent ECSTask via the unified workload chain.
     ```

--- a/docs/root/modules/azure/schema.md
+++ b/docs/root/modules/azure/schema.md
@@ -1980,10 +1980,6 @@ Representation of an [Azure Container Group](https://learn.microsoft.com/en-us/r
     ```cypher
     (AzureGroupContainer)-[:ATTACHED_TO]->(:AzureSubnet)
     ```
-- An Azure Container Group contains one or more AzureContainerInstances. (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
-    ```cypher
-    (AzureGroupContainer)-[:CONTAINS]->(:AzureContainerInstance)
-    ```
 
 ### AzureContainerInstance
 
@@ -2014,10 +2010,6 @@ Representation of an individual container within an [Azure Container Group](http
 - An AzureContainerInstance is a resource within an Azure Subscription.
     ```cypher
     (AzureSubscription)-[:RESOURCE]->(:AzureContainerInstance)
-    ```
-- An Azure Container Group contains its AzureContainerInstances. (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
-    ```cypher
-    (AzureGroupContainer)-[:CONTAINS]->(:AzureContainerInstance)
     ```
 - An AzureContainerInstance points at its parent AzureGroupContainer via the unified workload chain.
     ```cypher

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -2116,10 +2116,6 @@ Cloud Run Service is treated as an orchestrator (analogous to `ECSService`) and 
     ```
     (GCPCloudRunService)-[:USES_SERVICE_ACCOUNT]->(GCPServiceAccount)
     ```
-  - GCPCloudRunServices contain one GCPCloudRunServiceContainer per container declared in the `latestReadyRevision` spec (including sidecars). (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
-    ```
-    (GCPCloudRunService)-[:CONTAINS]->(GCPCloudRunServiceContainer)
-    ```
 
 ### GCPCloudRunRevision
 
@@ -2181,10 +2177,6 @@ Representation of a GCP [Cloud Run Job](https://cloud.google.com/run/docs/refere
     ```
     (GCPCloudRunJob)-[:USES_SERVICE_ACCOUNT]->(GCPServiceAccount)
     ```
-  - GCPCloudRunJobs contain one GCPCloudRunJobContainer per container declared in the task template (including sidecars). (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
-    ```
-    (GCPCloudRunJob)-[:CONTAINS]->(GCPCloudRunJobContainer)
-    ```
 
 ### GCPCloudRunJobContainer
 
@@ -2211,10 +2203,6 @@ Representation of an individual container spec from a [Cloud Run Job](https://cl
   - GCPCloudRunJobContainers are resources of GCPProjects.
     ```
     (GCPProject)-[:RESOURCE]->(GCPCloudRunJobContainer)
-    ```
-  - GCPCloudRunJobContainers live inside a GCPCloudRunJob. (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
-    ```
-    (GCPCloudRunJob)-[:CONTAINS]->(GCPCloudRunJobContainer)
     ```
   - GCPCloudRunJobContainers point at their parent GCPCloudRunJob via the unified workload chain.
     ```
@@ -2257,10 +2245,6 @@ Representation of an individual container spec from a [Cloud Run Service](https:
   - GCPCloudRunServiceContainers are resources of GCPProjects.
     ```
     (GCPProject)-[:RESOURCE]->(GCPCloudRunServiceContainer)
-    ```
-  - GCPCloudRunServiceContainers live inside a GCPCloudRunService (sourced from the `latestReadyRevision` spec). (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
-    ```
-    (GCPCloudRunService)-[:CONTAINS]->(GCPCloudRunServiceContainer)
     ```
   - GCPCloudRunServiceContainers point at their parent GCPCloudRunService via the unified workload chain.
     ```

--- a/docs/root/modules/keycloak/analysis.md
+++ b/docs/root/modules/keycloak/analysis.md
@@ -32,7 +32,7 @@ graph LR
 **Query**:
 ```cypher
 MATCH (u:KeycloakUser)-[:MEMBER_OF|INHERITED_MEMBER_OF]->(g:KeycloakGroup)-[:GRANTS]->(r:KeycloakRole)
-MERGE (u)-[r0:ASSUME_ROLE]->(r)
+MERGE (u)-[r0:HAS_ROLE]->(r)
 ON CREATE SET r0.firstseen = $UPDATE_TAG
 SET r0.lastupdated = $UPDATE_TAG
 ```
@@ -45,7 +45,7 @@ SET r0.lastupdated = $UPDATE_TAG
 graph LR
     U(KeycloakUser) -- MEMBER_OF --> G[KeycloakGroup]
     G -- GRANTS --> R(KeycloakRole)
-    U == ASSUME_ROLE ==> R
+    U == HAS_ROLE ==> R
 ```
 
 ### 3. Composite Role Grants Propagation
@@ -77,7 +77,7 @@ graph LR
 
 **Query**:
 ```cypher
-MATCH (u:KeycloakUser)-[:ASSUME_ROLE]->(:KeycloakRole)-[:GRANTS|INDIRECT_GRANTS]->(s:KeycloakScope)
+MATCH (u:KeycloakUser)-[:HAS_ROLE]->(:KeycloakRole)-[:GRANTS|INDIRECT_GRANTS]->(s:KeycloakScope)
 MERGE (u)-[r:ASSUME_SCOPE]->(s)
 ON CREATE SET r.firstseen = $UPDATE_TAG
 SET r.lastupdated = $UPDATE_TAG
@@ -89,7 +89,7 @@ SET r.lastupdated = $UPDATE_TAG
 
 ```mermaid
 graph LR
-    U(KeycloakUser) -- ASSUME_ROLE --> R(KeycloakRole)
+    U(KeycloakUser) -- HAS_ROLE --> R(KeycloakRole)
     R -- GRANTS --> S(KeycloakScope)
     U == ASSUME_SCOPE ==> S
 ```

--- a/docs/root/modules/keycloak/schema.md
+++ b/docs/root/modules/keycloak/schema.md
@@ -26,7 +26,7 @@ ROLE -- INCLUDES --> ROLE
 U -- HAS_IDENTITY --> IDP
 U -- MANAGED_MEMBER_OF --> O
 U -- UNMANAGED_MEMBER_OF --> O
-U == ASSUME_ROLE ==> ROLE
+U == HAS_ROLE ==> ROLE
 U == ASSUME_SCOPE ==> S
 O -- ENFORCES --> IDP
 OD -- BELONGS_TO --> O
@@ -303,9 +303,9 @@ Represents a user in the Keycloak realm with authentication and profile informat
     ```
     (:KeycloakUser)-[:HAS_IDENTITY]->(:KeycloakIdentityProvider)
     ```
-- `KeycloakUser` can assume Role (this can be direct definition or inherited from groups)
+- `KeycloakUser` is granted a Role (direct definition or inherited from groups).
     ```
-    (:KeycloakUser)-[:ASSUME_ROLE]->(:KeycloakRole)
+    (:KeycloakUser)-[:HAS_ROLE]->(:KeycloakRole)
     ```
 - `KeycloakUser` can assume Scope (drawn by analysis job)
     ```
@@ -360,9 +360,9 @@ Represents a role in Keycloak that defines permissions and can be assigned to us
     ```
     (:KeycloakRole)-[:INDIRECT_GRANTS]->(:KeycloakScope)
     ```
-- `KeycloakUser` can assume Role (this can be direct definition or inherited from groups)
+- `KeycloakUser` is granted a Role (direct definition or inherited from groups).
     ```
-    (:KeycloakUser)-[:ASSUME_ROLE]->(:KeycloakRole)
+    (:KeycloakUser)-[:HAS_ROLE]->(:KeycloakRole)
     ```
 
 

--- a/docs/root/modules/kubernetes/schema.md
+++ b/docs/root/modules/kubernetes/schema.md
@@ -108,9 +108,7 @@ Representation of a [Kubernetes Namespace.](https://kubernetes.io/docs/concepts/
 #### Relationships
 - All namespace-scoped resources belong to a `KubernetesNamespace`.
     ```
-    (:KubernetesNamespace)-[:CONTAINS]->(:KubernetesPod,
-                                         :KubernetesContainer,
-                                         :KubernetesService,
+    (:KubernetesNamespace)-[:CONTAINS]->(:KubernetesService,
                                          :KubernetesSecret,
                                          :KubernetesIngress,
                                          :KubernetesServiceAccount,
@@ -158,16 +156,6 @@ Representation of a [Kubernetes Pod.](https://kubernetes.io/docs/concepts/worklo
 - `KubernetesPod` uses a `KubernetesServiceAccount`.
     ```
     (:KubernetesPod)-[:USES_SERVICE_ACCOUNT]->(:KubernetesServiceAccount)
-    ```
-
-- `KubernetesPod` has `KubernetesContainer`. (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
-    ```
-    (:KubernetesPod)-[:CONTAINS]->(:KubernetesContainer)
-    ```
-
-- A `KubernetesNamespace` contains a `KubernetesPod`. (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
-    ```
-    (:KubernetesNamespace)-[:CONTAINS]->(:KubernetesPod)
     ```
 
 - `KubernetesPod` points at its parent `KubernetesNamespace` via the unified workload chain.
@@ -222,11 +210,6 @@ Representation of a [Kubernetes Container.](https://kubernetes.io/docs/concepts/
 
 
 #### Relationships
-- `KubernetesPod` has `KubernetesContainer`. (DEPRECATED: replaced by `WORKLOAD_PARENT`, will be removed in v1.0.0)
-    ```
-    (:KubernetesPod)-[:CONTAINS]->(:KubernetesContainer)
-    ```
-
 - `KubernetesContainer` points at its parent `KubernetesPod` via the unified workload chain.
     ```
     (:KubernetesContainer)-[:WORKLOAD_PARENT]->(:KubernetesPod)

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -39,6 +39,7 @@ REPO{{CodeRepository}}
 SC{{Secret}}
 EK{{EncryptionKey}}
 PR{{PermissionRole}}
+UA -- HAS_ROLE --> PR
 NAC{{NetworkAccessControl}}
 AIM{{AIModel}}
 PIP(PublicIP) -- POINTS_TO --> LB
@@ -574,6 +575,11 @@ Common role concepts across platforms include:
 | _ont_type | Whether the role is builtin or custom (e.g., "builtin", "custom"). |
 | _ont_scope | The scope level of the role (e.g., "global", "account", "org", "project", "namespace", "cluster"). |
 | _ont_source | Source of the data. |
+
+A `UserAccount` that is granted a permission role is linked via the canonical `HAS_ROLE` edge:
+```
+(:UserAccount)-[:HAS_ROLE]->(:PermissionRole)
+```
 
 
 ### ObjectStorage

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -40,6 +40,7 @@ SC{{Secret}}
 EK{{EncryptionKey}}
 PR{{PermissionRole}}
 UA -- HAS_ROLE --> PR
+SA -- HAS_ROLE --> PR
 NAC{{NetworkAccessControl}}
 AIM{{AIModel}}
 PIP(PublicIP) -- POINTS_TO --> LB
@@ -576,9 +577,10 @@ Common role concepts across platforms include:
 | _ont_scope | The scope level of the role (e.g., "global", "account", "org", "project", "namespace", "cluster"). |
 | _ont_source | Source of the data. |
 
-A `UserAccount` that is granted a permission role is linked via the canonical `HAS_ROLE` edge:
+A `UserAccount` or `ServiceAccount` that is granted a permission role is linked via the canonical `HAS_ROLE` edge:
 ```
 (:UserAccount)-[:HAS_ROLE]->(:PermissionRole)
+(:ServiceAccount)-[:HAS_ROLE]->(:PermissionRole)
 ```
 
 

--- a/tests/integration/cartography/intel/aws/test_identitycenter.py
+++ b/tests/integration/cartography/intel/aws/test_identitycenter.py
@@ -306,6 +306,21 @@ def test_link_sso_user_to_permission_set(neo4j_session):
             ps["PermissionSetArn"],
         )
     }
+    # Canonical ontology edge created in parallel with the deprecated one.
+    assert check_rels(
+        neo4j_session,
+        "AWSSSOUser",
+        "id",
+        "AWSPermissionSet",
+        "arn",
+        "HAS_ROLE",
+        True,
+    ) == {
+        (
+            user["UserId"],
+            ps["PermissionSetArn"],
+        )
+    }
 
 
 def test_group_allowed_by_role(neo4j_session):

--- a/tests/integration/cartography/intel/keycloak/test_roles.py
+++ b/tests/integration/cartography/intel/keycloak/test_roles.py
@@ -136,6 +136,16 @@ def test_load_keycloak_roles(_, __, neo4j_session):
         "ASSUME_ROLE",
         rel_direction_right=False,
     ) == set(expected_rels)
+    # Canonical ontology edge created in parallel with the deprecated one.
+    assert check_rels(
+        neo4j_session,
+        "KeycloakRole",
+        "id",
+        "KeycloakUser",
+        "id",
+        "HAS_ROLE",
+        rel_direction_right=False,
+    ) == set(expected_rels)
 
     # Check roles / scopes mapping
     expected_rels = []


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary

Introduces a canonical cross-provider ontology relationship `HAS_ROLE` between identity nodes and roles, following the same pattern as the existing `WORKLOAD_PARENT` unification.

- **`(:UserAccount)-[:HAS_ROLE]->(:PermissionRole)`** and **`(:ServiceAccount)-[:HAS_ROLE]->(:PermissionRole)`** are now canonical edges enforced by the `test_ontology_rel_constraints` CI guard via two new `RelConstraint` entries.
- Provider edges that already linked an identity to a role are exposed under the canonical `HAS_ROLE` label **in parallel**, while the original edge is kept and marked deprecated for backward compatibility (removed in v1.0.0):
  - AWS Identity Center: `AWSSSOUser -[:HAS_ROLE]-> AWSPermissionSet` (alongside the deprecated `HAS_PERMISSION_SET`).
  - Keycloak: `KeycloakUser -[:HAS_ROLE]-> KeycloakRole`, for both direct members and group-inherited roles (alongside the deprecated `ASSUME_ROLE`).
  - Cloudflare already used `HAS_ROLE` and is now covered by the constraint.
- Edges that share the `UserAccount`/`ServiceAccount`-`PermissionRole` label pair but carry a distinct semantic are whitelisted, not migrated: `ALLOWED_BY` (role-assumable-by), `MAPS_TO` (identity federation), `ASSUMED_ROLE_WITH_SAML` (runtime assumption event), and `ASSUMES_ROLE` (Kubernetes IRSA workload identity).

`HAS_ROLE` was chosen as the neutral verb because `PermissionRole` generalises IAM roles, permission sets, and SaaS roles, where "assume" would be inaccurate. `ASSUME_ROLE`/`ASSUMES` is left reserved for workload-identity semantics.

Also included:
- A developer skill (`.agents/skills/promote-ontology-relationship/`) documenting this promotion procedure for future canonical edges, with a worked example.
- A documentation cleanup: relationships replaced by the canonical `WORKLOAD_PARENT` edge are no longer documented in the module `schema.md` files (the rel classes remain in code and in `LEGACY_REL_WHITELIST` until v1.0.0). This applies the "deprecated relationships are not documented" convention consistently.


### Related issues or links

Cross-provider relationship normalization: https://github.com/cartography-cncf/cartography/discussions/2772


### How was this tested?

```bash
uv run pytest tests/unit/cartography/graph/test_ontology_rel_constraints.py tests/unit/cartography/test_doc.py -q
uv run pytest tests/integration/cartography/intel/aws/test_identitycenter.py \
              tests/integration/cartography/intel/keycloak/ \
              tests/integration/cartography/intel/cloudflare/test_members.py -q
make test_lint
```

All green: the ontology constraint guard passes with the two new constraints, and integration tests assert the new `HAS_ROLE` edges alongside the existing (deprecated) ones.


### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the schema documentation.


### Notes for reviewers

The new `HAS_ROLE` edges are additive and backward compatible: the previous provider labels (`HAS_PERMISSION_SET`, `ASSUME_ROLE`) are still created and whitelisted until v1.0.0, so existing queries keep working. The constraint is the governance mechanism that prevents future drift. Each canonical edge is its own commit; the skill and the doc cleanup are separate commits.
