### PR TITLE
fix(ontology): map Scaleway Elastic Metal flexible IPs to PublicIP

### DIFF
--- a/cartography/models/ontology/mapping/data/publicips.py
+++ b/cartography/models/ontology/mapping/data/publicips.py
@@ -38,7 +38,7 @@ azure_pip_mapping = OntologyMapping(
 )
 
 
-# Scaleway - ScalewayFlexibleIp
+# Scaleway - ScalewayFlexibleIp (instances) and ScalewayElasticMetalFlexibleIp (bare metal)
 scaleway_fip_mapping = OntologyMapping(
     module_name="scaleway",
     nodes=[
@@ -47,6 +47,14 @@ scaleway_fip_mapping = OntologyMapping(
             fields=[
                 OntologyFieldMapping(
                     ontology_field="ip_address", node_field="address", required=True
+                ),
+            ],
+        ),
+        OntologyNodeMapping(
+            node_label="ScalewayElasticMetalFlexibleIp",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="ip_address", node_field="ip_address", required=True
                 ),
             ],
         ),

--- a/cartography/models/ontology/publicip.py
+++ b/cartography/models/ontology/publicip.py
@@ -82,6 +82,18 @@ class PublicIPToScalewayFlexibleIpRel(CartographyRelSchema):
     properties: PublicIPToNodeRelProperties = PublicIPToNodeRelProperties()
 
 
+# (:PublicIP)-[:RESERVED_BY]->(:ScalewayElasticMetalFlexibleIp)
+@dataclass(frozen=True)
+class PublicIPToScalewayElasticMetalFlexibleIpRel(CartographyRelSchema):
+    target_node_label: str = "ScalewayElasticMetalFlexibleIp"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"ip_address": PropertyRef("ip_address")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RESERVED_BY"
+    properties: PublicIPToNodeRelProperties = PublicIPToNodeRelProperties()
+
+
 # (:PublicIP)-[:RESERVED_BY]->(:GCPNicAccessConfig)
 @dataclass(frozen=True)
 class PublicIPToGCPNicAccessConfigRel(CartographyRelSchema):
@@ -136,6 +148,7 @@ class PublicIPSchema(CartographyNodeSchema):
             PublicIPToElasticIPAddressRel(),
             PublicIPToAzurePublicIPAddressRel(),
             PublicIPToScalewayFlexibleIpRel(),
+            PublicIPToScalewayElasticMetalFlexibleIpRel(),
             PublicIPToGCPNicAccessConfigRel(),
             # POINTS_TO - Ontology semantic labels
             PublicIPToDeviceRel(),


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
Scaleway Elastic Metal (bare-metal) flexible IPs were synced as `ScalewayElasticMetalFlexibleIp` nodes but never surfaced as `PublicIP` ontology nodes. The `publicips` ontology mapping only covered `ScalewayFlexibleIp` (instances), and the `PublicIP` schema only reserved that same label. As a result, bare-metal flexible IPs were omitted from the public IP inventory and from cross-provider exposure views.

This adds `ScalewayElasticMetalFlexibleIp` (mapping `ip_address`) to the scaleway `publicips` mapping and a matching `RESERVED_BY` relationship in the `PublicIP` schema, so these IPs are now collected as `PublicIP` nodes like every other provider's public IPs.

### Related issues or links

- N/A

### How was this tested?
- Import-checked the edited models: `PublicIPSchema` now emits a `RESERVED_BY` rel to `ScalewayElasticMetalFlexibleIp`, and the scaleway mapping now lists both `ScalewayFlexibleIp` and `ScalewayElasticMetalFlexibleIp`.
- `ruff check` passes on both changed files.

### Checklist

#### General
- [ ] I have read the contributing guidelines.
- [x] The linter passes locally.
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### If you are changing a node or relationship
- [x] Reviewed the schema documentation: the ontology schema documents `RESERVED_BY` generically as `(:PublicIP)-[:RESERVED_BY]->(:*)`, which already covers the new label; no per-node doc change needed (consistent with the existing `ScalewayFlexibleIp` entry).

### Notes for reviewers
The downstream public IP inventory cache repopulates on the next Cartography sync now that these IPs land as `PublicIP` nodes; no cache is hand-edited in this repo.
