### PR TITLE
feat(doppler): add Doppler intel module

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -51,6 +51,7 @@ PANEL_CLOUDFLARE = "Cloudflare Options"
 PANEL_TAILSCALE = "Tailscale Options"
 PANEL_OPENAI = "OpenAI Options"
 PANEL_ANTHROPIC = "Anthropic Options"
+PANEL_DOPPLER = "Doppler Options"
 PANEL_AIRBYTE = "Airbyte Options"
 PANEL_DOCKER_SCOUT = "Docker Scout Options"
 PANEL_TRIVY = "Trivy Options"
@@ -106,6 +107,7 @@ MODULE_PANELS = {
     "tailscale": PANEL_TAILSCALE,
     "openai": PANEL_OPENAI,
     "anthropic": PANEL_ANTHROPIC,
+    "doppler": PANEL_DOPPLER,
     "airbyte": PANEL_AIRBYTE,
     "docker_scout": PANEL_DOCKER_SCOUT,
     "trivy": PANEL_TRIVY,
@@ -1335,6 +1337,18 @@ class CLI:
                 ),
             ] = None,
             # =================================================================
+            # Doppler Options
+            # =================================================================
+            doppler_apikey_env_var: Annotated[
+                str | None,
+                typer.Option(
+                    "--doppler-apikey-env-var",
+                    help="Environment variable name containing Doppler API key.",
+                    rich_help_panel=PANEL_DOPPLER,
+                    hidden=PANEL_DOPPLER not in visible_panels,
+                ),
+            ] = None,
+            # =================================================================
             # Sentry Options
             # =================================================================
             sentry_token_env_var: Annotated[
@@ -2394,6 +2408,15 @@ class CLI:
                 )
                 anthropic_apikey = os.environ.get(anthropic_apikey_env_var)
 
+            # Read Doppler API key
+            doppler_apikey = None
+            if doppler_apikey_env_var:
+                logger.debug(
+                    "Reading Doppler API key from environment variable %s",
+                    doppler_apikey_env_var,
+                )
+                doppler_apikey = os.environ.get(doppler_apikey_env_var)
+
             # Read Sentry token
             sentry_token = None
             if sentry_token_env_var:
@@ -2687,6 +2710,7 @@ class CLI:
                 openai_apikey=openai_apikey,
                 openai_org_id=openai_org_id,
                 anthropic_apikey=anthropic_apikey,
+                doppler_apikey=doppler_apikey,
                 sentry_token=sentry_token,
                 sentry_org=sentry_org,
                 sentry_host=sentry_host,

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -236,6 +236,8 @@ class Config:
     :param openai_org_id: OpenAI organization id. Optional.
     :type anthropic_apikey: string
     :param anthropic_apikey: Anthropic API key. Optional.
+    :type doppler_apikey: string
+    :param doppler_apikey: Doppler API key. Optional.
     :type socketdev_token: str
     :param socketdev_token: Socket.dev API token. Optional.
     :type airbyte_client_id: str
@@ -442,6 +444,7 @@ class Config:
         openai_apikey=None,
         openai_org_id=None,
         anthropic_apikey=None,
+        doppler_apikey=None,
         subimage_client_id=None,
         subimage_client_secret=None,
         subimage_tenant_url=None,
@@ -616,6 +619,7 @@ class Config:
         self.openai_apikey = openai_apikey
         self.openai_org_id = openai_org_id
         self.anthropic_apikey = anthropic_apikey
+        self.doppler_apikey = doppler_apikey
         self.subimage_client_id = subimage_client_id
         self.subimage_client_secret = subimage_client_secret
         self.subimage_tenant_url = subimage_tenant_url

