### PR TITLE
feat(cve_metadata): derive effect_tags on CVEMetadata from CWE/CVSS

### DIFF
--- a/cartography/intel/cve_metadata/__init__.py
+++ b/cartography/intel/cve_metadata/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from collections import Counter
 from typing import Any
 
 import neo4j
@@ -13,6 +14,8 @@ from cartography.config import Config
 from cartography.graph.job import GraphJob
 from cartography.intel.cve_metadata import epss
 from cartography.intel.cve_metadata import nvd
+from cartography.intel.cve_metadata.effect_tags import derive_effect_tags
+from cartography.intel.cve_metadata.effect_tags import unmapped_cwes
 from cartography.models.cve_metadata.cve_metadata import CVEMetadataSchema
 from cartography.models.cve_metadata.cve_metadata_feed import CVEMetadataFeedSchema
 from cartography.stats import get_stats_client
@@ -156,6 +159,10 @@ def start_cve_metadata_ingestion(
         )
         session.mount("https://", HTTPAdapter(max_retries=retry_policy))
 
+        # Count vulns per CWE we don't yet have in the effect_tags mapping table,
+        # so the aggregated gap is logged once at the end of the sync.
+        unmapped_cwe_counts: Counter[str] = Counter()
+
         with session as http_session:
             # Step 2: Enrich and load one CVE year at a time to keep memory bounded.
             for batch_cve_ids in yearly_batches:
@@ -182,7 +189,26 @@ def start_cve_metadata_ingestion(
                             exc_info=True,
                         )
 
+                # Derive effect_tags for every CVE (not just NVD-transformed ones),
+                # so the ingest contract holds even for epss-only / NVD-absent nodes.
+                for cve in cves:
+                    cve["effect_tags"], cve["effect_tags_source"] = derive_effect_tags(
+                        cve,
+                    )
+                    unmapped_cwe_counts.update(unmapped_cwes(cve.get("weaknesses", [])))
+
                 load_cve_metadata(neo4j_session, cves, config.update_tag)
