### PR TITLE
feat(kubernetes): model workload controllers in the WORKLOAD_PARENT chain

### DIFF
--- a/cartography/intel/kubernetes/__init__.py
+++ b/cartography/intel/kubernetes/__init__.py
@@ -18,6 +18,7 @@ from cartography.intel.kubernetes.rbac import sync_kubernetes_rbac
 from cartography.intel.kubernetes.secrets import sync_secrets
 from cartography.intel.kubernetes.services import sync_services
 from cartography.intel.kubernetes.util import get_k8s_clients
+from cartography.intel.kubernetes.workloads import sync_workloads
 from cartography.util import run_typed_analysis_job
 from cartography.util import timeit
 
@@ -68,6 +69,11 @@ def start_k8s_ingestion(session: Session, config: Config) -> None:
             sync_kubernetes_rbac(
                 session, client, config.update_tag, common_job_parameters
             )
+            # Sync workload controllers before pods so the pod sync can collapse
+            # Pod -> ReplicaSet -> Deployment using the returned RS->Deployment map.
+            replicaset_owner_map = sync_workloads(
+                session, client, config.update_tag, common_job_parameters
+            )
 
             # Extract region from cluster ARN (works for EKS; None for non-EKS clusters)
             region: str | None = None
@@ -96,6 +102,7 @@ def start_k8s_ingestion(session: Session, config: Config) -> None:
                 common_job_parameters,
                 region=region,
                 node_arch_map=node_arch_map,
