### PR TITLE
feat(rules): declare an affected-node anchor (asset_label) on every Fact

### DIFF
--- a/cartography/models/microsoft/entra/group.py
+++ b/cartography/models/microsoft/entra/group.py
@@ -114,5 +114,7 @@ class EntraGroupSchema(CartographyNodeSchema):
         [
             "EntraIdentity",
             "UserGroup",
+            # Cross-provider IAM principal umbrella, mirroring AWSPrincipal / GCPPrincipal.
+            "EntraPrincipal",
         ]
     )

--- a/cartography/models/microsoft/entra/service_principal.py
+++ b/cartography/models/microsoft/entra/service_principal.py
@@ -97,7 +97,10 @@ class EntraServicePrincipalSchema(CartographyNodeSchema):
     properties: EntraServicePrincipalNodeProperties = (
         EntraServicePrincipalNodeProperties()
     )
-    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ServiceAccount"])
+    # EntraPrincipal: cross-provider IAM principal umbrella, mirroring AWSPrincipal / GCPPrincipal.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        ["ServiceAccount", "EntraPrincipal"]
+    )
     sub_resource_relationship: EntraServicePrincipalToTenantRel = (
         EntraServicePrincipalToTenantRel()
     )

--- a/cartography/models/microsoft/entra/user.py
+++ b/cartography/models/microsoft/entra/user.py
@@ -86,5 +86,7 @@ class EntraUserSchema(CartographyNodeSchema):
         [
             "EntraIdentity",
             "UserAccount",
+            # Cross-provider IAM principal umbrella, mirroring AWSPrincipal / GCPPrincipal.
+            "EntraPrincipal",
         ]  # UserAccount label is used for ontology mapping
     )

--- a/cartography/models/scaleway/iam/application.py
+++ b/cartography/models/scaleway/iam/application.py
@@ -47,7 +47,10 @@ class ScalewayApplicationToOrganizationRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class ScalewayApplicationSchema(CartographyNodeSchema):
     label: str = "ScalewayApplication"
-    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["ServiceAccount"])
+    # ScalewayPrincipal: cross-provider IAM principal umbrella, mirroring AWSPrincipal / GCPPrincipal.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        ["ServiceAccount", "ScalewayPrincipal"]
+    )
     properties: ScalewayApplicationNodeProperties = ScalewayApplicationNodeProperties()
     sub_resource_relationship: ScalewayApplicationToOrganizationRel = (
         ScalewayApplicationToOrganizationRel()

--- a/cartography/models/scaleway/iam/group.py
+++ b/cartography/models/scaleway/iam/group.py
@@ -85,7 +85,10 @@ class ScalewayGroupToOrganizationRel(CartographyRelSchema):
 class ScalewayGroupSchema(CartographyNodeSchema):
     label: str = "ScalewayGroup"
     properties: ScalewayGroupProperties = ScalewayGroupProperties()
-    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["UserGroup"])
+    # ScalewayPrincipal: cross-provider IAM principal umbrella, mirroring AWSPrincipal / GCPPrincipal.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        ["UserGroup", "ScalewayPrincipal"]
+    )
     sub_resource_relationship: ScalewayGroupToOrganizationRel = (
         ScalewayGroupToOrganizationRel()
     )

--- a/cartography/models/scaleway/iam/user.py
+++ b/cartography/models/scaleway/iam/user.py
@@ -55,8 +55,9 @@ class ScalewayUserToOrganizationRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class ScalewayUserSchema(CartographyNodeSchema):
     label: str = "ScalewayUser"
