### PR TITLE
docs(databricks): split combined account-config schema section

### DIFF
--- a/docs/root/modules/databricks/schema.md
+++ b/docs/root/modules/databricks/schema.md
@@ -1561,21 +1561,199 @@ An account federation policy (account-wide or scoped to a service principal).
 (:DatabricksFederationPolicy)-[:OWNED_BY]->(:DatabricksAccountServicePrincipal)
 ```
 
-### DatabricksCredentialConfig / DatabricksStorageConfig / DatabricksNetworkConfig / DatabricksPrivateAccessSettings / DatabricksVpcEndpoint / DatabricksEncryptionKey / DatabricksNetworkConnectivityConfig / DatabricksLogDelivery / DatabricksBudget / DatabricksAccountSetting
+### DatabricksCredentialConfig
 
-Account-level workspace cloud configurations (AWS / GCP). Each is owned by the `DatabricksAccount` and, where the matching cloud node is already in the graph, links to it:
+An account-level cross-account IAM credential configuration (AWS). Owned by the `DatabricksAccount` and, where the matching cloud node is already in the graph, linked to it.
 
+| Field | Description |
+|-------|-------------|
+| id | `{account_id}/{credentials_id}` |
+| credentials_id | Databricks credential configuration id |
+| credentials_name | Credential configuration name |
+| aws_role_arn | ARN of the cross-account IAM role |
+| aws_account_id | AWS account id the role lives in |
+| created_time | Creation timestamp |
+| lastupdated | Timestamp of the last sync |
+
+#### Relationships
 ```
-(:DatabricksAccount)-[:RESOURCE]->(:DatabricksCredentialConfig)-[:ASSUMES_ROLE]->(:AWSPrincipal)
+(:DatabricksAccount)-[:RESOURCE]->(:DatabricksCredentialConfig)
+(:DatabricksCredentialConfig)-[:ASSUMES_ROLE]->(:AWSPrincipal)
 (:DatabricksCredentialConfig)-[:IN_ACCOUNT]->(:AWSAccount)
+```
+
+### DatabricksStorageConfig
+
+An account-level workspace root storage configuration (AWS S3). Owned by the `DatabricksAccount` and, where the matching cloud node is already in the graph, linked to it.
+
+| Field | Description |
+|-------|-------------|
+| id | `{account_id}/{storage_configuration_id}` |
+| storage_configuration_id | Databricks storage configuration id |
+| storage_configuration_name | Storage configuration name |
+| root_bucket_name | Name of the workspace root S3 bucket |
+| created_time | Creation timestamp |
+| lastupdated | Timestamp of the last sync |
+
+#### Relationships
+```
+(:DatabricksAccount)-[:RESOURCE]->(:DatabricksStorageConfig)
 (:DatabricksStorageConfig)-[:BACKED_BY]->(:S3Bucket)
+```
+
+### DatabricksNetworkConfig
+
+An account-level customer-managed VPC network configuration. Owned by the `DatabricksAccount` and, where the matching cloud nodes are already in the graph, linked to them.
+
+| Field | Description |
+|-------|-------------|
+| id | `{account_id}/{network_id}` |
+| network_id | Databricks network configuration id |
+| network_name | Network configuration name |
+| vpc_id | AWS VPC id |
+| subnet_ids | List of AWS subnet ids |
+| security_group_ids | List of AWS security group ids |
+| vpc_status | VPC validation status |
+| lastupdated | Timestamp of the last sync |
+
+#### Relationships
+```
+(:DatabricksAccount)-[:RESOURCE]->(:DatabricksNetworkConfig)
 (:DatabricksNetworkConfig)-[:USES_VPC]->(:AWSVpc)
 (:DatabricksNetworkConfig)-[:USES_SUBNET]->(:EC2Subnet)
 (:DatabricksNetworkConfig)-[:USES_SECURITY_GROUP]->(:EC2SecurityGroup)
+```
+
+### DatabricksPrivateAccessSettings
+
+An account-level private access (PrivateLink) settings object. Owned by the `DatabricksAccount`.
+
+| Field | Description |
+|-------|-------------|
+| id | `{account_id}/{private_access_settings_id}` |
+| private_access_settings_id | Databricks private access settings id |
+| private_access_settings_name | Private access settings name |
+| public_access_enabled | Whether public access is enabled |
+| private_access_level | Private access level |
+| region | AWS region |
+| lastupdated | Timestamp of the last sync |
+
+#### Relationships
+```
+(:DatabricksAccount)-[:RESOURCE]->(:DatabricksPrivateAccessSettings)
+```
+
+### DatabricksVpcEndpoint
+
+An account-level registered VPC endpoint. Owned by the `DatabricksAccount` and, where the matching cloud node is already in the graph, linked to it.
+
+| Field | Description |
+|-------|-------------|
+| id | `{account_id}/{vpc_endpoint_id}` |
+| vpc_endpoint_id | Databricks VPC endpoint id |
+| vpc_endpoint_name | VPC endpoint name |
+| aws_endpoint_service_id | AWS endpoint service id |
+| region | AWS region |
+| aws_vpc_endpoint_id | AWS VPC endpoint id |
+| lastupdated | Timestamp of the last sync |
+
+#### Relationships
+```
+(:DatabricksAccount)-[:RESOURCE]->(:DatabricksVpcEndpoint)
 (:DatabricksVpcEndpoint)-[:POINTS_TO]->(:AWSVpcEndpoint)
