### PR TITLE
feat(ontology): add supply-chain relationship constraints

### DIFF
--- a/cartography/models/ontology/constraints.py
+++ b/cartography/models/ontology/constraints.py
@@ -4,6 +4,15 @@ from cartography.models.anthropic.apikey import AnthropicApiKeyToUserRel
 from cartography.models.aws.cloudtrail.management_events import (
     AssumedRoleWithSAMLMatchLink,
 )
+
+# Raw ingest-time (:Container|:Function)-[:HAS_IMAGE]->(:Image) references,
+# whitelisted below as distinct from the analysis-derived RESOLVED_IMAGE edge.
+from cartography.models.aws.ecs.containers import ECSContainerToECRImageRel
+from cartography.models.aws.ecs.containers import (
+    ECSContainerToGCPArtifactRegistryImageRel,
+)
+from cartography.models.aws.ecs.containers import ECSContainerToGitHubContainerImageRel
+from cartography.models.aws.ecs.containers import ECSContainerToGitLabContainerImageRel
 from cartography.models.aws.ecs.containers import ECSContainerToTaskRel
 from cartography.models.aws.ecs.services import ECSServiceToECSClusterRel
 from cartography.models.aws.ecs.services import ECSServiceToECSTaskRel
@@ -27,15 +36,73 @@ from cartography.models.aws.identitycenter.awsssouser import (
 )
 from cartography.models.aws.identitycenter.awsssouser import AWSSSOUserToSSOGroupRel
 from cartography.models.aws.lambda_function.lambda_function import (
+    AWSLambdaToECRImageRel,
+)
+from cartography.models.aws.lambda_function.lambda_function import (
+    AWSLambdaToGCPArtifactRegistryImageRel,
+)
+from cartography.models.aws.lambda_function.lambda_function import (
+    AWSLambdaToGitHubContainerImageRel,
+)
+from cartography.models.aws.lambda_function.lambda_function import (
+    AWSLambdaToGitLabContainerImageRel,
+)
+from cartography.models.aws.lambda_function.lambda_function import (
     AWSLambdaToPrincipalRel,
+)
+from cartography.models.azure.container_instance import (
+    AzureContainerInstanceToECRImageRel,
+)
+from cartography.models.azure.container_instance import (
+    AzureContainerInstanceToGCPArtifactRegistryImageRel,
+)
+from cartography.models.azure.container_instance import (
+    AzureContainerInstanceToGitHubContainerImageRel,
+)
+from cartography.models.azure.container_instance import (
+    AzureContainerInstanceToGitLabContainerImageRel,
 )
 from cartography.models.azure.container_instance import (
     AzureGroupContainerToContainerInstanceRel,
 )
+from cartography.models.azure.function_app import AzureFunctionAppToECRImageRel
+from cartography.models.azure.function_app import (
+    AzureFunctionAppToGCPArtifactRegistryImageRel,
+)
+from cartography.models.azure.function_app import (
+    AzureFunctionAppToGitHubContainerImageRel,
+)
+from cartography.models.azure.function_app import (
+    AzureFunctionAppToGitLabContainerImageRel,
+)
 from cartography.models.duo.user import DuoGroupToDuoUserRel
 from cartography.models.gcp.cloudrun.job import CloudRunJobToServiceAccountRel
+from cartography.models.gcp.cloudrun.job_container import (
+    CloudRunJobContainerToArtifactRegistryImageRel,
+)
+from cartography.models.gcp.cloudrun.job_container import (
+    CloudRunJobContainerToECRImageRel,
+)
+from cartography.models.gcp.cloudrun.job_container import (
+    CloudRunJobContainerToGitHubContainerImageRel,
+)
+from cartography.models.gcp.cloudrun.job_container import (
+    CloudRunJobContainerToGitLabContainerImageRel,
+)
 from cartography.models.gcp.cloudrun.job_container import CloudRunJobToContainerRel
 from cartography.models.gcp.cloudrun.service import CloudRunServiceToServiceAccountRel
