### PR TITLE
feat(aws): add App Runner service intel module

### DIFF
--- a/cartography/data/permission_relationships.yaml
+++ b/cartography/data/permission_relationships.yaml
@@ -74,6 +74,14 @@
   permissions:
   - cloudformation:UpdateStack
   relationship_name: CAN_EXEC
+# Map principals that can deploy or update App Runner services.
+# iam:PassRole is modeled separately as CAN_PASS_ROLE → AWSRole; combine both
+# edges in queries for the CreateService privilege-escalation path.
+- target_label: AWSAppRunnerService
+  permissions:
+  - apprunner:CreateService
+  - apprunner:UpdateService
+  relationship_name: CAN_EXEC
 # Map principals that can open an SSM Session Manager shell on an EC2 instance.
 # Two conditions must both hold (see issue #1643):
 #   1. the principal has ssm:StartSession on the instance, and

--- a/cartography/intel/aws/apprunner.py
+++ b/cartography/intel/aws/apprunner.py
@@ -1,0 +1,167 @@
+import logging
+import time
+from typing import Any
+
+import boto3
+import botocore.exceptions
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.aws.util.botocore_config import create_boto3_client
+from cartography.intel.aws.util.service_regions import (
+    filter_regions_to_supported_service_regions,
+)
+from cartography.models.aws.apprunner import AppRunnerServiceSchema
+from cartography.util import aws_handle_regions
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+# App Runner DescribeService default quota is 10 req/s. Sleep briefly between
+# describes so a large account does not burn the quota and restart pagination
+# from scratch via aws_handle_regions retries.
+DESCRIBE_SLEEP = 0.1
+
+
+@timeit
+@aws_handle_regions
+def get_apprunner_services(
+    boto3_session: boto3.session.Session,
+    region: str,
+) -> list[dict[str, Any]]:
+    client = create_boto3_client(boto3_session, "apprunner", region_name=region)
+    paginator = client.get_paginator("list_services")
+    services: list[dict[str, Any]] = []
+    for page in paginator.paginate():
+        services.extend(page.get("ServiceSummaryList", []))
+
+    described_services: list[dict[str, Any]] = []
+    for service in services:
+        service_arn = service["ServiceArn"]
+        try:
+            desc_response = client.describe_service(ServiceArn=service_arn)
+        except botocore.exceptions.ClientError as e:
+            # Service deleted between list and describe — skip, do not fail the sync.
+            if e.response.get("Error", {}).get("Code") == "ResourceNotFoundException":
+                logger.warning(
+                    "App Runner service %s not found during describe; skipping.",
+                    service_arn,
+                )
+                continue
+            raise
+        described_services.append(desc_response["Service"])
+        time.sleep(DESCRIBE_SLEEP)
+    return described_services
+
+
+def transform_apprunner_services(
+    services: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Flatten nested App Runner configuration fields for Neo4j ingestion.
+    """
+    transformed: list[dict[str, Any]] = []
+    for svc in services:
+        svc = dict(svc)
+
+        source_config = svc.get("SourceConfiguration", {}) or {}
+        image_repo = source_config.get("ImageRepository", {}) or {}
+        code_repo = source_config.get("CodeRepository", {}) or {}
+        svc["ImageIdentifier"] = image_repo.get("ImageIdentifier")
+        svc["CodeRepositoryUrl"] = code_repo.get("RepositoryUrl")
+        svc["AutoDeploymentsEnabled"] = source_config.get("AutoDeploymentsEnabled")
+        auth_config = source_config.get("AuthenticationConfiguration", {}) or {}
+        svc["AccessRoleArn"] = auth_config.get("AccessRoleArn")
+
+        instance_config = svc.get("InstanceConfiguration", {}) or {}
+        svc["Cpu"] = instance_config.get("Cpu")
+        svc["Memory"] = instance_config.get("Memory")
+        svc["InstanceRoleArn"] = instance_config.get("InstanceRoleArn")
+
+        network_config = svc.get("NetworkConfiguration", {}) or {}
+        egress_config = network_config.get("EgressConfiguration", {}) or {}
+        svc["EgressType"] = egress_config.get("EgressType")
+        ingress_config = network_config.get("IngressConfiguration", {}) or {}
+        svc["IsPubliclyAccessible"] = ingress_config.get("IsPubliclyAccessible")
+
+        transformed.append(svc)
+    return transformed
+
+
+@timeit
+def load_apprunner_services(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    region: str,
+    current_aws_account_id: str,
+    aws_update_tag: int,
+) -> None:
+    logger.info(
+        "Loading AppRunner %s services for region '%s' into graph.",
+        len(data),
+        region,
+    )
+    load(
+        neo4j_session,
+        AppRunnerServiceSchema(),
+        data,
+        lastupdated=aws_update_tag,
+        Region=region,
+        AWS_ID=current_aws_account_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    logger.debug("Running AppRunner cleanup job.")
+    cleanup_job = GraphJob.from_node_schema(
+        AppRunnerServiceSchema(),
+        common_job_parameters,
+    )
+    cleanup_job.run(neo4j_session)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    boto3_session: boto3.session.Session,
+    regions: list[str],
+    current_aws_account_id: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    apprunner_regions, unsupported_regions = (
+        filter_regions_to_supported_service_regions(
+            boto3_session,
+            "apprunner",
+            regions,
+        )
+    )
+    for region in unsupported_regions:
+        logger.info(
+            "Skipping AppRunner sync for unsupported region '%s'.",
+            region,
+        )
+
+    for region in apprunner_regions:
+        logger.info(
+            "Syncing AppRunner for region '%s' in account '%s'.",
+            region,
+            current_aws_account_id,
+        )
+
+        services = get_apprunner_services(boto3_session, region)
+        transformed_services = transform_apprunner_services(services)
+        load_apprunner_services(
+            neo4j_session,
+            transformed_services,
+            region,
+            current_aws_account_id,
+            update_tag,
+        )
+
+    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/aws/resources.py
+++ b/cartography/intel/aws/resources.py
@@ -6,6 +6,7 @@ from cartography.intel.aws.ec2.route_tables import sync_route_tables
 from . import acm
 from . import apigateway
 from . import apigatewayv2
+from . import apprunner
 from . import bedrock
 from . import cloudformation
 from . import cloudfront
@@ -129,8 +130,10 @@ RESOURCE_FUNCTIONS: OrderedDict[str, Callable[..., None]] = OrderedDict(
         "redshift": redshift.sync,
         "route53": route53.sync,
         "elasticsearch": elasticsearch.sync,
-        # `cloudformation` must run before `permission_relationships` so that AWSCloudFormationStack
-        # nodes exist when CAN_EXEC edges are evaluated.
+        # `apprunner` and `cloudformation` must run before `permission_relationships`
+        # so that AWSAppRunnerService / AWSCloudFormationStack nodes exist when
+        # CAN_EXEC edges are evaluated.
+        "apprunner": apprunner.sync,
         "cloudformation": cloudformation.sync,
         "permission_relationships": permission_relationships.sync,
         "resourcegroupstaggingapi": resourcegroupstaggingapi.sync,

--- a/cartography/models/aws/apprunner.py
+++ b/cartography/models/aws/apprunner.py
@@ -1,0 +1,104 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AppRunnerServiceNodeProperties(CartographyNodeProperties):
+    access_role_arn: PropertyRef = PropertyRef("AccessRoleArn")
+    arn: PropertyRef = PropertyRef("ServiceArn", extra_index=True)
+    auto_deployments_enabled: PropertyRef = PropertyRef("AutoDeploymentsEnabled")
+    code_repository_url: PropertyRef = PropertyRef("CodeRepositoryUrl")
+    cpu: PropertyRef = PropertyRef("Cpu")
+    created_at: PropertyRef = PropertyRef("CreatedAt")
+    egress_type: PropertyRef = PropertyRef("EgressType")
+    id: PropertyRef = PropertyRef("ServiceArn")
+    image_identifier: PropertyRef = PropertyRef("ImageIdentifier")
+    instance_role_arn: PropertyRef = PropertyRef("InstanceRoleArn")
+    is_publicly_accessible: PropertyRef = PropertyRef("IsPubliclyAccessible")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    memory: PropertyRef = PropertyRef("Memory")
+    name: PropertyRef = PropertyRef("ServiceName")
+    region: PropertyRef = PropertyRef("Region", set_in_kwargs=True)
+    service_id: PropertyRef = PropertyRef("ServiceId")
+    service_url: PropertyRef = PropertyRef("ServiceUrl")
+    status: PropertyRef = PropertyRef("Status")
+    updated_at: PropertyRef = PropertyRef("UpdatedAt")
+
+
+@dataclass(frozen=True)
+class AppRunnerServiceToAWSAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AWSAppRunnerService)<-[:RESOURCE]-(:AWSAccount)
+class AppRunnerServiceToAWSAccountRel(CartographyRelSchema):
+    target_node_label: str = "AWSAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("AWS_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AppRunnerServiceToAWSAccountRelProperties = (
+        AppRunnerServiceToAWSAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AppRunnerServiceToAWSRoleRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AWSAppRunnerService)-[:USES_ACCESS_ROLE]->(:AWSRole)
+class AppRunnerServiceToAccessRoleRel(CartographyRelSchema):
+    target_node_label: str = "AWSRole"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("AccessRoleArn")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_ACCESS_ROLE"
+    properties: AppRunnerServiceToAWSRoleRelProperties = (
+        AppRunnerServiceToAWSRoleRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+# (:AWSAppRunnerService)-[:USES_INSTANCE_ROLE]->(:AWSRole)
+class AppRunnerServiceToInstanceRoleRel(CartographyRelSchema):
+    target_node_label: str = "AWSRole"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("InstanceRoleArn")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_INSTANCE_ROLE"
+    properties: AppRunnerServiceToAWSRoleRelProperties = (
+        AppRunnerServiceToAWSRoleRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AppRunnerServiceSchema(CartographyNodeSchema):
+    label: str = "AWSAppRunnerService"
+    # Compatibility alias matching #2264 draft label name.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(["AppRunnerService"])
+    properties: AppRunnerServiceNodeProperties = AppRunnerServiceNodeProperties()
+    sub_resource_relationship: AppRunnerServiceToAWSAccountRel = (
+        AppRunnerServiceToAWSAccountRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AppRunnerServiceToAccessRoleRel(),
+            AppRunnerServiceToInstanceRoleRel(),
+        ],
+    )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -45,7 +45,8 @@ Configured AWS sync accounts are marked `inscope=true`. Accounts discovered only
 - Many node types belong to an `AWSAccount`.
 
     ```cypher
-    (:AWSAccount)-[:RESOURCE]->(:AWSDNSZone,
+    (:AWSAccount)-[:RESOURCE]->(:AWSAppRunnerService,
+                                :AWSDNSZone,
                                 :AWSGroup,
                                 :AWSInspectorFinding,
                                 :AWSInspectorPackage,
@@ -4679,6 +4680,54 @@ Representation of an AWS [API Gateway v2 API](https://docs.aws.amazon.com/apigat
 - AWS API Gateway v2 APIs are resources in an AWS Account.
     ```
     (:AWSAccount)-[:RESOURCE]->(:AWSAPIGatewayV2API)
+    ```
+
+### AWSAppRunnerService
+
+Representation of an AWS [App Runner service](https://docs.aws.amazon.com/apprunner/latest/api/API_Service.html).
+
+> **Ontology Mapping**: This node has the extra label `AppRunnerService` to enable queries that use the unprefixed App Runner service label alongside the provider-prefixed `AWSAppRunnerService` label.
+
+| Field | Description |
+|-------|-------------|
+| firstseen| Timestamp of when a sync job first discovered this node |
+| lastupdated | Timestamp of the last time the node was updated |
+| **id** | The App Runner service ARN (same as arn) |
+| **arn** | The App Runner service ARN |
+| name | The service name |
+| service\_id | The App Runner service ID |
+| service\_url | The subdomain URL of the service |
+| status | Current service status (e.g. RUNNING) |
+| created\_at | When the service was created |
+| updated\_at | When the service was last updated |
+| image\_identifier | Container image identifier when sourced from an image repository |
+| code\_repository\_url | Source repository URL when sourced from a code repository |
+| auto\_deployments\_enabled | Whether automatic deployments are enabled |
+| access\_role\_arn | IAM role ARN used to access a private ECR image repository |
+| instance\_role\_arn | IAM instance role ARN assumed by the running service |
+| cpu | Configured CPU |
+| memory | Configured memory |
+| egress\_type | Egress configuration type (DEFAULT or VPC) |
+| is\_publicly\_accessible | Whether the service accepts public ingress |
+| region | The AWS region of the service |
+
+#### Relationships
+
+- App Runner services are resources in an AWS Account.
+    ```
+    (:AWSAccount)-[:RESOURCE]->(:AWSAppRunnerService)
+    ```
+- App Runner services may use an access role for private image pulls.
+    ```
+    (:AWSAppRunnerService)-[:USES_ACCESS_ROLE]->(:AWSRole)
+    ```
+- App Runner services may use an instance role at runtime (privesc surface with `iam:PassRole`).
+    ```
+    (:AWSAppRunnerService)-[:USES_INSTANCE_ROLE]->(:AWSRole)
+    ```
+- Principals that can create or update App Runner services.
+    ```
+    (:AWSPrincipal)-[:CAN_EXEC]->(:AWSAppRunnerService)
     ```
 
 ### AWSAutoScalingGroup

--- a/tests/data/aws/apprunner.py
+++ b/tests/data/aws/apprunner.py
@@ -1,0 +1,98 @@
+DESCRIBE_SERVICES = [
+    {
+        "ServiceName": "my-service",
+        "ServiceId": "abc123",
+        "ServiceArn": "arn:aws:apprunner:us-east-1:123456789012:service/my-service/abc123",
+        "ServiceUrl": "abc123.us-east-1.awsapprunner.com",
+        "CreatedAt": "2023-01-01T00:00:00Z",
+        "UpdatedAt": "2023-01-02T00:00:00Z",
+        "Status": "RUNNING",
+        "SourceConfiguration": {
+            "ImageRepository": {
+                "ImageIdentifier": "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:latest",
+                "ImageRepositoryType": "ECR",
+                "ImageConfiguration": {},
+            },
+            "AutoDeploymentsEnabled": True,
+            "AuthenticationConfiguration": {
+                "AccessRoleArn": "arn:aws:iam::1234:role/cartography-read-only",
+            },
+        },
+        "InstanceConfiguration": {
+            "Cpu": "1 vCPU",
+            "Memory": "2 GB",
+            "InstanceRoleArn": "arn:aws:iam::1234:role/cartography-service",
+        },
+        "NetworkConfiguration": {
+            "EgressConfiguration": {
+                "EgressType": "DEFAULT",
+            },
+            "IngressConfiguration": {
+                "IsPubliclyAccessible": True,
+            },
+        },
+    },
+    {
+        "ServiceName": "my-other-service",
+        "ServiceId": "def456",
+        "ServiceArn": "arn:aws:apprunner:us-east-1:123456789012:service/my-other-service/def456",
+        "ServiceUrl": "def456.us-east-1.awsapprunner.com",
+        "CreatedAt": "2023-02-01T00:00:00Z",
+        "UpdatedAt": "2023-02-02T00:00:00Z",
+        "Status": "RUNNING",
+        "SourceConfiguration": {
+            "ImageRepository": {
+                "ImageIdentifier": "123456789012.dkr.ecr.us-east-1.amazonaws.com/other-repo:latest",
+                "ImageRepositoryType": "ECR",
+                "ImageConfiguration": {},
+            },
+            "AutoDeploymentsEnabled": False,
+            "AuthenticationConfiguration": {
+                "AccessRoleArn": "arn:aws:iam::1234:role/cartography-read-only",
+            },
+        },
+        "InstanceConfiguration": {
+            "Cpu": "2 vCPU",
+            "Memory": "4 GB",
+            "InstanceRoleArn": "arn:aws:iam::1234:role/cartography-service",
+        },
+        "NetworkConfiguration": {
+            "EgressConfiguration": {
+                "EgressType": "VPC",
+            },
+            "IngressConfiguration": {
+                "IsPubliclyAccessible": False,
+            },
+        },
+    },
+    {
+        "ServiceName": "my-code-service",
+        "ServiceId": "ghi789",
+        "ServiceArn": "arn:aws:apprunner:us-east-1:123456789012:service/my-code-service/ghi789",
+        "ServiceUrl": "ghi789.us-east-1.awsapprunner.com",
+        "CreatedAt": "2023-03-01T00:00:00Z",
+        "UpdatedAt": "2023-03-02T00:00:00Z",
+        "Status": "RUNNING",
+        "SourceConfiguration": {
+            "CodeRepository": {
+                "RepositoryUrl": "https://github.com/example/my-code-service",
+                "SourceCodeVersion": {"Type": "BRANCH", "Value": "main"},
+                "CodeConfiguration": {},
+            },
+            "AutoDeploymentsEnabled": True,
+        },
+        "InstanceConfiguration": {
+            "Cpu": "1 vCPU",
+            "Memory": "2 GB",
+            "InstanceRoleArn": "arn:aws:iam::1234:role/cartography-service",
+        },
+        "NetworkConfiguration": {
+            "EgressConfiguration": {
+                "EgressType": "DEFAULT",
+            },
+            "IngressConfiguration": {
+                "IsPubliclyAccessible": True,
+            },
+        },
+    },
+]

--- a/tests/integration/cartography/intel/aws/test_apprunner.py
+++ b/tests/integration/cartography/intel/aws/test_apprunner.py
@@ -1,0 +1,224 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.aws.apprunner
+import tests.data.aws.apprunner
+from cartography.intel.aws.apprunner import cleanup
+from cartography.intel.aws.iam import load_role_data
+from cartography.intel.aws.iam import transform_role_trust_policies
+from tests.data.aws.iam.roles import ROLES
+from tests.integration.cartography.intel.aws.common import create_test_account
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_ACCOUNT_ID = "000000000000"
+TEST_REGION = "us-east-1"
+TEST_UPDATE_TAG = 123456789
+
+
+def _boto3_session_supporting_region() -> MagicMock:
+    boto3_session = MagicMock()
+    boto3_session.get_partition_for_region.return_value = "aws"
+    boto3_session.get_available_regions.return_value = [TEST_REGION]
+    return boto3_session
+
+
+def _seed_roles(neo4j_session):
+    transformed = transform_role_trust_policies(ROLES["Roles"], TEST_ACCOUNT_ID)
+    load_role_data(
+        neo4j_session,
+        transformed.role_data,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.aws.apprunner,
+    "get_apprunner_services",
+    return_value=tests.data.aws.apprunner.DESCRIBE_SERVICES,
+)
+def test_sync_apprunner_services_nodes(mock_get, neo4j_session):
+    boto3_session = _boto3_session_supporting_region()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+    cartography.intel.aws.apprunner.sync(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+
+    expected_nodes = {
+        ("arn:aws:apprunner:us-east-1:123456789012:service/my-service/abc123",),
+        ("arn:aws:apprunner:us-east-1:123456789012:service/my-other-service/def456",),
+        ("arn:aws:apprunner:us-east-1:123456789012:service/my-code-service/ghi789",),
+    }
+    assert (
+        check_nodes(neo4j_session, "AWSAppRunnerService", ["arn"]) == expected_nodes
+    )
+    # Compatibility alias from ExtraNodeLabels
+    assert check_nodes(neo4j_session, "AppRunnerService", ["arn"]) == expected_nodes
+
+    code_service_props = check_nodes(
+        neo4j_session,
+        "AWSAppRunnerService",
+        ["arn", "code_repository_url"],
+    )
+    assert (
+        "arn:aws:apprunner:us-east-1:123456789012:service/my-code-service/ghi789",
+        "https://github.com/example/my-code-service",
+    ) in code_service_props
+
+
+@patch.object(
+    cartography.intel.aws.apprunner,
+    "get_apprunner_services",
+    return_value=tests.data.aws.apprunner.DESCRIBE_SERVICES,
+)
+def test_sync_apprunner_services_relationships(mock_get, neo4j_session):
+    boto3_session = _boto3_session_supporting_region()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    _seed_roles(neo4j_session)
+
+    cartography.intel.aws.apprunner.sync(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+
+    expected_account_rels = {
+        (
+            TEST_ACCOUNT_ID,
+            "arn:aws:apprunner:us-east-1:123456789012:service/my-service/abc123",
+        ),
+        (
+            TEST_ACCOUNT_ID,
+            "arn:aws:apprunner:us-east-1:123456789012:service/my-other-service/def456",
+        ),
+        (
+            TEST_ACCOUNT_ID,
+            "arn:aws:apprunner:us-east-1:123456789012:service/my-code-service/ghi789",
+        ),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "AWSAccount",
+            "id",
+            "AWSAppRunnerService",
+            "arn",
+            "RESOURCE",
+        )
+        == expected_account_rels
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "AWSAppRunnerService",
+        "arn",
+        "AWSRole",
+        "arn",
+        "USES_ACCESS_ROLE",
+        rel_direction_right=True,
+    ) == {
+        (
+            "arn:aws:apprunner:us-east-1:123456789012:service/my-service/abc123",
+            "arn:aws:iam::1234:role/cartography-read-only",
+        ),
+        (
+            "arn:aws:apprunner:us-east-1:123456789012:service/my-other-service/def456",
+            "arn:aws:iam::1234:role/cartography-read-only",
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "AWSAppRunnerService",
+        "arn",
+        "AWSRole",
+        "arn",
+        "USES_INSTANCE_ROLE",
+        rel_direction_right=True,
+    ) == {
+        (
+            "arn:aws:apprunner:us-east-1:123456789012:service/my-service/abc123",
+            "arn:aws:iam::1234:role/cartography-service",
+        ),
+        (
+            "arn:aws:apprunner:us-east-1:123456789012:service/my-other-service/def456",
+            "arn:aws:iam::1234:role/cartography-service",
+        ),
+        (
+            "arn:aws:apprunner:us-east-1:123456789012:service/my-code-service/ghi789",
+            "arn:aws:iam::1234:role/cartography-service",
+        ),
+    }
+
+
+@patch.object(
+    cartography.intel.aws.apprunner,
+    "get_apprunner_services",
+    return_value=tests.data.aws.apprunner.DESCRIBE_SERVICES,
+)
+def test_cleanup_apprunner(mock_get, neo4j_session):
+    boto3_session = _boto3_session_supporting_region()
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+    cartography.intel.aws.apprunner.sync(
+        neo4j_session,
+        boto3_session,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "AWS_ID": TEST_ACCOUNT_ID},
+    )
+    neo4j_session.run(
+        """
+        MERGE (i:AWSEC2Instance{id:1234, lastupdated: $lastupdated})
+              <-[r:RESOURCE]-(:AWSAccount{id: $aws_account_id})
+        SET r.lastupdated = $lastupdated
+        """,
+        aws_account_id=TEST_ACCOUNT_ID,
+        lastupdated=TEST_UPDATE_TAG,
+    )
+
+    assert check_nodes(neo4j_session, "AWSAppRunnerService", ["arn"]) == {
+        ("arn:aws:apprunner:us-east-1:123456789012:service/my-service/abc123",),
+        ("arn:aws:apprunner:us-east-1:123456789012:service/my-other-service/def456",),
+        ("arn:aws:apprunner:us-east-1:123456789012:service/my-code-service/ghi789",),
+    }
+    assert check_rels(
+        neo4j_session,
+        "AWSAccount",
+        "id",
+        "AWSEC2Instance",
+        "id",
+        "RESOURCE",
+    ) == {
+        (TEST_ACCOUNT_ID, 1234),
+    }
+
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG + 1,
+        "AWS_ID": TEST_ACCOUNT_ID,
+        "permission_relationships_file": "/path/to/perm/rels/file",
+        "OKTA_ORG_ID": "my-org-id",
+    }
+    cleanup(neo4j_session, common_job_parameters)
+
+    assert check_nodes(neo4j_session, "AWSAppRunnerService", ["arn"]) == set()
+    assert check_rels(
+        neo4j_session,
+        "AWSAccount",
+        "id",
+        "AWSEC2Instance",
+        "id",
+        "RESOURCE",
+    ) == {
+        (TEST_ACCOUNT_ID, 1234),
+    }

--- a/tests/integration/cartography/intel/aws/test_init.py
+++ b/tests/integration/cartography/intel/aws/test_init.py
@@ -912,6 +912,14 @@ def test_kms_syncs_before_kms_dependent_resources():
         )
 
 
+def test_apprunner_syncs_before_permission_relationships():
+    order = list(RESOURCE_FUNCTIONS.keys())
+    assert order.index("apprunner") < order.index("permission_relationships"), (
+        "'apprunner' must sync before 'permission_relationships' so "
+        "AWSAppRunnerService nodes exist when CAN_EXEC edges are evaluated"
+    )
+
+
 @mock.patch("cartography.intel.aws.aioboto3.Session")
 @mock.patch("cartography.intel.aws.boto3.Session")
 @mock.patch("cartography.intel.aws.organizations")

--- a/tests/integration/cartography/intel/aws/test_permission_relationships.py
+++ b/tests/integration/cartography/intel/aws/test_permission_relationships.py
@@ -70,6 +70,20 @@ PASSROLE_POLICY_DATA = {
     }
 }
 
+APPRUNNER_CREATE_SERVICE_POLICY_DATA = {
+    "arn:aws:iam::000000000000:role/TestReadRole": {
+        "AppRunnerCreateServicePolicy": [
+            {
+                "Effect": "Allow",
+                "Action": ["apprunner:CreateService"],
+                "Resource": [
+                    "arn:aws:apprunner:us-east-1:000000000000:service/test-service/*",
+                ],
+            }
+        ]
+    }
+}
+
 
 def test_permission_relationships_with_iam_integration(neo4j_session):
     """
@@ -399,3 +413,72 @@ def test_permission_relationships_skips_resources_without_arn(neo4j_session):
     )
 
     assert actual_rels == set()
