### PR TITLE
feat(kubernetes): connect to EKS via boto3 auth without a kubeconfig file

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -911,6 +911,32 @@ class CLI:
                     hidden=PANEL_KUBERNETES not in visible_panels,
                 ),
             ] = None,
+            k8s_eks_cluster_names: Annotated[
+                str | None,
+                typer.Option(
+                    "--k8s-eks-cluster-names",
+                    help=(
+                        "Comma-separated EKS cluster names to sync via boto3 auth "
+                        "instead of a kubeconfig file, using the ambient AWS "
+                        "credentials. All clusters must be in one region."
+                    ),
+                    rich_help_panel=PANEL_KUBERNETES,
+                    hidden=PANEL_KUBERNETES not in visible_panels,
+                ),
+            ] = None,
+            k8s_eks_region: Annotated[
+                str | None,
+                typer.Option(
+                    "--k8s-eks-region",
+                    help=(
+                        "AWS region for --k8s-eks-cluster-names. Defaults to the "
+                        "ambient AWS region (AWS_REGION / AWS_DEFAULT_REGION / "
+                        "AWS config)."
+                    ),
+                    rich_help_panel=PANEL_KUBERNETES,
+                    hidden=PANEL_KUBERNETES not in visible_panels,
+                ),
+            ] = None,
             # =================================================================
             # CVE Options
             # =================================================================
@@ -2633,6 +2659,8 @@ class CLI:
                 kandji_token=kandji_token,
                 k8s_kubeconfig=k8s_kubeconfig,
                 managed_kubernetes=managed_kubernetes,
+                k8s_eks_cluster_names=k8s_eks_cluster_names,
+                k8s_eks_region=k8s_eks_region,
                 statsd_enabled=statsd_enabled,
                 statsd_prefix=statsd_prefix,
                 statsd_host=statsd_host,

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -391,6 +391,8 @@ class Config:
         kandji_token=None,
         k8s_kubeconfig=None,
         managed_kubernetes=None,
+        k8s_eks_cluster_names=None,
+        k8s_eks_region=None,
         statsd_enabled=False,
         statsd_prefix=None,
         statsd_host=None,
@@ -565,6 +567,8 @@ class Config:
         self.kandji_token = kandji_token
         self.k8s_kubeconfig = k8s_kubeconfig
         self.managed_kubernetes = managed_kubernetes
+        self.k8s_eks_cluster_names = k8s_eks_cluster_names
+        self.k8s_eks_region = k8s_eks_region
         self.statsd_enabled = statsd_enabled
         self.statsd_prefix = statsd_prefix
         self.statsd_host = statsd_host

--- a/cartography/intel/kubernetes/__init__.py
+++ b/cartography/intel/kubernetes/__init__.py
@@ -14,6 +14,7 @@ from cartography.intel.kubernetes.pods import sync_pods
 from cartography.intel.kubernetes.rbac import sync_kubernetes_rbac
 from cartography.intel.kubernetes.secrets import sync_secrets
 from cartography.intel.kubernetes.services import sync_services
+from cartography.intel.kubernetes.util import get_eks_k8s_clients
 from cartography.intel.kubernetes.util import get_k8s_clients
 from cartography.util import run_scoped_analysis_job
 from cartography.util import timeit
@@ -38,13 +39,31 @@ def start_k8s_ingestion(session: Session, config: Config) -> None:
         logger.error("Cartography update tag not provided.")
         return
 
-    if not config.k8s_kubeconfig:
-        logger.error("Kubernetes kubeconfig not provided.")
+    if config.k8s_eks_cluster_names:
+        # region_name=None lets boto3 fall back to its default region resolution.
+        boto3_session = boto3.Session(region_name=config.k8s_eks_region)
+        if not boto3_session.region_name:
+            logger.error(
+                "Could not determine an AWS region for EKS sync. Set "
+                "--k8s-eks-region or configure a default AWS region.",
+            )
+            return
+        cluster_names = [
+            c.strip() for c in config.k8s_eks_cluster_names.split(",") if c.strip()
+        ]
+        k8s_clients = get_eks_k8s_clients(cluster_names, boto3_session)
+    elif config.k8s_kubeconfig:
+        k8s_clients = get_k8s_clients(config.k8s_kubeconfig)
+    else:
+        logger.error(
+            "Kubernetes not configured: provide --k8s-kubeconfig or "
+            "--k8s-eks-cluster-names.",
+        )
         return
 
     common_job_parameters = {"UPDATE_TAG": config.update_tag}
 
