### PR TITLE
feat(aws): add WAFv2 web ACL support

### DIFF
--- a/cartography/intel/aws/resources.py
+++ b/cartography/intel/aws/resources.py
@@ -47,6 +47,7 @@ from . import ses
 from . import sns
 from . import sqs
 from . import ssm
+from . import wafv2
 from .ec2.auto_scaling_groups import sync_ec2_auto_scaling_groups
 from .ec2.elastic_ip_addresses import sync_elastic_ip_addresses
 from .ec2.images import sync_ec2_images
@@ -160,5 +161,8 @@ RESOURCE_FUNCTIONS: OrderedDict[str, Callable[..., None]] = OrderedDict(
         "cognito": cognito.sync,
         "eventbridge": eventbridge.sync,
         "glue": glue.sync,
+        # `wafv2` must run after `ec2:load_balancer_v2`, `apigateway`, and
+        # `cloudfront` so that web ACL PROTECTS edges can match those nodes.
+        "wafv2": wafv2.sync,
     }
 )

--- a/cartography/intel/aws/resources.py
+++ b/cartography/intel/aws/resources.py
@@ -47,6 +47,7 @@ from . import ses
 from . import sns
 from . import sqs
 from . import ssm
+from . import wafv2
 from .ec2.auto_scaling_groups import sync_ec2_auto_scaling_groups
 from .ec2.elastic_ip_addresses import sync_elastic_ip_addresses
 from .ec2.images import sync_ec2_images
@@ -164,6 +165,9 @@ RESOURCE_FUNCTIONS: OrderedDict[str, Callable[..., None]] = OrderedDict(
         "cognito": cognito.sync,
         "eventbridge": eventbridge.sync,
         "glue": glue.sync,
+        # `wafv2` must run after `ec2:load_balancer_v2`, `apigateway`, and
+        # `cloudfront` so that web ACL PROTECTS edges can match those nodes.
+        "wafv2": wafv2.sync,
         # These resources feed final AWS analysis jobs and have no remaining
         # regular-resource consumers, so keep them close to that analysis.
         "ec2:autoscalinggroup": sync_ec2_auto_scaling_groups,

--- a/cartography/intel/aws/wafv2.py
+++ b/cartography/intel/aws/wafv2.py
@@ -1,0 +1,178 @@
+import logging
+from typing import Any
+from typing import Dict
+from typing import List
+
+import boto3
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.aws.util.botocore_config import create_boto3_client
+from cartography.intel.aws.util.botocore_config import get_botocore_config
+from cartography.models.aws.wafv2 import AWSWebACLSchema
+from cartography.util import aws_handle_regions
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+# CLOUDFRONT-scoped web ACLs are global and can only be listed via us-east-1.
+CLOUDFRONT_SCOPE_REGION = "us-east-1"
+
+
+def _list_web_acls(client: Any, scope: str) -> List[Dict[str, Any]]:
+    """
+    List WAFv2 web ACLs for the given scope.
+
+    WAFv2 does not provide a paginator for list_web_acls, so we paginate
+    manually with NextMarker.
+    """
+    web_acls: List[Dict[str, Any]] = []
+    next_marker = None
+    while True:
+        params: Dict[str, Any] = {"Scope": scope}
+        if next_marker:
+            params["NextMarker"] = next_marker
+        page = client.list_web_acls(**params)
+        page_acls = page.get("WebACLs", [])
+        web_acls.extend(page_acls)
+        next_marker = page.get("NextMarker")
+        if not next_marker or not page_acls:
+            break
+    return web_acls
+
+
+def _get_alb_arns_for_web_acl(client: Any, web_acl_arn: str) -> List[str]:
+    response = client.list_resources_for_web_acl(
+        WebACLArn=web_acl_arn,
+        ResourceType="APPLICATION_LOAD_BALANCER",
+    )
+    return response.get("ResourceArns", [])
+
+
+@timeit
+@aws_handle_regions
+def get_web_acls(
+    boto3_session: boto3.session.Session,
+    region: str,
+    scope: str,
+) -> List[Dict[str, Any]]:
+    """
+    Get WAFv2 web ACLs for the given scope, including the ARNs of the
+    application load balancers each REGIONAL web ACL protects.
+
+    API Gateway stages and CloudFront distributions are not fetched here:
+    their nodes already carry the associated web ACL ARN (webaclarn and
+    web_acl_id respectively), so those relationships are resolved at load
+    time by matching on existing node properties.
+    """
+    client = create_boto3_client(
+        boto3_session,
+        "wafv2",
+        region_name=region,
+        config=get_botocore_config(),
+    )
+    web_acls = _list_web_acls(client, scope)
+    if scope == "REGIONAL":
+        for web_acl in web_acls:
+            web_acl["AlbArns"] = _get_alb_arns_for_web_acl(client, web_acl["ARN"])
+    return web_acls
+
+
+def transform_web_acls(
+    web_acls: List[Dict[str, Any]],
+    scope: str,
+) -> List[Dict[str, Any]]:
+    transformed: List[Dict[str, Any]] = []
+    for web_acl in web_acls:
+        transformed.append(
+            {
+                "ARN": web_acl["ARN"],
+                "Id": web_acl["Id"],
+                "Name": web_acl.get("Name"),
+                "Description": web_acl.get("Description"),
+                "Scope": scope,
+                "AlbArns": web_acl.get("AlbArns", []),
+            }
+        )
+    return transformed
+
+
+@timeit
+def load_web_acls(
+    neo4j_session: neo4j.Session,
+    web_acl_data: List[Dict[str, Any]],
+    region: str,
+    current_aws_account_id: str,
+    aws_update_tag: int,
+) -> None:
+    logger.info(
+        "Loading %d WAFv2 web ACLs for region '%s' into graph.",
+        len(web_acl_data),
+        region,
+    )
+    load(
+        neo4j_session,
+        AWSWebACLSchema(),
+        web_acl_data,
+        lastupdated=aws_update_tag,
+        Region=region,
+        AWS_ID=current_aws_account_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: Dict[str, Any],
+) -> None:
+    logger.debug("Running WAFv2 cleanup job.")
+    cleanup_job = GraphJob.from_node_schema(
+        AWSWebACLSchema(),
+        common_job_parameters,
+    )
+    cleanup_job.run(neo4j_session)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    boto3_session: boto3.session.Session,
+    regions: List[str],
+    current_aws_account_id: str,
+    update_tag: int,
+    common_job_parameters: Dict[str, Any],
+) -> None:
+    for region in regions:
+        logger.info(
+            "Syncing WAFv2 regional web ACLs for region '%s' in account '%s'.",
+            region,
+            current_aws_account_id,
+        )
+        regional_acls = get_web_acls(boto3_session, region, "REGIONAL")
+        load_web_acls(
+            neo4j_session,
+            transform_web_acls(regional_acls, "REGIONAL"),
+            region,
+            current_aws_account_id,
+            update_tag,
+        )
+
+    logger.info(
+        "Syncing WAFv2 CloudFront-scoped web ACLs in account '%s'.",
+        current_aws_account_id,
+    )
+    cloudfront_acls = get_web_acls(
+        boto3_session,
+        CLOUDFRONT_SCOPE_REGION,
+        "CLOUDFRONT",
+    )
+    load_web_acls(
+        neo4j_session,
+        transform_web_acls(cloudfront_acls, "CLOUDFRONT"),
+        CLOUDFRONT_SCOPE_REGION,
+        current_aws_account_id,
+        update_tag,
+    )
+
+    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/wafv2.py
+++ b/cartography/intel/aws/wafv2.py
@@ -4,6 +4,7 @@ from typing import Dict
 from typing import List
 
 import boto3
