### PR TITLE
feat(databricks): add intel module with workspace identity coverage

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -2479,7 +2479,11 @@ class CLI:
                 )
                 databricks_token = os.environ.get(databricks_token_env_var)
             databricks_client_secret = None
-            if databricks_client_id and databricks_client_secret_env_var:
+            if databricks_client_secret_env_var:
+                # Read the secret whenever the env-var flag is set, even if
+                # --databricks-client-id is missing, so the module entry's
+                # partial-OAuth guard sees the asymmetric configuration and
+                # fails loudly instead of silently skipping ingestion.
                 logger.debug(
                     "Reading Databricks OAuth M2M secret from environment variable %s",
                     databricks_client_secret_env_var,

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -52,6 +52,7 @@ PANEL_TAILSCALE = "Tailscale Options"
 PANEL_OPENAI = "OpenAI Options"
 PANEL_ANTHROPIC = "Anthropic Options"
 PANEL_AIRBYTE = "Airbyte Options"
+PANEL_DATABRICKS = "Databricks Options"
 PANEL_DOCKER_SCOUT = "Docker Scout Options"
 PANEL_TRIVY = "Trivy Options"
 PANEL_SYFT = "Syft Options"
@@ -107,6 +108,7 @@ MODULE_PANELS = {
     "openai": PANEL_OPENAI,
     "anthropic": PANEL_ANTHROPIC,
     "airbyte": PANEL_AIRBYTE,
+    "databricks": PANEL_DATABRICKS,
     "docker_scout": PANEL_DOCKER_SCOUT,
     "trivy": PANEL_TRIVY,
     "syft": PANEL_SYFT,
@@ -1434,6 +1436,45 @@ class CLI:
                 ),
             ] = "https://api.airbyte.com/v1",
             # =================================================================
+            # Databricks Options
+            # =================================================================
+            databricks_workspace_url: Annotated[
+                str | None,
+                typer.Option(
+                    "--databricks-workspace-url",
+                    help="Databricks workspace URL, e.g. https://dbc-xxxx.cloud.databricks.com.",
+                    rich_help_panel=PANEL_DATABRICKS,
+                    hidden=PANEL_DATABRICKS not in visible_panels,
+                ),
+            ] = None,
+            databricks_token_env_var: Annotated[
+                str | None,
+                typer.Option(
+                    "--databricks-token-env-var",
+                    help="Environment variable name containing the Databricks personal access token (PAT).",
+                    rich_help_panel=PANEL_DATABRICKS,
+                    hidden=PANEL_DATABRICKS not in visible_panels,
+                ),
+            ] = None,
+            databricks_client_id: Annotated[
+                str | None,
+                typer.Option(
+                    "--databricks-client-id",
+                    help="Databricks OAuth M2M client ID (workspace-level service principal).",
+                    rich_help_panel=PANEL_DATABRICKS,
+                    hidden=PANEL_DATABRICKS not in visible_panels,
+                ),
+            ] = None,
+            databricks_client_secret_env_var: Annotated[
+                str | None,
+                typer.Option(
+                    "--databricks-client-secret-env-var",
+                    help="Environment variable name containing the Databricks OAuth M2M client secret.",
+                    rich_help_panel=PANEL_DATABRICKS,
+                    hidden=PANEL_DATABRICKS not in visible_panels,
+                ),
+            ] = None,
+            # =================================================================
             # Docker Scout Options
             # =================================================================
             docker_scout_source: Annotated[
@@ -2429,6 +2470,24 @@ class CLI:
                 )
                 airbyte_client_secret = os.environ.get(airbyte_client_secret_env_var)
 
+            # Read Databricks credentials
+            databricks_token = None
+            if databricks_token_env_var:
+                logger.debug(
+                    "Reading Databricks PAT from environment variable %s",
+                    databricks_token_env_var,
+                )
+                databricks_token = os.environ.get(databricks_token_env_var)
+            databricks_client_secret = None
+            if databricks_client_id and databricks_client_secret_env_var:
+                logger.debug(
+                    "Reading Databricks OAuth M2M secret from environment variable %s",
+                    databricks_client_secret_env_var,
+                )
+                databricks_client_secret = os.environ.get(
+                    databricks_client_secret_env_var,
+                )
+
             resolved_docker_scout_source = _resolve_report_source_option(
                 module="docker_scout",
                 source=docker_scout_source,
@@ -2697,6 +2756,10 @@ class CLI:
                 airbyte_client_id=airbyte_client_id,
                 airbyte_client_secret=airbyte_client_secret,
                 airbyte_api_url=airbyte_api_url,
+                databricks_workspace_url=databricks_workspace_url,
+                databricks_token=databricks_token,
+                databricks_client_id=databricks_client_id,
+                databricks_client_secret=databricks_client_secret,
                 # Forward the user-provided values (not resolved). Config calls
                 # resolve_report_source_with_legacy_fields() internally; the CLI's
                 # _resolve_report_source_option above runs the same logic for early

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -244,6 +244,14 @@ class Config:
     :param airbyte_client_secret: Airbyte client secret for API authentication. Optional.
     :type airbyte_api_url: str
     :param airbyte_api_url: Airbyte API base URL, e.g. https://api.airbyte.com/v1. Optional.
+    :type databricks_workspace_url: str
+    :param databricks_workspace_url: Databricks workspace URL, e.g. https://dbc-xxxx.cloud.databricks.com. Optional.
+    :type databricks_token: str
+    :param databricks_token: Databricks personal access token (PAT). Optional.
+    :type databricks_client_id: str
+    :param databricks_client_id: Databricks OAuth M2M client ID. Optional.
+    :type databricks_client_secret: str
+    :param databricks_client_secret: Databricks OAuth M2M client secret. Optional.
     :type docker_scout_results_dir: str
     :param docker_scout_results_dir: Local directory containing Docker Scout recommendation text reports. Optional.
     :type docker_scout_source: str
@@ -449,6 +457,10 @@ class Config:
         airbyte_client_id=None,
         airbyte_client_secret=None,
         airbyte_api_url=None,
+        databricks_workspace_url=None,
+        databricks_token=None,
+        databricks_client_id=None,
+        databricks_client_secret=None,
         docker_scout_source=None,
         docker_scout_results_dir=None,
         docker_scout_s3_bucket=None,
@@ -623,6 +635,10 @@ class Config:
         self.airbyte_client_id = airbyte_client_id
         self.airbyte_client_secret = airbyte_client_secret
         self.airbyte_api_url = airbyte_api_url
+        self.databricks_workspace_url = databricks_workspace_url
+        self.databricks_token = databricks_token
+        self.databricks_client_id = databricks_client_id
+        self.databricks_client_secret = databricks_client_secret
         # DEPRECATED: `*_results_dir` and `*_s3_*` compat shims; removed in Cartography v1.0.0.
         self.docker_scout_source = _resolve_report_source_config(
             module="docker_scout",

--- a/cartography/intel/databricks/__init__.py
+++ b/cartography/intel/databricks/__init__.py
@@ -1,0 +1,94 @@
+import logging
+
+import neo4j
+
+import cartography.intel.databricks.groups
+import cartography.intel.databricks.service_principals
+import cartography.intel.databricks.tokens
+import cartography.intel.databricks.users
+import cartography.intel.databricks.workspaces
+from cartography.config import Config
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def start_databricks_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
+    """
+    If this module is configured, perform ingestion of Databricks data. Otherwise warn and exit.
+
+    Authentication supports either:
+      - Personal Access Token (PAT) via ``--databricks-token-env-var``
+      - OAuth M2M (workspace-level service principal) via
+        ``--databricks-client-id`` + ``--databricks-client-secret-env-var``
+
+    :param neo4j_session: Neo4J session for database interface
+    :param config: A cartography.config object
+    :return: None
+    """
+    if not config.databricks_workspace_url:
+        logger.info(
+            "Databricks import is not configured - skipping this module. "
+            "See docs to configure.",
+        )
+        return
+
+    if not config.databricks_token and not (
+        config.databricks_client_id and config.databricks_client_secret
+    ):
+        logger.info(
+            "Databricks import is not configured - skipping this module. "
+            "Set --databricks-token-env-var or "
+            "--databricks-client-id + --databricks-client-secret-env-var.",
+        )
+        return
+
+    api_client = DatabricksWorkspaceClient(
+        host=config.databricks_workspace_url,
+        token=config.databricks_token,
+        client_id=config.databricks_client_id,
+        client_secret=config.databricks_client_secret,
+    )
+
+    workspace = cartography.intel.databricks.workspaces.sync(
+        neo4j_session,
+        api_client,
+        {"UPDATE_TAG": config.update_tag},
+    )
+    workspace_id = workspace["id"]
+    common_job_parameters = {
+        "UPDATE_TAG": config.update_tag,
+        "WORKSPACE_ID": workspace_id,
+    }
+
+    # Groups must be synced before users + service principals so the
+    # User/SP -[:MEMBER_OF]-> Group MATCH lands the relationship.
+    cartography.intel.databricks.groups.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
+    )
+
+    cartography.intel.databricks.users.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
+    )
+
+    cartography.intel.databricks.service_principals.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
+    )
+
+    cartography.intel.databricks.tokens.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
+    )

