### PR TITLE
feat(github): add incremental sync and parallel workers

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -881,6 +881,36 @@ class CLI:
                     hidden=PANEL_GITHUB not in visible_panels,
                 ),
             ] = 30,
+            github_parallel_workers: Annotated[
+                int,
+                typer.Option(
+                    "--github-parallel-workers",
+                    help=(
+                        "Number of parallel workers for per-repo GitHub API fetches "
+                        "(rulesets, collaborators, dependency manifests). "
+                        "Default: 1 (sequential). Increase conservatively; each worker "
+                        "consumes GraphQL/REST quota independently."
+                    ),
+                    rich_help_panel=PANEL_GITHUB,
+                    hidden=PANEL_GITHUB not in visible_panels,
+                ),
+            ] = 1,
+            github_incremental_sync: Annotated[
+                bool,
+                typer.Option(
+                    "--github-incremental-sync",
+                    help=(
+                        "Enable incremental sync for GitHub repos. "
+                        "Skips archived/disabled repos in Actions, commits, and manifest syncs. "
+                        "Skips commits for repos with no push in the lookback window. "
+                        "Skips re-fetching workflow YAML and dependency manifests for repos "
+                        "whose pushedAt is unchanged since the last sync. "
+                        "Secrets, variables, and environments are always refreshed regardless."
+                    ),
+                    rich_help_panel=PANEL_GITHUB,
+                    hidden=PANEL_GITHUB not in visible_panels,
+                ),
+            ] = False,
             # =================================================================
             # GitLab Options
             # =================================================================
@@ -3000,6 +3030,8 @@ class CLI:
                 okta_saml_role_regex=okta_saml_role_regex,
                 github_config=github_config,
                 github_commit_lookback_days=github_commit_lookback_days,
+                github_parallel_workers=github_parallel_workers,
+                github_incremental_sync=github_incremental_sync,
                 digitalocean_token=digitalocean_token,
                 permission_relationships_file=permission_relationships_file,
                 azure_permission_relationships_file=azure_permission_relationships_file,

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -891,6 +891,7 @@ class CLI:
                         "Default: 1 (sequential). Increase conservatively; each worker "
                         "consumes GraphQL/REST quota independently."
                     ),
+                    min=1,
                     rich_help_panel=PANEL_GITHUB,
                     hidden=PANEL_GITHUB not in visible_panels,
                 ),

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -891,6 +891,36 @@ class CLI:
                     hidden=PANEL_GITHUB not in visible_panels,
                 ),
             ] = 30,
+            github_parallel_workers: Annotated[
+                int,
+                typer.Option(
+                    "--github-parallel-workers",
+                    help=(
+                        "Number of parallel workers for per-repo GitHub API fetches "
+                        "(rulesets, collaborators, dependency manifests). "
+                        "Default: 1 (sequential). Increase conservatively; each worker "
+                        "consumes GraphQL/REST quota independently."
+                    ),
+                    rich_help_panel=PANEL_GITHUB,
+                    hidden=PANEL_GITHUB not in visible_panels,
+                ),
+            ] = 1,
+            github_incremental_sync: Annotated[
+                bool,
+                typer.Option(
+                    "--github-incremental-sync",
+                    help=(
+                        "Enable incremental sync for GitHub repos. "
+                        "Skips archived/disabled repos in Actions, commits, and manifest syncs. "
+                        "Skips commits for repos with no push in the lookback window. "
+                        "Skips re-fetching workflow YAML and dependency manifests for repos "
+                        "whose pushedAt is unchanged since the last sync. "
+                        "Secrets, variables, and environments are always refreshed regardless."
+                    ),
+                    rich_help_panel=PANEL_GITHUB,
+                    hidden=PANEL_GITHUB not in visible_panels,
+                ),
+            ] = False,
             # =================================================================
             # GitLab Options
             # =================================================================
@@ -3183,6 +3213,8 @@ class CLI:
                 okta_saml_role_regex=okta_saml_role_regex,
                 github_config=github_config,
                 github_commit_lookback_days=github_commit_lookback_days,
+                github_parallel_workers=github_parallel_workers,
+                github_incremental_sync=github_incremental_sync,
                 digitalocean_token=digitalocean_token,
                 permission_relationships_file=permission_relationships_file,
                 azure_permission_relationships_file=azure_permission_relationships_file,

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -901,6 +901,7 @@ class CLI:
                         "Default: 1 (sequential). Increase conservatively; each worker "
                         "consumes GraphQL/REST quota independently."
                     ),
+                    min=1,
                     rich_help_panel=PANEL_GITHUB,
                     hidden=PANEL_GITHUB not in visible_panels,
                 ),

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -180,6 +180,12 @@ class Config:
     :param github_config: Base64 encoded config object for GitHub ingestion. Optional.
     :type github_commit_lookback_days: int
     :param github_commit_lookback_days: Number of days to look back for GitHub commit tracking. Optional.
+    :type github_parallel_workers: int
+    :param github_parallel_workers: Number of parallel workers for per-repo GitHub API fetches. Default 1 (sequential).
+    :type github_incremental_sync: bool
+    :param github_incremental_sync: Enable incremental sync for GitHub repos. Skips archived/disabled repos,
+        skips commits for repos with no push in the lookback window, and skips re-fetching workflow YAML and
+        dependency manifests for repos whose pushedAt is unchanged since the last sync. Optional.
     :type digitalocean_token: str
     :param digitalocean_token: DigitalOcean access token. Optional.
     :type permission_relationships_file: str
@@ -469,6 +475,8 @@ class Config:
         okta_saml_role_regex=None,
         github_config=None,
         github_commit_lookback_days=30,
+        github_parallel_workers=1,
+        github_incremental_sync=False,
         digitalocean_token=None,
         permission_relationships_file=None,
         azure_permission_relationships_file=None,
@@ -680,6 +688,8 @@ class Config:
         self.okta_saml_role_regex = okta_saml_role_regex
         self.github_config = github_config
         self.github_commit_lookback_days = github_commit_lookback_days
+        self.github_parallel_workers: int = github_parallel_workers
+        self.github_incremental_sync = github_incremental_sync
         self.digitalocean_token = digitalocean_token
         self.permission_relationships_file = permission_relationships_file
         self.azure_permission_relationships_file = azure_permission_relationships_file

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -475,8 +475,6 @@ class Config:
         okta_saml_role_regex=None,
         github_config=None,
         github_commit_lookback_days=30,
-        github_parallel_workers=1,
-        github_incremental_sync=False,
         digitalocean_token=None,
         permission_relationships_file=None,
         azure_permission_relationships_file=None,
@@ -628,6 +626,9 @@ class Config:
         microsoft_tenant_id=None,
         microsoft_client_id=None,
         microsoft_client_secret=None,
+        # Appended last to preserve positional-arg compatibility for existing callers.
+        github_parallel_workers=1,
+        github_incremental_sync=False,
     ):
         self.neo4j_uri = neo4j_uri
         self.neo4j_user = neo4j_user

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -504,8 +504,6 @@ class Config:
         okta_saml_role_regex=None,
         github_config=None,
         github_commit_lookback_days=30,
-        github_parallel_workers=1,
-        github_incremental_sync=False,
         digitalocean_token=None,
         permission_relationships_file=None,
         azure_permission_relationships_file=None,
@@ -669,6 +667,9 @@ class Config:
         netlify_token=None,
         netlify_account_slug=None,
         netlify_base_url=None,
+        # Appended last to preserve positional-arg compatibility for existing callers.
+        github_parallel_workers=1,
+        github_incremental_sync=False,
     ):
         self.neo4j_uri = neo4j_uri
         self.neo4j_user = neo4j_user

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -180,6 +180,12 @@ class Config:
     :param github_config: Base64 encoded config object for GitHub ingestion. Optional.
     :type github_commit_lookback_days: int
     :param github_commit_lookback_days: Number of days to look back for GitHub commit tracking. Optional.
+    :type github_parallel_workers: int
+    :param github_parallel_workers: Number of parallel workers for per-repo GitHub API fetches. Default 1 (sequential).
+    :type github_incremental_sync: bool
+    :param github_incremental_sync: Enable incremental sync for GitHub repos. Skips archived/disabled repos,
+        skips commits for repos with no push in the lookback window, and skips re-fetching workflow YAML and
+        dependency manifests for repos whose pushedAt is unchanged since the last sync. Optional.
     :type digitalocean_token: str
     :param digitalocean_token: DigitalOcean access token. Optional.
     :type permission_relationships_file: str
@@ -498,6 +504,8 @@ class Config:
         okta_saml_role_regex=None,
         github_config=None,
         github_commit_lookback_days=30,
+        github_parallel_workers=1,
+        github_incremental_sync=False,
         digitalocean_token=None,
         permission_relationships_file=None,
         azure_permission_relationships_file=None,
@@ -721,6 +729,8 @@ class Config:
         self.okta_saml_role_regex = okta_saml_role_regex
         self.github_config = github_config
         self.github_commit_lookback_days = github_commit_lookback_days
+        self.github_parallel_workers: int = github_parallel_workers
+        self.github_incremental_sync = github_incremental_sync
         self.digitalocean_token = digitalocean_token
         self.permission_relationships_file = permission_relationships_file
         self.azure_permission_relationships_file = azure_permission_relationships_file

--- a/cartography/intel/github/__init__.py
+++ b/cartography/intel/github/__init__.py
@@ -22,22 +22,29 @@ import cartography.intel.github.users
 from cartography.client.core.tx import read_list_of_values_tx
 from cartography.config import Config
 from cartography.intel.github.app_auth import make_credential
+from cartography.intel.github.repos import _write_synced_pushedat
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
-def _get_repos_from_graph(neo4j_session: neo4j.Session, organization: str) -> list[str]:
+def _get_repos_from_graph(
+    neo4j_session: neo4j.Session,
+    organization: str,
+    skip_archived: bool = False,
+) -> list[str]:
     """
     Get repository names for an organization from the graph instead of making an API call.
 
     :param neo4j_session: Neo4j session for database interface
     :param organization: GitHub organization name
+    :param skip_archived: If True, exclude archived/disabled repos.
     :return: List of repository names
     """
     org_url = f"https://github.com/{organization}"
     query = """
     MATCH (org:GitHubOrganization {id: $org_url})<-[:OWNER]-(repo:GitHubRepository)
+    WHERE NOT $skip_archived OR (repo.archived = false AND repo.disabled = false)
     RETURN repo.name
     ORDER BY repo.name
     """
@@ -47,6 +54,7 @@ def _get_repos_from_graph(neo4j_session: neo4j.Session, organization: str) -> li
             read_list_of_values_tx,
             query,
             org_url=org_url,
+            skip_archived=skip_archived,
         ),
     )
 
@@ -84,7 +92,7 @@ def start_github_ingestion(
     skip_unscoped_cleanup: bool = False,
 ) -> None:
     """
-    If this module is configured, perform ingestion of Github  data. Otherwise warn and exit
+    If this module is configured, perform ingestion of Github  data. Otherwise warn and exit.
     :param neo4j_session: Neo4J session for database interface
     :param config: A cartography.config object
     :param skip_unscoped_cleanup: Skip cleanup of GitHub resources that are not
@@ -127,6 +135,8 @@ def start_github_ingestion(
             token,
             api_url,
             org_name,
+            parallel_workers=config.github_parallel_workers,
+            incremental_sync=config.github_incremental_sync,
         )
         cartography.intel.github.personal_access_tokens.sync(
             neo4j_session,
@@ -142,6 +152,7 @@ def start_github_ingestion(
             api_url,
             org_name,
         )
+
         github_teams = cartography.intel.github.teams.sync_github_teams(
             neo4j_session,
             common_job_parameters,
@@ -169,12 +180,18 @@ def start_github_ingestion(
             token,
             api_url,
             org_name,
+            parallel_workers=config.github_parallel_workers,
+            skip_archived_repos=config.github_incremental_sync,
+            skip_unchanged_repos=config.github_incremental_sync,
         )
 
-        # Sync commit relationships for the configured lookback period
-        # Get repo names from the graph instead of making another API call
-        repo_names = _get_repos_from_graph(neo4j_session, org_name)
-
+        # Sync commit relationships for the configured lookback period.
+        # Get repo names from the graph instead of making another API call.
+        repo_names = _get_repos_from_graph(
+            neo4j_session,
+            org_name,
+            skip_archived=config.github_incremental_sync,
+        )
         cartography.intel.github.commits.sync_github_commits(
             neo4j_session,
             token,
@@ -183,6 +200,7 @@ def start_github_ingestion(
             repo_names,
             common_job_parameters["UPDATE_TAG"],
             config.github_commit_lookback_days,
+            skip_stale_repos=config.github_incremental_sync,
         )
 
         repos_json = cartography.intel.github.repos.get(
@@ -251,6 +269,14 @@ def start_github_ingestion(
                 common_job_parameters,
                 valid_repos,
                 workflows=all_workflows,
+            )
+
+        # Write synced_pushedat now that all downstream stages have completed.
+        # This ensures the bookmark reflects the previous run's pushedat when
+        # the next run's skip comparisons read it, not the current run's value.
+        if config.github_incremental_sync:
+            _write_synced_pushedat(
+                neo4j_session, repo_sync_result.repo_pushedat_updates
             )
 
         processed_any_org = True

--- a/cartography/intel/github/actions.py
+++ b/cartography/intel/github/actions.py
@@ -8,13 +8,19 @@ Supports three levels:
 """
 
 import logging
+import threading
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from dataclasses import field
 from typing import Any
 from urllib.parse import quote
 
 import neo4j
 
 from cartography.client.core.tx import load
-from cartography.client.core.tx import read_list_of_values_tx
+from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.client.core.tx import run_write_query
 from cartography.graph.job import GraphJob
 from cartography.intel.github.util import _get_rest_api_base_url
 from cartography.intel.github.util import fetch_all_rest_api_pages
