### PR TITLE
fix(aws): stop AWSIpRange from claiming multi-account ownership

### DIFF
--- a/cartography/models/aws/ec2/security_group_rules.py
+++ b/cartography/models/aws/ec2/security_group_rules.py
@@ -108,8 +108,24 @@ class IpPermissionInboundSchema(CartographyNodeSchema):
 
 @dataclass(frozen=True)
 class IpRangeSchema(CartographyNodeSchema):
+    """
+    There is no sub-resource relationship here because a CIDR that appears as a
+    source or destination in a security group rule is a *reference*, not a
+    resource the account owns. The node is keyed solely on the raw CIDR string,
+    so it is a single global node that can be referenced by rules in more than
+    one account; scoping it to a single account via a (:AWSAccount)-[:RESOURCE]->
+    (:AWSIpRange) edge would falsely imply multi-account ownership. Genuine CIDR
+    ownership is expressed transitively through VPC membership
+    (AWSAccount)-[:RESOURCE]->(AWSVpc)-[:BLOCK_ASSOCIATION]->(AWSCidrBlock).
+
+    This matches AWSIPv4CidrBlockSchema / AWSIPv6CidrBlockSchema, which omit a
+    sub-resource relationship for the same reason. The AWSIpRule /
+    AWSIpPermissionInbound nodes keep their RESOURCE edge to the account because
+    the rule genuinely belongs to that account's security group; only the shared
+    CIDR node should not be owned.
+    """
+
     label: str = "AWSIpRange"
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["IpRange"])
     properties: IpRangeNodeProperties = IpRangeNodeProperties()
-    sub_resource_relationship: IpRuleToAWSAccountRel = IpRuleToAWSAccountRel()
     other_relationships: OtherRelationships = OtherRelationships([IpRangeToIpRuleRel()])

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -3387,12 +3387,9 @@ Represents an IP address range (CIDR block) associated with an EC2 Security Grou
 | **id** | Unique identifier for the IP range (typically the CIDR block) |
 | range | The IP address range in CIDR notation (e.g., 0.0.0.0/0, 10.0.0.0/16) |
 
-#### Relationships
+> **Note**: An AWSIpRange is a *reference* to a CIDR used by a security group rule, not a resource an account owns, so it intentionally has no `(:AWSAccount)-[:RESOURCE]->(:AWSIpRange)` ownership edge. The same CIDR can be referenced by rules in multiple accounts. Genuine CIDR ownership is expressed transitively through VPC membership: `(AWSAccount)-[:RESOURCE]->(AWSVpc)-[:BLOCK_ASSOCIATION]->(AWSCidrBlock)`.
 