-    for client in get_k8s_clients(config.k8s_kubeconfig):
+    for client in k8s_clients:
         logger.info(f"Syncing data for k8s cluster {client.name}...")
         try:
             cluster_info = sync_kubernetes_cluster(
@@ -68,7 +87,10 @@ def start_k8s_ingestion(session: Session, config: Config) -> None:
 
             # Extract region from cluster ARN (works for EKS; None for non-EKS clusters)
             region: str | None = None
-            if config.managed_kubernetes == "eks":
+            is_eks = config.managed_kubernetes == "eks" or bool(
+                config.k8s_eks_cluster_names
+            )
+            if is_eks:
                 # EKS clusters always have a valid ARN — let ValueError propagate if not
                 region = get_region_from_arn(cluster_external_ref)
                 boto3_session = boto3.Session()

--- a/cartography/intel/kubernetes/util.py
+++ b/cartography/intel/kubernetes/util.py
@@ -1,4 +1,6 @@
+import base64
 import logging
+import ssl
 from datetime import datetime
 from typing import Any
 from typing import Callable
@@ -6,6 +8,7 @@ from typing import Callable
 from dateutil.parser import isoparse
 from kubernetes import config
 from kubernetes.client import ApiClient
+from kubernetes.client import Configuration
 from kubernetes.client import CoreV1Api
 from kubernetes.client import CustomObjectsApi
 from kubernetes.client import NetworkingV1Api
@@ -15,6 +18,9 @@ from kubernetes.client.exceptions import ApiException
 from kubernetes.config.kube_config import KubeConfigMerger
 
 logger = logging.getLogger(__name__)
+
+# EKS bearer-token lifetime is ~15 min; mint just before use.
+_EKS_TOKEN_TTL_SECONDS = 60
 
 
 class KubernetesContextNotFound(Exception):
@@ -100,17 +106,18 @@ class K8sClient:
     def __init__(
         self,
         name: str,
-        config_file: str,
+        config_file: str | None = None,
         external_id: str | None = None,
+        api_client: ApiClient | None = None,
     ) -> None:
         self.name = name
         self.config_file = config_file
         self.external_id = external_id
-        self.core = K8CoreApiClient(self.name, self.config_file)
-        self.networking = K8NetworkingApiClient(self.name, self.config_file)
-        self.version = K8VersionApiClient(self.name, self.config_file)
-        self.rbac = K8RbacApiClient(self.name, self.config_file)
-        self.custom = K8CustomObjectsApiClient(self.name, self.config_file)
+        self.core = K8CoreApiClient(self.name, self.config_file, api_client)
+        self.networking = K8NetworkingApiClient(self.name, self.config_file, api_client)
+        self.version = K8VersionApiClient(self.name, self.config_file, api_client)
+        self.rbac = K8RbacApiClient(self.name, self.config_file, api_client)
+        self.custom = K8CustomObjectsApiClient(self.name, self.config_file, api_client)
 
 
 def get_k8s_clients(kubeconfig: str) -> list[K8sClient]:
@@ -126,6 +133,79 @@ def get_k8s_clients(kubeconfig: str) -> list[K8sClient]:
                 context["name"],
                 kubeconfig,
                 external_id=context["context"].get("cluster"),
+            ),
+        )
+    return clients
+
+
+def _get_eks_token(cluster_name: str, boto3_session: Any) -> str:
+    """Mint an EKS bearer token from a presigned STS GetCallerIdentity URL.
+
+    Uses the boto3 session's STS client, so no aws CLI or kubeconfig exec plugin
+    is required. The ``x-k8s-aws-id`` header EKS requires is attached to the
+    GetCallerIdentity request via the client event system.
+    """
+    sts = boto3_session.client("sts")
+
+    def _add_cluster_header(request, **kwargs):
+        request.headers["x-k8s-aws-id"] = cluster_name
+
+    sts.meta.events.register("before-sign.sts.GetCallerIdentity", _add_cluster_header)
+    signed_url = sts.generate_presigned_url(
+        "get_caller_identity",
+        Params={},
+        ExpiresIn=_EKS_TOKEN_TTL_SECONDS,
+        HttpMethod="GET",
+    )
+    return "k8s-aws-v1." + base64.urlsafe_b64encode(
+        signed_url.encode()
+    ).decode().rstrip("=")
+
+
+def _build_eks_api_client(endpoint: str, ca_cert_pem: str, token: str) -> ApiClient:
+    """Build a kubernetes ApiClient for an EKS endpoint with a relaxed-but-verifying
+    TLS context.
+
+    EKS cluster CA certs do not carry an Authority Key Identifier extension, which
+    Python 3.13 / urllib3 reject under the default VERIFY_X509_STRICT flag. We clear
+    only that subflag; certificate verification against the cluster CA stays on
+    (CERT_REQUIRED). This is not InsecureSkipVerify. The kubernetes client does not
+    plumb a custom ssl_context through Configuration, so it is injected via the
+    urllib3 pool args the RESTClientObject forwards.
+    """
+    ssl_context = ssl.create_default_context(cadata=ca_cert_pem)
+    ssl_context.check_hostname = True
+    ssl_context.verify_mode = ssl.CERT_REQUIRED
+    ssl_context.verify_flags &= ~ssl.VERIFY_X509_STRICT
+
+    cfg = Configuration()
+    cfg.host = endpoint
+    cfg.api_key = {"authorization": f"Bearer {token}"}
+    cfg.verify_ssl = True
+
+    api_client = ApiClient(configuration=cfg)
+    api_client.rest_client.pool_manager.connection_pool_kw["ssl_context"] = ssl_context
+    return api_client
+
+
+def get_eks_k8s_clients(
+    cluster_names: list[str], boto3_session: Any
+) -> list[K8sClient]:
+    """Build K8sClients for EKS clusters using boto3 auth instead of a kubeconfig file."""
+    eks = boto3_session.client("eks")
+    clients = []
+    for cluster_name in cluster_names:
+        described = eks.describe_cluster(name=cluster_name)["cluster"]
+        ca_cert_pem = base64.b64decode(
+            described["certificateAuthority"]["data"]
+        ).decode()
+        token = _get_eks_token(cluster_name, boto3_session)
+        api_client = _build_eks_api_client(described["endpoint"], ca_cert_pem, token)
+        clients.append(
+            K8sClient(
+                cluster_name,
+                external_id=described["arn"],
+                api_client=api_client,
             ),
         )
     return clients