--- a/cartography/intel/databricks/__init__.py
+++ b/cartography/intel/databricks/__init__.py
@@ -35,9 +35,21 @@ def start_databricks_ingestion(neo4j_session: neo4j.Session, config: Config) -> 
         )
         return
 
-    if not config.databricks_token and not (
-        config.databricks_client_id and config.databricks_client_secret
-    ):
+    has_token = bool(config.databricks_token)
+    has_client_id = bool(config.databricks_client_id)
+    has_client_secret = bool(config.databricks_client_secret)
+
+    # OAuth requires *both* halves. A partial pair is an operator mistake
+    # (typo in --databricks-client-secret-env-var, missing env variable) —
+    # fail loudly so it cannot silently fall through to "not configured".
+    if has_client_id ^ has_client_secret:
+        raise ValueError(
+            "Databricks OAuth M2M is partially configured: "
+            "--databricks-client-id and --databricks-client-secret-env-var "
+            "must be set together (and the env variable must be populated).",
+        )
+
+    if not has_token and not (has_client_id and has_client_secret):
         logger.info(
             "Databricks import is not configured - skipping this module. "
             "Set --databricks-token-env-var or "

--- a/cartography/intel/databricks/groups.py
+++ b/cartography/intel/databricks/groups.py
@@ -1,0 +1,111 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import scoped_id
+from cartography.models.databricks.group import DatabricksGroupSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    groups = get(api_session)
+    transformed = transform(groups, workspace_id)
+    load_groups(
+        neo4j_session, transformed, workspace_id, common_job_parameters["UPDATE_TAG"]
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    return api_session.scim_list("/api/2.0/preview/scim/v2/Groups")
+
+
+@timeit
+def transform(groups: list[dict[str, Any]], workspace_id: str) -> list[dict[str, Any]]:
+    """Flatten SCIM nested-group memberships into parent_group_ids on each group.
+
+    Databricks SCIM exposes group nesting via two paths and only one is
+    guaranteed to be populated on any given response:
+      - the parent's ``members`` list (with ``$ref: "Groups/..."``), and
+      - the child's own ``groups`` list (same shape as Users / SPs).
+    Both are consumed and deduplicated so the Group -> Group MEMBER_OF edge
+    lands regardless of which side the API fills in.
+
+    Edges to users and service principals are reverse-materialised on those
+    nodes via the ``group_ids`` list returned by the SCIM Users /
+    ServicePrincipals endpoints.
+
+    Node ids are scoped to the workspace so multi-workspace ingestion does
+    not collide on workspace-scoped SCIM ids.
+    """
+    by_scim_id: dict[str, dict[str, Any]] = {}
+    for g in groups:
+        scim_id = g["id"]
+        by_scim_id[scim_id] = {
+            "id": scoped_id(workspace_id, scim_id),
+            "scim_id": scim_id,
+            "display_name": g.get("displayName"),
+            "external_id": g.get("externalId"),
+            # set() during accumulation, list() before return so the load layer
+            # gets a deterministic, JSON-friendly value.
+            "_parent_set": set(),
+        }
+    for g in groups:
+        scim_id = g["id"]
+        # Upward: the child group's own ``groups`` field.
+        for parent in g.get("groups", []) or []:
+            parent_id = parent.get("value")
+            if parent_id and parent_id in by_scim_id:
+                by_scim_id[scim_id]["_parent_set"].add(
+                    scoped_id(workspace_id, parent_id)
+                )
+        # Downward: the parent group's ``members`` field with $ref="Groups/...".
+        for member in g.get("members", []) or []:
+            member_id = member.get("value")
+            member_ref = member.get("$ref", "") or ""
+            if not member_id:
+                continue
+            if member_ref.startswith("Groups/") and member_id in by_scim_id:
+                by_scim_id[member_id]["_parent_set"].add(
+                    scoped_id(workspace_id, scim_id)
+                )
+    result: list[dict[str, Any]] = []
+    for entry in by_scim_id.values():
+        entry["parent_group_ids"] = sorted(entry.pop("_parent_set"))
+        result.append(entry)
+    return result
+
+
+@timeit
+def load_groups(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksGroupSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksGroupSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/service_principals.py
+++ b/cartography/intel/databricks/service_principals.py
@@ -1,0 +1,80 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import scoped_id
+from cartography.models.databricks.service_principal import (
+    DatabricksServicePrincipalSchema,
+)
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    sps = get(api_session)
+    transformed = transform(sps, workspace_id)
+    load_service_principals(
+        neo4j_session, transformed, workspace_id, common_job_parameters["UPDATE_TAG"]
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    return api_session.scim_list("/api/2.0/preview/scim/v2/ServicePrincipals")
+
+
+@timeit
+def transform(sps: list[dict[str, Any]], workspace_id: str) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for sp in sps:
+        scim_id = sp["id"]
+        result.append(
+            {
+                "id": scoped_id(workspace_id, scim_id),
+                "scim_id": scim_id,
+                "application_id": sp.get("applicationId"),
+                "display_name": sp.get("displayName"),
+                "external_id": sp.get("externalId"),
+                "active": sp.get("active"),
+                "group_ids": [
+                    scoped_id(workspace_id, g["value"])
+                    for g in (sp.get("groups") or [])
+                    if g.get("value")
+                ],
+            }
+        )
+    return result
+
+
+@timeit
+def load_service_principals(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksServicePrincipalSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(
+        DatabricksServicePrincipalSchema(), common_job_parameters
+    ).run(neo4j_session)

--- a/cartography/intel/databricks/tokens.py
+++ b/cartography/intel/databricks/tokens.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from datetime import timezone
 from typing import Any
 
 import neo4j
@@ -14,6 +16,17 @@ def _scoped_or_none(workspace_id: str, value: Any) -> str | None:
     if value is None:
         return None
     return scoped_id(workspace_id, str(value))
+
+
+def _epoch_ms_to_datetime(value: Any) -> datetime | None:
+    """Convert a Unix-epoch-milliseconds value to a UTC datetime.
+
+    The Databricks token-management API encodes ``expiry_time = -1`` as a
+    sentinel for "no expiry"; both that and a missing value yield ``None``.
+    """
+    if value in (None, -1):
+        return None
+    return datetime.fromtimestamp(int(value) / 1000, tz=timezone.utc)
 
 
 @timeit
@@ -55,8 +68,8 @@ def transform(tokens: list[dict[str, Any]], workspace_id: str) -> list[dict[str,
                 "id": scoped_id(workspace_id, token_id),
                 "token_id": token_id,
                 "comment": t.get("comment"),
-                "creation_time": t.get("creation_time"),
-                "expiry_time": t.get("expiry_time"),
+                "creation_time": _epoch_ms_to_datetime(t.get("creation_time")),
+                "expiry_time": _epoch_ms_to_datetime(t.get("expiry_time")),
                 "owner_id": _scoped_or_none(workspace_id, t.get("owner_id")),
                 "created_by_id": _scoped_or_none(workspace_id, t.get("created_by_id")),
                 "created_by_username": t.get("created_by_username"),

--- a/cartography/intel/databricks/tokens.py
+++ b/cartography/intel/databricks/tokens.py
@@ -1,0 +1,90 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import scoped_id
+from cartography.models.databricks.token import DatabricksTokenSchema
+from cartography.util import timeit
+
+
+def _scoped_or_none(workspace_id: str, value: Any) -> str | None:
+    if value is None:
+        return None
+    return scoped_id(workspace_id, str(value))
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    tokens = get(api_session)
+    transformed = transform(tokens, workspace_id)
+    load_tokens(
+        neo4j_session, transformed, workspace_id, common_job_parameters["UPDATE_TAG"]
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    response = api_session.get("/api/2.0/token-management/tokens")
+    return response.get("token_infos", []) or []
+
+
+@timeit
+def transform(tokens: list[dict[str, Any]], workspace_id: str) -> list[dict[str, Any]]:
+    """Scope token ids to the workspace.
+
+    The token-management API returns workspace-scoped ``token_id`` strings and
+    integer ``owner_id`` / ``created_by_id`` referencing SCIM principals. Both
+    are namespaced under the workspace so multi-workspace ingestion cannot
+    collapse same-id tokens, and OWNER_OF MATCH lines up with the composite
+    ``DatabricksUser.id`` / ``DatabricksServicePrincipal.id``.
+    """
+    result: list[dict[str, Any]] = []
+    for t in tokens:
+        token_id = t["token_id"]
+        result.append(
+            {
+                "id": scoped_id(workspace_id, token_id),
+                "token_id": token_id,
+                "comment": t.get("comment"),
+                "creation_time": t.get("creation_time"),
+                "expiry_time": t.get("expiry_time"),
+                "owner_id": _scoped_or_none(workspace_id, t.get("owner_id")),
+                "created_by_id": _scoped_or_none(workspace_id, t.get("created_by_id")),
+                "created_by_username": t.get("created_by_username"),
+            }
+        )
+    return result
+
+
+@timeit
+def load_tokens(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksTokenSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksTokenSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/users.py
+++ b/cartography/intel/databricks/users.py
@@ -1,0 +1,88 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import scoped_id
+from cartography.models.databricks.user import DatabricksUserSchema
+from cartography.util import timeit
+
+
+def _primary_email(emails: list[dict[str, Any]] | None) -> str | None:
+    if not emails:
+        return None
+    for entry in emails:
+        if entry.get("primary"):
+            return entry.get("value")
+    return emails[0].get("value")
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    users = get(api_session)
+    transformed = transform(users, workspace_id)
+    load_users(
+        neo4j_session, transformed, workspace_id, common_job_parameters["UPDATE_TAG"]
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    return api_session.scim_list("/api/2.0/preview/scim/v2/Users")
+
+
+@timeit
+def transform(users: list[dict[str, Any]], workspace_id: str) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for u in users:
+        scim_id = u["id"]
+        result.append(
+            {
+                "id": scoped_id(workspace_id, scim_id),
+                "scim_id": scim_id,
+                "user_name": u.get("userName"),
+                "display_name": u.get("displayName"),
+                "external_id": u.get("externalId"),
+                "active": u.get("active"),
+                "email": _primary_email(u.get("emails")),
+                "group_ids": [
+                    scoped_id(workspace_id, g["value"])
+                    for g in (u.get("groups") or [])
+                    if g.get("value")
+                ],
+            }
+        )
+    return result
+
+
+@timeit
+def load_users(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksUserSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksUserSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/util.py
+++ b/cartography/intel/databricks/util.py
@@ -1,0 +1,99 @@
+import logging
+import time
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Connect and read timeouts of 60 seconds each.
+_TIMEOUT = (60, 60)
+_SCIM_PAGE_SIZE = 100
+
+
+def scoped_id(workspace_id: str, scim_id: str) -> str:
+    """Build a workspace-scoped node id ``{workspace_id}/{scim_id}``.
+
+    Databricks SCIM ids are workspace-scoped, not globally unique, so node ids
+    must include the workspace to keep multi-workspace ingestion from collapsing
+    same-id principals into a single Neo4j node.
+    """
+    return f"{workspace_id}/{scim_id}"
+
+
+class DatabricksWorkspaceClient:
+    """A thin client for the Databricks Workspace REST API.
+
+    Supports two authentication modes:
+      - Personal Access Token (PAT): pass ``token``.
+      - OAuth M2M (workspace-level service principal client credentials):
+        pass ``client_id`` and ``client_secret``.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        token: str | None = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+    ) -> None:
+        if not token and not (client_id and client_secret):
+            raise ValueError(
+                "Must provide either token, or both client_id and client_secret.",
+            )
+        self.host = host.rstrip("/")
+        self._token = token
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._access_token_expiry: float | None = None
+        self._session = requests.Session()
+
+    def authenticate(self) -> None:
+        if self._token:
+            self._session.headers["Authorization"] = f"Bearer {self._token}"
+            return
+        if self._access_token_expiry and self._access_token_expiry >= time.time():
+            return
+        self._session.headers.pop("Authorization", None)
+        response = self._session.post(
+            f"{self.host}/oidc/v1/token",
+            data={"grant_type": "client_credentials", "scope": "all-apis"},
+            auth=(self._client_id, self._client_secret),  # type: ignore[arg-type]
+            timeout=_TIMEOUT,
+        )
+        response.raise_for_status()
+        data = response.json()
+        self._session.headers["Authorization"] = f"Bearer {data['access_token']}"
+        self._access_token_expiry = time.time() + data.get("expires_in", 0)
+        logger.debug(
+            "Databricks access token renewed, expires in %s seconds.",
+            data.get("expires_in", 0),
+        )
+
+    def get(self, uri: str, params: dict | None = None) -> Any:
+        """Single GET that returns the parsed JSON body."""
+        self.authenticate()
+        response = self._session.get(
+            f"{self.host}{uri}",
+            params=params or {},
+            timeout=_TIMEOUT,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def scim_list(self, uri: str) -> list[dict[str, Any]]:
+        """Paginate a SCIM listing endpoint and return all resources."""
+        results: list[dict[str, Any]] = []
+        start_index = 1
+        while True:
+            data = self.get(
+                uri,
+                params={"startIndex": start_index, "count": _SCIM_PAGE_SIZE},
+            )
+            resources = data.get("Resources", []) or []
+            results.extend(resources)
+            total = int(data.get("totalResults", 0))
+            if not resources or start_index + len(resources) - 1 >= total:
+                break
+            start_index += len(resources)
+        return results

--- a/cartography/intel/databricks/workspaces.py
+++ b/cartography/intel/databricks/workspaces.py
@@ -1,0 +1,77 @@
+from typing import Any
+from urllib.parse import urlparse
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.models.databricks.workspace import DatabricksWorkspaceSchema
+from cartography.util import timeit
+
+
+def _workspace_id_from_host(host: str) -> str:
+    """Derive a stable workspace identifier from the workspace host URL.
+
+    Uses the host's deployment hostname (e.g. ``dbc-aaeaddda-e52f.cloud.databricks.com``)
+    which is the natural unique key Databricks exposes to PAT-scoped clients.
+    """
+    parsed = urlparse(host if "://" in host else f"https://{host}")
+    return (parsed.netloc or parsed.path).lower()
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    common_job_parameters: dict[str, Any],
+) -> dict[str, Any]:
+    workspace = get(api_session)
+    load_workspaces(neo4j_session, [workspace], common_job_parameters["UPDATE_TAG"])
+    cleanup(neo4j_session, common_job_parameters)
+    return workspace
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> dict[str, Any]:
+    """Build a workspace summary from the host URL and token management settings."""
+    workspace_id = _workspace_id_from_host(api_session.host)
+    token_conf = api_session.get(
+        "/api/2.0/workspace-conf",
+        params={"keys": "enableTokensConfig,maxTokenLifetimeDays"},
+    )
+    enable_tokens = token_conf.get("enableTokensConfig")
+    max_lifetime = token_conf.get("maxTokenLifetimeDays")
+    return {
+        "id": workspace_id,
+        "host": api_session.host,
+        "tokens_enabled": (
+            str(enable_tokens).lower() == "true" if enable_tokens is not None else None
+        ),
+        "max_token_lifetime_days": (
+            int(max_lifetime) if max_lifetime not in (None, "") else None
+        ),
+    }
+
+
+@timeit
+def load_workspaces(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksWorkspaceSchema(),
+        data,
+        lastupdated=update_tag,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksWorkspaceSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/workspaces.py
+++ b/cartography/intel/databricks/workspaces.py
@@ -42,15 +42,22 @@ def get(api_session: DatabricksWorkspaceClient) -> dict[str, Any]:
     )
     enable_tokens = token_conf.get("enableTokensConfig")
     max_lifetime = token_conf.get("maxTokenLifetimeDays")
+    # Databricks treats ``maxTokenLifetimeDays == "0"`` as a sentinel meaning
+    # "revert to the system default" (730 days as of 2026-06), not a literal
+    # zero-day lifetime. Map "" and "0" to None so security queries comparing
+    # the explicit cap stay correct.
+    parsed_lifetime: int | None
+    if max_lifetime in (None, "", "0"):
+        parsed_lifetime = None
+    else:
+        parsed_lifetime = int(max_lifetime)
     return {
         "id": workspace_id,
         "host": api_session.host,
         "tokens_enabled": (
             str(enable_tokens).lower() == "true" if enable_tokens is not None else None
         ),
-        "max_token_lifetime_days": (
-            int(max_lifetime) if max_lifetime not in (None, "") else None
-        ),
+        "max_token_lifetime_days": parsed_lifetime,
     }
 
 

--- a/cartography/models/databricks/group.py
+++ b/cartography/models/databricks/group.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksGroupNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    scim_id: PropertyRef = PropertyRef("scim_id", extra_index=True)
+    display_name: PropertyRef = PropertyRef("display_name", extra_index=True)
+    external_id: PropertyRef = PropertyRef("external_id")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksGroupToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksGroup)
+class DatabricksGroupToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksGroupToWorkspaceRelProperties = (
+        DatabricksGroupToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksGroupToParentGroupRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksGroup)-[:MEMBER_OF]->(:DatabricksGroup)
+class DatabricksGroupToParentGroupRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("parent_group_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MEMBER_OF"
+    properties: DatabricksGroupToParentGroupRelProperties = (
+        DatabricksGroupToParentGroupRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksGroupSchema(CartographyNodeSchema):
+    label: str = "DatabricksGroup"
+    properties: DatabricksGroupNodeProperties = DatabricksGroupNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["UserGroup"])
+    sub_resource_relationship: DatabricksGroupToWorkspaceRel = (
+        DatabricksGroupToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DatabricksGroupToParentGroupRel()],
+    )

--- a/cartography/models/databricks/service_principal.py
+++ b/cartography/models/databricks/service_principal.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksServicePrincipalNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    scim_id: PropertyRef = PropertyRef("scim_id", extra_index=True)
+    application_id: PropertyRef = PropertyRef("application_id", extra_index=True)
+    display_name: PropertyRef = PropertyRef("display_name")
+    external_id: PropertyRef = PropertyRef("external_id")
+    active: PropertyRef = PropertyRef("active")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksServicePrincipalToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksServicePrincipal)
+class DatabricksServicePrincipalToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksServicePrincipalToWorkspaceRelProperties = (
+        DatabricksServicePrincipalToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksServicePrincipalToGroupRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksServicePrincipal)-[:MEMBER_OF]->(:DatabricksGroup)
+class DatabricksServicePrincipalToGroupRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("group_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MEMBER_OF"
+    properties: DatabricksServicePrincipalToGroupRelProperties = (
+        DatabricksServicePrincipalToGroupRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksServicePrincipalSchema(CartographyNodeSchema):
+    label: str = "DatabricksServicePrincipal"
+    properties: DatabricksServicePrincipalNodeProperties = (
+        DatabricksServicePrincipalNodeProperties()
+    )
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ServiceAccount"])
+    sub_resource_relationship: DatabricksServicePrincipalToWorkspaceRel = (
+        DatabricksServicePrincipalToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DatabricksServicePrincipalToGroupRel()],
+    )

--- a/cartography/models/databricks/token.py
+++ b/cartography/models/databricks/token.py
@@ -1,0 +1,95 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksTokenNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    token_id: PropertyRef = PropertyRef("token_id", extra_index=True)
+    comment: PropertyRef = PropertyRef("comment")
+    creation_time: PropertyRef = PropertyRef("creation_time")
+    expiry_time: PropertyRef = PropertyRef("expiry_time")
+    owner_id: PropertyRef = PropertyRef("owner_id")
+    created_by_id: PropertyRef = PropertyRef("created_by_id")
+    created_by_username: PropertyRef = PropertyRef(
+        "created_by_username", extra_index=True
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksTokenToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksToken)
+class DatabricksTokenToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksTokenToWorkspaceRelProperties = (
+        DatabricksTokenToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksTokenToOwnerUserRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksUser)-[:OWNER_OF]->(:DatabricksToken)
+class DatabricksTokenToOwnerUserRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksUser"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("owner_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "OWNER_OF"
+    properties: DatabricksTokenToOwnerUserRelProperties = (
+        DatabricksTokenToOwnerUserRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksTokenToOwnerSPRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksServicePrincipal)-[:OWNER_OF]->(:DatabricksToken)
+class DatabricksTokenToOwnerSPRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksServicePrincipal"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("owner_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "OWNER_OF"
+    properties: DatabricksTokenToOwnerSPRelProperties = (
+        DatabricksTokenToOwnerSPRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksTokenSchema(CartographyNodeSchema):
+    label: str = "DatabricksToken"
+    properties: DatabricksTokenNodeProperties = DatabricksTokenNodeProperties()
+    sub_resource_relationship: DatabricksTokenToWorkspaceRel = (
+        DatabricksTokenToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DatabricksTokenToOwnerUserRel(), DatabricksTokenToOwnerSPRel()],
+    )

--- a/cartography/models/databricks/user.py
+++ b/cartography/models/databricks/user.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksUserNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    scim_id: PropertyRef = PropertyRef("scim_id", extra_index=True)
+    user_name: PropertyRef = PropertyRef("user_name", extra_index=True)
+    email: PropertyRef = PropertyRef("email", extra_index=True)
+    display_name: PropertyRef = PropertyRef("display_name")
+    external_id: PropertyRef = PropertyRef("external_id")
+    active: PropertyRef = PropertyRef("active")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksUserToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksUser)
+class DatabricksUserToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksUserToWorkspaceRelProperties = (
+        DatabricksUserToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksUserToGroupRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksUser)-[:MEMBER_OF]->(:DatabricksGroup)
+class DatabricksUserToGroupRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("group_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MEMBER_OF"
+    properties: DatabricksUserToGroupRelProperties = (
+        DatabricksUserToGroupRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksUserSchema(CartographyNodeSchema):
+    label: str = "DatabricksUser"
+    properties: DatabricksUserNodeProperties = DatabricksUserNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["UserAccount"])
+    sub_resource_relationship: DatabricksUserToWorkspaceRel = (
+        DatabricksUserToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DatabricksUserToGroupRel()],
+    )

--- a/cartography/models/databricks/workspace.py
+++ b/cartography/models/databricks/workspace.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+
+
+@dataclass(frozen=True)
+class DatabricksWorkspaceNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    host: PropertyRef = PropertyRef("host", extra_index=True)
+    tokens_enabled: PropertyRef = PropertyRef("tokens_enabled")
+    max_token_lifetime_days: PropertyRef = PropertyRef("max_token_lifetime_days")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksWorkspaceSchema(CartographyNodeSchema):
+    label: str = "DatabricksWorkspace"
+    properties: DatabricksWorkspaceNodeProperties = DatabricksWorkspaceNodeProperties()
+    # `Tenant` is the ontology label for the top-level resource container.
+    # ponytail: scoped under the workspace; account-level (`DatabricksAccount`) lands
+    # in a follow-up PR alongside the Accounts API client.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Tenant"])

--- a/cartography/models/ontology/mapping/data/groups.py
+++ b/cartography/models/ontology/mapping/data/groups.py
@@ -373,4 +373,21 @@ GROUPS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "tailscale": tailscale_mapping,
     "kubernetes": kubernetes_mapping,
     "vercel": vercel_mapping,
+    "databricks": OntologyMapping(
+        module_name="databricks",
+        nodes=[
+            OntologyNodeMapping(
+                node_label="DatabricksGroup",
+                fields=[
+                    OntologyFieldMapping(
+                        ontology_field="name",
+                        node_field="display_name",
+                        required=True,
+                    ),
+                    # description: Not available
+                    # email: Not available
+                ],
+            ),
+        ],
+    ),
 }

--- a/cartography/models/ontology/mapping/data/serviceaccounts.py
+++ b/cartography/models/ontology/mapping/data/serviceaccounts.py
@@ -122,4 +122,21 @@ SERVICEACCOUNTS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "scaleway": scaleway_mapping,
     "aws": aws_mapping,
     "microsoft": microsoft_mapping,
+    "databricks": OntologyMapping(
+        module_name="databricks",
+        nodes=[
+            OntologyNodeMapping(
+                node_label="DatabricksServicePrincipal",
+                fields=[
+                    OntologyFieldMapping(
+                        ontology_field="name",
+                        node_field="display_name",
+                        required=True,
+                    ),
+                    # email: Not available
+                    OntologyFieldMapping(ontology_field="active", node_field="active"),
+                ],
+            ),
+        ],
+    ),
 }

--- a/cartography/models/ontology/mapping/data/tenants.py
+++ b/cartography/models/ontology/mapping/data/tenants.py
@@ -449,4 +449,18 @@ TENANTS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "socketdev": socketdev_mapping,
     "workos": workos_tenants_mapping,
     "vercel": vercel_mapping,
+    "databricks": OntologyMapping(
+        module_name="databricks",
+        nodes=[
+            OntologyNodeMapping(
+                node_label="DatabricksWorkspace",
+                fields=[
+                    OntologyFieldMapping(
+                        ontology_field="name", node_field="host", required=True
+                    ),
+                    OntologyFieldMapping(ontology_field="domain", node_field="host"),
+                ],
+            ),
+        ],
+    ),
 }

--- a/cartography/models/ontology/mapping/data/useraccounts.py
+++ b/cartography/models/ontology/mapping/data/useraccounts.py
@@ -636,4 +636,21 @@ USERACCOUNTS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "kubernetes": kubernetes_mapping,
     "jumpcloud": jumpcloud_mapping,
     "vercel": vercel_mapping,
+    "databricks": OntologyMapping(
+        module_name="databricks",
+        nodes=[
+            OntologyNodeMapping(
+                node_label="DatabricksUser",
+                fields=[
+                    OntologyFieldMapping(
+                        ontology_field="email", node_field="email", required=True
+                    ),
+                    OntologyFieldMapping(
+                        ontology_field="fullname", node_field="display_name"
+                    ),
+                    OntologyFieldMapping(ontology_field="active", node_field="active"),
+                ],
+            ),
+        ],
+    ),
 }

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -46,6 +46,9 @@ TOP_LEVEL_MODULES: OrderedDict[str, Callable[..., None]] = OrderedDict(
     {  # preserve order so that the default sync always runs `analysis` at the very end
         "create-indexes": _LazyStage("cartography.intel.create_indexes", "run"),
         "airbyte": _LazyStage("cartography.intel.airbyte", "start_airbyte_ingestion"),
+        "databricks": _LazyStage(
+            "cartography.intel.databricks", "start_databricks_ingestion"
+        ),
         "anthropic": _LazyStage(
             "cartography.intel.anthropic", "start_anthropic_ingestion"
         ),

--- a/docs/root/modules/databricks/config.md
+++ b/docs/root/modules/databricks/config.md
@@ -1,0 +1,12 @@
+## Databricks Configuration
+
+Follow these steps to analyze Databricks objects with Cartography.
+
+1. Pass your workspace URL via `--databricks-workspace-url`, e.g. `https://dbc-xxxx.cloud.databricks.com`.
+1. Provide credentials with one of the following:
+    - **Personal Access Token (PAT)**: populate an environment variable with the PAT and pass its name via `--databricks-token-env-var`.
+    - **OAuth M2M (workspace service principal)**: create a workspace-level service principal with a client ID and secret, then pass `--databricks-client-id` and the env var name holding the secret via `--databricks-client-secret-env-var`.
+
+The principal used by Cartography needs workspace admin privileges to enumerate SCIM users, groups, service principals, and to read the token management API.
+
+Account-level coverage (Accounts API, federation policies, workspace assignments, cross-cloud links to AWS/GCP/Azure) is added in follow-up PRs and will introduce dedicated `--databricks-account-*` options.

--- a/docs/root/modules/databricks/index.md
+++ b/docs/root/modules/databricks/index.md
@@ -1,0 +1,6 @@
+# Databricks
+
+```{toctree}
+config
+schema
+```

--- a/docs/root/modules/databricks/schema.md
+++ b/docs/root/modules/databricks/schema.md
@@ -1,0 +1,153 @@
+## Databricks Schema
+
+```mermaid
+graph LR
+W(DatabricksWorkspace) -- RESOURCE --> U(DatabricksUser)
+W -- RESOURCE --> S(DatabricksServicePrincipal)
+W -- RESOURCE --> G(DatabricksGroup)
+W -- RESOURCE --> T(DatabricksToken)
+U -- MEMBER_OF --> G
+S -- MEMBER_OF --> G
+G -- MEMBER_OF --> G
+U -- OWNER_OF --> T
+S -- OWNER_OF --> T
+```
+
+### DatabricksWorkspace
+
+A Databricks workspace, scoped by host URL.
+
+> **Ontology Mapping**: This node has the extra label `Tenant` to enable cross-platform queries for organizational tenants across different systems.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace host (e.g. `dbc-xxxx.cloud.databricks.com`) |
+| **host** | Full workspace URL (indexed) |
+| tokens_enabled | Whether PATs are enabled in the workspace |
+| max_token_lifetime_days | Max PAT lifetime in days, per workspace token management settings |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- `DatabricksUser`, `DatabricksServicePrincipal`, `DatabricksGroup`, `DatabricksToken` belong to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(
+        :DatabricksUser,
+        :DatabricksServicePrincipal,
+        :DatabricksGroup,
+        :DatabricksToken
+    )
+    ```
+
+### DatabricksUser
+
+A workspace SCIM user.
+
+> **Ontology Mapping**: This node has the extra label `UserAccount` to enable cross-platform queries for user accounts across different systems.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{scim_id}` (SCIM ids are not unique across workspaces) |
+| **scim_id** | Raw SCIM user ID returned by Databricks (indexed) |
+| **user_name** | SCIM `userName` (typically the email, indexed) |
+| **email** | Primary email address (indexed) |
+| display_name | SCIM display name |
+| external_id | External SCIM ID (federation) |
+| active | Whether the user is active |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksUser` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksUser)
+    ```
+- A `DatabricksUser` is a member of one or more `DatabricksGroup`.
+    ```
+    (:DatabricksUser)-[:MEMBER_OF]->(:DatabricksGroup)
+    ```
+
+### DatabricksServicePrincipal
+
+A workspace SCIM service principal.
+
+> **Ontology Mapping**: This node has the extra label `ServiceAccount` to enable cross-platform queries for non-human accounts across different systems.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{scim_id}` (SCIM ids are not unique across workspaces) |
+| **scim_id** | Raw SCIM service principal ID (indexed) |
+| **application_id** | OAuth application ID (indexed) |
+| display_name | SCIM display name |
+| external_id | External SCIM ID (federation) |
+| active | Whether the service principal is active |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksServicePrincipal` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksServicePrincipal)
+    ```
+- A `DatabricksServicePrincipal` is a member of one or more `DatabricksGroup`.
+    ```
+    (:DatabricksServicePrincipal)-[:MEMBER_OF]->(:DatabricksGroup)
+    ```
+
+### DatabricksGroup
+
+A workspace SCIM group.
+
+> **Ontology Mapping**: This node has the extra label `UserGroup` to enable cross-platform group queries.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{scim_id}` (SCIM ids are not unique across workspaces) |
+| **scim_id** | Raw SCIM group ID (indexed) |
+| **display_name** | Group display name (indexed) |
+| external_id | External SCIM ID (federation) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksGroup` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksGroup)
+    ```
+- A `DatabricksGroup` can be a member of another `DatabricksGroup` (nested groups).
+    ```
+    (:DatabricksGroup)-[:MEMBER_OF]->(:DatabricksGroup)
+    ```
+
+### DatabricksToken
+
+A Databricks personal access token (PAT) returned by the token management API.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{token_id}` (token-management ids are workspace-local) |
+| **token_id** | Raw token id returned by the token-management API (indexed) |
+| comment | Token description provided at creation |
+| creation_time | Unix epoch (ms) when the token was created |
+| expiry_time | Unix epoch (ms) when the token expires (-1 if no expiry) |
+| owner_id | Workspace-scoped composite id of the token owner (matches `DatabricksUser.id` or `DatabricksServicePrincipal.id`) |
+| created_by_id | Workspace-scoped composite id of the principal that created the token |
+| created_by_username | Username/email of the principal that created the token (indexed) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksToken` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksToken)
+    ```
+- A `DatabricksUser` or `DatabricksServicePrincipal` owns a `DatabricksToken`.
+    ```
+    (:DatabricksUser)-[:OWNER_OF]->(:DatabricksToken)
+    (:DatabricksServicePrincipal)-[:OWNER_OF]->(:DatabricksToken)
+    ```

--- a/docs/root/modules/databricks/schema.md
+++ b/docs/root/modules/databricks/schema.md
@@ -24,7 +24,7 @@ A Databricks workspace, scoped by host URL.
 | **id** | Workspace host (e.g. `dbc-xxxx.cloud.databricks.com`) |
 | **host** | Full workspace URL (indexed) |
 | tokens_enabled | Whether PATs are enabled in the workspace |
-| max_token_lifetime_days | Max PAT lifetime in days, per workspace token management settings |
+| max_token_lifetime_days | Max PAT lifetime in days from the workspace token management settings, or null when the workspace is on the Databricks default policy (the API encodes that as the string `"0"`) |
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
 
@@ -132,8 +132,8 @@ A Databricks personal access token (PAT) returned by the token management API.
 | **id** | Workspace-scoped composite id `{workspace_id}/{token_id}` (token-management ids are workspace-local) |
 | **token_id** | Raw token id returned by the token-management API (indexed) |
 | comment | Token description provided at creation |
-| creation_time | Unix epoch (ms) when the token was created |
-| expiry_time | Unix epoch (ms) when the token expires (-1 if no expiry) |
+| creation_time | Native datetime when the token was created (UTC) |
+| expiry_time | Native datetime when the token expires (UTC); null when the token has no expiry |
 | owner_id | Workspace-scoped composite id of the token owner (matches `DatabricksUser.id` or `DatabricksServicePrincipal.id`) |
 | created_by_id | Workspace-scoped composite id of the principal that created the token |
 | created_by_username | Username/email of the principal that created the token (indexed) |

--- a/docs/root/usage/schema.md
+++ b/docs/root/usage/schema.md
@@ -51,6 +51,9 @@
 ```{include} ../modules/crowdstrike/schema.md
 ```
 
+```{include} ../modules/databricks/schema.md
+```
+
 ```{include} ../modules/cve/schema.md
 ```
 

--- a/tests/data/databricks/groups.py
+++ b/tests/data/databricks/groups.py
@@ -1,0 +1,44 @@
+DATABRICKS_GROUPS = [
+    {
+        "id": "87707764220300",
+        "displayName": "account users",
+        "members": [
+            {
+                "value": "70718330587535",
+                "display": "jeremy@subimage.io",
+                "$ref": "Users/70718330587535",
+            },
+            {
+                "value": "76890358753905",
+                "display": "kunaal@subimage.io",
+                "$ref": "Users/76890358753905",
+            },
+        ],
+    },
+    {
+        "id": "80972003232721",
+        "displayName": "admins",
+        "members": [
+            {
+                "value": "70718330587535",
+                "display": "jeremy@subimage.io",
+                "$ref": "Users/70718330587535",
+            },
+            {
+                "value": "12345678901234",
+                "display": "cartography-sp",
+                "$ref": "ServicePrincipals/12345678901234",
+            },
+            {
+                "value": "99999999999999",
+                "display": "nested-group",
+                "$ref": "Groups/99999999999999",
+            },
+        ],
+    },
+    {
+        "id": "99999999999999",
+        "displayName": "nested-group",
+        "members": [],
+    },
+]

--- a/tests/data/databricks/service_principals.py
+++ b/tests/data/databricks/service_principals.py
@@ -1,0 +1,11 @@
+DATABRICKS_SERVICE_PRINCIPALS = [
+    {
+        "id": "12345678901234",
+        "applicationId": "abcd1234-5678-90ab-cdef-1234567890ab",
+        "displayName": "cartography-sp",
+        "active": True,
+        "groups": [
+            {"value": "80972003232721", "display": "admins"},
+        ],
+    },
+]

--- a/tests/data/databricks/tokens.py
+++ b/tests/data/databricks/tokens.py
@@ -1,0 +1,20 @@
+DATABRICKS_TOKENS = [
+    {
+        "token_id": "token-abc",
+        "comment": "ci/cd token",
+        "creation_time": 1700000000000,
+        "expiry_time": 1800000000000,
+        "owner_id": "70718330587535",
+        "created_by_id": "70718330587535",
+        "created_by_username": "jeremy@subimage.io",
+    },
+    {
+        "token_id": "token-sp",
+        "comment": "service principal token",
+        "creation_time": 1700000001000,
+        "expiry_time": -1,
+        "owner_id": "12345678901234",
+        "created_by_id": "70718330587535",
+        "created_by_username": "jeremy@subimage.io",
+    },
+]

--- a/tests/data/databricks/users.py
+++ b/tests/data/databricks/users.py
@@ -1,0 +1,27 @@
+DATABRICKS_USERS = [
+    {
+        "id": "70718330587535",
+        "userName": "jeremy@subimage.io",
+        "displayName": "Jeremy",
+        "active": True,
+        "emails": [
+            {"primary": True, "type": "work", "value": "jeremy@subimage.io"},
+        ],
+        "groups": [
+            {"value": "87707764220300", "display": "account users"},
+            {"value": "80972003232721", "display": "admins"},
+        ],
+    },
+    {
+        "id": "76890358753905",
+        "userName": "kunaal@subimage.io",
+        "displayName": "Kunaal",
+        "active": True,
+        "emails": [
+            {"primary": True, "type": "work", "value": "kunaal@subimage.io"},
+        ],
+        "groups": [
+            {"value": "87707764220300", "display": "account users"},
+        ],
+    },
+]

--- a/tests/data/databricks/workspace.py
+++ b/tests/data/databricks/workspace.py
@@ -1,0 +1,18 @@
+DATABRICKS_WORKSPACE_HOST = "https://dbc-aaeaddda-e52f.cloud.databricks.com"
+DATABRICKS_WORKSPACE_ID = "dbc-aaeaddda-e52f.cloud.databricks.com"
+
+DATABRICKS_WORKSPACE_CONF = {
+    "enableTokensConfig": "true",
+    "maxTokenLifetimeDays": "730",
+}
+
+DATABRICKS_WORKSPACE = {
+    "id": DATABRICKS_WORKSPACE_ID,
+    "host": DATABRICKS_WORKSPACE_HOST,
+    "tokens_enabled": True,
+    "max_token_lifetime_days": 730,
+}
+
+
+def scoped(scim_id: str) -> str:
+    return f"{DATABRICKS_WORKSPACE_ID}/{scim_id}"

--- a/tests/integration/cartography/intel/databricks/test_groups.py
+++ b/tests/integration/cartography/intel/databricks/test_groups.py
@@ -1,0 +1,90 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.groups
+from tests.data.databricks.groups import DATABRICKS_GROUPS
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+def _ensure_local_neo4j_has_test_groups(neo4j_session):
+    transformed = cartography.intel.databricks.groups.transform(
+        DATABRICKS_GROUPS, DATABRICKS_WORKSPACE_ID
+    )
+    cartography.intel.databricks.groups.load_groups(
+        neo4j_session,
+        transformed,
+        DATABRICKS_WORKSPACE_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.databricks.groups,
+    "get",
+    return_value=DATABRICKS_GROUPS,
+)
+def test_load_databricks_groups(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+
+    cartography.intel.databricks.groups.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    expected_nodes = {
+        (scoped("87707764220300"), "87707764220300", "account users"),
+        (scoped("80972003232721"), "80972003232721", "admins"),
+        (scoped("99999999999999"), "99999999999999", "nested-group"),
+    }
+    assert (
+        check_nodes(neo4j_session, "DatabricksGroup", ["id", "scim_id", "display_name"])
+        == expected_nodes
+    )
+
+    # UserGroup ontology label is applied
+    assert check_nodes(neo4j_session, "UserGroup", ["id"]) >= {
+        (scoped("87707764220300"),),
+        (scoped("80972003232721"),),
+        (scoped("99999999999999"),),
+    }
+
+    # Group -> Workspace RESOURCE
+    assert check_rels(
+        neo4j_session,
+        "DatabricksGroup",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        (scoped("87707764220300"), DATABRICKS_WORKSPACE_ID),
+        (scoped("80972003232721"), DATABRICKS_WORKSPACE_ID),
+        (scoped("99999999999999"), DATABRICKS_WORKSPACE_ID),
+    }
+
+    # Nested group MEMBER_OF parent (nested-group is a member of admins)
+    assert check_rels(
+        neo4j_session,
+        "DatabricksGroup",
+        "id",
+        "DatabricksGroup",
+        "id",
+        "MEMBER_OF",
+        rel_direction_right=True,
+    ) == {(scoped("99999999999999"), scoped("80972003232721"))}

--- a/tests/integration/cartography/intel/databricks/test_service_principals.py
+++ b/tests/integration/cartography/intel/databricks/test_service_principals.py
@@ -1,0 +1,83 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.service_principals
+from tests.data.databricks.service_principals import DATABRICKS_SERVICE_PRINCIPALS
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_groups import (
+    _ensure_local_neo4j_has_test_groups,
+)
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+@patch.object(
+    cartography.intel.databricks.service_principals,
+    "get",
+    return_value=DATABRICKS_SERVICE_PRINCIPALS,
+)
+def test_load_databricks_service_principals(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+    _ensure_local_neo4j_has_test_groups(neo4j_session)
+
+    cartography.intel.databricks.service_principals.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    expected_nodes = {
+        (
+            scoped("12345678901234"),
+            "12345678901234",
+            "abcd1234-5678-90ab-cdef-1234567890ab",
+            "cartography-sp",
+        ),
+    }
+    assert (
+        check_nodes(
+            neo4j_session,
+            "DatabricksServicePrincipal",
+            ["id", "scim_id", "application_id", "display_name"],
+        )
+        == expected_nodes
+    )
+
+    # ServiceAccount ontology label is applied
+    assert check_nodes(neo4j_session, "ServiceAccount", ["id"]) >= {
+        (scoped("12345678901234"),),
+    }
+
+    # SP -> Workspace RESOURCE
+    assert check_rels(
+        neo4j_session,
+        "DatabricksServicePrincipal",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {(scoped("12345678901234"), DATABRICKS_WORKSPACE_ID)}
+
+    # SP -> Group MEMBER_OF
+    assert check_rels(
+        neo4j_session,
+        "DatabricksServicePrincipal",
+        "id",
+        "DatabricksGroup",
+        "id",
+        "MEMBER_OF",
+        rel_direction_right=True,
+    ) == {(scoped("12345678901234"), scoped("80972003232721"))}

--- a/tests/integration/cartography/intel/databricks/test_tokens.py
+++ b/tests/integration/cartography/intel/databricks/test_tokens.py
@@ -1,0 +1,152 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.service_principals
+import cartography.intel.databricks.tokens
+import cartography.intel.databricks.users
+from tests.data.databricks.service_principals import DATABRICKS_SERVICE_PRINCIPALS
+from tests.data.databricks.tokens import DATABRICKS_TOKENS
+from tests.data.databricks.users import DATABRICKS_USERS
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+def _seed_users_and_sps(neo4j_session):
+    cartography.intel.databricks.users.load_users(
+        neo4j_session,
+        cartography.intel.databricks.users.transform(
+            DATABRICKS_USERS, DATABRICKS_WORKSPACE_ID
+        ),
+        DATABRICKS_WORKSPACE_ID,
+        TEST_UPDATE_TAG,
+    )
+    cartography.intel.databricks.service_principals.load_service_principals(
+        neo4j_session,
+        cartography.intel.databricks.service_principals.transform(
+            DATABRICKS_SERVICE_PRINCIPALS, DATABRICKS_WORKSPACE_ID
+        ),
+        DATABRICKS_WORKSPACE_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.databricks.tokens,
+    "get",
+    return_value=DATABRICKS_TOKENS,
+)
+def test_load_databricks_tokens(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+    _seed_users_and_sps(neo4j_session)
+
+    cartography.intel.databricks.tokens.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    expected_nodes = {
+        (scoped("token-abc"), "token-abc", "ci/cd token", scoped("70718330587535")),
+        (
+            scoped("token-sp"),
+            "token-sp",
+            "service principal token",
+            scoped("12345678901234"),
+        ),
+    }
+    assert (
+        check_nodes(
+            neo4j_session,
+            "DatabricksToken",
+            ["id", "token_id", "comment", "owner_id"],
+        )
+        == expected_nodes
+    )
+
+    # Token -> Workspace RESOURCE
+    assert check_rels(
+        neo4j_session,
+        "DatabricksToken",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        (scoped("token-abc"), DATABRICKS_WORKSPACE_ID),
+        (scoped("token-sp"), DATABRICKS_WORKSPACE_ID),
+    }
+
+    # User OWNER_OF Token (token-abc owned by Jeremy)
+    assert check_rels(
+        neo4j_session,
+        "DatabricksUser",
+        "id",
+        "DatabricksToken",
+        "id",
+        "OWNER_OF",
+        rel_direction_right=True,
+    ) == {(scoped("70718330587535"), scoped("token-abc"))}
+
+    # ServicePrincipal OWNER_OF Token (token-sp owned by SP)
+    assert check_rels(
+        neo4j_session,
+        "DatabricksServicePrincipal",
+        "id",
+        "DatabricksToken",
+        "id",
+        "OWNER_OF",
+        rel_direction_right=True,
+    ) == {(scoped("12345678901234"), scoped("token-sp"))}
+
+
+def test_token_ids_are_workspace_scoped(neo4j_session):
+    """Two workspaces with overlapping token_ids must stay as separate nodes."""
+    workspace_a = "workspace-a.cloud.databricks.com"
+    workspace_b = "workspace-b.cloud.databricks.com"
+    shared_payload = [
+        {
+            "token_id": "shared-token",
+            "comment": "shared",
+            "creation_time": 1,
+            "expiry_time": -1,
+            "owner_id": 1,
+            "created_by_id": 1,
+            "created_by_username": "x",
+        },
+    ]
+
+    cartography.intel.databricks.tokens.load_tokens(
+        neo4j_session,
+        cartography.intel.databricks.tokens.transform(shared_payload, workspace_a),
+        workspace_a,
+        TEST_UPDATE_TAG,
+    )
+    cartography.intel.databricks.tokens.load_tokens(
+        neo4j_session,
+        cartography.intel.databricks.tokens.transform(shared_payload, workspace_b),
+        workspace_b,
+        TEST_UPDATE_TAG,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksToken",
+        ["id", "token_id"],
+    ) >= {
+        (f"{workspace_a}/shared-token", "shared-token"),
+        (f"{workspace_b}/shared-token", "shared-token"),
+    }

--- a/tests/integration/cartography/intel/databricks/test_users.py
+++ b/tests/integration/cartography/intel/databricks/test_users.py
@@ -1,0 +1,108 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.users
+from tests.data.databricks.users import DATABRICKS_USERS
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_groups import (
+    _ensure_local_neo4j_has_test_groups,
+)
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+@patch.object(
+    cartography.intel.databricks.users,
+    "get",
+    return_value=DATABRICKS_USERS,
+)
+def test_load_databricks_users(mock_get, neo4j_session):
+    # Arrange
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+    _ensure_local_neo4j_has_test_groups(neo4j_session)
+
+    # Act
+    cartography.intel.databricks.users.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    # Assert user nodes
+    expected_nodes = {
+        (
+            scoped("70718330587535"),
+            "70718330587535",
+            "jeremy@subimage.io",
+            "jeremy@subimage.io",
+        ),
+        (
+            scoped("76890358753905"),
+            "76890358753905",
+            "kunaal@subimage.io",
+            "kunaal@subimage.io",
+        ),
+    }
+    assert (
+        check_nodes(
+            neo4j_session,
+            "DatabricksUser",
+            ["id", "scim_id", "user_name", "email"],
+        )
+        == expected_nodes
+    )
+
+    # UserAccount ontology label is applied
+    assert check_nodes(neo4j_session, "UserAccount", ["id"]) >= {
+        (scoped("70718330587535"),),
+        (scoped("76890358753905"),),
+    }
+
+    # Assert User -> Workspace RESOURCE
+    expected_rels = {
+        (scoped("70718330587535"), DATABRICKS_WORKSPACE_ID),
+        (scoped("76890358753905"), DATABRICKS_WORKSPACE_ID),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "DatabricksUser",
+            "id",
+            "DatabricksWorkspace",
+            "id",
+            "RESOURCE",
+            rel_direction_right=False,
+        )
+        == expected_rels
+    )
+
+    # Assert User -> Group MEMBER_OF
+    expected_rels = {
+        (scoped("70718330587535"), scoped("87707764220300")),
+        (scoped("70718330587535"), scoped("80972003232721")),
+        (scoped("76890358753905"), scoped("87707764220300")),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "DatabricksUser",
+            "id",
+            "DatabricksGroup",
+            "id",
+            "MEMBER_OF",
+            rel_direction_right=True,
+        )
+        == expected_rels
+    )

--- a/tests/integration/cartography/intel/databricks/test_workspaces.py
+++ b/tests/integration/cartography/intel/databricks/test_workspaces.py
@@ -1,0 +1,59 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.workspaces
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE
+from tests.integration.util import check_nodes
+
+TEST_UPDATE_TAG = 123456789
+
+
+def _ensure_local_neo4j_has_test_workspace(neo4j_session):
+    cartography.intel.databricks.workspaces.load_workspaces(
+        neo4j_session,
+        [DATABRICKS_WORKSPACE],
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.databricks.workspaces,
+    "get",
+    return_value=DATABRICKS_WORKSPACE,
+)
+def test_load_databricks_workspace(mock_get, neo4j_session):
+    # Arrange
+    api_session = Mock()
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG}
+
+    # Act
+    workspace = cartography.intel.databricks.workspaces.sync(
+        neo4j_session,
+        api_session,
+        common_job_parameters,
+    )
+
+    # Assert returned value
+    assert workspace["id"] == DATABRICKS_WORKSPACE["id"]
+
+    # Assert workspace node exists with extra label Tenant
+    expected_nodes = {
+        (
+            DATABRICKS_WORKSPACE["id"],
+            DATABRICKS_WORKSPACE["host"],
+            True,
+            730,
+        ),
+    }
+    assert (
+        check_nodes(
+            neo4j_session,
+            "DatabricksWorkspace",
+            ["id", "host", "tokens_enabled", "max_token_lifetime_days"],
+        )
+        == expected_nodes
+    )
+    # Tenant ontology label is applied
+    assert check_nodes(neo4j_session, "Tenant", ["id"]) == {
+        (DATABRICKS_WORKSPACE["id"],)
+    }


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

First slice of a new Databricks intel module, scoped to workspace-level identity. Brings:

- `DatabricksWorkspace` (extra label `Tenant`), keyed on workspace host, capturing the token management settings (`tokens_enabled`, `max_token_lifetime_days`).
- Workspace SCIM coverage: `DatabricksUser` (`UserAccount`), `DatabricksServicePrincipal` (`ServiceAccount`), `DatabricksGroup` (`UserGroup`), with `MEMBER_OF` edges from users / SPs / nested groups to their parent groups. Nested-group nesting is read from both the parent's `members` and the child's own `groups` so coverage does not depend on which side Databricks returns.
- `DatabricksToken` from the token management API, with `OWNER_OF` edges from the owning user or service principal.
- Authentication: personal access token (PAT) or OAuth M2M (workspace-level service principal). Module skips cleanly when not configured.
- CLI / `Config` / `sync.py` (`_LazyStage`) wiring, schema docs (`docs/root/modules/databricks/`), and ontology semantic mappings (`tenants`, `useraccounts`, `serviceaccounts`, `groups`) so `_ont_*` projection fields land for cross-provider queries.

Node ids for User / SP / Group / Token are workspace-scoped (`{workspace_id}/{scim_id}` and `{workspace_id}/{token_id}`); the raw SCIM/token id stays as an indexed `scim_id` / `token_id` property. This keeps multi-workspace ingestion (planned in the follow-up) from collapsing same-id principals or tokens across workspaces.

Account-level API surface (`accounts.cloud.databricks.com`) -- `DatabricksAccount` node, account SCIM, federation policies, workspace assignments, permission assignments, cross-cloud links to AWS / GCP / Azure -- is intentionally deferred to a follow-up so this PR stays reviewable and can be exercised end-to-end against a workspace-only sandbox.


### Related issues or links

N/A


### How was this tested?

- Mocked integration suite: `pytest tests/integration/cartography/intel/databricks/ -v` -- 6 passing, covering workspace, users, service principals, groups (incl. nested), tokens, and an explicit multi-workspace collision test for `DatabricksToken.id`.
- End-to-end against a real Databricks workspace (PAT auth). The sync loaded the workspace + SCIM users + service principals + groups + a freshly created PAT, and queries confirmed:
  - Composite ids on User / SP / Group / Token with the raw scim/token id on `scim_id` / `token_id`.
  - `Tenant`, `UserAccount`, `ServiceAccount`, `UserGroup` labels applied and `_ont_*` ontology projection fields populated.
  - `(:DatabricksUser)-[:MEMBER_OF]->(:DatabricksGroup)` and `(:DatabricksUser)-[:OWNER_OF]->(:DatabricksToken)` materialised correctly.
- `make test_lint` clean.

E2E sync log excerpt (run against a sandbox workspace):

```
INFO:cartography.intel.databricks.workspaces:[email protected] in 1.13 seconds
INFO:cartography.intel.databricks.groups:[email protected] in 0.94 seconds
INFO:cartography.intel.databricks.users:[email protected] in 1.21 seconds
INFO:cartography.intel.databricks.service_principals:[email protected] in 0.78 seconds
INFO:cartography.intel.databricks.tokens:[email protected] in 0.42 seconds
```


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [x] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [x] Updated the schema documentation.

#### If you are implementing a new intel module
- [x] Used the NodeSchema data model.


### Notes for reviewers

- IDs are intentionally workspace-scoped composites. The raw SCIM / token id is preserved on `scim_id` / `token_id` (indexed) so existing operator queries by raw id keep working.
- Ontology mappings are registered for `Tenant`, `UserAccount`, `ServiceAccount`, and `UserGroup`; cross-provider queries like \`MATCH (u:UserAccount) WHERE u._ont_email = '...'\` will now surface Databricks rows.
- `DatabricksGroup` nesting reads from both `members` (parent's downward list) and `groups` (child's upward list) and dedupes, since the Databricks SCIM response can populate either side.
- Account-level API + cross-cloud links are deliberately out of scope for this PR; the follow-up will add `DatabricksAccount`, account SCIM, federation policies, workspace assignments, and permission assignments.