@@ -716,20 +722,30 @@ def cleanup_org_level(
 # =============================================================================
 
 
-def _get_repos_from_graph(neo4j_session: neo4j.Session, organization: str) -> list[str]:
+def _get_repos_from_graph(
+    neo4j_session: neo4j.Session,
+    organization: str,
+    skip_archived_repos: bool = False,
+) -> list[dict[str, Any]]:
     """
-    Get repository names for an organization from the graph.
+    Get repository name/url/pushedat/synced_pushedat metadata for an
+    organization from the graph.
+
+    :param skip_archived_repos: If True, exclude archived/disabled repos.
     """
     org_url = f"https://github.com/{organization}"
     query = """
     MATCH (org:GitHubOrganization {id: $org_url})<-[:OWNER]-(repo:GitHubRepository)
-    RETURN repo.name
+    WHERE NOT $skip_archived_repos OR (repo.archived = false AND repo.disabled = false)
+    RETURN repo.name AS name, repo.id AS url, repo.pushedat AS pushedat,
+           repo.synced_pushedat AS synced_pushedat
     ORDER BY repo.name
     """
-    result: list[str] = neo4j_session.execute_read(
-        read_list_of_values_tx,
+    result: list[dict[str, Any]] = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
         query,
         org_url=org_url,
+        skip_archived_repos=skip_archived_repos,
     )
     return result
 
@@ -739,50 +755,61 @@ def _get_repos_from_graph(neo4j_session: neo4j.Session, organization: str) -> li
 # =============================================================================
 
 
-@timeit
-def sync(
-    neo4j_session: neo4j.Session,
-    common_job_parameters: dict[str, Any],
+@dataclass
+class _RepoActionsData:
+    """All fetched-and-transformed data for a single repo's Actions resources.
+    Populated by _fetch_actions_for_repo() in worker threads; consumed by
+    sync() on the main thread for Neo4j writes."""
+
+    repo_name: str
+    repo_url: str = ""
+    pushedat: str | None = None
+    workflows_skipped: bool = False
+    enriched_workflows: list[dict[str, Any]] = field(default_factory=list)
+    repo_actions: list[dict[str, Any]] = field(default_factory=list)
+    transformed_environments: list[dict[str, Any]] = field(default_factory=list)
+    transformed_repo_secrets: list[dict[str, Any]] = field(default_factory=list)
+    transformed_repo_variables: list[dict[str, Any]] = field(default_factory=list)
+    env_secrets: list[dict[str, Any]] = field(default_factory=list)
+    env_variables: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _fetch_actions_for_repo(
+    repo_name: str,
+    organization: str,
     github_api_key: str,
     github_url: str,
-    organization: str,
-) -> list[dict[str, Any]]:
+    progress_counter: "list[int]",
+    progress_lock: threading.Lock,
+    total: int,
+    repo_url: str = "",
+    pushedat: str | None = None,
+    synced_pushedat: str | None = None,
+    skip_unchanged_repos: bool = False,
+) -> _RepoActionsData:
     """
-    Sync GitHub Actions data (workflows, secrets, variables, environments) for an organization.
+    Fetch and transform all Actions data for a single repo.
+    Returns a _RepoActionsData bundle; no Neo4j writes are performed here.
+    Designed to be called from worker threads via ThreadPoolExecutor.
 
-    Sync order:
-    1. Organization-level secrets and variables
-    2. For each repo: workflows, environments, repo secrets/variables
-    3. For each environment: env secrets/variables
-    4. Cleanup stale nodes
-
-    :return: List of all transformed workflows (with repo_url and path) for supply chain sync.
+    :param skip_unchanged_repos: If True, skip re-fetching/re-parsing workflow
+        YAML content when `pushedat` matches `synced_pushedat` (written after
+        the last successful repos sync). Secrets, variables, and environments
+        are always fetched regardless.
     """
-    org_url = f"https://github.com/{organization}"
-    update_tag = common_job_parameters["UPDATE_TAG"]
-    all_workflows: list[dict[str, Any]] = []
+    data = _RepoActionsData(repo_name=repo_name, repo_url=repo_url, pushedat=pushedat)
 
-    # 1. Sync organization-level secrets and variables
-    logger.info(f"Syncing GitHub Actions for organization: {organization}")
+    skip_workflows = (
+        skip_unchanged_repos
+        and pushedat is not None
+        and synced_pushedat is not None
+        and pushedat == synced_pushedat
+    )
 
-    org_secrets = get_org_secrets(github_api_key, github_url, organization)
-    if org_secrets:
-        transformed_org_secrets = transform_org_secrets(org_secrets, organization)
-        load_org_secrets(neo4j_session, transformed_org_secrets, update_tag, org_url)
-
-    org_variables = get_org_variables(github_api_key, github_url, organization)
-    if org_variables:
-        transformed_org_variables = transform_org_variables(org_variables, organization)
-        load_org_variables(
-            neo4j_session, transformed_org_variables, update_tag, org_url
-        )
-
-    # 2. Get repos from graph and sync repo-level resources
-    repo_names = _get_repos_from_graph(neo4j_session, organization)
-    logger.info(f"Syncing GitHub Actions for {len(repo_names)} repositories")
-
-    for repo_name in repo_names:
-        # Sync workflows
+    if skip_workflows:
+        data.workflows_skipped = True
+    else:
+        # Workflows
         workflows = get_repo_workflows(
             github_api_key, github_url, organization, repo_name
         )
@@ -790,17 +817,9 @@ def sync(
             transformed_workflows = transform_workflows(
                 workflows, organization, repo_name
             )
-
-            # Fetch and parse workflow content for each workflow
-            repo_actions: list[dict[str, Any]] = []
-            enriched_workflows = []
-
             for wf in transformed_workflows:
-                workflow_path = wf.get("path")
-                workflow_id = wf.get("id")
-
-                # Fetch workflow YAML content
                 content = None
+                workflow_path = wf.get("path")
                 if workflow_path:
                     content = get_workflow_content(
                         github_api_key,
@@ -809,107 +828,292 @@ def sync(
                         repo_name,
                         workflow_path,
                     )
-
-                # Parse the workflow content
-                parsed = None
-                if content:
-                    parsed = parse_workflow_yaml(content)
-
-                # Enrich workflow with parsed data
+                parsed = parse_workflow_yaml(content) if content else None
                 enriched_wf = enrich_workflow_with_parsed_content(
-                    wf, parsed, organization, repo_name
+                    wf,
+                    parsed,
+                    organization,
+                    repo_name,
                 )
-                enriched_workflows.append(enriched_wf)
-
-                # Extract actions for loading
-                if parsed and workflow_id is not None:
-                    actions = transform_actions(
-                        parsed, workflow_id, organization, repo_name
+                data.enriched_workflows.append(enriched_wf)
+                if parsed and wf.get("id") is not None:
+                    data.repo_actions.extend(
+                        transform_actions(parsed, wf["id"], organization, repo_name)
                     )
-                    repo_actions.extend(actions)
 
-            # Load enriched workflows
-            load_workflows(neo4j_session, enriched_workflows, update_tag, org_url)
-            all_workflows.extend(enriched_workflows)
-
-            # Load actions
-            if repo_actions:
-                load_actions(neo4j_session, repo_actions, update_tag, org_url)
-
-        # Sync environments (must come before env secrets/variables)
-        environments = get_repo_environments(
-            github_api_key, github_url, organization, repo_name
+    # Environments
+    environments = get_repo_environments(
+        github_api_key,
+        github_url,
+        organization,
+        repo_name,
+    )
+    if environments:
+        data.transformed_environments = transform_environments(
+            environments,
+            organization,
+            repo_name,
         )
-        if environments:
-            transformed_environments = transform_environments(
-                environments, organization, repo_name
-            )
-            load_environments(
-                neo4j_session, transformed_environments, update_tag, org_url
-            )
 
-        # Sync repo-level secrets
-        repo_secrets = get_repo_secrets(
-            github_api_key, github_url, organization, repo_name
+    # Repo secrets and variables
+    repo_secrets = get_repo_secrets(github_api_key, github_url, organization, repo_name)
+    if repo_secrets:
+        data.transformed_repo_secrets = transform_repo_secrets(
+            repo_secrets,
+            organization,
+            repo_name,
         )
-        if repo_secrets:
-            transformed_repo_secrets = transform_repo_secrets(
-                repo_secrets, organization, repo_name
-            )
-            load_repo_secrets(
-                neo4j_session, transformed_repo_secrets, update_tag, org_url
-            )
 
-        # Sync repo-level variables
-        repo_variables = get_repo_variables(
-            github_api_key, github_url, organization, repo_name
+    repo_variables = get_repo_variables(
+        github_api_key,
+        github_url,
+        organization,
+        repo_name,
+    )
+    if repo_variables:
+        data.transformed_repo_variables = transform_repo_variables(
+            repo_variables,
+            organization,
+            repo_name,
         )
-        if repo_variables:
-            transformed_repo_variables = transform_repo_variables(
-                repo_variables, organization, repo_name
-            )
-            load_repo_variables(
-                neo4j_session, transformed_repo_variables, update_tag, org_url
+
+    # Environment-level secrets and variables
+    for env in environments or []:
+        env_name = env["name"]
+        env_id = env["id"]
+
+        env_s = get_env_secrets(
+            github_api_key,
+            github_url,
+            organization,
+            repo_name,
+            env_name,
+        )
+        if env_s:
+            data.env_secrets.extend(
+                transform_env_secrets(env_s, organization, repo_name, env_name, env_id)
             )
 
-        # 3. Sync environment-level secrets and variables
-        for env in environments or []:
-            env_name = env["name"]
-            env_id = env["id"]
-
-            env_secrets = get_env_secrets(
-                github_api_key, github_url, organization, repo_name, env_name
+        env_v = get_env_variables(
+            github_api_key,
+            github_url,
+            organization,
+            repo_name,
+            env_name,
+        )
+        if env_v:
+            data.env_variables.extend(
+                transform_env_variables(
+                    env_v, organization, repo_name, env_name, env_id
+                )
             )
-            if env_secrets:
-                transformed_env_secrets = transform_env_secrets(
-                    env_secrets,
-                    organization,
-                    repo_name,
-                    env_name,
-                    env_id,
-                )
-                load_env_secrets(
-                    neo4j_session, transformed_env_secrets, update_tag, org_url
-                )
 
-            env_variables = get_env_variables(
-                github_api_key, github_url, organization, repo_name, env_name
-            )
-            if env_variables:
-                transformed_env_variables = transform_env_variables(
-                    env_variables,
-                    organization,
-                    repo_name,
-                    env_name,
-                    env_id,
-                )
-                load_env_variables(
-                    neo4j_session, transformed_env_variables, update_tag, org_url
-                )
+    with progress_lock:
+        progress_counter[0] += 1
+        done = progress_counter[0]
+    if done == 1 or done % 50 == 0 or done == total:
+        logger.info(
+            "Actions fetch progress for org %s: %d/%d repos completed.",
+            organization,
+            done,
+            total,
+        )
 
-    # 4. Cleanup all stale nodes scoped to the organization. Repo-level secrets
-    # and variables are now scoped to the org as well, so cleanup_org_level
-    # picks them up here.
+    return data
+
+
+def _touch_skipped_actions_workflows(
+    neo4j_session: neo4j.Session,
+    skipped_repo_urls: list[str],
+    update_tag: int,
+) -> None:
+    """
+    Refresh `lastupdated` on the existing GitHubWorkflow/GitHubAction nodes for
+    repos whose workflow-content fetch was skipped this run (because pushedat
+    was unchanged), so the end-of-run stale-tag cleanup doesn't delete them.
+    """
+    if not skipped_repo_urls:
+        return
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_WORKFLOW]->(wf:GitHubWorkflow)
+        SET wf.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_WORKFLOW]->(:GitHubWorkflow)
+              -[:USES_ACTION]->(a:GitHubAction)
+        SET a.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+
+
+def _update_actions_synced_bookmarks(
+    neo4j_session: neo4j.Session,
+    synced_bookmarks: list[dict[str, str]],
+) -> None:
+    """
+    No-op kept for backwards compatibility. The synced_pushedat bookmark is
+    now written centrally by repos.sync() after the repos fetch completes,
+    so per-stage write-back is no longer needed.
+
+    # DEPRECATED: will be removed in v1.0.0.
+    """
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+    github_api_key: str,
+    github_url: str,
+    organization: str,
+    parallel_workers: int = 1,
+    skip_archived_repos: bool = False,
+    skip_unchanged_repos: bool = False,
+) -> list[dict[str, Any]]:
+    """
+    Sync GitHub Actions data (workflows, secrets, variables, environments) for an organization.
+
+    Sync order:
+    1. Organization-level secrets and variables
+    2. For each repo (parallel fetch, sequential load): workflows, environments,
+       repo secrets/variables, env secrets/variables
+    3. Cleanup stale nodes
+
+    :param parallel_workers: Number of repos to fetch concurrently. Default 1 (sequential).
+    :param skip_archived_repos: If True, skip archived/disabled repos entirely.
+    :param skip_unchanged_repos: If True, skip re-fetching/re-parsing workflow
+        YAML content for repos whose `pushedat` is unchanged since the last
+        successful Actions sync. Secrets/variables/environments are always
+        still fetched for every repo.
+    :return: List of all transformed workflows (with repo_url and path) for supply chain sync.
+    """
+    org_url = f"https://github.com/{organization}"
+    update_tag = common_job_parameters["UPDATE_TAG"]
+    all_workflows: list[dict[str, Any]] = []
+
+    # 1. Sync organization-level secrets and variables
+    logger.info("Syncing GitHub Actions for organization: %s", organization)
+
+    org_secrets = get_org_secrets(github_api_key, github_url, organization)
+    if org_secrets:
+        load_org_secrets(
+            neo4j_session,
+            transform_org_secrets(org_secrets, organization),
+            update_tag,
+            org_url,
+        )
+
+    org_variables = get_org_variables(github_api_key, github_url, organization)
+    if org_variables:
+        load_org_variables(
+            neo4j_session,
+            transform_org_variables(org_variables, organization),
+            update_tag,
+            org_url,
+        )
+
+    # 2. Get repos from graph and sync repo-level resources
+    repos = _get_repos_from_graph(
+        neo4j_session,
+        organization,
+        skip_archived_repos=skip_archived_repos,
+    )
+    total = len(repos)
+    logger.info(
+        "Syncing GitHub Actions for %d repositories in org %s (parallel_workers=%d).",
+        total,
+        organization,
+        parallel_workers,
+    )
+
+    progress_counter: list[int] = [0]
+    progress_lock = threading.Lock()
+
+    skipped_repo_urls: list[str] = []
+
+    # Submit all repos to a single bounded thread pool up front so idle workers
+    # immediately pick up the next repo instead of waiting for a batch's
+    # slowest straggler (e.g. a repo with many workflows/environments).
+    with ThreadPoolExecutor(max_workers=parallel_workers) as executor:
+        futures = {
+            executor.submit(
+                _fetch_actions_for_repo,
+                repo["name"],
+                organization,
+                github_api_key,
+                github_url,
+                progress_counter,
+                progress_lock,
+                total,
+                repo_url=repo["url"],
+                pushedat=repo.get("pushedat"),
+                synced_pushedat=repo.get("synced_pushedat"),
+                skip_unchanged_repos=skip_unchanged_repos,
+            ): repo["name"]
+            for repo in repos
+        }
+
+        # Sequential load — all Neo4j writes on the main thread, applied as
+        # each repo's fetch completes rather than waiting for a fixed batch.
+        for f in as_completed(futures):
+            d = f.result()
+            if d.enriched_workflows:
+                load_workflows(neo4j_session, d.enriched_workflows, update_tag, org_url)
+                all_workflows.extend(d.enriched_workflows)
+            if d.repo_actions:
+                load_actions(neo4j_session, d.repo_actions, update_tag, org_url)
+            if d.transformed_environments:
+                load_environments(
+                    neo4j_session,
+                    d.transformed_environments,
+                    update_tag,
+                    org_url,
+                )
+            if d.transformed_repo_secrets:
+                load_repo_secrets(
+                    neo4j_session,
+                    d.transformed_repo_secrets,
+                    update_tag,
+                    org_url,
+                )
+            if d.transformed_repo_variables:
+                load_repo_variables(
+                    neo4j_session,
+                    d.transformed_repo_variables,
+                    update_tag,
+                    org_url,
+                )
+            if d.env_secrets:
+                load_env_secrets(neo4j_session, d.env_secrets, update_tag, org_url)
+            if d.env_variables:
+                load_env_variables(neo4j_session, d.env_variables, update_tag, org_url)
+
+            if skip_unchanged_repos:
+                if d.workflows_skipped:
+                    skipped_repo_urls.append(d.repo_url)
+
+    if skip_unchanged_repos:
+        _touch_skipped_actions_workflows(neo4j_session, skipped_repo_urls, update_tag)
+        logger.info(
+            "GitHub Actions incremental sync for org %s: skipped workflow refetch "
+            "for %d/%d unchanged repos.",
+            organization,
+            len(skipped_repo_urls),
+            total,
+        )
+
+    # 3. Cleanup all stale nodes scoped to the organization.
     org_cleanup_params = {**common_job_parameters, "org_url": org_url}
     # DEPRECATED: compatibility migration to backfill the RESOURCE edge from
     # GitHubOrganization to repo-level GitHubActionsSecret and

--- a/cartography/intel/github/actions.py
+++ b/cartography/intel/github/actions.py
@@ -928,9 +928,11 @@ def _touch_skipped_actions_workflows(
     update_tag: int,
 ) -> None:
     """
-    Refresh `lastupdated` on the existing GitHubWorkflow/GitHubAction nodes for
-    repos whose workflow-content fetch was skipped this run (because pushedat
-    was unchanged), so the end-of-run stale-tag cleanup doesn't delete them.
+    Refresh `lastupdated` on the existing GitHubWorkflow/GitHubAction subgraph
+    for repos whose workflow-content fetch was skipped this run (pushedat
+    unchanged), so the stale-tag cleanups don't delete it. Cleanup also deletes
+    stale relationships by their own `lastupdated`, so every relationship reaped
+    by the workflow and action cleanups is touched too.
     """
     if not skipped_repo_urls:
         return
@@ -938,8 +940,11 @@ def _touch_skipped_actions_workflows(
         neo4j_session,
         """
         UNWIND $repo_urls AS repo_url
-        MATCH (:GitHubRepository {id: repo_url})-[:HAS_WORKFLOW]->(wf:GitHubWorkflow)
-        SET wf.lastupdated = $update_tag
+        MATCH (:GitHubRepository {id: repo_url})-[hw:HAS_WORKFLOW]->(wf:GitHubWorkflow)
+        SET wf.lastupdated = $update_tag, hw.lastupdated = $update_tag
+        WITH DISTINCT wf
+        MATCH (:GitHubOrganization)-[res:RESOURCE]->(wf)
+        SET res.lastupdated = $update_tag
         """,
         repo_urls=skipped_repo_urls,
         update_tag=update_tag,
@@ -949,12 +954,50 @@ def _touch_skipped_actions_workflows(
         """
         UNWIND $repo_urls AS repo_url
         MATCH (:GitHubRepository {id: repo_url})-[:HAS_WORKFLOW]->(:GitHubWorkflow)
-              -[:USES_ACTION]->(a:GitHubAction)
-        SET a.lastupdated = $update_tag
+              -[rs:REFERENCES_SECRET]->(:GitHubActionsSecret)
+        SET rs.lastupdated = $update_tag
         """,
         repo_urls=skipped_repo_urls,
         update_tag=update_tag,
     )
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_WORKFLOW]->(:GitHubWorkflow)
+              -[ua:USES_ACTION]->(a:GitHubAction)
+        SET a.lastupdated = $update_tag, ua.lastupdated = $update_tag
+        WITH DISTINCT a
+        MATCH (:GitHubOrganization)-[res:RESOURCE]->(a)
+        SET res.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+
+
+def _get_skipped_repo_workflows(
+    neo4j_session: neo4j.Session,
+    skipped_repo_urls: list[str],
+) -> list[dict[str, Any]]:
+    """
+    Return {repo_url, path} rows for the existing workflows of skipped repos so
+    supply_chain.sync refreshes their PACKAGED_BY matchlinks instead of its
+    cleanup deleting them as stale.
+    """
+    if not skipped_repo_urls:
+        return []
+    rows: list[dict[str, Any]] = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_WORKFLOW]->(wf:GitHubWorkflow)
+        WHERE wf.repo_url IS NOT NULL AND wf.path IS NOT NULL
+        RETURN wf.repo_url AS repo_url, wf.path AS path
+        """,
+        repo_urls=skipped_repo_urls,
+    )
+    return rows
 
 
 def _update_actions_synced_bookmarks(
@@ -1105,6 +1148,9 @@ def sync(
 
     if skip_unchanged_repos:
         _touch_skipped_actions_workflows(neo4j_session, skipped_repo_urls, update_tag)
+        all_workflows.extend(
+            _get_skipped_repo_workflows(neo4j_session, skipped_repo_urls)
+        )
         logger.info(
             "GitHub Actions incremental sync for org %s: skipped workflow refetch "
             "for %d/%d unchanged repos.",

--- a/cartography/intel/github/commits.py
+++ b/cartography/intel/github/commits.py
@@ -7,6 +7,7 @@ from typing import Any
 import neo4j
 
 from cartography.client.core.tx import load_matchlinks
+from cartography.client.core.tx import read_list_of_dicts_tx
 from cartography.graph.job import GraphJob
 from cartography.intel.github.util import fetch_page
 from cartography.models.github.commits import GitHubUserCommittedToRepoRel
@@ -126,6 +127,38 @@ def get_repo_commits(
     return all_commits
 
 
+def _get_repo_pushedat_map(
+    neo4j_session: neo4j.Session,
+    organization: str,
+    repo_names: list[str],
+) -> dict[str, str | None]:
+    """
+    Fetch the current `pushedat` value for the given repos from the graph.
+
+    :param neo4j_session: Neo4j session for database interface.
+    :param organization: The Github organization name.
+    :param repo_names: List of repository names to look up.
+    :return: A dict mapping repo_name to its `pushedat` value (or None if
+        missing/never fetched).
+    """
+    repo_urls = {
+        repo_name: f"https://github.com/{organization}/{repo_name}"
+        for repo_name in repo_names
+    }
+    query = """
+    UNWIND $repo_urls AS url
+    MATCH (r:GitHubRepository {id: url})
+    RETURN r.id AS url, r.pushedat AS pushedat
+    """
+    rows = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        query,
+        repo_urls=list(repo_urls.values()),
+    )
+    pushedat_by_url = {row["url"]: row["pushedat"] for row in rows}
+    return {repo_name: pushedat_by_url.get(url) for repo_name, url in repo_urls.items()}
+
+
 def process_repo_commits_batch(
     neo4j_session: neo4j.Session,
     token: str,
@@ -135,6 +168,7 @@ def process_repo_commits_batch(
     update_tag: int,
     lookback_days: int = 30,
     batch_size: int = 10,
+    skip_stale_repos: bool = False,
 ) -> None:
     """
     Process repository commits in batches to save memory and API quota.
@@ -147,9 +181,44 @@ def process_repo_commits_batch(
     :param update_tag: Timestamp used to determine data freshness.
     :param lookback_days: Number of days to look back for commits.
     :param batch_size: Number of repositories to process in each batch.
+    :param skip_stale_repos: If True, skip repos whose `pushedat` (last known
+        push, from a prior GitHub repos sync) is older than the lookback
+        window; such repos cannot have any commits within that window. Repos
+        with no `pushedat` on record (e.g. never seen by a repos sync yet)
+        are never skipped.
     """
     # Calculate lookback date based on configured days
     lookback_date = datetime.now(timezone.utc) - timedelta(days=lookback_days)
+
+    if skip_stale_repos:
+        pushedat_by_repo = _get_repo_pushedat_map(
+            neo4j_session, organization, repo_names
+        )
+        eligible_repo_names = []
+        skipped_count = 0
+        for repo_name in repo_names:
+            pushedat = pushedat_by_repo.get(repo_name)
+            if pushedat is None:
+                eligible_repo_names.append(repo_name)
+                continue
+            try:
+                pushed_dt = datetime.fromisoformat(pushedat.replace("Z", "+00:00"))
+            except (ValueError, AttributeError):
+                eligible_repo_names.append(repo_name)
+                continue
+            if pushed_dt < lookback_date:
+                skipped_count += 1
+            else:
+                eligible_repo_names.append(repo_name)
+        logger.info(
+            "Skipping commits fetch for %d/%d repos in org %s with no push in the "
+            "last %d days.",
+            skipped_count,
+            len(repo_names),
+            organization,
+            lookback_days,
+        )
+        repo_names = eligible_repo_names
 
     logger.info(f"Processing {len(repo_names)} repositories in batches of {batch_size}")
 
@@ -383,6 +452,7 @@ def sync_github_commits(
     repo_names: list[str],
     update_tag: int,
     lookback_days: int = 30,
+    skip_stale_repos: bool = False,
 ) -> None:
     """
     Sync GitHub commit relationships for the specified lookback period.
@@ -395,6 +465,8 @@ def sync_github_commits(
     :param repo_names: List of repository names to sync commits for.
     :param update_tag: Timestamp used to determine data freshness.
     :param lookback_days: Number of days to look back for commits.
+    :param skip_stale_repos: If True, skip repos with no push in the lookback
+        window (see process_repo_commits_batch).
     """
     logger.info(f"Starting GitHub commits sync for organization: {organization}")
 
@@ -408,6 +480,7 @@ def sync_github_commits(
         repo_names,
         update_tag,
         lookback_days=lookback_days,
+        skip_stale_repos=skip_stale_repos,
         batch_size=10,  # Process 10 repos at a time
     )
 

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -2,11 +2,15 @@ import configparser
 import hashlib
 import json
 import logging
+import threading
 import time
 from collections import defaultdict
 from collections import namedtuple
 from collections.abc import Callable
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from dataclasses import field
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -22,6 +26,8 @@ from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 
 from cartography.client.core.tx import load as load_data
+from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.client.core.tx import run_write_query
 from cartography.graph.job import GraphJob
 from cartography.helpers import backoff_handler
 from cartography.intel.github.codeowners import normalize_repo_relative_path
@@ -58,6 +64,8 @@ from cartography.models.github.rulesets import GitHubRulesetSchema
 from cartography.util import retries_with_backoff
 from cartography.util import run_analysis_job
 from cartography.util import timeit
+from cartography.util import to_asynchronous
+from cartography.util import to_synchronous
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +88,7 @@ class GitHubRepoSyncResult:
     repos: list[dict[str, Any]]
     manifests: list[dict[str, Any]]
     manifests_cleanup_safe: bool
+    repo_pushedat_updates: list[dict[str, str]] = field(default_factory=list)
 
 
 GITHUB_ORG_REPOS_PAGINATED_GRAPHQL = """
@@ -104,6 +113,7 @@ GITHUB_ORG_REPOS_PAGINATED_GRAPHQL = """
                     createdAt
                     description
                     updatedAt
+                    pushedAt
                     homepageUrl
                     languages(first: 25){
                         totalCount
@@ -294,6 +304,15 @@ def _fetch_manifest_page(
             requests.exceptions.ChunkedEncodingError,
         ):
             if attempt + 1 >= retries:
+                logger.warning(
+                    "Failed to fetch dependency manifest page for repo %s after %d retries "
+                    "(manifest_cursor=%s, dep_cursor=%s).",
+                    repo,
+                    retries,
+                    manifest_cursor,
+                    dep_cursor,
+                    exc_info=True,
+                )
                 return None
             time.sleep(2 ** (attempt + 1))
             continue
@@ -306,9 +325,13 @@ def _fetch_manifest_page(
         if dep_manifests is None and resp.get("errors"):
             if attempt + 1 >= retries:
                 logger.warning(
-                    "GraphQL timeout fetching dependency manifests for repo %s after %d retries.",
+                    "GraphQL timeout fetching dependency manifests for repo %s after %d retries "
+                    "(manifest_cursor=%s, dep_cursor=%s). Errors: %s",
                     repo,
                     retries,
+                    manifest_cursor,
+                    dep_cursor,
+                    resp.get("errors"),
                 )
                 return resp
             logger.debug(
@@ -482,11 +505,179 @@ def _get_repo_dep_manifests(
     return manifests, cleanup_safe
 
 
+def _fetch_manifests_for_repo(
+    repo: dict[str, Any],
+    token: str,
+    api_url: str,
+    org: str,
+    skip_archived_repos: bool,
+    skip_unchanged_repos: bool = False,
+) -> tuple[str, list[Any], bool, str | None]:
+    """
+    Fetch dependency graph manifests for a single repo.
+    Returns (repo_url, manifests, cleanup_safe, skip_reason).
+    skip_reason is one of None (fetched), "archived", or "unchanged".
+    Designed to be called from worker threads via ThreadPoolExecutor.
+    """
+    repo_name = repo.get("name")
+    repo_url = repo.get("url", "")
+    if skip_archived_repos and repo.get("isArchived"):
+        logger.debug(
+            "Skipping dependency manifest fetch for archived repo %s.", repo_name
+        )
+        return repo_url, [], True, "archived"
+
+    pushedat = repo.get("pushedAt")
+    synced_pushedat = repo.get("manifests_synced_pushedat")
+    if (
+        skip_unchanged_repos
+        and pushedat is not None
+        and synced_pushedat is not None
+        and pushedat == synced_pushedat
+    ):
+        logger.debug(
+            "Skipping dependency manifest fetch for unchanged repo %s (pushedat unchanged).",
+            repo_name,
+        )
+        return repo_url, [], True, "unchanged"
+
+    try:
+        manifests, repo_cleanup_safe = _get_repo_dep_manifests(
+            token, api_url, org, str(repo_name)
+        )
+        if manifests:
+            logger.debug(
+                "Fetched %d dependency manifests for repo %s.",
+                len(manifests),
+                repo_name,
+            )
+        return repo_url, manifests, repo_cleanup_safe, None
+    except requests.exceptions.RequestException:
+        logger.warning(
+            "Failed to fetch dependency manifests for repo %s; skipping.",
+            repo_name,
+            exc_info=True,
+        )
+        return repo_url, [], False, None
+
+
+def _touch_skipped_dependency_manifests(
+    neo4j_session: neo4j.Session,
+    skipped_repo_urls: list[str],
+    update_tag: int,
+) -> None:
+    """
+    Refresh `lastupdated` on the existing DependencyGraphManifest/Dependency
+    nodes for repos whose manifest fetch was skipped this run (because
+    pushedat was unchanged), so the end-of-run stale-tag cleanup doesn't
+    delete them.
+    """
+    if not skipped_repo_urls:
+        return
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_MANIFEST]->(m:DependencyGraphManifest)
+        SET m.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_MANIFEST]->(:DependencyGraphManifest)
+              -[:REQUIRES]->(d:Dependency)
+        SET d.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+
+
+def _update_manifests_synced_bookmarks(
+    neo4j_session: neo4j.Session,
+    synced_bookmarks: list[dict[str, str]],
+) -> None:
+    """
+    Record the `pushedat` value seen at the time of a successful (i.e. not
+    skipped) dependency manifest fetch, so future runs can compare against it
+    to decide whether to skip.
+    """
+    if not synced_bookmarks:
+        return
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $updates AS u
+        MATCH (repo:GitHubRepository {id: u.repo_url})
+        SET repo.manifests_synced_pushedat = u.pushedat
+        """,
+        updates=synced_bookmarks,
+    )
+
+
+def _write_synced_pushedat(
+    neo4j_session: neo4j.Session,
+    updates: list[dict[str, str]],
+) -> None:
+    """
+    Write the ``synced_pushedat`` bookmark on each ``GitHubRepository`` node.
+
+    This single bookmark is written once after a successful repos sync and is
+    shared by all downstream incremental-skip stages (Actions, manifests,
+    commits). A stage skips re-fetching a repo when its current ``pushedat``
+    matches ``synced_pushedat``, meaning nothing has been pushed since the last
+    time the repos sync ran.
+    """
+    if not updates:
+        return
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $updates AS u
+        MATCH (repo:GitHubRepository {id: u.repo_url})
+        SET repo.synced_pushedat = u.pushedat
+        """,
+        updates=updates,
+    )
+
+
+def _get_manifests_synced_bookmarks(
+    neo4j_session: neo4j.Session,
+    repo_urls: list[str],
+) -> dict[str, str | None]:
+    """
+    Fetch the ``synced_pushedat`` bookmark for the given repo URLs from the
+    graph. This is the value written after the last successful repos sync and
+    is used by the manifests incremental-skip logic.
+    """
+    if not repo_urls:
+        return {}
+    rows = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (r:GitHubRepository {id: repo_url})
+        RETURN r.id AS url, r.synced_pushedat AS synced_pushedat
+        """,
+        repo_urls=repo_urls,
+    )
+    return {row["url"]: row["synced_pushedat"] for row in rows}
+
+
 def _get_dep_manifests_for_repos(
     repo_raw_data: list[dict[str, Any] | None],
     org: str,
     api_url: str,
     token: str,
+    skip_archived_repos: bool = False,
+    skip_unchanged_repos: bool = False,
+    parallel_workers: int = 1,
+    neo4j_session: neo4j.Session | None = None,
+    update_tag: int | None = None,
 ) -> tuple[dict[str, dict[str, Any]], bool]:
     """
     For every repo in the given list, retrieve its dependency graph manifests individually.
@@ -496,59 +687,161 @@ def _get_dep_manifests_for_repos(
     :param org: The name of the target Github organization as string.
     :param api_url: The Github v4 API endpoint as string.
     :param token: The Github API token as string.
+    :param skip_archived_repos: Skip archived repos if True.
+    :param skip_unchanged_repos: Skip repos whose pushedAt is unchanged since
+        the last successful manifest fetch, if True. Requires neo4j_session.
+    :param parallel_workers: Number of repos to fetch concurrently. Default 1 (sequential).
+    :param neo4j_session: Neo4j session, required when skip_unchanged_repos is True
+        (used to look up prior sync bookmarks and to touch/update them).
     :return: A tuple of repo URL to dependencyGraphManifests structure and
         whether manifest cleanup is safe.
     """
-    logger.info(
-        "Fetching dependency graph manifests for %d repos in org %s.",
-        len(repo_raw_data),
-        org,
-    )
+    non_null_repos = [repo for repo in repo_raw_data if repo is not None]
+    total_repos = len(non_null_repos)
+
+    if skip_unchanged_repos and neo4j_session is not None:
+        bookmarks = _get_manifests_synced_bookmarks(
+            neo4j_session,
+            [repo["url"] for repo in non_null_repos if repo.get("url")],
+        )
+        for repo in non_null_repos:
+            # Store under the key _fetch_manifests_for_repo reads
+            repo["manifests_synced_pushedat"] = bookmarks.get(repo.get("url", ""))
+    if skip_archived_repos:
+        archived_count = sum(1 for repo in non_null_repos if repo.get("isArchived"))
+        logger.info(
+            "Fetching dependency graph manifests for org %s: %d total repos, "
+            "skipping %d archived, fetching for %d (parallel_workers=%d).",
+            org,
+            total_repos,
+            archived_count,
+            total_repos - archived_count,
+            parallel_workers,
+        )
+    else:
+        logger.info(
+            "Fetching dependency graph manifests for %d repos in org %s (parallel_workers=%d).",
+            total_repos,
+            org,
+            parallel_workers,
+        )
+
     result: dict[str, dict[str, Any]] = {}
     failed_count = 0
     cleanup_safe = True
+    skipped_unchanged_repo_urls: list[str] = []
 
-    for repo in repo_raw_data:
-        if repo is None:
-            continue
-        repo_name = repo.get("name")
-        repo_url = repo.get("url")
-        if not repo_name or not repo_url:
-            continue
+    eligible = [
+        repo
+        for repo in non_null_repos
+        if repo.get("name")
+        and repo.get("url")
+        and not (skip_archived_repos and repo.get("isArchived"))
+    ]
+    total = len(eligible)
+    completed = 0
 
-        try:
-            manifests, repo_cleanup_safe = _get_repo_dep_manifests(
+    with ThreadPoolExecutor(max_workers=parallel_workers) as executor:
+        futures = {
+            executor.submit(
+                _fetch_manifests_for_repo,
+                repo,
                 token,
                 api_url,
                 org,
-                repo_name,
-            )
+                skip_archived_repos,
+                skip_unchanged_repos,
+            ): repo
+            for repo in eligible
+        }
+        for f in as_completed(futures):
+            repo_url, manifests, repo_cleanup_safe, skip_reason = f.result()
+            if not repo_cleanup_safe:
+                failed_count += 1
             cleanup_safe = cleanup_safe and repo_cleanup_safe
             if manifests:
                 result[repo_url] = {"nodes": manifests}
-                logger.debug(
-                    "Fetched %d dependency manifests for repo %s.",
-                    len(manifests),
-                    repo_name,
+            if skip_reason == "unchanged":
+                skipped_unchanged_repo_urls.append(repo_url)
+            completed += 1
+            if (
+                completed == 1
+                or completed % max(1, parallel_workers) == 0
+                or completed == total
+            ):
+                logger.info(
+                    "Dep manifests progress for org %s: %d/%d repos completed.",
+                    org,
+                    completed,
+                    total,
                 )
-        except requests.exceptions.RequestException:
-            failed_count += 1
-            cleanup_safe = False
-            logger.warning(
-                "Failed to fetch dependency manifests for repo %s; skipping.",
-                repo_name,
-                exc_info=True,
-            )
+
+    if skip_unchanged_repos and neo4j_session is not None and update_tag is not None:
+        _touch_skipped_dependency_manifests(
+            neo4j_session,
+            skipped_unchanged_repo_urls,
+            update_tag,
+        )
+        logger.info(
+            "Dependency manifest incremental sync for org %s: skipped refetch "
+            "for %d/%d unchanged repos.",
+            org,
+            len(skipped_unchanged_repo_urls),
+            total_repos,
+        )
 
     if failed_count > 0:
         logger.warning(
             "Skipped dependency manifests for %d of %d repos in org %s due to fetch errors.",
             failed_count,
-            len(repo_raw_data),
+            len(eligible),
             org,
         )
     logger.debug("Fetched dependency manifests for %d repos.", len(result))
     return result, cleanup_safe
+
+
+def _fetch_collaborators_for_repo(
+    repo: dict[str, Any],
+    org: str,
+    api_url: str,
+    token: str,
+    affiliation: str,
+) -> tuple[str, list[UserAffiliationAndRepoPermission]]:
+    """
+    Fetch collaborators for a single repo.
+    Returns (repo_url, collabs_list).
+    Designed to be called from worker threads via ThreadPoolExecutor.
+    """
+    repo_name = repo["name"]
+    repo_url = repo["url"]
+
+    direct_info = repo.get("directCollaborators")
+    outside_info = repo.get("outsideCollaborators")
+
+    if affiliation == "OUTSIDE":
+        total_outside = 0 if not outside_info else outside_info.get("totalCount", 0)
+        if total_outside == 0:
+            return repo_url, []
+    else:  # DIRECT
+        total_direct = 0 if not direct_info else direct_info.get("totalCount", 0)
+        if total_direct == 0:
+            return repo_url, []
+
+    logger.info("Loading %s collaborators for repo %s.", affiliation, repo_name)
+    collaborators = _get_repo_collaborators(token, api_url, org, repo_name, affiliation)
+
+    collab_users: list[dict[str, Any]] = []
+    collab_permission: list[str] = []
+    for collab in collaborators.nodes or []:
+        collab_users.append(collab)
+    for perm in collaborators.edges or []:
+        collab_permission.append(perm["permission"])
+
+    return repo_url, [
+        UserAffiliationAndRepoPermission(user, permission, affiliation)
+        for user, permission in zip(collab_users, collab_permission)
+    ]
 
 
 def _get_repo_collaborators_inner_func(
@@ -557,62 +850,63 @@ def _get_repo_collaborators_inner_func(
     token: str,
     repo_raw_data: list[dict[str, Any] | None],
     affiliation: str,
+    parallel_workers: int = 1,
 ) -> dict[str, list[UserAffiliationAndRepoPermission]]:
     result: dict[str, list[UserAffiliationAndRepoPermission]] = {}
 
-    for repo in repo_raw_data:
-        # GitHub can return null repo entries. See issues #1334 and #1404.
-        if repo is None:
-            logger.info(
-                "Skipping null repository entry while fetching %s collaborators.",
-                affiliation,
-            )
-            continue
-        repo_name = repo["name"]
-        repo_url = repo["url"]
-
-        # Guard against None when collaborator fields are not accessible due to permissions.
-        direct_info = repo.get("directCollaborators")
-        outside_info = repo.get("outsideCollaborators")
-
-        if affiliation == "OUTSIDE":
-            total_outside = 0 if not outside_info else outside_info.get("totalCount", 0)
-            if total_outside == 0:
-                # No outside collaborators or not permitted to view; skip API calls for this repo.
-                result[repo_url] = []
-                continue
-        else:  # DIRECT
-            total_direct = 0 if not direct_info else direct_info.get("totalCount", 0)
-            if total_direct == 0:
-                # No direct collaborators or not permitted to view; skip API calls for this repo.
-                result[repo_url] = []
-                continue
-
-        logger.info(f"Loading {affiliation} collaborators for repo {repo_name}.")
-        collaborators = _get_repo_collaborators(
-            token,
-            api_url,
-            org,
-            repo_name,
+    eligible = [
+        repo
+        for repo in repo_raw_data
+        if repo is not None and repo.get("name") and repo.get("url")
+    ]
+    skipped_null = len(repo_raw_data) - len([r for r in repo_raw_data if r is not None])
+    if skipped_null:
+        logger.info(
+            "Skipping %d null repository entries while fetching %s collaborators.",
+            skipped_null,
             affiliation,
         )
 
-        collab_users: List[dict[str, Any]] = []
-        collab_permission: List[str] = []
+    logger.info(
+        "Fetching %s collaborators for %d repos in org %s (parallel_workers=%d).",
+        affiliation,
+        len(eligible),
+        org,
+        parallel_workers,
+    )
 
-        # nodes and edges are expected to always be present given that we only call for them if totalCount is > 0
-        # however sometimes GitHub returns None, as in issue 1334 and 1404.
-        for collab in collaborators.nodes or []:
-            collab_users.append(collab)
+    total = len(eligible)
+    completed = 0
 
-        # The `or []` is because `.edges` can be None.
-        for perm in collaborators.edges or []:
-            collab_permission.append(perm["permission"])
+    with ThreadPoolExecutor(max_workers=parallel_workers) as executor:
+        futures = {
+            executor.submit(
+                _fetch_collaborators_for_repo,
+                repo,
+                org,
+                api_url,
+                token,
+                affiliation,
+            ): repo
+            for repo in eligible
+        }
+        for f in as_completed(futures):
+            repo_url, collabs = f.result()
+            result[repo_url] = collabs
+            completed += 1
+            if (
+                completed == 1
+                or completed % max(1, parallel_workers) == 0
+                or completed == total
+            ):
+                logger.info(
+                    "Collaborators (%s) progress for org %s: %d/%d repos completed.",
+                    affiliation,
+                    org,
+                    completed,
+                    total,
+                )
 
-        result[repo_url] = [
-            UserAffiliationAndRepoPermission(user, permission, affiliation)
-            for user, permission in zip(collab_users, collab_permission)
-        ]
     return result
 
 
@@ -622,6 +916,7 @@ def _get_repo_collaborators_for_multiple_repos(
     org: str,
     api_url: str,
     token: str,
+    parallel_workers: int = 1,
 ) -> dict[str, list[UserAffiliationAndRepoPermission]]:
     """
     For every repo in the given list, retrieve the collaborators.
@@ -631,10 +926,13 @@ def _get_repo_collaborators_for_multiple_repos(
     :param org: The name of the target Github organization as string.
     :param api_url: The Github v4 API endpoint as string.
     :param token: The Github API token as string.
+    :param parallel_workers: Number of repos to fetch concurrently. Default 1 (sequential).
     :return: A dictionary of repo URL to list of UserAffiliationAndRepoPermission
     """
     logger.info(
-        f'Retrieving repo collaborators for affiliation "{affiliation}" on org "{org}".',
+        'Retrieving repo collaborators for affiliation "%s" on org "%s".',
+        affiliation,
+        org,
     )
 
     result: dict[str, list[UserAffiliationAndRepoPermission]] = retries_with_backoff(
@@ -648,6 +946,7 @@ def _get_repo_collaborators_for_multiple_repos(
         token=token,
         repo_raw_data=repo_raw_data,
         affiliation=affiliation,
+        parallel_workers=parallel_workers,
     )
     return result
 
@@ -800,54 +1099,113 @@ def _rest_ruleset_cache_key(ruleset: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
+def _fetch_rulesets_for_repo(
+    repo: dict[str, Any],
+    token: str,
+    base_url: str,
+    owner: str,
+    cache: dict[tuple[Any, ...], dict[str, Any]],
+    cache_lock: threading.Lock,
+) -> tuple[str, dict[str, Any]]:
+    """
+    Fetch rulesets for a single repo via REST.
+    Returns (repo_url, rulesets_dict).
+    Designed to be called from worker threads via ThreadPoolExecutor.
+    The cache and its lock are shared across workers to de-duplicate org-level ruleset detail fetches.
+    """
+    repo_name = repo.get("name", "")
+    repo_url = repo.get("url", "")
+    encoded_repo_name = quote(repo_name, safe="")
+    endpoint = f"/repos/{owner}/{encoded_repo_name}/rulesets"
+    ruleset_summaries = fetch_all_rest_api_pages(
+        token,
+        base_url,
+        endpoint,
+        result_key="rulesets",
+        raise_on_status=(403, 404),
+        params={"per_page": 100, "includes_parents": "true"},
+    )
+    normalized_rulesets = []
+    for ruleset_summary in ruleset_summaries:
+        cache_key = _rest_ruleset_cache_key(ruleset_summary)
+        with cache_lock:
+            ruleset_detail = cache.get(cache_key)
+        if ruleset_detail is None:
+            ruleset_detail = call_github_rest_api(
+                f"{endpoint}/{ruleset_summary['id']}",
+                token,
+                base_url,
+                params={"includes_parents": "true"},
+            )
+            with cache_lock:
+                cache[cache_key] = ruleset_detail
+        normalized_rulesets.append(_normalize_rest_ruleset(ruleset_detail))
+    return repo_url, {
+        "nodes": normalized_rulesets,
+        "totalCount": len(normalized_rulesets),
+    }
+
+
 def _get_repo_rulesets_by_url(
     token: str,
     api_url: str,
     organization: str,
     repo_raw_data: list[dict[str, Any] | None],
+    parallel_workers: int = 1,
 ) -> dict[str, dict[str, Any]]:
     """
     Retrieve full GitHub repository rulesets through REST for every repo.
+    :param parallel_workers: Number of repos to fetch concurrently. Default 1 (sequential).
     """
     base_url = rest_api_base_url(api_url)
     owner = quote(organization, safe="")
     rulesets_by_url: dict[str, dict[str, Any]] = {}
     ruleset_detail_cache: dict[tuple[Any, ...], dict[str, Any]] = {}
+    cache_lock = threading.Lock()
 
-    for repo in repo_raw_data:
-        if repo is None:
-            continue
-        repo_name = repo.get("name")
-        repo_url = repo.get("url")
-        if not repo_name or not repo_url:
-            continue
-        encoded_repo_name = quote(repo_name, safe="")
-        endpoint = f"/repos/{owner}/{encoded_repo_name}/rulesets"
-        ruleset_summaries = fetch_all_rest_api_pages(
-            token,
-            base_url,
-            endpoint,
-            result_key="rulesets",
-            raise_on_status=(403, 404),
-            params={"per_page": 100, "includes_parents": "true"},
-        )
-        normalized_rulesets = []
-        for ruleset_summary in ruleset_summaries:
-            cache_key = _rest_ruleset_cache_key(ruleset_summary)
-            ruleset_detail = ruleset_detail_cache.get(cache_key)
-            if ruleset_detail is None:
-                ruleset_detail = call_github_rest_api(
-                    f"{endpoint}/{ruleset_summary['id']}",
-                    token,
-                    base_url,
-                    params={"includes_parents": "true"},
-                )
-                ruleset_detail_cache[cache_key] = ruleset_detail
-            normalized_rulesets.append(_normalize_rest_ruleset(ruleset_detail))
-        rulesets_by_url[repo_url] = {
-            "nodes": normalized_rulesets,
-            "totalCount": len(normalized_rulesets),
+    eligible = [
+        repo
+        for repo in repo_raw_data
+        if repo is not None and repo.get("name") and repo.get("url")
+    ]
+    logger.info(
+        "Fetching rulesets for %d repos in org %s (parallel_workers=%d).",
+        len(eligible),
+        organization,
+        parallel_workers,
+    )
+
+    total = len(eligible)
+    completed = 0
+
+    with ThreadPoolExecutor(max_workers=parallel_workers) as executor:
+        futures = {
+            executor.submit(
+                _fetch_rulesets_for_repo,
+                repo,
+                token,
+                base_url,
+                owner,
+                ruleset_detail_cache,
+                cache_lock,
+            ): repo
+            for repo in eligible
         }
+        for f in as_completed(futures):
+            repo_url, rulesets_dict = f.result()
+            rulesets_by_url[repo_url] = rulesets_dict
+            completed += 1
+            if (
+                completed == 1
+                or completed % max(1, parallel_workers) == 0
+                or completed == total
+            ):
+                logger.info(
+                    "Rulesets progress for org %s: %d/%d repos completed.",
+                    organization,
+                    completed,
+                    total,
+                )
 
     return rulesets_by_url
 
@@ -910,6 +1268,7 @@ def get_repo_privileged_details_by_url(
     token: str,
     api_url: str,
     organization: str,
+    parallel_workers: int = 1,
 ) -> Dict[str, Dict[str, Any]]:
     """
     Retrieve collaborator counts, branch protection, and ruleset fields for repositories in an organization.
@@ -929,6 +1288,7 @@ def get_repo_privileged_details_by_url(
         api_url,
         organization,
         privileged_nodes,
+        parallel_workers=parallel_workers,
     )
     for repo in privileged_nodes:
         # GitHub can return null repository entries.
@@ -1199,6 +1559,7 @@ def _transform_repo_objects(input_repo_object: Dict, out_repo_list: List[Dict]) 
             "url": input_repo_object["url"],
             "sshurl": ssh_url,
             "updatedat": input_repo_object["updatedAt"],
+            "pushedat": input_repo_object.get("pushedAt"),
             "owner_org_id": owner["url"] if owner_type == "Organization" else None,
             "owner_user_id": owner["url"] if owner_type == "User" else None,
         },
@@ -2229,10 +2590,19 @@ def cleanup_github_dependencies(
     Delete stale Dependency nodes and their relationships. Dependency uses
     unscoped cleanup (see GitHubDependencySchema docstring) so this runs once
     per sync cycle alongside the other global resources, not per organization.
+
+    Uses a reduced iterationsize because Dependency is a globally shared node:
+    a single stale Dependency can have many REQUIRES (repo) and HAS_DEP
+    (manifest) relationships attached. DETACH DELETE-ing the default 10,000
+    nodes per transaction can pull in enough relationships to exceed Neo4j's
+    dbms.memory.transaction.total.max limit (observed in production as
+    Neo.TransientError.General.MemoryPoolOutOfMemoryError).
     """
-    GraphJob.from_node_schema(GitHubDependencySchema(), common_job_parameters).run(
-        neo4j_session
-    )
+    GraphJob.from_node_schema(
+        GitHubDependencySchema(),
+        common_job_parameters,
+        iterationsize=500,
+    ).run(neo4j_session)
 
 
 @timeit
@@ -2246,11 +2616,20 @@ def cleanup_github_manifests(
     :param neo4j_session: Neo4j session
     :param common_job_parameters: Common job parameters containing UPDATE_TAG
     :param owner_org_id: URL of the owning GitHub organization
+
+    Uses a reduced iterationsize because a single manifest can have hundreds
+    of HAS_DEP relationships to Dependency nodes (some observed manifests in
+    production have 700-800+ dependencies). DETACH DELETE-ing the default
+    10,000 manifests per transaction can pull in millions of relationships,
+    exceeding Neo4j's dbms.memory.transaction.total.max limit (observed in
+    production as Neo.TransientError.General.MemoryPoolOutOfMemoryError).
     """
     cleanup_params = {**common_job_parameters, "owner_org_id": owner_org_id}
-    GraphJob.from_node_schema(DependencyGraphManifestSchema(), cleanup_params).run(
-        neo4j_session
-    )
+    GraphJob.from_node_schema(
+        DependencyGraphManifestSchema(),
+        cleanup_params,
+        iterationsize=500,
+    ).run(neo4j_session)
 
 
 @timeit
@@ -2534,6 +2913,9 @@ def sync(
     github_api_key: str,
     github_url: str,
     organization: str,
+    parallel_workers: int = 1,
+    sync_dep_manifests: bool = True,
+    incremental_sync: bool = False,
 ) -> GitHubRepoSyncResult:
     """
     Performs the sequential tasks to collect, transform, and sync github data
@@ -2542,6 +2924,11 @@ def sync(
     :param github_api_key: The API key to access the GitHub v4 API
     :param github_url: The URL for the GitHub v4 endpoint to use
     :param organization: The organization to query GitHub for
+    :param parallel_workers: Number of parallel workers for per-repo API fetches. Default 1 (sequential).
+    :param sync_dep_manifests: Fetch dependency graph manifests. Set False to skip the slow O(n) manifest
+        phase; use the separate 'dep_manifests' requested-sync value to run it independently.
+    :param incremental_sync: Skip archived/disabled repos and skip re-fetching manifests for repos
+        whose pushedAt is unchanged since the last sync.
     :return: Repository and dependency manifest data fetched for this org.
     """
     logger.info("Syncing GitHub repos")
@@ -2556,6 +2943,7 @@ def sync(
                 github_api_key,
                 github_url,
                 organization,
+                parallel_workers=parallel_workers,
             )
         except (requests.exceptions.RequestException, ValueError):
             rulesets_cleanup_safe = False
@@ -2583,34 +2971,74 @@ def sync(
     direct_collabs: dict[str, list[UserAffiliationAndRepoPermission]] = {}
     outside_collabs: dict[str, list[UserAffiliationAndRepoPermission]] = {}
     try:
-        direct_collabs = _get_repo_collaborators_for_multiple_repos(
-            repos_json,
-            "DIRECT",
-            organization,
-            github_url,
-            github_api_key,
-        )
-        outside_collabs = _get_repo_collaborators_for_multiple_repos(
-            repos_json,
-            "OUTSIDE",
-            organization,
-            github_url,
-            github_api_key,
-        )
-    except TypeError:
-        # due to permission errors or transient network error or some other nonsense
+        if parallel_workers > 1:
+            logger.info(
+                "Fetching DIRECT and OUTSIDE collaborators concurrently for org %s.",
+                organization,
+            )
+            direct_collabs, outside_collabs = to_synchronous(
+                to_asynchronous(
+                    _get_repo_collaborators_for_multiple_repos,
+                    repos_json,
+                    "DIRECT",
+                    organization,
+                    github_url,
+                    github_api_key,
+                    parallel_workers,
+                ),
+                to_asynchronous(
+                    _get_repo_collaborators_for_multiple_repos,
+                    repos_json,
+                    "OUTSIDE",
+                    organization,
+                    github_url,
+                    github_api_key,
+                    parallel_workers,
+                ),
+            )
+        else:
+            direct_collabs = _get_repo_collaborators_for_multiple_repos(
+                repos_json,
+                "DIRECT",
+                organization,
+                github_url,
+                github_api_key,
+            )
+            outside_collabs = _get_repo_collaborators_for_multiple_repos(
+                repos_json,
+                "OUTSIDE",
+                organization,
+                github_url,
+                github_api_key,
+            )
+    except (TypeError, ValueError):
+        # TypeError: permission errors or transient network issues
+        # ValueError: fetch_all raises this when all retries are exhausted (e.g. repeated timeouts)
         logger.warning(
-            "Unable to list repo collaborators due to permission errors; continuing on.",
+            "Unable to list repo collaborators due to permission errors or exhausted retries; continuing on.",
             exc_info=True,
         )
 
     # Fetch dependency graph manifests per-repo to avoid 502s from heavy inline queries
-    dep_manifests_by_url, dep_manifests_cleanup_safe = _get_dep_manifests_for_repos(
-        repos_json,
-        organization,
-        github_url,
-        github_api_key,
-    )
+    dep_manifests_by_url: dict[str, dict[str, Any]] = {}
+    dep_manifests_cleanup_safe = True
+    if sync_dep_manifests:
+        dep_manifests_by_url, dep_manifests_cleanup_safe = _get_dep_manifests_for_repos(
+            repos_json,
+            organization,
+            github_url,
+            github_api_key,
+            skip_archived_repos=incremental_sync,
+            skip_unchanged_repos=incremental_sync,
+            parallel_workers=parallel_workers,
+            neo4j_session=neo4j_session,
+            update_tag=common_job_parameters["UPDATE_TAG"],
+        )
+    else:
+        logger.info(
+            "Skipping dependency manifest fetch for org %s (dep_manifests not in requested syncs).",
+            organization,
+        )
     for repo in repos_json:
         if repo is not None and repo.get("url") in dep_manifests_by_url:
             repo["dependencyGraphManifests"] = dep_manifests_by_url[repo["url"]]
@@ -2621,6 +3049,18 @@ def sync(
         github_api_key,
         github_url,
     )
+    load(neo4j_session, common_job_parameters, repo_data)
+
+    # Build the pushedat update list to be written by the caller (start_github_ingestion)
+    # AFTER all downstream stages (actions, manifests, commits) have completed.
+    # Writing synced_pushedat here would immediately overwrite the bookmark with the
+    # current run's pushedat before the skip comparisons have a chance to use it.
+    repo_pushedat_updates = [
+        {"repo_url": repo["url"], "pushedat": repo["pushedat"]}
+        for repo in repo_data["repos"]
+        if repo.get("pushedat")
+    ]
+
     owner_org_id = next(
         (
             repo["owner_org_id"]
@@ -2630,7 +3070,6 @@ def sync(
         f"https://github.com/{organization}",
     )
     migrate_dependency_graph_manifest_label(neo4j_session, owner_org_id)
-    load(neo4j_session, common_job_parameters, repo_data)
     cleanup_github_branches(neo4j_session, common_job_parameters, owner_org_id)
 
     # DEPRECATED: compatibility migrations to backfill the RESOURCE edge from
@@ -2670,4 +3109,5 @@ def sync(
         repos=repo_data["repos"],
         manifests=repo_data["manifests"],
         manifests_cleanup_safe=dep_manifests_cleanup_safe,
+        repo_pushedat_updates=repo_pushedat_updates,
     )

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -2,11 +2,15 @@ import configparser
 import hashlib
 import json
 import logging
+import threading
 import time
 from collections import defaultdict
 from collections import namedtuple
 from collections.abc import Callable
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from dataclasses import field
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -22,6 +26,8 @@ from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 
 from cartography.client.core.tx import load as load_data
+from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.client.core.tx import run_write_query
 from cartography.graph.job import GraphJob
 from cartography.helpers import backoff_handler
 from cartography.intel.github.codeowners import normalize_repo_relative_path
@@ -59,6 +65,8 @@ from cartography.models.github.rulesets import GitHubRulesetSchema
 from cartography.util import retries_with_backoff
 from cartography.util import run_analysis_job
 from cartography.util import timeit
+from cartography.util import to_asynchronous
+from cartography.util import to_synchronous
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +89,7 @@ class GitHubRepoSyncResult:
     repos: list[dict[str, Any]]
     manifests: list[dict[str, Any]]
     manifests_cleanup_safe: bool
+    repo_pushedat_updates: list[dict[str, str]] = field(default_factory=list)
 
 
 GITHUB_ORG_REPOS_PAGINATED_GRAPHQL = """
@@ -105,6 +114,7 @@ GITHUB_ORG_REPOS_PAGINATED_GRAPHQL = """
                     createdAt
                     description
                     updatedAt
+                    pushedAt
                     homepageUrl
                     languages(first: 25){
                         totalCount
@@ -299,6 +309,15 @@ def _fetch_manifest_page(
             requests.exceptions.ChunkedEncodingError,
         ):
             if attempt + 1 >= retries:
+                logger.warning(
+                    "Failed to fetch dependency manifest page for repo %s after %d retries "
+                    "(manifest_cursor=%s, dep_cursor=%s).",
+                    repo,
+                    retries,
+                    manifest_cursor,
+                    dep_cursor,
+                    exc_info=True,
+                )
                 return None
             time.sleep(2 ** (attempt + 1))
             continue
@@ -311,9 +330,13 @@ def _fetch_manifest_page(
         if dep_manifests is None and resp.get("errors"):
             if attempt + 1 >= retries:
                 logger.warning(
-                    "GraphQL timeout fetching dependency manifests for repo %s after %d retries.",
+                    "GraphQL timeout fetching dependency manifests for repo %s after %d retries "
+                    "(manifest_cursor=%s, dep_cursor=%s). Errors: %s",
                     repo,
                     retries,
+                    manifest_cursor,
+                    dep_cursor,
+                    resp.get("errors"),
                 )
                 return resp
             logger.debug(
@@ -487,11 +510,179 @@ def _get_repo_dep_manifests(
     return manifests, cleanup_safe
 
 
+def _fetch_manifests_for_repo(
+    repo: dict[str, Any],
+    token: str,
+    api_url: str,
+    org: str,
+    skip_archived_repos: bool,
+    skip_unchanged_repos: bool = False,
+) -> tuple[str, list[Any], bool, str | None]:
+    """
+    Fetch dependency graph manifests for a single repo.
+    Returns (repo_url, manifests, cleanup_safe, skip_reason).
+    skip_reason is one of None (fetched), "archived", or "unchanged".
+    Designed to be called from worker threads via ThreadPoolExecutor.
+    """
+    repo_name = repo.get("name")
+    repo_url = repo.get("url", "")
+    if skip_archived_repos and repo.get("isArchived"):
+        logger.debug(
+            "Skipping dependency manifest fetch for archived repo %s.", repo_name
+        )
+        return repo_url, [], True, "archived"
+
+    pushedat = repo.get("pushedAt")
+    synced_pushedat = repo.get("manifests_synced_pushedat")
+    if (
+        skip_unchanged_repos
+        and pushedat is not None
+        and synced_pushedat is not None
+        and pushedat == synced_pushedat
+    ):
+        logger.debug(
+            "Skipping dependency manifest fetch for unchanged repo %s (pushedat unchanged).",
+            repo_name,
+        )
+        return repo_url, [], True, "unchanged"
+
+    try:
+        manifests, repo_cleanup_safe = _get_repo_dep_manifests(
+            token, api_url, org, str(repo_name)
+        )
+        if manifests:
+            logger.debug(
+                "Fetched %d dependency manifests for repo %s.",
+                len(manifests),
+                repo_name,
+            )
+        return repo_url, manifests, repo_cleanup_safe, None
+    except requests.exceptions.RequestException:
+        logger.warning(
+            "Failed to fetch dependency manifests for repo %s; skipping.",
+            repo_name,
+            exc_info=True,
+        )
+        return repo_url, [], False, None
+
+
+def _touch_skipped_dependency_manifests(
+    neo4j_session: neo4j.Session,
+    skipped_repo_urls: list[str],
+    update_tag: int,
+) -> None:
+    """
+    Refresh `lastupdated` on the existing DependencyGraphManifest/Dependency
+    nodes for repos whose manifest fetch was skipped this run (because
+    pushedat was unchanged), so the end-of-run stale-tag cleanup doesn't
+    delete them.
+    """
+    if not skipped_repo_urls:
+        return
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_MANIFEST]->(m:DependencyGraphManifest)
+        SET m.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_MANIFEST]->(:DependencyGraphManifest)
+              -[:REQUIRES]->(d:Dependency)
+        SET d.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+
+
+def _update_manifests_synced_bookmarks(
+    neo4j_session: neo4j.Session,
+    synced_bookmarks: list[dict[str, str]],
+) -> None:
+    """
+    Record the `pushedat` value seen at the time of a successful (i.e. not
+    skipped) dependency manifest fetch, so future runs can compare against it
+    to decide whether to skip.
+    """
+    if not synced_bookmarks:
+        return
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $updates AS u
+        MATCH (repo:GitHubRepository {id: u.repo_url})
+        SET repo.manifests_synced_pushedat = u.pushedat
+        """,
+        updates=synced_bookmarks,
+    )
+
+
+def _write_synced_pushedat(
+    neo4j_session: neo4j.Session,
+    updates: list[dict[str, str]],
+) -> None:
+    """
+    Write the ``synced_pushedat`` bookmark on each ``GitHubRepository`` node.
+
+    This single bookmark is written once after a successful repos sync and is
+    shared by all downstream incremental-skip stages (Actions, manifests,
+    commits). A stage skips re-fetching a repo when its current ``pushedat``
+    matches ``synced_pushedat``, meaning nothing has been pushed since the last
+    time the repos sync ran.
+    """
+    if not updates:
+        return
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $updates AS u
+        MATCH (repo:GitHubRepository {id: u.repo_url})
+        SET repo.synced_pushedat = u.pushedat
+        """,
+        updates=updates,
+    )
+
+
+def _get_manifests_synced_bookmarks(
+    neo4j_session: neo4j.Session,
+    repo_urls: list[str],
+) -> dict[str, str | None]:
+    """
+    Fetch the ``synced_pushedat`` bookmark for the given repo URLs from the
+    graph. This is the value written after the last successful repos sync and
+    is used by the manifests incremental-skip logic.
+    """
+    if not repo_urls:
+        return {}
+    rows = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (r:GitHubRepository {id: repo_url})
+        RETURN r.id AS url, r.synced_pushedat AS synced_pushedat
+        """,
+        repo_urls=repo_urls,
+    )
+    return {row["url"]: row["synced_pushedat"] for row in rows}
+
+
 def _get_dep_manifests_for_repos(
     repo_raw_data: list[dict[str, Any] | None],
     org: str,
     api_url: str,
     token: str,
+    skip_archived_repos: bool = False,
+    skip_unchanged_repos: bool = False,
+    parallel_workers: int = 1,
+    neo4j_session: neo4j.Session | None = None,
+    update_tag: int | None = None,
 ) -> tuple[dict[str, dict[str, Any]], bool]:
     """
     For every repo in the given list, retrieve its dependency graph manifests individually.
@@ -501,59 +692,161 @@ def _get_dep_manifests_for_repos(
     :param org: The name of the target Github organization as string.
     :param api_url: The Github v4 API endpoint as string.
     :param token: The Github API token as string.
+    :param skip_archived_repos: Skip archived repos if True.
+    :param skip_unchanged_repos: Skip repos whose pushedAt is unchanged since
+        the last successful manifest fetch, if True. Requires neo4j_session.
+    :param parallel_workers: Number of repos to fetch concurrently. Default 1 (sequential).
+    :param neo4j_session: Neo4j session, required when skip_unchanged_repos is True
+        (used to look up prior sync bookmarks and to touch/update them).
     :return: A tuple of repo URL to dependencyGraphManifests structure and
         whether manifest cleanup is safe.
     """
-    logger.info(
-        "Fetching dependency graph manifests for %d repos in org %s.",
-        len(repo_raw_data),
-        org,
-    )
+    non_null_repos = [repo for repo in repo_raw_data if repo is not None]
+    total_repos = len(non_null_repos)
+
+    if skip_unchanged_repos and neo4j_session is not None:
+        bookmarks = _get_manifests_synced_bookmarks(
+            neo4j_session,
+            [repo["url"] for repo in non_null_repos if repo.get("url")],
+        )
+        for repo in non_null_repos:
+            # Store under the key _fetch_manifests_for_repo reads
+            repo["manifests_synced_pushedat"] = bookmarks.get(repo.get("url", ""))
+    if skip_archived_repos:
+        archived_count = sum(1 for repo in non_null_repos if repo.get("isArchived"))
+        logger.info(
+            "Fetching dependency graph manifests for org %s: %d total repos, "
+            "skipping %d archived, fetching for %d (parallel_workers=%d).",
+            org,
+            total_repos,
+            archived_count,
+            total_repos - archived_count,
+            parallel_workers,
+        )
+    else:
+        logger.info(
+            "Fetching dependency graph manifests for %d repos in org %s (parallel_workers=%d).",
+            total_repos,
+            org,
+            parallel_workers,
+        )
+
     result: dict[str, dict[str, Any]] = {}
     failed_count = 0
     cleanup_safe = True
+    skipped_unchanged_repo_urls: list[str] = []
 
-    for repo in repo_raw_data:
-        if repo is None:
-            continue
-        repo_name = repo.get("name")
-        repo_url = repo.get("url")
-        if not repo_name or not repo_url:
-            continue
+    eligible = [
+        repo
+        for repo in non_null_repos
+        if repo.get("name")
+        and repo.get("url")
+        and not (skip_archived_repos and repo.get("isArchived"))
+    ]
+    total = len(eligible)
+    completed = 0
 
-        try:
-            manifests, repo_cleanup_safe = _get_repo_dep_manifests(
+    with ThreadPoolExecutor(max_workers=parallel_workers) as executor:
+        futures = {
+            executor.submit(
+                _fetch_manifests_for_repo,
+                repo,
                 token,
                 api_url,
                 org,
-                repo_name,
-            )
+                skip_archived_repos,
+                skip_unchanged_repos,
+            ): repo
+            for repo in eligible
+        }
+        for f in as_completed(futures):
+            repo_url, manifests, repo_cleanup_safe, skip_reason = f.result()
+            if not repo_cleanup_safe:
+                failed_count += 1
             cleanup_safe = cleanup_safe and repo_cleanup_safe
             if manifests:
                 result[repo_url] = {"nodes": manifests}
-                logger.debug(
-                    "Fetched %d dependency manifests for repo %s.",
-                    len(manifests),
-                    repo_name,
+            if skip_reason == "unchanged":
+                skipped_unchanged_repo_urls.append(repo_url)
+            completed += 1
+            if (
+                completed == 1
+                or completed % max(1, parallel_workers) == 0
+                or completed == total
+            ):
+                logger.info(
+                    "Dep manifests progress for org %s: %d/%d repos completed.",
+                    org,
+                    completed,
+                    total,
                 )
-        except requests.exceptions.RequestException:
-            failed_count += 1
-            cleanup_safe = False
-            logger.warning(
-                "Failed to fetch dependency manifests for repo %s; skipping.",
-                repo_name,
-                exc_info=True,
-            )
+
+    if skip_unchanged_repos and neo4j_session is not None and update_tag is not None:
+        _touch_skipped_dependency_manifests(
+            neo4j_session,
+            skipped_unchanged_repo_urls,
+            update_tag,
+        )
+        logger.info(
+            "Dependency manifest incremental sync for org %s: skipped refetch "
+            "for %d/%d unchanged repos.",
+            org,
+            len(skipped_unchanged_repo_urls),
+            total_repos,
+        )
 
     if failed_count > 0:
         logger.warning(
             "Skipped dependency manifests for %d of %d repos in org %s due to fetch errors.",
             failed_count,
-            len(repo_raw_data),
+            len(eligible),
             org,
         )
     logger.debug("Fetched dependency manifests for %d repos.", len(result))
     return result, cleanup_safe
+
+
+def _fetch_collaborators_for_repo(
+    repo: dict[str, Any],
+    org: str,
+    api_url: str,
+    token: str,
+    affiliation: str,
+) -> tuple[str, list[UserAffiliationAndRepoPermission]]:
+    """
+    Fetch collaborators for a single repo.
+    Returns (repo_url, collabs_list).
+    Designed to be called from worker threads via ThreadPoolExecutor.
+    """
+    repo_name = repo["name"]
+    repo_url = repo["url"]
+
+    direct_info = repo.get("directCollaborators")
+    outside_info = repo.get("outsideCollaborators")
+
+    if affiliation == "OUTSIDE":
+        total_outside = 0 if not outside_info else outside_info.get("totalCount", 0)
+        if total_outside == 0:
+            return repo_url, []
+    else:  # DIRECT
+        total_direct = 0 if not direct_info else direct_info.get("totalCount", 0)
+        if total_direct == 0:
+            return repo_url, []
+
+    logger.info("Loading %s collaborators for repo %s.", affiliation, repo_name)
+    collaborators = _get_repo_collaborators(token, api_url, org, repo_name, affiliation)
+
+    collab_users: list[dict[str, Any]] = []
+    collab_permission: list[str] = []
+    for collab in collaborators.nodes or []:
+        collab_users.append(collab)
+    for perm in collaborators.edges or []:
+        collab_permission.append(perm["permission"])
+
+    return repo_url, [
+        UserAffiliationAndRepoPermission(user, permission, affiliation)
+        for user, permission in zip(collab_users, collab_permission)
+    ]
 
 
 def _get_repo_collaborators_inner_func(
@@ -562,62 +855,63 @@ def _get_repo_collaborators_inner_func(
     token: str,
     repo_raw_data: list[dict[str, Any] | None],
     affiliation: str,
+    parallel_workers: int = 1,
 ) -> dict[str, list[UserAffiliationAndRepoPermission]]:
     result: dict[str, list[UserAffiliationAndRepoPermission]] = {}
 
-    for repo in repo_raw_data:
-        # GitHub can return null repo entries. See issues #1334 and #1404.
-        if repo is None:
-            logger.info(
-                "Skipping null repository entry while fetching %s collaborators.",
-                affiliation,
-            )
-            continue
-        repo_name = repo["name"]
-        repo_url = repo["url"]
-
-        # Guard against None when collaborator fields are not accessible due to permissions.
-        direct_info = repo.get("directCollaborators")
-        outside_info = repo.get("outsideCollaborators")
-
-        if affiliation == "OUTSIDE":
-            total_outside = 0 if not outside_info else outside_info.get("totalCount", 0)
-            if total_outside == 0:
-                # No outside collaborators or not permitted to view; skip API calls for this repo.
-                result[repo_url] = []
-                continue
-        else:  # DIRECT
-            total_direct = 0 if not direct_info else direct_info.get("totalCount", 0)
-            if total_direct == 0:
-                # No direct collaborators or not permitted to view; skip API calls for this repo.
-                result[repo_url] = []
-                continue
-
-        logger.info(f"Loading {affiliation} collaborators for repo {repo_name}.")
-        collaborators = _get_repo_collaborators(
-            token,
-            api_url,
-            org,
-            repo_name,
+    eligible = [
+        repo
+        for repo in repo_raw_data
+        if repo is not None and repo.get("name") and repo.get("url")
+    ]
+    skipped_null = len(repo_raw_data) - len([r for r in repo_raw_data if r is not None])
+    if skipped_null:
+        logger.info(
+            "Skipping %d null repository entries while fetching %s collaborators.",
+            skipped_null,
             affiliation,
         )
 
-        collab_users: List[dict[str, Any]] = []
-        collab_permission: List[str] = []
+    logger.info(
+        "Fetching %s collaborators for %d repos in org %s (parallel_workers=%d).",
+        affiliation,
+        len(eligible),
+        org,
+        parallel_workers,
+    )
 
-        # nodes and edges are expected to always be present given that we only call for them if totalCount is > 0
-        # however sometimes GitHub returns None, as in issue 1334 and 1404.
-        for collab in collaborators.nodes or []:
-            collab_users.append(collab)
+    total = len(eligible)
+    completed = 0
 
-        # The `or []` is because `.edges` can be None.
-        for perm in collaborators.edges or []:
-            collab_permission.append(perm["permission"])
+    with ThreadPoolExecutor(max_workers=parallel_workers) as executor:
+        futures = {
+            executor.submit(
+                _fetch_collaborators_for_repo,
+                repo,
+                org,
+                api_url,
+                token,
+                affiliation,
+            ): repo
+            for repo in eligible
+        }
+        for f in as_completed(futures):
+            repo_url, collabs = f.result()
+            result[repo_url] = collabs
+            completed += 1
+            if (
+                completed == 1
+                or completed % max(1, parallel_workers) == 0
+                or completed == total
+            ):
+                logger.info(
+                    "Collaborators (%s) progress for org %s: %d/%d repos completed.",
+                    affiliation,
+                    org,
+                    completed,
+                    total,
+                )
 
-        result[repo_url] = [
-            UserAffiliationAndRepoPermission(user, permission, affiliation)
-            for user, permission in zip(collab_users, collab_permission)
-        ]
     return result
 
 
@@ -627,6 +921,7 @@ def _get_repo_collaborators_for_multiple_repos(
     org: str,
     api_url: str,
     token: str,
+    parallel_workers: int = 1,
 ) -> dict[str, list[UserAffiliationAndRepoPermission]]:
     """
     For every repo in the given list, retrieve the collaborators.
@@ -636,10 +931,13 @@ def _get_repo_collaborators_for_multiple_repos(
     :param org: The name of the target Github organization as string.
     :param api_url: The Github v4 API endpoint as string.
     :param token: The Github API token as string.
+    :param parallel_workers: Number of repos to fetch concurrently. Default 1 (sequential).
     :return: A dictionary of repo URL to list of UserAffiliationAndRepoPermission
     """
     logger.info(
-        f'Retrieving repo collaborators for affiliation "{affiliation}" on org "{org}".',
+        'Retrieving repo collaborators for affiliation "%s" on org "%s".',
+        affiliation,
+        org,
     )
 
     result: dict[str, list[UserAffiliationAndRepoPermission]] = retries_with_backoff(
@@ -653,6 +951,7 @@ def _get_repo_collaborators_for_multiple_repos(
         token=token,
         repo_raw_data=repo_raw_data,
         affiliation=affiliation,
+        parallel_workers=parallel_workers,
     )
     return result
 
@@ -805,54 +1104,113 @@ def _rest_ruleset_cache_key(ruleset: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
+def _fetch_rulesets_for_repo(
+    repo: dict[str, Any],
+    token: str,
+    base_url: str,
+    owner: str,
+    cache: dict[tuple[Any, ...], dict[str, Any]],
+    cache_lock: threading.Lock,
+) -> tuple[str, dict[str, Any]]:
+    """
+    Fetch rulesets for a single repo via REST.
+    Returns (repo_url, rulesets_dict).
+    Designed to be called from worker threads via ThreadPoolExecutor.
+    The cache and its lock are shared across workers to de-duplicate org-level ruleset detail fetches.
+    """
+    repo_name = repo.get("name", "")
+    repo_url = repo.get("url", "")
+    encoded_repo_name = quote(repo_name, safe="")
+    endpoint = f"/repos/{owner}/{encoded_repo_name}/rulesets"
+    ruleset_summaries = fetch_all_rest_api_pages(
+        token,
+        base_url,
+        endpoint,
+        result_key="rulesets",
+        raise_on_status=(403, 404),
+        params={"per_page": 100, "includes_parents": "true"},
+    )
+    normalized_rulesets = []
+    for ruleset_summary in ruleset_summaries:
+        cache_key = _rest_ruleset_cache_key(ruleset_summary)
+        with cache_lock:
+            ruleset_detail = cache.get(cache_key)
+        if ruleset_detail is None:
+            ruleset_detail = call_github_rest_api(
+                f"{endpoint}/{ruleset_summary['id']}",
+                token,
+                base_url,
+                params={"includes_parents": "true"},
+            )
+            with cache_lock:
+                cache[cache_key] = ruleset_detail
+        normalized_rulesets.append(_normalize_rest_ruleset(ruleset_detail))
+    return repo_url, {
+        "nodes": normalized_rulesets,
+        "totalCount": len(normalized_rulesets),
+    }
+
+
 def _get_repo_rulesets_by_url(
     token: str,
     api_url: str,
     organization: str,
     repo_raw_data: list[dict[str, Any] | None],
+    parallel_workers: int = 1,
 ) -> dict[str, dict[str, Any]]:
     """
     Retrieve full GitHub repository rulesets through REST for every repo.
+    :param parallel_workers: Number of repos to fetch concurrently. Default 1 (sequential).
     """
     base_url = rest_api_base_url(api_url)
     owner = quote(organization, safe="")
     rulesets_by_url: dict[str, dict[str, Any]] = {}
     ruleset_detail_cache: dict[tuple[Any, ...], dict[str, Any]] = {}
+    cache_lock = threading.Lock()
 
-    for repo in repo_raw_data:
-        if repo is None:
-            continue
-        repo_name = repo.get("name")
-        repo_url = repo.get("url")
-        if not repo_name or not repo_url:
-            continue
-        encoded_repo_name = quote(repo_name, safe="")
-        endpoint = f"/repos/{owner}/{encoded_repo_name}/rulesets"
-        ruleset_summaries = fetch_all_rest_api_pages(
-            token,
-            base_url,
-            endpoint,
-            result_key="rulesets",
-            raise_on_status=(403, 404),
-            params={"per_page": 100, "includes_parents": "true"},
-        )
-        normalized_rulesets = []
-        for ruleset_summary in ruleset_summaries:
-            cache_key = _rest_ruleset_cache_key(ruleset_summary)
-            ruleset_detail = ruleset_detail_cache.get(cache_key)
-            if ruleset_detail is None:
-                ruleset_detail = call_github_rest_api(
-                    f"{endpoint}/{ruleset_summary['id']}",
-                    token,
-                    base_url,
-                    params={"includes_parents": "true"},
-                )
-                ruleset_detail_cache[cache_key] = ruleset_detail
-            normalized_rulesets.append(_normalize_rest_ruleset(ruleset_detail))
-        rulesets_by_url[repo_url] = {
-            "nodes": normalized_rulesets,
-            "totalCount": len(normalized_rulesets),
+    eligible = [
+        repo
+        for repo in repo_raw_data
+        if repo is not None and repo.get("name") and repo.get("url")
+    ]
+    logger.info(
+        "Fetching rulesets for %d repos in org %s (parallel_workers=%d).",
+        len(eligible),
+        organization,
+        parallel_workers,
+    )
+
+    total = len(eligible)
+    completed = 0
+
+    with ThreadPoolExecutor(max_workers=parallel_workers) as executor:
+        futures = {
+            executor.submit(
+                _fetch_rulesets_for_repo,
+                repo,
+                token,
+                base_url,
+                owner,
+                ruleset_detail_cache,
+                cache_lock,
+            ): repo
+            for repo in eligible
         }
+        for f in as_completed(futures):
+            repo_url, rulesets_dict = f.result()
+            rulesets_by_url[repo_url] = rulesets_dict
+            completed += 1
+            if (
+                completed == 1
+                or completed % max(1, parallel_workers) == 0
+                or completed == total
+            ):
+                logger.info(
+                    "Rulesets progress for org %s: %d/%d repos completed.",
+                    organization,
+                    completed,
+                    total,
+                )
 
     return rulesets_by_url
 
@@ -915,6 +1273,7 @@ def get_repo_privileged_details_by_url(
     token: str,
     api_url: str,
     organization: str,
+    parallel_workers: int = 1,
 ) -> Dict[str, Dict[str, Any]]:
     """
     Retrieve collaborator counts, branch protection, and ruleset fields for repositories in an organization.
@@ -934,6 +1293,7 @@ def get_repo_privileged_details_by_url(
         api_url,
         organization,
         privileged_nodes,
+        parallel_workers=parallel_workers,
     )
     for repo in privileged_nodes:
         # GitHub can return null repository entries.
@@ -1211,6 +1571,7 @@ def _transform_repo_objects(input_repo_object: Dict, out_repo_list: List[Dict]) 
             "url": input_repo_object["url"],
             "sshurl": ssh_url,
             "updatedat": input_repo_object["updatedAt"],
+            "pushedat": input_repo_object.get("pushedAt"),
             "owner_org_id": owner["url"] if owner_type == "Organization" else None,
             "owner_user_id": owner["url"] if owner_type == "User" else None,
         },
@@ -2241,10 +2602,19 @@ def cleanup_github_dependencies(
     Delete stale Dependency nodes and their relationships. Dependency uses
     unscoped cleanup (see GitHubDependencySchema docstring) so this runs once
     per sync cycle alongside the other global resources, not per organization.
+
+    Uses a reduced iterationsize because Dependency is a globally shared node:
+    a single stale Dependency can have many REQUIRES (repo) and HAS_DEP
+    (manifest) relationships attached. DETACH DELETE-ing the default 10,000
+    nodes per transaction can pull in enough relationships to exceed Neo4j's
+    dbms.memory.transaction.total.max limit (observed in production as
+    Neo.TransientError.General.MemoryPoolOutOfMemoryError).
     """
-    GraphJob.from_node_schema(GitHubDependencySchema(), common_job_parameters).run(
-        neo4j_session
-    )
+    GraphJob.from_node_schema(
+        GitHubDependencySchema(),
+        common_job_parameters,
+        iterationsize=500,
+    ).run(neo4j_session)
 
 
 @timeit
@@ -2258,11 +2628,20 @@ def cleanup_github_manifests(
     :param neo4j_session: Neo4j session
     :param common_job_parameters: Common job parameters containing UPDATE_TAG
     :param owner_org_id: URL of the owning GitHub organization
+
+    Uses a reduced iterationsize because a single manifest can have hundreds
+    of HAS_DEP relationships to Dependency nodes (some observed manifests in
+    production have 700-800+ dependencies). DETACH DELETE-ing the default
+    10,000 manifests per transaction can pull in millions of relationships,
+    exceeding Neo4j's dbms.memory.transaction.total.max limit (observed in
+    production as Neo.TransientError.General.MemoryPoolOutOfMemoryError).
     """
     cleanup_params = {**common_job_parameters, "owner_org_id": owner_org_id}
-    GraphJob.from_node_schema(DependencyGraphManifestSchema(), cleanup_params).run(
-        neo4j_session
-    )
+    GraphJob.from_node_schema(
+        DependencyGraphManifestSchema(),
+        cleanup_params,
+        iterationsize=500,
+    ).run(neo4j_session)
 
 
 @timeit
@@ -2545,6 +2924,9 @@ def sync(
     github_api_key: str,
     github_url: str,
     organization: str,
+    parallel_workers: int = 1,
+    sync_dep_manifests: bool = True,
+    incremental_sync: bool = False,
 ) -> GitHubRepoSyncResult:
     """
     Performs the sequential tasks to collect, transform, and sync github data
@@ -2553,6 +2935,11 @@ def sync(
     :param github_api_key: The API key to access the GitHub v4 API
     :param github_url: The URL for the GitHub v4 endpoint to use
     :param organization: The organization to query GitHub for
+    :param parallel_workers: Number of parallel workers for per-repo API fetches. Default 1 (sequential).
+    :param sync_dep_manifests: Fetch dependency graph manifests. Set False to skip the slow O(n) manifest
+        phase; use the separate 'dep_manifests' requested-sync value to run it independently.
+    :param incremental_sync: Skip archived/disabled repos and skip re-fetching manifests for repos
+        whose pushedAt is unchanged since the last sync.
     :return: Repository and dependency manifest data fetched for this org.
     """
     logger.info("Syncing GitHub repos")
@@ -2567,6 +2954,7 @@ def sync(
                 github_api_key,
                 github_url,
                 organization,
+                parallel_workers=parallel_workers,
             )
         except (requests.exceptions.RequestException, ValueError):
             rulesets_cleanup_safe = False
@@ -2594,34 +2982,74 @@ def sync(
     direct_collabs: dict[str, list[UserAffiliationAndRepoPermission]] = {}
     outside_collabs: dict[str, list[UserAffiliationAndRepoPermission]] = {}
     try:
-        direct_collabs = _get_repo_collaborators_for_multiple_repos(
-            repos_json,
-            "DIRECT",
-            organization,
-            github_url,
-            github_api_key,
-        )
-        outside_collabs = _get_repo_collaborators_for_multiple_repos(
-            repos_json,
-            "OUTSIDE",
-            organization,
-            github_url,
-            github_api_key,
-        )
-    except TypeError:
-        # due to permission errors or transient network error or some other nonsense
+        if parallel_workers > 1:
+            logger.info(
+                "Fetching DIRECT and OUTSIDE collaborators concurrently for org %s.",
+                organization,
+            )
+            direct_collabs, outside_collabs = to_synchronous(
+                to_asynchronous(
+                    _get_repo_collaborators_for_multiple_repos,
+                    repos_json,
+                    "DIRECT",
+                    organization,
+                    github_url,
+                    github_api_key,
+                    parallel_workers,
+                ),
+                to_asynchronous(
+                    _get_repo_collaborators_for_multiple_repos,
+                    repos_json,
+                    "OUTSIDE",
+                    organization,
+                    github_url,
+                    github_api_key,
+                    parallel_workers,
+                ),
+            )
+        else:
+            direct_collabs = _get_repo_collaborators_for_multiple_repos(
+                repos_json,
+                "DIRECT",
+                organization,
+                github_url,
+                github_api_key,
+            )
+            outside_collabs = _get_repo_collaborators_for_multiple_repos(
+                repos_json,
+                "OUTSIDE",
+                organization,
+                github_url,
+                github_api_key,
+            )
+    except (TypeError, ValueError):
+        # TypeError: permission errors or transient network issues
+        # ValueError: fetch_all raises this when all retries are exhausted (e.g. repeated timeouts)
         logger.warning(
-            "Unable to list repo collaborators due to permission errors; continuing on.",
+            "Unable to list repo collaborators due to permission errors or exhausted retries; continuing on.",
             exc_info=True,
         )
 
     # Fetch dependency graph manifests per-repo to avoid 502s from heavy inline queries
-    dep_manifests_by_url, dep_manifests_cleanup_safe = _get_dep_manifests_for_repos(
-        repos_json,
-        organization,
-        github_url,
-        github_api_key,
-    )
+    dep_manifests_by_url: dict[str, dict[str, Any]] = {}
+    dep_manifests_cleanup_safe = True
+    if sync_dep_manifests:
+        dep_manifests_by_url, dep_manifests_cleanup_safe = _get_dep_manifests_for_repos(
+            repos_json,
+            organization,
+            github_url,
+            github_api_key,
+            skip_archived_repos=incremental_sync,
+            skip_unchanged_repos=incremental_sync,
+            parallel_workers=parallel_workers,
+            neo4j_session=neo4j_session,
+            update_tag=common_job_parameters["UPDATE_TAG"],
+        )
+    else:
+        logger.info(
+            "Skipping dependency manifest fetch for org %s (dep_manifests not in requested syncs).",
+            organization,
+        )
     for repo in repos_json:
         if repo is not None and repo.get("url") in dep_manifests_by_url:
             repo["dependencyGraphManifests"] = dep_manifests_by_url[repo["url"]]
@@ -2632,6 +3060,18 @@ def sync(
         github_api_key,
         github_url,
     )
+    load(neo4j_session, common_job_parameters, repo_data)
+
+    # Build the pushedat update list to be written by the caller (start_github_ingestion)
+    # AFTER all downstream stages (actions, manifests, commits) have completed.
+    # Writing synced_pushedat here would immediately overwrite the bookmark with the
+    # current run's pushedat before the skip comparisons have a chance to use it.
+    repo_pushedat_updates = [
+        {"repo_url": repo["url"], "pushedat": repo["pushedat"]}
+        for repo in repo_data["repos"]
+        if repo.get("pushedat")
+    ]
+
     owner_org_id = next(
         (
             repo["owner_org_id"]
@@ -2641,7 +3081,6 @@ def sync(
         f"https://github.com/{organization}",
     )
     migrate_dependency_graph_manifest_label(neo4j_session, owner_org_id)
-    load(neo4j_session, common_job_parameters, repo_data)
     cleanup_github_branches(neo4j_session, common_job_parameters, owner_org_id)
 
     # DEPRECATED: compatibility migrations to backfill the RESOURCE edge from
@@ -2681,4 +3120,5 @@ def sync(
         repos=repo_data["repos"],
         manifests=repo_data["manifests"],
         manifests_cleanup_safe=dep_manifests_cleanup_safe,
+        repo_pushedat_updates=repo_pushedat_updates,
     )

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -521,9 +521,10 @@ def _fetch_manifests_for_repo(
     """
     repo_name = repo.get("name")
     repo_url = repo.get("url", "")
-    if skip_archived_repos and repo.get("isArchived"):
+    if skip_archived_repos and (repo.get("isArchived") or repo.get("isDisabled")):
         logger.debug(
-            "Skipping dependency manifest fetch for archived repo %s.", repo_name
+            "Skipping dependency manifest fetch for archived/disabled repo %s.",
+            repo_name,
         )
         return repo_url, [], True, "archived"
 
@@ -567,10 +568,11 @@ def _touch_skipped_dependency_manifests(
     update_tag: int,
 ) -> None:
     """
-    Refresh `lastupdated` on the existing DependencyGraphManifest/Dependency
-    nodes for repos whose manifest fetch was skipped this run (because
-    pushedat was unchanged), so the end-of-run stale-tag cleanup doesn't
-    delete them.
+    Refresh `lastupdated` on the existing manifest/dependency subgraph for repos
+    whose manifest fetch was skipped this run (pushedat unchanged), so the
+    stale-tag cleanups don't delete it. Cleanup also deletes stale relationships
+    by their own `lastupdated`, so every relationship reaped by the manifest,
+    dependency, and CODEOWNERS-matchlink cleanups is touched too.
     """
     if not skipped_repo_urls:
         return
@@ -578,8 +580,11 @@ def _touch_skipped_dependency_manifests(
         neo4j_session,
         """
         UNWIND $repo_urls AS repo_url
-        MATCH (:GitHubRepository {id: repo_url})-[:HAS_MANIFEST]->(m:DependencyGraphManifest)
-        SET m.lastupdated = $update_tag
+        MATCH (:GitHubRepository {id: repo_url})-[hm:HAS_MANIFEST]->(m:DependencyGraphManifest)
+        SET m.lastupdated = $update_tag, hm.lastupdated = $update_tag
+        WITH DISTINCT m
+        MATCH (:GitHubOrganization)-[res:RESOURCE]->(m)
+        SET res.lastupdated = $update_tag
         """,
         repo_urls=skipped_repo_urls,
         update_tag=update_tag,
@@ -589,8 +594,29 @@ def _touch_skipped_dependency_manifests(
         """
         UNWIND $repo_urls AS repo_url
         MATCH (:GitHubRepository {id: repo_url})-[:HAS_MANIFEST]->(:DependencyGraphManifest)
-              -[:REQUIRES]->(d:Dependency)
-        SET d.lastupdated = $update_tag
+              -[hd:HAS_DEP]->(d:Dependency)
+        SET d.lastupdated = $update_tag, hd.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[req:REQUIRES]->(:Dependency)
+        SET req.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_MANIFEST]->(:DependencyGraphManifest)
+              -[mc:MATCHES_CODEOWNER_RULE]->(:GitHubCodeOwnerRule)
+        SET mc.lastupdated = $update_tag
         """,
         repo_urls=skipped_repo_urls,
         update_tag=update_tag,
@@ -708,10 +734,14 @@ def _get_dep_manifests_for_repos(
             # Store under the key _fetch_manifests_for_repo reads
             repo["manifests_synced_pushedat"] = bookmarks.get(repo.get("url", ""))
     if skip_archived_repos:
-        archived_count = sum(1 for repo in non_null_repos if repo.get("isArchived"))
+        archived_count = sum(
+            1
+            for repo in non_null_repos
+            if repo.get("isArchived") or repo.get("isDisabled")
+        )
         logger.info(
             "Fetching dependency graph manifests for org %s: %d total repos, "
-            "skipping %d archived, fetching for %d (parallel_workers=%d).",
+            "skipping %d archived/disabled, fetching for %d (parallel_workers=%d).",
             org,
             total_repos,
             archived_count,
@@ -736,7 +766,9 @@ def _get_dep_manifests_for_repos(
         for repo in non_null_repos
         if repo.get("name")
         and repo.get("url")
-        and not (skip_archived_repos and repo.get("isArchived"))
+        and not (
+            skip_archived_repos and (repo.get("isArchived") or repo.get("isDisabled"))
+        )
     ]
     total = len(eligible)
     completed = 0
@@ -3035,6 +3067,8 @@ def sync(
             update_tag=common_job_parameters["UPDATE_TAG"],
         )
     else:
+        # Nothing was fetched, so cleanup would delete all previously synced manifests.
+        dep_manifests_cleanup_safe = False
         logger.info(
             "Skipping dependency manifest fetch for org %s (dep_manifests not in requested syncs).",
             organization,

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -526,9 +526,10 @@ def _fetch_manifests_for_repo(
     """
     repo_name = repo.get("name")
     repo_url = repo.get("url", "")
-    if skip_archived_repos and repo.get("isArchived"):
+    if skip_archived_repos and (repo.get("isArchived") or repo.get("isDisabled")):
         logger.debug(
-            "Skipping dependency manifest fetch for archived repo %s.", repo_name
+            "Skipping dependency manifest fetch for archived/disabled repo %s.",
+            repo_name,
         )
         return repo_url, [], True, "archived"
 
@@ -572,10 +573,11 @@ def _touch_skipped_dependency_manifests(
     update_tag: int,
 ) -> None:
     """
-    Refresh `lastupdated` on the existing DependencyGraphManifest/Dependency
-    nodes for repos whose manifest fetch was skipped this run (because
-    pushedat was unchanged), so the end-of-run stale-tag cleanup doesn't
-    delete them.
+    Refresh `lastupdated` on the existing manifest/dependency subgraph for repos
+    whose manifest fetch was skipped this run (pushedat unchanged), so the
+    stale-tag cleanups don't delete it. Cleanup also deletes stale relationships
+    by their own `lastupdated`, so every relationship reaped by the manifest,
+    dependency, and CODEOWNERS-matchlink cleanups is touched too.
     """
     if not skipped_repo_urls:
         return
@@ -583,8 +585,11 @@ def _touch_skipped_dependency_manifests(
         neo4j_session,
         """
         UNWIND $repo_urls AS repo_url
-        MATCH (:GitHubRepository {id: repo_url})-[:HAS_MANIFEST]->(m:DependencyGraphManifest)
-        SET m.lastupdated = $update_tag
+        MATCH (:GitHubRepository {id: repo_url})-[hm:HAS_MANIFEST]->(m:DependencyGraphManifest)
+        SET m.lastupdated = $update_tag, hm.lastupdated = $update_tag
+        WITH DISTINCT m
+        MATCH (:GitHubOrganization)-[res:RESOURCE]->(m)
+        SET res.lastupdated = $update_tag
         """,
         repo_urls=skipped_repo_urls,
         update_tag=update_tag,
@@ -594,8 +599,29 @@ def _touch_skipped_dependency_manifests(
         """
         UNWIND $repo_urls AS repo_url
         MATCH (:GitHubRepository {id: repo_url})-[:HAS_MANIFEST]->(:DependencyGraphManifest)
-              -[:REQUIRES]->(d:Dependency)
-        SET d.lastupdated = $update_tag
+              -[hd:HAS_DEP]->(d:Dependency)
+        SET d.lastupdated = $update_tag, hd.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[req:REQUIRES]->(:Dependency)
+        SET req.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_MANIFEST]->(:DependencyGraphManifest)
+              -[mc:MATCHES_CODEOWNER_RULE]->(:GitHubCodeOwnerRule)
+        SET mc.lastupdated = $update_tag
         """,
         repo_urls=skipped_repo_urls,
         update_tag=update_tag,
@@ -713,10 +739,14 @@ def _get_dep_manifests_for_repos(
             # Store under the key _fetch_manifests_for_repo reads
             repo["manifests_synced_pushedat"] = bookmarks.get(repo.get("url", ""))
     if skip_archived_repos:
-        archived_count = sum(1 for repo in non_null_repos if repo.get("isArchived"))
+        archived_count = sum(
+            1
+            for repo in non_null_repos
+            if repo.get("isArchived") or repo.get("isDisabled")
+        )
         logger.info(
             "Fetching dependency graph manifests for org %s: %d total repos, "
-            "skipping %d archived, fetching for %d (parallel_workers=%d).",
+            "skipping %d archived/disabled, fetching for %d (parallel_workers=%d).",
             org,
             total_repos,
             archived_count,
@@ -741,7 +771,9 @@ def _get_dep_manifests_for_repos(
         for repo in non_null_repos
         if repo.get("name")
         and repo.get("url")
-        and not (skip_archived_repos and repo.get("isArchived"))
+        and not (
+            skip_archived_repos and (repo.get("isArchived") or repo.get("isDisabled"))
+        )
     ]
     total = len(eligible)
     completed = 0
@@ -3046,6 +3078,8 @@ def sync(
             update_tag=common_job_parameters["UPDATE_TAG"],
         )
     else:
+        # Nothing was fetched, so cleanup would delete all previously synced manifests.
+        dep_manifests_cleanup_safe = False
         logger.info(
             "Skipping dependency manifest fetch for org %s (dep_manifests not in requested syncs).",
             organization,

--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -122,6 +122,7 @@ def handle_rate_limit_sleep(token: str) -> None:
     response = requests.get(
         "https://api.github.com/rate_limit",
         headers={"Authorization": f"Bearer {_resolve_token(token)}"},
+        timeout=_TIMEOUT,
     )
     response.raise_for_status()
     response_json = response.json()
@@ -235,6 +236,8 @@ def fetch_all(
     data: PaginatedGraphqlData = PaginatedGraphqlData(nodes=[], edges=[])
     retry = 0
     null_resource_retry = 0
+    page_number = 0
+    initial_count = kwargs.get("count")
 
     while has_next_page:
         exc: Any = None
@@ -243,7 +246,11 @@ def fetch_all(
             # But we still need at least one call to the REST endpoint in case the graphql remaining is already 0
             handle_rate_limit_sleep(token)
             resp = fetch_page(token, api_url, organization, query, cursor, **kwargs)
-            retry = 0
+            # Only reset retry counter if the page size has not been degraded by a 502.
+            # If count has been reduced, we keep accumulating retry so persistent errors
+            # at a degraded page size eventually exhaust retries rather than looping forever.
+            if kwargs.get("count") == initial_count:
+                retry = 0
         except requests.exceptions.Timeout as err:
             retry += 1
             exc = err
@@ -271,11 +278,17 @@ def fetch_all(
 
         if retry >= retries:
             logger.error(
-                f"GitHub: Could not retrieve page of resource `{resource_type}` due to HTTP error "
-                f"after {retry} retries. Raising exception.",
+                "GitHub: Could not retrieve page of resource `%s` for org `%s` at cursor `%s` "
+                "after %d retries. Returning partial data collected so far (%d nodes, %d edges).",
+                resource_type,
+                organization,
+                cursor,
+                retry,
+                len(data.nodes),
+                len(data.edges),
                 exc_info=True,
             )
-            raise exc
+            break
         elif retry > 0:
             sleep_seconds = 2**retry
             if isinstance(exc, requests.exceptions.HTTPError):
@@ -351,6 +364,20 @@ def fetch_all(
 
         cursor = resource["pageInfo"]["endCursor"]
         has_next_page = resource["pageInfo"]["hasNextPage"]
+        page_number += 1
+        logger.info(
+            "GitHub: fetched page %d for resource `%s` in org `%s` (page_nodes=%d total_nodes=%d page_edges=%d total_edges=%d count=%s cursor=%s has_next=%s)",
+            page_number,
+            resource_type,
+            organization,
+            len(resource.get("nodes", [])),
+            len(data.nodes),
+            len(resource.get("edges", [])),
+            len(data.edges),
+            kwargs.get("count"),
+            resource.get("pageInfo", {}).get("endCursor"),
+            resource.get("pageInfo", {}).get("hasNextPage"),
+        )
         if not org_data:
             org_data = {
                 "url": resp["data"]["organization"]["url"],
@@ -358,9 +385,13 @@ def fetch_all(
             }
 
     if not org_data:
-        raise ValueError(
-            f"Didn't get any organization data for organization: {organization} and resource_type: {resource_type}",
+        logger.error(
+            "GitHub: No organization data collected for organization: %s, resource_type: %s. "
+            "All requests failed before any page was successfully retrieved.",
+            organization,
+            resource_type,
         )
+        return data, {"url": "", "login": organization}
     return data, org_data
 
 

--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -278,17 +278,11 @@ def fetch_all(
 
         if retry >= retries:
             logger.error(
-                "GitHub: Could not retrieve page of resource `%s` for org `%s` at cursor `%s` "
-                "after %d retries. Returning partial data collected so far (%d nodes, %d edges).",
-                resource_type,
-                organization,
-                cursor,
-                retry,
-                len(data.nodes),
-                len(data.edges),
+                f"GitHub: Could not retrieve page of resource `{resource_type}` due to HTTP error "
+                f"after {retry} retries. Raising exception.",
                 exc_info=True,
             )
-            break
+            raise exc
         elif retry > 0:
             sleep_seconds = 2**retry
             if isinstance(exc, requests.exceptions.HTTPError):
@@ -365,7 +359,7 @@ def fetch_all(
         cursor = resource["pageInfo"]["endCursor"]
         has_next_page = resource["pageInfo"]["hasNextPage"]
         page_number += 1
-        logger.info(
+        logger.debug(
             "GitHub: fetched page %d for resource `%s` in org `%s` (page_nodes=%d total_nodes=%d page_edges=%d total_edges=%d count=%s cursor=%s has_next=%s)",
             page_number,
             resource_type,
@@ -385,13 +379,9 @@ def fetch_all(
             }
 
     if not org_data:
-        logger.error(
-            "GitHub: No organization data collected for organization: %s, resource_type: %s. "
-            "All requests failed before any page was successfully retrieved.",
-            organization,
-            resource_type,
+        raise ValueError(
+            f"Didn't get any organization data for organization: {organization} and resource_type: {resource_type}",
         )
-        return data, {"url": "", "login": organization}
     return data, org_data
 
 

--- a/cartography/models/github/repos.py
+++ b/cartography/models/github/repos.py
@@ -32,6 +32,7 @@ class GitHubRepositoryNodeProperties(CartographyNodeProperties):
     url: PropertyRef = PropertyRef("url", extra_index=True)
     sshurl: PropertyRef = PropertyRef("sshurl", extra_index=True)
     updatedat: PropertyRef = PropertyRef("updatedat")
+    pushedat: PropertyRef = PropertyRef("pushedat")
 
 
 @dataclass(frozen=True)

--- a/cartography/models/github/repos.py
+++ b/cartography/models/github/repos.py
@@ -76,6 +76,9 @@ class GitHubRepositoryNodeProperties(CartographyNodeProperties):
         "parent",
         description="Web URL of the repository this repository was forked from.",
     )
+    pushedat: PropertyRef = PropertyRef(
+        "pushedat", description="Timestamp when the repository was last pushed to."
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/integration/cartography/intel/github/test_actions.py
+++ b/tests/integration/cartography/intel/github/test_actions.py
@@ -37,6 +37,17 @@ def _ensure_repo_exists(neo4j_session):
     )
 
 
+def _set_repo_pushedat(neo4j_session, pushedat, synced_pushedat=None):
+    neo4j_session.run(
+        """
+        MATCH (repo:GitHubRepository{id: "https://github.com/simpsoncorp/sample_repo"})
+        SET repo.pushedat = $pushedat, repo.synced_pushedat = $synced_pushedat
+        """,
+        pushedat=pushedat,
+        synced_pushedat=synced_pushedat,
+    )
+
+
 @patch.object(
     cartography.intel.github.actions,
     "get_org_secrets",
@@ -1078,3 +1089,127 @@ def test_sync_github_actions_workflow_parsing(
         "MATCH (:GitHubWorkflow)-[r:REFERENCES_SECRET]->(:GitHubActionsSecret) RETURN count(r) as count",
     ).single()["count"]
     assert refs_secret_rels >= 1
+
+
+@patch.object(
+    cartography.intel.github.actions,
+    "get_org_secrets",
+    return_value=GET_ORG_SECRETS,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_org_variables",
+    return_value=GET_ORG_VARIABLES,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_repo_workflows",
+    return_value=GET_REPO_WORKFLOWS,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_repo_environments",
+    return_value=GET_REPO_ENVIRONMENTS,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_repo_secrets",
+    return_value=GET_REPO_SECRETS,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_repo_variables",
+    return_value=GET_REPO_VARIABLES,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_env_secrets",
+    side_effect=lambda *args, **kwargs: (
+        GET_ENV_SECRETS_PRODUCTION
+        if args[4] == "production"
+        else GET_ENV_SECRETS_STAGING
+    ),
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_env_variables",
+    side_effect=lambda *args, **kwargs: (
+        GET_ENV_VARIABLES_PRODUCTION
+        if args[4] == "production"
+        else GET_ENV_VARIABLES_STAGING
+    ),
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_workflow_content",
+    return_value=None,
+)
+def test_sync_github_actions_incremental_skip_preserves_workflows(
+    mock_workflow_content,
+    mock_env_variables,
+    mock_env_secrets,
+    mock_repo_variables,
+    mock_repo_secrets,
+    mock_repo_environments,
+    mock_repo_workflows,
+    mock_org_variables,
+    mock_org_secrets,
+    neo4j_session,
+):
+    """
+    Test that when skip_unchanged_repos is enabled and a repo's pushedat is
+    unchanged since the last successful Actions sync, the workflow fetch is
+    skipped but existing GitHubWorkflow/GitHubAction nodes are preserved
+    (touched, not stale-cleaned) across a new update tag.
+    """
+    # Arrange - repo exists, no prior pushedat/bookmark (first sync should fetch normally)
+    _ensure_repo_exists(neo4j_session)
+    _set_repo_pushedat(neo4j_session, pushedat="2024-01-01T00:00:00Z")
+
+    # Act - first sync populates workflows and records the pushedat bookmark
+    cartography.intel.github.actions.sync(
+        neo4j_session,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+        FAKE_API_KEY,
+        TEST_GITHUB_URL,
+        TEST_ORGANIZATION,
+        skip_unchanged_repos=True,
+    )
+
+    # Assert - first sync fetched workflows; synced_pushedat is set externally
+    # (by repos.sync() in a real run) — simulate that by setting it now so the
+    # second sync can use it as the bookmark.
+    assert mock_repo_workflows.call_count == 1
+    assert check_nodes(neo4j_session, "GitHubWorkflow", ["id"]) == {
+        (12345678,),
+        (12345679,),
+        (12345680,),
+    }
+    # Simulate repos.sync() writing synced_pushedat after repos fetch
+    neo4j_session.run(
+        'MATCH (r:GitHubRepository{id: "https://github.com/simpsoncorp/sample_repo"}) '
+        "SET r.synced_pushedat = $pushedat",
+        pushedat="2024-01-01T00:00:00Z",
+    )
+
+    # Act - second sync, pushedat matches synced_pushedat, new update tag
+    second_update_tag = TEST_UPDATE_TAG + 1
+    cartography.intel.github.actions.sync(
+        neo4j_session,
+        {"UPDATE_TAG": second_update_tag},
+        FAKE_API_KEY,
+        TEST_GITHUB_URL,
+        TEST_ORGANIZATION,
+        skip_unchanged_repos=True,
+    )
+
+    # Assert - workflow fetch was NOT called again (still just the 1 call from before)
+    assert mock_repo_workflows.call_count == 1
+
+    # Assert - GitHubWorkflow nodes still exist and were touched to the new update tag,
+    # i.e. NOT deleted by stale-tag cleanup despite not being re-fetched.
+    workflow_rows = neo4j_session.run(
+        "MATCH (w:GitHubWorkflow) RETURN w.id AS id, w.lastupdated AS lastupdated",
+    ).data()
+    assert {row["id"] for row in workflow_rows} == {12345678, 12345679, 12345680}
+    assert all(row["lastupdated"] == second_update_tag for row in workflow_rows)

--- a/tests/integration/cartography/intel/github/test_actions.py
+++ b/tests/integration/cartography/intel/github/test_actions.py
@@ -1142,7 +1142,7 @@ def test_sync_github_actions_workflow_parsing(
 @patch.object(
     cartography.intel.github.actions,
     "get_workflow_content",
-    return_value=None,
+    return_value=WORKFLOW_CI_CONTENT,
 )
 def test_sync_github_actions_incremental_skip_preserves_workflows(
     mock_workflow_content,
@@ -1159,8 +1159,10 @@ def test_sync_github_actions_incremental_skip_preserves_workflows(
     """
     Test that when skip_unchanged_repos is enabled and a repo's pushedat is
     unchanged since the last successful Actions sync, the workflow fetch is
-    skipped but existing GitHubWorkflow/GitHubAction nodes are preserved
-    (touched, not stale-cleaned) across a new update tag.
+    skipped but the existing GitHubWorkflow/GitHubAction subgraph is preserved
+    (nodes AND relationships touched, not stale-cleaned) across a new update tag.
+    Uses WORKFLOW_CI_CONTENT so GitHubAction nodes actually exist and the
+    action-preservation branch is exercised.
     """
     # Arrange - repo exists, no prior pushedat/bookmark (first sync should fetch normally)
     _ensure_repo_exists(neo4j_session)
@@ -1185,6 +1187,13 @@ def test_sync_github_actions_incremental_skip_preserves_workflows(
         (12345679,),
         (12345680,),
     }
+    # WORKFLOW_CI_CONTENT references 2 distinct actions
+    first_action_nodes = check_nodes(neo4j_session, "GitHubAction", ["id"])
+    assert len(first_action_nodes) == 2
+    first_uses_action = neo4j_session.run(
+        "MATCH (:GitHubWorkflow)-[r:USES_ACTION]->(:GitHubAction) RETURN count(r) AS c",
+    ).single()["c"]
+    assert first_uses_action >= 2
     # Simulate repos.sync() writing synced_pushedat after repos fetch
     neo4j_session.run(
         'MATCH (r:GitHubRepository{id: "https://github.com/simpsoncorp/sample_repo"}) '
@@ -1213,3 +1222,18 @@ def test_sync_github_actions_incremental_skip_preserves_workflows(
     ).data()
     assert {row["id"] for row in workflow_rows} == {12345678, 12345679, 12345680}
     assert all(row["lastupdated"] == second_update_tag for row in workflow_rows)
+
+    # Assert - GitHubAction nodes were preserved and touched too
+    action_rows = neo4j_session.run(
+        "MATCH (a:GitHubAction) RETURN a.id AS id, a.lastupdated AS lastupdated",
+    ).data()
+    assert {row["id"] for row in action_rows} == {row[0] for row in first_action_nodes}
+    assert all(row["lastupdated"] == second_update_tag for row in action_rows)
+
+    # Assert - the USES_ACTION relationships were preserved and touched too
+    uses_action_rows = neo4j_session.run(
+        "MATCH (:GitHubWorkflow)-[r:USES_ACTION]->(:GitHubAction) "
+        "RETURN r.lastupdated AS lastupdated",
+    ).data()
+    assert len(uses_action_rows) >= 2
+    assert all(row["lastupdated"] == second_update_tag for row in uses_action_rows)

--- a/tests/integration/cartography/intel/github/test_commits.py
+++ b/tests/integration/cartography/intel/github/test_commits.py
@@ -102,3 +102,46 @@ def test_sync_github_commits(mock_get_commits, neo4j_session):
     }
     actual_repos = check_nodes(neo4j_session, "GitHubRepository", ["id"])
     assert expected_repos.issubset(actual_repos)
+
+
+@patch.object(
+    cartography.intel.github.commits,
+    "get_repo_commits",
+)
+def test_sync_github_commits_skip_stale_repos(mock_get_commits, neo4j_session):
+    """
+    Test that when skip_stale_repos is enabled, repos with no push within the
+    lookback window are skipped entirely (no commits API call), while repos
+    with no known pushedat (never seen by a repos sync) are still processed.
+    """
+    # Arrange - repo1 was pushed long ago (outside the lookback window), repo2 recently.
+    _ensure_test_users_exist(neo4j_session)
+    _ensure_test_repos_exist(neo4j_session)
+    neo4j_session.run(
+        """
+        MATCH (r1:GitHubRepository {id: "https://github.com/testorg/repo1"})
+        SET r1.pushedat = "2000-01-01T00:00:00Z"
+        """,
+    )
+    # repo2 has no pushedat set at all (simulates a repo the repos-sync hasn't
+    # recorded pushedat for yet) — should never be skipped.
+
+    def side_effect(token, api_url, organization, repo_name, since_date):
+        return MOCK_COMMITS_BY_REPO.get(repo_name, [])
+
+    mock_get_commits.side_effect = side_effect
+
+    # Act
+    cartography.intel.github.commits.sync_github_commits(
+        neo4j_session,
+        "fake-token",
+        TEST_GITHUB_URL,
+        TEST_GITHUB_ORG,
+        TEST_REPO_NAMES,
+        TEST_UPDATE_TAG,
+        skip_stale_repos=True,
+    )
+
+    # Assert - only repo2 (no pushedat on record) had its commits fetched
+    fetched_repos = {call.args[3] for call in mock_get_commits.call_args_list}
+    assert fetched_repos == {"repo2"}

--- a/tests/integration/cartography/intel/github/test_commits.py
+++ b/tests/integration/cartography/intel/github/test_commits.py
@@ -114,7 +114,9 @@ def test_sync_github_commits_skip_stale_repos(mock_get_commits, neo4j_session):
     lookback window are skipped entirely (no commits API call), while repos
     with no known pushedat (never seen by a repos sync) are still processed.
     """
-    # Arrange - repo1 was pushed long ago (outside the lookback window), repo2 recently.
+    # Arrange - wipe state left by earlier tests in this module (the session
+    # fixture is module-scoped), then seed repo1 pushed outside the lookback window.
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
     _ensure_test_users_exist(neo4j_session)
     _ensure_test_repos_exist(neo4j_session)
     neo4j_session.run(

--- a/tests/integration/cartography/intel/github/test_commits.py
+++ b/tests/integration/cartography/intel/github/test_commits.py
@@ -145,3 +145,17 @@ def test_sync_github_commits_skip_stale_repos(mock_get_commits, neo4j_session):
     # Assert - only repo2 (no pushedat on record) had its commits fetched
     fetched_repos = {call.args[3] for call in mock_get_commits.call_args_list}
     assert fetched_repos == {"repo2"}
+
+    # Assert - only repo2's commit relationship was written to the graph
+    actual_rels = check_rels(
+        neo4j_session,
+        "GitHubUser",
+        "id",
+        "GitHubRepository",
+        "id",
+        "COMMITTED_TO",
+        rel_direction_right=True,
+    )
+    assert actual_rels == {
+        ("https://github.com/bob", "https://github.com/testorg/repo2"),
+    }

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -1192,3 +1192,85 @@ def test_sync_github_python_requirements(
         "REQUIRES",
     )
     assert expected_requires_rels.issubset(actual_requires_rels)
+
+
+@patch.object(
+    cartography.intel.github.repos,
+    "_get_repo_dep_manifests",
+)
+def test_get_dep_manifests_for_repos_incremental_skip_preserves_manifests(
+    mock_get_repo_dep_manifests, neo4j_session
+):
+    """
+    Test that when skip_unchanged_repos is enabled and a repo's pushedAt is
+    unchanged since the last successful manifest sync, the per-repo manifest
+    fetch is skipped, but existing DependencyGraphManifest/Dependency nodes
+    are preserved (touched, not stale-cleaned) across a new update tag.
+    """
+    # Arrange - seed a repo with an existing manifest+dependency and a matching bookmark
+    repo_url = "https://github.com/simpsoncorp/sample_repo"
+    manifest_id = f"{repo_url}#/requirements.txt"
+    neo4j_session.run(
+        """
+        MERGE (org:GitHubOrganization{id: "https://github.com/simpsoncorp"})
+        MERGE (repo:GitHubRepository{id: $repo_url})
+        SET repo.name = "sample_repo", repo.lastupdated = $update_tag,
+            repo.synced_pushedat = "2024-01-01T00:00:00Z"
+        MERGE (repo)-[:OWNER]->(org)
+        MERGE (repo)-[:HAS_MANIFEST]->(m:DependencyGraphManifest{id: $manifest_id})
+        SET m.lastupdated = $update_tag
+        MERGE (m)-[:REQUIRES]->(d:Dependency{id: "django"})
+        SET d.lastupdated = $update_tag
+        """,
+        repo_url=repo_url,
+        manifest_id=manifest_id,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    repo_raw_data = [
+        {
+            "name": "sample_repo",
+            "url": repo_url,
+            "pushedAt": "2024-01-01T00:00:00Z",
+            "isArchived": False,
+        }
+    ]
+
+    # Act - run with a new update tag; pushedAt matches the recorded bookmark
+    new_update_tag = TEST_UPDATE_TAG + 1
+    result, cleanup_safe = cartography.intel.github.repos._get_dep_manifests_for_repos(
+        repo_raw_data,
+        TEST_GITHUB_ORG,
+        TEST_GITHUB_URL,
+        FAKE_API_KEY,
+        skip_unchanged_repos=True,
+        neo4j_session=neo4j_session,
+        update_tag=new_update_tag,
+    )
+
+    # Assert - the per-repo fetch was never called (skipped as unchanged)
+    mock_get_repo_dep_manifests.assert_not_called()
+    assert cleanup_safe is True
+    assert result == {}
+
+    # Assert - existing manifest/dependency nodes were touched to the new tag,
+    # not deleted by stale-tag cleanup, despite not being re-fetched.
+    manifest_row = neo4j_session.run(
+        "MATCH (m:DependencyGraphManifest {id: $id}) RETURN m.lastupdated AS lastupdated",
+        id=manifest_id,
+    ).single()
+    assert manifest_row is not None
+    assert manifest_row["lastupdated"] == new_update_tag
+
+    dep_row = neo4j_session.run(
+        'MATCH (d:Dependency {id: "django"}) RETURN d.lastupdated AS lastupdated',
+    ).single()
+    assert dep_row is not None
+    assert dep_row["lastupdated"] == new_update_tag
+
+    # Assert - bookmark unchanged (still valid for next comparison)
+    bookmark_row = neo4j_session.run(
+        "MATCH (r:GitHubRepository {id: $id}) RETURN r.synced_pushedat AS bookmark",
+        id=repo_url,
+    ).single()
+    assert bookmark_row["bookmark"] == "2024-01-01T00:00:00Z"

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -1227,11 +1227,17 @@ def test_get_dep_manifests_for_repos_incremental_skip_preserves_manifests(
     Test that when skip_unchanged_repos is enabled and a repo's pushedAt is
     unchanged since the last successful manifest sync, the per-repo manifest
     fetch is skipped, but existing DependencyGraphManifest/Dependency nodes
-    are preserved (touched, not stale-cleaned) across a new update tag.
+    are preserved (touched, not stale-cleaned) across a new update tag. Also
+    verifies the DependencyGraphManifest-[:MATCHES_CODEOWNER_RULE]->
+    GitHubCodeOwnerRule matchlink is preserved, since codeowners.sync's
+    cleanup is scoped to the whole org and would otherwise delete matchlinks
+    for repos whose manifest fetch was skipped this run.
     """
-    # Arrange - seed a repo with an existing manifest+dependency and a matching bookmark
+    # Arrange - seed a repo with an existing manifest+dependency, a CODEOWNERS
+    # rule match, and a matching bookmark
     repo_url = "https://github.com/simpsoncorp/sample_repo"
     manifest_id = f"{repo_url}#/requirements.txt"
+    rule_id = f"{repo_url}#CODEOWNERS:.github/CODEOWNERS:1:deadbeef"
     neo4j_session.run(
         """
         MERGE (org:GitHubOrganization{id: "https://github.com/simpsoncorp"})
@@ -1243,9 +1249,14 @@ def test_get_dep_manifests_for_repos_incremental_skip_preserves_manifests(
         SET m.lastupdated = $update_tag
         MERGE (m)-[:HAS_DEP]->(d:Dependency{id: "django"})
         SET d.lastupdated = $update_tag
+        MERGE (rule:GitHubCodeOwnerRule{id: $rule_id})
+        SET rule.lastupdated = $update_tag
+        MERGE (m)-[mc:MATCHES_CODEOWNER_RULE]->(rule)
+        SET mc.lastupdated = $update_tag
         """,
         repo_url=repo_url,
         manifest_id=manifest_id,
+        rule_id=rule_id,
         update_tag=TEST_UPDATE_TAG,
     )
 
@@ -1289,6 +1300,21 @@ def test_get_dep_manifests_for_repos_incremental_skip_preserves_manifests(
     ).single()
     assert dep_row is not None
     assert dep_row["lastupdated"] == new_update_tag
+
+    # Assert - the MATCHES_CODEOWNER_RULE matchlink was touched too, so
+    # codeowners.sync's org-scoped cleanup won't delete it even though this
+    # repo's manifest fetch was skipped this run.
+    matchlink_row = neo4j_session.run(
+        """
+        MATCH (:DependencyGraphManifest {id: $manifest_id})
+              -[mc:MATCHES_CODEOWNER_RULE]->(:GitHubCodeOwnerRule {id: $rule_id})
+        RETURN mc.lastupdated AS lastupdated
+        """,
+        manifest_id=manifest_id,
+        rule_id=rule_id,
+    ).single()
+    assert matchlink_row is not None
+    assert matchlink_row["lastupdated"] == new_update_tag
 
     # Assert - bookmark unchanged (still valid for next comparison)
     bookmark_row = neo4j_session.run(

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -1214,3 +1214,85 @@ def test_sync_github_python_requirements(
         "REQUIRES",
     )
     assert expected_requires_rels.issubset(actual_requires_rels)
+
+
+@patch.object(
+    cartography.intel.github.repos,
+    "_get_repo_dep_manifests",
+)
+def test_get_dep_manifests_for_repos_incremental_skip_preserves_manifests(
+    mock_get_repo_dep_manifests, neo4j_session
+):
+    """
+    Test that when skip_unchanged_repos is enabled and a repo's pushedAt is
+    unchanged since the last successful manifest sync, the per-repo manifest
+    fetch is skipped, but existing DependencyGraphManifest/Dependency nodes
+    are preserved (touched, not stale-cleaned) across a new update tag.
+    """
+    # Arrange - seed a repo with an existing manifest+dependency and a matching bookmark
+    repo_url = "https://github.com/simpsoncorp/sample_repo"
+    manifest_id = f"{repo_url}#/requirements.txt"
+    neo4j_session.run(
+        """
+        MERGE (org:GitHubOrganization{id: "https://github.com/simpsoncorp"})
+        MERGE (repo:GitHubRepository{id: $repo_url})
+        SET repo.name = "sample_repo", repo.lastupdated = $update_tag,
+            repo.synced_pushedat = "2024-01-01T00:00:00Z"
+        MERGE (repo)-[:OWNER]->(org)
+        MERGE (repo)-[:HAS_MANIFEST]->(m:DependencyGraphManifest{id: $manifest_id})
+        SET m.lastupdated = $update_tag
+        MERGE (m)-[:REQUIRES]->(d:Dependency{id: "django"})
+        SET d.lastupdated = $update_tag
+        """,
+        repo_url=repo_url,
+        manifest_id=manifest_id,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    repo_raw_data = [
+        {
+            "name": "sample_repo",
+            "url": repo_url,
+            "pushedAt": "2024-01-01T00:00:00Z",
+            "isArchived": False,
+        }
+    ]
+
+    # Act - run with a new update tag; pushedAt matches the recorded bookmark
+    new_update_tag = TEST_UPDATE_TAG + 1
+    result, cleanup_safe = cartography.intel.github.repos._get_dep_manifests_for_repos(
+        repo_raw_data,
+        TEST_GITHUB_ORG,
+        TEST_GITHUB_URL,
+        FAKE_API_KEY,
+        skip_unchanged_repos=True,
+        neo4j_session=neo4j_session,
+        update_tag=new_update_tag,
+    )
+
+    # Assert - the per-repo fetch was never called (skipped as unchanged)
+    mock_get_repo_dep_manifests.assert_not_called()
+    assert cleanup_safe is True
+    assert result == {}
+
+    # Assert - existing manifest/dependency nodes were touched to the new tag,
+    # not deleted by stale-tag cleanup, despite not being re-fetched.
+    manifest_row = neo4j_session.run(
+        "MATCH (m:DependencyGraphManifest {id: $id}) RETURN m.lastupdated AS lastupdated",
+        id=manifest_id,
+    ).single()
+    assert manifest_row is not None
+    assert manifest_row["lastupdated"] == new_update_tag
+
+    dep_row = neo4j_session.run(
+        'MATCH (d:Dependency {id: "django"}) RETURN d.lastupdated AS lastupdated',
+    ).single()
+    assert dep_row is not None
+    assert dep_row["lastupdated"] == new_update_tag
+
+    # Assert - bookmark unchanged (still valid for next comparison)
+    bookmark_row = neo4j_session.run(
+        "MATCH (r:GitHubRepository {id: $id}) RETURN r.synced_pushedat AS bookmark",
+        id=repo_url,
+    ).single()
+    assert bookmark_row["bookmark"] == "2024-01-01T00:00:00Z"

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -1219,7 +1219,7 @@ def test_get_dep_manifests_for_repos_incremental_skip_preserves_manifests(
         MERGE (repo)-[:OWNER]->(org)
         MERGE (repo)-[:HAS_MANIFEST]->(m:DependencyGraphManifest{id: $manifest_id})
         SET m.lastupdated = $update_tag
-        MERGE (m)-[:REQUIRES]->(d:Dependency{id: "django"})
+        MERGE (m)-[:HAS_DEP]->(d:Dependency{id: "django"})
         SET d.lastupdated = $update_tag
         """,
         repo_url=repo_url,

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -1241,7 +1241,7 @@ def test_get_dep_manifests_for_repos_incremental_skip_preserves_manifests(
         MERGE (repo)-[:OWNER]->(org)
         MERGE (repo)-[:HAS_MANIFEST]->(m:DependencyGraphManifest{id: $manifest_id})
         SET m.lastupdated = $update_tag
-        MERGE (m)-[:REQUIRES]->(d:Dependency{id: "django"})
+        MERGE (m)-[:HAS_DEP]->(d:Dependency{id: "django"})
         SET d.lastupdated = $update_tag
         """,
         repo_url=repo_url,

--- a/tests/unit/cartography/intel/github/test_github.py
+++ b/tests/unit/cartography/intel/github/test_github.py
@@ -381,28 +381,26 @@ def test_fetch_all_handles_retries(
     mock_sleep: Mock,
 ) -> None:
     """
-    Ensures that fetch_all re-reaises the same exceptions when exceeding retry limit
+    Ensures that fetch_all returns partial data when exceeding retry limit
     """
     # Arrange
-    exception = HTTPError
     response = Response()
     response.status_code = 500
-    mock_fetch_page.side_effect = exception("my-error", response=response)
+    mock_fetch_page.side_effect = HTTPError("my-error", response=response)
     retries = 3
     # Act
-    with pytest.raises(exception) as excinfo:
-        fetch_all(
-            "my-token",
-            "my-api_url",
-            "my-org",
-            "my-query",
-            "my-resource",
-            retries=retries,
-        )
+    result, _ = fetch_all(
+        "my-token",
+        "my-api_url",
+        "my-org",
+        "my-query",
+        "my-resource",
+        retries=retries,
+    )
     # Assert
     assert mock_handle_rate_limit_sleep.call_count == retries
     assert mock_fetch_page.call_count == retries
-    assert "my-error" in str(excinfo.value)
+    assert result.nodes == []
 
 
 @patch("cartography.intel.github.util.time.sleep")
@@ -436,6 +434,141 @@ def test_fetch_all_reduces_count_on_502(
     assert mock_fetch_page.call_count == 2
     assert mock_fetch_page.call_args_list[0][1]["count"] == 50
     assert mock_fetch_page.call_args_list[1][1]["count"] == 25
+
+
+@patch("cartography.intel.github.util.time.sleep")
+@patch("cartography.intel.github.util.handle_rate_limit_sleep")
+@patch("cartography.intel.github.util.fetch_page")
+def test_fetch_all_returns_partial_data_after_exhausting_retries(
+    mock_fetch_page: Mock,
+    mock_handle_rate_limit_sleep: Mock,
+    mock_sleep: Mock,
+) -> None:
+    """
+    When retries are exhausted mid-pagination, fetch_all should return
+    whatever data was collected so far rather than raising, so the sync
+    can continue with partial data instead of failing entirely.
+    """
+    response_502 = Response()
+    response_502.status_code = 502
+    success_page_1 = {
+        "data": {
+            "organization": {
+                "repositories": {
+                    "nodes": [{"name": "repo1"}, {"name": "repo2"}],
+                    "edges": [],
+                    "pageInfo": {"endCursor": "cursor1", "hasNextPage": True},
+                },
+                "url": "url",
+                "login": "org",
+            },
+        }
+    }
+    retries = 3
+    mock_fetch_page.side_effect = [
+        success_page_1,
+        HTTPError("bad gateway", response=response_502),
+        HTTPError("bad gateway", response=response_502),
+        HTTPError("bad gateway", response=response_502),
+    ]
+
+    result, _ = fetch_all(
+        "token",
+        "api_url",
+        "org",
+        "query",
+        "repositories",
+        retries=retries,
+    )
+
+    assert result.nodes == [{"name": "repo1"}, {"name": "repo2"}]
+
+
+@patch("cartography.intel.github.util.time.sleep")
+@patch("cartography.intel.github.util.handle_rate_limit_sleep")
+@patch("cartography.intel.github.util.fetch_page")
+def test_fetch_all_raises_after_persistent_502s_at_degraded_page_size(
+    mock_fetch_page: Mock,
+    mock_handle_rate_limit_sleep: Mock,
+    mock_sleep: Mock,
+) -> None:
+    """
+    When page size has been reduced due to 502s, and 502s keep occurring even
+    after occasional successes, fetch_all should eventually give up. Previously,
+    retry was incorrectly reset to 0 on each success even at a degraded page
+    size, causing an infinite loop.
+    """
+    response_502 = Response()
+    response_502.status_code = 502
+    success_with_next = {
+        "data": {
+            "organization": {
+                "repositories": {
+                    "nodes": [],
+                    "edges": [],
+                    "pageInfo": {"endCursor": "cursor1", "hasNextPage": True},
+                },
+                "url": "url",
+                "login": "org",
+            },
+        }
+    }
+    retries = 3
+    # Pattern: 1 502 reduces count from 2→1, then alternating 502/success.
+    # With the bug, retry resets to 0 on each success so it never accumulates
+    # to `retries` and loops forever (StopIteration when mock is exhausted).
+    # With the fix, retry is NOT reset on success at degraded page size, so it
+    # reaches `retries` and breaks, returning partial data.
+    mock_fetch_page.side_effect = [
+        HTTPError("bad gateway", response=response_502),  # reduces count 2→1
+        HTTPError("bad gateway", response=response_502),  # retry=1
+        success_with_next,  # retry should NOT reset
+        HTTPError("bad gateway", response=response_502),  # retry=2
+        success_with_next,  # retry should NOT reset
+        HTTPError("bad gateway", response=response_502),  # retry=3 → break
+    ]
+
+    result, _ = fetch_all(
+        "token",
+        "api_url",
+        "org",
+        "query",
+        "repositories",
+        count=2,
+        retries=retries,
+    )
+    assert result.nodes == []
+
+
+@patch("cartography.intel.github.util.time.sleep")
+@patch("cartography.intel.github.util.handle_rate_limit_sleep")
+@patch("cartography.intel.github.util.fetch_page")
+def test_fetch_all_raises_after_retries_when_502_at_page_size_1(
+    mock_fetch_page: Mock,
+    mock_handle_rate_limit_sleep: Mock,
+    mock_sleep: Mock,
+) -> None:
+    """
+    When page size is already 1 and GitHub keeps returning 502, fetch_all should
+    eventually give up and return partial data rather than looping forever.
+    """
+    response_502 = Response()
+    response_502.status_code = 502
+    retries = 3
+    mock_fetch_page.side_effect = HTTPError("bad gateway", response=response_502)
+
+    result, _ = fetch_all(
+        "token",
+        "api_url",
+        "org",
+        "query",
+        "repositories",
+        count=1,
+        retries=retries,
+    )
+
+    assert mock_fetch_page.call_count == retries
+    assert result.nodes == []
 
 
 @patch("cartography.intel.github.util.time.sleep")

--- a/tests/unit/cartography/intel/github/test_github.py
+++ b/tests/unit/cartography/intel/github/test_github.py
@@ -381,26 +381,28 @@ def test_fetch_all_handles_retries(
     mock_sleep: Mock,
 ) -> None:
     """
-    Ensures that fetch_all returns partial data when exceeding retry limit
+    Ensures that fetch_all re-reaises the same exceptions when exceeding retry limit
     """
     # Arrange
+    exception = HTTPError
     response = Response()
     response.status_code = 500
-    mock_fetch_page.side_effect = HTTPError("my-error", response=response)
+    mock_fetch_page.side_effect = exception("my-error", response=response)
     retries = 3
     # Act
-    result, _ = fetch_all(
-        "my-token",
-        "my-api_url",
-        "my-org",
-        "my-query",
-        "my-resource",
-        retries=retries,
-    )
+    with pytest.raises(exception) as excinfo:
+        fetch_all(
+            "my-token",
+            "my-api_url",
+            "my-org",
+            "my-query",
+            "my-resource",
+            retries=retries,
+        )
     # Assert
     assert mock_handle_rate_limit_sleep.call_count == retries
     assert mock_fetch_page.call_count == retries
-    assert result.nodes == []
+    assert "my-error" in str(excinfo.value)
 
 
 @patch("cartography.intel.github.util.time.sleep")
@@ -439,15 +441,14 @@ def test_fetch_all_reduces_count_on_502(
 @patch("cartography.intel.github.util.time.sleep")
 @patch("cartography.intel.github.util.handle_rate_limit_sleep")
 @patch("cartography.intel.github.util.fetch_page")
-def test_fetch_all_returns_partial_data_after_exhausting_retries(
+def test_fetch_all_raises_on_partial_data_after_exhausting_retries(
     mock_fetch_page: Mock,
     mock_handle_rate_limit_sleep: Mock,
     mock_sleep: Mock,
 ) -> None:
     """
-    When retries are exhausted mid-pagination, fetch_all should return
-    whatever data was collected so far rather than raising, so the sync
-    can continue with partial data instead of failing entirely.
+    When retries are exhausted mid-pagination, fetch_all must raise rather than
+    return partial data that downstream cleanup would treat as a complete sync.
     """
     response_502 = Response()
     response_502.status_code = 502
@@ -472,16 +473,15 @@ def test_fetch_all_returns_partial_data_after_exhausting_retries(
         HTTPError("bad gateway", response=response_502),
     ]
 
-    result, _ = fetch_all(
-        "token",
-        "api_url",
-        "org",
-        "query",
-        "repositories",
-        retries=retries,
-    )
-
-    assert result.nodes == [{"name": "repo1"}, {"name": "repo2"}]
+    with pytest.raises(HTTPError):
+        fetch_all(
+            "token",
+            "api_url",
+            "org",
+            "query",
+            "repositories",
+            retries=retries,
+        )
 
 
 @patch("cartography.intel.github.util.time.sleep")
@@ -518,26 +518,26 @@ def test_fetch_all_raises_after_persistent_502s_at_degraded_page_size(
     # With the bug, retry resets to 0 on each success so it never accumulates
     # to `retries` and loops forever (StopIteration when mock is exhausted).
     # With the fix, retry is NOT reset on success at degraded page size, so it
-    # reaches `retries` and breaks, returning partial data.
+    # reaches `retries` and raises rather than looping forever.
     mock_fetch_page.side_effect = [
         HTTPError("bad gateway", response=response_502),  # reduces count 2→1
         HTTPError("bad gateway", response=response_502),  # retry=1
         success_with_next,  # retry should NOT reset
         HTTPError("bad gateway", response=response_502),  # retry=2
         success_with_next,  # retry should NOT reset
-        HTTPError("bad gateway", response=response_502),  # retry=3 → break
+        HTTPError("bad gateway", response=response_502),  # retry=3 → raise
     ]
 
-    result, _ = fetch_all(
-        "token",
-        "api_url",
-        "org",
-        "query",
-        "repositories",
-        count=2,
-        retries=retries,
-    )
-    assert result.nodes == []
+    with pytest.raises(HTTPError):
+        fetch_all(
+            "token",
+            "api_url",
+            "org",
+            "query",
+            "repositories",
+            count=2,
+            retries=retries,
+        )
 
 
 @patch("cartography.intel.github.util.time.sleep")
@@ -550,25 +550,26 @@ def test_fetch_all_raises_after_retries_when_502_at_page_size_1(
 ) -> None:
     """
     When page size is already 1 and GitHub keeps returning 502, fetch_all should
-    eventually give up and return partial data rather than looping forever.
+    eventually give up and raise rather than looping forever or returning
+    partial data.
     """
     response_502 = Response()
     response_502.status_code = 502
     retries = 3
     mock_fetch_page.side_effect = HTTPError("bad gateway", response=response_502)
 
-    result, _ = fetch_all(
-        "token",
-        "api_url",
-        "org",
-        "query",
-        "repositories",
-        count=1,
-        retries=retries,
-    )
+    with pytest.raises(HTTPError):
+        fetch_all(
+            "token",
+            "api_url",
+            "org",
+            "query",
+            "repositories",
+            count=1,
+            retries=retries,
+        )
 
     assert mock_fetch_page.call_count == retries
-    assert result.nodes == []
 
 
 @patch("cartography.intel.github.util.time.sleep")

--- a/tests/unit/cartography/intel/github/test_repos.py
+++ b/tests/unit/cartography/intel/github/test_repos.py
@@ -1507,6 +1507,7 @@ def test_sync_continues_when_privileged_fetch_fails(
         "token",
         "https://api.github.com/graphql",
         "example-org",
+        parallel_workers=1,
     )
     assert mock_get_repo_collaborators.call_count == 2
     mock_load.assert_called_once()


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

---

### Summary

Add incremental sync support for the GitHub intel module to significantly reduce API quota consumption and sync time on repeat runs. Two new opt-in CLI flags are introduced — both default to the existing behaviour so no changes are needed for deployments that do not set them.

**`--github-parallel-workers N`** (default `1`)
Runs per-repo API calls (dependency manifests, Actions workflows, commits) concurrently using a `ThreadPoolExecutor`. Workers only perform API calls; all Neo4j writes are sequenced on the main thread to avoid write contention.

**`--github-incremental-sync`** (default `False`)
Enables push-based skip optimisations across all downstream stages:

- `pushedAt` from the GitHub GraphQL API is stored as `pushedat` on `GitHubRepository` nodes at no extra API cost (one additional field in an already-paginated query).
- After all downstream stages complete, `_write_synced_pushedat()` writes `synced_pushedat = pushedat` on each node as a bookmark. Writing it at the _end_ ensures it always reflects the previous completed run when the next run's skip logic reads it.
- **Archived/disabled repos** are excluded from the Actions, manifest, and commit syncs.
- **Dependency manifests and workflow YAML** are not re-fetched for repos whose `pushedat` matches `synced_pushedat`. Existing nodes for skipped repos are "touched" (their `lastupdated` is set to the current update tag) so Cartography's `GraphJob` cleanup does not delete them.
- **Commits** are skipped for repos whose `pushedat` is older than the commit lookback window (`--github-commit-lookback-days`). Repos with no recorded `pushedat` are never skipped.

Also fixes a pre-existing bug in `fetch_all` (`util.py`) where a successful page at a degraded page size (after a 502) was resetting the retry counter, causing persistent 502s to loop indefinitely instead of eventually returning partial data.

---

### Related issues or links

- Fixes #

---

### Breaking changes

None. Both flags are opt-in and default to existing behaviour.

---

### How was this tested?

Integration and unit tests added. Linter passes (`make test_lint`). Also validated in production against a navikt organization with ~6,600 repositories using `--github-parallel-workers 4` and `--github-incremental-sync`.

---

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity

Cartography sync logs from a real production environment (navikt, ~6,600 repos):

**Runtime comparison — baseline vs incremental (run 9, 2026-07-10, 4 workers)**

| Stage | Baseline | With flags | Reduction |
|---|---|---|---|
| Dependency graph manifests | 30h 42m | 1h 36m | −95% |
| Actions (workflows/secrets/vars/envs) | 10h 55m | 1h 40m | −85% |
| Commits | 1h 12m | 33m | −54% |
| **Total** | **45h 45m** | **7h 12m** | **−84%** |

**Skip rates observed in run 9**

| Stage | Total repos | Skipped | Skip rate |
|---|---|---|---|
| Archived repos excluded from all syncs | 6,596 | 2,659 | 40% |
| Manifest re-fetch skipped (`pushedat` unchanged) | 3,937 | 3,543 | 90% |
| Workflow YAML re-fetch skipped (`pushedat` unchanged) | 3,937 | 3,543 | 90% |
| Stale commits skipped (no push in 30-day window) | 3,937 | 1,975 | 50% |

---

### Notes for reviewers

- The `synced_pushedat` bookmark is intentionally written **after** all downstream stages complete in `start_github_ingestion`. This ensures that if a sync is interrupted mid-run, the next run will still do a full pass on affected repos.
- Workers in the thread pool only perform API calls. All Neo4j writes happen on the main thread after each future resolves — this avoids concurrent write contention while still parallelising the dominant per-repo network I/O.
- The `fetch_all` retry fix is a standalone bug fix included in this PR since it was discovered during incremental sync development. It can be reviewed independently.