### PR TITLE
fix(microsoft): retry transient Graph 500/502 across all calls

### DIFF
--- a/cartography/intel/microsoft/client.py
+++ b/cartography/intel/microsoft/client.py
@@ -5,15 +5,23 @@ from kiota_abstractions.api_error import APIError
 from kiota_authentication_azure.azure_identity_authentication_provider import (
     AzureIdentityAuthenticationProvider,
 )
+from kiota_http.kiota_client_factory import KiotaClientFactory
+from kiota_http.middleware import RetryHandler
 from kiota_http.middleware.options.retry_handler_option import RetryHandlerOption
 from msgraph import GraphServiceClient
 from msgraph.graph_request_adapter import GraphRequestAdapter
 from msgraph.graph_request_adapter import options as graph_request_adapter_options
 from msgraph_core import GraphClientFactory
+from msgraph_core.middleware import GraphTelemetryHandler
+from msgraph_core.middleware.options import GraphTelemetryHandlerOption
 
 GRAPH_SCOPES = ["https://graph.microsoft.com/.default"]
 GRAPH_RETRY_DELAY_SECONDS = 5.0
 GRAPH_MAX_RETRIES = 6
+# kiota's RetryHandler only retries {429, 503, 504} out of the box, but Graph
+# also emits transient 500/502 ("UnknownError") that strand a sync. Add them so
+# every Graph call retries them (RetryHandlerOption exposes no status-code hook).
+GRAPH_EXTRA_RETRY_STATUS_CODES = frozenset({500, 502})
 
 
 def create_graph_service_client(credentials: Any) -> GraphServiceClient:
@@ -21,12 +29,24 @@ def create_graph_service_client(credentials: Any) -> GraphServiceClient:
         delay=GRAPH_RETRY_DELAY_SECONDS,
         max_retries=GRAPH_MAX_RETRIES,
     )
-    client = GraphClientFactory.create_with_default_middleware(
-        options={
-            **graph_request_adapter_options,
-            RetryHandlerOption.get_key(): retry_option,
-        },
+    options = {
+        **graph_request_adapter_options,
+        RetryHandlerOption.get_key(): retry_option,
+    }
+    # Rebuild the default middleware so we can widen the retry status codes, then
+    # re-append the telemetry handler that create_with_default_middleware adds.
+    middleware = KiotaClientFactory.get_default_middleware(options)
+    for handler in middleware:
+        if isinstance(handler, RetryHandler):
+            handler.retry_on_status_codes = (
+                handler.retry_on_status_codes | GRAPH_EXTRA_RETRY_STATUS_CODES
+            )
+    middleware.append(
+        GraphTelemetryHandler(
+            options=options[GraphTelemetryHandlerOption.get_key()],
+        )
     )
+    client = GraphClientFactory.create_with_custom_middleware(middleware)
     request_adapter = GraphRequestAdapter(
         AzureIdentityAuthenticationProvider(credentials, scopes=GRAPH_SCOPES),
         client=client,

--- a/tests/unit/cartography/intel/microsoft/test_client.py
+++ b/tests/unit/cartography/intel/microsoft/test_client.py
@@ -2,10 +2,11 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from kiota_abstractions.api_error import APIError
-from kiota_http.middleware.options.retry_handler_option import RetryHandlerOption
+from kiota_http.middleware import RetryHandler
 
 from cartography.intel.microsoft.client import create_graph_service_client
 from cartography.intel.microsoft.client import get_api_error_response_header
+from cartography.intel.microsoft.client import GRAPH_EXTRA_RETRY_STATUS_CODES
 from cartography.intel.microsoft.client import GRAPH_MAX_RETRIES
 from cartography.intel.microsoft.client import GRAPH_RETRY_DELAY_SECONDS
 from cartography.intel.microsoft.client import GRAPH_SCOPES
@@ -14,12 +15,12 @@ from cartography.intel.microsoft.client import GRAPH_SCOPES
 @patch("cartography.intel.microsoft.client.GraphServiceClient")
 @patch("cartography.intel.microsoft.client.GraphRequestAdapter")
 @patch(
-    "cartography.intel.microsoft.client.GraphClientFactory.create_with_default_middleware"
+    "cartography.intel.microsoft.client.GraphClientFactory.create_with_custom_middleware"
 )
 @patch("cartography.intel.microsoft.client.AzureIdentityAuthenticationProvider")
 def test_create_graph_service_client_configures_retry_middleware(
     mock_auth_provider,
-    mock_create_with_default_middleware,
+    mock_create_with_custom_middleware,
     mock_graph_request_adapter,
     mock_graph_service_client,
 ):
@@ -27,7 +28,7 @@ def test_create_graph_service_client_configures_retry_middleware(
     http_client = MagicMock()
     request_adapter = MagicMock()
 
-    mock_create_with_default_middleware.return_value = http_client
+    mock_create_with_custom_middleware.return_value = http_client
     mock_graph_request_adapter.return_value = request_adapter
 
     create_graph_service_client(credential)
@@ -39,10 +40,13 @@ def test_create_graph_service_client_configures_retry_middleware(
     )
     mock_graph_service_client.assert_called_once_with(request_adapter=request_adapter)
 
-    options = mock_create_with_default_middleware.call_args.kwargs["options"]
-    retry_option = options[RetryHandlerOption.get_key()]
-    assert retry_option.max_retry == GRAPH_MAX_RETRIES
-    assert retry_option.max_delay == GRAPH_RETRY_DELAY_SECONDS
+    middleware = mock_create_with_custom_middleware.call_args.args[0]
+    retry_handler = next(m for m in middleware if isinstance(m, RetryHandler))
+    assert retry_handler.options.max_retry == GRAPH_MAX_RETRIES
+    assert retry_handler.options.max_delay == GRAPH_RETRY_DELAY_SECONDS
+    # transient Graph 500/502 are retried on top of kiota's default 429/503/504
+    assert GRAPH_EXTRA_RETRY_STATUS_CODES <= retry_handler.retry_on_status_codes
+    assert {429, 503, 504} <= retry_handler.retry_on_status_codes
 
 
 def test_get_api_error_response_header_is_case_insensitive():


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary

kiota's `RetryHandler` only retries `{429, 503, 504}` out of the box. A transient Microsoft Graph `500`/`502` ("UnknownError") therefore escaped the centralized retry middleware and failed the entire `microsoft` sync (observed while polling an Intune report export job).

This widens the retry status codes to also cover `500`/`502` when building the Graph client, so every Graph call (Intune and Entra) tolerates these transient gateway errors with the existing retry budget (`delay=5s`, `max_retries=6`).

`RetryHandlerOption` exposes no status-code hook, so the client rebuilds the default middleware, extends the `RetryHandler`, and re-appends the telemetry handler (preserving its sdk/api version).

### How was this tested?

- Updated unit test asserts the Graph client's `RetryHandler` covers `{500, 502}` on top of kiota's default `{429, 503, 504}`.
- `uv run python -m pytest tests/unit/cartography/intel/microsoft/` — 17 passed.
- Linter passes locally.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

### Notes for reviewers

Retries now also apply to POST on `500`/`502`. A `502` typically originates at the gateway before reaching the app, and the report export path already tolerates duplicate/stranded jobs, so there is no practical regression. The middleware surgery relies on kiota internals (`get_default_middleware`, `retry_on_status_codes`); worth a re-check on the next `msgraph-sdk` bump.
