### PR TITLE
docs: use custom domain and improve discovery

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,7 +32,7 @@
 ### Checklist
 
 #### General
-- [ ] I have read the [contributing guidelines](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
+- [ ] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
 - [ ] The linter passes locally (`make test_lint`).
 - [ ] I have added/updated tests that prove my fix is effective or my feature works.
 
@@ -56,7 +56,7 @@
 - [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).
 
 #### If you are implementing a new intel module
-- [ ] Used the NodeSchema [data model](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#defining-a-node).
+- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).
 
 
 ### Notes for reviewers

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -108,3 +108,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: _gh-pages/
           force_orphan: true
+          cname: docs.cartography.dev

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9637/badge)](https://www.bestpractices.dev/projects/9637)
 ![build](https://github.com/cartography-cncf/cartography/actions/workflows/publish-to-ghcr-and-pypi.yml/badge.svg)
 
-[Documentation](https://cartography-cncf.github.io/cartography/)
+[Documentation](https://docs.cartography.dev/)
 </div>
 
 Cartography is a Python tool that pulls infrastructure assets and their relationships into a [Neo4j](https://www.neo4j.com) graph database.
@@ -48,7 +48,7 @@ Run Cartography:
 cartography --neo4j-uri bolt://localhost:7687 --selected-modules aws
 ```
 
-See the [full install guide](https://cartography-cncf.github.io/cartography/install.html) for other platforms.
+See the [full install guide](https://docs.cartography.dev/install.html) for other platforms.
 
 ### Query the graph
 
@@ -66,7 +66,7 @@ MATCH (instance:AWSEC2Instance{exposed_internet: true})
 RETURN instance.instanceid, instance.publicdnsname
 ```
 
-See the [querying tutorial](https://cartography-cncf.github.io/cartography/usage/tutorial.html) and [data schema](https://cartography-cncf.github.io/cartography/usage/schema.html) for more use-cases.
+See the [querying tutorial](https://docs.cartography.dev/usage/tutorial.html) and [data schema](https://docs.cartography.dev/usage/schema.html) for more use-cases.
 
 ### Run security rules
 
@@ -81,47 +81,47 @@ cartography-rules run object_storage_public
 ```
 
 For authenticated Neo4j, set `NEO4J_PASSWORD` or use one of the other secure
-password options in [the rules docs](https://cartography-cncf.github.io/cartography/usage/rules.html).
+password options in [the rules docs](https://docs.cartography.dev/usage/rules.html).
 
 ## Supported platforms
 
 <details>
 <summary>Click to expand full list of 30+ supported platforms</summary>
 
-- [Airbyte](https://cartography-cncf.github.io/cartography/modules/airbyte/index.html) - Organization, Workspace, User, Source, Destination, Connection, Tag, Stream
-- [Amazon Web Services](https://cartography-cncf.github.io/cartography/modules/aws/index.html) - ACM, API Gateway, Bedrock, CloudWatch, CodeBuild, Config, Cognito, EC2, ECS, ECR (including multi-arch images, image layers, and attestations), EFS, Elasticsearch, Elastic Kubernetes Service (EKS), DynamoDB, Glue,  GuardDuty, IAM, Inspector, KMS, Lambda, RDS, Redshift, Route53, S3, SageMaker, Secrets Manager(Secret Versions), Security Hub, SNS, SQS, SSM, STS, Tags
-- [AIBOM](https://cartography-cncf.github.io/cartography/modules/aibom/index.html) - AI component detections linked to ECR images
-- [Anthropic](https://cartography-cncf.github.io/cartography/modules/anthropic/index.html) - Organization, ApiKey, User, Workspace
-- [BigFix](https://cartography-cncf.github.io/cartography/modules/bigfix/index.html) - Computers
-- [Cloudflare](https://cartography-cncf.github.io/cartography/modules/cloudflare/index.html) - Account, Role, Member, Zone, DNSRecord
-- [Crowdstrike Falcon](https://cartography-cncf.github.io/cartography/modules/crowdstrike/index.html) - Hosts, Spotlight vulnerabilities, CVEs
-- [DigitalOcean](https://cartography-cncf.github.io/cartography/modules/digitalocean/index.html)
-- [Duo](https://cartography-cncf.github.io/cartography/modules/duo/index.html) - Users, Groups, Endpoints
-- [GitHub](https://cartography-cncf.github.io/cartography/modules/github/index.html) - repos, branches, users, teams, dependency graph manifests, dependencies
-- [Google Cloud Platform](https://cartography-cncf.github.io/cartography/modules/gcp/index.html) - Artifact Registry, Bigtable, Cloud Functions, Cloud Resource Manager, Cloud Run, Cloud SQL, Compute, DNS, IAM, KMS, Secret Manager, Storage, Google Kubernetes Engine, Vertex AI
-- [Google Workspace](https://cartography-cncf.github.io/cartography/modules/googleworkspace/index.html) - users, groups, devices, OAuth apps
-- [Jumpcloud](https://cartography-cncf.github.io/cartography/modules/jumpcloud/index.html)
-- [Kandji](https://cartography-cncf.github.io/cartography/modules/kandji/index.html) - Devices
-- [Keycloak](https://cartography-cncf.github.io/cartography/modules/keycloak/index.html) - Realms, Users, Groups, Roles, Scopes, Clients, IdentityProviders, Authentication Flows, Authentication Executions, Organizations, Organization Domains
-- [Kubernetes](https://cartography-cncf.github.io/cartography/modules/kubernetes/index.html) - Cluster, Namespace, Service, Pod, Container, ServiceAccount, Role, RoleBinding, ClusterRole, ClusterRoleBinding, OIDCProvider
-- [Lastpass](https://cartography-cncf.github.io/cartography/modules/lastpass/index.html) - users
-- [Microsoft Azure](https://cartography-cncf.github.io/cartography/modules/azure/index.html) - App Service, Container Instance, CosmosDB, Data Factory, Event Grid, Firewall, Firewall Policy, Functions, Key Vault, Azure Kubernetes Service (AKS), Load Balancer, Logic Apps, Management Groups, Resource Group, SQL, Storage, Virtual Machine, Virtual Networks
-- [Microsoft Entra ID](https://cartography-cncf.github.io/cartography/modules/entra/index.html) -  Users, Groups, Applications, OUs, App Roles, federation to AWS Identity Center, Intune Managed Devices, Intune Detected Apps, Intune Compliance Policies
-- [CVE Metadata](https://cartography-cncf.github.io/cartography/modules/cve_metadata/index.html) - CVE enrichment with CVSS, EPSS scores, and CISA KEV data from NVD and FIRST.org
-- [NIST CVE](https://cartography-cncf.github.io/cartography/modules/cve/index.html) - Common Vulnerabilities and Exposures (CVE) data from NIST database (deprecated - use CVE Metadata instead)
-- [Okta](https://cartography-cncf.github.io/cartography/modules/okta/index.html) - users, groups, organizations, roles, applications, factors, trusted origins, reply URIs, federation to AWS roles, federation to AWS Identity Center
-- [OpenAI](https://cartography-cncf.github.io/cartography/modules/openai/index.html) - Organization, AdminApiKey, User, Project, ServiceAccount, ApiKey
-- [Oracle Cloud Infrastructure](https://cartography-cncf.github.io/cartography/modules/oci/index.html) - IAM
-- [PagerDuty](https://cartography-cncf.github.io/cartography/modules/pagerduty/index.html) - Users, teams, services, schedules, escalation policies, integrations, vendors
-- [Scaleway](https://cartography-cncf.github.io/cartography/modules/scaleway/index.html) - Projects, IAM, Local Storage, Instances
-- [SentinelOne](https://cartography-cncf.github.io/cartography/modules/sentinelone/index.html) - Accounts, Agents, Applications, Application Versions, CVEs
-- [Slack](https://cartography-cncf.github.io/cartography/modules/slack/index.html) - Teams, Users, UserGroups, Channels
-- [SnipeIT](https://cartography-cncf.github.io/cartography/modules/snipeit/index.html) - Users, Assets
-- [Socket.dev](https://cartography-cncf.github.io/cartography/modules/socketdev/index.html) - Organizations, Repositories, Dependencies, Security Alerts (CVE, malware, supply chain risks), Fixes
-- [Spacelift](https://cartography-cncf.github.io/cartography/modules/spacelift/index.html) - Accounts, Spaces,Users, Stacks, WorkerPools, Workers, Runs, GitCommits
-- [SubImage](https://cartography-cncf.github.io/cartography/modules/subimage/index.html) - Tenant, TeamMember, APIKey, Neo4jUser, Module, Framework
-- [Tailscale](https://cartography-cncf.github.io/cartography/modules/tailscale/index.html) - Tailnet, Users, Devices, Groups, Tags, PostureIntegrations, DevicePostures, DevicePostureConditions, device posture compliance relationships
-- [Trivy Scanner](https://cartography-cncf.github.io/cartography/modules/trivy/index.html) - AWS ECR Images
+- [Airbyte](https://docs.cartography.dev/modules/airbyte/index.html) - Organization, Workspace, User, Source, Destination, Connection, Tag, Stream
+- [Amazon Web Services](https://docs.cartography.dev/modules/aws/index.html) - ACM, API Gateway, Bedrock, CloudWatch, CodeBuild, Config, Cognito, EC2, ECS, ECR (including multi-arch images, image layers, and attestations), EFS, Elasticsearch, Elastic Kubernetes Service (EKS), DynamoDB, Glue,  GuardDuty, IAM, Inspector, KMS, Lambda, RDS, Redshift, Route53, S3, SageMaker, Secrets Manager(Secret Versions), Security Hub, SNS, SQS, SSM, STS, Tags
+- [AIBOM](https://docs.cartography.dev/modules/aibom/index.html) - AI component detections linked to ECR images
+- [Anthropic](https://docs.cartography.dev/modules/anthropic/index.html) - Organization, ApiKey, User, Workspace
+- [BigFix](https://docs.cartography.dev/modules/bigfix/index.html) - Computers
+- [Cloudflare](https://docs.cartography.dev/modules/cloudflare/index.html) - Account, Role, Member, Zone, DNSRecord
+- [Crowdstrike Falcon](https://docs.cartography.dev/modules/crowdstrike/index.html) - Hosts, Spotlight vulnerabilities, CVEs
+- [DigitalOcean](https://docs.cartography.dev/modules/digitalocean/index.html)
+- [Duo](https://docs.cartography.dev/modules/duo/index.html) - Users, Groups, Endpoints
+- [GitHub](https://docs.cartography.dev/modules/github/index.html) - repos, branches, users, teams, dependency graph manifests, dependencies
+- [Google Cloud Platform](https://docs.cartography.dev/modules/gcp/index.html) - Artifact Registry, Bigtable, Cloud Functions, Cloud Resource Manager, Cloud Run, Cloud SQL, Compute, DNS, IAM, KMS, Secret Manager, Storage, Google Kubernetes Engine, Vertex AI
+- [Google Workspace](https://docs.cartography.dev/modules/googleworkspace/index.html) - users, groups, devices, OAuth apps
+- [Jumpcloud](https://docs.cartography.dev/modules/jumpcloud/index.html)
+- [Kandji](https://docs.cartography.dev/modules/kandji/index.html) - Devices
+- [Keycloak](https://docs.cartography.dev/modules/keycloak/index.html) - Realms, Users, Groups, Roles, Scopes, Clients, IdentityProviders, Authentication Flows, Authentication Executions, Organizations, Organization Domains
+- [Kubernetes](https://docs.cartography.dev/modules/kubernetes/index.html) - Cluster, Namespace, Service, Pod, Container, ServiceAccount, Role, RoleBinding, ClusterRole, ClusterRoleBinding, OIDCProvider
+- [Lastpass](https://docs.cartography.dev/modules/lastpass/index.html) - users
+- [Microsoft Azure](https://docs.cartography.dev/modules/azure/index.html) - App Service, Container Instance, CosmosDB, Data Factory, Event Grid, Firewall, Firewall Policy, Functions, Key Vault, Azure Kubernetes Service (AKS), Load Balancer, Logic Apps, Management Groups, Resource Group, SQL, Storage, Virtual Machine, Virtual Networks
+- [Microsoft Entra ID](https://docs.cartography.dev/modules/entra/index.html) -  Users, Groups, Applications, OUs, App Roles, federation to AWS Identity Center, Intune Managed Devices, Intune Detected Apps, Intune Compliance Policies
+- [CVE Metadata](https://docs.cartography.dev/modules/cve_metadata/index.html) - CVE enrichment with CVSS, EPSS scores, and CISA KEV data from NVD and FIRST.org
+- [NIST CVE](https://docs.cartography.dev/modules/cve/index.html) - Common Vulnerabilities and Exposures (CVE) data from NIST database (deprecated - use CVE Metadata instead)
+- [Okta](https://docs.cartography.dev/modules/okta/index.html) - users, groups, organizations, roles, applications, factors, trusted origins, reply URIs, federation to AWS roles, federation to AWS Identity Center
+- [OpenAI](https://docs.cartography.dev/modules/openai/index.html) - Organization, AdminApiKey, User, Project, ServiceAccount, ApiKey
+- [Oracle Cloud Infrastructure](https://docs.cartography.dev/modules/oci/index.html) - IAM
+- [PagerDuty](https://docs.cartography.dev/modules/pagerduty/index.html) - Users, teams, services, schedules, escalation policies, integrations, vendors
+- [Scaleway](https://docs.cartography.dev/modules/scaleway/index.html) - Projects, IAM, Local Storage, Instances
+- [SentinelOne](https://docs.cartography.dev/modules/sentinelone/index.html) - Accounts, Agents, Applications, Application Versions, CVEs
+- [Slack](https://docs.cartography.dev/modules/slack/index.html) - Teams, Users, UserGroups, Channels
+- [SnipeIT](https://docs.cartography.dev/modules/snipeit/index.html) - Users, Assets
+- [Socket.dev](https://docs.cartography.dev/modules/socketdev/index.html) - Organizations, Repositories, Dependencies, Security Alerts (CVE, malware, supply chain risks), Fixes
+- [Spacelift](https://docs.cartography.dev/modules/spacelift/index.html) - Accounts, Spaces,Users, Stacks, WorkerPools, Workers, Runs, GitCommits
+- [SubImage](https://docs.cartography.dev/modules/subimage/index.html) - Tenant, TeamMember, APIKey, Neo4jUser, Module, Framework
+- [Tailscale](https://docs.cartography.dev/modules/tailscale/index.html) - Tailnet, Users, Devices, Groups, Tags, PostureIntegrations, DevicePostures, DevicePostureConditions, device posture compliance relationships
+- [Trivy Scanner](https://docs.cartography.dev/modules/trivy/index.html) - AWS ECR Images
 
 </details>
 
@@ -140,7 +140,7 @@ All contributors and participants must follow the [CNCF Code of Conduct](https:/
 
 Submit a GitHub issue to report a bug or request a new feature. Larger discussions happen in [GitHub Discussions](https://github.com/cartography-cncf/cartography/discussions).
 
-Get started with our [developer documentation](https://cartography-cncf.github.io/cartography/dev/developer-guide.html).
+Get started with our [developer documentation](https://docs.cartography.dev/dev/developer-guide.html).
 
 
 ## Who uses Cartography?

--- a/cartography/driftdetect/cli.py
+++ b/cartography/driftdetect/cli.py
@@ -29,7 +29,7 @@ class CLI:
                 "graph database and reports the deviations."
             ),
             epilog="For more documentation please visit: "
-            "https://cartography-cncf.github.io/cartography/usage/drift-detect.html",
+            "https://docs.cartography.dev/usage/drift-detect.html",
         )
         parser.add_argument(
             "-v",

--- a/cartography/rules/README.md
+++ b/cartography/rules/README.md
@@ -1,1 +1,1 @@
-See [the rules docs](https://cartography-cncf.github.io/cartography/usage/rules.html) for how Cartography develops and approaches security rules.
+See [the rules docs](https://docs.cartography.dev/usage/rules.html) for how Cartography develops and approaches security rules.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,13 @@ from datetime import datetime
 # Use __file__ for robustness when conf.py is copied to generated/rst/ by build.sh
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+# Local development loads this config from docs/ while the production build
+# copies it next to the documentation sources in generated/rst/.
+_config_dir = os.path.dirname(os.path.abspath(__file__))
+_source_asset_prefix = (
+    "root" if os.path.isdir(os.path.join(_config_dir, "root")) else "."
+)
+
 
 def setup(app):
     app.add_config_value("release_level", "", "env")
@@ -45,7 +52,7 @@ extensions = [
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ["_templates"]
+templates_path = [os.path.join(_source_asset_prefix, "_templates")]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -163,17 +170,17 @@ html_short_title = "Cartography Docs"
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = "images/logo-vertical.svg"
+html_logo = os.path.join(_source_asset_prefix, "images/logo-vertical.svg")
 
 # The name of an image file (relative to this directory) to use as a favicon of
 # the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = "images/logo-vertical.svg"
+html_favicon = os.path.join(_source_asset_prefix, "images/logo-vertical.svg")
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = [os.path.join(_source_asset_prefix, "_static")]
 html_css_files = ["custom.css"]
 
 # html_style = 'css/cartography.css'
@@ -181,7 +188,10 @@ html_css_files = ["custom.css"]
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-html_extra_path = ["robots.txt", "llms.txt"]
+html_extra_path = [
+    os.path.join(_source_asset_prefix, "robots.txt"),
+    os.path.join(_source_asset_prefix, "llms.txt"),
+]
 
 # If not None, a 'Last updated on:' timestamp is inserted at every page
 # bottom, using the given strftime format.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.ifconfig",
     "sphinx.ext.githubpages",
+    "sphinx_sitemap",
     "sphinxcontrib.mermaid",
     "myst_parser",
     "sphinx.ext.napoleon",
@@ -63,7 +64,7 @@ html_sourcelink_suffix = ""
 master_doc = "index"
 
 # General information about the project.
-project = "cartography"
+project = "Cartography"
 copyright = f"2021-{datetime.now().year}, The Linux Foundation"
 author = "cartography Project Authors"
 
@@ -123,6 +124,10 @@ todo_include_todos = False
 
 # -- Options for HTML output ----------------------------------------------
 
+# Canonical public URL used by Sphinx and sphinx-sitemap.
+html_baseurl = "https://docs.cartography.dev/"
+sitemap_url_scheme = "{link}"
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = "shibuya"
@@ -151,10 +156,10 @@ html_context = {
 
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.
-# html_title = "cartography v1.0.0"
+html_title = "Cartography Documentation"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-# html_short_title = None
+html_short_title = "Cartography Docs"
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
@@ -176,7 +181,7 @@ html_css_files = ["custom.css"]
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-# html_extra_path = []
+html_extra_path = ["robots.txt", "llms.txt"]
 
 # If not None, a 'Last updated on:' timestamp is inserted at every page
 # bottom, using the given strftime format.

--- a/docs/root/_templates/partials/extra-head.html
+++ b/docs/root/_templates/partials/extra-head.html
@@ -1,0 +1,6 @@
+<meta property="og:site_name" content="Cartography" />
+{% if pagename == "index" %}
+  <meta name="description" content="Official documentation for Cartography, the open-source Python tool that maps cloud and SaaS infrastructure assets and their relationships into a Neo4j graph." />
+  <meta property="og:description" content="Official documentation for Cartography, the open-source Python tool that maps cloud and SaaS infrastructure assets and their relationships into a Neo4j graph." />
+  <meta name="twitter:description" content="Official documentation for Cartography, the open-source Python tool that maps cloud and SaaS infrastructure assets and their relationships into a Neo4j graph." />
+{% endif %}

--- a/docs/root/install.md
+++ b/docs/root/install.md
@@ -34,7 +34,7 @@ machine to pull data from AWS.
 
 1. **Configure and run Cartography.**
 
-    In this example we will run Cartography on [AWS](https://cartography-cncf.github.io/cartography/modules/aws/config.html) with a profile called "1234_testprofile" and default region set to "us-east-1".
+    In this example we will run Cartography on [AWS](https://docs.cartography.dev/modules/aws/config.html) with a profile called "1234_testprofile" and default region set to "us-east-1".
 
     ```bash
     docker-compose run \
@@ -52,7 +52,7 @@ machine to pull data from AWS.
     **Notes:**
     - You can view a full list of Cartography's CLI arguments by running `docker-compose run cartography --help`.
 
-    - Refer to the configuration sections of the relevant intel modules - such as [AWS](https://cartography-cncf.github.io/cartography/modules/aws/index.html), [GCP](https://cartography-cncf.github.io/cartography/modules/gcp/index.html), [Azure](https://cartography-cncf.github.io/cartography/modules/azure/index.html), and others - to properly set up each data source. The instructions for configuring additional modules can be found in the sidebar menu under the "Intel Modules" section. This generally involves specifying environment variables to cartography, or making a config/credential file on the host available to the container.
+    - Refer to the configuration sections of the relevant intel modules - such as [AWS](https://docs.cartography.dev/modules/aws/index.html), [GCP](https://docs.cartography.dev/modules/gcp/index.html), [Azure](https://docs.cartography.dev/modules/azure/index.html), and others - to properly set up each data source. The instructions for configuring additional modules can be found in the sidebar menu under the "Intel Modules" section. This generally involves specifying environment variables to cartography, or making a config/credential file on the host available to the container.
 
         - You can pass in environment variables to the cartography container using the docker-compose format like this: `-e VARIABLE1 -e VARIABLE2=value2`.
         - You can make files available to the cartography container by editing the volumes in the docker-compose.yml file. See docker-compose documentation on how to do that.
@@ -63,7 +63,7 @@ machine to pull data from AWS.
 
         - `AWS_DEFAULT_REGION` must be specified.
         - The docker-compose.yml maps in `~/.aws/` on your host machine to `/var/cartography/.aws` in the cartography container so that the container has access to AWS profile and credential files.
-        - You can use `--aws-requested-syncs` to sync only specific AWS resources instead of all of them. This accepts a comma-separated list of resource identifiers. For example, to sync only EC2 instances, S3 buckets, and IAM resources: `--aws-requested-syncs "ec2:instance,s3,iam"`. See [AWS Configuration](https://cartography-cncf.github.io/cartography/modules/aws/config.html#selective-syncing-with---aws-requested-syncs) for the full list of available resources.
+        - You can use `--aws-requested-syncs` to sync only specific AWS resources instead of all of them. This accepts a comma-separated list of resource identifiers. For example, to sync only EC2 instances, S3 buckets, and IAM resources: `--aws-requested-syncs "ec2:instance,s3,iam"`. See [AWS Configuration](https://docs.cartography.dev/modules/aws/config.html#selective-syncing-with---aws-requested-syncs) for the full list of available resources.
 
 1. **Run security frameworks against your graph.**
 
@@ -134,7 +134,7 @@ Read on to see [other things you can do with Cartography](#things-to-do-next).
 
 1. **Configure and run Cartography.**
 
-    See the configuration section of [each relevant intel module](https://cartography-cncf.github.io/cartography/modules) to set up each data source. In this example we will use [AWS](https://cartography-cncf.github.io/cartography/modules/aws/config.html).
+    See the configuration section of [each relevant intel module](https://docs.cartography.dev/modules) to set up each data source. In this example we will use [AWS](https://docs.cartography.dev/modules/aws/config.html).
 
     This command runs cartography on an AWS profile called "1234_testprofile" on region us-east-1. We also expose the host machine's ~/.aws directory to ~/var/cartography/.aws in the container so that AWS configs work.
 
@@ -239,7 +239,7 @@ Do this if you prefer to install and manage all the dependencies yourself. Carto
 
 1. **Configure your data sources.**
 
-    See the configuration section of [each relevant intel module](https://cartography-cncf.github.io/cartography/modules) for more details. In this example we will use [AWS](https://cartography-cncf.github.io/cartography/modules/aws/config.html).
+    See the configuration section of [each relevant intel module](https://docs.cartography.dev/modules) for more details. In this example we will use [AWS](https://docs.cartography.dev/modules/aws/config.html).
 
 1. **Run cartography.**
 

--- a/docs/root/llms.txt
+++ b/docs/root/llms.txt
@@ -1,0 +1,35 @@
+# Cartography
+
+> Cartography is an open-source Python tool that consolidates cloud and SaaS infrastructure assets and their relationships into a Neo4j graph.
+
+Use these resources to install Cartography, configure integrations, query the graph, develop new modules, and understand Cartography's data model.
+
+## Start here
+
+- [Documentation home](https://docs.cartography.dev/): Overview of Cartography and its use cases.
+- [Installation](https://docs.cartography.dev/install.html): Install and run Cartography with Docker or Python.
+- [Usage](https://docs.cartography.dev/usage/index.html): Querying, rules, drift detection, and operational guides.
+- [Command-line interface](https://docs.cartography.dev/usage/cli.html): CLI commands and configuration options.
+- [Cartography schema](https://docs.cartography.dev/usage/schema.html): Nodes, relationships, and graph conventions.
+
+## Integrations
+
+- [Amazon Web Services](https://docs.cartography.dev/modules/aws/index.html): AWS configuration and schema.
+- [Google Cloud Platform](https://docs.cartography.dev/modules/gcp/index.html): GCP configuration and schema.
+- [Microsoft Azure](https://docs.cartography.dev/modules/azure/index.html): Azure configuration and schema.
+- [GitHub](https://docs.cartography.dev/modules/github/index.html): GitHub configuration and schema.
+- [Kubernetes](https://docs.cartography.dev/modules/kubernetes/index.html): Kubernetes configuration and schema.
+- [All integrations](https://docs.cartography.dev/module-list.html): Complete list of supported intel modules.
+
+## Development
+
+- [Developer guide](https://docs.cartography.dev/dev/developer-guide.html): Set up a development environment and contribute.
+- [Write an intel module](https://docs.cartography.dev/dev/writing-intel-modules.html): Build a new data ingestion module.
+- [Write an analysis job](https://docs.cartography.dev/dev/writing-analysis-jobs.html): Add graph enrichment and analysis.
+- [Source code](https://github.com/cartography-cncf/cartography): Cartography's GitHub repository.
+
+## Optional
+
+- [Community](https://cartography.dev/community): Community meetings, Slack, and commercial support.
+- [GitHub discussions](https://github.com/cartography-cncf/cartography/discussions): Questions and project discussions.
+- [CNCF project page](https://www.cncf.io/projects/cartography/): Cartography's Cloud Native Computing Foundation listing.

--- a/docs/root/modules/docker_scout/config.md
+++ b/docs/root/modules/docker_scout/config.md
@@ -4,9 +4,9 @@
 
 Currently, Cartography allows you to use Docker Scout to scan the following resources:
 
-- [AWSECRImage](https://cartography-cncf.github.io/cartography/modules/aws/schema.html#ecrimage)
-- [GCPArtifactRegistryImage](https://cartography-cncf.github.io/cartography/modules/gcp/schema.html#gcpartifactregistryimage)
-- [GitLabContainerImage](https://cartography-cncf.github.io/cartography/modules/gitlab/schema.html#gitlabcontainerimage)
+- [AWSECRImage](https://docs.cartography.dev/modules/aws/schema.html#ecrimage)
+- [GCPArtifactRegistryImage](https://docs.cartography.dev/modules/gcp/schema.html#gcpartifactregistryimage)
+- [GitLabContainerImage](https://docs.cartography.dev/modules/gitlab/schema.html#gitlabcontainerimage)
 
 ### Prerequisites
 

--- a/docs/root/modules/trivy/config.md
+++ b/docs/root/modules/trivy/config.md
@@ -4,7 +4,7 @@
 
 Currently, Cartography allows you to use Trivy to scan the following resources:
 
-- [AWSECRImage](https://cartography-cncf.github.io/cartography/modules/aws/schema.html#ecrimage) (note that you scan ECRRepositoryImages but findings attach to their underlying AWSECRImage nodes)
+- [AWSECRImage](https://docs.cartography.dev/modules/aws/schema.html#ecrimage) (note that you scan ECRRepositoryImages but findings attach to their underlying AWSECRImage nodes)
 
 
 To use Trivy with Cartography,
@@ -84,4 +84,4 @@ Ensure that the machine running Trivy has the necessary permissions to scan your
 
 | Cartography Node label | Cloud permissions required to scan with Trivy |
 |---|---|
-| [AWSECRRepositoryImage](https://cartography-cncf.github.io/cartography/modules/aws/schema.html#ecrrepositoryimage) | `ecr:GetAuthorizationToken`, `ecr:BatchGetImage`, `ecr:GetDownloadUrlForLayer` |
+| [AWSECRRepositoryImage](https://docs.cartography.dev/modules/aws/schema.html#ecrrepositoryimage) | `ecr:GetAuthorizationToken`, `ecr:BatchGetImage`, `ecr:GetDownloadUrlForLayer` |

--- a/docs/root/ops.md
+++ b/docs/root/ops.md
@@ -35,13 +35,13 @@ how that process works.
 
 Each sync run has an `update_tag` associated with it,
 which is the [Unix timestamp of when the sync started](https://github.com/cartography-cncf/cartography/blob/8d60311a10156cd8aa16de7e1fe3e109cc3eca0f/cartography/sync.py#L131-L134).
-See our [docs for more details](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#handling-cartographys-update_tag).
+See our [docs for more details](https://docs.cartography.dev/dev/writing-intel-modules.html#handling-cartographys-update_tag).
 
 ### Cleanup jobs
 
 Each node and relationship created or updated during the sync will have their `lastupdated` field set to the
 `update_tag`. At the end of a sync run, nodes and relationships with out-of-date `lastupdated` fields are considered
-stale and will be deleted via a [cleanup job](https://cartography-cncf.github.io/cartography/dev/writing-intel-modules.html#cleanup).
+stale and will be deleted via a [cleanup job](https://docs.cartography.dev/dev/writing-intel-modules.html#cleanup).
 
 ### Sync frequency
 

--- a/docs/root/robots.txt
+++ b/docs/root/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.cartography.dev/sitemap.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ doc = [
     "sphinx>=8.1.3",
     "sphinx-autobuild>=2024.10.3",
     "sphinx-copybutton>=0.5.2",
+    "sphinx-sitemap>=2.8.0",
     "sphinxcontrib-mermaid>=1.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,8 +156,8 @@ cartography-rules = "cartography.rules.cli:main"
 "cartography.data.jobs.cleanup" = ["*.json"]
 
 [project.urls]
-Homepage = "https://cartography-cncf.github.io/cartography"
-Documentation = "https://cartography-cncf.github.io/cartography"
+Homepage = "https://docs.cartography.dev"
+Documentation = "https://docs.cartography.dev"
 Repository = "https://github.com/cartography-cncf/cartography"
 Issues = "https://github.com/cartography-cncf/cartography/issues"
 Changelog = "https://github.com/cartography-cncf/cartography/releases"

--- a/uv.lock
+++ b/uv.lock
@@ -988,6 +988,7 @@ doc = [
     { name = "sphinx-autobuild", version = "2024.10.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-autobuild", version = "2025.8.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-copybutton" },
+    { name = "sphinx-sitemap" },
     { name = "sphinxcontrib-mermaid" },
 ]
 
@@ -1084,6 +1085,7 @@ doc = [
     { name = "sphinx", specifier = ">=8.1.3" },
     { name = "sphinx-autobuild", specifier = ">=2024.10.3" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
+    { name = "sphinx-sitemap", specifier = ">=2.8.0" },
     { name = "sphinxcontrib-mermaid", specifier = ">=1.0.0" },
 ]
 
@@ -4272,6 +4274,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/48/1ea60e74949eecb12cdd6ac43987f9fd331156388dcc2319b45e2ebb81bf/sphinx_copybutton-0.5.2-py3-none-any.whl", hash = "sha256:fb543fd386d917746c9a2c50360c7905b605726b9355cd26e9974857afeae06e", size = 13343, upload-time = "2023-04-14T08:10:20.844Z" },
+]
+
+[[package]]
+name = "sphinx-last-updated-by-git"
+version = "0.3.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/fd/de1685b6dab173dff31da24e0d3b29f02873fc24a1cdbb7678721ddc8581/sphinx_last_updated_by_git-0.3.8.tar.gz", hash = "sha256:c145011f4609d841805b69a9300099fc02fed8f5bb9e5bcef77d97aea97b7761", size = 10785, upload-time = "2024-08-11T07:15:54.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/fb/e496f16fa11fbe2dbdd0b5e306ede153dfed050aae4766fc89d500720dc7/sphinx_last_updated_by_git-0.3.8-py3-none-any.whl", hash = "sha256:6382c8285ac1f222483a58569b78c0371af5e55f7fbf9c01e5e8a72d6fdfa499", size = 8580, upload-time = "2024-08-11T07:15:53.244Z" },
+]
+
+[[package]]
+name = "sphinx-sitemap"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx-last-updated-by-git" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/17/56fe0f65e3567f829b2b4153a622be1d4b222b781e0d90d7db5a7738f30f/sphinx_sitemap-2.9.0.tar.gz", hash = "sha256:70f97bcdf444e3d68e118355cf82a1f54c4d3c03d651cd17fe87398b26e25e21", size = 6978, upload-time = "2025-10-06T00:24:00.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/94/3c57e8b1985e755c48972e2ecd59526d4bf0b52a1fe805bc52a8e98cb92d/sphinx_sitemap-2.9.0-py3-none-any.whl", hash = "sha256:f1f1d3a9ad012ba17a7ef0b560d303bff2d0db26647567d6e810bcc754466664", size = 6218, upload-time = "2025-10-06T00:23:58.778Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Type of change

- [x] Documentation update

### Summary

Move repository links to docs.cartography.dev and improve documentation discovery with canonical URLs, a sitemap, robots.txt, llms.txt, descriptive metadata, and durable custom-domain publishing. Also capitalize the generated site title.

### How was this tested?

- Full Sphinx docs build
- Validated the generated sitemap and discovery files
- Verified generated titles, descriptions, and canonical links
- Verified linked pages and the old-host redirect

### Checklist

- [x] I have read the contributing guidelines.
- [x] The linter passes locally.
- [x] No tests needed; this is a docs and publishing configuration update.