### PR TITLE
feat(scaleway): IAM permissions, ontology coverage, and container code-to-cloud

### DIFF
--- a/cartography/intel/github/supply_chain.py
+++ b/cartography/intel/github/supply_chain.py
@@ -11,6 +11,7 @@ from cartography.intel.github.util import call_github_rest_api
 from cartography.intel.supply_chain import ContainerImage
 from cartography.intel.supply_chain import convert_layer_history_records
 from cartography.intel.supply_chain import get_unmatched_gcp_images_with_history
+from cartography.intel.supply_chain import get_unmatched_scaleway_images_with_history
 from cartography.intel.supply_chain import match_images_to_dockerfiles
 from cartography.intel.supply_chain import parse_dockerfile_info
 from cartography.intel.supply_chain import transform_matches_for_matchlink
@@ -502,6 +503,17 @@ def sync(
     )
     if remaining_limit != 0:
         unmatched += get_unmatched_gcp_images_with_history(
+            neo4j_session,
+            sub_resource_label="GitHubOrganization",
+            sub_resource_id=organization,
+            update_tag=update_tag,
+            limit=remaining_limit,
+        )
+    remaining_limit = (
+        None if image_limit is None else max(image_limit - len(unmatched), 0)
+    )
+    if remaining_limit != 0:
+        unmatched += get_unmatched_scaleway_images_with_history(
             neo4j_session,
             sub_resource_label="GitHubOrganization",
             sub_resource_id=organization,

--- a/cartography/intel/gitlab/supply_chain.py
+++ b/cartography/intel/gitlab/supply_chain.py
@@ -13,6 +13,7 @@ from cartography.intel.gitlab.util import get_single
 from cartography.intel.supply_chain import ContainerImage
 from cartography.intel.supply_chain import convert_layer_history_records
 from cartography.intel.supply_chain import get_unmatched_gcp_images_with_history
+from cartography.intel.supply_chain import get_unmatched_scaleway_images_with_history
 from cartography.intel.supply_chain import match_images_to_dockerfiles
 from cartography.intel.supply_chain import parse_dockerfile_info
 from cartography.intel.supply_chain import transform_matches_for_matchlink
@@ -433,6 +434,17 @@ def sync(
     )
     if remaining_limit != 0:
         unmatched += get_unmatched_gcp_images_with_history(
+            neo4j_session,
+            sub_resource_label="GitLabOrganization",
+            sub_resource_id=organization_id,
+            update_tag=update_tag,
+            limit=remaining_limit,
+        )
+    remaining_limit = (
+        None if image_limit is None else max(image_limit - len(unmatched), 0)
+    )
+    if remaining_limit != 0:
+        unmatched += get_unmatched_scaleway_images_with_history(
             neo4j_session,
             sub_resource_label="GitLabOrganization",
             sub_resource_id=organization_id,

--- a/cartography/intel/scaleway/__init__.py
+++ b/cartography/intel/scaleway/__init__.py
@@ -8,6 +8,7 @@ import cartography.intel.scaleway.baremetal.dedibox
 import cartography.intel.scaleway.baremetal.elastic_metal
 import cartography.intel.scaleway.baremetal.flexible_ips
 import cartography.intel.scaleway.container_registry.namespaces
+import cartography.intel.scaleway.container_registry.supply_chain
 import cartography.intel.scaleway.databases.datawarehouse
 import cartography.intel.scaleway.databases.mongodb
 import cartography.intel.scaleway.databases.rdb
@@ -340,6 +341,15 @@ def start_scaleway_ingestion(neo4j_session: neo4j.Session, config: Config) -> No
             projects_id=projects_id,
             update_tag=config.update_tag,
         )
+    )
+    # Enrich registry images with layers + provenance from the OCI registry
+    # endpoint (source for code-to-cloud); runs after the registry nodes exist.
+    cartography.intel.scaleway.container_registry.supply_chain.sync(
+        neo4j_session,
+        config.scaleway_secret_key,
+        common_job_parameters,
+        projects_id=projects_id,
+        update_tag=config.update_tag,
     )
 
     # Managed Databases (loaded after PrivateNetworks so ATTACHED_TO edges resolve).

--- a/cartography/intel/scaleway/__init__.py
+++ b/cartography/intel/scaleway/__init__.py
@@ -328,14 +328,18 @@ def start_scaleway_ingestion(neo4j_session: neo4j.Session, config: Config) -> No
         update_tag=config.update_tag,
     )
 
-    # Container Registry
-    cartography.intel.scaleway.container_registry.namespaces.sync(
-        neo4j_session,
-        client,
-        common_job_parameters,
-        org_id=config.scaleway_org,
-        projects_id=projects_id,
-        update_tag=config.update_tag,
+    # Container Registry. Returns the tag URI -> digest map so serverless
+    # containers can resolve their `registry_image` to a digest and declare a
+    # HAS_IMAGE edge to the Image node.
+    registry_image_digests = (
+        cartography.intel.scaleway.container_registry.namespaces.sync(
+            neo4j_session,
+            client,
+            common_job_parameters,
+            org_id=config.scaleway_org,
+            projects_id=projects_id,
+            update_tag=config.update_tag,
+        )
     )
 
     # Managed Databases (loaded after PrivateNetworks so ATTACHED_TO edges resolve).
@@ -389,7 +393,8 @@ def start_scaleway_ingestion(neo4j_session: neo4j.Session, config: Config) -> No
     )
 
     # Serverless (Functions / Containers / Jobs). Loaded after PrivateNetworks
-    # so the ATTACHED_TO edges resolve.
+    # so the ATTACHED_TO edges resolve, and after the Container Registry so the
+    # container HAS_IMAGE -> Image edges resolve (registry_image_digests below).
     cartography.intel.scaleway.serverless.functions.sync(
         neo4j_session,
         client,
@@ -405,6 +410,7 @@ def start_scaleway_ingestion(neo4j_session: neo4j.Session, config: Config) -> No
         org_id=config.scaleway_org,
         projects_id=projects_id,
         update_tag=config.update_tag,
+        registry_image_digests=registry_image_digests,
     )
     cartography.intel.scaleway.serverless.jobs.sync(
         neo4j_session,

--- a/cartography/intel/scaleway/__init__.py
+++ b/cartography/intel/scaleway/__init__.py
@@ -19,6 +19,7 @@ import cartography.intel.scaleway.dns.domains
 import cartography.intel.scaleway.iam.apikeys
 import cartography.intel.scaleway.iam.applications
 import cartography.intel.scaleway.iam.groups
+import cartography.intel.scaleway.iam.permissions
 import cartography.intel.scaleway.iam.permissionsets
 import cartography.intel.scaleway.iam.policies
 import cartography.intel.scaleway.iam.sshkeys
@@ -406,6 +407,18 @@ def start_scaleway_ingestion(neo4j_session: neo4j.Session, config: Config) -> No
         update_tag=config.update_tag,
     )
     cartography.intel.scaleway.serverless.jobs.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=config.scaleway_org,
+        projects_id=projects_id,
+        update_tag=config.update_tag,
+    )
+
+    # IAM permissions: materialize principal -> permission set (HAS_ROLE) and
+    # principal -> project (CAN_ACCESS) edges from the policy/rule graph. Runs
+    # last so all IAM and project nodes are present.
+    cartography.intel.scaleway.iam.permissions.sync(
         neo4j_session,
         client,
         common_job_parameters,

--- a/cartography/intel/scaleway/container_registry/namespaces.py
+++ b/cartography/intel/scaleway/container_registry/namespaces.py
@@ -36,7 +36,7 @@ def sync(
     org_id: str,
     projects_id: list[str],
     update_tag: int,
-) -> None:
+) -> dict[str, str]:
     namespaces, images, tags = get(client, org_id)
     namespaces_by_project, images_by_project, tags_by_project = transform_namespaces(
         namespaces, images, tags
@@ -49,6 +49,15 @@ def sync(
         update_tag,
     )
     cleanup(neo4j_session, projects_id, common_job_parameters)
+    # Return the tag URI -> digest map so downstream syncs (e.g. serverless
+    # containers) can resolve a `registry_image` pull URI to its digest and
+    # declare a HAS_IMAGE relationship to the Image node.
+    return {
+        tag["uri"]: tag["digest"]
+        for tags in tags_by_project.values()
+        for tag in tags
+        if tag.get("uri") and tag.get("digest")
+    }
 
 
 @timeit

--- a/cartography/intel/scaleway/container_registry/namespaces.py
+++ b/cartography/intel/scaleway/container_registry/namespaces.py
@@ -6,13 +6,19 @@ import scaleway
 from scaleway.registry.v1 import Image
 from scaleway.registry.v1 import Namespace
 from scaleway.registry.v1 import RegistryV1API
+from scaleway.registry.v1 import Tag
+from scaleway_core.api import ScalewayException
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.scaleway.utils import DEFAULT_REGIONS
 from cartography.intel.scaleway.utils import list_all_regions
 from cartography.intel.scaleway.utils import scaleway_obj_to_dict
 from cartography.models.scaleway.container_registry.image import (
     ScalewayContainerRegistryImageSchema,
+)
+from cartography.models.scaleway.container_registry.image_tag import (
+    ScalewayContainerRegistryImageTagSchema,
 )
 from cartography.models.scaleway.container_registry.namespace import (
     ScalewayContainerRegistryNamespaceSchema,
@@ -31,9 +37,17 @@ def sync(
     projects_id: list[str],
     update_tag: int,
 ) -> None:
-    namespaces, images = get(client, org_id)
-    namespaces_by_project, images_by_project = transform_namespaces(namespaces, images)
-    load_namespaces(neo4j_session, namespaces_by_project, images_by_project, update_tag)
+    namespaces, images, tags = get(client, org_id)
+    namespaces_by_project, images_by_project, tags_by_project = transform_namespaces(
+        namespaces, images, tags
+    )
+    load_namespaces(
+        neo4j_session,
+        namespaces_by_project,
+        images_by_project,
+        tags_by_project,
+        update_tag,
+    )
     cleanup(neo4j_session, projects_id, common_job_parameters)
 
 
@@ -41,32 +55,59 @@ def sync(
 def get(
     client: scaleway.Client,
     org_id: str,
-) -> tuple[list[Namespace], list[Image]]:
+) -> tuple[list[Namespace], list[Image], list[Tag]]:
     api = RegistryV1API(client)
     namespaces = list_all_regions(api.list_namespaces_all, organization_id=org_id)
-    # Images are listable per-region with org_id, no need to iterate per
-    # namespace. This both saves API calls and keeps the cross-namespace
-    # ordering stable.
-    images = list_all_regions(api.list_images_all, organization_id=org_id)
-    return namespaces, images
+    # Images and tags are region-scoped and tags can only be listed per-image
+    # (image_id is required), so fan out over regions and query each image's
+    # tags in the region it was found in. The "named image" (list_images) is
+    # only used here to enumerate images and carry name/visibility onto their
+    # tags; it is not persisted as its own node (Scaleway's namespace is the
+    # registry, mirroring GCP's Artifact Registry repository).
+    images: list[Image] = []
+    tags: list[Tag] = []
+    for region in DEFAULT_REGIONS:
+        try:
+            region_images = api.list_images_all(region=region, organization_id=org_id)
+        except ScalewayException as exc:
+            if "unknown service" in str(exc).lower():
+                logger.info(
+                    "Scaleway Container Registry not available in region %s, skipping.",
+                    region,
+                )
+                continue
+            raise
+        images.extend(region_images)
+        for image in region_images:
+            tags.extend(api.list_tags_all(image_id=image.id, region=region))
+    return namespaces, images, tags
 
 
 def transform_namespaces(
     namespaces: list[Namespace],
     images: list[Image],
-) -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[dict[str, Any]]]]:
+    tags: list[Tag],
+) -> tuple[
+    dict[str, list[dict[str, Any]]],
+    dict[str, list[dict[str, Any]]],
+    dict[str, list[dict[str, Any]]],
+]:
     namespaces_by_project: dict[str, list[dict[str, Any]]] = {}
+    # Digest-addressed image content, deduplicated by digest per project.
     images_by_project: dict[str, list[dict[str, Any]]] = {}
+    tags_by_project: dict[str, list[dict[str, Any]]] = {}
 
-    # Images inherit the project of their parent namespace: the API does not
-    # return project_id on them.
     project_by_namespace_id = {ns.id: ns.project_id for ns in namespaces}
+    endpoint_by_namespace_id = {ns.id: ns.endpoint for ns in namespaces}
 
     for namespace in namespaces:
         namespaces_by_project.setdefault(namespace.project_id, []).append(
             scaleway_obj_to_dict(namespace)
         )
 
+    # Resolve each named image to the project/namespace/name/visibility we
+    # denormalize onto its tags. The named image is not loaded as a node.
+    image_meta: dict[str, dict[str, Any]] = {}
     for image in images:
         project_id = project_by_namespace_id.get(image.namespace_id)
         if project_id is None:
@@ -76,9 +117,45 @@ def transform_namespaces(
                 image.namespace_id,
             )
             continue
-        images_by_project.setdefault(project_id, []).append(scaleway_obj_to_dict(image))
+        image_dict = scaleway_obj_to_dict(image)
+        image_meta[image.id] = {
+            "project_id": project_id,
+            "namespace_id": image.namespace_id,
+            "name": image_dict.get("name"),
+            "visibility": image_dict.get("visibility"),
+            "endpoint": endpoint_by_namespace_id.get(image.namespace_id),
+        }
 
-    return namespaces_by_project, images_by_project
+    seen_digests: dict[str, set[str]] = {}
+    for tag in tags:
+        meta = image_meta.get(tag.image_id)
+        if meta is None:
+            logger.warning(
+                "Skipping Scaleway Container Registry tag %s: unknown parent image %s.",
+                tag.id,
+                tag.image_id,
+            )
+            continue
+        project_id = meta["project_id"]
+        row = scaleway_obj_to_dict(tag)
+        row["image_name"] = meta["name"]
+        row["visibility"] = meta["visibility"]
+        row["namespace_id"] = meta["namespace_id"]
+        if meta["endpoint"] and meta["name"]:
+            row["uri"] = f"{meta['endpoint']}/{meta['name']}:{tag.name}"
+        else:
+            row["uri"] = None
+        tags_by_project.setdefault(project_id, []).append(row)
+
+        if tag.digest:
+            project_digests = seen_digests.setdefault(project_id, set())
+            if tag.digest not in project_digests:
+                project_digests.add(tag.digest)
+                images_by_project.setdefault(project_id, []).append(
+                    {"digest": tag.digest}
+                )
+
+    return namespaces_by_project, images_by_project, tags_by_project
 
 
 @timeit
@@ -86,6 +163,7 @@ def load_namespaces(
     neo4j_session: neo4j.Session,
     namespaces_by_project: dict[str, list[dict[str, Any]]],
     images_by_project: dict[str, list[dict[str, Any]]],
+    tags_by_project: dict[str, list[dict[str, Any]]],
     update_tag: int,
 ) -> None:
     for project_id, namespaces in namespaces_by_project.items():
@@ -101,11 +179,21 @@ def load_namespaces(
             lastupdated=update_tag,
             PROJECT_ID=project_id,
         )
