### PR TITLE
fix(gcp): route Cloud Asset Inventory calls through the standard retry wrapper

### DIFF
--- a/cartography/intel/gcp/cai.py
+++ b/cartography/intel/gcp/cai.py
@@ -9,14 +9,13 @@ from googleapiclient.discovery import Resource
 
 from cartography.client.core.tx import load
 from cartography.intel.gcp.util import determine_role_type_and_scope
+from cartography.intel.gcp.util import gcp_api_execute_with_retry
 from cartography.models.gcp.iam import GCPProjectRoleSchema
 from cartography.models.gcp.iam import GCPServiceAccountSchema
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
-# Maximum number of retries for Google API requests (handles transient errors and rate limiting)
-GOOGLE_API_NUM_RETRIES = 5
 # Delay between CAI API calls to avoid hitting rate limits (100 requests/min per project)
 CAI_CALL_DELAY_SECONDS = 1
 
@@ -39,7 +38,7 @@ def get_gcp_service_accounts_cai(
         contentType="RESOURCE",  # Request full resource data, not just metadata
     )
     while request is not None:
-        response = request.execute(num_retries=GOOGLE_API_NUM_RETRIES)
+        response = gcp_api_execute_with_retry(request)
         if "assets" in response:
             # Extract the actual service account data from CAI response
             for asset in response["assets"]:
@@ -76,7 +75,7 @@ def get_gcp_roles_cai(cai_client: Resource, project_id: str) -> List[Dict]:
         contentType="RESOURCE",  # Request full resource data, not just metadata
     )
     while custom_request is not None:
-        resp = custom_request.execute(num_retries=GOOGLE_API_NUM_RETRIES)
+        resp = gcp_api_execute_with_retry(custom_request)
         if "assets" in resp:
             for asset in resp["assets"]:
                 if "resource" in asset and "data" in asset["resource"]:

--- a/tests/unit/cartography/intel/gcp/test_cai_http_errors.py
+++ b/tests/unit/cartography/intel/gcp/test_cai_http_errors.py
@@ -1,0 +1,58 @@
+import json
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from googleapiclient.errors import HttpError
+
+from cartography.intel.gcp.cai import get_gcp_roles_cai
+from cartography.intel.gcp.cai import get_gcp_service_accounts_cai
+
+
+def _http_error(status: int) -> HttpError:
+    resp = MagicMock()
+    resp.status = status
+    content = json.dumps({"error": {"code": status}}).encode("utf-8")
+    return HttpError(resp=resp, content=content)
+
+
+CAI_GETTERS = [
+    (get_gcp_service_accounts_cai, ("test-project",)),
+    (get_gcp_roles_cai, ("test-project",)),
+]
+
+
+@pytest.mark.parametrize("func,args", CAI_GETTERS)
+@patch("time.sleep", return_value=None)
+def test_cai_getter_retries_transient_http_error(mock_sleep, func, args):
+    # A retryable 5xx on the first execute must be retried (matching every other
+    # GCP module, which routes list calls through gcp_api_execute_with_retry)
+    # rather than aborting the sync.
+    cai_client = MagicMock()
+    request = MagicMock()
+    request.execute.side_effect = [
+        _http_error(503),
+        {"assets": [{"resource": {"data": {"id": "asset-1"}}}]},
+    ]
+    cai_client.assets.return_value.list.return_value = request
+    cai_client.assets.return_value.list_next.return_value = None
+
+    result = func(cai_client, *args)
+
+    assert result == [{"id": "asset-1"}]
+    assert request.execute.call_count == 2  # retried once after the 503
+
+
+@pytest.mark.parametrize("func,args", CAI_GETTERS)
+@patch("time.sleep", return_value=None)
+def test_cai_getter_does_not_retry_non_retryable_error(mock_sleep, func, args):
+    # A non-retryable error (e.g. 404) must propagate immediately, not be retried.
+    cai_client = MagicMock()
+    request = MagicMock()
+    request.execute.side_effect = _http_error(404)
+    cai_client.assets.return_value.list.return_value = request
+    cai_client.assets.return_value.list_next.return_value = None
+
+    with pytest.raises(HttpError):
+        func(cai_client, *args)
+    assert request.execute.call_count == 1


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary

The `cai` (Cloud Asset Inventory) module was the only GCP intel module still calling `request.execute(num_retries=...)` directly instead of the shared `gcp_api_execute_with_retry()` helper that the other 26 GCP modules use.

Because of that, its Asset Inventory list calls missed the standard retryable-error handling every other GCP module gets:
- exponential backoff on HTTP 5xx / 429,
- retry of the legacy `403 rateLimitExceeded` / `userRateLimitExceeded` responses that older GCP APIs return, classified via `is_retryable_gcp_http_error`,
- the common give-up / backoff logging.

Asset Inventory is rate-limit-prone (100 requests/min per project), so a transient error there aborted the whole sync instead of backing off and retrying.

This routes both `cai` getters through `gcp_api_execute_with_retry` (which still applies `num_retries=GCP_API_NUM_RETRIES` internally, unchanged) and drops the now-unused local `GOOGLE_API_NUM_RETRIES` constant. No behavior change on the success path.

### Related issues or links

None — found while auditing retry handling across the GCP modules; `cai` was the sole holdout.

### How was this tested?

Added `tests/unit/cartography/intel/gcp/test_cai_http_errors.py` (mirroring the other `*_http_errors.py` suites): asserts that a transient `503` on the first call is retried and the getter still returns its data, and that a non-retryable `404` propagates without retrying. The retry tests fail before this change (the `503` aborts the call) and pass after. Full `tests/unit/cartography/intel/gcp/` suite passes (327 passed). `black`, `isort`, `flake8`, `pyupgrade --py36-plus`, and `mypy` are clean on both changed files.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally.
- [x] I have added/updated tests that prove my fix is effective.

#### Proof of functionality
- [x] New or updated unit/integration tests.