### PR TITLE
fix(databricks): tolerate 400 when probing online-table twins

### DIFF
--- a/cartography/intel/databricks/online_tables.py
+++ b/cartography/intel/databricks/online_tables.py
@@ -65,9 +65,10 @@ def get(
             ot = api_session.get(f"/api/2.0/online-tables/{full_name}")
         except requests.HTTPError as e:
             # 404 = the table has no online-table twin, which is the common
-            # case. Any other error (auth, rate-limit, 5xx) must abort so
-            # cleanup does not run on partial data.
-            skip_or_raise_http(e, 404)
+            # case. 400 = the securable is not online-table-eligible (e.g. the
+            # Databricks-provided `samples` catalog). Any other error (auth,
+            # rate-limit, 5xx) must abort so cleanup does not run on partial data.
+            skip_or_raise_http(e, 400, 404)
             continue
         if ot.get("name"):
             ot["_metastore_id"] = c.get("metastore_id")


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary

The Databricks online-tables sync probes every managed Unity Catalog table for an online-table twin via `GET /api/2.0/online-tables/{full_name}` (the API has no list endpoint, only get-by-name). For most managed tables there is no twin and the API returns `404`, which the code already tolerated.

Tables in the Databricks-provided `samples` catalog (e.g. `samples.tpch.partsupp`) instead return `400 Bad Request`: the online-tables feature is not applicable to that securable. The handler in `online_tables.py` only skipped `404`, so a single non-eligible table re-raised and aborted the entire Databricks sync:

```
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url:
https://.../api/2.0/online-tables/samples.tpch.partsupp
```

`400` here is semantically identical to `404` ("this table cannot have an online-table twin, move on"), so it is now added to the skippable statuses. This matches the existing pattern already used in this module (`dashboards.py`, `clean_rooms.py`). Genuine failures (auth, rate-limit, 5xx) still abort so cleanup never runs on partial data.

### How was this tested?

- `make test_lint` equivalents pass locally (flake8, black, isort).
- The existing integration test `tests/integration/cartography/intel/databricks/test_online_tables.py` mocks `online_tables.get` wholesale and continues to pass; the change only widens the tolerated status list in the HTTP error path.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

_No new test: the existing test mocks `get` wholesale, and prior 400-tolerance fixes in this module (dashboards, clean_rooms) shipped without new unit tests for the same one-line status-list widening._