+    # Digest images before tags so the tag -> IMAGE -> image edge resolves at
+    # load time.
     for project_id, images in images_by_project.items():
         load(
             neo4j_session,
             ScalewayContainerRegistryImageSchema(),
             images,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+    for project_id, tags in tags_by_project.items():
+        load(
+            neo4j_session,
+            ScalewayContainerRegistryImageTagSchema(),
+            tags,
             lastupdated=update_tag,
             PROJECT_ID=project_id,
         )
@@ -120,7 +208,10 @@ def cleanup(
     for project_id in projects_id:
         scoped_job_parameters = common_job_parameters.copy()
         scoped_job_parameters["PROJECT_ID"] = project_id
-        # Children before parent: Image -> Namespace.
+        # Children before parents: Tag -> Image -> Namespace.
+        GraphJob.from_node_schema(
+            ScalewayContainerRegistryImageTagSchema(), scoped_job_parameters
+        ).run(neo4j_session)
         GraphJob.from_node_schema(
             ScalewayContainerRegistryImageSchema(), scoped_job_parameters
         ).run(neo4j_session)

--- a/cartography/intel/scaleway/container_registry/supply_chain.py
+++ b/cartography/intel/scaleway/container_registry/supply_chain.py
@@ -33,7 +33,7 @@ from cartography.intel.supply_chain import extract_layers_from_oci_config
 from cartography.intel.supply_chain import extract_provenance_from_oci_config
 from cartography.intel.supply_chain import normalize_vcs_url
 from cartography.models.scaleway.container_registry.image import (
-    ScalewayContainerRegistryImageSchema,
+    ScalewayContainerRegistryImageEnrichmentSchema,
 )
 from cartography.models.scaleway.container_registry.image_layer import (
     ScalewayContainerRegistryImageLayerSchema,
@@ -374,7 +374,7 @@ def load_supply_chain(
     for project_id, images in images_by_project.items():
         load(
             neo4j_session,
-            ScalewayContainerRegistryImageSchema(),
+            ScalewayContainerRegistryImageEnrichmentSchema(),
             images,
             lastupdated=update_tag,
             PROJECT_ID=project_id,

--- a/cartography/intel/scaleway/container_registry/supply_chain.py
+++ b/cartography/intel/scaleway/container_registry/supply_chain.py
@@ -213,11 +213,16 @@ def fetch_image_supply_chain(
 def _get_images_to_enrich(
     neo4j_session: neo4j.Session,
 ) -> list[dict[str, Any]]:
-    """Return the digest/project/uri of every Scaleway registry image to enrich."""
+    """Return the digest/project/uri of every Scaleway registry image to enrich.
+
+    An image digest is deduplicated globally, so the same node can belong to
+    several projects. Scope the tag to the same project as the image so the pull
+    URI is always project-local (never a repository from another project).
+    """
     result = neo4j_session.run(
         """
         MATCH (p:ScalewayProject)-[:RESOURCE]->(i:ScalewayContainerRegistryImage)
-        MATCH (i)<-[:IMAGE]-(t:ScalewayContainerRegistryImageTag)
+        MATCH (p)-[:RESOURCE]->(t:ScalewayContainerRegistryImageTag)-[:IMAGE]->(i)
         WITH i, p, collect(t.uri) AS uris
         RETURN i.digest AS digest, p.id AS project_id, uris[0] AS uri
         """

--- a/cartography/intel/scaleway/container_registry/supply_chain.py
+++ b/cartography/intel/scaleway/container_registry/supply_chain.py
@@ -1,0 +1,272 @@
+"""Enrich Scaleway Container Registry images with supply-chain data.
+
+Scaleway's management SDK does not expose image layers or provenance, but the
+registry endpoint (``rg.<region>.scw.cloud``) is a standard OCI Distribution v2
+registry. This module fetches each image's OCI manifest + config (authenticating
+with the Scaleway secret key as a registry Bearer token) and enriches the
+``ScalewayContainerRegistryImage`` node with:
+
+* ``layer_diff_ids`` + ``ScalewayContainerRegistryImageLayer`` nodes -- feed the
+  shared supply-chain *dockerfile-matching* arm.
+
+The GitHub/GitLab supply-chain matchers then draw ``PACKAGED_FROM`` edges from
+these images to their source repositories; nothing registry-specific is needed
+there because those matchers key on the generic ``:Image`` / ``:ImageLayer``
+labels.
+"""
+
+import base64
+import logging
+from typing import Any
+
+import httpx
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.supply_chain import extract_layers_from_oci_config
+from cartography.models.scaleway.container_registry.image import (
+    ScalewayContainerRegistryImageSchema,
+)
+from cartography.models.scaleway.container_registry.image_layer import (
+    ScalewayContainerRegistryImageLayerSchema,
+)
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+_HTTP_TIMEOUT = 30.0
+_MANIFEST_ACCEPT = ", ".join(
+    [
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    ]
+)
+# Attestation manifests reference a subject image, not a runnable config.
+_ATTESTATION_REFERENCE_TYPE = "attestation-manifest"
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    secret_key: str,
+    common_job_parameters: dict[str, Any],
+    projects_id: list[str],
+    update_tag: int,
+) -> None:
+    raw = get(neo4j_session, secret_key)
+    images_by_project, layers_by_project = transform(raw)
+    load_supply_chain(neo4j_session, images_by_project, layers_by_project, update_tag)
+    cleanup(neo4j_session, projects_id, common_job_parameters)
+
+
+def _parse_image_uri(uri: str) -> tuple[str, str, str] | None:
+    """Split a tag URI (``rg.<region>.scw.cloud/<ns>/<img>:<tag>``) into
+    (registry_host, region, repo_path)."""
+    host, _, remainder = uri.partition("/")
+    if not remainder:
+        return None
+    host_parts = host.split(".")
+    if len(host_parts) < 4 or host_parts[0] != "rg":
+        return None
+    region = host_parts[1]
+    repo_path = remainder.rsplit(":", 1)[0]
+    return host, region, repo_path
+
+
+def _registry_token(host: str, region: str, repo_path: str, secret_key: str) -> str:
+    realm = f"https://api.scaleway.com/registry-internal/v1/regions/{region}/tokens"
+    auth = base64.b64encode(f"nologin:{secret_key}".encode()).decode()
+    resp = httpx.get(
+        realm,
+        params={"service": "registry", "scope": f"repository:{repo_path}:pull"},
+        headers={"Authorization": f"Basic {auth}"},
+        timeout=_HTTP_TIMEOUT,
+    )
+    resp.raise_for_status()
+    return resp.json()["token"]
+
+
+def _get_json(client: httpx.Client, url: str, accept: str) -> dict[str, Any]:
+    resp = client.get(url, headers={"Accept": accept})
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_image_config(
+    host: str,
+    region: str,
+    repo_path: str,
+    reference: str,
+    secret_key: str,
+) -> dict[str, Any] | None:
+    """Fetch and return the OCI image config JSON for an image reference.
+
+    Resolves a multi-arch index to its first runnable platform manifest. Returns
+    None when there is no enrichable config (e.g. an attestation-only manifest).
+    """
+    token = _registry_token(host, region, repo_path, secret_key)
+    base = f"https://{host}/v2/{repo_path}"
+    with httpx.Client(
+        headers={"Authorization": f"Bearer {token}"}, timeout=_HTTP_TIMEOUT
+    ) as client:
+        manifest = _get_json(client, f"{base}/manifests/{reference}", _MANIFEST_ACCEPT)
+        # Resolve an index to a concrete platform image manifest.
+        if manifest.get("manifests"):
+            platform_digest = None
+            for entry in manifest["manifests"]:
+                ann = entry.get("annotations") or {}
+                if ann.get("vnd.docker.reference.type") == _ATTESTATION_REFERENCE_TYPE:
+                    continue
+                platform = entry.get("platform") or {}
+                if platform.get("os") in (None, "unknown"):
+                    continue
+                platform_digest = entry.get("digest")
+                break
+            if platform_digest is None:
+                return None
+            manifest = _get_json(
+                client, f"{base}/manifests/{platform_digest}", _MANIFEST_ACCEPT
+            )
+        config_descriptor = manifest.get("config") or {}
+        config_digest = config_descriptor.get("digest")
+        if not config_digest:
+            return None
+        return _get_json(
+            client,
+            f"{base}/blobs/{config_digest}",
+            config_descriptor.get(
+                "mediaType", "application/vnd.oci.image.config.v1+json"
+            ),
+        )
+
+
+def _get_images_to_enrich(
+    neo4j_session: neo4j.Session,
+) -> list[dict[str, Any]]:
+    """Return the digest/project/uri of every Scaleway registry image to enrich."""
+    result = neo4j_session.run(
+        """
+        MATCH (p:ScalewayProject)-[:RESOURCE]->(i:ScalewayContainerRegistryImage)
+        MATCH (i)<-[:IMAGE]-(t:ScalewayContainerRegistryImageTag)
+        WITH i, p, collect(t.uri) AS uris
+        RETURN i.digest AS digest, p.id AS project_id, uris[0] AS uri
+        """
+    )
+    return [dict(record) for record in result]
+
+
+@timeit
+def get(neo4j_session: neo4j.Session, secret_key: str) -> list[dict[str, Any]]:
+    """Fetch the OCI config for every Scaleway registry image."""
+    enriched: list[dict[str, Any]] = []
+    for image in _get_images_to_enrich(neo4j_session):
+        uri = image.get("uri")
+        digest = image.get("digest")
+        if not uri or not digest:
+            continue
+        parsed = _parse_image_uri(uri)
+        if parsed is None:
+            logger.warning("Unparseable Scaleway image URI, skipping: %s", uri)
+            continue
+        host, region, repo_path = parsed
+        try:
+            config = fetch_image_config(host, region, repo_path, digest, secret_key)
+        except httpx.HTTPError as exc:
+            logger.warning(
+                "Failed to fetch OCI config for %s@%s: %s", repo_path, digest, exc
+            )
+            continue
+        if config is None:
+            continue
+        enriched.append(
+            {
+                "digest": digest,
+                "project_id": image["project_id"],
+                "config": config,
+            }
+        )
+    return enriched
+
+
+def transform(
+    raw: list[dict[str, Any]],
+) -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[dict[str, Any]]]]:
+    images_by_project: dict[str, list[dict[str, Any]]] = {}
+    layers_by_project: dict[str, list[dict[str, Any]]] = {}
+
+    for entry in raw:
+        project_id = entry["project_id"]
+        config = entry["config"]
+        diff_ids, layer_history = extract_layers_from_oci_config(config)
+        if not diff_ids:
+            continue
+
+        image_update: dict[str, Any] = {
+            "digest": entry["digest"],
+            "layer_diff_ids": diff_ids,
+        }
+        images_by_project.setdefault(project_id, []).append(image_update)
+
+        # Align each non-empty history command to its diff_id (empty layers such
+        # as ENV/WORKDIR carry no diff_id). Standard OCI: the count of non-empty
+        # history entries equals len(diff_ids).
+        project_layers = layers_by_project.setdefault(project_id, [])
+        idx = 0
+        for record in layer_history:
+            if record.get("empty_layer"):
+                continue
+            if idx >= len(diff_ids):
+                break
+            project_layers.append(
+                {
+                    "diff_id": diff_ids[idx],
+                    "history": record.get("created_by", ""),
+                    "is_empty": False,
+                }
+            )
+            idx += 1
+
+    return images_by_project, layers_by_project
+
+
+@timeit
+def load_supply_chain(
+    neo4j_session: neo4j.Session,
+    images_by_project: dict[str, list[dict[str, Any]]],
+    layers_by_project: dict[str, list[dict[str, Any]]],
+    update_tag: int,
+) -> None:
+    # Layers before the image enrichment so the image HAS_LAYER edges resolve.
+    for project_id, layers in layers_by_project.items():
+        load(
+            neo4j_session,
+            ScalewayContainerRegistryImageLayerSchema(),
+            layers,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+    for project_id, images in images_by_project.items():
+        load(
+            neo4j_session,
+            ScalewayContainerRegistryImageSchema(),
+            images,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    projects_id: list[str],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    for project_id in projects_id:
+        scoped_job_parameters = common_job_parameters.copy()
+        scoped_job_parameters["PROJECT_ID"] = project_id
+        GraphJob.from_node_schema(
+            ScalewayContainerRegistryImageLayerSchema(), scoped_job_parameters
+        ).run(neo4j_session)

--- a/cartography/intel/scaleway/container_registry/supply_chain.py
+++ b/cartography/intel/scaleway/container_registry/supply_chain.py
@@ -8,11 +8,14 @@ with the Scaleway secret key as a registry Bearer token) and enriches the
 
 * ``layer_diff_ids`` + ``ScalewayContainerRegistryImageLayer`` nodes -- feed the
   shared supply-chain *dockerfile-matching* arm.
+* ``source_uri`` / ``source_revision`` / ``source_file`` -- the *provenance* arm,
+  parsed from OCI labels/annotations (``org.opencontainers.image.source``) and,
+  when present, the buildx SLSA attestation manifest carried in the image index.
 
 The GitHub/GitLab supply-chain matchers then draw ``PACKAGED_FROM`` edges from
 these images to their source repositories; nothing registry-specific is needed
 there because those matchers key on the generic ``:Image`` / ``:ImageLayer``
-labels.
+labels and on ``source_uri``.
 """
 
 import base64
@@ -24,7 +27,11 @@ import neo4j
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.supply_chain import decode_attestation_blob_to_predicate
+from cartography.intel.supply_chain import extract_image_source_provenance
 from cartography.intel.supply_chain import extract_layers_from_oci_config
+from cartography.intel.supply_chain import extract_provenance_from_oci_config
+from cartography.intel.supply_chain import normalize_vcs_url
 from cartography.models.scaleway.container_registry.image import (
     ScalewayContainerRegistryImageSchema,
 )
@@ -46,6 +53,10 @@ _MANIFEST_ACCEPT = ", ".join(
 )
 # Attestation manifests reference a subject image, not a runnable config.
 _ATTESTATION_REFERENCE_TYPE = "attestation-manifest"
+_INTOTO_MEDIA_TYPE = "application/vnd.in-toto+json"
+_OCI_SOURCE_ANNOTATION = "org.opencontainers.image.source"
+_OCI_REVISION_ANNOTATION = "org.opencontainers.image.revision"
+_PROVENANCE_FIELDS = ("source_uri", "source_revision", "source_file")
 
 
 @timeit
@@ -56,9 +67,18 @@ def sync(
     projects_id: list[str],
     update_tag: int,
 ) -> None:
-    raw = get(neo4j_session, secret_key)
+    raw, fetch_failed = get(neo4j_session, secret_key)
     images_by_project, layers_by_project = transform(raw)
     load_supply_chain(neo4j_session, images_by_project, layers_by_project, update_tag)
+    if fetch_failed:
+        # A transient registry error (timeout/401/5xx) on any image means we did
+        # not refresh that image's layers this run. Skipping cleanup avoids
+        # deleting layer nodes (and their HAS_LAYER edges) that are merely
+        # stale-tagged, not actually gone; they get cleaned on a clean run.
+        logger.warning(
+            "Skipping Scaleway image-layer cleanup: one or more OCI fetches failed."
+        )
+        return
     cleanup(neo4j_session, projects_id, common_job_parameters)
 
 
@@ -95,52 +115,99 @@ def _get_json(client: httpx.Client, url: str, accept: str) -> dict[str, Any]:
     return resp.json()
 
 
-def fetch_image_config(
+def _fetch_config(
+    client: httpx.Client, base: str, manifest: dict[str, Any]
+) -> dict[str, Any] | None:
+    config_descriptor = manifest.get("config") or {}
+    config_digest = config_descriptor.get("digest")
+    if not config_digest:
+        return None
+    return _get_json(
+        client,
+        f"{base}/blobs/{config_digest}",
+        config_descriptor.get("mediaType", "application/vnd.oci.image.config.v1+json"),
+    )
+
+
+def _fetch_attestation_predicate(
+    client: httpx.Client, base: str, attestation_digest: str
+) -> dict[str, Any] | None:
+    """Fetch a buildx attestation manifest and return its SLSA provenance predicate."""
+    att_manifest = _get_json(
+        client, f"{base}/manifests/{attestation_digest}", _MANIFEST_ACCEPT
+    )
+    for layer in att_manifest.get("layers") or []:
+        if layer.get("mediaType") != _INTOTO_MEDIA_TYPE:
+            continue
+        predicate_type = (layer.get("annotations") or {}).get(
+            "in-toto.io/predicate-type", ""
+        )
+        if "slsa.dev/provenance" not in predicate_type:
+            continue
+        blob = _get_json(client, f"{base}/blobs/{layer['digest']}", _INTOTO_MEDIA_TYPE)
+        predicate = decode_attestation_blob_to_predicate(blob)
+        if predicate:
+            return predicate
+    return None
+
+
+def fetch_image_supply_chain(
     host: str,
     region: str,
     repo_path: str,
     reference: str,
     secret_key: str,
-) -> dict[str, Any] | None:
-    """Fetch and return the OCI image config JSON for an image reference.
+) -> tuple[dict[str, Any] | None, dict[str, str], dict[str, Any] | None]:
+    """Fetch OCI supply-chain data for an image reference.
 
-    Resolves a multi-arch index to its first runnable platform manifest. Returns
-    None when there is no enrichable config (e.g. an attestation-only manifest).
+    Returns ``(config, annotations, attestation_predicate)``, resolving a
+    multi-arch index to its runnable platform manifest and, if present, its
+    buildx SLSA attestation manifest. ``config``/``predicate`` are None when
+    absent; ``annotations`` merges index + platform manifest annotations.
     """
     token = _registry_token(host, region, repo_path, secret_key)
     base = f"https://{host}/v2/{repo_path}"
+    annotations: dict[str, str] = {}
+    attestation_predicate: dict[str, Any] | None = None
+    # Blob reads 307-redirect to object storage; httpx drops the Authorization
+    # header on the cross-host hop, so the presigned URL authenticates itself.
     with httpx.Client(
-        headers={"Authorization": f"Bearer {token}"}, timeout=_HTTP_TIMEOUT
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=_HTTP_TIMEOUT,
+        follow_redirects=True,
     ) as client:
         manifest = _get_json(client, f"{base}/manifests/{reference}", _MANIFEST_ACCEPT)
-        # Resolve an index to a concrete platform image manifest.
+        annotations.update(manifest.get("annotations") or {})
+        # Resolve an index to a concrete platform image manifest (and grab the
+        # attestation manifest for SLSA provenance, if any).
         if manifest.get("manifests"):
             platform_digest = None
             for entry in manifest["manifests"]:
-                ann = entry.get("annotations") or {}
-                if ann.get("vnd.docker.reference.type") == _ATTESTATION_REFERENCE_TYPE:
+                entry_ann = entry.get("annotations") or {}
+                if (
+                    entry_ann.get("vnd.docker.reference.type")
+                    == _ATTESTATION_REFERENCE_TYPE
+                ):
+                    try:
+                        attestation_predicate = _fetch_attestation_predicate(
+                            client, base, entry["digest"]
+                        )
+                    except httpx.HTTPError as exc:
+                        logger.debug("Attestation fetch failed for %s: %s", base, exc)
                     continue
                 platform = entry.get("platform") or {}
                 if platform.get("os") in (None, "unknown"):
                     continue
-                platform_digest = entry.get("digest")
-                break
+                if platform_digest is None:
+                    platform_digest = entry.get("digest")
             if platform_digest is None:
-                return None
+                return None, annotations, attestation_predicate
             manifest = _get_json(
                 client, f"{base}/manifests/{platform_digest}", _MANIFEST_ACCEPT
             )
-        config_descriptor = manifest.get("config") or {}
-        config_digest = config_descriptor.get("digest")
-        if not config_digest:
-            return None
-        return _get_json(
-            client,
-            f"{base}/blobs/{config_digest}",
-            config_descriptor.get(
-                "mediaType", "application/vnd.oci.image.config.v1+json"
-            ),
-        )
+            annotations.update(manifest.get("annotations") or {})
+        config = _fetch_config(client, base, manifest)
+    return config, annotations, attestation_predicate
 
 
 def _get_images_to_enrich(
@@ -159,9 +226,17 @@ def _get_images_to_enrich(
 
 
 @timeit
-def get(neo4j_session: neo4j.Session, secret_key: str) -> list[dict[str, Any]]:
-    """Fetch the OCI config for every Scaleway registry image."""
+def get(
+    neo4j_session: neo4j.Session, secret_key: str
+) -> tuple[list[dict[str, Any]], bool]:
+    """Fetch the OCI config for every Scaleway registry image.
+
+    Returns ``(enriched, fetch_failed)`` where ``fetch_failed`` is True if any
+    image's OCI fetch hit a transient registry error, so the caller can skip
+    layer cleanup and avoid deleting layers it could not refresh this run.
+    """
     enriched: list[dict[str, Any]] = []
+    fetch_failed = False
     for image in _get_images_to_enrich(neo4j_session):
         uri = image.get("uri")
         digest = image.get("digest")
@@ -173,11 +248,14 @@ def get(neo4j_session: neo4j.Session, secret_key: str) -> list[dict[str, Any]]:
             continue
         host, region, repo_path = parsed
         try:
-            config = fetch_image_config(host, region, repo_path, digest, secret_key)
+            config, annotations, attestation_predicate = fetch_image_supply_chain(
+                host, region, repo_path, digest, secret_key
+            )
         except httpx.HTTPError as exc:
             logger.warning(
-                "Failed to fetch OCI config for %s@%s: %s", repo_path, digest, exc
+                "Failed to fetch OCI data for %s@%s: %s", repo_path, digest, exc
             )
+            fetch_failed = True
             continue
         if config is None:
             continue
@@ -186,9 +264,40 @@ def get(neo4j_session: neo4j.Session, secret_key: str) -> list[dict[str, Any]]:
                 "digest": digest,
                 "project_id": image["project_id"],
                 "config": config,
+                "annotations": annotations,
+                "attestation_predicate": attestation_predicate,
             }
         )
-    return enriched
+    return enriched, fetch_failed
+
+
+def _provenance_from_annotations(annotations: dict[str, str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    source = annotations.get(_OCI_SOURCE_ANNOTATION)
+    if source:
+        result["source_uri"] = normalize_vcs_url(source)
+    revision = annotations.get(_OCI_REVISION_ANNOTATION)
+    if revision:
+        result["source_revision"] = revision
+    return result
+
+
+def _resolve_provenance(entry: dict[str, Any]) -> dict[str, str]:
+    """Coalesce source provenance from the SLSA attestation, OCI config labels,
+    and manifest annotations (in that order of authority)."""
+    predicate = entry.get("attestation_predicate")
+    sources = [
+        extract_image_source_provenance(predicate) if predicate else {},
+        extract_provenance_from_oci_config(entry["config"]),
+        _provenance_from_annotations(entry.get("annotations") or {}),
+    ]
+    provenance: dict[str, str] = {}
+    for source in sources:
+        for field in _PROVENANCE_FIELDS:
+            value = source.get(field)
+            if value and not provenance.get(field):
+                provenance[field] = value
+    return provenance
 
 
 def transform(
@@ -201,14 +310,23 @@ def transform(
         project_id = entry["project_id"]
         config = entry["config"]
         diff_ids, layer_history = extract_layers_from_oci_config(config)
-        if not diff_ids:
+        provenance = _resolve_provenance(entry)
+
+        # Skip images that yield neither layers nor provenance.
+        if not diff_ids and not provenance:
             continue
 
         image_update: dict[str, Any] = {
             "digest": entry["digest"],
             "layer_diff_ids": diff_ids,
+            "source_uri": provenance.get("source_uri"),
+            "source_revision": provenance.get("source_revision"),
+            "source_file": provenance.get("source_file"),
         }
         images_by_project.setdefault(project_id, []).append(image_update)
+
+        if not diff_ids:
+            continue
 
         # Align each non-empty history command to its diff_id (empty layers such
         # as ENV/WORKDIR carry no diff_id). Standard OCI: the count of non-empty

--- a/cartography/intel/scaleway/iam/permissions.py
+++ b/cartography/intel/scaleway/iam/permissions.py
@@ -1,0 +1,190 @@
+from typing import Any
+
+import neo4j
+import scaleway
+from scaleway.iam.v1alpha1 import IamV1Alpha1API
+from scaleway.iam.v1alpha1 import PermissionSetScopeType
+from scaleway.iam.v1alpha1 import Policy
+from scaleway.iam.v1alpha1 import Rule
+
+from cartography.client.core.tx import load_matchlinks
+from cartography.graph.job import GraphJob
+from cartography.models.scaleway.iam.permission_relationship import (
+    ScalewayApplicationToPermissionSetMatchLink,
+)
+from cartography.models.scaleway.iam.permission_relationship import (
+    ScalewayApplicationToProjectMatchLink,
+)
+from cartography.models.scaleway.iam.permission_relationship import (
+    ScalewayGroupToPermissionSetMatchLink,
+)
+from cartography.models.scaleway.iam.permission_relationship import (
+    ScalewayGroupToProjectMatchLink,
+)
+from cartography.models.scaleway.iam.permission_relationship import (
+    ScalewayUserToPermissionSetMatchLink,
+)
+from cartography.models.scaleway.iam.permission_relationship import (
+    ScalewayUserToProjectMatchLink,
+)
+from cartography.util import timeit
+
+# Scaleway policies target exactly one principal kind; map it to the id field
+# name expected by the MatchLink source matchers.
+_HAS_ROLE_MATCHLINKS = {
+    "user": ScalewayUserToPermissionSetMatchLink(),
+    "application": ScalewayApplicationToPermissionSetMatchLink(),
+    "group": ScalewayGroupToPermissionSetMatchLink(),
+}
+_CAN_ACCESS_MATCHLINKS = {
+    "user": ScalewayUserToProjectMatchLink(),
+    "application": ScalewayApplicationToProjectMatchLink(),
+    "group": ScalewayGroupToProjectMatchLink(),
+}
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: scaleway.Client,
+    common_job_parameters: dict[str, Any],
+    org_id: str,
+    projects_id: list[str],
+    update_tag: int,
+) -> None:
+    api = IamV1Alpha1API(client)
+    policies = get_policies(api, org_id)
+    rules_by_policy = {policy.id: get_rules(api, policy.id) for policy in policies}
+    has_role, can_access = transform(policies, rules_by_policy, projects_id)
+    load_permissions(neo4j_session, has_role, can_access, org_id, update_tag)
+    cleanup(neo4j_session, org_id, update_tag)
+
+
+@timeit
+def get_policies(api: IamV1Alpha1API, org_id: str) -> list[Policy]:
+    return api.list_policies_all(organization_id=org_id)
+
+
+@timeit
+def get_rules(api: IamV1Alpha1API, policy_id: str) -> list[Rule]:
+    return api.list_rules_all(policy_id=policy_id)
+
+
+def _principal(policy: Policy) -> tuple[str | None, str | None]:
+    if policy.user_id:
+        return "user", policy.user_id
+    if policy.application_id:
+        return "application", policy.application_id
+    if policy.group_id:
+        return "group", policy.group_id
+    return None, None
+
+
+def _scope_projects(rule: Rule, projects_id: list[str]) -> list[str]:
+    if rule.permission_sets_scope_type == PermissionSetScopeType.PROJECTS:
+        return rule.project_ids or []
+    if rule.permission_sets_scope_type == PermissionSetScopeType.ORGANIZATION:
+        # Organization-scoped rules apply to every project in the org.
+        return projects_id
+    # account_root_user (and any future scope): no project-level edge.
+    return []
+
+
+def transform(
+    policies: list[Policy],
+    rules_by_policy: dict[str, list[Rule]],
+    projects_id: list[str],
+) -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[dict[str, Any]]]]:
+    """Resolve the policy/rule graph into HAS_ROLE and CAN_ACCESS edge rows.
+
+    Returns two dicts keyed by principal kind ("user"/"application"/"group"),
+    each holding the row list for the matching MatchLink.
+    """
+    has_role: dict[str, list[dict[str, Any]]] = {
+        "user": [],
+        "application": [],
+        "group": [],
+    }
+    can_access: dict[str, list[dict[str, Any]]] = {
+        "user": [],
+        "application": [],
+        "group": [],
+    }
+    seen_roles: set[tuple[str, str, str]] = set()
+    # (kind, principal_id, project_id) -> has_condition (AND across grant paths:
+    # only True when every path to the project is conditional).
+    access_conditions: dict[tuple[str, str, str], bool] = {}
+
+    for policy in policies:
+        kind, principal_id = _principal(policy)
+        if kind is None or principal_id is None:
+            continue
+        id_field = f"{kind}_id"
+        for rule in rules_by_policy.get(policy.id, []):
+            has_condition = bool(rule.condition)
+            for ps_name in rule.permission_set_names or []:
+                role_key = (kind, principal_id, ps_name)
+                if role_key not in seen_roles:
+                    seen_roles.add(role_key)
+                    has_role[kind].append(
+                        {id_field: principal_id, "permission_set_name": ps_name}
+                    )
+            for project_id in _scope_projects(rule, projects_id):
+                access_key = (kind, principal_id, project_id)
+                if access_key in access_conditions:
+                    access_conditions[access_key] = (
+                        access_conditions[access_key] and has_condition
+                    )
+                else:
+                    access_conditions[access_key] = has_condition
+
+    for (kind, principal_id, project_id), has_condition in access_conditions.items():
+        can_access[kind].append(
+            {
+                f"{kind}_id": principal_id,
+                "project_id": project_id,
+                "has_condition": has_condition,
+            }
+        )
+
+    return has_role, can_access
+
+
+@timeit
+def load_permissions(
+    neo4j_session: neo4j.Session,
+    has_role: dict[str, list[dict[str, Any]]],
+    can_access: dict[str, list[dict[str, Any]]],
+    org_id: str,
+    update_tag: int,
+) -> None:
+    for kind, matchlink in _HAS_ROLE_MATCHLINKS.items():
+        load_matchlinks(
+            neo4j_session,
+            matchlink,
+            has_role[kind],
+            lastupdated=update_tag,
+            _sub_resource_label="ScalewayOrganization",
+            _sub_resource_id=org_id,
+        )
+    for kind, matchlink in _CAN_ACCESS_MATCHLINKS.items():
+        load_matchlinks(
+            neo4j_session,
+            matchlink,
+            can_access[kind],
+            lastupdated=update_tag,
+            _sub_resource_label="ScalewayOrganization",
+            _sub_resource_id=org_id,
+        )
+
+
+@timeit
+def cleanup(neo4j_session: neo4j.Session, org_id: str, update_tag: int) -> None:
+    for matchlink in _HAS_ROLE_MATCHLINKS.values():
+        GraphJob.from_matchlink(
+            matchlink, "ScalewayOrganization", org_id, update_tag
+        ).run(neo4j_session)
+    for matchlink in _CAN_ACCESS_MATCHLINKS.values():
+        GraphJob.from_matchlink(
+            matchlink, "ScalewayOrganization", org_id, update_tag
+        ).run(neo4j_session)

--- a/cartography/intel/scaleway/serverless/containers.py
+++ b/cartography/intel/scaleway/serverless/containers.py
@@ -31,9 +31,12 @@ def sync(
     org_id: str,
     projects_id: list[str],
     update_tag: int,
+    registry_image_digests: dict[str, str] | None = None,
 ) -> None:
     namespaces, containers = get(client, org_id)
-    namespaces_by_project, containers_by_project = transform(namespaces, containers)
+    namespaces_by_project, containers_by_project = transform(
+        namespaces, containers, registry_image_digests or {}
+    )
     load_containers(
         neo4j_session, namespaces_by_project, containers_by_project, update_tag
     )
@@ -72,9 +75,28 @@ def get(
     return namespaces, containers
 
 
+def _resolve_image_digest(
+    registry_image: str | None,
+    registry_image_digests: dict[str, str],
+) -> str | None:
+    """Resolve a container's `registry_image` pull reference to a digest.
+
+    A digest-pinned reference (`repo@sha256:...`) carries the digest inline;
+    a tag reference (`repo:tag`) is looked up against the tag URI -> digest map
+    built by the container-registry sync. Returns None when the image lives
+    outside a synced Scaleway namespace.
+    """
+    if not registry_image:
+        return None
+    if "@sha256:" in registry_image:
+        return registry_image.split("@", 1)[1]
+    return registry_image_digests.get(registry_image)
+
+
 def transform(
     namespaces: list[Namespace],
     containers: list[Container],
+    registry_image_digests: dict[str, str],
 ) -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[dict[str, Any]]]]:
     namespaces_by_project: dict[str, list[dict[str, Any]]] = {}
     containers_by_project: dict[str, list[dict[str, Any]]] = {}
@@ -97,9 +119,11 @@ def transform(
                 container.namespace_id,
             )
             continue
-        containers_by_project.setdefault(project_id, []).append(
-            scaleway_obj_to_dict(container)
+        formatted_container = scaleway_obj_to_dict(container)
+        formatted_container["image_digest"] = _resolve_image_digest(
+            container.registry_image, registry_image_digests
         )
+        containers_by_project.setdefault(project_id, []).append(formatted_container)
 
     return namespaces_by_project, containers_by_project
 

--- a/cartography/intel/supply_chain.py
+++ b/cartography/intel/supply_chain.py
@@ -1147,3 +1147,99 @@ def get_unmatched_gcp_images_with_history(
             len(images),
         )
     return images
+
+
+def get_unmatched_scaleway_images_with_history(
+    neo4j_session: neo4j.Session,
+    sub_resource_label: str,
+    sub_resource_id: str | int,
+    update_tag: int,
+    limit: int | None = None,
+) -> list[ContainerImage]:
+    """
+    Query Scaleway Container Registry images not yet matched by provenance.
+
+    Scaleway models the whole namespace as the ``ContainerRegistry`` (many named
+    images hang off one namespace), so the generic per-registry query collapses a
+    namespace to a single representative image. This helper groups per named image
+    instead (via the tag's ``image_name``), so every image in a namespace is sent
+    through Dockerfile analysis. Used by the GitHub and GitLab supply chain
+    modules alongside ECR / GitLab / GCP images.
+
+    :param neo4j_session: Neo4j session
+    :param sub_resource_label: The sub-resource label for scoping (e.g., 'GitHubOrganization')
+    :param sub_resource_id: The sub-resource ID for scoping (e.g., org name or ID)
+    :param update_tag: The current sync update tag
+    :param limit: Optional limit on number of images to return
+    :return: List of ContainerImage objects with layer history populated
+    """
+    query = """
+        MATCH (img:Image:ScalewayContainerRegistryImage)
+        WHERE img.layer_diff_ids IS NOT NULL
+          AND size(img.layer_diff_ids) > 0
+          AND NOT exists((img)-[:PACKAGED_FROM {lastupdated: $update_tag}]->())
+          AND (
+              NOT exists((img)-[:PACKAGED_FROM {_sub_resource_label: $sub_resource_label}]->())
+              OR exists((img)-[:PACKAGED_FROM {_sub_resource_id: $sub_resource_id}]->())
+          )
+        MATCH (img)<-[:IMAGE]-(t:ScalewayContainerRegistryImageTag)
+        OPTIONAL MATCH (ns:ScalewayContainerRegistryNamespace)-[:REPO_IMAGE]->(t)
+        // Group per repository (namespace + image name) so neither sibling
+        // images in a namespace nor same-named images across namespaces collapse.
+        WITH coalesce(ns.id + '/' + t.image_name, img.digest) AS group_key, img, t
+        ORDER BY
+            CASE WHEN t.name = 'latest' THEN 0 ELSE 1 END,
+            t.updated_at DESC
+        WITH group_key, collect({img: img, t: t})[0] AS selected
+        WITH selected.img AS img, selected.t AS t
+        UNWIND range(0, size(img.layer_diff_ids) - 1) AS idx
+        WITH img, t, img.layer_diff_ids[idx] AS diff_id, idx
+        OPTIONAL MATCH (layer:ImageLayer {diff_id: diff_id})
+        WITH img, t, idx, {
+            diff_id: diff_id,
+            history: layer.history,
+            is_empty: layer.is_empty
+        } AS layer_info
+        ORDER BY idx
+        WITH img, t, collect(layer_info) AS layer_history
+        RETURN
+            img.digest AS digest,
+            t.uri AS uri,
+            t.image_name AS name,
+            img.layer_diff_ids AS layer_diff_ids,
+            layer_history
+    """
+
+    if limit is not None:
+        query += f" LIMIT {int(limit)}"
+
+    result = neo4j_session.run(
+        query,
+        update_tag=update_tag,
+        sub_resource_label=sub_resource_label,
+        sub_resource_id=sub_resource_id,
+    )
+    images = []
+    for record in result:
+        layer_history = convert_layer_history_records(record["layer_history"])
+        images.append(
+            ContainerImage(
+                digest=record["digest"],
+                uri=record["uri"] or "",
+                registry_id=record["name"] or None,
+                display_name=record["name"] or None,
+                tag=None,
+                layer_diff_ids=record["layer_diff_ids"] or [],
+                image_type=None,
+                architecture=None,
+                os=None,
+                layer_history=layer_history,
+            ),
+        )
+
+    if images:
+        logger.info(
+            "Found %d Scaleway Container Registry images with layer history for dockerfile analysis",
+            len(images),
+        )
+    return images

--- a/cartography/models/ontology/mapping/data/computenamespaces.py
+++ b/cartography/models/ontology/mapping/data/computenamespaces.py
@@ -21,6 +21,27 @@ kubernetes_mapping = OntologyMapping(
     ],
 )
 
+scaleway_mapping = OntologyMapping(
+    module_name="scaleway",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="ScalewayServerlessFunctionNamespace",
+            fields=[
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(ontology_field="status", node_field="status"),
+            ],
+        ),
+        OntologyNodeMapping(
+            node_label="ScalewayServerlessContainerNamespace",
+            fields=[
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(ontology_field="status", node_field="status"),
+            ],
+        ),
+    ],
+)
+
 COMPUTENAMESPACES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "kubernetes": kubernetes_mapping,
+    "scaleway": scaleway_mapping,
 }

--- a/cartography/models/ontology/mapping/data/computeservices.py
+++ b/cartography/models/ontology/mapping/data/computeservices.py
@@ -51,8 +51,23 @@ gcp_cloudrun_job_mapping = OntologyMapping(
     ],
 )
 