--- a/docs/root/modules/kubernetes/config.md
+++ b/docs/root/modules/kubernetes/config.md
@@ -130,6 +130,30 @@ Notes:
 - Cartography derives the EKS region from the `cluster` field of each kubeconfig context entry. When using `aws eks update-kubeconfig`, this field is automatically set to the cluster ARN.
 - If you use `aws eks update-kubeconfig` to generate the kubeconfig that Cartography consumes, that command also requires `eks:DescribeCluster`.
 
+### Connecting to EKS without a kubeconfig file
+
+Instead of maintaining a kubeconfig file (and its short-lived `aws eks get-token`
+credentials), you can have Cartography connect to EKS directly using the AWS
+credentials it already uses for the AWS module. Pass `--k8s-eks-cluster-names`
+(comma-separated) and, optionally, `--k8s-eks-region`:
+
+```
+cartography ... --k8s-eks-cluster-names my-cluster,other-cluster --k8s-eks-region us-east-1
+```
+
+Cartography resolves the cluster endpoint and CA via `eks:DescribeCluster`, mints a
+short-lived bearer token from the ambient AWS credentials (the same mechanism as
+`aws eks get-token`), and connects — no kubeconfig file, no `aws` CLI, and no exec
+credential plugin required. If `--k8s-eks-region` is omitted, the region is taken
+from the standard AWS resolution chain (`AWS_REGION` / `AWS_DEFAULT_REGION` /
+`~/.aws/config`); all named clusters must be in that region. This implies EKS
+enrichment (Access Entries, OIDC), so `--managed-kubernetes eks` is not required.
+
+In addition to the Kubernetes RBAC above (bound to the calling IAM principal via an
+[EKS access entry](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html),
+e.g. the AWS-managed `AmazonEKSViewPolicy`), this path requires `eks:DescribeCluster`
+alongside the `eks:*` actions listed above.
+
 ### TLS Troubleshooting and Validation
 
 When Kubernetes API server cert settings are misconfigured, sync failures can be difficult to diagnose from raw kubeconfig alone. Cartography writes kubeconfig TLS posture fields onto `KubernetesCluster` so operators can quickly reason about configuration risk.

