### PR TITLE
[CIS AWS 3.1.4] fix(rules): exclude account-BPA-covered buckets from S3 BPA rule

### DIFF
--- a/cartography/rules/data/rules/cis_aws_storage.py
+++ b/cartography/rules/data/rules/cis_aws_storage.py
@@ -129,10 +129,27 @@ _aws_s3_block_public_access_disabled = Fact(
     ),
     cypher_query="""
     MATCH (a:AWSAccount)-[:RESOURCE]->(bucket:S3Bucket)
-    WHERE (bucket.block_public_acls IS NULL OR bucket.block_public_acls <> true)
-       OR (bucket.ignore_public_acls IS NULL OR bucket.ignore_public_acls <> true)
-       OR (bucket.block_public_policy IS NULL OR bucket.block_public_policy <> true)
-       OR (bucket.restrict_public_buckets IS NULL OR bucket.restrict_public_buckets <> true)
+    WHERE (
+        (bucket.block_public_acls IS NULL OR bucket.block_public_acls <> true)
+        OR (bucket.ignore_public_acls IS NULL OR bucket.ignore_public_acls <> true)
+        OR (bucket.block_public_policy IS NULL OR bucket.block_public_policy <> true)
+        OR (bucket.restrict_public_buckets IS NULL OR bucket.restrict_public_buckets <> true)
+    )
+    // Exclude buckets with no bucket-level BPA config that inherit a fully
+    // enforced account-level Block Public Access from their parent account.
+    AND NOT (
+        bucket.block_public_acls IS NULL
+        AND bucket.ignore_public_acls IS NULL
+        AND bucket.block_public_policy IS NULL
+        AND bucket.restrict_public_buckets IS NULL
+        AND EXISTS {
+            MATCH (a)-[:RESOURCE]->(pab:S3AccountPublicAccessBlock)
+            WHERE pab.block_public_acls = true
+              AND pab.ignore_public_acls = true
+              AND pab.block_public_policy = true
+              AND pab.restrict_public_buckets = true
+        }
+    )
     RETURN
         bucket.name AS bucket_name,
         bucket.id AS bucket_id,
@@ -146,10 +163,27 @@ _aws_s3_block_public_access_disabled = Fact(
     """,
     cypher_visual_query="""
     MATCH p=(a:AWSAccount)-[:RESOURCE]->(bucket:S3Bucket)
-    WHERE (bucket.block_public_acls IS NULL OR bucket.block_public_acls <> true)
-       OR (bucket.ignore_public_acls IS NULL OR bucket.ignore_public_acls <> true)
-       OR (bucket.block_public_policy IS NULL OR bucket.block_public_policy <> true)
-       OR (bucket.restrict_public_buckets IS NULL OR bucket.restrict_public_buckets <> true)
+    WHERE (
+        (bucket.block_public_acls IS NULL OR bucket.block_public_acls <> true)
+        OR (bucket.ignore_public_acls IS NULL OR bucket.ignore_public_acls <> true)
+        OR (bucket.block_public_policy IS NULL OR bucket.block_public_policy <> true)
+        OR (bucket.restrict_public_buckets IS NULL OR bucket.restrict_public_buckets <> true)
+    )
+    // Exclude buckets with no bucket-level BPA config that inherit a fully
+    // enforced account-level Block Public Access from their parent account.
+    AND NOT (
+        bucket.block_public_acls IS NULL
+        AND bucket.ignore_public_acls IS NULL
+        AND bucket.block_public_policy IS NULL
+        AND bucket.restrict_public_buckets IS NULL
+        AND EXISTS {
+            MATCH (a)-[:RESOURCE]->(pab:S3AccountPublicAccessBlock)
+            WHERE pab.block_public_acls = true
+              AND pab.ignore_public_acls = true
+              AND pab.block_public_policy = true
+              AND pab.restrict_public_buckets = true
+        }
+    )
     RETURN *
     """,
     cypher_count_query="""
@@ -171,7 +205,7 @@ aws_s3_block_public_access = Rule(
     output_model=S3BlockPublicAccessOutput,
     facts=(_aws_s3_block_public_access_disabled,),
     tags=("storage", "s3", "stride:information_disclosure"),
-    version="1.0.0",
+    version="1.1.0",
     references=CIS_REFERENCES,
     frameworks=(
         cis_aws("3.1.4"),


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

The CIS AWS 3.1.4 rule (`aws_s3_block_public_access`) flagged S3 buckets that have no bucket-level Block Public Access configuration (all four fields NULL). Such buckets inherit their account's account-level BPA, so when the account enforces BPA they are not actually publicly exposable. Flagging them produces significant false-positive noise.

This change excludes a bucket from the finding when **all four** bucket-level BPA fields are NULL **and** the parent account has an `S3AccountPublicAccessBlock` node with all four properties enforced (`= true`). Buckets with any explicit bucket-level configuration are still evaluated at the bucket level, unchanged.

The exclusion is applied to both `cypher_query` and `cypher_visual_query`; the `cypher_count_query` (total-bucket denominator) is left unchanged. The rule version is bumped `1.0.0` -> `1.1.0`.


### How was this tested?

- `make test_lint` (black, flake8, mypy, isort, pyupgrade) passes locally.
- `uv run pytest tests/unit/rules/test_cis_aws.py` — 256 passed.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.


### Test plan
- On an account with account-level BPA fully enforced (`S3AccountPublicAccessBlock` with all four props `= true`): a bucket whose four bucket-level BPA fields are all NULL is **not** flagged.
- On the same account: a bucket with an explicit non-enforcing bucket-level setting (e.g. `block_public_acls = false`) **is** still flagged.
- On an account **without** account-level BPA (or partially enforced): a bucket with all-NULL bucket-level fields **is** still flagged.
- Existing findings for buckets with explicit incomplete bucket-level BPA are unaffected.


### Notes for reviewers
Account-level BPA is modeled as a separate `S3AccountPublicAccessBlock` node linked `(:AWSAccount)-[:RESOURCE]->(:S3AccountPublicAccessBlock)`, so the exclusion uses an `EXISTS {}` subquery against that node rather than properties on `AWSAccount`.