+
+
+def test_permission_relationships_can_exec_apprunner_service(neo4j_session):
+    create_test_account(neo4j_session, TEST_ACCOUNT_ID, TEST_UPDATE_TAG)
+
+    neo4j_session.run(
+        """
+        MATCH (aws:AWSAccount{id: $AccountId})
+        MERGE (svc:AWSAppRunnerService:AppRunnerService{
+            arn: 'arn:aws:apprunner:us-east-1:000000000000:service/test-service/service-1234567890'
+        })<-[:RESOURCE]-(aws)
+        SET svc.id = svc.arn,
+            svc.name = 'test-service',
+            svc.lastupdated = $UpdateTag
+        """,
+        AccountId=TEST_ACCOUNT_ID,
+        UpdateTag=TEST_UPDATE_TAG,
+    )
+
+    with (
+        patch(
+            "cartography.intel.aws.iam.get_role_list_data",
+            return_value=SIMPLE_ROLE_DATA,
+        ),
+        patch(
+            "cartography.intel.aws.iam.get_role_policy_data",
+            return_value=APPRUNNER_CREATE_SERVICE_POLICY_DATA,
+        ),
+        patch(
+            "cartography.intel.aws.iam.get_role_managed_policy_data",
+            return_value={},
+        ),
+    ):
+        common_job_parameters = {"AWS_ID": TEST_ACCOUNT_ID}
+        cartography.intel.aws.iam.sync_roles(
+            neo4j_session,
+            MagicMock(),
+            TEST_ACCOUNT_ID,
+            TEST_UPDATE_TAG,
+            common_job_parameters,
+        )
+
+    cartography.intel.aws.permission_relationships.sync(
+        neo4j_session,
+        None,
+        [TEST_REGION],
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {
+            "permission_relationships_file": "cartography/data/permission_relationships.yaml",
+        },
+    )
+
+    actual_rels = check_rels(
+        neo4j_session,
+        "AWSRole",
+        "arn",
+        "AWSAppRunnerService",
+        "arn",
+        "CAN_EXEC",
+    )
+
+    expected_rels = {
+        (
+            "arn:aws:iam::000000000000:role/TestReadRole",
+            "arn:aws:apprunner:us-east-1:000000000000:service/test-service/service-1234567890",
+        )
+    }
+    assert actual_rels == expected_rels

