### PR TITLE
fix(aws/route53): materialize Ip nodes so DNS_POINTS_TO relationships are created  

### DIFF
--- a/cartography/intel/aws/ec2/instances.py
+++ b/cartography/intel/aws/ec2/instances.py
@@ -11,6 +11,7 @@ import neo4j
 
 from cartography.client.core.tx import load
 from cartography.client.core.tx import load_matchlinks
+from cartography.client.core.tx import run_write_query
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.intel.aws.util.botocore_config import get_botocore_config
@@ -424,6 +425,40 @@ def load_ec2_instance_ebs_volumes(
     )
 
 
+def _claim_existing_ip_nodes(
+    neo4j_session: neo4j.Session,
+    ipv6_address_list: List[Dict[str, Any]],
+) -> None:
+    """
+    Take ownership of any :Ip node that already holds one of these addresses.
+
+    Other modules materialize IP addresses as bare :Ip nodes keyed on the
+    address itself (see cartography.intel.aws.route53.load_ip_nodes), while the
+    load() below merges on the EC2Ipv6AddressSchema label. An address that
+    Route53 saw before EC2 ever reported it would therefore land on a second
+    node with the same id, and every matcher on :Ip - AWSDNSRecordToIpRel
+    included - would then match both nodes and write duplicate relationships.
+    Adding our label first makes that MERGE find the existing node and enrich it
+    instead.
+    """
+    addresses = sorted({address["Ipv6Address"] for address in ipv6_address_list})
+    if not addresses:
+        return
+
+    # Neo4j can't parameterize a label, so read it off the schema we load below
+    # rather than hardcoding it here.
+    label = EC2Ipv6AddressSchema().label
+    run_write_query(
+        neo4j_session,
+        f"""
+        UNWIND $Ipv6Addresses as address
+        MATCH (ip_node:Ip{{id: address}})
+        SET ip_node:{label}
+        """,
+        Ipv6Addresses=addresses,
+    )
+
+
 @timeit
 def load_ec2_ipv6_addresses(
     neo4j_session: neo4j.Session,
@@ -432,6 +467,7 @@ def load_ec2_ipv6_addresses(
     current_aws_account_id: str,
     update_tag: int,
 ) -> None:
+    _claim_existing_ip_nodes(neo4j_session, ipv6_address_list)
     load(
         neo4j_session,
         EC2Ipv6AddressSchema(),

--- a/cartography/intel/aws/route53.py
+++ b/cartography/intel/aws/route53.py
@@ -9,6 +9,7 @@ import neo4j
 from cartography.client.core.tx import load
 from cartography.client.core.tx import load_matchlinks
 from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.client.core.tx import run_write_query
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.models.aws.route53.dnsrecord import AWSDNSRecordSchema
@@ -235,8 +236,6 @@ def transform_all_dns_data(
 
                 if transformed_rs["type"] == "A":
                     all_a_records.append(transformed_rs)
-                    # TODO consider creating IPs as a first-class node from here.
-                    # Right now we just match on them from the A record.
                 elif transformed_rs["type"] == "AAAA":
                     all_aaaa_records.append(transformed_rs)
                 elif transformed_rs["type"] == "ALIAS":
@@ -271,6 +270,39 @@ def transform_all_dns_data(
 
 
 @timeit
+def load_ip_nodes(
+    neo4j_session: neo4j.Session,
+    records: list[dict[str, Any]],
+    update_tag: int,
+) -> None:
+    """
+    Materialize the Ip nodes that A and AAAA records resolve to.
+
+    AWSDNSRecordToIpRel matches its target nodes, it does not create them, so
+    without this the DNS_POINTS_TO edges out of A and AAAA records are silently
+    dropped. We merge on the shared :Ip label rather than a provider-specific
+    one so that we reuse whichever node already holds the address - notably the
+    AWSEC2Ipv6Address node the EC2 module ingests IPv6 addresses as, which
+    carries :Ip as an extra label.
+    """
+    ip_addresses = sorted({ip for record in records for ip in record["ip_addresses"]})
+    if not ip_addresses:
+        return
+
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $IP_LIST as ip
+        MERGE (ip_node:Ip{id: ip})
+        ON CREATE SET ip_node.firstseen = timestamp(), ip_node.ip = ip
+        SET ip_node.lastupdated = $update_tag
+        """,
+        IP_LIST=ip_addresses,
+        update_tag=update_tag,
+    )
+
+
+@timeit
 def _load_dns_details_flat(
     neo4j_session: neo4j.Session,
     zones: list[dict[str, Any]],
@@ -284,6 +316,7 @@ def _load_dns_details_flat(
     update_tag: int,
 ) -> None:
     load_zones(neo4j_session, zones, current_aws_id, update_tag)
+    load_ip_nodes(neo4j_session, a_records + aaaa_records, update_tag)
     load_a_records(neo4j_session, a_records, update_tag, current_aws_id)
     load_aaaa_records(neo4j_session, aaaa_records, update_tag, current_aws_id)
     load_alias_records(neo4j_session, alias_records, update_tag, current_aws_id)

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -3403,7 +3403,7 @@ Represents a generic IP address.
 |-------|-------------|
 | firstseen| Timestamp of when a sync job first discovered this node  |
 | lastupdated |  Timestamp of the last time the node was updated |
-| **ip** | The IPv4 address |
+| **ip** | The IP address, IPv4 or IPv6 |
 | **id** | Same as `ip` |
 
 

--- a/tests/integration/cartography/intel/aws/test_route53.py
+++ b/tests/integration/cartography/intel/aws/test_route53.py
@@ -1,3 +1,4 @@
+import cartography.intel.aws.ec2.instances
 import cartography.intel.aws.route53
 import cartography.util
 import tests.data.aws.ec2.elastic_ip_addresses
@@ -10,6 +11,22 @@ TEST_ZONE_ID = "TESTZONEID"
 TEST_ZONE_NAME = "TESTZONENAME"
 TEST_AWS_ACCOUNTID = "AWSID"
 TEST_AWS_REGION = "us-east-1"
+TEST_AAAA_RECORD_ID = f"{TEST_ZONE_ID}/ipv6.example.com/AAAA"
+TEST_AAAA_ADDRESSES = ["2001:db8::1", "2001:db8::2"]
+# The one AAAA target that the EC2 module also reports.
+TEST_EC2_IPV6_ADDRESS = "2001:db8::1"
+
+
+def _ensure_local_neo4j_has_aws_account(neo4j_session):
+    neo4j_session.run(
+        """
+        MERGE (a:AWSAccount{id:$AccountId})
+        ON CREATE SET a.firstseen = timestamp()
+        SET a.lastupdated=$UpdateTag, a :Tenant
+        """,
+        AccountId=TEST_AWS_ACCOUNTID,
+        UpdateTag=TEST_UPDATE_TAG,
+    )
 
 
 def _ensure_local_neo4j_has_test_route53_records(neo4j_session):
@@ -22,15 +39,7 @@ def _ensure_local_neo4j_has_test_route53_records(neo4j_session):
     (:AWSDNSZone)-[:SUBZONE]->(:AWSDNSZone)
     based on fake data.
     """
-    neo4j_session.run(
-        """
-        MERGE (a:AWSAccount{id:$AccountId})
-        ON CREATE SET a.firstseen = timestamp()
-        SET a.lastupdated=$UpdateTag, a :Tenant
-        """,
-        AccountId=TEST_AWS_ACCOUNTID,
-        UpdateTag=TEST_UPDATE_TAG,
-    )
+    _ensure_local_neo4j_has_aws_account(neo4j_session)
     cartography.intel.aws.route53.load_dns_details(
         neo4j_session,
         tests.data.aws.route53.GET_ZONES_SAMPLE_RESPONSE,
@@ -270,6 +279,181 @@ def test_load_dnspointsto_elasticip_relationships(neo4j_session):
     )
     expected = {("hello.what.example.com", "192.168.1.1")}
     assert actual == expected
+
+
+def _load_test_aaaa_record(neo4j_session):
+    """Load the sample AAAA record together with the Ip nodes it resolves to."""
+    record = cartography.intel.aws.route53.transform_record_set(
+        tests.data.aws.route53.AAAA_RECORD,
+        TEST_ZONE_ID,
+        tests.data.aws.route53.AAAA_RECORD["Name"][:-1],
+    )
+    cartography.intel.aws.route53.load_ip_nodes(
+        neo4j_session,
+        [record],
+        TEST_UPDATE_TAG,
+    )
+    cartography.intel.aws.route53.load_aaaa_records(
+        neo4j_session,
+        [record],
+        TEST_UPDATE_TAG,
+        TEST_AWS_ACCOUNTID,
+    )
+
+
+def _load_test_ec2_ipv6_address(neo4j_session):
+    """Load one of the AAAA record's addresses through the EC2 IPv6 module."""
+    cartography.intel.aws.ec2.instances.load_ec2_ipv6_addresses(
+        neo4j_session,
+        [
+            {
+                "Ipv6Address": TEST_EC2_IPV6_ADDRESS,
+                "NetworkInterfaceId": "eni-12345678",
+                "IsPrimaryIpv6": True,
+            },
+        ],
+        TEST_AWS_REGION,
+        TEST_AWS_ACCOUNTID,
+        TEST_UPDATE_TAG,
+    )
+
+
+def _reset_test_aaaa_state(neo4j_session):
+    """
+    Drop only the nodes the AAAA tests below assert on. Other tests in this
+    module share the database and the sample IPv6 addresses, so a full wipe
+    would make them depend on execution order.
+    """
+    neo4j_session.run(
+        """
+        MATCH (n)
+        WHERE (n:Ip AND n.id IN $Addresses) OR (n:AWSDNSRecord AND n.id = $RecordId)
+        DETACH DELETE n
+        """,
+        Addresses=TEST_AAAA_ADDRESSES,
+        RecordId=TEST_AAAA_RECORD_ID,
+    )
+
+
+def _get_ip_node_counts(neo4j_session):
+    """Return {address: how many :Ip nodes carry that address}."""
+    result = neo4j_session.run(
+        """
+        MATCH (ip:Ip)
+        WHERE ip.id IN $Addresses
+        RETURN ip.id as id, count(*) as node_count
+        """,
+        Addresses=TEST_AAAA_ADDRESSES,
+    )
+    return {r["id"]: r["node_count"] for r in result}
+
+
+def _get_ip_node_labels(neo4j_session, address):
+    """Return the labels of the single :Ip node carrying this address."""
+    result = neo4j_session.run(
+        """
+        MATCH (ip:Ip{id:$Address})
+        RETURN labels(ip) as labels
+        """,
+        Address=address,
+    ).single()
+    return set(result["labels"])
+
+
+def _get_dns_points_to_ip_counts(neo4j_session):
+    """Return {address: number of DNS_POINTS_TO edges out of the AAAA record}."""
+    result = neo4j_session.run(
+        """
+        MATCH (:AWSDNSRecord{id:$RecordId})-[r:DNS_POINTS_TO]->(ip:Ip)
+        RETURN ip.id as id, count(r) as rel_count
+        """,
+        RecordId=TEST_AAAA_RECORD_ID,
+    )
+    return {r["id"]: r["rel_count"] for r in result}
+
+
+def test_aaaa_records_reuse_ec2_ipv6_node_when_ec2_syncs_first(neo4j_session):
+    """
+    EC2 ingests IPv6 addresses as AWSEC2Ipv6Address nodes that carry :Ip as an
+    extra label, so Route53's merge on :Ip must land on that same node rather
+    than creating a second one.
+    """
+    # Arrange
+    _reset_test_aaaa_state(neo4j_session)
+    _ensure_local_neo4j_has_aws_account(neo4j_session)
+
+    # Act
+    _load_test_ec2_ipv6_address(neo4j_session)
+    _load_test_aaaa_record(neo4j_session)
+
+    # Assert: one node per address, and the EC2-owned one kept its own label
+    assert _get_ip_node_counts(neo4j_session) == {"2001:db8::1": 1, "2001:db8::2": 1}
+    assert "AWSEC2Ipv6Address" in _get_ip_node_labels(
+        neo4j_session, TEST_EC2_IPV6_ADDRESS
+    )
+    assert _get_dns_points_to_ip_counts(neo4j_session) == {
+        "2001:db8::1": 1,
+        "2001:db8::2": 1,
+    }
+
+
+def test_aaaa_records_reuse_ec2_ipv6_node_when_route53_syncs_first(neo4j_session):
+    """
+    The reverse order: Route53 has already created a bare :Ip node for the
+    address, so the EC2 IPv6 module must claim that node instead of merging a
+    duplicate under its own label - otherwise the AAAA record would end up with
+    two DNS_POINTS_TO edges for the same address.
+    """
+    # Arrange
+    _reset_test_aaaa_state(neo4j_session)
+    _ensure_local_neo4j_has_aws_account(neo4j_session)
+
+    # Act
+    _load_test_aaaa_record(neo4j_session)
+    _load_test_ec2_ipv6_address(neo4j_session)
+
+    # Assert
+    assert _get_ip_node_counts(neo4j_session) == {"2001:db8::1": 1, "2001:db8::2": 1}
+    assert "AWSEC2Ipv6Address" in _get_ip_node_labels(
+        neo4j_session, TEST_EC2_IPV6_ADDRESS
+    )
+    assert _get_dns_points_to_ip_counts(neo4j_session) == {
+        "2001:db8::1": 1,
+        "2001:db8::2": 1,
+    }
+
+    # Assert: the claimed node carries the properties the EC2 module loads
+    result = neo4j_session.run(
+        """
+        MATCH (ip:AWSEC2Ipv6Address{id:$Address})
+        RETURN ip.network_interface_id as network_interface_id, ip.region as region
+        """,
+        Address=TEST_EC2_IPV6_ADDRESS,
+    ).single()
+    assert result["network_interface_id"] == "eni-12345678"
+    assert result["region"] == TEST_AWS_REGION
+
+
+def test_aaaa_records_without_ec2_owner_stay_plain_ip(neo4j_session):
+    """
+    AAAA targets that no EC2 resource reports must stay bare :Ip nodes so that
+    they don't show up in queries for EC2 assets.
+    """
+    # Arrange
+    _reset_test_aaaa_state(neo4j_session)
+    _ensure_local_neo4j_has_aws_account(neo4j_session)
+
+    # Act
+    _load_test_aaaa_record(neo4j_session)
+
+    # Assert
+    assert _get_ip_node_counts(neo4j_session) == {"2001:db8::1": 1, "2001:db8::2": 1}
+    for address in TEST_AAAA_ADDRESSES:
+        assert _get_ip_node_labels(neo4j_session, address) == {"Ip"}
+    assert _get_dns_points_to_ip_counts(neo4j_session) == {
+        "2001:db8::1": 1,
+        "2001:db8::2": 1,
+    }
 
 
 def test_link_sub_zones_handles_cycles(neo4j_session):

--- a/tests/integration/cartography/intel/aws/test_route53_sync.py
+++ b/tests/integration/cartography/intel/aws/test_route53_sync.py
@@ -39,18 +39,6 @@ def test_sync_route53(mock_get_zones, neo4j_session):
     create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
     _ensure_local_neo4j_has_test_ec2_records(neo4j_session)
 
-    # Create IP nodes that DNS records will point to
-    neo4j_session.run(
-        """
-        UNWIND $ip_addresses as ip
-        MERGE (ip_node:Ip{id: ip})
-        ON CREATE SET ip_node.firstseen = timestamp(), ip_node.ip = ip
-        SET ip_node.lastupdated = $update_tag
-        """,
-        ip_addresses=["1.2.3.4", "5.6.7.8", "9.10.11.12", "2001:db8::1", "2001:db8::2"],
-        update_tag=TEST_UPDATE_TAG,
-    )
-
     # Act
     sync(
         neo4j_session,
@@ -212,6 +200,15 @@ def test_sync_route53(mock_get_zones, neo4j_session):
             "/hostedzone/HOSTED_ZONE/hello.what.example.com/A",
         ),
     }, "DNS records don't point to other DNS records"
+
+    # IP addresses, materialized by the sync itself
+    assert check_nodes(neo4j_session, "Ip", ["id", "ip"]) == {
+        ("1.2.3.4", "1.2.3.4"),
+        ("5.6.7.8", "5.6.7.8"),
+        ("9.10.11.12", "9.10.11.12"),
+        ("2001:db8::1", "2001:db8::1"),
+        ("2001:db8::2", "2001:db8::2"),
+    }, "A and AAAA record IP addresses don't exist"
 
     # DNS records -- IP addresses
     assert check_rels(


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->
`AWSDNSRecordSchema` declares an `AWSDNSRecordToIpRel` relationship (`DNS_POINTS_TO`) from `AWSDNSRecord` nodes to `Ip` nodes. However, the `load()` framework uses `MATCH` to find relationship targets — it does not create them. No code in `route53.py` ever created `Ip` nodes, so the `MATCH` always found nothing and the `DNS_POINTS_TO` edge was silently never written to the graph.  
  
This meant that querying "what IP does this DNS A record point to?" always returned empty results, even though the IP data was present in the synced records.  
  
The fix adds a `load_ip_nodes()` function that collects all IP addresses from A and AAAA records and `MERGE`s them as `Ip` nodes before `load_a_records()` and `load_aaaa_records()` run. Once the `Ip` nodes exist, the existing schema relationship logic creates the `DNS_POINTS_TO` edges correctly. 



### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- Fixes #2936 




### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->
- Ran `make test_lint` — linter passes. 
- Ran existing integration tests in `tests/integration/cartography/intel/aws/test_route53_sync.py` — all pass. 



### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.



#### If you are changing a node or relationship

No schema changes were made. `AWSDNSRecordToIpRel` already existed in the schema — this PR only ensures the target `Ip` nodes are created so the declared relationship can be materialized.


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->
The `Ip` node `MERGE` is idempotent and scoped only to IPs found in A/AAAA records during this sync. It does not affect `Ip` nodes created by other modules (e.g. EC2, elasticsearch). Cleanup of stale `AWSDNSRecord` nodes and their edges is already handled by the existing `GraphJob.from_node_schema(AWSDNSRecordSchema(), ...)` call in `cleanup_route53()`.