### PR TITLE
feat(scaleway): complete resource coverage (SSH keys, bare-metal, file/data services, domains)

### DIFF
--- a/cartography/intel/scaleway/__init__.py
+++ b/cartography/intel/scaleway/__init__.py
@@ -6,11 +6,16 @@ import scaleway
 import cartography.intel.scaleway.baremetal.apple_silicon
 import cartography.intel.scaleway.baremetal.dedibox
 import cartography.intel.scaleway.baremetal.elastic_metal
+import cartography.intel.scaleway.baremetal.flexible_ips
 import cartography.intel.scaleway.container_registry.namespaces
+import cartography.intel.scaleway.databases.datawarehouse
 import cartography.intel.scaleway.databases.mongodb
 import cartography.intel.scaleway.databases.rdb
 import cartography.intel.scaleway.databases.redis
+import cartography.intel.scaleway.databases.searchdb
+import cartography.intel.scaleway.databases.serverless_sql
 import cartography.intel.scaleway.dns.dns
+import cartography.intel.scaleway.dns.domains
 import cartography.intel.scaleway.iam.apikeys
 import cartography.intel.scaleway.iam.applications
 import cartography.intel.scaleway.iam.groups
@@ -33,6 +38,7 @@ import cartography.intel.scaleway.secrets.secrets
 import cartography.intel.scaleway.serverless.containers
 import cartography.intel.scaleway.serverless.functions
 import cartography.intel.scaleway.serverless.jobs
+import cartography.intel.scaleway.storage.filesystems
 import cartography.intel.scaleway.storage.objectstorage
 import cartography.intel.scaleway.storage.snapshots
 import cartography.intel.scaleway.storage.volumes
@@ -157,6 +163,14 @@ def start_scaleway_ingestion(neo4j_session: neo4j.Session, config: Config) -> No
         projects_id=projects_id,
         update_tag=config.update_tag,
     )
+    cartography.intel.scaleway.storage.filesystems.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=config.scaleway_org,
+        projects_id=projects_id,
+        update_tag=config.update_tag,
+    )
 
     # Instances
     cartography.intel.scaleway.instances.flexibleips.sync(
@@ -202,6 +216,16 @@ def start_scaleway_ingestion(neo4j_session: neo4j.Session, config: Config) -> No
         update_tag=config.update_tag,
     )
     cartography.intel.scaleway.baremetal.dedibox.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=config.scaleway_org,
+        projects_id=projects_id,
+        update_tag=config.update_tag,
+    )
+    # Elastic Metal Flexible IPs (loaded after Elastic Metal servers so the
+    # IDENTIFIES edge resolves).
+    cartography.intel.scaleway.baremetal.flexible_ips.sync(
         neo4j_session,
         client,
         common_job_parameters,
@@ -264,6 +288,13 @@ def start_scaleway_ingestion(neo4j_session: neo4j.Session, config: Config) -> No
         projects_id=projects_id,
         update_tag=config.update_tag,
     )
+    cartography.intel.scaleway.dns.domains.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=config.scaleway_org,
+        update_tag=config.update_tag,
+    )
 
     # Key Manager (loaded before Secrets so Secret -> Key ENCRYPTED_BY edges resolve).
     cartography.intel.scaleway.kms.keys.sync(
@@ -324,6 +355,30 @@ def start_scaleway_ingestion(neo4j_session: neo4j.Session, config: Config) -> No
         update_tag=config.update_tag,
     )
     cartography.intel.scaleway.databases.mongodb.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=config.scaleway_org,
+        projects_id=projects_id,
+        update_tag=config.update_tag,
+    )
+    cartography.intel.scaleway.databases.datawarehouse.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=config.scaleway_org,
+        projects_id=projects_id,
+        update_tag=config.update_tag,
+    )
+    cartography.intel.scaleway.databases.serverless_sql.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=config.scaleway_org,
+        projects_id=projects_id,
+        update_tag=config.update_tag,
+    )
+    cartography.intel.scaleway.databases.searchdb.sync(
         neo4j_session,
         client,
         common_job_parameters,

--- a/cartography/intel/scaleway/__init__.py
+++ b/cartography/intel/scaleway/__init__.py
@@ -3,6 +3,9 @@ import logging
 import neo4j
 import scaleway
 
+import cartography.intel.scaleway.baremetal.apple_silicon
+import cartography.intel.scaleway.baremetal.dedibox
+import cartography.intel.scaleway.baremetal.elastic_metal
 import cartography.intel.scaleway.container_registry.namespaces
 import cartography.intel.scaleway.databases.mongodb
 import cartography.intel.scaleway.databases.rdb
@@ -13,6 +16,7 @@ import cartography.intel.scaleway.iam.applications
 import cartography.intel.scaleway.iam.groups
 import cartography.intel.scaleway.iam.permissionsets
 import cartography.intel.scaleway.iam.policies
+import cartography.intel.scaleway.iam.sshkeys
 import cartography.intel.scaleway.iam.users
 import cartography.intel.scaleway.instances.flexibleips
 import cartography.intel.scaleway.instances.instances
@@ -120,6 +124,13 @@ def start_scaleway_ingestion(neo4j_session: neo4j.Session, config: Config) -> No
         org_id=config.scaleway_org,
         update_tag=config.update_tag,
     )
+    cartography.intel.scaleway.iam.sshkeys.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=config.scaleway_org,
+        update_tag=config.update_tag,
+    )
 
     # Storage
     cartography.intel.scaleway.storage.volumes.sync(
@@ -148,8 +159,6 @@ def start_scaleway_ingestion(neo4j_session: neo4j.Session, config: Config) -> No
     )
 
     # Instances
-    # DISABLED due to https://github.com/scaleway/scaleway-sdk-python/issues/1040
-    """
     cartography.intel.scaleway.instances.flexibleips.sync(
         neo4j_session,
         client,
@@ -158,7 +167,6 @@ def start_scaleway_ingestion(neo4j_session: neo4j.Session, config: Config) -> No
         projects_id=projects_id,
         update_tag=config.update_tag,
     )
-    """
     cartography.intel.scaleway.instances.instances.sync(
         neo4j_session,
         client,
@@ -168,6 +176,32 @@ def start_scaleway_ingestion(neo4j_session: neo4j.Session, config: Config) -> No
         update_tag=config.update_tag,
     )
     cartography.intel.scaleway.instances.securitygroups.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=config.scaleway_org,