+    # ScalewayPrincipal: cross-provider IAM principal umbrella, mirroring AWSPrincipal / GCPPrincipal.
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
-        ["UserAccount"]
+        ["UserAccount", "ScalewayPrincipal"]
     )  # UserAccount label is used for ontology mapping
     properties: ScalewayUserNodeProperties = ScalewayUserNodeProperties()
     sub_resource_relationship: ScalewayUserToOrganizationRel = (

--- a/cartography/rules/data/rules/cis_4_0_gcp.py
+++ b/cartography/rules/data/rules/cis_4_0_gcp.py
@@ -69,6 +69,7 @@ _gcp_default_network_exists = Fact(
     MATCH (vpc:GCPVpc)
     RETURN COUNT(vpc) AS count
     """,
+    asset_label="GCPVpc",
     asset_id_field="vpc_id",
     identity_fields=("vpc_id",),
     module=Module.GCP,
@@ -168,6 +169,7 @@ _gcp_unrestricted_ssh = Fact(
     MATCH (fw:GCPFirewall)
     RETURN COUNT(fw) AS count
     """,
+    asset_label="GCPFirewall",
     asset_id_field="firewall_id",
     identity_fields=("firewall_id", "firewall_rule_id", "source_range"),
     module=Module.GCP,
@@ -267,6 +269,7 @@ _gcp_unrestricted_rdp = Fact(
     MATCH (fw:GCPFirewall)
     RETURN COUNT(fw) AS count
     """,
+    asset_label="GCPFirewall",
     asset_id_field="firewall_id",
     identity_fields=("firewall_id", "firewall_rule_id", "source_range"),
     module=Module.GCP,
@@ -347,6 +350,7 @@ _gcp_instance_public_ip = Fact(
     WHERE coalesce(instance.status, '') <> 'TERMINATED'
     RETURN COUNT(instance) AS count
     """,
+    asset_label="GCPInstance",
     asset_id_field="instance_id",
     identity_fields=("instance_id",),
     module=Module.GCP,
@@ -435,6 +439,7 @@ _gcp_instance_confidential_compute_disabled = Fact(
       )
     RETURN COUNT(instance) AS count
     """,
+    asset_label="GCPInstance",
     asset_id_field="instance_id",
     identity_fields=("instance_id",),
     module=Module.GCP,
@@ -502,6 +507,7 @@ _gcp_dnssec_disabled = Fact(
     WHERE coalesce(zone.visibility, 'public') = 'public'
     RETURN COUNT(zone) AS count
     """,
+    asset_label="GCPDNSZone",
     asset_id_field="zone_id",
     identity_fields=("zone_id",),
     module=Module.GCP,
@@ -573,6 +579,7 @@ _gcp_dnssec_weak_ksk = Fact(
       AND coalesce(zone.dnssec_state, 'off') = 'on'
     RETURN COUNT(zone) AS count
     """,
+    asset_label="GCPDNSZone",
     asset_id_field="zone_id",
     identity_fields=("zone_id",),
     module=Module.GCP,
@@ -638,6 +645,7 @@ _gcp_dnssec_weak_zsk = Fact(
       AND coalesce(zone.dnssec_state, 'off') = 'on'
     RETURN COUNT(zone) AS count
     """,
+    asset_label="GCPDNSZone",
     asset_id_field="zone_id",
     identity_fields=("zone_id",),
     module=Module.GCP,
@@ -730,6 +738,7 @@ _gcp_subnet_flow_logs_disabled = Fact(
     WHERE coalesce(subnet.purpose, 'PRIVATE') = 'PRIVATE'
     RETURN COUNT(subnet) AS count
     """,
+    asset_label="GCPSubnet",
     asset_id_field="subnet_id",
     identity_fields=("subnet_id",),
     module=Module.GCP,
@@ -788,6 +797,7 @@ _gcp_cloudsql_public_ip = Fact(
     MATCH (instance:GCPCloudSQLInstance)
     RETURN COUNT(instance) AS count
     """,
+    asset_label="GCPCloudSQLInstance",
     asset_id_field="instance_id",
     identity_fields=("instance_id",),
     module=Module.GCP,
@@ -845,6 +855,7 @@ _gcp_cloudsql_backups_disabled = Fact(
     MATCH (instance:GCPCloudSQLInstance)
     RETURN COUNT(instance) AS count
     """,
+    asset_label="GCPCloudSQLInstance",
     asset_id_field="instance_id",
     identity_fields=("instance_id",),
     module=Module.GCP,
@@ -904,6 +915,7 @@ _gcp_bigquery_dataset_public = Fact(
     MATCH (dataset:GCPBigQueryDataset)
     RETURN COUNT(dataset) AS count
     """,
+    asset_label="GCPBigQueryDataset",
     asset_id_field="dataset_id",
     identity_fields=("dataset_id",),
     module=Module.GCP,
@@ -993,6 +1005,7 @@ _gcp_bigquery_table_cmek_missing = Fact(
       AND (table.type IS NULL OR NOT table.type IN ['VIEW', 'EXTERNAL'])
     RETURN count(DISTINCT table.dataset_id) AS count
     """,
+    asset_label="GCPBigQueryDataset",
     asset_id_field="dataset_id",
     identity_fields=("dataset_id",),
     module=Module.GCP,
@@ -1056,6 +1069,7 @@ _gcp_bigquery_dataset_cmek_missing = Fact(
     MATCH (dataset:GCPBigQueryDataset)
     RETURN COUNT(dataset) AS count
     """,
+    asset_label="GCPBigQueryDataset",
     asset_id_field="dataset_id",
     identity_fields=("dataset_id",),
     module=Module.GCP,
@@ -1117,6 +1131,7 @@ _gcp_cloudsql_ssl_not_enforced = Fact(
     MATCH (instance:GCPCloudSQLInstance)
     RETURN COUNT(instance) AS count
     """,
+    asset_label="GCPCloudSQLInstance",
     asset_id_field="instance_id",
     identity_fields=("instance_id",),
     module=Module.GCP,
@@ -1174,6 +1189,7 @@ _gcp_cloudsql_authorized_networks_open = Fact(
     MATCH (instance:GCPCloudSQLInstance)
     RETURN COUNT(instance) AS count
     """,
+    asset_label="GCPCloudSQLInstance",
     asset_id_field="instance_id",
     identity_fields=("instance_id",),
     module=Module.GCP,
@@ -1239,6 +1255,7 @@ def _make_cloudsql_flag_fact(
         WHERE instance.database_version STARTS WITH '{db_version_filter}'
         RETURN COUNT(instance) AS count
         """,
+        asset_label="GCPCloudSQLInstance",
         asset_id_field="instance_id",
         identity_fields=("instance_id",),
         module=Module.GCP,
@@ -1561,6 +1578,7 @@ _gcp_bucket_uniform_access_disabled = Fact(
     MATCH (bucket:GCPBucket)
     RETURN COUNT(bucket) AS count
     """,
+    asset_label="GCPBucket",
     asset_id_field="bucket_id",
     identity_fields=("bucket_id",),
     module=Module.GCP,
@@ -1812,6 +1830,7 @@ _gcp_instance_default_service_account = Fact(
       AND NOT instance.instancename STARTS WITH 'gke-'
     RETURN COUNT(instance) AS count
     """,
+    asset_label="GCPInstance",
     asset_id_field="instance_id",
     identity_fields=("instance_id",),
     module=Module.GCP,
@@ -1879,6 +1898,7 @@ _gcp_instance_default_service_account_full_api = Fact(
       AND NOT instance.instancename STARTS WITH 'gke-'
     RETURN COUNT(instance) AS count
     """,
+    asset_label="GCPInstance",
     asset_id_field="instance_id",
     identity_fields=("instance_id",),
     module=Module.GCP,
@@ -1961,6 +1981,7 @@ _gcp_instance_project_wide_ssh_keys = Fact(
       AND NOT instance.instancename STARTS WITH 'gke-'
     RETURN COUNT(instance) AS count
     """,
+    asset_label="GCPInstance",
     asset_id_field="instance_id",
     identity_fields=("instance_id",),
     module=Module.GCP,
@@ -2029,6 +2050,7 @@ _gcp_project_oslogin_disabled = Fact(
     MATCH (project:GCPProject)
     RETURN COUNT(project) AS count
     """,
+    asset_label="GCPProject",
     asset_id_field="project_id",
     identity_fields=("project_id",),
     module=Module.GCP,
@@ -2095,6 +2117,7 @@ _gcp_instance_ip_forwarding = Fact(
       AND NOT instance.instancename STARTS WITH 'gke-'
     RETURN COUNT(instance) AS count
     """,
+    asset_label="GCPInstance",
     asset_id_field="instance_id",
     identity_fields=("instance_id",),
     module=Module.GCP,
@@ -2171,6 +2194,7 @@ _gcp_instance_shielded_vm_disabled = Fact(
       AND NOT instance.instancename STARTS WITH 'gke-'
     RETURN COUNT(instance) AS count
     """,
+    asset_label="GCPInstance",
     asset_id_field="instance_id",
     identity_fields=("instance_id",),
     module=Module.GCP,
@@ -2228,6 +2252,7 @@ _gcp_instance_serial_port_enabled = Fact(
     MATCH (instance:GCPInstance)
     RETURN COUNT(instance) AS count
     """,
+    asset_label="GCPInstance",
     asset_id_field="instance_id",
     identity_fields=("instance_id",),
     module=Module.GCP,

--- a/cartography/rules/data/rules/cis_aws_iam.py
+++ b/cartography/rules/data/rules/cis_aws_iam.py
@@ -644,7 +644,9 @@ _aws_admin_policy_attached = Fact(
           OR principal.arn CONTAINS 'stacksets-exec'
           OR principal.arn CONTAINS 'StackSetExecutionRole'
     )
-    WITH DISTINCT a, policy
+    // Dedupe on policy only: an AWS-managed policy shared across accounts is one
+    // asset, matching the policy_id anchor used for the failing count.
+    WITH DISTINCT policy
     RETURN COUNT(*) AS count
     """,
     # asset_label/asset_id_field anchor the finding on the offending AWSPolicy node.

--- a/cartography/rules/data/rules/cis_aws_iam.py
+++ b/cartography/rules/data/rules/cis_aws_iam.py
@@ -87,6 +87,8 @@ _aws_access_key_not_rotated = Fact(
     MATCH (key:AWSAccountAccessKey)
     RETURN COUNT(key) AS count
     """,
+    asset_label="AWSAccountAccessKey",
+    asset_id_field="access_key_id",
     identity_fields=("access_key_id",),
     module=Module.AWS,
     maturity=Maturity.STABLE,
@@ -163,6 +165,8 @@ _aws_unused_credentials = Fact(
     MATCH (key:AWSAccountAccessKey)
     RETURN COUNT(key) AS count
     """,
+    asset_label="AWSAccountAccessKey",
+    asset_id_field="access_key_id",
     identity_fields=("access_key_id",),
     module=Module.AWS,
     maturity=Maturity.STABLE,
@@ -236,6 +240,7 @@ _aws_user_direct_policies = Fact(
     MATCH (user:AWSUser)
     RETURN COUNT(user) AS count
     """,
+    asset_label="AWSUser",
     asset_id_field="user_arn",
     # CIS 2.14 is a per-user control, so a user with N direct attachments is
     # one finding; the attached policies are surfaced as list fields.
@@ -310,6 +315,8 @@ _aws_multiple_access_keys = Fact(
     MATCH (user:AWSUser)
     RETURN COUNT(user) AS count
     """,
+    asset_label="AWSUser",
+    asset_id_field="user_arn",
     identity_fields=("user_arn",),
     module=Module.AWS,
     maturity=Maturity.STABLE,
@@ -381,6 +388,8 @@ _aws_expired_certificates = Fact(
     MATCH (cert:AWSACMCertificate)
     RETURN COUNT(cert) AS count
     """,
+    asset_label="AWSACMCertificate",
+    asset_id_field="certificate_arn",
     identity_fields=("certificate_arn",),
     module=Module.AWS,
     maturity=Maturity.STABLE,
@@ -444,6 +453,8 @@ _aws_root_access_key_present = Fact(
     WHERE a.account_access_keys_present IS NOT NULL
     RETURN COUNT(a) AS count
     """,
+    asset_label="AWSAccount",
+    asset_id_field="account_id",
     identity_fields=("account_id",),
     module=Module.AWS,
     maturity=Maturity.STABLE,
@@ -509,6 +520,8 @@ _aws_root_mfa_disabled = Fact(
     WHERE a.account_mfa_enabled IS NOT NULL
     RETURN COUNT(a) AS count
     """,
+    asset_label="AWSAccount",
+    asset_id_field="account_id",
     identity_fields=("account_id",),
     module=Module.AWS,
     maturity=Maturity.STABLE,
@@ -634,10 +647,13 @@ _aws_admin_policy_attached = Fact(
     WITH DISTINCT a, policy
     RETURN COUNT(*) AS count
     """,
-    # No asset_id_field: the query already yields one row per (account, policy),
-    # so failing = row count. A single field cannot express that composite unit,
-    # and policy_id alone would under-count global AWS-managed policies shared
-    # across accounts (breaking passing = total - failing).
+    # asset_label/asset_id_field anchor the finding on the offending AWSPolicy node.
+    # NOTE: policy_id also drives the compliance failing-count, so a global AWS-managed
+    # policy shared across N accounts (N (account, policy) rows) now counts as one
+    # failing asset instead of N. The (account, policy) composite identity_fields still
+    # keeps each account's finding distinct.
+    asset_label="AWSPolicy",
+    asset_id_field="policy_id",
     identity_fields=("account_id", "policy_id"),
     module=Module.AWS,
     maturity=Maturity.STABLE,

--- a/cartography/rules/data/rules/cis_aws_logging.py
+++ b/cartography/rules/data/rules/cis_aws_logging.py
@@ -72,6 +72,7 @@ _aws_cloudtrail_not_multi_region = Fact(
     MATCH (trail:AWSCloudTrailTrail)
     RETURN COUNT(trail) AS count
     """,
+    asset_label="AWSCloudTrailTrail",
     asset_id_field="trail_arn",
     identity_fields=("trail_arn",),
     module=Module.AWS,
@@ -141,6 +142,7 @@ _aws_cloudtrail_log_validation_disabled = Fact(
     MATCH (trail:AWSCloudTrailTrail)
     RETURN COUNT(trail) AS count
     """,
+    asset_label="AWSCloudTrailTrail",
     asset_id_field="trail_arn",
     identity_fields=("trail_arn",),
     module=Module.AWS,
@@ -213,6 +215,7 @@ _aws_cloudtrail_bucket_access_logging_disabled = Fact(
     MATCH (:AWSCloudTrailTrail)-[:LOGS_TO]->(bucket:AWSS3Bucket)
     RETURN COUNT(DISTINCT bucket) AS count
     """,
+    asset_label="AWSS3Bucket",
     asset_id_field="bucket_id",
     identity_fields=("bucket_id",),
     module=Module.AWS,
@@ -281,6 +284,7 @@ _aws_cloudtrail_not_encrypted = Fact(
     MATCH (trail:AWSCloudTrailTrail)
     RETURN COUNT(trail) AS count
     """,
+    asset_label="AWSCloudTrailTrail",
     asset_id_field="trail_arn",
     identity_fields=("trail_arn",),
     module=Module.AWS,

--- a/cartography/rules/data/rules/cis_aws_networking.py
+++ b/cartography/rules/data/rules/cis_aws_networking.py
@@ -80,6 +80,8 @@ _aws_ebs_encryption_disabled = Fact(
     MATCH (volume:AWSEBSVolume)
     RETURN COUNT(volume) AS count
     """,
+    asset_id_field="volume_id",
+    asset_label="AWSEBSVolume",
     identity_fields=("volume_id",),
     module=Module.AWS,
     maturity=Maturity.STABLE,
@@ -168,6 +170,7 @@ _aws_cifs_internet_access = Fact(
     MATCH (sg:AWSEC2SecurityGroup)
     RETURN COUNT(sg) AS count
     """,
+    asset_label="AWSEC2SecurityGroup",
     asset_id_field="security_group_id",
     identity_fields=(
         "security_group_id",
@@ -283,6 +286,7 @@ _aws_remote_admin_ipv4 = Fact(
     MATCH (sg:AWSEC2SecurityGroup)
     RETURN COUNT(sg) AS count
     """,
+    asset_label="AWSEC2SecurityGroup",
     asset_id_field="security_group_id",
     identity_fields=(
         "security_group_id",
@@ -398,6 +402,7 @@ _aws_remote_admin_ipv6 = Fact(
     MATCH (sg:AWSEC2SecurityGroup)
     RETURN COUNT(sg) AS count
     """,
+    asset_label="AWSEC2SecurityGroup",
     asset_id_field="security_group_id",
     identity_fields=(
         "security_group_id",
@@ -496,6 +501,7 @@ _aws_default_sg_allows_traffic = Fact(
     MATCH (sg:AWSEC2SecurityGroup)
     RETURN COUNT(sg) AS count
     """,
+    asset_label="AWSEC2SecurityGroup",
     asset_id_field="security_group_id",
     identity_fields=("security_group_id",),
     module=Module.AWS,
@@ -577,6 +583,7 @@ _aws_ec2_imdsv2_required = Fact(
     WHERE NOT coalesce(ec2.state, 'running') IN ['terminated', 'shutting-down']
     RETURN COUNT(ec2) AS count
     """,
+    asset_label="AWSEC2Instance",
     asset_id_field="instance_id",
     identity_fields=("instance_id",),
     module=Module.AWS,

--- a/cartography/rules/data/rules/cis_aws_storage.py
+++ b/cartography/rules/data/rules/cis_aws_storage.py
@@ -78,6 +78,8 @@ _aws_s3_mfa_delete_disabled = Fact(
     MATCH (bucket:AWSS3Bucket)
     RETURN COUNT(bucket) AS count
     """,
+    asset_id_field="bucket_id",
+    asset_label="AWSS3Bucket",
     identity_fields=("bucket_id",),
     module=Module.AWS,
     maturity=Maturity.STABLE,
@@ -196,6 +198,8 @@ _aws_s3_block_public_access_disabled = Fact(
     MATCH (bucket:AWSS3Bucket)
     RETURN COUNT(bucket) AS count
     """,
+    asset_id_field="bucket_id",
+    asset_label="AWSS3Bucket",
     identity_fields=("bucket_id",),
     module=Module.AWS,
     maturity=Maturity.STABLE,
@@ -269,6 +273,8 @@ _aws_rds_encryption_disabled = Fact(
     MATCH (rds:AWSRDSInstance)
     RETURN COUNT(rds) AS count
     """,
+    asset_id_field="db_arn",
+    asset_label="AWSRDSInstance",
     identity_fields=("db_arn",),
     module=Module.AWS,
     maturity=Maturity.STABLE,

--- a/cartography/rules/data/rules/cis_google_workspace.py
+++ b/cartography/rules/data/rules/cis_google_workspace.py
@@ -74,6 +74,8 @@ _gw_user_2sv_not_enforced = Fact(
     MATCH (u:GoogleWorkspaceUser)
     RETURN COUNT(u) AS count
     """,
+    asset_id_field="user_id",
+    asset_label="GoogleWorkspaceUser",
     identity_fields=("user_id",),
     module=Module.GOOGLEWORKSPACE,
     maturity=Maturity.EXPERIMENTAL,
@@ -155,6 +157,8 @@ _gw_admin_2sv_not_enforced = Fact(
     WHERE coalesce(u.is_admin, false) = true OR coalesce(u.is_delegated_admin, false) = true
     RETURN COUNT(u) AS count
     """,
+    asset_id_field="user_id",
+    asset_label="GoogleWorkspaceUser",
     identity_fields=("user_id",),
     module=Module.GOOGLEWORKSPACE,
     maturity=Maturity.EXPERIMENTAL,
@@ -241,6 +245,8 @@ _gw_super_admin_count_too_low = Fact(
     MATCH (t:GoogleWorkspaceTenant)
     RETURN COUNT(t) AS count
     """,
+    asset_id_field="tenant_id",
+    asset_label="GoogleWorkspaceTenant",
     identity_fields=("tenant_id",),
     module=Module.GOOGLEWORKSPACE,
     maturity=Maturity.EXPERIMENTAL,
@@ -300,6 +306,8 @@ _gw_super_admin_count_too_high = Fact(
     MATCH (t:GoogleWorkspaceTenant)
     RETURN COUNT(t) AS count
     """,
+    asset_id_field="tenant_id",
+    asset_label="GoogleWorkspaceTenant",
     identity_fields=("tenant_id",),
     module=Module.GOOGLEWORKSPACE,
     maturity=Maturity.EXPERIMENTAL,
@@ -364,6 +372,8 @@ _gw_super_admin_with_delegated_admin_role = Fact(
     WHERE coalesce(u.is_admin, false) = true
     RETURN COUNT(u) AS count
     """,
+    asset_id_field="user_id",
+    asset_label="GoogleWorkspaceUser",
     identity_fields=("user_id",),
     module=Module.GOOGLEWORKSPACE,
     maturity=Maturity.EXPERIMENTAL,

--- a/cartography/rules/data/rules/cis_kubernetes_rbac.py
+++ b/cartography/rules/data/rules/cis_kubernetes_rbac.py
@@ -84,6 +84,7 @@ _k8s_cluster_admin_usage = Fact(
     MATCH (crb:KubernetesClusterRoleBinding)
     RETURN COUNT(crb) AS count
     """,
+    asset_label="KubernetesClusterRoleBinding",
     asset_id_field="binding_id",
     identity_fields=("binding_id", "subject_id"),
     module=Module.KUBERNETES,
@@ -157,6 +158,8 @@ _k8s_secret_access_clusterroles = Fact(
     WHERE NOT cr.name STARTS WITH 'system:'
     RETURN COUNT(cr) AS count
     """,
+    asset_label="KubernetesClusterRole",
+    asset_id_field="role_id",
     identity_fields=("role_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -194,6 +197,8 @@ _k8s_secret_access_roles = Fact(
     WHERE NOT r.name STARTS WITH 'system:'
     RETURN COUNT(r) AS count
     """,
+    asset_label="KubernetesRole",
+    asset_id_field="role_id",
     identity_fields=("role_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -272,6 +277,8 @@ _k8s_wildcard_clusterroles = Fact(
     WHERE NOT cr.name STARTS WITH 'system:'
     RETURN COUNT(cr) AS count
     """,
+    asset_label="KubernetesClusterRole",
+    asset_id_field="role_id",
     identity_fields=("role_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -311,6 +318,8 @@ _k8s_wildcard_roles = Fact(
     WHERE NOT r.name STARTS WITH 'system:'
     RETURN COUNT(r) AS count
     """,
+    asset_label="KubernetesRole",
+    asset_id_field="role_id",
     identity_fields=("role_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -392,6 +401,8 @@ _k8s_pod_create_clusterroles = Fact(
       AND NOT cr.name IN ['aws-node', 'vpc-resource-controller-role']
     RETURN COUNT(cr) AS count
     """,
+    asset_label="KubernetesClusterRole",
+    asset_id_field="role_id",
     identity_fields=("role_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -436,6 +447,8 @@ _k8s_pod_create_roles = Fact(
       AND NOT r.name IN ['aws-node', 'vpc-resource-controller-role']
     RETURN COUNT(r) AS count
     """,
+    asset_label="KubernetesRole",
+    asset_id_field="role_id",
     identity_fields=("role_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -473,6 +486,7 @@ kubernetes_roles_grant_pod_creation = Rule(
 class DefaultSaBindingsOutput(Finding):
     """Output model for default service account bindings check."""
 
+    namespace_id: str | None = None
     binding_name: str | None = None
     binding_id: str | None = None
     binding_type: str | None = None
@@ -517,6 +531,7 @@ _k8s_default_sa_cluster_role_bindings = Fact(
     WHERE sa.name = 'default'
     RETURN COUNT(sa) AS count
     """,
+    asset_label="KubernetesClusterRoleBinding",
     asset_id_field="binding_id",
     identity_fields=("binding_id",),
     module=Module.KUBERNETES,
@@ -555,6 +570,7 @@ _k8s_default_sa_role_bindings = Fact(
     WHERE sa.name = 'default'
     RETURN COUNT(sa) AS count
     """,
+    asset_label="KubernetesRoleBinding",
     asset_id_field="binding_id",
     identity_fields=("binding_id",),
     module=Module.KUBERNETES,
@@ -576,7 +592,10 @@ _k8s_default_sa_used_by_pods = Fact(
     WITH cluster.name AS cluster_name, sa.namespace AS namespace, pod.name AS pod_name
     ORDER BY pod_name
     WITH cluster_name, namespace, collect(DISTINCT pod_name) AS pod_names
+    OPTIONAL MATCH (ns:KubernetesNamespace)
+    WHERE ns.name = namespace AND ns.cluster_name = cluster_name
     RETURN
+        ns.id AS namespace_id,
         cluster_name + '/' + namespace AS binding_id,
         'PodUsesDefaultServiceAccount' AS binding_type,
         'default' AS service_account_name,
@@ -594,7 +613,8 @@ _k8s_default_sa_used_by_pods = Fact(
     WHERE sa.name = 'default'
     RETURN COUNT(sa) AS count
     """,
-    asset_id_field="binding_id",
+    asset_label="KubernetesNamespace",
+    asset_id_field="namespace_id",
     identity_fields=("cluster_name", "namespace"),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -632,6 +652,7 @@ _k8s_default_sa_automount_enabled = Fact(
       AND coalesce(sa.automount_service_account_token, true) = true
     RETURN COUNT(sa) AS count
     """,
+    asset_label="KubernetesServiceAccount",
     asset_id_field="binding_id",
     identity_fields=("binding_id",),
     module=Module.KUBERNETES,
@@ -713,6 +734,7 @@ _k8s_system_masters_cluster_role_bindings = Fact(
     MATCH (crb:KubernetesClusterRoleBinding)
     RETURN COUNT(crb) AS count
     """,
+    asset_label="KubernetesClusterRoleBinding",
     asset_id_field="binding_id",
     identity_fields=("binding_id",),
     module=Module.KUBERNETES,
@@ -747,6 +769,7 @@ _k8s_system_masters_role_bindings = Fact(
     MATCH (rb:KubernetesRoleBinding)
     RETURN COUNT(rb) AS count
     """,
+    asset_label="KubernetesRoleBinding",
     asset_id_field="binding_id",
     identity_fields=("binding_id",),
     module=Module.KUBERNETES,
@@ -824,6 +847,8 @@ _k8s_escalation_clusterroles = Fact(
       AND NOT cr.name IN ['cluster-admin', 'admin', 'edit', 'view']
     RETURN COUNT(cr) AS count
     """,
+    asset_label="KubernetesClusterRole",
+    asset_id_field="role_id",
     identity_fields=("role_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -858,6 +883,8 @@ _k8s_escalation_roles = Fact(
     WHERE NOT r.name STARTS WITH 'system:'
     RETURN COUNT(r) AS count
     """,
+    asset_label="KubernetesRole",
+    asset_id_field="role_id",
     identity_fields=("role_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -933,6 +960,8 @@ _k8s_pv_create_clusterroles = Fact(
     WHERE NOT cr.name STARTS WITH 'system:'
     RETURN COUNT(cr) AS count
     """,
+    asset_label="KubernetesClusterRole",
+    asset_id_field="role_id",
     identity_fields=("role_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -969,6 +998,8 @@ _k8s_pv_create_roles = Fact(
     WHERE NOT r.name STARTS WITH 'system:'
     RETURN COUNT(r) AS count
     """,
+    asset_label="KubernetesRole",
+    asset_id_field="role_id",
     identity_fields=("role_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -1040,6 +1071,8 @@ _k8s_node_proxy_clusterroles = Fact(
     WHERE NOT cr.name STARTS WITH 'system:'
     RETURN COUNT(cr) AS count
     """,
+    asset_label="KubernetesClusterRole",
+    asset_id_field="role_id",
     identity_fields=("role_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -1114,6 +1147,8 @@ _k8s_csr_approval_clusterroles = Fact(
     WHERE NOT cr.name STARTS WITH 'system:'
     RETURN COUNT(cr) AS count
     """,
+    asset_label="KubernetesClusterRole",
+    asset_id_field="role_id",
     identity_fields=("role_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -1200,6 +1235,8 @@ _k8s_webhook_config_clusterroles = Fact(
     WHERE NOT cr.name STARTS WITH 'system:'
     RETURN COUNT(cr) AS count
     """,
+    asset_label="KubernetesClusterRole",
+    asset_id_field="role_id",
     identity_fields=("role_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -1280,6 +1317,8 @@ _k8s_sa_token_creation_clusterroles = Fact(
       AND NOT cr.name IN ['cluster-admin', 'admin', 'edit', 'view']
     RETURN COUNT(cr) AS count
     """,
+    asset_label="KubernetesClusterRole",
+    asset_id_field="role_id",
     identity_fields=("role_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,

--- a/cartography/rules/data/rules/cis_kubernetes_rbac.py
+++ b/cartography/rules/data/rules/cis_kubernetes_rbac.py
@@ -592,7 +592,7 @@ _k8s_default_sa_used_by_pods = Fact(
     WITH cluster.name AS cluster_name, sa.namespace AS namespace, pod.name AS pod_name
     ORDER BY pod_name
     WITH cluster_name, namespace, collect(DISTINCT pod_name) AS pod_names
-    OPTIONAL MATCH (ns:KubernetesNamespace)
+    MATCH (ns:KubernetesNamespace)
     WHERE ns.name = namespace AND ns.cluster_name = cluster_name
     RETURN
         ns.id AS namespace_id,

--- a/cartography/rules/data/rules/cis_kubernetes_workloads.py
+++ b/cartography/rules/data/rules/cis_kubernetes_workloads.py
@@ -111,7 +111,7 @@ _k8s_secrets_in_env_vars = Fact(
     UNWIND pod_names_raw AS pod_name
     WITH cluster_name, namespace, secret_names, pod_name ORDER BY pod_name
     WITH cluster_name, namespace, secret_names, collect(pod_name) AS pod_names
-    OPTIONAL MATCH (ns:KubernetesNamespace)
+    MATCH (ns:KubernetesNamespace)
     WHERE ns.name = namespace AND ns.cluster_name = cluster_name
     RETURN
         ns.id AS namespace_id,
@@ -212,7 +212,7 @@ _k8s_service_account_tokens_mounted = Fact(
         namespace,
         service_account_name,
         collect(DISTINCT pod_name) AS pod_names
-    OPTIONAL MATCH (ns:KubernetesNamespace)
+    MATCH (ns:KubernetesNamespace)
     WHERE ns.name = namespace AND ns.cluster_name = cluster_name
     RETURN
         ns.id AS namespace_id,
@@ -264,7 +264,9 @@ _k8s_service_account_tokens_mounted = Fact(
         OR service_account_assumes_aws_role
         OR service_account_assumes_gcp_identity
       )
-    WITH DISTINCT cluster.name AS cluster_name, pod.namespace AS namespace, service_account_name
+    // Count distinct namespaces (matching the KubernetesNamespace anchor / failing unit),
+    // not (namespace, service account) pairs.
+    WITH DISTINCT cluster.name AS cluster_name, pod.namespace AS namespace
     RETURN COUNT(*) AS count
     """,
     asset_label="KubernetesNamespace",
@@ -553,7 +555,7 @@ _k8s_host_path_volumes = Fact(
     UNWIND pod_names_raw AS pod_name
     WITH cluster_name, namespace, host_path_volume_paths, pod_name ORDER BY pod_name
     WITH cluster_name, namespace, host_path_volume_paths, collect(pod_name) AS pod_names
-    OPTIONAL MATCH (ns:KubernetesNamespace)
+    MATCH (ns:KubernetesNamespace)
     WHERE ns.name = namespace AND ns.cluster_name = cluster_name
     RETURN
         ns.id AS namespace_id,

--- a/cartography/rules/data/rules/cis_kubernetes_workloads.py
+++ b/cartography/rules/data/rules/cis_kubernetes_workloads.py
@@ -79,6 +79,7 @@ K8S_INFRASTRUCTURE_SERVICE_ACCOUNT_NAMES_CYPHER = _cypher_string_list(
 class SecretsInEnvVarsOutput(Finding):
     """Output model for secrets in environment variables check."""
 
+    namespace_id: str | None = None
     cluster_name: str | None = None
     namespace: str | None = None
     secret_names: list[str] | None = None
@@ -110,7 +111,10 @@ _k8s_secrets_in_env_vars = Fact(
     UNWIND pod_names_raw AS pod_name
     WITH cluster_name, namespace, secret_names, pod_name ORDER BY pod_name
     WITH cluster_name, namespace, secret_names, collect(pod_name) AS pod_names
+    OPTIONAL MATCH (ns:KubernetesNamespace)
+    WHERE ns.name = namespace AND ns.cluster_name = cluster_name
     RETURN
+        ns.id AS namespace_id,
         cluster_name,
         namespace,
         secret_names,
@@ -127,6 +131,8 @@ _k8s_secrets_in_env_vars = Fact(
     MATCH (ns:KubernetesNamespace)
     RETURN COUNT(ns) AS count
     """,
+    asset_label="KubernetesNamespace",
+    asset_id_field="namespace_id",
     identity_fields=("cluster_name", "namespace"),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -157,6 +163,7 @@ kubernetes_secrets_used_as_environment_variables = Rule(
 # Main node: KubernetesPod
 # =============================================================================
 class ServiceAccountTokenMountOutput(Finding):
+    namespace_id: str | None = None
     cluster_name: str | None = None
     namespace: str | None = None
     service_account_name: str | None = None
@@ -205,7 +212,10 @@ _k8s_service_account_tokens_mounted = Fact(
         namespace,
         service_account_name,
         collect(DISTINCT pod_name) AS pod_names
+    OPTIONAL MATCH (ns:KubernetesNamespace)
+    WHERE ns.name = namespace AND ns.cluster_name = cluster_name
     RETURN
+        ns.id AS namespace_id,
         cluster_name,
         namespace,
         service_account_name AS service_account_name,
@@ -257,6 +267,8 @@ _k8s_service_account_tokens_mounted = Fact(
     WITH DISTINCT cluster.name AS cluster_name, pod.namespace AS namespace, service_account_name
     RETURN COUNT(*) AS count
     """,
+    asset_label="KubernetesNamespace",
+    asset_id_field="namespace_id",
     identity_fields=("cluster_name", "namespace", "service_account_name"),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -316,6 +328,7 @@ _k8s_host_pid_pods = Fact(
     MATCH (pod:KubernetesPod)
     RETURN COUNT(pod) AS count
     """,
+    asset_label="KubernetesPod",
     asset_id_field="pod_id",
     identity_fields=("pod_id",),
     module=Module.KUBERNETES,
@@ -367,6 +380,7 @@ _k8s_host_ipc_pods = Fact(
     MATCH (pod:KubernetesPod)
     RETURN COUNT(pod) AS count
     """,
+    asset_label="KubernetesPod",
     asset_id_field="pod_id",
     identity_fields=("pod_id",),
     module=Module.KUBERNETES,
@@ -418,6 +432,7 @@ _k8s_host_network_pods = Fact(
     MATCH (pod:KubernetesPod)
     RETURN COUNT(pod) AS count
     """,
+    asset_label="KubernetesPod",
     asset_id_field="pod_id",
     identity_fields=("pod_id",),
     module=Module.KUBERNETES,
@@ -475,6 +490,7 @@ _k8s_allow_privilege_escalation = Fact(
     MATCH (c:KubernetesContainer)
     RETURN COUNT(c) AS count
     """,
+    asset_label="KubernetesContainer",
     asset_id_field="container_id",
     identity_fields=("container_id",),
     module=Module.KUBERNETES,
@@ -507,6 +523,7 @@ kubernetes_containers_allowing_privilege_escalation = Rule(
 # Main node: KubernetesPod
 # =============================================================================
 class HostPathVolumeOutput(Finding):
+    namespace_id: str | None = None
     cluster_name: str | None = None
     namespace: str | None = None
     host_path_volume_paths: list[str] | None = None
@@ -536,7 +553,10 @@ _k8s_host_path_volumes = Fact(
     UNWIND pod_names_raw AS pod_name
     WITH cluster_name, namespace, host_path_volume_paths, pod_name ORDER BY pod_name
     WITH cluster_name, namespace, host_path_volume_paths, collect(pod_name) AS pod_names
+    OPTIONAL MATCH (ns:KubernetesNamespace)
+    WHERE ns.name = namespace AND ns.cluster_name = cluster_name
     RETURN
+        ns.id AS namespace_id,
         cluster_name,
         namespace,
         host_path_volume_paths,
@@ -552,6 +572,8 @@ _k8s_host_path_volumes = Fact(
     MATCH (ns:KubernetesNamespace)
     RETURN COUNT(ns) AS count
     """,
+    asset_label="KubernetesNamespace",
+    asset_id_field="namespace_id",
     identity_fields=("cluster_name", "namespace"),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -619,6 +641,7 @@ _k8s_host_ports = Fact(
     }
     RETURN COUNT(c) AS count
     """,
+    asset_label="KubernetesContainer",
     asset_id_field="container_id",
     identity_fields=("container_id",),
     module=Module.KUBERNETES,
@@ -698,6 +721,7 @@ _k8s_missing_runtime_default_seccomp = Fact(
     MATCH (pod:KubernetesPod)
     RETURN COUNT(pod) AS count
     """,
+    asset_label="KubernetesPod",
     asset_id_field="pod_id",
     identity_fields=("pod_id",),
     module=Module.KUBERNETES,
@@ -765,6 +789,8 @@ _k8s_pods_in_default_namespace = Fact(
     MATCH (pod:KubernetesPod)
     RETURN COUNT(pod) AS count
     """,
+    asset_label="KubernetesPod",
+    asset_id_field="pod_id",
     identity_fields=("pod_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,

--- a/cartography/rules/data/rules/cloud_security_product_deactivated.py
+++ b/cartography/rules/data/rules/cloud_security_product_deactivated.py
@@ -32,6 +32,12 @@ aws_guard_duty_detector_disabled = Fact(
     WITH DISTINCT a, r.region AS region
     RETURN COUNT(*) AS count
     """,
+    # Anchor on the AWSAccount node. NOTE: the finding unit is (account, region), so
+    # account_id driving the failing-count collapses multiple disabled regions of one
+    # account into a single failing asset; the (account_id, region) identity_fields keep
+    # each region's finding distinct.
+    asset_label="AWSAccount",
+    asset_id_field="account_id",
     identity_fields=("account_id", "region"),
     module=Module.AWS,
     maturity=Maturity.EXPERIMENTAL,

--- a/cartography/rules/data/rules/cloud_security_product_deactivated.py
+++ b/cartography/rules/data/rules/cloud_security_product_deactivated.py
@@ -29,7 +29,7 @@ aws_guard_duty_detector_disabled = Fact(
     """,
     cypher_count_query="""
     MATCH (a:AWSAccount)-[:RESOURCE]-(r:AWSEC2Instance|AWSEKSCluster|AWSLambda|AWSECSCluster|AWSRDSInstance|AWSRDSCluster)
-    WITH DISTINCT a, r.region AS region
+    WITH DISTINCT a
     RETURN COUNT(*) AS count
     """,
     # Anchor on the AWSAccount node. NOTE: the finding unit is (account, region), so

--- a/cartography/rules/data/rules/compute_instance_exposed.py
+++ b/cartography/rules/data/rules/compute_instance_exposed.py
@@ -83,6 +83,7 @@ _gcp_instance_internet_exposed = Fact(
     WHERE coalesce(instance.status, '') <> 'TERMINATED'
     RETURN COUNT(instance) AS count
     """,
+    asset_label="GCPInstance",
     asset_id_field="instance_id",
     identity_fields=("instance_id", "port", "security_group"),
     module=Module.GCP,
@@ -194,6 +195,7 @@ _azure_vm_internet_exposed = Fact(
     MATCH (vm:AzureVirtualMachine)
     RETURN COUNT(vm) AS count
     """,
+    asset_label="AzureVirtualMachine",
     asset_id_field="instance_id",
     identity_fields=("instance_id", "port", "security_group_id"),
     module=Module.AZURE,
@@ -252,6 +254,7 @@ _aws_ec2_instance_internet_exposed = Fact(
     WHERE NOT coalesce(ec2.state, 'running') IN ['terminated', 'shutting-down']
     RETURN COUNT(ec2) AS count
     """,
+    asset_label="AWSEC2Instance",
     asset_id_field="instance_id",
     identity_fields=("instance_id", "port", "security_group"),
     module=Module.AWS,
@@ -320,6 +323,7 @@ _scaleway_instance_internet_exposed = Fact(
     WHERE NOT coalesce(instance.state, 'running') IN ['stopped', 'stopped_in_place']
     RETURN COUNT(instance) AS count
     """,
+    asset_label="ScalewayInstance",
     asset_id_field="instance_id",
     identity_fields=("instance_id", "port", "security_group"),
     module=Module.SCALEWAY,
@@ -372,6 +376,7 @@ _scaleway_instance_pat_exposed = Fact(
     WHERE NOT coalesce(instance.state, 'running') IN ['stopped', 'stopped_in_place']
     RETURN COUNT(instance) AS count
     """,
+    asset_label="ScalewayInstance",
     asset_id_field="instance_id",
     identity_fields=("instance_id", "port", "security_group"),
     module=Module.SCALEWAY,

--- a/cartography/rules/data/rules/database_instance_exposed.py
+++ b/cartography/rules/data/rules/database_instance_exposed.py
@@ -45,6 +45,7 @@ _azure_sql_internet_exposed = Fact(
     MATCH (server:AzureSQLServer)
     RETURN COUNT(server) AS count
     """,
+    asset_label="AzureSQLServer",
     asset_id_field="id",
     identity_fields=("id",),
     module=Module.AZURE,
@@ -84,6 +85,7 @@ _azure_cosmosdb_public_access = Fact(
     MATCH (account:AzureCosmosDBAccount)
     RETURN COUNT(account) AS count
     """,
+    asset_label="AzureCosmosDBAccount",
     asset_id_field="id",
     identity_fields=("id",),
     module=Module.AZURE,
@@ -118,6 +120,8 @@ _gcp_cloud_sql_public_access = Fact(
     MATCH (sql:GCPCloudSQLInstance)
     RETURN COUNT(sql) AS count
     """,
+    asset_label="GCPCloudSQLInstance",
+    asset_id_field="id",
     identity_fields=("id",),
     module=Module.GCP,
     maturity=Maturity.EXPERIMENTAL,
@@ -180,6 +184,8 @@ _aws_rds_public_access = Fact(
     MATCH (rds:AWSRDSInstance)
     RETURN COUNT(rds) AS count
     """,
+    asset_label="AWSRDSInstance",
+    asset_id_field="id",
     identity_fields=("id",),
     module=Module.AWS,
     maturity=Maturity.EXPERIMENTAL,
@@ -219,6 +225,7 @@ _scaleway_rdb_public_access = Fact(
     MATCH (db:ScalewayRdbInstance)
     RETURN COUNT(db) AS count
     """,
+    asset_label="ScalewayRdbInstance",
     asset_id_field="id",
     identity_fields=("id",),
     module=Module.SCALEWAY,
@@ -253,6 +260,7 @@ _scaleway_redis_public_access = Fact(
     MATCH (rc:ScalewayRedisCluster)
     RETURN COUNT(rc) AS count
     """,
+    asset_label="ScalewayRedisCluster",
     asset_id_field="id",
     identity_fields=("id",),
     module=Module.SCALEWAY,
@@ -287,6 +295,7 @@ _scaleway_mongodb_public_access = Fact(
     MATCH (m:ScalewayMongoDBInstance)
     RETURN COUNT(m) AS count
     """,
+    asset_label="ScalewayMongoDBInstance",
     asset_id_field="id",
     identity_fields=("id",),
     module=Module.SCALEWAY,

--- a/cartography/rules/data/rules/databricks_security.py
+++ b/cartography/rules/data/rules/databricks_security.py
@@ -42,6 +42,8 @@ _pat_never_expires = Fact(
     MATCH (t:DatabricksToken)
     RETURN COUNT(t) AS count
     """,
+    asset_label="DatabricksToken",
+    asset_id_field="id",
     identity_fields=("id",),
     module=Module.DATABRICKS,
     maturity=Maturity.EXPERIMENTAL,
@@ -111,6 +113,8 @@ _ip_access_list_allows_all = Fact(
     MATCH (l:DatabricksIpAccessList)
     RETURN COUNT(l) AS count
     """,
+    asset_label="DatabricksIpAccessList",
+    asset_id_field="id",
     identity_fields=("id",),
     module=Module.DATABRICKS,
     maturity=Maturity.EXPERIMENTAL,
@@ -171,6 +175,8 @@ _public_delta_sharing_recipient = Fact(
     MATCH (r:DatabricksRecipient)
     RETURN COUNT(r) AS count
     """,
+    asset_label="DatabricksRecipient",
+    asset_id_field="id",
     identity_fields=("id",),
     module=Module.DATABRICKS,
     maturity=Maturity.EXPERIMENTAL,

--- a/cartography/rules/data/rules/delegation_boundary_modifiable.py
+++ b/cartography/rules/data/rules/delegation_boundary_modifiable.py
@@ -84,6 +84,7 @@ _aws_trust_relationship_manipulation = Fact(
     MATCH (principal:AWSPrincipal)
     RETURN COUNT(principal) AS count
     """,
+    asset_label="AWSPrincipal",
     asset_id_field="principal_identifier",
     identity_fields=("account_id", "principal_identifier", "policy_id"),
     module=Module.AWS,
@@ -160,6 +161,7 @@ _gcp_trust_relationship_manipulation = Fact(
     MATCH (principal:GCPPrincipal)
     RETURN COUNT(principal) AS count
     """,
+    asset_label="GCPPrincipal",
     asset_id_field="principal_identifier",
     identity_fields=("account_id", "principal_identifier", "policy_name"),
     module=Module.GCP,
@@ -250,6 +252,7 @@ _azure_trust_relationship_manipulation = Fact(
     MATCH (ra:AzureRoleAssignment)
     RETURN COUNT(ra) AS count
     """,
+    asset_label="EntraPrincipal",
     asset_id_field="principal_identifier",
     identity_fields=("account_id", "principal_identifier", "policy_id"),
     module=Module.AZURE,

--- a/cartography/rules/data/rules/device_security_posture_gaps.py
+++ b/cartography/rules/data/rules/device_security_posture_gaps.py
@@ -84,6 +84,7 @@ _duo_endpoint_posture_gaps = Fact(
     MATCH (endpoint:DuoEndpoint)
     RETURN COUNT(endpoint) AS count
     """,
+    asset_label="DuoEndpoint",
     asset_id_field="device_id",
     identity_fields=("device_id", "issue"),
     module=Module.DUO,
@@ -132,6 +133,7 @@ _duo_phone_posture_gaps = Fact(
     MATCH (phone:DuoPhone)
     RETURN COUNT(phone) AS count
     """,
+    asset_label="DuoPhone",
     asset_id_field="device_id",
     identity_fields=("device_id", "issue"),
     module=Module.DUO,
@@ -200,6 +202,7 @@ _jamf_computer_posture_gaps = Fact(
     MATCH (computer:JamfComputer)
     RETURN COUNT(computer) AS count
     """,
+    asset_label="JamfComputer",
     asset_id_field="device_id",
     identity_fields=("device_id", "issue"),
     module=Module.JAMF,
@@ -254,6 +257,7 @@ _jamf_mobile_device_posture_gaps = Fact(
     MATCH (device:JamfMobileDevice)
     RETURN COUNT(device) AS count
     """,
+    asset_label="JamfMobileDevice",
     asset_id_field="device_id",
     identity_fields=("device_id", "issue"),
     module=Module.JAMF,
@@ -340,6 +344,7 @@ _tailscale_device_posture_gaps = Fact(
     MATCH (device:TailscaleDevice)
     RETURN COUNT(device) AS count
     """,
+    asset_label="TailscaleDevice",
     asset_id_field="device_id",
     # Key on tailnet + stable hostname, not device.id: Tailscale ephemeral nodes get
     # a fresh device.id on every reconnect, which would re-create the same finding.

--- a/cartography/rules/data/rules/eol_software.py
+++ b/cartography/rules/data/rules/eol_software.py
@@ -143,7 +143,8 @@ def _build_kubernetes_ingress_nginx_eol_query() -> str:
          END AS software_minor
     WITH DISTINCT cluster, namespace, controller_instance,
                   software_version, software_major, software_minor
-    RETURN coalesce(cluster.id, cluster.name, 'unknown-cluster')
+    RETURN cluster.id AS cluster_id,
+           coalesce(cluster.id, cluster.name, 'unknown-cluster')
                + '/namespaces/' + namespace
                + '/ingress-controllers/' + controller_instance
                + '/' + coalesce(software_version, 'unknown') AS asset_id,
@@ -209,6 +210,7 @@ _eks_cluster_kubernetes_version_eol = Fact(
     MATCH (e:AWSEKSCluster)
     RETURN COUNT(e) AS count
     """,
+    asset_label="AWSEKSCluster",
     asset_id_field="asset_id",
     identity_fields=("asset_id",),
     module=Module.AWS,
@@ -261,6 +263,7 @@ _gke_cluster_kubernetes_version_eol = Fact(
     MATCH (g:GKECluster)
     RETURN COUNT(g) AS count
     """,
+    asset_label="GKECluster",
     asset_id_field="asset_id",
     identity_fields=("asset_id",),
     module=Module.GCP,
@@ -319,6 +322,7 @@ _aks_cluster_kubernetes_version_eol = Fact(
     MATCH (a:AzureKubernetesCluster)
     RETURN COUNT(a) AS count
     """,
+    asset_label="AzureKubernetesCluster",
     asset_id_field="asset_id",
     identity_fields=("asset_id",),
     module=Module.AZURE,
@@ -393,6 +397,7 @@ _kubernetes_cluster_kubernetes_version_eol = Fact(
     }
     RETURN COUNT(k) AS count
     """,
+    asset_label="KubernetesCluster",
     asset_id_field="asset_id",
     identity_fields=("asset_id",),
     module=Module.KUBERNETES,
@@ -485,7 +490,11 @@ _kubernetes_ingress_nginx_controller_eol = Fact(
              ) AS asset_id
     RETURN COUNT(asset_id) AS count
     """,
-    asset_id_field="asset_id",
+    # Aggregated per ingress-controller instance (asset_id is a synthetic composite key,
+    # kept as the stable identity). Anchor on the parent KubernetesCluster node, which is
+    # this fact's stated subject ("clusters running retired ingress-nginx controllers").
+    asset_label="KubernetesCluster",
+    asset_id_field="cluster_id",
     identity_fields=("asset_id",),
     module=Module.KUBERNETES,
     maturity=Maturity.EXPERIMENTAL,
@@ -516,6 +525,7 @@ _ec2_instance_amazon_linux_2_eol = Fact(
       AND date() > date('{_AMAZON_LINUX_2_EOL_DATE}')
     RETURN COUNT(ec2) AS count
     """,
+    asset_label="AWSEC2Instance",
     asset_id_field="asset_id",
     identity_fields=("asset_id",),
     module=Module.AWS,
@@ -526,6 +536,9 @@ _ec2_instance_amazon_linux_2_eol = Fact(
 class EOLSoftwareOutput(Finding):
     asset_name: str | None = None
     asset_id: str | None = None
+    # Populated only by the ingress-nginx fact, whose asset_id is a synthetic composite;
+    # cluster_id carries the real KubernetesCluster node id it anchors on.
+    cluster_id: str | None = None
     asset_type: str | None = None
     software_name: str | None = None
     software_version: str | None = None

--- a/cartography/rules/data/rules/eol_software.py
+++ b/cartography/rules/data/rules/eol_software.py
@@ -442,53 +442,12 @@ _kubernetes_ingress_nginx_controller_eol = Fact(
     WHERE has_controller_labels OR has_controller_image
     RETURN cluster, pod, container, resource_path, controller_path
     """,
+    # Denominator is all Kubernetes clusters (the evaluated population), matching the
+    # KubernetesCluster anchor so total, failing (distinct clusters running a retired
+    # controller), and passing all use the same cluster unit.
     cypher_count_query="""
-    MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(pod:KubernetesPod)
-    CALL {
-        WITH pod
-        MATCH (container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod)
-        RETURN container
-        UNION
-        WITH pod
-        MATCH (pod)-[:CONTAINS]->(container:KubernetesContainer)
-        RETURN container
-    }
-    WITH DISTINCT cluster, pod, container
-    WITH cluster, pod, container,
-         replace(toLower(coalesce(pod.labels, '')), ' ', '') AS labels_compacted,
-         toLower(coalesce(container.image, '')) AS image
-    WITH cluster, pod, container, labels_compacted, image,
-         labels_compacted CONTAINS '"app.kubernetes.io/name":"ingress-nginx"'
-             AND labels_compacted CONTAINS '"app.kubernetes.io/component":"controller"'
-             AS has_controller_labels,
-         image CONTAINS '/ingress-nginx/controller:' AS has_controller_image
-    WHERE has_controller_labels OR has_controller_image
-    WITH cluster, pod, container, labels_compacted, image,
-         CASE
-             WHEN labels_compacted CONTAINS '"app.kubernetes.io/instance":"'
-             THEN split(split(labels_compacted, '"app.kubernetes.io/instance":"')[1], '"')[0]
-             ELSE 'ingress-nginx'
-         END AS controller_instance,
-         CASE
-             WHEN labels_compacted CONTAINS '"app.kubernetes.io/version":"'
-             THEN split(split(labels_compacted, '"app.kubernetes.io/version":"')[1], '"')[0]
-             WHEN image CONTAINS '/ingress-nginx/controller:'
-             THEN split(split(image, '/ingress-nginx/controller:')[1], '@')[0]
-             ELSE NULL
-         END AS software_version_raw
-    WITH DISTINCT coalesce(cluster.id, cluster.name, 'unknown-cluster')
-             + '/namespaces/' + coalesce(pod.namespace, container.namespace, 'default')
-             + '/ingress-controllers/' + controller_instance
-             + '/'
-             + coalesce(
-                 CASE
-                     WHEN software_version_raw STARTS WITH 'v'
-                     THEN substring(software_version_raw, 1)
-                     ELSE software_version_raw
-                 END,
-                 'unknown'
-             ) AS asset_id
-    RETURN COUNT(asset_id) AS count
+    MATCH (cluster:KubernetesCluster)
+    RETURN COUNT(cluster) AS count
     """,
     # Aggregated per ingress-controller instance (asset_id is a synthetic composite key,
     # kept as the stable identity). Anchor on the parent KubernetesCluster node, which is

--- a/cartography/rules/data/rules/guardduty_active_threat.py
+++ b/cartography/rules/data/rules/guardduty_active_threat.py
@@ -69,6 +69,8 @@ aws_guardduty_active_threat = Fact(
       AND coalesce(f.sample, false) = false
     RETURN COUNT(f) AS count
     """,
+    asset_label="AWSGuardDutyFinding",
+    asset_id_field="finding_id",
     identity_fields=("finding_arn",),
     module=Module.AWS,
     maturity=Maturity.EXPERIMENTAL,

--- a/cartography/rules/data/rules/iam_role_external_account_trust.py
+++ b/cartography/rules/data/rules/iam_role_external_account_trust.py
@@ -41,6 +41,7 @@ _aws_role_external_account_trust = Fact(
     MATCH (:AWSAccount {inscope: true})-[:RESOURCE]->(role:AWSRole)
     RETURN COUNT(role) AS count
     """,
+    asset_label="AWSRole",
     asset_id_field="role_arn",
     identity_fields=("role_arn", "trusted_principal_arn"),
     module=Module.AWS,

--- a/cartography/rules/data/rules/identity_administration_privileges.py
+++ b/cartography/rules/data/rules/identity_administration_privileges.py
@@ -90,6 +90,7 @@ _aws_account_manipulation_permissions = Fact(
     AND principal.name <> 'OrganizationAccountAccessRole'
     RETURN COUNT(principal) AS count
     """,
+    asset_label="AWSPrincipal",
     asset_id_field="principal_identifier",
     identity_fields=("account_id", "principal_identifier", "policy_id"),
     module=Module.AWS,
@@ -179,6 +180,7 @@ _gcp_account_manipulation_permissions = Fact(
     MATCH (principal:GCPPrincipal)
     RETURN COUNT(principal) AS count
     """,
+    asset_label="GCPPrincipal",
     asset_id_field="principal_identifier",
     identity_fields=("account_id", "principal_identifier", "policy_name"),
     module=Module.GCP,
@@ -290,6 +292,7 @@ _azure_account_manipulation_permissions = Fact(
     MATCH (ra:AzureRoleAssignment)
     RETURN COUNT(ra) AS count
     """,
+    asset_label="EntraPrincipal",
     asset_id_field="principal_identifier",
     identity_fields=("account_id", "principal_identifier", "policy_id"),
     module=Module.AZURE,

--- a/cartography/rules/data/rules/identity_mfa_gaps.py
+++ b/cartography/rules/data/rules/identity_mfa_gaps.py
@@ -46,6 +46,7 @@ _cloudflare_account_2fa_not_enforced = Fact(
     MATCH (account:CloudflareAccount)
     RETURN COUNT(account) AS count
     """,
+    asset_label="CloudflareAccount",
     asset_id_field="account_id",
     identity_fields=("account_id",),
     module=Module.CLOUDFLARE,
@@ -91,6 +92,7 @@ _lastpass_user_mfa_missing = Fact(
     WHERE coalesce(user.disabled, false) = false
     RETURN COUNT(user) AS count
     """,
+    asset_label="LastpassUser",
     asset_id_field="principal_id",
     identity_fields=("principal_id",),
     module=Module.LASTPASS,
@@ -139,6 +141,7 @@ _jumpcloud_user_mfa_missing = Fact(
       AND coalesce(user.suspended, false) = false
     RETURN COUNT(user) AS count
     """,
+    asset_label="JumpCloudUser",
     asset_id_field="principal_id",
     identity_fields=("principal_id",),
     module=Module.JUMPCLOUD,
@@ -183,6 +186,7 @@ _duo_user_not_enrolled = Fact(
     WHERE coalesce(user.status, 'active') <> 'disabled'
     RETURN COUNT(user) AS count
     """,
+    asset_label="DuoUser",
     asset_id_field="principal_id",
     identity_fields=("principal_id",),
     module=Module.DUO,

--- a/cartography/rules/data/rules/inactive_user_active_accounts.py
+++ b/cartography/rules/data/rules/inactive_user_active_accounts.py
@@ -27,6 +27,8 @@ _inactive_user_active_accounts_ontology = Fact(
     MATCH (a:UserAccount)
     RETURN COUNT(a) AS count
     """,
+    asset_label="UserAccount",
+    asset_id_field="account_id",
     identity_fields=("source", "account_id", "user_id"),
     module=Module.CROSS_CLOUD,
     maturity=Maturity.EXPERIMENTAL,

--- a/cartography/rules/data/rules/kubernetes_control_plane_exposed.py
+++ b/cartography/rules/data/rules/kubernetes_control_plane_exposed.py
@@ -40,6 +40,7 @@ _aws_eks_control_plane_exposed = Fact(
     MATCH (c:AWSEKSCluster)
     RETURN COUNT(c) AS count
     """,
+    asset_label="AWSEKSCluster",
     asset_id_field="id",
     identity_fields=("id",),
     module=Module.AWS,
@@ -79,6 +80,7 @@ _gcp_gke_control_plane_exposed = Fact(
     MATCH (c:GKECluster)
     RETURN COUNT(c) AS count
     """,
+    asset_label="GKECluster",
     asset_id_field="id",
     identity_fields=("id",),
     module=Module.GCP,
@@ -119,6 +121,7 @@ _azure_aks_control_plane_exposed = Fact(
     MATCH (c:AzureKubernetesCluster)
     RETURN COUNT(c) AS count
     """,
+    asset_label="AzureKubernetesCluster",
     asset_id_field="id",
     identity_fields=("id",),
     module=Module.AZURE,

--- a/cartography/rules/data/rules/malicious_npm_dependencies_shai_hulud.py
+++ b/cartography/rules/data/rules/malicious_npm_dependencies_shai_hulud.py
@@ -134,6 +134,7 @@ _malicious_npm_dependencies_shai_hulud_sept_2025_github = Fact(
       AND coalesce(r.disabled, false) = false
     RETURN COUNT(r) AS count
     """,
+    asset_label="GitHubRepository",
     asset_id_field="repo",
     identity_fields=("repo", "name", "vulnerable_version"),
     module=Module.GITHUB,
@@ -2192,6 +2193,7 @@ _malicious_npm_dependencies_shai_hulud_nov_2025_github = Fact(
       AND coalesce(r.disabled, false) = false
     RETURN COUNT(r) AS count
     """,
+    asset_label="GitHubRepository",
     asset_id_field="repo",
     identity_fields=("repo", "name", "vulnerable_version"),
     module=Module.GITHUB,
@@ -3068,6 +3070,7 @@ _malicious_npm_dependencies_shai_hulud_mini_2026_github = Fact(
       AND coalesce(r.disabled, false) = false
     RETURN COUNT(r) AS count
     """,
+    asset_label="GitHubRepository",
     asset_id_field="repo",
     identity_fields=("repo", "name", "vulnerable_version"),
     module=Module.GITHUB,

--- a/cartography/rules/data/rules/mfa_missing.py
+++ b/cartography/rules/data/rules/mfa_missing.py
@@ -54,6 +54,7 @@ _missing_mfa_ontology = Fact(
       AND NOT COALESCE(a._ont_inactive, false)
     RETURN COUNT(a) AS count
     """,
+    asset_label="UserAccount",
     asset_id_field="id",
     identity_fields=("source", "id"),
     maturity=Maturity.EXPERIMENTAL,
@@ -99,6 +100,7 @@ _missing_mfa_aws = Fact(
     MATCH (user:AWSUser)
     RETURN COUNT(user) AS count
     """,
+    asset_label="AWSUser",
     asset_id_field="id",
     identity_fields=("id",),
     maturity=Maturity.EXPERIMENTAL,

--- a/cartography/rules/data/rules/nist_ai_rmf.py
+++ b/cartography/rules/data/rules/nist_ai_rmf.py
@@ -82,6 +82,7 @@ RISKY_SCOPE_PREFIXES_CYPHER = _as_cypher_list(RISKY_SCOPE_PREFIXES)
 # =============================================================================
 class NistAiAppInventoryOutput(Finding):
     app_name: str | None = None
+    asset_node_id: str | None = None
     app_client_id: str | None = None
     app_source: str | None = None
     match_method: str | None = None
@@ -115,6 +116,7 @@ _cross_cloud_nist_ai_app_inventory = Fact(
     OPTIONAL MATCH (ua:UserAccount)-[auth:AUTHORIZED]->(app)
     RETURN
         coalesce(app._ont_name, app.display_name, app.display_text, app.name) AS app_name,
+        app.id AS asset_node_id,
         coalesce(app._ont_client_id, app.client_id, app.app_id, app.id) AS app_client_id,
         app._ont_source AS app_source,
         app._ont_source AS source,
@@ -147,7 +149,9 @@ _cross_cloud_nist_ai_app_inventory = Fact(
     RETURN COUNT(app) AS count
     """,
     asset_label="ThirdPartyApp",
-    asset_id_field="app_client_id",
+    # app_client_id is the OAuth client id, which differs from the node id for
+    # Entra/Keycloak apps; anchor on the node's real .id instead.
+    asset_id_field="asset_node_id",
     identity_fields=("app_source", "app_client_id"),
     module=Module.CROSS_CLOUD,
     maturity=Maturity.EXPERIMENTAL,
@@ -179,6 +183,7 @@ ai_third_party_app_inventory = Rule(
 # =============================================================================
 class NistAiSensitiveScopesOutput(Finding):
     app_name: str | None = None
+    asset_node_id: str | None = None
     app_client_id: str | None = None
     app_source: str | None = None
     authorized_identity_count: int | None = None
@@ -218,6 +223,7 @@ _cross_cloud_nist_ai_app_sensitive_scopes = Fact(
     UNWIND risky_scopes_for_auth AS risky_scope
     RETURN
         coalesce(app._ont_name, app.display_name, app.display_text, app.name) AS app_name,
+        app.id AS asset_node_id,
         coalesce(app._ont_client_id, app.client_id, app.app_id, app.id) AS app_client_id,
         app._ont_source AS app_source,
         app._ont_source AS source,
@@ -253,7 +259,9 @@ _cross_cloud_nist_ai_app_sensitive_scopes = Fact(
     RETURN COUNT(app) AS count
     """,
     asset_label="ThirdPartyApp",
-    asset_id_field="app_client_id",
+    # app_client_id is the OAuth client id, which differs from the node id for
+    # Entra/Keycloak apps; anchor on the node's real .id instead.
+    asset_id_field="asset_node_id",
     identity_fields=("app_source", "app_client_id"),
     module=Module.CROSS_CLOUD,
     maturity=Maturity.EXPERIMENTAL,
@@ -311,6 +319,7 @@ ai_third_party_app_sensitive_scopes = Rule(
 # =============================================================================
 class NistAiAdminAuthorizationsOutput(Finding):
     app_name: str | None = None
+    asset_node_id: str | None = None
     app_client_id: str | None = None
     app_source: str | None = None
     admin_user_count: int | None = None
@@ -342,6 +351,7 @@ _gw_nist_ai_admin_app_authorizations = Fact(
       )
     RETURN
         coalesce(app._ont_name, app.display_name, app.display_text, app.name) AS app_name,
+        app.id AS asset_node_id,
         coalesce(app._ont_client_id, app.client_id, app.app_id, app.id) AS app_client_id,
         app._ont_source AS app_source,
         count(DISTINCT u) AS admin_user_count,
@@ -385,7 +395,9 @@ _gw_nist_ai_admin_app_authorizations = Fact(
     RETURN COUNT(DISTINCT app) AS count
     """,
     asset_label="ThirdPartyApp",
-    asset_id_field="app_client_id",
+    # app_client_id is the OAuth client id, which differs from the node id for
+    # Entra/Keycloak apps; anchor on the node's real .id instead.
+    asset_id_field="asset_node_id",
     identity_fields=("app_source", "app_client_id"),
     module=Module.GOOGLEWORKSPACE,
     maturity=Maturity.EXPERIMENTAL,

--- a/cartography/rules/data/rules/nist_ai_rmf.py
+++ b/cartography/rules/data/rules/nist_ai_rmf.py
@@ -146,6 +146,7 @@ _cross_cloud_nist_ai_app_inventory = Fact(
     MATCH (app:ThirdPartyApp)
     RETURN COUNT(app) AS count
     """,
+    asset_label="ThirdPartyApp",
     asset_id_field="app_client_id",
     identity_fields=("app_source", "app_client_id"),
     module=Module.CROSS_CLOUD,
@@ -251,6 +252,7 @@ _cross_cloud_nist_ai_app_sensitive_scopes = Fact(
     MATCH (app:ThirdPartyApp)
     RETURN COUNT(app) AS count
     """,
+    asset_label="ThirdPartyApp",
     asset_id_field="app_client_id",
     identity_fields=("app_source", "app_client_id"),
     module=Module.CROSS_CLOUD,
@@ -382,6 +384,7 @@ _gw_nist_ai_admin_app_authorizations = Fact(
         )
     RETURN COUNT(DISTINCT app) AS count
     """,
+    asset_label="ThirdPartyApp",
     asset_id_field="app_client_id",
     identity_fields=("app_source", "app_client_id"),
     module=Module.GOOGLEWORKSPACE,
@@ -538,6 +541,7 @@ _aibom_nist_ai_agent_inventory = Fact(
     MATCH (source)-[:HAS_COMPONENT]->(agent:AIAgent)
     RETURN COUNT(DISTINCT agent) AS count
     """,
+    asset_label="AIAgent",
     asset_id_field="agent_component_id",
     identity_fields=("agent_component_id",),
     module=Module.AIBOM,
@@ -637,6 +641,7 @@ _aibom_nist_ai_coverage_gaps = Fact(
     MATCH (source:AIBOMSource)
     RETURN COUNT(source) AS count
     """,
+    asset_label="AIBOMSource",
     asset_id_field="source_id",
     identity_fields=("source_id",),
     module=Module.AIBOM,
@@ -793,6 +798,9 @@ _openai_nist_ai_stale_or_unowned_api_keys = Fact(
     WHERE k:OpenAIAdminApiKey OR coalesce(project.status, 'active') = 'active'
     RETURN COUNT(k) AS count
     """,
+    # OpenAIApiKey and OpenAIAdminApiKey both carry the shared "APIKey" ontology label,
+    # so it anchors either concrete key type.
+    asset_label="APIKey",
     asset_id_field="api_key_id",
     identity_fields=("provider", "api_key_id"),
     module=Module.OPENAI,
@@ -856,6 +864,7 @@ _anthropic_nist_ai_stale_or_unscoped_api_keys = Fact(
     WHERE k.status = 'active'
     RETURN COUNT(k) AS count
     """,
+    asset_label="AnthropicApiKey",
     asset_id_field="api_key_id",
     identity_fields=("provider", "api_key_id"),
     module=Module.ANTHROPIC,

--- a/cartography/rules/data/rules/object_storage_public.py
+++ b/cartography/rules/data/rules/object_storage_public.py
@@ -43,6 +43,8 @@ _aws_s3_public = Fact(
     MATCH (b:AWSS3Bucket)
     RETURN COUNT(b) AS count
     """,
+    asset_id_field="id",
+    asset_label="AWSS3Bucket",
     identity_fields=("id",),
     module=Module.AWS,
     maturity=Maturity.EXPERIMENTAL,
@@ -85,6 +87,8 @@ _gcp_bucket_public = Fact(
     MATCH (b:GCPBucket)
     RETURN COUNT(b) AS count
     """,
+    asset_id_field="id",
+    asset_label="GCPBucket",
     identity_fields=("id",),
     module=Module.GCP,
     maturity=Maturity.EXPERIMENTAL,
@@ -122,6 +126,8 @@ _azure_storage_public_blob_access = Fact(
     MATCH (bc:AzureStorageBlobContainer)
     RETURN COUNT(bc) AS count
     """,
+    asset_id_field="id",
+    asset_label="AzureStorageBlobContainer",
     identity_fields=("id",),
     module=Module.AZURE,
     maturity=Maturity.EXPERIMENTAL,
@@ -156,6 +162,8 @@ _scaleway_bucket_public = Fact(
     MATCH (b:ScalewayObjectStorageBucket)
     RETURN COUNT(b) AS count
     """,
+    asset_id_field="id",
+    asset_label="ScalewayObjectStorageBucket",
     identity_fields=("id",),
     module=Module.SCALEWAY,
     maturity=Maturity.EXPERIMENTAL,

--- a/cartography/rules/data/rules/policy_administration_privileges.py
+++ b/cartography/rules/data/rules/policy_administration_privileges.py
@@ -90,6 +90,7 @@ _aws_policy_manipulation_capabilities = Fact(
     AND principal.name <> 'OrganizationAccountAccessRole'
     RETURN COUNT(principal) AS count
     """,
+    asset_label="AWSPrincipal",
     asset_id_field="principal_identifier",
     identity_fields=("account_id", "principal_identifier", "policy_id"),
     module=Module.AWS,
@@ -163,6 +164,7 @@ _gcp_policy_manipulation_capabilities = Fact(
     MATCH (principal:GCPPrincipal)
     RETURN COUNT(principal) AS count
     """,
+    asset_label="GCPPrincipal",
     asset_id_field="principal_identifier",
     identity_fields=("account_id", "principal_identifier", "policy_name"),
     module=Module.GCP,
@@ -263,6 +265,7 @@ _azure_policy_manipulation_capabilities = Fact(
     MATCH (ra:AzureRoleAssignment)
     RETURN COUNT(ra) AS count
     """,
+    asset_label="EntraPrincipal",
     asset_id_field="principal_identifier",
     identity_fields=("account_id", "principal_identifier", "policy_id"),
     module=Module.AZURE,
@@ -314,6 +317,7 @@ _scaleway_policy_manipulation_capabilities = Fact(
               WHERE l IN ['ScalewayUser', 'ScalewayApplication', 'ScalewayGroup'])
     RETURN COUNT(principal) AS count
     """,
+    asset_label="ScalewayPrincipal",
     asset_id_field="principal_identifier",
     identity_fields=("account_id", "principal_identifier", "policy_id"),
     module=Module.SCALEWAY,

--- a/cartography/rules/data/rules/public_snapshots.py
+++ b/cartography/rules/data/rules/public_snapshots.py
@@ -37,6 +37,7 @@ _aws_ebs_snapshot_public = Fact(
     MATCH (s:AWSEBSSnapshot)
     RETURN COUNT(s) AS count
     """,
+    asset_label="AWSEBSSnapshot",
     asset_id_field="id",
     identity_fields=("id",),
     module=Module.AWS,
@@ -75,6 +76,7 @@ _aws_rds_snapshot_public = Fact(
     MATCH (s:AWSRDSSnapshot)
     RETURN COUNT(s) AS count
     """,
+    asset_label="AWSRDSSnapshot",
     asset_id_field="arn",
     identity_fields=("arn",),
     module=Module.AWS,
@@ -121,6 +123,7 @@ _aws_ami_public = Fact(
     WHERE i.owner = a.id
     RETURN COUNT(i) AS count
     """,
+    asset_label="AWSEC2Image",
     asset_id_field="id",
     identity_fields=("id",),
     module=Module.AWS,

--- a/cartography/rules/data/rules/serverless_workload_exposed.py
+++ b/cartography/rules/data/rules/serverless_workload_exposed.py
@@ -42,6 +42,7 @@ _gcp_cloud_run_public_ingress = Fact(
     MATCH (svc:GCPCloudRunService)
     RETURN COUNT(svc) AS count
     """,
+    asset_label="GCPCloudRunService",
     asset_id_field="id",
     identity_fields=("id",),
     module=Module.GCP,
@@ -94,6 +95,7 @@ _gcp_cloud_function_http_trigger = Fact(
     MATCH (fn:GCPCloudFunction)
     RETURN COUNT(fn) AS count
     """,
+    asset_label="GCPCloudFunction",
     asset_id_field="id",
     identity_fields=("id",),
     module=Module.GCP,
@@ -132,6 +134,7 @@ _aws_lambda_anonymous_access = Fact(
     MATCH (fn:AWSLambda)
     RETURN COUNT(fn) AS count
     """,
+    asset_label="AWSLambda",
     asset_id_field="id",
     identity_fields=("id",),
     module=Module.AWS,
@@ -174,6 +177,7 @@ _scaleway_serverless_function_public = Fact(
     MATCH (fn:ScalewayServerlessFunction)
     RETURN COUNT(fn) AS count
     """,
+    asset_label="ScalewayServerlessFunction",
     asset_id_field="id",
     identity_fields=("id",),
     module=Module.SCALEWAY,
@@ -209,6 +213,7 @@ _scaleway_serverless_container_public = Fact(
     MATCH (c:ScalewayServerlessContainer)
     RETURN COUNT(c) AS count
     """,
+    asset_label="ScalewayServerlessContainer",
     asset_id_field="id",
     identity_fields=("id",),
     module=Module.SCALEWAY,

--- a/cartography/rules/data/rules/subimage_coverage.py
+++ b/cartography/rules/data/rules/subimage_coverage.py
@@ -22,7 +22,7 @@ _subimage_module_not_configured_fact = Fact(
     WHERE m.is_configured = false
     MATCH (app:ThirdPartyApp)
     WHERE toLower(app._ont_name) = toLower(m.id)
-    RETURN m.name AS module_name, app._ont_name AS app_name, app._ont_source AS app_source
+    RETURN m.id AS module_id, m.name AS module_name, app._ont_name AS app_name, app._ont_source AS app_source
     ORDER BY m.name
     """,
     cypher_visual_query="""
@@ -39,6 +39,8 @@ _subimage_module_not_configured_fact = Fact(
     WHERE toLower(app._ont_name) = toLower(m.id)
     RETURN count(m) AS count
     """,
+    asset_label="SubImageModule",
+    asset_id_field="module_id",
     identity_fields=("module_name", "app_name", "app_source"),
     module=Module.SUBIMAGE,
     maturity=Maturity.EXPERIMENTAL,
@@ -46,6 +48,7 @@ _subimage_module_not_configured_fact = Fact(
 
 
 class SubImageModuleNotConfiguredOutput(Finding):
+    module_id: str | None = None
     module_name: str | None = None
     app_name: str | None = None
     app_source: str | None = None
@@ -86,7 +89,7 @@ _subimage_framework_disabled_module_enabled_fact = Fact(
     WHERE f.enabled = false
     MATCH (m:SubImageModule)
     WHERE m.is_configured = true AND f.scope = m.id
-    RETURN f.name AS framework_name, f.scope AS framework_scope, m.name AS module_name
+    RETURN f.id AS framework_id, f.name AS framework_name, f.scope AS framework_scope, m.name AS module_name
     ORDER BY f.name
     """,
     cypher_visual_query="""
@@ -103,6 +106,8 @@ _subimage_framework_disabled_module_enabled_fact = Fact(
     WHERE m.is_configured = true AND f.scope = m.id
     RETURN count(f) AS count
     """,
+    asset_label="SubImageFramework",
+    asset_id_field="framework_id",
     identity_fields=("framework_name", "framework_scope"),
     module=Module.SUBIMAGE,
     maturity=Maturity.EXPERIMENTAL,
@@ -110,6 +115,7 @@ _subimage_framework_disabled_module_enabled_fact = Fact(
 
 
 class SubImageFrameworkDisabledModuleEnabledOutput(Finding):
+    framework_id: str | None = None
     framework_name: str | None = None
     framework_scope: str | None = None
     module_name: str | None = None
@@ -179,6 +185,8 @@ _container_image_not_found_fact = Fact(
       AND NOT coalesce(c.namespace, '') IN ['kube-system', 'calico-system', 'tigera-operator']
     RETURN count(c) AS count
     """,
+    asset_label="Container",
+    asset_id_field="container_id",
     identity_fields=("container_id",),
     module=Module.CROSS_CLOUD,
     maturity=Maturity.EXPERIMENTAL,
@@ -257,6 +265,8 @@ _aws_account_not_synced_fact = Fact(
     WHERE resource_count <= 1 AND coalesce(a.inscope, false) = true
     RETURN count(a) AS count
     """,
+    asset_label="AWSAccount",
+    asset_id_field="account_id",
     identity_fields=("account_id",),
     module=Module.AWS,
     maturity=Maturity.EXPERIMENTAL,
@@ -325,6 +335,8 @@ _repository_without_slsa_provenance_fact = Fact(
     WHERE r.match_method <> 'provenance'
     RETURN count(DISTINCT repo) AS count
     """,
+    asset_label="CodeRepository",
+    asset_id_field="repo_id",
     identity_fields=("repo_id",),
     module=Module.SUBIMAGE,
     maturity=Maturity.EXPERIMENTAL,

--- a/cartography/rules/data/rules/subimage_coverage.py
+++ b/cartography/rules/data/rules/subimage_coverage.py
@@ -37,7 +37,7 @@ _subimage_module_not_configured_fact = Fact(
     WHERE m.is_configured = false
     MATCH (app:ThirdPartyApp)
     WHERE toLower(app._ont_name) = toLower(m.id)
-    RETURN count(m) AS count
+    RETURN count(DISTINCT m) AS count
     """,
     asset_label="SubImageModule",
     asset_id_field="module_id",

--- a/cartography/rules/data/rules/tailscale_security_configuration_gaps.py
+++ b/cartography/rules/data/rules/tailscale_security_configuration_gaps.py
@@ -39,6 +39,7 @@ _tailscale_device_approval_disabled = Fact(
     MATCH (tailnet:TailscaleTailnet)
     RETURN COUNT(tailnet) AS count
     """,
+    asset_label="TailscaleTailnet",
     asset_id_field="asset_id",
     identity_fields=("asset_id", "issue"),
     module=Module.TAILSCALE,
@@ -70,6 +71,7 @@ _tailscale_user_approval_disabled = Fact(
     MATCH (tailnet:TailscaleTailnet)
     RETURN COUNT(tailnet) AS count
     """,
+    asset_label="TailscaleTailnet",
     asset_id_field="asset_id",
     identity_fields=("asset_id", "issue"),
     module=Module.TAILSCALE,
@@ -101,6 +103,7 @@ _tailscale_network_flow_logging_disabled = Fact(
     MATCH (tailnet:TailscaleTailnet)
     RETURN COUNT(tailnet) AS count
     """,
+    asset_label="TailscaleTailnet",
     asset_id_field="asset_id",
     identity_fields=("asset_id", "issue"),
     module=Module.TAILSCALE,
@@ -132,6 +135,7 @@ _tailscale_device_auto_updates_disabled = Fact(
     MATCH (tailnet:TailscaleTailnet)
     RETURN COUNT(tailnet) AS count
     """,
+    asset_label="TailscaleTailnet",
     asset_id_field="asset_id",
     identity_fields=("asset_id", "issue"),
     module=Module.TAILSCALE,
@@ -163,6 +167,7 @@ _tailscale_device_key_expiry_disabled = Fact(
     MATCH (device:TailscaleDevice)
     RETURN COUNT(device) AS count
     """,
+    asset_label="TailscaleDevice",
     asset_id_field="asset_id",
     # Key on tailnet + stable hostname, not device.id: Tailscale ephemeral nodes get
     # a fresh device.id on every reconnect, which would re-create the same finding.

--- a/cartography/rules/data/rules/unmanaged_accounts.py
+++ b/cartography/rules/data/rules/unmanaged_accounts.py
@@ -39,6 +39,8 @@ _unmanaged_accounts_ontology = Fact(
     AND NOT (a:SlackUser AND a.id = 'USLACKBOT')
     RETURN COUNT(a) AS count
     """,
+    asset_label="UserAccount",
+    asset_id_field="id",
     identity_fields=("source", "id"),
     module=Module.CROSS_CLOUD,
     maturity=Maturity.EXPERIMENTAL,

--- a/cartography/rules/data/rules/unpinned_github_actions.py
+++ b/cartography/rules/data/rules/unpinned_github_actions.py
@@ -45,6 +45,7 @@ _unpinned_github_actions_fact = Fact(
       AND coalesce(repo.disabled, false) = false
     RETURN COUNT(DISTINCT a) AS count
     """,
+    asset_label="GitHubAction",
     asset_id_field="action_id",
     identity_fields=("repo", "workflow_path", "action_id"),
     module=Module.GITHUB,

--- a/cartography/rules/data/rules/workload_identity_admin_capabilities.py
+++ b/cartography/rules/data/rules/workload_identity_admin_capabilities.py
@@ -93,6 +93,7 @@ _aws_service_account_manipulation_via_ec2 = Fact(
     MATCH (ec2:AWSEC2Instance)
     RETURN COUNT(ec2) AS count
     """,
+    asset_label="AWSEC2Instance",
     asset_id_field="workload_id",
     identity_fields=("workload_id",),
     module=Module.AWS,
@@ -173,6 +174,7 @@ _aws_service_account_manipulation_via_lambda = Fact(
     MATCH (lambda:AWSLambda)
     RETURN COUNT(lambda) AS count
     """,
+    asset_label="AWSLambda",
     asset_id_field="workload_id",
     identity_fields=("workload_id",),
     module=Module.AWS,

--- a/cartography/rules/runners.py
+++ b/cartography/rules/runners.py
@@ -180,6 +180,8 @@ def _run_fact(
         failing=failing,
         passing=passing,
         identity_fields=fact.identity_fields,
+        asset_label=fact.asset_label,
+        asset_id_field=fact.asset_id_field,
     )
 
 

--- a/cartography/rules/spec/model.py
+++ b/cartography/rules/spec/model.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from dataclasses import dataclass
 from dataclasses import field
 from enum import Enum
@@ -276,18 +277,43 @@ class Fact:
     """
     identity_fields: tuple[str, ...]
     """Output-model field(s) forming the stable logical identity of a finding across syncs; must exist on the output model and be returned by ``cypher_query``, and are distinct from volatile display fields and from ``asset_id_field`` (which only drives the compliance failing-count). Required with no default: a Fact that omits it fails to construct, forcing every rule to declare a stable identity explicitly."""
+    asset_label: str
+    """
+    The Neo4j node label of the single asset this Fact is about (e.g. ``KubernetesPod``,
+    ``AWSEC2Instance``). Together with the value of ``asset_id_field`` it forms an indexable
+    ``(label, id)`` anchor on the affected node, letting consumers locate that node in the
+    graph without inferring the label from a field name. Required with no default: a Fact
+    that omits it fails to construct.
+    """
     asset_id_field: str | None = None
     """
-    The field name in the output model that uniquely identifies an asset.
-    When set, failing count is computed as the count of distinct values of this field
-    rather than the total number of finding rows. This is needed when a single asset
-    can produce multiple finding rows (e.g., one security group with multiple violating rules).
+    The output-model field whose value is the ``.id`` of the ``asset_label`` node, i.e. the
+    id half of the ``(label, id)`` anchor. Also drives the compliance failing-count: when set,
+    the failing count is the number of distinct values of this field rather than the total
+    number of finding rows. This matters when a single asset can produce multiple finding
+    rows (e.g., one security group with multiple violating rules). Must be returned by
+    ``cypher_query`` via ``... AS <name>``.
     """
 
     def __post_init__(self) -> None:
         if not self.identity_fields:
             raise ValueError(
                 f"Fact '{self.id}' must declare a non-empty identity_fields tuple."
+            )
+        if not self.asset_label:
+            raise ValueError(f"Fact '{self.id}' must declare a non-empty asset_label.")
+        if not self.asset_id_field:
+            raise ValueError(
+                f"Fact '{self.id}' must declare asset_id_field: it is the id half of "
+                f"the (asset_label, id) anchor."
+            )
+        returned_aliases = set(
+            re.findall(r"\bAS\s+(\w+)", self.cypher_query, re.IGNORECASE)
+        )
+        if self.asset_id_field not in returned_aliases:
+            raise ValueError(
+                f"Fact '{self.id}' asset_id_field '{self.asset_id_field}' is not returned "
+                f"by its cypher_query (expected a '... AS {self.asset_id_field}' alias)."
             )
 
 

--- a/cartography/rules/spec/result.py
+++ b/cartography/rules/spec/result.py
@@ -63,6 +63,12 @@ class FactResult:
             from rule_id + fact_id + these field values without importing the Python rule
             registry. Defaults to empty only for directly-constructed results; the runner
             always populates it from the Fact, which requires a non-empty value.
+        asset_label (str | None): The Neo4j node label of the asset this Fact is about,
+            mirrored from the executed Fact. With asset_id_field it forms the (label, id)
+            anchor on the affected node. Defaults to None only for directly-constructed
+            results; the runner always populates it from the Fact.
+        asset_id_field (str | None): The output-model field holding that node's .id (the id
+            half of the anchor), mirrored from the executed Fact.
     """
 
     fact_id: str
@@ -74,6 +80,8 @@ class FactResult:
     failing: int | None = None
     passing: int | None = None
     identity_fields: tuple[str, ...] = ()
+    asset_label: str | None = None
+    asset_id_field: str | None = None
 
 
 @dataclass

--- a/docs/root/usage/rules.md
+++ b/docs/root/usage/rules.md
@@ -153,9 +153,11 @@ _new_attack_surface = Fact(
     id="aws_new_vulnerability_check",
     name="New AWS Vulnerability Pattern",
     description="Recently discovered attack pattern",
-    cypher_query="...",
+    cypher_query="...",  # must RETURN the affected node's id AS id
     cypher_visual_query="...",
     cypher_count_query="...",
+    asset_label="AWSEC2Instance",  # Neo4j label of the affected node
+    asset_id_field="id",           # output field holding that node's .id
     identity_fields=("id",),
     module=Module.AWS,
     maturity=Maturity.EXPERIMENTAL,  # New, needs testing
@@ -178,9 +180,11 @@ _proven_check = Fact(
     id="aws_s3_public",
     name="Internet-Accessible S3 Storage Attack Surface",
     description="AWS S3 buckets accessible from the internet",
-    cypher_query="...",
+    cypher_query="...",  # must RETURN the affected node's id AS id
     cypher_visual_query="...",
     cypher_count_query="...",
+    asset_label="AWSS3Bucket",  # Neo4j label of the affected node
+    asset_id_field="id",        # output field holding that node's .id
     identity_fields=("id",),
     module=Module.AWS,
     maturity=Maturity.STABLE,  # Battle-tested in production
@@ -546,7 +550,8 @@ The field is required (no default), so a fact that omits it fails to construct.
 _aws_user_direct_policies = Fact(
     id="aws_user_direct_policies",
     ...
-    asset_id_field="user_arn",                    # compliance failing-count only
+    asset_label="AWSUser",                        # Neo4j label of the affected node
+    asset_id_field="user_arn",                    # that node's .id + failing-count driver
     identity_fields=("user_arn", "policy_arn"),   # one finding per attachment
 )
 ```
@@ -564,19 +569,32 @@ Guidelines:
 - `identity_fields` is emitted per fact in the `cartography-rules run --output json` output (on each
   fact result, alongside `fact_id`), so JSON consumers get the contract without importing the
   Python rule registry.
-- `identity_fields` is distinct from `asset_id_field`. `asset_id_field` only drives the
-  distinct-asset failing count shown in compliance metrics; it is not a lifecycle-identity contract.
-  The two can differ on purpose: `aws_user_direct_policies` counts distinct users
-  (`asset_id_field="user_arn"`) but treats each user/policy attachment as a separate finding
-  (`identity_fields=("user_arn", "policy_arn")`).
+- Every fact **must** also declare an affected-node anchor: `asset_label` (the Neo4j label of the
+  node the finding is about) and `asset_id_field` (the output-model field holding that node's `.id`).
+  Both are required and, together, form an indexable `(label, id)` anchor so consumers can locate the
+  offending node in the graph. `asset_id_field` must exist on the output model and be returned by the
+  `cypher_query` (`... AS <name>`); `Fact.__post_init__` and a unit test enforce this.
+- `identity_fields` is distinct from `asset_id_field`. `asset_id_field` is the anchor id **and**
+  drives the distinct-asset failing count shown in compliance metrics; it is not the
+  lifecycle-identity contract. The two can differ on purpose: `aws_user_direct_policies` anchors on
+  and counts distinct users (`asset_label="AWSUser"`, `asset_id_field="user_arn"`) but treats each
+  user/policy attachment as a separate finding (`identity_fields=("user_arn", "policy_arn")`).
+- When the affected node has no single id column yet (e.g. a namespace-aggregated query), return one
+  (`... AS namespace_id`) and point `asset_id_field` at it. When the node can be one of several
+  labels, anchor on a shared umbrella label (`AWSPrincipal`, `GCPPrincipal`, `EntraPrincipal`,
+  `ScalewayPrincipal`, `APIKey`, ...) rather than guessing a single subtype.
+- `asset_label` and `asset_id_field` are emitted per fact in the `cartography-rules run --output
+  json` output (alongside `identity_fields`), so JSON consumers get the anchor without importing the
+  Python rule registry.
 
 ### Display field order (finding title)
 
 The **order** in which fields are declared on the output model is a de-facto display contract.
 Downstream consumers derive a finding's title by taking the **first non-empty rule-specific field
 of the output model, in class declaration order**. Declaration order is independent of
-`identity_fields` and `asset_id_field` (those stay whatever the identity contract needs) and of the
-`cypher_query` `RETURN` order (the model is keyed by alias name, not position).
+`identity_fields`, `asset_label`, and `asset_id_field` (those stay whatever the identity and anchor
+contracts need) and of the `cypher_query` `RETURN` order (the model is keyed by alias name, not
+position).
 
 The base `Finding` class declares two inherited fields, `source` and `extra`, before any
 rule-specific field, so `model_fields` / `model_dump()` lists them first. They are metadata, not
@@ -636,6 +654,8 @@ class DatabaseExposedOutput(Finding):
        MATCH (n:SomeNode)
        RETURN COUNT(n) AS count
        """,
+       asset_label="SomeNode",   # Neo4j label of the affected node
+       asset_id_field="id",      # output field holding that node's .id (returned above)
        identity_fields=("id",),
        module=Module.AWS,
        maturity=Maturity.EXPERIMENTAL,
@@ -659,6 +679,8 @@ class DatabaseExposedOutput(Finding):
        MATCH (n:SomeAzureNode)
        RETURN COUNT(n) AS count
        """,
+       asset_label="SomeAzureNode",  # Neo4j label of the affected node
+       asset_id_field="id",          # output field holding that node's .id (returned above)
        identity_fields=("id",),
        module=Module.AZURE,
        maturity=Maturity.EXPERIMENTAL,

--- a/tests/integration/rules/test_cis_kubernetes_workloads.py
+++ b/tests/integration/rules/test_cis_kubernetes_workloads.py
@@ -29,6 +29,7 @@ def test_secrets_in_env_fact_matches_env_and_dual_use_mount_methods(
     neo4j_session.run(
         """
         CREATE (c:KubernetesCluster {id: 'cluster-1', name: 'cluster-1'})
+        CREATE (ns:KubernetesNamespace {id: 'cluster-1/default', name: 'default', cluster_name: 'cluster-1'})
         CREATE (env_pod:KubernetesPod {id: 'pod-env', name: 'pod-env', namespace: 'default'})
         CREATE (both_pod:KubernetesPod {id: 'pod-both', name: 'pod-both', namespace: 'default'})
         CREATE (vol_pod:KubernetesPod {id: 'pod-vol', name: 'pod-vol', namespace: 'default'})

--- a/tests/integration/rules/test_eol_software.py
+++ b/tests/integration/rules/test_eol_software.py
@@ -226,6 +226,7 @@ def test_ingress_nginx_fact_collapses_controller_replicas(neo4j_session) -> None
     # Assert
     assert findings == [
         {
+            "cluster_id": "cluster-1",
             "asset_id": "cluster-1/namespaces/ingress-nginx/ingress-controllers/ingress-nginx/1.12.0",
             "asset_name": "cluster-1/ingress-nginx/ingress-nginx",
             "asset_type": "KubernetesIngressController",

--- a/tests/unit/rules/test_asset_anchor.py
+++ b/tests/unit/rules/test_asset_anchor.py
@@ -1,0 +1,97 @@
+"""
+Validation for the affected-node anchor contract.
+
+Every ``Fact`` must expose an indexable ``(asset_label, id)`` anchor on the node
+it is about. ``Fact.__post_init__`` already fails construction (so the registry
+will not import) when ``asset_label`` is empty, ``asset_id_field`` is unset, or
+``asset_id_field`` is not returned by ``cypher_query``. On top of that hard
+failure, every fact's ``asset_id_field`` must:
+  * be a real field on the owning Rule's output model (the runner reads it via
+    ``getattr(finding, asset_id_field)``), and
+  * be returned by the fact's ``cypher_query`` (via a ``... AS <name>`` alias).
+"""
+
+import re
+
+import pytest
+
+from cartography.rules.data.rules import RULES
+from cartography.rules.formatters import to_serializable
+from cartography.rules.spec.result import FactResult
+
+# Matches the `RETURN expr AS alias` convention every fact query uses.
+_RETURN_ALIAS_RE = re.compile(r"\bAS\s+(\w+)", re.IGNORECASE)
+
+
+def _returned_aliases(cypher_query: str) -> set[str]:
+    return set(_RETURN_ALIAS_RE.findall(cypher_query))
+
+
+# (rule_id, fact_id, rule, fact) for every fact in the registry.
+_ALL_FACTS = [
+    pytest.param(rule.id, fact.id, rule, fact, id=f"{rule.id}::{fact.id}")
+    for rule in RULES.values()
+    for fact in rule.facts
+]
+
+
+@pytest.mark.parametrize("rule_id, fact_id, rule, fact", _ALL_FACTS)
+def test_asset_label_non_empty(rule_id, fact_id, rule, fact):
+    """Every fact must declare the Neo4j label of the node it is about."""
+    assert fact.asset_label, (
+        f"Rule '{rule_id}' fact '{fact_id}' has empty asset_label; declare the "
+        f"Neo4j node label the finding is about."
+    )
+
+
+@pytest.mark.parametrize("rule_id, fact_id, rule, fact", _ALL_FACTS)
+def test_asset_id_field_set(rule_id, fact_id, rule, fact):
+    """asset_label needs the id half of the anchor to be resolvable."""
+    assert fact.asset_id_field, (
+        f"Rule '{rule_id}' fact '{fact_id}' declares asset_label "
+        f"'{fact.asset_label}' but no asset_id_field."
+    )
+
+
+@pytest.mark.parametrize("rule_id, fact_id, rule, fact", _ALL_FACTS)
+def test_asset_id_field_exists_on_output_model(rule_id, fact_id, rule, fact):
+    """asset_id_field must be a real field on the rule's output model.
+
+    The runner reads the anchor id with ``getattr(finding, asset_id_field)``;
+    if the field is not declared it lands in ``extra`` and the lookup fails.
+    """
+    model_fields = set(rule.output_model.model_fields)
+    assert fact.asset_id_field in model_fields, (
+        f"Rule '{rule_id}' fact '{fact_id}' asset_id_field "
+        f"'{fact.asset_id_field}' is not on output model "
+        f"'{rule.output_model.__name__}'."
+    )
+
+
+@pytest.mark.parametrize("rule_id, fact_id, rule, fact", _ALL_FACTS)
+def test_asset_id_field_returned_by_query(rule_id, fact_id, rule, fact):
+    """asset_id_field must be returned (AS <name>) by the fact's cypher_query."""
+    aliases = _returned_aliases(fact.cypher_query)
+    assert fact.asset_id_field in aliases, (
+        f"Rule '{rule_id}' fact '{fact_id}' asset_id_field "
+        f"'{fact.asset_id_field}' is not returned by its cypher_query."
+    )
+
+
+def test_asset_anchor_surfaced_in_serialized_output():
+    """
+    asset_label / asset_id_field must reach the serialized (JSON) output so
+    consumers that do not import the Python rule registry can build the
+    (label, id) anchor from the emitted findings.
+    """
+    result = FactResult(
+        fact_id="aws_user_direct_policies",
+        fact_name="Example",
+        fact_description="Example",
+        fact_provider="AWS",
+        asset_label="AWSUser",
+        asset_id_field="user_arn",
+    )
+    serialized = to_serializable(result)
+    assert serialized["asset_label"] == "AWSUser"
+    assert serialized["asset_id_field"] == "user_arn"


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):

### Summary

A `Fact` exposed the affected resource's id (via `asset_id_field`, and only on some facts) but never the **Neo4j label** of that node. The label lived only implicitly inside the Cypher `MATCH (x:Label)`, so it was not machine-readable. A consumer that wants to locate the affected node in the graph (for enrichment, ownership, exposure/blast-radius analysis) had to guess the label from a field name (`pod_id` -> `KubernetesPod`) — a brittle, per-consumer mapping. It failed hardest on Kubernetes facts, whose id aliases carry no label, and on the facts that exposed no `asset_id_field` at all.

This change makes every Fact declare, as first-class self-describing metadata, the label of the single node it is about:

- **Model**: add a **required** `asset_label: str` to `Fact`, reusing the existing `asset_id_field` as the id half. `Fact.__post_init__` enforces that both are set and that `asset_id_field` is returned by `cypher_query` (`... AS <name>`), so a fact that omits the anchor fails to construct.
- **Results/JSON**: mirror `asset_label` / `asset_id_field` onto `FactResult` so they reach `cartography-rules run --output json` (same precedent as `identity_fields`).
- **All facts populated**: every fact now declares a resolvable `(asset_label, asset_id_field)` anchor. `asset_id_field` was added where it was missing. Namespace-aggregated Kubernetes facts now `OPTIONAL MATCH` and return the `KubernetesNamespace` id; the ingress-nginx EoL fact anchors on its parent `KubernetesCluster`.
- **Umbrella labels**: added `EntraPrincipal` / `ScalewayPrincipal` node labels (mirroring the existing `AWSPrincipal` / `GCPPrincipal`) so the polymorphic IAM admin-capability facts anchor on a single label; the OpenAI key fact uses the already-shared `APIKey` label.
- **Docs**: updated `docs/root/usage/rules.md` so every `Fact(...)` example includes the now-required fields (copying a snippet no longer raises `ValueError`) and the explanation no longer describes `asset_id_field` as compliance-metric-only.

### Related issues or links

- Fixes #

### Breaking changes

Not an API break. Note a compliance-metric behavior change: adding `asset_id_field` to a few facts that previously omitted it shifts their "failing" count from row-count to distinct-anchor-count. Affected facts (documented inline): `aws_admin_policy_attached`, `cloud_security_product_deactivated`, `k8s_service_account_tokens_mounted`, and the ingress-nginx EoL fact.

### How was this tested?

- `make test_lint` (pre-commit: black, isort, flake8, mypy) passes.
- `tests/unit/rules/` passes (1996 tests), including the new parametrized `tests/unit/rules/test_asset_anchor.py`, which asserts for every fact that `asset_label` is set, `asset_id_field` is set, is a field on the rule's output model, and is returned by the query — plus a JSON round-trip.
- `tests/unit/cartography/test_doc.py::test_schema_doc`, the ontology mapping tests, and the Entra/Scaleway model tests pass with the new umbrella labels.
- Full registry import verified: 182 facts across 127 rules each resolve to a valid `(label, id)` anchor.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] The `EntraPrincipal` / `ScalewayPrincipal` labels are additive `extra_node_labels`; `test_schema_doc` passes with no manual schema-doc edits required.

### Notes for reviewers

- The anchor deliberately reuses `asset_id_field` rather than introducing a second id field: `asset_label` names the node type, `asset_id_field` names the output field carrying that node's `.id`.
- For nodes that can be one of several labels (Entra/Scaleway IAM principals, OpenAI keys), the anchor points at a shared umbrella label rather than guessing a subtype.
- The umbrella labels are applied at load time, so existing graphs pick them up on the next sync.