+from cartography.models.gcp.cloudrun.service_container import (
+    CloudRunServiceContainerToArtifactRegistryImageRel,
+)
+from cartography.models.gcp.cloudrun.service_container import (
+    CloudRunServiceContainerToECRImageRel,
+)
+from cartography.models.gcp.cloudrun.service_container import (
+    CloudRunServiceContainerToGitHubContainerImageRel,
+)
+from cartography.models.gcp.cloudrun.service_container import (
+    CloudRunServiceContainerToGitLabContainerImageRel,
+)
 from cartography.models.gcp.cloudrun.service_container import (
     CloudRunServiceToContainerRel,
 )
@@ -70,6 +137,16 @@ from cartography.models.keycloak.inheritance import (
     KeycloakUserInheritedMemberOfGroupMatchLink,
 )
 from cartography.models.keycloak.role import KeycloakRoleToUserRel
+from cartography.models.kubernetes.containers import KubernetesContainerToECRImageRel
+from cartography.models.kubernetes.containers import (
+    KubernetesContainerToGCPArtifactRegistryImageRel,
+)
+from cartography.models.kubernetes.containers import (
+    KubernetesContainerToGitHubContainerImageRel,
+)
+from cartography.models.kubernetes.containers import (
+    KubernetesContainerToGitLabContainerImageRel,
+)
 from cartography.models.kubernetes.containers import (
     KubernetesContainerToKubernetesPodRel,
 )
@@ -95,6 +172,9 @@ from cartography.models.openai.apikey import OpenAIApiKeyToSARel
 from cartography.models.openai.apikey import OpenAIApiKeyToUserRel
 from cartography.models.scaleway.iam.apikey import ScalewayApiKeyToApplicationRel
 from cartography.models.scaleway.iam.apikey import ScalewayApiKeyToUserRel