+import botocore.exceptions
 import neo4j
 
 from cartography.client.core.tx import load
@@ -36,17 +37,30 @@ def _list_web_acls(client: Any, scope: str) -> List[Dict[str, Any]]:
         page = client.list_web_acls(**params)
         page_acls = page.get("WebACLs", [])
         web_acls.extend(page_acls)
+        previous_marker = next_marker
         next_marker = page.get("NextMarker")
-        if not next_marker or not page_acls:
+        # WAFv2 can return a NextMarker on the final page. Stop on an empty
+        # page or a marker that makes no progress to avoid looping forever.
+        if not next_marker or not page_acls or next_marker == previous_marker:
             break
     return web_acls
 
 
 def _get_alb_arns_for_web_acl(client: Any, web_acl_arn: str) -> List[str]:
-    response = client.list_resources_for_web_acl(
-        WebACLArn=web_acl_arn,
-        ResourceType="APPLICATION_LOAD_BALANCER",
-    )
+    try:
+        response = client.list_resources_for_web_acl(
+            WebACLArn=web_acl_arn,
+            ResourceType="APPLICATION_LOAD_BALANCER",
+        )
+    except botocore.exceptions.ClientError as e:
+        if e.response["Error"]["Code"] == "WAFNonexistentItemException":
+            logger.warning(
+                "Web ACL %s was deleted between listing and fetching its "
+                "associated resources. Skipping.",
+                web_acl_arn,
+            )
+            return []
+        raise
     return response.get("ResourceArns", [])
 
 
