### PR TITLE
fix(subimage): unwrap Page envelope in team + apikeys intel get()

### DIFF
--- a/cartography/intel/subimage/apikeys.py
+++ b/cartography/intel/subimage/apikeys.py
@@ -27,9 +27,25 @@ def sync(
 
 @timeit
 def get(api_session: requests.Session, base_url: str) -> list[dict[str, Any]]:
-    response = api_session.get(f"{base_url}/api/api-keys/subimage", timeout=_TIMEOUT)
-    response.raise_for_status()
-    return response.json()
+    # The endpoint returns the paginated Page[T] envelope
+    # ({"items": [...], "total_count": N, "limit": N, "offset": N}). Walk every
+    # page so cleanup does not delete API keys that live on later pages.
+    apikeys: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        response = api_session.get(
+            f"{base_url}/api/api-keys/subimage",
+            params={"offset": offset},
+            timeout=_TIMEOUT,
+        )
+        response.raise_for_status()
+        page = response.json()
+        items = page["items"]
+        apikeys.extend(items)
+        offset += len(items)
+        if not items or offset >= page["total_count"]:
+            break
+    return apikeys
 
 
 def transform(raw_data: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/cartography/intel/subimage/team.py
+++ b/cartography/intel/subimage/team.py
@@ -27,9 +27,25 @@ def sync(
 
 @timeit
 def get(api_session: requests.Session, base_url: str) -> list[dict[str, Any]]:
-    response = api_session.get(f"{base_url}/api/team/members", timeout=_TIMEOUT)
-    response.raise_for_status()
-    return response.json()
+    # The endpoint returns the paginated Page[T] envelope
+    # ({"items": [...], "total_count": N, "limit": N, "offset": N}). Walk every
+    # page so cleanup does not delete members that live on later pages.
+    members: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        response = api_session.get(
+            f"{base_url}/api/team/members",
+            params={"offset": offset},
+            timeout=_TIMEOUT,
+        )
+        response.raise_for_status()
+        page = response.json()
+        items = page["items"]
+        members.extend(items)
+        offset += len(items)
+        if not items or offset >= page["total_count"]:
+            break
+    return members
 
 
 def transform(raw_data: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/unit/cartography/intel/subimage/test_apikeys.py
+++ b/tests/unit/cartography/intel/subimage/test_apikeys.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock
+
+from cartography.intel.subimage.apikeys import get
+
+
+def test_get_reads_page_envelope():
+    # Regression: GET /api/api-keys/subimage returns the Page[T] envelope
+    # ({"items": [...]}); get() must unwrap it, not iterate the dict keys.
+    api_session = MagicMock()
+    api_session.get.return_value.json.return_value = {
+        "items": [{"app_id": "app-1"}],
+        "total_count": 1,
+        "limit": 100,
+        "offset": 0,
+    }
+
+    assert get(api_session, "https://app.example.com") == [{"app_id": "app-1"}]
+
+
+def test_get_paginates_all_pages():
+    # Regression: get() must walk every page, not just the first, or cleanup
+    # would delete API keys living on later pages.
+    api_session = MagicMock()
+    api_session.get.return_value.json.side_effect = [
+        {
+            "items": [{"app_id": "app-1"}, {"app_id": "app-2"}],
+            "total_count": 3,
+            "limit": 2,
+        },
+        {"items": [{"app_id": "app-3"}], "total_count": 3, "limit": 2},
+    ]
+
+    assert get(api_session, "https://app.example.com") == [
+        {"app_id": "app-1"},
+        {"app_id": "app-2"},
+        {"app_id": "app-3"},
+    ]
+    assert api_session.get.call_count == 2

--- a/tests/unit/cartography/intel/subimage/test_team.py
+++ b/tests/unit/cartography/intel/subimage/test_team.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock
+
+from cartography.intel.subimage.team import get
+
+
+def test_get_reads_page_envelope():
+    # Regression: GET /api/team/members returns the Page[T] envelope
+    # ({"items": [...]}); get() must unwrap it, not iterate the dict keys.
+    api_session = MagicMock()
+    api_session.get.return_value.json.return_value = {
+        "items": [{"id": "member-1"}],
+        "total_count": 1,
+        "limit": 100,
+        "offset": 0,
+    }
+
+    assert get(api_session, "https://app.example.com") == [{"id": "member-1"}]
+
+
+def test_get_paginates_all_pages():
+    # Regression: get() must walk every page, not just the first, or cleanup
+    # would delete members living on later pages.
+    api_session = MagicMock()
+    api_session.get.return_value.json.side_effect = [
+        {
+            "items": [{"id": "member-1"}, {"id": "member-2"}],
+            "total_count": 3,
+            "limit": 2,
+        },
+        {"items": [{"id": "member-3"}], "total_count": 3, "limit": 2},
+    ]
+
+    assert get(api_session, "https://app.example.com") == [
+        {"id": "member-1"},
+        {"id": "member-2"},
+        {"id": "member-3"},
+    ]
+    assert api_session.get.call_count == 2


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
`GET /api/team/members` and `GET /api/api-keys/subimage` return the paginated `Page[T]` envelope (`{"items": [...], "total_count": N, "limit": N, "offset": N}`), but `get()` in both `team.py` and `apikeys.py` returned `response.json()` (the whole dict). `transform()` then iterated the dict's string keys, so `member["id"]` raised `TypeError: string indices must be integers, not 'str'` and crashed the sync.

This mirrors the existing `frameworks.py::get()` pattern: walk every page and accumulate `items`. Full pagination (not just reading `items` off the first page) is required because `Page` defaults to `limit=100` and `cleanup()` deletes any node not seen this run, so a truncated first page would silently delete every member/key beyond the first 100.

`apikeys.py` had the identical bug; it was masked only because `team` runs first in the sync order and crashed before `apikeys` executed. Both are fixed here.


### Related issues or links

- Fixes #


### How was this tested?
- Added regression unit tests for both `get()` functions (single-page envelope unwrap + multi-page pagination), mirroring `test_frameworks.py`.
- `uv run pytest tests/unit/cartography/intel/subimage/ -v` -> 6 passed.
- Full pre-commit gate (isort, black, flake8, pyupgrade, mypy) passes locally.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

### Notes for reviewers
No schema or node/relationship changes: this is purely a fix to how the paginated API response is unwrapped in the `get()` collectors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
