### PR TITLE
feat(databricks): jobs + SQL, ML serving + apps + content, and Delta Sharing coverage

### DIFF
--- a/cartography/intel/databricks/__init__.py
+++ b/cartography/intel/databricks/__init__.py
@@ -2,23 +2,30 @@ import logging
 
 import neo4j
 
+import cartography.intel.databricks.alerts
 import cartography.intel.databricks.artifact_allowlists
 import cartography.intel.databricks.catalogs
 import cartography.intel.databricks.cluster_policies
 import cartography.intel.databricks.clusters
 import cartography.intel.databricks.connections
+import cartography.intel.databricks.dashboards
+import cartography.intel.databricks.data_sources
 import cartography.intel.databricks.external_locations
 import cartography.intel.databricks.functions
 import cartography.intel.databricks.grants
 import cartography.intel.databricks.groups
 import cartography.intel.databricks.instance_pools
 import cartography.intel.databricks.ip_access_lists
+import cartography.intel.databricks.jobs
 import cartography.intel.databricks.metastores
 import cartography.intel.databricks.online_tables
+import cartography.intel.databricks.pipelines
+import cartography.intel.databricks.queries
 import cartography.intel.databricks.registered_models
 import cartography.intel.databricks.schemas
 import cartography.intel.databricks.secret_scopes
 import cartography.intel.databricks.service_principals
+import cartography.intel.databricks.sql_warehouses
 import cartography.intel.databricks.storage_credentials
 import cartography.intel.databricks.tables
 import cartography.intel.databricks.tokens
@@ -76,6 +83,35 @@ def _cleanup_unity_catalog(
         )
     cartography.intel.databricks.metastores.cleanup(
         neo4j_session, common_job_parameters
+    )
+
+
+def _sync_workflows(
+    neo4j_session: neo4j.Session,
+    api_client: DatabricksWorkspaceClient,
+    workspace_id: str,
+    metastore_id: str | None,
+    common_job_parameters: dict,
+) -> None:
+    """Sync pipelines then jobs.
+
+    Ordered so that a job task's RUNS_PIPELINE edge lands (pipelines first) and
+    a pipeline's PUBLISHES_TO edge lands (catalogs already synced by the caller
+    when a metastore is present). Both are workspace-level, so this runs whether
+    or not the workspace has Unity Catalog.
+    """
+    cartography.intel.databricks.pipelines.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        metastore_id,
+        common_job_parameters,
+    )
+    cartography.intel.databricks.jobs.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
     )
 
 
@@ -207,8 +243,47 @@ def start_databricks_ingestion(neo4j_session: neo4j.Session, config: Config) -> 
         common_job_parameters,
     )
 
+    # SQL workloads. Warehouses first so data sources / queries / dashboards /
+    # job tasks can attach to them; queries before alerts (alerts monitor a
+    # query). None of these need Unity Catalog.
+    cartography.intel.databricks.sql_warehouses.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
+    )
+
+    cartography.intel.databricks.data_sources.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
+    )
+
+    cartography.intel.databricks.queries.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
+    )
+
+    cartography.intel.databricks.alerts.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
+    )
+
+    cartography.intel.databricks.dashboards.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
+    )
+
     # Unity Catalog (data plane). The metastore anchors every UC object; when
-    # the workspace has no metastore assigned, skip the whole UC surface.
+    # the workspace has no metastore assigned, skip the whole UC surface but
+    # still sync workspace-level pipelines + jobs below.
     metastore_id = cartography.intel.databricks.metastores.sync(
         neo4j_session,
         api_client,
@@ -222,6 +297,12 @@ def start_databricks_ingestion(neo4j_session: neo4j.Session, config: Config) -> 
             workspace_id,
         )
         _cleanup_unity_catalog(neo4j_session, workspace_id, common_job_parameters)
+        # Pipelines + jobs are workspace-level: sync them even without UC. The
+        # pipeline -> catalog edge is skipped (no metastore), but nodes, run-as
+        # and job-task -> pipeline edges still land.
+        _sync_workflows(
+            neo4j_session, api_client, workspace_id, None, common_job_parameters
+        )
         return
 
     # Storage credentials + external locations first so catalogs / tables /
@@ -246,6 +327,12 @@ def start_databricks_ingestion(neo4j_session: neo4j.Session, config: Config) -> 
         api_client,
         workspace_id,
         common_job_parameters,
+    )
+
+    # Pipelines + jobs after catalogs so pipeline -> catalog and job-task ->
+    # pipeline edges resolve against nodes already in the graph.
+    _sync_workflows(
+        neo4j_session, api_client, workspace_id, metastore_id, common_job_parameters
     )
 
     schemas = cartography.intel.databricks.schemas.sync(

--- a/cartography/intel/databricks/__init__.py
+++ b/cartography/intel/databricks/__init__.py
@@ -3,6 +3,7 @@ import logging
 import neo4j
 
 import cartography.intel.databricks.alerts
+import cartography.intel.databricks.apps
 import cartography.intel.databricks.artifact_allowlists
 import cartography.intel.databricks.catalogs
 import cartography.intel.databricks.cluster_policies
@@ -12,19 +13,24 @@ import cartography.intel.databricks.dashboards
 import cartography.intel.databricks.data_sources
 import cartography.intel.databricks.external_locations
 import cartography.intel.databricks.functions
+import cartography.intel.databricks.genie_spaces
+import cartography.intel.databricks.git_credentials
 import cartography.intel.databricks.grants
 import cartography.intel.databricks.groups
 import cartography.intel.databricks.instance_pools
 import cartography.intel.databricks.ip_access_lists
 import cartography.intel.databricks.jobs
 import cartography.intel.databricks.metastores
+import cartography.intel.databricks.notebooks
 import cartography.intel.databricks.online_tables
 import cartography.intel.databricks.pipelines
 import cartography.intel.databricks.queries
 import cartography.intel.databricks.registered_models
+import cartography.intel.databricks.repos
 import cartography.intel.databricks.schemas
 import cartography.intel.databricks.secret_scopes
 import cartography.intel.databricks.service_principals
+import cartography.intel.databricks.serving_endpoints
 import cartography.intel.databricks.sql_warehouses
 import cartography.intel.databricks.storage_credentials
 import cartography.intel.databricks.tables
@@ -110,6 +116,13 @@ def _sync_workflows(
     cartography.intel.databricks.jobs.sync(
         neo4j_session,
         api_client,
+        workspace_id,
+        common_job_parameters,
+    )
+    # Notebooks are derived from the task notebook_paths just loaded, so this
+    # runs last and needs no api_client.
+    cartography.intel.databricks.notebooks.sync(
+        neo4j_session,
         workspace_id,
         common_job_parameters,
     )
@@ -275,6 +288,43 @@ def start_databricks_ingestion(neo4j_session: neo4j.Session, config: Config) -> 
     )
 
     cartography.intel.databricks.dashboards.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
+    )
+
+    # ML serving + apps + content. Genie spaces bind to a warehouse synced
+    # above; the rest are independent workspace-level surfaces.
+    cartography.intel.databricks.serving_endpoints.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
+    )
+
+    cartography.intel.databricks.genie_spaces.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
+    )
+
+    cartography.intel.databricks.apps.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
+    )
+
+    cartography.intel.databricks.repos.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
+    )
+
+    cartography.intel.databricks.git_credentials.sync(
         neo4j_session,
         api_client,
         workspace_id,

--- a/cartography/intel/databricks/__init__.py
+++ b/cartography/intel/databricks/__init__.py
@@ -6,6 +6,7 @@ import cartography.intel.databricks.alerts
 import cartography.intel.databricks.apps
 import cartography.intel.databricks.artifact_allowlists
 import cartography.intel.databricks.catalogs
+import cartography.intel.databricks.clean_rooms
 import cartography.intel.databricks.cluster_policies
 import cartography.intel.databricks.clusters
 import cartography.intel.databricks.connections
@@ -24,13 +25,16 @@ import cartography.intel.databricks.metastores
 import cartography.intel.databricks.notebooks
 import cartography.intel.databricks.online_tables
 import cartography.intel.databricks.pipelines
+import cartography.intel.databricks.providers
 import cartography.intel.databricks.queries
+import cartography.intel.databricks.recipients
 import cartography.intel.databricks.registered_models
 import cartography.intel.databricks.repos
 import cartography.intel.databricks.schemas
 import cartography.intel.databricks.secret_scopes
 import cartography.intel.databricks.service_principals
 import cartography.intel.databricks.serving_endpoints
+import cartography.intel.databricks.shares
 import cartography.intel.databricks.sql_warehouses
 import cartography.intel.databricks.storage_credentials
 import cartography.intel.databricks.tables
@@ -70,6 +74,13 @@ def _cleanup_unity_catalog(
         neo4j_session, workspace_id, common_job_parameters["UPDATE_TAG"]
     )
     for module in (
+        # Delta Sharing: share nodes carry the SHARED_WITH edge, so purge them
+        # before recipients. All are metastore-scoped leaves cleaned centrally
+        # (like the rest of UC) so the no-metastore path purges them too.
+        cartography.intel.databricks.shares,
+        cartography.intel.databricks.recipients,
+        cartography.intel.databricks.providers,
+        cartography.intel.databricks.clean_rooms,
         cartography.intel.databricks.online_tables,
         cartography.intel.databricks.vector_search,
         cartography.intel.databricks.registered_models,
@@ -456,6 +467,39 @@ def start_databricks_ingestion(neo4j_session: neo4j.Session, config: Config) -> 
             metastore_id,
             common_job_parameters,
         )
+    )
+
+    # Delta Sharing. Recipients + providers before shares so the share ->
+    # recipient SHARED_WITH edge resolves against recipient nodes already loaded.
+    cartography.intel.databricks.recipients.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        metastore_id,
+        common_job_parameters,
+    )
+
+    cartography.intel.databricks.providers.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        metastore_id,
+        common_job_parameters,
+    )
+
+    cartography.intel.databricks.clean_rooms.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        common_job_parameters,
+    )
+
+    cartography.intel.databricks.shares.sync(
+        neo4j_session,
+        api_client,
+        workspace_id,
+        metastore_id,
+        common_job_parameters,
     )
 
     # Grants last: materialises principal -> securable HAS_PRIVILEGE edges by

--- a/cartography/intel/databricks/__init__.py
+++ b/cartography/intel/databricks/__init__.py
@@ -55,6 +55,7 @@ def _cleanup_unity_catalog(
     workspace_id: str,
     common_job_parameters: dict,
     clean_artifact_allowlists: bool = True,
+    clean_clean_rooms: bool = True,
 ) -> None:
     """Run every Unity Catalog cleanup, in reverse dependency order.
 
@@ -66,7 +67,9 @@ def _cleanup_unity_catalog(
 
     ``clean_artifact_allowlists`` is False when the allowlist fetch was
     incomplete (a 403 on a type), so its cleanup is skipped rather than deleting
-    an allowlist node we could not re-read this run.
+    an allowlist node we could not re-read this run. ``clean_clean_rooms`` is
+    False when the clean-rooms listing was skipped (external OpenSharing
+    disabled), for the same reason.
     """
     # Grants (edges) first, then leaf resources, then up the containment
     # hierarchy, and the metastore last.
