### PR TITLE
feat(ontology): finding->package/device edges and endpoint finding labels

### DIFF
--- a/cartography/data/jobs/analysis/ontology_devices_linking.json
+++ b/cartography/data/jobs/analysis/ontology_devices_linking.json
@@ -45,6 +45,16 @@
       "__comment": "Link Device to User based on JumpCloudUser-JumpCloudSystem ownership",
       "query": "MATCH (u:User)-[:HAS_ACCOUNT]->(:JumpCloudUser)-[:OWNS]->(:JumpCloudSystem)<-[obs:OBSERVED_AS]-(d:Device) WHERE obs.lastupdated = $UPDATE_TAG AND d.lastupdated = $UPDATE_TAG MERGE (u)-[r:OWNS]->(d) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
+    },
+    {
+      "__comment": "Link SentinelOne S1AppFinding AFFECTS to the abstract Device via its agent",
+      "query": "MATCH (d:Device)-[obs:OBSERVED_AS]->(:S1Agent)<-[:AFFECTS]-(f:S1AppFinding) WHERE obs.lastupdated = $UPDATE_TAG AND d.lastupdated = $UPDATE_TAG MERGE (f)-[r:AFFECTS]->(d) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "iterative": false
+    },
+    {
+      "__comment": "Link CrowdStrike CrowdstrikeFinding AFFECTS to the abstract Device via host and Spotlight vulnerability",
+      "query": "MATCH (d:Device)-[obs:OBSERVED_AS]->(:CrowdstrikeHost)-[:HAS_VULNERABILITY]->(:SpotlightVulnerability)-[:HAS_CVE]->(f:CrowdstrikeFinding) WHERE obs.lastupdated = $UPDATE_TAG AND d.lastupdated = $UPDATE_TAG MERGE (f)-[r:AFFECTS]->(d) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "iterative": false
     }
   ]
 }

