### PR TITLE
feat(scaleway): add object storage buckets

### DIFF
--- a/cartography/intel/scaleway/__init__.py
+++ b/cartography/intel/scaleway/__init__.py
@@ -13,6 +13,7 @@ import cartography.intel.scaleway.instances.flexibleips
 import cartography.intel.scaleway.instances.instances
 import cartography.intel.scaleway.instances.securitygroups
 import cartography.intel.scaleway.projects
+import cartography.intel.scaleway.storage.objectstorage
 import cartography.intel.scaleway.storage.snapshots
 import cartography.intel.scaleway.storage.volumes
 from cartography.config import Config
@@ -114,6 +115,14 @@ def start_scaleway_ingestion(neo4j_session: neo4j.Session, config: Config) -> No
         update_tag=config.update_tag,
     )
     cartography.intel.scaleway.storage.snapshots.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=config.scaleway_org,
+        projects_id=projects_id,
+        update_tag=config.update_tag,
+    )
+    cartography.intel.scaleway.storage.objectstorage.sync(
         neo4j_session,
         client,
         common_job_parameters,

--- a/cartography/intel/scaleway/storage/objectstorage.py
+++ b/cartography/intel/scaleway/storage/objectstorage.py
@@ -46,34 +46,48 @@ def sync(
     projects_id: list[str],
     update_tag: int,
 ) -> None:
-    buckets = get(client)
+    buckets = get(client, projects_id)
     buckets_by_project = transform_buckets(buckets)
     load_buckets(neo4j_session, buckets_by_project, update_tag)
     cleanup(neo4j_session, projects_id, common_job_parameters)
 
 
 @timeit
-def get(client: scaleway.Client) -> list[dict[str, Any]]:
+def get(client: scaleway.Client, projects_id: list[str]) -> list[dict[str, Any]]:
     """Scaleway Object Storage is S3-compatible and is not exposed by the
-    Scaleway Python SDK, so we use boto3 against the regional S3 endpoints."""
+    Scaleway Python SDK, so we use boto3 against the regional S3 endpoints.
+
+    S3 calls are scoped to the access key's preferred Project unless the key is
+    suffixed with ``@<project_id>``, so we iterate every project explicitly to
+    cover multi-project orgs (and to keep ingestion aligned with cleanup)."""
     buckets: list[dict[str, Any]] = []
-    for region in OBJECT_STORAGE_REGIONS:
-        s3 = boto3.client(
-            "s3",
-            region_name=region,
-            endpoint_url=f"https://s3.{region}.scw.cloud",
-            aws_access_key_id=client.access_key,
-            aws_secret_access_key=client.secret_key,
-        )
-        listing = s3.list_buckets()
-        owner_id = listing.get("Owner", {}).get("ID", "")
-        for bucket in listing.get("Buckets", []):
-            buckets.append(_get_bucket_details(s3, bucket, region, owner_id))
+    for project_id in projects_id:
+        for region in OBJECT_STORAGE_REGIONS:
+            s3 = boto3.client(
+                "s3",
+                region_name=region,
+                endpoint_url=f"https://s3.{region}.scw.cloud",
+                aws_access_key_id=f"{client.access_key}@{project_id}",
+                aws_secret_access_key=client.secret_key,
+            )
+            try:
+                listing = s3.list_buckets()
+            except ClientError as e:
+                # Don't let one region/project abort the whole Scaleway sync.
+                logger.warning(
+                    "Could not list Scaleway buckets in project '%s' region '%s': %s",
+                    project_id,
+                    region,
+                    e.response.get("Error", {}).get("Code"),
+                )
+                continue
+            for bucket in listing.get("Buckets", []):
+                buckets.append(_get_bucket_details(s3, bucket, region, project_id))
     return buckets
 
 
 def _get_bucket_details(
-    s3: Any, bucket: dict[str, Any], region: str, owner_id: str
+    s3: Any, bucket: dict[str, Any], region: str, project_id: str
 ) -> dict[str, Any]:
     name = bucket["Name"]
     details: dict[str, Any] = {
@@ -81,7 +95,7 @@ def _get_bucket_details(
         "region": region,
         "endpoint": f"https://{name}.s3.{region}.scw.cloud",
         "creation_date": bucket.get("CreationDate"),
-        "owner_id": owner_id,
+        "project_id": project_id,
         "acl": None,
         "policy": None,
         "versioning": None,
@@ -118,8 +132,7 @@ def transform_buckets(
 ) -> dict[str, list[dict[str, Any]]]:
     result: dict[str, list[dict[str, Any]]] = {}
     for bucket in buckets:
-        # The S3 owner ID is "<project_id>:<project_id>" on Scaleway.
-        project_id = bucket["owner_id"].split(":")[0]
+        project_id = bucket["project_id"]
         # Leave the exposure signals null (unknown) when their source read
         # failed, rather than reporting a bucket as not-public on bad data.
         acl = bucket["acl"]
@@ -136,7 +149,6 @@ def transform_buckets(
             "region": bucket["region"],
             "endpoint": bucket["endpoint"],
             "creation_date": bucket["creation_date"],
-            "owner_id": bucket["owner_id"],
             "tags": (
                 None if bucket["tags"] is FETCH_FAILED else _format_tags(bucket["tags"])
             ),
@@ -148,9 +160,21 @@ def transform_buckets(
             "acl_public": acl_public,
             "anonymous_access": anonymous_access,
             "anonymous_actions": anonymous_actions,
+            # Tri-state combined public signal: True/False when known, None when
+            # both sources were unreadable (so "unknown" is not reported as safe).
+            "public": _combine_public(acl_public, anonymous_access),
         }
         result.setdefault(project_id, []).append(formatted)
     return result
+
+
+def _combine_public(
+    acl_public: bool | None, anonymous_access: bool | None
+) -> bool | None:
+    known = [v for v in (acl_public, anonymous_access) if v is not None]
+    if not known:
+        return None
+    return any(known)
 
 
 def _format_tags(tagging: dict[str, Any] | None) -> list[str] | None:

--- a/cartography/intel/scaleway/storage/objectstorage.py
+++ b/cartography/intel/scaleway/storage/objectstorage.py
@@ -46,22 +46,33 @@ def sync(
     projects_id: list[str],
     update_tag: int,
 ) -> None:
-    buckets = get(client, projects_id)
+    buckets, complete_projects = get(client, projects_id)
     buckets_by_project = transform_buckets(buckets)
     load_buckets(neo4j_session, buckets_by_project, update_tag)
-    cleanup(neo4j_session, projects_id, common_job_parameters)
+    # Only clean projects we fully enumerated: a project whose listing failed in
+    # any region has an incomplete view, so cleaning it would delete
+    # last-known-good buckets that simply weren't (re)listed this run.
+    cleanup(neo4j_session, complete_projects, common_job_parameters)
 
 
 @timeit
-def get(client: scaleway.Client, projects_id: list[str]) -> list[dict[str, Any]]:
+def get(
+    client: scaleway.Client, projects_id: list[str]
+) -> tuple[list[dict[str, Any]], list[str]]:
     """Scaleway Object Storage is S3-compatible and is not exposed by the
     Scaleway Python SDK, so we use boto3 against the regional S3 endpoints.
 
     S3 calls are scoped to the access key's preferred Project unless the key is
     suffixed with ``@<project_id>``, so we iterate every project explicitly to
-    cover multi-project orgs (and to keep ingestion aligned with cleanup)."""
+    cover multi-project orgs (and to keep ingestion aligned with cleanup).
+
+    Returns the discovered buckets and the list of projects that were fully
+    enumerated (every region listed without error) and are therefore safe to
+    clean up."""
     buckets: list[dict[str, Any]] = []
+    complete_projects: list[str] = []
     for project_id in projects_id:
+        project_complete = True
         for region in OBJECT_STORAGE_REGIONS:
             s3 = boto3.client(
                 "s3",
@@ -73,17 +84,21 @@ def get(client: scaleway.Client, projects_id: list[str]) -> list[dict[str, Any]]
             try:
                 listing = s3.list_buckets()
             except ClientError as e:
-                # Don't let one region/project abort the whole Scaleway sync.
+                # Don't let one region/project abort the whole Scaleway sync,
+                # but mark the project incomplete so cleanup skips it.
                 logger.warning(
                     "Could not list Scaleway buckets in project '%s' region '%s': %s",
                     project_id,
                     region,
                     e.response.get("Error", {}).get("Code"),
                 )
+                project_complete = False
                 continue
             for bucket in listing.get("Buckets", []):
                 buckets.append(_get_bucket_details(s3, bucket, region, project_id))
-    return buckets
+        if project_complete:
+            complete_projects.append(project_id)
+    return buckets, complete_projects
 
 
 def _get_bucket_details(

--- a/cartography/intel/scaleway/storage/objectstorage.py
+++ b/cartography/intel/scaleway/storage/objectstorage.py
@@ -1,0 +1,216 @@
+import json
+import logging
+from typing import Any
+
+import boto3
+import neo4j
+import scaleway
+from botocore.exceptions import ClientError
+from policyuniverse.policy import Policy
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.scaleway.utils import OBJECT_STORAGE_REGIONS
+from cartography.models.scaleway.storage.objectstorage import (
+    ScalewayObjectStorageBucketSchema,
+)
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+# Canned S3 group URIs that expose a bucket to everyone on the internet.
+PUBLIC_ACL_URIS = {
+    "http://acs.amazonaws.com/groups/global/AllUsers",
+    "http://acs.amazonaws.com/groups/global/AuthenticatedUsers",
+}
+
+# Sentinel for a detail call that could not be read (e.g. AccessDenied): the
+# state is unknown, which must NOT be collapsed into a "not public" signal.
+FETCH_FAILED = "__FETCH_FAILED__"
+
+# Error codes that mean the config genuinely does not exist (a real "absent"
+# answer, distinct from a read failure).
+_ABSENT_ERROR_CODES = {
+    "NoSuchBucketPolicy",
+    "NoSuchTagSet",
+    "NoSuchConfiguration",
+}
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: scaleway.Client,
+    common_job_parameters: dict[str, Any],
+    org_id: str,
+    projects_id: list[str],
+    update_tag: int,
+) -> None:
+    buckets = get(client)
+    buckets_by_project = transform_buckets(buckets)
+    load_buckets(neo4j_session, buckets_by_project, update_tag)
+    cleanup(neo4j_session, projects_id, common_job_parameters)
+
+
+@timeit
+def get(client: scaleway.Client) -> list[dict[str, Any]]:
+    """Scaleway Object Storage is S3-compatible and is not exposed by the
+    Scaleway Python SDK, so we use boto3 against the regional S3 endpoints."""
+    buckets: list[dict[str, Any]] = []
+    for region in OBJECT_STORAGE_REGIONS:
+        s3 = boto3.client(
+            "s3",
+            region_name=region,
+            endpoint_url=f"https://s3.{region}.scw.cloud",
+            aws_access_key_id=client.access_key,
+            aws_secret_access_key=client.secret_key,
+        )
+        listing = s3.list_buckets()
+        owner_id = listing.get("Owner", {}).get("ID", "")
+        for bucket in listing.get("Buckets", []):
+            buckets.append(_get_bucket_details(s3, bucket, region, owner_id))
+    return buckets
+
+
+def _get_bucket_details(
+    s3: Any, bucket: dict[str, Any], region: str, owner_id: str
+) -> dict[str, Any]:
+    name = bucket["Name"]
+    details: dict[str, Any] = {
+        "name": name,
+        "region": region,
+        "endpoint": f"https://{name}.s3.{region}.scw.cloud",
+        "creation_date": bucket.get("CreationDate"),
+        "owner_id": owner_id,
+        "acl": None,
+        "policy": None,
+        "versioning": None,
+        "tags": None,
+    }
+    # Each call is independent: a bucket policy can lock the owner out of the
+    # admin endpoints (AccessDenied), so we keep whatever we can read.
+    details["acl"] = _safe_call(s3.get_bucket_acl, name)
+    details["policy"] = _safe_call(s3.get_bucket_policy, name)
+    details["versioning"] = _safe_call(s3.get_bucket_versioning, name)
+    details["tags"] = _safe_call(s3.get_bucket_tagging, name)
+    return details
+
+
+def _safe_call(func: Any, name: str) -> Any:
+    """Returns the response, None if the config is genuinely absent, or
+    FETCH_FAILED if the call could not be read (so callers can keep the state
+    unknown instead of assuming a benign default)."""
+    try:
+        return func(Bucket=name)
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code")
+        logger.debug(
+            "Scaleway Object Storage %s on bucket '%s' failed: %s",
+            func.__name__,
+            name,
+            code,
+        )
+        return None if code in _ABSENT_ERROR_CODES else FETCH_FAILED
+
+
+def transform_buckets(
+    buckets: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {}
+    for bucket in buckets:
+        # The S3 owner ID is "<project_id>:<project_id>" on Scaleway.
+        project_id = bucket["owner_id"].split(":")[0]
+        # Leave the exposure signals null (unknown) when their source read
+        # failed, rather than reporting a bucket as not-public on bad data.
+        acl = bucket["acl"]
+        acl_public = None if acl is FETCH_FAILED else _is_acl_public(acl)
+        policy = bucket["policy"]
+        if policy is FETCH_FAILED:
+            anonymous_access, anonymous_actions = None, None
+        else:
+            anonymous_access, anonymous_actions = _parse_policy(policy)
+        versioning = bucket["versioning"]
+        formatted = {
+            "id": bucket["name"],
+            "name": bucket["name"],
+            "region": bucket["region"],
+            "endpoint": bucket["endpoint"],
+            "creation_date": bucket["creation_date"],
+            "owner_id": bucket["owner_id"],
+            "tags": (
+                None if bucket["tags"] is FETCH_FAILED else _format_tags(bucket["tags"])
+            ),
+            "versioning_status": (
+                None
+                if versioning in (None, FETCH_FAILED)
+                else (versioning.get("Status") or None)
+            ),
+            "acl_public": acl_public,
+            "anonymous_access": anonymous_access,
+            "anonymous_actions": anonymous_actions,
+        }
+        result.setdefault(project_id, []).append(formatted)
+    return result
+
+
+def _format_tags(tagging: dict[str, Any] | None) -> list[str] | None:
+    if not tagging:
+        return None
+    tags = [f"{t['Key']}={t['Value']}" for t in tagging.get("TagSet", [])]
+    return tags or None
+
+
+def _is_acl_public(acl: dict[str, Any] | None) -> bool:
+    if not acl:
+        return False
+    for grant in acl.get("Grants", []):
+        grantee = grant.get("Grantee", {})
+        if grantee.get("Type") == "Group" and grantee.get("URI") in PUBLIC_ACL_URIS:
+            return True
+    return False
+
+
+def _parse_policy(policy: dict[str, Any] | None) -> tuple[bool, list[str]]:
+    """Reuse policyuniverse (as the AWS S3 module does) to detect anonymous
+    access from an S3-compatible bucket policy."""
+    if not policy:
+        return False, []
+    parsed = Policy(json.loads(policy["Policy"]))
+    if parsed.is_internet_accessible():
+        return True, sorted(parsed.internet_accessible_actions())
+    return False, []
+
+
+@timeit
+def load_buckets(
+    neo4j_session: neo4j.Session,
+    data: dict[str, list[dict[str, Any]]],
+    update_tag: int,
+) -> None:
+    for project_id, buckets in data.items():
+        logger.info(
+            "Loading %d Scaleway ObjectStorageBuckets in project '%s' into Neo4j.",
+            len(buckets),
+            project_id,
+        )
+        load(
+            neo4j_session,
+            ScalewayObjectStorageBucketSchema(),
+            buckets,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    projects_id: list[str],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    for project_id in projects_id:
+        scoped_job_parameters = common_job_parameters.copy()
+        scoped_job_parameters["PROJECT_ID"] = project_id
+        GraphJob.from_node_schema(
+            ScalewayObjectStorageBucketSchema(), scoped_job_parameters
+        ).run(neo4j_session)

--- a/cartography/intel/scaleway/utils.py
+++ b/cartography/intel/scaleway/utils.py
@@ -5,6 +5,9 @@ from typing import Any
 # Zone does not really matter for readonly access, but we need to set it
 DEFAULT_ZONE = "fr-par-1"
 
+# Scaleway Object Storage regions (S3-compatible endpoints live per region).
+OBJECT_STORAGE_REGIONS = ("fr-par", "nl-ams", "pl-waw", "it-mil")
+
 
 def scaleway_obj_to_dict(obj: Any) -> dict[str, Any]:
     """Transform a Scaleway object (dataclass, dict, or list) into a dictionary."""

--- a/cartography/models/ontology/mapping/data/object_storage.py
+++ b/cartography/models/ontology/mapping/data/object_storage.py
@@ -100,8 +100,50 @@ azure_mapping = OntologyMapping(
     ],
 )
 
+scaleway_mapping = OntologyMapping(
+    module_name="scaleway",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="ScalewayObjectStorageBucket",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name",
+                    node_field="name",
+                    required=True,
+                ),
+                OntologyFieldMapping(ontology_field="location", node_field="region"),
+                # Scaleway Object Storage encrypts every object at rest by default,
+                # so report encrypted=True statically (as GCP does) rather than
+                # leaving it unset.
+                OntologyFieldMapping(
+                    ontology_field="encrypted",
+                    node_field="",
+                    special_handling="static_value",
+                    extra={"value": True},
+                ),
+                OntologyFieldMapping(
+                    ontology_field="versioning",
+                    node_field="versioning_status",
+                    special_handling="equal_boolean",
+                    extra={"values": ["Enabled"]},
+                ),
+                # A bucket is public if its policy grants anonymous access OR its ACL
+                # grants AllUsers/AuthenticatedUsers (the model stores these signals
+                # separately, so ACL-only public buckets must not be missed).
+                OntologyFieldMapping(
+                    ontology_field="public",
+                    node_field="anonymous_access",
+                    special_handling="or_boolean",
+                    extra={"fields": ["acl_public"]},
+                ),
+            ],
+        ),
+    ],
+)
+
 OBJECT_STORAGE_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws": aws_mapping,
     "gcp": gcp_mapping,
     "azure": azure_mapping,