+scaleway_mapping = OntologyMapping(
+    module_name="scaleway",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="ScalewayServerlessContainer",
+            fields=[
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(ontology_field="region", node_field="region"),
+                OntologyFieldMapping(ontology_field="status", node_field="status"),
+            ],
+        ),
+    ],
+)
+
 COMPUTESERVICES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws_ecs": aws_ecs_mapping,
     "gcp_cloudrun_service": gcp_cloudrun_service_mapping,
     "gcp_cloudrun_job": gcp_cloudrun_job_mapping,
+    "scaleway": scaleway_mapping,
 }

--- a/cartography/models/ontology/mapping/data/containers.py
+++ b/cartography/models/ontology/mapping/data/containers.py
@@ -112,9 +112,27 @@ gcp_mapping = OntologyMapping(
 )
 
 
+scaleway_mapping = OntologyMapping(
+    module_name="scaleway",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="ScalewayServerlessContainer",
+            fields=[
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(
+                    ontology_field="image", node_field="registry_image"
+                ),
+                OntologyFieldMapping(ontology_field="state", node_field="status"),
+                OntologyFieldMapping(ontology_field="region", node_field="region"),
+            ],
+        ),
+    ],
+)
+
 CONTAINER_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws_ecs_container": aws_ecs_container_mapping,
     "kubernetes": kubernetes_mapping,
     "azure": azure_mapping,
     "gcp": gcp_mapping,
+    "scaleway": scaleway_mapping,
 }

--- a/cartography/models/ontology/mapping/data/encryptionkeys.py
+++ b/cartography/models/ontology/mapping/data/encryptionkeys.py
@@ -83,8 +83,40 @@ azure_mapping = OntologyMapping(
     ],
 )
 
+scaleway_mapping = OntologyMapping(
+    module_name="scaleway",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="ScalewayKey",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name",
+                    node_field="name",
+                    required=True,
+                ),
+                OntologyFieldMapping(
+                    ontology_field="key_type",
+                    node_field="usage_type",
+                ),
+                OntologyFieldMapping(
+                    ontology_field="enabled",
+                    node_field="state",
+                    special_handling="equal_boolean",
+                    extra={"values": ["enabled"]},
+                ),
+                OntologyFieldMapping(
+                    ontology_field="rotation_enabled",
+                    node_field="rotation_period",
+                    special_handling="to_boolean",
+                ),
+            ],
+        ),
+    ],
+)
+
 ENCRYPTIONKEYS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws": aws_mapping,
     "gcp": gcp_mapping,
     "azure": azure_mapping,
+    "scaleway": scaleway_mapping,
 }

--- a/cartography/models/ontology/mapping/data/functions.py
+++ b/cartography/models/ontology/mapping/data/functions.py
@@ -97,8 +97,35 @@ azure_mapping = OntologyMapping(
     ],
 )
 