--- a/tests/unit/cartography/intel/kubernetes/test_eks_auth.py
+++ b/tests/unit/cartography/intel/kubernetes/test_eks_auth.py
@@ -1,0 +1,99 @@
+import base64
+import ssl
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from cartography.intel.kubernetes import util
+
+
+def _fake_boto3_session(presigned_url="https://sts.example/presigned"):
+    session = MagicMock()
+    sts = MagicMock()
+    sts.generate_presigned_url.return_value = presigned_url
+    session.client.return_value = sts
+    return session, sts
+
+
+def test_get_eks_token_format():
+    # The EKS token is "k8s-aws-v1." + base64url(presigned STS URL), unpadded,
+    # and the cluster-id header is registered on the GetCallerIdentity request.
+    presigned = "https://sts.us-east-1.amazonaws.com/?Action=GetCallerIdentity&X-Amz=x"
+    session, sts = _fake_boto3_session(presigned)
+
+    token = util._get_eks_token("my-cluster", session)
+
+    sts.generate_presigned_url.assert_called_once()
+    assert sts.generate_presigned_url.call_args.args[0] == "get_caller_identity"
+    sts.meta.events.register.assert_called_once()
+    assert (
+        sts.meta.events.register.call_args.args[0]
+        == "before-sign.sts.GetCallerIdentity"
+    )
+    assert token.startswith("k8s-aws-v1.")
+    assert "=" not in token  # base64url padding stripped
+    decoded = base64.urlsafe_b64decode(token[len("k8s-aws-v1.") :] + "==").decode()
+    assert decoded == presigned
+
+
+def _self_signed_ca_pem():
+    import datetime
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test-ca")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime(2020, 1, 1))
+        .not_valid_after(datetime.datetime(2040, 1, 1))
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def test_build_eks_api_client_clears_strict_but_keeps_verification():
+    api_client = util._build_eks_api_client(
+        "https://eks.example", _self_signed_ca_pem(), "tok"
+    )
+
+    ctx = api_client.rest_client.pool_manager.connection_pool_kw["ssl_context"]
+    # strict subflag cleared...
+    assert not (ctx.verify_flags & ssl.VERIFY_X509_STRICT)
+    # ...but full verification stays ON (this is not InsecureSkipVerify)
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+@patch("cartography.intel.kubernetes.util.K8sClient")
+@patch("cartography.intel.kubernetes.util._build_eks_api_client")
+@patch("cartography.intel.kubernetes.util._get_eks_token", return_value="tok")
+def test_get_eks_k8s_clients_uses_boto3_describe(
+    mock_token, mock_build, mock_client_cls
+):
+    session = MagicMock()
+    session.region_name = "us-east-1"
+    eks = MagicMock()
+    eks.describe_cluster.return_value = {
+        "cluster": {
+            "endpoint": "https://eks.example",
+            "certificateAuthority": {"data": base64.b64encode(b"ca").decode()},
+            "arn": "arn:aws:eks:us-east-1:123:cluster/c1",
+        }
+    }
+    session.client.return_value = eks
+
+    util.get_eks_k8s_clients(["c1"], session)
+
+    eks.describe_cluster.assert_called_once_with(name="c1")
+    mock_token.assert_called_once_with("c1", session)
+    # client built with the boto3-derived api_client, external_id = cluster ARN
+    _, kwargs = mock_client_cls.call_args
+    assert kwargs["external_id"] == "arn:aws:eks:us-east-1:123:cluster/c1"
+    assert kwargs["api_client"] is mock_build.return_value

--- a/tests/unit/cartography/intel/kubernetes/test_init.py
+++ b/tests/unit/cartography/intel/kubernetes/test_init.py
@@ -46,6 +46,8 @@ def test_start_k8s_ingestion_uses_external_id_for_eks_region(monkeypatch):
         update_tag=123456789,
         k8s_kubeconfig="/tmp/kubeconfig",
         managed_kubernetes="eks",
+        k8s_eks_cluster_names=None,
+        k8s_eks_region=None,
     )
 
     kubernetes.start_k8s_ingestion(session=object(), config=config)
@@ -53,3 +55,39 @@ def test_start_k8s_ingestion_uses_external_id_for_eks_region(monkeypatch):
     assert captured["region"] == "us-east-1"
     assert captured["cluster_id"] == "11111111-2222-4333-8444-555555555555"
     assert captured["cluster_name"] == cluster_arn
