### PR TITLE
fix(ontology): stop DNS linking cleanup from deleting provider-owned edges

### DIFF
--- a/cartography/data/jobs/analysis/ontology_dnsrecords_linking.json
+++ b/cartography/data/jobs/analysis/ontology_dnsrecords_linking.json
@@ -3,82 +3,82 @@
   "statements": [
     {
       "__comment": "Link DNSRecord to KubernetesIngress where the record name matches an ingress host",
-      "query": "MATCH (dns:DNSRecord) WHERE dns.lastupdated = $UPDATE_TAG AND dns._ont_name IS NOT NULL WITH dns MATCH (ing:KubernetesIngress) WHERE dns._ont_name IN ing.host_names MERGE (dns)-[r:DNS_POINTS_TO]->(ing) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_name IS NOT NULL WITH dns MATCH (ing:KubernetesIngress) WHERE dns._ont_name IN ing.host_names MERGE (dns)-[r:DNS_POINTS_TO]->(ing) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
-      "__comment": "Link DNSRecord to AWSLoadBalancerV2 via _ont_value (scalar, covers AWS/Cloudflare/Vercel records)",
-      "query": "MATCH (dns:DNSRecord) WHERE dns.lastupdated = $UPDATE_TAG AND dns._ont_value IS NOT NULL WITH dns MATCH (lb:AWSLoadBalancerV2) WHERE toLower(toString(dns._ont_value)) = toLower(lb.dnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(lb) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "__comment": "Link non-AWS DNSRecord (Cloudflare/Vercel/Scaleway) to AWSLoadBalancerV2 via _ont_value; AWS records are linked natively by the route53 loader",
+      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL AND NOT dns:AWSDNSRecord WITH dns MATCH (lb:AWSLoadBalancerV2) WHERE toLower(toString(dns._ont_value)) = toLower(lb.dnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(lb) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
       "__comment": "Link GCPRecordSet to AWSLoadBalancerV2 via UNWIND on list-valued data",
-      "query": "MATCH (dns:GCPRecordSet) WHERE dns.lastupdated = $UPDATE_TAG AND dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (lb:AWSLoadBalancerV2) WHERE toLower(val) = toLower(lb.dnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(lb) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:GCPRecordSet) WHERE dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (lb:AWSLoadBalancerV2) WHERE toLower(val) = toLower(lb.dnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(lb) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
-      "__comment": "Link DNSRecord to AWSLoadBalancer via _ont_value (scalar)",
-      "query": "MATCH (dns:DNSRecord) WHERE dns.lastupdated = $UPDATE_TAG AND dns._ont_value IS NOT NULL WITH dns MATCH (lb:AWSLoadBalancer) WHERE toLower(toString(dns._ont_value)) = toLower(lb.dnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(lb) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "__comment": "Link non-AWS DNSRecord (Cloudflare/Vercel/Scaleway) to AWSLoadBalancer via _ont_value; AWS records are linked natively by the route53 loader",
+      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL AND NOT dns:AWSDNSRecord WITH dns MATCH (lb:AWSLoadBalancer) WHERE toLower(toString(dns._ont_value)) = toLower(lb.dnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(lb) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
       "__comment": "Link GCPRecordSet to AWSLoadBalancer via UNWIND on list-valued data",
-      "query": "MATCH (dns:GCPRecordSet) WHERE dns.lastupdated = $UPDATE_TAG AND dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (lb:AWSLoadBalancer) WHERE toLower(val) = toLower(lb.dnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(lb) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:GCPRecordSet) WHERE dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (lb:AWSLoadBalancer) WHERE toLower(val) = toLower(lb.dnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(lb) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
       "__comment": "Link DNSRecord to CloudFrontDistribution via _ont_value (scalar)",
-      "query": "MATCH (dns:DNSRecord) WHERE dns.lastupdated = $UPDATE_TAG AND dns._ont_value IS NOT NULL WITH dns MATCH (cf:CloudFrontDistribution) WHERE toLower(toString(dns._ont_value)) = toLower(cf.domain_name) MERGE (dns)-[r:DNS_POINTS_TO]->(cf) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL WITH dns MATCH (cf:CloudFrontDistribution) WHERE toLower(toString(dns._ont_value)) = toLower(cf.domain_name) MERGE (dns)-[r:DNS_POINTS_TO]->(cf) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
       "__comment": "Link GCPRecordSet to CloudFrontDistribution via UNWIND on list-valued data",
-      "query": "MATCH (dns:GCPRecordSet) WHERE dns.lastupdated = $UPDATE_TAG AND dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (cf:CloudFrontDistribution) WHERE toLower(val) = toLower(cf.domain_name) MERGE (dns)-[r:DNS_POINTS_TO]->(cf) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:GCPRecordSet) WHERE dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (cf:CloudFrontDistribution) WHERE toLower(val) = toLower(cf.domain_name) MERGE (dns)-[r:DNS_POINTS_TO]->(cf) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
-      "__comment": "Link DNSRecord to EC2Instance via _ont_value (scalar)",
-      "query": "MATCH (dns:DNSRecord) WHERE dns.lastupdated = $UPDATE_TAG AND dns._ont_value IS NOT NULL WITH dns MATCH (i:EC2Instance) WHERE toLower(toString(dns._ont_value)) = toLower(i.publicdnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(i) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "__comment": "Link non-AWS DNSRecord (Cloudflare/Vercel/Scaleway) to EC2Instance via _ont_value; AWS records are linked natively by the route53 loader",
+      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL AND NOT dns:AWSDNSRecord WITH dns MATCH (i:EC2Instance) WHERE toLower(toString(dns._ont_value)) = toLower(i.publicdnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(i) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
       "__comment": "Link GCPRecordSet to EC2Instance via UNWIND on list-valued data",
-      "query": "MATCH (dns:GCPRecordSet) WHERE dns.lastupdated = $UPDATE_TAG AND dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (i:EC2Instance) WHERE toLower(val) = toLower(i.publicdnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(i) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:GCPRecordSet) WHERE dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (i:EC2Instance) WHERE toLower(val) = toLower(i.publicdnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(i) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
       "__comment": "Link DNSRecord to GCPInstance via _ont_value (scalar)",
-      "query": "MATCH (dns:DNSRecord) WHERE dns.lastupdated = $UPDATE_TAG AND dns._ont_value IS NOT NULL WITH dns MATCH (i:GCPInstance) WHERE toLower(toString(dns._ont_value)) = toLower(i.hostname) MERGE (dns)-[r:DNS_POINTS_TO]->(i) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL WITH dns MATCH (i:GCPInstance) WHERE toLower(toString(dns._ont_value)) = toLower(i.hostname) MERGE (dns)-[r:DNS_POINTS_TO]->(i) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
       "__comment": "Link GCPRecordSet to GCPInstance via UNWIND on list-valued data",
-      "query": "MATCH (dns:GCPRecordSet) WHERE dns.lastupdated = $UPDATE_TAG AND dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (i:GCPInstance) WHERE toLower(val) = toLower(i.hostname) MERGE (dns)-[r:DNS_POINTS_TO]->(i) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:GCPRecordSet) WHERE dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (i:GCPInstance) WHERE toLower(val) = toLower(i.hostname) MERGE (dns)-[r:DNS_POINTS_TO]->(i) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
       "__comment": "Link DNSRecord to AzureAppService via _ont_value (scalar)",
-      "query": "MATCH (dns:DNSRecord) WHERE dns.lastupdated = $UPDATE_TAG AND dns._ont_value IS NOT NULL WITH dns MATCH (app:AzureAppService) WHERE toLower(toString(dns._ont_value)) = toLower(app.default_host_name) MERGE (dns)-[r:DNS_POINTS_TO]->(app) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL WITH dns MATCH (app:AzureAppService) WHERE toLower(toString(dns._ont_value)) = toLower(app.default_host_name) MERGE (dns)-[r:DNS_POINTS_TO]->(app) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
       "__comment": "Link GCPRecordSet to AzureAppService via UNWIND on list-valued data",
-      "query": "MATCH (dns:GCPRecordSet) WHERE dns.lastupdated = $UPDATE_TAG AND dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (app:AzureAppService) WHERE toLower(val) = toLower(app.default_host_name) MERGE (dns)-[r:DNS_POINTS_TO]->(app) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:GCPRecordSet) WHERE dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (app:AzureAppService) WHERE toLower(val) = toLower(app.default_host_name) MERGE (dns)-[r:DNS_POINTS_TO]->(app) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
       "__comment": "Link DNSRecord to AzureFunctionApp via _ont_value (scalar)",
-      "query": "MATCH (dns:DNSRecord) WHERE dns.lastupdated = $UPDATE_TAG AND dns._ont_value IS NOT NULL WITH dns MATCH (func:AzureFunctionApp) WHERE toLower(toString(dns._ont_value)) = toLower(func.default_host_name) MERGE (dns)-[r:DNS_POINTS_TO]->(func) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL WITH dns MATCH (func:AzureFunctionApp) WHERE toLower(toString(dns._ont_value)) = toLower(func.default_host_name) MERGE (dns)-[r:DNS_POINTS_TO]->(func) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
       "__comment": "Link GCPRecordSet to AzureFunctionApp via UNWIND on list-valued data",
-      "query": "MATCH (dns:GCPRecordSet) WHERE dns.lastupdated = $UPDATE_TAG AND dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (func:AzureFunctionApp) WHERE toLower(val) = toLower(func.default_host_name) MERGE (dns)-[r:DNS_POINTS_TO]->(func) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:GCPRecordSet) WHERE dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (func:AzureFunctionApp) WHERE toLower(val) = toLower(func.default_host_name) MERGE (dns)-[r:DNS_POINTS_TO]->(func) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
-      "__comment": "Cleanup: remove stale analysis-created DNS_POINTS_TO edges from DNSRecord nodes. Runs after all MERGE statements so concurrent readers never observe a missing edge.",
-      "query": "MATCH (:DNSRecord)-[r:DNS_POINTS_TO]->() WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r RETURN COUNT(*) AS TotalCompleted",
+      "__comment": "Cleanup: delete stale ontology-created DNS_POINTS_TO edges, excluding the (AWSDNSRecord, target) tuples the route53 loader owns so its edges are never deleted even when the AWS and ontology syncs run with different update tags. The excluded target list must mirror every DNS_POINTS_TO target in the route53 dnsrecord model. MERGE runs first so live edges carry the current tag.",
+      "query": "MATCH (dns:DNSRecord)-[r:DNS_POINTS_TO]->(t) WHERE r.lastupdated <> $UPDATE_TAG AND NOT (dns:AWSDNSRecord AND (t:AWSLoadBalancer OR t:AWSLoadBalancerV2 OR t:EC2Instance OR t:ESDomain OR t:Ip OR t:ElasticIPAddress OR t:NameServer OR t:AWSDNSRecord)) WITH r LIMIT $LIMIT_SIZE DELETE r RETURN COUNT(*) AS TotalCompleted",
       "iterative": true,
       "iterationsize": 1000
     }


### PR DESCRIPTION
### Summary

The ontology DNSRecords linking job (`ontology_dnsrecords_linking.json`) intermittently deletes `DNS_POINTS_TO` edges that a provider loader owns, most visibly `(:AWSDNSRecord)-[:DNS_POINTS_TO]->(:AWSLoadBalancerV2)`. The edge is present after an AWS sync and gone after an ontology sync, so any query that relies on it "only works sometimes."

### Root cause

When ingestion and the analysis job run in the **same** cartography run they share one `update_tag`, so the job's `WHERE dns.lastupdated = $UPDATE_TAG` filter and its cleanup agree. But when the ontology sync is scheduled as its **own** run with a different `update_tag` (`O`) than the AWS run (`A`):

- the MERGEs are gated on `dns.lastupdated = $UPDATE_TAG`, which no separately-synced record ever satisfies, so they rebuild nothing;
- the cleanup deletes every `(:DNSRecord)-[:DNS_POINTS_TO]->()` edge whose `lastupdated <> O`, which includes the route53-owned edges (tag `A`).

`_ont_*` properties and `lastupdated` are written on the `AWSDNSRecord` node by the querybuilder during the AWS sync, and `AWSDNSRecord` carries the shared `DNSRecord` label, so the cleanup reaches route53's edges while the MERGEs never re-create them.

### Fix

- Drop the dead `dns.lastupdated = $UPDATE_TAG` filter on the MERGEs so they fire against records ingested in a different run.
- Exclude `AWSDNSRecord` sources on the route53-owned targets (`AWSLoadBalancer`, `AWSLoadBalancerV2`, `EC2Instance`) in those MERGEs, so the ontology never adopts and re-tags an edge route53 already owns (which route53's own cleanup would then delete under concurrency).
- Scope the cleanup to leave the `(AWSDNSRecord, target)` tuples route53 owns untouched, mirroring the `DNS_POINTS_TO` targets in the route53 dnsrecord model.

Provider-loader edges are now left untouched even when the AWS and ontology syncs overlap, and the cross-provider edges only this job can create (third-party DNS to AWS/CloudFront/Azure/GCP, DNS to Kubernetes Ingress) are rebuilt every run.

### Notes

`lastupdated` encodes freshness, not ownership, so an owner distinction has to be structural. This keeps it marker-free by keying on the fact that route53 is the only loader that writes `DNS_POINTS_TO`, and only from `AWSDNSRecord`.