### PR TITLE
fix(github): tolerate null dependency manifest nodes

### DIFF
--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -317,7 +317,7 @@ def _get_repo_dep_manifests(
     api_url: str,
     organization: str,
     repo: str,
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], bool]:
     """
     Retrieve dependency graph manifests for a single repository.
     Fetches one manifest at a time, and paginates dependencies within each manifest.
@@ -327,11 +327,13 @@ def _get_repo_dep_manifests(
     :param api_url: The Github v4 API endpoint as string.
     :param organization: The name of the target Github organization as string.
     :param repo: The name of the target Github repository as string.
-    :return: A list of manifest node dicts with all their dependencies collected.
+    :return: A tuple of manifest node dicts with all their dependencies collected
+        and whether manifest cleanup is safe.
     """
     manifest_cursor: str | None = None
     has_next_manifest = True
     manifests: list[dict[str, Any]] = []
+    cleanup_safe = True
 
     while has_next_manifest:
         # Save cursor before this manifest so we can re-query the same position
@@ -352,7 +354,7 @@ def _get_repo_dep_manifests(
                 repo,
                 len(manifests),
             )
-            return manifests
+            return manifests, cleanup_safe
 
         repository = resp["data"]["organization"].get("repository")
         dep_manifests = (
@@ -366,7 +368,7 @@ def _get_repo_dep_manifests(
                 repo,
                 len(manifests),
             )
-            return manifests
+            return manifests, cleanup_safe
 
         manifest_page_info = dep_manifests.get("pageInfo", {})
         manifest_cursor = manifest_page_info.get("endCursor")
@@ -378,6 +380,7 @@ def _get_repo_dep_manifests(
 
         manifest = manifest_nodes[0]
         if manifest is None:
+            cleanup_safe = False
             logger.warning(
                 "GitHub returned inaccessible/null dependency manifest node for "
                 "repo %s at manifest cursor %s; skipping manifest page.",
@@ -437,6 +440,7 @@ def _get_repo_dep_manifests(
 
             dep_manifest = dep_nodes_list[0]
             if dep_manifest is None:
+                cleanup_safe = False
                 logger.warning(
                     "GitHub returned inaccessible/null dependency manifest node "
                     "on dependency page for %s in repo %s; keeping %d deps "
@@ -461,7 +465,7 @@ def _get_repo_dep_manifests(
             len(all_dep_nodes),
         )
 
-    return manifests
+    return manifests, cleanup_safe
 
 
 def _get_dep_manifests_for_repos(
@@ -469,7 +473,7 @@ def _get_dep_manifests_for_repos(
     org: str,
     api_url: str,
     token: str,
-) -> dict[str, dict[str, Any]]:
+) -> tuple[dict[str, dict[str, Any]], bool]:
     """
     For every repo in the given list, retrieve its dependency graph manifests individually.
     Fetches one manifest at a time so that a timeout on a single heavy manifest (e.g.
@@ -478,7 +482,8 @@ def _get_dep_manifests_for_repos(
     :param org: The name of the target Github organization as string.
     :param api_url: The Github v4 API endpoint as string.
     :param token: The Github API token as string.
-    :return: A dict mapping repo URL to its dependencyGraphManifests structure.
+    :return: A tuple of repo URL to dependencyGraphManifests structure and
+        whether manifest cleanup is safe.
     """
     logger.info(
         "Fetching dependency graph manifests for %d repos in org %s.",
@@ -487,6 +492,7 @@ def _get_dep_manifests_for_repos(
     )
     result: dict[str, dict[str, Any]] = {}
     failed_count = 0
+    cleanup_safe = True
 
     for repo in repo_raw_data:
         if repo is None:
@@ -497,7 +503,13 @@ def _get_dep_manifests_for_repos(
             continue
 
         try:
-            manifests = _get_repo_dep_manifests(token, api_url, org, repo_name)
+            manifests, repo_cleanup_safe = _get_repo_dep_manifests(
+                token,
+                api_url,
+                org,
+                repo_name,
+            )
+            cleanup_safe = cleanup_safe and repo_cleanup_safe
             if manifests:
                 result[repo_url] = {"nodes": manifests}
                 logger.debug(
@@ -521,7 +533,7 @@ def _get_dep_manifests_for_repos(
             org,
         )
     logger.debug("Fetched dependency manifests for %d repos.", len(result))
-    return result
+    return result, cleanup_safe
 
 
 def _get_repo_collaborators_inner_func(
@@ -2567,7 +2579,7 @@ def sync(
         )
 
     # Fetch dependency graph manifests per-repo to avoid 502s from heavy inline queries
-    dep_manifests_by_url = _get_dep_manifests_for_repos(
+    dep_manifests_by_url, dep_manifests_cleanup_safe = _get_dep_manifests_for_repos(
         repos_json,
         organization,
         github_url,
@@ -2610,7 +2622,14 @@ def sync(
         neo4j_session,
         migration_params,
     )
-    cleanup_github_manifests(neo4j_session, common_job_parameters, owner_org_id)
+    if dep_manifests_cleanup_safe:
+        cleanup_github_manifests(neo4j_session, common_job_parameters, owner_org_id)
+    else:
+        logger.warning(
+            "Skipping GitHub dependency manifest cleanup for org %s because "
+            "GitHub returned inaccessible dependency manifest data.",
+            organization,
+        )
     cleanup_branch_protection_rules(neo4j_session, common_job_parameters, owner_org_id)
     if rulesets_cleanup_safe:
         cleanup_rulesets(neo4j_session, common_job_parameters, owner_org_id)

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -354,7 +354,7 @@ def _get_repo_dep_manifests(
                 repo,
                 len(manifests),
             )
-            return manifests, cleanup_safe
+            return manifests, False
 
         repository = resp["data"]["organization"].get("repository")
         dep_manifests = (
@@ -368,7 +368,7 @@ def _get_repo_dep_manifests(
                 repo,
                 len(manifests),
             )
-            return manifests, cleanup_safe
+            return manifests, False
 
         manifest_page_info = dep_manifests.get("pageInfo", {})
         manifest_cursor = manifest_page_info.get("endCursor")
@@ -409,6 +409,7 @@ def _get_repo_dep_manifests(
             )
 
             if dep_resp is None or "data" not in dep_resp:
+                cleanup_safe = False
                 logger.warning(
                     "Failed to fetch dependency page for %s in repo %s; "
                     "keeping %d deps already fetched for this manifest.",
@@ -425,6 +426,7 @@ def _get_repo_dep_manifests(
                 else None
             )
             if dep_dep_manifests is None:
+                cleanup_safe = False
                 logger.warning(
                     "GitHub API timeout on dependency page for %s in repo %s; "
                     "keeping %d deps already fetched for this manifest.",
@@ -519,6 +521,7 @@ def _get_dep_manifests_for_repos(
                 )
         except requests.exceptions.RequestException:
             failed_count += 1
+            cleanup_safe = False
             logger.warning(
                 "Failed to fetch dependency manifests for repo %s; skipping.",
                 repo_name,
@@ -2627,7 +2630,7 @@ def sync(
     else:
         logger.warning(
             "Skipping GitHub dependency manifest cleanup for org %s because "
-            "GitHub returned inaccessible dependency manifest data.",
+            "GitHub returned incomplete dependency manifest data.",
             organization,
         )
     cleanup_branch_protection_rules(neo4j_session, common_job_parameters, owner_org_id)

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -377,6 +377,15 @@ def _get_repo_dep_manifests(
             continue
 
         manifest = manifest_nodes[0]
+        if manifest is None:
+            logger.warning(
+                "GitHub returned inaccessible/null dependency manifest node for "
+                "repo %s at manifest cursor %s; skipping manifest page.",
+                repo,
+                prev_manifest_cursor,
+            )
+            continue
+
         blob_path = manifest.get("blobPath", "?")
 
         # Paginate dependencies within this manifest
@@ -426,7 +435,19 @@ def _get_repo_dep_manifests(
             if not dep_nodes_list:
                 break
 
-            inner_deps = dep_nodes_list[0].get("dependencies") or {}
+            dep_manifest = dep_nodes_list[0]
+            if dep_manifest is None:
+                logger.warning(
+                    "GitHub returned inaccessible/null dependency manifest node "
+                    "on dependency page for %s in repo %s; keeping %d deps "
+                    "already fetched for this manifest.",
+                    blob_path,
+                    repo,
+                    len(all_dep_nodes),
+                )
+                break
+
+            inner_deps = dep_manifest.get("dependencies") or {}
             all_dep_nodes.extend(inner_deps.get("nodes") or [])
             deps_page_info = inner_deps.get("pageInfo", {})
 

--- a/tests/integration/cartography/intel/aws/test_ecr_layers.py
+++ b/tests/integration/cartography/intel/aws/test_ecr_layers.py
@@ -522,7 +522,7 @@ def test_sync_circleci_label_provenance_links_github_repository(
     )
     mock_get_github_repos.return_value = github_test_data.GET_REPOS_CIRCLECI_PROVENANCE
     mock_get_repo_collaborators.return_value = {}
-    mock_get_dep_manifests.return_value = {}
+    mock_get_dep_manifests.return_value = ({}, True)
 
     create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
     cartography.intel.aws.ecr.sync(

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -40,7 +40,7 @@ def _no_lockfile_fetch():
 @patch.object(
     cartography.intel.github.repos,
     "_get_dep_manifests_for_repos",
-    return_value=DEP_MANIFESTS_BY_URL,
+    return_value=(DEP_MANIFESTS_BY_URL, True),
 )
 @patch.object(
     cartography.intel.github.repos,
@@ -153,7 +153,7 @@ def test_sync_github_repos(
 @patch.object(
     cartography.intel.github.repos,
     "_get_dep_manifests_for_repos",
-    return_value=DEP_MANIFESTS_BY_URL,
+    return_value=(DEP_MANIFESTS_BY_URL, True),
 )
 @patch.object(
     cartography.intel.github.repos,
@@ -329,7 +329,7 @@ def test_sync_github_repo_collaborators(
 @patch.object(
     cartography.intel.github.repos,
     "_get_dep_manifests_for_repos",
-    return_value=DEP_MANIFESTS_BY_URL,
+    return_value=(DEP_MANIFESTS_BY_URL, True),
 )
 @patch.object(
     cartography.intel.github.repos,
@@ -433,7 +433,7 @@ def test_sync_github_dependencies(
 @patch.object(
     cartography.intel.github.repos,
     "_get_dep_manifests_for_repos",
-    return_value=DEP_MANIFESTS_BY_URL,
+    return_value=(DEP_MANIFESTS_BY_URL, True),
 )
 @patch.object(
     cartography.intel.github.repos,
@@ -621,7 +621,7 @@ def test_load_dependencies_shared_id_exact_conflict_not_corrupted(neo4j_session)
 @patch.object(
     cartography.intel.github.repos,
     "_get_dep_manifests_for_repos",
-    return_value=DEP_MANIFESTS_BY_URL,
+    return_value=(DEP_MANIFESTS_BY_URL, True),
 )
 @patch.object(
     cartography.intel.github.repos,
@@ -721,7 +721,7 @@ def test_sync_github_manifests(
 @patch.object(
     cartography.intel.github.repos,
     "_get_dep_manifests_for_repos",
-    return_value=DEP_MANIFESTS_BY_URL,
+    return_value=(DEP_MANIFESTS_BY_URL, True),
 )
 @patch.object(
     cartography.intel.github.repos,
@@ -799,7 +799,7 @@ def test_sync_github_branch_protection_rules(
 @patch.object(
     cartography.intel.github.repos,
     "_get_dep_manifests_for_repos",
-    return_value=DEP_MANIFESTS_BY_URL,
+    return_value=(DEP_MANIFESTS_BY_URL, True),
 )
 @patch.object(
     cartography.intel.github.repos,
@@ -894,7 +894,7 @@ def test_sync_github_rulesets(
 @patch.object(
     cartography.intel.github.repos,
     "_get_dep_manifests_for_repos",
-    return_value=DEP_MANIFESTS_BY_URL,
+    return_value=(DEP_MANIFESTS_BY_URL, True),
 )
 @patch.object(cartography.intel.github.repos, "get")
 @patch.object(
@@ -945,7 +945,7 @@ def test_sync_github_rulesets_cleanup(
 @patch.object(
     cartography.intel.github.repos,
     "_get_dep_manifests_for_repos",
-    return_value={},
+    return_value=({}, True),
 )
 @patch.object(cartography.intel.github.repos, "get")
 @patch.object(cartography.intel.github.repos, "_get_repo_collaborators")
@@ -1056,7 +1056,7 @@ def test_sync_collaborators_per_repo(
 @patch.object(
     cartography.intel.github.repos,
     "_get_dep_manifests_for_repos",
-    return_value=DEP_MANIFESTS_BY_URL,
+    return_value=(DEP_MANIFESTS_BY_URL, True),
 )
 @patch.object(
     cartography.intel.github.repos,

--- a/tests/unit/cartography/intel/github/test_repos.py
+++ b/tests/unit/cartography/intel/github/test_repos.py
@@ -7,6 +7,7 @@ import pytest
 import cartography.intel.github.repos
 from cartography.intel.github.repos import _build_branch_data
 from cartography.intel.github.repos import _create_git_url_from_ssh_url
+from cartography.intel.github.repos import _get_repo_dep_manifests
 from cartography.intel.github.repos import _get_repo_rulesets_by_url
 from cartography.intel.github.repos import _merge_repos_with_privileged_details
 from cartography.intel.github.repos import _normalize_rest_ruleset
@@ -297,6 +298,84 @@ def test_transform_dependency_graph_logs_coverage_summary(caplog):
     assert "3 exact (75%)" in caplog.text
     assert "3 normalized_id (75%)" in caplog.text
     assert "3 with purl" in caplog.text
+
+
+def test_get_repo_dep_manifests_keeps_existing_deps_when_dep_page_node_is_null(
+    caplog,
+):
+    # Arrange
+    dependency = {
+        "packageName": "react",
+        "packageUrl": "pkg:npm/react@18.2.0",
+        "requirements": "18.2.0",
+        "packageManager": "NPM",
+    }
+    manifest_page = {
+        "data": {
+            "organization": {
+                "repository": {
+                    "dependencyGraphManifests": {
+                        "pageInfo": {
+                            "endCursor": "manifest-cursor-1",
+                            "hasNextPage": False,
+                        },
+                        "nodes": [
+                            {
+                                "blobPath": "/package.json",
+                                "dependencies": {
+                                    "pageInfo": {
+                                        "endCursor": "dep-cursor-1",
+                                        "hasNextPage": True,
+                                    },
+                                    "nodes": [dependency],
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    }
+    null_dep_node_page = {
+        "data": {
+            "organization": {
+                "repository": {
+                    "dependencyGraphManifests": {
+                        "pageInfo": {
+                            "endCursor": "manifest-cursor-1",
+                            "hasNextPage": False,
+                        },
+                        "nodes": [None],
+                    },
+                },
+            },
+        },
+    }
+
+    with patch.object(
+        cartography.intel.github.repos,
+        "_fetch_manifest_page",
+        side_effect=[manifest_page, null_dep_node_page],
+    ) as mock_fetch_manifest_page:
+        # Act
+        with caplog.at_level(logging.WARNING, logger="cartography.intel.github.repos"):
+            result = _get_repo_dep_manifests(
+                "token",
+                "https://api.github.com/graphql",
+                "test-org",
+                "test-repo",
+            )
+
+    # Assert
+    assert result == [
+        {
+            "blobPath": "/package.json",
+            "dependencies": {"nodes": [dependency]},
+        },
+    ]
+    assert mock_fetch_manifest_page.call_count == 2
+    assert "null dependency manifest node on dependency page" in caplog.text
+    assert "keeping 1 deps already fetched" in caplog.text
 
 
 def test_enrich_dependencies_with_lockfile_versions():

--- a/tests/unit/cartography/intel/github/test_repos.py
+++ b/tests/unit/cartography/intel/github/test_repos.py
@@ -300,6 +300,63 @@ def test_transform_dependency_graph_logs_coverage_summary(caplog):
     assert "3 with purl" in caplog.text
 
 
+def test_get_repo_dep_manifests_marks_manifest_fetch_failure_unsafe_for_cleanup(
+    caplog,
+):
+    # Arrange
+    manifest_page = {
+        "data": {
+            "organization": {
+                "repository": {
+                    "dependencyGraphManifests": {
+                        "pageInfo": {
+                            "endCursor": "manifest-cursor-1",
+                            "hasNextPage": True,
+                        },
+                        "nodes": [
+                            {
+                                "blobPath": "/package.json",
+                                "dependencies": {
+                                    "pageInfo": {
+                                        "endCursor": None,
+                                        "hasNextPage": False,
+                                    },
+                                    "nodes": [],
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    }
+
+    with patch.object(
+        cartography.intel.github.repos,
+        "_fetch_manifest_page",
+        side_effect=[manifest_page, None],
+    ) as mock_fetch_manifest_page:
+        # Act
+        with caplog.at_level(logging.WARNING, logger="cartography.intel.github.repos"):
+            result, cleanup_safe = _get_repo_dep_manifests(
+                "token",
+                "https://api.github.com/graphql",
+                "test-org",
+                "test-repo",
+            )
+
+    # Assert
+    assert result == [
+        {
+            "blobPath": "/package.json",
+            "dependencies": {"nodes": []},
+        },
+    ]
+    assert cleanup_safe is False
+    assert mock_fetch_manifest_page.call_count == 2
+    assert "No data fetching manifest for repo test-repo" in caplog.text
+
+
 def test_get_repo_dep_manifests_skips_first_page_null_manifest_node(caplog):
     # Arrange
     null_manifest_page = {
@@ -344,6 +401,70 @@ def test_get_repo_dep_manifests_skips_first_page_null_manifest_node(caplog):
     )
     assert "inaccessible/null dependency manifest node" in caplog.text
     assert "skipping manifest page" in caplog.text
+
+
+def test_get_repo_dep_manifests_marks_dependency_fetch_failure_unsafe_for_cleanup(
+    caplog,
+):
+    # Arrange
+    dependency = {
+        "packageName": "react",
+        "packageUrl": "pkg:npm/react@18.2.0",
+        "requirements": "18.2.0",
+        "packageManager": "NPM",
+    }
+    manifest_page = {
+        "data": {
+            "organization": {
+                "repository": {
+                    "dependencyGraphManifests": {
+                        "pageInfo": {
+                            "endCursor": "manifest-cursor-1",
+                            "hasNextPage": False,
+                        },
+                        "nodes": [
+                            {
+                                "blobPath": "/package.json",
+                                "dependencies": {
+                                    "pageInfo": {
+                                        "endCursor": "dep-cursor-1",
+                                        "hasNextPage": True,
+                                    },
+                                    "nodes": [dependency],
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    }
+
+    with patch.object(
+        cartography.intel.github.repos,
+        "_fetch_manifest_page",
+        side_effect=[manifest_page, None],
+    ) as mock_fetch_manifest_page:
+        # Act
+        with caplog.at_level(logging.WARNING, logger="cartography.intel.github.repos"):
+            result, cleanup_safe = _get_repo_dep_manifests(
+                "token",
+                "https://api.github.com/graphql",
+                "test-org",
+                "test-repo",
+            )
+
+    # Assert
+    assert result == [
+        {
+            "blobPath": "/package.json",
+            "dependencies": {"nodes": [dependency]},
+        },
+    ]
+    assert cleanup_safe is False
+    assert mock_fetch_manifest_page.call_count == 2
+    assert "Failed to fetch dependency page" in caplog.text
+    assert "keeping 1 deps already fetched" in caplog.text
 
 
 def test_get_repo_dep_manifests_keeps_existing_deps_when_dep_page_node_is_null(
@@ -423,6 +544,39 @@ def test_get_repo_dep_manifests_keeps_existing_deps_when_dep_page_node_is_null(
     assert mock_fetch_manifest_page.call_count == 2
     assert "null dependency manifest node on dependency page" in caplog.text
     assert "keeping 1 deps already fetched" in caplog.text
+
+
+def test_get_dep_manifests_for_repos_marks_request_exception_unsafe_for_cleanup(
+    caplog,
+):
+    # Arrange
+    repos = [{"name": "test-repo", "url": "https://github.com/test-org/test-repo"}]
+    with patch.object(
+        cartography.intel.github.repos,
+        "_get_repo_dep_manifests",
+        side_effect=cartography.intel.github.repos.requests.exceptions.ConnectionError,
+    ) as mock_get_repo_dep_manifests:
+        # Act
+        with caplog.at_level(logging.WARNING, logger="cartography.intel.github.repos"):
+            result, cleanup_safe = (
+                cartography.intel.github.repos._get_dep_manifests_for_repos(
+                    repos,
+                    "test-org",
+                    "https://api.github.com/graphql",
+                    "token",
+                )
+            )
+
+    # Assert
+    assert result == {}
+    assert cleanup_safe is False
+    mock_get_repo_dep_manifests.assert_called_once_with(
+        "token",
+        "https://api.github.com/graphql",
+        "test-org",
+        "test-repo",
+    )
+    assert "Skipped dependency manifests for 1 of 1 repos" in caplog.text
 
 
 def test_enrich_dependencies_with_lockfile_versions():

--- a/tests/unit/cartography/intel/github/test_repos.py
+++ b/tests/unit/cartography/intel/github/test_repos.py
@@ -325,7 +325,7 @@ def test_get_repo_dep_manifests_skips_first_page_null_manifest_node(caplog):
     ) as mock_fetch_manifest_page:
         # Act
         with caplog.at_level(logging.WARNING, logger="cartography.intel.github.repos"):
-            result = _get_repo_dep_manifests(
+            result, cleanup_safe = _get_repo_dep_manifests(
                 "token",
                 "https://api.github.com/graphql",
                 "test-org",
@@ -334,6 +334,7 @@ def test_get_repo_dep_manifests_skips_first_page_null_manifest_node(caplog):
 
     # Assert
     assert result == []
+    assert cleanup_safe is False
     mock_fetch_manifest_page.assert_called_once_with(
         "token",
         "https://api.github.com/graphql",
@@ -404,7 +405,7 @@ def test_get_repo_dep_manifests_keeps_existing_deps_when_dep_page_node_is_null(
     ) as mock_fetch_manifest_page:
         # Act
         with caplog.at_level(logging.WARNING, logger="cartography.intel.github.repos"):
-            result = _get_repo_dep_manifests(
+            result, cleanup_safe = _get_repo_dep_manifests(
                 "token",
                 "https://api.github.com/graphql",
                 "test-org",
@@ -418,6 +419,7 @@ def test_get_repo_dep_manifests_keeps_existing_deps_when_dep_page_node_is_null(
             "dependencies": {"nodes": [dependency]},
         },
     ]
+    assert cleanup_safe is False
     assert mock_fetch_manifest_page.call_count == 2
     assert "null dependency manifest node on dependency page" in caplog.text
     assert "keeping 1 deps already fetched" in caplog.text
@@ -1126,7 +1128,7 @@ def test_build_branch_data_includes_owner_org_id():
 @patch.object(
     cartography.intel.github.repos,
     "_get_dep_manifests_for_repos",
-    return_value={},
+    return_value=({}, True),
 )
 @patch.object(cartography.intel.github.repos, "get", return_value=[])
 def test_sync_cleans_up_branches_when_org_has_no_repos(
@@ -1184,6 +1186,48 @@ def test_sync_cleans_up_branches_when_org_has_no_repos(
     )
 
 
+@patch.object(cartography.intel.github.repos, "run_analysis_job")
+@patch.object(cartography.intel.github.repos, "cleanup_rulesets")
+@patch.object(cartography.intel.github.repos, "cleanup_branch_protection_rules")
+@patch.object(cartography.intel.github.repos, "cleanup_github_manifests")
+@patch.object(cartography.intel.github.repos, "cleanup_github_branches")
+@patch.object(cartography.intel.github.repos, "load")
+@patch.object(
+    cartography.intel.github.repos,
+    "_get_repo_collaborators_for_multiple_repos",
+    return_value={},
+)
+@patch.object(
+    cartography.intel.github.repos,
+    "_get_dep_manifests_for_repos",
+    return_value=({}, False),
+)
+@patch.object(cartography.intel.github.repos, "get", return_value=[])
+def test_sync_skips_manifest_cleanup_when_dependency_manifest_fetch_is_incomplete(
+    mock_get,
+    mock_get_dep_manifests,
+    mock_get_repo_collaborators,
+    mock_load,
+    mock_cleanup_github_branches,
+    mock_cleanup_github_manifests,
+    mock_cleanup_branch_protection_rules,
+    mock_cleanup_rulesets,
+    mock_run_analysis_job,
+):
+    cartography.intel.github.repos.sync(
+        None,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+        "token",
+        "https://api.github.com/graphql",
+        "example-org",
+    )
+
+    mock_cleanup_github_branches.assert_called_once()
+    mock_cleanup_github_manifests.assert_not_called()
+    mock_cleanup_branch_protection_rules.assert_called_once()
+    mock_cleanup_rulesets.assert_called_once()
+
+
 @patch.object(
     cartography.intel.github.repos,
     "get_repo_privileged_details_by_url",
@@ -1209,7 +1253,7 @@ def test_sync_cleans_up_branches_when_org_has_no_repos(
 @patch.object(
     cartography.intel.github.repos,
     "_get_dep_manifests_for_repos",
-    return_value={},
+    return_value=({}, True),
 )
 @patch.object(cartography.intel.github.repos, "get")
 def test_sync_continues_when_privileged_fetch_fails(

--- a/tests/unit/cartography/intel/github/test_repos.py
+++ b/tests/unit/cartography/intel/github/test_repos.py
@@ -300,6 +300,51 @@ def test_transform_dependency_graph_logs_coverage_summary(caplog):
     assert "3 with purl" in caplog.text
 
 
+def test_get_repo_dep_manifests_skips_first_page_null_manifest_node(caplog):
+    # Arrange
+    null_manifest_page = {
+        "data": {
+            "organization": {
+                "repository": {
+                    "dependencyGraphManifests": {
+                        "pageInfo": {
+                            "endCursor": "manifest-cursor-1",
+                            "hasNextPage": False,
+                        },
+                        "nodes": [None],
+                    },
+                },
+            },
+        },
+    }
+
+    with patch.object(
+        cartography.intel.github.repos,
+        "_fetch_manifest_page",
+        return_value=null_manifest_page,
+    ) as mock_fetch_manifest_page:
+        # Act
+        with caplog.at_level(logging.WARNING, logger="cartography.intel.github.repos"):
+            result = _get_repo_dep_manifests(
+                "token",
+                "https://api.github.com/graphql",
+                "test-org",
+                "test-repo",
+            )
+
+    # Assert
+    assert result == []
+    mock_fetch_manifest_page.assert_called_once_with(
+        "token",
+        "https://api.github.com/graphql",
+        "test-org",
+        "test-repo",
+        None,
+    )
+    assert "inaccessible/null dependency manifest node" in caplog.text
+    assert "skipping manifest page" in caplog.text
+
+
 def test_get_repo_dep_manifests_keeps_existing_deps_when_dep_page_node_is_null(
     caplog,
 ):


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)


### Summary
Hardens GitHub dependency graph ingestion against partial GraphQL responses where GitHub returns null manifest nodes with a \"Resource not accessible by integration\" error.

Previously, this response shape could fail an entire GitHub org sync with an AttributeError. The new behavior skips the inaccessible manifest page and preserves dependency data already fetched for a manifest if a later dependency page returns a null manifest node.

Existing handling for null dependencyGraphManifests responses, HTTP fetch errors, and GraphQL timeout responses is unchanged.

### How was this tested?

- Added unit tests


### Checklist

#### General
- [ ] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

This is intentionally scoped to tolerating null manifest nodes returned in otherwise partial GraphQL responses. It does not introduce new retry behavior.