### PR TITLE
fix(trivy): only set cve_id and :CVE on CVE-backed findings

### DIFF
--- a/cartography/intel/trivy/scanner.py
+++ b/cartography/intel/trivy/scanner.py
@@ -73,11 +73,20 @@ def transform_scan_results(
                     data_source_id = result["DataSource"].get("ID")
                     data_source_name = result["DataSource"].get("Name")
 
+                # Trivy reports more than CVEs: GHSA-, DLA-/DSA-, TEMP-, RUSTSEC-, etc.
+                # Only CVE-prefixed ids populate cve_id (which gates the :CVE label);
+                # GHSA-prefixed ids land in ghsa_id. Other schemes populate neither and
+                # remain readable through name/id.
+                vuln_id = result["VulnerabilityID"]
+                is_cve = vuln_id.startswith("CVE-")
+
                 # Transform finding data
                 finding = {
-                    "id": f'TIF|{result["VulnerabilityID"]}',
-                    "VulnerabilityID": result["VulnerabilityID"],
-                    "cve_id": result["VulnerabilityID"],
+                    "id": f"TIF|{vuln_id}",
+                    "VulnerabilityID": vuln_id,
+                    "cve_id": vuln_id if is_cve else None,
+                    "ghsa_id": vuln_id if vuln_id.startswith("GHSA-") else None,
+                    "has_cve": "true" if is_cve else "false",
                     "Description": result.get("Description"),
                     "LastModifiedDate": result.get("LastModifiedDate"),
                     "PrimaryURL": result.get("PrimaryURL"),

--- a/cartography/intel/trivy/scanner.py
+++ b/cartography/intel/trivy/scanner.py
@@ -75,19 +75,20 @@ def transform_scan_results(
 
                 # Trivy reports more than CVEs: GHSA-, DLA-/DSA-, TEMP-, RUSTSEC-, etc.
                 # The primary identifier lives in VulnerabilityID, and vendor advisory
-                # ids (e.g. RHSA-, DSA-) in VendorIDs. Classify the union so an
-                # identifier is recognised whichever slot it appears in, rather than
-                # assuming the scheme of the primary id. cve_id gates the :CVE label;
-                # schemes we have no field for populate neither and stay readable
-                # through name/id.
+                # ids (e.g. RHSA-, DSA-) in VendorIDs. Keep the whole set on the finding
+                # and classify it, so an identifier is recognised whichever slot it
+                # appears in and no authority is dropped for lack of a dedicated field.
+                # cve_id gates the :CVE label.
                 vuln_id = result["VulnerabilityID"]
-                all_ids = [vuln_id, *(result.get("VendorIDs") or [])]
+                vulnerability_ids = list(
+                    dict.fromkeys([vuln_id, *(result.get("VendorIDs") or [])]),
+                )
                 cve_id = next(
-                    (vid for vid in all_ids if vid.startswith("CVE-")),
+                    (vid for vid in vulnerability_ids if vid.startswith("CVE-")),
                     None,
                 )
                 ghsa_id = next(
-                    (vid for vid in all_ids if vid.startswith("GHSA-")),
+                    (vid for vid in vulnerability_ids if vid.startswith("GHSA-")),
                     None,
                 )
 
@@ -95,6 +96,7 @@ def transform_scan_results(
                 finding = {
                     "id": f"TIF|{vuln_id}",
                     "VulnerabilityID": vuln_id,
+                    "vulnerability_ids": vulnerability_ids,
                     "cve_id": cve_id,
                     "ghsa_id": ghsa_id,
                     "has_cve": "true" if cve_id else "false",

--- a/cartography/intel/trivy/scanner.py
+++ b/cartography/intel/trivy/scanner.py
@@ -74,19 +74,30 @@ def transform_scan_results(
                     data_source_name = result["DataSource"].get("Name")
 
                 # Trivy reports more than CVEs: GHSA-, DLA-/DSA-, TEMP-, RUSTSEC-, etc.
-                # Only CVE-prefixed ids populate cve_id (which gates the :CVE label);
-                # GHSA-prefixed ids land in ghsa_id. Other schemes populate neither and
-                # remain readable through name/id.
+                # The primary identifier lives in VulnerabilityID, and vendor advisory
+                # ids (e.g. RHSA-, DSA-) in VendorIDs. Classify the union so an
+                # identifier is recognised whichever slot it appears in, rather than
+                # assuming the scheme of the primary id. cve_id gates the :CVE label;
+                # schemes we have no field for populate neither and stay readable
+                # through name/id.
                 vuln_id = result["VulnerabilityID"]
-                is_cve = vuln_id.startswith("CVE-")
+                all_ids = [vuln_id, *(result.get("VendorIDs") or [])]
+                cve_id = next(
+                    (vid for vid in all_ids if vid.startswith("CVE-")),
+                    None,
+                )
+                ghsa_id = next(
+                    (vid for vid in all_ids if vid.startswith("GHSA-")),
+                    None,
+                )
 
                 # Transform finding data
                 finding = {
                     "id": f"TIF|{vuln_id}",
                     "VulnerabilityID": vuln_id,
-                    "cve_id": vuln_id if is_cve else None,
-                    "ghsa_id": vuln_id if vuln_id.startswith("GHSA-") else None,
-                    "has_cve": "true" if is_cve else "false",
+                    "cve_id": cve_id,
+                    "ghsa_id": ghsa_id,
+                    "has_cve": "true" if cve_id else "false",
                     "Description": result.get("Description"),
                     "LastModifiedDate": result.get("LastModifiedDate"),
                     "PrimaryURL": result.get("PrimaryURL"),

--- a/cartography/models/trivy/findings.py
+++ b/cartography/models/trivy/findings.py
@@ -18,6 +18,9 @@ from cartography.models.ontology.labels import CVE
 class TrivyImageFindingNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef("id")
     name: PropertyRef = PropertyRef("VulnerabilityID")
+    # Every identifier the report carries for this finding, primary first. Preserved in
+    # full so authorities without a dedicated field (DSA-, RHSA-, ...) are not lost.
+    vulnerability_ids: PropertyRef = PropertyRef("vulnerability_ids")
     cve_id: PropertyRef = PropertyRef("cve_id", extra_index=True)
     ghsa_id: PropertyRef = PropertyRef("ghsa_id", extra_index=True)
     has_cve: PropertyRef = PropertyRef("has_cve")

--- a/cartography/models/trivy/findings.py
+++ b/cartography/models/trivy/findings.py
@@ -19,6 +19,8 @@ class TrivyImageFindingNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef("id")
     name: PropertyRef = PropertyRef("VulnerabilityID")
     cve_id: PropertyRef = PropertyRef("cve_id", extra_index=True)
+    ghsa_id: PropertyRef = PropertyRef("ghsa_id", extra_index=True)
+    has_cve: PropertyRef = PropertyRef("has_cve")
     description: PropertyRef = PropertyRef("Description")
     last_modified_date: PropertyRef = PropertyRef("LastModifiedDate")
     primary_url: PropertyRef = PropertyRef("PrimaryURL")
@@ -67,7 +69,14 @@ class TrivyFindingToOntologyImageRel(CartographyRelSchema):
 class TrivyImageFindingSchema(CartographyNodeSchema):
     label: str = "TrivyImageFinding"
     scoped_cleanup: bool = False
-    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([RISK, CVE])
+    # Trivy reports CVEs alongside other identifier schemes (GHSA-, DLA-, TEMP-, ...),
+    # so :CVE is only applied to CVE-backed findings. :Risk covers all of them.
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        [
+            RISK,
+            CVE.when(has_cve="true"),
+        ],
+    )
     properties: TrivyImageFindingNodeProperties = TrivyImageFindingNodeProperties()
     other_relationships: OtherRelationships = OtherRelationships(
         [

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -1082,9 +1082,9 @@ to the concrete finding nodes that reference a CVE, so cross-scanner queries can
 CVE-backed finding with `MATCH (c:CVE)`.
 
 Contributing module nodes (each carries `:CVE` unconditionally or via a conditional label): the
-deprecated `CVE` node, `UbuntuCVE`, `TrivyImageFinding`, `CrowdstrikeFinding`, `GitHubDependabotAlert`,
-`S1AppFinding`, `SemgrepSCAFinding` (when `has_cve` is true), and `AWSInspectorFinding` (when
-`type = PACKAGE_VULNERABILITY`).
+deprecated `CVE` node, `UbuntuCVE`, `CrowdstrikeFinding`, `GitHubDependabotAlert`, `S1AppFinding`,
+`SemgrepSCAFinding` and `TrivyImageFinding` (both when `has_cve` is true), and
+`AWSInspectorFinding` (when `type = PACKAGE_VULNERABILITY`).
 
 | Field | Description |
 |-------|-------------|

--- a/docs/root/modules/trivy/schema.md
+++ b/docs/root/modules/trivy/schema.md
@@ -1,15 +1,22 @@
 ## Trivy Schema
 
-### TrivyImageFinding::Risk::CVE
+### TrivyImageFinding::Risk / ::CVE
 Representation of a vulnerability finding in a container image.
+
+Trivy reports several identifier schemes: CVEs, but also GitHub advisories (`GHSA-*`), Debian
+advisories (`DLA-*`, `DSA-*`, `TEMP-*`), `RUSTSEC-*`, and others. `:Risk` is applied to every
+finding, but `:CVE` is conditional: it is only set when the finding is CVE-backed
+(`has_cve = "true"`, i.e. `cve_id` is populated).
 
 | Field | Description |
 |-------|-------------|
 | firstseen | Timestamp of when a sync job first discovered this node |
 | lastupdated | Timestamp of the last time the node was updated |
-| **id** | Unique identifier for the finding (format: TIF|CVE-ID) |
-| name | The vulnerability ID (e.g. CVE-2024-1234) |
-| cve_id | The CVE identifier |
+| **id** | Unique identifier for the finding (format: TIF|VULNERABILITY-ID, e.g. `TIF|CVE-2024-1234` or `TIF|GHSA-xxxx-xxxx-xxxx`) |
+| name | The vulnerability ID, whatever its scheme (e.g. CVE-2024-1234, GHSA-xxxx-xxxx-xxxx) |
+| cve_id | The CVE identifier. Set only when the vulnerability ID is a CVE, null otherwise |
+| ghsa_id | The GitHub advisory identifier. Set only when the vulnerability ID is a GHSA, null otherwise |
+| has_cve | `"true"` when the finding is CVE-backed, `"false"` otherwise. Drives the conditional `:CVE` label |
 | description | Description of the vulnerability |
 | last_modified_date | Date when the vulnerability was last modified |
 | primary_url | Primary URL for vulnerability information |

--- a/docs/root/modules/trivy/schema.md
+++ b/docs/root/modules/trivy/schema.md
@@ -18,6 +18,7 @@ present (`has_cve = "true"`, i.e. `cve_id` is populated).
 | lastupdated | Timestamp of the last time the node was updated |
 | **id** | Unique identifier for the finding, built from the primary `VulnerabilityID` (format: TIF|VULNERABILITY-ID, e.g. `TIF|CVE-2024-1234` or `TIF|GHSA-xxxx-xxxx-xxxx`) |
 | name | The primary vulnerability ID, whatever its scheme (e.g. CVE-2024-1234, GHSA-xxxx-xxxx-xxxx) |
+| vulnerability_ids | Every identifier the report carries for this finding, primary first: the `VulnerabilityID` plus any `VendorIDs` (e.g. `["CVE-2025-31115", "DSA-5895-1"]`). Identifier authorities without a dedicated field below remain available here |
 | cve_id | The CVE identifier, if the finding carries one. Null when no reported identifier is a CVE |
 | ghsa_id | The GitHub advisory identifier, if the finding carries one. Null when no reported identifier is a GHSA |
 | has_cve | `"true"` when a CVE identifier is present, `"false"` otherwise. Drives the conditional `:CVE` label |

--- a/docs/root/modules/trivy/schema.md
+++ b/docs/root/modules/trivy/schema.md
@@ -3,20 +3,24 @@
 ### TrivyImageFinding::Risk / ::CVE
 Representation of a vulnerability finding in a container image.
 
-Trivy reports several identifier schemes: CVEs, but also GitHub advisories (`GHSA-*`), Debian
-advisories (`DLA-*`, `DSA-*`, `TEMP-*`), `RUSTSEC-*`, and others. `:Risk` is applied to every
-finding, but `:CVE` is conditional: it is only set when the finding is CVE-backed
-(`has_cve = "true"`, i.e. `cve_id` is populated).
+A Trivy finding can carry identifiers from several schemes: CVEs, but also GitHub advisories
+(`GHSA-*`), Debian advisories (`DLA-*`, `DSA-*`, `TEMP-*`), `RUSTSEC-*`, and others. These schemes
+are not mutually exclusive, so each identifier field below reflects **which identifiers are present
+in the report** (the primary `VulnerabilityID` plus any `VendorIDs`), not which scheme the primary
+identifier happens to use.
+
+`:Risk` is applied to every finding. `:CVE` is conditional: it is only set when a CVE identifier is
+present (`has_cve = "true"`, i.e. `cve_id` is populated).
 
 | Field | Description |
 |-------|-------------|
 | firstseen | Timestamp of when a sync job first discovered this node |
 | lastupdated | Timestamp of the last time the node was updated |
-| **id** | Unique identifier for the finding (format: TIF|VULNERABILITY-ID, e.g. `TIF|CVE-2024-1234` or `TIF|GHSA-xxxx-xxxx-xxxx`) |
-| name | The vulnerability ID, whatever its scheme (e.g. CVE-2024-1234, GHSA-xxxx-xxxx-xxxx) |
-| cve_id | The CVE identifier. Set only when the vulnerability ID is a CVE, null otherwise |
-| ghsa_id | The GitHub advisory identifier. Set only when the vulnerability ID is a GHSA, null otherwise |
-| has_cve | `"true"` when the finding is CVE-backed, `"false"` otherwise. Drives the conditional `:CVE` label |
+| **id** | Unique identifier for the finding, built from the primary `VulnerabilityID` (format: TIF|VULNERABILITY-ID, e.g. `TIF|CVE-2024-1234` or `TIF|GHSA-xxxx-xxxx-xxxx`) |
+| name | The primary vulnerability ID, whatever its scheme (e.g. CVE-2024-1234, GHSA-xxxx-xxxx-xxxx) |
+| cve_id | The CVE identifier, if the finding carries one. Null when no reported identifier is a CVE |
+| ghsa_id | The GitHub advisory identifier, if the finding carries one. Null when no reported identifier is a GHSA |
+| has_cve | `"true"` when a CVE identifier is present, `"false"` otherwise. Drives the conditional `:CVE` label |
 | description | Description of the vulnerability |
 | last_modified_date | Date when the vulnerability was last modified |
 | primary_url | Primary URL for vulnerability information |

--- a/tests/data/trivy/trivy_sample.py
+++ b/tests/data/trivy/trivy_sample.py
@@ -1517,6 +1517,7 @@ TRIVY_MIXED_IDENTIFIERS_SAMPLE = {
             "Vulnerabilities": [
                 {
                     "VulnerabilityID": "CVE-2024-11111",
+                    "VendorIDs": ["DSA-9999-1"],
                     "PkgName": "openssl",
                     "InstalledVersion": "3.0.15-1~deb12u1",
                     "FixedVersion": "3.0.16-1~deb12u1",

--- a/tests/data/trivy/trivy_sample.py
+++ b/tests/data/trivy/trivy_sample.py
@@ -1493,3 +1493,62 @@ TRIVY_SAMPLE = {
         },
     ],
 }
+
+
+# Trivy reports several identifier schemes, not just CVEs. This sample carries one
+# CVE, one GitHub advisory and one Debian TEMP id so tests can check that cve_id /
+# ghsa_id / has_cve and the conditional :CVE label are only set where they belong.
+TRIVY_MIXED_IDENTIFIERS_SAMPLE = {
+    "SchemaVersion": 2,
+    "ArtifactName": "example.com/repo/mixed-ids:latest",
+    "ArtifactType": "container_image",
+    "Metadata": {
+        "OS": {"Family": "debian", "Name": "12.8"},
+        "ImageID": "sha256:mixedids",
+        "RepoDigests": [
+            "example.com/repo/mixed-ids@sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        ],
+    },
+    "Results": [
+        {
+            "Target": "example.com/repo/mixed-ids:latest (debian 12.8)",
+            "Class": "os-pkgs",
+            "Type": "debian",
+            "Vulnerabilities": [
+                {
+                    "VulnerabilityID": "CVE-2024-11111",
+                    "PkgName": "openssl",
+                    "InstalledVersion": "3.0.15-1~deb12u1",
+                    "FixedVersion": "3.0.16-1~deb12u1",
+                    "Status": "fixed",
+                    "Severity": "HIGH",
+                    "Title": "A real CVE",
+                },
+                {
+                    "VulnerabilityID": "TEMP-0000000-ABCDEF",
+                    "PkgName": "liblzma5",
+                    "InstalledVersion": "5.4.1-0.2",
+                    "Status": "affected",
+                    "Severity": "LOW",
+                    "Title": "An unfixed Debian issue with no CVE assigned",
+                },
+            ],
+        },
+        {
+            "Target": "python-pkg",
+            "Class": "lang-pkgs",
+            "Type": "python-pkg",
+            "Vulnerabilities": [
+                {
+                    "VulnerabilityID": "GHSA-aaaa-bbbb-cccc",
+                    "PkgName": "h11",
+                    "InstalledVersion": "0.14.0",
+                    "FixedVersion": "0.16.0",
+                    "Status": "fixed",
+                    "Severity": "MEDIUM",
+                    "Title": "A GitHub advisory with no CVE",
+                },
+            ],
+        },
+    ],
+}

--- a/tests/integration/cartography/intel/trivy/test_trivy_finding_identifiers.py
+++ b/tests/integration/cartography/intel/trivy/test_trivy_finding_identifiers.py
@@ -1,0 +1,90 @@
+from cartography.intel.trivy.scanner import sync_single_image
+from tests.data.trivy.trivy_sample import TRIVY_MIXED_IDENTIFIERS_SAMPLE
+from tests.integration.util import check_nodes
+
+TEST_UPDATE_TAG = 123456789
+
+
+def _get_finding(neo4j_session, finding_id: str) -> dict:
+    record = neo4j_session.run(
+        """
+        MATCH (f:TrivyImageFinding {id: $id})
+        RETURN f.name AS name, f.cve_id AS cve_id, f.ghsa_id AS ghsa_id,
+               f.has_cve AS has_cve, f:CVE AS has_cve_label, f:Risk AS has_risk_label
+        """,
+        id=finding_id,
+    ).single()
+    assert record is not None, f"Expected a TrivyImageFinding with id {finding_id}"
+    return dict(record)
+
+
+def test_sync_mixed_identifiers_only_labels_cves(neo4j_session):
+    """Trivy findings only carry cve_id and the :CVE label when they are CVE-backed."""
+    # Act
+    sync_single_image(
+        neo4j_session,
+        TRIVY_MIXED_IDENTIFIERS_SAMPLE,
+        "mixed-ids.json",
+        TEST_UPDATE_TAG,
+    )
+
+    # Assert - all three identifier schemes are ingested
+    assert check_nodes(neo4j_session, "TrivyImageFinding", ["id", "name"]) == {
+        ("TIF|CVE-2024-11111", "CVE-2024-11111"),
+        ("TIF|GHSA-aaaa-bbbb-cccc", "GHSA-aaaa-bbbb-cccc"),
+        ("TIF|TEMP-0000000-ABCDEF", "TEMP-0000000-ABCDEF"),
+    }
+
+    # A CVE-backed finding gets cve_id and the :CVE label
+    cve = _get_finding(neo4j_session, "TIF|CVE-2024-11111")
+    assert cve["cve_id"] == "CVE-2024-11111"
+    assert cve["ghsa_id"] is None
+    assert cve["has_cve"] == "true"
+    assert cve["has_cve_label"] is True
+    assert cve["has_risk_label"] is True
+
+    # A GitHub advisory keeps its identifier in ghsa_id and is not a :CVE
+    ghsa = _get_finding(neo4j_session, "TIF|GHSA-aaaa-bbbb-cccc")
+    assert ghsa["cve_id"] is None
+    assert ghsa["ghsa_id"] == "GHSA-aaaa-bbbb-cccc"
+    assert ghsa["has_cve"] == "false"
+    assert ghsa["has_cve_label"] is False
+    assert ghsa["has_risk_label"] is True
+
+    # Any other scheme populates neither identifier field and is not a :CVE
+    temp = _get_finding(neo4j_session, "TIF|TEMP-0000000-ABCDEF")
+    assert temp["cve_id"] is None
+    assert temp["ghsa_id"] is None
+    assert temp["has_cve"] == "false"
+    assert temp["has_cve_label"] is False
+    assert temp["has_risk_label"] is True
+
+
+def test_sync_removes_stale_cve_label_and_cve_id(neo4j_session):
+    """A finding wrongly labelled :CVE by an older sync is corrected on the next sync."""
+    # Arrange - simulate the pre-fix state: raw identifier copied into cve_id and
+    # :CVE applied unconditionally.
+    neo4j_session.run(
+        """
+        MERGE (f:TrivyImageFinding {id: 'TIF|GHSA-aaaa-bbbb-cccc'})
+        SET f:Risk, f:CVE,
+            f.name = 'GHSA-aaaa-bbbb-cccc',
+            f.cve_id = 'GHSA-aaaa-bbbb-cccc',
+            f.lastupdated = $update_tag
+        """,
+        update_tag=TEST_UPDATE_TAG - 1,
+    )
+
+    # Act
+    sync_single_image(
+        neo4j_session,
+        TRIVY_MIXED_IDENTIFIERS_SAMPLE,
+        "mixed-ids.json",
+        TEST_UPDATE_TAG,
+    )
+
+    # Assert
+    ghsa = _get_finding(neo4j_session, "TIF|GHSA-aaaa-bbbb-cccc")
+    assert ghsa["cve_id"] is None
+    assert ghsa["ghsa_id"] == "GHSA-aaaa-bbbb-cccc"
+    assert ghsa["has_cve_label"] is False

--- a/tests/integration/cartography/intel/trivy/test_trivy_finding_identifiers.py
+++ b/tests/integration/cartography/intel/trivy/test_trivy_finding_identifiers.py
@@ -10,6 +10,7 @@ def _get_finding(neo4j_session, finding_id: str) -> dict:
         """
         MATCH (f:TrivyImageFinding {id: $id})
         RETURN f.name AS name, f.cve_id AS cve_id, f.ghsa_id AS ghsa_id,
+               f.vulnerability_ids AS vulnerability_ids,
                f.has_cve AS has_cve, f:CVE AS has_cve_label, f:Risk AS has_risk_label
         """,
         id=finding_id,
@@ -42,6 +43,8 @@ def test_sync_mixed_identifiers_only_labels_cves(neo4j_session):
     assert cve["has_cve"] == "true"
     assert cve["has_cve_label"] is True
     assert cve["has_risk_label"] is True
+    # The vendor advisory id has no dedicated field, but is preserved in the full list
+    assert cve["vulnerability_ids"] == ["CVE-2024-11111", "DSA-9999-1"]
 
     # A GitHub advisory keeps its identifier in ghsa_id and is not a :CVE
     ghsa = _get_finding(neo4j_session, "TIF|GHSA-aaaa-bbbb-cccc")

--- a/tests/unit/cartography/intel/trivy/test_scanner.py
+++ b/tests/unit/cartography/intel/trivy/test_scanner.py
@@ -686,3 +686,51 @@ def test_transform_scan_results_only_sets_cve_id_for_cves():
         "GHSA-aaaa-bbbb-cccc",
         "TEMP-0000000-ABCDEF",
     }
+
+
+def test_transform_scan_results_classifies_vendor_ids():
+    """Identifiers are picked up from VendorIDs too, not just the primary id."""
+    # Arrange - in practice VendorIDs carries vendor advisory ids (RHSA-, DSA-), which
+    # match neither scheme, but the classification does not assume that.
+    results = [
+        {
+            "Class": "os-pkgs",
+            "Type": "debian",
+            "Vulnerabilities": [
+                {
+                    "VulnerabilityID": "CVE-2025-31115",
+                    "VendorIDs": ["DSA-5895-1"],
+                    "PkgName": "liblzma5",
+                    "InstalledVersion": "5.4.1-0.2",
+                    "Severity": "HIGH",
+                },
+                {
+                    "VulnerabilityID": "DSA-5895-1",
+                    "VendorIDs": ["CVE-2025-31115", "GHSA-dddd-eeee-ffff"],
+                    "PkgName": "liblzma5",
+                    "InstalledVersion": "5.4.1-0.2",
+                    "Severity": "HIGH",
+                },
+            ],
+        },
+    ]
+
+    # Act
+    findings_list, _, _ = transform_scan_results(results, "sha256:testdigest")
+
+    # Assert
+    findings_by_id = {finding["id"]: finding for finding in findings_list}
+
+    # A vendor advisory id alongside a CVE changes nothing
+    cve = findings_by_id["TIF|CVE-2025-31115"]
+    assert cve["cve_id"] == "CVE-2025-31115"
+    assert cve["ghsa_id"] is None
+    assert cve["has_cve"] == "true"
+
+    # An identifier reported under VendorIDs is still classified, and id/name keep
+    # tracking the primary identifier
+    vendor_primary = findings_by_id["TIF|DSA-5895-1"]
+    assert vendor_primary["VulnerabilityID"] == "DSA-5895-1"
+    assert vendor_primary["cve_id"] == "CVE-2025-31115"
+    assert vendor_primary["ghsa_id"] == "GHSA-dddd-eeee-ffff"
+    assert vendor_primary["has_cve"] == "true"

--- a/tests/unit/cartography/intel/trivy/test_scanner.py
+++ b/tests/unit/cartography/intel/trivy/test_scanner.py
@@ -721,11 +721,13 @@ def test_transform_scan_results_classifies_vendor_ids():
     # Assert
     findings_by_id = {finding["id"]: finding for finding in findings_list}
 
-    # A vendor advisory id alongside a CVE changes nothing
+    # A vendor advisory id alongside a CVE changes the classification not at all, but is
+    # still preserved on the finding
     cve = findings_by_id["TIF|CVE-2025-31115"]
     assert cve["cve_id"] == "CVE-2025-31115"
     assert cve["ghsa_id"] is None
     assert cve["has_cve"] == "true"
+    assert cve["vulnerability_ids"] == ["CVE-2025-31115", "DSA-5895-1"]
 
     # An identifier reported under VendorIDs is still classified, and id/name keep
     # tracking the primary identifier
@@ -734,3 +736,35 @@ def test_transform_scan_results_classifies_vendor_ids():
     assert vendor_primary["cve_id"] == "CVE-2025-31115"
     assert vendor_primary["ghsa_id"] == "GHSA-dddd-eeee-ffff"
     assert vendor_primary["has_cve"] == "true"
+    # Primary first, then the vendor ids in report order
+    assert vendor_primary["vulnerability_ids"] == [
+        "DSA-5895-1",
+        "CVE-2025-31115",
+        "GHSA-dddd-eeee-ffff",
+    ]
+
+
+def test_transform_scan_results_dedupes_vulnerability_ids():
+    """A VendorIDs entry repeating the primary id is not duplicated in the list."""
+    # Arrange
+    results = [
+        {
+            "Class": "os-pkgs",
+            "Type": "debian",
+            "Vulnerabilities": [
+                {
+                    "VulnerabilityID": "CVE-2025-31115",
+                    "VendorIDs": ["CVE-2025-31115", "DSA-5895-1"],
+                    "PkgName": "liblzma5",
+                    "InstalledVersion": "5.4.1-0.2",
+                    "Severity": "HIGH",
+                },
+            ],
+        },
+    ]
+
+    # Act
+    findings_list, _, _ = transform_scan_results(results, "sha256:testdigest")
+
+    # Assert
+    assert findings_list[0]["vulnerability_ids"] == ["CVE-2025-31115", "DSA-5895-1"]

--- a/tests/unit/cartography/intel/trivy/test_scanner.py
+++ b/tests/unit/cartography/intel/trivy/test_scanner.py
@@ -10,6 +10,7 @@ from cartography.intel.trivy import sync_trivy_from_report_reader
 from cartography.intel.trivy import sync_trivy_from_s3
 from cartography.intel.trivy.scanner import get_json_files_in_s3
 from cartography.intel.trivy.scanner import sync_single_image_from_s3
+from cartography.intel.trivy.scanner import transform_scan_results
 
 
 @patch("boto3.Session")
@@ -621,3 +622,67 @@ def test_sync_trivy_skips_cleanup_when_no_reports_match_graph(
 
     mock_sync_single_image.assert_not_called()
     mock_cleanup.assert_not_called()
+
+
+def test_transform_scan_results_only_sets_cve_id_for_cves():
+    """Only CVE-prefixed ids populate cve_id; GHSA ids land in ghsa_id."""
+    # Arrange
+    results = [
+        {
+            "Class": "os-pkgs",
+            "Type": "debian",
+            "Vulnerabilities": [
+                {
+                    "VulnerabilityID": "CVE-2024-11111",
+                    "PkgName": "openssl",
+                    "InstalledVersion": "3.0.15-1~deb12u1",
+                    "Severity": "HIGH",
+                },
+                {
+                    "VulnerabilityID": "GHSA-aaaa-bbbb-cccc",
+                    "PkgName": "h11",
+                    "InstalledVersion": "0.14.0",
+                    "Severity": "MEDIUM",
+                },
+                {
+                    "VulnerabilityID": "TEMP-0000000-ABCDEF",
+                    "PkgName": "liblzma5",
+                    "InstalledVersion": "5.4.1-0.2",
+                    "Severity": "LOW",
+                },
+            ],
+        },
+    ]
+
+    # Act
+    findings_list, _, _ = transform_scan_results(results, "sha256:testdigest")
+
+    # Assert
+    findings_by_id = {finding["id"]: finding for finding in findings_list}
+    assert set(findings_by_id) == {
+        "TIF|CVE-2024-11111",
+        "TIF|GHSA-aaaa-bbbb-cccc",
+        "TIF|TEMP-0000000-ABCDEF",
+    }
+
+    cve = findings_by_id["TIF|CVE-2024-11111"]
+    assert cve["cve_id"] == "CVE-2024-11111"
+    assert cve["ghsa_id"] is None
+    assert cve["has_cve"] == "true"
+
+    ghsa = findings_by_id["TIF|GHSA-aaaa-bbbb-cccc"]
+    assert ghsa["cve_id"] is None
+    assert ghsa["ghsa_id"] == "GHSA-aaaa-bbbb-cccc"
+    assert ghsa["has_cve"] == "false"
+
+    temp = findings_by_id["TIF|TEMP-0000000-ABCDEF"]
+    assert temp["cve_id"] is None
+    assert temp["ghsa_id"] is None
+    assert temp["has_cve"] == "false"
+
+    # The raw identifier stays available on name regardless of its scheme
+    assert {finding["VulnerabilityID"] for finding in findings_list} == {
+        "CVE-2024-11111",
+        "GHSA-aaaa-bbbb-cccc",
+        "TEMP-0000000-ABCDEF",
+    }


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary

Trivy reports several vulnerability identifier schemes, not just CVEs: GitHub advisories (`GHSA-*`), Debian advisories (`DLA-*`, `DSA-*`, `TEMP-*`), `RUSTSEC-*`, `openSUSE-SU-*`, and others.

Today the transform copies the raw `VulnerabilityID` into `cve_id` unconditionally and the schema applies `:CVE` as an unconditional label. So a `GHSA-xxxx-xxxx-xxxx` finding ends up with a bogus `cve_id`, a bogus `_ont_cve_id` (via the trivy ontology mapping), and the `:CVE` semantic label it does not deserve. `MATCH (c:CVE)` therefore returns non-CVE findings.

This PR classifies the identifiers a finding actually reports, taking the union of the primary `VulnerabilityID` and any `VendorIDs`:

| Reported identifiers | `cve_id` | `ghsa_id` | `has_cve` | `:CVE` |
|---|---|---|---|---|
| `CVE-2024-11111` | set | null | `"true"` | yes |
| `GHSA-aaaa-bbbb-cccc` | null | set | `"false"` | no |
| `TEMP-…`, `DLA-…`, `RUSTSEC-…` | null | null | `"false"` | no |
| `DSA-5895-1` + `CVE-2025-31115` in `VendorIDs` | set | null | `"true"` | yes |

`:CVE` becomes conditional (`CVE.when(has_cve="true")`), and `:Risk` stays unconditional. `id` (`TIF|<vuln-id>`) and `name` keep tracking the primary identifier for every scheme, so nothing becomes unreachable.

This aligns Trivy with the other mixed-identifier scanners in the repo (`TenableFinding`, `SemgrepSCAFinding`, `GitHubDependabotAlert`, `AWSInspectorFinding`), which all already gate `:CVE` behind a conditional label and leave `cve_id` null for non-CVE identifiers. Trivy was the last one still doing it unconditionally.


### Related issues or links

Builds on #3032 (declarative extra node labels) and #3082 (conditional labels applied per row), both merged into this branch.


### How was this tested?

- New unit tests on `transform_scan_results()`: one covering a `CVE-*`, a `GHSA-*` and a `TEMP-*` primary identifier, one covering identifiers arriving through `VendorIDs`.
- New integration test (`tests/integration/cartography/intel/trivy/test_trivy_finding_identifiers.py`) driving `sync_single_image()` with a mixed-identifier fixture, asserting `cve_id` / `ghsa_id` / `has_cve` and the presence/absence of the `:CVE` and `:Risk` labels for each scheme. A second case seeds the pre-fix state (raw id in `cve_id`, `:CVE` applied) and asserts the sync corrects it.

```
uv run pytest tests/unit/cartography/intel/trivy tests/integration/cartography/intel/trivy -q                      # 40 passed
uv run pytest tests/unit/cartography/graph tests/integration/cartography/graph \
              tests/integration/cartography/intel/ontology -q                                                      # 298 passed
make test_lint                                                                                                     # all hooks pass
```

Post-sync graph checks, both expected to return 0 rows:

```cypher
MATCH (f:TrivyImageFinding) WHERE f.cve_id IS NOT NULL AND NOT f.cve_id STARTS WITH 'CVE-' RETURN f.id
```

```cypher
MATCH (f:TrivyImageFinding:CVE) WHERE f.cve_id IS NULL RETURN f.id
```


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).


### Notes for reviewers

**No migration job.** Existing bad data self-heals on the next full sync. The generated property SET clause is a direct `i.cve_id = item.cve_id`, so `None` nulls out stale values, and since #3082 the conditional label is maintained by a per-row `FOREACH` pair, whose negative branch strips a stale `:CVE` from any finding that is re-loaded. A finding that is no longer reported is deleted by cleanup instead. The integration test covers exactly this path.

**Ontology mapping unchanged.** `trivy_mapping` in `cartography/models/ontology/mapping/data/cves.py` is keyed on the primary label `TrivyImageFinding`, not on `:CVE`, so `_ont_cve_id` simply becomes null for non-CVE findings. This is the same behaviour `SemgrepSCAFinding` already relies on. `ghsa_id` gets no ontology field since none exists for GHSA today.

**On `VendorIDs`.** The union is classified rather than the primary identifier alone, so an identifier is recognised whichever slot it arrives in. In practice `VendorIDs` carries vendor advisory ids only: upstream documents the field as `// e.g. RHSA-ID and DSA-ID`, and every occurrence in our own captured fixtures is a `DSA-*` on a CVE-primary finding. So the added branch is defensive rather than load-bearing on today's Trivy output.

**Not in scope.** Non-CVE findings keep only `:Risk`; I did not add a `SecurityIssue` conditional label the way Semgrep and AWS Inspector do, since that would require adding `SecurityIssue` ontology field mappings (title/severity/status/first_seen) for Trivy. Happy to do it in a follow-up if wanted.

The redundant `WHERE c.cve_id STARTS WITH "CVE"` guard in `cartography/intel/cve_metadata/__init__.py` is left in place as defence in depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