@@ -80,7 +83,6 @@ def _cleanup_unity_catalog(
         cartography.intel.databricks.shares,
         cartography.intel.databricks.recipients,
         cartography.intel.databricks.providers,
-        cartography.intel.databricks.clean_rooms,
         cartography.intel.databricks.online_tables,
         cartography.intel.databricks.vector_search,
         cartography.intel.databricks.registered_models,
@@ -94,6 +96,10 @@ def _cleanup_unity_catalog(
         cartography.intel.databricks.connections,
     ):
         module.cleanup(neo4j_session, common_job_parameters)
+    if clean_clean_rooms:
+        cartography.intel.databricks.clean_rooms.cleanup(
+            neo4j_session, common_job_parameters
+        )
     if clean_artifact_allowlists:
         cartography.intel.databricks.artifact_allowlists.cleanup(
             neo4j_session, common_job_parameters
@@ -487,10 +493,11 @@ def start_databricks_ingestion(neo4j_session: neo4j.Session, config: Config) -> 
         common_job_parameters,
     )
 
-    cartography.intel.databricks.clean_rooms.sync(
+    clean_rooms_complete = cartography.intel.databricks.clean_rooms.sync(
         neo4j_session,
         api_client,
         workspace_id,
+        metastore_id,
         common_job_parameters,
     )
 
@@ -520,4 +527,5 @@ def start_databricks_ingestion(neo4j_session: neo4j.Session, config: Config) -> 
         workspace_id,
         common_job_parameters,
         clean_artifact_allowlists=artifact_allowlists_complete,
+        clean_clean_rooms=clean_rooms_complete,
     )

--- a/cartography/intel/databricks/alerts.py
+++ b/cartography/intel/databricks/alerts.py
@@ -1,0 +1,98 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import iso_to_datetime
+from cartography.intel.databricks.util import scoped_id
+from cartography.models.databricks.alert import DatabricksAlertSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    alerts = get(api_session)
+    transformed = transform(alerts, workspace_id)
+    load_alerts(
+        neo4j_session,
+        transformed,
+        workspace_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    """Paginate the SQL alerts listing (``results`` + ``next_page_token``)."""
+    results: list[dict[str, Any]] = []
+    params: dict[str, Any] = {"page_size": 100}
+    while True:
+        response = api_session.get("/api/2.0/sql/alerts", params=params)
+        results.extend(response.get("results", []) or [])
+        next_token = response.get("next_page_token")
+        if not next_token:
+            break
+        params = {"page_size": 100, "page_token": next_token}
+    return results
+
+
+@timeit
+def transform(alerts: list[dict[str, Any]], workspace_id: str) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for a in alerts:
+        alert_id = a.get("id")
+        if not alert_id:
+            raise ValueError("Databricks alert returned with empty id")
+        query_id = a.get("query_id")
+        result.append(
+            {
+                "id": scoped_id(workspace_id, alert_id),
+                "alert_id": alert_id,
+                "display_name": a.get("display_name"),
+                "query_id": query_id,
+                "query_scoped_id": (
+                    scoped_id(workspace_id, query_id) if query_id else None
+                ),
+                "owner_user_name": a.get("owner_user_name"),
+                "state": a.get("state"),
+                "lifecycle_state": a.get("lifecycle_state"),
+                "condition_op": (a.get("condition") or {}).get("op"),
+                "parent_path": a.get("parent_path"),
+                "create_time": iso_to_datetime(a.get("create_time")),
+                "update_time": iso_to_datetime(a.get("update_time")),
+            }
+        )
+    return result
+
+
+@timeit
+def load_alerts(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksAlertSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksAlertSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/apps.py
+++ b/cartography/intel/databricks/apps.py
@@ -1,0 +1,96 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import iso_to_datetime
+from cartography.intel.databricks.util import scoped_id
+from cartography.models.databricks.app import DatabricksAppSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    apps = get(api_session)
+    transformed = transform(apps, workspace_id)
+    load_apps(
+        neo4j_session,
+        transformed,
+        workspace_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    """Paginate Databricks Apps via ``apps`` + ``next_page_token``."""
+    results: list[dict[str, Any]] = []
+    params: dict[str, Any] = {"page_size": 100}
+    while True:
+        response = api_session.get("/api/2.0/apps", params=params)
+        results.extend(response.get("apps", []) or [])
+        next_token = response.get("next_page_token")
+        if not next_token:
+            break
+        params = {"page_size": 100, "page_token": next_token}
+    return results
+
+
+@timeit
+def transform(apps: list[dict[str, Any]], workspace_id: str) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for a in apps:
+        name = a.get("name")
+        if not name:
+            raise ValueError("Databricks app returned with empty name")
+        result.append(
+            {
+                "id": scoped_id(workspace_id, name),
+                "name": name,
+                "description": a.get("description"),
+                "url": a.get("url"),
+                "app_state": (a.get("app_status") or {}).get("state"),
+                "compute_state": (a.get("compute_status") or {}).get("state"),
+                "compute_size": a.get("compute_size"),
+                "creator": a.get("creator"),
+                "service_principal_client_id": a.get("service_principal_client_id"),
+                "service_principal_name": a.get("service_principal_name"),
+                "oauth2_app_client_id": a.get("oauth2_app_client_id"),
+                "create_time": iso_to_datetime(a.get("create_time")),
+                "update_time": iso_to_datetime(a.get("update_time")),
+            }
+        )
+    return result
+
+
+@timeit
+def load_apps(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksAppSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksAppSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/apps.py
+++ b/cartography/intel/databricks/apps.py
@@ -34,12 +34,19 @@ def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
     """Paginate Databricks Apps via ``apps`` + ``next_page_token``."""
     results: list[dict[str, Any]] = []
     params: dict[str, Any] = {"page_size": 100}
+    seen_tokens: set[str] = set()
     while True:
         response = api_session.get("/api/2.0/apps", params=params)
         results.extend(response.get("apps", []) or [])
         next_token = response.get("next_page_token")
         if not next_token:
             break
+        if next_token in seen_tokens:
+            raise ValueError(
+                f"Databricks apps list repeated page token {next_token!r}; "
+                "aborting to avoid an infinite loop.",
+            )
+        seen_tokens.add(next_token)
         params = {"page_size": 100, "page_token": next_token}
     return results
 

--- a/cartography/intel/databricks/clean_rooms.py
+++ b/cartography/intel/databricks/clean_rooms.py
@@ -8,8 +8,8 @@ from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.databricks.util import DatabricksWorkspaceClient
 from cartography.intel.databricks.util import epoch_ms_to_datetime
-from cartography.intel.databricks.util import scoped_id
 from cartography.intel.databricks.util import skip_or_raise_http
+from cartography.intel.databricks.util import uc_id
 from cartography.models.databricks.clean_room import DatabricksCleanRoomSchema
 from cartography.util import timeit
 
@@ -21,42 +21,62 @@ def sync(
     neo4j_session: neo4j.Session,
     api_session: DatabricksWorkspaceClient,
     workspace_id: str,
+    metastore_id: str,
     common_job_parameters: dict[str, Any],
-) -> None:
-    clean_rooms = get(api_session)
-    transformed = transform(clean_rooms, workspace_id)
+) -> bool:
+    """Sync clean rooms. Returns whether the fetch was complete.
+
+    Returns False when the listing was skipped (external OpenSharing disabled),
+    signalling that the caller must NOT clean up clean rooms: a skip is not proof
+    that none exist, so purging would delete previously ingested nodes.
+    """
+    clean_rooms, complete = get(api_session)
+    transformed = transform(clean_rooms, metastore_id)
     load_clean_rooms(
         neo4j_session, transformed, workspace_id, common_job_parameters["UPDATE_TAG"]
     )
+    return complete
 
 
 @timeit
-def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
-    """Paginate clean rooms.
+def get(api_session: DatabricksWorkspaceClient) -> tuple[list[dict[str, Any]], bool]:
+    """Paginate clean rooms. Returns ``(clean_rooms, complete)``.
 
-    The endpoint returns 400/403 when external OpenSharing is disabled on the
-    metastore; that is expected and skippable, so it never aborts the sync.
+    ``complete`` is False when the endpoint returns 400/403 (external OpenSharing
+    disabled on the metastore): a skip, not a genuine empty result, so cleanup is
+    unsafe.
     """
     results: list[dict[str, Any]] = []
     params: dict[str, Any] = {"page_size": 100}
+    seen_tokens: set[str] = set()
     while True:
         try:
             response = api_session.get("/api/2.0/clean-rooms", params=params)
         except requests.HTTPError as e:
             skip_or_raise_http(e, 400, 403)
-            logger.info("Clean Rooms unavailable (OpenSharing disabled?): %s", e)
-            break
+            logger.warning(
+                "Clean Rooms listing skipped (external OpenSharing disabled?); "
+                "not cleaning up clean rooms this run: %s",
+                e,
+            )
+            return [], False
         results.extend(response.get("clean_rooms", []) or [])
         next_token = response.get("next_page_token")
         if not next_token:
             break
+        if next_token in seen_tokens:
+            raise ValueError(
+                f"Databricks clean-rooms list repeated page token {next_token!r}; "
+                "aborting to avoid an infinite loop.",
+            )
+        seen_tokens.add(next_token)
         params = {"page_size": 100, "page_token": next_token}
-    return results
+    return results, True
 
 
 @timeit
 def transform(
-    clean_rooms: list[dict[str, Any]], workspace_id: str
+    clean_rooms: list[dict[str, Any]], metastore_id: str
 ) -> list[dict[str, Any]]:
     result: list[dict[str, Any]] = []
     for c in clean_rooms:
@@ -65,8 +85,9 @@ def transform(
             raise ValueError("Databricks clean room returned with empty name")
         result.append(
             {
-                "id": scoped_id(workspace_id, name),
+                "id": uc_id(metastore_id, name),
                 "name": name,
+                "metastore_id": metastore_id,
                 "owner": c.get("owner"),
                 "comment": c.get("comment"),
                 "access_restricted": c.get("access_restricted"),

--- a/cartography/intel/databricks/clean_rooms.py
+++ b/cartography/intel/databricks/clean_rooms.py
@@ -1,0 +1,102 @@
+import logging
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import epoch_ms_to_datetime
+from cartography.intel.databricks.util import scoped_id
+from cartography.intel.databricks.util import skip_or_raise_http
+from cartography.models.databricks.clean_room import DatabricksCleanRoomSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    clean_rooms = get(api_session)
+    transformed = transform(clean_rooms, workspace_id)
+    load_clean_rooms(
+        neo4j_session, transformed, workspace_id, common_job_parameters["UPDATE_TAG"]
+    )
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    """Paginate clean rooms.
+
+    The endpoint returns 400/403 when external OpenSharing is disabled on the
+    metastore; that is expected and skippable, so it never aborts the sync.
+    """
+    results: list[dict[str, Any]] = []
+    params: dict[str, Any] = {"page_size": 100}
+    while True:
+        try:
+            response = api_session.get("/api/2.0/clean-rooms", params=params)
+        except requests.HTTPError as e:
+            skip_or_raise_http(e, 400, 403)
+            logger.info("Clean Rooms unavailable (OpenSharing disabled?): %s", e)
+            break
+        results.extend(response.get("clean_rooms", []) or [])
+        next_token = response.get("next_page_token")
+        if not next_token:
+            break
+        params = {"page_size": 100, "page_token": next_token}
+    return results
+
+
+@timeit
+def transform(
+    clean_rooms: list[dict[str, Any]], workspace_id: str
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for c in clean_rooms:
+        name = c.get("name")
+        if not name:
+            raise ValueError("Databricks clean room returned with empty name")
+        result.append(
+            {
+                "id": scoped_id(workspace_id, name),
+                "name": name,
+                "owner": c.get("owner"),
+                "comment": c.get("comment"),
+                "access_restricted": c.get("access_restricted"),
+                "created_at": epoch_ms_to_datetime(c.get("created_at")),
+                "updated_at": epoch_ms_to_datetime(c.get("updated_at")),
+            }
+        )
+    return result
+
+
+@timeit
+def load_clean_rooms(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksCleanRoomSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksCleanRoomSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/dashboards.py
+++ b/cartography/intel/databricks/dashboards.py
@@ -1,0 +1,142 @@
+import logging
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import iso_to_datetime
+from cartography.intel.databricks.util import scoped_id
+from cartography.intel.databricks.util import skip_or_raise_http
+from cartography.models.databricks.dashboard import DatabricksDashboardSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    dashboards = get_lakeview(api_session) + get_legacy(api_session)
+    transformed = transform(dashboards, workspace_id)
+    load_dashboards(
+        neo4j_session,
+        transformed,
+        workspace_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get_lakeview(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    """Paginate current (Lakeview) dashboards."""
+    results: list[dict[str, Any]] = []
+    params: dict[str, Any] = {"page_size": 100}
+    while True:
+        response = api_session.get("/api/2.0/lakeview/dashboards", params=params)
+        for d in response.get("dashboards", []) or []:
+            results.append({**d, "_type": "LAKEVIEW"})
+        next_token = response.get("next_page_token")
+        if not next_token:
+            break
+        params = {"page_size": 100, "page_token": next_token}
+    return results
+
+
+@timeit
+def get_legacy(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    """Paginate legacy (redash-based) dashboards.
+
+    The legacy ``/preview/sql/dashboards`` surface is deprecated and absent in
+    some workspaces; a 404/400 there is skippable so it never aborts the sync.
+    """
+    results: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        try:
+            response = api_session.get(
+                "/api/2.0/preview/sql/dashboards",
+                params={"page_size": 100, "page": page},
+            )
+        except requests.HTTPError as e:
+            skip_or_raise_http(e, 400, 404)
+            logger.info("Legacy SQL dashboards API unavailable, skipping: %s", e)
+            break
+        batch = response.get("results", []) or []
+        for d in batch:
+            results.append({**d, "_type": "LEGACY"})
+        count = int(response.get("count", 0))
+        if not batch or len(results) >= count:
+            break
+        page += 1
+    return results
+
+
+@timeit
+def transform(
+    dashboards: list[dict[str, Any]], workspace_id: str
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for d in dashboards:
+        dashboard_type = d["_type"]
+        dashboard_id = d.get("dashboard_id") or d.get("id")
+        if not dashboard_id:
+            raise ValueError("Databricks dashboard returned with empty id")
+        warehouse_id = d.get("warehouse_id")
+        # Lakeview carries display_name + RFC-3339 timestamps; legacy carries
+        # name + a nested user object and created_at/updated_at.
+        result.append(
+            {
+                "id": scoped_id(workspace_id, dashboard_id),
+                "dashboard_id": dashboard_id,
+                "dashboard_type": dashboard_type,
+                "display_name": d.get("display_name") or d.get("name"),
+                "warehouse_id": warehouse_id,
+                "warehouse_scoped_id": (
+                    scoped_id(workspace_id, warehouse_id) if warehouse_id else None
+                ),
+                "owner_user_name": (d.get("user") or {}).get("email"),
+                "lifecycle_state": d.get("lifecycle_state"),
+                "parent_path": d.get("parent_path"),
+                "path": d.get("path"),
+                "create_time": iso_to_datetime(
+                    d.get("create_time") or d.get("created_at")
+                ),
+                "update_time": iso_to_datetime(
+                    d.get("update_time") or d.get("updated_at")
+                ),
+            }
+        )
+    return result
+
+
+@timeit
+def load_dashboards(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksDashboardSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksDashboardSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/data_sources.py
+++ b/cartography/intel/databricks/data_sources.py
@@ -1,0 +1,89 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import scoped_id
+from cartography.models.databricks.data_source import DatabricksDataSourceSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    data_sources = get(api_session)
+    transformed = transform(data_sources, workspace_id)
+    load_data_sources(
+        neo4j_session,
+        transformed,
+        workspace_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    """List SQL data sources. The endpoint returns a bare list, no pagination."""
+    response = api_session.get("/api/2.0/preview/sql/data_sources")
+    return response if isinstance(response, list) else []
+
+
+@timeit
+def transform(
+    data_sources: list[dict[str, Any]], workspace_id: str
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for d in data_sources:
+        data_source_id = d.get("id")
+        if not data_source_id:
+            raise ValueError("Databricks data source returned with empty id")
+        warehouse_id = d.get("warehouse_id")
+        result.append(
+            {
+                "id": scoped_id(workspace_id, data_source_id),
+                "data_source_id": data_source_id,
+                "name": d.get("name"),
+                "type": d.get("type"),
+                "warehouse_id": warehouse_id,
+                "warehouse_scoped_id": (
+                    scoped_id(workspace_id, warehouse_id) if warehouse_id else None
+                ),
+                "syntax": d.get("syntax"),
+                # The API reports paused as 0/1; keep it as-is (0 == running).
+                "paused": d.get("paused"),
+                "view_only": d.get("view_only"),
+            }
+        )
+    return result
+
+
+@timeit
+def load_data_sources(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksDataSourceSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksDataSourceSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/data_sources.py
+++ b/cartography/intel/databricks/data_sources.py
@@ -32,7 +32,12 @@ def sync(
 def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
     """List SQL data sources. The endpoint returns a bare list, no pagination."""
     response = api_session.get("/api/2.0/preview/sql/data_sources")
-    return response if isinstance(response, list) else []
+    if not isinstance(response, list):
+        raise ValueError(
+            "Databricks data sources endpoint returned "
+            f"{type(response).__name__}, expected a list.",
+        )
+    return response
 
 
 @timeit

--- a/cartography/intel/databricks/genie_spaces.py
+++ b/cartography/intel/databricks/genie_spaces.py
@@ -1,0 +1,91 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import scoped_id
+from cartography.models.databricks.genie_space import DatabricksGenieSpaceSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    spaces = get(api_session)
+    transformed = transform(spaces, workspace_id)
+    load_genie_spaces(
+        neo4j_session,
+        transformed,
+        workspace_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    """Paginate Genie spaces (``spaces`` + ``next_page_token``)."""
+    results: list[dict[str, Any]] = []
+    params: dict[str, Any] = {"page_size": 100}
+    while True:
+        response = api_session.get("/api/2.0/genie/spaces", params=params)
+        results.extend(response.get("spaces", []) or [])
+        next_token = response.get("next_page_token")
+        if not next_token:
+            break
+        params = {"page_size": 100, "page_token": next_token}
+    return results
+
+
+@timeit
+def transform(spaces: list[dict[str, Any]], workspace_id: str) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for s in spaces:
+        space_id = s.get("space_id")
+        if not space_id:
+            raise ValueError("Databricks Genie space returned with empty space_id")
+        warehouse_id = s.get("warehouse_id")
+        result.append(
+            {
+                "id": scoped_id(workspace_id, space_id),
+                "space_id": space_id,
+                "title": s.get("title"),
+                "description": s.get("description"),
+                "warehouse_id": warehouse_id,
+                "warehouse_scoped_id": (
+                    scoped_id(workspace_id, warehouse_id) if warehouse_id else None
+                ),
+            }
+        )
+    return result
+
+
+@timeit
+def load_genie_spaces(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksGenieSpaceSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksGenieSpaceSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/genie_spaces.py
+++ b/cartography/intel/databricks/genie_spaces.py
@@ -33,12 +33,19 @@ def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
     """Paginate Genie spaces (``spaces`` + ``next_page_token``)."""
     results: list[dict[str, Any]] = []
     params: dict[str, Any] = {"page_size": 100}
+    seen_tokens: set[str] = set()
     while True:
         response = api_session.get("/api/2.0/genie/spaces", params=params)
         results.extend(response.get("spaces", []) or [])
         next_token = response.get("next_page_token")
         if not next_token:
             break
+        if next_token in seen_tokens:
+            raise ValueError(
+                f"Databricks Genie spaces list repeated page token "
+                f"{next_token!r}; aborting to avoid an infinite loop.",
+            )
+        seen_tokens.add(next_token)
         params = {"page_size": 100, "page_token": next_token}
     return results
 

--- a/cartography/intel/databricks/git_credentials.py
+++ b/cartography/intel/databricks/git_credentials.py
@@ -1,0 +1,79 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import scoped_id
+from cartography.models.databricks.git_credential import DatabricksGitCredentialSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    credentials = get(api_session)
+    transformed = transform(credentials, workspace_id)
+    load_git_credentials(
+        neo4j_session,
+        transformed,
+        workspace_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    """List Git credentials. The endpoint returns the full set in one response."""
+    return api_session.get("/api/2.0/git-credentials").get("credentials", []) or []
+
+
+@timeit
+def transform(
+    credentials: list[dict[str, Any]], workspace_id: str
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for c in credentials:
+        credential_id = c.get("credential_id")
+        if not credential_id:
+            raise ValueError("Databricks git credential returned with empty id")
+        result.append(
+            {
+                "id": scoped_id(workspace_id, str(credential_id)),
+                "credential_id": str(credential_id),
+                "git_provider": c.get("git_provider"),
+                "git_username": c.get("git_username"),
+            }
+        )
+    return result
+
+
+@timeit
+def load_git_credentials(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksGitCredentialSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(
+        DatabricksGitCredentialSchema(), common_job_parameters
+    ).run(neo4j_session)

--- a/cartography/intel/databricks/jobs.py
+++ b/cartography/intel/databricks/jobs.py
@@ -1,0 +1,220 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import epoch_ms_to_datetime
+from cartography.intel.databricks.util import get_run_as_principal_index
+from cartography.intel.databricks.util import scoped_id
+from cartography.models.databricks.job import DatabricksJobSchema
+from cartography.models.databricks.job_task import DatabricksJobTaskSchema
+from cartography.util import timeit
+
+# Task settings carry exactly one of these blocks; the key names the task type.
+_TASK_TYPE_KEYS = (
+    "notebook_task",
+    "spark_jar_task",
+    "spark_python_task",
+    "python_wheel_task",
+    "pipeline_task",
+    "sql_task",
+    "dbt_task",
+    "run_job_task",
+    "condition_task",
+    "for_each_task",
+)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    jobs = get(api_session)
+    principals = get_run_as_principal_index(neo4j_session, workspace_id)
+    transformed_jobs = transform_jobs(jobs, workspace_id, principals)
+    transformed_tasks = transform_tasks(jobs, workspace_id)
+    load_jobs(
+        neo4j_session,
+        transformed_jobs,
+        workspace_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    load_tasks(
+        neo4j_session,
+        transformed_tasks,
+        workspace_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    """List jobs with their task graph expanded (paginated via page_token)."""
+    results: list[dict[str, Any]] = []
+    params: dict[str, Any] = {"limit": 100, "expand_tasks": "true"}
+    while True:
+        response = api_session.get("/api/2.1/jobs/list", params=params)
+        results.extend(response.get("jobs", []) or [])
+        next_token = response.get("next_page_token")
+        if not response.get("has_more") or not next_token:
+            break
+        params = {"limit": 100, "expand_tasks": "true", "page_token": next_token}
+    return results
+
+
+def _task_type(task: dict[str, Any]) -> str | None:
+    for key in _TASK_TYPE_KEYS:
+        if task.get(key) is not None:
+            return key
+    return None
+
+
+@timeit
+def transform_jobs(
+    jobs: list[dict[str, Any]],
+    workspace_id: str,
+    principals: dict[str, tuple[str, bool]],
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for j in jobs:
+        job_id = j.get("job_id")
+        if not job_id:
+            raise ValueError("Databricks job returned with empty job_id")
+        settings = j.get("settings") or {}
+        schedule = settings.get("schedule") or {}
+        run_as_name = j.get("run_as_user_name")
+        # A job runs as exactly one principal; route the scoped id to the
+        # user or service-principal field so only the matching RUN_AS edge fires.
+        resolved = principals.get(run_as_name) if run_as_name else None
+        run_as_id, is_sp = resolved if resolved else (None, False)
+        result.append(
+            {
+                "id": scoped_id(workspace_id, str(job_id)),
+                "job_id": str(job_id),
+                "name": settings.get("name"),
+                "creator_user_name": j.get("creator_user_name"),
+                "run_as_user_name": run_as_name,
+                "run_as_user_id": run_as_id if not is_sp else None,
+                "run_as_sp_id": run_as_id if is_sp else None,
+                "format": settings.get("format"),
+                "max_concurrent_runs": settings.get("max_concurrent_runs"),
+                "timeout_seconds": settings.get("timeout_seconds"),
+                "continuous": bool(settings.get("continuous")),
+                "schedule_quartz_cron_expression": schedule.get(
+                    "quartz_cron_expression"
+                ),
+                "schedule_timezone_id": schedule.get("timezone_id"),
+                "schedule_pause_status": schedule.get("pause_status"),
+                "created_time": epoch_ms_to_datetime(j.get("created_time")),
+            }
+        )
+    return result
+
+
+@timeit
+def transform_tasks(
+    jobs: list[dict[str, Any]], workspace_id: str
+) -> list[dict[str, Any]]:
+    """Flatten every job's task graph into standalone task rows.
+
+    Task ids are ``{workspace}/{job_id}/{task_key}`` so the same task_key reused
+    across jobs stays distinct. Cross-resource ids (pipeline / cluster /
+    warehouse) are workspace-scoped to match the nodes those syncs loaded.
+    """
+    result: list[dict[str, Any]] = []
+    for j in jobs:
+        job_id = j.get("job_id")
+        if not job_id:
+            continue
+        job_id = str(job_id)
+        job_scoped_id = scoped_id(workspace_id, job_id)
+        settings = j.get("settings") or {}
+        for task in settings.get("tasks", []) or []:
+            task_key = task.get("task_key")
+            if not task_key:
+                continue
+            pipeline_id = (task.get("pipeline_task") or {}).get("pipeline_id")
+            warehouse_id = (task.get("sql_task") or {}).get("warehouse_id")
+            run_job_id = (task.get("run_job_task") or {}).get("job_id")
+            notebook_path = (task.get("notebook_task") or {}).get("notebook_path")
+            existing_cluster_id = task.get("existing_cluster_id")
+            result.append(
+                {
+                    "id": f"{job_scoped_id}/{task_key}",
+                    "task_key": task_key,
+                    "job_id": job_id,
+                    "job_scoped_id": job_scoped_id,
+                    "task_type": _task_type(task),
+                    "notebook_path": notebook_path,
+                    "existing_cluster_id": existing_cluster_id,
+                    "existing_cluster_scoped_id": (
+                        scoped_id(workspace_id, existing_cluster_id)
+                        if existing_cluster_id
+                        else None
+                    ),
+                    "job_cluster_key": task.get("job_cluster_key"),
+                    "pipeline_id": pipeline_id,
+                    "pipeline_scoped_id": (
+                        scoped_id(workspace_id, pipeline_id) if pipeline_id else None
+                    ),
+                    "warehouse_id": warehouse_id,
+                    "warehouse_scoped_id": (
+                        scoped_id(workspace_id, warehouse_id) if warehouse_id else None
+                    ),
+                    "run_job_id": str(run_job_id) if run_job_id else None,
+                    "disabled": task.get("disabled"),
+                    "run_if": task.get("run_if"),
+                }
+            )
+    return result
+
+
+@timeit
+def load_jobs(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksJobSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def load_tasks(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksJobTaskSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    # Tasks first: they hang off jobs, so purge the children before the parents.
+    GraphJob.from_node_schema(DatabricksJobTaskSchema(), common_job_parameters).run(
+        neo4j_session
+    )
+    GraphJob.from_node_schema(DatabricksJobSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/jobs.py
+++ b/cartography/intel/databricks/jobs.py
@@ -58,12 +58,25 @@ def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
     """List jobs with their task graph expanded (paginated via page_token)."""
     results: list[dict[str, Any]] = []
     params: dict[str, Any] = {"limit": 100, "expand_tasks": "true"}
+    seen_tokens: set[str] = set()
     while True:
         response = api_session.get("/api/2.1/jobs/list", params=params)
         results.extend(response.get("jobs", []) or [])
-        next_token = response.get("next_page_token")
-        if not response.get("has_more") or not next_token:
+        if not response.get("has_more"):
             break
+        next_token = response.get("next_page_token")
+        # has_more with no token is a malformed response: breaking here would
+        # silently drop the remaining jobs and let cleanup delete their nodes.
+        if not next_token:
+            raise ValueError(
+                "Databricks jobs list reported has_more but no next_page_token",
+            )
+        if next_token in seen_tokens:
+            raise ValueError(
+                f"Databricks jobs list repeated page token {next_token!r}; "
+                "aborting to avoid an infinite loop.",
+            )
+        seen_tokens.add(next_token)
         params = {"limit": 100, "expand_tasks": "true", "page_token": next_token}
     return results
 
@@ -152,6 +165,11 @@ def transform_tasks(
                     "job_scoped_id": job_scoped_id,
                     "task_type": _task_type(task),
                     "notebook_path": notebook_path,
+                    "notebook_scoped_id": (
+                        scoped_id(workspace_id, notebook_path)
+                        if notebook_path
+                        else None
+                    ),
                     "existing_cluster_id": existing_cluster_id,
                     "existing_cluster_scoped_id": (
                         scoped_id(workspace_id, existing_cluster_id)

--- a/cartography/intel/databricks/notebooks.py
+++ b/cartography/intel/databricks/notebooks.py
@@ -1,0 +1,77 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import scoped_id
+from cartography.models.databricks.notebook import DatabricksNotebookSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    """Materialise notebooks referenced by workloads, without a workspace walk.
+
+    Rather than recursively listing the whole workspace tree (potentially
+    thousands of files), this creates one lightweight, path-keyed
+    ``DatabricksNotebook`` node per distinct notebook a job task points at, so
+    the code-to-cloud ``RUNS_NOTEBOOK`` edge lands with no extra API calls. Runs
+    after jobs so the task nodes it reads already exist.
+    """
+    paths = get_referenced_notebook_paths(neo4j_session, workspace_id)
+    transformed = transform(paths, workspace_id)
+    load_notebooks(
+        neo4j_session, transformed, workspace_id, common_job_parameters["UPDATE_TAG"]
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get_referenced_notebook_paths(
+    neo4j_session: neo4j.Session, workspace_id: str
+) -> list[str]:
+    """Return the distinct notebook paths referenced by this workspace's tasks."""
+    query = """
+    MATCH (:DatabricksWorkspace {id: $workspace_id})-[:RESOURCE]->(t:DatabricksJobTask)
+    WHERE t.notebook_path IS NOT NULL
+    RETURN collect(DISTINCT t.notebook_path) AS paths
+    """
+    record = neo4j_session.run(query, workspace_id=workspace_id).single()
+    return record["paths"] if record else []
+
+
+@timeit
+def transform(paths: list[str], workspace_id: str) -> list[dict[str, Any]]:
+    return [
+        {"id": scoped_id(workspace_id, path), "path": path} for path in paths if path
+    ]
+
+
+@timeit
+def load_notebooks(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksNotebookSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksNotebookSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/pipelines.py
+++ b/cartography/intel/databricks/pipelines.py
@@ -1,15 +1,20 @@
+import logging
 from typing import Any
 
 import neo4j
+import requests
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.databricks.util import DatabricksWorkspaceClient
 from cartography.intel.databricks.util import get_run_as_principal_index
 from cartography.intel.databricks.util import scoped_id
+from cartography.intel.databricks.util import skip_or_raise_http
 from cartography.intel.databricks.util import uc_id
 from cartography.models.databricks.pipeline import DatabricksPipelineSchema
 from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
 
 
 @timeit
@@ -41,12 +46,19 @@ def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
     """
     statuses: list[dict[str, Any]] = []
     params: dict[str, Any] = {"max_results": 100}
+    seen_tokens: set[str] = set()
     while True:
         response = api_session.get("/api/2.0/pipelines", params=params)
         statuses.extend(response.get("statuses", []) or [])
         next_token = response.get("next_page_token")
         if not next_token:
             break
+        if next_token in seen_tokens:
+            raise ValueError(
+                f"Databricks pipelines list repeated page token {next_token!r}; "
+                "aborting to avoid an infinite loop.",
+            )
+        seen_tokens.add(next_token)
         params = {"max_results": 100, "page_token": next_token}
 
     pipelines: list[dict[str, Any]] = []
@@ -54,7 +66,14 @@ def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
         pipeline_id = status.get("pipeline_id")
         if not pipeline_id:
             continue
-        pipelines.append(api_session.get(f"/api/2.0/pipelines/{pipeline_id}"))
+        try:
+            pipelines.append(api_session.get(f"/api/2.0/pipelines/{pipeline_id}"))
+        except requests.HTTPError as e:
+            # A pipeline deleted mid-sync (404) or one we cannot read (403) is
+            # skipped per-resource, matching the other UC modules; anything else
+            # aborts so cleanup does not run on partial data.
+            skip_or_raise_http(e, 403, 404)
+            logger.warning("Skipping pipeline %s: %s", pipeline_id, e)
     return pipelines
 
 

--- a/cartography/intel/databricks/pipelines.py
+++ b/cartography/intel/databricks/pipelines.py
@@ -1,0 +1,130 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import get_run_as_principal_index
+from cartography.intel.databricks.util import scoped_id
+from cartography.intel.databricks.util import uc_id
+from cartography.models.databricks.pipeline import DatabricksPipelineSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    metastore_id: str | None,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    pipelines = get(api_session)
+    principals = get_run_as_principal_index(neo4j_session, workspace_id)
+    transformed = transform(pipelines, workspace_id, metastore_id, principals)
+    load_pipelines(
+        neo4j_session,
+        transformed,
+        workspace_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    """List pipelines, then fetch each one's spec.
+
+    The list endpoint only returns status fields; the catalog / target schema /
+    compute flags live on the per-pipeline detail, so fetch it for each.
+    """
+    statuses: list[dict[str, Any]] = []
+    params: dict[str, Any] = {"max_results": 100}
+    while True:
+        response = api_session.get("/api/2.0/pipelines", params=params)
+        statuses.extend(response.get("statuses", []) or [])
+        next_token = response.get("next_page_token")
+        if not next_token:
+            break
+        params = {"max_results": 100, "page_token": next_token}
+
+    pipelines: list[dict[str, Any]] = []
+    for status in statuses:
+        pipeline_id = status.get("pipeline_id")
+        if not pipeline_id:
+            continue
+        pipelines.append(api_session.get(f"/api/2.0/pipelines/{pipeline_id}"))
+    return pipelines
+
+
+@timeit
+def transform(
+    pipelines: list[dict[str, Any]],
+    workspace_id: str,
+    metastore_id: str | None,
+    principals: dict[str, tuple[str, bool]],
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for p in pipelines:
+        pipeline_id = p.get("pipeline_id")
+        if not pipeline_id:
+            raise ValueError("Databricks pipeline returned with empty pipeline_id")
+        spec = p.get("spec") or {}
+        catalog = spec.get("catalog")
+        run_as_name = p.get("run_as_user_name")
+        resolved = principals.get(run_as_name) if run_as_name else None
+        run_as_id, is_sp = resolved if resolved else (None, False)
+        result.append(
+            {
+                "id": scoped_id(workspace_id, pipeline_id),
+                "pipeline_id": pipeline_id,
+                "name": p.get("name"),
+                "state": p.get("state"),
+                "creator_user_name": p.get("creator_user_name"),
+                "run_as_user_name": run_as_name,
+                "run_as_user_id": run_as_id if not is_sp else None,
+                "run_as_sp_id": run_as_id if is_sp else None,
+                "catalog": catalog,
+                # UC pipelines publish to spec.schema; legacy ones to spec.target.
+                "target_schema": spec.get("schema") or spec.get("target"),
+                "storage": spec.get("storage"),
+                "continuous": spec.get("continuous"),
+                "development": spec.get("development"),
+                "serverless": spec.get("serverless"),
+                "photon": spec.get("photon"),
+                "edition": spec.get("edition"),
+                "channel": spec.get("channel"),
+                "pipeline_type": spec.get("pipeline_type"),
+                # Only a UC catalog (metastore known) resolves to a catalog node.
+                "catalog_scoped_id": (
+                    uc_id(metastore_id, catalog) if metastore_id and catalog else None
+                ),
+            }
+        )
+    return result
+
+
+@timeit
+def load_pipelines(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksPipelineSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksPipelineSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/providers.py
+++ b/cartography/intel/databricks/providers.py
@@ -1,0 +1,86 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import epoch_ms_to_datetime
+from cartography.intel.databricks.util import uc_id
+from cartography.models.databricks.provider import DatabricksProviderSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    metastore_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    providers = get(api_session)
+    transformed = transform(providers, metastore_id)
+    load_providers(
+        neo4j_session, transformed, workspace_id, common_job_parameters["UPDATE_TAG"]
+    )
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    return api_session.uc_list("/api/2.1/unity-catalog/providers", "providers")
+
+
+@timeit
+def transform(
+    providers: list[dict[str, Any]], metastore_id: str
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for p in providers:
+        name = p["name"]
+        if not name:
+            raise ValueError("Databricks provider returned with empty name")
+        result.append(
+            {
+                "id": uc_id(metastore_id, name),
+                "name": name,
+                "metastore_id": metastore_id,
+                "authentication_type": p.get("authentication_type"),
+                "owner": p.get("owner"),
+                "comment": p.get("comment"),
+                "data_provider_global_metastore_id": p.get(
+                    "data_provider_global_metastore_id"
+                ),
+                "cloud": p.get("cloud"),
+                "region": p.get("region"),
+                "created_at": epoch_ms_to_datetime(p.get("created_at")),
+                "created_by": p.get("created_by"),
+                "updated_at": epoch_ms_to_datetime(p.get("updated_at")),
+            }
+        )
+    return result
+
+
+@timeit
+def load_providers(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksProviderSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksProviderSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/providers.py
+++ b/cartography/intel/databricks/providers.py
@@ -56,6 +56,7 @@ def transform(
                 "created_at": epoch_ms_to_datetime(p.get("created_at")),
                 "created_by": p.get("created_by"),
                 "updated_at": epoch_ms_to_datetime(p.get("updated_at")),
+                "updated_by": p.get("updated_by"),
             }
         )
     return result

--- a/cartography/intel/databricks/queries.py
+++ b/cartography/intel/databricks/queries.py
@@ -1,0 +1,99 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import iso_to_datetime
+from cartography.intel.databricks.util import scoped_id
+from cartography.models.databricks.query import DatabricksQuerySchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    queries = get(api_session)
+    transformed = transform(queries, workspace_id)
+    load_queries(
+        neo4j_session,
+        transformed,
+        workspace_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    """Paginate the SQL queries listing (``results`` + ``next_page_token``)."""
+    results: list[dict[str, Any]] = []
+    params: dict[str, Any] = {"page_size": 100}
+    while True:
+        response = api_session.get("/api/2.0/sql/queries", params=params)
+        results.extend(response.get("results", []) or [])
+        next_token = response.get("next_page_token")
+        if not next_token:
+            break
+        params = {"page_size": 100, "page_token": next_token}
+    return results
+
+
+@timeit
+def transform(queries: list[dict[str, Any]], workspace_id: str) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for q in queries:
+        query_id = q.get("id")
+        if not query_id:
+            raise ValueError("Databricks query returned with empty id")
+        warehouse_id = q.get("warehouse_id")
+        result.append(
+            {
+                "id": scoped_id(workspace_id, query_id),
+                "query_id": query_id,
+                "display_name": q.get("display_name"),
+                "warehouse_id": warehouse_id,
+                "warehouse_scoped_id": (
+                    scoped_id(workspace_id, warehouse_id) if warehouse_id else None
+                ),
+                "query_text": q.get("query_text"),
+                "owner_user_name": q.get("owner_user_name"),
+                "last_modifier_user_name": q.get("last_modifier_user_name"),
+                "run_as_mode": q.get("run_as_mode"),
+                "lifecycle_state": q.get("lifecycle_state"),
+                "parent_path": q.get("parent_path"),
+                "create_time": iso_to_datetime(q.get("create_time")),
+                "update_time": iso_to_datetime(q.get("update_time")),
+            }
+        )
+    return result
+
+
+@timeit
+def load_queries(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksQuerySchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksQuerySchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/recipients.py
+++ b/cartography/intel/databricks/recipients.py
@@ -1,0 +1,87 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import epoch_ms_to_datetime
+from cartography.intel.databricks.util import uc_id
+from cartography.models.databricks.recipient import DatabricksRecipientSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    metastore_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    recipients = get(api_session)
+    transformed = transform(recipients, metastore_id)
+    load_recipients(
+        neo4j_session, transformed, workspace_id, common_job_parameters["UPDATE_TAG"]
+    )
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    return api_session.uc_list("/api/2.1/unity-catalog/recipients", "recipients")
+
+
+@timeit
+def transform(
+    recipients: list[dict[str, Any]], metastore_id: str
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for r in recipients:
+        name = r["name"]
+        if not name:
+            raise ValueError("Databricks recipient returned with empty name")
+        result.append(
+            {
+                "id": uc_id(metastore_id, name),
+                "name": name,
+                "metastore_id": metastore_id,
+                "authentication_type": r.get("authentication_type"),
+                "activated": r.get("activated"),
+                "owner": r.get("owner"),
+                "comment": r.get("comment"),
+                "data_recipient_global_metastore_id": r.get(
+                    "data_recipient_global_metastore_id"
+                ),
+                "cloud": r.get("cloud"),
+                "region": r.get("region"),
+                "created_at": epoch_ms_to_datetime(r.get("created_at")),
+                "created_by": r.get("created_by"),
+                "updated_at": epoch_ms_to_datetime(r.get("updated_at")),
+            }
+        )
+    return result
+
+
+@timeit
+def load_recipients(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksRecipientSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksRecipientSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/recipients.py
+++ b/cartography/intel/databricks/recipients.py
@@ -57,6 +57,7 @@ def transform(
                 "created_at": epoch_ms_to_datetime(r.get("created_at")),
                 "created_by": r.get("created_by"),
                 "updated_at": epoch_ms_to_datetime(r.get("updated_at")),
+                "updated_by": r.get("updated_by"),
             }
         )
     return result

--- a/cartography/intel/databricks/repos.py
+++ b/cartography/intel/databricks/repos.py
@@ -1,0 +1,96 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import scoped_id
+from cartography.models.databricks.repo import DatabricksRepoSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    repos = get(api_session)
+    transformed = transform(repos, workspace_id)
+    load_repos(
+        neo4j_session,
+        transformed,
+        workspace_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    """Paginate repos (git folders) via ``repos`` + ``next_page_token``.
+
+    ``path_prefix=/Workspace`` is required: called with no prefix the endpoint
+    only returns repos under the legacy ``/Repos`` root and silently omits git
+    folders under user home directories, so every workspace path is anchored
+    under ``/Workspace``.
+    """
+    results: list[dict[str, Any]] = []
+    base = {"path_prefix": "/Workspace"}
+    params: dict[str, Any] = dict(base)
+    while True:
+        response = api_session.get("/api/2.0/repos", params=params)
+        results.extend(response.get("repos", []) or [])
+        next_token = response.get("next_page_token")
+        if not next_token:
+            break
+        params = {**base, "next_page_token": next_token}
+    return results
+
+
+@timeit
+def transform(repos: list[dict[str, Any]], workspace_id: str) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for r in repos:
+        repo_id = r.get("id")
+        if not repo_id:
+            raise ValueError("Databricks repo returned with empty id")
+        result.append(
+            {
+                "id": scoped_id(workspace_id, str(repo_id)),
+                "repo_id": str(repo_id),
+                "url": r.get("url"),
+                "provider": r.get("provider"),
+                "branch": r.get("branch"),
+                "head_commit_id": r.get("head_commit_id"),
+                "path": r.get("path"),
+            }
+        )
+    return result
+
+
+@timeit
+def load_repos(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksRepoSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksRepoSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/repos.py
+++ b/cartography/intel/databricks/repos.py
@@ -40,12 +40,19 @@ def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     base = {"path_prefix": "/Workspace"}
     params: dict[str, Any] = dict(base)
+    seen_tokens: set[str] = set()
     while True:
         response = api_session.get("/api/2.0/repos", params=params)
         results.extend(response.get("repos", []) or [])
         next_token = response.get("next_page_token")
         if not next_token:
             break
+        if next_token in seen_tokens:
+            raise ValueError(
+                f"Databricks repos list repeated page token {next_token!r}; "
+                "aborting to avoid an infinite loop.",
+            )
+        seen_tokens.add(next_token)
         params = {**base, "next_page_token": next_token}
     return results
 

--- a/cartography/intel/databricks/serving_endpoints.py
+++ b/cartography/intel/databricks/serving_endpoints.py
@@ -1,0 +1,158 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import epoch_ms_to_datetime
+from cartography.intel.databricks.util import scoped_id
+from cartography.models.databricks.served_entity import DatabricksServedEntitySchema
+from cartography.models.databricks.serving_endpoint import (
+    DatabricksServingEndpointSchema,
+)
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    endpoints = get(api_session)
+    transformed_endpoints = transform_endpoints(endpoints, workspace_id)
+    transformed_entities = transform_served_entities(endpoints, workspace_id)
+    load_endpoints(
+        neo4j_session,
+        transformed_endpoints,
+        workspace_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    load_served_entities(
+        neo4j_session,
+        transformed_entities,
+        workspace_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    """List serving endpoints. The endpoint returns the full set in one response."""
+    return api_session.get("/api/2.0/serving-endpoints").get("endpoints", []) or []
+
+
+@timeit
+def transform_endpoints(
+    endpoints: list[dict[str, Any]], workspace_id: str
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for e in endpoints:
+        name = e.get("name")
+        if not name:
+            raise ValueError("Databricks serving endpoint returned with empty name")
+        state = e.get("state") or {}
+        result.append(
+            {
+                "id": scoped_id(workspace_id, name),
+                "name": name,
+                "endpoint_type": e.get("endpoint_type"),
+                "task": e.get("task"),
+                "state_ready": state.get("ready"),
+                "state_config_update": state.get("config_update"),
+                "permission_level": e.get("permission_level"),
+                "route_optimized": e.get("route_optimized"),
+                "creator": e.get("creator"),
+                "creation_timestamp": epoch_ms_to_datetime(e.get("creation_timestamp")),
+                "last_updated_timestamp": epoch_ms_to_datetime(
+                    e.get("last_updated_timestamp")
+                ),
+            }
+        )
+    return result
+
+
+@timeit
+def transform_served_entities(
+    endpoints: list[dict[str, Any]], workspace_id: str
+) -> list[dict[str, Any]]:
+    """Flatten each endpoint's served entities into standalone rows.
+
+    Entity ids are ``{workspace}/{endpoint}/{served_name}`` so the same model
+    served behind two endpoints stays distinct.
+    """
+    result: list[dict[str, Any]] = []
+    for e in endpoints:
+        endpoint_name = e.get("name")
+        if not endpoint_name:
+            continue
+        endpoint_scoped_id = scoped_id(workspace_id, endpoint_name)
+        for se in (e.get("config") or {}).get("served_entities", []) or []:
+            served_name = se.get("name") or se.get("entity_name")
+            if not served_name:
+                continue
+            foundation = se.get("foundation_model") or {}
+            external = se.get("external_model") or {}
+            result.append(
+                {
+                    "id": f"{endpoint_scoped_id}/{served_name}",
+                    "served_name": served_name,
+                    "endpoint_name": endpoint_name,
+                    "endpoint_scoped_id": endpoint_scoped_id,
+                    "entity_name": se.get("entity_name"),
+                    "entity_type": se.get("type"),
+                    "entity_version": se.get("entity_version"),
+                    "foundation_model_name": foundation.get("name"),
+                    "external_model_provider": external.get("provider"),
+                    "external_model_name": external.get("name"),
+                }
+            )
+    return result
+
+
+@timeit
+def load_endpoints(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksServingEndpointSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def load_served_entities(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksServedEntitySchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    # Served entities hang off endpoints, so purge the children first.
+    GraphJob.from_node_schema(
+        DatabricksServedEntitySchema(), common_job_parameters
+    ).run(neo4j_session)
+    GraphJob.from_node_schema(
+        DatabricksServingEndpointSchema(), common_job_parameters
+    ).run(neo4j_session)

--- a/cartography/intel/databricks/shares.py
+++ b/cartography/intel/databricks/shares.py
@@ -55,29 +55,42 @@ def _recipient_names(
     share_scoped_id: str,
 ) -> list[str]:
     """Return the recipients granted access to a share (its SELECT grantees)."""
-    try:
-        data = api_session.get(
-            f"/api/2.1/unity-catalog/shares/{share_name}/permissions"
-        )
-    except requests.HTTPError as e:
-        # A share we can't read permissions on (403) or that vanished mid-sync
-        # (404) is skippable; anything else aborts the sync. On a skip we carry
-        # forward the last-known recipients from the graph: returning [] here
-        # would let this run's cleanup delete SHARED_WITH edges that are still
-        # valid, silently hiding who a share is exposed to.
-        skip_or_raise_http(e, 403, 404)
-        logger.warning(
-            "Could not read permissions for share %s (%s); keeping last-known "
-            "recipients.",
-            share_name,
-            e,
-        )
-        return _existing_recipient_names(neo4j_session, share_scoped_id)
+    uri = f"/api/2.1/unity-catalog/shares/{share_name}/permissions"
     names: list[str] = []
-    for assignment in data.get("privilege_assignments", []) or []:
-        principal = assignment.get("principal")
-        if principal:
-            names.append(principal)
+    params: dict[str, Any] = {}
+    seen_tokens: set[str] = set()
+    while True:
+        try:
+            data = api_session.get(uri, params=params)
+        except requests.HTTPError as e:
+            # A share we can't read permissions on (403) or that vanished
+            # mid-sync (404) is skippable; anything else aborts the sync. On a
+            # skip we carry forward the last-known recipients from the graph:
+            # returning [] here would let this run's cleanup delete SHARED_WITH
+            # edges that are still valid, silently hiding who a share is exposed
+            # to.
+            skip_or_raise_http(e, 403, 404)
+            logger.warning(
+                "Could not read permissions for share %s (%s); keeping "
+                "last-known recipients.",
+                share_name,
+                e,
+            )
+            return _existing_recipient_names(neo4j_session, share_scoped_id)
+        for assignment in data.get("privilege_assignments", []) or []:
+            principal = assignment.get("principal")
+            if principal:
+                names.append(principal)
+        next_token = data.get("next_page_token")
+        if not next_token:
+            break
+        if next_token in seen_tokens:
+            raise ValueError(
+                f"Databricks share permissions for {share_name} repeated page "
+                f"token {next_token!r}; aborting to avoid an infinite loop.",
+            )
+        seen_tokens.add(next_token)
+        params = {"page_token": next_token}
     return names
 
 
@@ -108,6 +121,7 @@ def transform(
                 "created_at": epoch_ms_to_datetime(s.get("created_at")),
                 "created_by": s.get("created_by"),
                 "updated_at": epoch_ms_to_datetime(s.get("updated_at")),
+                "updated_by": s.get("updated_by"),
                 "recipient_scoped_ids": [
                     uc_id(metastore_id, r) for r in recipient_names
                 ],

--- a/cartography/intel/databricks/shares.py
+++ b/cartography/intel/databricks/shares.py
@@ -1,0 +1,141 @@
+import logging
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import epoch_ms_to_datetime
+from cartography.intel.databricks.util import skip_or_raise_http
+from cartography.intel.databricks.util import uc_id
+from cartography.models.databricks.share import DatabricksShareSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    metastore_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    shares = get(api_session)
+    transformed = transform(neo4j_session, api_session, shares, metastore_id)
+    load_shares(
+        neo4j_session, transformed, workspace_id, common_job_parameters["UPDATE_TAG"]
+    )
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    return api_session.uc_list("/api/2.1/unity-catalog/shares", "shares")
+
+
+def _existing_recipient_names(
+    neo4j_session: neo4j.Session, share_scoped_id: str
+) -> list[str]:
+    """Return the recipient names already linked to a share in the graph."""
+    query = """
+    MATCH (:DatabricksShare {id: $share_id})-[:SHARED_WITH]->(r:DatabricksRecipient)
+    RETURN collect(r.name) AS names
+    """
+    record = neo4j_session.run(query, share_id=share_scoped_id).single()
+    return record["names"] if record else []
+
+
+def _recipient_names(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    share_name: str,
+    share_scoped_id: str,
+) -> list[str]:
+    """Return the recipients granted access to a share (its SELECT grantees)."""
+    try:
+        data = api_session.get(
+            f"/api/2.1/unity-catalog/shares/{share_name}/permissions"
+        )
+    except requests.HTTPError as e:
+        # A share we can't read permissions on (403) or that vanished mid-sync
+        # (404) is skippable; anything else aborts the sync. On a skip we carry
+        # forward the last-known recipients from the graph: returning [] here
+        # would let this run's cleanup delete SHARED_WITH edges that are still
+        # valid, silently hiding who a share is exposed to.
+        skip_or_raise_http(e, 403, 404)
+        logger.warning(
+            "Could not read permissions for share %s (%s); keeping last-known "
+            "recipients.",
+            share_name,
+            e,
+        )
+        return _existing_recipient_names(neo4j_session, share_scoped_id)
+    names: list[str] = []
+    for assignment in data.get("privilege_assignments", []) or []:
+        principal = assignment.get("principal")
+        if principal:
+            names.append(principal)
+    return names
+
+
+@timeit
+def transform(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    shares: list[dict[str, Any]],
+    metastore_id: str,
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for s in shares:
+        name = s["name"]
+        if not name:
+            raise ValueError("Databricks share returned with empty name")
+        share_scoped_id = uc_id(metastore_id, name)
+        recipient_names = _recipient_names(
+            neo4j_session, api_session, name, share_scoped_id
+        )
+        result.append(
+            {
+                "id": share_scoped_id,
+                "share_id": s.get("id"),
+                "name": name,
+                "metastore_id": metastore_id,
+                "owner": s.get("owner"),
+                "comment": s.get("comment"),
+                "created_at": epoch_ms_to_datetime(s.get("created_at")),
+                "created_by": s.get("created_by"),
+                "updated_at": epoch_ms_to_datetime(s.get("updated_at")),
+                "recipient_scoped_ids": [
+                    uc_id(metastore_id, r) for r in recipient_names
+                ],
+            }
+        )
+    return result
+
+
+@timeit
+def load_shares(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksShareSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(DatabricksShareSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/databricks/sql_warehouses.py
+++ b/cartography/intel/databricks/sql_warehouses.py
@@ -1,0 +1,93 @@
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
+from cartography.intel.databricks.util import scoped_id
+from cartography.models.databricks.sql_warehouse import DatabricksSqlWarehouseSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: DatabricksWorkspaceClient,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    warehouses = get(api_session)
+    transformed = transform(warehouses, workspace_id)
+    load_warehouses(
+        neo4j_session,
+        transformed,
+        workspace_id,
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(api_session: DatabricksWorkspaceClient) -> list[dict[str, Any]]:
+    """List SQL warehouses. The endpoint returns the full set in one response."""
+    return api_session.get("/api/2.0/sql/warehouses").get("warehouses", []) or []
+
+
+@timeit
+def transform(
+    warehouses: list[dict[str, Any]], workspace_id: str
+) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    for w in warehouses:
+        warehouse_id = w["id"]
+        if not warehouse_id:
+            raise ValueError("Databricks SQL warehouse returned with empty id")
+        result.append(
+            {
+                "id": scoped_id(workspace_id, warehouse_id),
+                "warehouse_id": warehouse_id,
+                "name": w.get("name"),
+                "state": w.get("state"),
+                "cluster_size": w.get("cluster_size"),
+                "size": w.get("size"),
+                "warehouse_type": w.get("warehouse_type"),
+                "enable_serverless_compute": w.get("enable_serverless_compute"),
+                "enable_photon": w.get("enable_photon"),
+                "auto_stop_mins": w.get("auto_stop_mins"),
+                "auto_resume": w.get("auto_resume"),
+                "spot_instance_policy": w.get("spot_instance_policy"),
+                "channel": (w.get("channel") or {}).get("name"),
+                "min_num_clusters": w.get("min_num_clusters"),
+                "max_num_clusters": w.get("max_num_clusters"),
+                "num_clusters": w.get("num_clusters"),
+                "creator_name": w.get("creator_name"),
+                "jdbc_url": w.get("jdbc_url"),
+            }
+        )
+    return result
+
+
+@timeit
+def load_warehouses(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        DatabricksSqlWarehouseSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(
+        DatabricksSqlWarehouseSchema(), common_job_parameters
+    ).run(neo4j_session)

--- a/cartography/intel/databricks/util.py
+++ b/cartography/intel/databricks/util.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import neo4j
 import requests
+from dateutil import parser as dateutil_parser
 
 logger = logging.getLogger(__name__)
 
@@ -21,12 +22,12 @@ def iso_to_datetime(value: Any) -> datetime | None:
     """Parse an ISO-8601 timestamp (as the SQL / Lakeview APIs return) to datetime.
 
     Unlike the older endpoints (epoch milliseconds), the SQL and Lakeview APIs
-    return RFC-3339 strings such as ``2026-07-01T23:27:40Z``; normalise the
-    trailing ``Z`` so :func:`datetime.fromisoformat` accepts it.
+    return RFC-3339 strings such as ``2026-07-01T23:27:40Z``; ``isoparse``
+    handles the trailing ``Z`` and offset forms, matching the rest of the repo.
     """
     if not value:
         return None
-    return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    return dateutil_parser.isoparse(str(value))
 
 
 def get_run_as_principal_index(

--- a/cartography/intel/databricks/util.py
+++ b/cartography/intel/databricks/util.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from datetime import timezone
 from typing import Any
 
+import neo4j
 import requests
 
 logger = logging.getLogger(__name__)
@@ -14,6 +15,48 @@ def epoch_ms_to_datetime(value: Any) -> datetime | None:
     if value in (None, 0):
         return None
     return datetime.fromtimestamp(int(value) / 1000, tz=timezone.utc)
+
+
+def iso_to_datetime(value: Any) -> datetime | None:
+    """Parse an ISO-8601 timestamp (as the SQL / Lakeview APIs return) to datetime.
+
+    Unlike the older endpoints (epoch milliseconds), the SQL and Lakeview APIs
+    return RFC-3339 strings such as ``2026-07-01T23:27:40Z``; normalise the
+    trailing ``Z`` so :func:`datetime.fromisoformat` accepts it.
+    """
+    if not value:
+        return None
+    return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+
+def get_run_as_principal_index(
+    neo4j_session: neo4j.Session, workspace_id: str
+) -> dict[str, tuple[str, bool]]:
+    """Map a run-as principal name to ``(scoped node id, is_service_principal)``.
+
+    Jobs and pipelines report their run-as identity by name (a user's
+    ``user_name`` or a service principal's ``application_id``). Resolving that
+    against *this workspace's* principals keeps a name shared across workspaces
+    (federated identities routinely share an email) from attaching the RUN_AS
+    edge to the wrong principal node. Mirrors ``grants.get_principals`` but
+    keeps the user/service-principal distinction the RUN_AS edge needs.
+    """
+    query = """
+    MATCH (:DatabricksWorkspace {id: $workspace_id})-[:RESOURCE]->(p)
+    WHERE p:DatabricksUser OR p:DatabricksServicePrincipal
+    RETURN p.id AS id,
+           p:DatabricksServicePrincipal AS is_sp,
+           CASE
+               WHEN p:DatabricksServicePrincipal THEN p.application_id
+               ELSE p.user_name
+           END AS name
+    """
+    result = neo4j_session.run(query, workspace_id=workspace_id)
+    index: dict[str, tuple[str, bool]] = {}
+    for record in result:
+        if record["name"] and record["id"]:
+            index[record["name"]] = (record["id"], bool(record["is_sp"]))
+    return index
 
 
 def uc_id(metastore_id: str, full_name: str) -> str:

--- a/cartography/models/databricks/alert.py
+++ b/cartography/models/databricks/alert.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksAlertNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    alert_id: PropertyRef = PropertyRef("alert_id", extra_index=True)
+    display_name: PropertyRef = PropertyRef("display_name", extra_index=True)
+    query_id: PropertyRef = PropertyRef("query_id", extra_index=True)
+    owner_user_name: PropertyRef = PropertyRef("owner_user_name", extra_index=True)
+    state: PropertyRef = PropertyRef("state")
+    lifecycle_state: PropertyRef = PropertyRef("lifecycle_state")
+    condition_op: PropertyRef = PropertyRef("condition_op")
+    parent_path: PropertyRef = PropertyRef("parent_path")
+    create_time: PropertyRef = PropertyRef("create_time")
+    update_time: PropertyRef = PropertyRef("update_time")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksAlertToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksAlert)
+class DatabricksAlertToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksAlertToWorkspaceRelProperties = (
+        DatabricksAlertToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksAlertToQueryRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksAlert)-[:MONITORS]->(:DatabricksQuery)
+class DatabricksAlertToQueryRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksQuery"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("query_scoped_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MONITORS"
+    properties: DatabricksAlertToQueryRelProperties = (
+        DatabricksAlertToQueryRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksAlertSchema(CartographyNodeSchema):
+    label: str = "DatabricksAlert"
+    properties: DatabricksAlertNodeProperties = DatabricksAlertNodeProperties()
+    sub_resource_relationship: DatabricksAlertToWorkspaceRel = (
+        DatabricksAlertToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DatabricksAlertToQueryRel()],
+    )

--- a/cartography/models/databricks/app.py
+++ b/cartography/models/databricks/app.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksAppNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    description: PropertyRef = PropertyRef("description")
+    url: PropertyRef = PropertyRef("url", extra_index=True)
+    app_state: PropertyRef = PropertyRef("app_state")
+    compute_state: PropertyRef = PropertyRef("compute_state")
+    compute_size: PropertyRef = PropertyRef("compute_size")
+    creator: PropertyRef = PropertyRef("creator", extra_index=True)
+    # The app runs as this auto-provisioned service principal; its application
+    # id is kept for the principal -> resource edge follow-up (PR8).
+    service_principal_client_id: PropertyRef = PropertyRef(
+        "service_principal_client_id", extra_index=True
+    )
+    service_principal_name: PropertyRef = PropertyRef("service_principal_name")
+    oauth2_app_client_id: PropertyRef = PropertyRef("oauth2_app_client_id")
+    create_time: PropertyRef = PropertyRef("create_time")
+    update_time: PropertyRef = PropertyRef("update_time")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksAppToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksApp)
+class DatabricksAppToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksAppToWorkspaceRelProperties = (
+        DatabricksAppToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksAppSchema(CartographyNodeSchema):
+    label: str = "DatabricksApp"
+    properties: DatabricksAppNodeProperties = DatabricksAppNodeProperties()
+    sub_resource_relationship: DatabricksAppToWorkspaceRel = (
+        DatabricksAppToWorkspaceRel()
+    )

--- a/cartography/models/databricks/clean_room.py
+++ b/cartography/models/databricks/clean_room.py
@@ -7,6 +7,7 @@ from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -14,6 +15,7 @@ from cartography.models.core.relationships import TargetNodeMatcher
 class DatabricksCleanRoomNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef("id")
     name: PropertyRef = PropertyRef("name", extra_index=True)
+    metastore_id: PropertyRef = PropertyRef("metastore_id", extra_index=True)
     owner: PropertyRef = PropertyRef("owner", extra_index=True)
     comment: PropertyRef = PropertyRef("comment")
     access_restricted: PropertyRef = PropertyRef("access_restricted")
@@ -42,9 +44,31 @@ class DatabricksCleanRoomToWorkspaceRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class DatabricksCleanRoomToMetastoreRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksMetastore)-[:CONTAINS]->(:DatabricksCleanRoom)
+class DatabricksCleanRoomToMetastoreRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksMetastore"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("metastore_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "CONTAINS"
+    properties: DatabricksCleanRoomToMetastoreRelProperties = (
+        DatabricksCleanRoomToMetastoreRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class DatabricksCleanRoomSchema(CartographyNodeSchema):
     label: str = "DatabricksCleanRoom"
     properties: DatabricksCleanRoomNodeProperties = DatabricksCleanRoomNodeProperties()
     sub_resource_relationship: DatabricksCleanRoomToWorkspaceRel = (
         DatabricksCleanRoomToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DatabricksCleanRoomToMetastoreRel()],
     )

--- a/cartography/models/databricks/clean_room.py
+++ b/cartography/models/databricks/clean_room.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksCleanRoomNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    owner: PropertyRef = PropertyRef("owner", extra_index=True)
+    comment: PropertyRef = PropertyRef("comment")
+    access_restricted: PropertyRef = PropertyRef("access_restricted")
+    created_at: PropertyRef = PropertyRef("created_at")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksCleanRoomToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksCleanRoom)
+class DatabricksCleanRoomToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksCleanRoomToWorkspaceRelProperties = (
+        DatabricksCleanRoomToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksCleanRoomSchema(CartographyNodeSchema):
+    label: str = "DatabricksCleanRoom"
+    properties: DatabricksCleanRoomNodeProperties = DatabricksCleanRoomNodeProperties()
+    sub_resource_relationship: DatabricksCleanRoomToWorkspaceRel = (
+        DatabricksCleanRoomToWorkspaceRel()
+    )

--- a/cartography/models/databricks/dashboard.py
+++ b/cartography/models/databricks/dashboard.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksDashboardNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    dashboard_id: PropertyRef = PropertyRef("dashboard_id", extra_index=True)
+    display_name: PropertyRef = PropertyRef("display_name", extra_index=True)
+    # LAKEVIEW (current) vs LEGACY (redash-based /preview/sql/dashboards).
+    dashboard_type: PropertyRef = PropertyRef("dashboard_type")
+    warehouse_id: PropertyRef = PropertyRef("warehouse_id", extra_index=True)
+    owner_user_name: PropertyRef = PropertyRef("owner_user_name", extra_index=True)
+    lifecycle_state: PropertyRef = PropertyRef("lifecycle_state")
+    parent_path: PropertyRef = PropertyRef("parent_path")
+    path: PropertyRef = PropertyRef("path")
+    create_time: PropertyRef = PropertyRef("create_time")
+    update_time: PropertyRef = PropertyRef("update_time")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksDashboardToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksDashboard)
+class DatabricksDashboardToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksDashboardToWorkspaceRelProperties = (
+        DatabricksDashboardToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksDashboardToWarehouseRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksDashboard)-[:USES_WAREHOUSE]->(:DatabricksSqlWarehouse)
+class DatabricksDashboardToWarehouseRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksSqlWarehouse"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("warehouse_scoped_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_WAREHOUSE"
+    properties: DatabricksDashboardToWarehouseRelProperties = (
+        DatabricksDashboardToWarehouseRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksDashboardSchema(CartographyNodeSchema):
+    label: str = "DatabricksDashboard"
+    properties: DatabricksDashboardNodeProperties = DatabricksDashboardNodeProperties()
+    sub_resource_relationship: DatabricksDashboardToWorkspaceRel = (
+        DatabricksDashboardToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DatabricksDashboardToWarehouseRel()],
+    )

--- a/cartography/models/databricks/data_source.py
+++ b/cartography/models/databricks/data_source.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksDataSourceNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    data_source_id: PropertyRef = PropertyRef("data_source_id", extra_index=True)
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    type: PropertyRef = PropertyRef("type")
+    warehouse_id: PropertyRef = PropertyRef("warehouse_id", extra_index=True)
+    syntax: PropertyRef = PropertyRef("syntax")
+    paused: PropertyRef = PropertyRef("paused")
+    view_only: PropertyRef = PropertyRef("view_only")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksDataSourceToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksDataSource)
+class DatabricksDataSourceToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksDataSourceToWorkspaceRelProperties = (
+        DatabricksDataSourceToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksDataSourceToWarehouseRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksDataSource)-[:BACKED_BY]->(:DatabricksSqlWarehouse)
+class DatabricksDataSourceToWarehouseRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksSqlWarehouse"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("warehouse_scoped_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "BACKED_BY"
+    properties: DatabricksDataSourceToWarehouseRelProperties = (
+        DatabricksDataSourceToWarehouseRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksDataSourceSchema(CartographyNodeSchema):
+    label: str = "DatabricksDataSource"
+    properties: DatabricksDataSourceNodeProperties = (
+        DatabricksDataSourceNodeProperties()
+    )
+    sub_resource_relationship: DatabricksDataSourceToWorkspaceRel = (
+        DatabricksDataSourceToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DatabricksDataSourceToWarehouseRel()],
+    )

--- a/cartography/models/databricks/genie_space.py
+++ b/cartography/models/databricks/genie_space.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksGenieSpaceNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    space_id: PropertyRef = PropertyRef("space_id", extra_index=True)
+    title: PropertyRef = PropertyRef("title", extra_index=True)
+    description: PropertyRef = PropertyRef("description")
+    warehouse_id: PropertyRef = PropertyRef("warehouse_id", extra_index=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksGenieSpaceToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksGenieSpace)
+class DatabricksGenieSpaceToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksGenieSpaceToWorkspaceRelProperties = (
+        DatabricksGenieSpaceToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksGenieSpaceToWarehouseRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksGenieSpace)-[:USES_WAREHOUSE]->(:DatabricksSqlWarehouse)
+class DatabricksGenieSpaceToWarehouseRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksSqlWarehouse"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("warehouse_scoped_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_WAREHOUSE"
+    properties: DatabricksGenieSpaceToWarehouseRelProperties = (
+        DatabricksGenieSpaceToWarehouseRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksGenieSpaceSchema(CartographyNodeSchema):
+    label: str = "DatabricksGenieSpace"
+    properties: DatabricksGenieSpaceNodeProperties = (
+        DatabricksGenieSpaceNodeProperties()
+    )
+    sub_resource_relationship: DatabricksGenieSpaceToWorkspaceRel = (
+        DatabricksGenieSpaceToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DatabricksGenieSpaceToWarehouseRel()],
+    )

--- a/cartography/models/databricks/git_credential.py
+++ b/cartography/models/databricks/git_credential.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksGitCredentialNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    credential_id: PropertyRef = PropertyRef("credential_id", extra_index=True)
+    git_provider: PropertyRef = PropertyRef("git_provider")
+    git_username: PropertyRef = PropertyRef("git_username", extra_index=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksGitCredentialToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksGitCredential)
+class DatabricksGitCredentialToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksGitCredentialToWorkspaceRelProperties = (
+        DatabricksGitCredentialToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksGitCredentialSchema(CartographyNodeSchema):
+    label: str = "DatabricksGitCredential"
+    properties: DatabricksGitCredentialNodeProperties = (
+        DatabricksGitCredentialNodeProperties()
+    )
+    sub_resource_relationship: DatabricksGitCredentialToWorkspaceRel = (
+        DatabricksGitCredentialToWorkspaceRel()
+    )

--- a/cartography/models/databricks/job.py
+++ b/cartography/models/databricks/job.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksJobNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    job_id: PropertyRef = PropertyRef("job_id", extra_index=True)
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    creator_user_name: PropertyRef = PropertyRef("creator_user_name", extra_index=True)
+    run_as_user_name: PropertyRef = PropertyRef("run_as_user_name", extra_index=True)
+    format: PropertyRef = PropertyRef("format")
+    max_concurrent_runs: PropertyRef = PropertyRef("max_concurrent_runs")
+    timeout_seconds: PropertyRef = PropertyRef("timeout_seconds")
+    continuous: PropertyRef = PropertyRef("continuous")
+    schedule_quartz_cron_expression: PropertyRef = PropertyRef(
+        "schedule_quartz_cron_expression"
+    )
+    schedule_timezone_id: PropertyRef = PropertyRef("schedule_timezone_id")
+    schedule_pause_status: PropertyRef = PropertyRef("schedule_pause_status")
+    created_time: PropertyRef = PropertyRef("created_time")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksJobToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksJob)
+class DatabricksJobToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksJobToWorkspaceRelProperties = (
+        DatabricksJobToWorkspaceRelProperties()
+    )
+
+
+# The run-as edges match by the workspace-scoped principal node id resolved in
+# the intel layer (see util.get_run_as_principal_index), never the bare name,
+# so a federated user_name shared across workspaces cannot attach the edge to
+# the wrong principal. A job runs as exactly one principal, so only one of the
+# two edges fires per job.
+
+
+@dataclass(frozen=True)
+class DatabricksJobToRunAsUserRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksJob)-[:RUN_AS]->(:DatabricksUser)
+class DatabricksJobToRunAsUserRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksUser"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("run_as_user_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RUN_AS"
+    properties: DatabricksJobToRunAsUserRelProperties = (
+        DatabricksJobToRunAsUserRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksJobToRunAsSPRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksJob)-[:RUN_AS]->(:DatabricksServicePrincipal)
+class DatabricksJobToRunAsSPRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksServicePrincipal"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("run_as_sp_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RUN_AS"
+    properties: DatabricksJobToRunAsSPRelProperties = (
+        DatabricksJobToRunAsSPRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksJobSchema(CartographyNodeSchema):
+    label: str = "DatabricksJob"
+    properties: DatabricksJobNodeProperties = DatabricksJobNodeProperties()
+    sub_resource_relationship: DatabricksJobToWorkspaceRel = (
+        DatabricksJobToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            DatabricksJobToRunAsUserRel(),
+            DatabricksJobToRunAsSPRel(),
+        ],
+    )

--- a/cartography/models/databricks/job_task.py
+++ b/cartography/models/databricks/job_task.py
@@ -18,6 +18,9 @@ class DatabricksJobTaskNodeProperties(CartographyNodeProperties):
     job_id: PropertyRef = PropertyRef("job_id", extra_index=True)
     task_type: PropertyRef = PropertyRef("task_type")
     notebook_path: PropertyRef = PropertyRef("notebook_path", extra_index=True)
+    notebook_scoped_id: PropertyRef = PropertyRef(
+        "notebook_scoped_id", extra_index=True
+    )
     existing_cluster_id: PropertyRef = PropertyRef("existing_cluster_id")
     job_cluster_key: PropertyRef = PropertyRef("job_cluster_key")
     pipeline_id: PropertyRef = PropertyRef("pipeline_id", extra_index=True)

--- a/cartography/models/databricks/job_task.py
+++ b/cartography/models/databricks/job_task.py
@@ -1,0 +1,140 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksJobTaskNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    task_key: PropertyRef = PropertyRef("task_key", extra_index=True)
+    job_id: PropertyRef = PropertyRef("job_id", extra_index=True)
+    task_type: PropertyRef = PropertyRef("task_type")
+    notebook_path: PropertyRef = PropertyRef("notebook_path", extra_index=True)
+    existing_cluster_id: PropertyRef = PropertyRef("existing_cluster_id")
+    job_cluster_key: PropertyRef = PropertyRef("job_cluster_key")
+    pipeline_id: PropertyRef = PropertyRef("pipeline_id", extra_index=True)
+    warehouse_id: PropertyRef = PropertyRef("warehouse_id", extra_index=True)
+    run_job_id: PropertyRef = PropertyRef("run_job_id", extra_index=True)
+    disabled: PropertyRef = PropertyRef("disabled")
+    run_if: PropertyRef = PropertyRef("run_if")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksJobTaskToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksJobTask)
+class DatabricksJobTaskToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksJobTaskToWorkspaceRelProperties = (
+        DatabricksJobTaskToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksJobTaskToJobRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksJob)-[:HAS_TASK]->(:DatabricksJobTask)
+class DatabricksJobTaskToJobRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksJob"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("job_scoped_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_TASK"
+    properties: DatabricksJobTaskToJobRelProperties = (
+        DatabricksJobTaskToJobRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksJobTaskToPipelineRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksJobTask)-[:RUNS_PIPELINE]->(:DatabricksPipeline)
+class DatabricksJobTaskToPipelineRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksPipeline"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("pipeline_scoped_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RUNS_PIPELINE"
+    properties: DatabricksJobTaskToPipelineRelProperties = (
+        DatabricksJobTaskToPipelineRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksJobTaskToClusterRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksJobTask)-[:USES_CLUSTER]->(:DatabricksCluster)
+class DatabricksJobTaskToClusterRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("existing_cluster_scoped_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_CLUSTER"
+    properties: DatabricksJobTaskToClusterRelProperties = (
+        DatabricksJobTaskToClusterRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksJobTaskToWarehouseRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksJobTask)-[:USES_WAREHOUSE]->(:DatabricksSqlWarehouse)
+class DatabricksJobTaskToWarehouseRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksSqlWarehouse"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("warehouse_scoped_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_WAREHOUSE"
+    properties: DatabricksJobTaskToWarehouseRelProperties = (
+        DatabricksJobTaskToWarehouseRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksJobTaskSchema(CartographyNodeSchema):
+    label: str = "DatabricksJobTask"
+    properties: DatabricksJobTaskNodeProperties = DatabricksJobTaskNodeProperties()
+    sub_resource_relationship: DatabricksJobTaskToWorkspaceRel = (
+        DatabricksJobTaskToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            DatabricksJobTaskToJobRel(),
+            DatabricksJobTaskToPipelineRel(),
+            DatabricksJobTaskToClusterRel(),
+            DatabricksJobTaskToWarehouseRel(),
+        ],
+    )

--- a/cartography/models/databricks/notebook.py
+++ b/cartography/models/databricks/notebook.py
@@ -44,13 +44,15 @@ class DatabricksNotebookToJobTaskRelProperties(CartographyRelProperties):
 
 @dataclass(frozen=True)
 # (:DatabricksJobTask)-[:RUNS_NOTEBOOK]->(:DatabricksNotebook)
-# Matches every job task whose notebook_path equals this notebook's path; the
-# notebook is a lightweight, path-keyed node (no content / permissions) derived
-# only from the workloads that reference it, so there is no full workspace walk.
+# Matches job tasks by the workspace-scoped notebook id (task.notebook_scoped_id
+# == notebook.id), not the raw path, so two workspaces sharing a notebook path
+# cannot produce a cross-workspace edge. The notebook is a lightweight,
+# path-keyed node (no content / permissions) derived only from the workloads
+# that reference it, so there is no full workspace walk.
 class DatabricksNotebookToJobTaskRel(CartographyRelSchema):
     target_node_label: str = "DatabricksJobTask"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"notebook_path": PropertyRef("path")},
+        {"notebook_scoped_id": PropertyRef("id")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "RUNS_NOTEBOOK"

--- a/cartography/models/databricks/notebook.py
+++ b/cartography/models/databricks/notebook.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksNotebookNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    path: PropertyRef = PropertyRef("path", extra_index=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksNotebookToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksNotebook)
+class DatabricksNotebookToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksNotebookToWorkspaceRelProperties = (
+        DatabricksNotebookToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksNotebookToJobTaskRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksJobTask)-[:RUNS_NOTEBOOK]->(:DatabricksNotebook)
+# Matches every job task whose notebook_path equals this notebook's path; the
+# notebook is a lightweight, path-keyed node (no content / permissions) derived
+# only from the workloads that reference it, so there is no full workspace walk.
+class DatabricksNotebookToJobTaskRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksJobTask"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"notebook_path": PropertyRef("path")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RUNS_NOTEBOOK"
+    properties: DatabricksNotebookToJobTaskRelProperties = (
+        DatabricksNotebookToJobTaskRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksNotebookSchema(CartographyNodeSchema):
+    label: str = "DatabricksNotebook"
+    properties: DatabricksNotebookNodeProperties = DatabricksNotebookNodeProperties()
+    sub_resource_relationship: DatabricksNotebookToWorkspaceRel = (
+        DatabricksNotebookToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DatabricksNotebookToJobTaskRel()],
+    )

--- a/cartography/models/databricks/pipeline.py
+++ b/cartography/models/databricks/pipeline.py
@@ -1,0 +1,127 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksPipelineNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    pipeline_id: PropertyRef = PropertyRef("pipeline_id", extra_index=True)
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    state: PropertyRef = PropertyRef("state")
+    creator_user_name: PropertyRef = PropertyRef("creator_user_name", extra_index=True)
+    run_as_user_name: PropertyRef = PropertyRef("run_as_user_name", extra_index=True)
+    catalog: PropertyRef = PropertyRef("catalog", extra_index=True)
+    target_schema: PropertyRef = PropertyRef("target_schema")
+    storage: PropertyRef = PropertyRef("storage")
+    continuous: PropertyRef = PropertyRef("continuous")
+    development: PropertyRef = PropertyRef("development")
+    serverless: PropertyRef = PropertyRef("serverless")
+    photon: PropertyRef = PropertyRef("photon")
+    edition: PropertyRef = PropertyRef("edition")
+    channel: PropertyRef = PropertyRef("channel")
+    pipeline_type: PropertyRef = PropertyRef("pipeline_type")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksPipelineToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksPipeline)
+class DatabricksPipelineToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksPipelineToWorkspaceRelProperties = (
+        DatabricksPipelineToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksPipelineToCatalogRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksPipeline)-[:PUBLISHES_TO]->(:DatabricksCatalog)
+class DatabricksPipelineToCatalogRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksCatalog"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("catalog_scoped_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "PUBLISHES_TO"
+    properties: DatabricksPipelineToCatalogRelProperties = (
+        DatabricksPipelineToCatalogRelProperties()
+    )
+
+
+# See job.py for why RUN_AS matches on the workspace-scoped principal id.
+
+
+@dataclass(frozen=True)
+class DatabricksPipelineToRunAsUserRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksPipeline)-[:RUN_AS]->(:DatabricksUser)
+class DatabricksPipelineToRunAsUserRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksUser"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("run_as_user_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RUN_AS"
+    properties: DatabricksPipelineToRunAsUserRelProperties = (
+        DatabricksPipelineToRunAsUserRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksPipelineToRunAsSPRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksPipeline)-[:RUN_AS]->(:DatabricksServicePrincipal)
+class DatabricksPipelineToRunAsSPRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksServicePrincipal"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("run_as_sp_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RUN_AS"
+    properties: DatabricksPipelineToRunAsSPRelProperties = (
+        DatabricksPipelineToRunAsSPRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksPipelineSchema(CartographyNodeSchema):
+    label: str = "DatabricksPipeline"
+    properties: DatabricksPipelineNodeProperties = DatabricksPipelineNodeProperties()
+    sub_resource_relationship: DatabricksPipelineToWorkspaceRel = (
+        DatabricksPipelineToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            DatabricksPipelineToCatalogRel(),
+            DatabricksPipelineToRunAsUserRel(),
+            DatabricksPipelineToRunAsSPRel(),
+        ],
+    )

--- a/cartography/models/databricks/provider.py
+++ b/cartography/models/databricks/provider.py
@@ -27,6 +27,7 @@ class DatabricksProviderNodeProperties(CartographyNodeProperties):
     created_at: PropertyRef = PropertyRef("created_at")
     created_by: PropertyRef = PropertyRef("created_by")
     updated_at: PropertyRef = PropertyRef("updated_at")
+    updated_by: PropertyRef = PropertyRef("updated_by")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 

--- a/cartography/models/databricks/provider.py
+++ b/cartography/models/databricks/provider.py
@@ -1,0 +1,80 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksProviderNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    metastore_id: PropertyRef = PropertyRef("metastore_id", extra_index=True)
+    authentication_type: PropertyRef = PropertyRef("authentication_type")
+    owner: PropertyRef = PropertyRef("owner", extra_index=True)
+    comment: PropertyRef = PropertyRef("comment")
+    data_provider_global_metastore_id: PropertyRef = PropertyRef(
+        "data_provider_global_metastore_id", extra_index=True
+    )
+    cloud: PropertyRef = PropertyRef("cloud")
+    region: PropertyRef = PropertyRef("region")
+    created_at: PropertyRef = PropertyRef("created_at")
+    created_by: PropertyRef = PropertyRef("created_by")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksProviderToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksProvider)
+class DatabricksProviderToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksProviderToWorkspaceRelProperties = (
+        DatabricksProviderToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksProviderToMetastoreRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksMetastore)-[:CONTAINS]->(:DatabricksProvider)
+class DatabricksProviderToMetastoreRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksMetastore"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("metastore_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "CONTAINS"
+    properties: DatabricksProviderToMetastoreRelProperties = (
+        DatabricksProviderToMetastoreRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksProviderSchema(CartographyNodeSchema):
+    label: str = "DatabricksProvider"
+    properties: DatabricksProviderNodeProperties = DatabricksProviderNodeProperties()
+    sub_resource_relationship: DatabricksProviderToWorkspaceRel = (
+        DatabricksProviderToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DatabricksProviderToMetastoreRel()],
+    )

--- a/cartography/models/databricks/query.py
+++ b/cartography/models/databricks/query.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksQueryNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    query_id: PropertyRef = PropertyRef("query_id", extra_index=True)
+    display_name: PropertyRef = PropertyRef("display_name", extra_index=True)
+    warehouse_id: PropertyRef = PropertyRef("warehouse_id", extra_index=True)
+    query_text: PropertyRef = PropertyRef("query_text")
+    owner_user_name: PropertyRef = PropertyRef("owner_user_name", extra_index=True)
+    last_modifier_user_name: PropertyRef = PropertyRef("last_modifier_user_name")
+    run_as_mode: PropertyRef = PropertyRef("run_as_mode")
+    lifecycle_state: PropertyRef = PropertyRef("lifecycle_state")
+    parent_path: PropertyRef = PropertyRef("parent_path")
+    create_time: PropertyRef = PropertyRef("create_time")
+    update_time: PropertyRef = PropertyRef("update_time")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksQueryToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksQuery)
+class DatabricksQueryToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksQueryToWorkspaceRelProperties = (
+        DatabricksQueryToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksQueryToWarehouseRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksQuery)-[:USES_WAREHOUSE]->(:DatabricksSqlWarehouse)
+class DatabricksQueryToWarehouseRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksSqlWarehouse"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("warehouse_scoped_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_WAREHOUSE"
+    properties: DatabricksQueryToWarehouseRelProperties = (
+        DatabricksQueryToWarehouseRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksQuerySchema(CartographyNodeSchema):
+    label: str = "DatabricksQuery"
+    properties: DatabricksQueryNodeProperties = DatabricksQueryNodeProperties()
+    sub_resource_relationship: DatabricksQueryToWorkspaceRel = (
+        DatabricksQueryToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DatabricksQueryToWarehouseRel()],
+    )

--- a/cartography/models/databricks/recipient.py
+++ b/cartography/models/databricks/recipient.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksRecipientNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    metastore_id: PropertyRef = PropertyRef("metastore_id", extra_index=True)
+    # TOKEN = open sharing to any party holding a bearer token (external
+    # exposure); DATABRICKS = sharing to another Databricks account.
+    authentication_type: PropertyRef = PropertyRef("authentication_type")
+    activated: PropertyRef = PropertyRef("activated")
+    owner: PropertyRef = PropertyRef("owner", extra_index=True)
+    comment: PropertyRef = PropertyRef("comment")
+    data_recipient_global_metastore_id: PropertyRef = PropertyRef(
+        "data_recipient_global_metastore_id", extra_index=True
+    )
+    cloud: PropertyRef = PropertyRef("cloud")
+    region: PropertyRef = PropertyRef("region")
+    created_at: PropertyRef = PropertyRef("created_at")
+    created_by: PropertyRef = PropertyRef("created_by")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksRecipientToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksRecipient)
+class DatabricksRecipientToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksRecipientToWorkspaceRelProperties = (
+        DatabricksRecipientToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksRecipientToMetastoreRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksMetastore)-[:CONTAINS]->(:DatabricksRecipient)
+class DatabricksRecipientToMetastoreRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksMetastore"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("metastore_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "CONTAINS"
+    properties: DatabricksRecipientToMetastoreRelProperties = (
+        DatabricksRecipientToMetastoreRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksRecipientSchema(CartographyNodeSchema):
+    label: str = "DatabricksRecipient"
+    properties: DatabricksRecipientNodeProperties = DatabricksRecipientNodeProperties()
+    sub_resource_relationship: DatabricksRecipientToWorkspaceRel = (
+        DatabricksRecipientToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DatabricksRecipientToMetastoreRel()],
+    )

--- a/cartography/models/databricks/recipient.py
+++ b/cartography/models/databricks/recipient.py
@@ -30,6 +30,7 @@ class DatabricksRecipientNodeProperties(CartographyNodeProperties):
     created_at: PropertyRef = PropertyRef("created_at")
     created_by: PropertyRef = PropertyRef("created_by")
     updated_at: PropertyRef = PropertyRef("updated_at")
+    updated_by: PropertyRef = PropertyRef("updated_by")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 

--- a/cartography/models/databricks/repo.py
+++ b/cartography/models/databricks/repo.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksRepoNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    repo_id: PropertyRef = PropertyRef("repo_id", extra_index=True)
+    url: PropertyRef = PropertyRef("url", extra_index=True)
+    provider: PropertyRef = PropertyRef("provider")
+    branch: PropertyRef = PropertyRef("branch")
+    head_commit_id: PropertyRef = PropertyRef("head_commit_id")
+    path: PropertyRef = PropertyRef("path", extra_index=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksRepoToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksRepo)
+class DatabricksRepoToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksRepoToWorkspaceRelProperties = (
+        DatabricksRepoToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksRepoSchema(CartographyNodeSchema):
+    label: str = "DatabricksRepo"
+    properties: DatabricksRepoNodeProperties = DatabricksRepoNodeProperties()
+    sub_resource_relationship: DatabricksRepoToWorkspaceRel = (
+        DatabricksRepoToWorkspaceRel()
+    )

--- a/cartography/models/databricks/served_entity.py
+++ b/cartography/models/databricks/served_entity.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksServedEntityNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    served_name: PropertyRef = PropertyRef("served_name", extra_index=True)
+    endpoint_name: PropertyRef = PropertyRef("endpoint_name", extra_index=True)
+    entity_name: PropertyRef = PropertyRef("entity_name", extra_index=True)
+    entity_type: PropertyRef = PropertyRef("entity_type")
+    entity_version: PropertyRef = PropertyRef("entity_version")
+    foundation_model_name: PropertyRef = PropertyRef("foundation_model_name")
+    # For EXTERNAL_MODEL entities: the third-party provider data is routed to
+    # (openai, anthropic, …) — a data-egress signal.
+    external_model_provider: PropertyRef = PropertyRef("external_model_provider")
+    external_model_name: PropertyRef = PropertyRef("external_model_name")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksServedEntityToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksServedEntity)
+class DatabricksServedEntityToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksServedEntityToWorkspaceRelProperties = (
+        DatabricksServedEntityToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksServedEntityToEndpointRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksServingEndpoint)-[:SERVES]->(:DatabricksServedEntity)
+class DatabricksServedEntityToEndpointRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksServingEndpoint"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("endpoint_scoped_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "SERVES"
+    properties: DatabricksServedEntityToEndpointRelProperties = (
+        DatabricksServedEntityToEndpointRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksServedEntitySchema(CartographyNodeSchema):
+    label: str = "DatabricksServedEntity"
+    properties: DatabricksServedEntityNodeProperties = (
+        DatabricksServedEntityNodeProperties()
+    )
+    sub_resource_relationship: DatabricksServedEntityToWorkspaceRel = (
+        DatabricksServedEntityToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DatabricksServedEntityToEndpointRel()],
+    )

--- a/cartography/models/databricks/serving_endpoint.py
+++ b/cartography/models/databricks/serving_endpoint.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksServingEndpointNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    endpoint_type: PropertyRef = PropertyRef("endpoint_type")
+    task: PropertyRef = PropertyRef("task")
+    state_ready: PropertyRef = PropertyRef("state_ready")
+    state_config_update: PropertyRef = PropertyRef("state_config_update")
+    permission_level: PropertyRef = PropertyRef("permission_level")
+    route_optimized: PropertyRef = PropertyRef("route_optimized")
+    creator: PropertyRef = PropertyRef("creator", extra_index=True)
+    creation_timestamp: PropertyRef = PropertyRef("creation_timestamp")
+    last_updated_timestamp: PropertyRef = PropertyRef("last_updated_timestamp")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksServingEndpointToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksServingEndpoint)
+class DatabricksServingEndpointToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksServingEndpointToWorkspaceRelProperties = (
+        DatabricksServingEndpointToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksServingEndpointSchema(CartographyNodeSchema):
+    label: str = "DatabricksServingEndpoint"
+    properties: DatabricksServingEndpointNodeProperties = (
+        DatabricksServingEndpointNodeProperties()
+    )
+    sub_resource_relationship: DatabricksServingEndpointToWorkspaceRel = (
+        DatabricksServingEndpointToWorkspaceRel()
+    )

--- a/cartography/models/databricks/share.py
+++ b/cartography/models/databricks/share.py
@@ -1,0 +1,99 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksShareNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    share_id: PropertyRef = PropertyRef("share_id", extra_index=True)
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    metastore_id: PropertyRef = PropertyRef("metastore_id", extra_index=True)
+    owner: PropertyRef = PropertyRef("owner", extra_index=True)
+    comment: PropertyRef = PropertyRef("comment")
+    created_at: PropertyRef = PropertyRef("created_at")
+    created_by: PropertyRef = PropertyRef("created_by")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksShareToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksShare)
+class DatabricksShareToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksShareToWorkspaceRelProperties = (
+        DatabricksShareToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksShareToMetastoreRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksMetastore)-[:CONTAINS]->(:DatabricksShare)
+class DatabricksShareToMetastoreRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksMetastore"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("metastore_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "CONTAINS"
+    properties: DatabricksShareToMetastoreRelProperties = (
+        DatabricksShareToMetastoreRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksShareToRecipientRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksShare)-[:SHARED_WITH]->(:DatabricksRecipient)
+# Materialised from the share's permission assignments: which recipients have
+# been granted access to the share.
+class DatabricksShareToRecipientRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksRecipient"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("recipient_scoped_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "SHARED_WITH"
+    properties: DatabricksShareToRecipientRelProperties = (
+        DatabricksShareToRecipientRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksShareSchema(CartographyNodeSchema):
+    label: str = "DatabricksShare"
+    properties: DatabricksShareNodeProperties = DatabricksShareNodeProperties()
+    sub_resource_relationship: DatabricksShareToWorkspaceRel = (
+        DatabricksShareToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            DatabricksShareToMetastoreRel(),
+            DatabricksShareToRecipientRel(),
+        ],
+    )

--- a/cartography/models/databricks/share.py
+++ b/cartography/models/databricks/share.py
@@ -22,6 +22,7 @@ class DatabricksShareNodeProperties(CartographyNodeProperties):
     created_at: PropertyRef = PropertyRef("created_at")
     created_by: PropertyRef = PropertyRef("created_by")
     updated_at: PropertyRef = PropertyRef("updated_at")
+    updated_by: PropertyRef = PropertyRef("updated_by")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 

--- a/cartography/models/databricks/sql_warehouse.py
+++ b/cartography/models/databricks/sql_warehouse.py
@@ -1,0 +1,63 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class DatabricksSqlWarehouseNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    warehouse_id: PropertyRef = PropertyRef("warehouse_id", extra_index=True)
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    state: PropertyRef = PropertyRef("state")
+    cluster_size: PropertyRef = PropertyRef("cluster_size")
+    size: PropertyRef = PropertyRef("size")
+    warehouse_type: PropertyRef = PropertyRef("warehouse_type")
+    enable_serverless_compute: PropertyRef = PropertyRef("enable_serverless_compute")
+    enable_photon: PropertyRef = PropertyRef("enable_photon")
+    auto_stop_mins: PropertyRef = PropertyRef("auto_stop_mins")
+    auto_resume: PropertyRef = PropertyRef("auto_resume")
+    spot_instance_policy: PropertyRef = PropertyRef("spot_instance_policy")
+    channel: PropertyRef = PropertyRef("channel")
+    min_num_clusters: PropertyRef = PropertyRef("min_num_clusters")
+    max_num_clusters: PropertyRef = PropertyRef("max_num_clusters")
+    num_clusters: PropertyRef = PropertyRef("num_clusters")
+    creator_name: PropertyRef = PropertyRef("creator_name", extra_index=True)
+    jdbc_url: PropertyRef = PropertyRef("jdbc_url")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DatabricksSqlWarehouseToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksSqlWarehouse)
+class DatabricksSqlWarehouseToWorkspaceRel(CartographyRelSchema):
+    target_node_label: str = "DatabricksWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DatabricksSqlWarehouseToWorkspaceRelProperties = (
+        DatabricksSqlWarehouseToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DatabricksSqlWarehouseSchema(CartographyNodeSchema):
+    label: str = "DatabricksSqlWarehouse"
+    properties: DatabricksSqlWarehouseNodeProperties = (
+        DatabricksSqlWarehouseNodeProperties()
+    )
+    sub_resource_relationship: DatabricksSqlWarehouseToWorkspaceRel = (
+        DatabricksSqlWarehouseToWorkspaceRel()
+    )

--- a/docs/root/modules/databricks/schema.md
+++ b/docs/root/modules/databricks/schema.md
@@ -87,6 +87,7 @@ W -- RESOURCE --> CR(DatabricksCleanRoom)
 M -- CONTAINS --> SHR
 M -- CONTAINS --> RCP
 M -- CONTAINS --> PRV
+M -- CONTAINS --> CR
 SHR -- SHARED_WITH --> RCP
 ```
 
@@ -1303,6 +1304,7 @@ with recipients.
 | created_at | Native datetime the share was created (UTC) |
 | created_by | User name that created the share |
 | updated_at | Native datetime the share was last updated (UTC) |
+| updated_by | User name that last updated the share |
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
 
@@ -1340,6 +1342,7 @@ A Delta Sharing recipient: an external party a share is shared with.
 | created_at | Native datetime the recipient was created (UTC) |
 | created_by | User name that created the recipient |
 | updated_at | Native datetime the recipient was last updated (UTC) |
+| updated_by | User name that last updated the recipient |
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
 
@@ -1373,6 +1376,7 @@ from.
 | created_at | Native datetime the provider was created (UTC) |
 | created_by | User name that created the provider |
 | updated_at | Native datetime the provider was last updated (UTC) |
+| updated_by | User name that last updated the provider |
 | firstseen | Timestamp of when a sync job first created this node |
 | lastupdated | Timestamp of the last time the node was updated |
 
@@ -1395,8 +1399,9 @@ skipped otherwise).
 
 | Field | Description |
 |-------|-------------|
-| **id** | Workspace-scoped composite id `{workspace_id}/{name}` |
+| **id** | Metastore-scoped id `{metastore_id}/{name}` |
 | **name** | Clean room name (indexed) |
+| metastore_id | Owning metastore id (indexed) |
 | owner | Clean room owner (indexed) |
 | comment | Free-text comment |
 | access_restricted | Whether access is restricted (e.g. on misconfiguration) |
@@ -1410,4 +1415,8 @@ skipped otherwise).
 - A `DatabricksCleanRoom` belongs to a `DatabricksWorkspace`.
     ```
     (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksCleanRoom)
+    ```
+- A `DatabricksCleanRoom` is contained by a `DatabricksMetastore`.
+    ```
+    (:DatabricksMetastore)-[:CONTAINS]->(:DatabricksCleanRoom)
     ```

--- a/docs/root/modules/databricks/schema.md
+++ b/docs/root/modules/databricks/schema.md
@@ -70,6 +70,16 @@ Q -- USES_WAREHOUSE --> WH
 AL -- MONITORS --> Q
 DSRC -- BACKED_BY --> WH
 DASH -- USES_WAREHOUSE --> WH
+W -- RESOURCE --> SVE(DatabricksServingEndpoint)
+W -- RESOURCE --> SVN(DatabricksServedEntity)
+W -- RESOURCE --> GEN(DatabricksGenieSpace)
+W -- RESOURCE --> APP(DatabricksApp)
+W -- RESOURCE --> REPO(DatabricksRepo)
+W -- RESOURCE --> GC(DatabricksGitCredential)
+SVE -- SERVES --> SVN
+GEN -- USES_WAREHOUSE --> WH
+W -- RESOURCE --> NB(DatabricksNotebook)
+JT -- RUNS_NOTEBOOK --> NB
 ```
 
 Grantable Unity Catalog nodes (`DatabricksMetastore`, `DatabricksCatalog`,
@@ -1081,4 +1091,190 @@ A Databricks dashboard. Both current Lakeview dashboards and legacy
 - A `DatabricksDashboard` uses a `DatabricksSqlWarehouse` (Lakeview dashboards).
     ```
     (:DatabricksDashboard)-[:USES_WAREHOUSE]->(:DatabricksSqlWarehouse)
+    ```
+
+### DatabricksServingEndpoint
+
+A Mosaic AI model serving endpoint (custom model, foundation model, or external
+model proxy).
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{name}` |
+| **name** | Endpoint name (indexed) |
+| endpoint_type | Endpoint type (`FOUNDATION_MODEL_API`, `EXTERNAL_MODEL`, …) |
+| task | Endpoint task (`llm/v1/chat`, `llm/v1/completions`, …) |
+| state_ready | Readiness state (`READY`, `NOT_READY`) |
+| state_config_update | Config update state (`NOT_UPDATING`, `IN_PROGRESS`, …) |
+| permission_level | The caller's permission level on the endpoint |
+| route_optimized | Whether the endpoint is route-optimized |
+| creator | User name of the endpoint creator (indexed) |
+| creation_timestamp | Native datetime the endpoint was created (UTC) |
+| last_updated_timestamp | Native datetime the endpoint was last updated (UTC) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksServingEndpoint` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksServingEndpoint)
+    ```
+- A `DatabricksServingEndpoint` serves one or more `DatabricksServedEntity`.
+    ```
+    (:DatabricksServingEndpoint)-[:SERVES]->(:DatabricksServedEntity)
+    ```
+
+### DatabricksServedEntity
+
+A single model served behind a serving endpoint. An endpoint can serve several
+entities (traffic split); each carries the model identity.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Composite id `{workspace_id}/{endpoint_name}/{served_name}` |
+| **served_name** | Name of the served entity within its endpoint (indexed) |
+| **endpoint_name** | Name of the owning endpoint (indexed) |
+| entity_name | Full name of the served entity (e.g. `catalog.schema.model` or `system.ai.*`) (indexed) |
+| entity_type | Entity type (`FOUNDATION_MODEL`, `CUSTOM_MODEL`, `EXTERNAL_MODEL`, `FEATURE_SPEC`) |
+| entity_version | Served model version, for custom models |
+| foundation_model_name | Backing foundation-model name, for `FOUNDATION_MODEL` entities |
+| external_model_provider | Third-party provider data is routed to (`openai`, `anthropic`, …), for `EXTERNAL_MODEL` entities — a data-egress signal |
+| external_model_name | Third-party model name, for `EXTERNAL_MODEL` entities |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksServedEntity` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksServedEntity)
+    ```
+- A `DatabricksServedEntity` is served by a `DatabricksServingEndpoint`.
+    ```
+    (:DatabricksServingEndpoint)-[:SERVES]->(:DatabricksServedEntity)
+    ```
+
+### DatabricksGenieSpace
+
+An AI/BI Genie space (natural-language analytics over a warehouse).
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{space_id}` |
+| **space_id** | Raw Genie space id (indexed) |
+| **title** | Space title (indexed) |
+| description | Space description |
+| warehouse_id | Raw id of the warehouse the space queries (indexed) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksGenieSpace` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksGenieSpace)
+    ```
+- A `DatabricksGenieSpace` uses a `DatabricksSqlWarehouse`.
+    ```
+    (:DatabricksGenieSpace)-[:USES_WAREHOUSE]->(:DatabricksSqlWarehouse)
+    ```
+
+### DatabricksApp
+
+A Databricks App (a hosted web application). The app runs as an auto-provisioned
+service principal whose client id is retained for principal-to-resource
+resolution.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{name}` |
+| **name** | App name (indexed) |
+| description | App description |
+| url | Public URL the app is served at (indexed) |
+| app_state | Application status (`RUNNING`, `UNAVAILABLE`, …) |
+| compute_state | Compute status (`ACTIVE`, `STOPPED`, …) |
+| compute_size | Compute size (`MEDIUM`, `LARGE`) |
+| creator | User name of the app creator (indexed) |
+| service_principal_client_id | Application id of the service principal the app runs as (indexed) |
+| service_principal_name | Display name of the app's service principal |
+| oauth2_app_client_id | OAuth2 client id of the app integration |
+| create_time | Native datetime the app was created (UTC) |
+| update_time | Native datetime the app was last updated (UTC) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksApp` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksApp)
+    ```
+
+### DatabricksRepo
+
+A Databricks repo (git folder) cloned into the workspace.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{repo_id}` |
+| **repo_id** | Raw repo id (indexed) |
+| url | Git remote URL (indexed) |
+| provider | Git provider (`gitHub`, `gitLab`, `bitbucketCloud`, …) |
+| branch | Checked-out branch |
+| head_commit_id | Currently checked-out commit sha |
+| path | Workspace path of the repo (indexed) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksRepo` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksRepo)
+    ```
+
+### DatabricksGitCredential
+
+A stored Git credential used to authenticate to a Git provider for repos.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{credential_id}` |
+| **credential_id** | Raw credential id (indexed) |
+| git_provider | Git provider the credential authenticates to |
+| git_username | Git username the credential is bound to (indexed) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksGitCredential` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksGitCredential)
+    ```
+
+### DatabricksNotebook
+
+A workspace notebook. To avoid walking the entire workspace tree, notebooks are
+materialised lazily: one lightweight, path-keyed node per distinct notebook a
+job task references (no content, permissions, or recursive listing). This is
+enough to carry the code-to-cloud `RUNS_NOTEBOOK` edge.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{path}` |
+| **path** | Workspace path of the notebook (indexed) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksNotebook` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksNotebook)
+    ```
+- A `DatabricksJobTask` runs a `DatabricksNotebook`.
+    ```
+    (:DatabricksJobTask)-[:RUNS_NOTEBOOK]->(:DatabricksNotebook)
     ```

--- a/docs/root/modules/databricks/schema.md
+++ b/docs/root/modules/databricks/schema.md
@@ -80,6 +80,14 @@ SVE -- SERVES --> SVN
 GEN -- USES_WAREHOUSE --> WH
 W -- RESOURCE --> NB(DatabricksNotebook)
 JT -- RUNS_NOTEBOOK --> NB
+W -- RESOURCE --> SHR(DatabricksShare)
+W -- RESOURCE --> RCP(DatabricksRecipient)
+W -- RESOURCE --> PRV(DatabricksProvider)
+W -- RESOURCE --> CR(DatabricksCleanRoom)
+M -- CONTAINS --> SHR
+M -- CONTAINS --> RCP
+M -- CONTAINS --> PRV
+SHR -- SHARED_WITH --> RCP
 ```
 
 Grantable Unity Catalog nodes (`DatabricksMetastore`, `DatabricksCatalog`,
@@ -1277,4 +1285,129 @@ enough to carry the code-to-cloud `RUNS_NOTEBOOK` edge.
 - A `DatabricksJobTask` runs a `DatabricksNotebook`.
     ```
     (:DatabricksJobTask)-[:RUNS_NOTEBOOK]->(:DatabricksNotebook)
+    ```
+
+### DatabricksShare
+
+A Delta Sharing share: a named, outbound collection of data a provider shares
+with recipients.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Metastore-scoped id `{metastore_id}/{name}` |
+| **share_id** | Raw share id (indexed) |
+| **name** | Share name (indexed) |
+| metastore_id | Owning metastore id (indexed) |
+| owner | Share owner (indexed) |
+| comment | Free-text comment |
+| created_at | Native datetime the share was created (UTC) |
+| created_by | User name that created the share |
+| updated_at | Native datetime the share was last updated (UTC) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksShare` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksShare)
+    ```
+- A `DatabricksShare` is contained by a `DatabricksMetastore`.
+    ```
+    (:DatabricksMetastore)-[:CONTAINS]->(:DatabricksShare)
+    ```
+- A `DatabricksShare` is shared with a `DatabricksRecipient` (from the share's permission assignments).
+    ```
+    (:DatabricksShare)-[:SHARED_WITH]->(:DatabricksRecipient)
+    ```
+
+### DatabricksRecipient
+
+A Delta Sharing recipient: an external party a share is shared with.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Metastore-scoped id `{metastore_id}/{name}` |
+| **name** | Recipient name (indexed) |
+| metastore_id | Owning metastore id (indexed) |
+| authentication_type | `TOKEN` (open, bearer-token sharing to any party — external exposure) or `DATABRICKS` (sharing to another Databricks account) |
+| activated | Whether the recipient's credential has been activated |
+| owner | Recipient owner (indexed) |
+| comment | Free-text comment |
+| data_recipient_global_metastore_id | For `DATABRICKS` recipients, the target account's metastore id (indexed) |
+| cloud | Recipient cloud |
+| region | Recipient region |
+| created_at | Native datetime the recipient was created (UTC) |
+| created_by | User name that created the recipient |
+| updated_at | Native datetime the recipient was last updated (UTC) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksRecipient` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksRecipient)
+    ```
+- A `DatabricksRecipient` is contained by a `DatabricksMetastore`.
+    ```
+    (:DatabricksMetastore)-[:CONTAINS]->(:DatabricksRecipient)
+    ```
+
+### DatabricksProvider
+
+A Delta Sharing provider: an external party this metastore receives shared data
+from.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Metastore-scoped id `{metastore_id}/{name}` |
+| **name** | Provider name (indexed) |
+| metastore_id | Owning metastore id (indexed) |
+| authentication_type | Provider authentication type (`TOKEN`, `DATABRICKS`) |
+| owner | Provider owner (indexed) |
+| comment | Free-text comment |
+| data_provider_global_metastore_id | The provider account's metastore id (indexed) |
+| cloud | Provider cloud |
+| region | Provider region |
+| created_at | Native datetime the provider was created (UTC) |
+| created_by | User name that created the provider |
+| updated_at | Native datetime the provider was last updated (UTC) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksProvider` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksProvider)
+    ```
+- A `DatabricksProvider` is contained by a `DatabricksMetastore`.
+    ```
+    (:DatabricksMetastore)-[:CONTAINS]->(:DatabricksProvider)
+    ```
+
+### DatabricksCleanRoom
+
+A Databricks clean room for privacy-safe multi-party collaboration. Ingested
+only when external OpenSharing is enabled on the metastore (the listing is
+skipped otherwise).
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{name}` |
+| **name** | Clean room name (indexed) |
+| owner | Clean room owner (indexed) |
+| comment | Free-text comment |
+| access_restricted | Whether access is restricted (e.g. on misconfiguration) |
+| created_at | Native datetime the clean room was created (UTC) |
+| updated_at | Native datetime the clean room was last updated (UTC) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksCleanRoom` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksCleanRoom)
     ```

--- a/docs/root/modules/databricks/schema.md
+++ b/docs/root/modules/databricks/schema.md
@@ -49,6 +49,27 @@ S -- HAS_PRIVILEGE --> DS
 OT(DatabricksOnlineTable) -- SOURCED_FROM --> TB
 VSI(DatabricksVectorSearchIndex) -- USES_ENDPOINT --> VSE(DatabricksVectorSearchEndpoint)
 VSI -- SOURCED_FROM --> TB
+W -- RESOURCE --> WH(DatabricksSqlWarehouse)
+W -- RESOURCE --> JOB(DatabricksJob)
+W -- RESOURCE --> JT(DatabricksJobTask)
+W -- RESOURCE --> PL(DatabricksPipeline)
+W -- RESOURCE --> Q(DatabricksQuery)
+W -- RESOURCE --> AL(DatabricksAlert)
+W -- RESOURCE --> DSRC(DatabricksDataSource)
+W -- RESOURCE --> DASH(DatabricksDashboard)
+JOB -- HAS_TASK --> JT
+JOB -- RUN_AS --> U
+JOB -- RUN_AS --> S
+PL -- RUN_AS --> U
+PL -- RUN_AS --> S
+PL -- PUBLISHES_TO --> CAT
+JT -- RUNS_PIPELINE --> PL
+JT -- USES_CLUSTER --> C
+JT -- USES_WAREHOUSE --> WH
+Q -- USES_WAREHOUSE --> WH
+AL -- MONITORS --> Q
+DSRC -- BACKED_BY --> WH
+DASH -- USES_WAREHOUSE --> WH
 ```
 
 Grantable Unity Catalog nodes (`DatabricksMetastore`, `DatabricksCatalog`,
@@ -775,4 +796,289 @@ securable.
     (:DatabricksUser)-[:HAS_PRIVILEGE {privileges}]->(:DatabricksSecurable)
     (:DatabricksGroup)-[:HAS_PRIVILEGE {privileges}]->(:DatabricksSecurable)
     (:DatabricksServicePrincipal)-[:HAS_PRIVILEGE {privileges}]->(:DatabricksSecurable)
+    ```
+
+### DatabricksSqlWarehouse
+
+A Databricks SQL warehouse (SQL endpoint) that queries, dashboards, alerts and
+data sources run against.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{warehouse_id}` |
+| **warehouse_id** | Raw warehouse id (indexed) |
+| **name** | Warehouse display name (indexed) |
+| state | Warehouse state (`RUNNING`, `STOPPED`, `STARTING`, …) |
+| cluster_size | T-shirt size label (`Small`, `Medium`, …) |
+| size | Normalised size enum (`SMALL`, `MEDIUM`, …) |
+| warehouse_type | Warehouse type (`CLASSIC`, `PRO`) |
+| enable_serverless_compute | Whether the warehouse runs on serverless compute |
+| enable_photon | Whether the Photon engine is enabled |
+| auto_stop_mins | Idle auto-stop window in minutes (0 disables auto-stop) |
+| auto_resume | Whether the warehouse auto-resumes on query |
+| spot_instance_policy | Spot vs on-demand policy (`COST_OPTIMIZED`, `RELIABILITY_OPTIMIZED`) |
+| channel | Release channel name (`CHANNEL_NAME_CURRENT`, `CHANNEL_NAME_PREVIEW`) |
+| min_num_clusters | Minimum cluster count for autoscaling |
+| max_num_clusters | Maximum cluster count for autoscaling |
+| num_clusters | Currently allocated cluster count |
+| creator_name | User name of the warehouse creator (indexed) |
+| jdbc_url | JDBC connection URL |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksSqlWarehouse` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksSqlWarehouse)
+    ```
+
+### DatabricksJob
+
+A Databricks job (Workflow). Schedule fields are flattened from the job's
+`schedule` block; `run_as_user_name` is the principal the job's tasks execute as.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{job_id}` |
+| **job_id** | Raw job id (indexed) |
+| **name** | Job name (indexed) |
+| creator_user_name | User name of the job creator (indexed) |
+| run_as_user_name | Principal the job runs as: a user name or SP application id (indexed) |
+| format | Job format (`MULTI_TASK`, `SINGLE_TASK`) |
+| max_concurrent_runs | Maximum concurrent runs |
+| timeout_seconds | Job timeout in seconds (0 = no timeout) |
+| continuous | Whether the job is configured for continuous execution |
+| schedule_quartz_cron_expression | Cron expression of the schedule, if scheduled |
+| schedule_timezone_id | Timezone id of the schedule |
+| schedule_pause_status | Schedule pause status (`PAUSED`, `UNPAUSED`) |
+| created_time | Native datetime when the job was created (UTC) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksJob` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksJob)
+    ```
+- A `DatabricksJob` runs as a workspace principal (a user or a service principal).
+    ```
+    (:DatabricksJob)-[:RUN_AS]->(:DatabricksUser)
+    (:DatabricksJob)-[:RUN_AS]->(:DatabricksServicePrincipal)
+    ```
+- A `DatabricksJob` is composed of one or more `DatabricksJobTask`.
+    ```
+    (:DatabricksJob)-[:HAS_TASK]->(:DatabricksJobTask)
+    ```
+
+### DatabricksJobTask
+
+A single task within a Databricks job. The task type is the name of the task's
+settings block (`notebook_task`, `pipeline_task`, `sql_task`, `run_job_task`, …).
+
+| Field | Description |
+|-------|-------------|
+| **id** | Composite id `{workspace_id}/{job_id}/{task_key}` |
+| **task_key** | Task key, unique within its job (indexed) |
+| **job_id** | Raw id of the owning job (indexed) |
+| task_type | The task's settings block name (`notebook_task`, `pipeline_task`, …) |
+| notebook_path | Notebook path for a notebook task (indexed) |
+| existing_cluster_id | Raw id of an existing cluster the task runs on |
+| job_cluster_key | Key of the job cluster the task runs on, if any |
+| pipeline_id | Raw pipeline id for a pipeline task (indexed) |
+| warehouse_id | Raw SQL warehouse id for a SQL task (indexed) |
+| run_job_id | Raw id of the job triggered by a run-job task (indexed) |
+| disabled | Whether the task is disabled |
+| run_if | Condition under which the task runs (`ALL_SUCCESS`, …) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksJobTask` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksJobTask)
+    ```
+- A `DatabricksJobTask` belongs to a `DatabricksJob`.
+    ```
+    (:DatabricksJob)-[:HAS_TASK]->(:DatabricksJobTask)
+    ```
+- A `DatabricksJobTask` triggers a `DatabricksPipeline` (pipeline task).
+    ```
+    (:DatabricksJobTask)-[:RUNS_PIPELINE]->(:DatabricksPipeline)
+    ```
+- A `DatabricksJobTask` runs on a `DatabricksCluster` (when it targets an existing cluster).
+    ```
+    (:DatabricksJobTask)-[:USES_CLUSTER]->(:DatabricksCluster)
+    ```
+- A `DatabricksJobTask` uses a `DatabricksSqlWarehouse` (SQL task).
+    ```
+    (:DatabricksJobTask)-[:USES_WAREHOUSE]->(:DatabricksSqlWarehouse)
+    ```
+
+### DatabricksPipeline
+
+A Delta Live Tables (Lakeflow Declarative) pipeline.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{pipeline_id}` |
+| **pipeline_id** | Raw pipeline id (indexed) |
+| **name** | Pipeline name (indexed) |
+| state | Pipeline state (`IDLE`, `RUNNING`, `FAILED`, …) |
+| creator_user_name | User name of the pipeline creator (indexed) |
+| run_as_user_name | Principal the pipeline runs as: a user name or SP application id (indexed) |
+| catalog | Target Unity Catalog catalog the pipeline publishes to (indexed) |
+| target_schema | Target schema the pipeline publishes to (`spec.schema`, or legacy `spec.target`) |
+| storage | DBFS/root storage location for a legacy (non-UC) pipeline |
+| continuous | Whether the pipeline runs continuously |
+| development | Whether the pipeline is in development mode |
+| serverless | Whether the pipeline uses serverless compute |
+| photon | Whether the Photon engine is enabled |
+| edition | Pipeline edition (`CORE`, `PRO`, `ADVANCED`) |
+| channel | Release channel (`CURRENT`, `PREVIEW`) |
+| pipeline_type | Pipeline type (`WORKSPACE`, …) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksPipeline` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksPipeline)
+    ```
+- A `DatabricksPipeline` runs as a workspace principal (a user or a service principal).
+    ```
+    (:DatabricksPipeline)-[:RUN_AS]->(:DatabricksUser)
+    (:DatabricksPipeline)-[:RUN_AS]->(:DatabricksServicePrincipal)
+    ```
+- A `DatabricksPipeline` publishes to a Unity Catalog `DatabricksCatalog`.
+    ```
+    (:DatabricksPipeline)-[:PUBLISHES_TO]->(:DatabricksCatalog)
+    ```
+
+### DatabricksQuery
+
+A saved Databricks SQL query.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{query_id}` |
+| **query_id** | Raw query id (indexed) |
+| **display_name** | Query display name (indexed) |
+| warehouse_id | Raw id of the warehouse the query runs on (indexed) |
+| query_text | The SQL text of the query |
+| owner_user_name | User name of the query owner (indexed) |
+| last_modifier_user_name | User name of the last modifier |
+| run_as_mode | Whether the query runs as its `OWNER` or the `VIEWER` |
+| lifecycle_state | Lifecycle state (`ACTIVE`, `TRASHED`) |
+| parent_path | Workspace folder path of the query |
+| create_time | Native datetime when the query was created (UTC) |
+| update_time | Native datetime when the query was last updated (UTC) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksQuery` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksQuery)
+    ```
+- A `DatabricksQuery` runs against a `DatabricksSqlWarehouse`.
+    ```
+    (:DatabricksQuery)-[:USES_WAREHOUSE]->(:DatabricksSqlWarehouse)
+    ```
+
+### DatabricksAlert
+
+A Databricks SQL alert that evaluates a query result against a condition.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{alert_id}` |
+| **alert_id** | Raw alert id (indexed) |
+| **display_name** | Alert display name (indexed) |
+| query_id | Raw id of the query the alert monitors (indexed) |
+| owner_user_name | User name of the alert owner (indexed) |
+| state | Latest evaluation state (`OK`, `TRIGGERED`, `UNKNOWN`) |
+| lifecycle_state | Lifecycle state (`ACTIVE`, `TRASHED`) |
+| condition_op | Comparison operator of the alert condition (`GREATER_THAN`, …) |
+| parent_path | Workspace folder path of the alert |
+| create_time | Native datetime when the alert was created (UTC) |
+| update_time | Native datetime when the alert was last updated (UTC) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksAlert` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksAlert)
+    ```
+- A `DatabricksAlert` monitors a `DatabricksQuery`.
+    ```
+    (:DatabricksAlert)-[:MONITORS]->(:DatabricksQuery)
+    ```
+
+### DatabricksDataSource
+
+A Databricks SQL data source, which maps a data-source id (referenced by legacy
+queries and dashboards) to the warehouse that backs it.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{data_source_id}` |
+| **data_source_id** | Raw data source id (indexed) |
+| **name** | Data source name (indexed) |
+| type | Data source type (`databricks_internal`, …) |
+| warehouse_id | Raw id of the backing warehouse (indexed) |
+| syntax | Query syntax (`sql`) |
+| paused | Whether the data source is paused (`0` = running, `1` = paused) |
+| view_only | Whether the data source is view-only |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksDataSource` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksDataSource)
+    ```
+- A `DatabricksDataSource` is backed by a `DatabricksSqlWarehouse`.
+    ```
+    (:DatabricksDataSource)-[:BACKED_BY]->(:DatabricksSqlWarehouse)
+    ```
+
+### DatabricksDashboard
+
+A Databricks dashboard. Both current Lakeview dashboards and legacy
+(redash-based) dashboards land as this node type, discriminated by
+`dashboard_type`.
+
+| Field | Description |
+|-------|-------------|
+| **id** | Workspace-scoped composite id `{workspace_id}/{dashboard_id}` |
+| **dashboard_id** | Raw dashboard id (indexed) |
+| **display_name** | Dashboard display name (indexed) |
+| dashboard_type | `LAKEVIEW` (current) or `LEGACY` (redash-based) |
+| warehouse_id | Raw id of the bound warehouse (Lakeview dashboards) (indexed) |
+| owner_user_name | User name of the dashboard owner (legacy dashboards) (indexed) |
+| lifecycle_state | Lifecycle state (`ACTIVE`, `TRASHED`) |
+| parent_path | Workspace folder path of the dashboard |
+| path | Full workspace path of the dashboard asset |
+| create_time | Native datetime when the dashboard was created (UTC) |
+| update_time | Native datetime when the dashboard was last updated (UTC) |
+| firstseen | Timestamp of when a sync job first created this node |
+| lastupdated | Timestamp of the last time the node was updated |
+
+#### Relationships
+
+- A `DatabricksDashboard` belongs to a `DatabricksWorkspace`.
+    ```
+    (:DatabricksWorkspace)-[:RESOURCE]->(:DatabricksDashboard)
+    ```
+- A `DatabricksDashboard` uses a `DatabricksSqlWarehouse` (Lakeview dashboards).
+    ```
+    (:DatabricksDashboard)-[:USES_WAREHOUSE]->(:DatabricksSqlWarehouse)
     ```

--- a/tests/data/databricks/alerts.py
+++ b/tests/data/databricks/alerts.py
@@ -1,0 +1,21 @@
+from tests.data.databricks.queries import DATABRICKS_QUERY_ID
+
+# Shape returned by alerts.get() (the "results" list).
+DATABRICKS_ALERTS = [
+    {
+        "id": "b24eb01c-16d1-4235-9caa-428b62f969f2",
+        "display_name": "carto-test-alert",
+        "query_id": DATABRICKS_QUERY_ID,
+        "owner_user_name": "jeremy@subimage.io",
+        "state": "UNKNOWN",
+        "lifecycle_state": "ACTIVE",
+        "condition": {
+            "op": "GREATER_THAN",
+            "operand": {"column": {"name": "carto_test"}},
+            "threshold": {"value": {"double_value": 0}},
+        },
+        "parent_path": "/Workspace/Users/jeremy@subimage.io",
+        "create_time": "2026-07-01T23:28:16Z",
+        "update_time": "2026-07-01T23:28:16Z",
+    },
+]

--- a/tests/data/databricks/apps.py
+++ b/tests/data/databricks/apps.py
@@ -1,0 +1,17 @@
+# Shape returned by apps.get() (the "apps" list).
+DATABRICKS_APPS = [
+    {
+        "name": "carto-test-app",
+        "description": "sub-1580 test app",
+        "url": "https://carto-test-app-7474652579390353.aws.databricksapps.com",
+        "app_status": {"state": "UNAVAILABLE", "message": "App status is unavailable."},
+        "compute_status": {"state": "STOPPED", "message": "Start the app compute."},
+        "compute_size": "MEDIUM",
+        "creator": "jeremy@subimage.io",
+        "service_principal_client_id": "7d58cdad-a4d5-4ba1-bd81-15dbde04c88c",
+        "service_principal_name": "app-2awyo9 carto-test-app",
+        "oauth2_app_client_id": "ac41c9af-a044-4efe-b1c3-dfc12bef42ec",
+        "create_time": "2026-07-02T00:10:29Z",
+        "update_time": "2026-07-02T00:10:29Z",
+    },
+]

--- a/tests/data/databricks/clean_rooms.py
+++ b/tests/data/databricks/clean_rooms.py
@@ -1,0 +1,12 @@
+# Shape returned by clean_rooms.get() (the "clean_rooms" list). Empty in
+# workspaces where external OpenSharing is disabled.
+DATABRICKS_CLEAN_ROOMS = [
+    {
+        "name": "carto_test_clean_room",
+        "owner": "jeremy@subimage.io",
+        "comment": "sub-1580 test clean room",
+        "access_restricted": "CSP_MISCONFIGURED",
+        "created_at": 1782952000000,
+        "updated_at": 1782952000000,
+    },
+]

--- a/tests/data/databricks/dashboards.py
+++ b/tests/data/databricks/dashboards.py
@@ -1,0 +1,30 @@
+from tests.data.databricks.sql_warehouses import DATABRICKS_WAREHOUSE_ID
+
+# Shapes as the get_lakeview() / get_legacy() helpers return them: the raw API
+# object with a "_type" discriminator added.
+DATABRICKS_LAKEVIEW_DASHBOARDS = [
+    {
+        "_type": "LAKEVIEW",
+        "dashboard_id": "01f175a4ac071e099d6cc5ce1c8ba9fb",
+        "display_name": "carto-test-dashboard",
+        "warehouse_id": DATABRICKS_WAREHOUSE_ID,
+        "lifecycle_state": "ACTIVE",
+        "parent_path": "/Users/jeremy@subimage.io",
+        "path": "/Users/jeremy@subimage.io/carto-test-dashboard.lvdash.json",
+        "create_time": "2026-07-01T23:29:14.783Z",
+        "update_time": "2026-07-01T23:29:14.869Z",
+    },
+]
+
+DATABRICKS_LEGACY_DASHBOARDS = [
+    {
+        "_type": "LEGACY",
+        "id": "9a1c2b3d-legacy-4567-89ab-cdef01234567",
+        "name": "legacy-sales-dashboard",
+        "user": {"email": "kunaal@subimage.io"},
+        "created_at": "2025-01-02T10:00:00Z",
+        "updated_at": "2025-02-03T11:00:00Z",
+        "is_draft": False,
+        "is_archived": False,
+    },
+]

--- a/tests/data/databricks/data_sources.py
+++ b/tests/data/databricks/data_sources.py
@@ -1,0 +1,14 @@
+from tests.data.databricks.sql_warehouses import DATABRICKS_WAREHOUSE_ID
+
+# Shape returned by data_sources.get() (a bare list).
+DATABRICKS_DATA_SOURCES = [
+    {
+        "id": "1811cbc7-42e8-46f9-875c-b613109cd172",
+        "name": "Serverless Starter Warehouse",
+        "type": "databricks_internal",
+        "warehouse_id": DATABRICKS_WAREHOUSE_ID,
+        "syntax": "sql",
+        "paused": 0,
+        "view_only": False,
+    },
+]

--- a/tests/data/databricks/genie_spaces.py
+++ b/tests/data/databricks/genie_spaces.py
@@ -1,0 +1,11 @@
+from tests.data.databricks.sql_warehouses import DATABRICKS_WAREHOUSE_ID
+
+# Shape returned by genie_spaces.get() (the "spaces" list).
+DATABRICKS_GENIE_SPACES = [
+    {
+        "space_id": "01f1749e632b10acab9da9a9ca010dfb",
+        "title": "Bakehouse Sales Starter Space",
+        "description": "AI/BI Genie over the fictional bakery sales data.",
+        "warehouse_id": DATABRICKS_WAREHOUSE_ID,
+    },
+]

--- a/tests/data/databricks/git_credentials.py
+++ b/tests/data/databricks/git_credentials.py
@@ -1,0 +1,8 @@
+# Shape returned by git_credentials.get() (the "credentials" list).
+DATABRICKS_GIT_CREDENTIALS = [
+    {
+        "credential_id": 6273842934,
+        "git_provider": "gitHub",
+        "git_username": "carto-bot",
+    },
+]

--- a/tests/data/databricks/jobs.py
+++ b/tests/data/databricks/jobs.py
@@ -1,0 +1,63 @@
+from tests.data.databricks.sql_warehouses import DATABRICKS_WAREHOUSE_ID
+
+# Shape returned by jobs.get() (the "jobs" list, with expand_tasks=true so each
+# job's settings carry its full task graph).
+DATABRICKS_JOBS = [
+    {
+        "job_id": 1011944831447606,
+        "creator_user_name": "jeremy@subimage.io",
+        "run_as_user_name": "jeremy@subimage.io",
+        "created_time": 1782948408553,
+        "settings": {
+            "name": "carto-test-job",
+            "format": "MULTI_TASK",
+            "max_concurrent_runs": 1,
+            "timeout_seconds": 0,
+            "schedule": {
+                "quartz_cron_expression": "0 0 12 * * ?",
+                "timezone_id": "UTC",
+                "pause_status": "PAUSED",
+            },
+            "tasks": [
+                {
+                    "task_key": "carto_task_nb",
+                    "notebook_task": {
+                        "notebook_path": "/Users/jeremy@subimage.io/carto_test_nb",
+                        "source": "WORKSPACE",
+                    },
+                    "run_if": "ALL_SUCCESS",
+                    "disabled": False,
+                },
+                {
+                    "task_key": "refresh_pipeline",
+                    "pipeline_task": {
+                        "pipeline_id": "e66810c3-f9ba-4bbd-b9af-4e23bd2de755"
+                    },
+                    "sql_task": {"warehouse_id": DATABRICKS_WAREHOUSE_ID},
+                    "run_if": "ALL_SUCCESS",
+                },
+            ],
+        },
+    },
+    {
+        # A job that runs as a service principal (matched by application_id).
+        "job_id": 2022955942558717,
+        "creator_user_name": "jeremy@subimage.io",
+        "run_as_user_name": "abcd1234-5678-90ab-cdef-1234567890ab",
+        "created_time": 1782948408553,
+        "settings": {
+            "name": "carto-sp-job",
+            "format": "MULTI_TASK",
+            "max_concurrent_runs": 1,
+            "continuous": {"pause_status": "UNPAUSED"},
+            "tasks": [
+                {
+                    "task_key": "sp_task",
+                    "notebook_task": {"notebook_path": "/Shared/sp_nb"},
+                    # Runs on a pre-existing all-purpose cluster.
+                    "existing_cluster_id": "0202-cluster-aaaa",
+                },
+            ],
+        },
+    },
+]

--- a/tests/data/databricks/pipelines.py
+++ b/tests/data/databricks/pipelines.py
@@ -1,0 +1,23 @@
+# Shape returned by pipelines.get() (each pipeline's detail, incl. its spec).
+DATABRICKS_PIPELINES = [
+    {
+        "pipeline_id": "e66810c3-f9ba-4bbd-b9af-4e23bd2de755",
+        "name": "carto-test-pipeline",
+        "state": "IDLE",
+        "creator_user_name": "jeremy@subimage.io",
+        "run_as_user_name": "jeremy@subimage.io",
+        "spec": {
+            "id": "e66810c3-f9ba-4bbd-b9af-4e23bd2de755",
+            "name": "carto-test-pipeline",
+            "catalog": "workspace",
+            "schema": "carto_test_schema",
+            "continuous": False,
+            "development": True,
+            "serverless": True,
+            "pipeline_type": "WORKSPACE",
+            "libraries": [
+                {"notebook": {"path": "/Users/jeremy@subimage.io/carto_test_nb"}},
+            ],
+        },
+    },
+]

--- a/tests/data/databricks/providers.py
+++ b/tests/data/databricks/providers.py
@@ -1,0 +1,19 @@
+from tests.data.databricks.metastore import DATABRICKS_METASTORE_ID
+
+# Shape returned by providers.get() (the "providers" list).
+DATABRICKS_PROVIDERS = [
+    {
+        "name": "acme_data_provider",
+        "authentication_type": "TOKEN",
+        "owner": "jeremy@subimage.io",
+        "comment": "sub-1580 test provider",
+        "data_provider_global_metastore_id": "aws:eu-west-1:acme-metastore",
+        "cloud": "aws",
+        "region": "eu-west-1",
+        "created_at": 1782952000000,
+        "created_by": "jeremy@subimage.io",
+        "updated_at": 1782952000000,
+    },
+]
+
+PROVIDER_ID = f"{DATABRICKS_METASTORE_ID}/acme_data_provider"

--- a/tests/data/databricks/queries.py
+++ b/tests/data/databricks/queries.py
@@ -1,0 +1,20 @@
+from tests.data.databricks.sql_warehouses import DATABRICKS_WAREHOUSE_ID
+
+DATABRICKS_QUERY_ID = "323e781f-df1c-4460-b513-1b293f9d8871"
+
+# Shape returned by queries.get() (the "results" list).
+DATABRICKS_QUERIES = [
+    {
+        "id": DATABRICKS_QUERY_ID,
+        "display_name": "carto-test-query",
+        "warehouse_id": DATABRICKS_WAREHOUSE_ID,
+        "query_text": "SELECT 1 AS carto_test",
+        "owner_user_name": "jeremy@subimage.io",
+        "last_modifier_user_name": "jeremy@subimage.io",
+        "run_as_mode": "OWNER",
+        "lifecycle_state": "ACTIVE",
+        "parent_path": "/Workspace/Users/jeremy@subimage.io",
+        "create_time": "2026-07-01T23:27:40Z",
+        "update_time": "2026-07-01T23:27:40Z",
+    },
+]

--- a/tests/data/databricks/recipients.py
+++ b/tests/data/databricks/recipients.py
@@ -1,0 +1,31 @@
+from tests.data.databricks.metastore import DATABRICKS_METASTORE_ID
+
+# Shape returned by recipients.get() (the "recipients" list). One open (TOKEN)
+# recipient and one Databricks-to-Databricks recipient.
+DATABRICKS_RECIPIENTS = [
+    {
+        "name": "carto_test_recipient",
+        "authentication_type": "TOKEN",
+        "activated": True,
+        "owner": "jeremy@subimage.io",
+        "comment": "sub-1580 open-sharing test",
+        "cloud": "aws",
+        "region": "us-west-2",
+        "created_at": 1782952000000,
+        "created_by": "jeremy@subimage.io",
+        "updated_at": 1782952000000,
+    },
+    {
+        "name": "partner_account",
+        "authentication_type": "DATABRICKS",
+        "activated": True,
+        "owner": "jeremy@subimage.io",
+        "data_recipient_global_metastore_id": "aws:us-east-1:abc-def-partner",
+        "created_at": 1782952000000,
+        "created_by": "jeremy@subimage.io",
+    },
+]
+
+# Metastore-scoped node id for each recipient (uc_id(metastore_id, name)).
+RECIPIENT_TOKEN_ID = f"{DATABRICKS_METASTORE_ID}/carto_test_recipient"
+RECIPIENT_DB_ID = f"{DATABRICKS_METASTORE_ID}/partner_account"

--- a/tests/data/databricks/repos.py
+++ b/tests/data/databricks/repos.py
@@ -1,0 +1,11 @@
+# Shape returned by repos.get() (the "repos" list).
+DATABRICKS_REPOS = [
+    {
+        "id": 1877866129247212,
+        "url": "https://github.com/databricks/databricks-empty-ide-project",
+        "provider": "gitHub",
+        "branch": "ide",
+        "head_commit_id": "4d1d76f97c214268f5179bb321f7275e88f656cc",
+        "path": "/Users/jeremy@subimage.io/databricks-empty-ide-project",
+    },
+]

--- a/tests/data/databricks/serving_endpoints.py
+++ b/tests/data/databricks/serving_endpoints.py
@@ -1,0 +1,42 @@
+# Shape returned by serving_endpoints.get() (the "endpoints" list). One
+# Databricks-hosted foundation model and one external (third-party) model so
+# the external_model_provider egress signal is exercised.
+DATABRICKS_SERVING_ENDPOINTS = [
+    {
+        "name": "databricks-gpt-5-5",
+        "endpoint_type": "FOUNDATION_MODEL_API",
+        "task": "llm/v1/chat",
+        "permission_level": "CAN_MANAGE",
+        "creation_timestamp": 1776902400000,
+        "last_updated_timestamp": 1776902400000,
+        "state": {"ready": "READY", "config_update": "NOT_UPDATING"},
+        "config": {
+            "served_entities": [
+                {
+                    "name": "databricks-gpt-5-5",
+                    "entity_name": "system.ai.databricks-gpt-5-5",
+                    "type": "FOUNDATION_MODEL",
+                    "foundation_model": {"name": "system.ai.databricks-gpt-5-5"},
+                },
+            ],
+        },
+    },
+    {
+        "name": "external-openai-proxy",
+        "endpoint_type": "EXTERNAL_MODEL",
+        "task": "llm/v1/chat",
+        "creator": "jeremy@subimage.io",
+        "creation_timestamp": 1782900000000,
+        "last_updated_timestamp": 1782900000000,
+        "state": {"ready": "READY", "config_update": "NOT_UPDATING"},
+        "config": {
+            "served_entities": [
+                {
+                    "name": "openai-gpt4",
+                    "type": "EXTERNAL_MODEL",
+                    "external_model": {"provider": "openai", "name": "gpt-4o"},
+                },
+            ],
+        },
+    },
+]

--- a/tests/data/databricks/shares.py
+++ b/tests/data/databricks/shares.py
@@ -1,0 +1,16 @@
+from tests.data.databricks.metastore import DATABRICKS_METASTORE_ID
+
+# Shape returned by shares.get() (the "shares" list).
+DATABRICKS_SHARES = [
+    {
+        "id": "08069ca2-3917-4304-aa4c-a32ea240bbef",
+        "name": "carto_test_share",
+        "owner": "jeremy@subimage.io",
+        "comment": "sub-1580 test",
+        "created_at": 1782952357810,
+        "created_by": "jeremy@subimage.io",
+        "updated_at": 1782952357810,
+    },
+]
+
+SHARE_ID = f"{DATABRICKS_METASTORE_ID}/carto_test_share"

--- a/tests/data/databricks/sql_warehouses.py
+++ b/tests/data/databricks/sql_warehouses.py
@@ -1,0 +1,24 @@
+DATABRICKS_WAREHOUSE_ID = "dbd303693ea90e9c"
+
+# Shape returned by sql_warehouses.get() (the "warehouses" list).
+DATABRICKS_SQL_WAREHOUSES = [
+    {
+        "id": DATABRICKS_WAREHOUSE_ID,
+        "name": "Serverless Starter Warehouse",
+        "state": "STOPPED",
+        "cluster_size": "Small",
+        "size": "SMALL",
+        "warehouse_type": "PRO",
+        "enable_serverless_compute": True,
+        "enable_photon": True,
+        "auto_stop_mins": 10,
+        "auto_resume": True,
+        "spot_instance_policy": "COST_OPTIMIZED",
+        "channel": {"name": "CHANNEL_NAME_CURRENT"},
+        "min_num_clusters": 1,
+        "max_num_clusters": 1,
+        "num_clusters": 0,
+        "creator_name": "kunaal@subimage.io",
+        "jdbc_url": "jdbc:spark://dbc-aaeaddda-e52f.cloud.databricks.com:443/default",
+    },
+]

--- a/tests/integration/cartography/intel/databricks/test_alerts.py
+++ b/tests/integration/cartography/intel/databricks/test_alerts.py
@@ -1,0 +1,74 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.alerts
+from tests.data.databricks.alerts import DATABRICKS_ALERTS
+from tests.data.databricks.queries import DATABRICKS_QUERY_ID
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_queries import (
+    _ensure_local_neo4j_has_test_queries,
+)
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+_ALERT_ID = "b24eb01c-16d1-4235-9caa-428b62f969f2"
+
+
+@patch.object(
+    cartography.intel.databricks.alerts,
+    "get",
+    return_value=DATABRICKS_ALERTS,
+)
+def test_load_databricks_alerts(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+    _ensure_local_neo4j_has_test_queries(neo4j_session)
+
+    cartography.intel.databricks.alerts.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksAlert",
+        ["id", "display_name", "condition_op", "owner_user_name"],
+    ) == {
+        (
+            scoped(_ALERT_ID),
+            "carto-test-alert",
+            "GREATER_THAN",
+            "jeremy@subimage.io",
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksAlert",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {(scoped(_ALERT_ID), DATABRICKS_WORKSPACE_ID)}
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksAlert",
+        "id",
+        "DatabricksQuery",
+        "id",
+        "MONITORS",
+        rel_direction_right=True,
+    ) == {(scoped(_ALERT_ID), scoped(DATABRICKS_QUERY_ID))}

--- a/tests/integration/cartography/intel/databricks/test_apps.py
+++ b/tests/integration/cartography/intel/databricks/test_apps.py
@@ -1,0 +1,58 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.apps
+from tests.data.databricks.apps import DATABRICKS_APPS
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+@patch.object(
+    cartography.intel.databricks.apps,
+    "get",
+    return_value=DATABRICKS_APPS,
+)
+def test_load_databricks_apps(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+
+    cartography.intel.databricks.apps.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksApp",
+        ["id", "name", "app_state", "service_principal_client_id"],
+    ) == {
+        (
+            scoped("carto-test-app"),
+            "carto-test-app",
+            "UNAVAILABLE",
+            "7d58cdad-a4d5-4ba1-bd81-15dbde04c88c",
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksApp",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {(scoped("carto-test-app"), DATABRICKS_WORKSPACE_ID)}

--- a/tests/integration/cartography/intel/databricks/test_clean_rooms.py
+++ b/tests/integration/cartography/intel/databricks/test_clean_rooms.py
@@ -3,8 +3,11 @@ from unittest.mock import patch
 
 import cartography.intel.databricks.clean_rooms
 from tests.data.databricks.clean_rooms import DATABRICKS_CLEAN_ROOMS
+from tests.data.databricks.metastore import DATABRICKS_METASTORE_ID
 from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
-from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_metastores import (
+    _ensure_local_neo4j_has_test_metastore,
+)
 from tests.integration.cartography.intel.databricks.test_workspaces import (
     _ensure_local_neo4j_has_test_workspace,
 )
@@ -12,12 +15,13 @@ from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
+_CLEAN_ROOM_ID = f"{DATABRICKS_METASTORE_ID}/carto_test_clean_room"
 
 
 @patch.object(
     cartography.intel.databricks.clean_rooms,
     "get",
-    return_value=DATABRICKS_CLEAN_ROOMS,
+    return_value=(DATABRICKS_CLEAN_ROOMS, True),
 )
 def test_load_databricks_clean_rooms(mock_get, neo4j_session):
     api_session = Mock()
@@ -26,20 +30,23 @@ def test_load_databricks_clean_rooms(mock_get, neo4j_session):
         "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
     }
     _ensure_local_neo4j_has_test_workspace(neo4j_session)
+    _ensure_local_neo4j_has_test_metastore(neo4j_session)
 
-    cartography.intel.databricks.clean_rooms.sync(
+    complete = cartography.intel.databricks.clean_rooms.sync(
         neo4j_session,
         api_session,
         DATABRICKS_WORKSPACE_ID,
+        DATABRICKS_METASTORE_ID,
         common_job_parameters,
     )
+    assert complete is True
 
     assert check_nodes(
         neo4j_session,
         "DatabricksCleanRoom",
         ["id", "name", "access_restricted"],
     ) == {
-        (scoped("carto_test_clean_room"), "carto_test_clean_room", "CSP_MISCONFIGURED"),
+        (_CLEAN_ROOM_ID, "carto_test_clean_room", "CSP_MISCONFIGURED"),
     }
 
     assert check_rels(
@@ -50,4 +57,14 @@ def test_load_databricks_clean_rooms(mock_get, neo4j_session):
         "id",
         "RESOURCE",
         rel_direction_right=False,
-    ) == {(scoped("carto_test_clean_room"), DATABRICKS_WORKSPACE_ID)}
+    ) == {(_CLEAN_ROOM_ID, DATABRICKS_WORKSPACE_ID)}
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksMetastore",
+        "id",
+        "DatabricksCleanRoom",
+        "id",
+        "CONTAINS",
+        rel_direction_right=True,
+    ) == {(DATABRICKS_METASTORE_ID, _CLEAN_ROOM_ID)}

--- a/tests/integration/cartography/intel/databricks/test_clean_rooms.py
+++ b/tests/integration/cartography/intel/databricks/test_clean_rooms.py
@@ -1,0 +1,53 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.clean_rooms
+from tests.data.databricks.clean_rooms import DATABRICKS_CLEAN_ROOMS
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+@patch.object(
+    cartography.intel.databricks.clean_rooms,
+    "get",
+    return_value=DATABRICKS_CLEAN_ROOMS,
+)
+def test_load_databricks_clean_rooms(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+
+    cartography.intel.databricks.clean_rooms.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksCleanRoom",
+        ["id", "name", "access_restricted"],
+    ) == {
+        (scoped("carto_test_clean_room"), "carto_test_clean_room", "CSP_MISCONFIGURED"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksCleanRoom",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {(scoped("carto_test_clean_room"), DATABRICKS_WORKSPACE_ID)}

--- a/tests/integration/cartography/intel/databricks/test_dashboards.py
+++ b/tests/integration/cartography/intel/databricks/test_dashboards.py
@@ -1,0 +1,83 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.dashboards
+from tests.data.databricks.dashboards import DATABRICKS_LAKEVIEW_DASHBOARDS
+from tests.data.databricks.dashboards import DATABRICKS_LEGACY_DASHBOARDS
+from tests.data.databricks.sql_warehouses import DATABRICKS_WAREHOUSE_ID
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_sql_warehouses import (
+    _ensure_local_neo4j_has_test_warehouses,
+)
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+_LAKEVIEW_ID = "01f175a4ac071e099d6cc5ce1c8ba9fb"
+_LEGACY_ID = "9a1c2b3d-legacy-4567-89ab-cdef01234567"
+
+
+@patch.object(
+    cartography.intel.databricks.dashboards,
+    "get_legacy",
+    return_value=DATABRICKS_LEGACY_DASHBOARDS,
+)
+@patch.object(
+    cartography.intel.databricks.dashboards,
+    "get_lakeview",
+    return_value=DATABRICKS_LAKEVIEW_DASHBOARDS,
+)
+def test_load_databricks_dashboards(mock_lakeview, mock_legacy, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+    _ensure_local_neo4j_has_test_warehouses(neo4j_session)
+
+    cartography.intel.databricks.dashboards.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    # Both Lakeview and legacy dashboards land as one node type, discriminated
+    # by dashboard_type; legacy carries an owner and no warehouse.
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksDashboard",
+        ["id", "display_name", "dashboard_type", "owner_user_name"],
+    ) == {
+        (scoped(_LAKEVIEW_ID), "carto-test-dashboard", "LAKEVIEW", None),
+        (scoped(_LEGACY_ID), "legacy-sales-dashboard", "LEGACY", "kunaal@subimage.io"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksDashboard",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        (scoped(_LAKEVIEW_ID), DATABRICKS_WORKSPACE_ID),
+        (scoped(_LEGACY_ID), DATABRICKS_WORKSPACE_ID),
+    }
+
+    # Only the Lakeview dashboard carries a warehouse binding.
+    assert check_rels(
+        neo4j_session,
+        "DatabricksDashboard",
+        "id",
+        "DatabricksSqlWarehouse",
+        "id",
+        "USES_WAREHOUSE",
+        rel_direction_right=True,
+    ) == {(scoped(_LAKEVIEW_ID), scoped(DATABRICKS_WAREHOUSE_ID))}

--- a/tests/integration/cartography/intel/databricks/test_data_sources.py
+++ b/tests/integration/cartography/intel/databricks/test_data_sources.py
@@ -1,0 +1,74 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.data_sources
+from tests.data.databricks.data_sources import DATABRICKS_DATA_SOURCES
+from tests.data.databricks.sql_warehouses import DATABRICKS_WAREHOUSE_ID
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_sql_warehouses import (
+    _ensure_local_neo4j_has_test_warehouses,
+)
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+_DATA_SOURCE_ID = "1811cbc7-42e8-46f9-875c-b613109cd172"
+
+
+@patch.object(
+    cartography.intel.databricks.data_sources,
+    "get",
+    return_value=DATABRICKS_DATA_SOURCES,
+)
+def test_load_databricks_data_sources(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+    _ensure_local_neo4j_has_test_warehouses(neo4j_session)
+
+    cartography.intel.databricks.data_sources.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksDataSource",
+        ["id", "name", "type", "warehouse_id"],
+    ) == {
+        (
+            scoped(_DATA_SOURCE_ID),
+            "Serverless Starter Warehouse",
+            "databricks_internal",
+            DATABRICKS_WAREHOUSE_ID,
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksDataSource",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {(scoped(_DATA_SOURCE_ID), DATABRICKS_WORKSPACE_ID)}
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksDataSource",
+        "id",
+        "DatabricksSqlWarehouse",
+        "id",
+        "BACKED_BY",
+        rel_direction_right=True,
+    ) == {(scoped(_DATA_SOURCE_ID), scoped(DATABRICKS_WAREHOUSE_ID))}

--- a/tests/integration/cartography/intel/databricks/test_genie_spaces.py
+++ b/tests/integration/cartography/intel/databricks/test_genie_spaces.py
@@ -1,0 +1,69 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.genie_spaces
+from tests.data.databricks.genie_spaces import DATABRICKS_GENIE_SPACES
+from tests.data.databricks.sql_warehouses import DATABRICKS_WAREHOUSE_ID
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_sql_warehouses import (
+    _ensure_local_neo4j_has_test_warehouses,
+)
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+_SPACE_ID = "01f1749e632b10acab9da9a9ca010dfb"
+
+
+@patch.object(
+    cartography.intel.databricks.genie_spaces,
+    "get",
+    return_value=DATABRICKS_GENIE_SPACES,
+)
+def test_load_databricks_genie_spaces(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+    _ensure_local_neo4j_has_test_warehouses(neo4j_session)
+
+    cartography.intel.databricks.genie_spaces.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksGenieSpace",
+        ["id", "title", "warehouse_id"],
+    ) == {
+        (scoped(_SPACE_ID), "Bakehouse Sales Starter Space", DATABRICKS_WAREHOUSE_ID),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksGenieSpace",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {(scoped(_SPACE_ID), DATABRICKS_WORKSPACE_ID)}
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksGenieSpace",
+        "id",
+        "DatabricksSqlWarehouse",
+        "id",
+        "USES_WAREHOUSE",
+        rel_direction_right=True,
+    ) == {(scoped(_SPACE_ID), scoped(DATABRICKS_WAREHOUSE_ID))}

--- a/tests/integration/cartography/intel/databricks/test_git_credentials.py
+++ b/tests/integration/cartography/intel/databricks/test_git_credentials.py
@@ -1,0 +1,52 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.git_credentials
+from tests.data.databricks.git_credentials import DATABRICKS_GIT_CREDENTIALS
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+_CREDENTIAL_ID = "6273842934"
+
+
+@patch.object(
+    cartography.intel.databricks.git_credentials,
+    "get",
+    return_value=DATABRICKS_GIT_CREDENTIALS,
+)
+def test_load_databricks_git_credentials(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+
+    cartography.intel.databricks.git_credentials.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksGitCredential",
+        ["id", "git_provider", "git_username"],
+    ) == {(scoped(_CREDENTIAL_ID), "gitHub", "carto-bot")}
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksGitCredential",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {(scoped(_CREDENTIAL_ID), DATABRICKS_WORKSPACE_ID)}

--- a/tests/integration/cartography/intel/databricks/test_jobs.py
+++ b/tests/integration/cartography/intel/databricks/test_jobs.py
@@ -1,0 +1,154 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.clusters
+import cartography.intel.databricks.jobs
+from tests.data.databricks.clusters import DATABRICKS_CLUSTERS
+from tests.data.databricks.jobs import DATABRICKS_JOBS
+from tests.data.databricks.sql_warehouses import DATABRICKS_WAREHOUSE_ID
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_pipelines import (
+    _ensure_local_neo4j_has_test_pipelines,
+)
+from tests.integration.cartography.intel.databricks.test_pipelines import (
+    _ensure_local_neo4j_has_test_principals,
+)
+from tests.integration.cartography.intel.databricks.test_sql_warehouses import (
+    _ensure_local_neo4j_has_test_warehouses,
+)
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+_JOB1 = "1011944831447606"
+_JOB2 = "2022955942558717"
+_PIPELINE_ID = "e66810c3-f9ba-4bbd-b9af-4e23bd2de755"
+
+
+@patch.object(
+    cartography.intel.databricks.jobs,
+    "get",
+    return_value=DATABRICKS_JOBS,
+)
+def test_load_databricks_jobs(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+    _ensure_local_neo4j_has_test_principals(neo4j_session)
+    _ensure_local_neo4j_has_test_warehouses(neo4j_session)
+    _ensure_local_neo4j_has_test_pipelines(neo4j_session)
+    cartography.intel.databricks.clusters.load_clusters(
+        neo4j_session,
+        cartography.intel.databricks.clusters.transform(
+            DATABRICKS_CLUSTERS, DATABRICKS_WORKSPACE_ID
+        ),
+        DATABRICKS_WORKSPACE_ID,
+        TEST_UPDATE_TAG,
+    )
+
+    cartography.intel.databricks.jobs.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksJob",
+        ["id", "name", "schedule_pause_status", "continuous"],
+    ) == {
+        (scoped(_JOB1), "carto-test-job", "PAUSED", False),
+        (scoped(_JOB2), "carto-sp-job", None, True),
+    }
+
+    # Job -> Workspace RESOURCE
+    assert check_rels(
+        neo4j_session,
+        "DatabricksJob",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        (scoped(_JOB1), DATABRICKS_WORKSPACE_ID),
+        (scoped(_JOB2), DATABRICKS_WORKSPACE_ID),
+    }
+
+    # Job -> User RUN_AS (job 1 runs as a user)
+    assert check_rels(
+        neo4j_session,
+        "DatabricksJob",
+        "id",
+        "DatabricksUser",
+        "id",
+        "RUN_AS",
+        rel_direction_right=True,
+    ) == {(scoped(_JOB1), scoped("70718330587535"))}
+
+    # Job -> ServicePrincipal RUN_AS (job 2 runs as a service principal)
+    assert check_rels(
+        neo4j_session,
+        "DatabricksJob",
+        "id",
+        "DatabricksServicePrincipal",
+        "id",
+        "RUN_AS",
+        rel_direction_right=True,
+    ) == {(scoped(_JOB2), scoped("12345678901234"))}
+
+    # Job -> Task HAS_TASK
+    assert check_rels(
+        neo4j_session,
+        "DatabricksJob",
+        "id",
+        "DatabricksJobTask",
+        "id",
+        "HAS_TASK",
+        rel_direction_right=True,
+    ) == {
+        (scoped(_JOB1), f"{scoped(_JOB1)}/carto_task_nb"),
+        (scoped(_JOB1), f"{scoped(_JOB1)}/refresh_pipeline"),
+        (scoped(_JOB2), f"{scoped(_JOB2)}/sp_task"),
+    }
+
+    # Task -> Pipeline RUNS_PIPELINE (only the pipeline_task)
+    assert check_rels(
+        neo4j_session,
+        "DatabricksJobTask",
+        "id",
+        "DatabricksPipeline",
+        "id",
+        "RUNS_PIPELINE",
+        rel_direction_right=True,
+    ) == {(f"{scoped(_JOB1)}/refresh_pipeline", scoped(_PIPELINE_ID))}
+
+    # Task -> Warehouse USES_WAREHOUSE (the sql_task)
+    assert check_rels(
+        neo4j_session,
+        "DatabricksJobTask",
+        "id",
+        "DatabricksSqlWarehouse",
+        "id",
+        "USES_WAREHOUSE",
+        rel_direction_right=True,
+    ) == {(f"{scoped(_JOB1)}/refresh_pipeline", scoped(DATABRICKS_WAREHOUSE_ID))}
+
+    # Task -> Cluster USES_CLUSTER (the task targeting an existing cluster)
+    assert check_rels(
+        neo4j_session,
+        "DatabricksJobTask",
+        "id",
+        "DatabricksCluster",
+        "id",
+        "USES_CLUSTER",
+        rel_direction_right=True,
+    ) == {(f"{scoped(_JOB2)}/sp_task", scoped("0202-cluster-aaaa"))}

--- a/tests/integration/cartography/intel/databricks/test_notebooks.py
+++ b/tests/integration/cartography/intel/databricks/test_notebooks.py
@@ -1,0 +1,83 @@
+from unittest.mock import patch
+
+import cartography.intel.databricks.jobs
+import cartography.intel.databricks.notebooks
+from tests.data.databricks.jobs import DATABRICKS_JOBS
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+_JOB1 = "1011944831447606"
+_JOB2 = "2022955942558717"
+_NB1 = "/Users/jeremy@subimage.io/carto_test_nb"
+_NB2 = "/Shared/sp_nb"
+
+
+def _seed_job_tasks(neo4j_session):
+    cartography.intel.databricks.jobs.load_tasks(
+        neo4j_session,
+        cartography.intel.databricks.jobs.transform_tasks(
+            DATABRICKS_JOBS, DATABRICKS_WORKSPACE_ID
+        ),
+        DATABRICKS_WORKSPACE_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.databricks.notebooks,
+    "get_referenced_notebook_paths",
+    wraps=cartography.intel.databricks.notebooks.get_referenced_notebook_paths,
+)
+def test_load_databricks_notebooks(mock_get, neo4j_session):
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+    _seed_job_tasks(neo4j_session)
+
+    cartography.intel.databricks.notebooks.sync(
+        neo4j_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    # One node per distinct notebook path referenced by a task; no other
+    # workspace content is walked.
+    assert check_nodes(neo4j_session, "DatabricksNotebook", ["id", "path"]) == {
+        (scoped(_NB1), _NB1),
+        (scoped(_NB2), _NB2),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksNotebook",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        (scoped(_NB1), DATABRICKS_WORKSPACE_ID),
+        (scoped(_NB2), DATABRICKS_WORKSPACE_ID),
+    }
+
+    # Each notebook task links to the notebook it runs.
+    assert check_rels(
+        neo4j_session,
+        "DatabricksJobTask",
+        "id",
+        "DatabricksNotebook",
+        "id",
+        "RUNS_NOTEBOOK",
+        rel_direction_right=True,
+    ) == {
+        (f"{scoped(_JOB1)}/carto_task_nb", scoped(_NB1)),
+        (f"{scoped(_JOB2)}/sp_task", scoped(_NB2)),
+    }

--- a/tests/integration/cartography/intel/databricks/test_pipelines.py
+++ b/tests/integration/cartography/intel/databricks/test_pipelines.py
@@ -1,0 +1,127 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.pipelines
+import cartography.intel.databricks.service_principals
+import cartography.intel.databricks.users
+from tests.data.databricks.metastore import DATABRICKS_METASTORE_ID
+from tests.data.databricks.pipelines import DATABRICKS_PIPELINES
+from tests.data.databricks.service_principals import DATABRICKS_SERVICE_PRINCIPALS
+from tests.data.databricks.users import DATABRICKS_USERS
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_catalogs import (
+    _ensure_local_neo4j_has_test_catalogs,
+)
+from tests.integration.cartography.intel.databricks.test_metastores import (
+    _ensure_local_neo4j_has_test_metastore,
+)
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+_PIPELINE_ID = "e66810c3-f9ba-4bbd-b9af-4e23bd2de755"
+
+
+def _ensure_local_neo4j_has_test_principals(neo4j_session):
+    cartography.intel.databricks.users.load_users(
+        neo4j_session,
+        cartography.intel.databricks.users.transform(
+            DATABRICKS_USERS, DATABRICKS_WORKSPACE_ID
+        ),
+        DATABRICKS_WORKSPACE_ID,
+        TEST_UPDATE_TAG,
+    )
+    cartography.intel.databricks.service_principals.load_service_principals(
+        neo4j_session,
+        cartography.intel.databricks.service_principals.transform(
+            DATABRICKS_SERVICE_PRINCIPALS, DATABRICKS_WORKSPACE_ID
+        ),
+        DATABRICKS_WORKSPACE_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+def _ensure_local_neo4j_has_test_pipelines(neo4j_session):
+    cartography.intel.databricks.pipelines.load_pipelines(
+        neo4j_session,
+        cartography.intel.databricks.pipelines.transform(
+            DATABRICKS_PIPELINES, DATABRICKS_WORKSPACE_ID, DATABRICKS_METASTORE_ID, {}
+        ),
+        DATABRICKS_WORKSPACE_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.databricks.pipelines,
+    "get",
+    return_value=DATABRICKS_PIPELINES,
+)
+def test_load_databricks_pipelines(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+    _ensure_local_neo4j_has_test_metastore(neo4j_session)
+    _ensure_local_neo4j_has_test_catalogs(neo4j_session)
+    _ensure_local_neo4j_has_test_principals(neo4j_session)
+
+    cartography.intel.databricks.pipelines.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        DATABRICKS_METASTORE_ID,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksPipeline",
+        ["id", "name", "catalog", "target_schema", "serverless"],
+    ) == {
+        (
+            scoped(_PIPELINE_ID),
+            "carto-test-pipeline",
+            "workspace",
+            "carto_test_schema",
+            True,
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksPipeline",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {(scoped(_PIPELINE_ID), DATABRICKS_WORKSPACE_ID)}
+
+    # Pipeline -> Catalog PUBLISHES_TO (catalog id is metastore-scoped).
+    assert check_rels(
+        neo4j_session,
+        "DatabricksPipeline",
+        "id",
+        "DatabricksCatalog",
+        "id",
+        "PUBLISHES_TO",
+        rel_direction_right=True,
+    ) == {(scoped(_PIPELINE_ID), f"{DATABRICKS_METASTORE_ID}/workspace")}
+
+    # Pipeline -> User RUN_AS (resolved to the workspace-scoped principal id).
+    assert check_rels(
+        neo4j_session,
+        "DatabricksPipeline",
+        "id",
+        "DatabricksUser",
+        "id",
+        "RUN_AS",
+        rel_direction_right=True,
+    ) == {(scoped(_PIPELINE_ID), scoped("70718330587535"))}

--- a/tests/integration/cartography/intel/databricks/test_providers.py
+++ b/tests/integration/cartography/intel/databricks/test_providers.py
@@ -1,0 +1,67 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.providers
+from tests.data.databricks.metastore import DATABRICKS_METASTORE_ID
+from tests.data.databricks.providers import DATABRICKS_PROVIDERS
+from tests.data.databricks.providers import PROVIDER_ID
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.integration.cartography.intel.databricks.test_metastores import (
+    _ensure_local_neo4j_has_test_metastore,
+)
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+@patch.object(
+    cartography.intel.databricks.providers,
+    "get",
+    return_value=DATABRICKS_PROVIDERS,
+)
+def test_load_databricks_providers(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+    _ensure_local_neo4j_has_test_metastore(neo4j_session)
+
+    cartography.intel.databricks.providers.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        DATABRICKS_METASTORE_ID,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksProvider",
+        ["id", "name", "authentication_type"],
+    ) == {(PROVIDER_ID, "acme_data_provider", "TOKEN")}
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksProvider",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {(PROVIDER_ID, DATABRICKS_WORKSPACE_ID)}
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksMetastore",
+        "id",
+        "DatabricksProvider",
+        "id",
+        "CONTAINS",
+        rel_direction_right=True,
+    ) == {(DATABRICKS_METASTORE_ID, PROVIDER_ID)}

--- a/tests/integration/cartography/intel/databricks/test_queries.py
+++ b/tests/integration/cartography/intel/databricks/test_queries.py
@@ -1,0 +1,85 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.queries
+from tests.data.databricks.queries import DATABRICKS_QUERIES
+from tests.data.databricks.queries import DATABRICKS_QUERY_ID
+from tests.data.databricks.sql_warehouses import DATABRICKS_WAREHOUSE_ID
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_sql_warehouses import (
+    _ensure_local_neo4j_has_test_warehouses,
+)
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+def _ensure_local_neo4j_has_test_queries(neo4j_session):
+    cartography.intel.databricks.queries.load_queries(
+        neo4j_session,
+        cartography.intel.databricks.queries.transform(
+            DATABRICKS_QUERIES, DATABRICKS_WORKSPACE_ID
+        ),
+        DATABRICKS_WORKSPACE_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.databricks.queries,
+    "get",
+    return_value=DATABRICKS_QUERIES,
+)
+def test_load_databricks_queries(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+    _ensure_local_neo4j_has_test_warehouses(neo4j_session)
+
+    cartography.intel.databricks.queries.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksQuery",
+        ["id", "display_name", "owner_user_name", "run_as_mode"],
+    ) == {
+        (
+            scoped(DATABRICKS_QUERY_ID),
+            "carto-test-query",
+            "jeremy@subimage.io",
+            "OWNER",
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksQuery",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {(scoped(DATABRICKS_QUERY_ID), DATABRICKS_WORKSPACE_ID)}
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksQuery",
+        "id",
+        "DatabricksSqlWarehouse",
+        "id",
+        "USES_WAREHOUSE",
+        rel_direction_right=True,
+    ) == {(scoped(DATABRICKS_QUERY_ID), scoped(DATABRICKS_WAREHOUSE_ID))}

--- a/tests/integration/cartography/intel/databricks/test_recipients.py
+++ b/tests/integration/cartography/intel/databricks/test_recipients.py
@@ -1,0 +1,88 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.recipients
+from tests.data.databricks.metastore import DATABRICKS_METASTORE_ID
+from tests.data.databricks.recipients import DATABRICKS_RECIPIENTS
+from tests.data.databricks.recipients import RECIPIENT_DB_ID
+from tests.data.databricks.recipients import RECIPIENT_TOKEN_ID
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.integration.cartography.intel.databricks.test_metastores import (
+    _ensure_local_neo4j_has_test_metastore,
+)
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+def _ensure_local_neo4j_has_test_recipients(neo4j_session):
+    cartography.intel.databricks.recipients.load_recipients(
+        neo4j_session,
+        cartography.intel.databricks.recipients.transform(
+            DATABRICKS_RECIPIENTS, DATABRICKS_METASTORE_ID
+        ),
+        DATABRICKS_WORKSPACE_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.databricks.recipients,
+    "get",
+    return_value=DATABRICKS_RECIPIENTS,
+)
+def test_load_databricks_recipients(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+    _ensure_local_neo4j_has_test_metastore(neo4j_session)
+
+    cartography.intel.databricks.recipients.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        DATABRICKS_METASTORE_ID,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksRecipient",
+        ["id", "name", "authentication_type"],
+    ) == {
+        (RECIPIENT_TOKEN_ID, "carto_test_recipient", "TOKEN"),
+        (RECIPIENT_DB_ID, "partner_account", "DATABRICKS"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksRecipient",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        (RECIPIENT_TOKEN_ID, DATABRICKS_WORKSPACE_ID),
+        (RECIPIENT_DB_ID, DATABRICKS_WORKSPACE_ID),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksMetastore",
+        "id",
+        "DatabricksRecipient",
+        "id",
+        "CONTAINS",
+        rel_direction_right=True,
+    ) == {
+        (DATABRICKS_METASTORE_ID, RECIPIENT_TOKEN_ID),
+        (DATABRICKS_METASTORE_ID, RECIPIENT_DB_ID),
+    }

--- a/tests/integration/cartography/intel/databricks/test_repos.py
+++ b/tests/integration/cartography/intel/databricks/test_repos.py
@@ -1,0 +1,52 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.repos
+from tests.data.databricks.repos import DATABRICKS_REPOS
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+_REPO_ID = "1877866129247212"
+
+
+@patch.object(
+    cartography.intel.databricks.repos,
+    "get",
+    return_value=DATABRICKS_REPOS,
+)
+def test_load_databricks_repos(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+
+    cartography.intel.databricks.repos.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksRepo",
+        ["id", "provider", "branch"],
+    ) == {(scoped(_REPO_ID), "gitHub", "ide")}
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksRepo",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {(scoped(_REPO_ID), DATABRICKS_WORKSPACE_ID)}

--- a/tests/integration/cartography/intel/databricks/test_serving_endpoints.py
+++ b/tests/integration/cartography/intel/databricks/test_serving_endpoints.py
@@ -1,0 +1,90 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.serving_endpoints
+from tests.data.databricks.serving_endpoints import DATABRICKS_SERVING_ENDPOINTS
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+@patch.object(
+    cartography.intel.databricks.serving_endpoints,
+    "get",
+    return_value=DATABRICKS_SERVING_ENDPOINTS,
+)
+def test_load_databricks_serving_endpoints(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+
+    cartography.intel.databricks.serving_endpoints.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksServingEndpoint",
+        ["id", "name", "endpoint_type"],
+    ) == {
+        (scoped("databricks-gpt-5-5"), "databricks-gpt-5-5", "FOUNDATION_MODEL_API"),
+        (scoped("external-openai-proxy"), "external-openai-proxy", "EXTERNAL_MODEL"),
+    }
+
+    # Served entities, incl. the external-model egress signal.
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksServedEntity",
+        ["id", "entity_type", "external_model_provider"],
+    ) == {
+        (
+            scoped("databricks-gpt-5-5") + "/databricks-gpt-5-5",
+            "FOUNDATION_MODEL",
+            None,
+        ),
+        (scoped("external-openai-proxy") + "/openai-gpt4", "EXTERNAL_MODEL", "openai"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksServingEndpoint",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        (scoped("databricks-gpt-5-5"), DATABRICKS_WORKSPACE_ID),
+        (scoped("external-openai-proxy"), DATABRICKS_WORKSPACE_ID),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksServingEndpoint",
+        "id",
+        "DatabricksServedEntity",
+        "id",
+        "SERVES",
+        rel_direction_right=True,
+    ) == {
+        (
+            scoped("databricks-gpt-5-5"),
+            scoped("databricks-gpt-5-5") + "/databricks-gpt-5-5",
+        ),
+        (
+            scoped("external-openai-proxy"),
+            scoped("external-openai-proxy") + "/openai-gpt4",
+        ),
+    }

--- a/tests/integration/cartography/intel/databricks/test_shares.py
+++ b/tests/integration/cartography/intel/databricks/test_shares.py
@@ -1,0 +1,76 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.shares
+from tests.data.databricks.metastore import DATABRICKS_METASTORE_ID
+from tests.data.databricks.recipients import RECIPIENT_TOKEN_ID
+from tests.data.databricks.shares import DATABRICKS_SHARES
+from tests.data.databricks.shares import SHARE_ID
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.integration.cartography.intel.databricks.test_metastores import (
+    _ensure_local_neo4j_has_test_metastore,
+)
+from tests.integration.cartography.intel.databricks.test_recipients import (
+    _ensure_local_neo4j_has_test_recipients,
+)
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+@patch.object(
+    cartography.intel.databricks.shares,
+    "_recipient_names",
+    return_value=["carto_test_recipient"],
+)
+@patch.object(
+    cartography.intel.databricks.shares,
+    "get",
+    return_value=DATABRICKS_SHARES,
+)
+def test_load_databricks_shares(mock_get, mock_perms, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+    _ensure_local_neo4j_has_test_metastore(neo4j_session)
+    _ensure_local_neo4j_has_test_recipients(neo4j_session)
+
+    cartography.intel.databricks.shares.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        DATABRICKS_METASTORE_ID,
+        common_job_parameters,
+    )
+
+    assert check_nodes(neo4j_session, "DatabricksShare", ["id", "name", "owner"]) == {
+        (SHARE_ID, "carto_test_share", "jeremy@subimage.io")
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksMetastore",
+        "id",
+        "DatabricksShare",
+        "id",
+        "CONTAINS",
+        rel_direction_right=True,
+    ) == {(DATABRICKS_METASTORE_ID, SHARE_ID)}
+
+    # Share -> Recipient SHARED_WITH, from the share's permission assignments.
+    assert check_rels(
+        neo4j_session,
+        "DatabricksShare",
+        "id",
+        "DatabricksRecipient",
+        "id",
+        "SHARED_WITH",
+        rel_direction_right=True,
+    ) == {(SHARE_ID, RECIPIENT_TOKEN_ID)}

--- a/tests/integration/cartography/intel/databricks/test_sql_warehouses.py
+++ b/tests/integration/cartography/intel/databricks/test_sql_warehouses.py
@@ -1,0 +1,71 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.databricks.sql_warehouses
+from tests.data.databricks.sql_warehouses import DATABRICKS_SQL_WAREHOUSES
+from tests.data.databricks.sql_warehouses import DATABRICKS_WAREHOUSE_ID
+from tests.data.databricks.workspace import DATABRICKS_WORKSPACE_ID
+from tests.data.databricks.workspace import scoped
+from tests.integration.cartography.intel.databricks.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspace,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+def _ensure_local_neo4j_has_test_warehouses(neo4j_session):
+    cartography.intel.databricks.sql_warehouses.load_warehouses(
+        neo4j_session,
+        cartography.intel.databricks.sql_warehouses.transform(
+            DATABRICKS_SQL_WAREHOUSES, DATABRICKS_WORKSPACE_ID
+        ),
+        DATABRICKS_WORKSPACE_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.databricks.sql_warehouses,
+    "get",
+    return_value=DATABRICKS_SQL_WAREHOUSES,
+)
+def test_load_databricks_sql_warehouses(mock_get, neo4j_session):
+    api_session = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "WORKSPACE_ID": DATABRICKS_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_workspace(neo4j_session)
+
+    cartography.intel.databricks.sql_warehouses.sync(
+        neo4j_session,
+        api_session,
+        DATABRICKS_WORKSPACE_ID,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "DatabricksSqlWarehouse",
+        ["id", "warehouse_id", "name", "enable_serverless_compute", "warehouse_type"],
+    ) == {
+        (
+            scoped(DATABRICKS_WAREHOUSE_ID),
+            DATABRICKS_WAREHOUSE_ID,
+            "Serverless Starter Warehouse",
+            True,
+            "PRO",
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "DatabricksSqlWarehouse",
+        "id",
+        "DatabricksWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {(scoped(DATABRICKS_WAREHOUSE_ID), DATABRICKS_WORKSPACE_ID)}

--- a/tests/unit/cartography/intel/databricks/test_util.py
+++ b/tests/unit/cartography/intel/databricks/test_util.py
@@ -1,4 +1,20 @@
+from datetime import timezone
+
+from cartography.intel.databricks.util import iso_to_datetime
 from cartography.intel.databricks.util import parse_storage_url
+
+
+def test_iso_to_datetime():
+    # Trailing Z (RFC-3339) and explicit offsets both parse to aware datetimes.
+    dt = iso_to_datetime("2026-07-01T23:27:40Z")
+    assert dt is not None
+    assert dt.tzinfo is not None
+    assert dt.astimezone(timezone.utc).hour == 23
+    # Fractional seconds (Lakeview) parse too.
+    assert iso_to_datetime("2026-07-01T23:29:14.783Z") is not None
+    # Empty / missing values are dropped.
+    assert iso_to_datetime(None) is None
+    assert iso_to_datetime("") is None
 
 
 def test_parse_storage_url():


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Extends the Databricks module beyond identity / compute / Unity Catalog to cover
workspace workloads, ML serving + apps + content, and Delta Sharing. Three
self-contained commits, one per area:

**Jobs + SQL** (`DatabricksJob`, `DatabricksJobTask`, `DatabricksPipeline`,
`DatabricksSqlWarehouse`, `DatabricksQuery`, `DatabricksAlert`,
`DatabricksDataSource`, `DatabricksDashboard`)
- Jobs + tasks with run-as identity, and task edges to the pipeline / cluster /
  warehouse each task drives (`RUNS_PIPELINE`, `USES_CLUSTER`, `USES_WAREHOUSE`).
- DLT pipelines with run-as and `PUBLISHES_TO` the Unity Catalog catalog.
- SQL warehouses (incl. serverless flag), saved queries, alerts (`MONITORS` a
  query), data sources (`BACKED_BY` a warehouse), and Lakeview + legacy
  dashboards folded into one node by `dashboard_type`.

**ML serving + apps + content** (`DatabricksServingEndpoint`,
`DatabricksServedEntity`, `DatabricksGenieSpace`, `DatabricksApp`,
`DatabricksRepo`, `DatabricksGitCredential`, `DatabricksNotebook`)
- Serving endpoints + served entities (`SERVES`); served entities carry the
  third-party provider for `EXTERNAL_MODEL` egress visibility.
- Genie spaces (`USES_WAREHOUSE`), Databricks Apps (with the run-as service
  principal client id retained), repos and stored git credentials.
- Notebooks are materialised lazily from the paths job tasks reference (no
  workspace-tree walk, no content/permissions), carrying the code-to-cloud
  `(:DatabricksJobTask)-[:RUNS_NOTEBOOK]->(:DatabricksNotebook)` edge.

**Delta Sharing** (`DatabricksShare`, `DatabricksRecipient`,
`DatabricksProvider`, `DatabricksCleanRoom`)
- Shares (`CONTAINS` from metastore) with a `SHARED_WITH` edge to recipients
  built from each share's permission assignments.
- Recipients expose `authentication_type` (TOKEN = open bearer-token external
  sharing vs DATABRICKS = account-to-account), providers, and clean rooms
  (skipped gracefully when external OpenSharing is disabled on the metastore).

Repos are listed under `path_prefix=/Workspace`: without a prefix the endpoint
only returns legacy `/Repos`-rooted repos and silently omits git folders under
user home directories. Delta Sharing cleanup is centralised in
`_cleanup_unity_catalog` so the no-metastore path purges those nodes too, and a
skipped share-permission fetch carries forward the last-known recipients so
`SHARED_WITH` edges are not dropped on a transient 403/404.

Account-level surfaces (cloud account configs, OAuth custom app integrations,
service principal federation policies) live on the `accounts` API and are left
to the account-level module.


### How was this tested?

- `make test_lint` passes; 46 Databricks unit + integration tests pass locally.
- End-to-end against a live Databricks workspace: created real resources (jobs
  with notebook / pipeline / SQL tasks, a DLT pipeline, query, alert, dashboard,
  app, repo, share, notebook), ran the sync, verified the nodes and edges landed
  (e.g. `JobTask-[:RUNS_PIPELINE|USES_WAREHOUSE|RUNS_NOTEBOOK]`, `Pipeline-[:PUBLISHES_TO]->Catalog`,
  `Share-[:CONTAINS]-Metastore`, 37 serving endpoints + 37 served entities), then
  deleted the resources. Clean rooms gracefully skipped where external
  OpenSharing is disabled.

Sample sync logs from the live workspace:

```
INFO:cartography.client.core.tx:Loaded 1 DatabricksWorkspace nodes
INFO:cartography.client.core.tx:Loaded 37 DatabricksServingEndpoint nodes
INFO:cartography.client.core.tx:Loaded 37 DatabricksServedEntity nodes
```


### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [x] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [x] Updated the schema documentation (`docs/root/modules/databricks/schema.md`).

#### If you are implementing a new intel module
- [x] Used the NodeSchema data model.


### Notes for reviewers

Each area is its own commit and can be reviewed independently. New node types are
workspace-scoped; Delta Sharing and Unity-Catalog-adjacent nodes are
metastore-scoped and cleaned centrally so they are purged when a workspace loses
its metastore.