+```
+
+### DatabricksEncryptionKey
+
+An account-level customer-managed encryption key (AWS KMS / GCP KMS). Owned by the `DatabricksAccount` and, where the matching cloud key is already in the graph, linked to it.
+
+| Field | Description |
+|-------|-------------|
+| id | `{account_id}/{customer_managed_key_id}` |
+| customer_managed_key_id | Databricks customer-managed key id |
+| use_cases | List of use cases the key applies to |
+| aws_key_arn | ARN of the AWS KMS key |
+| aws_key_alias | Alias of the AWS KMS key |
+| gcp_kms_key_name | Full GCP KMS key resource name |
+| lastupdated | Timestamp of the last sync |
+
+#### Relationships
+```
+(:DatabricksAccount)-[:RESOURCE]->(:DatabricksEncryptionKey)
 (:DatabricksEncryptionKey)-[:REFERENCES_KEY]->(:KMSKey)
 (:DatabricksEncryptionKey)-[:REFERENCES_KEY]->(:GCPCryptoKey)
+```
+
+### DatabricksNetworkConnectivityConfig
+
+An account-level serverless egress network connectivity configuration. Owned by the `DatabricksAccount`.
+
+| Field | Description |
+|-------|-------------|
+| id | `{account_id}/{network_connectivity_config_id}` |
+| network_connectivity_config_id | Databricks network connectivity configuration id |
+| name | Network connectivity configuration name |
+| region | AWS region |
+| default_rules_target_regions | Target regions of the default egress rules |
+| lastupdated | Timestamp of the last sync |
+
+#### Relationships
+```
+(:DatabricksAccount)-[:RESOURCE]->(:DatabricksNetworkConnectivityConfig)
+```
+
+### DatabricksLogDelivery
+
+An account-level log delivery configuration (billable usage / audit logs to S3). Owned by the `DatabricksAccount` and, where the matching bucket is already in the graph, linked to it.
+
+| Field | Description |
+|-------|-------------|
+| id | `{account_id}/{config_id}` |
+| config_id | Databricks log delivery configuration id |
+| config_name | Log delivery configuration name |
+| log_type | Log type (e.g. billable usage or audit) |
+| output_format | Delivered log output format |
+| status | Configuration status |
+| s3_bucket_name | Destination S3 bucket name |
+| delivery_path_prefix | Delivery path prefix within the bucket |
+| lastupdated | Timestamp of the last sync |
+
+#### Relationships
+```
+(:DatabricksAccount)-[:RESOURCE]->(:DatabricksLogDelivery)
 (:DatabricksLogDelivery)-[:DELIVERS_TO]->(:S3Bucket)
+```
+
+### DatabricksBudget
+
+An account-level budget configuration. Owned by the `DatabricksAccount`.
+
+| Field | Description |
+|-------|-------------|
+| id | `{account_id}/{budget_configuration_id}` |
+| budget_configuration_id | Databricks budget configuration id |
+| display_name | Budget display name |
+| lastupdated | Timestamp of the last sync |
+
+#### Relationships
+```
+(:DatabricksAccount)-[:RESOURCE]->(:DatabricksBudget)
+```
+
+### DatabricksAccountSetting
+
+An account-level setting key/value (e.g. security and workspace defaults). Owned by the `DatabricksAccount`.
+
+| Field | Description |
+|-------|-------------|
+| id | `{account_id}/{setting_name}` |
+| setting_name | Setting name |
+| value | Setting value |
+| lastupdated | Timestamp of the last sync |
+
+#### Relationships
+```
+(:DatabricksAccount)-[:RESOURCE]->(:DatabricksAccountSetting)
 ```
 
 ### DatabricksAclObject


### PR DESCRIPTION
### Type of change
- [x] Documentation update

### Summary

The Databricks schema page had a single section heading that concatenated 10 node types:

`### DatabricksCredentialConfig / DatabricksStorageConfig / DatabricksNetworkConfig / DatabricksPrivateAccessSettings / DatabricksVpcEndpoint / DatabricksEncryptionKey / DatabricksNetworkConnectivityConfig / DatabricksLogDelivery / DatabricksBudget / DatabricksAccountSetting`

This was the only slash-combined `###` heading anywhere under `docs/root/modules/`. It carried one shared description and one merged relationship block, skipping the per-node field tables and per-node `#### Relationships` blocks that every other node in the file (and in other modules) gets. It also hid content: four of the ten nodes named in the heading (`DatabricksPrivateAccessSettings`, `DatabricksNetworkConnectivityConfig`, `DatabricksBudget`, `DatabricksAccountSetting`) never appeared in the merged relationship block, so their `(:DatabricksAccount)-[:RESOURCE]->` edge was undocumented.

This PR splits it into 10 conventional per-node sections, each with its own heading, one-line description, `| Field | Description |` table, and `#### Relationships` block. Field lists and relationships are sourced from the models in `cartography/models/databricks/`; account-scoped ids follow the existing `{account_id}/{...}` convention.

### Related issues or links

N/A (reported via docs feedback)

### How was this tested?

- `uv run --frozen pre-commit run --files docs/root/modules/databricks/schema.md` passes.
- `pytest tests/unit/cartography/test_doc.py` passes.
- Verified no slash-combined heading remains and all 10 node names now have their own `###` heading.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works. (Documentation-only change; no code paths affected.)

#### If you are changing a node or relationship
- [x] Updated the schema documentation.

### Notes for reviewers

Documentation-only change. No code, tests, or fixtures are modified. Content is derived directly from the existing account-config models; no schema behavior changes.