### PR TITLE
fix(aws): stop IAM SAML provider sync from crashing on AccessDenied

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -344,7 +344,9 @@ def get_role_list_data(boto3_session: boto3.Session) -> Dict:
 
 @timeit
 @aws_handle_regions
-def get_saml_providers(boto3_session: boto3.session.Session) -> dict[str, Any]:
+def get_saml_providers(boto3_session: boto3.session.Session) -> list[dict[str, Any]]:
+    # Return a list (not a dict) so @aws_handle_regions' [] fallback on
+    # AccessDenied / SCP-deny matches the normal return shape.
     client = create_boto3_client(boto3_session, "iam")
     # list_saml_providers returns a single page
     response = client.list_saml_providers()
@@ -355,7 +357,7 @@ def get_saml_providers(boto3_session: boto3.session.Session) -> dict[str, Any]:
     for provider in providers:
         arn = provider.get("Arn", "")
         provider["Name"] = arn.rsplit("/", 1)[-1] if "/" in arn else arn
-    return {"SAMLProviderList": providers}
+    return providers
 
 
 @timeit
@@ -813,7 +815,10 @@ def transform_policy_data(
     policy_to_statements: dict[str, list[dict[str, Any]]] = {}
     policy_to_name: dict[str, str] = {}
 
-    for principal_arn, policy_statement_map in policy_map.items():
+    # get_*_policy_data wears @aws_handle_regions, which returns [] (not a dict)
+    # on AccessDenied / SCP-deny. Coerce so a skipped getter loads nothing
+    # instead of crashing the whole account sync.
+    for principal_arn, policy_statement_map in (policy_map or {}).items():
         for policy_key, statements in policy_statement_map.items():
             policy_id = (
                 transform_policy_id(principal_arn, policy_type, policy_key)
@@ -1793,10 +1798,10 @@ def sync(
         common_job_parameters,
     )
     # SAML providers are global (not region-scoped) for the account
-    saml = get_saml_providers(boto3_session)
+    saml_providers = get_saml_providers(boto3_session)
     load_saml_providers(
         neo4j_session,
-        saml.get("SAMLProviderList", []),
+        saml_providers,
         current_aws_account_id,
         update_tag,
     )

--- a/tests/integration/cartography/intel/aws/iam/test_iam_sync.py
+++ b/tests/integration/cartography/intel/aws/iam/test_iam_sync.py
@@ -32,7 +32,7 @@ TEST_UPDATE_TAG = 123456789
 @patch.object(
     cartography.intel.aws.iam,
     "get_saml_providers",
-    return_value={"SAMLProviderList": []},
+    return_value=[],
 )
 @patch.object(
     cartography.intel.aws.iam,

--- a/tests/unit/cartography/intel/aws/iam/test_iam.py
+++ b/tests/unit/cartography/intel/aws/iam/test_iam.py
@@ -1,4 +1,7 @@
 import datetime
+from unittest.mock import MagicMock
+
+from botocore.exceptions import ClientError
 
 from cartography.intel.aws import iam
 from cartography.intel.aws.iam import PolicyType
@@ -321,3 +324,21 @@ def test_transform_mfa_devices_empty():
     raw_data = []
     result = iam.transform_mfa_devices(raw_data)
     assert result == []
+
+
+def test_get_saml_providers_access_denied_returns_empty_list():
+    # @aws_handle_regions swallows AccessDenied and returns []; the getter and
+    # its caller must tolerate that instead of crashing the account sync.
+    session = MagicMock()
+    client = session.client.return_value
+    client.list_saml_providers.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "nope"}},
+        "ListSAMLProviders",
+    )
+
+    result = iam.get_saml_providers(session)
+
+    assert result == []
+    # transform_policy_data feeds the same [] fallback from sibling getters.
+    transformed = transform_policy_data([], PolicyType.inline.value)
+    assert transformed.statements_by_policy_id == {}


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
`get_saml_providers` in `cartography/intel/aws/iam.py` is decorated with `@aws_handle_regions`, which returns `[]` on skippable client errors (AccessDenied, SCP explicit deny, disabled region). The function's normal return was a `dict` and the caller in `sync()` did `saml.get("SAMLProviderList", [])`, so when an account denies `iam:ListSAMLProviders` the `[]` fallback raised `AttributeError: 'list' object has no attribute 'get'` and aborted the entire AWS account sync.

Fix: make the getter return the SAML provider list directly so the decorator's `[]` fallback matches the normal return shape (caller updated accordingly).

The same crash class affected the six `get_*_policy_data` siblings, whose dict output flows into `transform_policy_data`, which calls `policy_map.items()`. Guarded that with `(policy_map or {})`. `get_service_last_accessed_details` is already safe (its caller uses `if service_details:`).

### How was this tested?
- Added a unit test that mocks the IAM client to raise `ClientError`/`AccessDenied` on `list_saml_providers` and asserts `get_saml_providers` returns `[]` without raising, plus the `transform_policy_data([])` fallback path.
- `make test_lint` (pre-commit) passes locally; unit tests pass.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)