### PR TITLE
fix(github): Normalize GitHub PAT ontology timestamps

### DIFF
--- a/.agents/skills/enrich-ontology/SKILL.md
+++ b/.agents/skills/enrich-ontology/SKILL.md
@@ -16,7 +16,7 @@ Most modules only need semantic labels.
 
 1. **Mark primary identifiers `required=True`** in `OntologyFieldMapping` (e.g. `email` for `User`, `hostname` for `Device`). Records missing these are excluded from ontology node creation.
 2. **For semantic labels, just add `ExtraNodeLabels(["UserAccount"])`** to your node schema. The ontology system handles the `_ont_*` properties automatically.
-3. **`special_handling` values are strings**: `invert_boolean`, `to_boolean`, `or_boolean`, `nor_boolean`, `equal_boolean`, `static_value`. Boolean conditions inside `extra={"values": ...}` must also be strings (`"true"`, not `True`).
+3. **`special_handling` values are strings**: `invert_boolean`, `to_boolean`, `or_boolean`, `nor_boolean`, `equal_boolean`, `static_value`, `coalesce`. Boolean conditions inside `extra={"values": ...}` must also be strings (`"true"`, not `True`).
 4. **Document ontology mapping** in your schema doc using the standard blockquote phrase.
 5. **Module name `microsoft`** is the canonical source for Microsoft Graph. `entra` is still accepted as a backward-compatible alias during migration.
 
@@ -206,6 +206,7 @@ Standard phrases by semantic label:
 | `nor_boolean`     | Logical NOR over multiple boolean fields                   | `extra={"fields": [...]}`                 |
 | `equal_boolean`   | `true` if value matches any of the specified strings       | `extra={"values": ["active", "bypass"]}`  |
 | `static_value`    | Sets a static value, ignoring `node_field`                 | `extra={"value": "dynamodb"}`             |
+| `coalesce`        | Sets the first non-null value from multiple fields         | `extra={"fields": [...]}`                 |
 
 ## Canonical node configuration (CLI)
 