+    "scaleway": scaleway_mapping,
 }

--- a/cartography/models/ontology/mapping/data/object_storage.py
+++ b/cartography/models/ontology/mapping/data/object_storage.py
@@ -127,14 +127,13 @@ scaleway_mapping = OntologyMapping(
                     special_handling="equal_boolean",
                     extra={"values": ["Enabled"]},
                 ),
-                # A bucket is public if its policy grants anonymous access OR its ACL
-                # grants AllUsers/AuthenticatedUsers (the model stores these signals
-                # separately, so ACL-only public buckets must not be missed).
+                # `public` is the tri-state combined signal (policy anonymous
+                # access OR ACL AllUsers/AuthenticatedUsers; null when both
+                # sources were unreadable). Mapped directly to preserve the
+                # unknown state instead of coalescing it to false.
                 OntologyFieldMapping(
                     ontology_field="public",
-                    node_field="anonymous_access",
-                    special_handling="or_boolean",
-                    extra={"fields": ["acl_public"]},
+                    node_field="public",
                 ),
             ],
         ),

--- a/cartography/models/scaleway/storage/objectstorage.py
+++ b/cartography/models/scaleway/storage/objectstorage.py
@@ -19,12 +19,13 @@ class ScalewayObjectStorageBucketNodeProperties(CartographyNodeProperties):
     endpoint: PropertyRef = PropertyRef("endpoint")
     creation_date: PropertyRef = PropertyRef("creation_date")
     tags: PropertyRef = PropertyRef("tags")
