### PR TITLE
fix(okta): retry non-JSON SDK errors across all paged requests

### DIFF
--- a/cartography/intel/okta/applications.py
+++ b/cartography/intel/okta/applications.py
@@ -9,14 +9,35 @@ from typing import Optional
 import neo4j
 from okta.framework.ApiClient import ApiClient
 from okta.framework.OktaError import OktaError
+from requests import Response
 
 from cartography.client.core.tx import run_write_query
 from cartography.intel.okta.utils import check_rate_limit
 from cartography.intel.okta.utils import create_api_client
 from cartography.intel.okta.utils import is_last_page
+from cartography.intel.okta.utils import okta_paged_request_with_retry
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
+
+
+def _get_application_page(
+    api_client: ApiClient,
+    path: str,
+    next_url: Optional[str],
+    description: str,
+) -> Response:
+    """
+    Fetch one page of an Okta application listing, retrying transient non-JSON
+    error responses. See okta_paged_request_with_retry for details.
+    """
+
+    def _request() -> Response:
+        if next_url:
+            return api_client.get(next_url)
+        return api_client.get_path(path, {"limit": 500})
+
+    return okta_paged_request_with_retry(_request, description)
 
 
 @timeit
@@ -31,14 +52,9 @@ def _get_okta_applications(api_client: ApiClient) -> List[Dict]:
     next_url = None
     while True:
         try:
-            # https://developer.okta.com/docs/reference/api/apps/#list-applications
-            if next_url:
-                paged_response = api_client.get(next_url)
-            else:
-                params = {
-                    "limit": 500,
-                }
-                paged_response = api_client.get_path("/", params)
+            paged_response = _get_application_page(
+                api_client, "/", next_url, "listing applications"
+            )
         except OktaError as okta_error:
             logger.debug(f"Got error while listing applications {okta_error}")
             break
