### PR TITLE
fix(aws): skip Inspector region on transient endpoint failure

### DIFF
--- a/cartography/intel/aws/inspector.py
+++ b/cartography/intel/aws/inspector.py
@@ -1,4 +1,5 @@
 import logging
+from functools import wraps
 from typing import Any
 from typing import Dict
 from typing import Iterator
@@ -58,8 +59,50 @@ AWS_INSPECTOR_REGIONS = {
 
 BATCH_SIZE = 1000
 
+# Connection-level failures that indicate a regional inspector2 endpoint could not
+# be reached (e.g. an opt-in region listed in AWS_INSPECTOR_REGIONS but not enabled
+# on the account). These are NOT botocore ClientError subclasses.
+_INSPECTOR_TRANSIENT_CONNECTION_ERRORS = (
+    botocore.exceptions.ConnectTimeoutError,
+    botocore.exceptions.EndpointConnectionError,
+    botocore.exceptions.ReadTimeoutError,
+    botocore.exceptions.ConnectionClosedError,
+)
+
+
+class InspectorTransientRegionFailure(Exception):
+    """
+    Raised when a regional inspector2 endpoint fails at the connection level.
+
+    The generic @aws_handle_regions decorator catches most of these connection
+    errors and returns [], which makes a transient failure indistinguishable from
+    a region that legitimately has no data. We re-raise them as this distinct type
+    (which @aws_handle_regions does not catch) so sync() can skip the region and
+    skip cleanup, preserving last-known-good data.
+    """
+
+
+def _reraise_inspector_connection_errors(func: Any) -> Any:
+    """
+    Convert connection-level endpoint failures into InspectorTransientRegionFailure.
+
+    Stacked *inside* @aws_handle_regions so the re-raised exception bubbles past
+    that decorator (it only handles ClientError and the raw connection errors)
+    instead of being swallowed into an empty result.
+    """
+
+    @wraps(func)
+    def inner(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return func(*args, **kwargs)
+        except _INSPECTOR_TRANSIENT_CONNECTION_ERRORS as e:
+            raise InspectorTransientRegionFailure(str(e)) from e
+
+    return inner
+
 
 @aws_handle_regions
+@_reraise_inspector_connection_errors
 def get_member_accounts(
     session: boto3.session.Session,
     region: str,
@@ -359,12 +402,7 @@ def _sync_findings_for_account(
                 current_aws_account_id,
             )
         return True
-    except (
-        botocore.exceptions.ConnectTimeoutError,
-        botocore.exceptions.EndpointConnectionError,
-        botocore.exceptions.ReadTimeoutError,
-        botocore.exceptions.ConnectionClosedError,
-    ):
+    except _INSPECTOR_TRANSIENT_CONNECTION_ERRORS:
         # Connection-level failures are not ClientError subclasses, so the
         # @aws_handle_regions decorator and the ClientError handler below cannot
         # catch them. They occur during iteration of the get_inspector_findings
@@ -437,12 +475,7 @@ def sync(
         )
         try:
             member_accounts = get_member_accounts(boto3_session, region)
-        except (
-            botocore.exceptions.ConnectTimeoutError,
-            botocore.exceptions.EndpointConnectionError,
-            botocore.exceptions.ReadTimeoutError,
-            botocore.exceptions.ConnectionClosedError,
-        ):
+        except InspectorTransientRegionFailure:
             # Reaching the regional inspector2 endpoint failed at the connection
             # level (e.g. an opt-in region listed in AWS_INSPECTOR_REGIONS that is
             # not enabled on this account). Skip the whole region.

--- a/cartography/intel/aws/inspector.py
+++ b/cartography/intel/aws/inspector.py
@@ -311,9 +311,16 @@ def _sync_findings_for_account(
     update_tag: int,
     current_aws_account_id: str,
     batch_size: int = BATCH_SIZE,
-) -> None:
+) -> bool:
     """
     Syncs the findings for a given account in a given region.
+
+    Returns True if the sync completed (including the cases where the region was
+    skipped due to a ClientError such as AccessDenied or "Inspector not enabled",
+    which are expected and safe to treat as "no findings"). Returns False if the
+    region was skipped due to a transient connection-level failure to the regional
+    inspector2 endpoint, in which case the caller must not run cleanup for this
+    account so that last-known-good findings are preserved.
     """
     try:
         findings = get_inspector_findings(boto3_session, region, account_id, batch_size)
@@ -321,7 +328,7 @@ def _sync_findings_for_account(
             logger.info(
                 f"No findings to sync for account {account_id} in region {region}"
             )
-            return
+            return True
         for f_batch in findings:
             finding_data, package_data, finding_to_package_map = (
                 transform_inspector_findings(f_batch)
@@ -351,6 +358,26 @@ def _sync_findings_for_account(
                 update_tag,
                 current_aws_account_id,
             )
+        return True
+    except (
+        botocore.exceptions.ConnectTimeoutError,
+        botocore.exceptions.EndpointConnectionError,
+        botocore.exceptions.ReadTimeoutError,
+        botocore.exceptions.ConnectionClosedError,
+    ):
+        # Connection-level failures are not ClientError subclasses, so the
+        # @aws_handle_regions decorator and the ClientError handler below cannot
+        # catch them. They occur during iteration of the get_inspector_findings
+        # generator (e.g. opt-in regions whose inspector2 endpoint is not routable
+        # connect-time out). Skip just this region and signal the caller to skip
+        # cleanup so last-known-good findings are preserved.
+        logger.warning(
+            "Transient connection failure to Inspector endpoint for account %s "
+            "in region %s. Skipping region.",
+            account_id,
+            region,
+        )
+        return False
     except botocore.exceptions.ClientError as e:
         error_code = e.response.get("Error", {}).get("Code")
         # Handle the same error codes as aws_handle_regions decorator
@@ -369,7 +396,7 @@ def _sync_findings_for_account(
                     account_id,
                     region,
                 )
-            return
+            return True
         elif error_code == "ValidationException":
             logger.warning(
                 "AWS Inspector returned ValidationException for account %s in region %s. "
@@ -377,7 +404,7 @@ def _sync_findings_for_account(
                 account_id,
                 region,
             )
-            return
+            return True
         else:
             raise
 
@@ -399,16 +426,39 @@ def sync(
         region for region in regions if region in AWS_INSPECTOR_REGIONS
     ]
 
+    # If any region is skipped because of a transient connection-level failure to
+    # its inspector2 endpoint, we must not run cleanup: deleting findings for a
+    # region we couldn't reach would wipe out last-known-good data.
+    cleanup_safe = True
+
     for region in inspector_regions:
         logger.info(
             f"Syncing AWS Inspector findings delegated to account {current_aws_account_id} and region {region}",
         )
-        member_accounts = get_member_accounts(boto3_session, region)
+        try:
+            member_accounts = get_member_accounts(boto3_session, region)
+        except (
+            botocore.exceptions.ConnectTimeoutError,
+            botocore.exceptions.EndpointConnectionError,
+            botocore.exceptions.ReadTimeoutError,
+            botocore.exceptions.ConnectionClosedError,
+        ):
+            # Reaching the regional inspector2 endpoint failed at the connection
+            # level (e.g. an opt-in region listed in AWS_INSPECTOR_REGIONS that is
+            # not enabled on this account). Skip the whole region.
+            logger.warning(
+                "Transient connection failure to Inspector endpoint for account %s "
+                "in region %s while listing member accounts. Skipping region.",
+                current_aws_account_id,
+                region,
+            )
+            cleanup_safe = False
+            continue
         # the current host account may not be considered a "member", but we still fetch its findings
         member_accounts.append(current_aws_account_id)
         logger.info(f"Member accounts to be synced: {member_accounts}")
         for account_id in member_accounts:
-            _sync_findings_for_account(
+            synced = _sync_findings_for_account(
                 neo4j_session,
                 boto3_session,
                 region,
@@ -417,6 +467,16 @@ def sync(
                 current_aws_account_id,
                 batch_size,
             )
-    common_job_parameters["ACCOUNT_ID"] = current_aws_account_id
-    common_job_parameters["UPDATE_TAG"] = update_tag
-    cleanup(neo4j_session, common_job_parameters, batch_size)
+            if not synced:
+                cleanup_safe = False
+
+    if cleanup_safe:
+        common_job_parameters["ACCOUNT_ID"] = current_aws_account_id
+        common_job_parameters["UPDATE_TAG"] = update_tag
+        cleanup(neo4j_session, common_job_parameters, batch_size)
+    else:
+        logger.warning(
+            "Skipping AWS Inspector cleanup for account %s because one or more regions "
+            "were transiently skipped. Preserving last-known-good data.",
+            current_aws_account_id,
+        )

--- a/tests/integration/cartography/intel/aws/inspector/test_inspector_sync.py
+++ b/tests/integration/cartography/intel/aws/inspector/test_inspector_sync.py
@@ -220,3 +220,62 @@ def test_sync_findings_for_account_skips_validation_exception(
         BATCH_SIZE,
     )
     assert check_nodes(neo4j_session, "AWSInspectorFinding", ["id"]) == set()
+
+
+def _raising_findings_generator(*args, **kwargs):
+    # Mimics get_inspector_findings raising a connection-level error while the
+    # paginator is being iterated (the failure mode reported for unreachable /
+    # opt-in inspector2 regional endpoints).
+    raise botocore.exceptions.ConnectTimeoutError(
+        endpoint_url="https://inspector2.me-south-1.amazonaws.com/findings/list",
+    )
+    yield  # pragma: no cover - makes this function a generator
+
+
+@patch.object(
+    cartography.intel.aws.inspector,
+    "get_member_accounts",
+    return_value=[],
+)
+@patch.object(
+    cartography.intel.aws.inspector,
+    "get_inspector_findings",
+    side_effect=_raising_findings_generator,
+)
+def test_sync_inspector_survives_connection_timeout(
+    mock_get,
+    mock_members,
+    neo4j_session,
+):
+    # Arrange: a finding from a previous (successful) run already lives in the
+    # graph, stamped with an older update tag.
+    old_update_tag = TEST_UPDATE_TAG - 1
+    boto3_session = MagicMock()
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (a:AWSAccount{id: $acc})
+        MERGE (f:AWSInspectorFinding{id: 'arn:aws:stale'})
+        SET f.lastupdated = $old_tag
+        MERGE (a)-[r:RESOURCE]->(f)
+        SET r.lastupdated = $old_tag
+        """,
+        acc=TEST_ACC_ID_1,
+        old_tag=old_update_tag,
+    )
+
+    # Act: a fresh sync hits a transient connection failure for the region.
+    sync(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACC_ID_1,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACC_ID_1},
+    )
+
+    # Assert: the account sync completed without raising, and cleanup was skipped
+    # so the last-known-good finding from the previous run was preserved.
+    assert check_nodes(neo4j_session, "AWSInspectorFinding", ["id"]) == {
+        ("arn:aws:stale",),
+    }

--- a/tests/integration/cartography/intel/aws/inspector/test_inspector_sync.py
+++ b/tests/integration/cartography/intel/aws/inspector/test_inspector_sync.py
@@ -279,3 +279,58 @@ def test_sync_inspector_survives_connection_timeout(
     assert check_nodes(neo4j_session, "AWSInspectorFinding", ["id"]) == {
         ("arn:aws:stale",),
     }
+
+
+@patch.object(
+    cartography.intel.aws.inspector,
+    "get_inspector_findings",
+    return_value=[],
+)
+@patch.object(cartography.intel.aws.inspector, "create_boto3_client")
+@patch.object(
+    cartography.intel.aws.inspector,
+    "aws_paginate",
+    side_effect=botocore.exceptions.ConnectTimeoutError(
+        endpoint_url="https://inspector2.me-south-1.amazonaws.com/members/list",
+    ),
+)
+def test_sync_inspector_preserves_data_on_member_listing_timeout(
+    mock_paginate,
+    mock_client,
+    mock_findings,
+    neo4j_session,
+):
+    # This exercises the real get_member_accounts() decorator stack: a transient
+    # connection failure while listing members must NOT be swallowed into an empty
+    # member list (which would let cleanup run and delete stale member findings).
+    old_update_tag = TEST_UPDATE_TAG - 1
+    boto3_session = MagicMock()
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    # A delegated-member finding from a previous successful run, stamped older.
+    neo4j_session.run(
+        """
+        MERGE (a:AWSAccount{id: $acc})
+        MERGE (f:AWSInspectorFinding{id: 'arn:aws:stale-member'})
+        SET f.lastupdated = $old_tag
+        MERGE (a)-[r:RESOURCE]->(f)
+        SET r.lastupdated = $old_tag
+        """,
+        acc=TEST_ACC_ID_1,
+        old_tag=old_update_tag,
+    )
+
+    # Act: list_members connect-times-out for the region.
+    sync(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACC_ID_1,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACC_ID_1},
+    )
+
+    # Assert: the region was skipped, cleanup was skipped, and the stale member
+    # finding was preserved rather than deleted.
+    assert check_nodes(neo4j_session, "AWSInspectorFinding", ["id"]) == {
+        ("arn:aws:stale-member",),
+    }


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
`cartography.intel.aws.inspector` did not handle connection-level failures (connect/read timeouts, endpoint connection errors) when reaching a regional `inspector2` endpoint. These exceptions are **not** `botocore.exceptions.ClientError` subclasses, so neither the generic `@aws_handle_regions` decorator nor the inspector module's existing `ClientError` handler caught them.

As a result, a single unreachable regional endpoint aborted the sync for the **entire account**. This is most easily triggered by an opt-in region (e.g. `me-south-1`) that is listed in `AWS_INSPECTOR_REGIONS` but is not enabled on the target account: every call to its endpoint connect-times-out and the account fails on every run.

This PR mirrors the existing SageMaker pattern (`sagemaker_handle_regions`):

- Catch the connection-error family (`ConnectTimeoutError`, `EndpointConnectionError`, `ReadTimeoutError`, `ConnectionClosedError`) and skip only the affected region, continuing with the other regions and accounts.
- The guard is applied to **both** the `get_member_accounts` probe and the findings sync. For the opt-in-region case the failure actually surfaces first at `list_members` (inside `get_member_accounts`, which is only decorated with `@aws_handle_regions`), before the findings paginator is ever reached, so guarding only the findings path would not have fixed it.
- Track a `cleanup_safe` flag: when any region is transiently skipped, cleanup is skipped (with a warning) so findings already in the graph for the unreachable region are not deleted. This preserves last-known-good data, the same reasoning SageMaker uses for its `cleanup_safe` flag.

### How was this tested?
- `make test_lint` passes locally (black, flake8, isort, pyupgrade, mypy).
- Existing inspector unit and integration tests pass.
- Added a regression test, `test_sync_inspector_survives_connection_timeout`, that seeds a finding from a prior run, makes `get_inspector_findings` raise a `ConnectTimeoutError` during pagination, and asserts the account sync completes without raising and the pre-existing finding is preserved (cleanup skipped).

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)