+
+        if unmapped_cwe_counts:
+            summary = ", ".join(
+                f"{count} vuln(s) with {cwe}"
+                for cwe, count in unmapped_cwe_counts.most_common()
+            )
+            logger.warning(
+                "effect_tags: %d CWE(s) not in the mapping table: %s",
+                len(unmapped_cwe_counts),
+                summary,
+            )
 
     # Step 4: Cleanup stale CVEMetadata nodes from previous syncs
     GraphJob.from_node_schema(CVEMetadataSchema(), common_job_parameters).run(

--- a/cartography/intel/cve_metadata/effect_tags.py
+++ b/cartography/intel/cve_metadata/effect_tags.py
@@ -18,16 +18,6 @@ DISCLOSE_DATA = "disclose-data"
 TAMPER_DATA = "tamper-data"
 DENY_SERVICE = "deny-service"
 
-EFFECT_TAG_VOCABULARY = {
-    EXECUTE_CODE,
-    GAIN_PRIVILEGES,
-    ACCESS_CREDENTIALS,
-    BYPASS_CONTROL,
-    DISCLOSE_DATA,
-    TAMPER_DATA,
-    DENY_SERVICE,
-}
-
 # Static CWE -> effect_tags bootstrap table, hand-curated from MITRE CWE Common
 # Consequences. Covers the CWEs actually observed in current data plus common
 # neighbours. Grows over time via PR. Uninformative CWEs (NVD-CWE-noinfo,

--- a/cartography/intel/cve_metadata/effect_tags.py
+++ b/cartography/intel/cve_metadata/effect_tags.py
@@ -1,0 +1,206 @@
+"""Derive `effect_tags` on CVEMetadata: a small, queryable, controlled vocabulary
+describing *what a vulnerability lets an attacker do*, anchored in MITRE CWE/ATT&CK.
+
+Two-stage derivation with strict precedence (a node draws from exactly one source):
+  1. CWE mapping (preferred) via the in-repo CWE_EFFECT_TAGS table.
+  2. CVSS fallback from the decomposed CVSS metrics, only if stage 1 is empty.
+  3. Neither -> [] / "none".
+
+See docs/root/modules/cve_metadata/schema.md for the vocabulary + anchoring table.
+"""
+
+# Controlled vocabulary. effect_tags values MUST come from this set.
+EXECUTE_CODE = "execute-code"
+GAIN_PRIVILEGES = "gain-privileges"
+ACCESS_CREDENTIALS = "access-credentials"
+BYPASS_CONTROL = "bypass-control"
+DISCLOSE_DATA = "disclose-data"
+TAMPER_DATA = "tamper-data"
+DENY_SERVICE = "deny-service"
+
+EFFECT_TAG_VOCABULARY = {
+    EXECUTE_CODE,
+    GAIN_PRIVILEGES,
+    ACCESS_CREDENTIALS,
+    BYPASS_CONTROL,
+    DISCLOSE_DATA,
+    TAMPER_DATA,
+    DENY_SERVICE,
+}
+
+# Static CWE -> effect_tags bootstrap table, hand-curated from MITRE CWE Common
+# Consequences. Covers the CWEs actually observed in current data plus common
+# neighbours. Grows over time via PR. Uninformative CWEs (NVD-CWE-noinfo,
+# NVD-CWE-Other, generic pillars like CWE-707/CWE-20) are simply absent here and
+# so contribute nothing, letting derivation fall through to the CVSS stage.
+CWE_EFFECT_TAGS: dict[str, list[str]] = {
+    # --- Code / command injection: execution by construction ---
+    "CWE-77": [EXECUTE_CODE],  # Command Injection
+    "CWE-78": [EXECUTE_CODE],  # OS Command Injection
+    "CWE-88": [EXECUTE_CODE],  # Argument Injection
+    "CWE-94": [EXECUTE_CODE],  # Code Injection
+    "CWE-95": [EXECUTE_CODE],  # Eval Injection
+    "CWE-98": [EXECUTE_CODE],  # PHP Remote File Inclusion
+    "CWE-434": [EXECUTE_CODE],  # Unrestricted Upload of Dangerous File
+    "CWE-502": [EXECUTE_CODE],  # Deserialization of Untrusted Data
+    "CWE-917": [EXECUTE_CODE],  # Expression Language Injection
+    "CWE-1321": [EXECUTE_CODE],  # Prototype Pollution
+    # --- DLL / search-path hijack -> execution ---
+    "CWE-426": [EXECUTE_CODE],  # Untrusted Search Path
+    "CWE-427": [EXECUTE_CODE],  # Uncontrolled Search Path Element
+    # --- Memory corruption: conditional code execution + crash + memory tamper ---
+    "CWE-119": [EXECUTE_CODE, TAMPER_DATA, DENY_SERVICE],  # Improper mem bounds
+    "CWE-120": [EXECUTE_CODE, DENY_SERVICE],  # Classic Buffer Overflow
+    "CWE-121": [EXECUTE_CODE, DENY_SERVICE],  # Stack-based Buffer Overflow
+    "CWE-122": [EXECUTE_CODE, DENY_SERVICE],  # Heap-based Buffer Overflow
+    "CWE-125": [DISCLOSE_DATA, DENY_SERVICE],  # Out-of-bounds Read
+    "CWE-787": [EXECUTE_CODE, TAMPER_DATA, DENY_SERVICE],  # Out-of-bounds Write
+    "CWE-416": [EXECUTE_CODE, DENY_SERVICE],  # Use After Free
+    "CWE-415": [EXECUTE_CODE, DENY_SERVICE],  # Double Free
+    "CWE-476": [DENY_SERVICE],  # NULL Pointer Dereference
+    "CWE-190": [EXECUTE_CODE, DENY_SERVICE],  # Integer Overflow
+    "CWE-191": [EXECUTE_CODE, DENY_SERVICE],  # Integer Underflow
+    "CWE-193": [EXECUTE_CODE, DENY_SERVICE],  # Off-by-one Error
+    "CWE-824": [EXECUTE_CODE, DENY_SERVICE],  # Access of Uninitialized Pointer
+    # --- Resource exhaustion -> denial of service ---
+    "CWE-400": [DENY_SERVICE],  # Uncontrolled Resource Consumption
+    "CWE-401": [DENY_SERVICE],  # Missing Release of Memory
+    "CWE-404": [DENY_SERVICE],  # Improper Resource Shutdown
+    "CWE-674": [DENY_SERVICE],  # Uncontrolled Recursion
+    "CWE-770": [DENY_SERVICE],  # Allocation of Resources Without Limits
+    "CWE-772": [DENY_SERVICE],  # Missing Release of Resource
+    "CWE-834": [DENY_SERVICE],  # Excessive Iteration
+    "CWE-835": [DENY_SERVICE],  # Loop with Unreachable Exit (infinite loop)
+    # --- Path traversal: read + write files ---
+    "CWE-22": [DISCLOSE_DATA, TAMPER_DATA],  # Path Traversal
+    "CWE-23": [DISCLOSE_DATA, TAMPER_DATA],  # Relative Path Traversal
+    "CWE-36": [DISCLOSE_DATA, TAMPER_DATA],  # Absolute Path Traversal
+    "CWE-59": [DISCLOSE_DATA, TAMPER_DATA],  # Link Following
+    # --- Information disclosure ---
+    "CWE-79": [EXECUTE_CODE, DISCLOSE_DATA],  # Cross-site Scripting
+    "CWE-89": [DISCLOSE_DATA, TAMPER_DATA],  # SQL Injection
+    "CWE-200": [DISCLOSE_DATA],  # Exposure of Sensitive Information
+    "CWE-201": [DISCLOSE_DATA],  # Insertion of Sensitive Info Into Sent Data
+    "CWE-209": [DISCLOSE_DATA],  # Error Message Info Exposure
+    "CWE-312": [DISCLOSE_DATA],  # Cleartext Storage of Sensitive Information
+    "CWE-319": [DISCLOSE_DATA],  # Cleartext Transmission of Sensitive Info
+    "CWE-532": [DISCLOSE_DATA],  # Insertion of Sensitive Info into Log File
+    "CWE-611": [DISCLOSE_DATA],  # XML External Entity (XXE)
+    "CWE-918": [DISCLOSE_DATA],  # Server-Side Request Forgery (SSRF)
+    # --- Credential access ---
+    "CWE-256": [ACCESS_CREDENTIALS],  # Unprotected Storage of Credentials
+    "CWE-257": [ACCESS_CREDENTIALS],  # Storing Passwords in Recoverable Format
+    "CWE-259": [ACCESS_CREDENTIALS],  # Use of Hard-coded Password
+    "CWE-522": [ACCESS_CREDENTIALS],  # Insufficiently Protected Credentials
+    "CWE-798": [ACCESS_CREDENTIALS],  # Use of Hard-coded Credentials
+    # --- Privilege escalation ---
+    "CWE-250": [GAIN_PRIVILEGES],  # Execution with Unnecessary Privileges
+    "CWE-266": [GAIN_PRIVILEGES],  # Incorrect Privilege Assignment
+    "CWE-267": [GAIN_PRIVILEGES],  # Privilege Defined With Unsafe Actions
+    "CWE-268": [GAIN_PRIVILEGES],  # Privilege Chaining
+    "CWE-269": [GAIN_PRIVILEGES],  # Improper Privilege Management
+    "CWE-276": [GAIN_PRIVILEGES],  # Incorrect Default Permissions
+    "CWE-732": [GAIN_PRIVILEGES],  # Incorrect Permission Assignment
+    # --- Access control / authentication bypass ---
+    "CWE-284": [BYPASS_CONTROL],  # Improper Access Control
+    "CWE-285": [BYPASS_CONTROL],  # Improper Authorization
+    "CWE-287": [BYPASS_CONTROL],  # Improper Authentication
+    "CWE-290": [BYPASS_CONTROL],  # Authentication Bypass by Spoofing
+    "CWE-295": [BYPASS_CONTROL],  # Improper Certificate Validation
+    "CWE-306": [BYPASS_CONTROL],  # Missing Authentication for Critical Function
+    "CWE-347": [BYPASS_CONTROL],  # Improper Verification of Crypto Signature
+    "CWE-352": [TAMPER_DATA],  # Cross-Site Request Forgery
+    "CWE-354": [BYPASS_CONTROL, TAMPER_DATA],  # Improper Integrity Check Validation
+    "CWE-425": [BYPASS_CONTROL],  # Direct Request (Forced Browsing)
+    "CWE-639": [BYPASS_CONTROL],  # Authorization Bypass Through User-Controlled Key
+    "CWE-862": [BYPASS_CONTROL],  # Missing Authorization
+    "CWE-863": [BYPASS_CONTROL],  # Incorrect Authorization
+}
+
+
+# CWEs that intentionally contribute no effect (no-info markers / generic root-cause
+# pillars). Excluded from the "unmapped CWE" warning so it only surfaces genuinely
+# missing table entries worth curating, not expected noise.
+UNINFORMATIVE_CWES = {
+    "NVD-CWE-noinfo",
+    "NVD-CWE-Other",
+    "CWE-707",
+    "CWE-20",
+}
+
+
+def unmapped_cwes(weaknesses: list[str]) -> list[str]:
+    """CWEs absent from the mapping table and not known-uninformative: candidates
+    to add to CWE_EFFECT_TAGS."""
+    return [
+        cwe
+        for cwe in weaknesses
+        if cwe not in CWE_EFFECT_TAGS and cwe not in UNINFORMATIVE_CWES
+    ]
+
+
+def _derive_from_cwe(weaknesses: list[str]) -> list[str]:
+    """Union of mapped effects across all CWEs, deduplicated, vocabulary-ordered."""
+    tags: set[str] = set()
+    for cwe in weaknesses:
+        tags.update(CWE_EFFECT_TAGS.get(cwe, []))
+    return _ordered(tags)
+
+
+# Highest impact level per CVSS version: v3/v4 use HIGH, v2 uses COMPLETE.
+_HIGH_IMPACT = {"HIGH", "COMPLETE"}
+
+
+def _derive_from_cvss(cve: dict) -> list[str]:
+    """CVSS fallback from decomposed metrics. Degrades gracefully across versions:
+    the C/I/A impact mapping applies to all (v2 COMPLETE counts as high, same as
+    v3/v4 HIGH); the 'straight-shot' execute-code rule only fires where the required
+    exploitability metrics exist (skipped on v2, which lacks privileges_required /
+    user_interaction)."""
+    tags: set[str] = set()
+    integ = cve.get("integrityImpact")
+    if cve.get("confidentialityImpact") in _HIGH_IMPACT:
+        tags.add(DISCLOSE_DATA)
+    if integ in _HIGH_IMPACT:
+        tags.add(TAMPER_DATA)
+    if cve.get("availabilityImpact") in _HIGH_IMPACT:
+        tags.add(DENY_SERVICE)
+    if (
+        cve.get("attackVector") == "NETWORK"
+        and cve.get("privilegesRequired") == "NONE"
+        and cve.get("userInteraction") == "NONE"
+        and integ in _HIGH_IMPACT
+    ):
+        tags.add(EXECUTE_CODE)
+    return _ordered(tags)
+
+
+# Stable vocabulary order so output lists are deterministic and reviewable.
+_VOCAB_ORDER = [
+    EXECUTE_CODE,
+    GAIN_PRIVILEGES,
+    ACCESS_CREDENTIALS,
+    BYPASS_CONTROL,
+    DISCLOSE_DATA,
+    TAMPER_DATA,
+    DENY_SERVICE,
+]
+
+
+def _ordered(tags: set[str]) -> list[str]:
+    return [t for t in _VOCAB_ORDER if t in tags]
+
+
+def derive_effect_tags(cve: dict) -> tuple[list[str], str]:
+    """Derive (effect_tags, effect_tags_source) for a transformed CVE dict.
+
+    Precedence: CWE (source="cwe") > CVSS (source="cvss") > none (source="none").
+    A node draws from exactly one source.
+    """
+    cwe_tags = _derive_from_cwe(cve.get("weaknesses", []))
+    if cwe_tags:
+        return cwe_tags, "cwe"
+    cvss_tags = _derive_from_cvss(cve)
+    if cvss_tags:
+        return cvss_tags, "cvss"
+    return [], "none"

--- a/cartography/models/cve_metadata/cve_metadata.py
+++ b/cartography/models/cve_metadata/cve_metadata.py
@@ -19,6 +19,9 @@ class CVEMetadataNodeProperties(CartographyNodeProperties):
     description: PropertyRef = PropertyRef("description_en")
     references: PropertyRef = PropertyRef("references_urls")
     problem_types: PropertyRef = PropertyRef("weaknesses")
+    # Technical-effect labels derived from CWE (preferred) or CVSS fallback.
+    effect_tags: PropertyRef = PropertyRef("effect_tags")
+    effect_tags_source: PropertyRef = PropertyRef("effect_tags_source")
     cvss_version: PropertyRef = PropertyRef("cvss_version")
     vector_string: PropertyRef = PropertyRef("vectorString")
     attack_vector: PropertyRef = PropertyRef("attackVector")

--- a/docs/root/modules/cve_metadata/schema.md
+++ b/docs/root/modules/cve_metadata/schema.md
@@ -12,6 +12,8 @@ Enrichment metadata for a [CVE](../cve/schema.md) node, sourced from NVD and EPS
 | description | The english description of the vulnerability |
 | references | Reference URLs |
 | problem\_types | A list of CWE identifiers |
+| effect\_tags | Controlled-vocabulary labels for the vulnerability's technical effect (see below) |
+| effect\_tags\_source | Provenance of `effect_tags`: `cwe`, `cvss`, or `none` |
 | cvss\_version | The CVSS version used (4.0, 3.1, 3.0, or 2.0) |
 | vector\_string | The CVSS vector string |
 | attack\_vector | The CVSS attack vector |
@@ -36,6 +38,36 @@ Enrichment metadata for a [CVE](../cve/schema.md) node, sourced from NVD and EPS
 | cisa\_vulnerability\_name | CISA vulnerability name (if applicable) |
 | epss\_score | EPSS probability of exploitation (0.0-1.0) |
 | epss\_percentile | EPSS percentile ranking (0.0-1.0) |
+
+#### effect\_tags
+
+`effect_tags` answers "what does this vulnerability let an attacker do?" using a small
+controlled vocabulary, each value anchored to a MITRE ATT&CK tactic / CWE Common Consequence:
+
+| Tag | Anchor |
+|-----|--------|
+| `execute-code` | ATT&CK Execution / "Execute Unauthorized Code or Commands" |
+| `gain-privileges` | ATT&CK Privilege Escalation / "Gain Privileges or Assume Identity" |
+| `access-credentials` | ATT&CK Credential Access / "Read Application Data (credentials)" |
+| `bypass-control` | ATT&CK Defense Evasion / "Bypass Protection Mechanism" |
+| `disclose-data` | "Read Files or Directories" / "Read Application Data" |
+| `tamper-data` | ATT&CK Impact / "Modify Application Data" |
+| `deny-service` | ATT&CK Impact / "DoS: Crash, Exit, or Restart / Resource Consumption" |
+
+Derivation runs at ingest with strict precedence, so a node draws from exactly one source
+(recorded in `effect_tags_source`):
+
+1. **CWE (`cwe`)** — preferred. Union of effects mapped from the node's CWEs via the in-repo
+   `CWE_EFFECT_TAGS` table (`cartography/intel/cve_metadata/effect_tags.py`). Uninformative
+   CWEs (`NVD-CWE-noinfo`, `NVD-CWE-Other`, generic pillars like `CWE-707`/`CWE-20`) contribute nothing.
+2. **CVSS (`cvss`)** — fallback only when stage 1 yields nothing, derived from the decomposed
+   CVSS metrics. A "high" C/I/A impact means `HIGH` on v3/v4 or `COMPLETE` on v2:
+   high `confidentiality_impact`→`disclose-data`, high `integrity_impact`→`tamper-data`,
+   high `availability_impact`→`deny-service`, plus a coarse "straight-shot"
+   (`attack_vector=NETWORK` + `privileges_required=NONE` + `user_interaction=NONE` + high `integrity_impact`)
+   →`execute-code`. Degrades gracefully across CVSS versions (the straight-shot rule is skipped on v2,
+   which lacks `privileges_required` / `user_interaction`).
+3. **none (`none`)** — no usable CWE and no usable CVSS: `effect_tags=[]`.
 
 ### CVEMetadataFeed
 

--- a/tests/integration/cartography/intel/cve_metadata/test_cve_metadata.py
+++ b/tests/integration/cartography/intel/cve_metadata/test_cve_metadata.py
@@ -149,6 +149,18 @@ def test_sync(mock_nvd, mock_epss, neo4j_session):
         ("CVE-2024-22075", 6.1, "MEDIUM", 0.97530, 0.99940),
     }
 
