### PR TITLE
fix(github): synthesize token_name for classic PATs

### DIFF
--- a/cartography/intel/github/personal_access_tokens.py
+++ b/cartography/intel/github/personal_access_tokens.py
@@ -207,7 +207,7 @@ def _transform_saml_credential_authorization(
         "id": f"{org_url}/credential-authorizations/{credential_id}",
         "token_kind": "classic",
         "token_id": None,
-        "token_name": None,
+        "token_name": f"{owner_login} (classic PAT)" if owner_login else None,
         "owner_login": owner_login,
         "owner_user_id": owner_user_id,
         "repository_selection": None,

--- a/tests/integration/cartography/intel/github/test_personal_access_tokens.py
+++ b/tests/integration/cartography/intel/github/test_personal_access_tokens.py
@@ -131,7 +131,7 @@ def test_sync_github_personal_access_tokens(mock_pages, neo4j_session):
         (
             f"{ORG_URL}/credential-authorizations/161195",
             "classic",
-            None,
+            "hjsimpson (classic PAT)",
             "hjsimpson",
         ),
     }

--- a/tests/unit/cartography/intel/github/test_personal_access_tokens.py
+++ b/tests/unit/cartography/intel/github/test_personal_access_tokens.py
@@ -59,7 +59,7 @@ def test_transform_classic_pat_drops_token_fragment():
         "id": "https://github.com/simpsoncorp/credential-authorizations/161195",
         "token_kind": "classic",
         "token_id": None,
-        "token_name": None,
+        "token_name": "hjsimpson (classic PAT)",
         "owner_login": "hjsimpson",
         "owner_user_id": "https://github.com/hjsimpson",
         "repository_selection": None,


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
`GitHubPersonalAccessToken` nodes created from SAML SSO credential authorizations (`token_kind = "classic"`) were written with `token_name = None`, because the SAML credential-authorizations API does not return a token name. Since `token_name` is the only human-meaningful label for these nodes, classic PATs ended up with no usable display name and were hard to tell apart in inventory and downstream consumers (in a large org, classic PATs dominate, so this affects most PATs).

This change synthesizes a name from the data classic PATs do carry (`owner_login`):

```python
"token_name": f"{owner_login} (classic PAT)" if owner_login else None,
```

The node stays self-describing, is distinguishable from fine-grained PATs, and remains null only when even `owner_login` is missing. Fine-grained PATs are unaffected (their name comes from the API).

### How was this tested?
Updated the existing unit test asserting the classic-PAT transform output. `make test_lint` and the GitHub PAT unit tests pass locally.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.