+        projects_id=projects_id,
+        update_tag=config.update_tag,
+    )
+
+    # Bare Metal (Elastic Metal / Apple silicon / Dedibox)
+    cartography.intel.scaleway.baremetal.elastic_metal.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=config.scaleway_org,
+        projects_id=projects_id,
+        update_tag=config.update_tag,
+    )
+    cartography.intel.scaleway.baremetal.apple_silicon.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=config.scaleway_org,
+        projects_id=projects_id,
+        update_tag=config.update_tag,
+    )
+    cartography.intel.scaleway.baremetal.dedibox.sync(
         neo4j_session,
         client,
         common_job_parameters,

--- a/cartography/intel/scaleway/baremetal/apple_silicon.py
+++ b/cartography/intel/scaleway/baremetal/apple_silicon.py
@@ -8,7 +8,7 @@ from scaleway.applesilicon.v1alpha1 import Server
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
-from cartography.intel.scaleway.utils import DEFAULT_ZONE
+from cartography.intel.scaleway.utils import list_all_zones
 from cartography.intel.scaleway.utils import scaleway_obj_to_dict
 from cartography.models.scaleway.baremetal.apple_silicon import (
     ScalewayAppleSiliconServerSchema,
@@ -39,9 +39,7 @@ def get(
     org_id: str,
 ) -> list[Server]:
     api = ApplesiliconV1Alpha1API(client)
-    # ponytail: single zone like the Instance module; fan out over zones if
-    # multi-zone bare-metal inventory is ever needed.
-    return api.list_servers_all(organization_id=org_id, zone=DEFAULT_ZONE)
+    return list_all_zones(api.list_servers_all, organization_id=org_id)
 
 
 def transform_servers(

--- a/cartography/intel/scaleway/baremetal/apple_silicon.py
+++ b/cartography/intel/scaleway/baremetal/apple_silicon.py
@@ -1,0 +1,84 @@
+import logging
+from typing import Any
+
+import neo4j
+import scaleway
+from scaleway.applesilicon.v1alpha1 import ApplesiliconV1Alpha1API
+from scaleway.applesilicon.v1alpha1 import Server
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.scaleway.utils import DEFAULT_ZONE
+from cartography.intel.scaleway.utils import scaleway_obj_to_dict
+from cartography.models.scaleway.baremetal.apple_silicon import (
+    ScalewayAppleSiliconServerSchema,
+)
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: scaleway.Client,
+    common_job_parameters: dict[str, Any],
+    org_id: str,
+    projects_id: list[str],
+    update_tag: int,
+) -> None:
+    servers = get(client, org_id)
+    servers_by_project = transform_servers(servers)
+    load_servers(neo4j_session, servers_by_project, update_tag)
+    cleanup(neo4j_session, projects_id, common_job_parameters)
+
+
+@timeit
+def get(
+    client: scaleway.Client,
+    org_id: str,
+) -> list[Server]:
+    api = ApplesiliconV1Alpha1API(client)
+    # ponytail: single zone like the Instance module; fan out over zones if
+    # multi-zone bare-metal inventory is ever needed.
+    return api.list_servers_all(organization_id=org_id, zone=DEFAULT_ZONE)
+
+
+def transform_servers(
+    servers: list[Server],
+) -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {}
+    for server in servers:
+        formatted = scaleway_obj_to_dict(server)
+        result.setdefault(server.project_id, []).append(formatted)
+    return result
+
+
+@timeit
+def load_servers(
+    neo4j_session: neo4j.Session,
+    data: dict[str, list[dict[str, Any]]],
+    update_tag: int,
+) -> None:
+    for project_id, servers in data.items():
+        load(
+            neo4j_session,
+            ScalewayAppleSiliconServerSchema(),
+            servers,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    projects_id: list[str],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    for project_id in projects_id:
+        scopped_job_parameters = common_job_parameters.copy()
+        scopped_job_parameters["PROJECT_ID"] = project_id
+        GraphJob.from_node_schema(
+            ScalewayAppleSiliconServerSchema(), scopped_job_parameters
+        ).run(neo4j_session)

--- a/cartography/intel/scaleway/baremetal/dedibox.py
+++ b/cartography/intel/scaleway/baremetal/dedibox.py
@@ -1,0 +1,104 @@
+import logging
+from typing import Any
+
+import neo4j
+import scaleway
+from scaleway.dedibox.v1 import DediboxV1API
+from scaleway.dedibox.v1 import ServerSummary
+from scaleway_core.api import ScalewayException
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.scaleway.utils import DEFAULT_ZONE
+from cartography.intel.scaleway.utils import scaleway_obj_to_dict
+from cartography.models.scaleway.baremetal.dedibox import ScalewayDediboxServerSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: scaleway.Client,
+    common_job_parameters: dict[str, Any],
+    org_id: str,
+    projects_id: list[str],
+    update_tag: int,
+) -> None:
+    for project_id in projects_id:
+        servers = get(client, project_id)
+        formatted_servers = transform_servers(servers)
+        load_servers(neo4j_session, formatted_servers, project_id, update_tag)
+    cleanup(neo4j_session, projects_id, common_job_parameters)
+
+
+@timeit
+def get(
+    client: scaleway.Client,
+    project_id: str,
+) -> list[ServerSummary]:
+    api = DediboxV1API(client)
+    # Dedibox has no organization-wide list; it is scoped per project.
+    # ponytail: single zone like the Instance module; fan out over zones if
+    # multi-zone bare-metal inventory is ever needed.
+    try:
+        return api.list_servers_all(project_id=project_id, zone=DEFAULT_ZONE)
+    except ScalewayException as exc:
+        # Dedibox is a legacy, opt-in product; accounts that never subscribed to
+        # it answer "permissions_denied" for the whole API. Skip rather than
+        # aborting the sync.
+        if exc.status_code == 403:
+            logger.info(
+                "Scaleway Dedibox not enabled for project %s, skipping.",
+                project_id,
+            )
+            return []
+        raise
+
+
+def transform_servers(servers: list[ServerSummary]) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for server in servers:
+        formatted = scaleway_obj_to_dict(server)
+        # id is a numeric identifier in the Dedibox API; the graph node id must
+        # be a string.
+        formatted["id"] = str(formatted["id"])
+        formatted["ips"] = [
+            ip["address"]
+            for interface in (formatted.get("interfaces") or [])
+            for ip in (interface.get("ips") or [])
+            if ip.get("address")
+        ]
+        result.append(formatted)
+    return result
+
+
+@timeit
+def load_servers(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    project_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        ScalewayDediboxServerSchema(),
+        data,
+        lastupdated=update_tag,
+        PROJECT_ID=project_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    projects_id: list[str],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    for project_id in projects_id:
+        scopped_job_parameters = common_job_parameters.copy()
+        scopped_job_parameters["PROJECT_ID"] = project_id
+        GraphJob.from_node_schema(
+            ScalewayDediboxServerSchema(), scopped_job_parameters
+        ).run(neo4j_session)

--- a/cartography/intel/scaleway/baremetal/dedibox.py
+++ b/cartography/intel/scaleway/baremetal/dedibox.py
@@ -70,6 +70,7 @@ def transform_servers(servers: list[ServerSummary]) -> list[dict[str, Any]]:
             for ip in (interface.get("ips") or [])
             if ip.get("address")
         ]
+        formatted["public_ip"] = formatted["ips"][0] if formatted["ips"] else None
         result.append(formatted)
     return result
 

--- a/cartography/intel/scaleway/baremetal/dedibox.py
+++ b/cartography/intel/scaleway/baremetal/dedibox.py
@@ -9,7 +9,7 @@ from scaleway_core.api import ScalewayException
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
-from cartography.intel.scaleway.utils import DEFAULT_ZONE
+from cartography.intel.scaleway.utils import list_all_zones
 from cartography.intel.scaleway.utils import scaleway_obj_to_dict
 from cartography.models.scaleway.baremetal.dedibox import ScalewayDediboxServerSchema
 from cartography.util import timeit
@@ -26,34 +26,42 @@ def sync(
     projects_id: list[str],
     update_tag: int,
 ) -> None:
+    # Only clean up projects we could actually read. A project whose Dedibox
+    # API answered "permission denied" is skipped entirely, so its previously
+    # ingested nodes are not wiped by a cleanup that saw zero servers.
+    fetched_projects: list[str] = []
     for project_id in projects_id:
         servers = get(client, project_id)
+        if servers is None:
+            continue
         formatted_servers = transform_servers(servers)
         load_servers(neo4j_session, formatted_servers, project_id, update_tag)
-    cleanup(neo4j_session, projects_id, common_job_parameters)
+        fetched_projects.append(project_id)
+    cleanup(neo4j_session, fetched_projects, common_job_parameters)
 
 
 @timeit
 def get(
     client: scaleway.Client,
     project_id: str,
-) -> list[ServerSummary]:
+) -> list[ServerSummary] | None:
+    """Return the project's Dedibox servers, or None if the project cannot be
+    read (permission denied). None signals the caller to skip load/cleanup for
+    that project rather than treating the error as an authoritative empty set."""
     api = DediboxV1API(client)
     # Dedibox has no organization-wide list; it is scoped per project.
-    # ponytail: single zone like the Instance module; fan out over zones if
-    # multi-zone bare-metal inventory is ever needed.
     try:
-        return api.list_servers_all(project_id=project_id, zone=DEFAULT_ZONE)
+        return list_all_zones(api.list_servers_all, project_id=project_id)
     except ScalewayException as exc:
         # Dedibox is a legacy, opt-in product; accounts that never subscribed to
         # it answer "permissions_denied" for the whole API. Skip rather than
-        # aborting the sync.
+        # aborting the sync or wiping existing inventory.
         if exc.status_code == 403:
             logger.info(
                 "Scaleway Dedibox not enabled for project %s, skipping.",
                 project_id,
             )
-            return []
+            return None
         raise
 
 

--- a/cartography/intel/scaleway/baremetal/elastic_metal.py
+++ b/cartography/intel/scaleway/baremetal/elastic_metal.py
@@ -1,0 +1,87 @@
+import logging
+from typing import Any
+
+import neo4j
+import scaleway
+from scaleway.baremetal.v1 import BaremetalV1API
+from scaleway.baremetal.v1 import Server
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.scaleway.utils import DEFAULT_ZONE
+from cartography.intel.scaleway.utils import scaleway_obj_to_dict
+from cartography.models.scaleway.baremetal.elastic_metal import (
+    ScalewayElasticMetalServerSchema,
+)
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: scaleway.Client,
+    common_job_parameters: dict[str, Any],
+    org_id: str,
+    projects_id: list[str],
+    update_tag: int,
+) -> None:
+    servers = get(client, org_id)
+    servers_by_project = transform_servers(servers)
+    load_servers(neo4j_session, servers_by_project, update_tag)
+    cleanup(neo4j_session, projects_id, common_job_parameters)
+
+
+@timeit
+def get(
+    client: scaleway.Client,
+    org_id: str,
+) -> list[Server]:
+    api = BaremetalV1API(client)
+    # ponytail: single zone like the Instance module; fan out over zones if
+    # multi-zone bare-metal inventory is ever needed.
+    return api.list_servers_all(organization_id=org_id, zone=DEFAULT_ZONE)
+
+
+def transform_servers(
+    servers: list[Server],
+) -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {}
+    for server in servers:
+        formatted = scaleway_obj_to_dict(server)
+        formatted["ips"] = [
+            ip["address"] for ip in (formatted.get("ips") or []) if ip.get("address")
+        ]
+        result.setdefault(server.project_id, []).append(formatted)
+    return result
+
+
+@timeit
+def load_servers(
+    neo4j_session: neo4j.Session,
+    data: dict[str, list[dict[str, Any]]],
+    update_tag: int,
+) -> None:
+    for project_id, servers in data.items():
+        load(
+            neo4j_session,
+            ScalewayElasticMetalServerSchema(),
+            servers,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    projects_id: list[str],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    for project_id in projects_id:
+        scopped_job_parameters = common_job_parameters.copy()
+        scopped_job_parameters["PROJECT_ID"] = project_id
+        GraphJob.from_node_schema(
+            ScalewayElasticMetalServerSchema(), scopped_job_parameters
+        ).run(neo4j_session)

--- a/cartography/intel/scaleway/baremetal/elastic_metal.py
+++ b/cartography/intel/scaleway/baremetal/elastic_metal.py
@@ -8,7 +8,7 @@ from scaleway.baremetal.v1 import Server
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
-from cartography.intel.scaleway.utils import DEFAULT_ZONE
+from cartography.intel.scaleway.utils import list_all_zones
 from cartography.intel.scaleway.utils import scaleway_obj_to_dict
 from cartography.models.scaleway.baremetal.elastic_metal import (
     ScalewayElasticMetalServerSchema,
@@ -39,9 +39,7 @@ def get(
     org_id: str,
 ) -> list[Server]:
     api = BaremetalV1API(client)
-    # ponytail: single zone like the Instance module; fan out over zones if
-    # multi-zone bare-metal inventory is ever needed.
-    return api.list_servers_all(organization_id=org_id, zone=DEFAULT_ZONE)
+    return list_all_zones(api.list_servers_all, organization_id=org_id)
 
 
 def transform_servers(

--- a/cartography/intel/scaleway/baremetal/elastic_metal.py
+++ b/cartography/intel/scaleway/baremetal/elastic_metal.py
@@ -53,6 +53,7 @@ def transform_servers(
         formatted["ips"] = [
             ip["address"] for ip in (formatted.get("ips") or []) if ip.get("address")
         ]
+        formatted["public_ip"] = formatted["ips"][0] if formatted["ips"] else None
         result.setdefault(server.project_id, []).append(formatted)
     return result
 

--- a/cartography/intel/scaleway/baremetal/flexible_ips.py
+++ b/cartography/intel/scaleway/baremetal/flexible_ips.py
@@ -8,7 +8,7 @@ from scaleway.flexibleip.v1alpha1 import FlexibleipV1Alpha1API
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
-from cartography.intel.scaleway.utils import DEFAULT_ZONE
+from cartography.intel.scaleway.utils import list_all_zones
 from cartography.intel.scaleway.utils import scaleway_obj_to_dict
 from cartography.models.scaleway.baremetal.flexible_ip import (
     ScalewayElasticMetalFlexibleIpSchema,
@@ -39,9 +39,7 @@ def get(
     org_id: str,
 ) -> list[FlexibleIP]:
     api = FlexibleipV1Alpha1API(client)
-    # ponytail: single zone like the Instance module; fan out over zones if
-    # multi-zone bare-metal inventory is ever needed.
-    return api.list_flexible_i_ps_all(organization_id=org_id, zone=DEFAULT_ZONE)
+    return list_all_zones(api.list_flexible_i_ps_all, organization_id=org_id)
 
 
 def transform_flexibleips(

--- a/cartography/intel/scaleway/baremetal/flexible_ips.py
+++ b/cartography/intel/scaleway/baremetal/flexible_ips.py
@@ -1,0 +1,84 @@
+import logging
+from typing import Any
+
+import neo4j
+import scaleway
+from scaleway.flexibleip.v1alpha1 import FlexibleIP
+from scaleway.flexibleip.v1alpha1 import FlexibleipV1Alpha1API
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.scaleway.utils import DEFAULT_ZONE
+from cartography.intel.scaleway.utils import scaleway_obj_to_dict
+from cartography.models.scaleway.baremetal.flexible_ip import (
+    ScalewayElasticMetalFlexibleIpSchema,
+)
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: scaleway.Client,
+    common_job_parameters: dict[str, Any],
+    org_id: str,
+    projects_id: list[str],
+    update_tag: int,
+) -> None:
+    flexibleips = get(client, org_id)
+    flexibleips_by_project = transform_flexibleips(flexibleips)
+    load_flexibleips(neo4j_session, flexibleips_by_project, update_tag)
+    cleanup(neo4j_session, projects_id, common_job_parameters)
+
+
+@timeit
+def get(
+    client: scaleway.Client,
+    org_id: str,
+) -> list[FlexibleIP]:
+    api = FlexibleipV1Alpha1API(client)
+    # ponytail: single zone like the Instance module; fan out over zones if
+    # multi-zone bare-metal inventory is ever needed.
+    return api.list_flexible_i_ps_all(organization_id=org_id, zone=DEFAULT_ZONE)
+
+
+def transform_flexibleips(
+    flexibleips: list[FlexibleIP],
+) -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {}
+    for flexibleip in flexibleips:
+        formatted = scaleway_obj_to_dict(flexibleip)
+        result.setdefault(flexibleip.project_id, []).append(formatted)
+    return result
+
+
+@timeit
+def load_flexibleips(
+    neo4j_session: neo4j.Session,
+    data: dict[str, list[dict[str, Any]]],
+    update_tag: int,
+) -> None:
+    for project_id, flexibleips in data.items():
+        load(
+            neo4j_session,
+            ScalewayElasticMetalFlexibleIpSchema(),
+            flexibleips,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    projects_id: list[str],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    for project_id in projects_id:
+        scopped_job_parameters = common_job_parameters.copy()
+        scopped_job_parameters["PROJECT_ID"] = project_id
+        GraphJob.from_node_schema(
+            ScalewayElasticMetalFlexibleIpSchema(), scopped_job_parameters
+        ).run(neo4j_session)

--- a/cartography/intel/scaleway/databases/datawarehouse.py
+++ b/cartography/intel/scaleway/databases/datawarehouse.py
@@ -1,0 +1,87 @@
+import logging
+from typing import Any
+
+import neo4j
+import scaleway
+from scaleway.datawarehouse.v1beta1 import DatawarehouseV1Beta1API
+from scaleway.datawarehouse.v1beta1 import Deployment
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.scaleway.utils import list_all_regions
+from cartography.intel.scaleway.utils import scaleway_obj_to_dict
+from cartography.models.scaleway.database.datawarehouse import (
+    ScalewayDataWarehouseDeploymentSchema,
+)
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: scaleway.Client,
+    common_job_parameters: dict[str, Any],
+    org_id: str,
+    projects_id: list[str],
+    update_tag: int,
+) -> None:
+    deployments = get(client, org_id)
+    deployments_by_project = transform_deployments(deployments)
+    load_deployments(neo4j_session, deployments_by_project, update_tag)
+    cleanup(neo4j_session, projects_id, common_job_parameters)
+
+
+@timeit
+def get(
+    client: scaleway.Client,
+    org_id: str,
+) -> list[Deployment]:
+    api = DatawarehouseV1Beta1API(client)
+    return list_all_regions(api.list_deployments_all, organization_id=org_id)
+
+
+def transform_deployments(
+    deployments: list[Deployment],
+) -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {}
+    for deployment in deployments:
+        formatted = scaleway_obj_to_dict(deployment)
+        # Flatten the endpoints list to a single exposure flag; deeper endpoint
+        # modeling can come later if per-endpoint detail is ever needed.
+        formatted["is_public"] = any(
+            bool(getattr(e, "public", None)) for e in (deployment.endpoints or [])
+        )
+        result.setdefault(deployment.project_id, []).append(formatted)
+    return result
+
+
+@timeit
+def load_deployments(
+    neo4j_session: neo4j.Session,
+    data: dict[str, list[dict[str, Any]]],
+    update_tag: int,
+) -> None:
+    for project_id, deployments in data.items():
+        load(
+            neo4j_session,
+            ScalewayDataWarehouseDeploymentSchema(),
+            deployments,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    projects_id: list[str],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    for project_id in projects_id:
+        scopped_job_parameters = common_job_parameters.copy()
+        scopped_job_parameters["PROJECT_ID"] = project_id
+        GraphJob.from_node_schema(
+            ScalewayDataWarehouseDeploymentSchema(), scopped_job_parameters
+        ).run(neo4j_session)

--- a/cartography/intel/scaleway/databases/searchdb.py
+++ b/cartography/intel/scaleway/databases/searchdb.py
@@ -1,0 +1,83 @@
+import logging
+from typing import Any
+
+import neo4j
+import scaleway
+from scaleway.searchdb.v1alpha1 import Deployment
+from scaleway.searchdb.v1alpha1 import SearchdbV1Alpha1API
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.scaleway.utils import list_all_regions
+from cartography.intel.scaleway.utils import scaleway_obj_to_dict
+from cartography.models.scaleway.database.searchdb import ScalewaySearchDeploymentSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: scaleway.Client,
+    common_job_parameters: dict[str, Any],
+    org_id: str,
+    projects_id: list[str],
+    update_tag: int,
+) -> None:
+    deployments = get(client, org_id)
+    deployments_by_project = transform_deployments(deployments)
+    load_deployments(neo4j_session, deployments_by_project, update_tag)
+    cleanup(neo4j_session, projects_id, common_job_parameters)
+
+
+@timeit
+def get(
+    client: scaleway.Client,
+    org_id: str,
+) -> list[Deployment]:
+    api = SearchdbV1Alpha1API(client)
+    return list_all_regions(api.list_deployments_all, organization_id=org_id)
+
+
+def transform_deployments(
+    deployments: list[Deployment],
+) -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {}
+    for deployment in deployments:
+        formatted = scaleway_obj_to_dict(deployment)
+        formatted["is_public"] = any(
+            bool(getattr(e, "public", None)) for e in (deployment.endpoints or [])
+        )
+        result.setdefault(deployment.project_id, []).append(formatted)
+    return result
+
+
+@timeit
+def load_deployments(
+    neo4j_session: neo4j.Session,
+    data: dict[str, list[dict[str, Any]]],
+    update_tag: int,
+) -> None:
+    for project_id, deployments in data.items():
+        load(
+            neo4j_session,
+            ScalewaySearchDeploymentSchema(),
+            deployments,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    projects_id: list[str],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    for project_id in projects_id:
+        scopped_job_parameters = common_job_parameters.copy()
+        scopped_job_parameters["PROJECT_ID"] = project_id
+        GraphJob.from_node_schema(
+            ScalewaySearchDeploymentSchema(), scopped_job_parameters
+        ).run(neo4j_session)

--- a/cartography/intel/scaleway/databases/serverless_sql.py
+++ b/cartography/intel/scaleway/databases/serverless_sql.py
@@ -55,6 +55,9 @@ def transform_databases(
             formatted["endpoint"] = (
                 endpoint.get("url") or endpoint.get("host") or endpoint.get("ip")
             )
+        # Serverless SQL databases are exposed through a public connection
+        # endpoint; flag it for exposure analysis like the other data services.
+        formatted["is_public"] = formatted.get("endpoint") is not None
         result.setdefault(database.project_id, []).append(formatted)
     return result
 

--- a/cartography/intel/scaleway/databases/serverless_sql.py
+++ b/cartography/intel/scaleway/databases/serverless_sql.py
@@ -1,0 +1,89 @@
+import logging
+from typing import Any
+
+import neo4j
+import scaleway
+from scaleway.serverless_sqldb.v1alpha1 import Database
+from scaleway.serverless_sqldb.v1alpha1 import ServerlessSqldbV1Alpha1API
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.scaleway.utils import list_all_regions
+from cartography.intel.scaleway.utils import scaleway_obj_to_dict
+from cartography.models.scaleway.database.serverless_sql import (
+    ScalewayServerlessSQLDatabaseSchema,
+)
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: scaleway.Client,
+    common_job_parameters: dict[str, Any],
+    org_id: str,
+    projects_id: list[str],
+    update_tag: int,
+) -> None:
+    databases = get(client, org_id)
+    databases_by_project = transform_databases(databases)
+    load_databases(neo4j_session, databases_by_project, update_tag)
+    cleanup(neo4j_session, projects_id, common_job_parameters)
+
+
+@timeit
+def get(
+    client: scaleway.Client,
+    org_id: str,
+) -> list[Database]:
+    api = ServerlessSqldbV1Alpha1API(client)
+    return list_all_regions(api.list_databases_all, organization_id=org_id)
+
+
+def transform_databases(
+    databases: list[Database],
+) -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {}
+    for database in databases:
+        formatted = scaleway_obj_to_dict(database)
+        # `endpoint` is the connection URL; keep it as a scalar even if the SDK
+        # ever wraps it in an object.
+        endpoint = formatted.get("endpoint")
+        if isinstance(endpoint, dict):
+            formatted["endpoint"] = (
+                endpoint.get("url") or endpoint.get("host") or endpoint.get("ip")
+            )
+        result.setdefault(database.project_id, []).append(formatted)
+    return result
+
+
+@timeit
+def load_databases(
+    neo4j_session: neo4j.Session,
+    data: dict[str, list[dict[str, Any]]],
+    update_tag: int,
+) -> None:
+    for project_id, databases in data.items():
+        load(
+            neo4j_session,
+            ScalewayServerlessSQLDatabaseSchema(),
+            databases,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    projects_id: list[str],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    for project_id in projects_id:
+        scopped_job_parameters = common_job_parameters.copy()
+        scopped_job_parameters["PROJECT_ID"] = project_id
+        GraphJob.from_node_schema(
+            ScalewayServerlessSQLDatabaseSchema(), scopped_job_parameters
+        ).run(neo4j_session)

--- a/cartography/intel/scaleway/dns/domains.py
+++ b/cartography/intel/scaleway/dns/domains.py
@@ -1,0 +1,77 @@
+import logging
+from typing import Any
+
+import neo4j
+import scaleway
+from scaleway.domain.v2beta1 import DomainSummary
+from scaleway.domain.v2beta1 import DomainV2Beta1RegistrarAPI
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.scaleway.utils import scaleway_obj_to_dict
+from cartography.models.scaleway.dns.registered_domain import (
+    ScalewayRegisteredDomainSchema,
+)
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: scaleway.Client,
+    common_job_parameters: dict[str, Any],
+    org_id: str,
+    update_tag: int,
+) -> None:
+    domains = get(client, org_id)
+    formatted_domains = transform_domains(domains)
+    load_domains(neo4j_session, formatted_domains, org_id, update_tag)
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    client: scaleway.Client,
+    org_id: str,
+) -> list[DomainSummary]:
+    api = DomainV2Beta1RegistrarAPI(client)
+    # Registered domains are a global (non-regional) resource.
+    return api.list_domains_all(organization_id=org_id)
+
+
+def transform_domains(domains: list[DomainSummary]) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for domain in domains:
+        formatted = scaleway_obj_to_dict(domain)
+        # The domain name is the natural unique id.
+        formatted["id"] = formatted["domain"]
+        formatted["name"] = formatted["domain"]
+        result.append(formatted)
+    return result
+
+
+@timeit
+def load_domains(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    org_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        ScalewayRegisteredDomainSchema(),
+        data,
+        lastupdated=update_tag,
+        ORG_ID=org_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(
+        ScalewayRegisteredDomainSchema(), common_job_parameters
+    ).run(neo4j_session)

--- a/cartography/intel/scaleway/iam/sshkeys.py
+++ b/cartography/intel/scaleway/iam/sshkeys.py
@@ -1,0 +1,64 @@
+from typing import Any
+
+import neo4j
+import scaleway
+from scaleway.iam.v1alpha1 import IamV1Alpha1API
+from scaleway.iam.v1alpha1 import SSHKey
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.scaleway.utils import scaleway_obj_to_dict
+from cartography.models.scaleway.iam.sshkey import ScalewaySSHKeySchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: scaleway.Client,
+    common_job_parameters: dict[str, Any],
+    org_id: str,
+    update_tag: int,
+) -> None:
+    sshkeys = get(client, org_id)
+    formatted_sshkeys = transform_sshkeys(sshkeys)
+    load_sshkeys(neo4j_session, formatted_sshkeys, org_id, update_tag)
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    client: scaleway.Client,
+    org_id: str,
+) -> list[SSHKey]:
+    api = IamV1Alpha1API(client)
+    return api.list_ssh_keys_all(organization_id=org_id)
+
+
+def transform_sshkeys(sshkeys: list[SSHKey]) -> list[dict[str, Any]]:
+    return [scaleway_obj_to_dict(sshkey) for sshkey in sshkeys]
+
+
+@timeit
+def load_sshkeys(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    org_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        ScalewaySSHKeySchema(),
+        data,
+        lastupdated=update_tag,
+        ORG_ID=org_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(ScalewaySSHKeySchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/scaleway/storage/filesystems.py
+++ b/cartography/intel/scaleway/storage/filesystems.py
@@ -1,0 +1,80 @@
+import logging
+from typing import Any
+
+import neo4j
+import scaleway
+from scaleway.file.v1alpha1 import FileSystem
+from scaleway.file.v1alpha1 import FileV1Alpha1API
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.scaleway.utils import list_all_regions
+from cartography.intel.scaleway.utils import scaleway_obj_to_dict
+from cartography.models.scaleway.storage.filesystem import ScalewayFileSystemSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: scaleway.Client,
+    common_job_parameters: dict[str, Any],
+    org_id: str,
+    projects_id: list[str],
+    update_tag: int,
+) -> None:
+    filesystems = get(client, org_id)
+    filesystems_by_project = transform_filesystems(filesystems)
+    load_filesystems(neo4j_session, filesystems_by_project, update_tag)
+    cleanup(neo4j_session, projects_id, common_job_parameters)
+
+
+@timeit
+def get(
+    client: scaleway.Client,
+    org_id: str,
+) -> list[FileSystem]:
+    api = FileV1Alpha1API(client)
+    return list_all_regions(api.list_file_systems_all, organization_id=org_id)
+
+
+def transform_filesystems(
+    filesystems: list[FileSystem],
+) -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {}
+    for filesystem in filesystems:
+        formatted = scaleway_obj_to_dict(filesystem)
+        result.setdefault(filesystem.project_id, []).append(formatted)
+    return result
+
+
+@timeit
+def load_filesystems(
+    neo4j_session: neo4j.Session,
+    data: dict[str, list[dict[str, Any]]],
+    update_tag: int,
+) -> None:
+    for project_id, filesystems in data.items():
+        load(
+            neo4j_session,
+            ScalewayFileSystemSchema(),
+            filesystems,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    projects_id: list[str],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    for project_id in projects_id:
+        scopped_job_parameters = common_job_parameters.copy()
+        scopped_job_parameters["PROJECT_ID"] = project_id
+        GraphJob.from_node_schema(
+            ScalewayFileSystemSchema(), scopped_job_parameters
+        ).run(neo4j_session)

--- a/cartography/intel/scaleway/utils.py
+++ b/cartography/intel/scaleway/utils.py
@@ -17,6 +17,21 @@ DEFAULT_ZONE = "fr-par-1"
 # service is deployed in every region; list_all_regions skips the gaps.
 DEFAULT_REGIONS = ("fr-par", "nl-ams", "pl-waw", "it-mil")
 
+# Scaleway availability zones. Zone-scoped APIs (Elastic Metal, Apple silicon,
+# Dedibox, flexible IPs, ...) list per-zone, so we fan out over all of them.
+# Not every product is available in every zone; list_all_zones skips the gaps.
+DEFAULT_ZONES = (
+    "fr-par-1",
+    "fr-par-2",
+    "fr-par-3",
+    "nl-ams-1",
+    "nl-ams-2",
+    "nl-ams-3",
+    "pl-waw-1",
+    "pl-waw-2",
+    "pl-waw-3",
+)
+
 T = TypeVar("T")
 
 
@@ -37,6 +52,30 @@ def list_all_regions(fetcher: Callable[..., list[T]], **kwargs: Any) -> list[T]:
                     "Scaleway service %s not available in region %s, skipping.",
                     getattr(fetcher, "__name__", "list"),
                     region,
+                )
+                continue
+            raise
+    return items
+
+
+def list_all_zones(fetcher: Callable[..., list[T]], **kwargs: Any) -> list[T]:
+    """Call a zone-scoped SDK ``list_*_all`` fetcher across every zone.
+
+    Each zone is passed as the ``zone`` keyword. Zones where the product is not
+    available answer with an "unknown" error; those are skipped rather than
+    aborting the whole sync. Other errors (e.g. permission denied) propagate so
+    the caller can decide how to handle them.
+    """
+    items: list[T] = []
+    for zone in DEFAULT_ZONES:
+        try:
+            items.extend(fetcher(zone=zone, **kwargs))
+        except ScalewayException as exc:
+            if "unknown" in str(exc).lower():
+                logger.info(
+                    "Scaleway service %s not available in zone %s, skipping.",
+                    getattr(fetcher, "__name__", "list"),
+                    zone,
                 )
                 continue
             raise

--- a/cartography/models/ontology/mapping/data/computeinstance.py
+++ b/cartography/models/ontology/mapping/data/computeinstance.py
@@ -50,6 +50,57 @@ scaleway_mapping = OntologyMapping(
                 ),
             ],
         ),
+        OntologyNodeMapping(
+            node_label="ScalewayElasticMetalServer",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                OntologyFieldMapping(ontology_field="region", node_field="zone"),
+                OntologyFieldMapping(
+                    ontology_field="public_ip_address", node_field="public_ip"
+                ),
+                OntologyFieldMapping(ontology_field="state", node_field="status"),
+                OntologyFieldMapping(ontology_field="type", node_field="offer_name"),
+                OntologyFieldMapping(
+                    ontology_field="created_at", node_field="created_at"
+                ),
+            ],
+        ),
+        OntologyNodeMapping(
+            node_label="ScalewayAppleSiliconServer",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                OntologyFieldMapping(ontology_field="region", node_field="zone"),
+                OntologyFieldMapping(
+                    ontology_field="public_ip_address", node_field="ip"
+                ),
+                OntologyFieldMapping(ontology_field="state", node_field="status"),
+                OntologyFieldMapping(ontology_field="type", node_field="type"),
+                OntologyFieldMapping(
+                    ontology_field="created_at", node_field="created_at"
+                ),
+            ],
+        ),
+        OntologyNodeMapping(
+            node_label="ScalewayDediboxServer",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="hostname", required=True
+                ),
+                OntologyFieldMapping(ontology_field="region", node_field="zone"),
+                OntologyFieldMapping(
+                    ontology_field="public_ip_address", node_field="public_ip"
+                ),
+                OntologyFieldMapping(ontology_field="state", node_field="status"),
+                OntologyFieldMapping(ontology_field="type", node_field="offer_name"),
+                OntologyFieldMapping(
+                    ontology_field="created_at", node_field="created_at"
+                ),
+            ],
+        ),
     ],
 )
 