+scaleway_mapping = OntologyMapping(
+    module_name="scaleway",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="ScalewayServerlessFunction",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                OntologyFieldMapping(ontology_field="runtime", node_field="runtime"),
+                OntologyFieldMapping(
+                    ontology_field="memory", node_field="memory_limit"
+                ),
+                OntologyFieldMapping(ontology_field="timeout", node_field="timeout"),
+                # Scaleway Serverless Functions are source-code deployments.
+                OntologyFieldMapping(
+                    ontology_field="deployment_type",
+                    node_field="",
+                    special_handling="static_value",
+                    extra={"value": "code"},
+                ),
+            ],
+        ),
+    ],
+)
+
 FUNCTIONS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws": aws_mapping,
     "gcp": gcp_mapping,
     "azure": azure_mapping,
+    "scaleway": scaleway_mapping,
 }

--- a/cartography/models/ontology/mapping/data/images.py
+++ b/cartography/models/ontology/mapping/data/images.py
@@ -78,9 +78,24 @@ github_mapping = OntologyMapping(
     ],
 )
 
+scaleway_mapping = OntologyMapping(
+    module_name="scaleway",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="ScalewayContainerRegistryImage",
+            fields=[
+                OntologyFieldMapping(ontology_field="digest", node_field="digest"),
+                # Scaleway's registry API exposes no per-digest architecture/os
+                # or manifest-list metadata, so only the digest is mapped.
+            ],
+        ),
+    ],
+)
+
 IMAGES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws": aws_ecr_mapping,
     "gcp": gcp_mapping,
     "github": github_mapping,
     "gitlab": gitlab_mapping,
+    "scaleway": scaleway_mapping,
 }

--- a/cartography/models/scaleway/container_registry/image.py
+++ b/cartography/models/scaleway/container_registry/image.py
@@ -24,6 +24,12 @@ class ScalewayContainerRegistryImageProperties(CartographyNodeProperties):
     # Ordered uncompressed layer digests, from the OCI image config; feeds the
     # supply-chain dockerfile matcher. Populated by the supply_chain enrichment.
     layer_diff_ids: PropertyRef = PropertyRef("layer_diff_ids")
+    # Source provenance (code-to-cloud): the VCS repo the image was built from,
+    # from OCI labels/annotations or the SLSA attestation. `source_uri` is the
+    # match key for (:Image)-[:PACKAGED_FROM]->(:GitHubRepository|GitLab repo).
+    source_uri: PropertyRef = PropertyRef("source_uri", extra_index=True)
+    source_revision: PropertyRef = PropertyRef("source_revision")
+    source_file: PropertyRef = PropertyRef("source_file")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 

--- a/cartography/models/scaleway/container_registry/image.py
+++ b/cartography/models/scaleway/container_registry/image.py
@@ -3,27 +3,23 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
-from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
 @dataclass(frozen=True)
 class ScalewayContainerRegistryImageProperties(CartographyNodeProperties):
-    id: PropertyRef = PropertyRef("id", extra_index=True)
-    name: PropertyRef = PropertyRef("name", extra_index=True)
-    status: PropertyRef = PropertyRef("status")
-    status_message: PropertyRef = PropertyRef("status_message")
-    # Per-image visibility (`public`, `private`, `inherit`). Combined with
-    # the namespace `is_public`, drives the public-image exposure signal.
-    visibility: PropertyRef = PropertyRef("visibility")
-    size: PropertyRef = PropertyRef("size")
-    tags: PropertyRef = PropertyRef("tags")
-    created_at: PropertyRef = PropertyRef("created_at")
-    updated_at: PropertyRef = PropertyRef("updated_at")
+    # The digest-addressed image content. Scaleway's registry keys content by
+    # digest (carried on tags); the "named image" from list_images is only a
+    # repository grouping and is not modeled as its own node. Many tags (and
+    # repositories) can reference the same digest, so this node is deduplicated
+    # by digest.
+    id: PropertyRef = PropertyRef("digest")
+    digest: PropertyRef = PropertyRef("digest", extra_index=True)
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -47,35 +43,14 @@ class ScalewayContainerRegistryImageToProjectRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
-class ScalewayContainerRegistryImageToNamespaceRelProperties(CartographyRelProperties):
-    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
-
-
-@dataclass(frozen=True)
-# (:ScalewayContainerRegistryNamespace)-[:HAS]->(:ScalewayContainerRegistryImage)
-class ScalewayContainerRegistryImageToNamespaceRel(CartographyRelSchema):
-    target_node_label: str = "ScalewayContainerRegistryNamespace"
-    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("namespace_id")},
-    )
-    direction: LinkDirection = LinkDirection.INWARD
-    rel_label: str = "HAS"
-    properties: ScalewayContainerRegistryImageToNamespaceRelProperties = (
-        ScalewayContainerRegistryImageToNamespaceRelProperties()
-    )
-
-
-@dataclass(frozen=True)
 class ScalewayContainerRegistryImageSchema(CartographyNodeSchema):
     label: str = "ScalewayContainerRegistryImage"
+    # Ontology `Image`: the digest-addressed content, the join target for
+    # (:Container|:Function)-[:HAS_IMAGE]->(:Image) and RESOLVED_IMAGE.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Image"])
     properties: ScalewayContainerRegistryImageProperties = (
         ScalewayContainerRegistryImageProperties()
     )
     sub_resource_relationship: ScalewayContainerRegistryImageToProjectRel = (
         ScalewayContainerRegistryImageToProjectRel()
-    )
-    other_relationships: OtherRelationships = OtherRelationships(
-        [
-            ScalewayContainerRegistryImageToNamespaceRel(),
-        ]
     )

--- a/cartography/models/scaleway/container_registry/image.py
+++ b/cartography/models/scaleway/container_registry/image.py
@@ -8,6 +8,7 @@ from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -20,6 +21,9 @@ class ScalewayContainerRegistryImageProperties(CartographyNodeProperties):
     # by digest.
     id: PropertyRef = PropertyRef("digest")
     digest: PropertyRef = PropertyRef("digest", extra_index=True)
+    # Ordered uncompressed layer digests, from the OCI image config; feeds the
+    # supply-chain dockerfile matcher. Populated by the supply_chain enrichment.
+    layer_diff_ids: PropertyRef = PropertyRef("layer_diff_ids")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -43,6 +47,25 @@ class ScalewayContainerRegistryImageToProjectRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class ScalewayContainerRegistryImageToLayerRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayContainerRegistryImage)-[:HAS_LAYER]->(:ScalewayContainerRegistryImageLayer)
+class ScalewayContainerRegistryImageToLayerRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayContainerRegistryImageLayer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"diff_id": PropertyRef("layer_diff_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_LAYER"
+    properties: ScalewayContainerRegistryImageToLayerRelProperties = (
+        ScalewayContainerRegistryImageToLayerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class ScalewayContainerRegistryImageSchema(CartographyNodeSchema):
     label: str = "ScalewayContainerRegistryImage"
     # Ontology `Image`: the digest-addressed content, the join target for
@@ -53,4 +76,9 @@ class ScalewayContainerRegistryImageSchema(CartographyNodeSchema):
     )
     sub_resource_relationship: ScalewayContainerRegistryImageToProjectRel = (
         ScalewayContainerRegistryImageToProjectRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            ScalewayContainerRegistryImageToLayerRel(),
+        ]
     )

--- a/cartography/models/scaleway/container_registry/image.py
+++ b/cartography/models/scaleway/container_registry/image.py
@@ -14,15 +14,32 @@ from cartography.models.core.relationships import TargetNodeMatcher
 
 @dataclass(frozen=True)
 class ScalewayContainerRegistryImageProperties(CartographyNodeProperties):
-    # The digest-addressed image content. Scaleway's registry keys content by
-    # digest (carried on tags); the "named image" from list_images is only a
-    # repository grouping and is not modeled as its own node. Many tags (and
-    # repositories) can reference the same digest, so this node is deduplicated
-    # by digest.
+    # Base inventory properties, loaded from the registry listing. The
+    # digest-addressed image content: Scaleway keys content by digest (carried
+    # on tags); the "named image" from list_images is only a repository grouping
+    # and is not modeled as its own node. Deduplicated by digest.
+    #
+    # Layer/provenance fields are intentionally NOT here: `load()` rewrites every
+    # property of its schema, so a base `{digest}` load would null the fields the
+    # supply_chain enrichment owns. Those live on the enrichment schema below.
+    id: PropertyRef = PropertyRef("digest")
+    digest: PropertyRef = PropertyRef("digest", extra_index=True)
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewayContainerRegistryImageEnrichmentProperties(CartographyNodeProperties):
+    """Full property set written by the OCI supply-chain enrichment.
+
+    Includes the base fields (so identity/lastupdated stay set) plus the
+    layer/provenance fields; used only by ``supply_chain`` so the registry
+    inventory load never clears these.
+    """
+
     id: PropertyRef = PropertyRef("digest")
     digest: PropertyRef = PropertyRef("digest", extra_index=True)
     # Ordered uncompressed layer digests, from the OCI image config; feeds the
-    # supply-chain dockerfile matcher. Populated by the supply_chain enrichment.
+    # supply-chain dockerfile matcher.
     layer_diff_ids: PropertyRef = PropertyRef("layer_diff_ids")
     # Source provenance (code-to-cloud): the VCS repo the image was built from,
     # from OCI labels/annotations or the SLSA attestation. `source_uri` is the
@@ -73,12 +90,33 @@ class ScalewayContainerRegistryImageToLayerRel(CartographyRelSchema):
 
 @dataclass(frozen=True)
 class ScalewayContainerRegistryImageSchema(CartographyNodeSchema):
+    """Base image node from the registry inventory (namespaces sync).
+
+    Does not carry layer/provenance fields or HAS_LAYER so it never overwrites
+    what the supply_chain enrichment sets.
+    """
+
     label: str = "ScalewayContainerRegistryImage"
     # Ontology `Image`: the digest-addressed content, the join target for
     # (:Container|:Function)-[:HAS_IMAGE]->(:Image) and RESOLVED_IMAGE.
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Image"])
     properties: ScalewayContainerRegistryImageProperties = (
         ScalewayContainerRegistryImageProperties()
+    )
+    sub_resource_relationship: ScalewayContainerRegistryImageToProjectRel = (
+        ScalewayContainerRegistryImageToProjectRel()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayContainerRegistryImageEnrichmentSchema(CartographyNodeSchema):
+    """Enrichment view written by the OCI supply-chain step: adds layer/provenance
+    fields and the HAS_LAYER relationship without disturbing base inventory."""
+
+    label: str = "ScalewayContainerRegistryImage"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Image"])
+    properties: ScalewayContainerRegistryImageEnrichmentProperties = (
+        ScalewayContainerRegistryImageEnrichmentProperties()
     )
     sub_resource_relationship: ScalewayContainerRegistryImageToProjectRel = (
         ScalewayContainerRegistryImageToProjectRel()

--- a/cartography/models/scaleway/container_registry/image_layer.py
+++ b/cartography/models/scaleway/container_registry/image_layer.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class ScalewayContainerRegistryImageLayerNodeProperties(CartographyNodeProperties):
+    # A filesystem layer, keyed by its uncompressed digest (diff_id). Shared
+    # across images that reuse the same layer. `history` is the build command
+    # (`created_by`) that produced it; the supply-chain dockerfile matcher
+    # compares these against repository Dockerfiles.
+    id: PropertyRef = PropertyRef("diff_id")
+    diff_id: PropertyRef = PropertyRef("diff_id", extra_index=True)
+    history: PropertyRef = PropertyRef("history")
+    is_empty: PropertyRef = PropertyRef("is_empty")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewayContainerRegistryImageLayerToProjectRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewayContainerRegistryImageLayer)
+class ScalewayContainerRegistryImageLayerToProjectRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewayContainerRegistryImageLayerToProjectRelProperties = (
+        ScalewayContainerRegistryImageLayerToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayContainerRegistryImageLayerSchema(CartographyNodeSchema):
+    label: str = "ScalewayContainerRegistryImageLayer"
+    # `ImageLayer` is the cross-provider label the supply-chain dockerfile
+    # matcher looks up by diff_id (mirrors ECRImageLayer / GCPArtifactRegistryImageLayer).
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ImageLayer"])
+    properties: ScalewayContainerRegistryImageLayerNodeProperties = (
+        ScalewayContainerRegistryImageLayerNodeProperties()
+    )
+    sub_resource_relationship: ScalewayContainerRegistryImageLayerToProjectRel = (
+        ScalewayContainerRegistryImageLayerToProjectRel()
+    )

--- a/cartography/models/scaleway/container_registry/image_tag.py
+++ b/cartography/models/scaleway/container_registry/image_tag.py
@@ -1,0 +1,113 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class ScalewayContainerRegistryImageTagNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    # `name` is the tag string (e.g. "latest", "v1.2.3").
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    # The repository (named image) the tag belongs to, denormalized from
+    # list_images since Scaleway does not model the named image as its own node.
+    image_name: PropertyRef = PropertyRef("image_name", extra_index=True)
+    # Full pull URI, e.g. rg.fr-par.scw.cloud/<namespace>/<image>:<tag>.
+    uri: PropertyRef = PropertyRef("uri", extra_index=True)
+    digest: PropertyRef = PropertyRef("digest", extra_index=True)
+    status: PropertyRef = PropertyRef("status")
+    # Per-image visibility (`public`, `private`, `inherit`); combined with the
+    # namespace `is_public` flag it drives the public-image exposure signal.
+    visibility: PropertyRef = PropertyRef("visibility")
+    created_at: PropertyRef = PropertyRef("created_at")
+    updated_at: PropertyRef = PropertyRef("updated_at")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewayContainerRegistryImageTagToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewayContainerRegistryImageTag)
+class ScalewayContainerRegistryImageTagToProjectRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewayContainerRegistryImageTagToProjectRelProperties = (
+        ScalewayContainerRegistryImageTagToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayContainerRegistryImageTagToNamespaceRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayContainerRegistryNamespace)-[:REPO_IMAGE]->(:ScalewayContainerRegistryImageTag)
+# REPO_IMAGE is the canonical cross-provider registry -> tag edge (mirrors
+# ECRRepository / GCPArtifactRegistryRepository), consumed by the supply-chain
+# code-to-cloud matchers.
+class ScalewayContainerRegistryImageTagToNamespaceRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayContainerRegistryNamespace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("namespace_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "REPO_IMAGE"
+    properties: ScalewayContainerRegistryImageTagToNamespaceRelProperties = (
+        ScalewayContainerRegistryImageTagToNamespaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayContainerRegistryImageTagToImageRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayContainerRegistryImageTag)-[:IMAGE]->(:ScalewayContainerRegistryImage)
+class ScalewayContainerRegistryImageTagToImageRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayContainerRegistryImage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"digest": PropertyRef("digest")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "IMAGE"
+    properties: ScalewayContainerRegistryImageTagToImageRelProperties = (
+        ScalewayContainerRegistryImageTagToImageRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayContainerRegistryImageTagSchema(CartographyNodeSchema):
+    label: str = "ScalewayContainerRegistryImageTag"
+    # Ontology `ImageTag`: a named pointer (tag) to a digest-addressed Image.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ImageTag"])
+    properties: ScalewayContainerRegistryImageTagNodeProperties = (
+        ScalewayContainerRegistryImageTagNodeProperties()
+    )
+    sub_resource_relationship: ScalewayContainerRegistryImageTagToProjectRel = (
+        ScalewayContainerRegistryImageTagToProjectRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            ScalewayContainerRegistryImageTagToNamespaceRel(),
+            ScalewayContainerRegistryImageTagToImageRel(),
+        ]
+    )

--- a/cartography/models/scaleway/iam/permission_relationship.py
+++ b/cartography/models/scaleway/iam/permission_relationship.py
@@ -1,0 +1,151 @@
+"""MatchLink schemas for materialized Scaleway IAM permission edges.
+
+Scaleway IAM is coarse-grained: a Policy applies to a principal (user,
+application or group) and holds Rules, each granting one or more named
+permission sets scoped to a Project or the whole Organization. The API exposes
+neither the individual actions inside a permission set nor per-resource ARNs, so
+the AWS/GCP/Azure permission_relationships engine (which matches
+action-string x resource-ARN) does not apply here.
+
+Instead we materialize two factual, first-class edges from the policy/rule graph:
+
+* ``(principal)-[:HAS_ROLE]->(:ScalewayPermissionSet)`` -- the canonical
+  cross-provider role grant (mirrors AWS/GCP/Azure HAS_ROLE).
+* ``(principal)-[:CAN_ACCESS]->(:ScalewayProject)`` -- the concrete scope of the
+  grant, derived from ``rule.project_ids`` (organization-scoped rules fan out to
+  every project). Resources hang off the project via ``RESOURCE``, so this makes
+  principal -> resource access-path analysis traversable. ``has_condition`` flags
+  grants that are only reachable under an IAM rule condition.
+"""
+
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import SourceNodeMatcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+# --- HAS_ROLE: principal -> permission set -------------------------------------
+
+
+@dataclass(frozen=True)
+class ScalewayHasRoleRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label", set_in_kwargs=True
+    )
+    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayUser)-[:HAS_ROLE]->(:ScalewayPermissionSet)
+class ScalewayUserToPermissionSetMatchLink(CartographyRelSchema):
+    source_node_label: str = "ScalewayUser"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("user_id")},
+    )
+    target_node_label: str = "ScalewayPermissionSet"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"name": PropertyRef("permission_set_name")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_ROLE"
+    properties: ScalewayHasRoleRelProperties = ScalewayHasRoleRelProperties()
+
+
+@dataclass(frozen=True)
+# (:ScalewayApplication)-[:HAS_ROLE]->(:ScalewayPermissionSet)
+class ScalewayApplicationToPermissionSetMatchLink(CartographyRelSchema):
+    source_node_label: str = "ScalewayApplication"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("application_id")},
+    )
+    target_node_label: str = "ScalewayPermissionSet"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"name": PropertyRef("permission_set_name")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_ROLE"
+    properties: ScalewayHasRoleRelProperties = ScalewayHasRoleRelProperties()
+
+
+@dataclass(frozen=True)
+# (:ScalewayGroup)-[:HAS_ROLE]->(:ScalewayPermissionSet)
+class ScalewayGroupToPermissionSetMatchLink(CartographyRelSchema):
+    source_node_label: str = "ScalewayGroup"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("group_id")},
+    )
+    target_node_label: str = "ScalewayPermissionSet"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"name": PropertyRef("permission_set_name")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_ROLE"
+    properties: ScalewayHasRoleRelProperties = ScalewayHasRoleRelProperties()
+
+
+# --- CAN_ACCESS: principal -> project (scope) ----------------------------------
+
+
+@dataclass(frozen=True)
+class ScalewayCanAccessRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label", set_in_kwargs=True
+    )
+    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
+    # True when every grant path to this project is gated by an IAM rule condition.
+    has_condition: PropertyRef = PropertyRef("has_condition")
+
+
+@dataclass(frozen=True)
+# (:ScalewayUser)-[:CAN_ACCESS]->(:ScalewayProject)
+class ScalewayUserToProjectMatchLink(CartographyRelSchema):
+    source_node_label: str = "ScalewayUser"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("user_id")},
+    )
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("project_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "CAN_ACCESS"
+    properties: ScalewayCanAccessRelProperties = ScalewayCanAccessRelProperties()
+
+
+@dataclass(frozen=True)
+# (:ScalewayApplication)-[:CAN_ACCESS]->(:ScalewayProject)
+class ScalewayApplicationToProjectMatchLink(CartographyRelSchema):
+    source_node_label: str = "ScalewayApplication"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("application_id")},
+    )
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("project_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "CAN_ACCESS"
+    properties: ScalewayCanAccessRelProperties = ScalewayCanAccessRelProperties()
+
+
+@dataclass(frozen=True)
+# (:ScalewayGroup)-[:CAN_ACCESS]->(:ScalewayProject)
+class ScalewayGroupToProjectMatchLink(CartographyRelSchema):
+    source_node_label: str = "ScalewayGroup"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("group_id")},
+    )
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("project_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "CAN_ACCESS"
+    properties: ScalewayCanAccessRelProperties = ScalewayCanAccessRelProperties()

--- a/cartography/models/scaleway/serverless/container.py
+++ b/cartography/models/scaleway/serverless/container.py
@@ -18,6 +18,9 @@ class ScalewayServerlessContainerProperties(CartographyNodeProperties):
     name: PropertyRef = PropertyRef("name", extra_index=True)
     status: PropertyRef = PropertyRef("status")
     registry_image: PropertyRef = PropertyRef("registry_image", extra_index=True)
+    # Digest the `registry_image` pull URI resolves to, populated at ingest from
+    # the container-registry sync so HAS_IMAGE can match the Image node.
+    image_digest: PropertyRef = PropertyRef("image_digest", extra_index=True)
     # Exposure signal: `public` lets anyone invoke the container without auth.
     privacy: PropertyRef = PropertyRef("privacy")
     domain_name: PropertyRef = PropertyRef("domain_name", extra_index=True)
@@ -99,11 +102,38 @@ class ScalewayServerlessContainerToPrivateNetworkRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class ScalewayServerlessContainerToImageRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayServerlessContainer)-[:HAS_IMAGE]->(:ScalewayContainerRegistryImage)
+# The container's `registry_image` pull URI is resolved to a digest at ingest;
+# this ties the running container to the digest-addressed Image so the shared
+# RESOLVED_IMAGE analysis can reach it.
+class ScalewayServerlessContainerToImageRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayContainerRegistryImage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"digest": PropertyRef("image_digest")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_IMAGE"
+    properties: ScalewayServerlessContainerToImageRelProperties = (
+        ScalewayServerlessContainerToImageRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class ScalewayServerlessContainerSchema(CartographyNodeSchema):
     label: str = "ScalewayServerlessContainer"
     # A Scaleway Serverless Container is a managed, autoscaled container service
-    # (the Cloud Run Service / AWS App Runner analog), so it maps to ComputeService.
-    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeService"])
+    # (the Cloud Run Service / AWS App Runner analog) that runs a single
+    # container. It is both the service (`ComputeService`) and the running
+    # container (`Container`); the `Container` label lets the shared
+    # RESOLVED_IMAGE analysis reach it via HAS_IMAGE.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        ["ComputeService", "Container"]
+    )
     properties: ScalewayServerlessContainerProperties = (
         ScalewayServerlessContainerProperties()
     )