@@ -69,13 +85,12 @@ def _get_application_assigned_users(api_client: ApiClient, app_id: str) -> List[
     while True:
         try:
             # https://developer.okta.com/docs/reference/api/apps/#list-users-assigned-to-application
-            if next_url:
-                paged_response = api_client.get(next_url)
-            else:
-                params = {
-                    "limit": 500,
-                }
-                paged_response = api_client.get_path(f"/{app_id}/users", params)
+            paged_response = _get_application_page(
+                api_client,
+                f"/{app_id}/users",
+                next_url,
+                f"listing users assigned to application {app_id}",
+            )
         except OktaError as okta_error:
             logger.debug(
                 f"Got error while going through list application assigned users {okta_error}",
@@ -108,13 +123,12 @@ def _get_application_assigned_groups(api_client: ApiClient, app_id: str) -> List
 
     while True:
         try:
-            if next_url:
-                paged_response = api_client.get(next_url)
-            else:
-                params = {
-                    "limit": 500,
-                }
-                paged_response = api_client.get_path(f"/{app_id}/groups", params)
+            paged_response = _get_application_page(
+                api_client,
+                f"/{app_id}/groups",
+                next_url,
+                f"listing groups assigned to application {app_id}",
+            )
         except OktaError as okta_error:
             logger.debug(
                 f"Got error while going through list application assigned groups {okta_error}",

--- a/cartography/intel/okta/groups.py
+++ b/cartography/intel/okta/groups.py
@@ -1,7 +1,6 @@
 # Okta intel module - Group
 import json
 import logging
-import time
 from typing import Dict
 from typing import List
 from typing import Tuple
@@ -19,12 +18,10 @@ from cartography.intel.okta.utils import check_rate_limit
 from cartography.intel.okta.utils import create_api_client
 from cartography.intel.okta.utils import is_last_page
 from cartography.intel.okta.utils import is_resource_not_found_error
+from cartography.intel.okta.utils import okta_paged_request_with_retry
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
-
-OKTA_GROUP_MEMBER_REQUEST_ATTEMPTS = 3
-OKTA_GROUP_MEMBER_RETRY_DELAY_SECONDS = 1
 
 
 @timeit
@@ -41,14 +38,7 @@ def _get_okta_groups(api_client: ApiClient) -> List[str]:
     # get_paged_groups returns User object instead of UserGroup
 
     while True:
-        # https://developer.okta.com/docs/reference/api/groups/#list-groups
-        if next_url:
-            paged_response = api_client.get(next_url)
-        else:
-            params = {
-                "limit": 10000,
-            }
-            paged_response = api_client.get_path("/", params)
+        paged_response = _get_okta_groups_page(api_client, next_url)
 
         paged_results = PagedResults(paged_response, UserGroup)
 
@@ -97,40 +87,33 @@ def _get_next_url(paged_response: Response) -> str:
     return str(next_link["url"])
 
 
+def _get_okta_groups_page(
+    api_client: ApiClient,
+    next_url: str | None,
+) -> Response:
+    def _request() -> Response:
+        # https://developer.okta.com/docs/reference/api/groups/#list-groups
+        if next_url:
+            return api_client.get(next_url)
+        return api_client.get_path("/", {"limit": 10000})
+
+    return okta_paged_request_with_retry(_request, "listing groups")
+
+
 def _get_okta_group_members_page(
     api_client: ApiClient,
     group_id: str,
     next_url: str | None,
 ) -> Response:
-    for attempt in range(1, OKTA_GROUP_MEMBER_REQUEST_ATTEMPTS + 1):
-        try:
-            # https://developer.okta.com/docs/reference/api/groups/#list-group-members
-            if next_url:
-                return api_client.get(next_url)
-            params = {
-                "limit": 1000,
-            }
-            return api_client.get_path(f"/{group_id}/users", params)
-        except json.JSONDecodeError:
-            if attempt == OKTA_GROUP_MEMBER_REQUEST_ATTEMPTS:
-                logger.exception(
-                    "Okta returned a non-JSON error response while listing members of group %s after %d attempts.",
-                    group_id,
-                    attempt,
-                )
-                raise
-            logger.warning(
-                "Okta returned a non-JSON error response while listing members of group %s. Retrying request (%d/%d).",
-                group_id,
-                attempt + 1,
-                OKTA_GROUP_MEMBER_REQUEST_ATTEMPTS,
-            )
-            time.sleep(OKTA_GROUP_MEMBER_RETRY_DELAY_SECONDS)
-        except OktaError:
-            logger.error("OktaError while listing members of group %s", group_id)
-            raise
+    def _request() -> Response:
+        # https://developer.okta.com/docs/reference/api/groups/#list-group-members
+        if next_url:
+            return api_client.get(next_url)
+        return api_client.get_path(f"/{group_id}/users", {"limit": 1000})
 
-    raise RuntimeError("Unexpected Okta group member retry state.")
+    return okta_paged_request_with_retry(
+        _request, f"listing members of group {group_id}"
+    )
 
 
 @timeit

--- a/cartography/intel/okta/users.py
+++ b/cartography/intel/okta/users.py
@@ -6,11 +6,13 @@ from typing import Tuple
 
 import neo4j
 from okta import UsersClient
+from okta.framework.PagedResults import PagedResults
 from okta.models.user import User
 
 from cartography.client.core.tx import run_write_query
 from cartography.intel.okta.sync_state import OktaSyncState
 from cartography.intel.okta.utils import check_rate_limit
+from cartography.intel.okta.utils import okta_paged_request_with_retry
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -43,7 +45,7 @@ def _get_okta_users(user_client: UsersClient) -> List[Dict]:
     :return: Array of user data
     """
     user_list: List[Dict] = []
-    paged_users = user_client.get_paged_users()
+    paged_users = _get_okta_users_page(user_client, None)
 
     # TODO: Fix bug, we miss last page :(
     while True:
@@ -51,11 +53,23 @@ def _get_okta_users(user_client: UsersClient) -> List[Dict]:
         check_rate_limit(paged_users.response)
         if not paged_users.is_last_page():
             # Keep on fetching pages of users until the last page
-            paged_users = user_client.get_paged_users(url=paged_users.next_url)
+            paged_users = _get_okta_users_page(user_client, paged_users.next_url)
         else:
             break
 
     return user_list
+
+
+def _get_okta_users_page(user_client: UsersClient, url: str | None) -> PagedResults:
+    def _request() -> PagedResults:
+        # The UsersClient pager calls ApiClient.get/get_path under the hood, so
+        # it can raise JSONDecodeError on a non-JSON Okta error body just like
+        # the other paged requests.
+        if url:
+            return user_client.get_paged_users(url=url)
+        return user_client.get_paged_users()
+
+    return okta_paged_request_with_retry(_request, "listing users")
 
 
 @timeit

--- a/cartography/intel/okta/users.py
+++ b/cartography/intel/okta/users.py
@@ -52,8 +52,13 @@ def _get_okta_users(user_client: UsersClient) -> List[Dict]:
         user_list.extend(paged_users.result)
         check_rate_limit(paged_users.response)
         if not paged_users.is_last_page():
-            # Keep on fetching pages of users until the last page
-            paged_users = _get_okta_users_page(user_client, paged_users.next_url)
+            # Keep on fetching pages of users until the last page. A missing
+            # next URL here would otherwise be treated as an initial request
+            # and re-fetch the first page forever.
+            next_url = paged_users.next_url
+            if not next_url:
+                raise ValueError("Okta paginated response was missing a next URL.")
+            paged_users = _get_okta_users_page(user_client, next_url)
         else:
             break
 

--- a/cartography/intel/okta/utils.py
+++ b/cartography/intel/okta/utils.py
@@ -1,6 +1,8 @@
 # Okta intel module - utility functions
+import json
 import logging
 import time
+from typing import Callable
 
 from okta.framework import PagedResults
 from okta.framework.ApiClient import ApiClient
@@ -14,6 +16,46 @@ logger = logging.getLogger(__name__)
 # moment we fetch a follow-up sub-resource for it.
 # https://developer.okta.com/docs/reference/error-codes/#E0000007
 OKTA_RESOURCE_NOT_FOUND_ERROR_CODE = "E0000007"
+
+# The legacy Okta SDK parses every error body as JSON. When Okta / a proxy /
+# a rate-limiter returns an empty or non-JSON error body, the SDK raises
+# JSONDecodeError instead of OktaError, which crashes the sync. These edge
+# responses are usually transient, so we retry a few times before giving up.
+OKTA_REQUEST_ATTEMPTS = 3
+OKTA_RETRY_DELAY_SECONDS = 1
+
+
+def okta_paged_request_with_retry(
+    request: Callable[[], Response],
+    description: str,
+) -> Response:
+    """
+    Run an Okta paged request, retrying when the legacy Okta SDK raises
+    JSONDecodeError while parsing a non-JSON error body. OktaError is left for
+    the caller to handle.
+    :param request: zero-arg callable performing the api_client call
+    :param description: what the request is doing, for log messages
+    :return: the requests Response returned by the SDK
+    """
+    for attempt in range(1, OKTA_REQUEST_ATTEMPTS + 1):
+        try:
+            return request()
+        except json.JSONDecodeError:
+            if attempt == OKTA_REQUEST_ATTEMPTS:
+                logger.exception(
+                    "Okta returned a non-JSON error response while %s after %d attempts.",
+                    description,
+                    attempt,
+                )
+                raise
+            logger.warning(
+                "Okta returned a non-JSON error response while %s. Retrying request (%d/%d).",
+                description,
+                attempt + 1,
+                OKTA_REQUEST_ATTEMPTS,
+            )
+            time.sleep(OKTA_RETRY_DELAY_SECONDS)
+    raise RuntimeError("Unexpected Okta request retry state.")
 
 
 def is_resource_not_found_error(error: OktaError) -> bool:

--- a/cartography/intel/okta/utils.py
+++ b/cartography/intel/okta/utils.py
@@ -3,11 +3,14 @@ import json
 import logging
 import time
 from typing import Callable
+from typing import TypeVar
 
 from okta.framework import PagedResults
 from okta.framework.ApiClient import ApiClient
 from okta.framework.OktaError import OktaError
 from requests import Response
+
+T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
 
@@ -26,16 +29,17 @@ OKTA_RETRY_DELAY_SECONDS = 1
 
 
 def okta_paged_request_with_retry(
-    request: Callable[[], Response],
+    request: Callable[[], T],
     description: str,
-) -> Response:
+) -> T:
     """
     Run an Okta paged request, retrying when the legacy Okta SDK raises
     JSONDecodeError while parsing a non-JSON error body. OktaError is left for
     the caller to handle.
-    :param request: zero-arg callable performing the api_client call
+    :param request: zero-arg callable performing the SDK call (an ApiClient
+        get/get_path returning a Response, or a UsersClient pager call)
     :param description: what the request is doing, for log messages
-    :return: the requests Response returned by the SDK
+    :return: whatever the request callable returns
     """
     for attempt in range(1, OKTA_REQUEST_ATTEMPTS + 1):
         try:

--- a/tests/unit/cartography/intel/okta/test_group.py
+++ b/tests/unit/cartography/intel/okta/test_group.py
@@ -112,7 +112,7 @@ def test_group_member_list_transform():
     assert ("May", "OKTA_USER_ID_2") in last_names
 
 
-@mock.patch("cartography.intel.okta.groups.time.sleep", return_value=None)
+@mock.patch("cartography.intel.okta.utils.time.sleep", return_value=None)
 def test_get_okta_group_members_retries_non_json_sdk_error(
     mock_sleep: mock.MagicMock,
 ) -> None:
@@ -130,7 +130,7 @@ def test_get_okta_group_members_retries_non_json_sdk_error(
     mock_sleep.assert_called_once_with(1)
 
 
-@mock.patch("cartography.intel.okta.groups.time.sleep", return_value=None)
+@mock.patch("cartography.intel.okta.utils.time.sleep", return_value=None)
 def test_get_okta_group_members_raises_after_non_json_sdk_retries(
     mock_sleep: mock.MagicMock,
 ) -> None:

--- a/tests/unit/cartography/intel/okta/test_user.py
+++ b/tests/unit/cartography/intel/okta/test_user.py
@@ -1,5 +1,29 @@
+from unittest import mock
+
+import pytest
+
+from cartography.intel.okta.users import _get_okta_users
 from cartography.intel.okta.users import transform_okta_user
 from tests.data.okta.users import create_test_user
+
+
+@mock.patch("cartography.intel.okta.users.check_rate_limit", return_value=None)
+def test_get_okta_users_raises_on_malformed_next_link(
+    _mock_rate_limit: mock.MagicMock,
+) -> None:
+    """
+    A next link present but missing its URL must raise instead of silently
+    re-fetching the first page forever.
+    """
+    paged_users = mock.MagicMock()
+    paged_users.result = []
+    paged_users.is_last_page.return_value = False
+    paged_users.next_url = None
+    user_client = mock.MagicMock()
+    user_client.get_paged_users.return_value = paged_users
+
+    with pytest.raises(ValueError, match="missing a next URL"):
+        _get_okta_users(user_client)
 
 
 def test_user_transform_with_all_values():

--- a/tests/unit/cartography/intel/okta/test_utils.py
+++ b/tests/unit/cartography/intel/okta/test_utils.py
@@ -1,9 +1,11 @@
+import json
 import time
 from unittest import mock
 
 import pytest
 
 from cartography.intel.okta.utils import check_rate_limit
+from cartography.intel.okta.utils import okta_paged_request_with_retry
 from tests.data.okta.utils import create_long_timeout_response
 from tests.data.okta.utils import create_response
 from tests.data.okta.utils import create_throttled_response
@@ -33,3 +35,26 @@ def test_utils_log_rate_limit_reset():
 
     with pytest.raises(Exception):
         check_rate_limit(response)
+
+
+@mock.patch.object(time, "sleep", return_value=None)
+def test_paged_request_retries_non_json_error(mock_sleep: mock.MagicMock):
+    response = create_response()
+    request = mock.MagicMock(
+        side_effect=[json.JSONDecodeError("Expecting value", "", 0), response]
+    )
+
+    assert okta_paged_request_with_retry(request, "testing") is response
+    assert request.call_count == 2
+    mock_sleep.assert_called_once_with(1)
+
+
+@mock.patch.object(time, "sleep", return_value=None)
+def test_paged_request_raises_after_retries(mock_sleep: mock.MagicMock):
+    request = mock.MagicMock(side_effect=json.JSONDecodeError("Expecting value", "", 0))
+
+    with pytest.raises(json.JSONDecodeError):
+        okta_paged_request_with_retry(request, "testing")
+
+    assert request.call_count == 3
+    assert mock_sleep.call_count == 2


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
The legacy Okta SDK parses every error response body as JSON and raises `JSONDecodeError` (instead of `OktaError`) when Okta, a proxy, or a rate-limiter returns an empty or non-JSON error body. These edge responses are typically transient, but they crash the sync outright.

A previous fix added a bounded retry, but only around the group-members request. The group list fetch and the three application listing requests were still unprotected, so a transient non-JSON response on any of those still aborted the entire sync (the group list is fetched first, before the protected member fetch is ever reached).

This change lifts the retry into a single shared helper, `okta_paged_request_with_retry()` in `utils.py`, and routes every paged Okta request through it:

- group list (`_get_okta_groups`)
- group members (`_get_okta_group_members`)
- application list (`_get_okta_applications`)
- application-assigned users (`_get_application_assigned_users`)
- application-assigned groups (`_get_application_assigned_groups`)

Normal `OktaError` responses keep their existing behavior and are left for each caller to handle.

### Breaking changes
None.

### How was this tested?
- New unit tests for the shared helper in `tests/unit/cartography/intel/okta/test_utils.py` (retry-then-succeed and raise-after-max-attempts).
- Existing group-member retry tests repointed at the shared helper.
- `make test_lint` passes locally (flake8, black, isort, mypy).

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.