### PR TITLE
feat(ontology): materialize (:ComputeService)-[:RUNS_IMAGE]->(:Image) inventory

### DIFF
--- a/cartography/analysis/ontology/analysis.py
+++ b/cartography/analysis/ontology/analysis.py
@@ -622,6 +622,58 @@ FUNCTION_RESOLVED_IMAGE = AnalysisJob(
     ),
 )
 RESOLVED_IMAGE_JOBS = (CONTAINER_RESOLVED_IMAGE, FUNCTION_RESOLVED_IMAGE)
+WORKLOAD_RUNS_IMAGE = AnalysisJob(
+    name="Workload RUNS_IMAGE inventory analysis",
+    short_name="workload_runs_image_analysis",
+    cleanup_iterationsize=1000,
+    statements=(
+        AnalysisStatement(
+            comment=(
+                "Materialize the runtime image inventory of each ComputeService "
+                "workload, deduped per (workload, image), with workload-level internet "
+                "exposure denormalized onto the edge. Anchoring on ComputeService means "
+                "this covers workloads that run containers: ECS services, Cloud Run "
+                "services/jobs, Kubernetes controllers, and Scaleway serverless "
+                "containers. Standalone runtimes with no ComputeService controller "
+                "(bare pods, and functions such as AWS Lambda / GCP Cloud Functions / "
+                "Azure Function Apps / Scaleway serverless functions, which carry only "
+                ":Function) are intentionally NOT materialized here; they are per-instance "
+                "and low cardinality, and stay on the read-side live-collapse path. The "
+                "rt:Function branch therefore matches nothing today and exists only to "
+                "cover a future serverless function that is itself modeled as a "
+                "ComputeService (the symmetric case of Scaleway serverless containers). "
+                "The *0..6 lower bound of 0 covers serverless workloads "
+                "(e.g. ScalewayServerlessContainer) that carry both :ComputeService and "
+                ":Container on a single node with no intermediate WORKLOAD_PARENT hop. "
+                "Exposure is the OR of the service-level signal (svc.exposed_internet, "
+                "where GCP writes Cloud Run ingress exposure) and any running replica's "
+                "signal (rt.exposed_internet, where AWS ECS / Kubernetes write it). "
+                "The active-state filter accepts both 'running' (AWS ECS RUNNING, "
+                "Kubernetes running, Azure Running, GCP Cloud Run) and 'ready' (Scaleway "
+                "serverless ContainerStatus.READY) because _ont_state carries the raw "
+                "per-provider status string and providers use different words for a "
+                "container that is actively serving."
+            ),
+            match="""
+            MATCH (svc:ComputeService)<-[:WORKLOAD_PARENT*0..6]-(rt)-[:RESOLVED_IMAGE]->(img:Image)
+            WHERE (rt:Container OR rt:Function)
+              AND (NOT rt:Container OR toLower(rt._ont_state) IN ['running', 'ready'])
+            WITH svc, img, collect(coalesce(rt.exposed_internet, false)) AS rt_flags
+            WITH svc, img, (coalesce(svc.exposed_internet, false) OR true IN rt_flags) AS exposed
+            """,
+            effects=(
+                AddRelationship(
+                    "svc",
+                    "RUNS_IMAGE",
+                    "img",
+                    source_label="ComputeService",
+                    target_label="Image",
+                    properties={"exposed_internet": Var("exposed")},
+                ),
+            ),
+        ),
+    ),
+)
 SUPPLY_CHAIN_SOURCE_FILE = AnalysisJob(
     name="Enrich PACKAGED_FROM with source_file from Image provenance",
     short_name="supply_chain_source_file",

--- a/cartography/analysis/ontology/analysis.py
+++ b/cartography/analysis/ontology/analysis.py
@@ -622,9 +622,9 @@ FUNCTION_RESOLVED_IMAGE = AnalysisJob(
     ),
 )
 RESOLVED_IMAGE_JOBS = (CONTAINER_RESOLVED_IMAGE, FUNCTION_RESOLVED_IMAGE)
