### PR TITLE
docs(agents): add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,3 +258,13 @@ fixtures, and `check_nodes()` / `check_rels()` helpers, see `tests/AGENTS.md`.
 ---
 
 Remember: Start simple, iterate, and use existing modules as references. The Cartography community is here to help!
+
+## Cursor Cloud specific instructions
+
+Environment: Python project managed with `uv` (Python 3.13 per `.python-version`). Dependencies are refreshed automatically on startup by the update script (`uv sync --frozen --all-extras --dev`); `uv` is on `PATH` via `~/.profile`.
+
+- **Docker is not managed by systemd** in this VM. It is installed but the daemon does not auto-start. Start it manually once per session (e.g. `sudo dockerd > /tmp/dockerd.log 2>&1 &`, then `sudo chmod 666 /var/run/docker.sock`). Docker uses the `fuse-overlayfs` storage driver. Docker is only needed for Neo4j and integration tests.
+- **Neo4j** is the only backing datastore. Start it with `docker compose up -d neo4j` and wait for the container healthcheck (`docker inspect --format '{{.State.Health.Status}}' workspace-neo4j-1`). Bolt is at `bolt://localhost:7687`, browser at `http://localhost:7474`, auth is disabled (`NEO4J_AUTH=none`).
+- **Tests / lint / build** are defined in the `Makefile` and `docs/root/dev/developer-guide.md`: `make test_lint`, `make test_unit`, `make test_integration`, `make test`. Lint uses `pre-commit` (first run downloads hook envs).
+- **Integration tests DELETE ALL NODES** in their target DB. By default they spin up a disposable Neo4j testcontainer (Docker required) — leave `NEO4J_URL` unset to use it. Only set `NEO4J_URL` to point at a database you are OK clearing.
+- **Running the app**: `uv run cartography --neo4j-uri bolt://localhost:7687`. Most intel modules require provider credentials and are skipped if unconfigured; `--selected-modules create-indexes` runs a real sync stage against Neo4j without any credentials.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Type of change
- [x] Documentation update

### Summary
Sets up and documents the Cursor Cloud development environment for Cartography. Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing the non-obvious startup caveats discovered while bringing the environment up (Docker is not systemd-managed and must be started manually, Neo4j startup via docker-compose, integration tests delete all nodes / use disposable testcontainers, and how to run the CLI without provider credentials).

No application code is changed.

### Related issues or links
N/A

### How was this tested?
Full dev environment was set up and exercised end-to-end:

- `uv sync --frozen --all-extras --dev` (Python 3.13.14)
- `make test_lint` — all pre-commit hooks pass
- `make test_unit` — 2928 passed
- `make test_integration` — 1088 passed (Neo4j testcontainer)
- Ran the real CLI: `uv run cartography --neo4j-uri bolt://localhost:7687 --selected-modules create-indexes`
- Hello-world ingestion: loaded `LastpassUser`/`LastpassTenant` data via the core `load()` API and queried it back from Neo4j.

Verification log:
[cartography_env_verification.log](https://cursor.com/agents/bc-342b25b6-7c14-42e4-9202-6dedf4793cb7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcartography_env_verification.log)

### Checklist

#### General
- [x] The linter passes locally (`make test_lint`).

#### Proof of functionality
- [x] Sync logs / query output demonstrating data loaded into the graph (see verification log).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-342b25b6-7c14-42e4-9202-6dedf4793cb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-342b25b6-7c14-42e4-9202-6dedf4793cb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