--- a/cartography/intel/doppler/__init__.py
+++ b/cartography/intel/doppler/__init__.py
@@ -1,0 +1,114 @@
+import logging
+
+import neo4j
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
+
+import cartography.intel.doppler.configs
+import cartography.intel.doppler.environments
+import cartography.intel.doppler.groups
+import cartography.intel.doppler.integrations
+import cartography.intel.doppler.members
+import cartography.intel.doppler.projects
+import cartography.intel.doppler.roles
+import cartography.intel.doppler.secrets
+import cartography.intel.doppler.service_accounts
+import cartography.intel.doppler.service_tokens
+import cartography.intel.doppler.trusted_ips
+import cartography.intel.doppler.users
+import cartography.intel.doppler.webhooks
+import cartography.intel.doppler.workplace
+from cartography.config import Config
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def start_doppler_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
+    """
+    If this module is configured, perform ingestion of Doppler data. Otherwise warn and exit.
+    :param neo4j_session: Neo4J session for database interface
+    :param config: A cartography.config object
+    :return: None
+    """
+    if not config.doppler_apikey:
+        logger.info(
+            "Doppler import is not configured - skipping this module. "
+            "See docs to configure.",
+        )
+        return
+
+    api_session = requests.session()
+    retry_policy = Retry(
+        total=5,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
+    api_session.mount("https://", HTTPAdapter(max_retries=retry_policy))
+    api_session.headers.update(
+        {
+            "Authorization": f"Bearer {config.doppler_apikey}",
+            "Accept": "application/json",
+        }
+    )
+
+    common_job_parameters = {
+        "UPDATE_TAG": config.update_tag,
+        "BASE_URL": "https://api.doppler.com/v3",
+    }
+
+    # The workplace is the tenant root; every other node hangs off it.
+    workplace_id = cartography.intel.doppler.workplace.sync(
+        neo4j_session, api_session, common_job_parameters
+    )
+    common_job_parameters["WORKPLACE_ID"] = workplace_id
+
+    cartography.intel.doppler.roles.sync(
+        neo4j_session, api_session, common_job_parameters
+    )
+    cartography.intel.doppler.users.sync(
+        neo4j_session, api_session, common_job_parameters
+    )
+    cartography.intel.doppler.groups.sync(
+        neo4j_session, api_session, common_job_parameters
+    )
+    cartography.intel.doppler.service_accounts.sync(
+        neo4j_session, api_session, common_job_parameters
+    )
+
+    project_slugs = cartography.intel.doppler.projects.sync(
+        neo4j_session, api_session, common_job_parameters
+    )
+    cartography.intel.doppler.environments.sync(
+        neo4j_session, api_session, project_slugs, common_job_parameters
+    )
+    configs = cartography.intel.doppler.configs.sync(
+        neo4j_session, api_session, project_slugs, common_job_parameters
+    )
+
+    # Per-config fan-out reusing the config list from configs.sync.
+    cartography.intel.doppler.secrets.sync(
+        neo4j_session, api_session, configs, common_job_parameters
+    )
+    cartography.intel.doppler.service_tokens.sync(
+        neo4j_session, api_session, configs, common_job_parameters
+    )
+    cartography.intel.doppler.trusted_ips.sync(
+        neo4j_session, api_session, configs, common_job_parameters
+    )
+
+    cartography.intel.doppler.integrations.sync(
+        neo4j_session, api_session, common_job_parameters
+    )
+    cartography.intel.doppler.webhooks.sync(
+        neo4j_session, api_session, project_slugs, common_job_parameters
+    )
+
+    # Project membership links the user/group/service-account nodes loaded above to
+    # projects, so it must run last.
+    cartography.intel.doppler.members.sync(
+        neo4j_session, api_session, project_slugs, common_job_parameters
+    )

--- a/cartography/intel/doppler/configs.py
+++ b/cartography/intel/doppler/configs.py
@@ -1,0 +1,82 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.doppler.util import paginated_get
+from cartography.models.doppler.config import DopplerConfigSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    project_slugs: list[str],
+    common_job_parameters: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Returns a list of {"project", "config", "config_id"} dicts for the per-config
+    fan-out syncs (secrets, service tokens, trusted IPs)."""
+    configs = get(api_session, common_job_parameters["BASE_URL"], project_slugs)
+    load_configs(
+        neo4j_session,
+        configs,
+        common_job_parameters["WORKPLACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+    return [
+        {"project": c["project"], "config": c["name"], "config_id": c["id"]}
+        for c in configs
+    ]
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+    project_slugs: list[str],
+) -> list[dict[str, Any]]:
+    configs: list[dict[str, Any]] = []
+    for project in project_slugs:
+        for config in paginated_get(
+            api_session,
+            f"{base_url}/configs",
+            "configs",
+            params={"project": project},
+        ):
+            name = config["name"]
+            environment = config.get("environment")
+            config["project"] = project
+            config["id"] = f"{project}/{name}"
+            config["environment_id"] = f"{project}/{environment}"
+            configs.append(config)
+    return configs
+
+
+@timeit
+def load_configs(
+    neo4j_session: neo4j.Session,
+    configs: list[dict[str, Any]],
+    workplace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DopplerConfigSchema(),
+        configs,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(DopplerConfigSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/doppler/environments.py
+++ b/cartography/intel/doppler/environments.py
@@ -1,0 +1,81 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.doppler.util import paginated_get
+from cartography.models.doppler.environment import DopplerEnvironmentSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    project_slugs: list[str],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    environments = get(api_session, common_job_parameters["BASE_URL"], project_slugs)
+    load_environments(
+        neo4j_session,
+        environments,
+        common_job_parameters["WORKPLACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+    project_slugs: list[str],
+) -> list[dict[str, Any]]:
+    environments: list[dict[str, Any]] = []
+    for project in project_slugs:
+        for env in paginated_get(
+            api_session,
+            f"{base_url}/environments",
+            "environments",
+            params={"project": project},
+        ):
+            env_id = env["id"]
+            environments.append(
+                {
+                    "id": f"{project}/{env_id}",
+                    "env_id": env_id,
+                    "name": env.get("name"),
+                    "project": project,
+                    "created_at": env.get("created_at"),
+                    "initial_fetch_at": env.get("initial_fetch_at"),
+                }
+            )
+    return environments
+
+
+@timeit
+def load_environments(
+    neo4j_session: neo4j.Session,
+    environments: list[dict[str, Any]],
+    workplace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DopplerEnvironmentSchema(),
+        environments,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(DopplerEnvironmentSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/doppler/groups.py
+++ b/cartography/intel/doppler/groups.py
@@ -1,0 +1,98 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.client.core.tx import load_matchlinks
+from cartography.graph.job import GraphJob
+from cartography.intel.doppler.util import _TIMEOUT
+from cartography.intel.doppler.util import paginated_get
+from cartography.models.doppler.group import DopplerGroupMembershipMatchLink
+from cartography.models.doppler.group import DopplerGroupSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    groups, memberships = get(api_session, common_job_parameters["BASE_URL"])
+    groups = transform(groups)
+    load_groups(
+        neo4j_session,
+        groups,
+        memberships,
+        common_job_parameters["WORKPLACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    groups = paginated_get(api_session, f"{base_url}/workplace/groups", "groups")
+    memberships: list[dict[str, Any]] = []
+    for group in groups:
+        slug = group["slug"]
+        req = api_session.get(
+            f"{base_url}/workplace/groups/group/{slug}", timeout=_TIMEOUT
+        )
+        req.raise_for_status()
+        members = req.json().get("group", {}).get("members", []) or []
+        for member in members:
+            memberships.append({"user_id": member["slug"], "group_slug": slug})
+    return groups, memberships
+
+
+def transform(groups: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    for group in groups:
+        role = group.get("default_project_role") or {}
+        group["default_project_role"] = role.get("identifier")
+    return groups
+
+
+@timeit
+def load_groups(
+    neo4j_session: neo4j.Session,
+    groups: list[dict[str, Any]],
+    memberships: list[dict[str, Any]],
+    workplace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DopplerGroupSchema(),
+        groups,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+    load_matchlinks(
+        neo4j_session,
+        DopplerGroupMembershipMatchLink(),
+        memberships,
+        lastupdated=update_tag,
+        _sub_resource_label="DopplerWorkplace",
+        _sub_resource_id=workplace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(DopplerGroupSchema(), common_job_parameters).run(
+        neo4j_session
+    )
+    GraphJob.from_matchlink(
+        DopplerGroupMembershipMatchLink(),
+        "DopplerWorkplace",
+        common_job_parameters["WORKPLACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    ).run(neo4j_session)

--- a/cartography/intel/doppler/groups.py
+++ b/cartography/intel/doppler/groups.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import neo4j
@@ -11,6 +12,8 @@ from cartography.intel.doppler.util import paginated_get
 from cartography.models.doppler.group import DopplerGroupMembershipMatchLink
 from cartography.models.doppler.group import DopplerGroupSchema
 from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
 
 
 @timeit
@@ -40,10 +43,19 @@ def get(
     memberships: list[dict[str, Any]] = []
     for group in groups:
         slug = group["slug"]
-        req = api_session.get(
-            f"{base_url}/workplace/groups/group/{slug}", timeout=_TIMEOUT
-        )
-        req.raise_for_status()
+        # Best-effort: a single group's member fetch failing (e.g. it was deleted
+        # mid-sync, or a permissions edge case) should not abort the whole workplace
+        # sync, so log and skip that group's memberships.
+        try:
+            req = api_session.get(
+                f"{base_url}/workplace/groups/group/{slug}", timeout=_TIMEOUT
+            )
+            req.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            logger.warning(
+                "Failed to fetch members for Doppler group %s, skipping: %s", slug, e
+            )
+            continue
         members = req.json().get("group", {}).get("members", []) or []
         for member in members:
             memberships.append({"user_id": member["slug"], "group_slug": slug})

--- a/cartography/intel/doppler/groups.py
+++ b/cartography/intel/doppler/groups.py
@@ -22,7 +22,9 @@ def sync(
     api_session: requests.Session,
     common_job_parameters: dict[str, Any],
 ) -> None:
-    groups, memberships = get(api_session, common_job_parameters["BASE_URL"])
+    groups, memberships, memberships_complete = get(
+        api_session, common_job_parameters["BASE_URL"]
+    )
     groups = transform(groups)
     load_groups(
         neo4j_session,
@@ -31,16 +33,19 @@ def sync(
         common_job_parameters["WORKPLACE_ID"],
         common_job_parameters["UPDATE_TAG"],
     )
-    cleanup(neo4j_session, common_job_parameters)
+    cleanup(neo4j_session, common_job_parameters, memberships_complete)
 
 
 @timeit
 def get(
     api_session: requests.Session,
     base_url: str,
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], bool]:
+    """Returns (groups, memberships, memberships_complete). memberships_complete is
+    False only when there were groups to query but every member fetch failed."""
     groups = paginated_get(api_session, f"{base_url}/workplace/groups", "groups")
     memberships: list[dict[str, Any]] = []
+    success = False
     for group in groups:
         slug = group["slug"]
         # Best-effort: a single group's member fetch failing (e.g. it was deleted
@@ -56,10 +61,11 @@ def get(
                 "Failed to fetch members for Doppler group %s, skipping: %s", slug, e
             )
             continue
+        success = True
         members = req.json().get("group", {}).get("members", []) or []
         for member in members:
             memberships.append({"user_id": member["slug"], "group_slug": slug})
-    return groups, memberships
+    return groups, memberships, (success or not groups)
 
 
 def transform(groups: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -98,13 +104,23 @@ def load_groups(
 def cleanup(
     neo4j_session: neo4j.Session,
     common_job_parameters: dict[str, Any],
+    memberships_complete: bool = True,
 ) -> None:
+    # Group nodes come from the authoritative list endpoint, so always prune them.
     GraphJob.from_node_schema(DopplerGroupSchema(), common_job_parameters).run(
         neo4j_session
     )
-    GraphJob.from_matchlink(
-        DopplerGroupMembershipMatchLink(),
-        "DopplerWorkplace",
-        common_job_parameters["WORKPLACE_ID"],
-        common_job_parameters["UPDATE_TAG"],
-    ).run(neo4j_session)
+    # Only prune membership edges if at least one group's members were fetched; an
+    # all-fail run would otherwise delete every MEMBER_OF edge.
+    if memberships_complete:
+        GraphJob.from_matchlink(
+            DopplerGroupMembershipMatchLink(),
+            "DopplerWorkplace",
+            common_job_parameters["WORKPLACE_ID"],
+            common_job_parameters["UPDATE_TAG"],
+        ).run(neo4j_session)
+    else:
+        logger.warning(
+            "Skipping DopplerGroup membership cleanup: no group member fetch "
+            "succeeded this run, preserving existing edges."
+        )

--- a/cartography/intel/doppler/integrations.py
+++ b/cartography/intel/doppler/integrations.py
@@ -1,0 +1,95 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.doppler.util import paginated_get
+from cartography.models.doppler.integration import DopplerIntegrationSchema
+from cartography.models.doppler.secret_sync import DopplerSecretSyncSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    integrations = get(api_session, common_job_parameters["BASE_URL"])
+    integrations, secret_syncs = transform(integrations)
+    load_integrations(
+        neo4j_session,
+        integrations,
+        secret_syncs,
+        common_job_parameters["WORKPLACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: requests.Session, base_url: str) -> list[dict[str, Any]]:
+    return paginated_get(api_session, f"{base_url}/integrations", "integrations")
+
+
+def transform(
+    integrations: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    # Secret syncs are embedded in each integration's `syncs` array; lift them out
+    # into their own records linked back to the integration and target config.
+    secret_syncs: list[dict[str, Any]] = []
+    for integration in integrations:
+        for s in integration.pop("syncs", []) or []:
+            project = s.get("project")
+            config = s.get("config")
+            secret_syncs.append(
+                {
+                    "slug": s.get("slug"),
+                    "enabled": s.get("enabled"),
+                    "last_synced_at": s.get("lastSyncedAt"),
+                    "integration_slug": integration["slug"],
+                    "config_id": (
+                        f"{project}/{config}" if project and config else None
+                    ),
+                }
+            )
+    return integrations, secret_syncs
+
+
+@timeit
+def load_integrations(
+    neo4j_session: neo4j.Session,
+    integrations: list[dict[str, Any]],
+    secret_syncs: list[dict[str, Any]],
+    workplace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DopplerIntegrationSchema(),
+        integrations,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+    load(
+        neo4j_session,
+        DopplerSecretSyncSchema(),
+        secret_syncs,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(DopplerIntegrationSchema(), common_job_parameters).run(
+        neo4j_session
+    )
+    GraphJob.from_node_schema(DopplerSecretSyncSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/doppler/members.py
+++ b/cartography/intel/doppler/members.py
@@ -1,0 +1,102 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load_matchlinks
+from cartography.graph.job import GraphJob
+from cartography.intel.doppler.util import paginated_get
+from cartography.models.doppler.project_membership import DopplerGroupToProjectMatchLink
+from cartography.models.doppler.project_membership import (
+    DopplerServiceAccountToProjectMatchLink,
+)
+from cartography.models.doppler.project_membership import DopplerUserToProjectMatchLink
+from cartography.util import timeit
+
+# Maps a Doppler project-member `type` to its MatchLink schema. The `invite` type is
+# intentionally absent: there is no node to link a pending invite to.
+_MEMBER_LINKS = {
+    "workplace_user": DopplerUserToProjectMatchLink(),
+    "group": DopplerGroupToProjectMatchLink(),
+    "service_account": DopplerServiceAccountToProjectMatchLink(),
+}
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    project_slugs: list[str],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    members_by_type = get(api_session, common_job_parameters["BASE_URL"], project_slugs)
+    load_members(
+        neo4j_session,
+        members_by_type,
+        common_job_parameters["WORKPLACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+    project_slugs: list[str],
+) -> dict[str, list[dict[str, Any]]]:
+    members_by_type: dict[str, list[dict[str, Any]]] = {
+        member_type: [] for member_type in _MEMBER_LINKS
+    }
+    for project in project_slugs:
+        for member in paginated_get(
+            api_session,
+            f"{base_url}/projects/project/members",
+            "members",
+            params={"project": project},
+        ):
+            member_type = member.get("type")
+            if member_type not in members_by_type:
+                continue
+            role = member.get("role") or {}
+            members_by_type[member_type].append(
+                {
+                    "slug": member["slug"],
+                    "project": project,
+                    "role": role.get("identifier"),
+                    "access_all_environments": member.get("access_all_environments"),
+                }
+            )
+    return members_by_type
+
+
+@timeit
+def load_members(
+    neo4j_session: neo4j.Session,
+    members_by_type: dict[str, list[dict[str, Any]]],
+    workplace_id: str,
+    update_tag: int,
+) -> None:
+    for member_type, link in _MEMBER_LINKS.items():
+        load_matchlinks(
+            neo4j_session,
+            link,
+            members_by_type[member_type],
+            lastupdated=update_tag,
+            _sub_resource_label="DopplerWorkplace",
+            _sub_resource_id=workplace_id,
+        )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    for link in _MEMBER_LINKS.values():
+        GraphJob.from_matchlink(
+            link,
+            "DopplerWorkplace",
+            common_job_parameters["WORKPLACE_ID"],
+            common_job_parameters["UPDATE_TAG"],
+        ).run(neo4j_session)

--- a/cartography/intel/doppler/projects.py
+++ b/cartography/intel/doppler/projects.py
@@ -1,0 +1,58 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.doppler.util import paginated_get
+from cartography.models.doppler.project import DopplerProjectSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+) -> list[str]:
+    projects = get(api_session, common_job_parameters["BASE_URL"])
+    load_projects(
+        neo4j_session,
+        projects,
+        common_job_parameters["WORKPLACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+    return [project["slug"] for project in projects]
+
+
+@timeit
+def get(api_session: requests.Session, base_url: str) -> list[dict[str, Any]]:
+    return paginated_get(api_session, f"{base_url}/projects", "projects")
+
+
+@timeit
+def load_projects(
+    neo4j_session: neo4j.Session,
+    projects: list[dict[str, Any]],
+    workplace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DopplerProjectSchema(),
+        projects,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(DopplerProjectSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/doppler/roles.py
+++ b/cartography/intel/doppler/roles.py
@@ -1,0 +1,75 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.doppler.util import paginated_get
+from cartography.models.doppler.project_role import DopplerProjectRoleSchema
+from cartography.models.doppler.workplace_role import DopplerWorkplaceRoleSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    workplace_roles, project_roles = get(api_session, common_job_parameters["BASE_URL"])
+    load_roles(
+        neo4j_session,
+        workplace_roles,
+        project_roles,
+        common_job_parameters["WORKPLACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    workplace_roles = paginated_get(api_session, f"{base_url}/workplace/roles", "roles")
+    project_roles = paginated_get(api_session, f"{base_url}/projects/roles", "roles")
+    return workplace_roles, project_roles
+
+
+@timeit
+def load_roles(
+    neo4j_session: neo4j.Session,
+    workplace_roles: list[dict[str, Any]],
+    project_roles: list[dict[str, Any]],
+    workplace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DopplerWorkplaceRoleSchema(),
+        workplace_roles,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+    load(
+        neo4j_session,
+        DopplerProjectRoleSchema(),
+        project_roles,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(DopplerWorkplaceRoleSchema(), common_job_parameters).run(
+        neo4j_session
+    )
+    GraphJob.from_node_schema(DopplerProjectRoleSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/doppler/secrets.py
+++ b/cartography/intel/doppler/secrets.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import neo4j
@@ -8,6 +9,8 @@ from cartography.graph.job import GraphJob
 from cartography.intel.doppler.util import _TIMEOUT
 from cartography.models.doppler.secret import DopplerSecretSchema
 from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
 
 
 @timeit
@@ -41,12 +44,22 @@ def get(
             config["config"],
             config["config_id"],
         )
-        req = api_session.get(
-            f"{base_url}/configs/config/secrets/names",
-            params={"project": project, "config": name},
-            timeout=_TIMEOUT,
-        )
-        req.raise_for_status()
+        # Best-effort per config: a single inaccessible/missing config (e.g. a 404)
+        # should not halt secret-name ingestion for every other config.
+        try:
+            req = api_session.get(
+                f"{base_url}/configs/config/secrets/names",
+                params={"project": project, "config": name},
+                timeout=_TIMEOUT,
+            )
+            req.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            logger.warning(
+                "Failed to fetch secret names for Doppler config %s, skipping: %s",
+                config_id,
+                e,
+            )
+            continue
         for secret_name in req.json().get("names", []) or []:
             secrets.append(
                 {

--- a/cartography/intel/doppler/secrets.py
+++ b/cartography/intel/doppler/secrets.py
@@ -20,14 +20,25 @@ def sync(
     configs: list[dict[str, Any]],
     common_job_parameters: dict[str, Any],
 ) -> None:
-    secrets = get(api_session, common_job_parameters["BASE_URL"], configs)
+    secrets, fetch_complete = get(
+        api_session, common_job_parameters["BASE_URL"], configs
+    )
     load_secrets(
         neo4j_session,
         secrets,
         common_job_parameters["WORKPLACE_ID"],
         common_job_parameters["UPDATE_TAG"],
     )
-    cleanup(neo4j_session, common_job_parameters)
+    # Only prune stale secrets if the fetch was trustworthy. If every config fetch
+    # failed, `secrets` is [] not because there are none but because we could not see
+    # them, and cleanup would wipe previously-ingested secrets.
+    if fetch_complete:
+        cleanup(neo4j_session, common_job_parameters)
+    else:
+        logger.warning(
+            "Skipping DopplerSecret cleanup: no config secret fetch succeeded this "
+            "run, preserving existing data."
+        )
 
 
 @timeit
@@ -35,9 +46,12 @@ def get(
     api_session: requests.Session,
     base_url: str,
     configs: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], bool]:
+    """Returns (secret name records, fetch_complete). fetch_complete is False only when
+    there were configs to query but every per-config fetch failed."""
     # Use the names-only endpoint so secret VALUES are never pulled into the process.
     secrets: list[dict[str, Any]] = []
+    success = False
     for config in configs:
         project, name, config_id = (
             config["project"],
@@ -60,6 +74,7 @@ def get(
                 e,
             )
             continue
+        success = True
         for secret_name in req.json().get("names", []) or []:
             secrets.append(
                 {
@@ -70,7 +85,7 @@ def get(
                     "config_id": config_id,
                 }
             )
-    return secrets
+    return secrets, (success or not configs)
 
 
 @timeit

--- a/cartography/intel/doppler/secrets.py
+++ b/cartography/intel/doppler/secrets.py
@@ -1,0 +1,86 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.doppler.util import _TIMEOUT
+from cartography.models.doppler.secret import DopplerSecretSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    configs: list[dict[str, Any]],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    secrets = get(api_session, common_job_parameters["BASE_URL"], configs)
+    load_secrets(
+        neo4j_session,
+        secrets,
+        common_job_parameters["WORKPLACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+    configs: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    # Use the names-only endpoint so secret VALUES are never pulled into the process.
+    secrets: list[dict[str, Any]] = []
+    for config in configs:
+        project, name, config_id = (
+            config["project"],
+            config["config"],
+            config["config_id"],
+        )
+        req = api_session.get(
+            f"{base_url}/configs/config/secrets/names",
+            params={"project": project, "config": name},
+            timeout=_TIMEOUT,
+        )
+        req.raise_for_status()
+        for secret_name in req.json().get("names", []) or []:
+            secrets.append(
+                {
+                    "id": f"{config_id}/{secret_name}",
+                    "name": secret_name,
+                    "project": project,
+                    "config": name,
+                    "config_id": config_id,
+                }
+            )
+    return secrets
+
+
+@timeit
+def load_secrets(
+    neo4j_session: neo4j.Session,
+    secrets: list[dict[str, Any]],
+    workplace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DopplerSecretSchema(),
+        secrets,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(DopplerSecretSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/doppler/service_accounts.py
+++ b/cartography/intel/doppler/service_accounts.py
@@ -1,0 +1,112 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.doppler.util import paginated_get
+from cartography.models.doppler.service_account import DopplerServiceAccountSchema
+from cartography.models.doppler.service_account_identity import (
+    DopplerServiceAccountIdentitySchema,
+)
+from cartography.models.doppler.service_account_token import (
+    DopplerServiceAccountTokenSchema,
+)
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    accounts, tokens, identities = get(api_session, common_job_parameters["BASE_URL"])
+    accounts = transform(accounts)
+    load_service_accounts(
+        neo4j_session,
+        accounts,
+        tokens,
+        identities,
+        common_job_parameters["WORKPLACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    accounts = paginated_get(
+        api_session, f"{base_url}/workplace/service_accounts", "service_accounts"
+    )
+    tokens: list[dict[str, Any]] = []
+    identities: list[dict[str, Any]] = []
+    for account in accounts:
+        slug = account["slug"]
+        base = f"{base_url}/workplace/service_accounts/service_account/{slug}"
+        for token in paginated_get(api_session, f"{base}/tokens", "api_tokens"):
+            token["service_account_slug"] = slug
+            tokens.append(token)
+        for identity in paginated_get(api_session, f"{base}/identities", "identities"):
+            identity["service_account_slug"] = slug
+            identities.append(identity)
+    return accounts, tokens, identities
+
+
+def transform(accounts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    for account in accounts:
+        role = account.get("workplace_role") or {}
+        account["workplace_role"] = role.get("identifier")
+    return accounts
+
+
+@timeit
+def load_service_accounts(
+    neo4j_session: neo4j.Session,
+    accounts: list[dict[str, Any]],
+    tokens: list[dict[str, Any]],
+    identities: list[dict[str, Any]],
+    workplace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DopplerServiceAccountSchema(),
+        accounts,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+    load(
+        neo4j_session,
+        DopplerServiceAccountTokenSchema(),
+        tokens,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+    load(
+        neo4j_session,
+        DopplerServiceAccountIdentitySchema(),
+        identities,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(DopplerServiceAccountSchema(), common_job_parameters).run(
+        neo4j_session
+    )
+    GraphJob.from_node_schema(
+        DopplerServiceAccountTokenSchema(), common_job_parameters
+    ).run(neo4j_session)
+    GraphJob.from_node_schema(
+        DopplerServiceAccountIdentitySchema(), common_job_parameters
+    ).run(neo4j_session)

--- a/cartography/intel/doppler/service_tokens.py
+++ b/cartography/intel/doppler/service_tokens.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import neo4j
@@ -8,6 +9,8 @@ from cartography.graph.job import GraphJob
 from cartography.intel.doppler.util import _TIMEOUT
 from cartography.models.doppler.service_token import DopplerServiceTokenSchema
 from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
 
 
 @timeit
@@ -35,12 +38,22 @@ def get(
 ) -> list[dict[str, Any]]:
     tokens: list[dict[str, Any]] = []
     for config in configs:
-        req = api_session.get(
-            f"{base_url}/configs/config/tokens",
-            params={"project": config["project"], "config": config["config"]},
-            timeout=_TIMEOUT,
-        )
-        req.raise_for_status()
+        # Best-effort per config: a single inaccessible/missing config (e.g. a 404)
+        # should not halt service-token ingestion for every other config.
+        try:
+            req = api_session.get(
+                f"{base_url}/configs/config/tokens",
+                params={"project": config["project"], "config": config["config"]},
+                timeout=_TIMEOUT,
+            )
+            req.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            logger.warning(
+                "Failed to fetch service tokens for Doppler config %s, skipping: %s",
+                config["config_id"],
+                e,
+            )
+            continue
         for token in req.json().get("tokens", []) or []:
             token["config_id"] = config["config_id"]
             tokens.append(token)

--- a/cartography/intel/doppler/service_tokens.py
+++ b/cartography/intel/doppler/service_tokens.py
@@ -1,0 +1,73 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.doppler.util import _TIMEOUT
+from cartography.models.doppler.service_token import DopplerServiceTokenSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    configs: list[dict[str, Any]],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    tokens = get(api_session, common_job_parameters["BASE_URL"], configs)
+    load_service_tokens(
+        neo4j_session,
+        tokens,
+        common_job_parameters["WORKPLACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+    configs: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    tokens: list[dict[str, Any]] = []
+    for config in configs:
+        req = api_session.get(
+            f"{base_url}/configs/config/tokens",
+            params={"project": config["project"], "config": config["config"]},
+            timeout=_TIMEOUT,
+        )
+        req.raise_for_status()
+        for token in req.json().get("tokens", []) or []:
+            token["config_id"] = config["config_id"]
+            tokens.append(token)
+    return tokens
+
+
+@timeit
+def load_service_tokens(
+    neo4j_session: neo4j.Session,
+    tokens: list[dict[str, Any]],
+    workplace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DopplerServiceTokenSchema(),
+        tokens,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(DopplerServiceTokenSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/doppler/service_tokens.py
+++ b/cartography/intel/doppler/service_tokens.py
@@ -20,14 +20,23 @@ def sync(
     configs: list[dict[str, Any]],
     common_job_parameters: dict[str, Any],
 ) -> None:
-    tokens = get(api_session, common_job_parameters["BASE_URL"], configs)
+    tokens, fetch_complete = get(
+        api_session, common_job_parameters["BASE_URL"], configs
+    )
     load_service_tokens(
         neo4j_session,
         tokens,
         common_job_parameters["WORKPLACE_ID"],
         common_job_parameters["UPDATE_TAG"],
     )
-    cleanup(neo4j_session, common_job_parameters)
+    # Only prune stale tokens if the fetch was trustworthy; see secrets.sync for why.
+    if fetch_complete:
+        cleanup(neo4j_session, common_job_parameters)
+    else:
+        logger.warning(
+            "Skipping DopplerServiceToken cleanup: no config token fetch succeeded "
+            "this run, preserving existing data."
+        )
 
 
 @timeit
@@ -35,8 +44,11 @@ def get(
     api_session: requests.Session,
     base_url: str,
     configs: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], bool]:
+    """Returns (tokens, fetch_complete). fetch_complete is False only when there were
+    configs to query but every per-config fetch failed."""
     tokens: list[dict[str, Any]] = []
+    success = False
     for config in configs:
         # Best-effort per config: a single inaccessible/missing config (e.g. a 404)
         # should not halt service-token ingestion for every other config.
@@ -54,10 +66,11 @@ def get(
                 e,
             )
             continue
+        success = True
         for token in req.json().get("tokens", []) or []:
             token["config_id"] = config["config_id"]
             tokens.append(token)
-    return tokens
+    return tokens, (success or not configs)
 
 
 @timeit

--- a/cartography/intel/doppler/trusted_ips.py
+++ b/cartography/intel/doppler/trusted_ips.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import neo4j
@@ -8,6 +9,8 @@ from cartography.graph.job import GraphJob
 from cartography.intel.doppler.util import _TIMEOUT
 from cartography.models.doppler.trusted_ip import DopplerTrustedIPSchema
 from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
 
 
 @timeit
@@ -36,12 +39,22 @@ def get(
     trusted_ips: list[dict[str, Any]] = []
     for config in configs:
         config_id = config["config_id"]
-        req = api_session.get(
-            f"{base_url}/configs/config/trusted_ips",
-            params={"project": config["project"], "config": config["config"]},
-            timeout=_TIMEOUT,
-        )
-        req.raise_for_status()
+        # Best-effort per config: a single inaccessible/missing config (e.g. a 404)
+        # should not halt trusted-IP ingestion for every other config.
+        try:
+            req = api_session.get(
+                f"{base_url}/configs/config/trusted_ips",
+                params={"project": config["project"], "config": config["config"]},
+                timeout=_TIMEOUT,
+            )
+            req.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            logger.warning(
+                "Failed to fetch trusted IPs for Doppler config %s, skipping: %s",
+                config_id,
+                e,
+            )
+            continue
         for ip in req.json().get("ips", []) or []:
             trusted_ips.append(
                 {"id": f"{config_id}/{ip}", "cidr": ip, "config_id": config_id}

--- a/cartography/intel/doppler/trusted_ips.py
+++ b/cartography/intel/doppler/trusted_ips.py
@@ -20,14 +20,23 @@ def sync(
     configs: list[dict[str, Any]],
     common_job_parameters: dict[str, Any],
 ) -> None:
-    trusted_ips = get(api_session, common_job_parameters["BASE_URL"], configs)
+    trusted_ips, fetch_complete = get(
+        api_session, common_job_parameters["BASE_URL"], configs
+    )
     load_trusted_ips(
         neo4j_session,
         trusted_ips,
         common_job_parameters["WORKPLACE_ID"],
         common_job_parameters["UPDATE_TAG"],
     )
-    cleanup(neo4j_session, common_job_parameters)
+    # Only prune stale trusted IPs if the fetch was trustworthy; see secrets.sync.
+    if fetch_complete:
+        cleanup(neo4j_session, common_job_parameters)
+    else:
+        logger.warning(
+            "Skipping DopplerTrustedIP cleanup: no config trusted-IP fetch succeeded "
+            "this run, preserving existing data."
+        )
 
 
 @timeit
@@ -35,8 +44,11 @@ def get(
     api_session: requests.Session,
     base_url: str,
     configs: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], bool]:
+    """Returns (trusted IP records, fetch_complete). fetch_complete is False only when
+    there were configs to query but every per-config fetch failed."""
     trusted_ips: list[dict[str, Any]] = []
+    success = False
     for config in configs:
         config_id = config["config_id"]
         # Best-effort per config: a single inaccessible/missing config (e.g. a 404)
@@ -55,11 +67,12 @@ def get(
                 e,
             )
             continue
+        success = True
         for ip in req.json().get("ips", []) or []:
             trusted_ips.append(
                 {"id": f"{config_id}/{ip}", "cidr": ip, "config_id": config_id}
             )
-    return trusted_ips
+    return trusted_ips, (success or not configs)
 
 
 @timeit

--- a/cartography/intel/doppler/trusted_ips.py
+++ b/cartography/intel/doppler/trusted_ips.py
@@ -1,0 +1,75 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.doppler.util import _TIMEOUT
+from cartography.models.doppler.trusted_ip import DopplerTrustedIPSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    configs: list[dict[str, Any]],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    trusted_ips = get(api_session, common_job_parameters["BASE_URL"], configs)
+    load_trusted_ips(
+        neo4j_session,
+        trusted_ips,
+        common_job_parameters["WORKPLACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+    configs: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    trusted_ips: list[dict[str, Any]] = []
+    for config in configs:
+        config_id = config["config_id"]
+        req = api_session.get(
+            f"{base_url}/configs/config/trusted_ips",
+            params={"project": config["project"], "config": config["config"]},
+            timeout=_TIMEOUT,
+        )
+        req.raise_for_status()
+        for ip in req.json().get("ips", []) or []:
+            trusted_ips.append(
+                {"id": f"{config_id}/{ip}", "cidr": ip, "config_id": config_id}
+            )
+    return trusted_ips
+
+
+@timeit
+def load_trusted_ips(
+    neo4j_session: neo4j.Session,
+    trusted_ips: list[dict[str, Any]],
+    workplace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DopplerTrustedIPSchema(),
+        trusted_ips,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(DopplerTrustedIPSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/doppler/users.py
+++ b/cartography/intel/doppler/users.py
@@ -1,0 +1,77 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.doppler.util import paginated_get
+from cartography.models.doppler.user import DopplerWorkplaceUserSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    users = get(api_session, common_job_parameters["BASE_URL"])
+    users = transform(users)
+    load_users(
+        neo4j_session,
+        users,
+        common_job_parameters["WORKPLACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: requests.Session, base_url: str) -> list[dict[str, Any]]:
+    return paginated_get(api_session, f"{base_url}/workplace/users", "workplace_users")
+
+
+def transform(users: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    # Flatten the nested `user` object onto the membership record.
+    transformed = []
+    for member in users:
+        user = member.get("user", {}) or {}
+        transformed.append(
+            {
+                "id": member["id"],
+                "access": member.get("access"),
+                "created_at": member.get("created_at"),
+                "email": user.get("email"),
+                "name": user.get("name"),
+                "username": user.get("username"),
+                "profile_image_url": user.get("profile_image_url"),
+            }
+        )
+    return transformed
+
+
+@timeit
+def load_users(
+    neo4j_session: neo4j.Session,
+    users: list[dict[str, Any]],
+    workplace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DopplerWorkplaceUserSchema(),
+        users,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(DopplerWorkplaceUserSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/doppler/util.py
+++ b/cartography/intel/doppler/util.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+import requests
+
+# Connect and read timeouts of 60 seconds each; see
+# https://requests.readthedocs.io/en/master/user/advanced/#timeouts
+_TIMEOUT = (60, 60)
+
+# Doppler paginated endpoints default to per_page=20; request the max page size to
+# keep the number of round trips down.
+_PER_PAGE = 100
+
+
+def paginated_get(
+    api_session: requests.Session,
+    url: str,
+    results_key: str,
+    params: dict[str, Any] | None = None,
+    timeout: tuple[int, int] = _TIMEOUT,
+) -> list[dict[str, Any]]:
+    """Fetch every page of a paginated Doppler list endpoint.
+
+    Doppler wraps list results under a resource-specific key (e.g. ``projects``,
+    ``configs``) and paginates with ``page`` / ``per_page``. We request pages
+    starting at 1 until a page returns fewer than ``per_page`` items.
+
+    Args:
+        api_session: Authenticated requests session.
+        url: Full endpoint URL.
+        results_key: The key under which the list of items is returned.
+        params: Extra query parameters (e.g. ``{"project": "..."}``).
+        timeout: ``(connect, read)`` timeout tuple.
+    Returns:
+        The concatenated list of item dictionaries across all pages.
+    """
+    results: list[dict[str, Any]] = []
+    page = 1
+    base_params = dict(params or {})
+    while True:
+        req = api_session.get(
+            url,
+            params={**base_params, "page": page, "per_page": _PER_PAGE},
+            timeout=timeout,
+        )
+        req.raise_for_status()
+        page_results = req.json().get(results_key, []) or []
+        results.extend(page_results)
+        if len(page_results) < _PER_PAGE:
+            break
+        page += 1
+    return results

--- a/cartography/intel/doppler/util.py
+++ b/cartography/intel/doppler/util.py
@@ -43,7 +43,17 @@ def paginated_get(
             timeout=timeout,
         )
         req.raise_for_status()
-        page_results = req.json().get(results_key, []) or []
+        body = req.json()
+        # Fail fast if the expected list key is missing: a silent fallback to [] would
+        # mask an API shape / auth change and could trigger destructive cleanup of an
+        # otherwise-populated node type. An explicitly empty list is fine.
+        if not isinstance(body, dict) or results_key not in body:
+            raise ValueError(
+                f"Doppler response from {url} is missing the expected "
+                f"'{results_key}' key; got keys: "
+                f"{sorted(body) if isinstance(body, dict) else type(body).__name__}",
+            )
+        page_results = body[results_key] or []
         results.extend(page_results)
         if len(page_results) < _PER_PAGE:
             break

--- a/cartography/intel/doppler/webhooks.py
+++ b/cartography/intel/doppler/webhooks.py
@@ -1,0 +1,80 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.doppler.util import paginated_get
+from cartography.models.doppler.webhook import DopplerWebhookSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    project_slugs: list[str],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    webhooks = get(api_session, common_job_parameters["BASE_URL"], project_slugs)
+    load_webhooks(
+        neo4j_session,
+        webhooks,
+        common_job_parameters["WORKPLACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+    project_slugs: list[str],
+) -> list[dict[str, Any]]:
+    # Only non-sensitive webhook metadata is kept; the `secret` field is dropped.
+    webhooks: list[dict[str, Any]] = []
+    for project in project_slugs:
+        for webhook in paginated_get(
+            api_session,
+            f"{base_url}/webhooks",
+            "webhooks",
+            params={"project": project},
+        ):
+            webhooks.append(
+                {
+                    "id": webhook["id"],
+                    "name": webhook.get("name"),
+                    "url": webhook.get("url"),
+                    "enabled": webhook.get("enabled"),
+                    "project": project,
+                }
+            )
+    return webhooks
+
+
+@timeit
+def load_webhooks(
+    neo4j_session: neo4j.Session,
+    webhooks: list[dict[str, Any]],
+    workplace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DopplerWebhookSchema(),
+        webhooks,
+        lastupdated=update_tag,
+        WORKPLACE_ID=workplace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(DopplerWebhookSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/doppler/workplace.py
+++ b/cartography/intel/doppler/workplace.py
@@ -1,0 +1,41 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.intel.doppler.util import _TIMEOUT
+from cartography.models.doppler.workplace import DopplerWorkplaceSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+) -> str:
+    workplace = get(api_session, common_job_parameters["BASE_URL"])
+    load_workplace(neo4j_session, workplace, common_job_parameters["UPDATE_TAG"])
+    return workplace["id"]
+
+
+@timeit
+def get(api_session: requests.Session, base_url: str) -> dict[str, Any]:
+    req = api_session.get(f"{base_url}/workplace", timeout=_TIMEOUT)
+    req.raise_for_status()
+    return req.json()["workplace"]
+
+
+@timeit
+def load_workplace(
+    neo4j_session: neo4j.Session,
+    workplace: dict[str, Any],
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DopplerWorkplaceSchema(),
+        [workplace],
+        lastupdated=update_tag,
+    )

--- a/cartography/models/doppler/config.py
+++ b/cartography/models/doppler/config.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerConfigNodeProperties(CartographyNodeProperties):
+    # id is the composite "{project}/{name}" built in transform.
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    project: PropertyRef = PropertyRef("project")
+    environment: PropertyRef = PropertyRef("environment")
+    root: PropertyRef = PropertyRef("root")
+    locked: PropertyRef = PropertyRef("locked")
+    created_at: PropertyRef = PropertyRef("created_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerConfigToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerConfig)
+class DopplerConfigToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerConfigToWorkplaceRelProperties = (
+        DopplerConfigToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerConfigToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerProject)-[:HAS_CONFIG]->(:DopplerConfig)
+class DopplerConfigToProjectRel(CartographyRelSchema):
+    target_node_label: str = "DopplerProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"slug": PropertyRef("project")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_CONFIG"
+    properties: DopplerConfigToProjectRelProperties = (
+        DopplerConfigToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerConfigToEnvironmentRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerConfig)-[:IN_ENVIRONMENT]->(:DopplerEnvironment)
+class DopplerConfigToEnvironmentRel(CartographyRelSchema):
+    target_node_label: str = "DopplerEnvironment"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("environment_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "IN_ENVIRONMENT"
+    properties: DopplerConfigToEnvironmentRelProperties = (
+        DopplerConfigToEnvironmentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerConfigSchema(CartographyNodeSchema):
+    label: str = "DopplerConfig"
+    properties: DopplerConfigNodeProperties = DopplerConfigNodeProperties()
+    sub_resource_relationship: DopplerConfigToWorkplaceRel = (
+        DopplerConfigToWorkplaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DopplerConfigToProjectRel(), DopplerConfigToEnvironmentRel()],
+    )

--- a/cartography/models/doppler/environment.py
+++ b/cartography/models/doppler/environment.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerEnvironmentNodeProperties(CartographyNodeProperties):
+    # id is the composite "{project}/{env_id}" built in transform; env_id is the
+    # per-project environment slug (e.g. "dev").
+    id: PropertyRef = PropertyRef("id")
+    env_id: PropertyRef = PropertyRef("env_id")
+    name: PropertyRef = PropertyRef("name")
+    project: PropertyRef = PropertyRef("project")
+    created_at: PropertyRef = PropertyRef("created_at")
+    initial_fetch_at: PropertyRef = PropertyRef("initial_fetch_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerEnvironmentToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerEnvironment)
+class DopplerEnvironmentToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerEnvironmentToWorkplaceRelProperties = (
+        DopplerEnvironmentToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerEnvironmentToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerProject)-[:HAS_ENVIRONMENT]->(:DopplerEnvironment)
+class DopplerEnvironmentToProjectRel(CartographyRelSchema):
+    target_node_label: str = "DopplerProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"slug": PropertyRef("project")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_ENVIRONMENT"
+    properties: DopplerEnvironmentToProjectRelProperties = (
+        DopplerEnvironmentToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerEnvironmentSchema(CartographyNodeSchema):
+    label: str = "DopplerEnvironment"
+    properties: DopplerEnvironmentNodeProperties = DopplerEnvironmentNodeProperties()
+    sub_resource_relationship: DopplerEnvironmentToWorkplaceRel = (
+        DopplerEnvironmentToWorkplaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DopplerEnvironmentToProjectRel()],
+    )

--- a/cartography/models/doppler/group.py
+++ b/cartography/models/doppler/group.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import SourceNodeMatcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerGroupNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("slug")
+    name: PropertyRef = PropertyRef("name")
+    created_at: PropertyRef = PropertyRef("created_at")
+    default_project_role: PropertyRef = PropertyRef("default_project_role")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerGroupToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerGroup)
+class DopplerGroupToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerGroupToWorkplaceRelProperties = (
+        DopplerGroupToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerGroupSchema(CartographyNodeSchema):
+    label: str = "DopplerGroup"
+    properties: DopplerGroupNodeProperties = DopplerGroupNodeProperties()
+    sub_resource_relationship: DopplerGroupToWorkplaceRel = DopplerGroupToWorkplaceRel()
+
+
+@dataclass(frozen=True)
+class DopplerGroupMembershipRelProperties(CartographyRelProperties):
+    # Mandatory fields for MatchLinks
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label", set_in_kwargs=True
+    )
+    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplaceUser)-[:MEMBER_OF]->(:DopplerGroup)
+class DopplerGroupMembershipMatchLink(CartographyRelSchema):
+    rel_label: str = "MEMBER_OF"
+    direction: LinkDirection = LinkDirection.OUTWARD
+    properties: DopplerGroupMembershipRelProperties = (
+        DopplerGroupMembershipRelProperties()
+    )
+    source_node_label: str = "DopplerWorkplaceUser"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("user_id")},
+    )
+    target_node_label: str = "DopplerGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("group_slug")},
+    )

--- a/cartography/models/doppler/integration.py
+++ b/cartography/models/doppler/integration.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerIntegrationNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("slug")
+    name: PropertyRef = PropertyRef("name")
+    type: PropertyRef = PropertyRef("type")
+    kind: PropertyRef = PropertyRef("kind")
+    enabled: PropertyRef = PropertyRef("enabled")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerIntegrationToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerIntegration)
+class DopplerIntegrationToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerIntegrationToWorkplaceRelProperties = (
+        DopplerIntegrationToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerIntegrationSchema(CartographyNodeSchema):
+    label: str = "DopplerIntegration"
+    properties: DopplerIntegrationNodeProperties = DopplerIntegrationNodeProperties()
+    sub_resource_relationship: DopplerIntegrationToWorkplaceRel = (
+        DopplerIntegrationToWorkplaceRel()
+    )

--- a/cartography/models/doppler/project.py
+++ b/cartography/models/doppler/project.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerProjectNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    slug: PropertyRef = PropertyRef("slug")
+    name: PropertyRef = PropertyRef("name")
+    description: PropertyRef = PropertyRef("description")
+    created_at: PropertyRef = PropertyRef("created_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerProjectToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerProject)
+class DopplerProjectToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerProjectToWorkplaceRelProperties = (
+        DopplerProjectToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerProjectSchema(CartographyNodeSchema):
+    label: str = "DopplerProject"
+    properties: DopplerProjectNodeProperties = DopplerProjectNodeProperties()
+    sub_resource_relationship: DopplerProjectToWorkplaceRel = (
+        DopplerProjectToWorkplaceRel()
+    )

--- a/cartography/models/doppler/project_membership.py
+++ b/cartography/models/doppler/project_membership.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import SourceNodeMatcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerProjectMembershipRelProperties(CartographyRelProperties):
+    # Mandatory fields for MatchLinks
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label", set_in_kwargs=True
+    )
+    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
+
+    # Business properties carried on the edge
+    role: PropertyRef = PropertyRef("role")
+    access_all_environments: PropertyRef = PropertyRef("access_all_environments")
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplaceUser)-[:MEMBER_OF]->(:DopplerProject)
+class DopplerUserToProjectMatchLink(CartographyRelSchema):
+    rel_label: str = "MEMBER_OF"
+    direction: LinkDirection = LinkDirection.OUTWARD
+    properties: DopplerProjectMembershipRelProperties = (
+        DopplerProjectMembershipRelProperties()
+    )
+    source_node_label: str = "DopplerWorkplaceUser"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("slug")},
+    )
+    target_node_label: str = "DopplerProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"slug": PropertyRef("project")},
+    )
+
+
+@dataclass(frozen=True)
+# (:DopplerGroup)-[:MEMBER_OF]->(:DopplerProject)
+class DopplerGroupToProjectMatchLink(CartographyRelSchema):
+    rel_label: str = "MEMBER_OF"
+    direction: LinkDirection = LinkDirection.OUTWARD
+    properties: DopplerProjectMembershipRelProperties = (
+        DopplerProjectMembershipRelProperties()
+    )
+    source_node_label: str = "DopplerGroup"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("slug")},
+    )
+    target_node_label: str = "DopplerProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"slug": PropertyRef("project")},
+    )
+
+
+@dataclass(frozen=True)
+# (:DopplerServiceAccount)-[:MEMBER_OF]->(:DopplerProject)
+class DopplerServiceAccountToProjectMatchLink(CartographyRelSchema):
+    rel_label: str = "MEMBER_OF"
+    direction: LinkDirection = LinkDirection.OUTWARD
+    properties: DopplerProjectMembershipRelProperties = (
+        DopplerProjectMembershipRelProperties()
+    )
+    source_node_label: str = "DopplerServiceAccount"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("slug")},
+    )
+    target_node_label: str = "DopplerProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"slug": PropertyRef("project")},
+    )

--- a/cartography/models/doppler/project_role.py
+++ b/cartography/models/doppler/project_role.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerProjectRoleNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("identifier")
+    name: PropertyRef = PropertyRef("name")
+    permissions: PropertyRef = PropertyRef("permissions")
+    is_custom_role: PropertyRef = PropertyRef("is_custom_role")
+    created_at: PropertyRef = PropertyRef("created_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerProjectRoleToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerProjectRole)
+class DopplerProjectRoleToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerProjectRoleToWorkplaceRelProperties = (
+        DopplerProjectRoleToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerProjectRoleSchema(CartographyNodeSchema):
+    label: str = "DopplerProjectRole"
+    properties: DopplerProjectRoleNodeProperties = DopplerProjectRoleNodeProperties()
+    sub_resource_relationship: DopplerProjectRoleToWorkplaceRel = (
+        DopplerProjectRoleToWorkplaceRel()
+    )

--- a/cartography/models/doppler/secret.py
+++ b/cartography/models/doppler/secret.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerSecretNodeProperties(CartographyNodeProperties):
+    # id is the composite "{project}/{config}/{NAME}" built in transform.
+    # Only the secret NAME is stored, never the raw or computed value.
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    project: PropertyRef = PropertyRef("project")
+    config: PropertyRef = PropertyRef("config")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerSecretToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerSecret)
+class DopplerSecretToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerSecretToWorkplaceRelProperties = (
+        DopplerSecretToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerSecretToConfigRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerConfig)-[:CONTAINS]->(:DopplerSecret)
+class DopplerSecretToConfigRel(CartographyRelSchema):
+    target_node_label: str = "DopplerConfig"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("config_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "CONTAINS"
+    properties: DopplerSecretToConfigRelProperties = (
+        DopplerSecretToConfigRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerSecretSchema(CartographyNodeSchema):
+    label: str = "DopplerSecret"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        ["Secret"]
+    )  # Secret label is used for ontology mapping
+    properties: DopplerSecretNodeProperties = DopplerSecretNodeProperties()
+    sub_resource_relationship: DopplerSecretToWorkplaceRel = (
+        DopplerSecretToWorkplaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DopplerSecretToConfigRel()],
+    )

--- a/cartography/models/doppler/secret_sync.py
+++ b/cartography/models/doppler/secret_sync.py
@@ -1,0 +1,88 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerSecretSyncNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("slug")
+    enabled: PropertyRef = PropertyRef("enabled")
+    last_synced_at: PropertyRef = PropertyRef("last_synced_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerSecretSyncToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerSecretSync)
+class DopplerSecretSyncToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerSecretSyncToWorkplaceRelProperties = (
+        DopplerSecretSyncToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerSecretSyncToIntegrationRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerSecretSync)-[:USES]->(:DopplerIntegration)
+class DopplerSecretSyncToIntegrationRel(CartographyRelSchema):
+    target_node_label: str = "DopplerIntegration"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("integration_slug")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES"
+    properties: DopplerSecretSyncToIntegrationRelProperties = (
+        DopplerSecretSyncToIntegrationRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerSecretSyncToConfigRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerSecretSync)-[:SYNCS]->(:DopplerConfig)
+class DopplerSecretSyncToConfigRel(CartographyRelSchema):
+    target_node_label: str = "DopplerConfig"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("config_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "SYNCS"
+    properties: DopplerSecretSyncToConfigRelProperties = (
+        DopplerSecretSyncToConfigRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerSecretSyncSchema(CartographyNodeSchema):
+    label: str = "DopplerSecretSync"
+    properties: DopplerSecretSyncNodeProperties = DopplerSecretSyncNodeProperties()
+    sub_resource_relationship: DopplerSecretSyncToWorkplaceRel = (
+        DopplerSecretSyncToWorkplaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DopplerSecretSyncToIntegrationRel(), DopplerSecretSyncToConfigRel()],
+    )

--- a/cartography/models/doppler/service_account.py
+++ b/cartography/models/doppler/service_account.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerServiceAccountNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("slug")
+    name: PropertyRef = PropertyRef("name")
+    created_at: PropertyRef = PropertyRef("created_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerServiceAccountToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerServiceAccount)
+class DopplerServiceAccountToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerServiceAccountToWorkplaceRelProperties = (
+        DopplerServiceAccountToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerServiceAccountToRoleRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerServiceAccount)-[:HAS_ROLE]->(:DopplerWorkplaceRole)
+class DopplerServiceAccountToRoleRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplaceRole"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("workplace_role")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_ROLE"
+    properties: DopplerServiceAccountToRoleRelProperties = (
+        DopplerServiceAccountToRoleRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerServiceAccountSchema(CartographyNodeSchema):
+    label: str = "DopplerServiceAccount"
+    properties: DopplerServiceAccountNodeProperties = (
+        DopplerServiceAccountNodeProperties()
+    )
+    sub_resource_relationship: DopplerServiceAccountToWorkplaceRel = (
+        DopplerServiceAccountToWorkplaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DopplerServiceAccountToRoleRel()],
+    )

--- a/cartography/models/doppler/service_account_identity.py
+++ b/cartography/models/doppler/service_account_identity.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerServiceAccountIdentityNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("slug")
+    name: PropertyRef = PropertyRef("name")
+    method: PropertyRef = PropertyRef("method")
+    ttl_seconds: PropertyRef = PropertyRef("ttl_seconds")
+    created_at: PropertyRef = PropertyRef("created_at")
+    last_seen_at: PropertyRef = PropertyRef("last_seen_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerServiceAccountIdentityToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerServiceAccountIdentity)
+class DopplerServiceAccountIdentityToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerServiceAccountIdentityToWorkplaceRelProperties = (
+        DopplerServiceAccountIdentityToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerServiceAccountIdentityToAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerServiceAccount)-[:HAS_IDENTITY]->(:DopplerServiceAccountIdentity)
+class DopplerServiceAccountIdentityToAccountRel(CartographyRelSchema):
+    target_node_label: str = "DopplerServiceAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("service_account_slug")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_IDENTITY"
+    properties: DopplerServiceAccountIdentityToAccountRelProperties = (
+        DopplerServiceAccountIdentityToAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerServiceAccountIdentitySchema(CartographyNodeSchema):
+    label: str = "DopplerServiceAccountIdentity"
+    properties: DopplerServiceAccountIdentityNodeProperties = (
+        DopplerServiceAccountIdentityNodeProperties()
+    )
+    sub_resource_relationship: DopplerServiceAccountIdentityToWorkplaceRel = (
+        DopplerServiceAccountIdentityToWorkplaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DopplerServiceAccountIdentityToAccountRel()],
+    )

--- a/cartography/models/doppler/service_account_token.py
+++ b/cartography/models/doppler/service_account_token.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerServiceAccountTokenNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("slug")
+    name: PropertyRef = PropertyRef("name")
+    created_at: PropertyRef = PropertyRef("created_at")
+    expires_at: PropertyRef = PropertyRef("expires_at")
+    last_seen_at: PropertyRef = PropertyRef("last_seen_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerServiceAccountTokenToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerServiceAccountToken)
+class DopplerServiceAccountTokenToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerServiceAccountTokenToWorkplaceRelProperties = (
+        DopplerServiceAccountTokenToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerServiceAccountTokenToAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerServiceAccount)-[:HAS_TOKEN]->(:DopplerServiceAccountToken)
+class DopplerServiceAccountTokenToAccountRel(CartographyRelSchema):
+    target_node_label: str = "DopplerServiceAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("service_account_slug")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_TOKEN"
+    properties: DopplerServiceAccountTokenToAccountRelProperties = (
+        DopplerServiceAccountTokenToAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerServiceAccountTokenSchema(CartographyNodeSchema):
+    label: str = "DopplerServiceAccountToken"
+    properties: DopplerServiceAccountTokenNodeProperties = (
+        DopplerServiceAccountTokenNodeProperties()
+    )
+    sub_resource_relationship: DopplerServiceAccountTokenToWorkplaceRel = (
+        DopplerServiceAccountTokenToWorkplaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DopplerServiceAccountTokenToAccountRel()],
+    )

--- a/cartography/models/doppler/service_token.py
+++ b/cartography/models/doppler/service_token.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerServiceTokenNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("slug")
+    name: PropertyRef = PropertyRef("name")
+    project: PropertyRef = PropertyRef("project")
+    environment: PropertyRef = PropertyRef("environment")
+    config: PropertyRef = PropertyRef("config")
+    created_at: PropertyRef = PropertyRef("created_at")
+    expires_at: PropertyRef = PropertyRef("expires_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerServiceTokenToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerServiceToken)
+class DopplerServiceTokenToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerServiceTokenToWorkplaceRelProperties = (
+        DopplerServiceTokenToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerServiceTokenToConfigRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerConfig)-[:HAS_TOKEN]->(:DopplerServiceToken)
+class DopplerServiceTokenToConfigRel(CartographyRelSchema):
+    target_node_label: str = "DopplerConfig"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("config_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_TOKEN"
+    properties: DopplerServiceTokenToConfigRelProperties = (
+        DopplerServiceTokenToConfigRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerServiceTokenSchema(CartographyNodeSchema):
+    label: str = "DopplerServiceToken"
+    properties: DopplerServiceTokenNodeProperties = DopplerServiceTokenNodeProperties()
+    sub_resource_relationship: DopplerServiceTokenToWorkplaceRel = (
+        DopplerServiceTokenToWorkplaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DopplerServiceTokenToConfigRel()],
+    )

--- a/cartography/models/doppler/trusted_ip.py
+++ b/cartography/models/doppler/trusted_ip.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerTrustedIPNodeProperties(CartographyNodeProperties):
+    # id is the composite "{project}/{config}/{cidr}" built in transform.
+    id: PropertyRef = PropertyRef("id")
+    cidr: PropertyRef = PropertyRef("cidr")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerTrustedIPToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerTrustedIP)
+class DopplerTrustedIPToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerTrustedIPToWorkplaceRelProperties = (
+        DopplerTrustedIPToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerTrustedIPToConfigRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerConfig)-[:TRUSTS]->(:DopplerTrustedIP)
+class DopplerTrustedIPToConfigRel(CartographyRelSchema):
+    target_node_label: str = "DopplerConfig"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("config_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "TRUSTS"
+    properties: DopplerTrustedIPToConfigRelProperties = (
+        DopplerTrustedIPToConfigRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerTrustedIPSchema(CartographyNodeSchema):
+    label: str = "DopplerTrustedIP"
+    properties: DopplerTrustedIPNodeProperties = DopplerTrustedIPNodeProperties()
+    sub_resource_relationship: DopplerTrustedIPToWorkplaceRel = (
+        DopplerTrustedIPToWorkplaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DopplerTrustedIPToConfigRel()],
+    )

--- a/cartography/models/doppler/user.py
+++ b/cartography/models/doppler/user.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerWorkplaceUserNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    access: PropertyRef = PropertyRef("access")
+    email: PropertyRef = PropertyRef("email", extra_index=True)
+    name: PropertyRef = PropertyRef("name")
+    username: PropertyRef = PropertyRef("username")
+    profile_image_url: PropertyRef = PropertyRef("profile_image_url")
+    created_at: PropertyRef = PropertyRef("created_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerWorkplaceUserToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerWorkplaceUser)
+class DopplerWorkplaceUserToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerWorkplaceUserToWorkplaceRelProperties = (
+        DopplerWorkplaceUserToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerWorkplaceUserSchema(CartographyNodeSchema):
+    label: str = "DopplerWorkplaceUser"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        ["UserAccount"]
+    )  # UserAccount label is used for ontology mapping
+    properties: DopplerWorkplaceUserNodeProperties = (
+        DopplerWorkplaceUserNodeProperties()
+    )
+    sub_resource_relationship: DopplerWorkplaceUserToWorkplaceRel = (
+        DopplerWorkplaceUserToWorkplaceRel()
+    )

--- a/cartography/models/doppler/webhook.py
+++ b/cartography/models/doppler/webhook.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerWebhookNodeProperties(CartographyNodeProperties):
+    # The webhook `secret` field is intentionally never ingested.
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    url: PropertyRef = PropertyRef("url")
+    enabled: PropertyRef = PropertyRef("enabled")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerWebhookToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerWebhook)
+class DopplerWebhookToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerWebhookToWorkplaceRelProperties = (
+        DopplerWebhookToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerWebhookToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerProject)-[:HAS_WEBHOOK]->(:DopplerWebhook)
+class DopplerWebhookToProjectRel(CartographyRelSchema):
+    target_node_label: str = "DopplerProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"slug": PropertyRef("project")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_WEBHOOK"
+    properties: DopplerWebhookToProjectRelProperties = (
+        DopplerWebhookToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerWebhookSchema(CartographyNodeSchema):
+    label: str = "DopplerWebhook"
+    properties: DopplerWebhookNodeProperties = DopplerWebhookNodeProperties()
+    sub_resource_relationship: DopplerWebhookToWorkplaceRel = (
+        DopplerWebhookToWorkplaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DopplerWebhookToProjectRel()],
+    )

--- a/cartography/models/doppler/workplace.py
+++ b/cartography/models/doppler/workplace.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+
+
+@dataclass(frozen=True)
+class DopplerWorkplaceNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    billing_email: PropertyRef = PropertyRef("billing_email")
+    security_email: PropertyRef = PropertyRef("security_email")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerWorkplaceSchema(CartographyNodeSchema):
+    label: str = "DopplerWorkplace"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        ["Tenant"]
+    )  # Tenant label is used for ontology mapping
+    properties: DopplerWorkplaceNodeProperties = DopplerWorkplaceNodeProperties()

--- a/cartography/models/doppler/workplace_role.py
+++ b/cartography/models/doppler/workplace_role.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DopplerWorkplaceRoleNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("identifier")
+    name: PropertyRef = PropertyRef("name")
+    permissions: PropertyRef = PropertyRef("permissions")
+    is_custom_role: PropertyRef = PropertyRef("is_custom_role")
+    is_inline_role: PropertyRef = PropertyRef("is_inline_role")
+    created_at: PropertyRef = PropertyRef("created_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DopplerWorkplaceRoleToWorkplaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DopplerWorkplace)-[:RESOURCE]->(:DopplerWorkplaceRole)
+class DopplerWorkplaceRoleToWorkplaceRel(CartographyRelSchema):
+    target_node_label: str = "DopplerWorkplace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKPLACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DopplerWorkplaceRoleToWorkplaceRelProperties = (
+        DopplerWorkplaceRoleToWorkplaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DopplerWorkplaceRoleSchema(CartographyNodeSchema):
+    label: str = "DopplerWorkplaceRole"
+    properties: DopplerWorkplaceRoleNodeProperties = (
+        DopplerWorkplaceRoleNodeProperties()
+    )
+    sub_resource_relationship: DopplerWorkplaceRoleToWorkplaceRel = (
+        DopplerWorkplaceRoleToWorkplaceRel()
+    )

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -49,6 +49,7 @@ TOP_LEVEL_MODULES: OrderedDict[str, Callable[..., None]] = OrderedDict(
         "anthropic": _LazyStage(
             "cartography.intel.anthropic", "start_anthropic_ingestion"
         ),
+        "doppler": _LazyStage("cartography.intel.doppler", "start_doppler_ingestion"),
         "aws": _LazyStage("cartography.intel.aws", "start_aws_ingestion"),
         "azure": _LazyStage("cartography.intel.azure", "start_azure_ingestion"),
         "microsoft": _LazyStage(

--- a/docs/root/modules/doppler/config.md
+++ b/docs/root/modules/doppler/config.md
@@ -2,12 +2,21 @@
 
 Follow these steps to analyze Doppler objects with Cartography.
 
-1. Prepare your Doppler API token.
-    1. Create a token in the [Doppler Dashboard](https://dashboard.doppler.com/). A
-       **Personal token** or a **Service Account token** with read access to the
-       workplace works; the module only issues `GET` requests.
-    1. Populate an environment variable with the token. You can pass the environment
-       variable name via CLI with the `--doppler-apikey-env-var` parameter.
+1. Prepare your Doppler API token. The module only issues `GET` requests and needs
+   workplace-wide read access, so use one of:
+    - A **Personal token** (recommended, available on all plans): in the
+      [Doppler Dashboard](https://dashboard.doppler.com/) go to **Tokens** and create
+      a token under the **Personal** tab. It carries your account's read access to the
+      whole workplace.
+    - A **Service Account token** (requires a paid Team plan): create the service
+      account under **Team → Service Accounts**, give it a workplace role with read
+      access, then generate its API token.
+
+   Do not use a config-scoped **Service Token** (the "Service" tab under **Tokens**):
+   it only grants access to a single config's secrets and cannot list workplace
+   resources.
+1. Populate an environment variable with the token. You can pass the environment
+   variable name via CLI with the `--doppler-apikey-env-var` parameter.
 
 Example:
 

--- a/docs/root/modules/doppler/config.md
+++ b/docs/root/modules/doppler/config.md
@@ -1,0 +1,20 @@
+## Doppler Configuration
+
+Follow these steps to analyze Doppler objects with Cartography.
+
+1. Prepare your Doppler API token.
+    1. Create a token in the [Doppler Dashboard](https://dashboard.doppler.com/). A
+       **Personal token** or a **Service Account token** with read access to the
+       workplace works; the module only issues `GET` requests.
+    1. Populate an environment variable with the token. You can pass the environment
+       variable name via CLI with the `--doppler-apikey-env-var` parameter.
+
+Example:
+
+```bash
+export DOPPLER_TOKEN="dp.pt.xxxxxxxx"
+cartography --doppler-apikey-env-var DOPPLER_TOKEN
+```
+
+> **Note**: Cartography never ingests Doppler secret *values*. Only secret names are
+> stored, and webhook secrets are excluded.

--- a/docs/root/modules/doppler/index.md
+++ b/docs/root/modules/doppler/index.md
@@ -1,0 +1,6 @@
+# Doppler
+
+```{toctree}
+config
+schema
+```

--- a/docs/root/modules/doppler/schema.md
+++ b/docs/root/modules/doppler/schema.md
@@ -1,0 +1,400 @@
+## Doppler Schema
+
+```mermaid
+graph LR
+WP(DopplerWorkplace) -- RESOURCE --> P(DopplerProject)
+WP -- RESOURCE --> U(DopplerWorkplaceUser)
+WP -- RESOURCE --> G(DopplerGroup)
+WP -- RESOURCE --> SA(DopplerServiceAccount)
+WP -- RESOURCE --> WR(DopplerWorkplaceRole)
+WP -- RESOURCE --> PR(DopplerProjectRole)
+WP -- RESOURCE --> I(DopplerIntegration)
+P -- HAS_ENVIRONMENT --> E(DopplerEnvironment)
+P -- HAS_CONFIG --> C(DopplerConfig)
+P -- HAS_WEBHOOK --> WH(DopplerWebhook)
+C -- IN_ENVIRONMENT --> E
+C -- CONTAINS --> S(DopplerSecret)
+C -- HAS_TOKEN --> ST(DopplerServiceToken)
+C -- TRUSTS --> TIP(DopplerTrustedIP)
+SA -- HAS_TOKEN --> SAT(DopplerServiceAccountToken)
+SA -- HAS_IDENTITY --> SAI(DopplerServiceAccountIdentity)
+SA -- HAS_ROLE --> WR
+U -- MEMBER_OF --> G
+SY(DopplerSecretSync) -- USES --> I
+SY -- SYNCS --> C
+U -- MEMBER_OF --> P
+G -- MEMBER_OF --> P
+SA -- MEMBER_OF --> P
+```
+
+### DopplerWorkplace
+
+Represents a Doppler [workplace](https://docs.doppler.com/reference/workplace-get), the tenant root.
+
+> **Ontology Mapping**: This node has the extra label `Tenant` to enable cross-platform queries for organizational tenants across different systems.
+
+| Field | Description |
+|-------|-------------|
+| id | The workplace identifier |
+| name | The workplace name |
+| billing_email | Billing contact email |
+| security_email | Security contact email |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+- Resources belong to a `DopplerWorkplace`
+    ```
+    (DopplerWorkplace)-[:RESOURCE]->(
+        :DopplerProject,
+        :DopplerWorkplaceUser,
+        :DopplerGroup,
+        :DopplerServiceAccount,
+        :DopplerServiceAccountToken,
+        :DopplerServiceAccountIdentity,
+        :DopplerWorkplaceRole,
+        :DopplerProjectRole,
+        :DopplerEnvironment,
+        :DopplerConfig,
+        :DopplerSecret,
+        :DopplerServiceToken,
+        :DopplerTrustedIP,
+        :DopplerIntegration,
+        :DopplerSecretSync,
+        :DopplerWebhook)
+    ```
+
+### DopplerProject
+
+Represents a Doppler [project](https://docs.doppler.com/reference/projects-list).
+
+| Field | Description |
+|-------|-------------|
+| id | The project identifier |
+| slug | URL-friendly project name |
+| name | Display name |
+| description | Project description |
+| created_at | Creation timestamp |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+- A `DopplerProject` belongs to a workplace and contains environments, configs and webhooks.
+    ```
+    (DopplerWorkplace)-[:RESOURCE]->(DopplerProject)
+    (DopplerProject)-[:HAS_ENVIRONMENT]->(DopplerEnvironment)
+    (DopplerProject)-[:HAS_CONFIG]->(DopplerConfig)
+    (DopplerProject)-[:HAS_WEBHOOK]->(DopplerWebhook)
+    ```
+- Workplace users, groups and service accounts are members of projects (with the project role on the edge).
+    ```
+    (:DopplerWorkplaceUser)-[:MEMBER_OF]->(:DopplerProject)
+    (:DopplerGroup)-[:MEMBER_OF]->(:DopplerProject)
+    (:DopplerServiceAccount)-[:MEMBER_OF]->(:DopplerProject)
+    ```
+
+### DopplerEnvironment
+
+Represents a Doppler [environment](https://docs.doppler.com/reference/environments-list) within a project.
+
+| Field | Description |
+|-------|-------------|
+| id | Composite `{project}/{env_id}` identifier |
+| env_id | The per-project environment slug (e.g. `dev`) |
+| name | Display name |
+| project | Owning project slug |
+| created_at | Creation timestamp |
+| initial_fetch_at | First fetch timestamp (nullable) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+    ```
+    (DopplerProject)-[:HAS_ENVIRONMENT]->(DopplerEnvironment)
+    (DopplerConfig)-[:IN_ENVIRONMENT]->(DopplerEnvironment)
+    ```
+
+### DopplerConfig
+
+Represents a Doppler [config](https://docs.doppler.com/reference/configs-list).
+
+| Field | Description |
+|-------|-------------|
+| id | Composite `{project}/{name}` identifier |
+| name | Config name |
+| project | Owning project slug |
+| environment | Environment slug |
+| root | Whether this is a root config |
+| locked | Whether the config is locked |
+| created_at | Creation timestamp |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+    ```
+    (DopplerProject)-[:HAS_CONFIG]->(DopplerConfig)
+    (DopplerConfig)-[:IN_ENVIRONMENT]->(DopplerEnvironment)
+    (DopplerConfig)-[:CONTAINS]->(DopplerSecret)
+    (DopplerConfig)-[:HAS_TOKEN]->(DopplerServiceToken)
+    (DopplerConfig)-[:TRUSTS]->(DopplerTrustedIP)
+    (DopplerSecretSync)-[:SYNCS]->(DopplerConfig)
+    ```
+
+### DopplerSecret
+
+Represents the *name* of a Doppler [secret](https://docs.doppler.com/reference/secrets-list). **Secret values (raw/computed) are never ingested.**
+
+> **Ontology Mapping**: This node has the extra label `Secret`.
+
+| Field | Description |
+|-------|-------------|
+| id | Composite `{project}/{config}/{name}` identifier |
+| name | The secret name (key) |
+| project | Owning project slug |
+| config | Owning config name |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+    ```
+    (DopplerConfig)-[:CONTAINS]->(DopplerSecret)
+    ```
+
+### DopplerServiceToken
+
+Represents a config-scoped [service token](https://docs.doppler.com/reference/service_tokens-list) that can read a config's secrets.
+
+| Field | Description |
+|-------|-------------|
+| id | The token slug |
+| name | Token name |
+| project | Owning project slug |
+| environment | Environment slug |
+| config | Owning config name |
+| created_at | Creation timestamp |
+| expires_at | Expiration timestamp (nullable) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+    ```
+    (DopplerConfig)-[:HAS_TOKEN]->(DopplerServiceToken)
+    ```
+
+### DopplerTrustedIP
+
+Represents an IP/CIDR entry in a config's [trusted IPs](https://docs.doppler.com/reference/configs-list_trusted_ips) allowlist.
+
+| Field | Description |
+|-------|-------------|
+| id | Composite `{project}/{config}/{cidr}` identifier |
+| cidr | The trusted IP address or CIDR range |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+    ```
+    (DopplerConfig)-[:TRUSTS]->(DopplerTrustedIP)
+    ```
+
+### DopplerWorkplaceUser
+
+Represents a [member](https://docs.doppler.com/reference/users-list) of a workplace.
+
+> **Ontology Mapping**: This node has the extra label `UserAccount` to enable cross-platform queries for user accounts across different systems.
+
+| Field | Description |
+|-------|-------------|
+| id | The workplace user identifier |
+| access | Access level (e.g. `owner`, `collaborator`) |
+| email | User email |
+| name | User full name |
+| username | Username handle |
+| profile_image_url | Avatar URL |
+| created_at | When the user was added |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+    ```
+    (DopplerWorkplace)-[:RESOURCE]->(DopplerWorkplaceUser)
+    (DopplerWorkplaceUser)-[:MEMBER_OF]->(DopplerGroup)
+    (DopplerWorkplaceUser)-[:MEMBER_OF]->(DopplerProject)
+    ```
+
+### DopplerGroup
+
+Represents a workplace [group](https://docs.doppler.com/reference/groups-list).
+
+| Field | Description |
+|-------|-------------|
+| id | The group slug |
+| name | Group name |
+| created_at | Creation timestamp |
+| default_project_role | Default project role identifier for members |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+    ```
+    (DopplerWorkplace)-[:RESOURCE]->(DopplerGroup)
+    (DopplerWorkplaceUser)-[:MEMBER_OF]->(DopplerGroup)
+    (DopplerGroup)-[:MEMBER_OF]->(DopplerProject)
+    ```
+
+### DopplerServiceAccount
+
+Represents a workplace [service account](https://docs.doppler.com/reference/service_accounts-list) (machine identity).
+
+| Field | Description |
+|-------|-------------|
+| id | The service account slug |
+| name | Service account name |
+| created_at | Creation timestamp |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+    ```
+    (DopplerWorkplace)-[:RESOURCE]->(DopplerServiceAccount)
+    (DopplerServiceAccount)-[:HAS_ROLE]->(DopplerWorkplaceRole)
+    (DopplerServiceAccount)-[:HAS_TOKEN]->(DopplerServiceAccountToken)
+    (DopplerServiceAccount)-[:HAS_IDENTITY]->(DopplerServiceAccountIdentity)
+    (DopplerServiceAccount)-[:MEMBER_OF]->(DopplerProject)
+    ```
+
+### DopplerServiceAccountToken
+
+Represents an API [token](https://docs.doppler.com/reference/service_account_tokens-list) belonging to a service account.
+
+| Field | Description |
+|-------|-------------|
+| id | The token slug |
+| name | Token name |
+| created_at | Creation timestamp |
+| expires_at | Expiration timestamp (nullable) |
+| last_seen_at | Last usage timestamp (nullable) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+    ```
+    (DopplerServiceAccount)-[:HAS_TOKEN]->(DopplerServiceAccountToken)
+    ```
+
+### DopplerServiceAccountIdentity
+
+Represents a federated [identity](https://docs.doppler.com/reference/list) (e.g. OIDC) attached to a service account.
+
+| Field | Description |
+|-------|-------------|
+| id | The identity slug |
+| name | Identity name |
+| method | Authentication method |
+| ttl_seconds | Token lifetime |
+| created_at | Creation timestamp |
+| last_seen_at | Last usage timestamp (nullable) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+    ```
+    (DopplerServiceAccount)-[:HAS_IDENTITY]->(DopplerServiceAccountIdentity)
+    ```
+
+### DopplerWorkplaceRole
+
+Represents a workplace-level [role](https://docs.doppler.com/reference/workplace_roles-list).
+
+| Field | Description |
+|-------|-------------|
+| id | The role identifier |
+| name | Role name |
+| permissions | List of permission strings |
+| is_custom_role | Whether the role is custom |
+| is_inline_role | Whether the role is inline |
+| created_at | Creation timestamp |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+    ```
+    (DopplerWorkplace)-[:RESOURCE]->(DopplerWorkplaceRole)
+    (DopplerServiceAccount)-[:HAS_ROLE]->(DopplerWorkplaceRole)
+    ```
+
+### DopplerProjectRole
+
+Represents a project-level [role](https://docs.doppler.com/reference/project_roles-list).
+
+| Field | Description |
+|-------|-------------|
+| id | The role identifier |
+| name | Role name |
+| permissions | List of permission strings |
+| is_custom_role | Whether the role is custom |
+| created_at | Creation timestamp |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+    ```
+    (DopplerWorkplace)-[:RESOURCE]->(DopplerProjectRole)
+    ```
+
+### DopplerIntegration
+
+Represents a Doppler [integration](https://docs.doppler.com/reference/integrations-list).
+
+| Field | Description |
+|-------|-------------|
+| id | The integration slug |
+| name | Integration name |
+| type | Integration service type (e.g. `aws_secrets_manager`) |
+| kind | `sync` or `rotatedSecrets` |
+| enabled | Whether the integration is enabled |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+    ```
+    (DopplerWorkplace)-[:RESOURCE]->(DopplerIntegration)
+    (DopplerSecretSync)-[:USES]->(DopplerIntegration)
+    ```
+
+### DopplerSecretSync
+
+Represents a secret sync that pushes a config's secrets to an integration.
+
+| Field | Description |
+|-------|-------------|
+| id | The sync slug |
+| enabled | Whether the sync is enabled |
+| last_synced_at | Last successful sync timestamp |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+    ```
+    (DopplerWorkplace)-[:RESOURCE]->(DopplerSecretSync)
+    (DopplerSecretSync)-[:USES]->(DopplerIntegration)
+    (DopplerSecretSync)-[:SYNCS]->(DopplerConfig)
+    ```
+
+### DopplerWebhook
+
+Represents a project [webhook](https://docs.doppler.com/reference/webhooks-list). **The webhook secret is never ingested.**
+
+| Field | Description |
+|-------|-------------|
+| id | The webhook identifier |
+| name | Webhook name |
+| url | Webhook URL |
+| enabled | Whether the webhook is enabled |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+    ```
+    (DopplerProject)-[:HAS_WEBHOOK]->(DopplerWebhook)
+    ```

--- a/docs/root/usage/schema.md
+++ b/docs/root/usage/schema.md
@@ -63,6 +63,9 @@
 ```{include} ../modules/docker_scout/schema.md
 ```
 
+```{include} ../modules/doppler/schema.md
+```
+
 ```{include} ../modules/duo/schema.md
 ```
 

--- a/tests/data/doppler/doppler.py
+++ b/tests/data/doppler/doppler.py
@@ -1,0 +1,216 @@
+"""Test fixtures for the Doppler intel module.
+
+Each constant is shaped like the corresponding `get()` return value so tests can
+patch `get` and exercise transform + load. Secret fixtures contain NAMES only,
+mirroring the module's hard rule against ingesting secret values.
+"""
+
+WORKPLACE = {
+    "id": "wp1",
+    "name": "Acme",
+    "billing_email": "billing@acme.io",
+    "security_email": "security@acme.io",
+}
+
+# get() returns (workplace_roles, project_roles)
+WORKPLACE_ROLES = [
+    {
+        "identifier": "admin",
+        "name": "Admin",
+        "permissions": ["workplace_admin"],
+        "is_custom_role": False,
+        "is_inline_role": False,
+        "created_at": "2024-01-01T00:00:00Z",
+    },
+]
+PROJECT_ROLES = [
+    {
+        "identifier": "collaborator",
+        "name": "Collaborator",
+        "permissions": ["project_config_logs"],
+        "is_custom_role": False,
+        "created_at": "2024-01-01T00:00:00Z",
+    },
+]
+
+# Raw /workplace/users shape (nested user object); transform() flattens it.
+USERS = [
+    {
+        "id": "u1",
+        "access": "owner",
+        "created_at": "2024-01-02T00:00:00Z",
+        "user": {
+            "email": "alice@acme.io",
+            "name": "Alice",
+            "username": "alice",
+            "profile_image_url": "https://img/alice",
+        },
+    },
+]
+
+# get() returns (groups_raw, memberships)
+GROUPS = [
+    {
+        "slug": "g1",
+        "name": "Engineering",
+        "created_at": "2024-01-03T00:00:00Z",
+        "default_project_role": {"identifier": "collaborator"},
+    },
+]
+GROUP_MEMBERSHIPS = [{"user_id": "u1", "group_slug": "g1"}]
+
+# get() returns (accounts_raw, tokens, identities)
+SERVICE_ACCOUNTS = [
+    {
+        "slug": "sa1",
+        "name": "ci-bot",
+        "created_at": "2024-01-04T00:00:00Z",
+        "workplace_role": {"identifier": "admin"},
+    },
+]
+SERVICE_ACCOUNT_TOKENS = [
+    {
+        "slug": "sat1",
+        "name": "deploy-token",
+        "created_at": "2024-01-05T00:00:00Z",
+        "expires_at": None,
+        "last_seen_at": "2024-02-01T00:00:00Z",
+        "service_account_slug": "sa1",
+    },
+]
+SERVICE_ACCOUNT_IDENTITIES = [
+    {
+        "slug": "sai1",
+        "name": "github-oidc",
+        "method": "oidc",
+        "ttl_seconds": 3600,
+        "created_at": "2024-01-06T00:00:00Z",
+        "last_seen_at": "2024-02-02T00:00:00Z",
+        "service_account_slug": "sa1",
+    },
+]
+
+PROJECTS = [
+    {
+        "id": "p1",
+        "slug": "backend",
+        "name": "Backend",
+        "description": "Backend services",
+        "created_at": "2024-01-07T00:00:00Z",
+    },
+]
+
+# environments.get() output (composite ids already built)
+ENVIRONMENTS = [
+    {
+        "id": "backend/dev",
+        "env_id": "dev",
+        "name": "Development",
+        "project": "backend",
+        "created_at": "2024-01-08T00:00:00Z",
+        "initial_fetch_at": None,
+    },
+]
+
+# configs.get() output (full config dicts with composite ids)
+CONFIGS = [
+    {
+        "name": "dev",
+        "project": "backend",
+        "environment": "dev",
+        "root": True,
+        "locked": False,
+        "created_at": "2024-01-09T00:00:00Z",
+        "id": "backend/dev",
+        "environment_id": "backend/dev",
+    },
+]
+# configs.sync() return value (refs reused by per-config fan-out)
+CONFIG_REFS = [{"project": "backend", "config": "dev", "config_id": "backend/dev"}]
+
+# Secret NAMES only.
+SECRETS = [
+    {
+        "id": "backend/dev/DATABASE_URL",
+        "name": "DATABASE_URL",
+        "project": "backend",
+        "config": "dev",
+        "config_id": "backend/dev",
+    },
+]
+
+SERVICE_TOKENS = [
+    {
+        "slug": "st1",
+        "name": "lambda-token",
+        "project": "backend",
+        "environment": "dev",
+        "config": "dev",
+        "created_at": "2024-01-10T00:00:00Z",
+        "expires_at": None,
+        "config_id": "backend/dev",
+    },
+]
+
+TRUSTED_IPS = [
+    {"id": "backend/dev/10.0.0.0/8", "cidr": "10.0.0.0/8", "config_id": "backend/dev"},
+]
+
+# Raw /integrations shape with embedded syncs; transform() lifts the syncs out.
+INTEGRATIONS = [
+    {
+        "slug": "int1",
+        "name": "AWS Secrets Manager",
+        "type": "aws_secrets_manager",
+        "kind": "sync",
+        "enabled": True,
+        "syncs": [
+            {
+                "slug": "sync1",
+                "enabled": True,
+                "lastSyncedAt": "2024-02-03T00:00:00Z",
+                "project": "backend",
+                "config": "dev",
+                "integration": "int1",
+            },
+        ],
+    },
+]
+
+WEBHOOKS = [
+    {
+        "id": "wh1",
+        "name": "Slack notifier",
+        "url": "https://hooks.slack.com/services/xxx",
+        "enabled": True,
+        "project": "backend",
+    },
+]
+
+# members.get() output: member records grouped by type.
+PROJECT_MEMBERS = {
+    "workplace_user": [
+        {
+            "slug": "u1",
+            "project": "backend",
+            "role": "collaborator",
+            "access_all_environments": True,
+        },
+    ],
+    "group": [
+        {
+            "slug": "g1",
+            "project": "backend",
+            "role": "viewer",
+            "access_all_environments": False,
+        },
+    ],
+    "service_account": [
+        {
+            "slug": "sa1",
+            "project": "backend",
+            "role": "admin",
+            "access_all_environments": True,
+        },
+    ],
+}

--- a/tests/integration/cartography/intel/doppler/test_hierarchy.py
+++ b/tests/integration/cartography/intel/doppler/test_hierarchy.py
@@ -1,0 +1,146 @@
+from unittest.mock import patch
+
+import requests
+
+import cartography.intel.doppler.configs
+import cartography.intel.doppler.environments
+import cartography.intel.doppler.projects
+import cartography.intel.doppler.secrets
+import cartography.intel.doppler.service_tokens
+import cartography.intel.doppler.trusted_ips
+import cartography.intel.doppler.workplace
+import tests.data.doppler.doppler as data
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_WORKPLACE_ID = "wp1"
+
+
+def _common():
+    return {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "BASE_URL": "https://api.doppler.com/v3",
+        "WORKPLACE_ID": TEST_WORKPLACE_ID,
+    }
+
+
+@patch.object(
+    cartography.intel.doppler.trusted_ips, "get", return_value=data.TRUSTED_IPS
+)
+@patch.object(
+    cartography.intel.doppler.service_tokens, "get", return_value=data.SERVICE_TOKENS
+)
+@patch.object(cartography.intel.doppler.secrets, "get", return_value=data.SECRETS)
+@patch.object(cartography.intel.doppler.configs, "get", return_value=data.CONFIGS)
+@patch.object(
+    cartography.intel.doppler.environments, "get", return_value=data.ENVIRONMENTS
+)
+@patch.object(cartography.intel.doppler.projects, "get", return_value=data.PROJECTS)
+@patch.object(cartography.intel.doppler.workplace, "get", return_value=data.WORKPLACE)
+def test_doppler_hierarchy(
+    mock_wp, mock_proj, mock_env, mock_conf, mock_sec, mock_tok, mock_ip, neo4j_session
+):
+    # Arrange
+    api_session = requests.Session()
+    common = _common()
+
+    # Act
+    workplace_id = cartography.intel.doppler.workplace.sync(
+        neo4j_session, api_session, common
+    )
+    assert workplace_id == TEST_WORKPLACE_ID
+    project_slugs = cartography.intel.doppler.projects.sync(
+        neo4j_session, api_session, common
+    )
+    cartography.intel.doppler.environments.sync(
+        neo4j_session, api_session, project_slugs, common
+    )
+    configs = cartography.intel.doppler.configs.sync(
+        neo4j_session, api_session, project_slugs, common
+    )
+    cartography.intel.doppler.secrets.sync(neo4j_session, api_session, configs, common)
+    cartography.intel.doppler.service_tokens.sync(
+        neo4j_session, api_session, configs, common
+    )
+    cartography.intel.doppler.trusted_ips.sync(
+        neo4j_session, api_session, configs, common
+    )
+
+    # Assert: tenant root
+    assert check_nodes(neo4j_session, "DopplerWorkplace", ["id", "name"]) == {
+        ("wp1", "Acme")
+    }
+
+    # Assert: project -> RESOURCE -> workplace
+    assert check_rels(
+        neo4j_session,
+        "DopplerProject",
+        "id",
+        "DopplerWorkplace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {("p1", "wp1")}
+
+    # Assert: config in environment, config belongs to project
+    assert check_rels(
+        neo4j_session,
+        "DopplerProject",
+        "slug",
+        "DopplerConfig",
+        "id",
+        "HAS_CONFIG",
+        rel_direction_right=True,
+    ) == {("backend", "backend/dev")}
+    assert check_rels(
+        neo4j_session,
+        "DopplerConfig",
+        "id",
+        "DopplerEnvironment",
+        "id",
+        "IN_ENVIRONMENT",
+        rel_direction_right=True,
+    ) == {("backend/dev", "backend/dev")}
+
+    # Assert: secret name (no value) contained in config
+    assert check_nodes(neo4j_session, "DopplerSecret", ["id", "name"]) == {
+        ("backend/dev/DATABASE_URL", "DATABASE_URL")
+    }
+    assert check_rels(
+        neo4j_session,
+        "DopplerConfig",
+        "id",
+        "DopplerSecret",
+        "id",
+        "CONTAINS",
+        rel_direction_right=True,
+    ) == {("backend/dev", "backend/dev/DATABASE_URL")}
+
+    # Assert: service token + trusted ip on config
+    assert check_rels(
+        neo4j_session,
+        "DopplerConfig",
+        "id",
+        "DopplerServiceToken",
+        "id",
+        "HAS_TOKEN",
+        rel_direction_right=True,
+    ) == {("backend/dev", "st1")}
+    assert check_rels(
+        neo4j_session,
+        "DopplerConfig",
+        "id",
+        "DopplerTrustedIP",
+        "id",
+        "TRUSTS",
+        rel_direction_right=True,
+    ) == {("backend/dev", "backend/dev/10.0.0.0/8")}
+
+
+def test_doppler_secret_has_no_value():
+    # Guard: the secret model must never expose a raw/computed value property.
+    from cartography.models.doppler.secret import DopplerSecretNodeProperties
+
+    prop_names = set(vars(DopplerSecretNodeProperties()))
+    assert not prop_names & {"raw", "computed", "value"}

--- a/tests/integration/cartography/intel/doppler/test_hierarchy.py
+++ b/tests/integration/cartography/intel/doppler/test_hierarchy.py
@@ -26,12 +26,16 @@ def _common():
 
 
 @patch.object(
-    cartography.intel.doppler.trusted_ips, "get", return_value=data.TRUSTED_IPS
+    cartography.intel.doppler.trusted_ips, "get", return_value=(data.TRUSTED_IPS, True)
 )
 @patch.object(
-    cartography.intel.doppler.service_tokens, "get", return_value=data.SERVICE_TOKENS
+    cartography.intel.doppler.service_tokens,
+    "get",
+    return_value=(data.SERVICE_TOKENS, True),
 )
-@patch.object(cartography.intel.doppler.secrets, "get", return_value=data.SECRETS)
+@patch.object(
+    cartography.intel.doppler.secrets, "get", return_value=(data.SECRETS, True)
+)
 @patch.object(cartography.intel.doppler.configs, "get", return_value=data.CONFIGS)
 @patch.object(
     cartography.intel.doppler.environments, "get", return_value=data.ENVIRONMENTS

--- a/tests/integration/cartography/intel/doppler/test_identities.py
+++ b/tests/integration/cartography/intel/doppler/test_identities.py
@@ -1,0 +1,155 @@
+from unittest.mock import patch
+
+import requests
+
+import cartography.intel.doppler.groups
+import cartography.intel.doppler.members
+import cartography.intel.doppler.projects
+import cartography.intel.doppler.roles
+import cartography.intel.doppler.service_accounts
+import cartography.intel.doppler.users
+import cartography.intel.doppler.workplace
+import tests.data.doppler.doppler as data
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_WORKPLACE_ID = "wp1"
+
+
+def _common():
+    return {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "BASE_URL": "https://api.doppler.com/v3",
+        "WORKPLACE_ID": TEST_WORKPLACE_ID,
+    }
+
+
+@patch.object(
+    cartography.intel.doppler.members,
+    "get",
+    return_value=data.PROJECT_MEMBERS,
+)
+@patch.object(
+    cartography.intel.doppler.service_accounts,
+    "get",
+    return_value=(
+        data.SERVICE_ACCOUNTS,
+        data.SERVICE_ACCOUNT_TOKENS,
+        data.SERVICE_ACCOUNT_IDENTITIES,
+    ),
+)
+@patch.object(
+    cartography.intel.doppler.groups,
+    "get",
+    return_value=(data.GROUPS, data.GROUP_MEMBERSHIPS),
+)
+@patch.object(cartography.intel.doppler.users, "get", return_value=data.USERS)
+@patch.object(
+    cartography.intel.doppler.roles,
+    "get",
+    return_value=(data.WORKPLACE_ROLES, data.PROJECT_ROLES),
+)
+@patch.object(cartography.intel.doppler.projects, "get", return_value=data.PROJECTS)
+@patch.object(cartography.intel.doppler.workplace, "get", return_value=data.WORKPLACE)
+def test_doppler_identities(
+    mock_wp,
+    mock_proj,
+    mock_roles,
+    mock_users,
+    mock_groups,
+    mock_sa,
+    mock_members,
+    neo4j_session,
+):
+    # Arrange
+    api_session = requests.Session()
+    common = _common()
+
+    # Act
+    cartography.intel.doppler.workplace.sync(neo4j_session, api_session, common)
+    project_slugs = cartography.intel.doppler.projects.sync(
+        neo4j_session, api_session, common
+    )
+    cartography.intel.doppler.roles.sync(neo4j_session, api_session, common)
+    cartography.intel.doppler.users.sync(neo4j_session, api_session, common)
+    cartography.intel.doppler.groups.sync(neo4j_session, api_session, common)
+    cartography.intel.doppler.service_accounts.sync(neo4j_session, api_session, common)
+    cartography.intel.doppler.members.sync(
+        neo4j_session, api_session, project_slugs, common
+    )
+
+    # Assert: user flattened + UserAccount label + RESOURCE edge
+    assert check_nodes(neo4j_session, "DopplerWorkplaceUser", ["id", "email"]) == {
+        ("u1", "alice@acme.io")
+    }
+    assert check_nodes(neo4j_session, "UserAccount", ["id"]) >= {("u1",)}
+
+    # Assert: user MEMBER_OF group
+    assert check_rels(
+        neo4j_session,
+        "DopplerWorkplaceUser",
+        "id",
+        "DopplerGroup",
+        "id",
+        "MEMBER_OF",
+        rel_direction_right=True,
+    ) == {("u1", "g1")}
+
+    # Assert: service account HAS_ROLE workplace role, HAS_TOKEN, HAS_IDENTITY
+    assert check_rels(
+        neo4j_session,
+        "DopplerServiceAccount",
+        "id",
+        "DopplerWorkplaceRole",
+        "id",
+        "HAS_ROLE",
+        rel_direction_right=True,
+    ) == {("sa1", "admin")}
+    assert check_rels(
+        neo4j_session,
+        "DopplerServiceAccount",
+        "id",
+        "DopplerServiceAccountToken",
+        "id",
+        "HAS_TOKEN",
+        rel_direction_right=True,
+    ) == {("sa1", "sat1")}
+    assert check_rels(
+        neo4j_session,
+        "DopplerServiceAccount",
+        "id",
+        "DopplerServiceAccountIdentity",
+        "id",
+        "HAS_IDENTITY",
+        rel_direction_right=True,
+    ) == {("sa1", "sai1")}
+
+    # Assert: project membership MatchLinks for all three member types
+    assert check_rels(
+        neo4j_session,
+        "DopplerWorkplaceUser",
+        "id",
+        "DopplerProject",
+        "slug",
+        "MEMBER_OF",
+        rel_direction_right=True,
+    ) == {("u1", "backend")}
+    assert check_rels(
+        neo4j_session,
+        "DopplerGroup",
+        "id",
+        "DopplerProject",
+        "slug",
+        "MEMBER_OF",
+        rel_direction_right=True,
+    ) == {("g1", "backend")}
+    assert check_rels(
+        neo4j_session,
+        "DopplerServiceAccount",
+        "id",
+        "DopplerProject",
+        "slug",
+        "MEMBER_OF",
+        rel_direction_right=True,
+    ) == {("sa1", "backend")}

--- a/tests/integration/cartography/intel/doppler/test_identities.py
+++ b/tests/integration/cartography/intel/doppler/test_identities.py
@@ -42,7 +42,7 @@ def _common():
 @patch.object(
     cartography.intel.doppler.groups,
     "get",
-    return_value=(data.GROUPS, data.GROUP_MEMBERSHIPS),
+    return_value=(data.GROUPS, data.GROUP_MEMBERSHIPS, True),
 )
 @patch.object(cartography.intel.doppler.users, "get", return_value=data.USERS)
 @patch.object(

--- a/tests/integration/cartography/intel/doppler/test_integrations.py
+++ b/tests/integration/cartography/intel/doppler/test_integrations.py
@@ -1,0 +1,95 @@
+from unittest.mock import patch
+
+import requests
+
+import cartography.intel.doppler.configs
+import cartography.intel.doppler.integrations
+import cartography.intel.doppler.projects
+import cartography.intel.doppler.webhooks
+import cartography.intel.doppler.workplace
+import tests.data.doppler.doppler as data
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_WORKPLACE_ID = "wp1"
+
+
+def _common():
+    return {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "BASE_URL": "https://api.doppler.com/v3",
+        "WORKPLACE_ID": TEST_WORKPLACE_ID,
+    }
+
+
+@patch.object(cartography.intel.doppler.webhooks, "get", return_value=data.WEBHOOKS)
+@patch.object(
+    cartography.intel.doppler.integrations, "get", return_value=data.INTEGRATIONS
+)
+@patch.object(cartography.intel.doppler.configs, "get", return_value=data.CONFIGS)
+@patch.object(cartography.intel.doppler.projects, "get", return_value=data.PROJECTS)
+@patch.object(cartography.intel.doppler.workplace, "get", return_value=data.WORKPLACE)
+def test_doppler_integrations_and_webhooks(
+    mock_wp, mock_proj, mock_conf, mock_int, mock_wh, neo4j_session
+):
+    # Arrange
+    api_session = requests.Session()
+    common = _common()
+
+    # Act: configs must exist so the secret sync SYNCS edge can resolve.
+    cartography.intel.doppler.workplace.sync(neo4j_session, api_session, common)
+    project_slugs = cartography.intel.doppler.projects.sync(
+        neo4j_session, api_session, common
+    )
+    cartography.intel.doppler.configs.sync(
+        neo4j_session, api_session, project_slugs, common
+    )
+    cartography.intel.doppler.integrations.sync(neo4j_session, api_session, common)
+    cartography.intel.doppler.webhooks.sync(
+        neo4j_session, api_session, project_slugs, common
+    )
+
+    # Assert: integration node + RESOURCE edge
+    assert check_nodes(neo4j_session, "DopplerIntegration", ["id", "type"]) == {
+        ("int1", "aws_secrets_manager")
+    }
+
+    # Assert: the camelCase lastSyncedAt is mapped onto the node
+    assert check_nodes(
+        neo4j_session, "DopplerSecretSync", ["id", "last_synced_at"]
+    ) == {("sync1", "2024-02-03T00:00:00Z")}
+
+    # Assert: secret sync USES integration and SYNCS config
+    assert check_rels(
+        neo4j_session,
+        "DopplerSecretSync",
+        "id",
+        "DopplerIntegration",
+        "id",
+        "USES",
+        rel_direction_right=True,
+    ) == {("sync1", "int1")}
+    assert check_rels(
+        neo4j_session,
+        "DopplerSecretSync",
+        "id",
+        "DopplerConfig",
+        "id",
+        "SYNCS",
+        rel_direction_right=True,
+    ) == {("sync1", "backend/dev")}
+
+    # Assert: webhook has no secret property and is linked to its project
+    assert check_nodes(neo4j_session, "DopplerWebhook", ["id", "url"]) == {
+        ("wh1", "https://hooks.slack.com/services/xxx")
+    }
+    assert check_rels(
+        neo4j_session,
+        "DopplerProject",
+        "slug",
+        "DopplerWebhook",
+        "id",
+        "HAS_WEBHOOK",
+        rel_direction_right=True,
+    ) == {("backend", "wh1")}

--- a/tests/unit/cartography/intel/doppler/test_per_config.py
+++ b/tests/unit/cartography/intel/doppler/test_per_config.py
@@ -1,0 +1,56 @@
+from unittest.mock import Mock
+
+import requests
+
+import cartography.intel.doppler.secrets as secrets
+
+CONFIGS = [
+    {"project": "backend", "config": "dev", "config_id": "backend/dev"},
+    {"project": "backend", "config": "prd", "config_id": "backend/prd"},
+]
+
+
+def _ok(body):
+    resp = Mock()
+    resp.raise_for_status = Mock()
+    resp.json = Mock(return_value=body)
+    return resp
+
+
+def _fail():
+    resp = Mock()
+    resp.raise_for_status = Mock(side_effect=requests.exceptions.HTTPError("404"))
+    return resp
+
+
+def test_get_complete_when_a_config_succeeds():
+    session = Mock()
+    session.get = Mock(side_effect=[_ok({"names": ["DB_URL"]}), _fail()])
+    items, complete = secrets.get(session, "http://x", CONFIGS)
+    # One config succeeded -> trustworthy enough to clean up stale secrets.
+    assert complete is True
+    assert items == [
+        {
+            "id": "backend/dev/DB_URL",
+            "name": "DB_URL",
+            "project": "backend",
+            "config": "dev",
+            "config_id": "backend/dev",
+        }
+    ]
+
+
+def test_get_incomplete_when_all_configs_fail():
+    session = Mock()
+    session.get = Mock(side_effect=[_fail(), _fail()])
+    items, complete = secrets.get(session, "http://x", CONFIGS)
+    # Every config failed -> [] is "couldn't see them", cleanup must be skipped.
+    assert items == []
+    assert complete is False
+
+
+def test_get_complete_when_no_configs():
+    # No configs at all is a legitimate empty result; cleanup should still run.
+    items, complete = secrets.get(Mock(), "http://x", [])
+    assert items == []
+    assert complete is True

--- a/tests/unit/cartography/intel/doppler/test_util.py
+++ b/tests/unit/cartography/intel/doppler/test_util.py
@@ -1,0 +1,40 @@
+from unittest.mock import Mock
+
+import pytest
+
+from cartography.intel.doppler.util import paginated_get
+
+
+def _session(pages):
+    """Build a fake requests.Session whose .get() returns the given page bodies in order."""
+    responses = []
+    for body in pages:
+        resp = Mock()
+        resp.raise_for_status = Mock()
+        resp.json = Mock(return_value=body)
+        responses.append(resp)
+    session = Mock()
+    session.get = Mock(side_effect=responses)
+    return session
+
+
+def test_paginated_get_single_page():
+    session = _session([{"projects": [{"slug": "a"}, {"slug": "b"}]}])
+    assert paginated_get(session, "http://x/projects", "projects") == [
+        {"slug": "a"},
+        {"slug": "b"},
+    ]
+
+
+def test_paginated_get_empty_list_is_ok():
+    # An explicitly empty list is a valid "no items" response, not an error.
+    session = _session([{"projects": []}])
+    assert paginated_get(session, "http://x/projects", "projects") == []
+
+
+def test_paginated_get_missing_key_raises():
+    # A response missing the expected key must fail fast rather than silently
+    # returning [] (which would let cleanup delete a populated node type).
+    session = _session([{"unexpected": []}])
+    with pytest.raises(ValueError, match="missing the expected 'projects' key"):
+        paginated_get(session, "http://x/projects", "projects")


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary

Adds a new intel module that inventories a [Doppler](https://docs.doppler.com/reference/api) workplace (the tenant root) and the resources under it, giving the graph cross-provider visibility into "who and what can read which secrets".

Modeled nodes (all hang off `DopplerWorkplace` via `RESOURCE`):

- **Hierarchy**: `DopplerProject` → `DopplerEnvironment` / `DopplerConfig`; `DopplerConfig` → `DopplerSecret` (names only), `DopplerServiceToken`, `DopplerTrustedIP`.
- **Identity & access**: `DopplerWorkplaceUser` (`UserAccount`), `DopplerGroup`, `DopplerServiceAccount` (+ `DopplerServiceAccountToken` / `DopplerServiceAccountIdentity`), `DopplerWorkplaceRole`, `DopplerProjectRole`.
- **Outbound**: `DopplerIntegration`, `DopplerSecretSync`, `DopplerWebhook`.
- **Membership** is modeled as `MEMBER_OF` edges: user→group, and user/group/service-account→project (with the role carried on the edge).

The module is wired into the top-level sync, `Config`, and the CLI via `--doppler-apikey-env-var`.

**Security note:** Doppler secret *values* are never ingested. The module uses the `/configs/config/secrets/names` endpoint (names only) and excludes webhook secrets and any token secret material.

### Related issues or links



### How was this tested?

- New integration tests under `tests/integration/cartography/intel/doppler/` covering the project→config→secret chain, config→service-token/trusted-IP edges, user/group/service-account project membership MatchLinks, service-account tokens/identities/role, and integration→secret-sync→config edges. All pass against a local Neo4j.
- A guard test asserts the secret model exposes no `raw`/`computed`/`value` property.
- `make test_lint` passes locally.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the schema documentation.

#### If you are implementing a new intel module
- [x] Used the NodeSchema data model.

### Notes for reviewers

A few endpoint response shapes were inferred from the Doppler reference where the public OpenAPI page omitted exact bodies (e.g. some list wrapper keys). Worth a sanity check against a real workplace; I have not yet attached real sync logs.