@@ -64,7 +78,8 @@ def get_web_acls(
     API Gateway stages and CloudFront distributions are not fetched here:
     their nodes already carry the associated web ACL ARN (webaclarn and
     web_acl_id respectively), so those relationships are resolved at load
-    time by matching on existing node properties.
+    time by matching on existing node properties. Those edges are therefore
+    only as fresh as the last apigateway and cloudfront syncs.
     """
     client = create_boto3_client(
         boto3_session,
@@ -134,6 +149,30 @@ def cleanup(
     cleanup_job.run(neo4j_session)
 
 
+def _sync_scope(
+    neo4j_session: neo4j.Session,
+    boto3_session: boto3.session.Session,
+    region: str,
+    scope: str,
+    current_aws_account_id: str,
+    update_tag: int,
+) -> None:
+    logger.info(
+        "Syncing WAFv2 %s web ACLs for region '%s' in account '%s'.",
+        scope,
+        region,
+        current_aws_account_id,
+    )
+    web_acls = get_web_acls(boto3_session, region, scope)
+    load_web_acls(
+        neo4j_session,
+        transform_web_acls(web_acls, scope),
+        region,
+        current_aws_account_id,
+        update_tag,
+    )
+
+
 @timeit
 def sync(
     neo4j_session: neo4j.Session,
@@ -144,33 +183,20 @@ def sync(
     common_job_parameters: Dict[str, Any],
 ) -> None:
     for region in regions:
-        logger.info(
-            "Syncing WAFv2 regional web ACLs for region '%s' in account '%s'.",
-            region,
-            current_aws_account_id,
-        )
-        regional_acls = get_web_acls(boto3_session, region, "REGIONAL")
-        load_web_acls(
+        _sync_scope(
             neo4j_session,
-            transform_web_acls(regional_acls, "REGIONAL"),
+            boto3_session,
             region,
+            "REGIONAL",
             current_aws_account_id,
             update_tag,
         )
 
-    logger.info(
-        "Syncing WAFv2 CloudFront-scoped web ACLs in account '%s'.",
-        current_aws_account_id,
-    )
-    cloudfront_acls = get_web_acls(
+    _sync_scope(
+        neo4j_session,
         boto3_session,
         CLOUDFRONT_SCOPE_REGION,
         "CLOUDFRONT",
-    )
-    load_web_acls(
-        neo4j_session,
-        transform_web_acls(cloudfront_acls, "CLOUDFRONT"),
-        CLOUDFRONT_SCOPE_REGION,
         current_aws_account_id,
         update_tag,
     )

--- a/cartography/models/aws/wafv2.py
+++ b/cartography/models/aws/wafv2.py
@@ -1,0 +1,128 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AWSWebACLNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("ARN")
+    arn: PropertyRef = PropertyRef("ARN", extra_index=True)
+    web_acl_id: PropertyRef = PropertyRef("Id")
+    name: PropertyRef = PropertyRef("Name")
+    description: PropertyRef = PropertyRef("Description")
+    scope: PropertyRef = PropertyRef("Scope")
+    region: PropertyRef = PropertyRef("Region", set_in_kwargs=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AWSWebACLToAWSAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AWSWebACL)<-[:RESOURCE]-(:AWSAccount)
+class AWSWebACLToAWSAccountRel(CartographyRelSchema):
+    target_node_label: str = "AWSAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AWSWebACLToAWSAccountRelProperties = (
+        AWSWebACLToAWSAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AWSWebACLToLoadBalancerV2RelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AWSWebACLToLoadBalancerV2Rel(CartographyRelSchema):
+    """
+    Created when a REGIONAL web ACL is associated with an application load balancer.
+    (:AWSWebACL)-[:PROTECTS]->(:AWSLoadBalancerV2)
+    """
+
+    target_node_label: str = "AWSLoadBalancerV2"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("AlbArns", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "PROTECTS"
+    properties: AWSWebACLToLoadBalancerV2RelProperties = (
+        AWSWebACLToLoadBalancerV2RelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AWSWebACLToAPIGatewayStageRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AWSWebACLToAPIGatewayStageRel(CartographyRelSchema):
+    """
+    Created when a REGIONAL web ACL is associated with an API Gateway REST API stage.
+    Matches on the webaclarn property that the apigateway module already sets on stages.
+    (:AWSWebACL)-[:PROTECTS]->(:APIGatewayStage)
+    """
+
+    target_node_label: str = "APIGatewayStage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"webaclarn": PropertyRef("ARN")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "PROTECTS"
+    properties: AWSWebACLToAPIGatewayStageRelProperties = (
+        AWSWebACLToAPIGatewayStageRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AWSWebACLToCloudFrontDistributionRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AWSWebACLToCloudFrontDistributionRel(CartographyRelSchema):
+    """
+    Created when a CLOUDFRONT-scoped web ACL is associated with a distribution.
+    Matches on the web_acl_id property that the cloudfront module sets on
+    distributions, which holds the WAFv2 web ACL ARN.
+    (:AWSWebACL)-[:PROTECTS]->(:CloudFrontDistribution)
+    """
+
+    target_node_label: str = "CloudFrontDistribution"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"web_acl_id": PropertyRef("ARN")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "PROTECTS"
+    properties: AWSWebACLToCloudFrontDistributionRelProperties = (
+        AWSWebACLToCloudFrontDistributionRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AWSWebACLSchema(CartographyNodeSchema):
+    label: str = "AWSWebACL"
+    properties: AWSWebACLNodeProperties = AWSWebACLNodeProperties()
+    sub_resource_relationship: AWSWebACLToAWSAccountRel = AWSWebACLToAWSAccountRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AWSWebACLToLoadBalancerV2Rel(),
+            AWSWebACLToAPIGatewayStageRel(),
+            AWSWebACLToCloudFrontDistributionRel(),
+        ],
+    )

--- a/cartography/models/aws/wafv2.py
+++ b/cartography/models/aws/wafv2.py
@@ -13,13 +13,31 @@ from cartography.models.core.relationships import TargetNodeMatcher
 
 @dataclass(frozen=True)
 class AWSWebACLNodeProperties(CartographyNodeProperties):
-    id: PropertyRef = PropertyRef("ARN")
-    arn: PropertyRef = PropertyRef("ARN", extra_index=True)
-    web_acl_id: PropertyRef = PropertyRef("Id")
-    name: PropertyRef = PropertyRef("Name")
-    description: PropertyRef = PropertyRef("Description")
-    scope: PropertyRef = PropertyRef("Scope")
-    region: PropertyRef = PropertyRef("Region", set_in_kwargs=True)
+    id: PropertyRef = PropertyRef("ARN", description="The ARN of the web ACL")
+    arn: PropertyRef = PropertyRef(
+        "ARN",
+        extra_index=True,
+        description="The Amazon Resource Name (ARN) of the web ACL",
+    )
+    web_acl_id: PropertyRef = PropertyRef(
+        "Id",
+        description="The unique identifier WAF assigned to the web ACL. Required alongside the name and scope when calling the WAFv2 API",
+    )
+    name: PropertyRef = PropertyRef(
+        "Name", description="The customer-supplied name of the web ACL"
+    )
+    description: PropertyRef = PropertyRef(
+        "Description", description="The customer-supplied description of the web ACL"
+    )
+    scope: PropertyRef = PropertyRef(
+        "Scope",
+        description="Where the web ACL can be deployed, either REGIONAL for regional resources such as load balancers and API Gateway stages, or CLOUDFRONT for CloudFront distributions",
+    )
+    region: PropertyRef = PropertyRef(
+        "Region",
+        set_in_kwargs=True,
+        description="The region of the web ACL. CLOUDFRONT scoped web ACLs are global and are recorded as us-east-1, the only region that can list them",
+    )
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -29,8 +47,11 @@ class AWSWebACLToAWSAccountRelProperties(CartographyRelProperties):
 
 
 @dataclass(frozen=True)
-# (:AWSWebACL)<-[:RESOURCE]-(:AWSAccount)
 class AWSWebACLToAWSAccountRel(CartographyRelSchema):
+    """
+    Scopes each web ACL to the AWS account it was found in.
+    """
+
     target_node_label: str = "AWSAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
@@ -51,7 +72,6 @@ class AWSWebACLToLoadBalancerV2RelProperties(CartographyRelProperties):
 class AWSWebACLToLoadBalancerV2Rel(CartographyRelSchema):
     """
     Created when a REGIONAL web ACL is associated with an application load balancer.
-    (:AWSWebACL)-[:PROTECTS]->(:AWSLoadBalancerV2)
     """
 
     target_node_label: str = "AWSLoadBalancerV2"
@@ -75,10 +95,9 @@ class AWSWebACLToAPIGatewayStageRel(CartographyRelSchema):
     """
     Created when a REGIONAL web ACL is associated with an API Gateway REST API stage.
     Matches on the webaclarn property that the apigateway module already sets on stages.
-    (:AWSWebACL)-[:PROTECTS]->(:APIGatewayStage)
     """
 
-    target_node_label: str = "APIGatewayStage"
+    target_node_label: str = "AWSAPIGatewayStage"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"webaclarn": PropertyRef("ARN")},
     )
@@ -100,10 +119,9 @@ class AWSWebACLToCloudFrontDistributionRel(CartographyRelSchema):
     Created when a CLOUDFRONT-scoped web ACL is associated with a distribution.
     Matches on the web_acl_id property that the cloudfront module sets on
     distributions, which holds the WAFv2 web ACL ARN.
-    (:AWSWebACL)-[:PROTECTS]->(:CloudFrontDistribution)
     """
 
-    target_node_label: str = "CloudFrontDistribution"
+    target_node_label: str = "AWSCloudFrontDistribution"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"web_acl_id": PropertyRef("ARN")},
     )
