### PR TITLE
fix(gcp): scope BigQuery CMEK rule to persistent tables, aggregate by dataset

### DIFF
--- a/cartography/rules/data/rules/cis_4_0_gcp.py
+++ b/cartography/rules/data/rules/cis_4_0_gcp.py
@@ -927,52 +927,80 @@ gcp_bigquery_datasets_publicly_accessible = Rule(
 
 
 # =============================================================================
-# CIS GCP 7.2: BigQuery tables are encrypted with CMEK
-# Main node: GCPBigQueryTable
+# CIS GCP 7.2 (scoped): persistent BigQuery tables are encrypted with CMEK
+# Main node: GCPBigQueryTable, aggregated to the parent dataset.
+#
+# Two deliberate reductions vs the literal benchmark ("all BigQuery tables"):
+#
+# 1. Aggregate to the dataset. A single dataset can hold hundreds of thousands
+#    of tables (per-day shards, query-result cache). CMEK is remediated per
+#    dataset (default CMEK) or per logical table, not per shard, so one finding
+#    per table explodes cardinality without adding signal. We emit one finding
+#    per dataset holding >=1 in-scope table without CMEK, with the offending
+#    table count. No in-scope table is hidden: its dataset always surfaces.
+#
+# 2. Exclude expiring tables (expirationTime set). These are dominated by the
+#    ~24h query-result cache, which cannot be CMEK-encrypted. This also skips
+#    user tables with an explicit TTL, so the rule is scoped to *persistent*
+#    tables and does NOT fully cover CIS 7.2; the sibling dataset default-CMEK
+#    rule (7.3) governs future tables. This is an accepted trade-off to keep the
+#    finding volume actionable. https://cloud.google.com/bigquery/docs/cached-results
 # =============================================================================
 class BigQueryTableCmekMissingOutput(Finding):
-    table_name: str | None = None
-    table_id: str | None = None
+    dataset_name: str | None = None
     dataset_id: str | None = None
     project_id: str | None = None
     project_name: str | None = None
-    kms_key_name: str | None = None
+    tables_without_cmek: str | None = None
+    sample_tables: list[str] | None = None
 
 
 _gcp_bigquery_table_cmek_missing = Fact(
     id="gcp_bigquery_table_cmek_missing",
-    name="GCP BigQuery tables without CMEK",
-    description="Detects BigQuery tables whose encryptionConfiguration.kmsKeyName is not set.",
+    name="GCP BigQuery datasets containing persistent tables without CMEK",
+    description="Detects BigQuery datasets holding persistent (non-expiring) tables whose encryptionConfiguration.kmsKeyName is not set, with a count of the offending tables.",
     cypher_query="""
     MATCH (project:GCPProject)-[:RESOURCE]->(table:GCPBigQueryTable)
-    WHERE table.kms_key_name IS NULL OR table.kms_key_name = ''
+    WHERE (table.kms_key_name IS NULL OR table.kms_key_name = '')
+      AND (table.expiration_time IS NULL OR table.expiration_time = '')
+    WITH project, table.dataset_id AS dataset_id,
+         count(table) AS tables_without_cmek,
+         collect(coalesce(table.friendly_name, table.table_id))[..10] AS sample_tables
     RETURN
-        coalesce(table.friendly_name, table.table_id) AS table_name,
-        table.id AS table_id,
-        table.dataset_id AS dataset_id,
+        split(dataset_id, ':')[-1] AS dataset_name,
+        dataset_id,
         project.id AS project_id,
         project.displayname AS project_name,
-        table.kms_key_name AS kms_key_name
+        tables_without_cmek,
+        sample_tables
     """,
     cypher_visual_query="""
     MATCH p=(project:GCPProject)-[:RESOURCE]->(table:GCPBigQueryTable)
-    WHERE table.kms_key_name IS NULL OR table.kms_key_name = ''
+    WHERE (table.kms_key_name IS NULL OR table.kms_key_name = '')
+      AND (table.expiration_time IS NULL OR table.expiration_time = '')
     RETURN *
     """,
     cypher_count_query="""
-    MATCH (table:GCPBigQueryTable)
-    RETURN COUNT(table) AS count
+    MATCH (:GCPProject)-[:RESOURCE]->(table:GCPBigQueryTable)
+    WHERE table.expiration_time IS NULL OR table.expiration_time = ''
+    RETURN count(DISTINCT table.dataset_id) AS count
     """,
-    asset_id_field="table_id",
-    identity_fields=("table_id",),
+    asset_id_field="dataset_id",
+    identity_fields=("dataset_id",),
     module=Module.GCP,
     maturity=Maturity.STABLE,
 )
 
 gcp_bigquery_tables_without_cmek = Rule(
     id="gcp_bigquery_tables_without_cmek",
-    name="BigQuery Tables Without CMEK",
-    description="BigQuery tables should use customer-managed encryption keys.",
+    name="Persistent BigQuery Tables Without CMEK",
+    description=(
+        "Persistent BigQuery tables should use customer-managed encryption keys. "
+        "Findings are grouped by dataset, with a count of the tables missing CMEK. "
+        "Expiring/temporary tables (e.g. the query-result cache) are excluded, so "
+        "this partially covers CIS 7.2; the dataset default-CMEK rule (7.3) covers "
+        "future tables."
+    ),
     output_model=BigQueryTableCmekMissingOutput,
     facts=(_gcp_bigquery_table_cmek_missing,),
     tags=("bigquery", "encryption", "cmek", "stride:information_disclosure"),

--- a/cartography/rules/data/rules/cis_4_0_gcp.py
+++ b/cartography/rules/data/rules/cis_4_0_gcp.py
@@ -945,6 +945,11 @@ gcp_bigquery_datasets_publicly_accessible = Rule(
 #    tables and does NOT fully cover CIS 7.2; the sibling dataset default-CMEK
 #    rule (7.3) governs future tables. This is an accepted trade-off to keep the
 #    finding volume actionable. https://cloud.google.com/bigquery/docs/cached-results
+#
+# We also exclude VIEW and EXTERNAL tables: they have no BigQuery-managed data
+# at rest, so kms_key_name is always empty and they would be false positives.
+# MATERIALIZED_VIEW / SNAPSHOT / CLONE do store data and support CMEK, so they
+# stay in scope. A null type is kept in scope to avoid dropping real tables.
 # =============================================================================
 class BigQueryTableCmekMissingOutput(Finding):
     dataset_name: str | None = None
@@ -963,6 +968,7 @@ _gcp_bigquery_table_cmek_missing = Fact(
     MATCH (project:GCPProject)-[:RESOURCE]->(table:GCPBigQueryTable)
     WHERE (table.kms_key_name IS NULL OR table.kms_key_name = '')
       AND (table.expiration_time IS NULL OR table.expiration_time = '')
+      AND (table.type IS NULL OR NOT table.type IN ['VIEW', 'EXTERNAL'])
     WITH project, table.dataset_id AS dataset_id,
          count(table) AS tables_without_cmek,
          collect(coalesce(table.friendly_name, table.table_id))[..10] AS sample_tables
@@ -978,11 +984,13 @@ _gcp_bigquery_table_cmek_missing = Fact(
     MATCH p=(project:GCPProject)-[:RESOURCE]->(table:GCPBigQueryTable)
     WHERE (table.kms_key_name IS NULL OR table.kms_key_name = '')
       AND (table.expiration_time IS NULL OR table.expiration_time = '')
+      AND (table.type IS NULL OR NOT table.type IN ['VIEW', 'EXTERNAL'])
     RETURN *
     """,
     cypher_count_query="""
     MATCH (:GCPProject)-[:RESOURCE]->(table:GCPBigQueryTable)
-    WHERE table.expiration_time IS NULL OR table.expiration_time = ''
+    WHERE (table.expiration_time IS NULL OR table.expiration_time = '')
+      AND (table.type IS NULL OR NOT table.type IN ['VIEW', 'EXTERNAL'])
     RETURN count(DISTINCT table.dataset_id) AS count
     """,
     asset_id_field="dataset_id",


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

The CIS GCP 7.2 rule `gcp_bigquery_tables_without_cmek` emitted one finding per
`GCPBigQueryTable` lacking a CMEK key. On projects with heavy BigQuery usage this
produces a very large, effectively unbounded finding set: it is dominated by
query-result **cache tables** (auto-created, ~24h TTL, and not CMEK-encryptable)
and per-day **sharded tables**, where a single logical table maps to thousands of
physical shards. Reporting one finding per row buries the real signal and grows
with query volume rather than with the assets an org actually manages.

This PR scopes the rule to something actionable while keeping every relevant
dataset visible:

- **Aggregate to the parent dataset.** One finding per dataset that holds at
  least one in-scope table without CMEK, with the offending table count and a
  small sample of table names. Cardinality is now bounded by dataset count
  instead of table count, and per-day shards collapse into their dataset.
- **Exclude expiring tables** (`expirationTime` set). The query-result cache
  carries an expiration and cannot be CMEK-encrypted. This scopes the rule to
  *persistent* tables, so it now only **partially** covers the literal CIS 7.2
  wording ("all tables"); the sibling dataset default-CMEK rule
  (`gcp_bigquery_datasets_without_default_cmek`, CIS 7.3) governs future tables.
  The rule name and description are updated to make this scope explicit.
- **Fix the compliance denominator.** The count query now counts distinct
  in-scope `dataset_id` values (same `expiration_time` scope as the finding
  query), so totals reflect the datasets actually evaluated rather than every
  dataset.


### Related issues or links

<!-- N/A -->


### How was this tested?

- `make test_lint` passes locally (flake8, black, isort, mypy).
- `uv run pytest tests/unit/rules/test_cis_4_0_gcp.py` passes.
- Verified `Rule.parse_results(...)` correctly parses the new output model
  (aggregated count coerced to string, `sample_tables` as `list[str]`).
- Ran the finding and count Cypher queries against a populated GCP graph to
  confirm they execute and return the expected dataset-grained shape.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.


### Notes for reviewers

This changes the finding grain of an existing rule from per-table to per-dataset
and deliberately narrows its scope to persistent tables. The rule `id` is kept
stable to preserve finding history; only the display name/description change. The
CIS 7.2 framework mapping is retained but the rule now covers it only partially,
which is documented inline and in the description.