+from cartography.models.scaleway.serverless.container import (
+    ScalewayServerlessContainerToImageRel,
+)
 from cartography.models.sentry.member import SentryUserToTeamAdminOfRel
 from cartography.models.slack.group import SlackGroupToCreatorRel
 from cartography.models.tailscale.group import (
@@ -170,6 +250,19 @@ ONTOLOGY_REL_CONSTRAINTS: tuple[RelConstraint, ...] = (
     # software package. Both finding shapes point at the same canonical Package.
     RelConstraint(src="CVE", dst="Package", label="AFFECTS"),
     RelConstraint(src="SecurityIssue", dst="Package", label="AFFECTS"),
+    # A container/function resolves to the concrete single-platform image it
+    # runs. Materialized by resolved_image_analysis.json from the raw HAS_IMAGE
+    # references (which are whitelisted below as a distinct semantic).
+    RelConstraint(src="Container", dst="Image", label="RESOLVED_IMAGE"),
+    RelConstraint(src="Function", dst="Image", label="RESOLVED_IMAGE"),
+    # An image/function is built from a source code repository (CI provenance).
+    RelConstraint(src="Image", dst="CodeRepository", label="PACKAGED_FROM"),
+    # NOTE: no UserAccount->CodeRepository constraint. Several distinct edges
+    # legitimately span that pair (COMMITTED_TO commit authorship, OWNER
+    # ownership, DIRECT_COLLAB_*/OUTSIDE_COLLAB_* access grants), so a single
+    # canonical label cannot be enforced here yet.
+    # A software package is deployed inside a container image.
+    RelConstraint(src="Package", dst="Image", label="DEPLOYED"),
 )
 
 
@@ -296,5 +389,40 @@ LEGACY_REL_WHITELIST: frozenset[type] = frozenset(
         GoogleWorkspaceUserToGroupInheritedOwnerRel,
         KeycloakUserInheritedMemberOfGroupMatchLink,
         TailscaleUserToGroupInheritedMemberMatchLink,
+        # HAS_IMAGE is the raw ingest-time (:Container|:Function)->(:Image)
+        # reference, matched by runtime digest at load time and possibly pointing
+        # at a manifest list. The canonical RESOLVED_IMAGE edge is derived from it
+        # by resolved_image_analysis.json (resolving manifest lists to the concrete
+        # single-platform image). Both coexist, so HAS_IMAGE is whitelisted as a
+        # distinct semantic rather than a violation of RESOLVED_IMAGE.
+        KubernetesContainerToECRImageRel,
+        KubernetesContainerToGitLabContainerImageRel,
+        KubernetesContainerToGCPArtifactRegistryImageRel,
+        KubernetesContainerToGitHubContainerImageRel,
+        ECSContainerToECRImageRel,
+        ECSContainerToGitLabContainerImageRel,
+        ECSContainerToGCPArtifactRegistryImageRel,
+        ECSContainerToGitHubContainerImageRel,
+        CloudRunServiceContainerToECRImageRel,
+        CloudRunServiceContainerToGitLabContainerImageRel,
+        CloudRunServiceContainerToArtifactRegistryImageRel,
+        CloudRunServiceContainerToGitHubContainerImageRel,
+        CloudRunJobContainerToECRImageRel,
+        CloudRunJobContainerToGitLabContainerImageRel,
+        CloudRunJobContainerToArtifactRegistryImageRel,
+        CloudRunJobContainerToGitHubContainerImageRel,
+        AzureContainerInstanceToECRImageRel,
+        AzureContainerInstanceToGitLabContainerImageRel,
+        AzureContainerInstanceToGCPArtifactRegistryImageRel,
+        AzureContainerInstanceToGitHubContainerImageRel,
+        ScalewayServerlessContainerToImageRel,
+        AWSLambdaToECRImageRel,
+        AWSLambdaToGitLabContainerImageRel,
+        AWSLambdaToGCPArtifactRegistryImageRel,
+        AWSLambdaToGitHubContainerImageRel,
+        AzureFunctionAppToECRImageRel,
+        AzureFunctionAppToGitLabContainerImageRel,
+        AzureFunctionAppToGCPArtifactRegistryImageRel,
+        AzureFunctionAppToGitHubContainerImageRel,
     }
 )


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Formalizes the canonical supply-chain ontology edges in `ONTOLOGY_REL_CONSTRAINTS` so that `test_ontology_rel_constraints` enforces their label and direction across providers (ECR/GCR/GitLab/GitHub/Scaleway):

- `(:Container|:Function)-[:RESOLVED_IMAGE]->(:Image)`
- `(:Image)-[:PACKAGED_FROM]->(:CodeRepository)`
- `(:Package)-[:DEPLOYED]->(:Image)`

All three edges are already materialized today (`RESOLVED_IMAGE` via `resolved_image_analysis.json`, the others at ingest time), so this change is pure governance/enforcement and adds no new data.

It also whitelists the raw `HAS_IMAGE (:Container|:Function)->(:Image)` references as a semantic distinct from the derived `RESOLVED_IMAGE` edge (`HAS_IMAGE` is the ingest-time runtime-digest reference, possibly to a manifest list; `RESOLVED_IMAGE` is the analysis-resolved concrete single-platform image).

No `UserAccount -> CodeRepository` constraint is added: several distinct edges legitimately span that node pair (commit authorship, repository ownership, collaborator access grants), so a single canonical label cannot be enforced there yet. A code comment records this deliberate gap.


### Related issues or links

- Canonical relationship scheme from cartography discussion #2772.


### How was this tested?

- `uv run --frozen pytest tests/unit/cartography/graph/test_ontology_rel_constraints.py` passes.
- `make test_lint` passes locally.


### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests (the existing `test_ontology_rel_constraints` now enforces the new constraints).


### Notes for reviewers

The constraints are declarative governance backed by the existing `test_ontology_rel_constraints` guard; no ingestion or query behavior changes. Out of scope for this PR: `STORED_IN` (image->registry is already reachable through the `ImageTag` join node, so a materialized edge added no traversal value), `CONTAINS` (superseded by the existing `DEPLOYED` edge), `MAINTAINED_BY`, and `Function -> CodeRepository` (no provenance data source today).