--- a/cartography/data/jobs/analysis/ontology_packages_linking.json
+++ b/cartography/data/jobs/analysis/ontology_packages_linking.json
@@ -17,6 +17,11 @@
       "iterative": false
     },
     {
+      "__comment": "Link SemgrepSCAFinding AFFECTS to canonical Package via SemgrepDependency",
+      "query": "MATCH (f:SemgrepSCAFinding)-[:AFFECTS]->(d:SemgrepDependency)<-[:DETECTED_AS]-(p:Package) MERGE (f)-[r:AFFECTS]->(p) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "iterative": false
+    },
+    {
       "__comment": "DEPRECATED: Link Package SHOULD_UPDATE_TO TrivyFix via TrivyPackage for compatibility",
       "query": "MATCH (p:Package)-[:DETECTED_AS]->(tp:TrivyPackage)-[:SHOULD_UPDATE_TO]->(fix:TrivyFix) MERGE (p)-[r:SHOULD_UPDATE_TO]->(fix) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false

--- a/cartography/intel/semgrep/dependencies.py
+++ b/cartography/intel/semgrep/dependencies.py
@@ -166,7 +166,11 @@ def transform_dependencies(raw_deps: List[Dict[str, Any]]) -> List[Dict[str, Any
         version = raw_dep["package"]["versionSpecifier"]
         id = f"{name}|{version}"
 
-        # Cross-tool dedup key for the Package ontology node (matches Trivy/Syft).
+        # Cross-tool dedup key for the Package ontology node.
+        # ponytail: gomod dedup is best-effort. Go versions vary by source (bare
+        # "1.2.3" here vs purl-derived "v1.2.3") and names appear as full module
+        # path or short name, so some Go packages won't merge with Trivy/Syft.
+        # Normalize the leading "v" and the name form on all sources if it matters.
         pkg_type = ECOSYSTEM_TO_PACKAGE_TYPE.get(raw_dep["ecosystem"])
         normalized_id = make_normalized_package_id(
             name=name,

--- a/cartography/intel/semgrep/dependencies.py
+++ b/cartography/intel/semgrep/dependencies.py
@@ -11,6 +11,7 @@ from requests.exceptions import ReadTimeout
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.trivy.util import make_normalized_package_id
 from cartography.models.semgrep.dependencies import SemgrepGoLibrarySchema
 from cartography.models.semgrep.dependencies import SemgrepNpmLibrarySchema
 from cartography.stats import get_stats_client
@@ -28,6 +29,13 @@ _MAX_RETRIES = 3
 ECOSYSTEM_TO_SCHEMA: Dict = {
     "gomod": SemgrepGoLibrarySchema,
     "npm": SemgrepNpmLibrarySchema,
+}
+
+# Map Semgrep ecosystems to canonical purl types so the normalized_id lines up
+# with the same package discovered by Trivy/Syft (Package ontology dedup key).
+ECOSYSTEM_TO_PACKAGE_TYPE: Dict = {
+    "gomod": "golang",
+    "npm": "npm",
 }
 
 
@@ -158,6 +166,14 @@ def transform_dependencies(raw_deps: List[Dict[str, Any]]) -> List[Dict[str, Any
         version = raw_dep["package"]["versionSpecifier"]
         id = f"{name}|{version}"
 
+        # Cross-tool dedup key for the Package ontology node (matches Trivy/Syft).
+        pkg_type = ECOSYSTEM_TO_PACKAGE_TYPE.get(raw_dep["ecosystem"])
+        normalized_id = make_normalized_package_id(
+            name=name,
+            version=version,
+            pkg_type=pkg_type,
+        )
+
         # As of November 2024, Semgrep does not import dependencies with version specifiers such as >, <, etc.
         # For now, hardcode the specifier to ==<version> to align with GitHub-sourced Python dependencies.
         # If Semgrep eventually supports version specifiers, update this line accordingly.
@@ -173,6 +189,8 @@ def transform_dependencies(raw_deps: List[Dict[str, Any]]) -> List[Dict[str, Any
                 "repo_url": repo_url,
                 # Semgrep-specific properties:
                 "ecosystem": raw_dep["ecosystem"],
+                "type": pkg_type,
+                "normalized_id": normalized_id,
                 "transitivity": raw_dep["transitivity"].lower(),
                 "url": raw_dep["definedAt"]["url"],
             },

--- a/cartography/models/aws/inspector/findings.py
+++ b/cartography/models/aws/inspector/findings.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ConditionalNodeLabel
 from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
@@ -175,7 +176,26 @@ class InspectorFindingToPackageMatchLink(CartographyRelSchema):
 class AWSInspectorFindingSchema(CartographyNodeSchema):
     label: str = "AWSInspectorFinding"
     properties: AWSInspectorNodeProperties = AWSInspectorNodeProperties()
-    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Risk"])
+    # Inspector findings are mixed: package vulnerabilities are CVE-backed while
+    # network-reachability findings are configuration security issues. Label them
+    # by type so each shows up in the right ontology finding family.
+    # NOTE: the conditional-label mechanism removes-then-sets per entry, so a label
+    # can only be driven by a single condition (two entries sharing a label would
+    # clobber each other). CODE_VULNERABILITY is intentionally left unlabeled for
+    # now; give it its own distinct label if/when it needs one.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        [
+            "Risk",
+            ConditionalNodeLabel(
+                label="CVE",
+                conditions={"type": "PACKAGE_VULNERABILITY"},
+            ),
+            ConditionalNodeLabel(
+                label="SecurityIssue",
+                conditions={"type": "NETWORK_REACHABILITY"},
+            ),
+        ],
+    )
     sub_resource_relationship: InspectorFindingToAWSAccountRel = (
         InspectorFindingToAWSAccountRel()
     )

--- a/cartography/models/ontology/constraints.py
+++ b/cartography/models/ontology/constraints.py
@@ -166,6 +166,10 @@ ONTOLOGY_REL_CONSTRAINTS: tuple[RelConstraint, ...] = (
     # A workload assumes a permission role to obtain its privileges.
     RelConstraint(src="ComputeInstance", dst="PermissionRole", label="ASSUMES"),
     RelConstraint(src="Function", dst="PermissionRole", label="ASSUMES"),
+    # A vulnerability finding (CVE) or a rule-based security issue affects a
+    # software package. Both finding shapes point at the same canonical Package.
+    RelConstraint(src="CVE", dst="Package", label="AFFECTS"),
+    RelConstraint(src="SecurityIssue", dst="Package", label="AFFECTS"),
 )
 
 

--- a/cartography/models/ontology/device.py
+++ b/cartography/models/ontology/device.py
@@ -50,6 +50,36 @@ class DeviceOwnedByUserRel(CartographyRelSchema):
     properties: DeviceToNodeRelProperties = DeviceToNodeRelProperties()
 
 
+# Cleanup-only relationship.
+# Created by the devices linking query (walking OBSERVED_AS -> S1Agent <- AFFECTS),
+# not by load(DeviceSchema()). Kept on the schema so GraphJob cleanup removes stale edges.
+# (:S1AppFinding)-[:AFFECTS]->(:Device)
+@dataclass(frozen=True)
+class DeviceAffectedByS1AppFindingRel(CartographyRelSchema):
+    target_node_label: str = "S1AppFinding"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("_cleanup_finding_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "AFFECTS"
+    properties: DeviceToNodeRelProperties = DeviceToNodeRelProperties()
+
+
+# Cleanup-only relationship.
+# Created by the devices linking query (walking OBSERVED_AS -> CrowdstrikeHost ->
+# SpotlightVulnerability -> CrowdstrikeFinding), not by load(DeviceSchema()).
+# (:CrowdstrikeFinding)-[:AFFECTS]->(:Device)
+@dataclass(frozen=True)
+class DeviceAffectedByCrowdstrikeFindingRel(CartographyRelSchema):
+    target_node_label: str = "CrowdstrikeFinding"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("_cleanup_finding_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "AFFECTS"
+    properties: DeviceToNodeRelProperties = DeviceToNodeRelProperties()
+
+
 # (:Device)-[:OBSERVED_AS]->(:JumpCloudSystem)
 @dataclass(frozen=True)
 class DeviceToJumpCloudSystemRel(CartographyRelSchema):
@@ -181,6 +211,8 @@ class DeviceSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         rels=[
             DeviceOwnedByUserRel(),
+            DeviceAffectedByS1AppFindingRel(),
+            DeviceAffectedByCrowdstrikeFindingRel(),
             DeviceToJumpCloudSystemRel(),
             # Serial number-based relationships
             DeviceToCrowdstrikeHostBySerialRel(),

--- a/cartography/models/ontology/mapping/data/cves.py
+++ b/cartography/models/ontology/mapping/data/cves.py
@@ -289,10 +289,27 @@ github_mapping = OntologyMapping(
     ],
 )
 
+sentinelone_mapping = OntologyMapping(
+    module_name="sentinelone",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="S1AppFinding",
+            fields=[
+                OntologyFieldMapping(ontology_field="cve_id", node_field="cve_id"),
+                OntologyFieldMapping(
+                    ontology_field="base_severity",
+                    node_field="severity",
+                ),
+            ],
+        ),
+    ],
+)
+
 CVES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "cve": cve_mapping,
     "trivy": trivy_mapping,
     "ubuntu": ubuntu_mapping,
     "crowdstrike": crowdstrike_mapping,
     "github": github_mapping,
+    "sentinelone": sentinelone_mapping,
 }

--- a/cartography/models/ontology/mapping/data/packages.py
+++ b/cartography/models/ontology/mapping/data/packages.py
@@ -82,9 +82,30 @@ github_mapping = OntologyMapping(
     ],
 )
 
+semgrep_mapping = OntologyMapping(
+    module_name="semgrep",
+    nodes=[
+        OntologyNodeMapping(
+            # Both GoLibrary and NpmLibrary carry the :SemgrepDependency label.
+            node_label="SemgrepDependency",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="normalized_id",
+                    node_field="normalized_id",
+                    required=True,
+                ),
+                OntologyFieldMapping(ontology_field="name", node_field="name"),
+                OntologyFieldMapping(ontology_field="version", node_field="version"),
+                OntologyFieldMapping(ontology_field="type", node_field="type"),
+            ],
+        ),
+    ],
+)
+
 PACKAGES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "trivy": trivy_mapping,
     "syft": syft_mapping,
     "gitlab": gitlab_mapping,
     "github": github_mapping,
+    "semgrep": semgrep_mapping,
 }

