### PR TITLE
fix(azure): defer hierarchy cleanup

### DIFF
--- a/cartography/intel/azure/__init__.py
+++ b/cartography/intel/azure/__init__.py
@@ -311,9 +311,9 @@ def _sync_management_groups(
     credentials: Credentials,
     update_tag: int,
     common_job_parameters: dict,
-) -> None:
+) -> list[dict]:
     logger.info("Syncing Azure management groups for tenant: %s", credentials.tenant_id)
-    management_groups.sync(
+    return management_groups.sync(
         neo4j_session,
         credentials,
         credentials.tenant_id or "",
@@ -399,6 +399,14 @@ def start_azure_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
         config.update_tag,
         common_job_parameters,
     )
+    # IMPORTANT: Azure hierarchy cleanup is deferred like GCP hierarchy cleanup.
+    # The upper hierarchy is tenant -> management groups -> subscriptions, while
+    # subscription-contained resources are owned by AzureSubscription. Load the
+    # current management groups and subscriptions first, then clean stale
+    # subscriptions before stale management groups so parent cleanup does not
+    # orphan child resources or hierarchy edges. If management-group enumeration
+    # fails, skip management-group cleanup for this run to preserve prior data.
+    management_groups_synced = False
     try:
         _sync_management_groups(
             neo4j_session,
@@ -406,6 +414,7 @@ def start_azure_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             config.update_tag,
             common_job_parameters,
         )
+        management_groups_synced = True
     except RuntimeError as e:
         logger.warning(
             "Skipping Azure management groups sync. Details: %s",
@@ -435,6 +444,13 @@ def start_azure_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
             config.update_tag,
             common_job_parameters,
         )
+        if management_groups_synced:
+            logger.debug("Running deferred Azure management group cleanup")
+            management_groups.cleanup(
+                neo4j_session,
+                common_job_parameters,
+                cascade_delete=True,
+            )
 
         run_analysis_job(
             "azure_compute_asset_exposure.json",

--- a/cartography/intel/azure/management_groups.py
+++ b/cartography/intel/azure/management_groups.py
@@ -155,10 +155,13 @@ def load_azure_management_groups(
 def cleanup(
     neo4j_session: neo4j.Session,
     common_job_parameters: dict[str, Any],
+    cascade_delete: bool = False,
 ) -> None:
-    GraphJob.from_node_schema(AzureManagementGroupSchema(), common_job_parameters).run(
-        neo4j_session,
-    )
+    GraphJob.from_node_schema(
+        AzureManagementGroupSchema(),
+        common_job_parameters,
+        cascade_delete=cascade_delete,
+    ).run(neo4j_session)
 
 
 @timeit
@@ -181,5 +184,4 @@ def sync(
             tenant_id,
             update_tag,
         )
-    cleanup(neo4j_session, common_job_parameters)
     return transformed_management_groups

--- a/cartography/intel/azure/subscription.py
+++ b/cartography/intel/azure/subscription.py
@@ -214,10 +214,16 @@ def load_azure_subscriptions(
     )
 
 
-def cleanup(neo4j_session: neo4j.Session, common_job_parameters: Dict) -> None:
-    GraphJob.from_node_schema(AzureSubscriptionSchema(), common_job_parameters).run(
-        neo4j_session,
-    )
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: Dict,
+    cascade_delete: bool = False,
+) -> None:
+    GraphJob.from_node_schema(
+        AzureSubscriptionSchema(),
+        common_job_parameters,
+        cascade_delete=cascade_delete,
+    ).run(neo4j_session)
 
 
 @timeit
@@ -282,4 +288,4 @@ def sync(
         transformed_subscriptions,
         update_tag,
     )
-    cleanup(neo4j_session, common_job_parameters)
+    cleanup(neo4j_session, common_job_parameters, cascade_delete=True)

--- a/tests/integration/cartography/intel/azure/test_deferred_cleanup.py
+++ b/tests/integration/cartography/intel/azure/test_deferred_cleanup.py
@@ -1,0 +1,123 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.azure as azure
+from cartography.config import Config
+from cartography.graph.job import GraphJob
+from tests.data.azure.management_groups import AZURE_MANAGEMENT_GROUP_SUBSCRIPTIONS
+from tests.data.azure.management_groups import AZURE_MANAGEMENT_GROUPS
+from tests.data.azure.management_groups import TEST_CHILD_MANAGEMENT_GROUP_ID
+from tests.data.azure.management_groups import TEST_SUBSCRIPTION_ID
+from tests.data.azure.management_groups import TEST_TENANT_ID
+from tests.integration import settings
+from tests.integration.util import check_nodes
+
+TEST_UPDATE_TAG = 123456789
+TEST_UPDATE_TAG_V2 = 123456790
+
+
+def _make_config(update_tag: int) -> Config:
+    return Config(
+        neo4j_uri=settings.get("NEO4J_URL"),
+        update_tag=update_tag,
+        azure_sync_all_subscriptions=True,
+    )
+
+
+def _make_credentials() -> MagicMock:
+    credentials = MagicMock()
+    credentials.tenant_id = TEST_TENANT_ID
+    return credentials
+
+
+def _make_subscription() -> dict:
+    return {
+        "id": f"/subscriptions/{TEST_SUBSCRIPTION_ID}",
+        "subscriptionId": TEST_SUBSCRIPTION_ID,
+        "displayName": "Test Subscription",
+        "state": "Enabled",
+    }
+
+
+@patch("cartography.intel.azure.run_scoped_analysis_job")
+@patch("cartography.intel.azure.run_analysis_job")
+@patch("cartography.intel.azure._sync_one_subscription")
+@patch("cartography.intel.azure.subscription.get_all_azure_subscriptions")
+@patch("cartography.intel.azure.subscription.get_azure_management_group_subscriptions")
+@patch("cartography.intel.azure.management_groups.get_azure_management_groups")
+@patch("cartography.intel.azure.Authenticator.authenticate_cli")
+def test_deferred_hierarchy_cleanup_order(
+    mock_authenticate_cli,
+    mock_get_management_groups,
+    mock_get_management_group_subscriptions,
+    mock_get_all_subscriptions,
+    mock_sync_one_subscription,
+    mock_run_analysis_job,
+    mock_run_scoped_analysis_job,
+    neo4j_session,
+):
+    mock_authenticate_cli.return_value = _make_credentials()
+    mock_get_management_groups.return_value = AZURE_MANAGEMENT_GROUPS
+    mock_get_management_group_subscriptions.return_value = (
+        AZURE_MANAGEMENT_GROUP_SUBSCRIPTIONS,
+        set(),
+    )
+    mock_get_all_subscriptions.return_value = [_make_subscription()]
+
+    cleanup_order = []
+    original_run = GraphJob.run
+
+    def track_cleanup(self, session):
+        if hasattr(self, "name"):
+            cleanup_order.append(self.name)
+        return original_run(self, session)
+
+    with patch.object(GraphJob, "run", track_cleanup):
+        azure.start_azure_ingestion(neo4j_session, _make_config(TEST_UPDATE_TAG))
+
+    subscription_cleanup_idx = next(
+        i for i, name in enumerate(cleanup_order) if "AzureSubscription" in name
+    )
+    management_group_cleanup_idx = next(
+        i for i, name in enumerate(cleanup_order) if "AzureManagementGroup" in name
+    )
+    assert subscription_cleanup_idx < management_group_cleanup_idx
+
+
+@patch("cartography.intel.azure.run_scoped_analysis_job")
+@patch("cartography.intel.azure.run_analysis_job")
+@patch("cartography.intel.azure._sync_one_subscription")
+@patch("cartography.intel.azure.subscription.get_all_azure_subscriptions")
+@patch("cartography.intel.azure.subscription.get_azure_management_group_subscriptions")
+@patch("cartography.intel.azure.management_groups.get_azure_management_groups")
+@patch("cartography.intel.azure.Authenticator.authenticate_cli")
+def test_management_group_cleanup_skipped_after_management_group_access_loss(
+    mock_authenticate_cli,
+    mock_get_management_groups,
+    mock_get_management_group_subscriptions,
+    mock_get_all_subscriptions,
+    mock_sync_one_subscription,
+    mock_run_analysis_job,
+    mock_run_scoped_analysis_job,
+    neo4j_session,
+):
+    mock_authenticate_cli.return_value = _make_credentials()
+    mock_get_management_groups.side_effect = [
+        AZURE_MANAGEMENT_GROUPS,
+        RuntimeError("management group enumeration failed"),
+    ]
+    mock_get_management_group_subscriptions.side_effect = [
+        (AZURE_MANAGEMENT_GROUP_SUBSCRIPTIONS, set()),
+        ([], set()),
+    ]
+    mock_get_all_subscriptions.return_value = [_make_subscription()]
+
+    azure.start_azure_ingestion(neo4j_session, _make_config(TEST_UPDATE_TAG))
+    azure.start_azure_ingestion(neo4j_session, _make_config(TEST_UPDATE_TAG_V2))
+
+    management_group_nodes = check_nodes(
+        neo4j_session,
+        "AzureManagementGroup",
+        ["id"],
+    )
+    assert (TEST_CHILD_MANAGEMENT_GROUP_ID,) in management_group_nodes

--- a/tests/integration/cartography/intel/azure/test_subscription.py
+++ b/tests/integration/cartography/intel/azure/test_subscription.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import pytest
 from azure.core.exceptions import HttpResponseError
 
 import cartography.intel.azure.management_groups as management_groups
@@ -20,6 +21,39 @@ from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
 TEST_STALE_SUBSCRIPTION_ID = "ffffffff-1111-2222-3333-444444444444"
+
+
+@pytest.fixture(autouse=True)
+def cleanup_test_data(neo4j_session):
+    def cleanup() -> None:
+        neo4j_session.run(
+            """
+            MATCH (n)
+            WHERE (
+                (n:AzureTenant AND n.id = $tenant_id)
+                OR (n:AzureManagementGroup AND n.id IN $management_group_ids)
+                OR (n:AzureSubscription AND n.id IN $subscription_ids)
+                OR (
+                    n:AzureResourceGroup
+                    AND any(subscription_id IN $subscription_ids WHERE n.id CONTAINS subscription_id)
+                )
+            )
+            DETACH DELETE n
+            """,
+            tenant_id=TEST_TENANT_ID,
+            management_group_ids=[
+                TEST_PARENT_MANAGEMENT_GROUP_ID,
+                TEST_CHILD_MANAGEMENT_GROUP_ID,
+            ],
+            subscription_ids=[
+                TEST_SUBSCRIPTION_ID,
+                TEST_STALE_SUBSCRIPTION_ID,
+            ],
+        )
+
+    cleanup()
+    yield
+    cleanup()
 
 
 @patch("cartography.intel.azure.subscription.get_azure_management_group_subscriptions")
@@ -194,6 +228,11 @@ def test_cleanup_stale_management_group_hierarchy_and_subscription_parentage(
         subscriptions,
         second_update_tag,
         second_common_job_parameters,
+    )
+    management_groups.cleanup(
+        neo4j_session,
+        second_common_job_parameters,
+        cascade_delete=True,
     )
 
     # Assert
@@ -453,6 +492,54 @@ def test_sync_subscriptions_continues_when_management_group_enrichment_fails(
         "PARENT",
     )
     assert subscription_parent_rels == set()
+
+
+@patch("cartography.intel.azure.subscription.get_azure_management_group_subscriptions")
+def test_cleanup_stale_subscription_cascade_deletes_subscription_resources(
+    mock_get_management_group_subscriptions,
+    neo4j_session,
+):
+    mock_get_management_group_subscriptions.return_value = ([], set())
+
+    stale_resource_group_id = (
+        f"/subscriptions/{TEST_STALE_SUBSCRIPTION_ID}/resourceGroups/stale-rg"
+    )
+    neo4j_session.run(
+        """
+        MERGE (t:AzureTenant{id: $tenant_id})
+        SET t.lastupdated = $update_tag
+        MERGE (s:AzureSubscription{id: $subscription_id})
+        SET s.lastupdated = $previous_update_tag
+        MERGE (rg:AzureResourceGroup{id: $resource_group_id})
+        SET rg.lastupdated = $previous_update_tag
+        MERGE (t)-[:RESOURCE {lastupdated: $previous_update_tag}]->(s)
+        MERGE (s)-[:RESOURCE {lastupdated: $previous_update_tag}]->(rg)
+        """,
+        tenant_id=TEST_TENANT_ID,
+        subscription_id=TEST_STALE_SUBSCRIPTION_ID,
+        resource_group_id=stale_resource_group_id,
+        update_tag=TEST_UPDATE_TAG,
+        previous_update_tag=TEST_UPDATE_TAG - 1,
+    )
+
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "TENANT_ID": TEST_TENANT_ID,
+    }
+
+    subscription.sync(
+        neo4j_session,
+        MagicMock(),
+        TEST_TENANT_ID,
+        [],
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    subscription_nodes = check_nodes(neo4j_session, "AzureSubscription", ["id"])
+    resource_group_nodes = check_nodes(neo4j_session, "AzureResourceGroup", ["id"])
+    assert (TEST_STALE_SUBSCRIPTION_ID,) not in subscription_nodes
+    assert (stale_resource_group_id,) not in resource_group_nodes
 
 
 @patch("cartography.intel.azure.subscription.get_azure_management_group_subscriptions")

--- a/tests/integration/cartography/intel/azure/test_subscription.py
+++ b/tests/integration/cartography/intel/azure/test_subscription.py
@@ -328,7 +328,8 @@ def test_sync_subscriptions_preserves_existing_parent_only_for_failed_groups(
         common_job_parameters,
     )
 
-    # seed graph with existing state from a "previous sync"
+    # Seed graph with existing parentage from a previous sync. This is
+    # prerequisite state for the partial management-group access-loss path.
     neo4j_session.run(
         """
         MATCH (t:AzureTenant{id: $tenant_id})
@@ -401,16 +402,6 @@ def test_sync_subscriptions_preserves_existing_parent_only_for_failed_groups(
         (TEST_TENANT_ID, TEST_SUBSCRIPTION_ID),
         (TEST_TENANT_ID, TEST_STALE_SUBSCRIPTION_ID),
     }
-
-    neo4j_session.run(
-        """
-        MATCH (s:AzureSubscription)
-        WHERE s.id IN [$preserved_subscription_id, $stale_subscription_id]
-        DETACH DELETE s
-        """,
-        preserved_subscription_id=TEST_SUBSCRIPTION_ID,
-        stale_subscription_id=TEST_STALE_SUBSCRIPTION_ID,
-    )
 
 
 @patch("cartography.intel.azure.subscription.get_azure_management_group_subscriptions")
@@ -499,6 +490,7 @@ def test_cleanup_stale_subscription_cascade_deletes_subscription_resources(
     mock_get_management_group_subscriptions,
     neo4j_session,
 ):
+    # Arrange
     mock_get_management_group_subscriptions.return_value = ([], set())
 
     stale_resource_group_id = (
@@ -527,6 +519,7 @@ def test_cleanup_stale_subscription_cascade_deletes_subscription_resources(
         "TENANT_ID": TEST_TENANT_ID,
     }
 
+    # Act
     subscription.sync(
         neo4j_session,
         MagicMock(),
@@ -536,6 +529,7 @@ def test_cleanup_stale_subscription_cascade_deletes_subscription_resources(
         common_job_parameters,
     )
 
+    # Assert
     subscription_nodes = check_nodes(neo4j_session, "AzureSubscription", ["id"])
     resource_group_nodes = check_nodes(neo4j_session, "AzureResourceGroup", ["id"])
     assert (TEST_STALE_SUBSCRIPTION_ID,) not in subscription_nodes
@@ -555,6 +549,8 @@ def test_sync_subscriptions_preserves_existing_parent_when_global_enrichment_fai
         message="management group subscription lookup failed",
     )
 
+    # Seed graph with existing parentage from a previous sync. This is
+    # prerequisite state for the global management-group enrichment failure path.
     neo4j_session.run(
         """
         MERGE (t:AzureTenant{id: $tenant_id})


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
Defer Azure hierarchy cleanup so it follows the same child-before-parent shape as GCP hierarchy cleanup.

Management group sync now loads the current hierarchy without immediately deleting stale nodes. Subscription cleanup runs with cascade deletion after current subscriptions are loaded, then management group cleanup runs after subscription loading when management-group enumeration succeeded. If management-group enumeration fails, management-group cleanup is skipped for that run to preserve prior hierarchy data.


### Related issues or links
- Refs #2831


### Breaking changes
None expected. This changes cleanup timing for Azure hierarchy nodes, but keeps the existing node and relationship schema intact.


### How was this tested?
- Tested locally
- Added new integration tests


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
This intentionally does not add management-group-scoped RBAC. That remains follow-up work after the hierarchy cleanup semantics are stable.
