### PR TITLE
docs(aws): document glue:GetConnections permission gap

### DIFF
--- a/docs/root/modules/aws/config.md
+++ b/docs/root/modules/aws/config.md
@@ -18,6 +18,7 @@ Cartography supports single-account AWS syncs and multi-account AWS syncs. For A
    1. If you want to use AWS Inspector, the SecurityAudit policy does not yet contain permissions for `inspector2`, so you will also need the [AmazonInspector2ReadOnlyAccess policy](https://docs.aws.amazon.com/inspector/latest/user/security-iam-awsmanpol.html#security-iam-awsmanpol-AmazonInspector2ReadOnlyAccess).
    1. If you want to ingest EKS Access Entries, ensure the identity can call `eks:ListAccessEntries`. AWS SecurityAudit includes this action. Grant `eks:DescribeAccessEntry` as well to populate detailed entry fields such as access entry ARN, username, type, and Kubernetes groups.
    1. If you want to ingest allowlisted AWS-managed public SSM parameters, grant `ssm:GetParametersByPath` for the allowed `/aws/service/...` paths. The SecurityAudit policy does not include this permission.
+   1. If you want to ingest AWS Glue connections, grant `glue:GetConnections`. The SecurityAudit policy does not include this permission.
 1. Set up AWS credentials to this identity on your server, using a `config` and `credential` file.  For details, see AWS' [official guide](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
 1. [Optional] Configure Cartography's shared AWS client retry behavior with these environment variables:
    - `CARTOGRAPHY_AWS_RETRY_MODE`: Retry mode for Cartography-managed AWS clients. Valid values are `standard`, `adaptive`, and `legacy`. Default: `standard`.
@@ -170,3 +171,4 @@ For a complete and up-to-date list of resource identifiers that can be specified
 #### Additional Permissions
 
 - `ecr:pull_through_cache_rules` requires `ecr:DescribePullThroughCacheRules`.
+- `glue` requires `glue:GetConnections`, which is not included in the `SecurityAudit` managed policy.


### PR DESCRIPTION
### Type of change
- [x] Documentation update

### Summary

The AWS `glue` sync stage calls `glue:GetConnections` (via `get_paginator("get_connections")` in `cartography/intel/aws/glue.py`, inside `get_glue_connections`, reached from `glue.sync()`). This action is **not** included in AWS's `SecurityAudit` managed policy, which is the policy the setup guide instructs users to attach. Since `glue` is registered in `RESOURCE_FUNCTIONS` (`cartography/intel/aws/resources.py`), it runs in a default AWS sync and fails with `AccessDenied` on a role that only has the latest `SecurityAudit`.

This PR documents the extra permission in the AWS setup guide, mirroring the existing `inspector2` and public SSM parameter caveats:
- A note in the Single AWS Account Setup SecurityAudit caveats list.
- A bullet in the "Additional Permissions" section.

### Related issues or links

N/A

### How was this tested?

Documentation-only change. Verified the rendered markdown places the new caveat under the SecurityAudit list and the new bullet under "Additional Permissions", consistent with the surrounding items.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`). N/A for markdown-only doc change.
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

Documentation-only; no functional change to test.

### Notes for reviewers

The permission gap was observed empirically as an `AccessDenied` against a role using the latest `SecurityAudit` version. This mirrors the existing `inspector2` note (`docs/root/modules/aws/config.md`), which documents the analogous `SecurityAudit` gap for AWS Inspector.
