### PR TITLE
fix(aws): skip SES sync in regions where SES v2 is unavailable

### DIFF
--- a/cartography/intel/aws/ses.py
+++ b/cartography/intel/aws/ses.py
@@ -13,6 +13,9 @@ from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.intel.aws.util.botocore_config import get_botocore_config
+from cartography.intel.aws.util.service_regions import (
+    filter_regions_to_supported_service_regions,
+)
 from cartography.models.aws.ses import SESEmailIdentitySchema
 from cartography.util import aws_handle_regions
 from cartography.util import timeit
@@ -156,7 +159,18 @@ def sync(
     update_tag: int,
     common_job_parameters: Dict[str, Any],
 ) -> None:
-    for region in regions:
+    ses_regions, unsupported_regions = filter_regions_to_supported_service_regions(
+        boto3_session,
+        "sesv2",
+        regions,
+    )
+    for region in unsupported_regions:
+        logger.info(
+            "Skipping SES sync for unsupported region '%s'.",
+            region,
+        )
+
+    for region in ses_regions:
         logger.info(
             "Syncing SES for region '%s' in account '%s'.",
             region,

--- a/tests/unit/cartography/intel/aws/test_ses.py
+++ b/tests/unit/cartography/intel/aws/test_ses.py
@@ -90,10 +90,11 @@ def test_ses_sync_skips_regions_where_sesv2_is_unsupported(mocker) -> None:
     )
     cleanup = mocker.patch("cartography.intel.aws.ses.cleanup")
 
+    # eu-south-2 (Spain) has no SES endpoint, so it must be skipped.
     ses.sync(
         neo4j_session=MagicMock(),
         boto3_session=boto3_session,
-        regions=["us-east-1", "me-south-1"],
+        regions=["us-east-1", "eu-south-2"],
         current_aws_account_id="123456789012",
         update_tag=1,
         common_job_parameters={"UPDATE_TAG": 1, "AWS_ID": "123456789012"},

--- a/tests/unit/cartography/intel/aws/test_ses.py
+++ b/tests/unit/cartography/intel/aws/test_ses.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 import botocore.exceptions
 
+from cartography.intel.aws import ses
 from cartography.intel.aws.ses import get_ses_email_identities
 
 
@@ -73,3 +74,36 @@ def test_get_ses_email_identities_falls_back_when_not_pageable() -> None:
             "DkimStatus": "PENDING",
         },
     ]
+
+
+def test_ses_sync_skips_regions_where_sesv2_is_unsupported(mocker) -> None:
+    boto3_session = MagicMock()
+    boto3_session.get_partition_for_region.return_value = "aws"
+    boto3_session.get_available_regions.return_value = ["us-east-1"]
+
+    get_identities = mocker.patch(
+        "cartography.intel.aws.ses.get_ses_email_identities",
+        return_value=[],
+    )
+    load_identities = mocker.patch(
+        "cartography.intel.aws.ses.load_ses_email_identities",
+    )
+    cleanup = mocker.patch("cartography.intel.aws.ses.cleanup")
+
+    ses.sync(
+        neo4j_session=MagicMock(),
+        boto3_session=boto3_session,
+        regions=["us-east-1", "me-south-1"],
+        current_aws_account_id="123456789012",
+        update_tag=1,
+        common_job_parameters={"UPDATE_TAG": 1, "AWS_ID": "123456789012"},
+    )
+
+    boto3_session.get_available_regions.assert_called_once_with(
+        "sesv2",
+        partition_name="aws",
+    )
+    called_regions = [call.args[1] for call in get_identities.call_args_list]
+    assert called_regions == ["us-east-1"]
+    assert load_identities.call_count == 1
+    cleanup.assert_called_once()


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
In regions where the SES v2 API is not offered, `sesv2:ListEmailIdentities` raises `UnknownOperationException` with a **null/empty** error message. `get_ses_email_identities` is decorated with `@aws_handle_regions`, which should degrade regional-unavailability errors to an empty-list skip. But the shared classifier only treats `UnknownOperationException` as skippable when the message matches a known snippet; with a null message it is re-raised, and the **entire account sync fails**. In a multi-account / org-wide sync this is deterministic: the same accounts fail at the SES step on every run.

This PR opts SES out of unsupported regions using the existing `filter_regions_to_supported_service_regions` utility (the same pattern already used by `codebuild`, `bedrock`, and `sagemaker`). `ses.sync()` now filters the discovered region list against `sesv2`'s known endpoints via `boto3_session.get_available_regions("sesv2", ...)` before iterating, so the doomed call is never made in regions without SES v2. This fixes the issue at the SES layer rather than weakening the generic `aws_handle_regions` classifier for all services.

### Related issues or links

- N/A

### How was this tested?
- `uv run pytest tests/unit/cartography/intel/aws/test_ses.py -q` → passing, including a new test (`test_ses_sync_skips_regions_where_sesv2_is_unsupported`) that stubs `get_available_regions` to a subset and asserts unsupported regions are skipped while cleanup still runs.
- `uv run --frozen pre-commit run --files ...` (isort, black, flake8, mypy, pyupgrade) → all passing.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

### Notes for reviewers
The boto3 service name passed to the filter is `"sesv2"`, matching the string used in `create_boto3_client`. No node/relationship schema changes; behavior change is limited to which regions SES iterates over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