--- a/tests/unit/cartography/intel/aws/test_apprunner.py
+++ b/tests/unit/cartography/intel/aws/test_apprunner.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+
+from cartography.intel.aws.apprunner import get_apprunner_services
+from cartography.intel.aws.apprunner import transform_apprunner_services
+from tests.data.aws.apprunner import DESCRIBE_SERVICES
+
+
+def test_transform_apprunner_services_flattens_nested_fields():
+    transformed = transform_apprunner_services(DESCRIBE_SERVICES)
+
+    by_arn = {svc["ServiceArn"]: svc for svc in transformed}
+
+    image_svc = by_arn[
+        "arn:aws:apprunner:us-east-1:123456789012:service/my-service/abc123"
+    ]
+    assert (
+        image_svc["ImageIdentifier"]
+        == "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo:latest"
+    )
+    assert image_svc["CodeRepositoryUrl"] is None
+    assert image_svc["AccessRoleArn"] == "arn:aws:iam::1234:role/cartography-read-only"
+    assert image_svc["InstanceRoleArn"] == "arn:aws:iam::1234:role/cartography-service"
+    assert image_svc["Cpu"] == "1 vCPU"
+    assert image_svc["Memory"] == "2 GB"
+    assert image_svc["EgressType"] == "DEFAULT"
+    assert image_svc["IsPubliclyAccessible"] is True
+    assert image_svc["AutoDeploymentsEnabled"] is True
+
+    code_svc = by_arn[
+        "arn:aws:apprunner:us-east-1:123456789012:service/my-code-service/ghi789"
+    ]
+    assert code_svc["ImageIdentifier"] is None
+    assert code_svc["CodeRepositoryUrl"] == "https://github.com/example/my-code-service"
+    assert code_svc["AccessRoleArn"] is None
+    assert code_svc["InstanceRoleArn"] == "arn:aws:iam::1234:role/cartography-service"
+
+
+@patch("cartography.intel.aws.apprunner.time.sleep", return_value=None)
+@patch("cartography.intel.aws.apprunner.create_boto3_client")
+def test_get_apprunner_services_skips_resource_not_found(
+    mock_create_boto3_client,
+    _mock_sleep,
+):
+    client = MagicMock()
+    paginator = MagicMock()
+    paginator.paginate.return_value = [
+        {
+            "ServiceSummaryList": [
+                {
+                    "ServiceArn": "arn:aws:apprunner:us-east-1:123456789012:service/gone/abc",
+                },
+                {
+                    "ServiceArn": "arn:aws:apprunner:us-east-1:123456789012:service/alive/def",
+                },
+            ],
+        },
+    ]
+    client.get_paginator.return_value = paginator
+    client.describe_service.side_effect = [
+        ClientError(
+            {
+                "Error": {
+                    "Code": "ResourceNotFoundException",
+                    "Message": "Service not found",
+                },
+            },
+            "DescribeService",
+        ),
+        {"Service": DESCRIBE_SERVICES[0]},
+    ]
+    mock_create_boto3_client.return_value = client
+
+    result = get_apprunner_services(MagicMock(), "us-east-1")
+
+    assert result == [DESCRIBE_SERVICES[0]]
+    assert client.describe_service.call_count == 2


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary
Adds AWS App Runner service ingestion (`AWSAppRunnerService`, with compatibility label `AppRunnerService`) so Cartography can model App Runner deployments and related privilege-escalation paths.

