### PR TITLE
fix(gsuite): use immutable group id when listing members

### DIFF
--- a/cartography/intel/gsuite/groups.py
+++ b/cartography/intel/gsuite/groups.py
@@ -64,30 +64,43 @@ def get_all_groups(
 
 @timeit
 def get_members_for_groups(
-    admin: Resource, groups_email: list[str]
+    admin: Resource, group_ids: list[str]
 ) -> dict[str, list[dict[str, Any]]]:
-    """Get all members for given groups emails
+    """Get all members for the given group ids
 
     Args:
         admin (Resource): google's apiclient discovery resource object.  From googleapiclient.discovery.build
         See https://googleapis.github.io/google-api-python-client/docs/epy/googleapiclient.discovery-module.html#build.
-        groups_email (list[str]): List of group email addresses to get members for
+        group_ids (list[str]): List of immutable group ids to get members for. We key on the
+        immutable id rather than the email because Google returns HTTP 400 "Invalid Input" when
+        a group's email/alias cannot be resolved as a groupKey (renamed, aliased, or external
+        groups); the id always resolves.
 
 
-    :return: list of dictionaries representing Users or Groups grouped by group email
+    :return: list of dictionaries representing Users or Groups grouped by group id
     """
     results: dict[str, list[dict]] = {}
-    for group_email in groups_email:
+    for group_id in group_ids:
         request = admin.members().list(
-            groupKey=group_email,
-            maxResults=500,
+            groupKey=group_id,
+            maxResults=200,  # 200 is the documented maximum for members.list
         )
         members: list[dict] = []
-        while request is not None:
-            resp = request.execute(num_retries=GOOGLE_API_NUM_RETRIES)
-            members = members + resp.get("members", [])
-            request = admin.members().list_next(request, resp)
-        results[group_email] = members
+        try:
+            while request is not None:
+                resp = request.execute(num_retries=GOOGLE_API_NUM_RETRIES)
+                members = members + resp.get("members", [])
+                request = admin.members().list_next(request, resp)
+        except HttpError as e:
+            # Defense-in-depth: a single pathological group must not abort the whole tenant
+            # sync. The id-based key above should prevent the common 400 "Invalid Input", but
+            # keep skipping any group Google still rejects.
+            if e.resp.status == 400:
+                logger.warning("Skipping members for group %s: %s", group_id, e)
+                results[group_id] = []
+                continue
+            raise
+        results[group_id] = members
 
     return results
 
@@ -108,11 +121,10 @@ def transform_groups(
 
     for group in groups:
         group_id = group["id"]
-        group_email = group["email"]
         group["member_ids"] = []
         group["owner_ids"] = []
 
-        for member in group_memberships.get(group_email, []):
+        for member in group_memberships.get(group_id, []):
             if member["type"] == "GROUP":
                 # Create group-to-group relationships
                 relationship_data = {
@@ -281,7 +293,7 @@ def sync_gsuite_groups(
 
     # 1. GET - Fetch data from API
     resp_objs = get_all_groups(admin, customer_id)
-    group_members = get_members_for_groups(admin, [resp["email"] for resp in resp_objs])
+    group_members = get_members_for_groups(admin, [resp["id"] for resp in resp_objs])
 
     # 2. TRANSFORM - Shape data for ingestion
     groups, group_member_relationships, group_owner_relationships = transform_groups(

--- a/tests/data/gsuite/api.py
+++ b/tests/data/gsuite/api.py
@@ -86,8 +86,9 @@ MOCK_GSUITE_GROUPS_RESPONSE = [
 
 
 # See: https://developers.google.com/workspace/admin/directory/v1/guides/manage-group-members#json-response_3
-MOCK_GSUITE_MEMBERS_BY_GROUP_EMAIL = {
-    "engineering@example.com": [
+# Keyed by immutable group id (the groupKey we pass to members.list), not email.
+MOCK_GSUITE_MEMBERS_BY_GROUP_ID = {
+    "group-engineering": [
         {
             "id": "user-1",
             "email": "user-1@example.com",
@@ -107,7 +108,7 @@ MOCK_GSUITE_MEMBERS_BY_GROUP_EMAIL = {
             "role": "MEMBER",
         },
     ],
-    "operations@example.com": [
+    "group-operations": [
         {
             "id": "user-2",
             "email": "user-2@example.com",

--- a/tests/integration/cartography/intel/gsuite/test_api.py
+++ b/tests/integration/cartography/intel/gsuite/test_api.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from cartography.intel.gsuite import groups
 from cartography.intel.gsuite import users
 from tests.data.gsuite.api import MOCK_GSUITE_GROUPS_RESPONSE
-from tests.data.gsuite.api import MOCK_GSUITE_MEMBERS_BY_GROUP_EMAIL
+from tests.data.gsuite.api import MOCK_GSUITE_MEMBERS_BY_GROUP_ID
 from tests.data.gsuite.api import MOCK_GSUITE_USERS_RESPONSE
 from tests.integration.util import check_rels
 
@@ -16,7 +16,7 @@ COMMON_JOB_PARAMETERS = {
 
 
 @patch.object(
-    groups, "get_members_for_groups", return_value=MOCK_GSUITE_MEMBERS_BY_GROUP_EMAIL
+    groups, "get_members_for_groups", return_value=MOCK_GSUITE_MEMBERS_BY_GROUP_ID
 )
 @patch.object(groups, "get_all_groups", return_value=MOCK_GSUITE_GROUPS_RESPONSE)
 @patch.object(users, "get_all_users", return_value=MOCK_GSUITE_USERS_RESPONSE)
@@ -75,7 +75,7 @@ def test_sync_gsuite_users_creates_user_group_memberships(
 
 
 @patch.object(
-    groups, "get_members_for_groups", return_value=MOCK_GSUITE_MEMBERS_BY_GROUP_EMAIL
+    groups, "get_members_for_groups", return_value=MOCK_GSUITE_MEMBERS_BY_GROUP_ID
 )
 @patch.object(groups, "get_all_groups", return_value=MOCK_GSUITE_GROUPS_RESPONSE)
 @patch.object(users, "get_all_users", return_value=MOCK_GSUITE_USERS_RESPONSE)

--- a/tests/unit/cartography/intel/gsuite/test_groups.py
+++ b/tests/unit/cartography/intel/gsuite/test_groups.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+from cartography.intel.gsuite.groups import get_members_for_groups
+
+
+def _http_error(status: int) -> HttpError:
+    resp = MagicMock()
+    resp.status = status
+    return HttpError(resp=resp, content=b'{"error": "Invalid Input"}')
+
+
+def _admin_with_member_errors(error_by_group: dict[str, HttpError]) -> MagicMock:
+    admin = MagicMock()
+
+    def list_side_effect(groupKey: str, maxResults: int) -> MagicMock:
+        # members.list documents 200 as the maximum; never send more.
+        assert maxResults <= 200
+        request = MagicMock()
+        if groupKey in error_by_group:
+            request.execute.side_effect = error_by_group[groupKey]
+        else:
+            request.execute.return_value = {"members": [{"id": "1", "type": "USER"}]}
+        return request
+
+    admin.members.return_value.list.side_effect = list_side_effect
+    admin.members.return_value.list_next.return_value = None
+    return admin
+
+
+def test_get_members_uses_group_id_as_key():
+    admin = _admin_with_member_errors({})
+
+    results = get_members_for_groups(admin, ["grp-id-1", "grp-id-2"])
+
+    admin.members.return_value.list.assert_any_call(groupKey="grp-id-1", maxResults=200)
+    assert set(results) == {"grp-id-1", "grp-id-2"}
+
+
+def test_get_members_skips_group_with_400():
+    admin = _admin_with_member_errors({"grp-bad": _http_error(400)})
+
+    results = get_members_for_groups(admin, ["grp-good", "grp-bad"])
+
+    assert results["grp-bad"] == []
+    assert len(results["grp-good"]) == 1
+
+
+def test_get_members_reraises_non_400():
+    admin = _admin_with_member_errors({"grp-bad": _http_error(403)})
+
+    with pytest.raises(HttpError):
+        get_members_for_groups(admin, ["grp-bad"])


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
The GSuite groups sync passed each group's **email** address as the `groupKey` to the Admin SDK `members.list` call. Group emails/aliases are mutable and Google's resolver returns `HTTP 400 "Invalid Input"` for certain groups (renamed, aliased, or external/Cloud-Identity groups). A single such group made `get_members_for_groups` raise, aborting the entire tenant sync.

Changes:
- Pass the immutable group `id` as the `groupKey` (the documented `groupKey` also accepts the unique id, which always resolves), and key the membership map on the id.
- Lower `maxResults` from `500` to the documented maximum of `200` for `members.list`.
- Keep a defensive `400` skip so any group Google still rejects is logged and skipped rather than aborting the whole sync.

### Breaking changes
None.

### How was this tested?
- New unit tests in `tests/unit/cartography/intel/gsuite/test_groups.py` covering: id used as `groupKey` with `maxResults<=200`, a `400` group being skipped, and non-`400` errors still propagating.
- Updated the gsuite integration test fixtures to key memberships by group id.
- `make test_lint` (pre-commit) passes on the changed files.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

### Notes for reviewers
No node/relationship schema changes; only the API call key and pagination size change, plus a resilience guard. The newer `googleworkspace` module already uses the Cloud Identity API with an immutable resource name and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)