--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -269,6 +269,56 @@ def _build_ontology_field_statement_mapping(
     return f"i._ont_{mapping_field.ontology_field} = {case_expr}"
 
 
+def _build_ontology_field_statement_coalesce(
+    mapping_field: OntologyFieldMapping,
+    node_property_map: dict[str, PropertyRef],
+) -> str | None:
+    """Maps the first non-null source field to an ontology field."""
+    extra_fields = mapping_field.extra.get("fields")
+    if extra_fields is None:
+        logger.warning(
+            "coalesce special handling requires 'fields' in extra for field %s",
+            mapping_field.ontology_field,
+        )
+        return None
+    if not isinstance(extra_fields, list):
+        logger.warning(
+            "coalesce special handling 'fields' in extra for field %s must be a list",
+            mapping_field.ontology_field,
+        )
+        return None
+
+    primary_property_ref = node_property_map.get(mapping_field.node_field)
+    if not primary_property_ref:
+        logger.debug(
+            "Field '%s' not found in node properties for coalesce special handling of field %s",
+            mapping_field.node_field,
+            mapping_field.ontology_field,
+        )
+        return None
+
+    property_refs = [primary_property_ref]
+    for extra_field in extra_fields:
+        extra_property_ref = node_property_map.get(extra_field)
+        if not extra_property_ref:
+            # Expected for Composite Node Pattern schemas (see comment in
+            # _build_ontology_node_properties_statement).
+            logger.debug(
+                "Extra field '%s' not found in node properties for coalesce special handling of field %s",
+                extra_field,
+                mapping_field.ontology_field,
+            )
+            continue
+        property_refs.append(extra_property_ref)
+
+    property_ref_expression = ", ".join(
+        str(property_ref) for property_ref in property_refs
+    )
+    return (
+        f"i._ont_{mapping_field.ontology_field} = coalesce({property_ref_expression})"
+    )
+
+
 def _build_ontology_node_properties_statement(
     node_schema: CartographyNodeSchema,
     node_property_map: dict[str, PropertyRef],
@@ -346,6 +396,12 @@ def _build_ontology_node_properties_statement(
             )
             if mapping_statement:
                 set_clauses.append(mapping_statement)
+        elif mapping_field.special_handling == "coalesce":
+            coalesce_statement = _build_ontology_field_statement_coalesce(
+                mapping_field, node_property_map
+            )
+            if coalesce_statement:
+                set_clauses.append(coalesce_statement)
         else:
             simple_field_template = Template("i.$node_property = $property_ref")
             set_clauses.append(

--- a/cartography/models/ontology/mapping/data/apikeys.py
+++ b/cartography/models/ontology/mapping/data/apikeys.py
@@ -176,18 +176,20 @@ github_mapping = OntologyMapping(
                     ontology_field="name", node_field="token_name", required=True
                 ),
                 OntologyFieldMapping(ontology_field="type", node_field="token_kind"),
-                # created_at maps to access_granted_at, populated for fine-grained
-                # PATs. Classic SAML credential authorizations populate
-                # credential_authorized_at instead; the mapping supports one
-                # node_field per ontology_field, so classic PATs get a null here.
                 OntologyFieldMapping(
-                    ontology_field="created_at", node_field="access_granted_at"
+                    ontology_field="created_at",
+                    node_field="access_granted_at",
+                    special_handling="coalesce",
+                    extra={"fields": ["credential_authorized_at"]},
                 ),
                 OntologyFieldMapping(
                     ontology_field="expires_at", node_field="expires_at"
                 ),
                 OntologyFieldMapping(
-                    ontology_field="last_used_at", node_field="last_used_at"
+                    ontology_field="last_used_at",
+                    node_field="last_used_at",
+                    special_handling="coalesce",
+                    extra={"fields": ["credential_accessed_at"]},
                 ),
             ],
         ),

--- a/cartography/models/ontology/mapping/specs.py
+++ b/cartography/models/ontology/mapping/specs.py
@@ -26,6 +26,7 @@ class OntologyFieldMapping:
         - "static_value": Sets a static value for the ontology field (provided in extra['value']), ignoring node_field.
         - "mapping": Maps provider-specific values to normalized ontology values using extra['map'] dict
           (e.g., {"BASIC": "builtin", "PREDEFINED": "builtin", "CUSTOM": "custom"}). Unmapped values become NULL.
+        - "coalesce": Sets the first non-null value from node_field and extra['fields'].
 
     Example:
         OntologyFieldMapping(ontology_field="email", node_field="email_address", required=True)

--- a/tests/integration/cartography/intel/github/test_personal_access_tokens.py
+++ b/tests/integration/cartography/intel/github/test_personal_access_tokens.py
@@ -139,6 +139,66 @@ def test_sync_github_personal_access_tokens(mock_pages, neo4j_session):
         (f"{ORG_URL}/personal-access-tokens/25381",),
         (f"{ORG_URL}/credential-authorizations/161195",),
     }
