### PR TITLE
docs(entra): add directory role permission

### DIFF
--- a/docs/root/modules/entra/config.md
+++ b/docs/root/modules/entra/config.md
@@ -30,6 +30,9 @@ To set up the Entra client,
     - `GroupMember.Read.All`
         - Read all group memberships
         - Type: Application
+    - `RoleManagement.Read.Directory`
+        - Read Entra directory role definitions and role assignments
+        - Type: Application
     - `User.Read.All`
         - Read all users' full profiles
         - Type: Application


### PR DESCRIPTION
### Type of change
- [x] Documentation update


### Summary

Add `RoleManagement.Read.Directory` to the Entra setup permissions. The Entra directory role sync added in #2856 reads role definitions and role assignments from Microsoft Graph unified RBAC endpoints, and the code skips that dataset on 401/403 when this permission is missing.


### Related issues or links

- Refs #2856
- Refs #2831


### Breaking changes

None.


### How was this tested?
Locally


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make test_lint`). Not run; docs-only change.
- [ ] I have added/updated tests that prove my fix is effective or my feature works. Not applicable; docs-only change.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Not applicable; docs-only change.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md). Not applicable; this only updates module configuration docs.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node). Not applicable; docs-only change.


### Notes for reviewers

This keeps the public setup instructions aligned with the current Entra directory role ingestion path so tenant-level roles such as Global Administrator can populate when the app registration is configured.