--- a/cartography/models/ontology/mapping/data/databases.py
+++ b/cartography/models/ontology/mapping/data/databases.py
@@ -311,6 +311,64 @@ scaleway_mapping = OntologyMapping(
                 OntologyFieldMapping(ontology_field="location", node_field="region"),
             ],
         ),
+        OntologyNodeMapping(
+            node_label="ScalewayDataWarehouseDeployment",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                OntologyFieldMapping(
+                    ontology_field="type",
+                    node_field="",
+                    special_handling="static_value",
+                    extra={"value": "clickhouse"},
+                ),
+                OntologyFieldMapping(ontology_field="version", node_field="version"),
+                OntologyFieldMapping(ontology_field="location", node_field="region"),
+                # endpoint/port: not surfaced as scalars on the deployment; only
+                # a public-exposure flag (is_public) is retained.
+                # _ont_db_encrypted: encrypted at rest by default, not exposed.
+            ],
+        ),
+        OntologyNodeMapping(
+            node_label="ScalewayServerlessSQLDatabase",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                OntologyFieldMapping(
+                    ontology_field="type",
+                    node_field="",
+                    special_handling="static_value",
+                    extra={"value": "postgres"},
+                ),
+                OntologyFieldMapping(
+                    ontology_field="version", node_field="engine_major_version"
+                ),
+                OntologyFieldMapping(ontology_field="endpoint", node_field="endpoint"),
+                OntologyFieldMapping(ontology_field="location", node_field="region"),
+                # _ont_db_encrypted: encrypted at rest by default, not exposed.
+            ],
+        ),
+        OntologyNodeMapping(
+            node_label="ScalewaySearchDeployment",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                OntologyFieldMapping(
+                    ontology_field="type",
+                    node_field="",
+                    special_handling="static_value",
+                    extra={"value": "opensearch"},
+                ),
+                OntologyFieldMapping(ontology_field="version", node_field="version"),
+                OntologyFieldMapping(ontology_field="location", node_field="region"),
+                # endpoint/port: not surfaced as scalars; only a public-exposure
+                # flag (is_public) is retained.
+                # _ont_db_encrypted: encrypted at rest by default, not exposed.
+            ],
+        ),
     ],
 )
 