-WORKLOAD_RUNS_IMAGE = AnalysisJob(
-    name="Workload RUNS_IMAGE inventory analysis",
-    short_name="workload_runs_image_analysis",
+WORKLOAD_HAS_RUNTIME_IMAGE = AnalysisJob(
+    name="Workload HAS_RUNTIME_IMAGE inventory analysis",
+    short_name="workload_has_runtime_image_analysis",
     cleanup_iterationsize=1000,
     statements=(
         AnalysisStatement(
@@ -664,7 +664,7 @@ WORKLOAD_RUNS_IMAGE = AnalysisJob(
             effects=(
                 AddRelationship(
                     "svc",
-                    "RUNS_IMAGE",
+                    "HAS_RUNTIME_IMAGE",
                     "img",
                     source_label="ComputeService",
                     target_label="Image",

--- a/cartography/intel/ontology/__init__.py
+++ b/cartography/intel/ontology/__init__.py
@@ -11,7 +11,7 @@ import cartography.intel.ontology.users
 from cartography.analysis.aibom.analysis import AIBOM_RUNS_ON_CONTAINER
 from cartography.analysis.ontology.analysis import RESOLVED_IMAGE_JOBS
 from cartography.analysis.ontology.analysis import TAILSCALE_DEVICE_INSTANCE_LINKING
-from cartography.analysis.ontology.analysis import WORKLOAD_RUNS_IMAGE
+from cartography.analysis.ontology.analysis import WORKLOAD_HAS_RUNTIME_IMAGE
 from cartography.config import Config
 from cartography.intel.ontology.deprecated_indexes import (
     drop_deprecated_ontology_indexes,
@@ -89,12 +89,12 @@ def run(neo4j_session: neo4j.Session, config: Config) -> None:
     # Runs last so the :Container / :Image semantic labels and HAS_IMAGE edges from every provider are in place.
     for job in RESOLVED_IMAGE_JOBS:
         run_typed_analysis_job(job, neo4j_session, common_job_parameters)
-    # Materialize the (:ComputeService)-[:RUNS_IMAGE]->(:Image) runtime inventory by collapsing
+    # Materialize the (:ComputeService)-[:HAS_RUNTIME_IMAGE]->(:Image) runtime inventory by collapsing
     # running containers up the WORKLOAD_PARENT chain to their owning ComputeService controller.
     # Runs after RESOLVED_IMAGE_JOBS (needs the RESOLVED_IMAGE edges) and after the exposure
     # analysis jobs (needs the per-replica exposed_internet property it denormalizes onto the edge).
     run_typed_analysis_job(
-        WORKLOAD_RUNS_IMAGE,
+        WORKLOAD_HAS_RUNTIME_IMAGE,
         neo4j_session,
         common_job_parameters,
     )

--- a/cartography/intel/ontology/__init__.py
+++ b/cartography/intel/ontology/__init__.py
@@ -11,6 +11,7 @@ import cartography.intel.ontology.users
 from cartography.analysis.aibom.analysis import AIBOM_RUNS_ON_CONTAINER
 from cartography.analysis.ontology.analysis import RESOLVED_IMAGE_JOBS
 from cartography.analysis.ontology.analysis import TAILSCALE_DEVICE_INSTANCE_LINKING
+from cartography.analysis.ontology.analysis import WORKLOAD_RUNS_IMAGE
 from cartography.config import Config
 from cartography.intel.ontology.deprecated_indexes import (
     drop_deprecated_ontology_indexes,
@@ -88,6 +89,15 @@ def run(neo4j_session: neo4j.Session, config: Config) -> None:
     # Runs last so the :Container / :Image semantic labels and HAS_IMAGE edges from every provider are in place.
     for job in RESOLVED_IMAGE_JOBS:
         run_typed_analysis_job(job, neo4j_session, common_job_parameters)
+    # Materialize the (:ComputeService)-[:RUNS_IMAGE]->(:Image) runtime inventory by collapsing
+    # running containers up the WORKLOAD_PARENT chain to their owning ComputeService controller.
+    # Runs after RESOLVED_IMAGE_JOBS (needs the RESOLVED_IMAGE edges) and after the exposure
+    # analysis jobs (needs the per-replica exposed_internet property it denormalizes onto the edge).
+    run_typed_analysis_job(
+        WORKLOAD_RUNS_IMAGE,
+        neo4j_session,
+        common_job_parameters,
+    )
     # Create RUNS_ON shortcut edges from :AIBOMSource to :Container by joining through the shared :Image.
     # Runs after resolved_image_analysis so all semantic labels and HAS_IMAGE edges are in place.
     run_typed_analysis_job(

--- a/cartography/models/ontology/constraints.py
+++ b/cartography/models/ontology/constraints.py
@@ -279,6 +279,10 @@ ONTOLOGY_REL_CONSTRAINTS: tuple[RelConstraint, ...] = (
     # references (which are whitelisted below as a distinct semantic).
     RelConstraint(src="Container", dst="Image", label="RESOLVED_IMAGE"),
     RelConstraint(src="Function", dst="Image", label="RESOLVED_IMAGE"),
+    # A logical workload (ComputeService controller) runs an image. Materialized
+    # by workload_runs_image_analysis, which collapses running containers/functions
+    # up the WORKLOAD_PARENT chain to the owning controller.
+    RelConstraint(src="ComputeService", dst="Image", label="RUNS_IMAGE"),
     # An image/function is built from a source code repository (CI provenance).
     RelConstraint(src="Image", dst="CodeRepository", label="PACKAGED_FROM"),
     # NOTE: no UserAccount->CodeRepository constraint. Several distinct edges

--- a/cartography/models/ontology/constraints.py
+++ b/cartography/models/ontology/constraints.py
@@ -280,9 +280,9 @@ ONTOLOGY_REL_CONSTRAINTS: tuple[RelConstraint, ...] = (
     RelConstraint(src="Container", dst="Image", label="RESOLVED_IMAGE"),
     RelConstraint(src="Function", dst="Image", label="RESOLVED_IMAGE"),
     # A logical workload (ComputeService controller) runs an image. Materialized
-    # by workload_runs_image_analysis, which collapses running containers/functions
+    # by workload_has_runtime_image_analysis, which collapses running containers/functions
     # up the WORKLOAD_PARENT chain to the owning controller.
-    RelConstraint(src="ComputeService", dst="Image", label="RUNS_IMAGE"),
+    RelConstraint(src="ComputeService", dst="Image", label="HAS_RUNTIME_IMAGE"),
     # An image/function is built from a source code repository (CI provenance).
     RelConstraint(src="Image", dst="CodeRepository", label="PACKAGED_FROM"),
     # NOTE: no UserAccount->CodeRepository constraint. Several distinct edges

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -79,6 +79,7 @@ IM -- HAS_LAYER --> IL{{ImageLayer}}
 CT -- HAS_IMAGE --> IM
 CT -- HAS_IMAGE --> IML
 CT -- RESOLVED_IMAGE --> IM
+CS -- RUNS_IMAGE --> IM
 ```
 
 :::{note}
@@ -88,7 +89,7 @@ In this schema, `squares` represent `Abstract Nodes` and `hexagons` represent `S
 ### Where ontology relationships come from
 
 1. The abstract ontology node schemas (`User`, `Device`, `PublicIP`, `Package`) declare the edges they own to module nodes (e.g. `(:User)-[:HAS_ACCOUNT]->(:UserAccount)`).
-2. Ontology analysis jobs derive cross-module edges after sync (e.g. `USER_LINKING_JOBS` builds the `User`/`UserAccount` graph; `RESOLVED_IMAGE_JOBS` connects `Container` and `Function` to a single-platform `Image`).
+2. Ontology analysis jobs derive cross-module edges after sync (e.g. `USER_LINKING_JOBS` builds the `User`/`UserAccount` graph; `RESOLVED_IMAGE_JOBS` connects `Container` and `Function` to a single-platform `Image`; `WORKLOAD_RUNS_IMAGE` collapses running containers up the `WORKLOAD_PARENT` chain to record `(:ComputeService)-[:RUNS_IMAGE]->(:Image)` for each workload).
 3. Sync modules wire edges between two ontology-labelled nodes themselves (e.g. ECS adding `(:AWSECSContainer:Container)-[:WORKLOAD_PARENT]->(:AWSECSTask:ComputePod)`). For this last source, canonical `(src, dst, label)` triples are encoded as `RelConstraint` entries in [`cartography/models/ontology/constraints.py`](https://github.com/cartography-cncf/cartography/blob/master/cartography/models/ontology/constraints.py); a unit test rejects any module rel between those two ontology labels that uses a different name or direction.
 
 ### Ontology Properties on Nodes
@@ -479,6 +480,11 @@ It generalizes concepts like AWS ECS services and GCP Cloud Run services and job
     (:ComputePod)-[:WORKLOAD_PARENT]->(:ComputeService)
     (:Container)-[:WORKLOAD_PARENT]->(:ComputeService)
     ```
+- `ComputeService` runs an `Image`: the runtime image inventory of the logical workload. This edge is produced by `WORKLOAD_RUNS_IMAGE` in `cartography/analysis/ontology/analysis.py`, which collapses each running container up the `WORKLOAD_PARENT` chain to its owning controller and dedups to one edge per `(workload, image)` pair. The collapse is zero-or-more hops, so serverless workloads that are both `ComputeService` and `Container` on a single node (e.g. `ScalewayServerlessContainer`) are covered too. The edge carries an `exposed_internet` boolean: the OR of the service-level exposure signal (`svc.exposed_internet`, e.g. GCP Cloud Run ingress) and any running replica's signal (`rt.exposed_internet`, e.g. AWS ECS / Kubernetes), so a workload's runtime composition and exposure can be read without fanning back out to individual replicas.
+    ```
+    (:ComputeService)-[:RUNS_IMAGE]->(:Image)
+    ```
+    Standalone runtimes with no `ComputeService` controller are not materialized here and are served by the read-side live-collapse path instead: bare pods, and functions (`AWS Lambda`, `GCP Cloud Functions`, `Azure Function Apps`, `Scaleway serverless functions`) which carry only `:Function`.
 
 
 ### ComputeNamespace

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -79,7 +79,7 @@ IM -- HAS_LAYER --> IL{{ImageLayer}}
 CT -- HAS_IMAGE --> IM
 CT -- HAS_IMAGE --> IML
 CT -- RESOLVED_IMAGE --> IM
-CS -- RUNS_IMAGE --> IM
+CS -- HAS_RUNTIME_IMAGE --> IM
 ```
 
 :::{note}
@@ -89,7 +89,7 @@ In this schema, `squares` represent `Abstract Nodes` and `hexagons` represent `S
 ### Where ontology relationships come from
 
 1. The abstract ontology node schemas (`User`, `Device`, `PublicIP`, `Package`) declare the edges they own to module nodes (e.g. `(:User)-[:HAS_ACCOUNT]->(:UserAccount)`).
-2. Ontology analysis jobs derive cross-module edges after sync (e.g. `USER_LINKING_JOBS` builds the `User`/`UserAccount` graph; `RESOLVED_IMAGE_JOBS` connects `Container` and `Function` to a single-platform `Image`; `WORKLOAD_RUNS_IMAGE` collapses running containers up the `WORKLOAD_PARENT` chain to record `(:ComputeService)-[:RUNS_IMAGE]->(:Image)` for each workload).
+2. Ontology analysis jobs derive cross-module edges after sync (e.g. `USER_LINKING_JOBS` builds the `User`/`UserAccount` graph; `RESOLVED_IMAGE_JOBS` connects `Container` and `Function` to a single-platform `Image`; `WORKLOAD_HAS_RUNTIME_IMAGE` collapses running containers up the `WORKLOAD_PARENT` chain to record `(:ComputeService)-[:HAS_RUNTIME_IMAGE]->(:Image)` for each workload).
 3. Sync modules wire edges between two ontology-labelled nodes themselves (e.g. ECS adding `(:AWSECSContainer:Container)-[:WORKLOAD_PARENT]->(:AWSECSTask:ComputePod)`). For this last source, canonical `(src, dst, label)` triples are encoded as `RelConstraint` entries in [`cartography/models/ontology/constraints.py`](https://github.com/cartography-cncf/cartography/blob/master/cartography/models/ontology/constraints.py); a unit test rejects any module rel between those two ontology labels that uses a different name or direction.
 
 ### Ontology Properties on Nodes
@@ -480,9 +480,9 @@ It generalizes concepts like AWS ECS services and GCP Cloud Run services and job
     (:ComputePod)-[:WORKLOAD_PARENT]->(:ComputeService)
     (:Container)-[:WORKLOAD_PARENT]->(:ComputeService)
     ```
-- `ComputeService` runs an `Image`: the runtime image inventory of the logical workload. This edge is produced by `WORKLOAD_RUNS_IMAGE` in `cartography/analysis/ontology/analysis.py`, which collapses each running container up the `WORKLOAD_PARENT` chain to its owning controller and dedups to one edge per `(workload, image)` pair. The collapse is zero-or-more hops, so serverless workloads that are both `ComputeService` and `Container` on a single node (e.g. `ScalewayServerlessContainer`) are covered too. The edge carries an `exposed_internet` boolean: the OR of the service-level exposure signal (`svc.exposed_internet`, e.g. GCP Cloud Run ingress) and any running replica's signal (`rt.exposed_internet`, e.g. AWS ECS / Kubernetes), so a workload's runtime composition and exposure can be read without fanning back out to individual replicas.
+- `ComputeService` has a runtime `Image`: the runtime image inventory (composition) of the logical workload. This edge is produced by `WORKLOAD_HAS_RUNTIME_IMAGE` in `cartography/analysis/ontology/analysis.py`, which collapses each running container up the `WORKLOAD_PARENT` chain to its owning controller and dedups to one edge per `(workload, image)` pair. The collapse is zero-or-more hops, so serverless workloads that are both `ComputeService` and `Container` on a single node (e.g. `ScalewayServerlessContainer`) are covered too. The edge carries an `exposed_internet` boolean: the OR of the service-level exposure signal (`svc.exposed_internet`, e.g. GCP Cloud Run ingress) and any running replica's signal (`rt.exposed_internet`, e.g. AWS ECS / Kubernetes), so a workload's runtime composition and exposure can be read without fanning back out to individual replicas.
     ```
-    (:ComputeService)-[:RUNS_IMAGE]->(:Image)
+    (:ComputeService)-[:HAS_RUNTIME_IMAGE]->(:Image)
     ```
     Standalone runtimes with no `ComputeService` controller are not materialized here and are served by the read-side live-collapse path instead: bare pods, and functions (`AWS Lambda`, `GCP Cloud Functions`, `Azure Function Apps`, `Scaleway serverless functions`) which carry only `:Function`.
 

--- a/tests/integration/cartography/intel/ontology/test_has_runtime_image.py
+++ b/tests/integration/cartography/intel/ontology/test_has_runtime_image.py
@@ -1,8 +1,8 @@
 """
-Integration test for the ComputeService -> Image RUNS_IMAGE inventory analysis job.
+Integration test for the ComputeService -> Image HAS_RUNTIME_IMAGE inventory analysis job.
 """
 
-from cartography.analysis.ontology.analysis import WORKLOAD_RUNS_IMAGE
+from cartography.analysis.ontology.analysis import WORKLOAD_HAS_RUNTIME_IMAGE
 from cartography.util import run_typed_analysis_job
 from tests.integration.util import check_rels
 
@@ -10,17 +10,17 @@ TEST_UPDATE_TAG = 123456789
 TEST_UPDATE_TAG_2 = 123456790
 
 
-def _run_runs_image_analysis(neo4j_session, update_tag=TEST_UPDATE_TAG):
+def _run_has_runtime_image_analysis(neo4j_session, update_tag=TEST_UPDATE_TAG):
     run_typed_analysis_job(
-        WORKLOAD_RUNS_IMAGE, neo4j_session, {"UPDATE_TAG": update_tag}
+        WORKLOAD_HAS_RUNTIME_IMAGE, neo4j_session, {"UPDATE_TAG": update_tag}
     )
 
 
 def _edge_exposure(neo4j_session, svc_id, img_id):
-    """Return the exposed_internet property of a single RUNS_IMAGE edge."""
+    """Return the exposed_internet property of a single HAS_RUNTIME_IMAGE edge."""
     result = neo4j_session.run(
         """
-        MATCH (svc:ComputeService {id: $svc_id})-[r:RUNS_IMAGE]->(img:Image {id: $img_id})
+        MATCH (svc:ComputeService {id: $svc_id})-[r:HAS_RUNTIME_IMAGE]->(img:Image {id: $img_id})
         RETURN r.exposed_internet AS exposed
         """,
         svc_id=svc_id,
@@ -29,9 +29,9 @@ def _edge_exposure(neo4j_session, svc_id, img_id):
     return [record["exposed"] for record in result]
 
 
-def test_runs_image_collapses_replicas_to_single_edge(neo4j_session):
+def test_has_runtime_image_collapses_replicas_to_single_edge(neo4j_session):
     """Two running container replicas under the same controller, both resolving to the same
-    image, produce exactly one deduped (:ComputeService)-[:RUNS_IMAGE]->(:Image) edge.
+    image, produce exactly one deduped (:ComputeService)-[:HAS_RUNTIME_IMAGE]->(:Image) edge.
     """
     neo4j_session.run("MATCH (n) DETACH DELETE n")
     neo4j_session.run(
@@ -65,7 +65,7 @@ def test_runs_image_collapses_replicas_to_single_edge(neo4j_session):
         tag=TEST_UPDATE_TAG,
     )
 
-    _run_runs_image_analysis(neo4j_session)
+    _run_has_runtime_image_analysis(neo4j_session)
 
     assert check_rels(
         neo4j_session,
@@ -73,12 +73,12 @@ def test_runs_image_collapses_replicas_to_single_edge(neo4j_session):
         "id",
         "Image",
         "id",
-        "RUNS_IMAGE",
+        "HAS_RUNTIME_IMAGE",
     ) == {("deploy-1", "sha256:deadbeef")}
 
 
-def test_runs_image_ignores_non_running_container(neo4j_session):
-    """A non-running container does not contribute a RUNS_IMAGE edge for its image."""
+def test_has_runtime_image_ignores_non_running_container(neo4j_session):
+    """A non-running container does not contribute a HAS_RUNTIME_IMAGE edge for its image."""
     neo4j_session.run("MATCH (n) DETACH DELETE n")
     neo4j_session.run(
         """
@@ -113,7 +113,7 @@ def test_runs_image_ignores_non_running_container(neo4j_session):
         tag=TEST_UPDATE_TAG,
     )
 
-    _run_runs_image_analysis(neo4j_session)
+    _run_has_runtime_image_analysis(neo4j_session)
 
     assert check_rels(
         neo4j_session,
@@ -121,11 +121,11 @@ def test_runs_image_ignores_non_running_container(neo4j_session):
         "id",
         "Image",
         "id",
-        "RUNS_IMAGE",
+        "HAS_RUNTIME_IMAGE",
     ) == {("deploy-1", "sha256:running")}
 
 
-def test_runs_image_denormalizes_exposure(neo4j_session):
+def test_has_runtime_image_denormalizes_exposure(neo4j_session):
     """Exposure is the logical OR across running replicas: an exposed workload's edge is
     true, a non-exposed workload's edge is false."""
     neo4j_session.run("MATCH (n) DETACH DELETE n")
@@ -164,13 +164,13 @@ def test_runs_image_denormalizes_exposure(neo4j_session):
         tag=TEST_UPDATE_TAG,
     )
 
-    _run_runs_image_analysis(neo4j_session)
+    _run_has_runtime_image_analysis(neo4j_session)
 
     assert _edge_exposure(neo4j_session, "deploy-exposed", "sha256:imga") == [True]
     assert _edge_exposure(neo4j_session, "deploy-safe", "sha256:imgb") == [False]
 
 
-def test_runs_image_exposure_from_service_level_signal(neo4j_session):
+def test_has_runtime_image_exposure_from_service_level_signal(neo4j_session):
     """Cloud Run writes exposed_internet on the GCPCloudRunService (the ComputeService),
     not on its container. The edge must still be exposed=true from that service-level signal.
     """
@@ -194,7 +194,7 @@ def test_runs_image_exposure_from_service_level_signal(neo4j_session):
         tag=TEST_UPDATE_TAG,
     )
 
-    _run_runs_image_analysis(neo4j_session)
+    _run_has_runtime_image_analysis(neo4j_session)
 
     assert check_rels(
         neo4j_session,
@@ -202,15 +202,15 @@ def test_runs_image_exposure_from_service_level_signal(neo4j_session):
         "id",
         "Image",
         "id",
-        "RUNS_IMAGE",
+        "HAS_RUNTIME_IMAGE",
     ) == {("cloudrun-svc", "sha256:cloudrun")}
     assert _edge_exposure(neo4j_session, "cloudrun-svc", "sha256:cloudrun") == [True]
 
 
-def test_runs_image_self_service_workload(neo4j_session):
+def test_has_runtime_image_self_service_workload(neo4j_session):
     """A serverless workload that is both :ComputeService and :Container on a single node
     (e.g. ScalewayServerlessContainer), with a direct RESOLVED_IMAGE and no intermediate
-    WORKLOAD_PARENT hop, still gets a RUNS_IMAGE edge (zero-length collapse). Its active
+    WORKLOAD_PARENT hop, still gets a HAS_RUNTIME_IMAGE edge (zero-length collapse). Its active
     state comes from the raw Scaleway status 'ready', not 'running'."""
     neo4j_session.run("MATCH (n) DETACH DELETE n")
     neo4j_session.run(
@@ -227,7 +227,7 @@ def test_runs_image_self_service_workload(neo4j_session):
         tag=TEST_UPDATE_TAG,
     )
 
-    _run_runs_image_analysis(neo4j_session)
+    _run_has_runtime_image_analysis(neo4j_session)
 
     assert check_rels(
         neo4j_session,
@@ -235,13 +235,13 @@ def test_runs_image_self_service_workload(neo4j_session):
         "id",
         "Image",
         "id",
-        "RUNS_IMAGE",
+        "HAS_RUNTIME_IMAGE",
     ) == {("scw-container", "sha256:scaleway")}
     assert _edge_exposure(neo4j_session, "scw-container", "sha256:scaleway") == [True]
 
 
-def test_runs_image_is_idempotent_and_marks_gone(neo4j_session):
-    """Re-running after a workload stops running an image removes the stale RUNS_IMAGE edge,
+def test_has_runtime_image_is_idempotent_and_marks_gone(neo4j_session):
+    """Re-running after a workload stops running an image removes the stale HAS_RUNTIME_IMAGE edge,
     and re-running an unchanged graph does not duplicate edges."""
     neo4j_session.run("MATCH (n) DETACH DELETE n")
     neo4j_session.run(
@@ -261,26 +261,28 @@ def test_runs_image_is_idempotent_and_marks_gone(neo4j_session):
         tag=TEST_UPDATE_TAG,
     )
 
-    _run_runs_image_analysis(neo4j_session, TEST_UPDATE_TAG)
+    _run_has_runtime_image_analysis(neo4j_session, TEST_UPDATE_TAG)
     assert check_rels(
-        neo4j_session, "ComputeService", "id", "Image", "id", "RUNS_IMAGE"
+        neo4j_session, "ComputeService", "id", "Image", "id", "HAS_RUNTIME_IMAGE"
     ) == {("deploy-1", "sha256:deadbeef")}
 
     # The workload stops running the image: drop the RESOLVED_IMAGE basis, then re-run with a
-    # fresh update tag. The stale RUNS_IMAGE edge (not re-stamped) must be cleaned up.
+    # fresh update tag. The stale HAS_RUNTIME_IMAGE edge (not re-stamped) must be cleaned up.
     neo4j_session.run(
         "MATCH (:Container {id: 'container-1'})-[r:RESOLVED_IMAGE]->(:Image) DELETE r"
     )
-    _run_runs_image_analysis(neo4j_session, TEST_UPDATE_TAG_2)
+    _run_has_runtime_image_analysis(neo4j_session, TEST_UPDATE_TAG_2)
 
     assert (
-        check_rels(neo4j_session, "ComputeService", "id", "Image", "id", "RUNS_IMAGE")
+        check_rels(
+            neo4j_session, "ComputeService", "id", "Image", "id", "HAS_RUNTIME_IMAGE"
+        )
         == set()
     )
 
 
-def test_runs_image_no_edge_without_controller(neo4j_session):
-    """A running container with no ComputeService ancestor yields no RUNS_IMAGE edge; that
+def test_has_runtime_image_no_edge_without_controller(neo4j_session):
+    """A running container with no ComputeService ancestor yields no HAS_RUNTIME_IMAGE edge; that
     case stays on the live-collapse fallback path."""
     neo4j_session.run("MATCH (n) DETACH DELETE n")
     neo4j_session.run(
@@ -295,19 +297,21 @@ def test_runs_image_no_edge_without_controller(neo4j_session):
         tag=TEST_UPDATE_TAG,
     )
 
-    _run_runs_image_analysis(neo4j_session)
+    _run_has_runtime_image_analysis(neo4j_session)
 
     assert (
-        check_rels(neo4j_session, "ComputeService", "id", "Image", "id", "RUNS_IMAGE")
+        check_rels(
+            neo4j_session, "ComputeService", "id", "Image", "id", "HAS_RUNTIME_IMAGE"
+        )
         == set()
     )
 
 
-def test_runs_image_standalone_function_gets_no_edge(neo4j_session):
+def test_has_runtime_image_standalone_function_gets_no_edge(neo4j_session):
     """A container-based function (e.g. AWS Lambda) carries only :Function with a direct
     RESOLVED_IMAGE, but has no :ComputeService label and no WORKLOAD_PARENT chain. By design
-    it is NOT materialized into RUNS_IMAGE (it stays on the read-side live-collapse path);
-    RUNS_IMAGE is a ComputeService-anchored fact and a standalone function is not a workload
+    it is NOT materialized into HAS_RUNTIME_IMAGE (it stays on the read-side live-collapse path);
+    HAS_RUNTIME_IMAGE is a ComputeService-anchored fact and a standalone function is not a workload
     controller."""
     neo4j_session.run("MATCH (n) DETACH DELETE n")
     neo4j_session.run(
@@ -322,14 +326,16 @@ def test_runs_image_standalone_function_gets_no_edge(neo4j_session):
         tag=TEST_UPDATE_TAG,
     )
 
-    _run_runs_image_analysis(neo4j_session)
+    _run_has_runtime_image_analysis(neo4j_session)
 
     assert (
-        check_rels(neo4j_session, "ComputeService", "id", "Image", "id", "RUNS_IMAGE")
+        check_rels(
+            neo4j_session, "ComputeService", "id", "Image", "id", "HAS_RUNTIME_IMAGE"
+        )
         == set()
     )
-    # And the function itself is never a RUNS_IMAGE source.
+    # And the function itself is never a HAS_RUNTIME_IMAGE source.
     assert (
-        check_rels(neo4j_session, "Function", "id", "Image", "id", "RUNS_IMAGE")
+        check_rels(neo4j_session, "Function", "id", "Image", "id", "HAS_RUNTIME_IMAGE")
         == set()
     )

--- a/tests/integration/cartography/intel/ontology/test_runs_image.py
+++ b/tests/integration/cartography/intel/ontology/test_runs_image.py
@@ -1,0 +1,335 @@
+"""
+Integration test for the ComputeService -> Image RUNS_IMAGE inventory analysis job.
+"""
+
+from cartography.analysis.ontology.analysis import WORKLOAD_RUNS_IMAGE
+from cartography.util import run_typed_analysis_job
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_UPDATE_TAG_2 = 123456790
+
+
+def _run_runs_image_analysis(neo4j_session, update_tag=TEST_UPDATE_TAG):
+    run_typed_analysis_job(
+        WORKLOAD_RUNS_IMAGE, neo4j_session, {"UPDATE_TAG": update_tag}
+    )
+
+
+def _edge_exposure(neo4j_session, svc_id, img_id):
+    """Return the exposed_internet property of a single RUNS_IMAGE edge."""
+    result = neo4j_session.run(
+        """
+        MATCH (svc:ComputeService {id: $svc_id})-[r:RUNS_IMAGE]->(img:Image {id: $img_id})
+        RETURN r.exposed_internet AS exposed
+        """,
+        svc_id=svc_id,
+        img_id=img_id,
+    )
+    return [record["exposed"] for record in result]
+
+
+def test_runs_image_collapses_replicas_to_single_edge(neo4j_session):
+    """Two running container replicas under the same controller, both resolving to the same
+    image, produce exactly one deduped (:ComputeService)-[:RUNS_IMAGE]->(:Image) edge.
+    """
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (svc:ComputeService:KubernetesDeployment {id: 'deploy-1'})
+        SET svc.lastupdated = $tag
+
+        MERGE (pod:ComputePod:KubernetesPod {id: 'pod-1'})
+        SET pod.lastupdated = $tag
+
+        MERGE (c1:Container:KubernetesContainer {id: 'container-1'})
+        SET c1._ont_state = 'running', c1.lastupdated = $tag
+        MERGE (c2:Container:KubernetesContainer {id: 'container-2'})
+        SET c2._ont_state = 'running', c2.lastupdated = $tag
+
+        MERGE (img:Image:AWSECRImage {id: 'sha256:deadbeef'})
+        SET img._ont_digest = 'sha256:deadbeef', img.lastupdated = $tag
+
+        MERGE (c1)-[r1:WORKLOAD_PARENT]->(pod)
+        SET r1.lastupdated = $tag
+        MERGE (c2)-[r2:WORKLOAD_PARENT]->(pod)
+        SET r2.lastupdated = $tag
+        MERGE (pod)-[r3:WORKLOAD_PARENT]->(svc)
+        SET r3.lastupdated = $tag
+
+        MERGE (c1)-[r4:RESOLVED_IMAGE]->(img)
+        SET r4.lastupdated = $tag
+        MERGE (c2)-[r5:RESOLVED_IMAGE]->(img)
+        SET r5.lastupdated = $tag
+        """,
+        tag=TEST_UPDATE_TAG,
+    )
+
+    _run_runs_image_analysis(neo4j_session)
+
+    assert check_rels(
+        neo4j_session,
+        "ComputeService",
+        "id",
+        "Image",
+        "id",
+        "RUNS_IMAGE",
+    ) == {("deploy-1", "sha256:deadbeef")}
+
+
+def test_runs_image_ignores_non_running_container(neo4j_session):
+    """A non-running container does not contribute a RUNS_IMAGE edge for its image."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (svc:ComputeService:KubernetesDeployment {id: 'deploy-1'})
+        SET svc.lastupdated = $tag
+
+        MERGE (pod:ComputePod:KubernetesPod {id: 'pod-1'})
+        SET pod.lastupdated = $tag
+
+        MERGE (running:Container:KubernetesContainer {id: 'container-running'})
+        SET running._ont_state = 'running', running.lastupdated = $tag
+        MERGE (stopped:Container:KubernetesContainer {id: 'container-stopped'})
+        SET stopped._ont_state = 'terminated', stopped.lastupdated = $tag
+
+        MERGE (img_running:Image:AWSECRImage {id: 'sha256:running'})
+        SET img_running.lastupdated = $tag
+        MERGE (img_stopped:Image:AWSECRImage {id: 'sha256:stopped'})
+        SET img_stopped.lastupdated = $tag
+
+        MERGE (running)-[r1:WORKLOAD_PARENT]->(pod)
+        SET r1.lastupdated = $tag
+        MERGE (stopped)-[r2:WORKLOAD_PARENT]->(pod)
+        SET r2.lastupdated = $tag
+        MERGE (pod)-[r3:WORKLOAD_PARENT]->(svc)
+        SET r3.lastupdated = $tag
+
+        MERGE (running)-[r4:RESOLVED_IMAGE]->(img_running)
+        SET r4.lastupdated = $tag
+        MERGE (stopped)-[r5:RESOLVED_IMAGE]->(img_stopped)
+        SET r5.lastupdated = $tag
+        """,
+        tag=TEST_UPDATE_TAG,
+    )
+
+    _run_runs_image_analysis(neo4j_session)
+
+    assert check_rels(
+        neo4j_session,
+        "ComputeService",
+        "id",
+        "Image",
+        "id",
+        "RUNS_IMAGE",
+    ) == {("deploy-1", "sha256:running")}
+
+
+def test_runs_image_denormalizes_exposure(neo4j_session):
+    """Exposure is the logical OR across running replicas: an exposed workload's edge is
+    true, a non-exposed workload's edge is false."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        // Exposed workload: one replica is exposed, one is not -> edge should be true.
+        MERGE (svc_exposed:ComputeService:KubernetesDeployment {id: 'deploy-exposed'})
+        SET svc_exposed.lastupdated = $tag
+        MERGE (pod_exposed:ComputePod:KubernetesPod {id: 'pod-exposed'})
+        SET pod_exposed.lastupdated = $tag
+        MERGE (c_exposed:Container:KubernetesContainer {id: 'container-exposed'})
+        SET c_exposed._ont_state = 'running', c_exposed.exposed_internet = true, c_exposed.lastupdated = $tag
+        MERGE (c_internal:Container:KubernetesContainer {id: 'container-internal'})
+        SET c_internal._ont_state = 'running', c_internal.exposed_internet = false, c_internal.lastupdated = $tag
+        MERGE (img_a:Image:AWSECRImage {id: 'sha256:imga'})
+        SET img_a.lastupdated = $tag
+        MERGE (c_exposed)-[re1:WORKLOAD_PARENT]->(pod_exposed) SET re1.lastupdated = $tag
+        MERGE (c_internal)-[re2:WORKLOAD_PARENT]->(pod_exposed) SET re2.lastupdated = $tag
+        MERGE (pod_exposed)-[re3:WORKLOAD_PARENT]->(svc_exposed) SET re3.lastupdated = $tag
+        MERGE (c_exposed)-[re4:RESOLVED_IMAGE]->(img_a) SET re4.lastupdated = $tag
+        MERGE (c_internal)-[re5:RESOLVED_IMAGE]->(img_a) SET re5.lastupdated = $tag
+
+        // Non-exposed workload: replica has no exposure property at all -> edge should be false.
+        MERGE (svc_safe:ComputeService:KubernetesDeployment {id: 'deploy-safe'})
+        SET svc_safe.lastupdated = $tag
+        MERGE (pod_safe:ComputePod:KubernetesPod {id: 'pod-safe'})
+        SET pod_safe.lastupdated = $tag
+        MERGE (c_safe:Container:KubernetesContainer {id: 'container-safe'})
+        SET c_safe._ont_state = 'running', c_safe.lastupdated = $tag
+        MERGE (img_b:Image:AWSECRImage {id: 'sha256:imgb'})
+        SET img_b.lastupdated = $tag
+        MERGE (c_safe)-[rs1:WORKLOAD_PARENT]->(pod_safe) SET rs1.lastupdated = $tag
+        MERGE (pod_safe)-[rs2:WORKLOAD_PARENT]->(svc_safe) SET rs2.lastupdated = $tag
+        MERGE (c_safe)-[rs3:RESOLVED_IMAGE]->(img_b) SET rs3.lastupdated = $tag
+        """,
+        tag=TEST_UPDATE_TAG,
+    )
+
+    _run_runs_image_analysis(neo4j_session)
+
+    assert _edge_exposure(neo4j_session, "deploy-exposed", "sha256:imga") == [True]
+    assert _edge_exposure(neo4j_session, "deploy-safe", "sha256:imgb") == [False]
+
+
+def test_runs_image_exposure_from_service_level_signal(neo4j_session):
+    """Cloud Run writes exposed_internet on the GCPCloudRunService (the ComputeService),
+    not on its container. The edge must still be exposed=true from that service-level signal.
+    """
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (svc:ComputeService:GCPCloudRunService {id: 'cloudrun-svc'})
+        SET svc.exposed_internet = true, svc.lastupdated = $tag
+
+        MERGE (c:Container:GCPCloudRunServiceContainer {id: 'cloudrun-container'})
+        SET c._ont_state = 'running', c.lastupdated = $tag
+
+        MERGE (img:Image:GCPArtifactRegistryImage {id: 'sha256:cloudrun'})
+        SET img.lastupdated = $tag
+
+        MERGE (c)-[r1:WORKLOAD_PARENT]->(svc)
+        SET r1.lastupdated = $tag
+        MERGE (c)-[r2:RESOLVED_IMAGE]->(img)
+        SET r2.lastupdated = $tag
+        """,
+        tag=TEST_UPDATE_TAG,
+    )
+
+    _run_runs_image_analysis(neo4j_session)
+
+    assert check_rels(
+        neo4j_session,
+        "ComputeService",
+        "id",
+        "Image",
+        "id",
+        "RUNS_IMAGE",
+    ) == {("cloudrun-svc", "sha256:cloudrun")}
+    assert _edge_exposure(neo4j_session, "cloudrun-svc", "sha256:cloudrun") == [True]
+
+
+def test_runs_image_self_service_workload(neo4j_session):
+    """A serverless workload that is both :ComputeService and :Container on a single node
+    (e.g. ScalewayServerlessContainer), with a direct RESOLVED_IMAGE and no intermediate
+    WORKLOAD_PARENT hop, still gets a RUNS_IMAGE edge (zero-length collapse). Its active
+    state comes from the raw Scaleway status 'ready', not 'running'."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (svc:ComputeService:Container:ScalewayServerlessContainer {id: 'scw-container'})
+        SET svc._ont_state = 'ready', svc.exposed_internet = true, svc.lastupdated = $tag
+
+        MERGE (img:Image:ScalewayContainerRegistryImage {id: 'sha256:scaleway'})
+        SET img.lastupdated = $tag
+
+        MERGE (svc)-[r:RESOLVED_IMAGE]->(img)
+        SET r.lastupdated = $tag
+        """,
+        tag=TEST_UPDATE_TAG,
+    )
+
+    _run_runs_image_analysis(neo4j_session)
+
+    assert check_rels(
+        neo4j_session,
+        "ComputeService",
+        "id",
+        "Image",
+        "id",
+        "RUNS_IMAGE",
+    ) == {("scw-container", "sha256:scaleway")}
+    assert _edge_exposure(neo4j_session, "scw-container", "sha256:scaleway") == [True]
+
+
+def test_runs_image_is_idempotent_and_marks_gone(neo4j_session):
+    """Re-running after a workload stops running an image removes the stale RUNS_IMAGE edge,
+    and re-running an unchanged graph does not duplicate edges."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (svc:ComputeService:KubernetesDeployment {id: 'deploy-1'})
+        SET svc.lastupdated = $tag
+        MERGE (pod:ComputePod:KubernetesPod {id: 'pod-1'})
+        SET pod.lastupdated = $tag
+        MERGE (c:Container:KubernetesContainer {id: 'container-1'})
+        SET c._ont_state = 'running', c.lastupdated = $tag
+        MERGE (img:Image:AWSECRImage {id: 'sha256:deadbeef'})
+        SET img.lastupdated = $tag
+        MERGE (c)-[r1:WORKLOAD_PARENT]->(pod) SET r1.lastupdated = $tag
+        MERGE (pod)-[r2:WORKLOAD_PARENT]->(svc) SET r2.lastupdated = $tag
+        MERGE (c)-[r3:RESOLVED_IMAGE]->(img) SET r3.lastupdated = $tag
+        """,
+        tag=TEST_UPDATE_TAG,
+    )
+
+    _run_runs_image_analysis(neo4j_session, TEST_UPDATE_TAG)
+    assert check_rels(
+        neo4j_session, "ComputeService", "id", "Image", "id", "RUNS_IMAGE"
+    ) == {("deploy-1", "sha256:deadbeef")}
+
+    # The workload stops running the image: drop the RESOLVED_IMAGE basis, then re-run with a
+    # fresh update tag. The stale RUNS_IMAGE edge (not re-stamped) must be cleaned up.
+    neo4j_session.run(
+        "MATCH (:Container {id: 'container-1'})-[r:RESOLVED_IMAGE]->(:Image) DELETE r"
+    )
+    _run_runs_image_analysis(neo4j_session, TEST_UPDATE_TAG_2)
+
+    assert (
+        check_rels(neo4j_session, "ComputeService", "id", "Image", "id", "RUNS_IMAGE")
+        == set()
+    )
+
+
+def test_runs_image_no_edge_without_controller(neo4j_session):
+    """A running container with no ComputeService ancestor yields no RUNS_IMAGE edge; that
+    case stays on the live-collapse fallback path."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (c:Container:KubernetesContainer {id: 'bare-container'})
+        SET c._ont_state = 'running', c.lastupdated = $tag
+        MERGE (img:Image:AWSECRImage {id: 'sha256:deadbeef'})
+        SET img.lastupdated = $tag
+        MERGE (c)-[r:RESOLVED_IMAGE]->(img)
+        SET r.lastupdated = $tag
+        """,
+        tag=TEST_UPDATE_TAG,
+    )
+
+    _run_runs_image_analysis(neo4j_session)
+
+    assert (
+        check_rels(neo4j_session, "ComputeService", "id", "Image", "id", "RUNS_IMAGE")
+        == set()
+    )
+
+
+def test_runs_image_standalone_function_gets_no_edge(neo4j_session):
+    """A container-based function (e.g. AWS Lambda) carries only :Function with a direct
+    RESOLVED_IMAGE, but has no :ComputeService label and no WORKLOAD_PARENT chain. By design
+    it is NOT materialized into RUNS_IMAGE (it stays on the read-side live-collapse path);
+    RUNS_IMAGE is a ComputeService-anchored fact and a standalone function is not a workload
+    controller."""
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (f:Function:AWSLambda {id: 'arn:aws:lambda:us-east-1:1234:function:fn'})
+        SET f.lastupdated = $tag
+        MERGE (img:Image:AWSECRImage {id: 'sha256:lambda'})
+        SET img.lastupdated = $tag
+        MERGE (f)-[r:RESOLVED_IMAGE]->(img)
+        SET r.lastupdated = $tag
+        """,
+        tag=TEST_UPDATE_TAG,
+    )
+
+    _run_runs_image_analysis(neo4j_session)
+
+    assert (
+        check_rels(neo4j_session, "ComputeService", "id", "Image", "id", "RUNS_IMAGE")
+        == set()
+    )
+    # And the function itself is never a RUNS_IMAGE source.
+    assert (
+        check_rels(neo4j_session, "Function", "id", "Image", "id", "RUNS_IMAGE")
+        == set()
+    )


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary

Materialize the runtime image inventory of each logical workload as a first-class ontology edge:

```
(:ComputeService)-[:RUNS_IMAGE]->(:Image)
```

This is a standalone runtime-composition fact ("this workload runs this image"), useful for inventory, attack-path, and "what is actually running on this service" queries. It is bounded by the number of `(workload, image)` pairs, not by the replica fan-out, so consumers can answer "which workloads run an affected image" through a bounded pattern without scanning every container replica.

A new typed analysis job (`WORKLOAD_RUNS_IMAGE`) runs in the ontology module after `RESOLVED_IMAGE_JOBS`. It collapses each running container up its `WORKLOAD_PARENT` chain to the owning `ComputeService` and `MERGE`s one edge per `(workload, image)`. The typed framework's `MERGE` plus generated mark-gone cleanup (`DELETE r WHERE r.lastupdated <> $UPDATE_TAG`) make it idempotent across incremental syncs.

Design points:
- **Zero-or-more-hop collapse (`*0..6`)** also covers serverless workloads that carry both `:ComputeService` and `:Container` on a single node (e.g. `ScalewayServerlessContainer`), which have no intermediate `WORKLOAD_PARENT` hop.
- **Active-state filter** accepts both `running` (AWS ECS `RUNNING`, Kubernetes `running`, Azure `Running`, GCP Cloud Run) and `ready` (Scaleway serverless `ContainerStatus.READY`), because `_ont_state` carries the raw per-provider status string.
- **`exposed_internet`** is denormalized onto the edge as the OR of the service-level signal (`svc.exposed_internet`, e.g. GCP Cloud Run ingress) and any running replica's signal (`rt.exposed_internet`, e.g. AWS ECS / Kubernetes), so workload-level exposure is readable without fanning back out to replicas.
- **Standalone functions** (AWS Lambda, GCP Cloud Functions, Azure Function Apps, Scaleway serverless functions) carry only `:Function` with no `ComputeService` controller and are intentionally not materialized; they remain per-instance and low cardinality.

Also registers the canonical `ComputeService -> Image` `RUNS_IMAGE` `RelConstraint` and updates the ontology schema docs.


### Related issues or links

<!-- none -->


### How was this tested?

- New integration tests in `tests/integration/cartography/intel/ontology/test_runs_image.py` cover: replica collapse + dedup, `running`/`ready` state filtering, exposure denormalization (replica-level and service-level), idempotency / mark-gone across syncs, self-service (Scaleway-style) zero-hop collapse, and the no-controller / standalone-function cases (no edge).
- Governance guards pass: `tests/unit/cartography/graph/test_analysis_cleanup_coverage.py`, `tests/unit/cartography/graph/test_ontology_rel_constraints.py`.
- Full ontology integration suite passes (`tests/integration/cartography/intel/ontology/`).
- `make test_lint` passes locally.


### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the schema documentation.

### Notes for reviewers

`RUNS_IMAGE` only appears in environments that have `ComputeService` controllers, which for Kubernetes require the workload-controller modeling from #3053. The edge is derived (analysis-only), so like `RESOLVED_IMAGE` it is registered in `ONTOLOGY_REL_CONSTRAINTS` for documentation but is not enforced against a declarative schema.