@@ -116,6 +134,8 @@ class AWSWebACLToCloudFrontDistributionRel(CartographyRelSchema):
 
 @dataclass(frozen=True)
 class AWSWebACLSchema(CartographyNodeSchema):
+    """Representation of an AWS WAFv2 [web ACL](https://docs.aws.amazon.com/waf/latest/APIReference/API_WebACL.html)"""
+
     label: str = "AWSWebACL"
     properties: AWSWebACLNodeProperties = AWSWebACLNodeProperties()
     sub_resource_relationship: AWSWebACLToAWSAccountRel = AWSWebACLToAWSAccountRel()

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -6703,7 +6703,7 @@ Representation of an AWS WAFv2 [Web ACL](https://docs.aws.amazon.com/waf/latest/
 | lastupdated | Timestamp of the last time the node was updated |
 | **id** | The ARN of the web ACL |
 | arn | The ARN of the web ACL |
-| web\_acl\_id | The unique identifier of the web ACL |
+| web\_acl\_id | The unique identifier (UUID) of the web ACL. Note this differs from `CloudFrontDistribution.web_acl_id`, which holds the web ACL ARN; join on `AWSWebACL.arn` instead |
 | name | The name of the web ACL |
 | description | The description of the web ACL |
 | scope | The scope of the web ACL, either `REGIONAL` or `CLOUDFRONT` |

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -6692,3 +6692,38 @@ Representation of an AWS [CloudFormation Stack](https://docs.aws.amazon.com/AWSC
     (AWSPrincipal)-[:CAN_EXEC]->(CloudFormationStack)
     ```
     **Note:** This edge is created for any principal with `cloudformation:UpdateStack` permission on a stack. However, true privilege escalation only occurs when the target stack has a service role (`role_arn` is set), because stacks without a service role execute with the caller's own permissions. Downstream consumers should filter on `role_arn IS NOT NULL` for high-confidence escalation paths.
+
+### AWSWebACL
+
+Representation of an AWS WAFv2 [Web ACL](https://docs.aws.amazon.com/waf/latest/APIReference/API_WebACLSummary.html). A web ACL gives fine-grained control over the web requests that protected resources respond to.
+
+| Field | Description |
+|-------|-------------|
+| firstseen | Timestamp of when a sync job first discovered this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| **id** | The ARN of the web ACL |
+| arn | The ARN of the web ACL |
+| web\_acl\_id | The unique identifier of the web ACL |
+| name | The name of the web ACL |
+| description | The description of the web ACL |
+| scope | The scope of the web ACL, either `REGIONAL` or `CLOUDFRONT` |
+| region | The AWS region of the web ACL. CLOUDFRONT-scoped web ACLs are global and recorded under `us-east-1` |
+
+#### Relationships
+
+- Web ACLs are resources under an AWS Account.
+    ```
+    (AWSAccount)-[RESOURCE]->(AWSWebACL)
+    ```
+- REGIONAL web ACLs protect the application load balancers they are associated with.
+    ```
+    (AWSWebACL)-[PROTECTS]->(AWSLoadBalancerV2)
+    ```
+- REGIONAL web ACLs protect the API Gateway REST API stages they are associated with.
+    ```
+    (AWSWebACL)-[PROTECTS]->(APIGatewayStage)
+    ```
+- CLOUDFRONT-scoped web ACLs protect the CloudFront distributions they are associated with.
+    ```
+    (AWSWebACL)-[PROTECTS]->(CloudFrontDistribution)
+    ```

--- a/tests/data/aws/wafv2.py
+++ b/tests/data/aws/wafv2.py
@@ -1,0 +1,69 @@
+TEST_ACCOUNT_ID = "000000000000"
+TEST_REGION = "us-east-1"
+
+REGIONAL_WEB_ACL_ARN = (
+    f"arn:aws:wafv2:{TEST_REGION}:{TEST_ACCOUNT_ID}:regional/webacl/"
+    "regional-acl/11111111-1111-1111-1111-111111111111"
+)
+CLOUDFRONT_WEB_ACL_ARN = (
+    f"arn:aws:wafv2:us-east-1:{TEST_ACCOUNT_ID}:global/webacl/"
+    "cloudfront-acl/22222222-2222-2222-2222-222222222222"
+)
+PROTECTED_ALB_ARN = (
+    f"arn:aws:elasticloadbalancing:{TEST_REGION}:{TEST_ACCOUNT_ID}:"
+    "loadbalancer/app/my-alb/1234567890abcdef"
+)
+
+GET_WEB_ACLS_REGIONAL = [
+    {
+        "Name": "regional-acl",
+        "Id": "11111111-1111-1111-1111-111111111111",
+        "Description": "Protects the regional API",
+        "LockToken": "lock-token-1",
+        "ARN": REGIONAL_WEB_ACL_ARN,
+        "AlbArns": [PROTECTED_ALB_ARN],
+    },
+]
+
+GET_WEB_ACLS_CLOUDFRONT = [
+    {
+        "Name": "cloudfront-acl",
+        "Id": "22222222-2222-2222-2222-222222222222",
+        "Description": "Protects the CDN",
+        "LockToken": "lock-token-2",
+        "ARN": CLOUDFRONT_WEB_ACL_ARN,
+    },
+]
+
+LIST_WEB_ACLS_PAGES = [
+    {
+        "WebACLs": [
+            {
+                "Name": "regional-acl",
+                "Id": "11111111-1111-1111-1111-111111111111",
+                "Description": "Protects the regional API",
+                "LockToken": "lock-token-1",
+                "ARN": REGIONAL_WEB_ACL_ARN,
+            },
+        ],
+        "NextMarker": "regional-acl",
+    },
+    {
+        "WebACLs": [
+            {
+                "Name": "regional-acl-2",
+                "Id": "33333333-3333-3333-3333-333333333333",
+                "Description": "",
+                "LockToken": "lock-token-3",
+                "ARN": (
+                    f"arn:aws:wafv2:{TEST_REGION}:{TEST_ACCOUNT_ID}:regional/webacl/"
+                    "regional-acl-2/33333333-3333-3333-3333-333333333333"
+                ),
+            },
+        ],
+    },
+]
+
+LIST_RESOURCES_FOR_WEB_ACL = {
+    "ResourceArns": [PROTECTED_ALB_ARN],
+}

--- a/tests/data/aws/wafv2.py
+++ b/tests/data/aws/wafv2.py
@@ -1,3 +1,7 @@
+from typing import Any
+from typing import Dict
+from typing import List
+
 TEST_ACCOUNT_ID = "000000000000"
 TEST_REGION = "us-east-1"
 
@@ -21,6 +25,8 @@ GET_WEB_ACLS_REGIONAL = [
         "Description": "Protects the regional API",
         "LockToken": "lock-token-1",
         "ARN": REGIONAL_WEB_ACL_ARN,
+        # AlbArns is not part of the list_web_acls response; get_web_acls
+        # adds it from list_resources_for_web_acl.
         "AlbArns": [PROTECTED_ALB_ARN],
     },
 ]
@@ -35,7 +41,7 @@ GET_WEB_ACLS_CLOUDFRONT = [
     },
 ]
 
-LIST_WEB_ACLS_PAGES = [
+LIST_WEB_ACLS_PAGES: List[Dict[str, Any]] = [
     {
         "WebACLs": [
             {

--- a/tests/integration/cartography/intel/aws/test_wafv2.py
+++ b/tests/integration/cartography/intel/aws/test_wafv2.py
@@ -10,7 +10,8 @@ from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
 
 TEST_ACCOUNT_ID = "000000000000"
-TEST_REGION = "us-east-1"
+# Distinct from CLOUDFRONT_SCOPE_REGION so the test catches scope/region mixups
+TEST_REGION = "us-west-2"
 TEST_UPDATE_TAG = 123456789
 
 APIGW_STAGE_ARN = "arn:aws:apigateway:::test-api/prod"
@@ -20,9 +21,32 @@ CLOUDFRONT_DISTRIBUTION_ARN = (
 
 
 def _cleanup(neo4j_session):
+    neo4j_session.run("MATCH (n:AWSWebACL) DETACH DELETE n")
     neo4j_session.run(
-        "MATCH (n) WHERE n:AWSWebACL OR n:AWSLoadBalancerV2 OR n:APIGatewayStage "
-        "OR n:CloudFrontDistribution DETACH DELETE n",
+        "MATCH (n) WHERE (n:AWSLoadBalancerV2 AND n.arn = $alb_arn) "
+        "OR (n:APIGatewayStage AND n.id = $stage_arn) "
+        "OR (n:CloudFrontDistribution AND n.arn = $distribution_arn) "
+        "DETACH DELETE n",
+        alb_arn=test_data.PROTECTED_ALB_ARN,
+        stage_arn=APIGW_STAGE_ARN,
+        distribution_arn=CLOUDFRONT_DISTRIBUTION_ARN,
+    )
+
+
+def _seed_protected_resources(neo4j_session):
+    neo4j_session.run(
+        "MERGE (:AWSLoadBalancerV2 {arn: $arn})",
+        arn=test_data.PROTECTED_ALB_ARN,
+    )
+    neo4j_session.run(
+        "MERGE (:APIGatewayStage {id: $id, webaclarn: $webaclarn})",
+        id=APIGW_STAGE_ARN,
+        webaclarn=test_data.REGIONAL_WEB_ACL_ARN,
+    )
+    neo4j_session.run(
+        "MERGE (:CloudFrontDistribution {arn: $arn, web_acl_id: $web_acl_id})",
+        arn=CLOUDFRONT_DISTRIBUTION_ARN,
+        web_acl_id=test_data.CLOUDFRONT_WEB_ACL_ARN,
     )
 
 
@@ -41,22 +65,7 @@ def test_sync_wafv2_web_acls(mock_get_web_acls, neo4j_session):
     boto3_session = MagicMock()
     create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
     _cleanup(neo4j_session)
-
-    # Pre-create the nodes that web ACLs attach to
-    neo4j_session.run(
-        "MERGE (:AWSLoadBalancerV2 {arn: $arn})",
-        arn=test_data.PROTECTED_ALB_ARN,
-    )
-    neo4j_session.run(
-        "MERGE (:APIGatewayStage {id: $id, webaclarn: $webaclarn})",
-        id=APIGW_STAGE_ARN,
-        webaclarn=test_data.REGIONAL_WEB_ACL_ARN,
-    )
-    neo4j_session.run(
-        "MERGE (:CloudFrontDistribution {arn: $arn, web_acl_id: $web_acl_id})",
-        arn=CLOUDFRONT_DISTRIBUTION_ARN,
-        web_acl_id=test_data.CLOUDFRONT_WEB_ACL_ARN,
-    )
+    _seed_protected_resources(neo4j_session)
 
     sync(
         neo4j_session,
@@ -67,20 +76,31 @@ def test_sync_wafv2_web_acls(mock_get_web_acls, neo4j_session):
         {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
     )
 
+    # Regional ACLs are fetched per requested region, CLOUDFRONT-scoped ACLs
+    # only via us-east-1
+    assert [c[0][1:] for c in mock_get_web_acls.call_args_list] == [
+        (TEST_REGION, "REGIONAL"),
+        ("us-east-1", "CLOUDFRONT"),
+    ]
+
     assert check_nodes(
         neo4j_session,
         "AWSWebACL",
-        ["arn", "name", "scope", "region"],
+        ["arn", "web_acl_id", "name", "description", "scope", "region"],
     ) == {
         (
             test_data.REGIONAL_WEB_ACL_ARN,
+            "11111111-1111-1111-1111-111111111111",
             "regional-acl",
+            "Protects the regional API",
             "REGIONAL",
             TEST_REGION,
         ),
         (
             test_data.CLOUDFRONT_WEB_ACL_ARN,
+            "22222222-2222-2222-2222-222222222222",
             "cloudfront-acl",
+            "Protects the CDN",
             "CLOUDFRONT",
             "us-east-1",
         ),
@@ -134,6 +154,79 @@ def test_sync_wafv2_web_acls(mock_get_web_acls, neo4j_session):
     ) == {
         (test_data.CLOUDFRONT_WEB_ACL_ARN, CLOUDFRONT_DISTRIBUTION_ARN),
     }
+
+
+@patch.object(cartography.intel.aws.wafv2, "get_web_acls")
+def test_sync_wafv2_cleanup_removes_stale_nodes_and_rels(
+    mock_get_web_acls, neo4j_session
+):
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    _cleanup(neo4j_session)
+    _seed_protected_resources(neo4j_session)
+
+    # First sync: both ACLs exist and all PROTECTS edges materialize
+    mock_get_web_acls.side_effect = _mock_get_web_acls
+    sync(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+
+    # Second sync: the regional ACL was deleted in AWS, and the CloudFront
+    # distribution no longer has a web ACL associated
+    neo4j_session.run(
+        "MATCH (d:CloudFrontDistribution {arn: $arn}) SET d.web_acl_id = null",
+        arn=CLOUDFRONT_DISTRIBUTION_ARN,
+    )
+    mock_get_web_acls.side_effect = lambda boto3_session, region, scope: (
+        copy.deepcopy(test_data.GET_WEB_ACLS_CLOUDFRONT)
+        if scope == "CLOUDFRONT"
+        else []
+    )
+    sync(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG + 1,
+        {"UPDATE_TAG": TEST_UPDATE_TAG + 1, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+
+    # The stale regional ACL node is removed, the CloudFront ACL remains
+    assert check_nodes(neo4j_session, "AWSWebACL", ["arn"]) == {
+        (test_data.CLOUDFRONT_WEB_ACL_ARN,),
+    }
+
+    # The stale PROTECTS edge to the distribution is removed even though both
+    # nodes still exist
+    assert (
+        check_rels(
+            neo4j_session,
+            "AWSWebACL",
+            "arn",
+            "CloudFrontDistribution",
+            "arn",
+            "PROTECTS",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+
+    # The protected resource nodes are untouched by wafv2 cleanup
+    assert (test_data.PROTECTED_ALB_ARN,) in check_nodes(
+        neo4j_session,
+        "AWSLoadBalancerV2",
+        ["arn"],
+    )
+    assert (CLOUDFRONT_DISTRIBUTION_ARN,) in check_nodes(
+        neo4j_session,
+        "CloudFrontDistribution",
+        ["arn"],
+    )
 
 
 @patch.object(

--- a/tests/integration/cartography/intel/aws/test_wafv2.py
+++ b/tests/integration/cartography/intel/aws/test_wafv2.py
@@ -1,0 +1,158 @@
+import copy
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.aws.wafv2
+import tests.data.aws.wafv2 as test_data
+from cartography.intel.aws.wafv2 import sync
+from tests.integration.cartography.intel.aws.common import create_test_account
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_ACCOUNT_ID = "000000000000"
+TEST_REGION = "us-east-1"
+TEST_UPDATE_TAG = 123456789
+
+APIGW_STAGE_ARN = "arn:aws:apigateway:::test-api/prod"
+CLOUDFRONT_DISTRIBUTION_ARN = (
+    f"arn:aws:cloudfront::{TEST_ACCOUNT_ID}:distribution/EDFDVBD632BHDS5"
+)
+
+
+def _cleanup(neo4j_session):
+    neo4j_session.run(
+        "MATCH (n) WHERE n:AWSWebACL OR n:AWSLoadBalancerV2 OR n:APIGatewayStage "
+        "OR n:CloudFrontDistribution DETACH DELETE n",
+    )
+
+
+def _mock_get_web_acls(boto3_session, region, scope):
+    if scope == "REGIONAL":
+        return copy.deepcopy(test_data.GET_WEB_ACLS_REGIONAL)
+    return copy.deepcopy(test_data.GET_WEB_ACLS_CLOUDFRONT)
+
+
+@patch.object(
+    cartography.intel.aws.wafv2,
+    "get_web_acls",
+    side_effect=_mock_get_web_acls,
+)
+def test_sync_wafv2_web_acls(mock_get_web_acls, neo4j_session):
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    _cleanup(neo4j_session)
+
+    # Pre-create the nodes that web ACLs attach to
+    neo4j_session.run(
+        "MERGE (:AWSLoadBalancerV2 {arn: $arn})",
+        arn=test_data.PROTECTED_ALB_ARN,
+    )
+    neo4j_session.run(
+        "MERGE (:APIGatewayStage {id: $id, webaclarn: $webaclarn})",
+        id=APIGW_STAGE_ARN,
+        webaclarn=test_data.REGIONAL_WEB_ACL_ARN,
+    )
+    neo4j_session.run(
+        "MERGE (:CloudFrontDistribution {arn: $arn, web_acl_id: $web_acl_id})",
+        arn=CLOUDFRONT_DISTRIBUTION_ARN,
+        web_acl_id=test_data.CLOUDFRONT_WEB_ACL_ARN,
+    )
+
+    sync(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "AWSWebACL",
+        ["arn", "name", "scope", "region"],
+    ) == {
+        (
+            test_data.REGIONAL_WEB_ACL_ARN,
+            "regional-acl",
+            "REGIONAL",
+            TEST_REGION,
+        ),
+        (
+            test_data.CLOUDFRONT_WEB_ACL_ARN,
+            "cloudfront-acl",
+            "CLOUDFRONT",
+            "us-east-1",
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "AWSAccount",
+        "id",
+        "AWSWebACL",
+        "arn",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (TEST_ACCOUNT_ID, test_data.REGIONAL_WEB_ACL_ARN),
+        (TEST_ACCOUNT_ID, test_data.CLOUDFRONT_WEB_ACL_ARN),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "AWSWebACL",
+        "arn",
+        "AWSLoadBalancerV2",
+        "arn",
+        "PROTECTS",
+        rel_direction_right=True,
+    ) == {
+        (test_data.REGIONAL_WEB_ACL_ARN, test_data.PROTECTED_ALB_ARN),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "AWSWebACL",
+        "arn",
+        "APIGatewayStage",
+        "id",
+        "PROTECTS",
+        rel_direction_right=True,
+    ) == {
+        (test_data.REGIONAL_WEB_ACL_ARN, APIGW_STAGE_ARN),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "AWSWebACL",
+        "arn",
+        "CloudFrontDistribution",
+        "arn",
+        "PROTECTS",
+        rel_direction_right=True,
+    ) == {
+        (test_data.CLOUDFRONT_WEB_ACL_ARN, CLOUDFRONT_DISTRIBUTION_ARN),
+    }
+
+
+@patch.object(
+    cartography.intel.aws.wafv2,
+    "get_web_acls",
+    return_value=[],
+)
+def test_sync_wafv2_empty(mock_get_web_acls, neo4j_session):
+    boto3_session = MagicMock()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    _cleanup(neo4j_session)
+
+    sync(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+
+    assert check_nodes(neo4j_session, "AWSWebACL", ["arn"]) == set()

--- a/tests/integration/cartography/intel/aws/test_wafv2.py
+++ b/tests/integration/cartography/intel/aws/test_wafv2.py
@@ -24,8 +24,8 @@ def _cleanup(neo4j_session):
     neo4j_session.run("MATCH (n:AWSWebACL) DETACH DELETE n")
     neo4j_session.run(
         "MATCH (n) WHERE (n:AWSLoadBalancerV2 AND n.arn = $alb_arn) "
-        "OR (n:APIGatewayStage AND n.id = $stage_arn) "
-        "OR (n:CloudFrontDistribution AND n.arn = $distribution_arn) "
+        "OR (n:AWSAPIGatewayStage AND n.id = $stage_arn) "
+        "OR (n:AWSCloudFrontDistribution AND n.arn = $distribution_arn) "
         "DETACH DELETE n",
         alb_arn=test_data.PROTECTED_ALB_ARN,
         stage_arn=APIGW_STAGE_ARN,
@@ -39,12 +39,12 @@ def _seed_protected_resources(neo4j_session):
         arn=test_data.PROTECTED_ALB_ARN,
     )
     neo4j_session.run(
-        "MERGE (:APIGatewayStage {id: $id, webaclarn: $webaclarn})",
+        "MERGE (:AWSAPIGatewayStage {id: $id, webaclarn: $webaclarn})",
         id=APIGW_STAGE_ARN,
         webaclarn=test_data.REGIONAL_WEB_ACL_ARN,
     )
     neo4j_session.run(
-        "MERGE (:CloudFrontDistribution {arn: $arn, web_acl_id: $web_acl_id})",
+        "MERGE (:AWSCloudFrontDistribution {arn: $arn, web_acl_id: $web_acl_id})",
         arn=CLOUDFRONT_DISTRIBUTION_ARN,
         web_acl_id=test_data.CLOUDFRONT_WEB_ACL_ARN,
     )
@@ -135,7 +135,7 @@ def test_sync_wafv2_web_acls(mock_get_web_acls, neo4j_session):
         neo4j_session,
         "AWSWebACL",
         "arn",
-        "APIGatewayStage",
+        "AWSAPIGatewayStage",
         "id",
         "PROTECTS",
         rel_direction_right=True,
@@ -147,7 +147,7 @@ def test_sync_wafv2_web_acls(mock_get_web_acls, neo4j_session):
         neo4j_session,
         "AWSWebACL",
         "arn",
-        "CloudFrontDistribution",
+        "AWSCloudFrontDistribution",
         "arn",
         "PROTECTS",
         rel_direction_right=True,
@@ -179,7 +179,7 @@ def test_sync_wafv2_cleanup_removes_stale_nodes_and_rels(
     # Second sync: the regional ACL was deleted in AWS, and the CloudFront
     # distribution no longer has a web ACL associated
     neo4j_session.run(
-        "MATCH (d:CloudFrontDistribution {arn: $arn}) SET d.web_acl_id = null",
+        "MATCH (d:AWSCloudFrontDistribution {arn: $arn}) SET d.web_acl_id = null",
         arn=CLOUDFRONT_DISTRIBUTION_ARN,
     )
     mock_get_web_acls.side_effect = lambda boto3_session, region, scope: (
@@ -208,7 +208,7 @@ def test_sync_wafv2_cleanup_removes_stale_nodes_and_rels(
             neo4j_session,
             "AWSWebACL",
             "arn",
-            "CloudFrontDistribution",
+            "AWSCloudFrontDistribution",
             "arn",
             "PROTECTS",
             rel_direction_right=True,
@@ -224,7 +224,7 @@ def test_sync_wafv2_cleanup_removes_stale_nodes_and_rels(
     )
     assert (CLOUDFRONT_DISTRIBUTION_ARN,) in check_nodes(
         neo4j_session,
-        "CloudFrontDistribution",
+        "AWSCloudFrontDistribution",
         ["arn"],
     )
 

--- a/tests/unit/cartography/intel/aws/test_wafv2.py
+++ b/tests/unit/cartography/intel/aws/test_wafv2.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+import botocore.exceptions
+
 import tests.data.aws.wafv2 as test_data
 from cartography.intel.aws.wafv2 import get_web_acls
 from cartography.intel.aws.wafv2 import transform_web_acls
@@ -28,7 +30,59 @@ def test_get_web_acls_paginates_with_next_marker() -> None:
     assert second_call_kwargs["NextMarker"] == "regional-acl"
     # ALB associations are fetched for each regional web ACL
     assert result[0]["AlbArns"] == [test_data.PROTECTED_ALB_ARN]
-    assert mock_client.list_resources_for_web_acl.call_count == 2
+    resource_calls = mock_client.list_resources_for_web_acl.call_args_list
+    assert [c[1] for c in resource_calls] == [
+        {
+            "WebACLArn": result[0]["ARN"],
+            "ResourceType": "APPLICATION_LOAD_BALANCER",
+        },
+        {
+            "WebACLArn": result[1]["ARN"],
+            "ResourceType": "APPLICATION_LOAD_BALANCER",
+        },
+    ]
+
+
+def test_get_web_acls_stops_on_final_page_with_stale_next_marker() -> None:
+    mock_session = MagicMock()
+    mock_client = MagicMock()
+    mock_session.client.return_value = mock_client
+
+    # WAFv2 can return a NextMarker on the final page; an empty page or a
+    # marker that makes no progress must terminate pagination.
+    mock_client.list_web_acls.side_effect = [
+        test_data.LIST_WEB_ACLS_PAGES[0],
+        {"WebACLs": [], "NextMarker": "regional-acl"},
+    ]
+    mock_client.list_resources_for_web_acl.return_value = (
+        test_data.LIST_RESOURCES_FOR_WEB_ACL
+    )
+
+    result = get_web_acls(mock_session, "us-east-1", "REGIONAL")
+
+    assert len(result) == 1
+    assert mock_client.list_web_acls.call_count == 2
+
+
+def test_get_web_acls_skips_web_acl_deleted_mid_sync() -> None:
+    mock_session = MagicMock()
+    mock_client = MagicMock()
+    mock_session.client.return_value = mock_client
+
+    mock_client.list_web_acls.return_value = {
+        "WebACLs": test_data.LIST_WEB_ACLS_PAGES[0]["WebACLs"],
+    }
+    mock_client.list_resources_for_web_acl.side_effect = (
+        botocore.exceptions.ClientError(
+            error_response={"Error": {"Code": "WAFNonexistentItemException"}},
+            operation_name="ListResourcesForWebACL",
+        )
+    )
+
+    result = get_web_acls(mock_session, "us-east-1", "REGIONAL")
+
+    assert len(result) == 1
+    assert result[0]["AlbArns"] == []
 
 
 def test_get_web_acls_cloudfront_scope_skips_resource_lookup() -> None:

--- a/tests/unit/cartography/intel/aws/test_wafv2.py
+++ b/tests/unit/cartography/intel/aws/test_wafv2.py
@@ -3,8 +3,17 @@ from unittest.mock import MagicMock
 import botocore.exceptions
 
 import tests.data.aws.wafv2 as test_data
+from cartography.intel.aws.resources import RESOURCE_FUNCTIONS
 from cartography.intel.aws.wafv2 import get_web_acls
 from cartography.intel.aws.wafv2 import transform_web_acls
+
+
+def test_wafv2_syncs_after_the_modules_it_links_to() -> None:
+    # PROTECTS edges match on nodes loaded by these modules, so wafv2 must
+    # run after them
+    order = list(RESOURCE_FUNCTIONS)
+    for dependency in ("ec2:load_balancer_v2", "apigateway", "cloudfront"):
+        assert order.index(dependency) < order.index("wafv2")
 
 
 def test_get_web_acls_paginates_with_next_marker() -> None:

--- a/tests/unit/cartography/intel/aws/test_wafv2.py
+++ b/tests/unit/cartography/intel/aws/test_wafv2.py
@@ -1,0 +1,70 @@
+from unittest.mock import MagicMock
+
+import tests.data.aws.wafv2 as test_data
+from cartography.intel.aws.wafv2 import get_web_acls
+from cartography.intel.aws.wafv2 import transform_web_acls
+
+
+def test_get_web_acls_paginates_with_next_marker() -> None:
+    mock_session = MagicMock()
+    mock_client = MagicMock()
+    mock_session.client.return_value = mock_client
+
+    mock_client.list_web_acls.side_effect = [
+        test_data.LIST_WEB_ACLS_PAGES[0],
+        test_data.LIST_WEB_ACLS_PAGES[1],
+    ]
+    mock_client.list_resources_for_web_acl.return_value = (
+        test_data.LIST_RESOURCES_FOR_WEB_ACL
+    )
+
+    result = get_web_acls(mock_session, "us-east-1", "REGIONAL")
+
+    assert len(result) == 2
+    assert result[0]["Name"] == "regional-acl"
+    assert result[1]["Name"] == "regional-acl-2"
+    # Second list call must pass the NextMarker from the first page
+    second_call_kwargs = mock_client.list_web_acls.call_args_list[1][1]
+    assert second_call_kwargs["NextMarker"] == "regional-acl"
+    # ALB associations are fetched for each regional web ACL
+    assert result[0]["AlbArns"] == [test_data.PROTECTED_ALB_ARN]
+    assert mock_client.list_resources_for_web_acl.call_count == 2
+
+
+def test_get_web_acls_cloudfront_scope_skips_resource_lookup() -> None:
+    mock_session = MagicMock()
+    mock_client = MagicMock()
+    mock_session.client.return_value = mock_client
+
+    mock_client.list_web_acls.return_value = {
+        "WebACLs": test_data.GET_WEB_ACLS_CLOUDFRONT,
+    }
+
+    result = get_web_acls(mock_session, "us-east-1", "CLOUDFRONT")
+
+    assert len(result) == 1
+    # list_resources_for_web_acl does not support CLOUDFRONT-scoped ACLs;
+    # distributions are matched on their web_acl_id property instead.
+    mock_client.list_resources_for_web_acl.assert_not_called()
+
+
+def test_transform_web_acls() -> None:
+    transformed = transform_web_acls(test_data.GET_WEB_ACLS_REGIONAL, "REGIONAL")
+
+    assert transformed == [
+        {
+            "ARN": test_data.REGIONAL_WEB_ACL_ARN,
+            "Id": "11111111-1111-1111-1111-111111111111",
+            "Name": "regional-acl",
+            "Description": "Protects the regional API",
+            "Scope": "REGIONAL",
+            "AlbArns": [test_data.PROTECTED_ALB_ARN],
+        },
+    ]
+
+
+def test_transform_web_acls_defaults_missing_albs_to_empty_list() -> None:
+    transformed = transform_web_acls(test_data.GET_WEB_ACLS_CLOUDFRONT, "CLOUDFRONT")
+
+    assert transformed[0]["Scope"] == "CLOUDFRONT"
+    assert transformed[0]["AlbArns"] == []


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary
Adds WAFv2 web ACL support, following the roadmap laid out in #1067:

- New `AWSWebACL` node for REGIONAL and CLOUDFRONT scoped web ACLs, synced via `list_web_acls`
- `(:AWSWebACL)-[:PROTECTS]->(:AWSLoadBalancerV2)` from `list_resources_for_web_acl`
- `(:AWSWebACL)-[:PROTECTS]->(:APIGatewayStage)` and `(:AWSWebACL)-[:PROTECTS]->(:CloudFrontDistribution)` matched on the `webaclarn` and `web_acl_id` properties those nodes already carry, so no extra API calls are needed
- AppSync is not modeled in cartography yet, so no AppSync edge

CLOUDFRONT scoped ACLs are global and only listable via us-east-1, so they sync once outside the region loop. The module is registered after `ec2:load_balancer_v2`, `apigateway`, and `cloudfront` so the PROTECTS edges can match existing nodes.

### Related issues or links
- Closes #1067

### Breaking changes
None.

### How was this tested?
- Unit tests for pagination (including the NextMarker-on-final-page quirk), the deleted-ACL race on `list_resources_for_web_acl`, transform, and sync ordering
- Integration tests for nodes, all relationships, and cleanup of stale nodes and stale PROTECTS edges on re-sync
- `make test_lint` passes locally

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Sync logs from a real environment. I do not have WAFv2 resources in an account right now; happy to set some up and attach logs if needed.
