### PR TITLE
fix(rules): K8s 5.1.13 noise, filter-property indexes, KubernetesNode->EC2Instance link, quieter ECR sync

### DIFF
--- a/cartography/intel/aws/ecr_image_layers.py
+++ b/cartography/intel/aws/ecr_image_layers.py
@@ -1381,9 +1381,11 @@ def sync(
         )
 
         if not repo_images_list:
-            logger.warning(
-                f"No ECR images found in graph for region {region}. "
-                f"Run 'ecr' sync first to populate basic ECR data."
+            # Most regions legitimately have no ECR repositories, so this is
+            # the expected case rather than a problem worth a warning.
+            logger.debug(
+                f"No ECR images found in graph for region {region}; "
+                f"skipping layer sync for this region."
             )
             continue
 

--- a/cartography/intel/kubernetes/nodes.py
+++ b/cartography/intel/kubernetes/nodes.py
@@ -20,14 +20,29 @@ def get_nodes(client: K8sClient) -> list[V1Node]:
     return k8s_paginate(client.core.list_node)
 
 
+def _ec2_instance_id_from_provider_id(provider_id: str | None) -> str | None:
+    """Extract the EC2 instance id from an EKS node's providerID.
+
+    EKS sets ``spec.providerID`` to ``aws:///<availability-zone>/<instance-id>``.
+    Other providers (GCE, Azure) use different formats and return None.
+    """
+    if not provider_id or not provider_id.startswith("aws://"):
+        return None
+    instance_id = provider_id.rsplit("/", 1)[-1]
+    return instance_id if instance_id.startswith("i-") else None
+
+
 def transform_nodes(nodes: list[V1Node], cluster_name: str) -> list[dict[str, Any]]:
     transformed = []
     for node in nodes:
         ni = node.status.node_info if node.status else None
+        provider_id = getattr(getattr(node, "spec", None), "provider_id", None)
         transformed.append(
             {
                 "id": f"{cluster_name}/{node.metadata.name}",
                 "name": node.metadata.name,
+                "provider_id": provider_id,
+                "instance_id": _ec2_instance_id_from_provider_id(provider_id),
                 "architecture": getattr(ni, "architecture", None),
                 "architecture_normalized": normalize_architecture(
                     getattr(ni, "architecture", None),

--- a/cartography/models/aws/guardduty/findings.py
+++ b/cartography/models/aws/guardduty/findings.py
@@ -33,7 +33,7 @@ class GuardDutyFindingNodeProperties(CartographyNodeProperties):
     access_key_id: PropertyRef = PropertyRef("access_key_id", extra_index=True)
     principal_user_id: PropertyRef = PropertyRef("principal_user_id", extra_index=True)
     principal_role_id: PropertyRef = PropertyRef("principal_role_id", extra_index=True)
-    archived: PropertyRef = PropertyRef("archived")
+    archived: PropertyRef = PropertyRef("archived", extra_index=True)
     sample: PropertyRef = PropertyRef("sample")
     # Service-level fields (apply to all action types)
     service_action_type: PropertyRef = PropertyRef("service_action_type")

--- a/cartography/models/aws/s3/bucket.py
+++ b/cartography/models/aws/s3/bucket.py
@@ -76,7 +76,7 @@ class S3BucketPolicyProperties(CartographyNodeProperties):
 
     id: PropertyRef = PropertyRef("Name")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
-    anonymous_access: PropertyRef = PropertyRef("anonymous_access")
+    anonymous_access: PropertyRef = PropertyRef("anonymous_access", extra_index=True)
     anonymous_actions: PropertyRef = PropertyRef("anonymous_actions")
 
 

--- a/cartography/models/gcp/policy_bindings.py
+++ b/cartography/models/gcp/policy_bindings.py
@@ -23,7 +23,7 @@ class GCPPolicyBindingNodeProperties(CartographyNodeProperties):
     members: PropertyRef = PropertyRef("members")
     wif_pools: PropertyRef = PropertyRef("wif_pools")
     is_public: PropertyRef = PropertyRef("is_public", extra_index=True)
-    has_condition: PropertyRef = PropertyRef("has_condition")
+    has_condition: PropertyRef = PropertyRef("has_condition", extra_index=True)
     condition_title: PropertyRef = PropertyRef("condition_title")
     condition_expression: PropertyRef = PropertyRef("condition_expression")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)

--- a/cartography/models/kubernetes/nodes.py
+++ b/cartography/models/kubernetes/nodes.py
@@ -7,6 +7,7 @@ from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -24,6 +25,9 @@ class KubernetesNodeNodeProperties(CartographyNodeProperties):
     kernel_version: PropertyRef = PropertyRef("kernel_version")
     container_runtime_version: PropertyRef = PropertyRef("container_runtime_version")
     kubelet_version: PropertyRef = PropertyRef("kubelet_version")
+    # Cloud provider instance reference (e.g. EKS: aws:///<az>/<instance-id>)
+    provider_id: PropertyRef = PropertyRef("provider_id")
+    instance_id: PropertyRef = PropertyRef("instance_id", extra_index=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -47,9 +51,34 @@ class KubernetesNodeToKubernetesClusterRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class KubernetesNodeToEC2InstanceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesNode)-[:IS_INSTANCE]->(:EC2Instance)
+# Only created for EKS nodes whose providerID resolves to an EC2 instance id.
+class KubernetesNodeToEC2InstanceRel(CartographyRelSchema):
+    target_node_label: str = "EC2Instance"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("instance_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "IS_INSTANCE"
+    properties: KubernetesNodeToEC2InstanceRelProperties = (
+        KubernetesNodeToEC2InstanceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class KubernetesNodeSchema(CartographyNodeSchema):
     label: str = "KubernetesNode"
     properties: KubernetesNodeNodeProperties = KubernetesNodeNodeProperties()
     sub_resource_relationship: KubernetesNodeToKubernetesClusterRel = (
         KubernetesNodeToKubernetesClusterRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            KubernetesNodeToEC2InstanceRel(),
+        ]
     )

--- a/cartography/rules/data/rules/cis_kubernetes_rbac.py
+++ b/cartography/rules/data/rules/cis_kubernetes_rbac.py
@@ -1235,6 +1235,8 @@ _k8s_sa_token_creation_clusterroles = Fact(
     WHERE any(r IN cr.resources WHERE r IN ['serviceaccounts/token', '*'])
       AND any(v IN cr.verbs WHERE v IN ['create', '*'])
       AND NOT cr.name STARTS WITH 'system:'
+      AND NOT cr.name STARTS WITH 'eks:'
+      AND NOT cr.name IN ['cluster-admin', 'admin', 'edit', 'view']
     RETURN
         cr.id AS role_id,
         cr.name AS role_name,
@@ -1246,11 +1248,15 @@ _k8s_sa_token_creation_clusterroles = Fact(
     WHERE any(r IN cr.resources WHERE r IN ['serviceaccounts/token', '*'])
       AND any(v IN cr.verbs WHERE v IN ['create', '*'])
       AND NOT cr.name STARTS WITH 'system:'
+      AND NOT cr.name STARTS WITH 'eks:'
+      AND NOT cr.name IN ['cluster-admin', 'admin', 'edit', 'view']
     RETURN *
     """,
     cypher_count_query="""
     MATCH (cr:KubernetesClusterRole)
     WHERE NOT cr.name STARTS WITH 'system:'
+      AND NOT cr.name STARTS WITH 'eks:'
+      AND NOT cr.name IN ['cluster-admin', 'admin', 'edit', 'view']
     RETURN COUNT(cr) AS count
     """,
     identity_fields=("role_id",),

--- a/docs/root/modules/kubernetes/schema.md
+++ b/docs/root/modules/kubernetes/schema.md
@@ -75,6 +75,8 @@ Representation of a [Kubernetes Node.](https://kubernetes.io/docs/concepts/archi
 | kernel\_version | Kernel version of the node (e.g. `5.15.0-1034-aws`) |
 | container\_runtime\_version | Container runtime and version (e.g. `containerd://1.7.0`) |
 | kubelet\_version | Version of the kubelet running on the node (e.g. `v1.27.1`) |
+| provider\_id | Cloud provider instance reference from the node's `spec.providerID` (e.g. EKS: `aws:///us-east-1a/i-0123456789abcdef0`) |
+| instance\_id | EC2 instance id parsed from `provider_id` for EKS nodes (e.g. `i-0123456789abcdef0`); null for non-AWS providers |
 | firstseen | Timestamp of when a sync job first discovered this node |
 | **lastupdated** | Timestamp of the last time the node was updated |
 
@@ -87,6 +89,11 @@ Representation of a [Kubernetes Node.](https://kubernetes.io/docs/concepts/archi
 - `KubernetesPod` runs on a `KubernetesNode`.
     ```
     (:KubernetesPod)-[:RUNS_ON]->(:KubernetesNode)
+    ```
+
+- An EKS `KubernetesNode` is backed by an `EC2Instance`. Only created when the node's `spec.providerID` resolves to an EC2 instance id.
+    ```
+    (:KubernetesNode)-[:IS_INSTANCE]->(:EC2Instance)
     ```
 
 ### KubernetesNamespace

--- a/tests/data/kubernetes/nodes.py
+++ b/tests/data/kubernetes/nodes.py
@@ -8,6 +8,9 @@ CLUSTER_NAME = KUBERNETES_CLUSTER_NAMES[0]
 RAW_NODES = [
     SimpleNamespace(
         metadata=SimpleNamespace(name="my-node"),
+        spec=SimpleNamespace(
+            provider_id="aws:///us-east-1a/i-0123456789abcdef0",
+        ),
         status=SimpleNamespace(
             node_info=SimpleNamespace(
                 architecture="amd64",
@@ -21,6 +24,7 @@ RAW_NODES = [
     ),
     SimpleNamespace(
         metadata=SimpleNamespace(name="my-arm-node"),
+        spec=SimpleNamespace(provider_id=None),
         status=SimpleNamespace(
             node_info=SimpleNamespace(
                 architecture="arm64",
@@ -67,6 +71,8 @@ KUBERNETES_NODE_DATA = [
     {
         "id": f"{CLUSTER_NAME}/my-node",
         "name": "my-node",
+        "provider_id": "aws:///us-east-1a/i-0123456789abcdef0",
+        "instance_id": "i-0123456789abcdef0",
         "architecture": "amd64",
         "architecture_normalized": "amd64",
         "os": "linux",
@@ -78,6 +84,8 @@ KUBERNETES_NODE_DATA = [
     {
         "id": f"{CLUSTER_NAME}/my-arm-node",
         "name": "my-arm-node",
+        "provider_id": None,
+        "instance_id": None,
         "architecture": "arm64",
         "architecture_normalized": "arm64",
         "os": "linux",

--- a/tests/integration/cartography/intel/kubernetes/test_nodes.py
+++ b/tests/integration/cartography/intel/kubernetes/test_nodes.py
@@ -57,6 +57,13 @@ def test_sync_nodes_and_runs_on(neo4j_session, monkeypatch):
     client = SimpleNamespace(name=CLUSTER_NAME)
     common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "CLUSTER_ID": CLUSTER_ID}
 
+    # Arrange: the backing EC2 instance must already exist for the IS_INSTANCE
+    # link to be created when the node is loaded.
+    neo4j_session.run(
+        "MERGE (i:EC2Instance {id: 'i-0123456789abcdef0'}) "
+        "SET i.instanceid = 'i-0123456789abcdef0'"
+    )
+
     # Act
     node_arch_map = sync_nodes(
         neo4j_session, client, TEST_UPDATE_TAG, common_job_parameters
@@ -86,6 +93,19 @@ def test_sync_nodes_and_runs_on(neo4j_session, monkeypatch):
     ) == {
         ("arm-node-test-pod", "my-arm-node"),
         ("node-test-pod", "my-node"),
+    }
+
+    # Assert: EKS node is linked to its backing EC2 instance; the non-AWS
+    # node (provider_id None) produces no link.
+    assert check_rels(
+        neo4j_session,
+        "KubernetesNode",
+        "name",
+        "EC2Instance",
+        "id",
+        "IS_INSTANCE",
+    ) == {
+        ("my-node", "i-0123456789abcdef0"),
     }
 
     # Assert: pod and container inherit normalized runtime architecture


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
A batch of independent reliability, performance, and signal-to-noise improvements:

- **CIS Kubernetes 5.1.13 (service-account token creation):** the rule flagged the built-in `cluster-admin` / `admin` / `edit` ClusterRoles and the EKS-managed `eks:*` ClusterRoles. These are platform-owned defaults a tenant cannot remediate, so they were unactionable noise. Exclude them (scoped to ClusterRoles only, so user-defined namespaced Roles with those names still surface). Custom ClusterRoles granting `create` on `serviceaccounts/token` still trigger.

- **Index high-cardinality filter properties:** three model properties used as `WHERE`/inline filters lacked an index, causing full label scans:
  - `GuardDutyFinding.archived`
  - `GCPPolicyBinding.has_condition`
  - `S3Bucket.anonymous_access`

  Added `extra_index=True` to each so the filters use an index.

- **Link `KubernetesNode` to its backing `EC2Instance`:** EKS nodes expose `spec.providerID` as `aws:///<az>/<instance-id>`. We now capture `provider_id` during the node transform, parse the EC2 instance id from it, and create `(:KubernetesNode)-[:IS_INSTANCE]->(:EC2Instance)` (mirroring the existing `ECSContainerInstance` convention). The link is created only when the provider id resolves to an EC2 instance id, so non-AWS providers (GCE, Azure) are unaffected.

- **Quieter ECR image-layer sync:** the layer sync logged a WARNING for every region with no ECR repositories. Most regions legitimately have none, so this fired on nearly every region of every account. Demoted to DEBUG since an empty region is the expected case.


### Related issues or links

N/A


### Breaking changes

None.


### How was this tested?
- `make test_lint` passes locally (black, flake8, isort, mypy).
- Kubernetes integration suite passes (54 tests), including a new assertion that an EKS node links to its backing `EC2Instance` while a non-AWS node (null `provider_id`) produces no link.
- ECR image-layers unit tests pass (46 tests).
- CIS Kubernetes rule unit tests pass (364 tests).


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules) (KubernetesNode: new `provider_id` / `instance_id` fields and the `IS_INSTANCE` relationship).


### Notes for reviewers
These changes are independent and can be reviewed commit by commit. The `KubernetesNode` -> `EC2Instance` link uses the node schema's `other_relationships`, so the edge forms once the matching `EC2Instance` exists; on a fresh graph where the Kubernetes sync runs before the AWS sync, the link lands on the following run.
