### PR TITLE
feat: workload-identity ASSUMES/RUNS_AS edges for EC2 and Azure VMs/Function Apps

### DIFF
--- a/cartography/intel/aws/ec2/instances.py
+++ b/cartography/intel/aws/ec2/instances.py
@@ -10,6 +10,7 @@ import boto3
 import neo4j
 
 from cartography.client.core.tx import load
+from cartography.client.core.tx import load_matchlinks
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.intel.aws.util.botocore_config import get_botocore_config
@@ -17,6 +18,7 @@ from cartography.models.aws.ec2.auto_scaling_groups import (
     EC2InstanceAutoScalingGroupSchema,
 )
 from cartography.models.aws.ec2.instances import EC2InstanceSchema
+from cartography.models.aws.ec2.instances import EC2InstanceToRoleAssumesMatchLink
 from cartography.models.aws.ec2.ipv6_addresses import EC2Ipv6AddressSchema
 from cartography.models.aws.ec2.keypair_instance import EC2KeyPairInstanceSchema
 from cartography.models.aws.ec2.networkinterface_instance import (
@@ -513,6 +515,44 @@ def load_ec2_instance_data(
 
 
 @timeit
+def sync_ec2_instance_assumes_role(
+    neo4j_session: neo4j.Session,
+    current_aws_account_id: str,
+    update_tag: int,
+) -> None:
+    # Assemble (instance, role) pairs from the instance-profile binding chain,
+    # since the AWS API exposes no direct instance->role edge, and load them as
+    # the canonical ASSUMES ontology edge. Scoped to the current account so the
+    # MatchLink cleanup only touches this account's edges.
+    query = """
+    MATCH (:AWSAccount{id: $AccountId})-[:RESOURCE]->(i:EC2Instance)
+        -[:INSTANCE_PROFILE]->(:AWSInstanceProfile)-[:ASSOCIATED_WITH]->(r:AWSRole)
+    WHERE i.id IS NOT NULL AND r.arn IS NOT NULL
+    RETURN i.id AS instance_id, r.arn AS role_arn
+    """
+    pairs = [
+        {"instance_id": record["instance_id"], "role_arn": record["role_arn"]}
+        for record in neo4j_session.run(query, AccountId=current_aws_account_id)
+    ]
+
+    load_matchlinks(
+        neo4j_session,
+        EC2InstanceToRoleAssumesMatchLink(),
+        pairs,
+        lastupdated=update_tag,
+        _sub_resource_label="AWSAccount",
+        _sub_resource_id=current_aws_account_id,
+    )
+
+    GraphJob.from_matchlink(
+        EC2InstanceToRoleAssumesMatchLink(),
+        sub_resource_label="AWSAccount",
+        sub_resource_id=current_aws_account_id,
+        update_tag=update_tag,
+    ).run(neo4j_session)
+
+
+@timeit
 def cleanup(
     neo4j_session: neo4j.Session,
     common_job_parameters: Dict[str, Any],
@@ -564,4 +604,9 @@ def sync_ec2_instances(
             ec2_data.instance_ebs_volumes_list,
             ec2_data.ipv6_address_list,
         )
+    sync_ec2_instance_assumes_role(
+        neo4j_session,
+        current_aws_account_id,
+        update_tag,
+    )
     cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/ec2/instances.py
+++ b/cartography/intel/aws/ec2/instances.py
@@ -604,9 +604,12 @@ def sync_ec2_instances(
             ec2_data.instance_ebs_volumes_list,
             ec2_data.ipv6_address_list,
         )
+    # Clean up stale instances / INSTANCE_PROFILE edges first so the ASSUMES
+    # edges are derived from the current profile chain only (a re-profiled
+    # instance would otherwise keep an obsolete role binding for one cycle).
+    cleanup(neo4j_session, common_job_parameters)
     sync_ec2_instance_assumes_role(
         neo4j_session,
         current_aws_account_id,
         update_tag,
     )
-    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/azure/__init__.py
+++ b/cartography/intel/azure/__init__.py
@@ -39,6 +39,7 @@ from . import storage
 from . import subscription
 from . import synapse
 from . import tenant
+from . import workload_identity
 from .data_factory_util import AzureDataFactoryTransientError
 from .util.credentials import Authenticator
 from .util.credentials import Credentials
@@ -154,6 +155,13 @@ def _sync_one_subscription(
         subscription_id,
         update_tag,
         common_job_parameters,
+    )
+    # Runs after compute/functions (identity principal ids) and rbac (role
+    # assignments) so it can join them into the canonical ASSUMES edges.
+    workload_identity.sync(
+        neo4j_session,
+        subscription_id,
+        update_tag,
     )
     sql.sync(
         neo4j_session,

--- a/cartography/intel/azure/compute.py
+++ b/cartography/intel/azure/compute.py
@@ -18,6 +18,7 @@ from cartography.models.azure.vm.snapshot import AzureSnapshotSchema
 from cartography.models.azure.vm.virtualmachine import AzureVirtualMachineSchema
 from cartography.util import timeit
 
+from .util.common import extract_identity_principal_ids
 from .util.credentials import Credentials
 
 logger = logging.getLogger(__name__)
@@ -97,6 +98,8 @@ def transform_vm(vm: Dict) -> Dict:
                         managed_disk,
                         {"storage_account_type": ("storageAccountType",)},
                     )
+
+    vm["identity_principal_ids"] = extract_identity_principal_ids(vm.get("identity"))
     return vm
 
 

--- a/cartography/intel/azure/functions.py
+++ b/cartography/intel/azure/functions.py
@@ -9,6 +9,7 @@ from azure.mgmt.web import WebSiteManagementClient
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.azure.util.common import extract_identity_principal_ids
 from cartography.intel.azure.util.tag import transform_tags
 from cartography.intel.container_arch import normalize_architecture
 from cartography.intel.container_image import parse_image_uri
@@ -167,6 +168,9 @@ def transform_function_apps(
                 "image_digest": image_digest,
                 "architecture_normalized": architecture_normalized,
                 "tags": app.get("tags"),
+                "identity_principal_ids": extract_identity_principal_ids(
+                    app.get("identity"),
+                ),
             }
             transformed_apps.append(transformed_app)
     return transformed_apps

--- a/cartography/intel/azure/util/common.py
+++ b/cartography/intel/azure/util/common.py
@@ -1,6 +1,37 @@
 import logging
+from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+def extract_identity_principal_ids(identity: Any) -> list[str]:
+    """
+    Collect the object (principal) ids of a resource's managed identities from
+    the ARM `identity` block: the system-assigned principal plus every
+    user-assigned identity. These ids match an EntraServicePrincipal.id and an
+    AzureRoleAssignment.principal_id, so they anchor the workload-identity
+    (RUNS_AS / ASSUMES) edges. Handles both camelCase (ARM wire) and snake_case
+    key spellings defensively.
+    """
+    if not isinstance(identity, dict):
+        return []
+    ids: list[str] = []
+    system_pid = identity.get("principalId") or identity.get("principal_id")
+    if system_pid:
+        ids.append(system_pid)
+    user_assigned = (
+        identity.get("userAssignedIdentities")
+        or identity.get("user_assigned_identities")
+        or {}
+    )
+    if isinstance(user_assigned, dict):
+        for entry in user_assigned.values():
+            if isinstance(entry, dict):
+                pid = entry.get("principalId") or entry.get("principal_id")
+                if pid:
+                    ids.append(pid)
+    # Preserve order, drop duplicates.
+    return list(dict.fromkeys(ids))
 
 
 def get_resource_group_from_id(resource_id: str) -> str:

--- a/cartography/intel/azure/workload_identity.py
+++ b/cartography/intel/azure/workload_identity.py
@@ -1,0 +1,91 @@
+import logging
+
+import neo4j
+
+from cartography.client.core.tx import load_matchlinks
+from cartography.graph.job import GraphJob
+from cartography.models.azure.function_app import AzureFunctionAppToRoleAssumesMatchLink
+from cartography.models.azure.vm.virtualmachine import (
+    AzureVirtualMachineToRoleAssumesMatchLink,
+)
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+def _sync_assumes_for_label(
+    neo4j_session: neo4j.Session,
+    subscription_id: str,
+    update_tag: int,
+    source_label: str,
+    matchlink: CartographyRelSchema,
+) -> None:
+    # Assemble (workload, role definition) pairs by joining the workload's
+    # managed-identity principal ids to the role assignments held by that
+    # identity. This spans the compute/functions sync (which stamps
+    # identity_principal_ids on the node) and the RBAC sync (which loads the
+    # role assignments), so it can only run once both are done.
+    # source_label is a hardcoded node label, not user input.
+    query = f"""
+    MATCH (:AzureSubscription {{id: $SubscriptionId}})-[:RESOURCE]->(w:{source_label})
+    WHERE w.identity_principal_ids IS NOT NULL
+    UNWIND w.identity_principal_ids AS principal_id
+    MATCH (ra:AzureRoleAssignment {{principal_id: principal_id}})
+        -[:ROLE_ASSIGNED]->(rd:AzureRoleDefinition)
+    RETURN DISTINCT w.id AS workload_id, rd.id AS role_definition_id
+    """
+    pairs = [
+        {
+            "workload_id": record["workload_id"],
+            "role_definition_id": record["role_definition_id"],
+        }
+        for record in neo4j_session.run(query, SubscriptionId=subscription_id)
+    ]
+
+    load_matchlinks(
+        neo4j_session,
+        matchlink,
+        pairs,
+        lastupdated=update_tag,
+        _sub_resource_label="AzureSubscription",
+        _sub_resource_id=subscription_id,
+    )
+
+    GraphJob.from_matchlink(
+        matchlink,
+        sub_resource_label="AzureSubscription",
+        sub_resource_id=subscription_id,
+        update_tag=update_tag,
+    ).run(neo4j_session)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    subscription_id: str,
+    update_tag: int,
+) -> None:
+    """
+    Materialize the canonical (:AzureVirtualMachine|:AzureFunctionApp)
+    -[:ASSUMES]->(:AzureRoleDefinition) edges from managed-identity role
+    assignments. Must run after both the compute/functions and RBAC syncs.
+    """
+    logger.info(
+        "Syncing Azure workload-identity ASSUMES edges for subscription '%s'.",
+        subscription_id,
+    )
+    _sync_assumes_for_label(
+        neo4j_session,
+        subscription_id,
+        update_tag,
+        "AzureVirtualMachine",
+        AzureVirtualMachineToRoleAssumesMatchLink(),
+    )
+    _sync_assumes_for_label(
+        neo4j_session,
+        subscription_id,
+        update_tag,
+        "AzureFunctionApp",
+        AzureFunctionAppToRoleAssumesMatchLink(),
+    )

--- a/cartography/models/aws/ec2/instances.py
+++ b/cartography/models/aws/ec2/instances.py
@@ -7,8 +7,10 @@ from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
 from cartography.models.core.relationships import make_target_node_matcher
 from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -143,4 +145,36 @@ class EC2InstanceSchema(CartographyNodeSchema):
             EC2InstanceToInstanceProfileRel(),
             EC2InstanceToEKSClusterRel(),
         ],
+    )
+
+
+@dataclass(frozen=True)
+class EC2InstanceToRoleAssumesRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label", set_in_kwargs=True
+    )
+    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# Canonical ontology edge: (:EC2Instance)-[:ASSUMES]->(:AWSRole).
+# The instance runs with the permissions of the role attached through its
+# instance profile: EC2Instance-[:INSTANCE_PROFILE]->AWSInstanceProfile
+# -[:ASSOCIATED_WITH]->AWSRole. There is no direct instance->role edge in the
+# AWS API, so the pairs are assembled from that binding chain and loaded as a
+# MatchLink.
+class EC2InstanceToRoleAssumesMatchLink(CartographyRelSchema):
+    rel_label: str = "ASSUMES"
+    direction: LinkDirection = LinkDirection.OUTWARD
+    properties: EC2InstanceToRoleAssumesRelProperties = (
+        EC2InstanceToRoleAssumesRelProperties()
+    )
+    target_node_label: str = "AWSRole"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("role_arn")},
+    )
+    source_node_label: str = "EC2Instance"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("instance_id")},
     )

