### PR TITLE
fix(ontology): normalize Inspector and Semgrep CVE severity

### DIFF
--- a/cartography/models/ontology/mapping/data/cves.py
+++ b/cartography/models/ontology/mapping/data/cves.py
@@ -23,6 +23,13 @@ _CVSS_SEVERITY = {
     "CRITICAL": "critical",
 }
 
+# AWS Inspector severity: CVSS bands plus INFORMATIONAL. UNTRIAGED is left
+# unmapped so unscored findings keep a null base_severity instead of a fake band.
+_INSPECTOR_SEVERITY = {
+    **_CVSS_SEVERITY,
+    "INFORMATIONAL": "info",
+}
+
 # GitHub GraphQL severity (uppercase API + lowercase fixture variants)
 _GITHUB_SEVERITY = {
     "LOW": "low",
@@ -454,7 +461,7 @@ aws_inspector_mapping = OntologyMapping(
                     ontology_field="base_severity",
                     node_field="severity",
                     special_handling="mapping",
-                    extra={"map": _CVSS_SEVERITY},
+                    extra={"map": _INSPECTOR_SEVERITY},
                 ),
             ],
         ),

--- a/cartography/models/ontology/mapping/data/cves.py
+++ b/cartography/models/ontology/mapping/data/cves.py
@@ -403,6 +403,8 @@ semgrep_mapping = OntologyMapping(
                 OntologyFieldMapping(
                     ontology_field="base_severity",
                     node_field="severity",
+                    special_handling="mapping",
+                    extra={"map": _CVSS_SEVERITY},
                 ),
                 # SecurityIssue fields (preserved for advisory-only findings)
                 OntologyFieldMapping(
@@ -451,6 +453,8 @@ aws_inspector_mapping = OntologyMapping(
                 OntologyFieldMapping(
                     ontology_field="base_severity",
                     node_field="severity",
+                    special_handling="mapping",
+                    extra={"map": _CVSS_SEVERITY},
                 ),
             ],
         ),

--- a/tests/unit/cartography/intel/ontology/test_ontology_mapping.py
+++ b/tests/unit/cartography/intel/ontology/test_ontology_mapping.py
@@ -7,6 +7,7 @@ from cartography.models.ontology.mapping import get_deprecated_ontology_index_pr
 from cartography.models.ontology.mapping import ONTOLOGY_MODELS
 from cartography.models.ontology.mapping import ONTOLOGY_NODES_MAPPING
 from cartography.models.ontology.mapping import SEMANTIC_LABELS_MAPPING
+from cartography.models.ontology.mapping.data.cves import CVES_ONTOLOGY_MAPPING
 from cartography.models.ontology.mapping.data.tenants import TENANTS_ONTOLOGY_MAPPING
 from cartography.sync import TOP_LEVEL_MODULES
 from tests.utils import load_models
@@ -350,3 +351,29 @@ def test_aws_account_status_ontology_map_covers_all_states():
         "PENDING_CLOSURE": "pending_deletion",
         "CLOSED": "closed",
     }
+
+
+def test_uppercase_provider_cve_severities_are_canonicalized():
+    # Arrange
+    provider_nodes = {
+        "aws": "AWSInspectorFinding",
+        "semgrep": "SemgrepSCAFinding",
+    }
+    expected_map = {
+        "NONE": "info",
+        "LOW": "low",
+        "MEDIUM": "medium",
+        "HIGH": "high",
+        "CRITICAL": "critical",
+    }
+
+    for provider, node_label in provider_nodes.items():
+        mapping = CVES_ONTOLOGY_MAPPING[provider]
+        node = next(node for node in mapping.nodes if node.node_label == node_label)
+        severity = next(
+            field for field in node.fields if field.ontology_field == "base_severity"
+        )
+
+        # Act and assert
+        assert severity.special_handling == "mapping"
+        assert severity.extra["map"] == expected_map

--- a/tests/unit/cartography/intel/ontology/test_ontology_mapping.py
+++ b/tests/unit/cartography/intel/ontology/test_ontology_mapping.py
@@ -355,19 +355,21 @@ def test_aws_account_status_ontology_map_covers_all_states():
 
 def test_uppercase_provider_cve_severities_are_canonicalized():
     # Arrange
-    provider_nodes = {
-        "aws": "AWSInspectorFinding",
-        "semgrep": "SemgrepSCAFinding",
-    }
-    expected_map = {
+    cvss_map = {
         "NONE": "info",
         "LOW": "low",
         "MEDIUM": "medium",
         "HIGH": "high",
         "CRITICAL": "critical",
     }
+    # AWS Inspector additionally emits INFORMATIONAL (and UNTRIAGED, which is left
+    # unmapped on purpose); Semgrep SCA only emits the CVSS bands.
+    provider_expectations = {
+        "aws": ("AWSInspectorFinding", {**cvss_map, "INFORMATIONAL": "info"}),
+        "semgrep": ("SemgrepSCAFinding", cvss_map),
+    }
 
-    for provider, node_label in provider_nodes.items():
+    for provider, (node_label, expected_map) in provider_expectations.items():
         mapping = CVES_ONTOLOGY_MAPPING[provider]
         node = next(node for node in mapping.nodes if node.node_label == node_label)
         severity = next(


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

### Summary

Normalize `AWSInspectorFinding` and `SemgrepSCAFinding` `_ont_base_severity` values through the existing CVSS severity map. Both providers emit uppercase severity enums, while the ontology contract introduced by #3056 requires lowercase canonical values.

### Related issues or links

- Follow-up to #3056

### How was this tested?

- `uv run pytest tests/unit/cartography/intel/ontology/test_ontology_mapping.py -q`
- `make test_lint`

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the schema documentation.
- [ ] Updated the schema README.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema data model.

### Notes for reviewers

This reuses `_CVSS_SEVERITY`, which already covers the complete uppercase CVSS severity vocabulary emitted by both providers.