### PR TITLE
docs: add CircleCI, Databricks, Salesforce to module menu

### DIFF
--- a/docs/root/index.md
+++ b/docs/root/index.md
@@ -21,10 +21,12 @@ modules/anthropic/index
 modules/aws/index
 modules/azure/index
 modules/bigfix/index
+modules/circleci/index
 modules/cloudflare/index
 modules/crowdstrike/index
 modules/cve/index
 modules/cve_metadata/index
+modules/databricks/index
 modules/digitalocean/index
 modules/docker_scout/index
 modules/duo/index
@@ -45,6 +47,7 @@ modules/okta/index
 modules/ontology/index
 modules/openai/index
 modules/pagerduty/index
+modules/salesforce/index
 modules/scaleway/index
 modules/semgrep/index
 modules/sentinelone/index

--- a/docs/root/module-list.md
+++ b/docs/root/module-list.md
@@ -7,10 +7,12 @@ modules/anthropic/index
 modules/aws/index
 modules/azure/index
 modules/bigfix/index
+modules/circleci/index
 modules/cloudflare/index
 modules/crowdstrike/index
 modules/cve/index
 modules/cve_metadata/index
+modules/databricks/index
 modules/digitalocean/index
 modules/docker_scout/index
 modules/duo/index
@@ -31,6 +33,7 @@ modules/okta/index
 modules/ontology/index
 modules/openai/index
 modules/pagerduty/index
+modules/salesforce/index
 modules/scaleway/index
 modules/semgrep/index
 modules/sentinelone/index


### PR DESCRIPTION
### Type of change
- [x] Documentation update

### Summary
The CircleCI, Databricks, and Salesforce integrations have complete documentation pages (`index.md`, `config.md`, `schema.md`) under `docs/root/modules/`, but they never appeared in the docs navigation menu.

The Sphinx sidebar is built from `{toctree}` directives that list each module's `index` page. These three modules were never added to those toctrees, so their pages were orphaned: present on disk but invisible in the menu (Sphinx also emitted "document isn't included in any toctree" warnings for them).

This adds the three missing `modules/<name>/index` entries, in alphabetical order, to both files that list the intel modules:
- `docs/root/index.md` (the hidden "Intel Modules" toctree that renders the sidebar)
- `docs/root/module-list.md` (the standalone module list page)

Both files duplicate the same list by hand, which is why they drifted.

### Related issues or links

N/A

### How was this tested?
- Compared the on-disk `docs/root/modules/*/` folders against the toctree entries before and after; the only remaining gaps are expected non-menu folders (`tenable`, `ubuntu`, `_cartography-metadata` are schema-only; `entra` is superseded by the `microsoft` module).
- Built the docs with `uv run ./docs/build.sh`: build succeeds, the "isn't included in any toctree" warnings for the three modules are gone, and the generated `index.html` nav now links to each of `modules/{circleci,databricks,salesforce}/index.html`.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [ ] The linter passes locally (`make test_lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] Docs build verified locally (nav now includes the three modules; no orphan-page warnings for them).

### Notes for reviewers
Docs-only change. No code or schema changes. The two toctree files duplicate the same module list by hand, so a future cleanup could generate one from the other to prevent this drift, but that is out of scope here.
