### PR TITLE
fix(ontology): stop mapping list-valued GCPRecordSet.data to scalar _ont_value

### DIFF
--- a/cartography/models/ontology/mapping/data/dnsrecords.py
+++ b/cartography/models/ontology/mapping/data/dnsrecords.py
@@ -25,6 +25,9 @@ aws_mapping = OntologyMapping(
 )
 
 # GCP
+# GCPRecordSet.data is list-valued, so it is not mapped to the scalar _ont_value:
+# toString(_ont_value) in ontology_dnsrecords_linking.json rejects lists. GCP record
+# linking is done directly off the raw list field via UNWIND dns.data in that job.
 gcp_mapping = OntologyMapping(
     module_name="gcp",
     nodes=[
@@ -35,7 +38,6 @@ gcp_mapping = OntologyMapping(
                     ontology_field="name", node_field="name", required=True
                 ),
                 OntologyFieldMapping(ontology_field="type", node_field="type"),
-                OntologyFieldMapping(ontology_field="value", node_field="data"),
             ],
         ),
     ],

--- a/tests/unit/cartography/intel/ontology/test_dnsrecords_mapping.py
+++ b/tests/unit/cartography/intel/ontology/test_dnsrecords_mapping.py
@@ -1,0 +1,15 @@
+from cartography.models.ontology.mapping.data.dnsrecords import (
+    DNSRECORDS_ONTOLOGY_MAPPING,
+)
+
+
+def test_gcp_recordset_does_not_map_list_field_to_scalar_ont_value():
+    # GCPRecordSet.data is list-valued; mapping it to _ont_value makes the scalar
+    # toString(_ont_value) in ontology_dnsrecords_linking.json raise CypherTypeError
+    # on list values (e.g. a TXT record ["1.0.0"]). GCP is linked via UNWIND dns.data
+    # instead, so _ont_value must stay unset for GCPRecordSet.
+    gcp_nodes = DNSRECORDS_ONTOLOGY_MAPPING["gcp"].nodes
+    mapped_ontology_fields = {
+        field.ontology_field for node in gcp_nodes for field in node.fields
+    }
+    assert "value" not in mapped_ontology_fields


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

The `ontology` sync crashed with `CypherTypeError: Invalid input for function 'toString()' ... got: StringArray` while running `ontology_dnsrecords_linking.json`.

`GCPRecordSet.data` is list-valued, but the GCP DNS-records ontology mapping mapped it into the scalar ontology field `_ont_value`. The scalar linking statements in that job then swept every `:DNSRecord`-labelled node through `toLower(toString(dns._ont_value))`, which throws on list values (e.g. a TXT record `["1.0.0"]`).

GCP record sets are already linked correctly by the dedicated statements in the same job that `UNWIND dns.data`, so the scalar `value <- data` mapping was both redundant and the sole source of the crash. This PR drops it. `_ont_name` (Kubernetes Ingress linking) and the AWS / Cloudflare / Vercel scalar mappings are unchanged.


### Related issues or links

N/A


### How was this tested?

- Added a unit test asserting the GCP DNS-records ontology mapping does not map its list-valued field into the scalar `_ont_value`.
- `uv run pytest tests/unit/cartography/intel/ontology/test_dnsrecords_mapping.py` passes.
- Confirmed the remaining GCP linking statements in `ontology_dnsrecords_linking.json` operate on the raw `dns.data` list via `UNWIND`, so cross-resource linking coverage is preserved.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [ ] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.


### Notes for reviewers

The change is confined to the GCP entry of `DNSRECORDS_ONTOLOGY_MAPPING`; no node/relationship schema changes, so schema docs/README are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
