### PR TITLE
fix(databricks): retry transient API failures

### DIFF
--- a/cartography/intel/databricks/util.py
+++ b/cartography/intel/databricks/util.py
@@ -7,6 +7,8 @@ from typing import Any
 import neo4j
 import requests
 from dateutil import parser as dateutil_parser
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +96,7 @@ def skip_or_raise_http(error: requests.HTTPError, *skippable_statuses: int) -> N
 # Connect and read timeouts of 60 seconds each.
 _TIMEOUT = (60, 60)
 _SCIM_PAGE_SIZE = 100
+_RETRYABLE_STATUS_CODES = (429, 500, 502, 503, 504)
 
 
 def scoped_id(workspace_id: str, scim_id: str) -> str:
@@ -136,6 +139,14 @@ class _BaseDatabricksClient:
         self._client_secret = client_secret
         self._access_token_expiry: float | None = None
         self._session = requests.Session()
+        retry_policy = Retry(
+            total=5,
+            backoff_factor=1,
+            status_forcelist=_RETRYABLE_STATUS_CODES,
+            allowed_methods=frozenset({"GET"}),
+            respect_retry_after_header=True,
+        )
+        self._session.mount("https://", HTTPAdapter(max_retries=retry_policy))
 
     def _token_url(self) -> str:
         raise NotImplementedError

--- a/cartography/intel/databricks/util.py
+++ b/cartography/intel/databricks/util.py
@@ -143,7 +143,7 @@ class _BaseDatabricksClient:
             total=5,
             backoff_factor=1,
             status_forcelist=_RETRYABLE_STATUS_CODES,
-            allowed_methods=frozenset({"GET"}),
+            allowed_methods=frozenset({"GET", "POST"}),
             respect_retry_after_header=True,
         )
         self._session.mount("https://", HTTPAdapter(max_retries=retry_policy))

--- a/tests/unit/cartography/intel/databricks/test_util.py
+++ b/tests/unit/cartography/intel/databricks/test_util.py
@@ -1,11 +1,36 @@
 from datetime import timezone
+from http.server import BaseHTTPRequestHandler
+from http.server import ThreadingHTTPServer
+from threading import Thread
 
 from cartography.intel.databricks.util import DatabricksWorkspaceClient
 from cartography.intel.databricks.util import iso_to_datetime
 from cartography.intel.databricks.util import parse_storage_url
 
 
-def test_client_retries_transient_get_failures():
+class _RateLimitThenSuccessHandler(BaseHTTPRequestHandler):
+    attempts = 0
+
+    def do_GET(self) -> None:
+        type(self).attempts += 1
+        if self.attempts == 1:
+            self.send_response(429)
+            self.send_header("Retry-After", "1")
+            self.end_headers()
+            return
+
+        body = b'{"ok": true}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+def test_client_configures_transient_retries():
     # Arrange
     client = DatabricksWorkspaceClient(
         "https://example.cloud.databricks.com",
@@ -19,8 +44,35 @@ def test_client_retries_transient_get_failures():
     assert retry_policy.total == 5
     assert retry_policy.backoff_factor == 1
     assert retry_policy.status_forcelist == (429, 500, 502, 503, 504)
-    assert retry_policy.allowed_methods == frozenset({"GET"})
+    assert retry_policy.allowed_methods == frozenset({"GET", "POST"})
     assert retry_policy.respect_retry_after_header is True
+
+
+def test_client_retries_rate_limited_get_and_honors_retry_after(mocker):
+    # Arrange
+    _RateLimitThenSuccessHandler.attempts = 0
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _RateLimitThenSuccessHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    client = DatabricksWorkspaceClient(
+        f"http://127.0.0.1:{server.server_port}",
+        token="test-token",
+    )
+    client._session.mount("http://", client._session.adapters["https://"])
+    sleep = mocker.patch("urllib3.util.retry.time.sleep")
+
+    try:
+        # Act
+        result = client.get("/test")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+    # Assert
+    assert result == {"ok": True}
+    assert _RateLimitThenSuccessHandler.attempts == 2
+    sleep.assert_called_once_with(1)
 
 
 def test_iso_to_datetime():

--- a/tests/unit/cartography/intel/databricks/test_util.py
+++ b/tests/unit/cartography/intel/databricks/test_util.py
@@ -1,7 +1,26 @@
 from datetime import timezone
 
+from cartography.intel.databricks.util import DatabricksWorkspaceClient
 from cartography.intel.databricks.util import iso_to_datetime
 from cartography.intel.databricks.util import parse_storage_url
+
+
+def test_client_retries_transient_get_failures():
+    # Arrange
+    client = DatabricksWorkspaceClient(
+        "https://example.cloud.databricks.com",
+        token="test-token",
+    )
+
+    # Act
+    retry_policy = client._session.adapters["https://"].max_retries
+
+    # Assert
+    assert retry_policy.total == 5
+    assert retry_policy.backoff_factor == 1
+    assert retry_policy.status_forcelist == (429, 500, 502, 503, 504)
+    assert retry_policy.allowed_methods == frozenset({"GET"})
+    assert retry_policy.respect_retry_after_header is True
 
 
 def test_iso_to_datetime():


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary

Databricks enforces per-endpoint, per-workspace REST API rate limits and returns HTTP 429 when a client exceeds them. The shared Cartography Databricks client previously attempted each request only once, so a transient rate-limit response aborted the full sync.

Configure bounded retries for idempotent GET requests and OAuth client credentials token requests in the shared workspace/account client. The policy uses exponential backoff for 429 and transient 5xx responses, honors Retry-After when Databricks supplies it, and still propagates failures after retry exhaustion so partial ingestions cannot trigger unsafe cleanup.

### Related issues or links

- [Databricks REST API rate limits](https://docs.databricks.com/api/gcp/workspace/introduction#rate-limits)
- [Databricks SDK retry behavior](https://github.com/databricks/databricks-sdk-py#retries)

### How was this tested?

- Added a unit test that performs a real 429 then 200 request sequence and verifies the retry count and Retry-After sleep.
- Added policy assertions covering the retry budget, backoff, status codes, and allowed methods.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (make test_lint).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the schema documentation.
- [ ] Updated the schema README.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema data model.

### Notes for reviewers

This changes shared Databricks HTTP transport behavior only; it does not change any synced entity, graph schema, or cleanup contract.