### PR TITLE
fix(subimage): read snake_case tenant fields from API response

### DIFF
--- a/cartography/intel/subimage/tenant.py
+++ b/cartography/intel/subimage/tenant.py
@@ -36,9 +36,9 @@ def transform(raw: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for tenant in raw:
         result.append(
             {
-                "id": tenant["tenantId"],
-                "account_id": tenant["accountId"],
-                "scan_role_name": tenant["scanRoleName"],
+                "id": tenant["tenant_id"],
+                "account_id": tenant["account_id"],
+                "scan_role_name": tenant["scan_role_name"],
             }
         )
     return result

--- a/tests/data/subimage/tenant.py
+++ b/tests/data/subimage/tenant.py
@@ -1,8 +1,8 @@
 SUBIMAGE_TENANT = [
     {
-        "tenantId": "tenant-abc-123",
-        "accountId": "acct-001",
-        "scanRoleName": "SubImageScanRole",
+        "tenant_id": "tenant-abc-123",
+        "account_id": "acct-001",
+        "scan_role_name": "SubImageScanRole",
     },
 ]
 


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary

The SubImage tenant endpoint transform was the only parser in the module still reading camelCase response keys (`tenantId`, `accountId`, `scanRoleName`). An upcoming SubImage API release drops camelCase in favor of snake_case everywhere. Because `tenant.sync()` runs first and every other per-tenant sync (team, apikeys, neo4jusers, modules, frameworks) keys off the tenant `id`, this would have raised a `KeyError` and broken the entire module.

An audit of the whole module confirmed the other five endpoint transforms already read snake_case, so no other files need changing. The OAuth token exchange in `util.py` targets WorkOS/authkit rather than the SubImage API and is unaffected.

This PR switches the tenant transform to `tenant_id` / `account_id` / `scan_role_name` and updates the test fixture to match.

### How was this tested?

- Updated the tenant test fixture to the new snake_case shape; `test_sync_subimage_tenant` exercises `sync()` → `transform()` and asserts the loaded nodes are unchanged.
- `pre-commit` (isort, black, flake8, pyupgrade, mypy) passes on the changed files.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally.
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.