### PR TITLE
feat(github): add fork and parent attributes to GitHubRepository

### DIFF
--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -120,6 +120,10 @@ GITHUB_ORG_REPOS_PAGINATED_GRAPHQL = """
                     isArchived
                     isDisabled
                     isLocked
+                    isFork
+                    parent{
+                        url
+                    }
                     owner{
                         url
                         login
@@ -1177,6 +1181,11 @@ def _transform_repo_objects(input_repo_object: Dict, out_repo_list: List[Dict]) 
     owner = input_repo_object["owner"]
     owner_type = owner["__typename"]
 
+    # A fork's upstream repo. It is null when the repo is not a fork, and also when the repo is a
+    # fork whose upstream has been deleted, so we read `isFork` for the boolean rather than
+    # inferring it from the parent's presence.
+    parent = input_repo_object.get("parent")
+
     out_repo_list.append(
         {
             "id": input_repo_object["url"],
@@ -1196,6 +1205,8 @@ def _transform_repo_objects(input_repo_object: Dict, out_repo_list: List[Dict]) 
             "disabled": input_repo_object["isDisabled"],
             "archived": input_repo_object["isArchived"],
             "locked": input_repo_object["isLocked"],
+            "fork": input_repo_object.get("isFork", False),
+            "parent": parent["url"] if parent else None,
             "giturl": git_url,
             "url": input_repo_object["url"],
             "sshurl": ssh_url,

--- a/cartography/models/github/repos.py
+++ b/cartography/models/github/repos.py
@@ -69,6 +69,13 @@ class GitHubRepositoryNodeProperties(CartographyNodeProperties):
     updatedat: PropertyRef = PropertyRef(
         "updatedat", description="Timestamp when the repository was last updated."
     )
+    fork: PropertyRef = PropertyRef(
+        "fork", description="Whether the repository is a fork."
+    )
+    parent: PropertyRef = PropertyRef(
+        "parent",
+        description="Web URL of the repository this repository was forked from.",
+    )
 
 
 @dataclass(frozen=True)

--- a/cartography/models/ontology/mapping/data/coderepositories.py
+++ b/cartography/models/ontology/mapping/data/coderepositories.py
@@ -11,6 +11,7 @@ from cartography.models.ontology.mapping.specs import OntologyNodeMapping
 # - default_branch: Default branch name
 # - public: Whether the repository is publicly accessible
 # - archived: Whether the repository is archived
+# - fork: Whether the repository was created as a fork of another repository
 
 github_mapping = OntologyMapping(
     module_name="github",
@@ -35,11 +36,14 @@ github_mapping = OntologyMapping(
                     special_handling="invert_boolean",
                 ),
                 OntologyFieldMapping(ontology_field="archived", node_field="archived"),
+                OntologyFieldMapping(ontology_field="fork", node_field="fork"),
             ],
         ),
     ],
 )
 
+# NOTE: GitLab has forks too (a project carries `forked_from_project` rather than a boolean),
+# but the GitLab module does not ingest that data yet, so `fork` is deliberately unmapped here.
 gitlab_mapping = OntologyMapping(
     module_name="gitlab",
     nodes=[

--- a/tests/data/github/collaborators_test_data.py
+++ b/tests/data/github/collaborators_test_data.py
@@ -26,6 +26,8 @@ COLLABORATORS_TEST_REPOS: list[dict[str, Any]] = [
         "isArchived": False,
         "isDisabled": False,
         "isLocked": False,
+        "isFork": False,
+        "parent": None,
         "owner": {
             "url": "https://github.com/testorg",
             "login": "testorg",
@@ -54,6 +56,8 @@ COLLABORATORS_TEST_REPOS: list[dict[str, Any]] = [
         "isArchived": False,
         "isDisabled": False,
         "isLocked": False,
+        "isFork": False,
+        "parent": None,
         "owner": {
             "url": "https://github.com/testorg",
             "login": "testorg",

--- a/tests/data/github/repos.py
+++ b/tests/data/github/repos.py
@@ -84,6 +84,8 @@ GET_REPOS: List[dict[str, Any]] = [
         "isArchived": False,
         "isDisabled": False,
         "isLocked": True,
+        "isFork": False,
+        "parent": None,
         "owner": {
             "url": "https://github.com/simpsoncorp",
             "login": "SimpsonCorp",
@@ -132,6 +134,9 @@ GET_REPOS: List[dict[str, Any]] = [
         "isArchived": False,
         "isDisabled": False,
         "isLocked": False,
+        # Forked from a repo that is also synced.
+        "isFork": True,
+        "parent": {"url": "https://github.com/cartography-cncf/cartography"},
         "owner": {
             "url": "https://github.com/simpsoncorp",
             "login": "SimpsonCorp",
@@ -164,6 +169,9 @@ GET_REPOS: List[dict[str, Any]] = [
         "isArchived": False,
         "isDisabled": False,
         "isLocked": False,
+        # Forked from a repo that is not synced, which is the common case for forks.
+        "isFork": True,
+        "parent": {"url": "https://github.com/some-upstream-org/cartography"},
         "owner": {
             "url": "https://github.com/simpsoncorp",
             "login": "SimpsonCorp",
@@ -211,6 +219,8 @@ GET_REPOS_CIRCLECI_PROVENANCE: list[dict[str, Any]] = [
         "isArchived": False,
         "isDisabled": False,
         "isLocked": False,
+        "isFork": False,
+        "parent": None,
         "owner": {
             "url": "https://github.com/exampleorg",
             "login": "exampleorg",

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -149,6 +149,28 @@ def test_sync_github_repos(
         ("https://github.com/cartography-cncf/cartography", "Makefile"),
     }
 
+    # Assert - Verify fork and parent attributes
+    assert check_nodes(neo4j_session, "GitHubRepository", ["id", "fork", "parent"]) == {
+        ("https://github.com/simpsoncorp/sample_repo", False, None),
+        (
+            "https://github.com/simpsoncorp/SampleRepo2",
+            True,
+            "https://github.com/cartography-cncf/cartography",
+        ),
+        (
+            "https://github.com/cartography-cncf/cartography",
+            True,
+            "https://github.com/some-upstream-org/cartography",
+        ),
+    }
+
+    # Assert - Verify the fork attribute is projected onto the CodeRepository ontology label
+    assert check_nodes(neo4j_session, "CodeRepository", ["id", "_ont_fork"]) == {
+        ("https://github.com/simpsoncorp/sample_repo", False),
+        ("https://github.com/simpsoncorp/SampleRepo2", True),
+        ("https://github.com/cartography-cncf/cartography", True),
+    }
+
 
 @patch.object(
     cartography.intel.github.repos,


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)


### Summary

It is currently not possible to tell whether a repo in an organization is a fork. That makes it awkward to scope queries and rules to first-party code — forks inflate repo counts and carry code the org didn't write.

This adds two attributes to `GitHubRepository`:

- **`fork`** — boolean, sourced from GitHub's `isFork`.
- **`parent`** — the web URL of the repo this one was forked from, if any.

Two deliberate choices worth flagging for review:

**`fork` is not inferred from `parent` being non-null.** That inference is almost always right, but a fork whose upstream repo has been deleted still reports `isFork: true` with a null `parent`. Reading `isFork` directly keeps the boolean authoritative and leaves `parent` purely about lineage.

**`parent` is a plain attribute, not a relationship.** I considered adding a `(:GitHubRepository)-[:FORKED_FROM]->(:GitHubRepository)` edge, but in practice a fork's upstream almost always lives outside the synced orgs, so there is usually no node to link to. An edge that exists for a small minority of forks would misrepresent coverage. Anyone wanting lineage between two synced repos can join on `parent = id`.

Also maps `fork` onto the `CodeRepository` ontology as `_ont_fork`. GitLab has the same concept — a project carries `forked_from_project` rather than a boolean — but the GitLab module doesn't ingest it today, so the field is left unset there and documented as "absence is not `false`", matching the existing convention for `_ont_public` on snapshots.


### Related issues or links

N/A


### How was this tested?

- `tests/data/github/repos.py` now covers three cases: a non-fork, a fork whose upstream **is** synced, and a fork whose upstream is **not** synced (the common case).
- `test_sync_github_repos` asserts `id`/`fork`/`parent` on the nodes, and separately asserts `_ont_fork` on the `CodeRepository` label so the ontology projection is verified end to end rather than inferred from the mapping.
- Full GitHub integration suite (50 tests), ontology + GitLab integration (89 tests), and ontology/graph unit tests (227 tests) pass locally.
- `make test_lint` passes clean across all files.

<img width="1487" height="873" alt="Screenshot 2026-07-26 at 7 40 44 PM" src="https://github.com/user-attachments/assets/12f64574-6633-418e-8891-f0ce9a0f035e" />

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the schema documentation (`docs/root/modules/github/schema.md`, `docs/root/modules/ontology/schema.md`).
- [ ] Updated the schema README — `docs/schema/README.md` does not exist in the tree, so this appears to be N/A.


### Notes for reviewers

The `_ont_fork` mapping is `indexed` by default, so this creates a RANGE index on `_ont_fork` for the semantic labels carrying it. That's intended (the point is cheap `WHERE NOT r._ont_fork` scoping), but it is a schema change that lands on the next sync — flagging it in case you'd rather opt out with `indexed=False`.