### PR TITLE
fix(ontology): exclude GCPRecordSet from scalar DNS _ont_value linking

### DIFF
--- a/cartography/data/jobs/analysis/ontology_dnsrecords_linking.json
+++ b/cartography/data/jobs/analysis/ontology_dnsrecords_linking.json
@@ -2,13 +2,18 @@
   "name": "Ontology - DNSRecords relationship linking",
   "statements": [
     {
+      "__comment": "One-time cleanup: GCPRecordSet no longer maps its list-valued data to the scalar _ont_value (see models/ontology/mapping/data/dnsrecords.py), but pre-fix syncs left a stale list-valued _ont_value on existing nodes. Clear it so nothing downstream can toString() a StringArray. Idempotent; harmless once clean.",
+      "query": "MATCH (n:GCPRecordSet) WHERE n._ont_value IS NOT NULL REMOVE n._ont_value",
+      "iterative": false
+    },
+    {
       "__comment": "Link DNSRecord to KubernetesIngress where the record name matches an ingress host",
       "query": "MATCH (dns:DNSRecord) WHERE dns._ont_name IS NOT NULL WITH dns MATCH (ing:KubernetesIngress) WHERE dns._ont_name IN ing.host_names MERGE (dns)-[r:DNS_POINTS_TO]->(ing) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
       "__comment": "Link non-AWS DNSRecord (Cloudflare/Vercel/Scaleway) to AWSLoadBalancerV2 via _ont_value; AWS records are linked natively by the route53 loader",
-      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL AND NOT dns:AWSDNSRecord WITH dns MATCH (lb:AWSLoadBalancerV2) WHERE toLower(toString(dns._ont_value)) = toLower(lb.dnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(lb) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL AND NOT dns:AWSDNSRecord AND NOT dns:GCPRecordSet WITH dns MATCH (lb:AWSLoadBalancerV2) WHERE toLower(toString(dns._ont_value)) = toLower(lb.dnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(lb) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
@@ -18,7 +23,7 @@
     },
     {
       "__comment": "Link non-AWS DNSRecord (Cloudflare/Vercel/Scaleway) to AWSLoadBalancer via _ont_value; AWS records are linked natively by the route53 loader",
-      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL AND NOT dns:AWSDNSRecord WITH dns MATCH (lb:AWSLoadBalancer) WHERE toLower(toString(dns._ont_value)) = toLower(lb.dnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(lb) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL AND NOT dns:AWSDNSRecord AND NOT dns:GCPRecordSet WITH dns MATCH (lb:AWSLoadBalancer) WHERE toLower(toString(dns._ont_value)) = toLower(lb.dnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(lb) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
@@ -28,7 +33,7 @@
     },
     {
       "__comment": "Link DNSRecord to CloudFrontDistribution via _ont_value (scalar)",
-      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL WITH dns MATCH (cf:CloudFrontDistribution) WHERE toLower(toString(dns._ont_value)) = toLower(cf.domain_name) MERGE (dns)-[r:DNS_POINTS_TO]->(cf) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL AND NOT dns:GCPRecordSet WITH dns MATCH (cf:CloudFrontDistribution) WHERE toLower(toString(dns._ont_value)) = toLower(cf.domain_name) MERGE (dns)-[r:DNS_POINTS_TO]->(cf) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
@@ -38,7 +43,7 @@
     },
     {
       "__comment": "Link non-AWS DNSRecord (Cloudflare/Vercel/Scaleway) to EC2Instance via _ont_value; AWS records are linked natively by the route53 loader",
-      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL AND NOT dns:AWSDNSRecord WITH dns MATCH (i:EC2Instance) WHERE toLower(toString(dns._ont_value)) = toLower(i.publicdnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(i) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL AND NOT dns:AWSDNSRecord AND NOT dns:GCPRecordSet WITH dns MATCH (i:EC2Instance) WHERE toLower(toString(dns._ont_value)) = toLower(i.publicdnsname) MERGE (dns)-[r:DNS_POINTS_TO]->(i) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
@@ -48,7 +53,7 @@
     },
     {
       "__comment": "Link DNSRecord to GCPInstance via _ont_value (scalar)",
-      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL WITH dns MATCH (i:GCPInstance) WHERE toLower(toString(dns._ont_value)) = toLower(i.hostname) MERGE (dns)-[r:DNS_POINTS_TO]->(i) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL AND NOT dns:GCPRecordSet WITH dns MATCH (i:GCPInstance) WHERE toLower(toString(dns._ont_value)) = toLower(i.hostname) MERGE (dns)-[r:DNS_POINTS_TO]->(i) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
@@ -58,7 +63,7 @@
     },
     {
       "__comment": "Link DNSRecord to AzureAppService via _ont_value (scalar)",
-      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL WITH dns MATCH (app:AzureAppService) WHERE toLower(toString(dns._ont_value)) = toLower(app.default_host_name) MERGE (dns)-[r:DNS_POINTS_TO]->(app) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL AND NOT dns:GCPRecordSet WITH dns MATCH (app:AzureAppService) WHERE toLower(toString(dns._ont_value)) = toLower(app.default_host_name) MERGE (dns)-[r:DNS_POINTS_TO]->(app) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {
@@ -68,7 +73,7 @@
     },
     {
       "__comment": "Link DNSRecord to AzureFunctionApp via _ont_value (scalar)",
-      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL WITH dns MATCH (func:AzureFunctionApp) WHERE toLower(toString(dns._ont_value)) = toLower(func.default_host_name) MERGE (dns)-[r:DNS_POINTS_TO]->(func) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
+      "query": "MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL AND NOT dns:GCPRecordSet WITH dns MATCH (func:AzureFunctionApp) WHERE toLower(toString(dns._ont_value)) = toLower(func.default_host_name) MERGE (dns)-[r:DNS_POINTS_TO]->(func) ON CREATE SET r.firstseen = timestamp() SET r.lastupdated = $UPDATE_TAG",
       "iterative": false
     },
     {


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
`toString(dns._ont_value)` in the ontology DNS linking job threw `CypherTypeError` and aborted the whole ontology DNS linking stage whenever a `DNSRecord` carried a list-valued `_ont_value`.

This happens on `GCPRecordSet` nodes. The scalar `toString(dns._ont_value)` statements matched every non-AWS `DNSRecord`. They excluded `AWSDNSRecord` (linked natively by the route53 loader) but not `GCPRecordSet`, which is linked by the sibling `UNWIND dns.data` statements. `GCPRecordSet.data` is list-valued, so graphs synced by an older mapping kept a stale list-valued `_ont_value`, and `toString()` on a `StringArray` crashes the batch.

Changes:
- Add `AND NOT dns:GCPRecordSet` to all 7 scalar `toString(dns._ont_value)` statements, mirroring the existing `AND NOT dns:AWSDNSRecord` exclusion. GCP records are already linked via the `UNWIND dns.data` statements, so they must never take the scalar path.
- Add an idempotent one-time cleanup statement that clears the stale, list-valued `_ont_value` left on pre-fix `GCPRecordSet` nodes.

### How was this tested?
- Validated the JSON parses and that all 7 scalar `toString(dns._ont_value)` statements now carry `AND NOT dns:GCPRecordSet`.
- `make test_lint` (pre-commit) passes on the changed file.

### Checklist
- [x] The linter passes locally (`make test_lint`).