+
+
+def test_start_k8s_ingestion_eks_region_defaults_to_session(monkeypatch):
+    # With --k8s-eks-cluster-names and no --k8s-eks-region, the region comes from
+    # the boto3 session's resolved region.
+    captured = {}
+
+    class DummySession:
+        region_name = "eu-west-1"
+
+    def _fake_session(region_name=None):
+        # mimic boto3.Session: explicit region wins, else resolved default
+        s = DummySession()
+        s.region_name = region_name or "eu-west-1"
+        return s
+
+    def _capture_eks_clients(cluster_names, session):
+        captured["cluster_names"] = cluster_names
+        captured["session_region"] = session.region_name
+        return []  # no clients -> sync loop is a no-op
+
+    monkeypatch.setattr(kubernetes.boto3, "Session", _fake_session)
+    monkeypatch.setattr(kubernetes, "get_eks_k8s_clients", _capture_eks_clients)
+
+    config = SimpleNamespace(
+        update_tag=123456789,
+        k8s_kubeconfig=None,
+        managed_kubernetes=None,
+        k8s_eks_cluster_names="cluster-a, cluster-b",
+        k8s_eks_region=None,
+    )
+
+    kubernetes.start_k8s_ingestion(session=object(), config=config)
+
+    assert captured["session_region"] == "eu-west-1"
+    assert captured["cluster_names"] == ["cluster-a", "cluster-b"]


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Adds `--k8s-eks-cluster-names` (comma-separated) and optional `--k8s-eks-region` so
the Kubernetes module can connect to Amazon EKS using the ambient AWS credentials,
without a kubeconfig file. This avoids managing a kubeconfig whose
`aws eks get-token` credentials are short-lived, and avoids the kubeconfig exec
plugin, which requires the `aws` CLI in the runtime — useful for scheduled or
containerized syncs.

For each named cluster, Cartography:
1. resolves the API endpoint and cluster CA via `eks:DescribeCluster`,
2. mints a bearer token from the boto3 session's STS client (presigned
   `GetCallerIdentity` with the `x-k8s-aws-id` header — the EKS token scheme), and
3. builds the kubernetes client in memory (no temp files): the cluster CA is loaded
   into the SSL context via `cadata`, and the token is set as the bearer credential.

`--k8s-eks-region` is optional; when omitted, boto3 resolves the region from its
standard chain (`AWS_REGION` / `AWS_DEFAULT_REGION` / AWS config). Passing
`--k8s-eks-cluster-names` implies EKS, so `--managed-kubernetes eks` is not required
to also enrich with Access Entries / OIDC.

EKS API-server CA certificates omit the Authority Key Identifier extension, which
Python 3.13 / urllib3 reject under the default `VERIFY_X509_STRICT` flag. The client
clears only that strict subflag; certificate verification against the cluster CA
stays enabled (`CERT_REQUIRED`). This is not `InsecureSkipVerify`.

`--k8s-kubeconfig` and `--k8s-eks-cluster-names` are alternatives; provide one.

Required permissions (documented in `docs/root/modules/kubernetes/config.md`):
- AWS: `eks:DescribeCluster` plus the existing EKS enrichment actions, and
  `sts:GetCallerIdentity`.
- Kubernetes RBAC bound to the calling IAM principal via an EKS access entry
  (e.g. the AWS-managed `AmazonEKSViewPolicy`).


### Related issues or links



### How was this tested?

- New unit tests in `tests/unit/cartography/intel/kubernetes/test_eks_auth.py`:
  the bearer-token format and that the `x-k8s-aws-id` header is registered on the
  STS request; the SSL context clears `VERIFY_X509_STRICT` while keeping
  `CERT_REQUIRED`; and the `describe_cluster` → client-build wiring. A region
  resolution test is added to `test_init.py`. The
  `tests/unit/cartography/intel/kubernetes/` suite passes (31 tests).
- `make test_lint` passes locally (black, isort, flake8).
- Verified against a live EKS cluster using `--k8s-eks-cluster-names`. Sample sync
  output:

  ```
  INFO:cartography.intel.kubernetes:Syncing data for k8s cluster benzinga-production...
  INFO:cartography.client.core.tx:Loaded 193 KubernetesServiceAccount nodes
  INFO:cartography.client.core.tx:Loaded 1364 KubernetesPod nodes
  INFO:cartography.client.core.tx:Loaded 1584 KubernetesContainer nodes
  INFO:cartography.client.core.tx:Loaded 365 KubernetesService nodes
  INFO:cartography.client.core.tx:Loaded 140 KubernetesIngress nodes
  INFO:cartography.sync:Finishing sync stage 'kubernetes'
  ```


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [x] Included Cartography sync logs from a real environment (above). This PR adds an
  alternative connection/auth method for the existing Kubernetes entities; it does
  not add or change any node or relationship schema, so the schema docs are
  unchanged. Module configuration docs are updated with the new options and required
  permissions.