--- a/cartography/models/azure/function_app.py
+++ b/cartography/models/azure/function_app.py
@@ -8,8 +8,10 @@ from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
 from cartography.models.core.relationships import make_target_node_matcher
 from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
 
 logger = logging.getLogger(__name__)
@@ -30,6 +32,7 @@ class AzureFunctionAppProperties(CartographyNodeProperties):
     image_uri: PropertyRef = PropertyRef("image_uri")
     image_digest: PropertyRef = PropertyRef("image_digest")
     architecture_normalized: PropertyRef = PropertyRef("architecture_normalized")
+    identity_principal_ids: PropertyRef = PropertyRef("identity_principal_ids")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
@@ -124,6 +127,58 @@ class AzureFunctionAppToGitHubContainerImageRel(CartographyRelSchema):
     )
 
 
+@dataclass(frozen=True)
+class AzureFunctionAppToServicePrincipalRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# Canonical ontology edge: (:AzureFunctionApp)-[:RUNS_AS]->(:EntraServicePrincipal).
+# The function app's managed identity (system- or user-assigned) surfaces in
+# Entra as a service principal whose object id equals the identity's principalId.
+class AzureFunctionAppToServicePrincipalRel(CartographyRelSchema):
+    target_node_label: str = "EntraServicePrincipal"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("identity_principal_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RUNS_AS"
+    properties: AzureFunctionAppToServicePrincipalRelProperties = (
+        AzureFunctionAppToServicePrincipalRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AzureFunctionAppToRoleAssumesRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label", set_in_kwargs=True
+    )
+    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# Canonical ontology edge: (:AzureFunctionApp)-[:ASSUMES]->(:AzureRoleDefinition).
+# The function app runs with the permissions of the role definitions assigned to
+# its managed identity. Assembled by joining the identity principalId to
+# AzureRoleAssignment -> AzureRoleDefinition after the RBAC sync, so it is loaded
+# as a MatchLink rather than a direct edge on the node.
+class AzureFunctionAppToRoleAssumesMatchLink(CartographyRelSchema):
+    rel_label: str = "ASSUMES"
+    direction: LinkDirection = LinkDirection.OUTWARD
+    properties: AzureFunctionAppToRoleAssumesRelProperties = (
+        AzureFunctionAppToRoleAssumesRelProperties()
+    )
+    target_node_label: str = "AzureRoleDefinition"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("role_definition_id")},
+    )
+    source_node_label: str = "AzureFunctionApp"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("workload_id")},
+    )
+
+
 # --- Main Schema ---
 @dataclass(frozen=True)
 class AzureFunctionAppSchema(CartographyNodeSchema):