-- AWSIpRanges belong to AWS Accounts.
-    ```
-    (AWSAccount)-[RESOURCE]->(AWSIpRange)
-    ```
+#### Relationships
 
 - AWSIpRanges are members of AWSIpRules.
     ```

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_security_groups.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_security_groups.py
@@ -237,3 +237,54 @@ def test_sync_ec2_security_groupinfo(mock_get_security_groups, neo4j_session):
         # Test cross-security group relationships
         ("sg-web-server-12345", "sg-028e2522c72719996"),
     }
+
+    # Assert AWSIpRange nodes exist (one global node per CIDR)
+    assert check_nodes(neo4j_session, "AWSIpRange", ["id"]) == {
+        ("203.0.113.0/24",),
+        ("0.0.0.0/0",),
+        ("8.8.8.8/32",),
+        ("10.0.0.0/8",),
+    }
+
+    # Assert AWSIpRanges are connected to the rules that reference them
+    assert check_rels(
+        neo4j_session,
+        "AWSIpRange",
+        "id",
+        "AWSIpRule",
+        "ruleid",
+        "MEMBER_OF_IP_RULE",
+        rel_direction_right=True,
+    ) == {
+        ("203.0.113.0/24", "sg-028e2522c72719996/IpPermissions/8080tcp"),
+        ("203.0.113.0/24", "sg-028e2522c72719996/IpPermissions/443443tcp"),
+        ("0.0.0.0/0", "sg-028e2522c72719996/IpPermissionsEgress/8080tcp"),
+        ("8.8.8.8/32", "sg-028e2522c72719996/IpPermissionsEgress/NoneNone-1"),
+        ("0.0.0.0/0", "sg-028e2522c72719996/IpPermissionsEgress/443443tcp"),
+        ("0.0.0.0/0", "sg-053dba35430032a0d/IpPermissionsEgress/NoneNone-1"),
+        ("203.0.113.0/24", "sg-06c795c66be8937be/IpPermissions/8080tcp"),
+        ("203.0.113.0/24", "sg-06c795c66be8937be/IpPermissions/443443tcp"),
+        ("0.0.0.0/0", "sg-06c795c66be8937be/IpPermissionsEgress/8080tcp"),
+        ("8.8.8.8/32", "sg-06c795c66be8937be/IpPermissionsEgress/NoneNone-1"),
+        ("0.0.0.0/0", "sg-06c795c66be8937be/IpPermissionsEgress/443443tcp"),
+        ("0.0.0.0/0", "sg-0fd4fff275d63600f/IpPermissionsEgress/NoneNone-1"),
+        ("10.0.0.0/8", "sg-web-server-12345/IpPermissions/2222tcp"),
+        ("0.0.0.0/0", "sg-web-server-12345/IpPermissions/8080tcp"),
+        ("0.0.0.0/0", "sg-web-server-12345/IpPermissionsEgress/NoneNone-1"),
+    }
+
+    # Regression test for https://github.com/cartography-cncf/cartography/issues/2928:
+    # AWSIpRange is a reference to a shared CIDR, not a resource the account owns,
+    # so it must NOT carry a (:AWSAccount)-[:RESOURCE]->(:AWSIpRange) ownership edge.
+    assert (
+        check_rels(
+            neo4j_session,
+            "AWSAccount",
+            "id",
+            "AWSIpRange",
+            "id",
+            "RESOURCE",
+            rel_direction_right=True,
+        )
+        == set()
+    )


### PR DESCRIPTION
## Summary

Fixes #2928.

An `AWSIpRange` node is keyed solely on the raw CIDR string, so a CIDR referenced by security group rules in multiple accounts is a **single global node**. Because [`IpRangeSchema`](``https://github.com/cartography-cncf/cartography/blob/d5a619f6d6d8aae70eec75b5d16bedf36bd15fad/cartography/models/aws/ec2/security_group_rules.py#L110-L115``) declared a `sub_resource_relationship` to `AWSAccount`, and `load_ip_ranges` runs once per account, every referencing account accumulated a `(:AWSAccount)-[:RESOURCE]->(:AWSIpRange)` edge — falsely implying multi-account ownership of the same CIDR.

A CIDR that appears as a source/destination in a rule is a **reference**, not a resource the account owns.

## Change

- Remove the `sub_resource_relationship` from `IpRangeSchema` so `AWSIpRange` keeps only its `MEMBER_OF_IP_RULE` edge to the referencing rule, and add a docstring explaining why (mirroring `AWSIPv4CidrBlockSchema` / `AWSIPv6CidrBlockSchema`, which already omit a sub-resource relationship for the same reason).
- `AWSIpRule` / `AWSIpPermissionInbound` nodes **keep** their account `RESOURCE` edge — the rule genuinely belongs to the account's security group; only the shared CIDR node should not be owned.
- Update the AWS schema docs to drop the `(AWSAccount)-[RESOURCE]->(AWSIpRange)` edge and add a note explaining ownership.

Genuine CIDR ownership remains expressed transitively via `(AWSAccount)-[:RESOURCE]->(AWSVpc)-[:BLOCK_ASSOCIATION]->(AWSCidrBlock)`.

## Cleanup behavior

With no `sub_resource_relationship` and `scoped_cleanup` left at its default (`True`), cleanup follows the **same path as `AWSCidrBlock`** (cleanupbuilder "Case 3"): stale `MEMBER_OF_IP_RULE` relationships are removed and the shared CIDR node is left in place rather than being deleted per-account.

## Testing

Extended `test_sync_ec2_security_groupinfo` to assert:
- `AWSIpRange` nodes exist (one global node per CIDR),
- `(:AWSIpRange)-[:MEMBER_OF_IP_RULE]->(:AWSIpRule)` edges are created for both inbound and egress rules,
- a regression assertion that **no** `(:AWSAccount)-[:RESOURCE]->(:AWSIpRange)` edge exists.

> Note: the integration tests require a live Neo4j instance, which isn't available in this environment, so they were not executed here. Please run `tests/integration/cartography/intel/aws/ec2/test_ec2_security_groups.py` against Neo4j in CI to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y9LZsj16HEf243j3qNc85)_