### PR TITLE
fix(databricks): handle online table lookup misses

### DIFF
--- a/cartography/intel/databricks/online_tables.py
+++ b/cartography/intel/databricks/online_tables.py
@@ -64,10 +64,10 @@ def get(
         try:
             ot = api_session.get(f"/api/2.0/online-tables/{full_name}")
         except requests.HTTPError as e:
-            # 404 = the table has no online-table twin, which is the common
-            # case. Any other error (auth, rate-limit, 5xx) must abort so
-            # cleanup does not run on partial data.
-            skip_or_raise_http(e, 404)
+            # Databricks returns either 400 or 404 when a managed table has no
+            # online-table twin. Other errors must abort so cleanup does not
+            # run on partial data.
+            skip_or_raise_http(e, 400, 404)
             continue
         if ot.get("name"):
             ot["_metastore_id"] = c.get("metastore_id")

--- a/tests/unit/cartography/intel/databricks/test_online_tables.py
+++ b/tests/unit/cartography/intel/databricks/test_online_tables.py
@@ -1,0 +1,50 @@
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from cartography.intel.databricks.online_tables import get
+
+
+def _http_error(status_code: int) -> requests.HTTPError:
+    response = requests.Response()
+    response.status_code = status_code
+    return requests.HTTPError(response=response)
+
+
+@pytest.mark.parametrize("status_code", [400, 404])
+def test_get_skips_tables_without_online_table_twin(status_code):
+    # Arrange
+    api_session = Mock()
+    api_session.get.side_effect = _http_error(status_code)
+    candidates = [
+        {
+            "full_name": "catalog.schema.regular_table",
+            "metastore_id": "metastore-id",
+        },
+    ]
+
+    # Act
+    result = get(api_session, candidates)
+
+    # Assert
+    assert result == []
+
+
+@pytest.mark.parametrize("status_code", [401, 403, 429, 500])
+def test_get_raises_unexpected_http_errors(status_code):
+    # Arrange
+    api_session = Mock()
+    error = _http_error(status_code)
+    api_session.get.side_effect = error
+    candidates = [
+        {
+            "full_name": "catalog.schema.regular_table",
+            "metastore_id": "metastore-id",
+        },
+    ]
+
+    # Act and assert
+    with pytest.raises(requests.HTTPError) as exc_info:
+        get(api_session, candidates)
+    assert exc_info.value is error


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

### Summary

The Online Tables API provides get-by-name but no list operation, so Cartography probes managed Unity Catalog tables for an online-table twin. Databricks can return either HTTP 400 or 404 for a negative lookup. Treat both responses as an expected miss while continuing to abort on authentication, permission, throttling, and server errors so partial ingestion cannot trigger cleanup.

### Related issues or links

None.

### How was this tested?

- `uv run pytest -q tests/unit/cartography/intel/databricks` (10 passed)
- `make test_lint`
- Added unit coverage for expected 400/404 misses and unexpected 401/403/429/500 failures.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the schema documentation.
- [ ] Updated the schema README.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema data model.

### Notes for reviewers

This changes error handling only; it does not change any synced entity, node, relationship, or cleanup contract. Private runtime evidence is intentionally not attached because the focused unit tests reproduce the provider response without environment-derived data.