@@ -114,5 +144,6 @@ class ScalewayServerlessContainerSchema(CartographyNodeSchema):
         [
             ScalewayServerlessContainerToNamespaceRel(),
             ScalewayServerlessContainerToPrivateNetworkRel(),
+            ScalewayServerlessContainerToImageRel(),
         ]
     )

--- a/cartography/models/scaleway/serverless/container.py
+++ b/cartography/models/scaleway/serverless/container.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -100,6 +101,9 @@ class ScalewayServerlessContainerToPrivateNetworkRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class ScalewayServerlessContainerSchema(CartographyNodeSchema):
     label: str = "ScalewayServerlessContainer"
+    # A Scaleway Serverless Container is a managed, autoscaled container service
+    # (the Cloud Run Service / AWS App Runner analog), so it maps to ComputeService.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeService"])
     properties: ScalewayServerlessContainerProperties = (
         ScalewayServerlessContainerProperties()
     )

--- a/cartography/models/scaleway/serverless/container_namespace.py
+++ b/cartography/models/scaleway/serverless/container_namespace.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -52,6 +53,7 @@ class ScalewayServerlessContainerNamespaceToProjectRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class ScalewayServerlessContainerNamespaceSchema(CartographyNodeSchema):
     label: str = "ScalewayServerlessContainerNamespace"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeNamespace"])
     properties: ScalewayServerlessContainerNamespaceProperties = (
         ScalewayServerlessContainerNamespaceProperties()
     )

--- a/cartography/models/scaleway/serverless/function.py
+++ b/cartography/models/scaleway/serverless/function.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -96,6 +97,7 @@ class ScalewayServerlessFunctionToPrivateNetworkRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class ScalewayServerlessFunctionSchema(CartographyNodeSchema):
     label: str = "ScalewayServerlessFunction"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Function"])
     properties: ScalewayServerlessFunctionProperties = (
         ScalewayServerlessFunctionProperties()
     )

--- a/cartography/models/scaleway/serverless/function_namespace.py
+++ b/cartography/models/scaleway/serverless/function_namespace.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -52,6 +53,7 @@ class ScalewayServerlessFunctionNamespaceToProjectRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class ScalewayServerlessFunctionNamespaceSchema(CartographyNodeSchema):
     label: str = "ScalewayServerlessFunctionNamespace"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeNamespace"])
     properties: ScalewayServerlessFunctionNamespaceProperties = (
         ScalewayServerlessFunctionNamespaceProperties()
     )

--- a/cartography/rules/data/rules/policy_administration_privileges.py
+++ b/cartography/rules/data/rules/policy_administration_privileges.py
@@ -270,6 +270,57 @@ _azure_policy_manipulation_capabilities = Fact(
 )
 
 
