### PR TITLE
fix(gcp): retry Cloud Run list calls on transient 5xx

### DIFF
--- a/cartography/intel/gcp/cloudrun/util.py
+++ b/cartography/intel/gcp/cloudrun/util.py
@@ -8,12 +8,11 @@ from collections.abc import Iterable
 from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
 
-from google.api_core.exceptions import DeadlineExceeded
 from google.api_core.exceptions import GoogleAPICallError
 from google.api_core.exceptions import NotFound
 from google.api_core.exceptions import PermissionDenied
 from google.api_core.exceptions import ResourceExhausted
-from google.api_core.exceptions import ServiceUnavailable
+from google.api_core.exceptions import ServerError
 from google.api_core.retry import if_exception_type
 from google.api_core.retry import Retry
 from google.auth.credentials import Credentials as GoogleCredentials
@@ -66,9 +65,10 @@ def build_cloud_run_resource_retry(
 
     return Retry(
         predicate=if_exception_type(
-            DeadlineExceeded,
+            # ServerError is the base for all transient 5xx (500/502/503/504,
+            # incl. DeadlineExceeded via GatewayTimeout); ResourceExhausted is a 429.
             ResourceExhausted,
-            ServiceUnavailable,
+            ServerError,
         ),
         initial=CLOUD_RUN_LIST_RETRY_INITIAL,
         maximum=CLOUD_RUN_LIST_RETRY_MAX,

--- a/tests/unit/cartography/intel/gcp/test_cloudrun_util.py
+++ b/tests/unit/cartography/intel/gcp/test_cloudrun_util.py
@@ -2,8 +2,11 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from google.api_core.exceptions import BadGateway
 from google.api_core.exceptions import DeadlineExceeded
+from google.api_core.exceptions import GatewayTimeout
 from google.api_core.exceptions import GoogleAPICallError
+from google.api_core.exceptions import InternalServerError
 from google.api_core.exceptions import PermissionDenied
 from googleapiclient.errors import HttpError
 
@@ -276,6 +279,19 @@ def test_build_cloud_run_resource_retry_retries_deadline_exceeded(mocker):
 
     assert result == [{"id": "service-1"}]
     assert calls == 2
+
+
+def test_build_cloud_run_resource_retry_predicate_matches_transient_5xx():
+    retry = build_cloud_run_resource_retry(
+        resource_type="jobs",
+        location="projects/p/locations/us",
+        project_id="p",
+    )
+
+    assert retry._predicate(InternalServerError("500 Internal error"))
+    assert retry._predicate(BadGateway("502 bad gateway"))
+    assert retry._predicate(GatewayTimeout("504 gateway timeout"))
+    assert not retry._predicate(PermissionDenied("403 forbidden"))
 
 
 def test_list_cloud_run_resources_for_location_uses_retry_for_deadline_exceeded(


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
`build_cloud_run_resource_retry` only retried on `DeadlineExceeded`, `ResourceExhausted`, and `ServiceUnavailable`. A transient gRPC `500 INTERNAL` (and its 502/504 siblings) is a common transient GCP failure for read RPCs but was not covered, so a Cloud Run `list` call aborted the whole sync on the first 500 instead of retrying. All Cloud Run list paths (jobs, services, ...) share this builder, so they shared the gap.

The predicate now uses `google.api_core.exceptions.ServerError`, the common base for all transient 5xx (`InternalServerError` 500, `BadGateway` 502, `ServiceUnavailable` 503, `GatewayTimeout` 504, and `DeadlineExceeded` via `GatewayTimeout`), alongside the 429 `ResourceExhausted`.

### How was this tested?
`uv run python -m pytest tests/unit/cartography/intel/gcp/test_cloudrun_util.py` (13 passed). Added a predicate test asserting the retry matches `InternalServerError`/`BadGateway`/`GatewayTimeout` and does not match `PermissionDenied` (403).

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.