--- a/cartography/models/ontology/mapping/data/security_issues.py
+++ b/cartography/models/ontology/mapping/data/security_issues.py
@@ -66,6 +66,28 @@ semgrep_mapping = OntologyMapping(
                 ),
             ],
         ),
+        OntologyNodeMapping(
+            node_label="SemgrepSCAFinding",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="title",
+                    node_field="summary",
+                    required=True,
+                ),
+                OntologyFieldMapping(
+                    ontology_field="severity",
+                    node_field="severity",
+                ),
+                OntologyFieldMapping(
+                    ontology_field="status",
+                    node_field="triage_status",
+                ),
+                OntologyFieldMapping(
+                    ontology_field="first_seen",
+                    node_field="scan_time",
+                ),
+            ],
+        ),
         # SemgrepSecretsFinding has no dedicated title; type (e.g. "AWS Secret Key") serves as both
         OntologyNodeMapping(
             node_label="SemgrepSecretsFinding",

--- a/cartography/models/ontology/package.py
+++ b/cartography/models/ontology/package.py
@@ -87,6 +87,18 @@ class PackageToGitHubDependencyRel(CartographyRelSchema):
     properties: PackageToNodeRelProperties = PackageToNodeRelProperties()
 
 
+# (:Package)-[:DETECTED_AS]->(:SemgrepDependency) (GoLibrary / NpmLibrary)
+@dataclass(frozen=True)
+class PackageToSemgrepDependencyRel(CartographyRelSchema):
+    target_node_label: str = "SemgrepDependency"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"normalized_id": PropertyRef("normalized_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "DETECTED_AS"
+    properties: PackageToNodeRelProperties = PackageToNodeRelProperties()
+
+
 @dataclass(frozen=True)
 class PackageToOntologyImageRel(CartographyRelSchema):
     """
@@ -155,6 +167,7 @@ class PackageSchema(CartographyNodeSchema):
             PackageToSocketDevDependencyRel(),
             PackageToGitLabDependencyRel(),
             PackageToGitHubDependencyRel(),
+            PackageToSemgrepDependencyRel(),
             PackageToOntologyImageRel(),
             PackageToTrivyFixRel(),
             PackageToPackageDependsOnRel(),

--- a/cartography/models/semgrep/dependencies.py
+++ b/cartography/models/semgrep/dependencies.py
@@ -20,6 +20,8 @@ class SemgrepDependencyNodeProperties(CartographyNodeProperties):
     name: PropertyRef = PropertyRef("name")
     ecosystem: PropertyRef = PropertyRef("ecosystem")
     version: PropertyRef = PropertyRef("version")
+    type: PropertyRef = PropertyRef("type")
+    normalized_id: PropertyRef = PropertyRef("normalized_id", extra_index=True)
 
 
 @dataclass(frozen=True)

--- a/cartography/models/semgrep/findings.py
+++ b/cartography/models/semgrep/findings.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
@@ -162,6 +163,7 @@ class SemgrepSCAFindingToAssistantRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class SemgrepSCAFindingSchema(CartographyNodeSchema):
     label: str = "SemgrepSCAFinding"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["SecurityIssue"])
     properties: SemgrepSCAFindingNodeProperties = SemgrepSCAFindingNodeProperties()
     sub_resource_relationship: SemgrepSCAFindingToSemgrepDeploymentRel = (
         SemgrepSCAFindingToSemgrepDeploymentRel()

--- a/cartography/models/sentinelone/finding.py
+++ b/cartography/models/sentinelone/finding.py
@@ -119,7 +119,7 @@ class S1AppFindingToCVERel(CartographyRelSchema):
 @dataclass(frozen=True)
 class S1AppFindingSchema(CartographyNodeSchema):
     label: str = "S1AppFinding"
-    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["S1Finding", "Risk"])
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["S1Finding", "Risk", "CVE"])
     properties: S1AppFindingNodeProperties = S1AppFindingNodeProperties()
     sub_resource_relationship: S1AppFindingToAccountRel = S1AppFindingToAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -446,6 +446,8 @@ Representation of an AWS [GuardDuty Finding](https://docs.aws.amazon.com/guarddu
 
 Representation of an AWS [Inspector Finding](https://docs.aws.amazon.com/inspector/v2/APIReference/API_Finding.html)
 
+Depending on its `type`, the finding also carries an ontology finding label: `PACKAGE_VULNERABILITY` findings are labeled `:CVE`, and `NETWORK_REACHABILITY` findings are labeled `:SecurityIssue`.
+
 | Field | Description | Required|
 |-------|-------------|------|
 |firstseen|Timestamp of when a sync job first discovered this node|no|

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -8,6 +8,8 @@ graph LR
 
 U(User) -- HAS_ACCOUNT --> UA{{UserAccount}}
 U -- OWNS --> CC(Device)
+SAF[S1AppFinding] -- AFFECTS --> CC
+CSF[CrowdstrikeFinding] -- AFFECTS --> CC
 U -- OWNS --> AK{{APIKey}}
 U -- AUTHORIZED --> OA{{ThirdPartyApp}}
 UG{{UserGroup}}
@@ -262,6 +264,11 @@ A client computer is a host that accesses a service made available by a server o
     (:User)-[:OWNS]->(:Device)
     ```
   This relationship may be derived from provider signals such as Jamf device emails, CrowdStrike host emails, or native provider ownership edges.
+- A `Device` can be affected by one or many findings (propagated from the provider host/agent during the ontology linking job):
+    ```
+    (:S1AppFinding)-[:AFFECTS]->(:Device)
+    (:CrowdstrikeFinding)-[:AFFECTS]->(:Device)
+    ```
 
 
 ### APIKey

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -68,6 +68,7 @@ PIP -- POINTS_TO --> CI
 PKG(Package) -- DEPLOYED --> IM{{Image}}
 PKG -- DEPENDS_ON --> PKG
 F[TrivyImageFinding] -- AFFECTS --> PKG
+SCA[SemgrepSCAFinding] -- AFFECTS --> PKG
 CR{{ContainerRegistry}} -- REPO_IMAGE --> IT{{ImageTag}}
 IT -- IMAGE --> IM
 IML{{ImageManifestList}} -- CONTAINS_IMAGE --> IM
@@ -1032,14 +1033,16 @@ Package nodes are deduplicated by their `id`, which uses the format `{type}|{nam
     ```
     (:Package)-[:DETECTED_AS]->(:TrivyPackage)
     (:Package)-[:DETECTED_AS]->(:SyftPackage)
+    (:Package)-[:DETECTED_AS]->(:SemgrepDependency)
     ```
 - `Package` can be deployed in one or many container images (propagated from TrivyPackage and SyftPackage):
     ```
     (:Package)-[:DEPLOYED]->(:Image)
     ```
-- `Package` can be affected by one or many vulnerability findings (propagated from TrivyPackage):
+- `Package` can be affected by one or many vulnerability findings or security issues (propagated from TrivyPackage and SemgrepDependency):
     ```
     (:TrivyImageFinding)-[:AFFECTS]->(:Package)
+    (:SemgrepSCAFinding)-[:AFFECTS]->(:Package)
     ```
 - `Package` can have one or many recommended fix versions (propagated from TrivyPackage):
     ```

--- a/docs/root/modules/semgrep/schema.md
+++ b/docs/root/modules/semgrep/schema.md
@@ -161,7 +161,7 @@ Represents a [Semgrep Secrets](https://semgrep.dev/docs/semgrep-secrets/conceptu
     (SemgrepSecretsFinding)-[FOUND_IN]->(GitLabProject)
     ```
 
-### SemgrepSCAFinding
+### SemgrepSCAFinding::SecurityIssue
 
 Represents a [Semgrep Supply Chain](https://semgrep.dev/docs/semgrep-supply-chain/overview/) finding. This is, a vulnerability in a dependency of a project discovered by Semgrep performing software composition analysis (SCA) and code reachability analysis. Before ingesting this node, make sure you have run Semgrep CI and that it's connected to Semgrep Cloud Platform [Running Semgrep CI with Semgrep Cloud Platform](https://semgrep.dev/docs/semgrep-ci/running-semgrep-ci-with-semgrep-cloud-platform/). The API called to retrieve this information is documented at https://semgrep.dev/api/v1/docs/#tag/SupplyChainService.
 
@@ -290,6 +290,8 @@ Represents a dependency of a repository as returned by the Semgrep
 | name | Name of the dependency |
 | version | Version of the dependency |
 | ecosystem | Ecosystem of the dependency, e.g. "gomod" for dependencies defined in go.mod files. (see [API docs](https://semgrep.dev/api/v1/docs/#tag/SupplyChainService/operation/semgrep_app.products.sca.handlers.dependency.list_dependencies_conexxion) for full list of options) |
+| type | Canonical package type derived from the ecosystem (e.g. `golang`, `npm`), used to build the `normalized_id`. |
+| normalized_id | Cross-tool package identifier (`{type}\|{name}\|{version}`) used to dedup into the `Package` ontology node. |
 
 
 ### GoLibrary
@@ -322,3 +324,9 @@ See [SemgrepDependency](#semgrepdependency) for details.
     - specifier: A string describing the library version required by the repo (e.g. "==1.0.2")
     - transitivity: A string describing whether the dependency is direct or [transitive](https://en.wikipedia.org/wiki/Transitive_dependency) (e.g. direct, transitive)
     - url: The URL where the dependency is defined (e.g. `https://github.com/org/repo/blob/00000000000000000000000000000000/go.mod#L6`)
+
+- A SemgrepDependency is detected as a `Package` ontology node (optional)
+
+    ```
+    (:Package)-[:DETECTED_AS]->(:SemgrepDependency)
+    ```

--- a/docs/root/modules/semgrep/schema.md
+++ b/docs/root/modules/semgrep/schema.md
@@ -325,7 +325,7 @@ See [SemgrepDependency](#semgrepdependency) for details.
     - transitivity: A string describing whether the dependency is direct or [transitive](https://en.wikipedia.org/wiki/Transitive_dependency) (e.g. direct, transitive)
     - url: The URL where the dependency is defined (e.g. `https://github.com/org/repo/blob/00000000000000000000000000000000/go.mod#L6`)
 
-- A SemgrepDependency is detected as a `Package` ontology node (optional)
+- A canonical Package (ontology) is detected as a SemgrepDependency.
 
     ```
     (:Package)-[:DETECTED_AS]->(:SemgrepDependency)

--- a/docs/root/modules/sentinelone/schema.md
+++ b/docs/root/modules/sentinelone/schema.md
@@ -174,9 +174,9 @@ Represents a specific version of an application.
     (S1AppFinding)-[AFFECTS]->(S1ApplicationVersion)
     ```
 
-### S1AppFinding::S1Finding::Risk
+### S1AppFinding::S1Finding::Risk::CVE
 
-Represents a specific **instance** of a vulnerability detection (finding) on a specific endpoint. Unlike generic CVE definitions, each `S1AppFinding` node represents a unique finding on a specific agent.
+Represents a specific **instance** of a vulnerability detection (finding) on a specific endpoint. Unlike generic CVE definitions, each `S1AppFinding` node represents a unique finding on a specific agent. It carries the `:CVE` ontology label (it is keyed on a `cve_id`), so it participates in cross-tool vulnerability queries.
 
 | Field | Description |
 |-------|-------------|

--- a/tests/integration/cartography/intel/aws/inspector/test_inspector_sync.py
+++ b/tests/integration/cartography/intel/aws/inspector/test_inspector_sync.py
@@ -76,6 +76,14 @@ def test_sync_inspector_network_findings(mock_get, neo4j_session):
         ("123456789011", "arn:aws:test123"),
     }
 
+    # Network-reachability findings are labeled as configuration security issues,
+    # not CVEs.
+    labels = neo4j_session.run(
+        "MATCH (f:AWSInspectorFinding {id: 'arn:aws:test123'}) RETURN labels(f) AS labels",
+    ).single()["labels"]
+    assert "SecurityIssue" in labels
+    assert "CVE" not in labels
+
 
 @patch.object(
     cartography.intel.aws.inspector,
@@ -186,6 +194,13 @@ def test_sync_inspector_ec2_package_findings(mock_get, neo4j_session):
         ("123456789012", "kernel|0:4.9.17-6.29.amzn1.X86_64"),
         ("123456789012", "openssl|0:1.0.2k-1.amzn2.X86_64"),
     }
+
+    # Package-vulnerability findings are CVE-backed and labeled as such.
+    labels = neo4j_session.run(
+        "MATCH (f:AWSInspectorFinding {id: 'arn:aws:test456'}) RETURN labels(f) AS labels",
+    ).single()["labels"]
+    assert "CVE" in labels
+    assert "SecurityIssue" not in labels
 
 
 @patch.object(

--- a/tests/integration/cartography/intel/ontology/test_devices.py
+++ b/tests/integration/cartography/intel/ontology/test_devices.py
@@ -694,6 +694,85 @@ def test_load_ontology_devices_from_jamf_mobile_devices(neo4j_session):
     }
 
 
+def test_link_ontology_device_affected_by_sentinelone_finding(neo4j_session):
+    """SentinelOne app findings should AFFECTS the canonical Device via their agent."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        CREATE (a:S1Agent {
+            id: 's1-agent-affects',
+            computer_name: 'sentinel-host-01',
+            os_name: 'Windows 11',
+            os_revision: '23H2',
+            serial_number: 'SN-S1-AFFECTS',
+            lastupdated: $update_tag
+        })
+        CREATE (f:S1AppFinding {id: 'CVE-2024-0001', lastupdated: $update_tag})
+        MERGE (f)-[r:AFFECTS]->(a)
+        SET r.lastupdated = $update_tag
+        """,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    cartography.intel.ontology.devices.sync(
+        neo4j_session,
+        ["sentinelone"],
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "S1AppFinding",
+        "id",
+        "Device",
+        "serial_number",
+        "AFFECTS",
+        rel_direction_right=True,
+    ) == {("CVE-2024-0001", "SN-S1-AFFECTS")}
+
+
+def test_link_ontology_device_affected_by_crowdstrike_finding(neo4j_session):
+    """CrowdStrike findings should AFFECTS the canonical Device via host and Spotlight vuln."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        CREATE (h:CrowdstrikeHost {
+            id: 'crowdstrike-host-affects',
+            hostname: 'falcon-host-01',
+            platform_name: 'Windows',
+            os_version: '11.0.22631',
+            serial_number: 'SN-CROWDSTRIKE-AFFECTS',
+            lastupdated: $update_tag
+        })
+        CREATE (v:SpotlightVulnerability {id: 'spotlight-vuln-1', lastupdated: $update_tag})
+        CREATE (f:CrowdstrikeFinding {id: 'CVE-2024-0002', lastupdated: $update_tag})
+        MERGE (h)-[hv:HAS_VULNERABILITY]->(v)
+        SET hv.lastupdated = $update_tag
+        MERGE (v)-[hc:HAS_CVE]->(f)
+        SET hc.lastupdated = $update_tag
+        """,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    cartography.intel.ontology.devices.sync(
+        neo4j_session,
+        ["crowdstrike"],
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "CrowdstrikeFinding",
+        "id",
+        "Device",
+        "serial_number",
+        "AFFECTS",
+        rel_direction_right=True,
+    ) == {("CVE-2024-0002", "SN-CROWDSTRIKE-AFFECTS")}
+
+
 def test_link_ontology_devices_from_intune_enrolled_to(neo4j_session):
     """Intune enrollment should derive canonical User-OWNS-Device relationships."""
     neo4j_session.run("MATCH (n) DETACH DELETE n")

--- a/tests/integration/cartography/intel/semgrep/test_dependencies.py
+++ b/tests/integration/cartography/intel/semgrep/test_dependencies.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
+import cartography.intel.ontology.packages
 import cartography.intel.semgrep.dependencies
 import cartography.intel.semgrep.deployment
 import tests.data.semgrep.dependencies
@@ -248,6 +249,77 @@ def _mock_get_gitlab_dependencies(
     if ecosystem == "npm":
         return _build_gitlab_npm_deps()
     raise ValueError(f"Unexpected value for `ecosystem`: {ecosystem}")
+
+
+@patch.object(
+    cartography.intel.semgrep.deployment,
+    "get_deployment",
+    return_value=tests.data.semgrep.deployment.DEPLOYMENTS,
+)
+@patch.object(
+    cartography.intel.semgrep.dependencies,
+    "get_dependencies",
+    side_effect=_mock_get_dependencies,
+)
+def test_sync_dependencies_promotes_sca_finding_to_package_ontology(
+    mock_get_dependencies, mock_get_deployment, neo4j_session
+):
+    """
+    A SemgrepSCAFinding that AFFECTS a SemgrepDependency should reach the
+    canonical Package ontology node once the packages ontology sync runs:
+    the dependency dedups into a :Package via DETECTED_AS, and the finding's
+    AFFECTS edge is propagated onto that :Package.
+    """
+    # Arrange: real dependency nodes (carrying normalized_id) + a SCA finding
+    # that affects one of them.
+    create_github_repos(neo4j_session)
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG}
+    sync_deployment(
+        neo4j_session,
+        "your_semgrep_app_token",
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+    sync_dependencies(
+        neo4j_session,
+        "your_semgrep_app_token",
+        "gomod,npm",
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+    neo4j_session.run(
+        """
+        MATCH (d:SemgrepDependency {id: 'github.com/foo/baz|1.2.3'})
+        MERGE (f:SemgrepSCAFinding:SecurityIssue {id: 'test-sca-finding'})
+        MERGE (f)-[:AFFECTS]->(d)
+        """,
+    )
+
+    # Act
+    cartography.intel.ontology.packages.sync(
+        neo4j_session,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    # Assert: the dependency deduped into a canonical Package...
+    detected = neo4j_session.run(
+        """
+        MATCH (p:Package)-[:DETECTED_AS]->(:SemgrepDependency {id: 'github.com/foo/baz|1.2.3'})
+        RETURN count(p) AS c
+        """,
+    ).single()
+    assert detected["c"] == 1
+
+    # ...and the finding's AFFECTS edge reached that canonical Package.
+    affects = neo4j_session.run(
+        """
+        MATCH (:SemgrepSCAFinding {id: 'test-sca-finding'})-[:AFFECTS]->(p:Package)
+              -[:DETECTED_AS]->(:SemgrepDependency {id: 'github.com/foo/baz|1.2.3'})
+        RETURN count(p) AS c
+        """,
+    ).single()
+    assert affects["c"] == 1
 
 
 @patch.object(

--- a/tests/integration/cartography/intel/sentinelone/test_finding.py
+++ b/tests/integration/cartography/intel/sentinelone/test_finding.py
@@ -124,6 +124,13 @@ def test_sync_cves(mock_get_paginated_results, neo4j_session):
 
     assert actual_nodes == expected_nodes
 
+    # S1AppFinding is CVE-shaped (carries a cve_id) and is labeled :CVE.
+    labels = neo4j_session.run(
+        "MATCH (f:S1AppFinding {id: $id}) RETURN labels(f) AS labels",
+        id=CVE_ID_1,
+    ).single()["labels"]
+    assert "CVE" in labels
+
     # Verify that relationships to the account were created
     expected_rels = {
         (CVE_ID_1, TEST_ACCOUNT_ID),


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary

Expands ontology coverage for findings, packages and devices so cross-tool queries work regardless of the scanner that produced the data. Four self-contained commits:

1. **Map Semgrep SCA findings to the Package ontology.** `SemgrepSCAFinding` is labeled `:SecurityIssue` (consistent with the SAST/Secrets/OSS findings). Semgrep dependency nodes (`GoLibrary`/`NpmLibrary`) get a `normalized_id`/`type` computed with the shared `make_normalized_package_id` helper and are registered in the `packages` mapping so they dedup into the abstract `:Package`. The packages linking job then promotes `(:SemgrepSCAFinding)-[:AFFECTS]->(:Package)`, mirroring the existing Trivy path.

2. **Constrain `AFFECTS` to Package.** Adds `RelConstraint(CVE -> Package, AFFECTS)` and `RelConstraint(SecurityIssue -> Package, AFFECTS)`. A package can be affected both by a CVE-backed finding (Trivy) and a rule-based security issue (Semgrep SCA).

3. **Label endpoint findings.** `S1AppFinding` is CVE-shaped (keyed on `cve_id`) so it gets `:CVE` and is registered in the `cves` mapping. `AWSInspectorFinding` is mixed, so it is labeled by `type` via conditional labels: `PACKAGE_VULNERABILITY` -> `:CVE`, `NETWORK_REACHABILITY` -> `:SecurityIssue`.

4. **`AFFECTS` edges from endpoint findings to the abstract `Device`.** The devices linking job walks the `OBSERVED_AS` bridge to MERGE `(:S1AppFinding)-[:AFFECTS]->(:Device)` (via `S1Agent`) and `(:CrowdstrikeFinding)-[:AFFECTS]->(:Device)` (via `CrowdstrikeHost` -> `SpotlightVulnerability` -> `CrowdstrikeFinding`). Cleanup-only rels on `DeviceSchema` let `GraphJob` remove stale edges. This edge is owned by the abstract `Device` node (like `User`/`Package`), so no `RelConstraint` is added.

AWS Inspector is intentionally excluded from the Device edge: its findings target a `ComputeInstance`, not a `Device`.


### Related issues or links

Part of the ongoing ontology normalization effort (see upstream discussion #2772).


### How was this tested?

- Unit: `tests/unit/cartography/graph/test_ontology_rel_constraints.py` (constraint guard), `tests/unit/cartography/intel/ontology/`, `tests/unit/cartography/intel/semgrep/`.
- Integration (Neo4j): new assertions in `tests/integration/cartography/intel/ontology/test_devices.py` (finding -> Device), `tests/integration/cartography/intel/semgrep/test_dependencies.py` (SCA -> Package), `tests/integration/cartography/intel/aws/inspector/test_inspector_sync.py` and `tests/integration/cartography/intel/sentinelone/test_finding.py` (label assertions).
- `pre-commit run` (black, isort, flake8, mypy, pyupgrade) passes on all changed files.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).


### Notes for reviewers

The conditional-label loader removes-then-sets per entry, so a single label can only be driven by one condition (two entries sharing a label would clobber each other). That is why `AWSInspectorFinding` maps one `type` per label and `CODE_VULNERABILITY` is intentionally left unlabeled for now.