+# Scaleway
+_scaleway_policy_manipulation_capabilities = Fact(
+    id="scaleway_policy_manipulation_capabilities",
+    name="Scaleway Principals with IAM Administration Permissions",
+    description=(
+        "Scaleway principals (users, applications or groups) granted the "
+        "`IAMManager` permission set, which gives full access to IAM: creating "
+        "and editing policies, permission sets and API keys for any principal. "
+        "Indirect privilege-escalation surface. The grant is resolved through "
+        "the materialized principal-[:HAS_ROLE]->PermissionSet edge; group "
+        "grants are inherited by members via MEMBER_OF."
+    ),
+    cypher_query="""
+    MATCH (org:ScalewayOrganization)-[:RESOURCE]->(ps:ScalewayPermissionSet)
+    WHERE ps.name = 'IAMManager'
+    MATCH (principal)-[:HAS_ROLE]->(ps)
+    WHERE any(l IN labels(principal)
+              WHERE l IN ['ScalewayUser', 'ScalewayApplication', 'ScalewayGroup'])
+    RETURN
+        org.id AS account,
+        org.id AS account_id,
+        coalesce(principal.email, principal.name, principal.id) AS principal_name,
+        principal.id AS principal_identifier,
+        head([l IN ['UserAccount', 'ServiceAccount', 'UserGroup']
+              WHERE l IN labels(principal)]) AS principal_type,
+        ps.id AS policy_id,
+        ps.name AS policy_name,
+        [ps.name] AS actions,
+        [org.id] AS resources
+    ORDER BY account, principal_name
+    """,
+    cypher_visual_query="""
+    MATCH p=(org:ScalewayOrganization)-[:RESOURCE]->(ps:ScalewayPermissionSet)<-[:HAS_ROLE]-(principal)
+    WHERE ps.name = 'IAMManager'
+      AND any(l IN labels(principal)
+              WHERE l IN ['ScalewayUser', 'ScalewayApplication', 'ScalewayGroup'])
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (principal)
+    WHERE any(l IN labels(principal)
+              WHERE l IN ['ScalewayUser', 'ScalewayApplication', 'ScalewayGroup'])
+    RETURN COUNT(principal) AS count
+    """,
+    asset_id_field="principal_identifier",
+    identity_fields=("account_id", "principal_identifier", "policy_id"),
+    module=Module.SCALEWAY,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+
 # Findings
 class PolicyAdministrationPrivileges(Finding):
     principal_name: str | None = None
@@ -297,6 +348,7 @@ policy_administration_privileges = Rule(
         _aws_policy_manipulation_capabilities,
         _azure_policy_manipulation_capabilities,
         _gcp_policy_manipulation_capabilities,
+        _scaleway_policy_manipulation_capabilities,
     ),
     tags=(
         "iam",

--- a/docs/root/modules/scaleway/schema.md
+++ b/docs/root/modules/scaleway/schema.md
@@ -1384,9 +1384,9 @@ Represents a Scaleway Container Registry namespace (top-level repository scope).
     ```
     (:ScalewayProject)-[:RESOURCE]->(:ScalewayContainerRegistryNamespace)
     ```
-- A `ContainerRegistryNamespace` has `ContainerRegistryImage` members.
+- A `ContainerRegistryNamespace` exposes image tags (canonical `REPO_IMAGE` registry -> tag edge).
     ```
-    (:ScalewayContainerRegistryNamespace)-[:HAS]->(:ScalewayContainerRegistryImage)
+    (:ScalewayContainerRegistryNamespace)-[:REPO_IMAGE]->(:ScalewayContainerRegistryImageTag)
     ```
 
 

--- a/docs/root/modules/scaleway/schema.md
+++ b/docs/root/modules/scaleway/schema.md
@@ -1664,16 +1664,17 @@ Represents a Scaleway Serverless Containers namespace (project-scoped grouping o
 
 ### ScalewayServerlessContainer
 
-Represents a Scaleway Serverless Container (a managed, autoscaled container service).
+Represents a Scaleway Serverless Container (a managed, autoscaled container service that runs a single container).
 
-> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for container services across different systems (e.g., ECSService, GCPCloudRunService).
+> **Ontology Mapping**: This node has the extra labels `ComputeService` (cross-platform container services, e.g. ECSService, GCPCloudRunService) and `Container` (the running container, so the shared `RESOLVED_IMAGE` analysis reaches it via `HAS_IMAGE`).
 
 | Field      | Description                                  |
 |------------|----------------------------------------------|
 | id         | Container UUID.                              |
 | name       | Container name.                              |
 | status     | Container status.                            |
-| registry_image | Container image URI pulled at deploy time. |
+| registry_image | Container image pull URI.                |
+| image_digest | Digest the `registry_image` resolves to, populated at ingest from the container-registry sync. |
 | privacy    | Invocation privacy (`public` allows unauthenticated invokes, `private` requires a token). |
 | domain_name | Auto-assigned invocation domain.            |
 | http_option | `enabled` allows plain HTTP; `redirected` forces HTTPS. |
@@ -1704,6 +1705,10 @@ Represents a Scaleway Serverless Container (a managed, autoscaled container serv
 - A `ServerlessContainer` may be attached to a `PrivateNetwork`.
     ```
     (:ScalewayServerlessContainer)-[:ATTACHED_TO]->(:ScalewayPrivateNetwork)
+    ```
+- A `ServerlessContainer` runs a digest-addressed `Image` (its `registry_image` resolved to a digest). Feeds the shared `RESOLVED_IMAGE` analysis.
+    ```
+    (:ScalewayServerlessContainer)-[:HAS_IMAGE]->(:ScalewayContainerRegistryImage)
     ```
 
 

--- a/docs/root/modules/scaleway/schema.md
+++ b/docs/root/modules/scaleway/schema.md
@@ -191,6 +191,14 @@ Represents a User in Scaleway.
     ```
     (:ScalewayApiKey)-[:OWNED_BY]->(:ScalewayUser)
     ```
+- `User` is granted a `PermissionSet` (canonical `HAS_ROLE`, materialized from the policy/rule graph).
+    ```
+    (:ScalewayUser)-[:HAS_ROLE]->(:ScalewayPermissionSet)
+    ```
+- `User` can access a `Project` (materialized scope of the grant; `has_condition` flags condition-gated grants).
+    ```
+    (:ScalewayUser)-[:CAN_ACCESS]->(:ScalewayProject)
+    ```
 
 
 ### ScalewayGroup
@@ -221,6 +229,14 @@ Represents a Group in Scaleway.
     ```
     (:ScalewayUser)-[:MEMBER_OF]->(:ScalewayGroup)
     (:ScalewayApplication)-[:MEMBER_OF]->(:ScalewayGroup)
+    ```
+- `Group` is granted a `PermissionSet` (canonical `HAS_ROLE`; members inherit via `MEMBER_OF`).
+    ```
+    (:ScalewayGroup)-[:HAS_ROLE]->(:ScalewayPermissionSet)
+    ```
+- `Group` can access a `Project` (materialized scope of the grant).
+    ```
+    (:ScalewayGroup)-[:CAN_ACCESS]->(:ScalewayProject)
     ```
 
 
@@ -256,6 +272,14 @@ Represents an Application (Service Account) in Scaleway
 - `Application` owns `ApiKey`
     ```
     (:ScalewayApiKey)-[:OWNED_BY]->(:ScalewayApplication)
+    ```
+- `Application` is granted a `PermissionSet` (canonical `HAS_ROLE`, materialized from the policy/rule graph).
+    ```
+    (:ScalewayApplication)-[:HAS_ROLE]->(:ScalewayPermissionSet)
+    ```
+- `Application` can access a `Project` (materialized scope of the grant).
+    ```
+    (:ScalewayApplication)-[:CAN_ACCESS]->(:ScalewayProject)
     ```
 
 ### ScalewayApiKey
@@ -359,6 +383,8 @@ Represents an IAM Rule within a Policy. Rules define which permission sets apply
 
 Represents a Permission Set in Scaleway. Permission sets are predefined collections of permissions.
 
+> **Ontology Mapping**: This node has the extra label `PermissionRole` to enable cross-platform queries for roles across different systems (e.g., AWSRole, GCPRole, AzureRoleDefinition).
+
 | Field       | Description                                  |
 |-------------|----------------------------------------------|
 | id          | ID of the permission set.                    |
@@ -372,6 +398,12 @@ Represents a Permission Set in Scaleway. Permission sets are predefined collecti
 - `PermissionSet` belongs to an `Organization`.
     ```
     (:ScalewayOrganization)-[:RESOURCE]->(:ScalewayPermissionSet)
+    ```
+- Principals (`User`, `Application`, `Group`) are granted a `PermissionSet` via the canonical `HAS_ROLE` edge, materialized from the policy/rule graph.
+    ```
+    (:ScalewayUser)-[:HAS_ROLE]->(:ScalewayPermissionSet)
+    (:ScalewayApplication)-[:HAS_ROLE]->(:ScalewayPermissionSet)
+    (:ScalewayGroup)-[:HAS_ROLE]->(:ScalewayPermissionSet)
     ```
 
 
@@ -1347,31 +1379,60 @@ Represents a Scaleway Container Registry namespace (top-level repository scope).
     ```
 
 
-### ScalewayContainerRegistryImage
+### ScalewayContainerRegistryImageTag
 
-Represents a container image stored in a Container Registry namespace.
+Represents a tag (a named pointer such as `latest` or `v1.2.3`) inside a Container Registry namespace, resolving to a specific image digest. Scaleway's namespace is the registry (like a GCP Artifact Registry repository), so the "named image" from `list_images` is not modeled as its own node; its name and visibility are denormalized onto the tag.
+
+> **Ontology Mapping**: This node has the extra label `ImageTag` to enable cross-platform queries for image tags across registries (e.g. ECRRepositoryImage, GCPArtifactRegistryRepositoryImage, GitLabContainerRepositoryTag).
 
 | Field      | Description                                  |
 |------------|----------------------------------------------|
-| id         | Image UUID.                                  |
-| name       | Image name (without tag).                    |
-| status     | Image status.                                |
-| status_message | Human-readable status message.           |
+| id         | Tag UUID.                                    |
+| name       | Tag string (e.g. `latest`).                  |
+| image_name | Name of the repository (named image) the tag belongs to. |
+| uri        | Full pull URI, e.g. `rg.fr-par.scw.cloud/<namespace>/<image>:<tag>`. |
+| digest     | Digest (sha256) the tag resolves to.         |
+| status     | Tag status.                                  |
 | visibility | Per-image visibility (`public`, `private`, `inherit`). Combined with the namespace `is_public` flag to derive effective exposure. |
-| size       | Total image size in bytes.                   |
-| tags       | List of tag names available for this image.  |
 | created_at | Creation timestamp.                          |
 | updated_at | Last update timestamp.                       |
 | lastupdated | Timestamp of the last update                |
 
 #### Relationships
-- A `ContainerRegistryImage` belongs to a `Project`.
+- An `ImageTag` belongs to a `Project`.
+    ```
+    (:ScalewayProject)-[:RESOURCE]->(:ScalewayContainerRegistryImageTag)
+    ```
+- An `ImageTag` lives in a `ContainerRegistryNamespace` (canonical `REPO_IMAGE` registry -> tag edge).
+    ```
+    (:ScalewayContainerRegistryNamespace)-[:REPO_IMAGE]->(:ScalewayContainerRegistryImageTag)
+    ```
+- An `ImageTag` resolves to a digest-addressed `Image`.
+    ```
+    (:ScalewayContainerRegistryImageTag)-[:IMAGE]->(:ScalewayContainerRegistryImage)
+    ```
+
+
+### ScalewayContainerRegistryImage
+
+Represents the digest-addressed image content in a Container Registry. Deduplicated by digest, so multiple tags (and repositories) referencing the same digest share one node.
+
+> **Ontology Mapping**: This node has the extra label `Image` to enable cross-platform queries for container images across registries (e.g. ECRImage, GCPArtifactRegistryImage, GitLabContainerImage). It is the join target for `(:Container|:Function)-[:HAS_IMAGE]->(:Image)` and `RESOLVED_IMAGE`.
+
+| Field      | Description                                  |
+|------------|----------------------------------------------|
+| id         | Image digest (sha256).                       |
+| digest     | Image digest (sha256).                       |
+| lastupdated | Timestamp of the last update                |
+
+#### Relationships
+- An `Image` belongs to a `Project`.
     ```
     (:ScalewayProject)-[:RESOURCE]->(:ScalewayContainerRegistryImage)
     ```
-- A `ContainerRegistryImage` lives in a `ContainerRegistryNamespace`.
+- Tags resolve to an `Image`.
     ```
-    (:ScalewayContainerRegistryNamespace)-[:HAS]->(:ScalewayContainerRegistryImage)
+    (:ScalewayContainerRegistryImageTag)-[:IMAGE]->(:ScalewayContainerRegistryImage)
     ```
 
 
@@ -1496,6 +1557,8 @@ Represents a managed MongoDB instance (Scaleway "Managed Database for MongoDB").
 
 Represents a Scaleway Serverless Functions namespace (project-scoped grouping of functions, backed by a hidden container registry namespace).
 
+> **Ontology Mapping**: This node has the extra label `ComputeNamespace` to enable cross-platform queries for compute namespaces across different systems (e.g., KubernetesNamespace).
+
 | Field      | Description                                  |
 |------------|----------------------------------------------|
 | id         | Namespace UUID.                              |
@@ -1526,6 +1589,8 @@ Represents a Scaleway Serverless Functions namespace (project-scoped grouping of
 ### ScalewayServerlessFunction
 
 Represents a Scaleway Serverless Function.
+
+> **Ontology Mapping**: This node has the extra label `Function` to enable cross-platform queries for functions across different systems (e.g., AWSLambda, GCPCloudFunction, AzureFunctionApp).
 
 | Field      | Description                                  |
 |------------|----------------------------------------------|
@@ -1568,6 +1633,8 @@ Represents a Scaleway Serverless Function.
 
 Represents a Scaleway Serverless Containers namespace (project-scoped grouping of containers, backed by a hidden container registry namespace).
 
+> **Ontology Mapping**: This node has the extra label `ComputeNamespace` to enable cross-platform queries for compute namespaces across different systems (e.g., KubernetesNamespace).
+
 | Field      | Description                                  |
 |------------|----------------------------------------------|
 | id         | Namespace UUID.                              |
@@ -1597,7 +1664,9 @@ Represents a Scaleway Serverless Containers namespace (project-scoped grouping o
 
 ### ScalewayServerlessContainer
 
-Represents a Scaleway Serverless Container.
+Represents a Scaleway Serverless Container (a managed, autoscaled container service).
+
+> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for container services across different systems (e.g., ECSService, GCPCloudRunService).
 
 | Field      | Description                                  |
 |------------|----------------------------------------------|

--- a/docs/root/modules/scaleway/schema.md
+++ b/docs/root/modules/scaleway/schema.md
@@ -35,7 +35,9 @@ PRJ -- RESOURCE --> KC(KapsuleCluster)
 PRJ -- RESOURCE --> KP(KapsulePool)
 PRJ -- RESOURCE --> KN(KapsuleNode)
 PRJ -- RESOURCE --> CRN(ContainerRegistryNamespace)
+PRJ -- RESOURCE --> CIT(ContainerRegistryImageTag)
 PRJ -- RESOURCE --> CRI(ContainerRegistryImage)
+PRJ -- RESOURCE --> CIL(ContainerRegistryImageLayer)
 PRJ -- RESOURCE --> RDB(RdbInstance)
 PRJ -- RESOURCE --> RC(RedisCluster)
 PRJ -- RESOURCE --> MGO(MongoDBInstance)
@@ -64,7 +66,9 @@ KC -- HAS --> KP
 KC -- HAS --> KN
 KP -- HAS --> KN
 KC -- ATTACHED_TO --> PN
-CRN -- HAS --> CRI
+CRN -- REPO_IMAGE --> CIT
+CIT -- IMAGE --> CRI
+CRI -- HAS_LAYER --> CIL
 RDB -- ATTACHED_TO --> PN
 RC -- ATTACHED_TO --> PN
 MGO -- ATTACHED_TO --> PN
@@ -72,6 +76,7 @@ SFN -- HAS --> SF
 SCN -- HAS --> SC
 SF -- ATTACHED_TO --> PN
 SC -- ATTACHED_TO --> PN
+SC -- HAS_IMAGE --> CRI
 USR -- MEMBER_OF --> GRP(ScalewayGroup)
 APIKEY(ScalewayApiKey) -- OWNED_BY --> USR
 APP -- MEMBER_OF --> GRP(ScalewayGroup)
@@ -81,6 +86,12 @@ POL -- APPLIES_TO --> GRP
 POL -- APPLIES_TO --> APP
 POL -- HAS --> RULE(Rule)
 RULE -- SCOPED_TO --> PRJ
+USR -- HAS_ROLE --> PS
+APP -- HAS_ROLE --> PS
+GRP -- HAS_ROLE --> PS
+USR -- CAN_ACCESS --> PRJ
+APP -- CAN_ACCESS --> PRJ
+GRP -- CAN_ACCESS --> PRJ
 ```
 
 ### ScalewayOrganization

--- a/docs/root/modules/scaleway/schema.md
+++ b/docs/root/modules/scaleway/schema.md
@@ -1419,10 +1419,16 @@ Represents the digest-addressed image content in a Container Registry. Deduplica
 
 > **Ontology Mapping**: This node has the extra label `Image` to enable cross-platform queries for container images across registries (e.g. ECRImage, GCPArtifactRegistryImage, GitLabContainerImage). It is the join target for `(:Container|:Function)-[:HAS_IMAGE]->(:Image)` and `RESOLVED_IMAGE`.
 
+Provenance and layer fields are populated from the OCI registry endpoint by the supply-chain enrichment.
+
 | Field      | Description                                  |
 |------------|----------------------------------------------|
 | id         | Image digest (sha256).                       |
 | digest     | Image digest (sha256).                       |
+| layer_diff_ids | Ordered uncompressed layer digests (from the OCI image config). |
+| source_uri | Source VCS repository URL the image was built from (OCI label/annotation or SLSA attestation). Match key for `PACKAGED_FROM`. |
+| source_revision | Source commit the image was built from.   |
+| source_file | Dockerfile path within the source repository. |
 | lastupdated | Timestamp of the last update                |
 
 #### Relationships
@@ -1433,6 +1439,40 @@ Represents the digest-addressed image content in a Container Registry. Deduplica
 - Tags resolve to an `Image`.
     ```
     (:ScalewayContainerRegistryImageTag)-[:IMAGE]->(:ScalewayContainerRegistryImage)
+    ```
+- An `Image` is composed of filesystem layers.
+    ```
+    (:ScalewayContainerRegistryImage)-[:HAS_LAYER]->(:ScalewayContainerRegistryImageLayer)
+    ```
+- An `Image` is built from a source repository (code-to-cloud, drawn by the GitHub/GitLab supply-chain matchers from `source_uri` or layer analysis).
+    ```
+    (:ScalewayContainerRegistryImage)-[:PACKAGED_FROM]->(:GitHubRepository)
+    (:ScalewayContainerRegistryImage)-[:PACKAGED_FROM]->(:GitLabProject)
+    ```
+
+
+### ScalewayContainerRegistryImageLayer
+
+Represents a filesystem layer of a container image, keyed by its uncompressed digest (`diff_id`) and shared across images that reuse it.
+
+> **Ontology Mapping**: This node has the extra label `ImageLayer` to enable cross-platform queries and the supply-chain dockerfile matcher (e.g. ECRImageLayer, GCPArtifactRegistryImageLayer).
+
+| Field      | Description                                  |
+|------------|----------------------------------------------|
+| id         | Layer diff_id (sha256).                      |
+| diff_id    | Uncompressed layer digest (sha256).          |
+| history    | Build command (`created_by`) that produced the layer. |
+| is_empty   | Whether the layer is an empty (metadata-only) layer. |
+| lastupdated | Timestamp of the last update                |
+
+#### Relationships
+- A layer belongs to a `Project`.
+    ```
+    (:ScalewayProject)-[:RESOURCE]->(:ScalewayContainerRegistryImageLayer)
+    ```
+- An `Image` is composed of layers.
+    ```
+    (:ScalewayContainerRegistryImage)-[:HAS_LAYER]->(:ScalewayContainerRegistryImageLayer)
     ```
 
 

--- a/tests/data/scaleway/container_registry.py
+++ b/tests/data/scaleway/container_registry.py
@@ -6,11 +6,17 @@ from scaleway.registry.v1 import ImageStatus
 from scaleway.registry.v1 import ImageVisibility
 from scaleway.registry.v1 import Namespace
 from scaleway.registry.v1 import NamespaceStatus
+from scaleway.registry.v1 import Tag
+from scaleway.registry.v1 import TagStatus
 
 TEST_ORG_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
 TEST_PROJECT_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
 TEST_NAMESPACE_ID = "aaaaaaaa-1111-4820-b8d6-0eef10cfcd6d"
 TEST_IMAGE_ID = "bbbbbbbb-2222-4820-b8d6-0eef10cfcd6d"
+TEST_TAG_ID = "cccccccc-3333-4820-b8d6-0eef10cfcd6d"
+TEST_TAG_DIGEST = (
+    "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+)
 
 
 SCALEWAY_REGISTRY_NAMESPACES = [
@@ -43,6 +49,19 @@ SCALEWAY_REGISTRY_IMAGES = [
         size=1024,
         tags=["latest"],
         status_message=None,
+        created_at=datetime(2025, 3, 20, 14, 49, 48, 107731, tzinfo=tzutc()),
+        updated_at=datetime(2025, 3, 20, 14, 49, 48, 107731, tzinfo=tzutc()),
+    )
+]
+
+
+SCALEWAY_REGISTRY_TAGS = [
+    Tag(
+        id=TEST_TAG_ID,
+        name="latest",
+        image_id=TEST_IMAGE_ID,
+        status=TagStatus.READY,
+        digest=TEST_TAG_DIGEST,
         created_at=datetime(2025, 3, 20, 14, 49, 48, 107731, tzinfo=tzutc()),
         updated_at=datetime(2025, 3, 20, 14, 49, 48, 107731, tzinfo=tzutc()),
     )

--- a/tests/integration/cartography/intel/scaleway/test_code_to_cloud_full_chain.py
+++ b/tests/integration/cartography/intel/scaleway/test_code_to_cloud_full_chain.py
@@ -1,0 +1,193 @@
+"""End-to-end code-to-cloud chain in Neo4j, stitching the real sync/enrichment
+steps together with mocked registry/OCI/GitHub data:
+
+    (:GitHubRepository)<-[:PACKAGED_FROM]-(:Image)              # source repo
+    (:ContainerRegistry)-[:REPO_IMAGE]->(:ImageTag)-[:IMAGE]->(:Image)
+    (:Image)-[:HAS_LAYER]->(:ImageLayer)
+    (:ScalewayServerlessContainer)-[:HAS_IMAGE]->(:Image)
+    (:ScalewayServerlessContainer)-[:RESOLVED_IMAGE]->(:Image)  # runtime workload
+
+So a query can traverse: a running Scaleway workload -> the image it runs ->
+the layers it is built from -> the GitHub repository it was built from.
+"""
+
+from unittest.mock import patch
+
+import cartography.intel.github.supply_chain as github_supply_chain
+import cartography.intel.scaleway.container_registry.supply_chain as sc_supply_chain
+from cartography.client.core.tx import load
+from cartography.models.scaleway.container_registry.image import (
+    ScalewayContainerRegistryImageSchema,
+)
+from cartography.models.scaleway.container_registry.image_tag import (
+    ScalewayContainerRegistryImageTagSchema,
+)
+from cartography.models.scaleway.container_registry.namespace import (
+    ScalewayContainerRegistryNamespaceSchema,
+)
+from cartography.models.scaleway.serverless.container import (
+    ScalewayServerlessContainerSchema,
+)
+from cartography.util import run_analysis_job
+from tests.integration.cartography.intel.scaleway.test_projects import (
+    _ensure_local_neo4j_has_test_projects_and_orgs,
+)
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+TEST_PROJECT_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+
+REPO_URL = "https://github.com/acme/app"
+NS_ID = "ns-app-1111"
+IMAGE_DIGEST = "sha256:" + "e" * 64
+LAYER_DIFF_ID = "sha256:" + "f" * 64
+TAG_URI = "rg.fr-par.scw.cloud/app-ns/app:latest"
+CONTAINER_ID = "ct-app-2222"
+
+# OCI image config the (mocked) registry endpoint would return for the image:
+# one layer + the source-repo label used for provenance matching.
+FAKE_CONFIG = {
+    "architecture": "amd64",
+    "os": "linux",
+    "config": {"Labels": {"org.opencontainers.image.source": REPO_URL}},
+    "rootfs": {"type": "layers", "diff_ids": [LAYER_DIFF_ID]},
+    "history": [{"created_by": "COPY app /app"}],
+}
+
+
+@patch.object(github_supply_chain, "get_dockerfiles_for_repos", return_value=[])
+@patch.object(
+    sc_supply_chain,
+    "get",
+    return_value=(
+        [
+            {
+                "digest": IMAGE_DIGEST,
+                "project_id": TEST_PROJECT_ID,
+                "config": FAKE_CONFIG,
+                "annotations": {},
+                "attestation_predicate": None,
+            }
+        ],
+        False,
+    ),
+)
+def test_full_code_to_cloud_chain(_mock_sc_get, _mock_dockerfiles, neo4j_session):
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "ORG_ID": TEST_ORG_ID}
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+
+    # 1. Base registry nodes: namespace (ContainerRegistry) -> tag -> image.
+    load(
+        neo4j_session,
+        ScalewayContainerRegistryNamespaceSchema(),
+        [
+            {
+                "id": NS_ID,
+                "name": "app-ns",
+                "endpoint": "rg.fr-par.scw.cloud/app-ns",
+                "is_public": False,
+            }
+        ],
+        lastupdated=TEST_UPDATE_TAG,
+        PROJECT_ID=TEST_PROJECT_ID,
+    )
+    load(
+        neo4j_session,
+        ScalewayContainerRegistryImageSchema(),
+        [{"digest": IMAGE_DIGEST}],
+        lastupdated=TEST_UPDATE_TAG,
+        PROJECT_ID=TEST_PROJECT_ID,
+    )
+    load(
+        neo4j_session,
+        ScalewayContainerRegistryImageTagSchema(),
+        [
+            {
+                "id": "tag-app",
+                "name": "latest",
+                "image_name": "app",
+                "uri": TAG_URI,
+                "digest": IMAGE_DIGEST,
+                "namespace_id": NS_ID,
+            }
+        ],
+        lastupdated=TEST_UPDATE_TAG,
+        PROJECT_ID=TEST_PROJECT_ID,
+    )
+
+    # 2. Enrich the image from the (mocked) OCI registry: layers + source_uri.
+    sc_supply_chain.sync(
+        neo4j_session,
+        "fake-secret",
+        common_job_parameters,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # 3. A running Scaleway serverless container whose image resolves to the digest.
+    load(
+        neo4j_session,
+        ScalewayServerlessContainerSchema(),
+        [
+            {
+                "id": CONTAINER_ID,
+                "name": "app-svc",
+                "namespace_id": "scn-1",
+                "registry_image": TAG_URI,
+                "image_digest": IMAGE_DIGEST,
+                "privacy": "public",
+            }
+        ],
+        lastupdated=TEST_UPDATE_TAG,
+        PROJECT_ID=TEST_PROJECT_ID,
+    )
+
+    # 4. Mocked GitHub data: the source repository, then the provenance matcher.
+    neo4j_session.run(
+        "MERGE (r:GitHubRepository {id: $url}) SET r.lastupdated = $tag",
+        url=REPO_URL,
+        tag=TEST_UPDATE_TAG,
+    )
+    github_supply_chain.sync(
+        neo4j_session,
+        "fake-token",
+        "https://api.github.com/graphql",
+        "acme",
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+        repos=[{"url": REPO_URL}],
+    )
+
+    # 5. Shared ontology analysis: (:Container)-[:HAS_IMAGE]->(:Image) => RESOLVED_IMAGE.
+    run_analysis_job(
+        "resolved_image_analysis.json", neo4j_session, common_job_parameters
+    )
+
+    # Assert the entire chain resolves in a single traversal.
+    record = neo4j_session.run(
+        """
+        MATCH (gh:GitHubRepository {id: $url})
+              <-[:PACKAGED_FROM]-(img:ScalewayContainerRegistryImage {digest: $digest})
+        MATCH (ns:ScalewayContainerRegistryNamespace)
+              -[:REPO_IMAGE]->(tag:ScalewayContainerRegistryImageTag)-[:IMAGE]->(img)
+        MATCH (img)-[:HAS_LAYER]->(layer:ScalewayContainerRegistryImageLayer)
+        MATCH (sc:ScalewayServerlessContainer {id: $container})-[:HAS_IMAGE]->(img)
+        MATCH (sc)-[:RESOLVED_IMAGE]->(img)
+        RETURN
+            img.source_uri AS source_uri,
+            ns.id AS namespace_id,
+            tag.id AS tag_id,
+            layer.diff_id AS layer,
+            sc.id AS container_id
+        """,
+        url=REPO_URL,
+        digest=IMAGE_DIGEST,
+        container=CONTAINER_ID,
+    ).single()
+
+    assert record is not None, "full code-to-cloud chain did not resolve"
+    assert record["source_uri"] == REPO_URL
+    assert record["namespace_id"] == NS_ID
+    assert record["tag_id"] == "tag-app"
+    assert record["layer"] == LAYER_DIFF_ID
+    assert record["container_id"] == CONTAINER_ID

--- a/tests/integration/cartography/intel/scaleway/test_code_to_cloud_github.py
+++ b/tests/integration/cartography/intel/scaleway/test_code_to_cloud_github.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import cartography.intel.github.supply_chain as github_supply_chain
 from cartography.client.core.tx import load
 from cartography.models.scaleway.container_registry.image import (
-    ScalewayContainerRegistryImageSchema,
+    ScalewayContainerRegistryImageEnrichmentSchema,
 )
 from tests.integration.cartography.intel.scaleway.test_projects import (
     _ensure_local_neo4j_has_test_projects_and_orgs,
@@ -28,7 +28,7 @@ def test_scaleway_image_packaged_from_github_repo(_mock_dockerfiles, neo4j_sessi
     _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
     load(
         neo4j_session,
-        ScalewayContainerRegistryImageSchema(),
+        ScalewayContainerRegistryImageEnrichmentSchema(),
         [{"digest": TEST_DIGEST, "source_uri": REPO_URL}],
         lastupdated=TEST_UPDATE_TAG,
         PROJECT_ID=TEST_PROJECT_ID,

--- a/tests/integration/cartography/intel/scaleway/test_code_to_cloud_github.py
+++ b/tests/integration/cartography/intel/scaleway/test_code_to_cloud_github.py
@@ -1,0 +1,62 @@
+"""Code-to-cloud: a Scaleway registry image with source_uri is linked to its
+GitHub repository by the generic (registry-agnostic) GitHub supply-chain matcher.
+"""
+
+from unittest.mock import patch
+
+import cartography.intel.github.supply_chain as github_supply_chain
+from cartography.client.core.tx import load
+from cartography.models.scaleway.container_registry.image import (
+    ScalewayContainerRegistryImageSchema,
+)
+from tests.integration.cartography.intel.scaleway.test_projects import (
+    _ensure_local_neo4j_has_test_projects_and_orgs,
+)
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+TEST_PROJECT_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+TEST_DIGEST = "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+REPO_URL = "https://github.com/acme/app"
+
+
+@patch.object(github_supply_chain, "get_dockerfiles_for_repos", return_value=[])
+def test_scaleway_image_packaged_from_github_repo(_mock_dockerfiles, neo4j_session):
+    # Arrange: a Scaleway registry image enriched with source_uri, and the
+    # GitHub repository it was built from.
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+    load(
+        neo4j_session,
+        ScalewayContainerRegistryImageSchema(),
+        [{"digest": TEST_DIGEST, "source_uri": REPO_URL}],
+        lastupdated=TEST_UPDATE_TAG,
+        PROJECT_ID=TEST_PROJECT_ID,
+    )
+    neo4j_session.run(
+        "MERGE (r:GitHubRepository {id: $url}) SET r.lastupdated = $tag",
+        url=REPO_URL,
+        tag=TEST_UPDATE_TAG,
+    )
+
+    # Act: run the GitHub supply-chain matcher (provenance arm).
+    github_supply_chain.sync(
+        neo4j_session,
+        "fake-token",
+        "https://api.github.com/graphql",
+        "acme",
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+        repos=[{"url": REPO_URL}],
+    )
+
+    # Assert: the Scaleway image is PACKAGED_FROM the GitHub repository.
+    assert check_rels(
+        neo4j_session,
+        "ScalewayContainerRegistryImage",
+        "digest",
+        "GitHubRepository",
+        "id",
+        "PACKAGED_FROM",
+        rel_direction_right=True,
+    ) == {(TEST_DIGEST, REPO_URL)}

--- a/tests/integration/cartography/intel/scaleway/test_code_to_cloud_gitlab.py
+++ b/tests/integration/cartography/intel/scaleway/test_code_to_cloud_gitlab.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import cartography.intel.gitlab.supply_chain as gitlab_supply_chain
 from cartography.client.core.tx import load
 from cartography.models.scaleway.container_registry.image import (
-    ScalewayContainerRegistryImageSchema,
+    ScalewayContainerRegistryImageEnrichmentSchema,
 )
 from tests.integration.cartography.intel.scaleway.test_projects import (
     _ensure_local_neo4j_has_test_projects_and_orgs,
@@ -28,7 +28,7 @@ def test_scaleway_image_packaged_from_gitlab_project(_mock_dockerfiles, neo4j_se
     _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
     load(
         neo4j_session,
-        ScalewayContainerRegistryImageSchema(),
+        ScalewayContainerRegistryImageEnrichmentSchema(),
         [{"digest": TEST_DIGEST, "source_uri": PROJECT_URL}],
         lastupdated=TEST_UPDATE_TAG,
         PROJECT_ID=TEST_PROJECT_ID,

--- a/tests/integration/cartography/intel/scaleway/test_code_to_cloud_gitlab.py
+++ b/tests/integration/cartography/intel/scaleway/test_code_to_cloud_gitlab.py
@@ -1,0 +1,62 @@
+"""Code-to-cloud: a Scaleway registry image with source_uri is linked to its
+GitLab project by the generic (registry-agnostic) GitLab supply-chain matcher.
+"""
+
+from unittest.mock import patch
+
+import cartography.intel.gitlab.supply_chain as gitlab_supply_chain
+from cartography.client.core.tx import load
+from cartography.models.scaleway.container_registry.image import (
+    ScalewayContainerRegistryImageSchema,
+)
+from tests.integration.cartography.intel.scaleway.test_projects import (
+    _ensure_local_neo4j_has_test_projects_and_orgs,
+)
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+TEST_PROJECT_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+TEST_DIGEST = "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+PROJECT_URL = "https://gitlab.com/acme/app"
+
+
+@patch.object(gitlab_supply_chain, "get_dockerfiles_for_projects", return_value=[])
+def test_scaleway_image_packaged_from_gitlab_project(_mock_dockerfiles, neo4j_session):
+    # Arrange: a Scaleway registry image enriched with source_uri, and the
+    # GitLab project it was built from.
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+    load(
+        neo4j_session,
+        ScalewayContainerRegistryImageSchema(),
+        [{"digest": TEST_DIGEST, "source_uri": PROJECT_URL}],
+        lastupdated=TEST_UPDATE_TAG,
+        PROJECT_ID=TEST_PROJECT_ID,
+    )
+    neo4j_session.run(
+        "MERGE (p:GitLabProject {web_url: $url}) SET p.lastupdated = $tag",
+        url=PROJECT_URL,
+        tag=TEST_UPDATE_TAG,
+    )
+
+    # Act: run the GitLab supply-chain matcher (provenance arm).
+    gitlab_supply_chain.sync(
+        neo4j_session,
+        "https://gitlab.com",
+        "fake-token",
+        1,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+        projects=[{"web_url": PROJECT_URL}],
+    )
+
+    # Assert: the Scaleway image is PACKAGED_FROM the GitLab project.
+    assert check_rels(
+        neo4j_session,
+        "ScalewayContainerRegistryImage",
+        "digest",
+        "GitLabProject",
+        "web_url",
+        "PACKAGED_FROM",
+        rel_direction_right=True,
+    ) == {(TEST_DIGEST, PROJECT_URL)}

--- a/tests/integration/cartography/intel/scaleway/test_container_registry.py
+++ b/tests/integration/cartography/intel/scaleway/test_container_registry.py
@@ -4,8 +4,10 @@ from unittest.mock import patch
 import cartography.intel.scaleway.container_registry.namespaces
 from tests.data.scaleway.container_registry import SCALEWAY_REGISTRY_IMAGES
 from tests.data.scaleway.container_registry import SCALEWAY_REGISTRY_NAMESPACES
-from tests.data.scaleway.container_registry import TEST_IMAGE_ID
+from tests.data.scaleway.container_registry import SCALEWAY_REGISTRY_TAGS
 from tests.data.scaleway.container_registry import TEST_NAMESPACE_ID
+from tests.data.scaleway.container_registry import TEST_TAG_DIGEST
+from tests.data.scaleway.container_registry import TEST_TAG_ID
 from tests.integration.cartography.intel.scaleway.test_projects import (
     _ensure_local_neo4j_has_test_projects_and_orgs,
 )
@@ -20,7 +22,11 @@ TEST_PROJECT_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
 @patch.object(
     cartography.intel.scaleway.container_registry.namespaces,
     "get",
-    return_value=(SCALEWAY_REGISTRY_NAMESPACES, SCALEWAY_REGISTRY_IMAGES),
+    return_value=(
+        SCALEWAY_REGISTRY_NAMESPACES,
+        SCALEWAY_REGISTRY_IMAGES,
+        SCALEWAY_REGISTRY_TAGS,
+    ),
 )
 def test_load_scaleway_container_registry(_mock_get, neo4j_session):
     # Arrange
@@ -41,17 +47,12 @@ def test_load_scaleway_container_registry(_mock_get, neo4j_session):
         update_tag=TEST_UPDATE_TAG,
     )
 
-    # Assert nodes
+    # Assert the namespace (the registry) exists and carries ContainerRegistry.
     assert check_nodes(
         neo4j_session,
         "ScalewayContainerRegistryNamespace",
         ["id", "name", "is_public"],
     ) == {(TEST_NAMESPACE_ID, "demo-namespace", True)}
-    assert check_nodes(
-        neo4j_session, "ScalewayContainerRegistryImage", ["id", "name"]
-    ) == {(TEST_IMAGE_ID, "demo-image")}
-
-    # Cross-cloud ontology label.
     assert check_nodes(neo4j_session, "ContainerRegistry", ["id"]) == {
         (TEST_NAMESPACE_ID,)
     }
@@ -71,10 +72,36 @@ def test_load_scaleway_container_registry(_mock_get, neo4j_session):
         )
     }
 
+    # Tag node (ontology ImageTag) carries the denormalized image name + URI.
+    assert check_nodes(
+        neo4j_session,
+        "ScalewayContainerRegistryImageTag",
+        ["id", "name", "digest", "image_name", "uri", "visibility"],
+    ) == {
+        (
+            TEST_TAG_ID,
+            "latest",
+            TEST_TAG_DIGEST,
+            "demo-image",
+            "rg.fr-par.scw.cloud/demo-namespace/demo-image:latest",
+            "inherit",
+        )
+    }
+    assert check_nodes(neo4j_session, "ImageTag", ["id"]) == {(TEST_TAG_ID,)}
+
+    # Digest-addressed content node carries the cross-cloud Image label.
+    assert check_nodes(
+        neo4j_session, "ScalewayContainerRegistryImage", ["id", "digest"]
+    ) == {(TEST_TAG_DIGEST, TEST_TAG_DIGEST)}
+    assert check_nodes(neo4j_session, "Image", ["_ont_digest", "_ont_source"]) == {
+        (TEST_TAG_DIGEST, "scaleway")
+    }
+
     # Project ownership.
     for label in (
         "ScalewayContainerRegistryNamespace",
         "ScalewayContainerRegistryImage",
+        "ScalewayContainerRegistryImageTag",
     ):
         assert check_rels(
             neo4j_session,
@@ -86,13 +113,22 @@ def test_load_scaleway_container_registry(_mock_get, neo4j_session):
             rel_direction_right=False,
         ), f"{label} not linked to project"
 
-    # Namespace -> Image
+    # Namespace -[:REPO_IMAGE]-> Tag -[:IMAGE]-> Image  (canonical cross-provider shape)
     assert check_rels(
         neo4j_session,
         "ScalewayContainerRegistryNamespace",
         "id",
+        "ScalewayContainerRegistryImageTag",
+        "id",
+        "REPO_IMAGE",
+        rel_direction_right=True,
+    ) == {(TEST_NAMESPACE_ID, TEST_TAG_ID)}
+    assert check_rels(
+        neo4j_session,
+        "ScalewayContainerRegistryImageTag",
+        "id",
         "ScalewayContainerRegistryImage",
         "id",
-        "HAS",
+        "IMAGE",
         rel_direction_right=True,
-    ) == {(TEST_NAMESPACE_ID, TEST_IMAGE_ID)}
+    ) == {(TEST_TAG_ID, TEST_TAG_DIGEST)}

--- a/tests/integration/cartography/intel/scaleway/test_container_registry_supply_chain.py
+++ b/tests/integration/cartography/intel/scaleway/test_container_registry_supply_chain.py
@@ -1,0 +1,101 @@
+from unittest.mock import patch
+
+import cartography.intel.scaleway.container_registry.supply_chain as supply_chain
+from cartography.client.core.tx import load
+from cartography.models.scaleway.container_registry.image import (
+    ScalewayContainerRegistryImageSchema,
+)
+from tests.integration.cartography.intel.scaleway.test_projects import (
+    _ensure_local_neo4j_has_test_projects_and_orgs,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+TEST_PROJECT_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+TEST_DIGEST = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+DIFF_ID_1 = "sha256:aaaa000000000000000000000000000000000000000000000000000000000000"
+DIFF_ID_2 = "sha256:bbbb000000000000000000000000000000000000000000000000000000000000"
+
+# A minimal OCI image config: two real layers (a base + a COPY) plus an empty
+# metadata layer (WORKDIR) that carries no diff_id.
+FAKE_CONFIG = {
+    "architecture": "amd64",
+    "os": "linux",
+    "config": {
+        "Labels": {"org.opencontainers.image.source": "https://github.com/acme/app"}
+    },
+    "rootfs": {"type": "layers", "diff_ids": [DIFF_ID_1, DIFF_ID_2]},
+    "history": [
+        {"created_by": "/bin/sh -c #(nop) ADD file:base in /"},
+        {"created_by": "WORKDIR /app", "empty_layer": True},
+        {"created_by": "COPY app /app"},
+    ],
+}
+
+
+def _ensure_registry_image(neo4j_session):
+    load(
+        neo4j_session,
+        ScalewayContainerRegistryImageSchema(),
+        [{"digest": TEST_DIGEST}],
+        lastupdated=TEST_UPDATE_TAG,
+        PROJECT_ID=TEST_PROJECT_ID,
+    )
+
+
+@patch.object(
+    supply_chain,
+    "get",
+    return_value=[
+        {"digest": TEST_DIGEST, "project_id": TEST_PROJECT_ID, "config": FAKE_CONFIG}
+    ],
+)
+def test_scaleway_registry_image_layers(_mock_get, neo4j_session):
+    # Arrange
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "ORG_ID": TEST_ORG_ID}
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+    _ensure_registry_image(neo4j_session)
+
+    # Act
+    supply_chain.sync(
+        neo4j_session,
+        "fake-secret",
+        common_job_parameters,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # Assert: layer nodes (only the two non-empty layers) with commands.
+    assert check_nodes(
+        neo4j_session,
+        "ScalewayContainerRegistryImageLayer",
+        ["diff_id", "history"],
+    ) == {
+        (DIFF_ID_1, "/bin/sh -c #(nop) ADD file:base in /"),
+        (DIFF_ID_2, "COPY app /app"),
+    }
+    # Cross-provider ImageLayer label (what the supply-chain matcher looks up).
+    assert check_nodes(neo4j_session, "ImageLayer", ["diff_id"]) == {
+        (DIFF_ID_1,),
+        (DIFF_ID_2,),
+    }
+
+    # Assert: layer_diff_ids set on the image (ordered).
+    result = neo4j_session.run(
+        "MATCH (i:ScalewayContainerRegistryImage {digest: $d}) RETURN i.layer_diff_ids AS l",
+        d=TEST_DIGEST,
+    ).single()
+    assert result["l"] == [DIFF_ID_1, DIFF_ID_2]
+
+    # Assert: HAS_LAYER edges image -> layers.
+    assert check_rels(
+        neo4j_session,
+        "ScalewayContainerRegistryImage",
+        "digest",
+        "ScalewayContainerRegistryImageLayer",
+        "diff_id",
+        "HAS_LAYER",
+        rel_direction_right=True,
+    ) == {(TEST_DIGEST, DIFF_ID_1), (TEST_DIGEST, DIFF_ID_2)}

--- a/tests/integration/cartography/intel/scaleway/test_container_registry_supply_chain.py
+++ b/tests/integration/cartography/intel/scaleway/test_container_registry_supply_chain.py
@@ -172,3 +172,37 @@ def test_scaleway_registry_image_provenance_from_attestation(_mock_get, neo4j_se
     ).single()
     assert result["src"] == "https://github.com/acme/from-slsa"
     assert result["rev"] == "abc123"
+
+
+def test_registry_inventory_reload_preserves_enrichment(neo4j_session):
+    """A base `{digest}` inventory reload must not clear the layer/provenance
+    fields owned by the supply-chain enrichment (regression: kunaals review)."""
+    from cartography.models.scaleway.container_registry.image import (
+        ScalewayContainerRegistryImageEnrichmentSchema,
+    )
+
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+    # Enrich the image (as supply_chain does).
+    load(
+        neo4j_session,
+        ScalewayContainerRegistryImageEnrichmentSchema(),
+        [
+            {
+                "digest": TEST_DIGEST,
+                "layer_diff_ids": [DIFF_ID_1],
+                "source_uri": "https://github.com/acme/app",
+            }
+        ],
+        lastupdated=TEST_UPDATE_TAG,
+        PROJECT_ID=TEST_PROJECT_ID,
+    )
+    # Re-run the base registry inventory load (digest only).
+    _ensure_registry_image(neo4j_session)
+
+    result = neo4j_session.run(
+        "MATCH (i:ScalewayContainerRegistryImage {digest: $d}) "
+        "RETURN i.layer_diff_ids AS l, i.source_uri AS src",
+        d=TEST_DIGEST,
+    ).single()
+    assert result["l"] == [DIFF_ID_1]
+    assert result["src"] == "https://github.com/acme/app"

--- a/tests/integration/cartography/intel/scaleway/test_container_registry_supply_chain.py
+++ b/tests/integration/cartography/intel/scaleway/test_container_registry_supply_chain.py
@@ -48,9 +48,10 @@ def _ensure_registry_image(neo4j_session):
 @patch.object(
     supply_chain,
     "get",
-    return_value=[
-        {"digest": TEST_DIGEST, "project_id": TEST_PROJECT_ID, "config": FAKE_CONFIG}
-    ],
+    return_value=(
+        [{"digest": TEST_DIGEST, "project_id": TEST_PROJECT_ID, "config": FAKE_CONFIG}],
+        False,
+    ),
 )
 def test_scaleway_registry_image_layers(_mock_get, neo4j_session):
     # Arrange
@@ -82,12 +83,14 @@ def test_scaleway_registry_image_layers(_mock_get, neo4j_session):
         (DIFF_ID_2,),
     }
 
-    # Assert: layer_diff_ids set on the image (ordered).
+    # Assert: layer_diff_ids + source_uri (from the OCI config label) on the image.
     result = neo4j_session.run(
-        "MATCH (i:ScalewayContainerRegistryImage {digest: $d}) RETURN i.layer_diff_ids AS l",
+        "MATCH (i:ScalewayContainerRegistryImage {digest: $d}) "
+        "RETURN i.layer_diff_ids AS l, i.source_uri AS src",
         d=TEST_DIGEST,
     ).single()
     assert result["l"] == [DIFF_ID_1, DIFF_ID_2]
+    assert result["src"] == "https://github.com/acme/app"
 
     # Assert: HAS_LAYER edges image -> layers.
     assert check_rels(
@@ -99,3 +102,73 @@ def test_scaleway_registry_image_layers(_mock_get, neo4j_session):
         "HAS_LAYER",
         rel_direction_right=True,
     ) == {(TEST_DIGEST, DIFF_ID_1), (TEST_DIGEST, DIFF_ID_2)}
+
+
+# An image with no OCI labels but a buildx SLSA provenance attestation.
+FAKE_CONFIG_NO_LABELS = {
+    "architecture": "amd64",
+    "os": "linux",
+    "config": {},
+    "rootfs": {"type": "layers", "diff_ids": [DIFF_ID_1]},
+    "history": [{"created_by": "COPY app /app"}],
+}
+SLSA_PREDICATE = {
+    "buildDefinition": {
+        "externalParameters": {"configSource": {"path": "Dockerfile"}},
+        "resolvedDependencies": [
+            {
+                "uri": "https://github.com/acme/from-slsa",
+                "digest": {"gitCommit": "abc123"},
+            }
+        ],
+    },
+    "metadata": {
+        "https://mobyproject.org/buildkit@v1#metadata": {
+            "vcs": {
+                "source": "https://github.com/acme/from-slsa",
+                "revision": "abc123",
+            }
+        }
+    },
+}
+
+
+@patch.object(
+    supply_chain,
+    "get",
+    return_value=(
+        [
+            {
+                "digest": TEST_DIGEST,
+                "project_id": TEST_PROJECT_ID,
+                "config": FAKE_CONFIG_NO_LABELS,
+                "annotations": {},
+                "attestation_predicate": SLSA_PREDICATE,
+            }
+        ],
+        False,
+    ),
+)
+def test_scaleway_registry_image_provenance_from_attestation(_mock_get, neo4j_session):
+    # Arrange
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "ORG_ID": TEST_ORG_ID}
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+    _ensure_registry_image(neo4j_session)
+
+    # Act
+    supply_chain.sync(
+        neo4j_session,
+        "fake-secret",
+        common_job_parameters,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # Assert: source_uri + source_revision resolved from the SLSA attestation.
+    result = neo4j_session.run(
+        "MATCH (i:ScalewayContainerRegistryImage {digest: $d}) "
+        "RETURN i.source_uri AS src, i.source_revision AS rev",
+        d=TEST_DIGEST,
+    ).single()
+    assert result["src"] == "https://github.com/acme/from-slsa"
+    assert result["rev"] == "abc123"

--- a/tests/integration/cartography/intel/scaleway/test_iam.py
+++ b/tests/integration/cartography/intel/scaleway/test_iam.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import cartography.intel.scaleway.iam.apikeys
 import cartography.intel.scaleway.iam.applications
 import cartography.intel.scaleway.iam.groups
+import cartography.intel.scaleway.iam.permissions
 import cartography.intel.scaleway.iam.permissionsets
 import cartography.intel.scaleway.iam.policies
 import cartography.intel.scaleway.iam.sshkeys
@@ -476,6 +477,32 @@ def _ensure_local_neo4j_has_test_policies(neo4j_session):
     )
 
 
+def _ensure_local_neo4j_has_test_permission_sets(neo4j_session):
+    data = cartography.intel.scaleway.iam.permissionsets.transform_permission_sets(
+        tests.data.scaleway.iam.SCALEWAY_PERMISSION_SETS
+    )
+    cartography.intel.scaleway.iam.permissionsets.load_permission_sets(
+        neo4j_session, data, TEST_ORG_ID, TEST_UPDATE_TAG
+    )
+
+
+def _ensure_local_neo4j_has_test_rules(neo4j_session):
+    for policy_id, rules in (
+        (
+            "pol-11111111-1111-1111-1111-111111111111",
+            tests.data.scaleway.iam.SCALEWAY_RULES_POLICY_1,
+        ),
+        (
+            "pol-22222222-2222-2222-2222-222222222222",
+            tests.data.scaleway.iam.SCALEWAY_RULES_POLICY_2,
+        ),
+    ):
+        data = cartography.intel.scaleway.iam.policies.transform_rules(rules, policy_id)
+        cartography.intel.scaleway.iam.policies.load_rules(
+            neo4j_session, data, TEST_ORG_ID, TEST_UPDATE_TAG
+        )
+
+
 @patch.object(
     cartography.intel.scaleway.iam.policies,
     "get_rules",
@@ -729,4 +756,100 @@ def test_load_scaleway_sshkeys(_mock_get, neo4j_session):
         rel_direction_right=False,
     ) == {
         ("1a2b3c4d-5e6f-7890-abcd-ef1234567890", TEST_PROJECT_ID),
+    }
+
+
+@patch.object(
+    cartography.intel.scaleway.iam.permissions,
+    "get_rules",
+    side_effect=[
+        tests.data.scaleway.iam.SCALEWAY_RULES_POLICY_1,
+        tests.data.scaleway.iam.SCALEWAY_RULES_POLICY_2,
+    ],
+)
+@patch.object(
+    cartography.intel.scaleway.iam.permissions,
+    "get_policies",
+    return_value=tests.data.scaleway.iam.SCALEWAY_POLICIES,
+)
+def test_scaleway_iam_permissions(_mock_get_policies, _mock_get_rules, neo4j_session):
+    # Arrange: users, groups, permission sets and policies must exist first.
+    client = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "ORG_ID": TEST_ORG_ID,
+    }
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+    _ensure_local_neo4j_has_test_users(neo4j_session)
+    _ensure_local_neo4j_has_test_groups(neo4j_session)
+    _ensure_local_neo4j_has_test_permission_sets(neo4j_session)
+    _ensure_local_neo4j_has_test_policies(neo4j_session)
+    _ensure_local_neo4j_has_test_rules(neo4j_session)
+
+    # Act
+    cartography.intel.scaleway.iam.permissions.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # Assert: canonical HAS_ROLE from the user (direct policy) to its permission set
+    assert check_rels(
+        neo4j_session,
+        "ScalewayUser",
+        "id",
+        "ScalewayPermissionSet",
+        "id",
+        "HAS_ROLE",
+        rel_direction_right=True,
+    ) == {
+        (
+            "998cbe72-913f-4f55-8620-4b0f7655d343",
+            "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        ),
+    }
+
+    # Assert: canonical HAS_ROLE from the group (members inherit via MEMBER_OF)
+    assert check_rels(
+        neo4j_session,
+        "ScalewayGroup",
+        "id",
+        "ScalewayPermissionSet",
+        "id",
+        "HAS_ROLE",
+        rel_direction_right=True,
+    ) == {
+        (
+            "1f767996-f6f6-4b0e-a7b1-6a255e809ed6",
+            "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+        ),
+    }
+
+    # Assert: factual CAN_ACCESS scope edge from the user to the scoped project
+    assert check_rels(
+        neo4j_session,
+        "ScalewayUser",
+        "id",
+        "ScalewayProject",
+        "id",
+        "CAN_ACCESS",
+        rel_direction_right=True,
+    ) == {
+        ("998cbe72-913f-4f55-8620-4b0f7655d343", TEST_PROJECT_ID),
+    }
+
+    # Assert: factual CAN_ACCESS scope edge from the group to the scoped project
+    assert check_rels(
+        neo4j_session,
+        "ScalewayGroup",
+        "id",
+        "ScalewayProject",
+        "id",
+        "CAN_ACCESS",
+        rel_direction_right=True,
+    ) == {
+        ("1f767996-f6f6-4b0e-a7b1-6a255e809ed6", TEST_PROJECT_ID),
     }

--- a/tests/integration/cartography/intel/scaleway/test_serverless.py
+++ b/tests/integration/cartography/intel/scaleway/test_serverless.py
@@ -4,6 +4,10 @@ from unittest.mock import patch
 import cartography.intel.scaleway.serverless.containers
 import cartography.intel.scaleway.serverless.functions
 import cartography.intel.scaleway.serverless.jobs
+from cartography.client.core.tx import load
+from cartography.models.scaleway.container_registry.image import (
+    ScalewayContainerRegistryImageSchema,
+)
 from tests.data.scaleway.serverless import SCALEWAY_CONTAINER_NAMESPACES
 from tests.data.scaleway.serverless import SCALEWAY_CONTAINERS
 from tests.data.scaleway.serverless import SCALEWAY_FUNCTION_NAMESPACES
@@ -23,6 +27,11 @@ from tests.integration.util import check_rels
 TEST_UPDATE_TAG = 123456789
 TEST_ORG_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
 TEST_PROJECT_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+# Matches SCALEWAY_CONTAINERS[0].registry_image.
+TEST_CONTAINER_IMAGE_URI = "rg.fr-par.scw.cloud/contscwdemo/demo:latest"
+TEST_CONTAINER_IMAGE_DIGEST = (
+    "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+)
 
 
 @patch.object(
@@ -50,11 +59,18 @@ def test_load_scaleway_serverless(
         "ORG_ID": TEST_ORG_ID,
     }
     _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+    # A registry image (digest node) the container's registry_image resolves to.
+    load(
+        neo4j_session,
+        ScalewayContainerRegistryImageSchema(),
+        [{"digest": TEST_CONTAINER_IMAGE_DIGEST}],
+        lastupdated=TEST_UPDATE_TAG,
+        PROJECT_ID=TEST_PROJECT_ID,
+    )
 
     # Act
     for module in (
         cartography.intel.scaleway.serverless.functions,
-        cartography.intel.scaleway.serverless.containers,
         cartography.intel.scaleway.serverless.jobs,
     ):
         module.sync(
@@ -65,6 +81,15 @@ def test_load_scaleway_serverless(
             projects_id=[TEST_PROJECT_ID],
             update_tag=TEST_UPDATE_TAG,
         )
+    cartography.intel.scaleway.serverless.containers.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+        registry_image_digests={TEST_CONTAINER_IMAGE_URI: TEST_CONTAINER_IMAGE_DIGEST},
+    )
 
     # Assert nodes
     assert check_nodes(
@@ -124,3 +149,14 @@ def test_load_scaleway_serverless(
         "HAS",
         rel_direction_right=True,
     ) == {(TEST_CONTAINER_NAMESPACE_ID, TEST_CONTAINER_ID)}
+
+    # Container -[:HAS_IMAGE]-> registry Image (digest resolved from registry_image)
+    assert check_rels(
+        neo4j_session,
+        "ScalewayServerlessContainer",
+        "id",
+        "ScalewayContainerRegistryImage",
+        "id",
+        "HAS_IMAGE",
+        rel_direction_right=True,
+    ) == {(TEST_CONTAINER_ID, TEST_CONTAINER_IMAGE_DIGEST)}

--- a/tests/integration/cartography/intel/scaleway/test_supply_chain_dockerfile_coverage.py
+++ b/tests/integration/cartography/intel/scaleway/test_supply_chain_dockerfile_coverage.py
@@ -7,7 +7,7 @@ per repository (namespace + image name)."""
 from cartography.client.core.tx import load
 from cartography.intel.supply_chain import get_unmatched_scaleway_images_with_history
 from cartography.models.scaleway.container_registry.image import (
-    ScalewayContainerRegistryImageSchema,
+    ScalewayContainerRegistryImageEnrichmentSchema,
 )
 from cartography.models.scaleway.container_registry.image_tag import (
     ScalewayContainerRegistryImageTagSchema,
@@ -40,7 +40,7 @@ def test_get_unmatched_scaleway_images_covers_all_repositories(neo4j_session):
     # api + worker in ns-a, and api in ns-b (same name, different namespace).
     load(
         neo4j_session,
-        ScalewayContainerRegistryImageSchema(),
+        ScalewayContainerRegistryImageEnrichmentSchema(),
         [
             {"digest": DIGEST_API_A, "layer_diff_ids": [_diff("aa")]},
             {"digest": DIGEST_WORKER_A, "layer_diff_ids": [_diff("bb")]},

--- a/tests/integration/cartography/intel/scaleway/test_supply_chain_dockerfile_coverage.py
+++ b/tests/integration/cartography/intel/scaleway/test_supply_chain_dockerfile_coverage.py
@@ -1,0 +1,95 @@
+"""P2 coverage: every Scaleway registry image is sent through dockerfile
+analysis. The generic per-registry matcher keeps one representative per
+ContainerRegistry (= namespace), which would drop both sibling images in a
+namespace and same-named images across namespaces. The dedicated helper groups
+per repository (namespace + image name)."""
+
+from cartography.client.core.tx import load
+from cartography.intel.supply_chain import get_unmatched_scaleway_images_with_history
+from cartography.models.scaleway.container_registry.image import (
+    ScalewayContainerRegistryImageSchema,
+)
+from cartography.models.scaleway.container_registry.image_tag import (
+    ScalewayContainerRegistryImageTagSchema,
+)
+from tests.integration.cartography.intel.scaleway.test_projects import (
+    _ensure_local_neo4j_has_test_projects_and_orgs,
+)
+
+TEST_UPDATE_TAG = 123456789
+TEST_PROJECT_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+
+DIGEST_API_A = "sha256:" + "a" * 64
+DIGEST_WORKER_A = "sha256:" + "b" * 64
+DIGEST_API_B = "sha256:" + "c" * 64
+
+
+def _diff(prefix: str) -> str:
+    return "sha256:" + prefix + "0" * (64 - len(prefix))
+
+
+def test_get_unmatched_scaleway_images_covers_all_repositories(neo4j_session):
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+    # Two namespaces so we can test same-named images across namespaces.
+    neo4j_session.run(
+        "UNWIND ['ns-a', 'ns-b'] AS nid "
+        "MERGE (n:ScalewayContainerRegistryNamespace {id: nid}) "
+        "SET n.lastupdated = $tag",
+        tag=TEST_UPDATE_TAG,
+    )
+    # api + worker in ns-a, and api in ns-b (same name, different namespace).
+    load(
+        neo4j_session,
+        ScalewayContainerRegistryImageSchema(),
+        [
+            {"digest": DIGEST_API_A, "layer_diff_ids": [_diff("aa")]},
+            {"digest": DIGEST_WORKER_A, "layer_diff_ids": [_diff("bb")]},
+            {"digest": DIGEST_API_B, "layer_diff_ids": [_diff("cc")]},
+        ],
+        lastupdated=TEST_UPDATE_TAG,
+        PROJECT_ID=TEST_PROJECT_ID,
+    )
+    load(
+        neo4j_session,
+        ScalewayContainerRegistryImageTagSchema(),
+        [
+            {
+                "id": "tag-api-a",
+                "name": "latest",
+                "image_name": "api",
+                "digest": DIGEST_API_A,
+                "namespace_id": "ns-a",
+            },
+            {
+                "id": "tag-worker-a",
+                "name": "latest",
+                "image_name": "worker",
+                "digest": DIGEST_WORKER_A,
+                "namespace_id": "ns-a",
+            },
+            {
+                "id": "tag-api-b",
+                "name": "latest",
+                "image_name": "api",
+                "digest": DIGEST_API_B,
+                "namespace_id": "ns-b",
+            },
+        ],
+        lastupdated=TEST_UPDATE_TAG,
+        PROJECT_ID=TEST_PROJECT_ID,
+    )
+
+    images = get_unmatched_scaleway_images_with_history(
+        neo4j_session,
+        sub_resource_label="GitHubOrganization",
+        sub_resource_id="acme",
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # All three are distinct repositories (ns-a/api, ns-a/worker, ns-b/api):
+    # none are collapsed.
+    assert {img.digest for img in images} == {
+        DIGEST_API_A,
+        DIGEST_WORKER_A,
+        DIGEST_API_B,
+    }


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Extends the Scaleway module with cross-provider IAM, ontology, and container supply-chain (code-to-cloud) coverage so Scaleway participates in the same graph queries and rules as AWS/GCP/Azure. Scaleway IAM is project/org-scoped and its registry exposes no per-action or per-resource data through the management SDK, so this work resolves the equivalent signals from the data Scaleway does expose (policy/rule graph, the OCI registry endpoint).

- **IAM permissions** — materialize `(:ScalewayUser|Application|Group)-[:HAS_ROLE]->(:ScalewayPermissionSet)` and factual `(...)-[:CAN_ACCESS]->(:ScalewayProject)` scope edges (declarative MatchLinks) resolved from the policy/rule graph. The AWS/GCP `permission_relationships` engine does not apply (no action strings / resource ARNs); `CAN_ACCESS` carries the rule's project scope (org-scoped rules fan out to all projects) and a `has_condition` flag.
- **Ontology coverage** — map KMS keys to `EncryptionKey`; label serverless functions (`Function`), containers (`ComputeService` + `Container`), and namespaces (`ComputeNamespace`), each with ontology field mappings.
- **Rules** — flag Scaleway principals granted the `IAMManager` permission set in `policy_administration_privileges` (via the new `HAS_ROLE` edge).
- **Container registry** — model image tags and digest-addressed images (`ContainerRegistry` → `REPO_IMAGE` → `ImageTag` → `IMAGE` → `Image`), matching the canonical cross-provider shape.
- **Workload → image** — resolve serverless containers' `registry_image` to a digest at ingest and draw `(:ScalewayServerlessContainer)-[:HAS_IMAGE]->(:Image)`, completing the `RESOLVED_IMAGE` chain for Scaleway.
- **Code-to-cloud** — enrich registry images from the OCI Distribution endpoint: `layer_diff_ids` + `ImageLayer` nodes (dockerfile-matching arm) and `source_uri`/`source_revision`/`source_file` (provenance arm, from OCI labels/annotations and buildx SLSA attestations). The existing registry-agnostic GitHub/GitLab supply-chain matchers then draw `(:Image)-[:PACKAGED_FROM]->(:GitHubRepository|:GitLabProject)`. A Scaleway-specific unmatched-image query ensures every image in a namespace (per repository identity) reaches dockerfile analysis rather than one representative per namespace.


### How was this tested?

- New and updated unit/integration tests for every change (IAM permissions, ontology mappings/labels, the rule, registry tags/images, `HAS_IMAGE`, image layers/provenance, and GitHub/GitLab `PACKAGED_FROM`). `make test_lint` passes locally.
- End-to-end against a real Scaleway sandbox using the `scw` CLI + Docker (all resources created for the run were deleted afterward):
  - IAM: verified `HAS_ROLE` / `CAN_ACCESS` and the `IAMManager` rule against real policies.
  - Registry/code-to-cloud: pushed images (including a buildx `--provenance` build) to a real Scaleway Container Registry and ran the actual sync — confirmed `layer_diff_ids`, `ImageLayer` + `HAS_LAYER`, `source_uri`/`source_revision`, and the full `(:ContainerRegistry)-[:REPO_IMAGE]->(:ImageTag)-[:IMAGE]->(:Image)` + `RESOLVED_IMAGE` chain. This also surfaced (and fixed) that registry blob reads 307-redirect to object storage.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).

#### If you are implementing a new intel module
- [x] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

Design decisions worth a look:
- **Permissions granularity**: Scaleway IAM has no per-resource ARNs, so permissions are modeled as `HAS_ROLE` (principal → permission set) + a factual `CAN_ACCESS` scope edge, rather than the AWS/GCP action×ARN engine.
- **Registry shape**: the Scaleway *namespace* is the `ContainerRegistry` (mirrors GCP Artifact Registry, which also holds many images); the named image from `list_images` is folded onto the tag (`image_name`, `uri`, `visibility`) rather than modeled as a separate node.
- **No GitHub/GitLab-side matching changes**: their supply-chain matchers are registry-agnostic; Scaleway plugs in via the canonical labels + `source_uri`. The one addition is a Scaleway-specific unmatched-image query so sibling / same-named-across-namespace images all reach dockerfile analysis.
- The OCI-1.1 referrers API is not implemented by the Scaleway registry (404); attestations are read from the image index's attestation manifest instead.