- Sync: `list_services` (paginator) → `describe_service` → transform → load → cleanup
- Skips `ResourceNotFoundException` per ARN when a service disappears between list and describe
- Relationships: `(AWSAccount)-[:RESOURCE]->(AWSAppRunnerService)`, `USES_ACCESS_ROLE` / `USES_INSTANCE_ROLE` → `AWSRole`
- Permission mapping: `apprunner:CreateService` / `apprunner:UpdateService` → `CAN_EXEC` (`iam:PassRole` remains `CAN_PASS_ROLE` → `AWSRole`; combine in queries)
- Registers the module before `permission_relationships` so nodes exist when `CAN_EXEC` is evaluated
- Schema docs include the ontology mapping for `AppRunnerService`

### Related issues
Fixes #2264

### How was this tested?
```bash
uv run pytest tests/unit/cartography/intel/aws/test_apprunner.py -q
# 2 passed (transform + ResourceNotFound skip)
```

Integration coverage in `tests/integration/cartography/intel/aws/test_apprunner.py` exercises `sync()` with mocked `get_apprunner_services` (nodes, role relationships, cleanup) and will run in CI with Neo4j.

### How to validate live
1. Create a minimal App Runner service in a supported region (public hello image is enough) with an instance role.
2. Optionally use a private ECR image so an access role is present.
3. Sync AWS with this module enabled (included in the default AWS set after merge).
4. Confirm in Neo4j:
   ```cypher
   MATCH (a:AWSAccount)-[:RESOURCE]->(s:AWSAppRunnerService)
   OPTIONAL MATCH (s)-[:USES_INSTANCE_ROLE]->(ir:AWSRole)
   OPTIONAL MATCH (s)-[:USES_ACCESS_ROLE]->(ar:AWSRole)
   RETURN s.arn, s.name, s.status, ir.arn, ar.arn
   ```
5. With IAM policies granting `apprunner:CreateService` or `apprunner:UpdateService`, confirm `(:AWSPrincipal)-[:CAN_EXEC]->(:AWSAppRunnerService)`.

Happy to adjust naming or relationship labels if maintainers prefer a different convention.