### PR TITLE
fix(rules): lead finding output models with a human-readable display field

### DIFF
--- a/.agents/skills/create-rule/SKILL.md
+++ b/.agents/skills/create-rule/SKILL.md
@@ -93,8 +93,8 @@ _aws_public_databases = Fact(
 ```python
 class DatabaseExposedOutput(Finding):
     """Output model for publicly exposed databases."""
+    name: str | None = None    # human-readable label first: used as the finding title
     id: str | None = None
-    name: str | None = None
     region: str | None = None
 ```
 
@@ -102,6 +102,7 @@ class DatabaseExposedOutput(Finding):
 - Field names must match `cypher_query` aliases **exactly**.
 - All fields are `| None` with default `None`.
 - The `source` field is auto-populated with the module name.
+- **Declare a human-readable label as the first field.** Downstream consumers derive the finding's title from the first non-empty field in declaration order, so leading with an opaque id, ARN, URI, digest, region, or boolean produces an unreadable title. If the node has no natural name, alias one in the `cypher_query` (e.g. `coalesce(n.friendly_name, n.short_id) AS name`, or an AWS `Name` tag) and declare it first. This is independent of `identity_fields`/`asset_id_field` and of `RETURN` order. See "Display field order (finding title)" in `docs/root/usage/rules.md`.
 - Set `identity_fields` on the Fact (required) to the subset of these fields that forms the finding's stable logical identity, excluding volatile context (`*_count`, `days_*`, `last_used*`, `*_date`, posture booleans, aggregate lists) so downstream lifecycle tracking does not treat a changed metric as a new finding. See "Finding identity vs. display fields" in `docs/root/usage/rules.md`.
 
 ### Step 4 — Compose the Rule

--- a/.agents/skills/create-rule/references/cis-conventions.md
+++ b/.agents/skills/create-rule/references/cis-conventions.md
@@ -189,8 +189,8 @@ _aws_access_keys_not_rotated = Fact(
 
 
 class CIS114Output(Finding):
+    user_name: str | None = None    # human-readable label first: used as the finding title
     id: str | None = None
-    user_name: str | None = None
     create_date: str | None = None
 
 

--- a/cartography/rules/data/rules/cis_4_0_gcp.py
+++ b/cartography/rules/data/rules/cis_4_0_gcp.py
@@ -447,8 +447,8 @@ gcp_instances_without_confidential_computing_enabled = Rule(
 # Main node: GCPDNSZone
 # =============================================================================
 class DnssecDisabledOutput(Finding):
-    zone_id: str | None = None
     zone_name: str | None = None
+    zone_id: str | None = None
     project_id: str | None = None
     project_name: str | None = None
     dns_name: str | None = None
@@ -513,8 +513,8 @@ gcp_cloud_dns_dnssec_disabled = Rule(
 # Main node: GCPDNSZone
 # =============================================================================
 class DnssecWeakKskOutput(Finding):
-    zone_id: str | None = None
     zone_name: str | None = None
+    zone_id: str | None = None
     project_id: str | None = None
     project_name: str | None = None
     dns_name: str | None = None
@@ -578,8 +578,8 @@ gcp_cloud_dns_dnssec_key_signing_uses_rsasha1 = Rule(
 # Main node: GCPDNSZone
 # =============================================================================
 class DnssecWeakZskOutput(Finding):
-    zone_id: str | None = None
     zone_name: str | None = None
+    zone_id: str | None = None
     project_id: str | None = None
     project_name: str | None = None
     dns_name: str | None = None
@@ -643,8 +643,8 @@ gcp_cloud_dns_dnssec_zone_signing_uses_rsasha1 = Rule(
 # Main node: GCPSubnet
 # =============================================================================
 class SubnetFlowLogsDisabledOutput(Finding):
-    subnet_id: str | None = None
     subnet_name: str | None = None
+    subnet_id: str | None = None
     project_id: str | None = None
     project_name: str | None = None
     region: str | None = None
@@ -736,8 +736,8 @@ gcp_subnets_without_compliant_vpc_flow_logs = Rule(
 # Main node: GCPCloudSQLInstance
 # =============================================================================
 class CloudSqlPublicIpOutput(Finding):
-    instance_id: str | None = None
     instance_name: str | None = None
+    instance_id: str | None = None
     project_id: str | None = None
     project_name: str | None = None
     ip_addresses: str | None = None
@@ -793,8 +793,8 @@ gcp_cloudsql_public_ips = Rule(
 # Main node: GCPCloudSQLInstance
 # =============================================================================
 class CloudSqlBackupsDisabledOutput(Finding):
-    instance_id: str | None = None
     instance_name: str | None = None
+    instance_id: str | None = None
     project_id: str | None = None
     project_name: str | None = None
     database_version: str | None = None
@@ -850,6 +850,7 @@ gcp_cloudsql_automated_backups_disabled = Rule(
 # Main node: GCPBigQueryDataset
 # =============================================================================
 class BigQueryDatasetPublicAccessOutput(Finding):
+    dataset_name: str | None = None
     dataset_id: str | None = None
     project_id: str | None = None
     project_name: str | None = None
@@ -865,6 +866,7 @@ _gcp_bigquery_dataset_public = Fact(
     WHERE coalesce(dataset.access_entries, '') CONTAINS 'allUsers'
        OR coalesce(dataset.access_entries, '') CONTAINS 'allAuthenticatedUsers'
     RETURN
+        coalesce(dataset.friendly_name, dataset.dataset_id) AS dataset_name,
         dataset.id AS dataset_id,
         project.id AS project_id,
         project.displayname AS project_name,
@@ -907,6 +909,7 @@ gcp_bigquery_datasets_publicly_accessible = Rule(
 # Main node: GCPBigQueryTable
 # =============================================================================
 class BigQueryTableCmekMissingOutput(Finding):
+    table_name: str | None = None
     table_id: str | None = None
     dataset_id: str | None = None
     project_id: str | None = None
@@ -922,6 +925,7 @@ _gcp_bigquery_table_cmek_missing = Fact(
     MATCH (project:GCPProject)-[:RESOURCE]->(table:GCPBigQueryTable)
     WHERE table.kms_key_name IS NULL OR table.kms_key_name = ''
     RETURN
+        coalesce(table.friendly_name, table.table_id) AS table_name,
         table.id AS table_id,
         table.dataset_id AS dataset_id,
         project.id AS project_id,
@@ -964,6 +968,7 @@ gcp_bigquery_tables_without_cmek = Rule(
 # Main node: GCPBigQueryDataset
 # =============================================================================
 class BigQueryDatasetCmekMissingOutput(Finding):
+    dataset_name: str | None = None
     dataset_id: str | None = None
     project_id: str | None = None
     project_name: str | None = None
@@ -978,6 +983,7 @@ _gcp_bigquery_dataset_cmek_missing = Fact(
     MATCH (project:GCPProject)-[:RESOURCE]->(dataset:GCPBigQueryDataset)
     WHERE dataset.default_kms_key_name IS NULL OR dataset.default_kms_key_name = ''
     RETURN
+        coalesce(dataset.friendly_name, dataset.dataset_id) AS dataset_name,
         dataset.id AS dataset_id,
         project.id AS project_id,
         project.displayname AS project_name,
@@ -1019,8 +1025,8 @@ gcp_bigquery_datasets_without_default_cmek = Rule(
 # Main node: GCPCloudSQLInstance
 # =============================================================================
 class CloudSqlSslModeOutput(Finding):
-    instance_id: str | None = None
     instance_name: str | None = None
+    instance_id: str | None = None
     project_id: str | None = None
     project_name: str | None = None
     ssl_mode: str | None = None
@@ -1080,8 +1086,8 @@ gcp_cloudsql_ssl_not_enforced = Rule(
 # Main node: GCPCloudSQLInstance
 # =============================================================================
 class CloudSqlAuthorizedNetworksOutput(Finding):
-    instance_id: str | None = None
     instance_name: str | None = None
+    instance_id: str | None = None
     project_id: str | None = None
     project_name: str | None = None
     authorized_networks: str | None = None
@@ -1133,8 +1139,8 @@ gcp_cloudsql_authorized_networks_open_to_internet = Rule(
 
 
 class CloudSqlDatabaseFlagOutput(Finding):
-    instance_id: str | None = None
     instance_name: str | None = None
+    instance_id: str | None = None
     project_id: str | None = None
     project_name: str | None = None
     database_version: str | None = None
@@ -1924,8 +1930,8 @@ gcp_instances_not_blocking_project_wide_ssh_keys = Rule(
 # Main node: GCPProject
 # =============================================================================
 class ProjectOsloginDisabledOutput(Finding):
-    project_id: str | None = None
     project_name: str | None = None
+    project_id: str | None = None
     compute_project_enable_oslogin: str | None = None
     overriding_instance_count: int | None = None
 

--- a/cartography/rules/data/rules/cis_aws_iam.py
+++ b/cartography/rules/data/rules/cis_aws_iam.py
@@ -194,8 +194,8 @@ aws_unused_credentials = Rule(
 class UserDirectPoliciesOutput(Finding):
     """Output model for user direct policies check."""
 
-    user_arn: str | None = None
     user_name: str | None = None
+    user_arn: str | None = None
     policy_name: str | None = None
     policy_arn: str | None = None
     account_id: str | None = None
@@ -260,8 +260,8 @@ aws_users_with_direct_policy_attachments = Rule(
 class MultipleAccessKeysOutput(Finding):
     """Output model for multiple access keys check."""
 
-    user_arn: str | None = None
     user_name: str | None = None
+    user_arn: str | None = None
     active_key_count: int | None = None
     access_key_ids: list[str] | None = None
     account_id: str | None = None
@@ -402,8 +402,8 @@ aws_expired_ssl_tls_certificates = Rule(
 class RootAccessKeyOutput(Finding):
     """Output model for the root access key check."""
 
-    account_id: str | None = None
     account: str | None = None
+    account_id: str | None = None
     account_access_keys_present: int | None = None
 
 
@@ -467,8 +467,8 @@ aws_root_user_access_keys = Rule(
 class RootMfaDisabledOutput(Finding):
     """Output model for the root MFA check."""
 
-    account_id: str | None = None
     account: str | None = None
+    account_id: str | None = None
     account_mfa_enabled: int | None = None
 
 
@@ -547,9 +547,9 @@ aws_root_user_mfa_disabled = Rule(
 class AdminPolicyAttachedOutput(Finding):
     """Output model for the full administrative privileges check."""
 
+    policy_name: str | None = None
     policy_id: str | None = None
     policy_arn: str | None = None
-    policy_name: str | None = None
     statement_sid: str | None = None
     principal_arn: str | None = None
     account_id: str | None = None

--- a/cartography/rules/data/rules/cis_aws_networking.py
+++ b/cartography/rules/data/rules/cis_aws_networking.py
@@ -36,6 +36,7 @@ CIS_REFERENCES = [
 class EbsEncryptionOutput(Finding):
     """Output model for EBS encryption check."""
 
+    volume_name: str | None = None
     volume_id: str | None = None
     region: str | None = None
     volume_type: str | None = None
@@ -56,7 +57,9 @@ _aws_ebs_encryption_disabled = Fact(
     cypher_query="""
     MATCH (a:AWSAccount)-[:RESOURCE]->(volume:EBSVolume)
     WHERE volume.encrypted = false
+    OPTIONAL MATCH (volume)-[:TAGGED]->(nametag:AWSTag {key: 'Name'})
     RETURN
+        coalesce(nametag.value, volume.id) AS volume_name,
         volume.id AS volume_id,
         volume.region AS region,
         volume.volumetype AS volume_type,
@@ -208,8 +211,8 @@ aws_cifs_access_restricted_to_trusted_networks = Rule(
 class RemoteAdminIpv4Output(Finding):
     """Output model for IPv4 remote administration exposure check."""
 
-    security_group_id: str | None = None
     security_group_name: str | None = None
+    security_group_id: str | None = None
     region: str | None = None
     rule_id: str | None = None
     from_port: int | None = None
@@ -313,8 +316,8 @@ aws_ipv4_remote_administration_ports_open_to_internet = Rule(
 class RemoteAdminIpv6Output(Finding):
     """Output model for IPv6 remote administration exposure check."""
 
-    security_group_id: str | None = None
     security_group_name: str | None = None
+    security_group_id: str | None = None
     region: str | None = None
     rule_id: str | None = None
     from_port: int | None = None
@@ -418,8 +421,8 @@ aws_ipv6_remote_administration_ports_open_to_internet = Rule(
 class DefaultSgAllowsTrafficOutput(Finding):
     """Output model for default security group check."""
 
-    security_group_id: str | None = None
     security_group_name: str | None = None
+    security_group_id: str | None = None
     region: str | None = None
     has_inbound_rules: bool | None = None
     has_egress_rules: bool | None = None
@@ -509,6 +512,7 @@ aws_default_security_group_restricts_traffic = Rule(
 class Ec2Imdsv2RequiredOutput(Finding):
     """Output model for EC2 IMDSv2 requirement check."""
 
+    instance_name: str | None = None
     instance_id: str | None = None
     region: str | None = None
     metadata_http_tokens: str | None = None
@@ -528,7 +532,9 @@ _aws_ec2_imdsv2_required = Fact(
     cypher_query="""
     MATCH (a:AWSAccount)-[:RESOURCE]->(ec2:EC2Instance)
     WHERE ec2.metadatahttptokens = 'optional'
+    OPTIONAL MATCH (ec2)-[:TAGGED]->(nametag:AWSTag {key: 'Name'})
     RETURN
+        coalesce(nametag.value, ec2.instanceid) AS instance_name,
         ec2.instanceid AS instance_id,
         ec2.region AS region,
         ec2.metadatahttptokens AS metadata_http_tokens,

--- a/cartography/rules/data/rules/cis_google_workspace.py
+++ b/cartography/rules/data/rules/cis_google_workspace.py
@@ -197,16 +197,16 @@ googleworkspace_admins_without_enforced_2sv = Rule(
 class SuperAdminCoverageOutput(Finding):
     """Output model for tenant-level Super Admin coverage findings."""
 
-    tenant_id: str | None = None
     tenant_domain: str | None = None
+    tenant_id: str | None = None
     super_admin_count: int | None = None
 
 
 class SuperAdminExcessOutput(Finding):
     """Output model for tenants with excessive Super Admin coverage."""
 
-    tenant_id: str | None = None
     tenant_domain: str | None = None
+    tenant_id: str | None = None
     super_admin_count: int | None = None
 
 

--- a/cartography/rules/data/rules/cis_kubernetes_rbac.py
+++ b/cartography/rules/data/rules/cis_kubernetes_rbac.py
@@ -118,8 +118,8 @@ kubernetes_cluster_admin_role_usage = Rule(
 class SecretAccessOutput(Finding):
     """Output model for secret access check."""
 
-    role_id: str | None = None
     role_name: str | None = None
+    role_id: str | None = None
     role_type: str | None = None
     verbs: list[str] | None = None
     cluster_name: str | None = None
@@ -231,8 +231,8 @@ kubernetes_roles_grant_secret_access = Rule(
 class WildcardRoleOutput(Finding):
     """Output model for wildcard role check."""
 
-    role_id: str | None = None
     role_name: str | None = None
+    role_id: str | None = None
     role_type: str | None = None
     wildcard_in: str | None = None
     cluster_name: str | None = None
@@ -344,8 +344,8 @@ kubernetes_wildcard_roles = Rule(
 class PodCreateAccessOutput(Finding):
     """Output model for pod creation access check."""
 
-    role_id: str | None = None
     role_name: str | None = None
+    role_id: str | None = None
     role_type: str | None = None
     cluster_name: str | None = None
 
@@ -552,6 +552,7 @@ _k8s_default_sa_used_by_pods = Fact(
     MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)-[:USES_SERVICE_ACCOUNT]->(sa:KubernetesServiceAccount)
     WHERE sa.name = 'default'
     RETURN
+        pod.name AS binding_name,
         pod.id AS binding_id,
         'PodUsesDefaultServiceAccount' AS binding_type,
         sa.name AS service_account_name,
@@ -587,6 +588,7 @@ _k8s_default_sa_automount_enabled = Fact(
     WHERE sa.name = 'default'
       AND coalesce(sa.automount_service_account_token, true) = true
     RETURN
+        sa.namespace + '/' + sa.name AS binding_name,
         sa.id AS binding_id,
         'ServiceAccountAutomount' AS binding_type,
         sa.name AS service_account_name,
@@ -757,8 +759,8 @@ kubernetes_system_masters_group_usage = Rule(
 class EscalationPermissionsOutput(Finding):
     """Output model for escalation permissions check."""
 
-    role_id: str | None = None
     role_name: str | None = None
+    role_id: str | None = None
     role_type: str | None = None
     dangerous_verbs: list[str] | None = None
     cluster_name: str | None = None
@@ -865,8 +867,8 @@ kubernetes_bind_impersonate_escalate_permissions = Rule(
 class PvCreateAccessOutput(Finding):
     """Output model for PV creation access check."""
 
-    role_id: str | None = None
     role_name: str | None = None
+    role_id: str | None = None
     role_type: str | None = None
     cluster_name: str | None = None
 
@@ -974,8 +976,8 @@ kubernetes_roles_grant_persistent_volume_creation = Rule(
 class NodeProxyAccessOutput(Finding):
     """Output model for node proxy access check."""
 
-    role_id: str | None = None
     role_name: str | None = None
+    role_id: str | None = None
     role_type: str | None = None
     cluster_name: str | None = None
 
@@ -1046,8 +1048,8 @@ kubernetes_node_proxy_subresource_access = Rule(
 class CsrApprovalAccessOutput(Finding):
     """Output model for CSR approval access check."""
 
-    role_id: str | None = None
     role_name: str | None = None
+    role_id: str | None = None
     role_type: str | None = None
     cluster_name: str | None = None
 
@@ -1119,8 +1121,8 @@ kubernetes_csr_approval_subresource_access = Rule(
 class WebhookConfigAccessOutput(Finding):
     """Output model for webhook configuration access check."""
 
-    role_id: str | None = None
     role_name: str | None = None
+    role_id: str | None = None
     role_type: str | None = None
     webhook_resources: str | None = None
     cluster_name: str | None = None
@@ -1206,8 +1208,8 @@ kubernetes_webhook_configuration_access = Rule(
 class SaTokenCreationAccessOutput(Finding):
     """Output model for SA token creation access check."""
 
-    role_id: str | None = None
     role_name: str | None = None
+    role_id: str | None = None
     role_type: str | None = None
     cluster_name: str | None = None
 

--- a/cartography/rules/data/rules/cis_kubernetes_workloads.py
+++ b/cartography/rules/data/rules/cis_kubernetes_workloads.py
@@ -682,8 +682,8 @@ kubernetes_pods_missing_runtime_default_seccomp = Rule(
 class DefaultNamespaceOutput(Finding):
     """Output model for default namespace usage check."""
 
-    pod_id: str | None = None
     pod_name: str | None = None
+    pod_id: str | None = None
     status_phase: str | None = None
     cluster_name: str | None = None
 

--- a/cartography/rules/data/rules/cloud_security_product_deactivated.py
+++ b/cartography/rules/data/rules/cloud_security_product_deactivated.py
@@ -40,8 +40,8 @@ aws_guard_duty_detector_disabled = Fact(
 
 # Rule
 class CloudSecurityProductDeactivated(Finding):
-    region: str | None = None
     account_name: str | None = None
+    region: str | None = None
     account_id: str | None = None
 
 

--- a/cartography/rules/data/rules/device_security_posture_gaps.py
+++ b/cartography/rules/data/rules/device_security_posture_gaps.py
@@ -7,9 +7,9 @@ from cartography.rules.spec.model import Rule
 
 
 class DeviceSecurityPostureGapOutput(Finding):
+    device_name: str | None = None
     provider: str | None = None
     device_id: str | None = None
-    device_name: str | None = None
     user: str | None = None
     platform: str | None = None
     issue: str | None = None

--- a/cartography/rules/data/rules/iam_role_external_account_trust.py
+++ b/cartography/rules/data/rules/iam_role_external_account_trust.py
@@ -49,8 +49,8 @@ _aws_role_external_account_trust = Fact(
 
 
 class IamRoleExternalAccountTrust(Finding):
-    role_arn: str | None = None
     role_name: str | None = None
+    role_arn: str | None = None
     account_id: str | None = None
     external_account_id: str | None = None
     trusted_principal_arn: str | None = None

--- a/cartography/rules/data/rules/identity_mfa_gaps.py
+++ b/cartography/rules/data/rules/identity_mfa_gaps.py
@@ -7,11 +7,11 @@ from cartography.rules.spec.model import Rule
 
 
 class IdentityMfaGapOutput(Finding):
+    principal_name: str | None = None
     provider: str | None = None
     account_id: str | None = None
     account_name: str | None = None
     principal_id: str | None = None
-    principal_name: str | None = None
     principal_type: str | None = None
     issue: str | None = None
     current_value: str | None = None

--- a/cartography/rules/data/rules/kubernetes_control_plane_exposed.py
+++ b/cartography/rules/data/rules/kubernetes_control_plane_exposed.py
@@ -136,8 +136,8 @@ _azure_aks_control_plane_exposed = Fact(
 
 # Rule
 class KubernetesControlPlaneExposed(Finding):
-    id: str | None = None
     name: str | None = None
+    id: str | None = None
     region: str | None = None
     version: str | None = None
     cloud: str | None = None

--- a/cartography/rules/data/rules/nist_ai_rmf.py
+++ b/cartography/rules/data/rules/nist_ai_rmf.py
@@ -431,6 +431,7 @@ ai_admin_app_authorizations = Rule(
 # Main node: AIBOMComponent (AIAgent)
 # =============================================================================
 class NistAiAibomAgentInventoryOutput(Finding):
+    agent_name: str | None = None
     source_id: str | None = None
     image_uri: str | None = None
     manifest_digest: str | None = None
@@ -438,7 +439,6 @@ class NistAiAibomAgentInventoryOutput(Finding):
     scanner_version: str | None = None
     agent_component_id: str | None = None
     agent_logical_id: str | None = None
-    agent_name: str | None = None
     agent_framework: str | None = None
     agent_file_path: str | None = None
     agent_line_number: int | None = None
@@ -573,11 +573,11 @@ aibom_agent_inventory = Rule(
 # Main node: AIBOMSource
 # =============================================================================
 class NistAiAibomCoverageGapOutput(Finding):
+    scanner_name: str | None = None
     source_id: str | None = None
     image_uri: str | None = None
     manifest_digests: list[str] | None = None
     report_location: str | None = None
-    scanner_name: str | None = None
     scanner_version: str | None = None
     source_status: str | None = None
     analysis_status: str | None = None
@@ -702,11 +702,11 @@ aibom_coverage_gaps = Rule(
 # Main node: OpenAIApiKey/OpenAIAdminApiKey/AnthropicApiKey
 # =============================================================================
 class NistAiProviderApiKeyHygieneOutput(Finding):
+    api_key_name: str | None = None
     provider: str | None = None
     organization_id: str | None = None
     project_or_workspace_id: str | None = None
     api_key_id: str | None = None
-    api_key_name: str | None = None
     status: str | None = None
     created_at: str | None = None
     last_used_at: str | None = None

--- a/cartography/rules/data/rules/public_snapshots.py
+++ b/cartography/rules/data/rules/public_snapshots.py
@@ -18,6 +18,7 @@ _aws_ebs_snapshot_public = Fact(
     MATCH (a:AWSAccount)-[:RESOURCE]->(s:EBSSnapshot)
     WHERE s.ispublic = true
     RETURN
+        coalesce(s.description, s.id) AS name,
         s.id AS id,
         s.id AS arn,
         s.volumeid AS source_identifier,
@@ -55,6 +56,7 @@ _aws_rds_snapshot_public = Fact(
     MATCH (a:AWSAccount)-[:RESOURCE]->(s:RDSSnapshot)
     WHERE s.ispublic = true
     RETURN
+        s.db_snapshot_identifier AS name,
         s.db_snapshot_identifier AS id,
         s.arn AS arn,
         s.db_instance_identifier AS source_identifier,
@@ -98,6 +100,7 @@ _aws_ami_public = Fact(
     WHERE i.ispublic = true
       AND i.owner = a.id
     RETURN
+        coalesce(i.name, i.id) AS name,
         i.id AS id,
         i.imageid AS arn,
         i.name AS source_identifier,
@@ -127,6 +130,7 @@ _aws_ami_public = Fact(
 
 # Rule
 class PublicSnapshots(Finding):
+    name: str | None = None
     id: str | None = None
     arn: str | None = None
     source_identifier: str | None = None

--- a/cartography/rules/data/rules/subimage_coverage.py
+++ b/cartography/rules/data/rules/subimage_coverage.py
@@ -242,8 +242,8 @@ _aws_account_not_synced_fact = Fact(
 
 
 class AWSAccountNotSyncedOutput(Finding):
-    account_id: str | None = None
     account_name: str | None = None
+    account_id: str | None = None
     resource_count: int | None = None
 
 
@@ -310,8 +310,8 @@ _repository_without_slsa_provenance_fact = Fact(
 
 
 class RepositoryWithoutSLSAProvenanceOutput(Finding):
-    repo_id: str | None = None
     repo_name: str | None = None
+    repo_id: str | None = None
     repo_kind: str | None = None
     image_count: int | None = None
     match_methods: list[str] | None = None

--- a/docs/root/usage/rules.md
+++ b/docs/root/usage/rules.md
@@ -484,9 +484,10 @@ from cartography.rules.spec.model import Finding
 class MyRuleOutput(Finding):
     """Output model for my custom rule."""
 
-    # Define the fields that will be populated from cypher_query results
+    # Define the fields that will be populated from cypher_query results.
+    # Declare a human-readable label first: the first non-empty field is used as the finding title.
+    name: str | None = None         # Resource name (used as the finding title)
     id: str | None = None           # Resource identifier
-    name: str | None = None         # Resource name
     email: str | None = None        # User email (if applicable)
     region: str | None = None       # Cloud region
     public_access: bool | None = None  # Access level
@@ -568,6 +569,47 @@ Guidelines:
   (`asset_id_field="user_arn"`) but treats each user/policy attachment as a separate finding
   (`identity_fields=("user_arn", "policy_arn")`).
 
+### Display field order (finding title)
+
+The **order** in which fields are declared on the output model is a de-facto display contract.
+Downstream consumers derive a finding's title by taking the **first non-empty rule-specific field
+of the output model, in class declaration order**. Declaration order is independent of
+`identity_fields` and `asset_id_field` (those stay whatever the identity contract needs) and of the
+`cypher_query` `RETURN` order (the model is keyed by alias name, not position).
+
+The base `Finding` class declares two inherited fields, `source` and `extra`, before any
+rule-specific field, so `model_fields` / `model_dump()` lists them first. They are metadata, not
+display fields: a title-deriving consumer must **skip `source` and `extra`** and start from the
+first field declared on the rule's own subclass. (The text runner's sample output at
+`cartography/rules/runners.py` prints every field for debugging and is not the title consumer.)
+
+Guidelines:
+
+- Declare a **human-readable label first**: a name, `*_name`, `email`, domain, or title. Avoid
+  leading with an opaque id, ARN, URI, digest, region, or a boolean: those make the title an
+  unreadable string instead of the resource a user recognizes.
+- A scope-level name (project/account/org) is only a good title when the finding's resource **is**
+  that scope (e.g. a project-level or account-level check). For a resource inside a scope, lead with
+  the resource's own name, not the project/account name.
+- If the field would be **empty for every finding**, it cannot serve as the title even if declared
+  first. For example a "missing CMEK key" check whose key field is null by definition: the consumer
+  skips it and falls through to the next field.
+- If the node has no natural name, **alias one in the `cypher_query`** and declare it first rather
+  than leading with an id. Common patterns:
+  - `coalesce(n.friendly_name, n.short_id) AS name`
+  - an AWS `Name` tag: `OPTIONAL MATCH (n)-[:TAGGED]->(t:AWSTag {key: 'Name'})` then
+    `coalesce(t.value, n.id) AS name`
+  - a stable user-chosen identifier (e.g. an RDS DB instance identifier) is already human-readable
+    and fine as the first field.
+
+```python
+class DatabaseExposedOutput(Finding):
+    """Output model for publicly exposed databases."""
+    name: str | None = None    # human-readable label first: used as the finding title
+    id: str | None = None
+    region: str | None = None
+```
+
 ### Steps to add a new rule
 
 1. **Create a new rule file** in `cartography/rules/data/rules/`:
@@ -624,8 +666,8 @@ Guidelines:
    # Define output model
    class MyRuleOutput(Finding):
        """Output model for my custom rule."""
+       name: str | None = None    # human-readable label first: used as the finding title
        id: str | None = None
-       name: str | None = None
        region: str | None = None
 
    # Define rule


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary
A finding's display title is, by de-facto contract, the **first non-empty field of the rule's `output_model`, in class declaration order**. Many rules declared an opaque value first (an id, ARN, URI, digest, region, or boolean), so those findings were titled with an unreadable string instead of the resource a user recognizes.

This PR:
- Reorders `output_model` field declarations across the rule set so a **human-readable label is the first field**. `identity_fields`, `asset_id_field`, and existing `RETURN` aliases are left unchanged.
- Where no name field existed, **aliases one in the cypher query** rather than leading with an id:
  - EBS volumes / EC2 instances: `coalesce(<Name tag>, id)`
  - BigQuery datasets/tables: `coalesce(friendly_name, short id)` (the CMEK fields are empty by definition, so they could never be the title)
  - Public snapshots (multi-fact): a per-type name (snapshot description / DB snapshot identifier / image name)
- Fixes a multi-fact gap in the shared `DefaultSaBindingsOutput`: the pod-usage and service-account-automount facts did not return `binding_name`, so their findings fell through to an opaque `binding_id`. Both now alias a human-readable `binding_name`.
- **Documents the contract**: adds a "Display field order (finding title)" section to the rules docs and a note in the `create-rule` skill, and fixes the examples to lead with a human-readable label. The docs also note that the inherited `source` and `extra` base fields precede rule-specific fields, so a title-deriving consumer must skip them.

A sweep of every `Finding` subclass confirms none now lead with an id/ARN/URI/region/provider-style field.


### Related issues or links

N/A


### How was this tested?
- `make test_lint` passes locally.
- `uv run --frozen pytest tests/unit/rules/` passes (1223 tested).
- Wrote and ran a one-off sweep over all `Finding` subclasses to confirm zero remaining id-like first fields.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
  <!-- This is a display-ordering/docs change covered by the existing rules test suite; no node/relationship schema change. -->

#### Proof of functionality
- [x] New or updated unit/integration tests.
  <!-- Existing rules unit suite (1223 tests) exercises the rule registry and passes. -->


### Notes for reviewers
Field declaration order is the only behavioral surface here; cypher `RETURN` order does not affect the model (it is keyed by alias name). The few WEAK cases whose first field was already human-readable (e.g. an RDS DB instance identifier, an instance/host name, a GitHub action full name) were confirmed and left as-is.