+    # Assert - effect_tags derived (both test CVEs have uninformative/absent CWEs
+    # and no HIGH CVSS impacts, so they resolve to the "none" source)
+    effect_nodes = check_nodes(
+        neo4j_session,
+        "CVEMetadata",
+        ["id", "effect_tags_source"],
+    )
+    assert effect_nodes == {
+        ("CVE-2023-41782", "none"),
+        ("CVE-2024-22075", "none"),
+    }
+
     # Assert - CISA KEV fields on the KEV-listed CVE
     kev_nodes = check_nodes(
         neo4j_session,

--- a/tests/unit/cartography/intel/cve_metadata/test_effect_tags.py
+++ b/tests/unit/cartography/intel/cve_metadata/test_effect_tags.py
@@ -1,5 +1,5 @@
+from cartography.intel.cve_metadata.effect_tags import _VOCAB_ORDER
 from cartography.intel.cve_metadata.effect_tags import derive_effect_tags
-from cartography.intel.cve_metadata.effect_tags import EFFECT_TAG_VOCABULARY
 from cartography.intel.cve_metadata.effect_tags import unmapped_cwes
 
 
@@ -21,8 +21,8 @@ def test_multi_cwe_union_deduplicated():
     assert source == "cwe"
     assert set(tags) == {"execute-code", "tamper-data", "deny-service", "disclose-data"}
     # Output is vocabulary-ordered and within the controlled set.
-    assert tags == sorted(tags, key=_VOCAB.index)
-    assert set(tags) <= EFFECT_TAG_VOCABULARY
+    assert tags == sorted(tags, key=_VOCAB_ORDER.index)
+    assert set(tags) <= set(_VOCAB_ORDER)
 
 
 def test_uninformative_cwe_falls_through_to_cvss():
@@ -99,14 +99,3 @@ def test_cwe_precedence_over_cvss():
     tags, source = derive_effect_tags(cve)
     assert source == "cwe"
     assert tags == ["execute-code"]
-
-
-_VOCAB = [
-    "execute-code",
-    "gain-privileges",
-    "access-credentials",
-    "bypass-control",
-    "disclose-data",
-    "tamper-data",
-    "deny-service",
-]

--- a/tests/unit/cartography/intel/cve_metadata/test_effect_tags.py
+++ b/tests/unit/cartography/intel/cve_metadata/test_effect_tags.py
@@ -1,0 +1,112 @@
+from cartography.intel.cve_metadata.effect_tags import derive_effect_tags
+from cartography.intel.cve_metadata.effect_tags import EFFECT_TAG_VOCABULARY
+from cartography.intel.cve_metadata.effect_tags import unmapped_cwes
+
+
+def test_unmapped_cwes_excludes_mapped_and_uninformative():
+    weaknesses = ["CWE-78", "CWE-9999", "NVD-CWE-noinfo", "CWE-20", "CWE-1213"]
+    # CWE-78 is mapped; noinfo/CWE-20 are uninformative; only the unknowns remain.
+    assert unmapped_cwes(weaknesses) == ["CWE-9999", "CWE-1213"]
+
+
+def test_single_cwe_lookup():
+    tags, source = derive_effect_tags({"weaknesses": ["CWE-78"]})
+    assert tags == ["execute-code"]
+    assert source == "cwe"
+
+
+def test_multi_cwe_union_deduplicated():
+    # CWE-787 -> execute/tamper/deny, CWE-125 -> disclose/deny: union, deny dedup.
+    tags, source = derive_effect_tags({"weaknesses": ["CWE-787", "CWE-125"]})
+    assert source == "cwe"
+    assert set(tags) == {"execute-code", "tamper-data", "deny-service", "disclose-data"}
+    # Output is vocabulary-ordered and within the controlled set.
+    assert tags == sorted(tags, key=_VOCAB.index)
+    assert set(tags) <= EFFECT_TAG_VOCABULARY
+
+
+def test_uninformative_cwe_falls_through_to_cvss():
+    cve = {
+        "weaknesses": ["NVD-CWE-noinfo", "CWE-20"],
+        "confidentialityImpact": "HIGH",
+    }
+    tags, source = derive_effect_tags(cve)
+    assert source == "cvss"
+    assert tags == ["disclose-data"]
+
+
+def test_cvss_cia_impact_tags():
+    cve = {
+        "weaknesses": [],
+        "confidentialityImpact": "HIGH",
+        "integrityImpact": "HIGH",
+        "availabilityImpact": "HIGH",
+    }
+    tags, source = derive_effect_tags(cve)
+    assert source == "cvss"
+    assert set(tags) == {"disclose-data", "tamper-data", "deny-service"}
+
+
+def test_cvss_straight_shot_execute_code():
+    cve = {
+        "weaknesses": [],
+        "attackVector": "NETWORK",
+        "privilegesRequired": "NONE",
+        "userInteraction": "NONE",
+        "integrityImpact": "HIGH",
+    }
+    tags, source = derive_effect_tags(cve)
+    assert source == "cvss"
+    assert "execute-code" in tags
+
+
+def test_cvss_v2_complete_impacts_map():
+    # NVD CVSS v2 uses COMPLETE/PARTIAL/NONE (not HIGH). COMPLETE counts as high.
+    cve = {
+        "weaknesses": [],
+        "confidentialityImpact": "COMPLETE",
+        "integrityImpact": "COMPLETE",
+        "availabilityImpact": "COMPLETE",
+    }
+    tags, source = derive_effect_tags(cve)
+    assert source == "cvss"
+    assert set(tags) == {"disclose-data", "tamper-data", "deny-service"}
+
+
+def test_cvss_v2_skips_straight_shot_cleanly():
+    # v2 vectors lack privilegesRequired/userInteraction: straight-shot must not fire,
+    # but C/I/A impacts (COMPLETE) still map without error.
+    cve = {
+        "weaknesses": [],
+        "attackVector": "NETWORK",
+        "integrityImpact": "COMPLETE",
+    }
+    tags, source = derive_effect_tags(cve)
+    assert source == "cvss"
+    assert tags == ["tamper-data"]
+    assert "execute-code" not in tags
+
+
+def test_no_cwe_no_cvss():
+    tags, source = derive_effect_tags({"weaknesses": []})
+    assert tags == []
+    assert source == "none"
+
+
+def test_cwe_precedence_over_cvss():
+    # A usable CWE wins even when CVSS would also produce tags.
+    cve = {"weaknesses": ["CWE-78"], "confidentialityImpact": "HIGH"}
+    tags, source = derive_effect_tags(cve)
+    assert source == "cwe"
+    assert tags == ["execute-code"]
+
+
+_VOCAB = [
+    "execute-code",
+    "gain-privileges",
+    "access-credentials",
+    "bypass-control",
+    "disclose-data",
+    "tamper-data",
+    "deny-service",
+]

--- a/tests/unit/cartography/intel/cve_metadata/test_init.py
+++ b/tests/unit/cartography/intel/cve_metadata/test_init.py
@@ -94,15 +94,28 @@ def test_start_cve_metadata_ingestion_loads_one_year_at_a_time(
     assert mock_load_cve_metadata_feed.call_args_list == [
         call(neo4j_session, 123, {"nvd", "epss"}),
     ]
+    # merge_nvd_into_cves is mocked out, so cves stay stubs; effect_tags derivation
+    # still runs on each, resolving to []/none with no CWE or CVSS present.
     assert mock_load_cve_metadata.call_args_list == [
         call(
             neo4j_session,
-            [{"id": "CVE-2023-0001"}, {"id": "CVE-2023-0002"}],
+            [
+                {
+                    "id": "CVE-2023-0001",
+                    "effect_tags": [],
+                    "effect_tags_source": "none",
+                },
+                {
+                    "id": "CVE-2023-0002",
+                    "effect_tags": [],
+                    "effect_tags_source": "none",
+                },
+            ],
             123,
         ),
         call(
             neo4j_session,
-            [{"id": "CVE-2024-0001"}],
+            [{"id": "CVE-2024-0001", "effect_tags": [], "effect_tags_source": "none"}],
             123,
         ),
     ]
@@ -111,17 +124,34 @@ def test_start_cve_metadata_ingestion_loads_one_year_at_a_time(
         neo4j_session,
         {"UPDATE_TAG": 123, "FEED_ID": cve_metadata.CVE_METADATA_FEED_ID},
     )
+    # The merge mocks capture the cve dicts by reference; effect_tags are added to
+    # those same dicts before load, so they appear here by assertion time.
+    stub_2023_0001 = {
+        "id": "CVE-2023-0001",
+        "effect_tags": [],
+        "effect_tags_source": "none",
+    }
+    stub_2023_0002 = {
+        "id": "CVE-2023-0002",
+        "effect_tags": [],
+        "effect_tags_source": "none",
+    }
+    stub_2024_0001 = {
+        "id": "CVE-2024-0001",
+        "effect_tags": [],
+        "effect_tags_source": "none",
+    }
     mock_merge_nvd_into_cves.assert_has_calls(
         [
             call(
-                [{"id": "CVE-2023-0001"}, {"id": "CVE-2023-0002"}],
+                [stub_2023_0001, stub_2023_0002],
                 {
                     "CVE-2023-0001": {"id": "CVE-2023-0001", "baseScore": 1.0},
                     "CVE-2023-0002": {"id": "CVE-2023-0002", "baseScore": 2.0},
                 },
             ),
             call(
-                [{"id": "CVE-2024-0001"}],
+                [stub_2024_0001],
                 {"CVE-2024-0001": {"id": "CVE-2024-0001", "baseScore": 3.0}},
             ),
         ],
@@ -129,14 +159,14 @@ def test_start_cve_metadata_ingestion_loads_one_year_at_a_time(
     mock_merge_epss_into_cves.assert_has_calls(
         [
             call(
-                [{"id": "CVE-2023-0001"}, {"id": "CVE-2023-0002"}],
+                [stub_2023_0001, stub_2023_0002],
                 {
                     "CVE-2023-0001": {"epss_score": 0.1, "epss_percentile": 0.2},
                     "CVE-2023-0002": {"epss_score": 0.3, "epss_percentile": 0.4},
                 },
             ),
             call(
-                [{"id": "CVE-2024-0001"}],
+                [stub_2024_0001],
                 {"CVE-2024-0001": {"epss_score": 0.5, "epss_percentile": 0.6}},
             ),
         ],


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
Adds two queryable properties to `CVEMetadata` that answer "what does this vulnerability let an attacker do?", derived at ingest and anchored in MITRE CWE Common Consequences / ATT&CK:

- `effect_tags: list[str]` from a small controlled vocabulary (`execute-code`, `gain-privileges`, `access-credentials`, `bypass-control`, `disclose-data`, `tamper-data`, `deny-service`).
- `effect_tags_source: str` provenance marker (`cwe`, `cvss`, or `none`).

Today consumers fall back on noisy severity heuristics because the CWE-to-effect knowledge lives outside the graph. This makes the technical effect a first-class, stable label.

Derivation runs in two stages with strict precedence, so a node draws from exactly one source:

1. **CWE (preferred)** — union of effects mapped from the node's CWEs via an in-repo, PR-reviewable `CWE_EFFECT_TAGS` bootstrap table. Uninformative CWEs (`NVD-CWE-noinfo`, `NVD-CWE-Other`, generic pillars like `CWE-707`/`CWE-20`) contribute nothing.
2. **CVSS fallback** — only when stage 1 is empty, from the decomposed CVSS metrics. A "high" C/I/A impact means `HIGH` (v3/v4) or `COMPLETE` (v2). Includes a coarse "straight-shot" `execute-code` heuristic that is skipped on v2 (which lacks `privileges_required` / `user_interaction`).
3. **none** — no usable CWE and no usable CVSS resolves to `[]` / `none`, never fabricated.

Derivation runs on every CVE before load, so the contract holds for epss-only / NVD-absent nodes too. Unmapped CWEs (excluding known-uninformative ones) are aggregated into a single warning at the end of the sync so the table can grow over time.


### Related issues or links

- Fixes #3002


### How was this tested?
- New unit tests in `tests/unit/cartography/intel/cve_metadata/test_effect_tags.py` cover: single-CWE lookup, multi-CWE union/dedup, uninformative-CWE fall-through to CVSS, CVSS C/I/A impact tags, straight-shot `execute-code`, CVSS v2 `COMPLETE` impacts, v2 skipping straight-shot cleanly, no-CWE/no-CVSS -> `[]`/`none`, CWE precedence over CVSS, and the unmapped-CWE helper.
- Updated `test_init.py` and the integration test to assert `effect_tags_source` flows through to the graph.
- `make test_lint` passes locally.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).


### Notes for reviewers
The `CWE_EFFECT_TAGS` table is a hand-curated bootstrap set covering the CWEs present in current data plus common neighbours; it is intended to grow over time via PR (the end-of-sync warning surfaces gaps). Per the issue's open question, `execute-code` is kept flat for v1, with `effect_tags_source` carrying the confidence signal (cwe > cvss).

🤖 Generated with [Claude Code](https://claude.com/claude-code)