@@ -143,5 +198,6 @@ class AzureFunctionAppSchema(CartographyNodeSchema):
             AzureFunctionAppToGitLabContainerImageRel(),
             AzureFunctionAppToGCPArtifactRegistryImageRel(),
             AzureFunctionAppToGitHubContainerImageRel(),
+            AzureFunctionAppToServicePrincipalRel(),
         ],
     )

--- a/cartography/models/azure/vm/virtualmachine.py
+++ b/cartography/models/azure/vm/virtualmachine.py
@@ -7,7 +7,10 @@ from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
 from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -24,6 +27,7 @@ class AzureVirtualMachineProperties(CartographyNodeProperties):
     license_type: PropertyRef = PropertyRef("license_type")
     computer_name: PropertyRef = PropertyRef("os_profile.computer_name")
     identity_type: PropertyRef = PropertyRef("identity.type")
+    identity_principal_ids: PropertyRef = PropertyRef("identity_principal_ids")
     zones: PropertyRef = PropertyRef("zones")
     ultra_ssd_enabled: PropertyRef = PropertyRef(
         "additional_capabilities.ultra_ssd_enabled"
@@ -52,10 +56,67 @@ class AzureVirtualMachineToSubscriptionRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class AzureVirtualMachineToServicePrincipalRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# Canonical ontology edge: (:AzureVirtualMachine)-[:RUNS_AS]->(:EntraServicePrincipal).
+# The VM's managed identity (system- or user-assigned) surfaces in Entra as a
+# service principal whose object id equals the identity's principalId.
+class AzureVirtualMachineToServicePrincipalRel(CartographyRelSchema):
+    target_node_label: str = "EntraServicePrincipal"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("identity_principal_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RUNS_AS"
+    properties: AzureVirtualMachineToServicePrincipalRelProperties = (
+        AzureVirtualMachineToServicePrincipalRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class AzureVirtualMachineSchema(CartographyNodeSchema):
     label: str = "AzureVirtualMachine"
     properties: AzureVirtualMachineProperties = AzureVirtualMachineProperties()
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeInstance"])
     sub_resource_relationship: AzureVirtualMachineToSubscriptionRel = (
         AzureVirtualMachineToSubscriptionRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AzureVirtualMachineToServicePrincipalRel(),
+        ],
+    )
+
+
+@dataclass(frozen=True)
+class AzureVirtualMachineToRoleAssumesRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label", set_in_kwargs=True
+    )
+    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# Canonical ontology edge: (:AzureVirtualMachine)-[:ASSUMES]->(:AzureRoleDefinition).
+# The VM runs with the permissions of the role definitions assigned to its
+# managed identity. Assembled by joining the identity principalId to
+# AzureRoleAssignment -> AzureRoleDefinition after the RBAC sync, so it is loaded
+# as a MatchLink rather than a direct edge on the node.
+class AzureVirtualMachineToRoleAssumesMatchLink(CartographyRelSchema):
+    rel_label: str = "ASSUMES"
+    direction: LinkDirection = LinkDirection.OUTWARD
+    properties: AzureVirtualMachineToRoleAssumesRelProperties = (
+        AzureVirtualMachineToRoleAssumesRelProperties()
+    )
+    target_node_label: str = "AzureRoleDefinition"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("role_definition_id")},
+    )
+    source_node_label: str = "AzureVirtualMachine"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("workload_id")},
     )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -2275,6 +2275,11 @@ Our representation of an AWS [EC2 Instance](https://docs.aws.amazon.com/AWSEC2/l
     (AWSAccount)-[RESOURCE]->(EC2Instance)
     ```
 
+- EC2 Instances assume the AWS Role attached through their instance profile (canonical ontology `ASSUMES` edge).
+    ```
+    (EC2Instance)-[ASSUMES]->(AWSRole)
+    ```
+
 -  EC2 Instances can be tagged with AWSTags.
     ```
     (EC2Instance)-[TAGGED]->(AWSTag)

--- a/docs/root/modules/azure/schema.md
+++ b/docs/root/modules/azure/schema.md
@@ -357,6 +357,16 @@ Representation of an [Azure Virtual Machine](https://docs.microsoft.com/en-us/re
     (AzureVirtualMachine)-[:TAGGED]->(AzureTag)
     ```
 
+- An Azure Virtual Machine runs as its managed identity's service principal (canonical ontology `RUNS_AS` edge).
+    ```cypher
+    (AzureVirtualMachine)-[:RUNS_AS]->(EntraServicePrincipal)
+    ```
+
+- An Azure Virtual Machine assumes the role definitions assigned to its managed identity (canonical ontology `ASSUMES` edge).
+    ```cypher
+    (AzureVirtualMachine)-[:ASSUMES]->(AzureRoleDefinition)
+    ```
+
 ### AzureDataDisk
 
 Representation of an [Azure Data Disk](https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines/get#datadisk).
@@ -1616,6 +1626,16 @@ Representation of an [Azure Function App](https://learn.microsoft.com/en-us/rest
 - Azure Function Apps can be tagged with Azure Tags.
     ```cypher
     (AzureFunctionApp)-[:TAGGED]->(AzureTag)
+    ```
+
+- An Azure Function App runs as its managed identity's service principal (canonical ontology `RUNS_AS` edge).
+    ```cypher
+    (AzureFunctionApp)-[:RUNS_AS]->(EntraServicePrincipal)
+    ```
+
+- An Azure Function App assumes the role definitions assigned to its managed identity (canonical ontology `ASSUMES` edge).
+    ```cypher
+    (AzureFunctionApp)-[:ASSUMES]->(AzureRoleDefinition)
     ```
 
 - Container-deployed Function Apps are linked to the image they run via `HAS_IMAGE` (matched on `image_digest`):

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -657,7 +657,11 @@ A workload that assumes a permission role to obtain its privileges is linked via
 (:ComputeInstance)-[:ASSUMES]->(:PermissionRole)
 (:Function)-[:ASSUMES]->(:PermissionRole)
 ```
-Currently only `Function` is wired: an AWS Lambda is linked to its execution role (`(:AWSLambda)-[:ASSUMES]->(:AWSRole)`). `ComputeInstance` coverage is governed by the constraint but not yet materialized: an EC2 instance still reaches its role only through the instance profile (`EC2Instance-[:INSTANCE_PROFILE]->AWSInstanceProfile-[:ASSOCIATED_WITH]->AWSRole`, plus the analysis-job `STS_ASSUMEROLE_ALLOW` edge), so the direct `ASSUMES` edge for EC2 / GCP / Azure compute is still pending.
+Wired for both `Function` and `ComputeInstance`:
+- `Function`: an AWS Lambda is linked to its execution role (`(:AWSLambda)-[:ASSUMES]->(:AWSRole)`); an Azure Function App is linked to the role definitions assigned to its managed identity (`(:AzureFunctionApp)-[:ASSUMES]->(:AzureRoleDefinition)`).
+- `ComputeInstance`: an EC2 instance is linked to the role attached through its instance profile (`(:EC2Instance)-[:ASSUMES]->(:AWSRole)`, assembled from `EC2Instance-[:INSTANCE_PROFILE]->AWSInstanceProfile-[:ASSOCIATED_WITH]->AWSRole`); an Azure VM is linked to the role definitions assigned to its managed identity (`(:AzureVirtualMachine)-[:ASSUMES]->(:AzureRoleDefinition)`). The AWS analysis-job `STS_ASSUMEROLE_ALLOW` edge is kept as the distinct IAM trust-policy view.
+
+GCP compute (`ComputeInstance -[:ASSUMES]-> GCPRole`) is still pending, as it spans the compute and IAM-policy-binding syncs.
 
 
 ### ObjectStorage

--- a/tests/integration/cartography/intel/aws/test_iam_instance_profiles.py
+++ b/tests/integration/cartography/intel/aws/test_iam_instance_profiles.py
@@ -119,6 +119,20 @@ def test_sync_iam_instance_profiles(
         ("i-00bd", "arn:aws:iam::1234:instance-profile/cartography-service"),
     }
 
+    # Assert canonical EC2Instance -[:ASSUMES]-> AWSRole edge (assembled from the
+    # instance-profile binding chain by sync_ec2_instances).
+    assert check_rels(
+        neo4j_session,
+        "EC2Instance",
+        "id",
+        "AWSRole",
+        "arn",
+        "ASSUMES",
+        rel_direction_right=True,
+    ) == {
+        ("i-00bd", "arn:aws:iam::1234:role/cartography-service"),
+    }
+
     # Act
     run_scoped_analysis_job(
         "aws_ec2_iaminstanceprofile.json",

--- a/tests/integration/cartography/intel/azure/test_workload_identity.py
+++ b/tests/integration/cartography/intel/azure/test_workload_identity.py
@@ -1,0 +1,175 @@
+"""
+Integration test for the Azure workload-identity ontology edges
+(RUNS_AS to EntraServicePrincipal, ASSUMES to AzureRoleDefinition).
+"""
+
+from typing import Any
+from typing import AsyncGenerator
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+import cartography.intel.azure.compute
+import cartography.intel.azure.functions
+import cartography.intel.azure.rbac
+import cartography.intel.azure.workload_identity
+import cartography.intel.microsoft.entra.service_principals
+from tests.data.azure.rbac import AZURE_ROLE_ASSIGNMENTS
+from tests.data.azure.rbac import AZURE_ROLE_DEFINITIONS
+from tests.data.azure.rbac import ENTRA_SERVICE_PRINCIPALS
+from tests.integration.cartography.intel.azure.common import (
+    create_test_azure_subscription,
+)
+from tests.integration.cartography.intel.microsoft.entra.common import (
+    create_test_entra_tenant,
+)
+from tests.integration.util import check_rels
+
+TEST_SUBSCRIPTION_ID = "12345678-1234-1234-1234-123456789012"
+TEST_TENANT_ID = "tenant-123"
+TEST_UPDATE_TAG = 123456789
+
+# sp-101 is a ServicePrincipal that holds role assignment `assignment-4`
+# (-> Reader role definition) in the shared RBAC fixture.
+MANAGED_IDENTITY_PRINCIPAL_ID = "sp-101"
+READER_ROLE_DEFINITION_ID = (
+    "/subscriptions/12345678-1234-1234-1234-123456789012"
+    "/providers/Microsoft.Authorization/roleDefinitions/"
+    "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+)
+VM_ID = (
+    "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/"
+    "TestRG/providers/Microsoft.Compute/virtualMachines/TestVM"
+)
+FUNCTION_APP_ID = (
+    "/subscriptions/12345678-1234-1234-1234-123456789012/resourceGroups/"
+    "TestRG/providers/Microsoft.Web/sites/TestFunc"
+)
+
+
+async def _async_gen(items: list[Any]) -> AsyncGenerator[Any, None]:
+    for item in items:
+        yield item
+
+
+@patch.object(
+    cartography.intel.microsoft.entra.service_principals,
+    "get_entra_service_principals",
+    return_value=_async_gen(ENTRA_SERVICE_PRINCIPALS),
+)
+@patch.object(
+    cartography.intel.azure.rbac,
+    "get_role_assignments",
+    return_value=AZURE_ROLE_ASSIGNMENTS,
+)
+@patch.object(
+    cartography.intel.azure.rbac,
+    "get_role_definitions_by_ids",
+    return_value=AZURE_ROLE_DEFINITIONS,
+)
+@pytest.mark.asyncio
+async def test_sync_workload_identity_edges(
+    mock_get_role_definitions,
+    mock_get_role_assignments,
+    mock_get_service_principals,
+    neo4j_session,
+):
+    # Arrange
+    create_test_azure_subscription(neo4j_session, TEST_SUBSCRIPTION_ID, TEST_UPDATE_TAG)
+    create_test_entra_tenant(neo4j_session, TEST_TENANT_ID, TEST_UPDATE_TAG)
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "TENANT_ID": TEST_TENANT_ID,
+        "AZURE_SUBSCRIPTION_ID": TEST_SUBSCRIPTION_ID,
+    }
+
+    # The managed identity surfaces as an EntraServicePrincipal (RUNS_AS target).
+    await cartography.intel.microsoft.entra.service_principals.sync_service_principals(
+        neo4j_session,
+        TEST_TENANT_ID,
+        "client-id",
+        "client-secret",
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+    # Role assignments for the managed identity (ASSUMES source data).
+    cartography.intel.azure.rbac.sync(
+        neo4j_session,
+        MagicMock(),
+        TEST_SUBSCRIPTION_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+    # A VM and a Function App whose managed identity is sp-101.
+    cartography.intel.azure.compute.load_vms(
+        neo4j_session,
+        TEST_SUBSCRIPTION_ID,
+        [
+            {
+                "id": VM_ID,
+                "name": "TestVM",
+                "identity_principal_ids": [MANAGED_IDENTITY_PRINCIPAL_ID],
+            }
+        ],
+        TEST_UPDATE_TAG,
+    )
+    cartography.intel.azure.functions.load_function_apps(
+        neo4j_session,
+        [
+            {
+                "id": FUNCTION_APP_ID,
+                "name": "TestFunc",
+                "identity_principal_ids": [MANAGED_IDENTITY_PRINCIPAL_ID],
+            }
+        ],
+        TEST_SUBSCRIPTION_ID,
+        TEST_UPDATE_TAG,
+    )
+
+    # Act
+    cartography.intel.azure.workload_identity.sync(
+        neo4j_session,
+        TEST_SUBSCRIPTION_ID,
+        TEST_UPDATE_TAG,
+    )
+
+    # Assert RUNS_AS -> EntraServicePrincipal (materialized when the node loads).
+    assert check_rels(
+        neo4j_session,
+        "AzureVirtualMachine",
+        "id",
+        "EntraServicePrincipal",
+        "id",
+        "RUNS_AS",
+        rel_direction_right=True,
+    ) == {(VM_ID, MANAGED_IDENTITY_PRINCIPAL_ID)}
+    assert check_rels(
+        neo4j_session,
+        "AzureFunctionApp",
+        "id",
+        "EntraServicePrincipal",
+        "id",
+        "RUNS_AS",
+        rel_direction_right=True,
+    ) == {(FUNCTION_APP_ID, MANAGED_IDENTITY_PRINCIPAL_ID)}
+
+    # Assert ASSUMES -> AzureRoleDefinition (assembled from the role assignment).
+    assert check_rels(
+        neo4j_session,
+        "AzureVirtualMachine",
+        "id",
+        "AzureRoleDefinition",
+        "id",
+        "ASSUMES",
+        rel_direction_right=True,
+    ) == {(VM_ID, READER_ROLE_DEFINITION_ID)}
+    assert check_rels(
+        neo4j_session,
+        "AzureFunctionApp",
+        "id",
+        "AzureRoleDefinition",
+        "id",
+        "ASSUMES",
+        rel_direction_right=True,
+    ) == {(FUNCTION_APP_ID, READER_ROLE_DEFINITION_ID)}

--- a/tests/unit/cartography/intel/azure/test_functions.py
+++ b/tests/unit/cartography/intel/azure/test_functions.py
@@ -42,5 +42,6 @@ def test_transform_function_apps_reads_sdk_11_site_config_shape() -> None:
             "image_digest": digest,
             "architecture_normalized": "amd64",
             "tags": None,
+            "identity_principal_ids": [],
         },
     ]

--- a/tests/unit/cartography/intel/azure/test_workload_identity_util.py
+++ b/tests/unit/cartography/intel/azure/test_workload_identity_util.py
@@ -1,0 +1,35 @@
+from cartography.intel.azure.util.common import extract_identity_principal_ids
+
+
+def test_extract_identity_principal_ids_system_and_user_assigned():
+    identity = {
+        "type": "SystemAssigned, UserAssigned",
+        "principalId": "system-pid",
+        "userAssignedIdentities": {
+            "/subscriptions/s/resourceGroups/rg/.../ua1": {
+                "principalId": "ua-pid-1",
+                "clientId": "ua-cid-1",
+            },
+            "/subscriptions/s/resourceGroups/rg/.../ua2": {
+                "principalId": "ua-pid-2",
+            },
+        },
+    }
+    assert extract_identity_principal_ids(identity) == [
+        "system-pid",
+        "ua-pid-1",
+        "ua-pid-2",
+    ]
+
+
+def test_extract_identity_principal_ids_dedupes_and_handles_missing():
+    # No identity block, or a scalar/None, yields no principals.
+    assert extract_identity_principal_ids(None) == []
+    assert extract_identity_principal_ids("SystemAssigned") == []
+    assert extract_identity_principal_ids({"type": "None"}) == []
+    # Same principal id appearing twice collapses to one.
+    identity = {
+        "principalId": "pid",
+        "userAssignedIdentities": {"ua": {"principalId": "pid"}},
+    }
+    assert extract_identity_principal_ids(identity) == ["pid"]


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

Populates the canonical workload-identity ontology edges (`ASSUMES`, `RUNS_AS`) for the compute workloads where they were not yet wired, so cross-provider "what can this workload do" queries work without provider-specific traversals.

**AWS**
- `(:EC2Instance)-[:ASSUMES]->(:AWSRole)`. The AWS API exposes no direct instance-to-role edge; the role is only reachable through `EC2Instance-[:INSTANCE_PROFILE]->AWSInstanceProfile-[:ASSOCIATED_WITH]->AWSRole`. The pairs are assembled from that binding chain after the EC2 and IAM syncs and loaded as a MatchLink scoped to the account.

**Azure**
- Ingest the managed-identity principal ids (system- and user-assigned) of `AzureVirtualMachine` and `AzureFunctionApp` into a new `identity_principal_ids` property.
- `(:AzureVirtualMachine|:AzureFunctionApp)-[:RUNS_AS]->(:EntraServicePrincipal)`, matched on the identity object id as a direct node relationship at load time.
- `(:AzureVirtualMachine|:AzureFunctionApp)-[:ASSUMES]->(:AzureRoleDefinition)`, assembled after the RBAC sync by joining the identity principal id to its role assignments, loaded as a MatchLink scoped to the subscription.

The edge assembly adds a constant number of queries per account/subscription (not one per workload), so there is no N+1 regression.


### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

N/A


### How was this tested?
<!-- Describe how you tested your changes. -->

Unit and integration tests, run against the Neo4j testcontainer:

- `tests/integration/cartography/intel/aws/test_iam_instance_profiles.py` asserts the `EC2Instance -[:ASSUMES]-> AWSRole` edge.
- `tests/integration/cartography/intel/azure/test_workload_identity.py` asserts both `RUNS_AS -> EntraServicePrincipal` and `ASSUMES -> AzureRoleDefinition` for VMs and Function Apps.
- `tests/unit/cartography/intel/azure/test_workload_identity_util.py` covers the managed-identity principal-id extraction (system + user-assigned, dedup).
- `tests/unit/cartography/graph/test_ontology_rel_constraints.py` and `tests/unit/cartography/test_doc.py` stay green.

```
uv run --frozen pytest tests/unit/cartography/graph/test_ontology_rel_constraints.py \
  tests/unit/cartography/intel/azure/test_workload_identity_util.py \
  tests/integration/cartography/intel/aws/test_iam_instance_profiles.py \
  tests/integration/cartography/intel/azure/test_workload_identity.py
```


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).


### Notes for reviewers

- Azure `RUNS_AS` is a plain node relationship (matched at load time via a `one_to_many` matcher on the principal-id list), so it needs no post-processing step.
- Azure `ASSUMES` genuinely spans the compute/functions sync (which stamps the principal ids) and the RBAC sync (which loads the role assignments), so it is assembled in a small `workload_identity.py` step that runs after `rbac.sync`.
