### PR TITLE
feat(scaleway): add instance autoscaling resources

### DIFF
--- a/cartography/intel/scaleway/__init__.py
+++ b/cartography/intel/scaleway/__init__.py
@@ -25,6 +25,7 @@ import cartography.intel.scaleway.iam.permissionsets
 import cartography.intel.scaleway.iam.policies
 import cartography.intel.scaleway.iam.sshkeys
 import cartography.intel.scaleway.iam.users
+import cartography.intel.scaleway.instances.autoscaling
 import cartography.intel.scaleway.instances.flexibleips
 import cartography.intel.scaleway.instances.instances
 import cartography.intel.scaleway.instances.securitygroups
@@ -273,6 +274,17 @@ def start_scaleway_ingestion(neo4j_session: neo4j.Session, config: Config) -> No
 
     # Load Balancers
     cartography.intel.scaleway.loadbalancers.loadbalancers.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=config.scaleway_org,
+        projects_id=projects_id,
+        update_tag=config.update_tag,
+    )
+
+    # Instance Autoscaling (loaded after PrivateNetworks and Load Balancers so
+    # the ATTACHED_TO / USES edges resolve).
+    cartography.intel.scaleway.instances.autoscaling.sync(
         neo4j_session,
         client,
         common_job_parameters,

--- a/cartography/intel/scaleway/instances/autoscaling.py
+++ b/cartography/intel/scaleway/instances/autoscaling.py
@@ -1,0 +1,263 @@
+import logging
+from typing import Any
+
+import neo4j
+import scaleway
+from scaleway.autoscaling.v1alpha1 import AutoscalingV1Alpha1API
+from scaleway.autoscaling.v1alpha1 import InstanceGroup
+from scaleway.autoscaling.v1alpha1 import InstancePolicy
+from scaleway.autoscaling.v1alpha1 import InstanceTemplate
+from scaleway_core.api import ScalewayException
+
+from cartography.client.core.tx import load
+from cartography.client.core.tx import load_matchlinks
+from cartography.graph.job import GraphJob
+from cartography.intel.scaleway.utils import list_all_zones
+from cartography.intel.scaleway.utils import scaleway_obj_to_dict
+from cartography.models.scaleway.instance.autoscaling import ScalewayInstanceGroupSchema
+from cartography.models.scaleway.instance.autoscaling import (
+    ScalewayInstanceTemplateSchema,
+)
+from cartography.models.scaleway.instance.autoscaling import ScalewayScalingPolicySchema
+from cartography.models.scaleway.loadbalancer.loadbalancer import (
+    ScalewayLoadBalancerToPrivateNetworkMatchLink,
+)
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: scaleway.Client,
+    common_job_parameters: dict[str, Any],
+    org_id: str,
+    projects_id: list[str],
+    update_tag: int,
+) -> None:
+    result = get(client)
+    if result is None:
+        return
+    templates, groups, policies = result
+    (
+        templates_by_project,
+        groups_by_project,
+        policies_by_project,
+        lb_private_network_links_by_project,
+    ) = transform(
+        templates,
+        groups,
+        policies,
+        projects_id,
+    )
+    load_autoscaling_resources(
+        neo4j_session,
+        templates_by_project,
+        groups_by_project,
+        policies_by_project,
+        update_tag,
+    )
+    load_lb_private_network_links(
+        neo4j_session,
+        lb_private_network_links_by_project,
+        update_tag,
+    )
+    cleanup(neo4j_session, projects_id, common_job_parameters)
+
+
+@timeit
+def get(
+    client: scaleway.Client,
+) -> tuple[list[InstanceTemplate], list[InstanceGroup], list[InstancePolicy]] | None:
+    """Return org-wide Autoscaling templates, groups, and policies, or None if
+    Autoscaling cannot be read. None signals the caller to skip load/cleanup
+    entirely rather than treating the error as an authoritative empty set."""
+    api = AutoscalingV1Alpha1API(client)
+    try:
+        templates = list_all_zones(api.list_instance_templates_all)
+        groups = list_all_zones(api.list_instance_groups_all)
+        policies: list[InstancePolicy] = []
+        for group in groups:
+            policies.extend(
+                api.list_instance_policies_all(
+                    instance_group_id=group.id,
+                    zone=group.zone,
+                )
+            )
+        return templates, groups, policies
+    except ScalewayException as exc:
+        # Autoscaling is a public beta product; accounts without access
+        # answer 403 for the whole API. Skip rather than aborting the sync or
+        # wiping existing inventory.
+        if exc.status_code == 403:
+            logger.info(
+                "Scaleway Autoscaling not enabled for this account, skipping.",
+            )
+            return None
+        raise
+
+
+def transform(
+    templates: list[InstanceTemplate],
+    groups: list[InstanceGroup],
+    policies: list[InstancePolicy],
+    projects_id: list[str],
+) -> tuple[
+    dict[str, list[dict[str, Any]]],
+    dict[str, list[dict[str, Any]]],
+    dict[str, list[dict[str, Any]]],
+    dict[str, list[dict[str, Any]]],
+]:
+    templates_by_project: dict[str, list[dict[str, Any]]] = {}
+    groups_by_project: dict[str, list[dict[str, Any]]] = {}
+    policies_by_project: dict[str, list[dict[str, Any]]] = {}
+    lb_private_network_links_by_project: dict[str, list[dict[str, Any]]] = {}
+
+    allowed_projects = set(projects_id)
+    project_by_group_id = {group.id: group.project_id for group in groups}
+
+    for template in templates:
+        if template.project_id not in allowed_projects:
+            continue
+        templates_by_project.setdefault(template.project_id, []).append(
+            scaleway_obj_to_dict(template)
+        )
+
+    for group in groups:
+        if group.project_id not in allowed_projects:
+            continue
+        formatted_group = scaleway_obj_to_dict(group)
+        loadbalancer = formatted_group.get("loadbalancer") or {}
+        loadbalancer_id = loadbalancer.get("id")
+        private_network_id = loadbalancer.get("private_network_id")
+        formatted_group["loadbalancer_id"] = loadbalancer_id
+        formatted_group["loadbalancer_backend_ids"] = loadbalancer.get("backend_ids")
+        formatted_group["loadbalancer_private_network_id"] = private_network_id
+        groups_by_project.setdefault(group.project_id, []).append(formatted_group)
+
+        # The private network attachment is a fact about the LoadBalancer
+        # itself, not the InstanceGroup, so it's linked via a MatchLink onto
+        # the already-existing ScalewayLoadBalancer node (loadbalancers.py
+        # owns that node's properties; this module must not overwrite them).
+        if loadbalancer_id and private_network_id:
+            lb_private_network_links_by_project.setdefault(group.project_id, []).append(
+                {
+                    "loadbalancer_id": loadbalancer_id,
+                    "private_network_id": private_network_id,
+                }
+            )
+
+    for policy in policies:
+        project_id = project_by_group_id.get(policy.instance_group_id)
+        if project_id not in allowed_projects:
+            continue
+        policies_by_project.setdefault(project_id, []).append(
+            scaleway_obj_to_dict(policy)
+        )
+
+    return (
+        templates_by_project,
+        groups_by_project,
+        policies_by_project,
+        lb_private_network_links_by_project,
+    )
+
+
+@timeit
+def load_autoscaling_resources(
+    neo4j_session: neo4j.Session,
+    templates_by_project: dict[str, list[dict[str, Any]]],
+    groups_by_project: dict[str, list[dict[str, Any]]],
+    policies_by_project: dict[str, list[dict[str, Any]]],
+    update_tag: int,
+) -> None:
+    for project_id, templates in templates_by_project.items():
+        logger.info(
+            "Loading %d Scaleway Instance Templates in project '%s' into Neo4j.",
+            len(templates),
+            project_id,
+        )
+        load(
+            neo4j_session,
+            ScalewayInstanceTemplateSchema(),
+            templates,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+
+    for project_id, groups in groups_by_project.items():
+        logger.info(
+            "Loading %d Scaleway Instance Groups in project '%s' into Neo4j.",
+            len(groups),
+            project_id,
+        )
+        load(
+            neo4j_session,
+            ScalewayInstanceGroupSchema(),
+            groups,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+
+    for project_id, policies in policies_by_project.items():
+        logger.info(
+            "Loading %d Scaleway Scaling Policies in project '%s' into Neo4j.",
+            len(policies),
+            project_id,
+        )
+        load(
+            neo4j_session,
+            ScalewayScalingPolicySchema(),
+            policies,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+
+
+@timeit
+def load_lb_private_network_links(
+    neo4j_session: neo4j.Session,
+    lb_private_network_links_by_project: dict[str, list[dict[str, Any]]],
+    update_tag: int,
+) -> None:
+    for project_id, links in lb_private_network_links_by_project.items():
+        logger.info(
+            "Loading %d Scaleway LoadBalancer -> PrivateNetwork links in project '%s' into Neo4j.",
+            len(links),
+            project_id,
+        )
+        load_matchlinks(
+            neo4j_session,
+            ScalewayLoadBalancerToPrivateNetworkMatchLink(),
+            links,
+            lastupdated=update_tag,
+            _sub_resource_label="ScalewayProject",
+            _sub_resource_id=project_id,
+        )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    projects_id: list[str],
+    common_job_parameters: dict[str, Any],
+) -> None:
+    for project_id in projects_id:
+        scoped_job_parameters = common_job_parameters.copy()
+        scoped_job_parameters["PROJECT_ID"] = project_id
+        GraphJob.from_node_schema(
+            ScalewayScalingPolicySchema(), scoped_job_parameters
+        ).run(neo4j_session)
+        GraphJob.from_node_schema(
+            ScalewayInstanceGroupSchema(), scoped_job_parameters
+        ).run(neo4j_session)
+        GraphJob.from_node_schema(
+            ScalewayInstanceTemplateSchema(), scoped_job_parameters
+        ).run(neo4j_session)
+        GraphJob.from_matchlink(
+            ScalewayLoadBalancerToPrivateNetworkMatchLink(),
+            "ScalewayProject",
+            project_id,
+            common_job_parameters["UPDATE_TAG"],
+        ).run(neo4j_session)

--- a/cartography/models/scaleway/instance/autoscaling.py
+++ b/cartography/models/scaleway/instance/autoscaling.py
@@ -1,0 +1,352 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class ScalewayInstanceTemplateProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Instance template unique ID.")
+    name: PropertyRef = PropertyRef("name", description="Instance template name.")
+    commercial_type: PropertyRef = PropertyRef(
+        "commercial_type", description="Instance commercial type."
+    )
+    image_id: PropertyRef = PropertyRef(
+        "image_id", description="Image ID used for created Instances."
+    )
+    security_group_id: PropertyRef = PropertyRef(
+        "security_group_id",
+        description="Security Group ID applied to created Instances.",
+    )
+    placement_group_id: PropertyRef = PropertyRef(
+        "placement_group_id",
+        description="Placement Group ID applied to created Instances.",
+    )
+    public_ips_v4_count: PropertyRef = PropertyRef(
+        "public_ips_v4_count", description="Number of IPv4 addresses to attach."
+    )
+    public_ips_v6_count: PropertyRef = PropertyRef(
+        "public_ips_v6_count", description="Number of IPv6 addresses to attach."
+    )
+    private_network_ids: PropertyRef = PropertyRef(
+        "private_network_ids",
+        description="Private Networks to attach to created Instances.",
+    )
+    status: PropertyRef = PropertyRef(
+        "status", description="Template status, such as `ready` or `error`."
+    )
+    tags: PropertyRef = PropertyRef(
+        "tags", description="Tags associated with the template."
+    )
+    zone: PropertyRef = PropertyRef(
+        "zone", description="Zone in which the template is located."
+    )
+    created_at: PropertyRef = PropertyRef(
+        "created_at", description="Template creation date."
+    )
+    updated_at: PropertyRef = PropertyRef(
+        "updated_at", description="Template last update date."
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewayInstanceTemplateToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewayInstanceTemplate)
+class ScalewayInstanceTemplateToProjectRel(CartographyRelSchema):
+    """Connects `ScalewayProject` to `ScalewayInstanceTemplate` through `RESOURCE`."""
+
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewayInstanceTemplateToProjectRelProperties = (
+        ScalewayInstanceTemplateToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayInstanceTemplateToPrivateNetworkRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayInstanceTemplate)-[:ATTACHED_TO]->(:ScalewayPrivateNetwork)
+class ScalewayInstanceTemplateToPrivateNetworkRel(CartographyRelSchema):
+    """Connects `ScalewayInstanceTemplate` to `ScalewayPrivateNetwork`."""
+
+    target_node_label: str = "ScalewayPrivateNetwork"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("private_network_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "ATTACHED_TO"
+    properties: ScalewayInstanceTemplateToPrivateNetworkRelProperties = (
+        ScalewayInstanceTemplateToPrivateNetworkRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayInstanceTemplateSchema(CartographyNodeSchema):
+    """Defines how Instances are created for an autoscaling Instance Group."""
+
+    label: str = "ScalewayInstanceTemplate"
+    properties: ScalewayInstanceTemplateProperties = (
+        ScalewayInstanceTemplateProperties()
+    )
+    sub_resource_relationship: ScalewayInstanceTemplateToProjectRel = (
+        ScalewayInstanceTemplateToProjectRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            ScalewayInstanceTemplateToPrivateNetworkRel(),
+        ]
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayInstanceGroupProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Instance group unique ID.")
+    name: PropertyRef = PropertyRef("name", description="Instance group name.")
+    tags: PropertyRef = PropertyRef(
+        "tags", description="Tags associated with the group."
+    )
+    instance_template_id: PropertyRef = PropertyRef(
+        "instance_template_id",
+        description="Instance Template used to create Instances.",
+    )
+    capacity_max_replicas: PropertyRef = PropertyRef(
+        "capacity.max_replicas",
+        description="Maximum number of Instances in the group.",
+    )
+    capacity_min_replicas: PropertyRef = PropertyRef(
+        "capacity.min_replicas",
+        description="Minimum number of Instances in the group.",
+    )
+    capacity_cooldown_delay: PropertyRef = PropertyRef(
+        "capacity.cooldown_delay",
+        description="Cooldown duration between scaling actions.",
+    )
+    loadbalancer_id: PropertyRef = PropertyRef(
+        "loadbalancer_id", description="Load Balancer attached to the group."
+    )
+    loadbalancer_backend_ids: PropertyRef = PropertyRef(
+        "loadbalancer_backend_ids",
+        description="Load Balancer backends maintained by the group.",
+    )
+    loadbalancer_private_network_id: PropertyRef = PropertyRef(
+        "loadbalancer_private_network_id",
+        description="Private Network shared with the Load Balancer.",
+    )
+    error_messages: PropertyRef = PropertyRef(
+        "error_messages", description="Configuration error messages."
+    )
+    zone: PropertyRef = PropertyRef(
+        "zone", description="Zone in which the group is located."
+    )
+    created_at: PropertyRef = PropertyRef(
+        "created_at", description="Group creation date."
+    )
+    updated_at: PropertyRef = PropertyRef(
+        "updated_at", description="Group last update date."
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewayInstanceGroupToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewayInstanceGroup)
+class ScalewayInstanceGroupToProjectRel(CartographyRelSchema):
+    """Connects `ScalewayProject` to `ScalewayInstanceGroup` through `RESOURCE`."""
+
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewayInstanceGroupToProjectRelProperties = (
+        ScalewayInstanceGroupToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayInstanceGroupToTemplateRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayInstanceGroup)-[:USES]->(:ScalewayInstanceTemplate)
+class ScalewayInstanceGroupToTemplateRel(CartographyRelSchema):
+    """Connects `ScalewayInstanceGroup` to the Instance Template it uses."""
+
+    target_node_label: str = "ScalewayInstanceTemplate"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("instance_template_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES"
+    properties: ScalewayInstanceGroupToTemplateRelProperties = (
+        ScalewayInstanceGroupToTemplateRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayInstanceGroupToLoadBalancerRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayInstanceGroup)-[:USES]->(:ScalewayLoadBalancer)
+class ScalewayInstanceGroupToLoadBalancerRel(CartographyRelSchema):
+    """Connects `ScalewayInstanceGroup` to the Load Balancer it uses."""
+
+    target_node_label: str = "ScalewayLoadBalancer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("loadbalancer_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES"
+    properties: ScalewayInstanceGroupToLoadBalancerRelProperties = (
+        ScalewayInstanceGroupToLoadBalancerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayInstanceGroupSchema(CartographyNodeSchema):
+    """Manages a fleet of Instances using a template, capacity, and policies."""
+
+    label: str = "ScalewayInstanceGroup"
+    properties: ScalewayInstanceGroupProperties = ScalewayInstanceGroupProperties()
+    sub_resource_relationship: ScalewayInstanceGroupToProjectRel = (
+        ScalewayInstanceGroupToProjectRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            ScalewayInstanceGroupToTemplateRel(),
+            ScalewayInstanceGroupToLoadBalancerRel(),
+        ]
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayScalingPolicyProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Scaling policy unique ID.")
+    name: PropertyRef = PropertyRef("name", description="Scaling policy name.")
+    action: PropertyRef = PropertyRef(
+        "action", description="Scaling action, such as `scale_up` or `scale_down`."
+    )
+    type: PropertyRef = PropertyRef(
+        "type_", description="How the value is applied to group capacity."
+    )
+    value: PropertyRef = PropertyRef(
+        "value", description="Magnitude of the scaling action."
+    )
+    priority: PropertyRef = PropertyRef(
+        "priority", description="Policy priority; lower values are evaluated first."
+    )
+    instance_group_id: PropertyRef = PropertyRef(
+        "instance_group_id", description="Instance Group the policy applies to."
+    )
+    metric_name: PropertyRef = PropertyRef(
+        "metric.name", description="Metric name or description."
+    )
+    metric_operator: PropertyRef = PropertyRef(
+        "metric.operator",
+        description="Operator used to compare the metric to the threshold.",
+    )
+    metric_aggregate: PropertyRef = PropertyRef(
+        "metric.aggregate",
+        description="Aggregation method for sampled metric values.",
+    )
+    metric_sampling_range_min: PropertyRef = PropertyRef(
+        "metric.sampling_range_min", description="Sampling window in minutes."
+    )
+    metric_threshold: PropertyRef = PropertyRef(
+        "metric.threshold", description="Threshold value for the scaling condition."
+    )
+    metric_managed_metric: PropertyRef = PropertyRef(
+        "metric.managed_metric", description="Scaleway managed metric identifier."
+    )
+    metric_cockpit_metric_name: PropertyRef = PropertyRef(
+        "metric.cockpit_metric_name", description="Custom Cockpit metric name."
+    )
+    zone: PropertyRef = PropertyRef(
+        "zone", description="Zone in which the policy is located."
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class ScalewayScalingPolicyToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayProject)-[:RESOURCE]->(:ScalewayScalingPolicy)
+class ScalewayScalingPolicyToProjectRel(CartographyRelSchema):
+    """Connects `ScalewayProject` to `ScalewayScalingPolicy` through `RESOURCE`."""
+
+    target_node_label: str = "ScalewayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: ScalewayScalingPolicyToProjectRelProperties = (
+        ScalewayScalingPolicyToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayScalingPolicyToInstanceGroupRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayScalingPolicy)-[:APPLIES_TO]->(:ScalewayInstanceGroup)
+class ScalewayScalingPolicyToInstanceGroupRel(CartographyRelSchema):
+    """Connects `ScalewayScalingPolicy` to the Instance Group it applies to."""
+
+    target_node_label: str = "ScalewayInstanceGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("instance_group_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "APPLIES_TO"
+    properties: ScalewayScalingPolicyToInstanceGroupRelProperties = (
+        ScalewayScalingPolicyToInstanceGroupRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayScalingPolicySchema(CartographyNodeSchema):
+    """Defines a metric condition and scaling action for an Instance Group."""
+
+    label: str = "ScalewayScalingPolicy"
+    properties: ScalewayScalingPolicyProperties = ScalewayScalingPolicyProperties()
+    sub_resource_relationship: ScalewayScalingPolicyToProjectRel = (
+        ScalewayScalingPolicyToProjectRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            ScalewayScalingPolicyToInstanceGroupRel(),
+        ]
+    )

--- a/cartography/models/scaleway/loadbalancer/loadbalancer.py
+++ b/cartography/models/scaleway/loadbalancer/loadbalancer.py
@@ -7,8 +7,10 @@ from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
 from cartography.models.core.relationships import make_target_node_matcher
 from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
 from cartography.models.ontology.labels import LOAD_BALANCER
 
@@ -99,6 +101,39 @@ class ScalewayLoadBalancerSchema(CartographyNodeSchema):
     properties: ScalewayLoadBalancerProperties = ScalewayLoadBalancerProperties()
     sub_resource_relationship: ScalewayLoadBalancerToProjectRel = (
         ScalewayLoadBalancerToProjectRel()
+    )
+
+
+@dataclass(frozen=True)
+class ScalewayLoadBalancerToPrivateNetworkRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label",
+        set_in_kwargs=True,
+    )
+    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:ScalewayLoadBalancer)-[:ATTACHED_TO]->(:ScalewayPrivateNetwork)
+# A MatchLink (not an OtherRelationships entry) because the private network
+# attachment is only known from the Autoscaling API response, which does not
+# own (and must not overwrite) the rest of the LoadBalancer node's properties.
+class ScalewayLoadBalancerToPrivateNetworkMatchLink(CartographyRelSchema):
+    """Connects `ScalewayLoadBalancer` to an attached Scaleway Private Network."""
+
+    source_node_label: str = "ScalewayLoadBalancer"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("loadbalancer_id")},
+    )
+    target_node_label: str = "ScalewayPrivateNetwork"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("private_network_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "ATTACHED_TO"
+    properties: ScalewayLoadBalancerToPrivateNetworkRelProperties = (
+        ScalewayLoadBalancerToPrivateNetworkRelProperties()
     )
 
 

--- a/tests/data/scaleway/autoscaling.py
+++ b/tests/data/scaleway/autoscaling.py
@@ -1,0 +1,92 @@
+from datetime import datetime
+
+from dateutil.tz import tzutc
+from scaleway.autoscaling.v1alpha1 import Capacity
+from scaleway.autoscaling.v1alpha1 import InstanceGroup
+from scaleway.autoscaling.v1alpha1 import InstancePolicy
+from scaleway.autoscaling.v1alpha1 import InstancePolicyAction
+from scaleway.autoscaling.v1alpha1 import InstancePolicyType
+from scaleway.autoscaling.v1alpha1 import InstanceTemplate
+from scaleway.autoscaling.v1alpha1 import InstanceTemplateStatus
+from scaleway.autoscaling.v1alpha1 import Loadbalancer
+from scaleway.autoscaling.v1alpha1 import Metric
+from scaleway.autoscaling.v1alpha1 import MetricAggregate
+from scaleway.autoscaling.v1alpha1 import MetricManagedMetric
+from scaleway.autoscaling.v1alpha1 import MetricOperator
+
+TEST_ORG_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+TEST_PROJECT_ID = "0681c477-fbb9-4820-b8d6-0eef10cfcd6d"
+TEST_INSTANCE_TEMPLATE_ID = "11111111-1111-4820-b8d6-0eef10cfcd6d"
+TEST_INSTANCE_GROUP_ID = "22222222-2222-4820-b8d6-0eef10cfcd6d"
+TEST_SCALING_POLICY_ID = "33333333-3333-4820-b8d6-0eef10cfcd6d"
+TEST_PRIVATE_NETWORK_ID = "44444444-4444-4820-b8d6-0eef10cfcd6d"
+TEST_LB_ID = "55555555-5555-4820-b8d6-0eef10cfcd6d"
+TEST_BACKEND_ID = "66666666-6666-4820-b8d6-0eef10cfcd6d"
+
+SCALEWAY_INSTANCE_TEMPLATES = [
+    InstanceTemplate(
+        id=TEST_INSTANCE_TEMPLATE_ID,
+        commercial_type="DEV1-S",
+        volumes={},
+        tags=["demo"],
+        project_id=TEST_PROJECT_ID,
+        name="demo-template",
+        private_network_ids=[TEST_PRIVATE_NETWORK_ID],
+        status=InstanceTemplateStatus.READY,
+        zone="fr-par-1",
+        image_id="ubuntu-noble",
+        security_group_id=None,
+        placement_group_id=None,
+        public_ips_v4_count=1,
+        public_ips_v6_count=0,
+        cloud_init=None,
+        created_at=datetime(2025, 3, 20, 14, 49, 48, 107731, tzinfo=tzutc()),
+        updated_at=datetime(2025, 3, 20, 14, 49, 48, 107731, tzinfo=tzutc()),
+    )
+]
+
+SCALEWAY_INSTANCE_GROUPS = [
+    InstanceGroup(
+        id=TEST_INSTANCE_GROUP_ID,
+        project_id=TEST_PROJECT_ID,
+        name="demo-group",
+        tags=["demo"],
+        instance_template_id=TEST_INSTANCE_TEMPLATE_ID,
+        capacity=Capacity(
+            max_replicas=5,
+            min_replicas=2,
+            cooldown_delay="300s",
+        ),
+        loadbalancer=Loadbalancer(
+            id=TEST_LB_ID,
+            backend_ids=[TEST_BACKEND_ID],
+            private_network_id=TEST_PRIVATE_NETWORK_ID,
+        ),
+        error_messages=[],
+        zone="fr-par-1",
+        created_at=datetime(2025, 3, 20, 14, 49, 48, 107731, tzinfo=tzutc()),
+        updated_at=datetime(2025, 3, 20, 14, 49, 48, 107731, tzinfo=tzutc()),
+    )
+]
+
+SCALEWAY_SCALING_POLICIES = [
+    InstancePolicy(
+        id=TEST_SCALING_POLICY_ID,
+        name="scale-up-cpu",
+        action=InstancePolicyAction.SCALE_UP,
+        type_=InstancePolicyType.FLAT_COUNT,
+        value=1,
+        priority=1,
+        instance_group_id=TEST_INSTANCE_GROUP_ID,
+        zone="fr-par-1",
+        metric=Metric(
+            name="cpu high",
+            operator=MetricOperator.OPERATOR_GREATER_THAN,
+            aggregate=MetricAggregate.AGGREGATE_AVERAGE,
+            sampling_range_min=5,
+            threshold=80.0,
+            managed_metric=MetricManagedMetric.MANAGED_METRIC_INSTANCE_CPU,
+            cockpit_metric_name=None,
+        ),
+    )
+]

--- a/tests/integration/cartography/intel/scaleway/test_autoscaling.py
+++ b/tests/integration/cartography/intel/scaleway/test_autoscaling.py
@@ -1,0 +1,231 @@
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import cartography.intel.scaleway.instances.autoscaling
+from tests.data.scaleway.autoscaling import SCALEWAY_INSTANCE_GROUPS
+from tests.data.scaleway.autoscaling import SCALEWAY_INSTANCE_TEMPLATES
+from tests.data.scaleway.autoscaling import SCALEWAY_SCALING_POLICIES
+from tests.data.scaleway.autoscaling import TEST_BACKEND_ID
+from tests.data.scaleway.autoscaling import TEST_INSTANCE_GROUP_ID
+from tests.data.scaleway.autoscaling import TEST_INSTANCE_TEMPLATE_ID
+from tests.data.scaleway.autoscaling import TEST_LB_ID
+from tests.data.scaleway.autoscaling import TEST_ORG_ID
+from tests.data.scaleway.autoscaling import TEST_PRIVATE_NETWORK_ID
+from tests.data.scaleway.autoscaling import TEST_PROJECT_ID
+from tests.data.scaleway.autoscaling import TEST_SCALING_POLICY_ID
+from tests.integration.cartography.intel.scaleway.test_projects import (
+    _ensure_local_neo4j_has_test_projects_and_orgs,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+def _ensure_local_neo4j_has_test_autoscaling_dependencies(neo4j_session):
+    neo4j_session.run(
+        """
+        MERGE (:ScalewayPrivateNetwork {id: $private_network_id})
+        MERGE (:ScalewayLoadBalancer {id: $lb_id})
+        MERGE (:ScalewayLBBackend {id: $backend_id})
+        """,
+        private_network_id=TEST_PRIVATE_NETWORK_ID,
+        lb_id=TEST_LB_ID,
+        backend_id=TEST_BACKEND_ID,
+    )
+
+
+@patch.object(
+    cartography.intel.scaleway.instances.autoscaling,
+    "get",
+    return_value=(
+        SCALEWAY_INSTANCE_TEMPLATES,
+        SCALEWAY_INSTANCE_GROUPS,
+        SCALEWAY_SCALING_POLICIES,
+    ),
+)
+def test_load_scaleway_autoscaling(_mock_get, neo4j_session):
+    # Arrange
+    client = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "ORG_ID": TEST_ORG_ID,
+    }
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+    _ensure_local_neo4j_has_test_autoscaling_dependencies(neo4j_session)
+
+    # Act
+    cartography.intel.scaleway.instances.autoscaling.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # Assert nodes exist
+    assert check_nodes(neo4j_session, "ScalewayInstanceTemplate", ["id", "name"]) == {
+        (TEST_INSTANCE_TEMPLATE_ID, "demo-template"),
+    }
+    assert check_nodes(neo4j_session, "ScalewayInstanceGroup", ["id", "name"]) == {
+        (TEST_INSTANCE_GROUP_ID, "demo-group"),
+    }
+    assert check_nodes(neo4j_session, "ScalewayScalingPolicy", ["id", "name"]) == {
+        (TEST_SCALING_POLICY_ID, "scale-up-cpu"),
+    }
+
+    # Assert everything is linked to the project
+    for label in (
+        "ScalewayInstanceTemplate",
+        "ScalewayInstanceGroup",
+        "ScalewayScalingPolicy",
+    ):
+        assert check_rels(
+            neo4j_session,
+            label,
+            "id",
+            "ScalewayProject",
+            "id",
+            "RESOURCE",
+            rel_direction_right=False,
+        ), f"{label} not linked to project"
+
+    # Assert Instance Group uses its template
+    assert check_rels(
+        neo4j_session,
+        "ScalewayInstanceGroup",
+        "id",
+        "ScalewayInstanceTemplate",
+        "id",
+        "USES",
+        rel_direction_right=True,
+    ) == {(TEST_INSTANCE_GROUP_ID, TEST_INSTANCE_TEMPLATE_ID)}
+
+    # Assert Scaling Policy applies to Instance Group
+    assert check_rels(
+        neo4j_session,
+        "ScalewayScalingPolicy",
+        "id",
+        "ScalewayInstanceGroup",
+        "id",
+        "APPLIES_TO",
+        rel_direction_right=True,
+    ) == {(TEST_SCALING_POLICY_ID, TEST_INSTANCE_GROUP_ID)}
+
+    # Assert Instance Group uses its load balancer
+    assert check_rels(
+        neo4j_session,
+        "ScalewayInstanceGroup",
+        "id",
+        "ScalewayLoadBalancer",
+        "id",
+        "USES",
+        rel_direction_right=True,
+    ) == {(TEST_INSTANCE_GROUP_ID, TEST_LB_ID)}
+
+    # Assert the Template is attached to the private network
+    assert check_rels(
+        neo4j_session,
+        "ScalewayInstanceTemplate",
+        "id",
+        "ScalewayPrivateNetwork",
+        "id",
+        "ATTACHED_TO",
+        rel_direction_right=True,
+    ) == {(TEST_INSTANCE_TEMPLATE_ID, TEST_PRIVATE_NETWORK_ID)}
+
+    # Assert the Load Balancer (not the Group) is attached to the private
+    # network: this is a fact about the LB, sourced from the Autoscaling API,
+    # and linked via a MatchLink so the LB node's own properties aren't
+    # touched by this sync.
+    assert check_rels(
+        neo4j_session,
+        "ScalewayLoadBalancer",
+        "id",
+        "ScalewayPrivateNetwork",
+        "id",
+        "ATTACHED_TO",
+        rel_direction_right=True,
+    ) == {(TEST_LB_ID, TEST_PRIVATE_NETWORK_ID)}
+
+
+@patch.object(cartography.intel.scaleway.instances.autoscaling, "get")
+def test_stale_autoscaling_resources_are_cleaned_up(mock_get, neo4j_session):
+    # Arrange
+    client = Mock()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "ORG_ID": TEST_ORG_ID,
+    }
+    _ensure_local_neo4j_has_test_projects_and_orgs(neo4j_session)
+    _ensure_local_neo4j_has_test_autoscaling_dependencies(neo4j_session)
+
+    # Act: initial sync loads a template, group, and policy
+    mock_get.return_value = (
+        SCALEWAY_INSTANCE_TEMPLATES,
+        SCALEWAY_INSTANCE_GROUPS,
+        SCALEWAY_SCALING_POLICIES,
+    )
+    cartography.intel.scaleway.instances.autoscaling.sync(
+        neo4j_session,
+        client,
+        common_job_parameters,
+        org_id=TEST_ORG_ID,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # Act: second sync with a new update tag and nothing returned, simulating
+    # the template, group, and policy being removed upstream
+    next_update_tag = TEST_UPDATE_TAG + 1
+    mock_get.return_value = ([], [], [])
+    cartography.intel.scaleway.instances.autoscaling.sync(
+        neo4j_session,
+        client,
+        {**common_job_parameters, "UPDATE_TAG": next_update_tag},
+        org_id=TEST_ORG_ID,
+        projects_id=[TEST_PROJECT_ID],
+        update_tag=next_update_tag,
+    )
+
+    # Assert stale nodes and relationships were removed
+    assert check_nodes(neo4j_session, "ScalewayInstanceTemplate", ["id"]) == set()
+    assert check_nodes(neo4j_session, "ScalewayInstanceGroup", ["id"]) == set()
+    assert check_nodes(neo4j_session, "ScalewayScalingPolicy", ["id"]) == set()
+    assert (
+        check_rels(
+            neo4j_session,
+            "ScalewayInstanceGroup",
+            "id",
+            "ScalewayInstanceTemplate",
+            "id",
+            "USES",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+    assert (
+        check_rels(
+            neo4j_session,
+            "ScalewayScalingPolicy",
+            "id",
+            "ScalewayInstanceGroup",
+            "id",
+            "APPLIES_TO",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+    assert (
+        check_rels(
+            neo4j_session,
+            "ScalewayLoadBalancer",
+            "id",
+            "ScalewayPrivateNetwork",
+            "id",
+            "ATTACHED_TO",
+            rel_direction_right=True,
+        )
+        == set()
+    )


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):

### Summary

Adds Scaleway Instance Autoscaling ingestion.

This PR syncs:

- `ScalewayInstanceTemplate`
- `ScalewayInstanceGroup`
- `ScalewayScalingPolicy`

It also models:

- `(:ScalewayProject)-[:RESOURCE]->(:ScalewayInstanceTemplate)`
- `(:ScalewayProject)-[:RESOURCE]->(:ScalewayInstanceGroup)`
- `(:ScalewayProject)-[:RESOURCE]->(:ScalewayScalingPolicy)`
- `(:ScalewayInstanceTemplate)-[:ATTACHED_TO]->(:ScalewayPrivateNetwork)`
- `(:ScalewayInstanceGroup)-[:USES]->(:ScalewayInstanceTemplate)`
- `(:ScalewayInstanceGroup)-[:USES]->(:ScalewayLoadBalancer)`
- `(:ScalewayScalingPolicy)-[:APPLIES_TO]->(:ScalewayInstanceGroup)`
- `(:ScalewayLoadBalancer)-[:ATTACHED_TO]->(:ScalewayPrivateNetwork)`

The LoadBalancer-to-PrivateNetwork edge is loaded as a MatchLink from Autoscaling data because the autoscaling API exposes that attachment, but the LoadBalancer node itself remains owned by the Load Balancer sync.

### Related issues or links

- Part of #2980

### Breaking changes

None.

### How was this tested?


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [ ] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [x] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
Scaleway Autoscaling is currently a public beta product. If the Autoscaling API returns `403`, the sync skips load and cleanup rather than failing the whole Scaleway sync or treating the response as an authoritative empty inventory.