### PR TITLE
feat(ontology): materialize runtime container images

### DIFF
--- a/cartography/intel/ontology/__init__.py
+++ b/cartography/intel/ontology/__init__.py
@@ -7,6 +7,7 @@ import cartography.intel.ontology.dnsrecords
 import cartography.intel.ontology.loadbalancers
 import cartography.intel.ontology.packages
 import cartography.intel.ontology.publicips
+import cartography.intel.ontology.runtime_images
 import cartography.intel.ontology.users
 from cartography.analysis.aibom.analysis import AIBOM_RUNS_ON_CONTAINER
 from cartography.analysis.ontology.analysis import RESOLVED_IMAGE_JOBS
@@ -75,6 +76,11 @@ def run(neo4j_session: neo4j.Session, config: Config) -> None:
         common_job_parameters,
     )
     cartography.intel.ontology.publicips.sync(
+        neo4j_session,
+        config.update_tag,
+        common_job_parameters,
+    )
+    cartography.intel.ontology.runtime_images.sync(
         neo4j_session,
         config.update_tag,
         common_job_parameters,

--- a/cartography/intel/ontology/runtime_images.py
+++ b/cartography/intel/ontology/runtime_images.py
@@ -1,0 +1,98 @@
+import logging
+from typing import Any
+
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.models.ontology.runtime_image import RuntimeImageSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+_RUNTIME_IMAGES_QUERY = """
+CALL {
+    MATCH (workload:Container)
+    WHERE toLower(coalesce(workload._ont_state, '')) = 'running'
+    RETURN workload, 'container' AS workload_kind
+
+    UNION
+
+    MATCH (workload:Function)
+    WHERE workload._ont_deployment_type = 'container'
+    RETURN workload, 'function' AS workload_kind
+}
+WITH workload, workload_kind
+WHERE workload._ont_image IS NOT NULL
+  AND trim(workload._ont_image) <> ''
+  AND workload._ont_image_digest IS NOT NULL
+  AND trim(workload._ont_image_digest) <> ''
+  AND NOT EXISTS {
+      MATCH (workload)-[:HAS_IMAGE]->(existing:Image)
+      WHERE NOT existing:RuntimeImage
+        AND coalesce(existing._ont_digest, existing.digest) = workload._ont_image_digest
+  }
+WITH workload._ont_image_digest AS digest,
+     collect(DISTINCT workload._ont_image) AS runtime_refs,
+     collect(DISTINCT CASE WHEN workload_kind = 'container' THEN workload.id END) AS raw_container_ids,
+     collect(DISTINCT CASE WHEN workload_kind = 'function' THEN workload.id END) AS raw_function_ids
+RETURN digest,
+       runtime_refs,
+       [id IN raw_container_ids WHERE id IS NOT NULL] AS container_ids,
+       [id IN raw_function_ids WHERE id IS NOT NULL] AS function_ids
+ORDER BY digest
+"""
+
+
+def _digest_ref(image_ref: str, digest: str) -> str:
+    repository = image_ref.split("@", 1)[0]
+    last_slash = repository.rfind("/")
+    last_colon = repository.rfind(":")
+    if last_colon > last_slash:
+        repository = repository[:last_colon]
+    return f"{repository}@{digest}"
+
+
+def get_runtime_images(neo4j_session: neo4j.Session) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for record in neo4j_session.run(_RUNTIME_IMAGES_QUERY):
+        digest = record["digest"].strip()
+        runtime_refs = sorted(
+            {
+                ref.strip()
+                for ref in record["runtime_refs"]
+                if isinstance(ref, str) and ref.strip()
+            },
+        )
+        if not runtime_refs:
+            continue
+        rows.append(
+            {
+                "id": f"runtime-image:{digest}",
+                "digest": digest,
+                "uri": _digest_ref(runtime_refs[0], digest),
+                "runtime_refs": runtime_refs,
+                "container_ids": record["container_ids"],
+                "function_ids": record["function_ids"],
+            },
+        )
+    return rows
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    runtime_images = get_runtime_images(neo4j_session)
+    load(
+        neo4j_session,
+        RuntimeImageSchema(),
+        runtime_images,
+        lastupdated=update_tag,
+    )
+    GraphJob.from_node_schema(RuntimeImageSchema(), common_job_parameters).run(
+        neo4j_session,
+    )
+    logger.info("Loaded %d runtime image(s)", len(runtime_images))

--- a/cartography/intel/trivy/__init__.py
+++ b/cartography/intel/trivy/__init__.py
@@ -20,6 +20,7 @@ from cartography.intel.common.report_reader_builder import (
     build_report_reader_for_source,
 )
 from cartography.intel.common.report_source import parse_report_source
+from cartography.intel.ontology.runtime_images import _digest_ref
 from cartography.intel.trivy.scanner import cleanup
 from cartography.intel.trivy.scanner import sync_single_image
 from cartography.stats import get_stats_client
@@ -130,12 +131,40 @@ def _get_gitlab_scan_targets_and_aliases(
     return image_uris, digest_aliases
 
 
+def _get_runtime_image_scan_targets_and_aliases(
+    neo4j_session: Session,
+) -> tuple[set[str], dict[str, str]]:
+    image_uris: set[str] = set()
+    digest_aliases: dict[str, str] = {}
+    records = neo4j_session.run(
+        """
+        MATCH (image:RuntimeImage)
+        WHERE image.digest IS NOT NULL
+        RETURN image.digest AS digest,
+               image.uri AS uri,
+               image.runtime_refs AS runtime_refs
+        ORDER BY image.id
+        """,
+    )
+    for record in records:
+        digest = record["digest"]
+        runtime_refs = sorted(set(record["runtime_refs"] or []))
+        image_uris.update(runtime_refs)
+        if record["uri"]:
+            digest_aliases[record["uri"]] = (
+                runtime_refs[0] if runtime_refs else record["uri"]
+            )
+        for runtime_ref in runtime_refs:
+            digest_aliases[_digest_ref(runtime_ref, digest)] = runtime_ref
+    return image_uris, digest_aliases
+
+
 def _get_scan_targets_and_aliases(
     neo4j_session: Session,
     account_ids: list[str] | None = None,
 ) -> tuple[set[str], dict[str, str]]:
     """
-    Return image URIs and digest aliases for ECR, GCP, and GitLab container images.
+    Return image URIs and digest aliases for known and runtime container images.
     """
     # Get ECR targets
     ecr_uris, ecr_aliases = _get_ecr_scan_targets_and_aliases(
@@ -148,9 +177,18 @@ def _get_scan_targets_and_aliases(
     # Get GitLab targets
     gitlab_uris, gitlab_aliases = _get_gitlab_scan_targets_and_aliases(neo4j_session)
 
+    runtime_uris, runtime_aliases = _get_runtime_image_scan_targets_and_aliases(
+        neo4j_session,
+    )
+
     # Merge results
-    image_uris = ecr_uris | gcp_uris | gitlab_uris
-    digest_aliases = {**ecr_aliases, **gcp_aliases, **gitlab_aliases}
+    image_uris = ecr_uris | gcp_uris | gitlab_uris | runtime_uris
+    digest_aliases = {
+        **ecr_aliases,
+        **gcp_aliases,
+        **gitlab_aliases,
+        **runtime_aliases,
+    }
 
     return image_uris, digest_aliases
 

--- a/cartography/intel/trivy/__init__.py
+++ b/cartography/intel/trivy/__init__.py
@@ -133,9 +133,10 @@ def _get_gitlab_scan_targets_and_aliases(
 
 def _get_runtime_image_scan_targets_and_aliases(
     neo4j_session: Session,
-) -> tuple[set[str], dict[str, str]]:
+) -> tuple[set[str], dict[str, str], dict[str, set[str]]]:
     image_uris: set[str] = set()
     digest_aliases: dict[str, str] = {}
+    target_digests: dict[str, set[str]] = {}
     records = neo4j_session.run(
         """
         MATCH (image:RuntimeImage)
@@ -151,18 +152,22 @@ def _get_runtime_image_scan_targets_and_aliases(
         runtime_refs = sorted(set(record["runtime_refs"] or []))
         image_uris.update(runtime_refs)
         if record["uri"]:
+            target_digests.setdefault(record["uri"], set()).add(digest)
             digest_aliases[record["uri"]] = (
                 runtime_refs[0] if runtime_refs else record["uri"]
             )
         for runtime_ref in runtime_refs:
-            digest_aliases[_digest_ref(runtime_ref, digest)] = runtime_ref
-    return image_uris, digest_aliases
+            digest_ref = _digest_ref(runtime_ref, digest)
+            digest_aliases[digest_ref] = runtime_ref
+            target_digests.setdefault(runtime_ref, set()).add(digest)
+            target_digests.setdefault(digest_ref, set()).add(digest)
+    return image_uris, digest_aliases, target_digests
 
 
 def _get_scan_targets_and_aliases(
     neo4j_session: Session,
     account_ids: list[str] | None = None,
-) -> tuple[set[str], dict[str, str]]:
+) -> tuple[set[str], dict[str, str], dict[str, set[str]]]:
     """
     Return image URIs and digest aliases for known and runtime container images.
     """
@@ -177,9 +182,11 @@ def _get_scan_targets_and_aliases(
     # Get GitLab targets
     gitlab_uris, gitlab_aliases = _get_gitlab_scan_targets_and_aliases(neo4j_session)
 
-    runtime_uris, runtime_aliases = _get_runtime_image_scan_targets_and_aliases(
-        neo4j_session,
-    )
+    (
+        runtime_uris,
+        runtime_aliases,
+        runtime_target_digests,
+    ) = _get_runtime_image_scan_targets_and_aliases(neo4j_session)
 
     # Merge results
     image_uris = ecr_uris | gcp_uris | gitlab_uris | runtime_uris
@@ -190,7 +197,7 @@ def _get_scan_targets_and_aliases(
         **runtime_aliases,
     }
 
-    return image_uris, digest_aliases
+    return image_uris, digest_aliases, runtime_target_digests
 
 
 @timeit
@@ -201,7 +208,7 @@ def get_scan_targets(
     """
     Return list of ECR images from all accounts in the graph.
     """
-    image_uris, _ = _get_scan_targets_and_aliases(neo4j_session, account_ids)
+    image_uris, _, _ = _get_scan_targets_and_aliases(neo4j_session, account_ids)
     return image_uris
 
 
@@ -209,13 +216,15 @@ def _prepare_trivy_data(
     trivy_data: dict[str, Any],
     image_uris: set[str],
     digest_aliases: dict[str, str],
+    runtime_target_digests: dict[str, set[str]],
     source: str,
-) -> tuple[dict[str, Any], str] | None:
+) -> tuple[dict[str, Any], str, str | None] | None:
     """
     Determine the tag URI that corresponds to this Trivy payload.
 
-    Returns (trivy_data, display_uri) if the payload can be linked to an image present
-    in the graph; otherwise returns None so the caller can skip ingestion.
+    Returns the payload, display URI, and optional runtime target digest when the
+    payload can be linked to an image present in the graph. The override keeps
+    findings attached to the workload digest when Trivy reports a platform digest.
     """
 
     artifact_name = (trivy_data.get("ArtifactName") or "").strip()
@@ -231,9 +240,17 @@ def _prepare_trivy_data(
     candidates.extend(stripped_tags_digests)
 
     display_uri: str | None = None
+    image_digest_override: str | None = None
 
     for candidate in candidates:
         if not candidate:
+            continue
+        target_digests = runtime_target_digests.get(candidate, set())
+        if len(target_digests) == 1:
+            image_digest_override = next(iter(target_digests))
+            display_uri = digest_aliases.get(candidate, candidate)
+            break
+        if len(target_digests) > 1:
             continue
         if candidate in image_uris:
             display_uri = candidate
@@ -250,7 +267,7 @@ def _prepare_trivy_data(
         )
         return None
 
-    return trivy_data, display_uri
+    return trivy_data, display_uri, image_digest_override
 
 
 @timeit
@@ -271,7 +288,11 @@ def sync_trivy_from_report_reader(
     """
     logger.info("Using Trivy scan results from %s", reader.source_uri)
 
-    image_uris, digest_aliases = _get_scan_targets_and_aliases(neo4j_session)
+    (
+        image_uris,
+        digest_aliases,
+        runtime_target_digests,
+    ) = _get_scan_targets_and_aliases(neo4j_session)
     json_files = filter_report_refs(
         reader.list_reports(),
         suffix=".json",
@@ -306,17 +327,19 @@ def sync_trivy_from_report_reader(
             trivy_data,
             image_uris=image_uris,
             digest_aliases=digest_aliases,
+            runtime_target_digests=runtime_target_digests,
             source=ref.uri,
         )
         if prepared is None:
             continue
 
-        prepared_data, display_uri = prepared
+        prepared_data, display_uri, image_digest_override = prepared
         sync_single_image(
             neo4j_session,
             prepared_data,
             display_uri,
             update_tag,
+            image_digest_override=image_digest_override,
         )
         processed_reports += 1
 

--- a/cartography/intel/trivy/scanner.py
+++ b/cartography/intel/trivy/scanner.py
@@ -288,6 +288,7 @@ def sync_single_image(
     trivy_data: dict,
     source: str,
     update_tag: int,
+    image_digest_override: str | None = None,
 ) -> None:
     """
     Sync a single image's Trivy scan results to Neo4j.
@@ -297,9 +298,11 @@ def sync_single_image(
         trivy_data: Raw Trivy JSON data
         source: Source identifier for logging (file path or image URI)
         update_tag: Update tag for tracking
+        image_digest_override: Workload-observed digest to use for image relationships
     """
     try:
-        _, results, image_digest = _parse_trivy_data(trivy_data, source)
+        _, results, parsed_image_digest = _parse_trivy_data(trivy_data, source)
+        image_digest = image_digest_override or parsed_image_digest
 
         # Transform all data in one pass
         findings_list, packages_list, fixes_list = transform_scan_results(

--- a/cartography/models/ontology/constraints.py
+++ b/cartography/models/ontology/constraints.py
@@ -180,6 +180,8 @@ from cartography.models.kubernetes.statefulsets import (
 from cartography.models.kubernetes.users import KubernetesUserToAWSRoleRel
 from cartography.models.oci.group import OCIGroupToOCIUserRel
 from cartography.models.oci.policy import OCIPolicyToGroupRefRel
+from cartography.models.ontology.runtime_image import RuntimeImageToContainerRel
+from cartography.models.ontology.runtime_image import RuntimeImageToFunctionRel
 from cartography.models.openai.adminapikey import OpenAIAdminApiKeyToSARel
 from cartography.models.openai.adminapikey import OpenAIAdminApiKeyToUserRel
 from cartography.models.openai.apikey import OpenAIApiKeyToSARel
@@ -463,5 +465,7 @@ LEGACY_REL_WHITELIST: frozenset[type] = frozenset(
         AzureFunctionAppToGitLabContainerImageRel,
         AzureFunctionAppToGCPArtifactRegistryImageRel,
         AzureFunctionAppToGitHubContainerImageRel,
+        RuntimeImageToContainerRel,
+        RuntimeImageToFunctionRel,
     }
 )

--- a/cartography/models/ontology/mapping/data/images.py
+++ b/cartography/models/ontology/mapping/data/images.py
@@ -92,10 +92,24 @@ scaleway_mapping = OntologyMapping(
     ],
 )
 
+ontology_mapping = OntologyMapping(
+    module_name="ontology",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="RuntimeImage",
+            fields=[
+                OntologyFieldMapping(ontology_field="digest", node_field="digest"),
+                OntologyFieldMapping(ontology_field="uri", node_field="uri"),
+            ],
+        ),
+    ],
+)
+
 IMAGES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws": aws_ecr_mapping,
     "gcp": gcp_mapping,
     "github": github_mapping,
     "gitlab": gitlab_mapping,
+    "ontology": ontology_mapping,
     "scaleway": scaleway_mapping,
 }

--- a/cartography/models/ontology/runtime_image.py
+++ b/cartography/models/ontology/runtime_image.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class RuntimeImageNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id")
+    digest: PropertyRef = PropertyRef("digest")
+    uri: PropertyRef = PropertyRef("uri")
+    runtime_refs: PropertyRef = PropertyRef("runtime_refs")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class RuntimeImageHasImageRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class RuntimeImageToContainerRel(CartographyRelSchema):
+    target_node_label: str = "Container"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("container_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_IMAGE"
+    properties: RuntimeImageHasImageRelProperties = RuntimeImageHasImageRelProperties()
+
+
+@dataclass(frozen=True)
+class RuntimeImageToFunctionRel(CartographyRelSchema):
+    target_node_label: str = "Function"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("function_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_IMAGE"
+    properties: RuntimeImageHasImageRelProperties = RuntimeImageHasImageRelProperties()
+
+
+@dataclass(frozen=True)
+class RuntimeImageSchema(CartographyNodeSchema):
+    label: str = "RuntimeImage"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["Image", "Ontology"])
+    properties: RuntimeImageNodeProperties = RuntimeImageNodeProperties()
+    scoped_cleanup: bool = False
+    other_relationships: OtherRelationships = OtherRelationships(
+        [RuntimeImageToContainerRel(), RuntimeImageToFunctionRel()],
+    )

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -79,6 +79,9 @@ IM -- HAS_LAYER --> IL{{ImageLayer}}
 CT -- HAS_IMAGE --> IM
 CT -- HAS_IMAGE --> IML
 CT -- RESOLVED_IMAGE --> IM
+RI(RuntimeImage) -- BUILT_ON --> DSPI{{DockerScoutPublicImage}}
+CT -- HAS_IMAGE --> RI
+FN -- HAS_IMAGE --> RI
 CS -- HAS_RUNTIME_IMAGE --> IM
 ```
 
@@ -411,6 +414,7 @@ GCP Cloud Run Services, Jobs and Revisions are themselves **not** modeled as `Co
     (:Container)-[:HAS_IMAGE]->(:Image)
     (:Container)-[:HAS_IMAGE]->(:ImageManifestList)
     ```
+  When no provider image node exists for the runtime digest, the ontology sync creates a `RuntimeImage` target instead.
 - `Container` is connected to a concrete single platform `Image` that actually ran via `RESOLVED_IMAGE`. This edge is produced by `RESOLVED_IMAGE_JOBS` in `cartography/analysis/ontology/analysis.py`, which runs after the ontology stage. It is only created when the target can be deterministically identified:
     - When `HAS_IMAGE` already points at an `:Image` (not `:ImageManifestList`), `RESOLVED_IMAGE` is created directly.
     - When `HAS_IMAGE` points at an `:ImageManifestList`, `RESOLVED_IMAGE` is created to the child `:Image` reached via `CONTAINS_IMAGE` whose architecture matches the container's `architecture_normalized`. If zero or more than one child match, no edge is created (determinism guard).
@@ -1188,6 +1192,36 @@ It generalizes concepts like AWS AWSECRImage (type=image), GCP Container Images,
     ```
     (:Package)-[:DEPLOYED]->(:Image)
     ```
+
+
+### RuntimeImage
+
+```{note}
+RuntimeImage is an abstract ontology node with the `Image` semantic label.
+```
+
+A runtime image represents a digest observed on a running container or container-based function when no provider-owned image node exists for that digest. It preserves every declared runtime reference without implying that the image is customer-built or that its base image can be edited.
+
+| Field | Description |
+|-------|-------------|
+| **id** | The unique identifier derived from the image digest. |
+| digest | The content-addressable digest observed on the workload. |
+| uri | A deterministic digest-qualified image reference. |
+| runtime_refs | Sorted declared image references observed for the digest. |
+| lastupdated | Timestamp of the last ontology sync that observed the image. |
+
+#### Relationships
+
+- Running containers and container-based functions reference the runtime image through `HAS_IMAGE`. The existing ontology analysis then derives `RESOLVED_IMAGE` because `RuntimeImage` also carries the `Image` label:
+    ```
+    (:Container)-[:HAS_IMAGE]->(:RuntimeImage:Image)
+    (:Function)-[:HAS_IMAGE]->(:RuntimeImage:Image)
+    ```
+- Docker Scout may attach its existing public-base recommendation without asserting source inheritance:
+    ```
+    (:RuntimeImage)-[:BUILT_ON]->(:DockerScoutPublicImage)
+    ```
+- Runtime image materialization never creates `BUILT_FROM`.
 
 
 ### ImageAttestation

--- a/tests/integration/cartography/intel/ontology/test_runtime_images.py
+++ b/tests/integration/cartography/intel/ontology/test_runtime_images.py
@@ -1,0 +1,165 @@
+import cartography.intel.ontology.runtime_images
+from cartography.analysis.ontology.analysis import RESOLVED_IMAGE_JOBS
+from cartography.intel.docker_scout.scanner import attach_public_image_to_target_image
+from cartography.intel.docker_scout.scanner import load_public_image
+from cartography.intel.trivy import _get_runtime_image_scan_targets_and_aliases
+from cartography.util import run_typed_analysis_job
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_DIGEST = "sha256:deadbeef"
+
+
+def _sync_runtime_images(neo4j_session, update_tag=TEST_UPDATE_TAG):
+    params = {"UPDATE_TAG": update_tag}
+    cartography.intel.ontology.runtime_images.sync(
+        neo4j_session,
+        update_tag,
+        params,
+    )
+    for job in RESOLVED_IMAGE_JOBS:
+        run_typed_analysis_job(job, neo4j_session, params)
+
+
+def test_runtime_image_supports_scan_and_scout_without_base_lineage(neo4j_session):
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        CREATE (first:Container {id: 'container-1'})
+        SET first._ont_state = 'running',
+            first._ont_image = 'ghcr.io/subimagesec/subimage-outpost:latest',
+            first._ont_image_digest = $digest
+        CREATE (second:Container {id: 'container-2'})
+        SET second._ont_state = 'running',
+            second._ont_image = 'ghcr.io/subimagesec/subimage-outpost:v1',
+            second._ont_image_digest = $digest
+        CREATE (function:Function {id: 'function-1'})
+        SET function._ont_deployment_type = 'container',
+            function._ont_image = 'ghcr.io/subimagesec/subimage-outpost:latest',
+            function._ont_image_digest = $digest
+        """,
+        digest=TEST_DIGEST,
+    )
+
+    # Act
+    _sync_runtime_images(neo4j_session)
+    load_public_image(
+        neo4j_session,
+        {
+            "id": "alpine:3.20",
+            "name": "alpine",
+            "tag": "3.20",
+            "digest": "sha256:base",
+        },
+        TEST_UPDATE_TAG,
+    )
+    attach_public_image_to_target_image(
+        neo4j_session,
+        {"id": "alpine:3.20", "target_digest": "deadbeef"},
+        TEST_UPDATE_TAG,
+    )
+
+    # Assert
+    assert check_nodes(
+        neo4j_session,
+        "RuntimeImage",
+        ["id", "digest", "uri", "_ont_digest"],
+    ) == {
+        (
+            f"runtime-image:{TEST_DIGEST}",
+            TEST_DIGEST,
+            f"ghcr.io/subimagesec/subimage-outpost@{TEST_DIGEST}",
+            TEST_DIGEST,
+        ),
+    }
+    assert neo4j_session.run(
+        "MATCH (image:RuntimeImage) RETURN image.runtime_refs AS refs",
+    ).single()["refs"] == [
+        "ghcr.io/subimagesec/subimage-outpost:latest",
+        "ghcr.io/subimagesec/subimage-outpost:v1",
+    ]
+    assert check_rels(
+        neo4j_session,
+        "Container",
+        "id",
+        "RuntimeImage",
+        "id",
+        "HAS_IMAGE",
+    ) == {
+        ("container-1", f"runtime-image:{TEST_DIGEST}"),
+        ("container-2", f"runtime-image:{TEST_DIGEST}"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "Function",
+        "id",
+        "RuntimeImage",
+        "id",
+        "RESOLVED_IMAGE",
+    ) == {("function-1", f"runtime-image:{TEST_DIGEST}")}
+    assert check_rels(
+        neo4j_session,
+        "RuntimeImage",
+        "id",
+        "DockerScoutPublicImage",
+        "id",
+        "BUILT_ON",
+    ) == {(f"runtime-image:{TEST_DIGEST}", "alpine:3.20")}
+    assert (
+        neo4j_session.run(
+            "MATCH (:RuntimeImage)-[r:BUILT_FROM]->() RETURN count(r) AS count",
+        ).single()["count"]
+        == 0
+    )
+    assert _get_runtime_image_scan_targets_and_aliases(neo4j_session) == (
+        {
+            "ghcr.io/subimagesec/subimage-outpost:latest",
+            "ghcr.io/subimagesec/subimage-outpost:v1",
+        },
+        {
+            f"ghcr.io/subimagesec/subimage-outpost@{TEST_DIGEST}": (
+                "ghcr.io/subimagesec/subimage-outpost:v1"
+            ),
+        },
+    )
+
+
+def test_provider_image_replaces_runtime_image(neo4j_session):
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        CREATE (container:Container {id: 'container-1'})
+        SET container._ont_state = 'running',
+            container._ont_image = 'ghcr.io/example/app:latest',
+            container._ont_image_digest = $digest
+        """,
+        digest=TEST_DIGEST,
+    )
+    _sync_runtime_images(neo4j_session)
+    neo4j_session.run(
+        """
+        MATCH (container:Container {id: 'container-1'})
+        CREATE (image:Image:GitHubContainerImage {id: $digest})
+        SET image.digest = $digest, image._ont_digest = $digest
+        CREATE (container)-[:HAS_IMAGE {lastupdated: $update_tag}]->(image)
+        """,
+        digest=TEST_DIGEST,
+        update_tag=TEST_UPDATE_TAG + 1,
+    )
+
+    # Act
+    _sync_runtime_images(neo4j_session, TEST_UPDATE_TAG + 1)
+
+    # Assert
+    assert check_nodes(neo4j_session, "RuntimeImage", ["id"]) == set()
+    assert check_rels(
+        neo4j_session,
+        "Container",
+        "id",
+        "GitHubContainerImage",
+        "id",
+        "HAS_IMAGE",
+    ) == {("container-1", TEST_DIGEST)}

--- a/tests/integration/cartography/intel/ontology/test_runtime_images.py
+++ b/tests/integration/cartography/intel/ontology/test_runtime_images.py
@@ -3,6 +3,8 @@ from cartography.analysis.ontology.analysis import RESOLVED_IMAGE_JOBS
 from cartography.intel.docker_scout.scanner import attach_public_image_to_target_image
 from cartography.intel.docker_scout.scanner import load_public_image
 from cartography.intel.trivy import _get_runtime_image_scan_targets_and_aliases
+from cartography.intel.trivy import _prepare_trivy_data
+from cartography.intel.trivy.scanner import sync_single_image
 from cartography.util import run_typed_analysis_job
 from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
@@ -113,7 +115,8 @@ def test_runtime_image_supports_scan_and_scout_without_base_lineage(neo4j_sessio
         ).single()["count"]
         == 0
     )
-    assert _get_runtime_image_scan_targets_and_aliases(neo4j_session) == (
+    runtime_targets = _get_runtime_image_scan_targets_and_aliases(neo4j_session)
+    assert runtime_targets == (
         {
             "ghcr.io/subimagesec/subimage-outpost:latest",
             "ghcr.io/subimagesec/subimage-outpost:v1",
@@ -123,7 +126,69 @@ def test_runtime_image_supports_scan_and_scout_without_base_lineage(neo4j_sessio
                 "ghcr.io/subimagesec/subimage-outpost:v1"
             ),
         },
+        {
+            "ghcr.io/subimagesec/subimage-outpost:latest": {TEST_DIGEST},
+            "ghcr.io/subimagesec/subimage-outpost:v1": {TEST_DIGEST},
+            f"ghcr.io/subimagesec/subimage-outpost@{TEST_DIGEST}": {TEST_DIGEST},
+        },
     )
+
+    platform_digest = "sha256:platform"
+    trivy_data = {
+        "ArtifactName": "ghcr.io/subimagesec/subimage-outpost:latest",
+        "Metadata": {
+            "RepoTags": ["ghcr.io/subimagesec/subimage-outpost:latest"],
+            "RepoDigests": [f"ghcr.io/subimagesec/subimage-outpost@{platform_digest}"],
+        },
+        "Results": [
+            {
+                "Class": "os-pkgs",
+                "Type": "alpine",
+                "Vulnerabilities": [
+                    {
+                        "VulnerabilityID": "CVE-2026-0001",
+                        "PkgName": "libcrypto",
+                        "InstalledVersion": "1.0",
+                        "FixedVersion": "1.1",
+                        "Severity": "HIGH",
+                    },
+                ],
+            },
+        ],
+    }
+    prepared = _prepare_trivy_data(
+        trivy_data,
+        image_uris=runtime_targets[0],
+        digest_aliases=runtime_targets[1],
+        runtime_target_digests=runtime_targets[2],
+        source="runtime-image.json",
+    )
+    assert prepared is not None
+    prepared_data, display_uri, image_digest_override = prepared
+    assert image_digest_override == TEST_DIGEST
+    sync_single_image(
+        neo4j_session,
+        prepared_data,
+        display_uri,
+        TEST_UPDATE_TAG,
+        image_digest_override=image_digest_override,
+    )
+    assert check_rels(
+        neo4j_session,
+        "TrivyPackage",
+        "id",
+        "RuntimeImage",
+        "id",
+        "DEPLOYED",
+    ) == {("1.0|libcrypto", f"runtime-image:{TEST_DIGEST}")}
+    assert check_rels(
+        neo4j_session,
+        "TrivyImageFinding",
+        "id",
+        "RuntimeImage",
+        "id",
+        "AFFECTS",
+    ) == {("TIF|CVE-2026-0001", f"runtime-image:{TEST_DIGEST}")}
 
 
 def test_provider_image_replaces_runtime_image(neo4j_session):

--- a/tests/unit/cartography/intel/trivy/test_scanner.py
+++ b/tests/unit/cartography/intel/trivy/test_scanner.py
@@ -435,6 +435,7 @@ def test_sync_trivy_from_s3_no_matches(
     mock_get_targets_and_aliases.return_value = (
         {"987654321098.dkr.ecr.us-east-1.amazonaws.com/my-repo:4e380d"},
         {},
+        {},
     )
     mock_list_objects.return_value = []  # No scan results available
 
@@ -470,6 +471,7 @@ def test_sync_trivy_from_s3_digest_files(
     mock_get_targets_and_aliases.return_value = (
         {display_uri},
         {digest_uri: display_uri},
+        {},
     )
     mock_list_objects.return_value = [
         ReportRef(
@@ -517,6 +519,7 @@ def test_sync_trivy_from_report_reader_skips_cleanup_after_parse_failure(
     mock_get_targets_and_aliases.return_value = (
         {"123456789012.dkr.ecr.us-west-2.amazonaws.com/app:latest"},
         {},
+        {},
     )
     reader = MagicMock()
     reader.source_uri = "s3://example-bucket/reports/trivy/"
@@ -548,7 +551,7 @@ def test_sync_trivy_skips_cleanup_when_some_reports_succeed_and_some_fail(
 ):
     """If 1 report ingests cleanly but another fails to read, cleanup is skipped to preserve data."""
     image_uri = "123456789012.dkr.ecr.us-west-2.amazonaws.com/app:latest"
-    mock_get_targets_and_aliases.return_value = ({image_uri}, {})
+    mock_get_targets_and_aliases.return_value = ({image_uri}, {}, {})
 
     good_ref = ReportRef(
         uri="s3://example-bucket/reports/trivy/good.json", name="good.json"
@@ -593,6 +596,7 @@ def test_sync_trivy_skips_cleanup_when_no_reports_match_graph(
     """If reads succeed but no reports match an image in the graph, cleanup is skipped."""
     mock_get_targets_and_aliases.return_value = (
         {"some-other-image:tag"},
+        {},
         {},
     )
 


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):

### Summary

Materialize a digest-addressed `RuntimeImage:Image:Ontology` for running containers and container-based functions when provider discovery has no usable image node. This lets downstream scanners and Docker Scout operate on public vendor images while preserving the distinction between an observed runtime image and a customer-built base image.

Runtime images retain sorted declared references, create only workload `HAS_IMAGE` relationships, participate in the existing `RESOLVED_IMAGE` analysis, and are eligible for the existing Docker Scout `BUILT_ON` relationship. Runtime materialization never creates `BUILT_FROM`.

Trivy target matching now recognizes the runtime image URI, declared references, and digest-qualified aliases.

### Related issues or links

- [SUB-1966](https://linear.app/subimagesec/issue/SUB-1966/surface-vendor-cves-with-available-fixes)

### Breaking changes

None.

### How was this tested?

- `uv run pre-commit run --files ...`
- 52 focused ontology mapping, Trivy, Docker Scout, and runtime-image integration tests
- 44 focused tests after consolidating digest-reference parsing
- 18 post-review ontology, Trivy, and relationship-governance tests, including a multi-arch platform-digest mismatch

The integration coverage proves runtime node deduplication, Container/Function `HAS_IMAGE`, derived `RESOLVED_IMAGE`, Docker Scout `BUILT_ON` without `BUILT_FROM`, Trivy aliases, workload-digest retention when Trivy reports a platform digest, and cleanup when a provider image becomes available.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

This is an ontology-derived internal entity and was validated with Neo4j integration tests. A customer-environment sync is intentionally deferred until SubImage consumes the branch.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the schema README (the linked `docs/schema/README.md` does not exist on the current `master` branch).

#### If you are implementing a new intel module
- [x] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).

### Notes for reviewers

Please focus on the ownership boundary: `RuntimeImage` represents observation only. Existing provider-owned image discovery remains authoritative, and the runtime node is cleaned up once a matching provider image exists.