--- a/cartography/models/ontology/mapping/data/file_storage.py
+++ b/cartography/models/ontology/mapping/data/file_storage.py
@@ -39,7 +39,25 @@ azure_mapping = OntologyMapping(
     ],
 )
 
+scaleway_mapping = OntologyMapping(
+    module_name="scaleway",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="ScalewayFileSystem",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                OntologyFieldMapping(ontology_field="location", node_field="region"),
+                # _ont_encrypted: Scaleway File Storage is encrypted at rest by
+                # default but the flag isn't surfaced on the file system object.
+            ],
+        ),
+    ],
+)
+
 FILE_STORAGE_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws": aws_mapping,
     "azure": azure_mapping,
+    "scaleway": scaleway_mapping,
 }

--- a/cartography/models/scaleway/baremetal/apple_silicon.py
+++ b/cartography/models/scaleway/baremetal/apple_silicon.py
@@ -1,0 +1,61 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class ScalewayAppleSiliconServerProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    type: PropertyRef = PropertyRef("type_")
+    tags: PropertyRef = PropertyRef("tags")
+    status: PropertyRef = PropertyRef("status")
+    ip: PropertyRef = PropertyRef("ip")
+    vpc_status: PropertyRef = PropertyRef("vpc_status")
+    public_bandwidth_bps: PropertyRef = PropertyRef("public_bandwidth_bps")
+    deletion_scheduled: PropertyRef = PropertyRef("deletion_scheduled")
+    delivered: PropertyRef = PropertyRef("delivered")
+    zone: PropertyRef = PropertyRef("zone")
+    created_at: PropertyRef = PropertyRef("created_at")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    deletable_at: PropertyRef = PropertyRef("deletable_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewayAppleSiliconServerToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewayAppleSiliconServer)
+class ScalewayAppleSiliconServerToProjectRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewayAppleSiliconServerToProjectRelProperties = (
+        ScalewayAppleSiliconServerToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayAppleSiliconServerSchema(CartographyNodeSchema):
+    label: str = "ScalewayAppleSiliconServer"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeInstance"])
+    properties: ScalewayAppleSiliconServerProperties = (
+        ScalewayAppleSiliconServerProperties()
+    )
+    sub_resource_relationship: ScalewayAppleSiliconServerToProjectRel = (
+        ScalewayAppleSiliconServerToProjectRel()
+    )

--- a/cartography/models/scaleway/baremetal/dedibox.py
+++ b/cartography/models/scaleway/baremetal/dedibox.py
@@ -22,6 +22,8 @@ class ScalewayDediboxServerProperties(CartographyNodeProperties):
     # Public IP addresses across the server network interfaces. Persisted so
     # exposure rules can test for a public IP without a separate node.
     ips: PropertyRef = PropertyRef("ips")
+    # First public IP, as a scalar, for the ComputeInstance ontology mapping.
+    public_ip: PropertyRef = PropertyRef("public_ip")
     is_outsourced: PropertyRef = PropertyRef("is_outsourced")
     is_hds: PropertyRef = PropertyRef("is_hds")
     zone: PropertyRef = PropertyRef("zone")

--- a/cartography/models/scaleway/baremetal/dedibox.py
+++ b/cartography/models/scaleway/baremetal/dedibox.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class ScalewayDediboxServerProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    hostname: PropertyRef = PropertyRef("hostname")
+    datacenter_name: PropertyRef = PropertyRef("datacenter_name")
+    offer_id: PropertyRef = PropertyRef("offer_id")
+    offer_name: PropertyRef = PropertyRef("offer_name")
+    status: PropertyRef = PropertyRef("status")
+    # Public IP addresses across the server network interfaces. Persisted so
+    # exposure rules can test for a public IP without a separate node.
+    ips: PropertyRef = PropertyRef("ips")
+    is_outsourced: PropertyRef = PropertyRef("is_outsourced")
+    is_hds: PropertyRef = PropertyRef("is_hds")
+    zone: PropertyRef = PropertyRef("zone")
+    created_at: PropertyRef = PropertyRef("created_at")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    expired_at: PropertyRef = PropertyRef("expired_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewayDediboxServerToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewayDediboxServer)
+class ScalewayDediboxServerToProjectRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewayDediboxServerToProjectRelProperties = (
+        ScalewayDediboxServerToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayDediboxServerSchema(CartographyNodeSchema):
+    label: str = "ScalewayDediboxServer"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeInstance"])
+    properties: ScalewayDediboxServerProperties = ScalewayDediboxServerProperties()
+    sub_resource_relationship: ScalewayDediboxServerToProjectRel = (
+        ScalewayDediboxServerToProjectRel()
+    )

--- a/cartography/models/scaleway/baremetal/elastic_metal.py
+++ b/cartography/models/scaleway/baremetal/elastic_metal.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class ScalewayElasticMetalServerProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    description: PropertyRef = PropertyRef("description")
+    tags: PropertyRef = PropertyRef("tags")
+    status: PropertyRef = PropertyRef("status")
+    offer_id: PropertyRef = PropertyRef("offer_id")
+    offer_name: PropertyRef = PropertyRef("offer_name")
+    domain: PropertyRef = PropertyRef("domain")
+    boot_type: PropertyRef = PropertyRef("boot_type")
+    ping_status: PropertyRef = PropertyRef("ping_status")
+    protected: PropertyRef = PropertyRef("protected")
+    # Public IP addresses attached to the server. Persisted so exposure rules
+    # can test for a public IP without a separate node.
+    ips: PropertyRef = PropertyRef("ips")
+    zone: PropertyRef = PropertyRef("zone")
+    created_at: PropertyRef = PropertyRef("created_at")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewayElasticMetalServerToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewayElasticMetalServer)
+class ScalewayElasticMetalServerToProjectRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewayElasticMetalServerToProjectRelProperties = (
+        ScalewayElasticMetalServerToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayElasticMetalServerSchema(CartographyNodeSchema):
+    label: str = "ScalewayElasticMetalServer"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeInstance"])
+    properties: ScalewayElasticMetalServerProperties = (
+        ScalewayElasticMetalServerProperties()
+    )
+    sub_resource_relationship: ScalewayElasticMetalServerToProjectRel = (
+        ScalewayElasticMetalServerToProjectRel()
+    )

--- a/cartography/models/scaleway/baremetal/elastic_metal.py
+++ b/cartography/models/scaleway/baremetal/elastic_metal.py
@@ -27,6 +27,8 @@ class ScalewayElasticMetalServerProperties(CartographyNodeProperties):
     # Public IP addresses attached to the server. Persisted so exposure rules
     # can test for a public IP without a separate node.
     ips: PropertyRef = PropertyRef("ips")
+    # First public IP, as a scalar, for the ComputeInstance ontology mapping.
+    public_ip: PropertyRef = PropertyRef("public_ip")
     zone: PropertyRef = PropertyRef("zone")
     created_at: PropertyRef = PropertyRef("created_at")
     updated_at: PropertyRef = PropertyRef("updated_at")

--- a/cartography/models/scaleway/baremetal/flexible_ip.py
+++ b/cartography/models/scaleway/baremetal/flexible_ip.py
@@ -1,0 +1,80 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class ScalewayElasticMetalFlexibleIpProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    description: PropertyRef = PropertyRef("description")
+    tags: PropertyRef = PropertyRef("tags")
+    status: PropertyRef = PropertyRef("status")
+    ip_address: PropertyRef = PropertyRef("ip_address")
+    reverse: PropertyRef = PropertyRef("reverse")
+    server_id: PropertyRef = PropertyRef("server_id")
+    zone: PropertyRef = PropertyRef("zone")
+    created_at: PropertyRef = PropertyRef("created_at")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewayElasticMetalFlexibleIpToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewayElasticMetalFlexibleIp)
+class ScalewayElasticMetalFlexibleIpToProjectRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewayElasticMetalFlexibleIpToProjectRelProperties = (
+        ScalewayElasticMetalFlexibleIpToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayElasticMetalFlexibleIpToServerRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayElasticMetalFlexibleIp)-[:IDENTIFIES]->(:ScalewayElasticMetalServer)
+class ScalewayElasticMetalFlexibleIpToServerRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayElasticMetalServer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("server_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "IDENTIFIES"
+    properties: ScalewayElasticMetalFlexibleIpToServerRelProperties = (
+        ScalewayElasticMetalFlexibleIpToServerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayElasticMetalFlexibleIpSchema(CartographyNodeSchema):
+    label: str = "ScalewayElasticMetalFlexibleIp"
+    properties: ScalewayElasticMetalFlexibleIpProperties = (
+        ScalewayElasticMetalFlexibleIpProperties()
+    )
+    sub_resource_relationship: ScalewayElasticMetalFlexibleIpToProjectRel = (
+        ScalewayElasticMetalFlexibleIpToProjectRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            ScalewayElasticMetalFlexibleIpToServerRel(),
+        ]
+    )

--- a/cartography/models/scaleway/database/datawarehouse.py
+++ b/cartography/models/scaleway/database/datawarehouse.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class ScalewayDataWarehouseDeploymentProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    status: PropertyRef = PropertyRef("status")
+    tags: PropertyRef = PropertyRef("tags")
+    version: PropertyRef = PropertyRef("version")
+    replica_count: PropertyRef = PropertyRef("replica_count")
+    shard_count: PropertyRef = PropertyRef("shard_count")
+    cpu_min: PropertyRef = PropertyRef("cpu_min")
+    cpu_max: PropertyRef = PropertyRef("cpu_max")
+    ram_per_cpu: PropertyRef = PropertyRef("ram_per_cpu")
+    # Derived from the endpoints list: true if any endpoint is public-facing.
+    is_public: PropertyRef = PropertyRef("is_public")
+    region: PropertyRef = PropertyRef("region")
+    created_at: PropertyRef = PropertyRef("created_at")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewayDataWarehouseDeploymentToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewayDataWarehouseDeployment)
+class ScalewayDataWarehouseDeploymentToProjectRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewayDataWarehouseDeploymentToProjectRelProperties = (
+        ScalewayDataWarehouseDeploymentToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayDataWarehouseDeploymentSchema(CartographyNodeSchema):
+    label: str = "ScalewayDataWarehouseDeployment"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Database"])
+    properties: ScalewayDataWarehouseDeploymentProperties = (
+        ScalewayDataWarehouseDeploymentProperties()
+    )
+    sub_resource_relationship: ScalewayDataWarehouseDeploymentToProjectRel = (
+        ScalewayDataWarehouseDeploymentToProjectRel()
+    )

--- a/cartography/models/scaleway/database/searchdb.py
+++ b/cartography/models/scaleway/database/searchdb.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class ScalewaySearchDeploymentProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    status: PropertyRef = PropertyRef("status")
+    tags: PropertyRef = PropertyRef("tags")
+    node_amount: PropertyRef = PropertyRef("node_amount")
+    node_type: PropertyRef = PropertyRef("node_type")
+    version: PropertyRef = PropertyRef("version")
+    # Derived from the endpoints list: true if any endpoint is public-facing.
+    is_public: PropertyRef = PropertyRef("is_public")
+    region: PropertyRef = PropertyRef("region")
+    created_at: PropertyRef = PropertyRef("created_at")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewaySearchDeploymentToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewaySearchDeployment)
+class ScalewaySearchDeploymentToProjectRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewaySearchDeploymentToProjectRelProperties = (
+        ScalewaySearchDeploymentToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewaySearchDeploymentSchema(CartographyNodeSchema):
+    label: str = "ScalewaySearchDeployment"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Database"])
+    properties: ScalewaySearchDeploymentProperties = (
+        ScalewaySearchDeploymentProperties()
+    )
+    sub_resource_relationship: ScalewaySearchDeploymentToProjectRel = (
+        ScalewaySearchDeploymentToProjectRel()
+    )

--- a/cartography/models/scaleway/database/serverless_sql.py
+++ b/cartography/models/scaleway/database/serverless_sql.py
@@ -17,6 +17,9 @@ class ScalewayServerlessSQLDatabaseProperties(CartographyNodeProperties):
     name: PropertyRef = PropertyRef("name")
     status: PropertyRef = PropertyRef("status")
     endpoint: PropertyRef = PropertyRef("endpoint")
+    # Serverless SQL is reached over a public connection endpoint; kept
+    # consistent with the other data-service exposure flags.
+    is_public: PropertyRef = PropertyRef("is_public")
     cpu_min: PropertyRef = PropertyRef("cpu_min")
     cpu_max: PropertyRef = PropertyRef("cpu_max")
     cpu_current: PropertyRef = PropertyRef("cpu_current")

--- a/cartography/models/scaleway/database/serverless_sql.py
+++ b/cartography/models/scaleway/database/serverless_sql.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class ScalewayServerlessSQLDatabaseProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    status: PropertyRef = PropertyRef("status")
+    endpoint: PropertyRef = PropertyRef("endpoint")
+    cpu_min: PropertyRef = PropertyRef("cpu_min")
+    cpu_max: PropertyRef = PropertyRef("cpu_max")
+    cpu_current: PropertyRef = PropertyRef("cpu_current")
+    started: PropertyRef = PropertyRef("started")
+    engine_major_version: PropertyRef = PropertyRef("engine_major_version")
+    region: PropertyRef = PropertyRef("region")
+    created_at: PropertyRef = PropertyRef("created_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewayServerlessSQLDatabaseToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewayServerlessSQLDatabase)
+class ScalewayServerlessSQLDatabaseToProjectRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewayServerlessSQLDatabaseToProjectRelProperties = (
+        ScalewayServerlessSQLDatabaseToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayServerlessSQLDatabaseSchema(CartographyNodeSchema):
+    label: str = "ScalewayServerlessSQLDatabase"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Database"])
+    properties: ScalewayServerlessSQLDatabaseProperties = (
+        ScalewayServerlessSQLDatabaseProperties()
+    )
+    sub_resource_relationship: ScalewayServerlessSQLDatabaseToProjectRel = (
+        ScalewayServerlessSQLDatabaseToProjectRel()
+    )

--- a/cartography/models/scaleway/dns/registered_domain.py
+++ b/cartography/models/scaleway/dns/registered_domain.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class ScalewayRegisteredDomainProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    status: PropertyRef = PropertyRef("status")
+    registrar: PropertyRef = PropertyRef("registrar")
+    is_external: PropertyRef = PropertyRef("is_external")
+    epp_code: PropertyRef = PropertyRef("epp_code")
+    auto_renew_status: PropertyRef = PropertyRef("auto_renew_status")
+    dnssec_status: PropertyRef = PropertyRef("dnssec_status")
+    external_domain_registration_status: PropertyRef = PropertyRef(
+        "external_domain_registration_status"
+    )
+    transfer_registration_status: PropertyRef = PropertyRef(
+        "transfer_registration_status"
+    )
+    expired_at: PropertyRef = PropertyRef("expired_at")
+    created_at: PropertyRef = PropertyRef("created_at")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewayRegisteredDomainToOrganizationRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayOrganization)-[:RESOURCE]->(:ScalewayRegisteredDomain)
+class ScalewayRegisteredDomainToOrganizationRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ORG_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewayRegisteredDomainToOrganizationRelProperties = (
+        ScalewayRegisteredDomainToOrganizationRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayRegisteredDomainToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewayRegisteredDomain)
+class ScalewayRegisteredDomainToProjectRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("project_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewayRegisteredDomainToProjectRelProperties = (
+        ScalewayRegisteredDomainToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayRegisteredDomainSchema(CartographyNodeSchema):
+    label: str = "ScalewayRegisteredDomain"
+    properties: ScalewayRegisteredDomainProperties = (
+        ScalewayRegisteredDomainProperties()
+    )
+    sub_resource_relationship: ScalewayRegisteredDomainToOrganizationRel = (
+        ScalewayRegisteredDomainToOrganizationRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            ScalewayRegisteredDomainToProjectRel(),
+        ]
+    )

--- a/cartography/models/scaleway/iam/sshkey.py
+++ b/cartography/models/scaleway/iam/sshkey.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class ScalewaySSHKeyProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    public_key: PropertyRef = PropertyRef("public_key")
+    fingerprint: PropertyRef = PropertyRef("fingerprint")
+    disabled: PropertyRef = PropertyRef("disabled")
+    created_at: PropertyRef = PropertyRef("created_at")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewaySSHKeyToOrganizationRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayOrganization)-[:RESOURCE]->(:ScalewaySSHKey)
+class ScalewaySSHKeyToOrganizationRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ORG_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewaySSHKeyToOrganizationRelProperties = (
+        ScalewaySSHKeyToOrganizationRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewaySSHKeyToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewaySSHKey)
+class ScalewaySSHKeyToProjectRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("project_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewaySSHKeyToProjectRelProperties = (
+        ScalewaySSHKeyToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewaySSHKeySchema(CartographyNodeSchema):
+    label: str = "ScalewaySSHKey"
+    properties: ScalewaySSHKeyProperties = ScalewaySSHKeyProperties()
+    sub_resource_relationship: ScalewaySSHKeyToOrganizationRel = (
+        ScalewaySSHKeyToOrganizationRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            ScalewaySSHKeyToProjectRel(),
+        ]
+    )

--- a/cartography/models/scaleway/storage/filesystem.py
+++ b/cartography/models/scaleway/storage/filesystem.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class ScalewayFileSystemProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name")
+    size: PropertyRef = PropertyRef("size")
+    status: PropertyRef = PropertyRef("status")
+    tags: PropertyRef = PropertyRef("tags")
+    number_of_attachments: PropertyRef = PropertyRef("number_of_attachments")
+    region: PropertyRef = PropertyRef("region")
+    created_at: PropertyRef = PropertyRef("created_at")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewayFileSystemToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewayFileSystem)
+class ScalewayFileSystemToProjectRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewayFileSystemToProjectRelProperties = (
+        ScalewayFileSystemToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayFileSystemSchema(CartographyNodeSchema):
+    label: str = "ScalewayFileSystem"
+    # FileStorage label is used for cross-provider ontology mapping.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["FileStorage"])
+    properties: ScalewayFileSystemProperties = ScalewayFileSystemProperties()
+    sub_resource_relationship: ScalewayFileSystemToProjectRel = (
+        ScalewayFileSystemToProjectRel()
+    )

--- a/docs/root/modules/scaleway/schema.md
+++ b/docs/root/modules/scaleway/schema.md
@@ -1736,6 +1736,7 @@ Represents a Serverless SQL Database (PostgreSQL) in Scaleway.
 | name                 | Name of the database.                  |
 | status               | Status of the database.                |
 | endpoint             | Connection endpoint URL.               |
+| is_public            | True if reachable over a public endpoint. |
 | cpu_min              | Minimum vCPU.                          |
 | cpu_max              | Maximum vCPU.                          |
 | cpu_current          | Current vCPU.                          |

--- a/docs/root/modules/scaleway/schema.md
+++ b/docs/root/modules/scaleway/schema.md
@@ -636,6 +636,7 @@ Represents an Elastic Metal (bare-metal) server in Scaleway.
 | ping_status | Status of the server ping.                   |
 | protected   | If enabled, the server can not be deleted.   |
 | ips         | Public IP addresses attached to the server.  |
+| public_ip   | First public IP (scalar, for ontology).      |
 | zone        | Zone in which the server is located.         |
 | created_at  | Date and time of server creation.            |
 | updated_at  | Date and time of last server update.         |
@@ -694,6 +695,7 @@ Represents a Dedibox (dedicated) server in Scaleway.
 | offer_name      | Offer name of the server.                |
 | status          | Status of the server.                    |
 | ips             | Public IP addresses of the server.       |
+| public_ip       | First public IP (scalar, for ontology).  |
 | is_outsourced   | Whether the server is outsourced.        |
 | is_hds          | Whether the server is HDS certified.     |
 | zone            | Zone in which the server is located.     |

--- a/docs/root/modules/scaleway/schema.md
+++ b/docs/root/modules/scaleway/schema.md
@@ -1663,3 +1663,177 @@ Represents a Scaleway Serverless Job definition (a runnable, optionally schedule
     ```
     (:ScalewayProject)-[:RESOURCE]->(:ScalewayServerlessJobDefinition)
     ```
+
+
+### ScalewayFileSystem
+
+Represents a File Storage file system in Scaleway.
+
+> **Ontology Mapping**: This node has the extra label `FileStorage` to enable cross-platform queries for managed file storage across different providers.
+
+| Field                 | Description                            |
+|-----------------------|----------------------------------------|
+| id                    | ID of the file system.                 |
+| name                  | Name of the file system.               |
+| size                  | Size of the file system in bytes.      |
+| status                | Status of the file system.             |
+| tags                  | Tags attached to the file system.      |
+| number_of_attachments | Number of resources it is attached to. |
+| region                | Region the file system lives in.       |
+| created_at            | Creation timestamp.                    |
+| updated_at            | Last update timestamp.                 |
+| lastupdated           | Timestamp of the last update           |
+
+#### Relationships
+- A `FileSystem` belongs to a `Project`.
+    ```
+    (:ScalewayProject)-[:RESOURCE]->(:ScalewayFileSystem)
+    ```
+
+
+### ScalewayDataWarehouseDeployment
+
+Represents a Data Warehouse (ClickHouse) deployment in Scaleway.
+
+> **Ontology Mapping**: This node has the extra label `Database`.
+
+| Field         | Description                                  |
+|---------------|----------------------------------------------|
+| id            | ID of the deployment.                        |
+| name          | Name of the deployment.                      |
+| status        | Status of the deployment.                    |
+| tags          | Tags attached to the deployment.             |
+| version       | Engine version.                              |
+| replica_count | Number of replicas.                          |
+| shard_count   | Number of shards.                            |
+| cpu_min       | Minimum vCPU.                                |
+| cpu_max       | Maximum vCPU.                                |
+| ram_per_cpu   | RAM per vCPU.                                |
+| is_public     | True if any endpoint is public-facing.       |
+| region        | Region the deployment lives in.              |
+| created_at    | Creation timestamp.                          |
+| updated_at    | Last update timestamp.                       |
+| lastupdated   | Timestamp of the last update                 |
+
+#### Relationships
+- A `DataWarehouseDeployment` belongs to a `Project`.
+    ```
+    (:ScalewayProject)-[:RESOURCE]->(:ScalewayDataWarehouseDeployment)
+    ```
+
+
+### ScalewayServerlessSQLDatabase
+
+Represents a Serverless SQL Database (PostgreSQL) in Scaleway.
+
+> **Ontology Mapping**: This node has the extra label `Database`.
+
+| Field                | Description                            |
+|----------------------|----------------------------------------|
+| id                   | ID of the database.                    |
+| name                 | Name of the database.                  |
+| status               | Status of the database.                |
+| endpoint             | Connection endpoint URL.               |
+| cpu_min              | Minimum vCPU.                          |
+| cpu_max              | Maximum vCPU.                          |
+| cpu_current          | Current vCPU.                          |
+| started              | Whether the database is started.       |
+| engine_major_version | Major engine version.                  |
+| region               | Region the database lives in.          |
+| created_at           | Creation timestamp.                    |
+| lastupdated          | Timestamp of the last update           |
+
+#### Relationships
+- A `ServerlessSQLDatabase` belongs to a `Project`.
+    ```
+    (:ScalewayProject)-[:RESOURCE]->(:ScalewayServerlessSQLDatabase)
+    ```
+
+
+### ScalewaySearchDeployment
+
+Represents a managed OpenSearch deployment (SearchDB) in Scaleway.
+
+> **Ontology Mapping**: This node has the extra label `Database`.
+
+| Field       | Description                                  |
+|-------------|----------------------------------------------|
+| id          | ID of the deployment.                        |
+| name        | Name of the deployment.                      |
+| status      | Status of the deployment.                    |
+| tags        | Tags attached to the deployment.             |
+| node_amount | Number of nodes.                             |
+| node_type   | Node type.                                   |
+| version     | Engine version.                              |
+| is_public   | True if any endpoint is public-facing.       |
+| region      | Region the deployment lives in.              |
+| created_at  | Creation timestamp.                          |
+| updated_at  | Last update timestamp.                       |
+| lastupdated | Timestamp of the last update                 |
+
+#### Relationships
+- A `SearchDeployment` belongs to a `Project`.
+    ```
+    (:ScalewayProject)-[:RESOURCE]->(:ScalewaySearchDeployment)
+    ```
+
+
+### ScalewayElasticMetalFlexibleIp
+
+Represents a flexible (portable) public IP for Elastic Metal servers in Scaleway.
+
+| Field       | Description                                  |
+|-------------|----------------------------------------------|
+| id          | ID of the flexible IP.                       |
+| description | Description of the flexible IP.              |
+| tags        | Tags attached to the flexible IP.            |
+| status      | Status of the flexible IP.                   |
+| ip_address  | The IP address.                              |
+| reverse     | Reverse DNS value.                           |
+| server_id   | ID of the server the IP is attached to.      |
+| zone        | Availability zone.                           |
+| created_at  | Creation timestamp.                          |
+| updated_at  | Last update timestamp.                       |
+| lastupdated | Timestamp of the last update                 |
+
+#### Relationships
+- An `ElasticMetalFlexibleIp` belongs to a `Project`.
+    ```
+    (:ScalewayProject)-[:RESOURCE]->(:ScalewayElasticMetalFlexibleIp)
+    ```
+- An `ElasticMetalFlexibleIp` identifies an `ElasticMetalServer`.
+    ```
+    (:ScalewayElasticMetalFlexibleIp)-[:IDENTIFIES]->(:ScalewayElasticMetalServer)
+    ```
+
+
+### ScalewayRegisteredDomain
+
+Represents a domain registered with the Scaleway registrar.
+
+| Field                               | Description                     |
+|-------------------------------------|---------------------------------|
+| id                                  | Domain name (unique id).        |
+| name                                | Domain name.                    |
+| status                              | Status of the domain.           |
+| registrar                           | Registrar of the domain.        |
+| is_external                         | Whether the domain is external. |
+| epp_code                            | EPP status codes.               |
+| auto_renew_status                   | Auto-renewal status.            |
+| dnssec_status                       | DNSSEC status.                  |
+| external_domain_registration_status | External registration status.  |
+| transfer_registration_status        | Transfer registration status.   |
+| expired_at                          | Expiration timestamp.           |
+| created_at                          | Creation timestamp.             |
+| updated_at                          | Last update timestamp.          |
+| lastupdated                         | Timestamp of the last update    |
+
+#### Relationships
+- A `RegisteredDomain` belongs to an `Organization`.
+    ```
+    (:ScalewayOrganization)-[:RESOURCE]->(:ScalewayRegisteredDomain)
+    ```
+- A `RegisteredDomain` belongs to a `Project`.
+    ```
+    (:ScalewayProject)-[:RESOURCE]->(:ScalewayRegisteredDomain)
+    ```

--- a/docs/root/modules/scaleway/schema.md
+++ b/docs/root/modules/scaleway/schema.md
@@ -375,6 +375,32 @@ Represents a Permission Set in Scaleway. Permission sets are predefined collecti
     ```
 
 
+### ScalewaySSHKey
+
+Represents an SSH key registered in Scaleway IAM.
+
+| Field       | Description                                  |
+|-------------|----------------------------------------------|
+| id          | ID of the SSH key.                           |
+| name        | Name of the SSH key.                         |
+| public_key  | Public key material.                         |
+| fingerprint | Fingerprint of the SSH key.                  |
+| disabled    | Defines whether or not the SSH key is disabled. |
+| created_at  | Date and time of SSH key creation.           |
+| updated_at  | Date and time of last SSH key update.        |
+| lastupdated | Timestamp of the last update                 |
+
+#### Relationships
+- `SSHKey` belongs to an `Organization`.
+    ```
+    (:ScalewayOrganization)-[:RESOURCE]->(:ScalewaySSHKey)
+    ```
+- `SSHKey` belongs to a `Project`.
+    ```
+    (:ScalewayProject)-[:RESOURCE]->(:ScalewaySSHKey)
+    ```
+
+
 ### ScalewayVolume
 
 Volumes are storage space used by your Instances. You can attach several volumes to an Instance.
@@ -588,6 +614,98 @@ A Security Group Rule is a single firewall rule (inbound or outbound) belonging 
 - A `SecurityGroupRule` is a member of a `SecurityGroup`
     ```
     (:ScalewaySecurityGroupRule)-[:MEMBER_OF_SCALEWAY_SECURITY_GROUP]->(:ScalewaySecurityGroup)
+    ```
+
+### ScalewayElasticMetalServer
+
+Represents an Elastic Metal (bare-metal) server in Scaleway.
+
+> **Ontology Mapping**: This node has the extra label `ComputeInstance` to enable cross-platform queries for compute instances across different providers.
+
+| Field       | Description                                  |
+|-------------|----------------------------------------------|
+| id          | ID of the server.                            |
+| name        | Name of the server.                          |
+| description | Description of the server.                   |
+| tags        | Tags attached to the server.                 |
+| status      | Status of the server.                        |
+| offer_id    | Offer ID of the server.                      |
+| offer_name  | Offer name of the server.                    |
+| domain      | Domain of the server.                        |
+| boot_type   | Boot type of the server.                     |
+| ping_status | Status of the server ping.                   |
+| protected   | If enabled, the server can not be deleted.   |
+| ips         | Public IP addresses attached to the server.  |
+| zone        | Zone in which the server is located.         |
+| created_at  | Date and time of server creation.            |
+| updated_at  | Date and time of last server update.         |
+| lastupdated | Timestamp of the last update                 |
+
+#### Relationships
+- An `ElasticMetalServer` belongs to a `Project`.
+    ```
+    (:ScalewayProject)-[:RESOURCE]->(:ScalewayElasticMetalServer)
+    ```
+
+
+### ScalewayAppleSiliconServer
+
+Represents an Apple silicon (Mac mini) server in Scaleway.
+
+> **Ontology Mapping**: This node has the extra label `ComputeInstance` to enable cross-platform queries for compute instances across different providers.
+
+| Field                | Description                             |
+|----------------------|-----------------------------------------|
+| id                   | ID of the server.                       |
+| name                 | Name of the server.                     |
+| type                 | Commercial type of the server.          |
+| tags                 | Tags attached to the server.            |
+| status               | Status of the server.                   |
+| ip                   | Public IP address of the server.        |
+| vpc_status           | Private network status of the server.   |
+| public_bandwidth_bps | Public bandwidth in bits per second.    |
+| deletion_scheduled   | Whether deletion is scheduled.          |
+| delivered            | Whether the server has been delivered.  |
+| zone                 | Zone in which the server is located.    |
+| created_at           | Date and time of server creation.       |
+| updated_at           | Date and time of last server update.    |
+| deletable_at         | Date and time the server can be deleted.|
+| lastupdated          | Timestamp of the last update            |
+
+#### Relationships
+- An `AppleSiliconServer` belongs to a `Project`.
+    ```
+    (:ScalewayProject)-[:RESOURCE]->(:ScalewayAppleSiliconServer)
+    ```
+
+
+### ScalewayDediboxServer
+
+Represents a Dedibox (dedicated) server in Scaleway.
+
+> **Ontology Mapping**: This node has the extra label `ComputeInstance` to enable cross-platform queries for compute instances across different providers.
+
+| Field           | Description                              |
+|-----------------|------------------------------------------|
+| id              | ID of the server (stringified).          |
+| hostname        | Hostname of the server.                  |
+| datacenter_name | Datacenter hosting the server.           |
+| offer_id        | Offer ID of the server.                  |
+| offer_name      | Offer name of the server.                |
+| status          | Status of the server.                    |
+| ips             | Public IP addresses of the server.       |
+| is_outsourced   | Whether the server is outsourced.        |
+| is_hds          | Whether the server is HDS certified.     |
+| zone            | Zone in which the server is located.     |
+| created_at      | Date and time of server creation.        |
+| updated_at      | Date and time of last server update.     |
+| expired_at      | Date and time the server expires.        |
+| lastupdated     | Timestamp of the last update             |
+
+#### Relationships
+- A `DediboxServer` belongs to a `Project`.
+    ```
+    (:ScalewayProject)-[:RESOURCE]->(:ScalewayDediboxServer)
     ```
 
 ### ScalewayObjectStorageBucket

--- a/tests/data/scaleway/baremetal.py
+++ b/tests/data/scaleway/baremetal.py
@@ -7,6 +7,7 @@ from scaleway.baremetal.v1 import Server as ElasticMetalServer
 from scaleway.dedibox.v1 import IP as DediboxIP
 from scaleway.dedibox.v1 import NetworkInterface
 from scaleway.dedibox.v1 import ServerSummary as DediboxServer
+from scaleway.flexibleip.v1alpha1 import FlexibleIP as ElasticMetalFlexibleIP
 
 TEST_ORG_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
 TEST_PROJECT_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
@@ -103,6 +104,23 @@ SCALEWAY_DEDIBOX_SERVERS = [
         is_outsourced=False,
         qinq=False,
         is_hds=False,
+        created_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+        updated_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+    ),
+]
+
+SCALEWAY_ELASTIC_METAL_FLEXIBLE_IPS = [
+    ElasticMetalFlexibleIP(
+        id="fip00000-0000-0000-0000-000000000001",
+        organization_id=TEST_ORG_ID,
+        project_id=TEST_PROJECT_ID,
+        description="em flexible ip",
+        tags=["demo"],
+        status="attached",
+        ip_address="51.15.9.9",
+        reverse="em-demo.example.com",
+        zone="fr-par-1",
+        server_id="11111111-1111-1111-1111-111111111111",
         created_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
         updated_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
     ),

--- a/tests/data/scaleway/baremetal.py
+++ b/tests/data/scaleway/baremetal.py
@@ -1,0 +1,109 @@
+from datetime import datetime
+
+from dateutil.tz import tzutc
+from scaleway.applesilicon.v1alpha1 import Server as AppleSiliconServer
+from scaleway.baremetal.v1 import IP as BaremetalIP
+from scaleway.baremetal.v1 import Server as ElasticMetalServer
+from scaleway.dedibox.v1 import IP as DediboxIP
+from scaleway.dedibox.v1 import NetworkInterface
+from scaleway.dedibox.v1 import ServerSummary as DediboxServer
+
+TEST_ORG_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+TEST_PROJECT_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+
+SCALEWAY_ELASTIC_METAL_SERVERS = [
+    ElasticMetalServer(
+        id="11111111-1111-1111-1111-111111111111",
+        organization_id=TEST_ORG_ID,
+        project_id=TEST_PROJECT_ID,
+        name="em-demo",
+        description="demo elastic metal",
+        status="ready",
+        offer_id="offer-em-a115x",
+        offer_name="EM-A115X-SSD",
+        tags=["demo"],
+        ips=[
+            BaremetalIP(
+                id="ip-1",
+                address="51.15.1.1",
+                reverse="em-demo.example.com",
+                version="IPv4",
+                reverse_status="active",
+                reverse_status_message="",
+            ),
+        ],
+        domain="em-demo.example.com",
+        boot_type="normal",
+        zone="fr-par-1",
+        ping_status="ping_status_up",
+        options=[],
+        protected=False,
+        created_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+        updated_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+    ),
+]
+
+SCALEWAY_APPLE_SILICON_SERVERS = [
+    AppleSiliconServer(
+        id="22222222-2222-2222-2222-222222222222",
+        type_="M2-M",
+        name="mac-demo",
+        project_id=TEST_PROJECT_ID,
+        organization_id=TEST_ORG_ID,
+        ip="51.15.2.2",
+        vnc_url="",
+        ssh_username="m1",
+        sudo_password="",
+        vnc_port=5900,
+        status="ready",
+        deletion_scheduled=False,
+        zone="fr-par-1",
+        delivered=True,
+        vpc_status="disabled",
+        public_bandwidth_bps=1000000000,
+        tags=["demo"],
+        applied_runner_configuration_ids=[],
+        created_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+        updated_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+    ),
+]
+
+SCALEWAY_DEDIBOX_SERVERS = [
+    DediboxServer(
+        id=12345,
+        datacenter_name="DC5",
+        organization_id=TEST_ORG_ID,
+        project_id=TEST_PROJECT_ID,
+        hostname="dedibox-demo",
+        offer_id=678,
+        offer_name="Start-1-M-SATA",
+        status="active",
+        interfaces=[
+            NetworkInterface(
+                card_id=1,
+                device_id=2,
+                mac="de:ad:be:ef:00:01",
+                type_="public",
+                ips=[
+                    DediboxIP(
+                        ip_id=9001,
+                        address="163.172.3.3",
+                        reverse="dedibox-demo.example.com",
+                        version="IPv4",
+                        cidr=32,
+                        netmask="255.255.255.255",
+                        semantic="main",
+                        gateway="163.172.3.1",
+                        status="active",
+                    ),
+                ],
+            ),
+        ],
+        zone="fr-par-1",
+        is_outsourced=False,
+        qinq=False,
+        is_hds=False,
+        created_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+        updated_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+    ),
+]

--- a/tests/data/scaleway/databases.py
+++ b/tests/data/scaleway/databases.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from dateutil.tz import tzutc
+from scaleway.datawarehouse.v1beta1 import Deployment as DWDeployment
 from scaleway.mongodb.v1 import Endpoint as MongoEndpoint
 from scaleway.mongodb.v1 import EndpointPrivateNetworkDetails as MongoPrivateNetDetails
 from scaleway.mongodb.v1 import EndpointPublicNetworkDetails as MongoPublicNetDetails
@@ -19,6 +20,8 @@ from scaleway.redis.v1 import Cluster as RedisCluster
 from scaleway.redis.v1 import Endpoint as RedisEndpoint
 from scaleway.redis.v1 import PrivateNetwork as RedisPrivateNet
 from scaleway.redis.v1 import PublicNetwork as RedisPublicNet
+from scaleway.searchdb.v1alpha1 import Deployment as SearchDeployment
+from scaleway.serverless_sqldb.v1alpha1 import Database as ServerlessSqlDatabase
 
 TEST_ORG_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
 TEST_PROJECT_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
@@ -172,5 +175,62 @@ SCALEWAY_MONGO_INSTANCES = [
         volume=MongoVolume(type_=MongoVolumeType.SBS_5K, size_bytes=5368709120),
         created_at=datetime(2025, 3, 20, 14, 49, 48, 107731, tzinfo=tzutc()),
         snapshot_schedule=None,
+    ),
+]
+
+SCALEWAY_DATAWAREHOUSE = [
+    DWDeployment(
+        id="dw000000-0000-0000-0000-000000000001",
+        name="analytics-dw",
+        organization_id="0681c477-fbb9-4820-b8d6-0eef10cfcd6d",
+        project_id="0681c477-fbb9-4820-b8d6-0eef10cfcd6d",
+        status="ready",
+        tags=["demo"],
+        version="24.8",
+        replica_count=2,
+        shard_count=1,
+        cpu_min=2,
+        cpu_max=8,
+        endpoints=[],
+        ram_per_cpu=4,
+        region="fr-par",
+        created_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+        updated_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+    ),
+]
+
+SCALEWAY_SERVERLESS_SQL = [
+    ServerlessSqlDatabase(
+        id="sq000000-0000-0000-0000-000000000001",
+        name="serverless-pg",
+        status="ready",
+        endpoint="postgres://serverless-pg.fr-par.sdb.scw.cloud:5432/main",
+        organization_id="0681c477-fbb9-4820-b8d6-0eef10cfcd6d",
+        project_id="0681c477-fbb9-4820-b8d6-0eef10cfcd6d",
+        region="fr-par",
+        cpu_min=0,
+        cpu_max=8,
+        cpu_current=1,
+        started=True,
+        engine_major_version="16",
+        created_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+    ),
+]
+
+SCALEWAY_SEARCHDB = [
+    SearchDeployment(
+        id="se000000-0000-0000-0000-000000000001",
+        name="logs-search",
+        organization_id="0681c477-fbb9-4820-b8d6-0eef10cfcd6d",
+        project_id="0681c477-fbb9-4820-b8d6-0eef10cfcd6d",
+        status="ready",
+        tags=["demo"],
+        node_amount=3,
+        node_type="essentials",
+        endpoints=[],
+        version="2.17",
+        region="fr-par",
+        created_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+        updated_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
     ),
 ]

--- a/tests/data/scaleway/dns.py
+++ b/tests/data/scaleway/dns.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from dateutil.tz import tzutc
 from scaleway.domain.v2beta1 import DNSZone
+from scaleway.domain.v2beta1 import DomainSummary
 from scaleway.domain.v2beta1 import Record
 
 TEST_ORG_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
@@ -53,3 +54,21 @@ SCALEWAY_DNS_RECORDS_BY_ZONE = {
         ),
     ],
 }
+
+SCALEWAY_REGISTERED_DOMAINS = [
+    DomainSummary(
+        domain="example.com",
+        project_id="0681c477-fbb9-4820-b8d6-0eef10cfcd6d",
+        organization_id="0681c477-fbb9-4820-b8d6-0eef10cfcd6d",
+        auto_renew_status="enabled",
+        dnssec_status="enabled",
+        epp_code=["clientTransferProhibited"],
+        registrar="scaleway",
+        is_external=False,
+        status="active",
+        pending_trade=False,
+        expired_at=datetime(2026, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+        updated_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+        created_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+    ),
+]

--- a/tests/data/scaleway/iam.py
+++ b/tests/data/scaleway/iam.py
@@ -8,6 +8,7 @@ from scaleway.iam.v1alpha1 import PermissionSet
 from scaleway.iam.v1alpha1 import PermissionSetScopeType
 from scaleway.iam.v1alpha1 import Policy
 from scaleway.iam.v1alpha1 import Rule
+from scaleway.iam.v1alpha1 import SSHKey
 from scaleway.iam.v1alpha1 import User
 
 SCALEWAY_USERS = [
@@ -131,6 +132,20 @@ SCALEWAY_APIKEYS = [
         expires_at=datetime(2026, 3, 23, 20, 52, 20, tzinfo=tzutc()),
         application_id=None,
         user_id="b49932b2-2faa-4c56-905e-ffac52f063dc",
+    ),
+]
+
+SCALEWAY_SSH_KEYS = [
+    SSHKey(
+        id="1a2b3c4d-5e6f-7890-abcd-ef1234567890",
+        name="laptop",
+        public_key="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI laptop@example",
+        fingerprint="256 MD5:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff",
+        organization_id="0681c477-fbb9-4820-b8d6-0eef10cfcd6d",
+        project_id="0681c477-fbb9-4820-b8d6-0eef10cfcd6d",
+        disabled=False,
+        created_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+        updated_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
     ),
 ]
 

--- a/tests/data/scaleway/storages.py
+++ b/tests/data/scaleway/storages.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from dateutil.tz import tzutc
+from scaleway.file.v1alpha1 import FileSystem
 from scaleway.instance.v1 import ServerSummary
 from scaleway.instance.v1 import Snapshot
 from scaleway.instance.v1 import SnapshotBaseVolume
@@ -103,4 +104,20 @@ SCALEWAY_BUCKETS = [
         "versioning": None,
         "tags": None,
     },
+]
+
+SCALEWAY_FILESYSTEMS = [
+    FileSystem(
+        id="a1a1a1a1-0000-0000-0000-000000000001",
+        name="shared-fs",
+        size=100000000000,
+        status="available",
+        project_id="0681c477-fbb9-4820-b8d6-0eef10cfcd6d",
+        organization_id="0681c477-fbb9-4820-b8d6-0eef10cfcd6d",
+        tags=["demo"],
+        number_of_attachments=1,
+        region="fr-par",
+        created_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+        updated_at=datetime(2025, 3, 20, 10, 58, 0, 784077, tzinfo=tzutc()),
+    ),
 ]

--- a/tests/integration/cartography/intel/scaleway/test_baremetal.py
+++ b/tests/integration/cartography/intel/scaleway/test_baremetal.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import cartography.intel.scaleway.baremetal.apple_silicon
 import cartography.intel.scaleway.baremetal.dedibox
 import cartography.intel.scaleway.baremetal.elastic_metal
+import cartography.intel.scaleway.baremetal.flexible_ips
 import tests.data.scaleway.baremetal
 from tests.integration.cartography.intel.scaleway.test_projects import (
     _ensure_local_neo4j_has_test_projects_and_orgs,
@@ -127,4 +128,73 @@ def test_load_scaleway_dedibox(_mock_get, neo4j_session):
         rel_direction_right=False,
     ) == {
         ("12345", TEST_PROJECT_ID),
+    }
+
+
+@patch.object(
+    cartography.intel.scaleway.baremetal.elastic_metal,
+    "get",
+    return_value=tests.data.scaleway.baremetal.SCALEWAY_ELASTIC_METAL_SERVERS,
+)
+@patch.object(
+    cartography.intel.scaleway.baremetal.flexible_ips,
+    "get",
+    return_value=tests.data.scaleway.baremetal.SCALEWAY_ELASTIC_METAL_FLEXIBLE_IPS,
+)
+def test_load_scaleway_elastic_metal_flexible_ips(
+    _mock_fip_get, _mock_em_get, neo4j_session
+):
+    # Arrange
+    client = Mock()
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "ORG_ID": TEST_ORG_ID}
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+    cartography.intel.scaleway.baremetal.elastic_metal.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # Act
+    cartography.intel.scaleway.baremetal.flexible_ips.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # Assert node + project + IDENTIFIES edge to its Elastic Metal server
+    assert check_nodes(
+        neo4j_session, "ScalewayElasticMetalFlexibleIp", ["id", "ip_address"]
+    ) == {
+        ("fip00000-0000-0000-0000-000000000001", "51.15.9.9"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "ScalewayElasticMetalFlexibleIp",
+        "id",
+        "ScalewayProject",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        ("fip00000-0000-0000-0000-000000000001", TEST_PROJECT_ID),
+    }
+    assert check_rels(
+        neo4j_session,
+        "ScalewayElasticMetalFlexibleIp",
+        "id",
+        "ScalewayElasticMetalServer",
+        "id",
+        "IDENTIFIES",
+        rel_direction_right=True,
+    ) == {
+        (
+            "fip00000-0000-0000-0000-000000000001",
+            "11111111-1111-1111-1111-111111111111",
+        ),
     }

--- a/tests/integration/cartography/intel/scaleway/test_baremetal.py
+++ b/tests/integration/cartography/intel/scaleway/test_baremetal.py
@@ -1,0 +1,130 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.scaleway.baremetal.apple_silicon
+import cartography.intel.scaleway.baremetal.dedibox
+import cartography.intel.scaleway.baremetal.elastic_metal
+import tests.data.scaleway.baremetal
+from tests.integration.cartography.intel.scaleway.test_projects import (
+    _ensure_local_neo4j_has_test_projects_and_orgs,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+TEST_PROJECT_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+
+
+@patch.object(
+    cartography.intel.scaleway.baremetal.elastic_metal,
+    "get",
+    return_value=tests.data.scaleway.baremetal.SCALEWAY_ELASTIC_METAL_SERVERS,
+)
+def test_load_scaleway_elastic_metal(_mock_get, neo4j_session):
+    # Arrange
+    client = Mock()
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "ORG_ID": TEST_ORG_ID}
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+
+    # Act
+    cartography.intel.scaleway.baremetal.elastic_metal.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # Assert
+    assert check_nodes(neo4j_session, "ScalewayElasticMetalServer", ["id", "name"]) == {
+        ("11111111-1111-1111-1111-111111111111", "em-demo"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "ScalewayElasticMetalServer",
+        "id",
+        "ScalewayProject",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        ("11111111-1111-1111-1111-111111111111", TEST_PROJECT_ID),
+    }
+
+
+@patch.object(
+    cartography.intel.scaleway.baremetal.apple_silicon,
+    "get",
+    return_value=tests.data.scaleway.baremetal.SCALEWAY_APPLE_SILICON_SERVERS,
+)
+def test_load_scaleway_apple_silicon(_mock_get, neo4j_session):
+    # Arrange
+    client = Mock()
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "ORG_ID": TEST_ORG_ID}
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+
+    # Act
+    cartography.intel.scaleway.baremetal.apple_silicon.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # Assert
+    assert check_nodes(neo4j_session, "ScalewayAppleSiliconServer", ["id", "name"]) == {
+        ("22222222-2222-2222-2222-222222222222", "mac-demo"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "ScalewayAppleSiliconServer",
+        "id",
+        "ScalewayProject",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        ("22222222-2222-2222-2222-222222222222", TEST_PROJECT_ID),
+    }
+
+
+@patch.object(
+    cartography.intel.scaleway.baremetal.dedibox,
+    "get",
+    return_value=tests.data.scaleway.baremetal.SCALEWAY_DEDIBOX_SERVERS,
+)
+def test_load_scaleway_dedibox(_mock_get, neo4j_session):
+    # Arrange
+    client = Mock()
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "ORG_ID": TEST_ORG_ID}
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+
+    # Act
+    cartography.intel.scaleway.baremetal.dedibox.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # Assert (id is stringified from the numeric Dedibox identifier)
+    assert check_nodes(neo4j_session, "ScalewayDediboxServer", ["id", "hostname"]) == {
+        ("12345", "dedibox-demo"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "ScalewayDediboxServer",
+        "id",
+        "ScalewayProject",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        ("12345", TEST_PROJECT_ID),
+    }

--- a/tests/integration/cartography/intel/scaleway/test_databases.py
+++ b/tests/integration/cartography/intel/scaleway/test_databases.py
@@ -1,13 +1,19 @@
 from unittest.mock import Mock
 from unittest.mock import patch
 
+import cartography.intel.scaleway.databases.datawarehouse
 import cartography.intel.scaleway.databases.mongodb
 import cartography.intel.scaleway.databases.rdb
 import cartography.intel.scaleway.databases.redis
+import cartography.intel.scaleway.databases.searchdb
+import cartography.intel.scaleway.databases.serverless_sql
 import cartography.intel.scaleway.network.private_networks
+from tests.data.scaleway.databases import SCALEWAY_DATAWAREHOUSE
 from tests.data.scaleway.databases import SCALEWAY_MONGO_INSTANCES
 from tests.data.scaleway.databases import SCALEWAY_RDB_INSTANCES
 from tests.data.scaleway.databases import SCALEWAY_REDIS_CLUSTERS
+from tests.data.scaleway.databases import SCALEWAY_SEARCHDB
+from tests.data.scaleway.databases import SCALEWAY_SERVERLESS_SQL
 from tests.data.scaleway.databases import TEST_MONGO_INSTANCE_ID
 from tests.data.scaleway.databases import TEST_PRIVATE_NETWORK_ID
 from tests.data.scaleway.databases import TEST_RDB_INSTANCE_ID
@@ -233,3 +239,106 @@ def test_load_scaleway_databases(
         None,
         "scaleway",
     ) in rdb_rows
+
+
+@patch.object(
+    cartography.intel.scaleway.databases.datawarehouse,
+    "get",
+    return_value=SCALEWAY_DATAWAREHOUSE,
+)
+def test_load_scaleway_datawarehouse(_mock_get, neo4j_session):
+    client = Mock()
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "ORG_ID": TEST_ORG_ID}
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+    cartography.intel.scaleway.databases.datawarehouse.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+    assert check_nodes(
+        neo4j_session, "ScalewayDataWarehouseDeployment", ["id", "is_public"]
+    ) == {
+        ("dw000000-0000-0000-0000-000000000001", False),
+    }
+    assert check_rels(
+        neo4j_session,
+        "ScalewayDataWarehouseDeployment",
+        "id",
+        "ScalewayProject",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        ("dw000000-0000-0000-0000-000000000001", TEST_PROJECT_ID),
+    }
+
+
+@patch.object(
+    cartography.intel.scaleway.databases.serverless_sql,
+    "get",
+    return_value=SCALEWAY_SERVERLESS_SQL,
+)
+def test_load_scaleway_serverless_sql(_mock_get, neo4j_session):
+    client = Mock()
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "ORG_ID": TEST_ORG_ID}
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+    cartography.intel.scaleway.databases.serverless_sql.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+    assert check_nodes(
+        neo4j_session, "ScalewayServerlessSQLDatabase", ["id", "name"]
+    ) == {
+        ("sq000000-0000-0000-0000-000000000001", "serverless-pg"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "ScalewayServerlessSQLDatabase",
+        "id",
+        "ScalewayProject",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        ("sq000000-0000-0000-0000-000000000001", TEST_PROJECT_ID),
+    }
+
+
+@patch.object(
+    cartography.intel.scaleway.databases.searchdb,
+    "get",
+    return_value=SCALEWAY_SEARCHDB,
+)
+def test_load_scaleway_searchdb(_mock_get, neo4j_session):
+    client = Mock()
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "ORG_ID": TEST_ORG_ID}
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+    cartography.intel.scaleway.databases.searchdb.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+    assert check_nodes(neo4j_session, "ScalewaySearchDeployment", ["id", "name"]) == {
+        ("se000000-0000-0000-0000-000000000001", "logs-search"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "ScalewaySearchDeployment",
+        "id",
+        "ScalewayProject",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        ("se000000-0000-0000-0000-000000000001", TEST_PROJECT_ID),
+    }

--- a/tests/integration/cartography/intel/scaleway/test_dns.py
+++ b/tests/integration/cartography/intel/scaleway/test_dns.py
@@ -2,8 +2,10 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 import cartography.intel.scaleway.dns.dns
+import cartography.intel.scaleway.dns.domains
 from tests.data.scaleway.dns import SCALEWAY_DNS_RECORDS_BY_ZONE
 from tests.data.scaleway.dns import SCALEWAY_DNS_ZONES
+from tests.data.scaleway.dns import SCALEWAY_REGISTERED_DOMAINS
 from tests.data.scaleway.dns import TEST_RECORD_A_ID
 from tests.data.scaleway.dns import TEST_RECORD_MX_ID
 from tests.data.scaleway.dns import TEST_ZONE_ID
@@ -82,4 +84,51 @@ def test_load_scaleway_dns(_mock_get, neo4j_session):
     ) == {
         (TEST_ZONE_ID, TEST_RECORD_A_ID),
         (TEST_ZONE_ID, TEST_RECORD_MX_ID),
+    }
+
+
+@patch.object(
+    cartography.intel.scaleway.dns.domains,
+    "get",
+    return_value=SCALEWAY_REGISTERED_DOMAINS,
+)
+def test_load_scaleway_registered_domains(_mock_get, neo4j_session):
+    client = Mock()
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "ORG_ID": TEST_ORG_ID}
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+
+    cartography.intel.scaleway.dns.domains.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    assert check_nodes(
+        neo4j_session, "ScalewayRegisteredDomain", ["id", "registrar"]
+    ) == {
+        ("example.com", "scaleway"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "ScalewayRegisteredDomain",
+        "id",
+        "ScalewayOrganization",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        ("example.com", TEST_ORG_ID),
+    }
+    assert check_rels(
+        neo4j_session,
+        "ScalewayRegisteredDomain",
+        "id",
+        "ScalewayProject",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        ("example.com", TEST_PROJECT_ID),
     }

--- a/tests/integration/cartography/intel/scaleway/test_iam.py
+++ b/tests/integration/cartography/intel/scaleway/test_iam.py
@@ -6,6 +6,7 @@ import cartography.intel.scaleway.iam.applications
 import cartography.intel.scaleway.iam.groups
 import cartography.intel.scaleway.iam.permissionsets
 import cartography.intel.scaleway.iam.policies
+import cartography.intel.scaleway.iam.sshkeys
 import cartography.intel.scaleway.iam.users
 import tests.data.scaleway.iam
 from tests.integration.cartography.intel.scaleway.test_projects import (
@@ -16,6 +17,7 @@ from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
 TEST_ORG_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+TEST_PROJECT_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
 
 
 def _ensure_local_neo4j_has_test_users(neo4j_session):
@@ -673,3 +675,58 @@ def test_load_scaleway_policies(_mock_get_policies, _mock_get_rules, neo4j_sessi
         )
         == expected_rule_project_rels
     )
+
+
+@patch.object(
+    cartography.intel.scaleway.iam.sshkeys,
+    "get",
+    return_value=tests.data.scaleway.iam.SCALEWAY_SSH_KEYS,
+)
+def test_load_scaleway_sshkeys(_mock_get, neo4j_session):
+    # Arrange
+    client = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "ORG_ID": TEST_ORG_ID,
+    }
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+
+    # Act
+    cartography.intel.scaleway.iam.sshkeys.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # Assert SSH keys exist
+    assert check_nodes(neo4j_session, "ScalewaySSHKey", ["id", "name"]) == {
+        ("1a2b3c4d-5e6f-7890-abcd-ef1234567890", "laptop"),
+    }
+
+    # Assert SSH keys are linked to the organization
+    assert check_rels(
+        neo4j_session,
+        "ScalewaySSHKey",
+        "id",
+        "ScalewayOrganization",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        ("1a2b3c4d-5e6f-7890-abcd-ef1234567890", TEST_ORG_ID),
+    }
+
+    # Assert SSH keys are linked to the project
+    assert check_rels(
+        neo4j_session,
+        "ScalewaySSHKey",
+        "id",
+        "ScalewayProject",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        ("1a2b3c4d-5e6f-7890-abcd-ef1234567890", TEST_PROJECT_ID),
+    }

--- a/tests/integration/cartography/intel/scaleway/test_storage.py
+++ b/tests/integration/cartography/intel/scaleway/test_storage.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 from unittest.mock import patch
 
+import cartography.intel.scaleway.storage.filesystems
 import cartography.intel.scaleway.storage.objectstorage
 import cartography.intel.scaleway.storage.snapshots
 import cartography.intel.scaleway.storage.volumes
@@ -258,3 +259,38 @@ def test_load_scaleway_object_storage_buckets(_mock_get, neo4j_session):
         )
         == expected_rels
     )
+
+
+@patch.object(
+    cartography.intel.scaleway.storage.filesystems,
+    "get",
+    return_value=tests.data.scaleway.storages.SCALEWAY_FILESYSTEMS,
+)
+def test_load_scaleway_filesystems(_mock_get, neo4j_session):
+    client = Mock()
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "ORG_ID": TEST_ORG_ID}
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+
+    cartography.intel.scaleway.storage.filesystems.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    assert check_nodes(neo4j_session, "ScalewayFileSystem", ["id", "name"]) == {
+        ("a1a1a1a1-0000-0000-0000-000000000001", "shared-fs"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "ScalewayFileSystem",
+        "id",
+        "ScalewayProject",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        ("a1a1a1a1-0000-0000-0000-000000000001", TEST_PROJECT_ID),
+    }


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary
Extends the Scaleway module to close the coverage gaps found by diffing the `scw` CLI
domains against what we ingest, bringing Scaleway in line with the AWS/GCP/Azure baseline.

New node types:
- **IAM**: `ScalewaySSHKey` (linked to Organization and Project).
- **Bare Metal**: `ScalewayElasticMetalServer`, `ScalewayAppleSiliconServer`,
  `ScalewayDediboxServer` (Dedibox tolerates a 403 when the product is not subscribed).
- **File Storage**: `ScalewayFileSystem`.
- **Data services**: `ScalewayDataWarehouseDeployment`, `ScalewayServerlessSQLDatabase`,
  `ScalewaySearchDeployment` (managed OpenSearch); each derives a public-exposure flag.
- **Elastic Metal Flexible IPs**: `ScalewayElasticMetalFlexibleIp`, linked to its server via
  `IDENTIFIES`.
- **Registered Domains**: `ScalewayRegisteredDomain` (registrar inventory, distinct from the
  DNS zones/records already synced).

Also:
- Re-enabled Instance Flexible IPs (the upstream SDK bug that had disabled them is resolved;
  verified against the live API).
- Wired the ontology mappings for the new nodes so their semantic labels (`Database`,
  `FileStorage`, `ComputeInstance`) actually populate `_ont_*` fields for cross-provider
  queries.
- Kosmos clusters need no new code: the Kapsule sync already lists every cluster type.

The `compute_instance_exposed` rule stays Instance-only on purpose: it keys on a Security
Group with a permissive inbound rule, and Scaleway bare-metal has no Security Group model, so
a bare-metal exposure fact needs a distinct design. Left for the rules pass.


### Related issues or links
Remaining (lower-priority / niche) Scaleway domains are tracked as a follow-up in #2980.


### How was this tested?
- `make test_lint` (pre-commit: black, flake8, mypy, isort, pyupgrade) passes.
- Unit tests: the ontology mapping consistency suite passes (validates every mapped field
  exists on its schema).
- Integration tests: 31 Scaleway integration tests pass.
- Live end-to-end against a real Scaleway project using the `scw` CLI:
  - Created an SSH key and an Instance Flexible IP, ran the sync, confirmed the nodes and
    their relationships, then deleted the resources.
  - Created a File System, ran the sync, confirmed the node with its `FileStorage` label and
    project edge, then deleted it.
  - List-only calls confirmed the bare-metal, data-service, Elastic Metal flexible IP and
    registered-domain APIs are reachable with the correct region/zone/org arguments.

Example sync output (File Storage, live project):
```
ScalewayFileSystem rows: [{'id': '4b857b30-f9bb-496f-899c-c801222bac2d', 'name': 'cartography-e2e', 'size': 100000000000, 'status': 'available'}]
FileStorage label present: 1
Proj-[:RESOURCE]->FS: 1
```


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [x] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity (see "How was this tested?").

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).

#### If you are implementing a new intel module
- [x] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
Three commits: (1) SSH keys + bare-metal + Flexible IPs re-enable, (2) File Storage + data
services + Elastic Metal flexible IPs + registered domains, (3) ontology mappings for the new
nodes. The ontology commit adds a scalar `public_ip` (first public IP) on the Elastic Metal
and Dedibox models so the singular `public_ip_address` ontology field maps cleanly.