+                replicaset_owner_map=replicaset_owner_map,
             )
             sync_secrets(session, client, config.update_tag, common_job_parameters)
             sync_services(

--- a/cartography/intel/kubernetes/pods.py
+++ b/cartography/intel/kubernetes/pods.py
@@ -8,6 +8,7 @@ from kubernetes.client.models import V1Pod
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.kubernetes.util import get_controller_owner_reference
 from cartography.intel.kubernetes.util import get_epoch
 from cartography.intel.kubernetes.util import k8s_paginate
 from cartography.intel.kubernetes.util import K8sClient
@@ -212,21 +213,73 @@ def _format_pod_labels(labels: dict[str, str]) -> str:
     return json.dumps(labels)
 
 
+def _resolve_pod_workload_parent(
+    pod: V1Pod, replicaset_owner_map: dict[str, str]
+) -> dict[str, str | None]:
+    """Resolve a pod's single surfaced WORKLOAD_PARENT and its raw ReplicaSet owner.
+
+    Exactly one of the ``_workload_parent_*`` fields is set so the pod gets one
+    WORKLOAD_PARENT edge (mirrors the ECS task -> service/cluster gating). A pod
+    owned by a ReplicaSet collapses straight to the ReplicaSet's Deployment; the
+    raw ``_owner_replicaset_id`` is kept for the OWNED_BY edge. Pods with no
+    controller (or an unrecognised / bare-ReplicaSet controller) fall back to the
+    namespace.
+    """
+    parent: dict[str, str | None] = {
+        "_workload_parent_deployment_id": None,
+        "_workload_parent_statefulset_id": None,
+        "_workload_parent_daemonset_id": None,
+        "_workload_parent_job_id": None,
+        "_owner_replicaset_id": None,
+        "_workload_parent_namespace_name": None,
+    }
+    owner = get_controller_owner_reference(pod.metadata)
+    if owner is None:
+        parent["_workload_parent_namespace_name"] = pod.metadata.namespace
+        return parent
+
+    kind, uid = owner
+    if kind == "ReplicaSet":
+        parent["_owner_replicaset_id"] = uid
+        deployment_id = replicaset_owner_map.get(uid)
+        if deployment_id:
+            parent["_workload_parent_deployment_id"] = deployment_id
+        else:
+            # Bare ReplicaSet (no Deployment owner): the ReplicaSet is not
+            # surfaced, so anchor the pod to its namespace.
+            parent["_workload_parent_namespace_name"] = pod.metadata.namespace
+    elif kind == "StatefulSet":
+        parent["_workload_parent_statefulset_id"] = uid
+    elif kind == "DaemonSet":
+        parent["_workload_parent_daemonset_id"] = uid
+    elif kind == "Job":
+        parent["_workload_parent_job_id"] = uid
+    else:
+        # Unrecognised controller kind (e.g. a CRD-managed pod): anchor to the
+        # namespace so the pod still reaches the chain.
+        parent["_workload_parent_namespace_name"] = pod.metadata.namespace
+    return parent
+
+
 def transform_pods(
     pods: list[V1Pod],
     cluster_name: str,
     node_arch_map: dict[str, str] | None = None,
+    replicaset_owner_map: dict[str, str] | None = None,
 ) -> list[dict[str, Any]]:
     transformed_pods = []
     arch_map = node_arch_map or {}
+    rs_owner_map = replicaset_owner_map or {}
 
     for pod in pods:
         node_arch = arch_map.get(pod.spec.node_name or "")
         containers = _extract_pod_containers(pod, node_arch=node_arch)
         volume_secrets, env_secrets = _extract_pod_secrets(pod, cluster_name)
         service_account_name = pod.spec.service_account_name or "default"
+        workload_parent = _resolve_pod_workload_parent(pod, rs_owner_map)
         transformed_pods.append(
             {
+                **workload_parent,
                 "uid": pod.metadata.uid,
                 "name": pod.metadata.name,
                 "status_phase": pod.status.phase,
@@ -369,10 +422,16 @@ def sync_pods(
     common_job_parameters: dict[str, Any],
     region: str | None = None,
     node_arch_map: dict[str, str] | None = None,
+    replicaset_owner_map: dict[str, str] | None = None,
 ) -> list[dict[str, Any]]:
     pods = get_pods(client)
 
-    transformed_pods = transform_pods(pods, client.name, node_arch_map=node_arch_map)
+    transformed_pods = transform_pods(
+        pods,
+        client.name,
+        node_arch_map=node_arch_map,
+        replicaset_owner_map=replicaset_owner_map,
+    )
     load_pods(
         session=session,
         pods=transformed_pods,

--- a/cartography/intel/kubernetes/pods.py
+++ b/cartography/intel/kubernetes/pods.py
@@ -214,7 +214,9 @@ def _format_pod_labels(labels: dict[str, str]) -> str:
 
 
 def _resolve_pod_workload_parent(
-    pod: V1Pod, replicaset_owner_map: dict[str, str]
+    pod: V1Pod,
+    replicaset_owner_map: dict[str, str],
+    workloads_available: bool = True,
 ) -> dict[str, str | None]:
     """Resolve a pod's single surfaced WORKLOAD_PARENT and its raw ReplicaSet owner.
 
@@ -224,6 +226,11 @@ def _resolve_pod_workload_parent(
     raw ``_owner_replicaset_id`` is kept for the OWNED_BY edge. Pods with no
     controller (or an unrecognised / bare-ReplicaSet controller) fall back to the
     namespace.
+
+    When ``workloads_available`` is False the workload sync was skipped (e.g. the
+    apps/batch list verbs are not granted), so no controller node exists to point
+    at. Every controller-owned pod then falls back to a namespace WORKLOAD_PARENT
+    instead of pointing at a controller id that cannot match.
     """
     parent: dict[str, str | None] = {
         "_workload_parent_deployment_id": None,
@@ -234,7 +241,7 @@ def _resolve_pod_workload_parent(
         "_workload_parent_namespace_name": None,
     }
     owner = get_controller_owner_reference(pod.metadata)
-    if owner is None:
+    if owner is None or not workloads_available:
         parent["_workload_parent_namespace_name"] = pod.metadata.namespace
         return parent
 
@@ -266,6 +273,7 @@ def transform_pods(
     cluster_name: str,
     node_arch_map: dict[str, str] | None = None,
     replicaset_owner_map: dict[str, str] | None = None,
+    workloads_available: bool = True,
 ) -> list[dict[str, Any]]:
     transformed_pods = []
     arch_map = node_arch_map or {}
@@ -276,7 +284,9 @@ def transform_pods(
         containers = _extract_pod_containers(pod, node_arch=node_arch)
         volume_secrets, env_secrets = _extract_pod_secrets(pod, cluster_name)
         service_account_name = pod.spec.service_account_name or "default"
-        workload_parent = _resolve_pod_workload_parent(pod, rs_owner_map)
+        workload_parent = _resolve_pod_workload_parent(
+            pod, rs_owner_map, workloads_available=workloads_available
+        )
         transformed_pods.append(
             {
                 **workload_parent,
@@ -426,11 +436,18 @@ def sync_pods(
 ) -> list[dict[str, Any]]:
     pods = get_pods(client)
 
+    # replicaset_owner_map is None when the workload sync was skipped (e.g. the
+    # apps/batch list verbs are not granted): no controller nodes were ingested,
+    # so controller-owned pods must fall back to a namespace WORKLOAD_PARENT
+    # rather than pointing at a controller id that cannot match.
+    workloads_available = replicaset_owner_map is not None
+
     transformed_pods = transform_pods(
         pods,
         client.name,
         node_arch_map=node_arch_map,
         replicaset_owner_map=replicaset_owner_map,
+        workloads_available=workloads_available,
     )
     load_pods(
         session=session,

--- a/cartography/intel/kubernetes/util.py
+++ b/cartography/intel/kubernetes/util.py
@@ -6,6 +6,8 @@ from typing import Callable
 from dateutil.parser import isoparse
 from kubernetes import config
 from kubernetes.client import ApiClient
+from kubernetes.client import AppsV1Api
+from kubernetes.client import BatchV1Api
 from kubernetes.client import CoreV1Api
 from kubernetes.client import CustomObjectsApi
 from kubernetes.client import NetworkingV1Api
@@ -96,6 +98,36 @@ class K8RbacApiClient(RbacAuthorizationV1Api):
         super().__init__(api_client=api_client)
 
 
+class K8AppsApiClient(AppsV1Api):
+    def __init__(
+        self,
+        name: str,
+        config_file: str,
+        api_client: ApiClient | None = None,
+    ) -> None:
+        self.name = name
+        if not api_client:
+            api_client = config.new_client_from_config(
+                context=name, config_file=config_file
+            )
+        super().__init__(api_client=api_client)
+
+
+class K8BatchApiClient(BatchV1Api):
+    def __init__(
+        self,
+        name: str,
+        config_file: str,
+        api_client: ApiClient | None = None,
+    ) -> None:
+        self.name = name
+        if not api_client:
+            api_client = config.new_client_from_config(
+                context=name, config_file=config_file
+            )
+        super().__init__(api_client=api_client)
+
+
 class K8sClient:
     def __init__(
         self,
@@ -111,6 +143,8 @@ class K8sClient:
         self.version = K8VersionApiClient(self.name, self.config_file)
         self.rbac = K8RbacApiClient(self.name, self.config_file)
         self.custom = K8CustomObjectsApiClient(self.name, self.config_file)
+        self.apps = K8AppsApiClient(self.name, self.config_file)
+        self.batch = K8BatchApiClient(self.name, self.config_file)
 
 
 def get_k8s_clients(kubeconfig: str) -> list[K8sClient]:
@@ -133,6 +167,20 @@ def get_k8s_clients(kubeconfig: str) -> list[K8sClient]:
 
 def get_qualified_resource_name(namespace: str, name: str) -> str:
     return f"{namespace}/{name}"
+
+
+def get_controller_owner_reference(metadata: Any) -> tuple[str, str] | None:
+    """Return the ``(kind, uid)`` of the controlling ownerReference, if any.
+
+    Kubernetes marks exactly one ownerReference with ``controller=true`` (the
+    object that actually manages this resource, e.g. a ReplicaSet's Deployment,
+    a Job's CronJob, or a pod's ReplicaSet/StatefulSet/DaemonSet/Job).
+    Non-controller owners are ignored.
+    """
+    for owner in getattr(metadata, "owner_references", None) or []:
+        if getattr(owner, "controller", False):
+            return owner.kind, owner.uid
+    return None
 
 
 def _get_kubeconfig_merger(kubeconfig: str) -> KubeConfigMerger:

--- a/cartography/intel/kubernetes/util.py
+++ b/cartography/intel/kubernetes/util.py
@@ -284,6 +284,7 @@ def parse_rfc3339(value: str | None) -> datetime | None:
 def k8s_paginate(
     list_func: Callable,
     raise_on_forbidden: bool = False,
+    raise_on_error: bool = False,
     **kwargs: Any,
 ) -> list[dict[str, Any]]:
     """
@@ -293,6 +294,10 @@ def k8s_paginate(
     :param raise_on_forbidden: When True, re-raise ApiException with status 401/403 so the caller
         can handle missing permissions (used for optional RBAC verbs). Other ApiExceptions are still
         logged and swallowed.
+    :param raise_on_error: When True, re-raise *any* ApiException (after logging) instead of
+        swallowing it and returning a partial result. Use when a partial result must not be
+        mistaken for a complete one (e.g. the workload sync, where missing controller nodes would
+        leave pods with unmatched WORKLOAD_PARENT edges and trigger a destructive cleanup).
     :param kwargs: Keyword arguments to pass to the list function (e.g. limit=100)
     :return: A list of all resources returned by the list function
     """
@@ -335,11 +340,17 @@ def k8s_paginate(
                 break
 
         except ApiException as e:
-            if raise_on_forbidden and e.status in (401, 403):
+            is_forbidden = e.status in (401, 403)
+            # 401/403 re-raise quietly so the caller can log a permission-specific
+            # message; other errors are logged here before propagating (or being
+            # swallowed when neither raise flag is set).
+            if is_forbidden and (raise_on_forbidden or raise_on_error):
                 raise
             logger.error(
                 f"Kubernetes API error retrieving {function_name} resources. {e}: {e.status} - {e.reason}"
             )
+            if raise_on_error:
+                raise
             break
 
     logger.debug(

--- a/cartography/intel/kubernetes/workloads.py
+++ b/cartography/intel/kubernetes/workloads.py
@@ -285,10 +285,8 @@ def sync_workloads(
     its WORKLOAD_PARENT straight to the owning Deployment (the ReplicaSet is
     collapsed out of the ontology chain).
 
-    The apps/batch list verbs are optional. If any is not granted, we skip the
-    whole workload sync (load + cleanup) and return an empty map: previously
-    synced workload nodes are preserved and pods fall back to a namespace
-    WORKLOAD_PARENT, exactly like the secrets / network-policy syncs.
+    The apps/batch list verbs are required (see the Kubernetes config docs). The
+    401/403 grace period below is a temporary migration aid, not an opt-out.
     """
     try:
         deployments = transform_deployments(get_deployments(client))
@@ -300,17 +298,20 @@ def sync_workloads(
         )
         jobs = transform_jobs(get_jobs(client))
     except ApiException as e:
+        # DEPRECATED: transitional grace period. The apps/batch `list` verbs are
+        # required; until v1.0.0 a missing verb is tolerated here (warn + skip
+        # load and cleanup) so existing deployments are not broken or wiped on
+        # upgrade. This except block will be removed in v1.0.0, after which a
+        # 401/403 will fail loudly and propagate like any other required sync.
         if e.status in (401, 403):
-            # Skipping load + cleanup is intentional: cleaning up against an
-            # empty result would wipe the existing workload subgraph for this
-            # cluster. Pods still resolve WORKLOAD_PARENT to their namespace.
             logger.warning(
                 "Cartography lacks permission to list workload controllers on "
                 "cluster %s (status %s). Skipping workload sync and preserving "
                 "previously synced Deployment/StatefulSet/DaemonSet/ReplicaSet/"
-                "Job/CronJob nodes. Grant `list` on apps/v1 (deployments, "
+                "Job/CronJob nodes for now. Grant `list` on apps/v1 (deployments, "
                 "replicasets, statefulsets, daemonsets) and batch/v1 (jobs, "
-                "cronjobs) to enable the controller workload chain.",
+                "cronjobs): this is required and will become a hard failure in "
+                "v1.0.0.",
                 client.name,
                 e.status,
             )

--- a/cartography/intel/kubernetes/workloads.py
+++ b/cartography/intel/kubernetes/workloads.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any
 
 import neo4j
+from kubernetes.client.exceptions import ApiException
 from kubernetes.client.models import V1CronJob
 from kubernetes.client.models import V1DaemonSet
 from kubernetes.client.models import V1Deployment
@@ -31,34 +32,49 @@ def _format_labels(labels: dict[str, str] | None) -> str:
     return json.dumps(labels or {})
 
 
+# The workload list calls re-raise on 401/403 so sync_workloads can skip load +
+# cleanup when the operator has not granted the (optional) apps/batch list verbs,
+# preserving previously synced workload nodes instead of wiping them.
 @timeit
 def get_deployments(client: K8sClient) -> list[V1Deployment]:
-    return k8s_paginate(client.apps.list_deployment_for_all_namespaces)
+    return k8s_paginate(
+        client.apps.list_deployment_for_all_namespaces, raise_on_forbidden=True
+    )
 
 
 @timeit
 def get_replicasets(client: K8sClient) -> list[V1ReplicaSet]:
-    return k8s_paginate(client.apps.list_replica_set_for_all_namespaces)
+    return k8s_paginate(
+        client.apps.list_replica_set_for_all_namespaces, raise_on_forbidden=True
+    )
 
 
 @timeit
 def get_statefulsets(client: K8sClient) -> list[V1StatefulSet]:
-    return k8s_paginate(client.apps.list_stateful_set_for_all_namespaces)
+    return k8s_paginate(
+        client.apps.list_stateful_set_for_all_namespaces, raise_on_forbidden=True
+    )
 
 
 @timeit
 def get_daemonsets(client: K8sClient) -> list[V1DaemonSet]:
-    return k8s_paginate(client.apps.list_daemon_set_for_all_namespaces)
+    return k8s_paginate(
+        client.apps.list_daemon_set_for_all_namespaces, raise_on_forbidden=True
+    )
 
 
 @timeit
 def get_jobs(client: K8sClient) -> list[V1Job]:
-    return k8s_paginate(client.batch.list_job_for_all_namespaces)
+    return k8s_paginate(
+        client.batch.list_job_for_all_namespaces, raise_on_forbidden=True
+    )
 
 
 @timeit
 def get_cronjobs(client: K8sClient) -> list[V1CronJob]:
-    return k8s_paginate(client.batch.list_cron_job_for_all_namespaces)
+    return k8s_paginate(
+        client.batch.list_cron_job_for_all_namespaces, raise_on_forbidden=True
+    )
 
 
 def transform_deployments(deployments: list[V1Deployment]) -> list[dict[str, Any]]:
@@ -268,15 +284,38 @@ def sync_workloads(
     The map is consumed by the pod sync so a pod owned by a ReplicaSet resolves
     its WORKLOAD_PARENT straight to the owning Deployment (the ReplicaSet is
     collapsed out of the ontology chain).
+
+    The apps/batch list verbs are optional. If any is not granted, we skip the
+    whole workload sync (load + cleanup) and return an empty map: previously
+    synced workload nodes are preserved and pods fall back to a namespace
+    WORKLOAD_PARENT, exactly like the secrets / network-policy syncs.
     """
-    deployments = transform_deployments(get_deployments(client))
-    statefulsets = transform_statefulsets(get_statefulsets(client))
-    daemonsets = transform_daemonsets(get_daemonsets(client))
-    cronjobs = transform_cronjobs(get_cronjobs(client))
-    replicasets, replicaset_to_deployment = transform_replicasets(
-        get_replicasets(client)
-    )
-    jobs = transform_jobs(get_jobs(client))
+    try:
+        deployments = transform_deployments(get_deployments(client))
+        statefulsets = transform_statefulsets(get_statefulsets(client))
+        daemonsets = transform_daemonsets(get_daemonsets(client))
+        cronjobs = transform_cronjobs(get_cronjobs(client))
+        replicasets, replicaset_to_deployment = transform_replicasets(
+            get_replicasets(client)
+        )
+        jobs = transform_jobs(get_jobs(client))
+    except ApiException as e:
+        if e.status in (401, 403):
+            # Skipping load + cleanup is intentional: cleaning up against an
+            # empty result would wipe the existing workload subgraph for this
+            # cluster. Pods still resolve WORKLOAD_PARENT to their namespace.
+            logger.warning(
+                "Cartography lacks permission to list workload controllers on "
+                "cluster %s (status %s). Skipping workload sync and preserving "
+                "previously synced Deployment/StatefulSet/DaemonSet/ReplicaSet/"
+                "Job/CronJob nodes. Grant `list` on apps/v1 (deployments, "
+                "replicasets, statefulsets, daemonsets) and batch/v1 (jobs, "
+                "cronjobs) to enable the controller workload chain.",
+                client.name,
+                e.status,
+            )
+            return {}
+        raise
 
     load_workloads(
         session=session,

--- a/cartography/intel/kubernetes/workloads.py
+++ b/cartography/intel/kubernetes/workloads.py
@@ -32,48 +32,47 @@ def _format_labels(labels: dict[str, str] | None) -> str:
     return json.dumps(labels or {})
 
 
-# The workload list calls re-raise on 401/403 so sync_workloads can skip load +
-# cleanup when the operator has not granted the (optional) apps/batch list verbs,
-# preserving previously synced workload nodes instead of wiping them.
+# The workload list calls re-raise on ANY error (raise_on_error) so sync_workloads
+# never mistakes a partial/empty result for a complete one: a missing controller
+# would otherwise leave pods with unmatched WORKLOAD_PARENT edges and trigger a
+# destructive cleanup. sync_workloads turns any failure into a skip (return None).
 @timeit
 def get_deployments(client: K8sClient) -> list[V1Deployment]:
     return k8s_paginate(
-        client.apps.list_deployment_for_all_namespaces, raise_on_forbidden=True
+        client.apps.list_deployment_for_all_namespaces, raise_on_error=True
     )
 
 
 @timeit
 def get_replicasets(client: K8sClient) -> list[V1ReplicaSet]:
     return k8s_paginate(
-        client.apps.list_replica_set_for_all_namespaces, raise_on_forbidden=True
+        client.apps.list_replica_set_for_all_namespaces, raise_on_error=True
     )
 
 
 @timeit
 def get_statefulsets(client: K8sClient) -> list[V1StatefulSet]:
     return k8s_paginate(
-        client.apps.list_stateful_set_for_all_namespaces, raise_on_forbidden=True
+        client.apps.list_stateful_set_for_all_namespaces, raise_on_error=True
     )
 
 
 @timeit
 def get_daemonsets(client: K8sClient) -> list[V1DaemonSet]:
     return k8s_paginate(
-        client.apps.list_daemon_set_for_all_namespaces, raise_on_forbidden=True
+        client.apps.list_daemon_set_for_all_namespaces, raise_on_error=True
     )
 
 
 @timeit
 def get_jobs(client: K8sClient) -> list[V1Job]:
-    return k8s_paginate(
-        client.batch.list_job_for_all_namespaces, raise_on_forbidden=True
-    )
+    return k8s_paginate(client.batch.list_job_for_all_namespaces, raise_on_error=True)
 
 
 @timeit
 def get_cronjobs(client: K8sClient) -> list[V1CronJob]:
     return k8s_paginate(
-        client.batch.list_cron_job_for_all_namespaces, raise_on_forbidden=True
+        client.batch.list_cron_job_for_all_namespaces, raise_on_error=True
     )
 
 
@@ -283,12 +282,14 @@ def sync_workloads(
 
     The map is consumed by the pod sync so a pod owned by a ReplicaSet resolves
     its WORKLOAD_PARENT straight to the owning Deployment (the ReplicaSet is
-    collapsed out of the ontology chain). Returns ``None`` (not ``{}``) when the
-    workload sync was skipped, so the pod sync can tell "controllers ingested,
-    none map to a Deployment" apart from "controllers not ingested at all" and
-    fall back to a namespace WORKLOAD_PARENT for every controller-owned pod.
+    collapsed out of the ontology chain). Returns ``None`` (not ``{}``) whenever
+    the workload sync could not complete every controller list, so the pod sync
+    can tell "controllers ingested, none map to a Deployment" apart from
+    "controllers not fully ingested" and fall back to a namespace WORKLOAD_PARENT
+    for every controller-owned pod (avoiding unmatched edges to missing nodes).
 
-    The apps/batch list verbs are required (see the Kubernetes config docs). The
+    Any list failure skips load and cleanup so existing nodes are preserved. The
+    apps/batch list verbs are required (see the Kubernetes config docs); the
     401/403 grace period below is a temporary migration aid, not an opt-out.
     """
     try:
@@ -301,12 +302,12 @@ def sync_workloads(
         )
         jobs = transform_jobs(get_jobs(client))
     except ApiException as e:
-        # DEPRECATED: transitional grace period. The apps/batch `list` verbs are
-        # required; until v1.0.0 a missing verb is tolerated here (warn + skip
-        # load and cleanup) so existing deployments are not broken or wiped on
-        # upgrade. This except block will be removed in v1.0.0, after which a
-        # 401/403 will fail loudly and propagate like any other required sync.
         if e.status in (401, 403):
+            # DEPRECATED: transitional grace period. The apps/batch `list` verbs
+            # are required; until v1.0.0 a missing verb is tolerated here (warn +
+            # skip load and cleanup) so existing deployments are not broken or
+            # wiped on upgrade. This branch will be removed in v1.0.0, after which
+            # a 401/403 will fail loudly like any other required sync.
             logger.warning(
                 "Cartography lacks permission to list workload controllers on "
                 "cluster %s (status %s). Skipping workload sync and preserving "
@@ -319,7 +320,18 @@ def sync_workloads(
                 e.status,
             )
             return None
-        raise
+        # Any other API error (transient 5xx, timeout surfaced as ApiException,
+        # etc.): skip load + cleanup and signal unavailability. Loading a partial
+        # result would delete controllers absent from it and leave pods pointing
+        # at controller ids that were never ingested.
+        logger.error(
+            "Kubernetes API error listing workload controllers on cluster %s "
+            "(status %s). Skipping workload sync for this run and preserving "
+            "previously synced nodes; pods fall back to a namespace WORKLOAD_PARENT.",
+            client.name,
+            e.status,
+        )
+        return None
 
     load_workloads(
         session=session,

--- a/cartography/intel/kubernetes/workloads.py
+++ b/cartography/intel/kubernetes/workloads.py
@@ -1,0 +1,294 @@
+import json
+import logging
+from typing import Any
+
+import neo4j
+from kubernetes.client.models import V1CronJob
+from kubernetes.client.models import V1DaemonSet
+from kubernetes.client.models import V1Deployment
+from kubernetes.client.models import V1Job
+from kubernetes.client.models import V1ReplicaSet
+from kubernetes.client.models import V1StatefulSet
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.kubernetes.util import get_controller_owner_reference
+from cartography.intel.kubernetes.util import get_epoch
+from cartography.intel.kubernetes.util import k8s_paginate
+from cartography.intel.kubernetes.util import K8sClient
+from cartography.models.kubernetes.cronjobs import KubernetesCronJobSchema
+from cartography.models.kubernetes.daemonsets import KubernetesDaemonSetSchema
+from cartography.models.kubernetes.deployments import KubernetesDeploymentSchema
+from cartography.models.kubernetes.jobs import KubernetesJobSchema
+from cartography.models.kubernetes.replicasets import KubernetesReplicaSetSchema
+from cartography.models.kubernetes.statefulsets import KubernetesStatefulSetSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+def _format_labels(labels: dict[str, str] | None) -> str:
+    return json.dumps(labels or {})
+
+
+@timeit
+def get_deployments(client: K8sClient) -> list[V1Deployment]:
+    return k8s_paginate(client.apps.list_deployment_for_all_namespaces)
+
+
+@timeit
+def get_replicasets(client: K8sClient) -> list[V1ReplicaSet]:
+    return k8s_paginate(client.apps.list_replica_set_for_all_namespaces)
+
+
+@timeit
+def get_statefulsets(client: K8sClient) -> list[V1StatefulSet]:
+    return k8s_paginate(client.apps.list_stateful_set_for_all_namespaces)
+
+
+@timeit
+def get_daemonsets(client: K8sClient) -> list[V1DaemonSet]:
+    return k8s_paginate(client.apps.list_daemon_set_for_all_namespaces)
+
+
+@timeit
+def get_jobs(client: K8sClient) -> list[V1Job]:
+    return k8s_paginate(client.batch.list_job_for_all_namespaces)
+
+
+@timeit
+def get_cronjobs(client: K8sClient) -> list[V1CronJob]:
+    return k8s_paginate(client.batch.list_cron_job_for_all_namespaces)
+
+
+def transform_deployments(deployments: list[V1Deployment]) -> list[dict[str, Any]]:
+    out = []
+    for deployment in deployments:
+        status = deployment.status
+        out.append(
+            {
+                "uid": deployment.metadata.uid,
+                "name": deployment.metadata.name,
+                "namespace": deployment.metadata.namespace,
+                "creation_timestamp": get_epoch(deployment.metadata.creation_timestamp),
+                "deletion_timestamp": get_epoch(deployment.metadata.deletion_timestamp),
+                "replicas": deployment.spec.replicas if deployment.spec else None,
+                "ready_replicas": getattr(status, "ready_replicas", None),
+                "available_replicas": getattr(status, "available_replicas", None),
+                "labels": _format_labels(deployment.metadata.labels),
+            }
+        )
+    return out
+
+
+def transform_statefulsets(statefulsets: list[V1StatefulSet]) -> list[dict[str, Any]]:
+    out = []
+    for statefulset in statefulsets:
+        spec = statefulset.spec
+        status = statefulset.status
+        out.append(
+            {
+                "uid": statefulset.metadata.uid,
+                "name": statefulset.metadata.name,
+                "namespace": statefulset.metadata.namespace,
+                "creation_timestamp": get_epoch(
+                    statefulset.metadata.creation_timestamp
+                ),
+                "deletion_timestamp": get_epoch(
+                    statefulset.metadata.deletion_timestamp
+                ),
+                "replicas": getattr(spec, "replicas", None),
+                "ready_replicas": getattr(status, "ready_replicas", None),
+                "service_name": getattr(spec, "service_name", None),
+                "labels": _format_labels(statefulset.metadata.labels),
+            }
+        )
+    return out
+
+
+def transform_daemonsets(daemonsets: list[V1DaemonSet]) -> list[dict[str, Any]]:
+    out = []
+    for daemonset in daemonsets:
+        status = daemonset.status
+        out.append(
+            {
+                "uid": daemonset.metadata.uid,
+                "name": daemonset.metadata.name,
+                "namespace": daemonset.metadata.namespace,
+                "creation_timestamp": get_epoch(daemonset.metadata.creation_timestamp),
+                "deletion_timestamp": get_epoch(daemonset.metadata.deletion_timestamp),
+                "desired_number_scheduled": getattr(
+                    status, "desired_number_scheduled", None
+                ),
+                "number_ready": getattr(status, "number_ready", None),
+                "labels": _format_labels(daemonset.metadata.labels),
+            }
+        )
+    return out
+
+
+def transform_cronjobs(cronjobs: list[V1CronJob]) -> list[dict[str, Any]]:
+    out = []
+    for cronjob in cronjobs:
+        spec = cronjob.spec
+        out.append(
+            {
+                "uid": cronjob.metadata.uid,
+                "name": cronjob.metadata.name,
+                "namespace": cronjob.metadata.namespace,
+                "creation_timestamp": get_epoch(cronjob.metadata.creation_timestamp),
+                "deletion_timestamp": get_epoch(cronjob.metadata.deletion_timestamp),
+                "schedule": getattr(spec, "schedule", None),
+                "suspend": getattr(spec, "suspend", None),
+                "labels": _format_labels(cronjob.metadata.labels),
+            }
+        )
+    return out
+
+
+def transform_replicasets(
+    replicasets: list[V1ReplicaSet],
+) -> tuple[list[dict[str, Any]], dict[str, str]]:
+    """Transform ReplicaSets and build the ``replicaset_uid -> deployment_uid`` map.
+
+    The map lets the pod transform collapse ``Pod -> ReplicaSet -> Deployment``
+    into a single ``Pod -[:WORKLOAD_PARENT]-> Deployment`` edge.
+    """
+    out = []
+    replicaset_to_deployment: dict[str, str] = {}
+    for replicaset in replicasets:
+        status = replicaset.status
+        owner = get_controller_owner_reference(replicaset.metadata)
+        owner_deployment_id = None
+        if owner and owner[0] == "Deployment":
+            owner_deployment_id = owner[1]
+            replicaset_to_deployment[replicaset.metadata.uid] = owner_deployment_id
+        out.append(
+            {
+                "uid": replicaset.metadata.uid,
+                "name": replicaset.metadata.name,
+                "namespace": replicaset.metadata.namespace,
+                "creation_timestamp": get_epoch(replicaset.metadata.creation_timestamp),
+                "deletion_timestamp": get_epoch(replicaset.metadata.deletion_timestamp),
+                "replicas": replicaset.spec.replicas if replicaset.spec else None,
+                "ready_replicas": getattr(status, "ready_replicas", None),
+                "labels": _format_labels(replicaset.metadata.labels),
+                "_owner_deployment_id": owner_deployment_id,
+            }
+        )
+    return out, replicaset_to_deployment
+
+
+def transform_jobs(jobs: list[V1Job]) -> list[dict[str, Any]]:
+    out = []
+    for job in jobs:
+        spec = job.spec
+        status = job.status
+        owner = get_controller_owner_reference(job.metadata)
+        cronjob_id = owner[1] if owner and owner[0] == "CronJob" else None
+        out.append(
+            {
+                "uid": job.metadata.uid,
+                "name": job.metadata.name,
+                "namespace": job.metadata.namespace,
+                "creation_timestamp": get_epoch(job.metadata.creation_timestamp),
+                "deletion_timestamp": get_epoch(job.metadata.deletion_timestamp),
+                "completions": getattr(spec, "completions", None),
+                "parallelism": getattr(spec, "parallelism", None),
+                "active": getattr(status, "active", None),
+                "succeeded": getattr(status, "succeeded", None),
+                "failed": getattr(status, "failed", None),
+                "labels": _format_labels(job.metadata.labels),
+                "_workload_parent_cronjob_id": cronjob_id,
+                # Standalone Jobs (no owning CronJob) anchor to their namespace.
+                "_workload_parent_namespace_name": (
+                    None if cronjob_id else job.metadata.namespace
+                ),
+            }
+        )
+    return out
+
+
+@timeit
+def load_workloads(
+    session: neo4j.Session,
+    deployments: list[dict[str, Any]],
+    statefulsets: list[dict[str, Any]],
+    daemonsets: list[dict[str, Any]],
+    cronjobs: list[dict[str, Any]],
+    replicasets: list[dict[str, Any]],
+    jobs: list[dict[str, Any]],
+    update_tag: int,
+    cluster_id: str,
+    cluster_name: str,
+) -> None:
+    # Load top-level controllers first so the child edges (ReplicaSet ->
+    # Deployment, Job -> CronJob) can match their targets.
+    for schema, data in (
+        (KubernetesDeploymentSchema(), deployments),
+        (KubernetesStatefulSetSchema(), statefulsets),
+        (KubernetesDaemonSetSchema(), daemonsets),
+        (KubernetesCronJobSchema(), cronjobs),
+        (KubernetesReplicaSetSchema(), replicasets),
+        (KubernetesJobSchema(), jobs),
+    ):
+        load(
+            session,
+            schema,
+            data,
+            lastupdated=update_tag,
+            CLUSTER_ID=cluster_id,
+            CLUSTER_NAME=cluster_name,
+        )
+
+
+@timeit
+def cleanup(session: neo4j.Session, common_job_parameters: dict[str, Any]) -> None:
+    for schema in (
+        KubernetesJobSchema(),
+        KubernetesReplicaSetSchema(),
+        KubernetesCronJobSchema(),
+        KubernetesDaemonSetSchema(),
+        KubernetesStatefulSetSchema(),
+        KubernetesDeploymentSchema(),
+    ):
+        logger.debug("Running cleanup job for %s", schema.label)
+        GraphJob.from_node_schema(schema, common_job_parameters).run(session)
+
+
+@timeit
+def sync_workloads(
+    session: neo4j.Session,
+    client: K8sClient,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> dict[str, str]:
+    """Sync Kubernetes workload controllers and return the ReplicaSet -> Deployment map.
+
+    The map is consumed by the pod sync so a pod owned by a ReplicaSet resolves
+    its WORKLOAD_PARENT straight to the owning Deployment (the ReplicaSet is
+    collapsed out of the ontology chain).
+    """
+    deployments = transform_deployments(get_deployments(client))
+    statefulsets = transform_statefulsets(get_statefulsets(client))
+    daemonsets = transform_daemonsets(get_daemonsets(client))
+    cronjobs = transform_cronjobs(get_cronjobs(client))
+    replicasets, replicaset_to_deployment = transform_replicasets(
+        get_replicasets(client)
+    )
+    jobs = transform_jobs(get_jobs(client))
+
+    load_workloads(
+        session=session,
+        deployments=deployments,
+        statefulsets=statefulsets,
+        daemonsets=daemonsets,
+        cronjobs=cronjobs,
+        replicasets=replicasets,
+        jobs=jobs,
+        update_tag=update_tag,
+        cluster_id=common_job_parameters["CLUSTER_ID"],
+        cluster_name=client.name,
+    )
+    cleanup(session, common_job_parameters)
+    return replicaset_to_deployment

--- a/cartography/intel/kubernetes/workloads.py
+++ b/cartography/intel/kubernetes/workloads.py
@@ -278,12 +278,15 @@ def sync_workloads(
     client: K8sClient,
     update_tag: int,
     common_job_parameters: dict[str, Any],
-) -> dict[str, str]:
+) -> dict[str, str] | None:
     """Sync Kubernetes workload controllers and return the ReplicaSet -> Deployment map.
 
     The map is consumed by the pod sync so a pod owned by a ReplicaSet resolves
     its WORKLOAD_PARENT straight to the owning Deployment (the ReplicaSet is
-    collapsed out of the ontology chain).
+    collapsed out of the ontology chain). Returns ``None`` (not ``{}``) when the
+    workload sync was skipped, so the pod sync can tell "controllers ingested,
+    none map to a Deployment" apart from "controllers not ingested at all" and
+    fall back to a namespace WORKLOAD_PARENT for every controller-owned pod.
 
     The apps/batch list verbs are required (see the Kubernetes config docs). The
     401/403 grace period below is a temporary migration aid, not an opt-out.
@@ -315,7 +318,7 @@ def sync_workloads(
                 client.name,
                 e.status,
             )
-            return {}
+            return None
         raise
 
     load_workloads(

--- a/cartography/models/kubernetes/cronjobs.py
+++ b/cartography/models/kubernetes/cronjobs.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class KubernetesCronJobNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("uid")
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    namespace: PropertyRef = PropertyRef("namespace", extra_index=True)
+    creation_timestamp: PropertyRef = PropertyRef("creation_timestamp")
+    deletion_timestamp: PropertyRef = PropertyRef("deletion_timestamp")
+    schedule: PropertyRef = PropertyRef("schedule")
+    suspend: PropertyRef = PropertyRef("suspend")
+    labels: PropertyRef = PropertyRef("labels")
+    cluster_name: PropertyRef = PropertyRef(
+        "CLUSTER_NAME", set_in_kwargs=True, extra_index=True
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesCronJobToKubernetesClusterRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesCronJob)<-[:RESOURCE]-(:KubernetesCluster)
+class KubernetesCronJobToKubernetesClusterRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("CLUSTER_ID", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: KubernetesCronJobToKubernetesClusterRelProperties = (
+        KubernetesCronJobToKubernetesClusterRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesCronJobToKubernetesNamespaceWorkloadParentRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesCronJob)-[:WORKLOAD_PARENT]->(:KubernetesNamespace)
+class KubernetesCronJobToKubernetesNamespaceWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesNamespace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "cluster_name": PropertyRef("CLUSTER_NAME", set_in_kwargs=True),
+            "name": PropertyRef("namespace"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: KubernetesCronJobToKubernetesNamespaceWorkloadParentRelProperties = (
+        KubernetesCronJobToKubernetesNamespaceWorkloadParentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesCronJobSchema(CartographyNodeSchema):
+    label: str = "KubernetesCronJob"
+    # ComputeService is the cross-provider "logical workload / controller" label.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeService"])
+    properties: KubernetesCronJobNodeProperties = KubernetesCronJobNodeProperties()
+    sub_resource_relationship: KubernetesCronJobToKubernetesClusterRel = (
+        KubernetesCronJobToKubernetesClusterRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            KubernetesCronJobToKubernetesNamespaceWorkloadParentRel(),
+        ]
+    )

--- a/cartography/models/kubernetes/daemonsets.py
+++ b/cartography/models/kubernetes/daemonsets.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class KubernetesDaemonSetNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("uid")
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    namespace: PropertyRef = PropertyRef("namespace", extra_index=True)
+    creation_timestamp: PropertyRef = PropertyRef("creation_timestamp")
+    deletion_timestamp: PropertyRef = PropertyRef("deletion_timestamp")
+    desired_number_scheduled: PropertyRef = PropertyRef("desired_number_scheduled")
+    number_ready: PropertyRef = PropertyRef("number_ready")
+    labels: PropertyRef = PropertyRef("labels")
+    cluster_name: PropertyRef = PropertyRef(
+        "CLUSTER_NAME", set_in_kwargs=True, extra_index=True
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesDaemonSetToKubernetesClusterRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesDaemonSet)<-[:RESOURCE]-(:KubernetesCluster)
+class KubernetesDaemonSetToKubernetesClusterRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("CLUSTER_ID", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: KubernetesDaemonSetToKubernetesClusterRelProperties = (
+        KubernetesDaemonSetToKubernetesClusterRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesDaemonSetToKubernetesNamespaceWorkloadParentRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesDaemonSet)-[:WORKLOAD_PARENT]->(:KubernetesNamespace)
+class KubernetesDaemonSetToKubernetesNamespaceWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesNamespace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "cluster_name": PropertyRef("CLUSTER_NAME", set_in_kwargs=True),
+            "name": PropertyRef("namespace"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: KubernetesDaemonSetToKubernetesNamespaceWorkloadParentRelProperties = (
+        KubernetesDaemonSetToKubernetesNamespaceWorkloadParentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesDaemonSetSchema(CartographyNodeSchema):
+    label: str = "KubernetesDaemonSet"
+    # ComputeService is the cross-provider "logical workload / controller" label.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeService"])
+    properties: KubernetesDaemonSetNodeProperties = KubernetesDaemonSetNodeProperties()
+    sub_resource_relationship: KubernetesDaemonSetToKubernetesClusterRel = (
+        KubernetesDaemonSetToKubernetesClusterRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            KubernetesDaemonSetToKubernetesNamespaceWorkloadParentRel(),
+        ]
+    )

--- a/cartography/models/kubernetes/deployments.py
+++ b/cartography/models/kubernetes/deployments.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class KubernetesDeploymentNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("uid")
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    namespace: PropertyRef = PropertyRef("namespace", extra_index=True)
+    creation_timestamp: PropertyRef = PropertyRef("creation_timestamp")
+    deletion_timestamp: PropertyRef = PropertyRef("deletion_timestamp")
+    replicas: PropertyRef = PropertyRef("replicas")
+    ready_replicas: PropertyRef = PropertyRef("ready_replicas")
+    available_replicas: PropertyRef = PropertyRef("available_replicas")
+    labels: PropertyRef = PropertyRef("labels")
+    cluster_name: PropertyRef = PropertyRef(
+        "CLUSTER_NAME", set_in_kwargs=True, extra_index=True
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesDeploymentToKubernetesClusterRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesDeployment)<-[:RESOURCE]-(:KubernetesCluster)
+class KubernetesDeploymentToKubernetesClusterRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("CLUSTER_ID", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: KubernetesDeploymentToKubernetesClusterRelProperties = (
+        KubernetesDeploymentToKubernetesClusterRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesDeploymentToKubernetesNamespaceWorkloadParentRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesDeployment)-[:WORKLOAD_PARENT]->(:KubernetesNamespace)
+class KubernetesDeploymentToKubernetesNamespaceWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesNamespace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "cluster_name": PropertyRef("CLUSTER_NAME", set_in_kwargs=True),
+            "name": PropertyRef("namespace"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: KubernetesDeploymentToKubernetesNamespaceWorkloadParentRelProperties = (
+        KubernetesDeploymentToKubernetesNamespaceWorkloadParentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesDeploymentSchema(CartographyNodeSchema):
+    label: str = "KubernetesDeployment"
+    # ComputeService is the cross-provider "logical workload / controller" label
+    # (peer of AWSECSService, GCPCloudRunService). It makes the Deployment the
+    # surfaced parent in the WORKLOAD_PARENT chain above the pod.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeService"])
+    properties: KubernetesDeploymentNodeProperties = (
+        KubernetesDeploymentNodeProperties()
+    )
+    sub_resource_relationship: KubernetesDeploymentToKubernetesClusterRel = (
+        KubernetesDeploymentToKubernetesClusterRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            KubernetesDeploymentToKubernetesNamespaceWorkloadParentRel(),
+        ]
+    )

--- a/cartography/models/kubernetes/jobs.py
+++ b/cartography/models/kubernetes/jobs.py
@@ -1,0 +1,118 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class KubernetesJobNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("uid")
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    namespace: PropertyRef = PropertyRef("namespace", extra_index=True)
+    creation_timestamp: PropertyRef = PropertyRef("creation_timestamp")
+    deletion_timestamp: PropertyRef = PropertyRef("deletion_timestamp")
+    completions: PropertyRef = PropertyRef("completions")
+    parallelism: PropertyRef = PropertyRef("parallelism")
+    active: PropertyRef = PropertyRef("active")
+    succeeded: PropertyRef = PropertyRef("succeeded")
+    failed: PropertyRef = PropertyRef("failed")
+    labels: PropertyRef = PropertyRef("labels")
+    cluster_name: PropertyRef = PropertyRef(
+        "CLUSTER_NAME", set_in_kwargs=True, extra_index=True
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesJobToKubernetesClusterRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesJob)<-[:RESOURCE]-(:KubernetesCluster)
+class KubernetesJobToKubernetesClusterRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("CLUSTER_ID", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: KubernetesJobToKubernetesClusterRelProperties = (
+        KubernetesJobToKubernetesClusterRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesJobToKubernetesCronJobWorkloadParentRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesJob)-[:WORKLOAD_PARENT]->(:KubernetesCronJob)
+# Only fires when the Job is owned by a CronJob (the loader sets
+# `_workload_parent_cronjob_id` from the Job's controller ownerReference).
+# Standalone Jobs fall through to the namespace edge below.
+class KubernetesJobToKubernetesCronJobWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesCronJob"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("_workload_parent_cronjob_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: KubernetesJobToKubernetesCronJobWorkloadParentRelProperties = (
+        KubernetesJobToKubernetesCronJobWorkloadParentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesJobToKubernetesNamespaceWorkloadParentRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesJob)-[:WORKLOAD_PARENT]->(:KubernetesNamespace)
+# Fallback parent for standalone Jobs (no owning CronJob). The matcher is gated
+# on `_workload_parent_namespace_name`, which the loader sets only when the Job
+# has no CronJob owner, so CronJob-owned Jobs don't get a duplicate edge.
+class KubernetesJobToKubernetesNamespaceWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesNamespace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "cluster_name": PropertyRef("CLUSTER_NAME", set_in_kwargs=True),
+            "name": PropertyRef("_workload_parent_namespace_name"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: KubernetesJobToKubernetesNamespaceWorkloadParentRelProperties = (
+        KubernetesJobToKubernetesNamespaceWorkloadParentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesJobSchema(CartographyNodeSchema):
+    label: str = "KubernetesJob"
+    # ComputeService is the cross-provider "logical workload / controller" label.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeService"])
+    properties: KubernetesJobNodeProperties = KubernetesJobNodeProperties()
+    sub_resource_relationship: KubernetesJobToKubernetesClusterRel = (
+        KubernetesJobToKubernetesClusterRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            KubernetesJobToKubernetesCronJobWorkloadParentRel(),
+            KubernetesJobToKubernetesNamespaceWorkloadParentRel(),
+        ]
+    )

--- a/cartography/models/kubernetes/pods.py
+++ b/cartography/models/kubernetes/pods.py
@@ -73,18 +73,110 @@ class KubernetesPodToKubernetesNamespaceWorkloadParentRelProperties(
 
 @dataclass(frozen=True)
 # (:KubernetesPod)-[:WORKLOAD_PARENT]->(:KubernetesNamespace)
+# Fallback parent for bare pods (no owning workload controller). The matcher is
+# gated on `_workload_parent_namespace_name`, which the loader sets only when the
+# pod has no surfaced controller, so controlled pods point at their controller
+# (Deployment / StatefulSet / DaemonSet / Job) instead of the namespace.
 class KubernetesPodToKubernetesNamespaceWorkloadParentRel(CartographyRelSchema):
     target_node_label: str = "KubernetesNamespace"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {
             "cluster_name": PropertyRef("CLUSTER_NAME", set_in_kwargs=True),
-            "name": PropertyRef("namespace"),
+            "name": PropertyRef("_workload_parent_namespace_name"),
         }
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "WORKLOAD_PARENT"
     properties: KubernetesPodToKubernetesNamespaceWorkloadParentRelProperties = (
         KubernetesPodToKubernetesNamespaceWorkloadParentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesPodToWorkloadControllerRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesPod)-[:WORKLOAD_PARENT]->(:KubernetesDeployment)
+# The Deployment is resolved through the owning ReplicaSet at ingest, so the
+# ReplicaSet is collapsed out of the chain. Gated on `_workload_parent_deployment_id`.
+class KubernetesPodToDeploymentWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesDeployment"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("_workload_parent_deployment_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: KubernetesPodToWorkloadControllerRelProperties = (
+        KubernetesPodToWorkloadControllerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+# (:KubernetesPod)-[:WORKLOAD_PARENT]->(:KubernetesStatefulSet)
+# Gated on `_workload_parent_statefulset_id`.
+class KubernetesPodToStatefulSetWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesStatefulSet"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("_workload_parent_statefulset_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: KubernetesPodToWorkloadControllerRelProperties = (
+        KubernetesPodToWorkloadControllerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+# (:KubernetesPod)-[:WORKLOAD_PARENT]->(:KubernetesDaemonSet)
+# Gated on `_workload_parent_daemonset_id`.
+class KubernetesPodToDaemonSetWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesDaemonSet"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("_workload_parent_daemonset_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: KubernetesPodToWorkloadControllerRelProperties = (
+        KubernetesPodToWorkloadControllerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+# (:KubernetesPod)-[:WORKLOAD_PARENT]->(:KubernetesJob)
+# Gated on `_workload_parent_job_id`.
+class KubernetesPodToJobWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesJob"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("_workload_parent_job_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: KubernetesPodToWorkloadControllerRelProperties = (
+        KubernetesPodToWorkloadControllerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesPodToReplicaSetOwnedByRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesPod)-[:OWNED_BY]->(:KubernetesReplicaSet)
+# Raw Kubernetes ownerReference. The ReplicaSet stays off the WORKLOAD_PARENT
+# chain (see the Deployment edge above), so this edge preserves the literal
+# ownership hierarchy. Gated on `_owner_replicaset_id`.
+class KubernetesPodToReplicaSetOwnedByRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesReplicaSet"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("_owner_replicaset_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "OWNED_BY"
+    properties: KubernetesPodToReplicaSetOwnedByRelProperties = (
+        KubernetesPodToReplicaSetOwnedByRelProperties()
     )
 
 
@@ -302,6 +394,11 @@ class KubernetesPodSchema(CartographyNodeSchema):
         [
             KubernetesPodToKubernetesNamespaceRel(),
             KubernetesPodToKubernetesNamespaceWorkloadParentRel(),
+            KubernetesPodToDeploymentWorkloadParentRel(),
+            KubernetesPodToStatefulSetWorkloadParentRel(),
+            KubernetesPodToDaemonSetWorkloadParentRel(),
+            KubernetesPodToJobWorkloadParentRel(),
+            KubernetesPodToReplicaSetOwnedByRel(),
             KubernetesPodToKubernetesNodeRel(),
             KubernetesPodToServiceAccountRel(),
             KubernetesPodToServiceAccountRunsAsRel(),

--- a/cartography/models/kubernetes/replicasets.py
+++ b/cartography/models/kubernetes/replicasets.py
@@ -1,0 +1,88 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class KubernetesReplicaSetNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("uid")
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    namespace: PropertyRef = PropertyRef("namespace", extra_index=True)
+    creation_timestamp: PropertyRef = PropertyRef("creation_timestamp")
+    deletion_timestamp: PropertyRef = PropertyRef("deletion_timestamp")
+    replicas: PropertyRef = PropertyRef("replicas")
+    ready_replicas: PropertyRef = PropertyRef("ready_replicas")
+    labels: PropertyRef = PropertyRef("labels")
+    cluster_name: PropertyRef = PropertyRef(
+        "CLUSTER_NAME", set_in_kwargs=True, extra_index=True
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesReplicaSetToKubernetesClusterRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesReplicaSet)<-[:RESOURCE]-(:KubernetesCluster)
+class KubernetesReplicaSetToKubernetesClusterRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("CLUSTER_ID", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: KubernetesReplicaSetToKubernetesClusterRelProperties = (
+        KubernetesReplicaSetToKubernetesClusterRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesReplicaSetToKubernetesDeploymentRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesReplicaSet)-[:OWNED_BY]->(:KubernetesDeployment)
+# Raw Kubernetes ownerReference. The ReplicaSet is an implementation detail and
+# is deliberately kept off the WORKLOAD_PARENT chain (it carries no ontology
+# label), so the pod's WORKLOAD_PARENT collapses straight to the Deployment.
+# Only fires when the ReplicaSet is owned by a Deployment (loader sets
+# `_owner_deployment_id`); bare ReplicaSets get no edge.
+class KubernetesReplicaSetToKubernetesDeploymentRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesDeployment"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("_owner_deployment_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "OWNED_BY"
+    properties: KubernetesReplicaSetToKubernetesDeploymentRelProperties = (
+        KubernetesReplicaSetToKubernetesDeploymentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesReplicaSetSchema(CartographyNodeSchema):
+    label: str = "KubernetesReplicaSet"
+    # No ontology label: the ReplicaSet is collapsed out of the WORKLOAD_PARENT
+    # chain, so its owning Deployment is the surfaced workload parent.
+    properties: KubernetesReplicaSetNodeProperties = (
+        KubernetesReplicaSetNodeProperties()
+    )
+    sub_resource_relationship: KubernetesReplicaSetToKubernetesClusterRel = (
+        KubernetesReplicaSetToKubernetesClusterRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            KubernetesReplicaSetToKubernetesDeploymentRel(),
+        ]
+    )

--- a/cartography/models/kubernetes/statefulsets.py
+++ b/cartography/models/kubernetes/statefulsets.py
@@ -1,0 +1,90 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class KubernetesStatefulSetNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("uid")
+    name: PropertyRef = PropertyRef("name", extra_index=True)
+    namespace: PropertyRef = PropertyRef("namespace", extra_index=True)
+    creation_timestamp: PropertyRef = PropertyRef("creation_timestamp")
+    deletion_timestamp: PropertyRef = PropertyRef("deletion_timestamp")
+    replicas: PropertyRef = PropertyRef("replicas")
+    ready_replicas: PropertyRef = PropertyRef("ready_replicas")
+    service_name: PropertyRef = PropertyRef("service_name")
+    labels: PropertyRef = PropertyRef("labels")
+    cluster_name: PropertyRef = PropertyRef(
+        "CLUSTER_NAME", set_in_kwargs=True, extra_index=True
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesStatefulSetToKubernetesClusterRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesStatefulSet)<-[:RESOURCE]-(:KubernetesCluster)
+class KubernetesStatefulSetToKubernetesClusterRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("CLUSTER_ID", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: KubernetesStatefulSetToKubernetesClusterRelProperties = (
+        KubernetesStatefulSetToKubernetesClusterRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesStatefulSetToKubernetesNamespaceWorkloadParentRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:KubernetesStatefulSet)-[:WORKLOAD_PARENT]->(:KubernetesNamespace)
+class KubernetesStatefulSetToKubernetesNamespaceWorkloadParentRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesNamespace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "cluster_name": PropertyRef("CLUSTER_NAME", set_in_kwargs=True),
+            "name": PropertyRef("namespace"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "WORKLOAD_PARENT"
+    properties: (
+        KubernetesStatefulSetToKubernetesNamespaceWorkloadParentRelProperties
+    ) = KubernetesStatefulSetToKubernetesNamespaceWorkloadParentRelProperties()
+
+
+@dataclass(frozen=True)
+class KubernetesStatefulSetSchema(CartographyNodeSchema):
+    label: str = "KubernetesStatefulSet"
+    # ComputeService is the cross-provider "logical workload / controller" label.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ComputeService"])
+    properties: KubernetesStatefulSetNodeProperties = (
+        KubernetesStatefulSetNodeProperties()
+    )
+    sub_resource_relationship: KubernetesStatefulSetToKubernetesClusterRel = (
+        KubernetesStatefulSetToKubernetesClusterRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            KubernetesStatefulSetToKubernetesNamespaceWorkloadParentRel(),
+        ]
+    )

--- a/cartography/models/ontology/constraints.py
+++ b/cartography/models/ontology/constraints.py
@@ -151,8 +151,18 @@ from cartography.models.kubernetes.containers import (
 from cartography.models.kubernetes.containers import (
     KubernetesContainerToKubernetesPodRel,
 )
+from cartography.models.kubernetes.cronjobs import (
+    KubernetesCronJobToKubernetesClusterRel,
+)
+from cartography.models.kubernetes.daemonsets import (
+    KubernetesDaemonSetToKubernetesClusterRel,
+)
+from cartography.models.kubernetes.deployments import (
+    KubernetesDeploymentToKubernetesClusterRel,
+)
 from cartography.models.kubernetes.groups import KubernetesGroupToAWSRoleRel
 from cartography.models.kubernetes.groups import KubernetesGroupToAWSUserRel
+from cartography.models.kubernetes.jobs import KubernetesJobToKubernetesClusterRel
 from cartography.models.kubernetes.namespaces import (
     KubernetesNamespaceToKubernetesClusterRel,
 )
@@ -163,6 +173,9 @@ from cartography.models.kubernetes.pods import KubernetesPodToSecretVolumeRel
 from cartography.models.kubernetes.pods import KubernetesPodToServiceAccountRel
 from cartography.models.kubernetes.serviceaccounts import (
     KubernetesServiceAccountToAWSRoleRel,
+)
+from cartography.models.kubernetes.statefulsets import (
+    KubernetesStatefulSetToKubernetesClusterRel,
 )
 from cartography.models.kubernetes.users import KubernetesUserToAWSRoleRel
 from cartography.models.oci.group import OCIGroupToOCIUserRel
@@ -175,6 +188,9 @@ from cartography.models.scaleway.iam.apikey import ScalewayApiKeyToApplicationRe
 from cartography.models.scaleway.iam.apikey import ScalewayApiKeyToUserRel
 from cartography.models.scaleway.serverless.container import (
     ScalewayServerlessContainerToImageRel,
+)
+from cartography.models.scaleway.serverless.container import (
+    ScalewayServerlessContainerToNamespaceRel,
 )
 from cartography.models.sentry.member import SentryUserToTeamAdminOfRel
 from cartography.models.slack.group import SlackGroupToCreatorRel
@@ -213,6 +229,13 @@ ONTOLOGY_REL_CONSTRAINTS: tuple[RelConstraint, ...] = (
     RelConstraint(
         src="ComputeNamespace", dst="ComputeCluster", label="WORKLOAD_PARENT"
     ),
+    # A logical workload controller (k8s Deployment / StatefulSet / DaemonSet /
+    # Job / CronJob) lives in a namespace.
+    RelConstraint(
+        src="ComputeService", dst="ComputeNamespace", label="WORKLOAD_PARENT"
+    ),
+    # A batch Job points at its owning CronJob (both are logical workloads).
+    RelConstraint(src="ComputeService", dst="ComputeService", label="WORKLOAD_PARENT"),
     # A user account is granted a role.
     RelConstraint(src="UserAccount", dst="PermissionRole", label="HAS_ROLE"),
     # A service account (workload identity) is granted a role. No provider
@@ -280,12 +303,22 @@ LEGACY_REL_WHITELIST: frozenset[type] = frozenset(
         ECSTaskToECSClusterRel,
         KubernetesContainerToKubernetesPodRel,
         KubernetesPodToKubernetesNamespaceRel,
-        # Kubernetes models its cluster as the tenant, so the pod's and
-        # namespace's sub_resource_relationship uses RESOURCE on a pair that
-        # the ontology also constrains as WORKLOAD_PARENT. Whitelisted until
-        # tenant scoping and the workload chain are reconciled.
+        # Kubernetes models its cluster as the tenant, so the pod's, namespace's
+        # and workload controllers' sub_resource_relationship uses RESOURCE on a
+        # pair that the ontology also constrains as WORKLOAD_PARENT. Whitelisted
+        # until tenant scoping and the workload chain are reconciled.
         KubernetesNamespaceToKubernetesClusterRel,
         KubernetesPodToKubernetesClusterRel,
+        KubernetesDeploymentToKubernetesClusterRel,
+        KubernetesStatefulSetToKubernetesClusterRel,
+        KubernetesDaemonSetToKubernetesClusterRel,
+        KubernetesJobToKubernetesClusterRel,
+        KubernetesCronJobToKubernetesClusterRel,
+        # Scaleway namespace HAS its serverless container: this is downward
+        # containment (:ComputeNamespace)-[:HAS]->(:ComputeService), the reverse
+        # of the ComputeService->ComputeNamespace WORKLOAD_PARENT constraint, so
+        # it is a distinct semantic rather than a workload-parent edge.
+        ScalewayServerlessContainerToNamespaceRel,
         # DEPRECATED: replaced by HAS_ROLE, will be removed in v1.0.0.
         AWSSSOUserToPermissionSetRel,
         KeycloakRoleToUserRel,

--- a/cartography/models/ontology/mapping/data/computeservices.py
+++ b/cartography/models/ontology/mapping/data/computeservices.py
@@ -65,9 +65,39 @@ scaleway_mapping = OntologyMapping(
     ],
 )
 
+# Kubernetes workload controllers are the logical-workload peer of an ECS service
+# / Cloud Run service. They carry no region and no single provisioning-status
+# field, so only the display name is mapped.
+kubernetes_mapping = OntologyMapping(
+    module_name="kubernetes",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="KubernetesDeployment",
+            fields=[OntologyFieldMapping(ontology_field="name", node_field="name")],
+        ),
+        OntologyNodeMapping(
+            node_label="KubernetesStatefulSet",
+            fields=[OntologyFieldMapping(ontology_field="name", node_field="name")],
+        ),
+        OntologyNodeMapping(
+            node_label="KubernetesDaemonSet",
+            fields=[OntologyFieldMapping(ontology_field="name", node_field="name")],
+        ),
+        OntologyNodeMapping(
+            node_label="KubernetesJob",
+            fields=[OntologyFieldMapping(ontology_field="name", node_field="name")],
+        ),
+        OntologyNodeMapping(
+            node_label="KubernetesCronJob",
+            fields=[OntologyFieldMapping(ontology_field="name", node_field="name")],
+        ),
+    ],
+)
+
 COMPUTESERVICES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws_ecs": aws_ecs_mapping,
     "gcp_cloudrun_service": gcp_cloudrun_service_mapping,
     "gcp_cloudrun_job": gcp_cloudrun_job_mapping,
     "scaleway": scaleway_mapping,
+    "kubernetes": kubernetes_mapping,
 }

--- a/docs/root/modules/kubernetes/config.md
+++ b/docs/root/modules/kubernetes/config.md
@@ -28,6 +28,7 @@ These permissions are recommended but Cartography degrades gracefully if they ar
 
 - `list gateways` and `list httproutes` in the `gateway.networking.k8s.io` group — enables ingestion of `KubernetesGateway` and `KubernetesHTTPRoute` and the `Gateway -[:ROUTES]-> HTTPRoute -[:TARGETS]-> Service` traffic path. The Gateway API CRDs are not installed on most clusters out of the box; if the CRDs are absent Cartography logs an info message and treats Gateway API as empty for the current sync, so previously synced `KubernetesGateway`/`KubernetesHTTPRoute` nodes for that cluster are cleaned up as stale. If the CRDs are present but the verbs are not granted, Cartography logs a warning, skips Gateway API ingestion, skips Gateway API cleanup, and continues with the rest of the cluster sync, preserving any previously synced `KubernetesGateway`/`KubernetesHTTPRoute` nodes.
 - `list networkpolicies` in the `networking.k8s.io` group — enables ingestion of `KubernetesNetworkPolicy` and the `(:KubernetesNetworkPolicy)-[:APPLIES_TO]->(:KubernetesPod)` edges used to reason about namespace segmentation. It is included in the recommended ClusterRole below. If the verb is not granted, Cartography logs a warning, skips NetworkPolicy ingestion, and skips its cleanup step, so previously synced `KubernetesNetworkPolicy` nodes are preserved rather than being wiped and every namespace silently modeled as unsegmented.
+- `list deployments`, `list replicasets`, `list statefulsets`, `list daemonsets` in the `apps` group and `list jobs`, `list cronjobs` in the `batch` group — enables ingestion of the workload controllers (`KubernetesDeployment`, `KubernetesReplicaSet`, `KubernetesStatefulSet`, `KubernetesDaemonSet`, `KubernetesJob`, `KubernetesCronJob`) and the `WORKLOAD_PARENT` chain that climbs from a pod through its controller (`Pod -> Deployment / StatefulSet / DaemonSet / Job -> Namespace`, with the intermediate `ReplicaSet` collapsed and `Job -> CronJob` for batch workloads). If any of these verbs is not granted, Cartography logs a warning, skips the workload sync **and** its cleanup step, and leaves pods pointing `WORKLOAD_PARENT` at their `Namespace` (the pre-controller behavior), so previously synced controller nodes are preserved rather than wiped. Grant the full set to enable the controller workload chain.
 - `list secrets` — enables ingestion of `KubernetesSecret` metadata (name, namespace, type, owner references). Kubernetes RBAC has no verb that exposes secret metadata without also exposing the content: granting `list secrets` also authorizes reading the base64-encoded `data` field of every secret in scope. Cartography never reads or stores secret content, but any identity with this permission can. Operators who prefer not to grant cluster-wide read access to secret content can omit this verb. When omitted, Cartography skips `sync_secrets` entirely — including the cleanup step — so previously synced `KubernetesSecret` nodes are preserved.
 - `get configmaps` (EKS only) — enables ingestion of legacy IAM identity mappings from the `aws-auth` ConfigMap in `kube-system`. Cartography processes the `mapRoles`, `mapUsers`, and `mapAccounts` fields. For `mapAccounts`, every IAM principal already synced from a listed AWS account (users, roles, and the account root principal) is mapped to a `KubernetesUser` named after the principal ARN (with no Kubernetes groups), so the AWS account must be synced for these mappings to resolve. This is optional because:
   - Clusters that use [EKS Access Entries](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html) exclusively may not have an `aws-auth` ConfigMap at all.
@@ -64,6 +65,22 @@ rules:
 - apiGroups: [""]
   resources:
     - secrets
+  verbs: ["list"]
+# Workload controllers (optional) — enable the WORKLOAD_PARENT chain from a pod
+# up to its owning controller. If these verbs are withheld, Cartography skips the
+# workload sync and its cleanup, and pods fall back to a namespace WORKLOAD_PARENT.
+# See the Optional Permissions section above.
+- apiGroups: ["apps"]
+  resources:
+    - deployments
+    - replicasets
+    - statefulsets
+    - daemonsets
+  verbs: ["list"]
+- apiGroups: ["batch"]
+  resources:
+    - jobs
+    - cronjobs
   verbs: ["list"]
 # RBAC resources
 - apiGroups: ["rbac.authorization.k8s.io"]

--- a/docs/root/modules/kubernetes/config.md
+++ b/docs/root/modules/kubernetes/config.md
@@ -22,19 +22,15 @@ Cartography's Kubernetes module requires read-only access to the following Kuber
 - `list clusterrolebindings`
 - `list ingresses`
 - `list deployments`, `list replicasets`, `list statefulsets`, `list daemonsets` in the `apps` group and `list jobs`, `list cronjobs` in the `batch` group: required to ingest the workload controllers (`KubernetesDeployment`, `KubernetesReplicaSet`, `KubernetesStatefulSet`, `KubernetesDaemonSet`, `KubernetesJob`, `KubernetesCronJob`) and the `WORKLOAD_PARENT` chain that climbs from a pod through its controller (`Pod -> Deployment / StatefulSet / DaemonSet / Job -> Namespace`, with the intermediate `ReplicaSet` collapsed and `Job -> CronJob` for batch workloads). Until v1.0.0, if these verbs are missing Cartography logs a warning and skips the workload sync (and its cleanup) so existing graphs are not broken or wiped on upgrade, and pods fall back to a namespace `WORKLOAD_PARENT`; from v1.0.0 a missing verb will be a hard failure.
+- `list networkpolicies` in the `networking.k8s.io` group: required to ingest `KubernetesNetworkPolicy` and the `(:KubernetesNetworkPolicy)-[:APPLIES_TO]->(:KubernetesPod)` edges used to reason about namespace segmentation. Until v1.0.0, if the verb is missing Cartography logs a warning and skips NetworkPolicy ingestion and its cleanup, so previously synced `KubernetesNetworkPolicy` nodes are preserved rather than wiped and namespaces are not silently modeled as unsegmented; from v1.0.0 a missing verb will be a hard failure.
+- `list gateways` and `list httproutes` in the `gateway.networking.k8s.io` group: required to ingest `KubernetesGateway` and `KubernetesHTTPRoute` and the `Gateway -[:ROUTES]-> HTTPRoute -[:TARGETS]-> Service` traffic path. The Gateway API CRDs are not installed on every cluster; when the CRDs are absent Cartography logs an info message and treats Gateway API as empty for that sync (previously synced `KubernetesGateway`/`KubernetesHTTPRoute` nodes are cleaned up as stale), which is expected and stays supported. Until v1.0.0, if the CRDs are present but the verbs are missing Cartography logs a warning and skips Gateway API ingestion and cleanup so previously synced nodes are preserved; from v1.0.0 a missing verb (with the CRDs present) will be a hard failure.
+- `get configmaps` (EKS only): required to ingest legacy IAM identity mappings from the `aws-auth` ConfigMap in `kube-system`. Cartography processes the `mapRoles`, `mapUsers`, and `mapAccounts` fields. For `mapAccounts`, every IAM principal already synced from a listed AWS account (users, roles, and the account root principal) is mapped to a `KubernetesUser` named after the principal ARN (with no Kubernetes groups), so the AWS account must be synced for these mappings to resolve. When the ConfigMap does not exist (clusters using [EKS Access Entries](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html) exclusively), Cartography logs an info message and continues with Access Entries and external OIDC providers, which is expected and stays supported. Until v1.0.0, if the verb is missing Cartography logs a warning and continues without legacy mappings; from v1.0.0 a missing verb will be a hard failure. Note that the EKS identity sync still runs its cleanup over `KubernetesUser` and `KubernetesGroup`: mappings that previously came only from `aws-auth` (not re-asserted by Access Entries in the current run) are removed from the graph.
 
 ### Optional Permissions
 
-These permissions are recommended but Cartography degrades gracefully if they are withheld: it logs a warning and skips the corresponding step. See each bullet for the precise behavior, since the trade-off differs per resource.
+The permission below is genuinely optional: withholding it is a supported long-term configuration (not a transitional grace period), because it carries a data-exposure trade-off. Cartography logs a warning and skips the corresponding step, including its cleanup, so previously synced nodes are preserved.
 
-- `list gateways` and `list httproutes` in the `gateway.networking.k8s.io` group — enables ingestion of `KubernetesGateway` and `KubernetesHTTPRoute` and the `Gateway -[:ROUTES]-> HTTPRoute -[:TARGETS]-> Service` traffic path. The Gateway API CRDs are not installed on most clusters out of the box; if the CRDs are absent Cartography logs an info message and treats Gateway API as empty for the current sync, so previously synced `KubernetesGateway`/`KubernetesHTTPRoute` nodes for that cluster are cleaned up as stale. If the CRDs are present but the verbs are not granted, Cartography logs a warning, skips Gateway API ingestion, skips Gateway API cleanup, and continues with the rest of the cluster sync, preserving any previously synced `KubernetesGateway`/`KubernetesHTTPRoute` nodes.
-- `list networkpolicies` in the `networking.k8s.io` group — enables ingestion of `KubernetesNetworkPolicy` and the `(:KubernetesNetworkPolicy)-[:APPLIES_TO]->(:KubernetesPod)` edges used to reason about namespace segmentation. It is included in the recommended ClusterRole below. If the verb is not granted, Cartography logs a warning, skips NetworkPolicy ingestion, and skips its cleanup step, so previously synced `KubernetesNetworkPolicy` nodes are preserved rather than being wiped and every namespace silently modeled as unsegmented.
 - `list secrets` — enables ingestion of `KubernetesSecret` metadata (name, namespace, type, owner references). Kubernetes RBAC has no verb that exposes secret metadata without also exposing the content: granting `list secrets` also authorizes reading the base64-encoded `data` field of every secret in scope. Cartography never reads or stores secret content, but any identity with this permission can. Operators who prefer not to grant cluster-wide read access to secret content can omit this verb. When omitted, Cartography skips `sync_secrets` entirely — including the cleanup step — so previously synced `KubernetesSecret` nodes are preserved.
-- `get configmaps` (EKS only) — enables ingestion of legacy IAM identity mappings from the `aws-auth` ConfigMap in `kube-system`. Cartography processes the `mapRoles`, `mapUsers`, and `mapAccounts` fields. For `mapAccounts`, every IAM principal already synced from a listed AWS account (users, roles, and the account root principal) is mapped to a `KubernetesUser` named after the principal ARN (with no Kubernetes groups), so the AWS account must be synced for these mappings to resolve. This is optional because:
-  - Clusters that use [EKS Access Entries](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html) exclusively may not have an `aws-auth` ConfigMap at all.
-  - Some operators prefer not to grant `get` on all ConfigMaps just to read `aws-auth`.
-
-  When omitted or when the ConfigMap does not exist, Cartography still ingests identity mappings from EKS Access Entries and external OIDC providers. Note that the EKS identity sync still runs its cleanup step over `KubernetesUser` and `KubernetesGroup`: mappings that previously came only from `aws-auth` (i.e. not also re-asserted by Access Entries in the current run) will be removed from the graph. If you want to preserve legacy `aws-auth` mappings across syncs, grant this verb.
 
 Create a ClusterRole and bind it to the identity used by Cartography:
 
@@ -96,18 +92,20 @@ rules:
     - ingresses
     - networkpolicies
   verbs: ["list"]
-# Gateway API resources (optional) — only useful when the Gateway API CRDs are
-# installed in the cluster. Cartography skips ingestion gracefully if the CRDs
-# are absent or the verbs are not granted. See the Optional Permissions section
-# above for behavior when these verbs are withheld.
+# Gateway API resources (required). Only apply when the Gateway API CRDs are
+# installed in the cluster (a genuinely absent CRD stays a supported no-op).
+# Until v1.0.0 a missing verb is tolerated (warn + skip ingestion and cleanup);
+# from v1.0.0 it is a hard failure. See the Required Permissions section above.
 - apiGroups: ["gateway.networking.k8s.io"]
   resources:
     - gateways
     - httproutes
   verbs: ["list"]
-# ConfigMaps (EKS only, optional) — only used to read the aws-auth ConfigMap for
-# legacy IAM identity mappings. Omit if your cluster uses EKS Access Entries
-# exclusively or if you don't want to grant `get` on all ConfigMaps.
+# ConfigMaps (EKS only, required). Used to read the aws-auth ConfigMap for
+# legacy IAM identity mappings (a genuinely absent aws-auth ConfigMap stays a
+# supported no-op on Access-Entry-only clusters). Until v1.0.0 a missing verb is
+# tolerated (warn + continue without legacy mappings); from v1.0.0 it is a hard
+# failure. See the Required Permissions section above.
 - apiGroups: [""]
   resources:
     - configmaps

--- a/docs/root/modules/kubernetes/config.md
+++ b/docs/root/modules/kubernetes/config.md
@@ -21,6 +21,7 @@ Cartography's Kubernetes module requires read-only access to the following Kuber
 - `list clusterroles`
 - `list clusterrolebindings`
 - `list ingresses`
+- `list deployments`, `list replicasets`, `list statefulsets`, `list daemonsets` in the `apps` group and `list jobs`, `list cronjobs` in the `batch` group: required to ingest the workload controllers (`KubernetesDeployment`, `KubernetesReplicaSet`, `KubernetesStatefulSet`, `KubernetesDaemonSet`, `KubernetesJob`, `KubernetesCronJob`) and the `WORKLOAD_PARENT` chain that climbs from a pod through its controller (`Pod -> Deployment / StatefulSet / DaemonSet / Job -> Namespace`, with the intermediate `ReplicaSet` collapsed and `Job -> CronJob` for batch workloads). Until v1.0.0, if these verbs are missing Cartography logs a warning and skips the workload sync (and its cleanup) so existing graphs are not broken or wiped on upgrade, and pods fall back to a namespace `WORKLOAD_PARENT`; from v1.0.0 a missing verb will be a hard failure.
 
 ### Optional Permissions
 
@@ -28,7 +29,6 @@ These permissions are recommended but Cartography degrades gracefully if they ar
 
 - `list gateways` and `list httproutes` in the `gateway.networking.k8s.io` group — enables ingestion of `KubernetesGateway` and `KubernetesHTTPRoute` and the `Gateway -[:ROUTES]-> HTTPRoute -[:TARGETS]-> Service` traffic path. The Gateway API CRDs are not installed on most clusters out of the box; if the CRDs are absent Cartography logs an info message and treats Gateway API as empty for the current sync, so previously synced `KubernetesGateway`/`KubernetesHTTPRoute` nodes for that cluster are cleaned up as stale. If the CRDs are present but the verbs are not granted, Cartography logs a warning, skips Gateway API ingestion, skips Gateway API cleanup, and continues with the rest of the cluster sync, preserving any previously synced `KubernetesGateway`/`KubernetesHTTPRoute` nodes.
 - `list networkpolicies` in the `networking.k8s.io` group — enables ingestion of `KubernetesNetworkPolicy` and the `(:KubernetesNetworkPolicy)-[:APPLIES_TO]->(:KubernetesPod)` edges used to reason about namespace segmentation. It is included in the recommended ClusterRole below. If the verb is not granted, Cartography logs a warning, skips NetworkPolicy ingestion, and skips its cleanup step, so previously synced `KubernetesNetworkPolicy` nodes are preserved rather than being wiped and every namespace silently modeled as unsegmented.
-- `list deployments`, `list replicasets`, `list statefulsets`, `list daemonsets` in the `apps` group and `list jobs`, `list cronjobs` in the `batch` group — enables ingestion of the workload controllers (`KubernetesDeployment`, `KubernetesReplicaSet`, `KubernetesStatefulSet`, `KubernetesDaemonSet`, `KubernetesJob`, `KubernetesCronJob`) and the `WORKLOAD_PARENT` chain that climbs from a pod through its controller (`Pod -> Deployment / StatefulSet / DaemonSet / Job -> Namespace`, with the intermediate `ReplicaSet` collapsed and `Job -> CronJob` for batch workloads). If any of these verbs is not granted, Cartography logs a warning, skips the workload sync **and** its cleanup step, and leaves pods pointing `WORKLOAD_PARENT` at their `Namespace` (the pre-controller behavior), so previously synced controller nodes are preserved rather than wiped. Grant the full set to enable the controller workload chain.
 - `list secrets` — enables ingestion of `KubernetesSecret` metadata (name, namespace, type, owner references). Kubernetes RBAC has no verb that exposes secret metadata without also exposing the content: granting `list secrets` also authorizes reading the base64-encoded `data` field of every secret in scope. Cartography never reads or stores secret content, but any identity with this permission can. Operators who prefer not to grant cluster-wide read access to secret content can omit this verb. When omitted, Cartography skips `sync_secrets` entirely — including the cleanup step — so previously synced `KubernetesSecret` nodes are preserved.
 - `get configmaps` (EKS only) — enables ingestion of legacy IAM identity mappings from the `aws-auth` ConfigMap in `kube-system`. Cartography processes the `mapRoles`, `mapUsers`, and `mapAccounts` fields. For `mapAccounts`, every IAM principal already synced from a listed AWS account (users, roles, and the account root principal) is mapped to a `KubernetesUser` named after the principal ARN (with no Kubernetes groups), so the AWS account must be synced for these mappings to resolve. This is optional because:
   - Clusters that use [EKS Access Entries](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html) exclusively may not have an `aws-auth` ConfigMap at all.
@@ -66,10 +66,10 @@ rules:
   resources:
     - secrets
   verbs: ["list"]
-# Workload controllers (optional) — enable the WORKLOAD_PARENT chain from a pod
-# up to its owning controller. If these verbs are withheld, Cartography skips the
-# workload sync and its cleanup, and pods fall back to a namespace WORKLOAD_PARENT.
-# See the Optional Permissions section above.
+# Workload controllers (required): enable the WORKLOAD_PARENT chain from a pod
+# up to its owning controller. Until v1.0.0 Cartography tolerates these verbs
+# being withheld (warns and skips the workload sync + cleanup, pods fall back to
+# a namespace WORKLOAD_PARENT); from v1.0.0 a missing verb is a hard failure.
 - apiGroups: ["apps"]
   resources:
     - deployments

--- a/docs/root/modules/kubernetes/schema.md
+++ b/docs/root/modules/kubernetes/schema.md
@@ -35,6 +35,12 @@ Representation of a [Kubernetes Cluster.](https://kubernetes.io/docs/concepts/ov
                                        :KubernetesNode,
                                        :KubernetesPod,
                                        :KubernetesContainer,
+                                       :KubernetesDeployment,
+                                       :KubernetesReplicaSet,
+                                       :KubernetesStatefulSet,
+                                       :KubernetesDaemonSet,
+                                       :KubernetesCronJob,
+                                       :KubernetesJob,
                                        :KubernetesService,
                                        :KubernetesSecret,
                                        :KubernetesIngress,
@@ -167,9 +173,18 @@ Representation of a [Kubernetes Pod.](https://kubernetes.io/docs/concepts/worklo
     (:KubernetesPod)-[:RUNS_AS]->(:KubernetesServiceAccount)
     ```
 
-- `KubernetesPod` points at its parent `KubernetesNamespace` via the unified workload chain.
+- `KubernetesPod` points at its owning workload controller via the unified workload chain. A pod owned by a Deployment collapses through its `KubernetesReplicaSet` straight to the Deployment. A pod with no controller (a bare pod) points at its `KubernetesNamespace` instead.
     ```
+    (:KubernetesPod)-[:WORKLOAD_PARENT]->(:KubernetesDeployment)
+    (:KubernetesPod)-[:WORKLOAD_PARENT]->(:KubernetesStatefulSet)
+    (:KubernetesPod)-[:WORKLOAD_PARENT]->(:KubernetesDaemonSet)
+    (:KubernetesPod)-[:WORKLOAD_PARENT]->(:KubernetesJob)
     (:KubernetesPod)-[:WORKLOAD_PARENT]->(:KubernetesNamespace)
+    ```
+
+- `KubernetesPod` is owned by a `KubernetesReplicaSet` via the raw Kubernetes ownerReference (kept even though the ReplicaSet is collapsed out of the workload chain).
+    ```
+    (:KubernetesPod)-[:OWNED_BY]->(:KubernetesReplicaSet)
     ```
 
 - `KubernetesPod` runs on a `KubernetesNode`. Not created for unscheduled pods.
@@ -240,6 +255,220 @@ Representation of a [Kubernetes Container.](https://kubernetes.io/docs/concepts/
 - An internet-facing `AWSLoadBalancerV2` exposes a `KubernetesContainer`. Created by the `k8s_lb_exposure` analysis job.
     ```
     (:AWSLoadBalancerV2)-[:EXPOSE {exposure_type: 'via_lb_only'}]->(:KubernetesContainer)
+    ```
+
+### KubernetesDeployment
+Representation of a [Kubernetes Deployment.](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+
+> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for the logical workload / controller unit across different systems (e.g., AWSECSService, GCPCloudRunService).
+
+| Field | Description |
+|-------|-------------|
+| **id** | UID of the Kubernetes deployment |
+| **name** | Name of the Kubernetes deployment |
+| **namespace** | The Kubernetes namespace where this deployment is deployed |
+| creation\_timestamp | Timestamp of the creation time of the Kubernetes deployment |
+| deletion\_timestamp | Timestamp of the deletion time of the Kubernetes deployment |
+| replicas | Desired number of replicas. Derived from `deployment.spec.replicas`. |
+| ready\_replicas | Number of ready replicas. Derived from `deployment.status.ready_replicas`. |
+| available\_replicas | Number of available replicas. Derived from `deployment.status.available_replicas`. |
+| labels | Labels from `deployment.metadata.labels`, stored as a JSON-encoded string. |
+| **cluster\_name** | Name of the Kubernetes cluster where this deployment lives |
+| firstseen | Timestamp of when a sync job first discovered this node |
+| **lastupdated** | Timestamp of the last time the node was updated |
+
+#### Relationships
+- `KubernetesDeployment` belongs to a `KubernetesCluster`.
+    ```
+    (:KubernetesCluster)-[:RESOURCE]->(:KubernetesDeployment)
+    ```
+
+- `KubernetesDeployment` points at its parent `KubernetesNamespace` via the unified workload chain.
+    ```
+    (:KubernetesDeployment)-[:WORKLOAD_PARENT]->(:KubernetesNamespace)
+    ```
+
+- A `KubernetesReplicaSet` is owned by a `KubernetesDeployment`.
+    ```
+    (:KubernetesReplicaSet)-[:OWNED_BY]->(:KubernetesDeployment)
+    ```
+
+### KubernetesReplicaSet
+Representation of a [Kubernetes ReplicaSet.](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/) The ReplicaSet is an implementation detail of a Deployment: it is modeled so the raw ownerReference chain is preserved, but it carries no ontology label and is collapsed out of the `WORKLOAD_PARENT` chain (a pod's surfaced workload parent is the owning Deployment).
+
+| Field | Description |
+|-------|-------------|
+| **id** | UID of the Kubernetes replica set |
+| **name** | Name of the Kubernetes replica set |
+| **namespace** | The Kubernetes namespace where this replica set is deployed |
+| creation\_timestamp | Timestamp of the creation time of the Kubernetes replica set |
+| deletion\_timestamp | Timestamp of the deletion time of the Kubernetes replica set |
+| replicas | Desired number of replicas. Derived from `replicaset.spec.replicas`. |
+| ready\_replicas | Number of ready replicas. Derived from `replicaset.status.ready_replicas`. |
+| labels | Labels from `replicaset.metadata.labels`, stored as a JSON-encoded string. |
+| **cluster\_name** | Name of the Kubernetes cluster where this replica set lives |
+| firstseen | Timestamp of when a sync job first discovered this node |
+| **lastupdated** | Timestamp of the last time the node was updated |
+
+#### Relationships
+- `KubernetesReplicaSet` belongs to a `KubernetesCluster`.
+    ```
+    (:KubernetesCluster)-[:RESOURCE]->(:KubernetesReplicaSet)
+    ```
+
+- `KubernetesReplicaSet` is owned by a `KubernetesDeployment` (raw ownerReference).
+    ```
+    (:KubernetesReplicaSet)-[:OWNED_BY]->(:KubernetesDeployment)
+    ```
+
+- `KubernetesPod` is owned by a `KubernetesReplicaSet` (raw ownerReference).
+    ```
+    (:KubernetesPod)-[:OWNED_BY]->(:KubernetesReplicaSet)
+    ```
+
+### KubernetesStatefulSet
+Representation of a [Kubernetes StatefulSet.](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)
+
+> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for the logical workload / controller unit across different systems (e.g., AWSECSService, GCPCloudRunService).
+
+| Field | Description |
+|-------|-------------|
+| **id** | UID of the Kubernetes stateful set |
+| **name** | Name of the Kubernetes stateful set |
+| **namespace** | The Kubernetes namespace where this stateful set is deployed |
+| creation\_timestamp | Timestamp of the creation time of the Kubernetes stateful set |
+| deletion\_timestamp | Timestamp of the deletion time of the Kubernetes stateful set |
+| replicas | Desired number of replicas. Derived from `statefulset.spec.replicas`. |
+| ready\_replicas | Number of ready replicas. Derived from `statefulset.status.ready_replicas`. |
+| service\_name | Name of the governing headless service. Derived from `statefulset.spec.service_name`. |
+| labels | Labels from `statefulset.metadata.labels`, stored as a JSON-encoded string. |
+| **cluster\_name** | Name of the Kubernetes cluster where this stateful set lives |
+| firstseen | Timestamp of when a sync job first discovered this node |
+| **lastupdated** | Timestamp of the last time the node was updated |
+
+#### Relationships
+- `KubernetesStatefulSet` belongs to a `KubernetesCluster`.
+    ```
+    (:KubernetesCluster)-[:RESOURCE]->(:KubernetesStatefulSet)
+    ```
+
+- `KubernetesStatefulSet` points at its parent `KubernetesNamespace` via the unified workload chain.
+    ```
+    (:KubernetesStatefulSet)-[:WORKLOAD_PARENT]->(:KubernetesNamespace)
+    ```
+
+- A `KubernetesPod` points at its owning `KubernetesStatefulSet` via the unified workload chain.
+    ```
+    (:KubernetesPod)-[:WORKLOAD_PARENT]->(:KubernetesStatefulSet)
+    ```
+
+### KubernetesDaemonSet
+Representation of a [Kubernetes DaemonSet.](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
+
+> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for the logical workload / controller unit across different systems (e.g., AWSECSService, GCPCloudRunService).
+
+| Field | Description |
+|-------|-------------|
+| **id** | UID of the Kubernetes daemon set |
+| **name** | Name of the Kubernetes daemon set |
+| **namespace** | The Kubernetes namespace where this daemon set is deployed |
+| creation\_timestamp | Timestamp of the creation time of the Kubernetes daemon set |
+| deletion\_timestamp | Timestamp of the deletion time of the Kubernetes daemon set |
+| desired\_number\_scheduled | Number of nodes that should run the daemon pod. Derived from `daemonset.status.desired_number_scheduled`. |
+| number\_ready | Number of nodes running a ready daemon pod. Derived from `daemonset.status.number_ready`. |
+| labels | Labels from `daemonset.metadata.labels`, stored as a JSON-encoded string. |
+| **cluster\_name** | Name of the Kubernetes cluster where this daemon set lives |
+| firstseen | Timestamp of when a sync job first discovered this node |
+| **lastupdated** | Timestamp of the last time the node was updated |
+
+#### Relationships
+- `KubernetesDaemonSet` belongs to a `KubernetesCluster`.
+    ```
+    (:KubernetesCluster)-[:RESOURCE]->(:KubernetesDaemonSet)
+    ```
+
+- `KubernetesDaemonSet` points at its parent `KubernetesNamespace` via the unified workload chain.
+    ```
+    (:KubernetesDaemonSet)-[:WORKLOAD_PARENT]->(:KubernetesNamespace)
+    ```
+
+- A `KubernetesPod` points at its owning `KubernetesDaemonSet` via the unified workload chain.
+    ```
+    (:KubernetesPod)-[:WORKLOAD_PARENT]->(:KubernetesDaemonSet)
+    ```
+
+### KubernetesCronJob
+Representation of a [Kubernetes CronJob.](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)
+
+> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for the logical workload / controller unit across different systems (e.g., AWSECSService, GCPCloudRunService).
+
+| Field | Description |
+|-------|-------------|
+| **id** | UID of the Kubernetes cron job |
+| **name** | Name of the Kubernetes cron job |
+| **namespace** | The Kubernetes namespace where this cron job is deployed |
+| creation\_timestamp | Timestamp of the creation time of the Kubernetes cron job |
+| deletion\_timestamp | Timestamp of the deletion time of the Kubernetes cron job |
+| schedule | Cron schedule the job runs on. Derived from `cronjob.spec.schedule`. |
+| suspend | Whether the cron job is suspended. Derived from `cronjob.spec.suspend`. |
+| labels | Labels from `cronjob.metadata.labels`, stored as a JSON-encoded string. |
+| **cluster\_name** | Name of the Kubernetes cluster where this cron job lives |
+| firstseen | Timestamp of when a sync job first discovered this node |
+| **lastupdated** | Timestamp of the last time the node was updated |
+
+#### Relationships
+- `KubernetesCronJob` belongs to a `KubernetesCluster`.
+    ```
+    (:KubernetesCluster)-[:RESOURCE]->(:KubernetesCronJob)
+    ```
+
+- `KubernetesCronJob` points at its parent `KubernetesNamespace` via the unified workload chain.
+    ```
+    (:KubernetesCronJob)-[:WORKLOAD_PARENT]->(:KubernetesNamespace)
+    ```
+
+- A `KubernetesJob` points at its owning `KubernetesCronJob` via the unified workload chain.
+    ```
+    (:KubernetesJob)-[:WORKLOAD_PARENT]->(:KubernetesCronJob)
+    ```
+
+### KubernetesJob
+Representation of a [Kubernetes Job.](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
+
+> **Ontology Mapping**: This node has the extra label `ComputeService` to enable cross-platform queries for the logical workload / controller unit across different systems (e.g., AWSECSService, GCPCloudRunService).
+
+| Field | Description |
+|-------|-------------|
+| **id** | UID of the Kubernetes job |
+| **name** | Name of the Kubernetes job |
+| **namespace** | The Kubernetes namespace where this job is deployed |
+| creation\_timestamp | Timestamp of the creation time of the Kubernetes job |
+| deletion\_timestamp | Timestamp of the deletion time of the Kubernetes job |
+| completions | Desired number of successful completions. Derived from `job.spec.completions`. |
+| parallelism | Maximum desired parallelism. Derived from `job.spec.parallelism`. |
+| active | Number of actively running pods. Derived from `job.status.active`. |
+| succeeded | Number of pods that reached the Succeeded phase. Derived from `job.status.succeeded`. |
+| failed | Number of pods that reached the Failed phase. Derived from `job.status.failed`. |
+| labels | Labels from `job.metadata.labels`, stored as a JSON-encoded string. |
+| **cluster\_name** | Name of the Kubernetes cluster where this job lives |
+| firstseen | Timestamp of when a sync job first discovered this node |
+| **lastupdated** | Timestamp of the last time the node was updated |
+
+#### Relationships
+- `KubernetesJob` belongs to a `KubernetesCluster`.
+    ```
+    (:KubernetesCluster)-[:RESOURCE]->(:KubernetesJob)
+    ```
+
+- `KubernetesJob` points at its owning `KubernetesCronJob` via the unified workload chain. A standalone Job (no owning CronJob) points at its `KubernetesNamespace` instead.
+    ```
+    (:KubernetesJob)-[:WORKLOAD_PARENT]->(:KubernetesCronJob)
+    (:KubernetesJob)-[:WORKLOAD_PARENT]->(:KubernetesNamespace)
+    ```
+
+- A `KubernetesPod` points at its owning `KubernetesJob` via the unified workload chain.
+    ```
+    (:KubernetesPod)-[:WORKLOAD_PARENT]->(:KubernetesJob)
     ```
 
 ### KubernetesService

--- a/tests/data/kubernetes/pods.py
+++ b/tests/data/kubernetes/pods.py
@@ -63,6 +63,10 @@ KUBERNETES_PODS_DATA = [
         "creation_timestamp": 1633581666,
         "deletion_timestamp": None,
         "namespace": KUBERNETES_CLUSTER_1_NAMESPACES_DATA[-1]["name"],
+        # Bare pod (no controller): its surfaced workload parent is the namespace.
+        "_workload_parent_namespace_name": KUBERNETES_CLUSTER_1_NAMESPACES_DATA[-1][
+            "name"
+        ],
         "service_account_name": "default",
         "service_account_id": (
             f"{KUBERNETES_CLUSTER_NAMES[0]}/"
@@ -91,6 +95,10 @@ KUBERNETES_PODS_DATA = [
         "creation_timestamp": 1633581666,
         "deletion_timestamp": None,
         "namespace": KUBERNETES_CLUSTER_1_NAMESPACES_DATA[-1]["name"],
+        # Bare pod (no controller): its surfaced workload parent is the namespace.
+        "_workload_parent_namespace_name": KUBERNETES_CLUSTER_1_NAMESPACES_DATA[-1][
+            "name"
+        ],
         "service_account_name": "workload-sa",
         "service_account_id": (
             f"{KUBERNETES_CLUSTER_NAMES[0]}/"

--- a/tests/data/kubernetes/workloads.py
+++ b/tests/data/kubernetes/workloads.py
@@ -1,0 +1,193 @@
+"""Raw (kubernetes-client-like) fixtures for the workload-controller sync.
+
+Each object mimics the attributes of the typed ``V1*`` models that the intel
+transforms read (``metadata`` / ``spec`` / ``status``), so tests can monkeypatch
+the ``get_*`` functions and exercise ``sync_workloads`` / ``sync_pods``
+end-to-end.
+
+Scenario (cluster 1, namespace ``my-namespace``):
+
+- Deployment ``web`` -> ReplicaSet ``web-rs`` -> Pod ``web-pod``
+- StatefulSet ``db`` -> Pod ``db-pod``
+- DaemonSet ``agent`` -> Pod ``agent-pod``
+- CronJob ``report`` -> Job ``report-123`` -> Pod ``report-pod``
+- standalone Job ``migrate`` -> Pod ``migrate-pod``
+- bare Pod ``bare-pod`` (no controller)
+"""
+
+from types import SimpleNamespace
+
+NAMESPACE = "my-namespace"
+
+DEPLOYMENT_UID = "dep-web-uid"
+REPLICASET_UID = "rs-web-uid"
+STATEFULSET_UID = "ss-db-uid"
+DAEMONSET_UID = "ds-agent-uid"
+CRONJOB_UID = "cj-report-uid"
+JOB_CRON_UID = "job-report-uid"
+JOB_STANDALONE_UID = "job-migrate-uid"
+
+POD_WEB_UID = "pod-web-uid"
+POD_DB_UID = "pod-db-uid"
+POD_AGENT_UID = "pod-agent-uid"
+POD_REPORT_UID = "pod-report-uid"
+POD_MIGRATE_UID = "pod-migrate-uid"
+POD_BARE_UID = "pod-bare-uid"
+
+
+def _owner_ref(
+    kind: str, uid: str, name: str, controller: bool = True
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        kind=kind,
+        uid=uid,
+        name=name,
+        api_version="apps/v1",
+        controller=controller,
+    )
+
+
+def _meta(
+    uid: str,
+    name: str,
+    owner_references: list | None = None,
+    labels: dict | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        uid=uid,
+        name=name,
+        namespace=NAMESPACE,
+        creation_timestamp=None,
+        deletion_timestamp=None,
+        labels=labels or {},
+        owner_references=owner_references or [],
+    )
+
+
+def get_raw_deployments() -> list[SimpleNamespace]:
+    return [
+        SimpleNamespace(
+            metadata=_meta(DEPLOYMENT_UID, "web"),
+            spec=SimpleNamespace(replicas=3),
+            status=SimpleNamespace(ready_replicas=3, available_replicas=3),
+        ),
+    ]
+
+
+def get_raw_replicasets() -> list[SimpleNamespace]:
+    return [
+        SimpleNamespace(
+            metadata=_meta(
+                REPLICASET_UID,
+                "web-rs",
+                owner_references=[_owner_ref("Deployment", DEPLOYMENT_UID, "web")],
+            ),
+            spec=SimpleNamespace(replicas=3),
+            status=SimpleNamespace(ready_replicas=3),
+        ),
+    ]
+
+
+def get_raw_statefulsets() -> list[SimpleNamespace]:
+    return [
+        SimpleNamespace(
+            metadata=_meta(STATEFULSET_UID, "db"),
+            spec=SimpleNamespace(replicas=2, service_name="db"),
+            status=SimpleNamespace(ready_replicas=2),
+        ),
+    ]
+
+
+def get_raw_daemonsets() -> list[SimpleNamespace]:
+    return [
+        SimpleNamespace(
+            metadata=_meta(DAEMONSET_UID, "agent"),
+            spec=SimpleNamespace(),
+            status=SimpleNamespace(desired_number_scheduled=5, number_ready=5),
+        ),
+    ]
+
+
+def get_raw_cronjobs() -> list[SimpleNamespace]:
+    return [
+        SimpleNamespace(
+            metadata=_meta(CRONJOB_UID, "report"),
+            spec=SimpleNamespace(schedule="*/5 * * * *", suspend=False),
+            status=SimpleNamespace(),
+        ),
+    ]
+
+
+def get_raw_jobs() -> list[SimpleNamespace]:
+    return [
+        SimpleNamespace(
+            metadata=_meta(
+                JOB_CRON_UID,
+                "report-123",
+                owner_references=[_owner_ref("CronJob", CRONJOB_UID, "report")],
+            ),
+            spec=SimpleNamespace(completions=1, parallelism=1),
+            status=SimpleNamespace(active=0, succeeded=1, failed=0),
+        ),
+        SimpleNamespace(
+            metadata=_meta(JOB_STANDALONE_UID, "migrate"),
+            spec=SimpleNamespace(completions=1, parallelism=1),
+            status=SimpleNamespace(active=1, succeeded=0, failed=0),
+        ),
+    ]
+
+
+def _raw_pod(
+    uid: str,
+    name: str,
+    owner_references: list | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        metadata=SimpleNamespace(
+            uid=uid,
+            name=name,
+            namespace=NAMESPACE,
+            creation_timestamp=None,
+            deletion_timestamp=None,
+            labels={},
+            owner_references=owner_references or [],
+        ),
+        spec=SimpleNamespace(
+            containers=[],
+            volumes=[],
+            node_name="my-node",
+            service_account_name="default",
+        ),
+        status=SimpleNamespace(phase="Running", container_statuses=[]),
+    )
+
+
+def get_raw_pods() -> list[SimpleNamespace]:
+    return [
+        _raw_pod(
+            POD_WEB_UID,
+            "web-pod",
+            owner_references=[_owner_ref("ReplicaSet", REPLICASET_UID, "web-rs")],
+        ),
+        _raw_pod(
+            POD_DB_UID,
+            "db-pod",
+            owner_references=[_owner_ref("StatefulSet", STATEFULSET_UID, "db")],
+        ),
+        _raw_pod(
+            POD_AGENT_UID,
+            "agent-pod",
+            owner_references=[_owner_ref("DaemonSet", DAEMONSET_UID, "agent")],
+        ),
+        _raw_pod(
+            POD_REPORT_UID,
+            "report-pod",
+            owner_references=[_owner_ref("Job", JOB_CRON_UID, "report-123")],
+        ),
+        _raw_pod(
+            POD_MIGRATE_UID,
+            "migrate-pod",
+            owner_references=[_owner_ref("Job", JOB_STANDALONE_UID, "migrate")],
+        ),
+        _raw_pod(POD_BARE_UID, "bare-pod"),
+    ]

--- a/tests/integration/cartography/intel/kubernetes/test_pods.py
+++ b/tests/integration/cartography/intel/kubernetes/test_pods.py
@@ -173,6 +173,35 @@ def test_load_pod_relationships(neo4j_session, _create_test_cluster):
     )
 
 
+def test_bare_pod_workload_parent_namespace(neo4j_session, _create_test_cluster):
+    # Act
+    load_pods(
+        neo4j_session,
+        KUBERNETES_PODS_DATA,
+        update_tag=TEST_UPDATE_TAG,
+        cluster_id=KUBERNETES_CLUSTER_IDS[0],
+        cluster_name=KUBERNETES_CLUSTER_NAMES[0],
+    )
+
+    # Assert: bare pods (no controller) still resolve WORKLOAD_PARENT to their
+    # namespace (no regression from the controller work).
+    expected_rels = {
+        ("my-pod", "my-namespace"),
+        ("my-service-pod", "my-namespace"),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "KubernetesPod",
+            "name",
+            "KubernetesNamespace",
+            "name",
+            "WORKLOAD_PARENT",
+        )
+        == expected_rels
+    )
+
+
 def test_load_pod_containers(neo4j_session, _create_test_cluster):
     # Arrange
     load_pods(

--- a/tests/integration/cartography/intel/kubernetes/test_workloads.py
+++ b/tests/integration/cartography/intel/kubernetes/test_workloads.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import pytest
+from kubernetes.client.exceptions import ApiException
 
 import cartography.intel.kubernetes.pods as pods
 import cartography.intel.kubernetes.workloads as workloads
@@ -202,6 +203,36 @@ def test_controller_workload_parent_up_the_chain(
             rel_direction_right=False,
         )
         assert rels, f"expected {label} -> namespace WORKLOAD_PARENT edge"
+
+
+def test_forbidden_workload_list_preserves_nodes(
+    neo4j_session, _create_test_cluster, monkeypatch
+):
+    # First a normal sync populates the controllers.
+    _run_sync(neo4j_session, monkeypatch)
+    assert check_nodes(neo4j_session, "KubernetesDeployment", ["name"]) == {("web",)}
+
+    # A later run where the operator revoked `list deployments` (403) must NOT
+    # wipe the existing workload nodes: sync_workloads skips load + cleanup and
+    # returns an empty map.
+    client = SimpleNamespace(name=KUBERNETES_CLUSTER_NAMES[0])
+
+    def _forbidden(_c):
+        raise ApiException(status=403, reason="Forbidden")
+
+    monkeypatch.setattr(workloads, "get_deployments", _forbidden)
+
+    result = workloads.sync_workloads(
+        neo4j_session,
+        client,
+        TEST_UPDATE_TAG + 1,
+        {"UPDATE_TAG": TEST_UPDATE_TAG + 1, "CLUSTER_ID": KUBERNETES_CLUSTER_IDS[0]},
+    )
+
+    assert result == {}
+    # Nodes from the previous successful sync are preserved.
+    assert check_nodes(neo4j_session, "KubernetesDeployment", ["name"]) == {("web",)}
+    assert check_nodes(neo4j_session, "KubernetesReplicaSet", ["name"]) == {("web-rs",)}
 
 
 def test_bare_pod_still_resolves_to_namespace(

--- a/tests/integration/cartography/intel/kubernetes/test_workloads.py
+++ b/tests/integration/cartography/intel/kubernetes/test_workloads.py
@@ -31,8 +31,21 @@ def _create_test_cluster(neo4j_session):
         KUBERNETES_CLUSTER_IDS[0],
     )
     yield
-    neo4j_session.run("MATCH (n:KubernetesNamespace) DETACH DELETE n")
-    neo4j_session.run("MATCH (n:KubernetesCluster) DETACH DELETE n")
+    # Clear every Kubernetes node so workload/pod state does not leak between
+    # tests (the forbidden-sync tests assert on the absence of controller nodes).
+    for label in (
+        "KubernetesContainer",
+        "KubernetesPod",
+        "KubernetesDeployment",
+        "KubernetesReplicaSet",
+        "KubernetesStatefulSet",
+        "KubernetesDaemonSet",
+        "KubernetesJob",
+        "KubernetesCronJob",
+        "KubernetesNamespace",
+        "KubernetesCluster",
+    ):
+        neo4j_session.run(f"MATCH (n:{label}) DETACH DELETE n")
 
 
 def _run_sync(neo4j_session, monkeypatch):
@@ -214,7 +227,7 @@ def test_forbidden_workload_list_preserves_nodes(
 
     # A later run where the operator revoked `list deployments` (403) must NOT
     # wipe the existing workload nodes: sync_workloads skips load + cleanup and
-    # returns an empty map.
+    # returns None (signalling "workloads unavailable", distinct from {}).
     client = SimpleNamespace(name=KUBERNETES_CLUSTER_NAMES[0])
 
     def _forbidden(_c):
@@ -229,10 +242,62 @@ def test_forbidden_workload_list_preserves_nodes(
         {"UPDATE_TAG": TEST_UPDATE_TAG + 1, "CLUSTER_ID": KUBERNETES_CLUSTER_IDS[0]},
     )
 
-    assert result == {}
+    assert result is None
     # Nodes from the previous successful sync are preserved.
     assert check_nodes(neo4j_session, "KubernetesDeployment", ["name"]) == {("web",)}
     assert check_nodes(neo4j_session, "KubernetesReplicaSet", ["name"]) == {("web-rs",)}
+
+
+def test_forbidden_workloads_pods_fall_back_to_namespace(
+    neo4j_session, _create_test_cluster, monkeypatch
+):
+    # When the workload sync is skipped (403), no controller node is ingested, so
+    # every controller-owned pod (StatefulSet/DaemonSet/Job as well as the
+    # collapsed ReplicaSet case) must fall back to a namespace WORKLOAD_PARENT
+    # rather than being orphaned from the chain.
+    client = SimpleNamespace(name=KUBERNETES_CLUSTER_NAMES[0])
+    common = {"UPDATE_TAG": TEST_UPDATE_TAG, "CLUSTER_ID": KUBERNETES_CLUSTER_IDS[0]}
+
+    def _forbidden(_c):
+        raise ApiException(status=403, reason="Forbidden")
+
+    monkeypatch.setattr(workloads, "get_deployments", _forbidden)
+    monkeypatch.setattr(pods, "get_pods", lambda c: workload_data.get_raw_pods())
+
+    rs_map = workloads.sync_workloads(neo4j_session, client, TEST_UPDATE_TAG, common)
+    assert rs_map is None
+    sync_pods(
+        neo4j_session, client, TEST_UPDATE_TAG, common, replicaset_owner_map=rs_map
+    )
+
+    # No controller nodes were ingested.
+    for label in (
+        "KubernetesDeployment",
+        "KubernetesStatefulSet",
+        "KubernetesDaemonSet",
+        "KubernetesJob",
+        "KubernetesCronJob",
+    ):
+        assert check_nodes(neo4j_session, label, ["name"]) == set()
+
+    ns = workload_data.NAMESPACE
+    # Every pod (RS/StatefulSet/DaemonSet/Job-owned and the bare pod) falls back
+    # to the namespace.
+    assert check_rels(
+        neo4j_session,
+        "KubernetesPod",
+        "name",
+        "KubernetesNamespace",
+        "name",
+        "WORKLOAD_PARENT",
+    ) == {
+        ("web-pod", ns),
+        ("db-pod", ns),
+        ("agent-pod", ns),
+        ("report-pod", ns),
+        ("migrate-pod", ns),
+        ("bare-pod", ns),
+    }
 
 
 def test_bare_pod_still_resolves_to_namespace(

--- a/tests/integration/cartography/intel/kubernetes/test_workloads.py
+++ b/tests/integration/cartography/intel/kubernetes/test_workloads.py
@@ -248,6 +248,36 @@ def test_forbidden_workload_list_preserves_nodes(
     assert check_nodes(neo4j_session, "KubernetesReplicaSet", ["name"]) == {("web-rs",)}
 
 
+def test_transient_workload_error_skips_and_preserves(
+    neo4j_session, _create_test_cluster, monkeypatch
+):
+    # A non-permission API error (e.g. 500) on any controller list must not be
+    # mistaken for a successful empty sync: get_* re-raise (raise_on_error) and
+    # sync_workloads returns None, skipping load + cleanup so existing nodes are
+    # preserved and pods fall back to a namespace WORKLOAD_PARENT.
+    _run_sync(neo4j_session, monkeypatch)
+    assert check_nodes(neo4j_session, "KubernetesStatefulSet", ["name"]) == {("db",)}
+
+    client = SimpleNamespace(name=KUBERNETES_CLUSTER_NAMES[0])
+
+    def _server_error(_c):
+        raise ApiException(status=500, reason="ServerError")
+
+    monkeypatch.setattr(workloads, "get_statefulsets", _server_error)
+
+    result = workloads.sync_workloads(
+        neo4j_session,
+        client,
+        TEST_UPDATE_TAG + 1,
+        {"UPDATE_TAG": TEST_UPDATE_TAG + 1, "CLUSTER_ID": KUBERNETES_CLUSTER_IDS[0]},
+    )
+
+    assert result is None
+    # Nodes from the previous successful sync are preserved (no destructive cleanup).
+    assert check_nodes(neo4j_session, "KubernetesDeployment", ["name"]) == {("web",)}
+    assert check_nodes(neo4j_session, "KubernetesStatefulSet", ["name"]) == {("db",)}
+
+
 def test_forbidden_workloads_pods_fall_back_to_namespace(
     neo4j_session, _create_test_cluster, monkeypatch
 ):

--- a/tests/integration/cartography/intel/kubernetes/test_workloads.py
+++ b/tests/integration/cartography/intel/kubernetes/test_workloads.py
@@ -1,0 +1,222 @@
+from types import SimpleNamespace
+
+import pytest
+
+import cartography.intel.kubernetes.pods as pods
+import cartography.intel.kubernetes.workloads as workloads
+from cartography.intel.kubernetes.clusters import load_kubernetes_cluster
+from cartography.intel.kubernetes.namespaces import load_namespaces
+from cartography.intel.kubernetes.pods import sync_pods
+from cartography.intel.kubernetes.workloads import sync_workloads
+from tests.data.kubernetes import workloads as workload_data
+from tests.data.kubernetes.clusters import KUBERNETES_CLUSTER_DATA
+from tests.data.kubernetes.clusters import KUBERNETES_CLUSTER_IDS
+from tests.data.kubernetes.clusters import KUBERNETES_CLUSTER_NAMES
+from tests.data.kubernetes.namespaces import KUBERNETES_CLUSTER_1_NAMESPACES_DATA
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+@pytest.fixture
+def _create_test_cluster(neo4j_session):
+    load_kubernetes_cluster(neo4j_session, KUBERNETES_CLUSTER_DATA, TEST_UPDATE_TAG)
+    load_namespaces(
+        neo4j_session,
+        KUBERNETES_CLUSTER_1_NAMESPACES_DATA,
+        TEST_UPDATE_TAG,
+        KUBERNETES_CLUSTER_NAMES[0],
+        KUBERNETES_CLUSTER_IDS[0],
+    )
+    yield
+    neo4j_session.run("MATCH (n:KubernetesNamespace) DETACH DELETE n")
+    neo4j_session.run("MATCH (n:KubernetesCluster) DETACH DELETE n")
+
+
+def _run_sync(neo4j_session, monkeypatch):
+    client = SimpleNamespace(name=KUBERNETES_CLUSTER_NAMES[0])
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "CLUSTER_ID": KUBERNETES_CLUSTER_IDS[0],
+    }
+
+    monkeypatch.setattr(
+        workloads, "get_deployments", lambda c: workload_data.get_raw_deployments()
+    )
+    monkeypatch.setattr(
+        workloads, "get_replicasets", lambda c: workload_data.get_raw_replicasets()
+    )
+    monkeypatch.setattr(
+        workloads, "get_statefulsets", lambda c: workload_data.get_raw_statefulsets()
+    )
+    monkeypatch.setattr(
+        workloads, "get_daemonsets", lambda c: workload_data.get_raw_daemonsets()
+    )
+    monkeypatch.setattr(
+        workloads, "get_cronjobs", lambda c: workload_data.get_raw_cronjobs()
+    )
+    monkeypatch.setattr(workloads, "get_jobs", lambda c: workload_data.get_raw_jobs())
+    monkeypatch.setattr(pods, "get_pods", lambda c: workload_data.get_raw_pods())
+
+    replicaset_owner_map = sync_workloads(
+        neo4j_session, client, TEST_UPDATE_TAG, common_job_parameters
+    )
+    sync_pods(
+        neo4j_session,
+        client,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+        replicaset_owner_map=replicaset_owner_map,
+    )
+
+
+def test_workload_nodes(neo4j_session, _create_test_cluster, monkeypatch):
+    _run_sync(neo4j_session, monkeypatch)
+
+    assert check_nodes(neo4j_session, "KubernetesDeployment", ["name"]) == {("web",)}
+    assert check_nodes(neo4j_session, "KubernetesReplicaSet", ["name"]) == {("web-rs",)}
+    assert check_nodes(neo4j_session, "KubernetesStatefulSet", ["name"]) == {("db",)}
+    assert check_nodes(neo4j_session, "KubernetesDaemonSet", ["name"]) == {("agent",)}
+    assert check_nodes(neo4j_session, "KubernetesCronJob", ["name"]) == {("report",)}
+    assert check_nodes(neo4j_session, "KubernetesJob", ["name"]) == {
+        ("report-123",),
+        ("migrate",),
+    }
+
+    # Surfaced controllers carry the ComputeService ontology label; ReplicaSet
+    # does not (it is collapsed out of the chain).
+    assert check_nodes(neo4j_session, "ComputeService", ["name"]) >= {
+        ("web",),
+        ("db",),
+        ("agent",),
+        ("report",),
+        ("report-123",),
+        ("migrate",),
+    }
+    assert ("web-rs",) not in check_nodes(neo4j_session, "ComputeService", ["name"])
+
+
+def test_ownerreferences_edges(neo4j_session, _create_test_cluster, monkeypatch):
+    _run_sync(neo4j_session, monkeypatch)
+
+    # Raw ownerReference chain through the (collapsed) ReplicaSet.
+    assert check_rels(
+        neo4j_session,
+        "KubernetesPod",
+        "name",
+        "KubernetesReplicaSet",
+        "name",
+        "OWNED_BY",
+    ) == {("web-pod", "web-rs")}
+    assert check_rels(
+        neo4j_session,
+        "KubernetesReplicaSet",
+        "name",
+        "KubernetesDeployment",
+        "name",
+        "OWNED_BY",
+    ) == {("web-rs", "web")}
+
+
+def test_pod_workload_parent_collapses_replicaset(
+    neo4j_session, _create_test_cluster, monkeypatch
+):
+    _run_sync(neo4j_session, monkeypatch)
+
+    # Pod skips the ReplicaSet and points straight at the Deployment.
+    assert check_rels(
+        neo4j_session,
+        "KubernetesPod",
+        "name",
+        "KubernetesDeployment",
+        "name",
+        "WORKLOAD_PARENT",
+    ) == {("web-pod", "web")}
+    assert check_rels(
+        neo4j_session,
+        "KubernetesPod",
+        "name",
+        "KubernetesStatefulSet",
+        "name",
+        "WORKLOAD_PARENT",
+    ) == {("db-pod", "db")}
+    assert check_rels(
+        neo4j_session,
+        "KubernetesPod",
+        "name",
+        "KubernetesDaemonSet",
+        "name",
+        "WORKLOAD_PARENT",
+    ) == {("agent-pod", "agent")}
+    assert check_rels(
+        neo4j_session,
+        "KubernetesPod",
+        "name",
+        "KubernetesJob",
+        "name",
+        "WORKLOAD_PARENT",
+    ) == {("report-pod", "report-123"), ("migrate-pod", "migrate")}
+
+
+def test_controller_workload_parent_up_the_chain(
+    neo4j_session, _create_test_cluster, monkeypatch
+):
+    _run_sync(neo4j_session, monkeypatch)
+
+    # Job owned by a CronJob points at it; standalone Job falls back to namespace.
+    assert check_rels(
+        neo4j_session,
+        "KubernetesJob",
+        "name",
+        "KubernetesCronJob",
+        "name",
+        "WORKLOAD_PARENT",
+    ) == {("report-123", "report")}
+
+    controller_to_namespace = check_rels(
+        neo4j_session,
+        "KubernetesNamespace",
+        "name",
+        "KubernetesJob",
+        "name",
+        "WORKLOAD_PARENT",
+        rel_direction_right=False,
+    )
+    assert controller_to_namespace == {(workload_data.NAMESPACE, "migrate")}
+
+    # The long-running controllers and the CronJob anchor to the namespace.
+    for label in (
+        "KubernetesDeployment",
+        "KubernetesStatefulSet",
+        "KubernetesDaemonSet",
+        "KubernetesCronJob",
+    ):
+        rels = check_rels(
+            neo4j_session,
+            "KubernetesNamespace",
+            "name",
+            label,
+            "name",
+            "WORKLOAD_PARENT",
+            rel_direction_right=False,
+        )
+        assert rels, f"expected {label} -> namespace WORKLOAD_PARENT edge"
+
+
+def test_bare_pod_still_resolves_to_namespace(
+    neo4j_session, _create_test_cluster, monkeypatch
+):
+    _run_sync(neo4j_session, monkeypatch)
+
+    # A pod with no controller keeps its namespace WORKLOAD_PARENT (no regression);
+    # controlled pods do NOT get a namespace WORKLOAD_PARENT edge.
+    pod_to_namespace = check_rels(
+        neo4j_session,
+        "KubernetesPod",
+        "name",
+        "KubernetesNamespace",
+        "name",
+        "WORKLOAD_PARENT",
+    )
+    assert pod_to_namespace == {("bare-pod", workload_data.NAMESPACE)}

--- a/tests/unit/cartography/intel/kubernetes/test_init.py
+++ b/tests/unit/cartography/intel/kubernetes/test_init.py
@@ -31,6 +31,7 @@ def test_start_k8s_ingestion_uses_external_id_for_eks_region(monkeypatch):
     monkeypatch.setattr(
         kubernetes, "sync_kubernetes_rbac", lambda *args, **kwargs: None
     )
+    monkeypatch.setattr(kubernetes, "sync_workloads", lambda *args, **kwargs: {})
     monkeypatch.setattr(kubernetes, "sync_pods", lambda *args, **kwargs: [])
     monkeypatch.setattr(kubernetes, "sync_secrets", lambda *args, **kwargs: None)
     monkeypatch.setattr(kubernetes, "sync_services", lambda *args, **kwargs: None)

--- a/tests/unit/cartography/intel/kubernetes/test_pods.py
+++ b/tests/unit/cartography/intel/kubernetes/test_pods.py
@@ -131,6 +131,26 @@ def test_transform_pods_direct_controllers():
     assert job["_workload_parent_job_id"] == "job-uid"
 
 
+def test_transform_pods_unavailable_workloads_fall_back_to_namespace():
+    # When the workload sync was skipped (workloads_available=False), a pod owned
+    # by a StatefulSet/DaemonSet/Job must anchor to its namespace rather than
+    # point at a controller id that was never ingested.
+    ss_pod = _owned_pod("pod-ss", "db-pod", "StatefulSet", "ss-uid")
+    job_pod = _owned_pod("pod-job", "job-pod", "Job", "job-uid")
+
+    ss, job = transform_pods(
+        [ss_pod, job_pod], "my-cluster-1", workloads_available=False
+    )
+
+    for p in (ss, job):
+        assert p["_workload_parent_namespace_name"] == "my-namespace"
+        assert p["_workload_parent_statefulset_id"] is None
+        assert p["_workload_parent_daemonset_id"] is None
+        assert p["_workload_parent_job_id"] is None
+        assert p["_workload_parent_deployment_id"] is None
+        assert p["_owner_replicaset_id"] is None
+
+
 def test_transform_pods_propagates_node_architecture_to_pod_and_container():
     pod = SimpleNamespace(
         metadata=SimpleNamespace(

--- a/tests/unit/cartography/intel/kubernetes/test_pods.py
+++ b/tests/unit/cartography/intel/kubernetes/test_pods.py
@@ -27,6 +27,14 @@ def test_transform_pods_defaults_service_account_name():
 
     assert transformed == [
         {
+            # A pod with no controller (no ownerReferences) resolves its
+            # workload parent to its namespace; the controller ids stay None.
+            "_workload_parent_deployment_id": None,
+            "_workload_parent_statefulset_id": None,
+            "_workload_parent_daemonset_id": None,
+            "_workload_parent_job_id": None,
+            "_owner_replicaset_id": None,
+            "_workload_parent_namespace_name": "my-namespace",
             "uid": "pod-1",
             "name": "default-sa-pod",
             "status_phase": "Running",
@@ -50,6 +58,77 @@ def test_transform_pods_defaults_service_account_name():
             "secret_env_ids": [],
         },
     ]
+
+
+def _owned_pod(uid: str, name: str, owner_kind: str, owner_uid: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        metadata=SimpleNamespace(
+            uid=uid,
+            name=name,
+            namespace="my-namespace",
+            creation_timestamp=None,
+            deletion_timestamp=None,
+            labels={},
+            owner_references=[
+                SimpleNamespace(
+                    kind=owner_kind,
+                    uid=owner_uid,
+                    name="owner",
+                    api_version="apps/v1",
+                    controller=True,
+                ),
+            ],
+        ),
+        spec=SimpleNamespace(
+            containers=[],
+            volumes=[],
+            node_name="node-a",
+            service_account_name="default",
+        ),
+        status=SimpleNamespace(phase="Running", container_statuses=[]),
+    )
+
+
+def test_transform_pods_collapses_replicaset_to_deployment():
+    # A pod owned by a ReplicaSet resolves straight to the ReplicaSet's
+    # Deployment (the ReplicaSet is collapsed out of the workload chain), and
+    # the raw ReplicaSet owner is retained for the OWNED_BY edge.
+    pod = _owned_pod("pod-rs", "web-pod", "ReplicaSet", "rs-uid")
+
+    transformed = transform_pods(
+        [pod], "my-cluster-1", replicaset_owner_map={"rs-uid": "dep-uid"}
+    )[0]
+
+    assert transformed["_owner_replicaset_id"] == "rs-uid"
+    assert transformed["_workload_parent_deployment_id"] == "dep-uid"
+    assert transformed["_workload_parent_namespace_name"] is None
+    assert transformed["_workload_parent_statefulset_id"] is None
+
+
+def test_transform_pods_bare_replicaset_falls_back_to_namespace():
+    # A ReplicaSet with no owning Deployment is not surfaced, so the pod anchors
+    # to its namespace while still recording the raw ReplicaSet owner.
+    pod = _owned_pod("pod-rs2", "bare-rs-pod", "ReplicaSet", "rs-bare")
+
+    transformed = transform_pods([pod], "my-cluster-1", replicaset_owner_map={})[0]
+
+    assert transformed["_owner_replicaset_id"] == "rs-bare"
+    assert transformed["_workload_parent_deployment_id"] is None
+    assert transformed["_workload_parent_namespace_name"] == "my-namespace"
+
+
+def test_transform_pods_direct_controllers():
+    # StatefulSet / DaemonSet / Job owners are surfaced directly (no collapse).
+    ss_pod = _owned_pod("pod-ss", "db-pod", "StatefulSet", "ss-uid")
+    ds_pod = _owned_pod("pod-ds", "agent-pod", "DaemonSet", "ds-uid")
+    job_pod = _owned_pod("pod-job", "job-pod", "Job", "job-uid")
+
+    ss, ds, job = transform_pods([ss_pod, ds_pod, job_pod], "my-cluster-1")
+
+    assert ss["_workload_parent_statefulset_id"] == "ss-uid"
+    assert ss["_workload_parent_namespace_name"] is None
+    assert ds["_workload_parent_daemonset_id"] == "ds-uid"
+    assert job["_workload_parent_job_id"] == "job-uid"
 
 
 def test_transform_pods_propagates_node_architecture_to_pod_and_container():

--- a/tests/unit/cartography/intel/kubernetes/test_util.py
+++ b/tests/unit/cartography/intel/kubernetes/test_util.py
@@ -1,0 +1,32 @@
+import pytest
+from kubernetes.client.exceptions import ApiException
+
+from cartography.intel.kubernetes.util import k8s_paginate
+
+
+def _raiser(status: int):
+    def list_func(**kwargs):
+        raise ApiException(status=status, reason="boom")
+
+    return list_func
+
+
+def test_k8s_paginate_swallows_errors_by_default():
+    # With no raise flags, an API error is logged and swallowed (partial result).
+    assert k8s_paginate(_raiser(500)) == []
+
+
+def test_k8s_paginate_raise_on_error_reraises_any_status():
+    # raise_on_error propagates every ApiException so callers cannot mistake a
+    # partial result for a complete one.
+    with pytest.raises(ApiException):
+        k8s_paginate(_raiser(500), raise_on_error=True)
+    with pytest.raises(ApiException):
+        k8s_paginate(_raiser(403), raise_on_error=True)
+
+
+def test_k8s_paginate_raise_on_forbidden_is_status_scoped():
+    # raise_on_forbidden re-raises only 401/403; other errors stay swallowed.
+    with pytest.raises(ApiException):
+        k8s_paginate(_raiser(403), raise_on_forbidden=True)
+    assert k8s_paginate(_raiser(500), raise_on_forbidden=True) == []


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Model Kubernetes workload controllers (Deployment, StatefulSet, DaemonSet, ReplicaSet, Job, CronJob) and wire their `ownerReferences` into the unified `WORKLOAD_PARENT` chain.

Previously the Kubernetes chain stopped at the pod: `Namespace -> Pod`, with no node for the controller that owns the pod. Because pod names are unique per replica, any consumer that walks `WORKLOAD_PARENT` was forced to per-pod granularity, which is unbounded in cardinality. Every other compute platform already collapses to a logical unit (ECS -> service, Cloud Run -> service, Lambda -> function); Kubernetes was the only per-instance outlier because the controller was not modeled.

With this change a pod points `WORKLOAD_PARENT` at its owning controller:

- `Container -> Pod -> Deployment -> Namespace -> Cluster` (the `ReplicaSet` is collapsed: it is kept as a node with raw `OWNED_BY` edges but carries no ontology label and is off the chain, so the surfaced parent is the Deployment, mirroring an ECS task under a service)
- `Container -> Pod -> StatefulSet / DaemonSet -> Namespace -> Cluster`
- `Container -> Pod -> Job -> CronJob -> Namespace -> Cluster` (standalone Jobs fall back to the namespace)
- Bare pods (no controller) keep resolving to their `Namespace`, as before.

Taxonomy: the surfaced controllers reuse the existing `ComputeService` ontology label (the cross-provider "logical workload" level, already carried by `AWSECSService`, `GCPCloudRunService`, `ScalewayServerlessContainer`) rather than introducing a new label, so a Kubernetes Deployment sits at the same level as an ECS service.

Key changes:
- New node schemas for the six controllers under `cartography/models/kubernetes/`.
- New intel sync `cartography/intel/kubernetes/workloads.py` (AppsV1/BatchV1 clients added to `K8sClient`), run before the pod sync; it returns the `ReplicaSet -> Deployment` map so the pod transform can collapse the intermediate ReplicaSet.
- Pod schema/transform gain a single gated `WORKLOAD_PARENT` parent (one of Deployment/StatefulSet/DaemonSet/Job, else namespace) plus a raw `OWNED_BY` edge to the ReplicaSet.
- Ontology: added the `ComputeService -> ComputeNamespace` and `ComputeService -> ComputeService` (Job -> CronJob) `WORKLOAD_PARENT` constraints, whitelisted the controllers' cluster `RESOURCE` edges (as already done for pods/namespaces) and the reverse Scaleway namespace `HAS` edge, and registered the controllers in the `ComputeService` ontology mapping.


### Related issues or links

N/A


### How was this tested?

- New unit tests for the pod workload-parent resolution (ReplicaSet -> Deployment collapse, bare-ReplicaSet namespace fallback, direct StatefulSet/DaemonSet/Job owners): `tests/unit/cartography/intel/kubernetes/test_pods.py`.
- New end-to-end integration test `tests/integration/cartography/intel/kubernetes/test_workloads.py` covering the controller nodes, the raw `OWNED_BY` edges, the collapsed `Pod -> Deployment` edge, `Job -> CronJob`, and the bare-pod namespace fallback; plus a regression assertion in `test_pods.py` that bare pods still resolve `WORKLOAD_PARENT -> Namespace`.
- The ontology parity guard `tests/unit/cartography/graph/test_ontology_rel_constraints.py` and the doc guard `tests/unit/cartography/test_doc.py` pass.
- `make test_lint` (pre-commit: isort/black/flake8/mypy) passes.
- Ran a real sync against a test EKS cluster. The sync completed without errors and the graph matched the cluster (`get`): 5 Deployments, 50 ReplicaSets, 0 StatefulSets, 2 DaemonSets, 1 Job, 1 CronJob, 10 Pods. Verified in the graph:
  - all 5 surfaced controller kinds carry `ComputeService`; the ReplicaSet does not;
  - every pod's `WORKLOAD_PARENT` points at a controller (7 -> Deployment, 2 -> DaemonSet, 1 -> Job), and no pod points at a ReplicaSet;
  - `OWNED_BY`: Pod -> ReplicaSet and ReplicaSet -> Deployment are present, and the collapsed `Pod -> Deployment` `WORKLOAD_PARENT` edge coexists with the raw two-hop ownership;
  - the Job owned by a CronJob resolves `WORKLOAD_PARENT -> CronJob`;
  - the full `Container -> Pod -> controller -> Namespace -> Cluster` walk resolves end to end.


### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [x] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity (node counts and graph verification summarized above).

#### If you are changing a node or relationship
- [x] Updated the schema documentation (`docs/root/modules/kubernetes/schema.md`).
- [ ] Updated the schema README.

#### If you are implementing a new intel module
- [x] Used the NodeSchema data model.


### Notes for reviewers

- The `ReplicaSet` is intentionally kept off the `WORKLOAD_PARENT` chain (no ontology label) but retained as a node with raw `OWNED_BY` edges, so the ownerReference hierarchy stays queryable while the surfaced parent is the Deployment.
- The two new whitelist entries (controllers' cluster `RESOURCE` edges; the reverse Scaleway namespace `HAS` edge) follow existing precedent: Kubernetes models its cluster as the tenant, so the `RESOURCE` sub-resource lands on a pair the ontology also constrains as `WORKLOAD_PARENT`, exactly as already whitelisted for `KubernetesPod` / `KubernetesNamespace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