-    owner_id: PropertyRef = PropertyRef("owner_id")
     versioning_status: PropertyRef = PropertyRef("versioning_status")
     # Public-exposure signals (mirrors AWS S3 anonymous_access / GCP acl_public).
+    # `public` is the combined tri-state (null = unknown, both sources unreadable).
     acl_public: PropertyRef = PropertyRef("acl_public")
     anonymous_access: PropertyRef = PropertyRef("anonymous_access", extra_index=True)
     anonymous_actions: PropertyRef = PropertyRef("anonymous_actions")
+    public: PropertyRef = PropertyRef("public", extra_index=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 

--- a/cartography/models/scaleway/storage/objectstorage.py
+++ b/cartography/models/scaleway/storage/objectstorage.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class ScalewayObjectStorageBucketNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    region: PropertyRef = PropertyRef("region")
+    endpoint: PropertyRef = PropertyRef("endpoint")
+    creation_date: PropertyRef = PropertyRef("creation_date")
+    tags: PropertyRef = PropertyRef("tags")
+    owner_id: PropertyRef = PropertyRef("owner_id")
+    versioning_status: PropertyRef = PropertyRef("versioning_status")
+    # Public-exposure signals (mirrors AWS S3 anonymous_access / GCP acl_public).
+    acl_public: PropertyRef = PropertyRef("acl_public")
+    anonymous_access: PropertyRef = PropertyRef("anonymous_access", extra_index=True)
+    anonymous_actions: PropertyRef = PropertyRef("anonymous_actions")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewayObjectStorageBucketToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewayObjectStorageBucket)
+class ScalewayObjectStorageBucketToProjectRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewayObjectStorageBucketToProjectRelProperties = (
+        ScalewayObjectStorageBucketToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayObjectStorageBucketSchema(CartographyNodeSchema):
+    label: str = "ScalewayObjectStorageBucket"
+    properties: ScalewayObjectStorageBucketNodeProperties = (
+        ScalewayObjectStorageBucketNodeProperties()
+    )
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ObjectStorage"])
+    sub_resource_relationship: ScalewayObjectStorageBucketToProjectRel = (
+        ScalewayObjectStorageBucketToProjectRel()
+    )

--- a/cartography/rules/data/rules/object_storage_public.py
+++ b/cartography/rules/data/rules/object_storage_public.py
@@ -139,19 +139,17 @@ _scaleway_bucket_public = Fact(
     ),
     cypher_query="""
     MATCH (b:ScalewayObjectStorageBucket)
-    WHERE coalesce(b.anonymous_access, false) = true
-    OR coalesce(b.acl_public, false) = true
+    WHERE b.public = true
     RETURN
         b.id AS id,
         b.name AS name,
         b.region AS region,
-        coalesce(b.anonymous_access, false) OR coalesce(b.acl_public, false) AS public_access,
+        b.public AS public_access,
         b.anonymous_actions AS public_actions
     """,
     cypher_visual_query="""
     MATCH p=(b:ScalewayObjectStorageBucket)<-[:RESOURCE]-(prj:ScalewayProject)
-    WHERE coalesce(b.anonymous_access, false) = true
-    OR coalesce(b.acl_public, false) = true
+    WHERE b.public = true
     RETURN *
     """,
     cypher_count_query="""

--- a/cartography/rules/data/rules/object_storage_public.py
+++ b/cartography/rules/data/rules/object_storage_public.py
@@ -128,6 +128,42 @@ _azure_storage_public_blob_access = Fact(
 )
 
 
+# Scaleway Facts
+_scaleway_bucket_public = Fact(
+    id="scaleway_bucket_public",
+    name="Internet-Accessible Scaleway Object Storage Attack Surface",
+    description=(
+        "Scaleway Object Storage buckets accessible from the internet, either "
+        "through a bucket policy granting anonymous access or an ACL granting "
+        "AllUsers / AuthenticatedUsers."
+    ),
+    cypher_query="""
+    MATCH (b:ScalewayObjectStorageBucket)
+    WHERE coalesce(b.anonymous_access, false) = true
+    OR coalesce(b.acl_public, false) = true
+    RETURN
+        b.id AS id,
+        b.name AS name,
+        b.region AS region,
+        coalesce(b.anonymous_access, false) OR coalesce(b.acl_public, false) AS public_access,
+        b.anonymous_actions AS public_actions
+    """,
+    cypher_visual_query="""
+    MATCH p=(b:ScalewayObjectStorageBucket)<-[:RESOURCE]-(prj:ScalewayProject)
+    WHERE coalesce(b.anonymous_access, false) = true
+    OR coalesce(b.acl_public, false) = true
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (b:ScalewayObjectStorageBucket)
+    RETURN COUNT(b) AS count
+    """,
+    identity_fields=("id",),
+    module=Module.SCALEWAY,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
 # Rule
 class ObjectStoragePublic(Finding):
     name: str | None = None
@@ -143,13 +179,15 @@ object_storage_public = Rule(
     name="Public Object Storage Attack Surface",
     description=(
         "Publicly accessible object storage services such as AWS S3 buckets, "
-        "Azure Storage Blob Containers, and GCS buckets"
+        "Azure Storage Blob Containers, GCS buckets, and Scaleway Object "
+        "Storage buckets"
     ),
     output_model=ObjectStoragePublic,
     facts=(
         _aws_s3_public,
         _azure_storage_public_blob_access,
         _gcp_bucket_public,
+        _scaleway_bucket_public,
     ),
     tags=(
         "infrastructure",

--- a/docs/root/modules/scaleway/schema.md
+++ b/docs/root/modules/scaleway/schema.md
@@ -543,15 +543,15 @@ An Object Storage bucket is an S3-compatible container for objects. Scaleway Obj
 |------------|----------------------------------------------|
 | id         | Bucket name (globally unique).               |
 | name       | Bucket name.                                 |
-| region     | Region the bucket lives in (`fr-par`, `nl-ams`, `pl-waw`). |
+| region     | Region the bucket lives in (`fr-par`, `nl-ams`, `pl-waw`, `it-mil`). |
 | endpoint   | Public S3 endpoint URL of the bucket.        |
 | creation_date | Bucket creation date.                     |
 | tags       | Bucket tags (`key=value`).                   |
-| owner_id   | S3 owner ID (`<project_id>:<project_id>`).   |
 | versioning_status | Versioning status (`Enabled`, `Suspended`, or unset). |
-| acl_public | True if the bucket ACL grants access to `AllUsers` / `AuthenticatedUsers`. |
-| anonymous_access | True if the bucket policy grants anonymous (internet) access. |
+| acl_public | True if the bucket ACL grants access to `AllUsers` / `AuthenticatedUsers` (null if the ACL could not be read). |
+| anonymous_access | True if the bucket policy grants anonymous (internet) access (null if the policy could not be read). |
 | anonymous_actions | Actions granted to anonymous principals by the bucket policy. |
+| public     | Combined public-exposure signal: `acl_public` OR `anonymous_access`; null when both sources were unreadable. |
 | lastupdated | Timestamp of the last update                 |
 
 #### Relationships

--- a/docs/root/modules/scaleway/schema.md
+++ b/docs/root/modules/scaleway/schema.md
@@ -16,6 +16,7 @@ PRJ -- RESOURCE --> VOL(Volume)
 PRJ -- RESOURCE --> SNAP(VolumeSnapshot)
 PRJ -- RESOURCE --> SG(SecurityGroup)
 PRJ -- RESOURCE --> SGR(SecurityGroupRule)
+PRJ -- RESOURCE --> BKT(ObjectStorageBucket)
 INS -- MOUNTS --> VOL
 INS -- MEMBER_OF_SCALEWAY_SECURITY_GROUP --> SG
 SGR -- MEMBER_OF_SCALEWAY_SECURITY_GROUP --> SG
@@ -86,7 +87,8 @@ Represents a Project in Scaleway. Projects are groupings of Scaleway resources.
         :ScalewayVolumeSnapshot,
         :ScalewayInstance,
         :ScalewaySecurityGroup,
-        :ScalewaySecurityGroupRule
+        :ScalewaySecurityGroupRule,
+        :ScalewayObjectStorageBucket
     )
     ```
 
@@ -529,4 +531,31 @@ A Security Group Rule is a single firewall rule (inbound or outbound) belonging 
 - A `SecurityGroupRule` is a member of a `SecurityGroup`
     ```
     (:ScalewaySecurityGroupRule)-[:MEMBER_OF_SCALEWAY_SECURITY_GROUP]->(:ScalewaySecurityGroup)
+    ```
+
+### ScalewayObjectStorageBucket
+
+An Object Storage bucket is an S3-compatible container for objects. Scaleway Object Storage is not exposed by the Scaleway Python SDK, so it is collected through the regional S3-compatible endpoints.
+
+> **Ontology Mapping**: This node has the extra label `ObjectStorage` to enable cross-platform queries for object storage across different systems (e.g., S3Bucket, GCPBucket).
+
+| Field      | Description                                  |
+|------------|----------------------------------------------|
+| id         | Bucket name (globally unique).               |
+| name       | Bucket name.                                 |
+| region     | Region the bucket lives in (`fr-par`, `nl-ams`, `pl-waw`). |
+| endpoint   | Public S3 endpoint URL of the bucket.        |
+| creation_date | Bucket creation date.                     |
+| tags       | Bucket tags (`key=value`).                   |
+| owner_id   | S3 owner ID (`<project_id>:<project_id>`).   |
+| versioning_status | Versioning status (`Enabled`, `Suspended`, or unset). |
+| acl_public | True if the bucket ACL grants access to `AllUsers` / `AuthenticatedUsers`. |
+| anonymous_access | True if the bucket policy grants anonymous (internet) access. |
+| anonymous_actions | Actions granted to anonymous principals by the bucket policy. |
+| lastupdated | Timestamp of the last update                 |
+
+#### Relationships
+- An `ObjectStorageBucket` belongs to a `Project`
+    ```
+    (:ScalewayProject)-[:RESOURCE]->(:ScalewayObjectStorageBucket)
     ```

--- a/tests/data/scaleway/storages.py
+++ b/tests/data/scaleway/storages.py
@@ -44,3 +44,62 @@ SCALEWAY_SNAPSHOTS = [
         error_reason=None,
     )
 ]
+
+# Object Storage buckets are S3-compatible: get() returns raw boto3-shaped dicts.
+# The S3 owner ID is "<project_id>:<project_id>" on Scaleway.
+_OWNER_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d:0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+
+SCALEWAY_BUCKETS = [
+    {
+        "name": "cartography-private-bucket",
+        "region": "fr-par",
+        "endpoint": "https://cartography-private-bucket.s3.fr-par.scw.cloud",
+        "creation_date": datetime(2025, 6, 20, 12, 0, 0, tzinfo=tzutc()),
+        "owner_id": _OWNER_ID,
+        "acl": {
+            "Owner": {"ID": _OWNER_ID, "DisplayName": _OWNER_ID},
+            "Grants": [
+                {
+                    "Grantee": {"ID": _OWNER_ID, "Type": "CanonicalUser"},
+                    "Permission": "FULL_CONTROL",
+                }
+            ],
+        },
+        "policy": None,
+        "versioning": {"Status": "Enabled"},
+        "tags": {
+            "TagSet": [
+                {"Key": "env", "Value": "test"},
+                {"Key": "owner", "Value": "cartography"},
+            ]
+        },
+    },
+    {
+        "name": "cartography-public-bucket",
+        "region": "nl-ams",
+        "endpoint": "https://cartography-public-bucket.s3.nl-ams.scw.cloud",
+        "creation_date": datetime(2025, 6, 20, 12, 5, 0, tzinfo=tzutc()),
+        "owner_id": _OWNER_ID,
+        "acl": {
+            "Owner": {"ID": _OWNER_ID, "DisplayName": _OWNER_ID},
+            "Grants": [
+                {
+                    "Grantee": {
+                        "Type": "Group",
+                        "URI": "http://acs.amazonaws.com/groups/global/AllUsers",
+                    },
+                    "Permission": "READ",
+                }
+            ],
+        },
+        "policy": {
+            "Policy": (
+                '{"Version":"2023-04-17","Statement":[{"Sid":"AllowPublicRead",'
+                '"Effect":"Allow","Principal":"*","Action":"s3:GetObject",'
+                '"Resource":"cartography-public-bucket/*"}]}'
+            )
+        },
+        "versioning": None,
+        "tags": None,
+    },
+]

--- a/tests/data/scaleway/storages.py
+++ b/tests/data/scaleway/storages.py
@@ -46,8 +46,9 @@ SCALEWAY_SNAPSHOTS = [
 ]
 
 # Object Storage buckets are S3-compatible: get() returns raw boto3-shaped dicts.
-# The S3 owner ID is "<project_id>:<project_id>" on Scaleway.
-_OWNER_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d:0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+# get() tags each bucket with the project it was enumerated under.
+_PROJECT_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+_OWNER_ID = f"{_PROJECT_ID}:{_PROJECT_ID}"
 
 SCALEWAY_BUCKETS = [
     {
@@ -55,7 +56,7 @@ SCALEWAY_BUCKETS = [
         "region": "fr-par",
         "endpoint": "https://cartography-private-bucket.s3.fr-par.scw.cloud",
         "creation_date": datetime(2025, 6, 20, 12, 0, 0, tzinfo=tzutc()),
-        "owner_id": _OWNER_ID,
+        "project_id": _PROJECT_ID,
         "acl": {
             "Owner": {"ID": _OWNER_ID, "DisplayName": _OWNER_ID},
             "Grants": [
@@ -79,7 +80,7 @@ SCALEWAY_BUCKETS = [
         "region": "nl-ams",
         "endpoint": "https://cartography-public-bucket.s3.nl-ams.scw.cloud",
         "creation_date": datetime(2025, 6, 20, 12, 5, 0, tzinfo=tzutc()),
-        "owner_id": _OWNER_ID,
+        "project_id": _PROJECT_ID,
         "acl": {
             "Owner": {"ID": _OWNER_ID, "DisplayName": _OWNER_ID},
             "Grants": [

--- a/tests/integration/cartography/intel/scaleway/test_storage.py
+++ b/tests/integration/cartography/intel/scaleway/test_storage.py
@@ -204,13 +204,13 @@ def test_load_scaleway_object_storage_buckets(_mock_get, neo4j_session):
     assert check_nodes(
         neo4j_session,
         "ScalewayObjectStorageBucket",
-        ["id", "region", "acl_public", "anonymous_access"],
+        ["id", "region", "acl_public", "anonymous_access", "public"],
     ) == {
-        ("cartography-private-bucket", "fr-par", False, False),
-        ("cartography-public-bucket", "nl-ams", True, True),
+        ("cartography-private-bucket", "fr-par", False, False, False),
+        ("cartography-public-bucket", "nl-ams", True, True, True),
     }
     # Assert the ObjectStorage ontology mapping populates normalized _ont_* fields.
-    # _ont_public ORs anonymous_access (policy) and acl_public (ACL).
+    # _ont_public is mapped from the tri-state `public` field.
     assert check_nodes(
         neo4j_session,
         "ObjectStorage",

--- a/tests/integration/cartography/intel/scaleway/test_storage.py
+++ b/tests/integration/cartography/intel/scaleway/test_storage.py
@@ -179,7 +179,7 @@ def test_load_scaleway_snapshots(_mock_get, neo4j_session):
 @patch.object(
     cartography.intel.scaleway.storage.objectstorage,
     "get",
-    return_value=tests.data.scaleway.storages.SCALEWAY_BUCKETS,
+    return_value=(tests.data.scaleway.storages.SCALEWAY_BUCKETS, [TEST_PROJECT_ID]),
 )
 def test_load_scaleway_object_storage_buckets(_mock_get, neo4j_session):
     # Arrange

--- a/tests/integration/cartography/intel/scaleway/test_storage.py
+++ b/tests/integration/cartography/intel/scaleway/test_storage.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 from unittest.mock import patch
 
+import cartography.intel.scaleway.storage.objectstorage
 import cartography.intel.scaleway.storage.snapshots
 import cartography.intel.scaleway.storage.volumes
 import tests.data.scaleway.storages
@@ -172,4 +173,88 @@ def test_load_scaleway_snapshots(_mock_get, neo4j_session):
             rel_direction_right=False,
         )
         == expected_volume_rels
+    )
+
+
+@patch.object(
+    cartography.intel.scaleway.storage.objectstorage,
+    "get",
+    return_value=tests.data.scaleway.storages.SCALEWAY_BUCKETS,
+)
+def test_load_scaleway_object_storage_buckets(_mock_get, neo4j_session):
+    # Arrange
+    client = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "ORG_ID": TEST_ORG_ID,
+    }
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+
+    # Act
+    cartography.intel.scaleway.storage.objectstorage.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # Assert Buckets exist with the ObjectStorage ontology label
+    assert check_nodes(
+        neo4j_session,
+        "ScalewayObjectStorageBucket",
+        ["id", "region", "acl_public", "anonymous_access"],
+    ) == {
+        ("cartography-private-bucket", "fr-par", False, False),
+        ("cartography-public-bucket", "nl-ams", True, True),
+    }
+    # Assert the ObjectStorage ontology mapping populates normalized _ont_* fields.
+    # _ont_public ORs anonymous_access (policy) and acl_public (ACL).
+    assert check_nodes(
+        neo4j_session,
+        "ObjectStorage",
+        [
+            "id",
+            "_ont_name",
+            "_ont_location",
+            "_ont_encrypted",
+            "_ont_versioning",
+            "_ont_public",
+        ],
+    ) == {
+        (
+            "cartography-private-bucket",
+            "cartography-private-bucket",
+            "fr-par",
+            True,
+            True,
+            False,
+        ),
+        (
+            "cartography-public-bucket",
+            "cartography-public-bucket",
+            "nl-ams",
+            True,
+            None,  # versioning unset -> _ont_versioning is null
+            True,
+        ),
+    }
+
+    # Assert buckets are linked to the project
+    expected_rels = {
+        ("cartography-private-bucket", TEST_PROJECT_ID),
+        ("cartography-public-bucket", TEST_PROJECT_ID),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "ScalewayObjectStorageBucket",
+            "id",
+            "ScalewayProject",
+            "id",
+            "RESOURCE",
+            rel_direction_right=False,
+        )
+        == expected_rels
     )


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary

Adds a Scaleway **Object Storage** intel module. Scaleway Object Storage is S3-compatible and is not exposed by the Scaleway Python SDK, so buckets are collected with `boto3` against the regional S3 endpoints (`fr-par`, `nl-ams`, `pl-waw`).

Each bucket becomes a `ScalewayObjectStorageBucket` node linked to its `ScalewayProject` (the project is derived from the S3 owner id, which Scaleway reports as `<project_id>:<project_id>`). The model captures the public-exposure signals that matter for findings, mirroring the AWS S3 and GCP bucket models:

- `acl_public` — derived from the bucket ACL (`AllUsers` / `AuthenticatedUsers` grants)
- `anonymous_access` / `anonymous_actions` — derived from the bucket policy via `policyuniverse` (same approach as the AWS S3 module)
- plus `region`, `endpoint`, `creation_date`, `tags`, `owner_id`, `versioning_status`

Cross-provider wiring:
- **Ontology**: the node carries the `ObjectStorage` semantic label and is registered in `OBJECT_STORAGE_ONTOLOGY_MAPPING`, so it populates `_ont_name`, `_ont_location`, `_ont_encrypted` (Scaleway encrypts at rest by default → static `true`, as GCP does), `_ont_versioning`, and `_ont_public` (`anonymous_access OR acl_public`, so ACL-only public buckets are not missed).
- **Rules**: a Scaleway fact is added to the `object_storage_public` rule so a public Scaleway bucket is surfaced by the "Public Object Storage Attack Surface" detection alongside AWS / Azure / GCP.

Note on the Scaleway API: a bucket policy can lock the owner out of the admin endpoints (`get_bucket_acl` / `get_bucket_versioning` / ... return `AccessDenied`), and `get_bucket_policy_status` is unreliable, so each per-bucket detail call is exception-tolerant and public exposure is derived from the ACL + policy document directly.

### How was this tested?

- `make test_lint` passes locally (isort / black / flake8 / mypy).
- New integration test `test_load_scaleway_object_storage_buckets` (public + private bucket, asserts the node, the `ObjectStorage` `_ont_*` fields, and the `RESOURCE` edge to the project). Existing scaleway storage tests still pass.
- Rules unit suite passes; the new rule fact's Cypher (query / visual / count) parses and runs against Neo4j.
- End-to-end against a real Scaleway account: created one public (anonymous bucket policy) and one private bucket, ran the real `get()` + `transform()` across all three regions → the public bucket was flagged (`anonymous_access=true`), the private one clean, project correctly resolved. Test buckets were deleted afterward.

Sample sync log:

```
INFO:cartography.intel.scaleway.storage.objectstorage:Loading 2 Scaleway ObjectStorageBuckets in project '0681c477-...' into Neo4j.
INFO:cartography.client.core.tx:Loaded 2 ScalewayObjectStorageBucket nodes
```

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [x] Included Cartography sync logs demonstrating successful synchronization of the new entity.

#### If you are changing a node or relationship
- [x] Updated the schema documentation.

#### If you are implementing a new intel module
- [x] Used the NodeSchema data model.

### Notes for reviewers

This is the Object Storage step of the broader Scaleway coverage effort. Public exposure is intentionally folded into bucket properties (like the GCP model) rather than modeled as separate ACL-grant / policy-statement nodes (the AWS approach); that finer granularity can be added later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
