### PR TITLE
fix(ontology): populate _ont_source for SubImage, Crowdstrike, Azure tenants

### DIFF
--- a/cartography/models/ontology/mapping/data/tenants.py
+++ b/cartography/models/ontology/mapping/data/tenants.py
@@ -57,7 +57,11 @@ aws_mapping = OntologyMapping(
 azure_mapping = OntologyMapping(
     module_name="azure",
     nodes=[
-        # No field to map in AzureTenant (minimal properties)
+        # AzureTenant has no mappable fields but the entry must exist so the
+        # _ont_source side-effect of _build_ontology_node_properties_statement
+        # fires for both AzureTenantSchema and the composite EntraTenantSchema
+        # (which carries `AzureTenant` as its primary label).
+        OntologyNodeMapping(node_label="AzureTenant", fields=[]),
         OntologyNodeMapping(
             node_label="AzureSubscription",
             fields=[
@@ -391,7 +395,23 @@ workos_tenants_mapping = OntologyMapping(
 )
 
 
-# SubImage: No field to map in SubImageTenant (minimal properties beyond id)
+# SubImage: SubImageTenant has no mappable Tenant fields; the entry exists
+# only so _ont_source is written on the node.
+subimage_mapping = OntologyMapping(
+    module_name="subimage",
+    nodes=[
+        OntologyNodeMapping(node_label="SubImageTenant", fields=[]),
+    ],
+)
+
+# Crowdstrike: CrowdstrikeTenant has no mappable Tenant fields; the entry
+# exists only so _ont_source is written on the node.
+crowdstrike_mapping = OntologyMapping(
+    module_name="crowdstrike",
+    nodes=[
+        OntologyNodeMapping(node_label="CrowdstrikeTenant", fields=[]),
+    ],
+)
 
 # Socket.dev
 socketdev_mapping = OntologyMapping(
@@ -432,6 +452,7 @@ TENANTS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws": aws_mapping,
     "azure": azure_mapping,
     "cloudflare": cloudflare_mapping,
+    "crowdstrike": crowdstrike_mapping,
     "digitalocean": digitalocean_mapping,
     "microsoft": entra_mapping,
     "gcp": gcp_mapping,
@@ -446,6 +467,7 @@ TENANTS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "jumpcloud": jumpcloud_mapping,
     "slack": slack_mapping,
     "spacelift": spacelift_mapping,
+    "subimage": subimage_mapping,
     "socketdev": socketdev_mapping,
     "workos": workos_tenants_mapping,
     "vercel": vercel_mapping,


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
Three Tenant labels had `_ont_source IS NULL` because their `OntologyMapping` was missing:

| Labels | Module | Root cause |
|---|---|---|
| `SubImageTenant, Tenant` | subimage | No entry at all |
| `CrowdstrikeTenant, Tenant` | crowdstrike | No entry at all |
| `AzureTenant, EntraTenant, Tenant` (composite) | microsoft | `azure_mapping` had `AzureSubscription` only, no `AzureTenant` |

`_build_ontology_node_properties_statement` writes `_ont_source` only when `get_semantic_label_mapping_from_node_schema` returns a mapping. The lookup keys on the schema's **primary label**. Once a mapping exists, the source string is derived from the schema's module path (`_get_module_from_schema`), **not** the mapping's `module_name`.

This means an empty-fields entry per missing label is enough:
- `SubImageTenant` -> `_ont_source = 'subimage'`
- `CrowdstrikeTenant` -> `_ont_source = 'crowdstrike'`
- `AzureTenant` (in `azure_mapping`) -> `_ont_source = 'azure'` for `AzureTenantSchema` and `_ont_source = 'microsoft'` for the composite `EntraTenantSchema` (primary label is `AzureTenant`, module path is `models.microsoft.entra.tenant`).

Downstream filters that key off `_ont_source` previously dropped these tenants silently or fell back to client-side `_module_name` matching, which can't be pushed to Neo4j.

### Related issues or links

### How was this tested?
- `uv run --frozen pytest tests/unit/cartography/intel/ontology/test_ontology_mapping.py tests/unit/cartography/graph/` -> all green (134 tests).
- `make test_lint` -> clean.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

Existing ontology-mapping unit tests cover the data model and validate the new entries (`test_ontology_mapping_fields`, etc.).

### Notes for reviewers
Two follow-ups are deliberately out of scope:
1. **`EntraTenant` field mapping is unreachable.** `entra_mapping` declares `name=display_name` / `status=state` keyed by `EntraTenant`, but the lookup uses the schema's primary label (`AzureTenant`), so `_ont_name` / `_ont_status` are never written on entra-loaded tenants. Fixing this requires either consolidating those fields under `AzureTenant` in `azure_mapping` or extending the lookup to also consider `extra_node_labels` - a broader change.
2. **Orphan `AWSAccount, Tenant` stubs.** Created by `MatchLink` from foreign accounts, they have no owning intel module so neither `_module_name` nor `_ont_source` is set. Downstream can filter them by the `AWSAccount` label; introducing a `_ont_source = <creator_module>` convention on MatchLink-created stubs would touch the framework and is out of scope here.