+    assert (
+        {
+            row["id"]: (
+                row["source"],
+                row["has_created_at"],
+                row["created_at_matches"],
+                row["expires_at_matches"],
+                row["has_last_used_at"],
+                row["last_used_at_matches"],
+            )
+            for row in neo4j_session.run(
+                """
+            MATCH (k:GitHubPersonalAccessToken)
+            RETURN k.id AS id,
+                k._ont_source AS source,
+                k._ont_created_at IS NOT NULL AS has_created_at,
+                k._ont_created_at = coalesce(
+                    k.access_granted_at,
+                    k.credential_authorized_at
+                ) AS created_at_matches,
+                k._ont_expires_at = k.expires_at AS expires_at_matches,
+                k._ont_last_used_at IS NOT NULL AS has_last_used_at,
+                CASE
+                    WHEN coalesce(k.last_used_at, k.credential_accessed_at) IS NULL
+                    THEN k._ont_last_used_at IS NULL
+                    ELSE k._ont_last_used_at = coalesce(
+                        k.last_used_at,
+                        k.credential_accessed_at
+                    )
+                END AS last_used_at_matches
+            """
+            )
+        }
+        == {
+            f"{ORG_URL}/personal-access-tokens/25381": (
+                "github",
+                True,
+                True,
+                True,
+                True,
+                True,
+            ),
+            f"{ORG_URL}/personal-access-tokens/25382": (
+                "github",
+                True,
+                True,
+                True,
+                False,
+                True,
+            ),
+            f"{ORG_URL}/credential-authorizations/161195": (
+                "github",
+                True,
+                True,
+                True,
+                True,
+                True,
+            ),
+        }
+    )
     assert check_nodes(
         neo4j_session, "GitHubFineGrainedPersonalAccessToken", ["id"]
     ) == {

--- a/tests/unit/cartography/graph/test_ontology_fields.py
+++ b/tests/unit/cartography/graph/test_ontology_fields.py
@@ -1,3 +1,4 @@
+from cartography.graph.querybuilder import _build_ontology_field_statement_coalesce
 from cartography.graph.querybuilder import _build_ontology_field_statement_equal_boolean
 from cartography.graph.querybuilder import (
     _build_ontology_field_statement_invert_boolean,
@@ -53,6 +54,81 @@ def test_build_ontology_field_statement_to_boolean():
     # Assert
     expected = "i._ont_is_enabled = coalesce(toBooleanOrNull(item.enabled), (item.enabled IS NOT NULL))"
     assert result == expected
+
+
+def test_build_ontology_field_statement_coalesce():
+    """
+    Test _build_ontology_field_statement_coalesce function.
+    This function picks the first non-null field from a primary field and fallback fields.
+    """
+    # Arrange
+    mapping_field = OntologyFieldMapping(
+        ontology_field="created_at",
+        node_field="access_granted_at",
+        special_handling="coalesce",
+        extra={"fields": ["credential_authorized_at"]},
+    )
+    node_property_map = {
+        "access_granted_at": PropertyRef("access_granted_at"),
+        "credential_authorized_at": PropertyRef("credential_authorized_at"),
+    }
+
+    # Act
+    result = _build_ontology_field_statement_coalesce(mapping_field, node_property_map)
+
+    # Assert
+    expected = (
+        "i._ont_created_at = coalesce("
+        "item.access_granted_at, item.credential_authorized_at"
+        ")"
+    )
+    assert result == expected
+
+
+def test_build_ontology_field_statement_coalesce_missing_fields():
+    """
+    Test _build_ontology_field_statement_coalesce function when 'fields' is missing in extra.
+    Should return None and log a warning.
+    """
+    # Arrange
+    mapping_field = OntologyFieldMapping(
+        ontology_field="created_at",
+        node_field="access_granted_at",
+        special_handling="coalesce",
+        extra={},
+    )
+    node_property_map = {
+        "access_granted_at": PropertyRef("access_granted_at"),
+    }
+
+    # Act
+    result = _build_ontology_field_statement_coalesce(mapping_field, node_property_map)
+
+    # Assert
+    assert result is None
+
+
+def test_build_ontology_field_statement_coalesce_invalid_fields_type():
+    """
+    Test _build_ontology_field_statement_coalesce function when 'fields' is not a list.
+    Should return None and log a warning.
+    """
+    # Arrange
+    mapping_field = OntologyFieldMapping(
+        ontology_field="created_at",
+        node_field="access_granted_at",
+        special_handling="coalesce",
+        extra={"fields": "credential_authorized_at"},
+    )
+    node_property_map = {
+        "access_granted_at": PropertyRef("access_granted_at"),
+    }
+
+    # Act
+    result = _build_ontology_field_statement_coalesce(mapping_field, node_property_map)
+
+    # Assert
+    assert result is None
 
 
 def test_build_ontology_field_statement_equal_boolean_with_values():


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

GitHub personal access tokens expose timestamp fields under different names depending on token type. Fine-grained PATs use `access_granted_at` and `last_used_at`, while classic PATs from SAML credential authorizations use `credential_authorized_at` and `credential_accessed_at`.

This adds a generic ontology `coalesce` field handler, then uses it for the GitHub APIKey mapping so `_ont_created_at` and `_ont_last_used_at` can populate from the first available provider timestamp. This keeps the raw GitHub fields intact while making normalized APIKey inventory fields useful for both fine-grained and classic PATs.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

N/A


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

None.


### How was this tested?
<!-- Describe how you tested your changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- Added unit and integration tests


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

This does not change the raw GitHub PAT model or ingestion shape. `credential_accessed_at` remains available as its own raw field; the ontology mapping only uses it as the normalized fallback when fine-grained `last_used_at` is absent.
