### PR TITLE
perf(querybuilder): apply conditional node labels per row instead of via global remove/set passes

### DIFF
--- a/.agents/skills/add-node-type/references/advanced-properties.md
+++ b/.agents/skills/add-node-type/references/advanced-properties.md
@@ -52,7 +52,7 @@ production ECR values are `image`, `attestation`, and `manifest_list`.
 - Compose conditions with `CONSTANT.when(field="value")`.
 - Conditions use **case-sensitive exact string equality** and combine with **AND** logic.
 - Conditions are stored as immutable, sorted `(field, value)` tuples.
-- Indexes are created automatically for conditional labels and their condition fields.
+- Indexes are created automatically for conditional labels themselves. Condition fields are not indexed: they are evaluated against the already-bound node of the current row, so there is no lookup for an index to serve.
 - When conditions change, labels are added or removed on subsequent syncs.
 
 ### Important notes

--- a/.agents/skills/add-node-type/references/advanced-properties.md
+++ b/.agents/skills/add-node-type/references/advanced-properties.md
@@ -47,8 +47,8 @@ production ECR values are `image`, `attestation`, and `manifest_list`.
 
 ### How it works
 
-- Declarative labels with empty conditions are applied unconditionally during ingestion.
-- Labels with conditions are applied in a separate query after ingestion, only on nodes matching all specified conditions.
+- Declarative labels with empty conditions are applied unconditionally in the ingestion query's `SET` clause.
+- Labels with conditions are applied row by row in the same ingestion query, with a pair of `FOREACH` clauses that add the label when the conditions hold and remove it when they do not.
 - Compose conditions with `CONSTANT.when(field="value")`.
 - Conditions use **case-sensitive exact string equality** and combine with **AND** logic.
 - Conditions are stored as immutable, sorted `(field, value)` tuples.
@@ -58,7 +58,8 @@ production ECR values are `image`, `attestation`, and `manifest_list`.
 ### Important notes
 
 - Condition values must be strings (`"true"`, not `True`).
-- All conditions must match (AND).
+- All conditions in one `when()` call must match (AND). Declaring the same label more than once with different conditions is allowed: the label applies if any declaration matches (OR).
+- Only the nodes in the current batch are relabeled. A node whose conditions no longer hold is corrected the next time it is loaded, or deleted by cleanup if it is no longer reported.
 
 ## Common schema mistakes (custom fields are ignored)
 

--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -14,7 +14,6 @@ import backoff
 import neo4j
 import neo4j.exceptions
 
-from cartography.graph.querybuilder import build_conditional_label_queries
 from cartography.graph.querybuilder import build_create_index_queries
 from cartography.graph.querybuilder import build_create_index_queries_for_matchlink
 from cartography.graph.querybuilder import build_ingestion_query
@@ -837,12 +836,6 @@ def load(
     load_graph_data(
         neo4j_session, ingestion_query, dict_list, batch_size=batch_size, **kwargs
     )
-
-    # Apply conditional labels if any are defined
-    # Pass kwargs to provide sub-resource parameters (e.g., AWS_ID) for scoped queries
-    conditional_label_queries = build_conditional_label_queries(node_schema)
-    for query in conditional_label_queries:
-        run_write_query(neo4j_session, query, **kwargs)
 
     # Emit metrics for loaded nodes
     node_count = len(dict_list)

--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -483,6 +483,98 @@ def _build_node_properties_statement(
     return set_clause
 
 
+def _build_conditional_labels_statement(
+    extra_node_labels: ExtraNodeLabels | None = None,
+) -> str:
+    r"""
+    Generate Neo4j clauses that apply conditional extra labels to the node of the current row.
+
+    Conditional labels are declared with ``ExtraNodeLabel.when(...)``. For each such label we emit a
+    pair of ``FOREACH`` clauses: one that adds the label when the conditions hold, and one that
+    removes it when they do not. ``FOREACH`` over a one-or-zero element list is the standard
+    pure-Cypher conditional-write idiom, so no APOC dependency is needed.
+
+    Applying the label row by row means a sync never has to scan a whole label to keep conditional
+    labels in sync: a node is either re-loaded (and corrected here) or no longer reported (and
+    deleted by cleanup).
+
+    Args:
+        extra_node_labels (ExtraNodeLabels | None): Extra labels declared on the node schema.
+            Defaults to None.
+
+    Returns:
+        str: Neo4j ``FOREACH`` clauses, or an empty string if there are no conditional labels.
+
+    Examples:
+        >>> extra_node_labels = ExtraNodeLabels([IMAGE.when(type="image")])
+        >>> print(_build_conditional_labels_statement(extra_node_labels))
+        FOREACH (_ IN CASE WHEN i.type = "image" THEN [1] ELSE [] END | SET i:Image)
+        FOREACH (_ IN CASE WHEN i.type = "image" THEN [] ELSE [1] END | REMOVE i:Image)
+
+    Note:
+        - The conditions name *node properties*, not source dict keys, so the predicate reads
+          ``i.<property>``. The preceding SET clause has already run for the current row, so the
+          value is up to date. This also keeps the semantics identical for schemas that share a
+          primary label but populate it from different source keys.
+        - Conditions within one label declaration are ANDed; several declarations of the same label
+          are ORed together.
+        - The negative clause inverts the branches of the same positive predicate rather than
+          negating it, so a node whose condition property is missing (``null`` predicate) still has
+          the stale label removed.
+        - A label declared both unconditionally and conditionally is left to the unconditional SET
+          clause; otherwise the negative clause would strip a label that was just applied.
+    """
+    if not extra_node_labels:
+        return ""
+
+    unconditional_labels = {
+        label.label for label in extra_node_labels.labels if not label.conditions
+    }
+
+    # Group condition sets by label name, preserving declaration order.
+    conditions_by_label: dict[str, list[tuple[tuple[str, str], ...]]] = {}
+    for label in extra_node_labels.labels:
+        if not label.conditions or label.label in unconditional_labels:
+            continue
+        conditions_by_label.setdefault(label.label, []).append(label.conditions)
+
+    if not conditions_by_label:
+        return ""
+
+    set_template = Template(
+        "FOREACH (_ IN CASE WHEN $predicate THEN [1] ELSE [] END | SET i:$label)",
+    )
+    remove_template = Template(
+        "FOREACH (_ IN CASE WHEN $predicate THEN [] ELSE [1] END | REMOVE i:$label)",
+    )
+
+    clauses = []
+    for label_name, condition_sets in conditions_by_label.items():
+        predicates = []
+        for conditions in condition_sets:
+            comparisons = [
+                f'i.{field_name} = "{_escape_cypher_string(str(field_value))}"'
+                for field_name, field_value in conditions
+            ]
+            predicates.append(" AND ".join(comparisons))
+
+        if len(predicates) == 1:
+            predicate = predicates[0]
+        else:
+            # Several declarations of the same label: the label applies if any of them matches.
+            predicate = " OR ".join(f"({p})" for p in predicates)
+
+        clauses.append(
+            set_template.safe_substitute(predicate=predicate, label=label_name),
+        )
+        clauses.append(
+            remove_template.safe_substitute(predicate=predicate, label=label_name),
+        )
+
+    # The first clause is indented by the ingestion query template; indent the rest to match.
+    return "\n            ".join(clauses)
+
+
 def _build_rel_properties_statement(
     rel_var: str,
     rel_property_map: dict[str, PropertyRef] | None = None,
@@ -1181,6 +1273,7 @@ def build_ingestion_query(
                 i._module_version = "$module_version",
                 $set_node_properties_statement
                 $set_ontology_node_properties_statement
+            $conditional_labels_statement
             $attach_relationships_statement
         """,
     )
@@ -1212,136 +1305,15 @@ def build_ingestion_query(
             node_schema,
             node_props_as_dict,
         ),
+        conditional_labels_statement=_build_conditional_labels_statement(
+            node_schema.extra_node_labels,
+        ),
         attach_relationships_statement=_build_attach_relationships_statement(
             sub_resource_rel,
             other_rels,
         ),
     )
     return ingest_query
-
-
-def build_conditional_label_queries(
-    node_schema: CartographyNodeSchema,
-) -> list[str]:
-    """
-    Generate Neo4j queries to apply conditional labels to nodes.
-
-    Args:
-        node_schema (CartographyNodeSchema): The CartographyNodeSchema object containing
-            conditional labels in its extra_node_labels property.
-
-    Returns:
-        list[str]: A list of Neo4j queries, one per conditional label. Each query matches
-            nodes of the schema's primary label that satisfy the conditions, and applies
-            the conditional label.
-
-    Note:
-        - Labels with empty conditions are applied by the ingestion query
-        - Returns an empty list if no conditional labels are defined
-        - Values are escaped for Cypher string literals
-    """
-    if not node_schema.extra_node_labels:
-        return []
-
-    conditional_labels = [
-        label for label in node_schema.extra_node_labels.labels if label.conditions
-    ]
-
-    if not conditional_labels:
-        return []
-
-    queries = []
-    sub_rel = node_schema.sub_resource_relationship
-
-    # Build the sub-resource matching clause if a sub_resource_relationship exists
-    # This scopes the queries to the current tenant to avoid affecting other tenants' nodes
-    if sub_rel:
-        # Build the relationship pattern based on direction
-        if sub_rel.direction == LinkDirection.INWARD:
-            # (node)<-[:REL]-(sub_resource)
-            rel_pattern = f"<-[:{sub_rel.rel_label}]-"
-        else:
-            # (node)-[:REL]->(sub_resource)
-            rel_pattern = f"-[:{sub_rel.rel_label}]->"
-
-        # Build the match clause for the sub-resource node
-        sub_match_clause = _build_match_clause(sub_rel.target_node_matcher)
-
-        # Scoped templates that filter by sub-resource
-        remove_template = Template(
-            """
-            MATCH (n:$node_label:$conditional_label)$rel_pattern(sub:$sub_label{$sub_match_clause})
-            REMOVE n:$conditional_label
-            """,
-        )
-
-        set_template = Template(
-            """
-            MATCH (n:$node_label)$rel_pattern(sub:$sub_label{$sub_match_clause})
-            WHERE $where_clause
-            SET n:$conditional_label
-            """,
-        )
-    else:
-        # Unscoped templates for global resources without a tenant relationship
-        remove_template = Template(
-            """
-            MATCH (n:$node_label:$conditional_label)
-            REMOVE n:$conditional_label
-            """,
-        )
-
-        set_template = Template(
-            """
-            MATCH (n:$node_label)
-            WHERE $where_clause
-            SET n:$conditional_label
-            """,
-        )
-
-    for cond_label in conditional_labels:
-        # Build WHERE clause from conditions
-        where_parts = []
-        for field_name, field_value in cond_label.conditions:
-            # Escape the value for Cypher string literal
-            escaped_value = _escape_cypher_string(str(field_value))
-            where_parts.append(f'n.{field_name} = "{escaped_value}"')
-
-        where_clause = " AND ".join(where_parts)
-
-        if sub_rel:
-            # Scoped queries
-            remove_query = remove_template.safe_substitute(
-                node_label=node_schema.label,
-                conditional_label=cond_label.label,
-                rel_pattern=rel_pattern,
-                sub_label=sub_rel.target_node_label,
-                sub_match_clause=sub_match_clause,
-            )
-            set_query = set_template.safe_substitute(
-                node_label=node_schema.label,
-                where_clause=where_clause,
-                conditional_label=cond_label.label,
-                rel_pattern=rel_pattern,
-                sub_label=sub_rel.target_node_label,
-                sub_match_clause=sub_match_clause,
-            )
-        else:
-            # Unscoped queries
-            remove_query = remove_template.safe_substitute(
-                node_label=node_schema.label,
-                conditional_label=cond_label.label,
-            )
-            set_query = set_template.safe_substitute(
-                node_label=node_schema.label,
-                where_clause=where_clause,
-                conditional_label=cond_label.label,
-            )
-
-        queries.append(remove_query)
-        queries.append(set_query)
-
-    return queries
 
 
 def build_create_index_queries(node_schema: CartographyNodeSchema) -> list[str]:

--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -1384,15 +1384,9 @@ def build_create_index_queries(node_schema: CartographyNodeSchema) -> list[str]:
                     TargetAttribute="lastupdated",
                 ),
             )
-            if label.conditions:
-                # Index condition fields on the primary label to speed up matching.
-                for condition_field, _ in label.conditions:
-                    result.append(
-                        index_template.safe_substitute(
-                            TargetNodeLabel=node_schema.label,
-                            TargetAttribute=condition_field,
-                        ),
-                    )
+            # No index is created for a label's condition fields: the conditions are evaluated
+            # against the already-bound node of the current row in the ingestion query, so there is
+            # no lookup for an index to serve.
 
     # Next, for all relationships possible out of this node, ensure that indexes exist for all target nodes' properties
     # as specified in their TargetNodeMatchers.

--- a/cartography/intel/gcp/artifact_registry/artifact.py
+++ b/cartography/intel/gcp/artifact_registry/artifact.py
@@ -713,7 +713,6 @@ def load_docker_images(
         repository_image_schema,
         data,
         batch_size=ARTIFACT_REGISTRY_LOAD_BATCH_SIZE,
-        apply_labels=False,
         progress_description=(
             f"Artifact Registry repository image nodes for project {project_id}"
         ),

--- a/cartography/intel/gcp/artifact_registry/util.py
+++ b/cartography/intel/gcp/artifact_registry/util.py
@@ -17,8 +17,6 @@ from google.cloud.artifactregistry_v1 import ArtifactRegistryClient
 from cartography.client.core.tx import ensure_indexes
 from cartography.client.core.tx import ensure_indexes_for_matchlinks
 from cartography.client.core.tx import load_graph_data
-from cartography.client.core.tx import run_write_query
-from cartography.graph.querybuilder import build_conditional_label_queries
 from cartography.graph.querybuilder import build_ingestion_query
 from cartography.graph.querybuilder import build_matchlink_query
 from cartography.helpers import batch
@@ -84,15 +82,6 @@ def _load_with_progress(
         )
 
 
-def apply_conditional_labels(
-    neo4j_session: neo4j.Session,
-    node_schema: CartographyNodeSchema,
-    **kwargs: Any,
-) -> None:
-    for query in build_conditional_label_queries(node_schema):
-        run_write_query(neo4j_session, query, **kwargs)
-
-
 def load_nodes_without_relationships(
     neo4j_session: neo4j.Session,
     node_schema: CartographyNodeSchema,
@@ -100,7 +89,6 @@ def load_nodes_without_relationships(
     *,
     batch_size: int,
     progress_description: str,
-    apply_labels: bool = True,
     **kwargs: Any,
 ) -> None:
     if not data:
@@ -116,8 +104,6 @@ def load_nodes_without_relationships(
         progress_description=progress_description,
         **kwargs,
     )
-    if apply_labels:
-        apply_conditional_labels(neo4j_session, node_schema, **kwargs)
 
     node_count = len(data)
     stat_handler.incr(f"node.{node_schema.label.lower()}.loaded", node_count)

--- a/cartography/models/aws/inspector/findings.py
+++ b/cartography/models/aws/inspector/findings.py
@@ -184,10 +184,8 @@ class AWSInspectorFindingSchema(CartographyNodeSchema):
     # Inspector findings are mixed: package vulnerabilities are CVE-backed while
     # network-reachability findings are configuration security issues. Label them
     # by type so each shows up in the right ontology finding family.
-    # NOTE: the conditional-label mechanism removes-then-sets per entry, so a label
-    # can only be driven by a single condition (two entries sharing a label would
-    # clobber each other). CODE_VULNERABILITY is intentionally left unlabeled for
-    # now; give it its own distinct label if/when it needs one.
+    # CODE_VULNERABILITY is intentionally left unlabeled for now; give it its own
+    # distinct label if/when it needs one.
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
         [
             RISK,

--- a/docs/root/dev/writing-intel-modules.md
+++ b/docs/root/dev/writing-intel-modules.md
@@ -286,8 +286,8 @@ values are `image`, `attestation`, and `manifest_list`. Exact matching is
 case-sensitive, so uppercase variants do not match.
 
 **How it works:**
-- Labels with empty `conditions` are applied unconditionally during ingestion
-- Labels with nonempty `conditions` are applied in a separate query after ingestion, only to nodes matching all specified conditions
+- Labels with empty `conditions` are applied unconditionally in the ingestion query's `SET` clause
+- Labels with nonempty `conditions` are applied row by row in the same ingestion query, with a pair of `FOREACH` clauses that add the label when the conditions hold and remove it when they do not
 - `when()` returns a new immutable label value and leaves the exported constant unchanged
 - Conditions are stored as immutable, sorted `(field, value)` tuples
 - Conditions use case-sensitive exact string equality and are combined with AND logic
@@ -296,7 +296,8 @@ case-sensitive, so uppercase variants do not match.
 **Important notes:**
 - Condition values must be strings (e.g., `"true"` not `True`)
 - Condition field names must exist on the concrete node's properties schema
-- All conditions must match for the label to be applied (AND logic)
+- All conditions in one `when()` call must match for the label to be applied (AND logic). Declaring the same label more than once with different conditions is allowed: the label applies if any of the declarations matches (OR logic)
+- Because labels are applied per row, only the nodes in the current batch are relabeled. A node whose conditions no longer hold is corrected the next time it is loaded, or deleted by cleanup if it is no longer reported
 - Indexes are automatically created for conditional labels and their condition fields
 
 

--- a/docs/root/dev/writing-intel-modules.md
+++ b/docs/root/dev/writing-intel-modules.md
@@ -298,7 +298,7 @@ case-sensitive, so uppercase variants do not match.
 - Condition field names must exist on the concrete node's properties schema
 - All conditions in one `when()` call must match for the label to be applied (AND logic). Declaring the same label more than once with different conditions is allowed: the label applies if any of the declarations matches (OR logic)
 - Because labels are applied per row, only the nodes in the current batch are relabeled. A node whose conditions no longer hold is corrected the next time it is loaded, or deleted by cleanup if it is no longer reported
-- Indexes are automatically created for conditional labels and their condition fields
+- Indexes are automatically created for conditional labels themselves. Condition fields are not indexed: they are evaluated against the already-bound node of the current row, so there is no lookup for an index to serve
 
 
 #### Defining relationships

--- a/tests/data/graph/querybuilder/sample_models/conditional_label_models.py
+++ b/tests/data/graph/querybuilder/sample_models/conditional_label_models.py
@@ -159,3 +159,23 @@ class VulnerabilitySchema(CartographyNodeSchema):
         ],
     )
     scoped_cleanup: bool = False
+
+
+@dataclass(frozen=True)
+class VulnerabilitySchemaSharedLabel(CartographyNodeSchema):
+    """
+    Schema where one label is declared twice with different conditions.
+
+    The two declarations are ORed together, so a node matching either one carries the label.
+    """
+
+    label: str = "Vulnerability"
+    properties: VulnerabilityProperties = VulnerabilityProperties()
+    extra_node_labels: Optional[ExtraNodeLabels] = ExtraNodeLabels(
+        [
+            SECURITY_FINDING,
+            URGENT.when(severity="critical"),
+            URGENT.when(is_exploitable="true"),
+        ],
+    )
+    scoped_cleanup: bool = False

--- a/tests/integration/cartography/graph/test_querybuilder_conditional_labels.py
+++ b/tests/integration/cartography/graph/test_querybuilder_conditional_labels.py
@@ -29,6 +29,9 @@ from tests.data.graph.querybuilder.sample_models.conditional_label_models import
 from tests.data.graph.querybuilder.sample_models.conditional_label_models import (
     VulnerabilitySchema,
 )
+from tests.data.graph.querybuilder.sample_models.conditional_label_models import (
+    VulnerabilitySchemaSharedLabel,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -204,12 +207,13 @@ def test_conditional_labels_not_applied_when_conditions_not_met(neo4j_session):
     assert "Urgent" not in labels
 
 
-def test_conditional_labels_scoped_to_sub_resource(neo4j_session):
+def test_conditional_labels_only_touch_the_loaded_rows(neo4j_session):
     """
-    Test that conditional labels are correctly scoped to the sub-resource.
+    Test that loading one sub-resource's nodes leaves another sub-resource's labels alone.
 
-    When using a schema with sub_resource_relationship, the conditional label
-    queries should only affect nodes within the current sub-resource scope.
+    Conditional labels are applied row by row inside the ingestion query, so only the nodes in the
+    current batch are ever relabeled. Nodes belonging to another sub-resource are untouched because
+    they are not in the batch, not because the label queries are scoped to a tenant.
     """
     # Arrange: Create two container registries
     neo4j_session.run(
@@ -359,3 +363,82 @@ def test_all_labels_present_on_node(neo4j_session):
     # Should NOT have other conditional labels
     assert "ImageAttestation" not in labels
     assert "ImageManifestList" not in labels
+
+
+def test_label_declared_twice_ors_its_conditions(neo4j_session):
+    """
+    Test that two declarations of the same label are ORed rather than clobbering each other.
+
+    VulnerabilitySchemaSharedLabel declares Urgent both for severity="critical" and for
+    is_exploitable="true", so a node matching either condition carries the label.
+    """
+    # Act: Load vulnerabilities
+    load(
+        neo4j_session,
+        VulnerabilitySchemaSharedLabel(),
+        VULNERABILITIES,
+        lastupdated=1,
+    )
+
+    # Assert: Urgent is set on the critical nodes and on the exploitable high-severity one
+    result = neo4j_session.run(
+        "MATCH (n:Vulnerability:Urgent) RETURN n.id AS id ORDER BY n.id"
+    )
+    assert [r["id"] for r in result] == [
+        "CVE-2024-0001",  # critical AND exploitable
+        "CVE-2024-0002",  # critical only
+        "CVE-2024-0003",  # exploitable only
+    ]
+
+    # Assert: the node matching neither condition does not carry the label
+    result = neo4j_session.run(
+        "MATCH (n:Vulnerability{id: 'CVE-2024-0004'}) RETURN labels(n) AS labels"
+    )
+    assert "Urgent" not in set(result.single()["labels"])
+
+
+def test_label_removed_when_neither_shared_condition_holds(neo4j_session):
+    """
+    Test that a label driven by two ORed declarations is removed once neither declaration matches.
+    """
+    # Arrange: load a node that matches on severity
+    load(
+        neo4j_session,
+        VulnerabilitySchemaSharedLabel(),
+        [
+            {
+                "id": "CVE-2024-0001",
+                "severity": "critical",
+                "is_exploitable": "false",
+                "has_fix": "true",
+            },
+        ],
+        lastupdated=1,
+    )
+    result = neo4j_session.run(
+        "MATCH (n:Vulnerability{id: 'CVE-2024-0001'}) RETURN labels(n) AS labels"
+    )
+    assert "Urgent" in set(result.single()["labels"])
+
+    # Act: re-load the same node so that neither declaration matches
+    load(
+        neo4j_session,
+        VulnerabilitySchemaSharedLabel(),
+        [
+            {
+                "id": "CVE-2024-0001",
+                "severity": "low",
+                "is_exploitable": "false",
+                "has_fix": "true",
+            },
+        ],
+        lastupdated=2,
+    )
+
+    # Assert: the label is gone, the unconditional one stays
+    result = neo4j_session.run(
+        "MATCH (n:Vulnerability{id: 'CVE-2024-0001'}) RETURN labels(n) AS labels"
+    )
+    labels = set(result.single()["labels"])
+    assert "Urgent" not in labels
+    assert "SecurityFinding" in labels

--- a/tests/unit/cartography/client/core/test_tx.py
+++ b/tests/unit/cartography/client/core/test_tx.py
@@ -939,13 +939,11 @@ def test_buffer_error_with_none_wait_time(mock_logger, mock_sleep):
 @patch("cartography.client.core.tx.load_graph_data")
 @patch("cartography.client.core.tx.ensure_indexes")
 @patch("cartography.client.core.tx.build_ingestion_query")
-@patch("cartography.client.core.tx.build_conditional_label_queries")
 @patch("cartography.client.core.tx.stat_handler")
 @patch("cartography.client.core.tx.logger")
 def test_load_emits_metrics_and_logs(
     mock_logger,
     mock_stat_handler,
-    mock_build_cond_labels,
     mock_build_query,
     mock_ensure_indexes,
     mock_load_graph_data,
@@ -958,7 +956,6 @@ def test_load_emits_metrics_and_logs(
     mock_node_schema = MagicMock()
     mock_node_schema.label = "TestNode"
     mock_build_query.return_value = "UNWIND ..."
-    mock_build_cond_labels.return_value = []
 
     test_data = [{"id": "1"}, {"id": "2"}, {"id": "3"}]
 
@@ -974,13 +971,11 @@ def test_load_emits_metrics_and_logs(
 @patch("cartography.client.core.tx.load_graph_data")
 @patch("cartography.client.core.tx.ensure_indexes")
 @patch("cartography.client.core.tx.build_ingestion_query")
-@patch("cartography.client.core.tx.build_conditional_label_queries")
 @patch("cartography.client.core.tx.stat_handler")
 @patch("cartography.client.core.tx.logger")
 def test_load_no_metrics_for_empty_data(
     mock_logger,
     mock_stat_handler,
-    mock_build_cond_labels,
     mock_build_query,
     mock_ensure_indexes,
     mock_load_graph_data,

--- a/tests/unit/cartography/graph/test_querybuilder_conditional_labels.py
+++ b/tests/unit/cartography/graph/test_querybuilder_conditional_labels.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from cartography.graph.querybuilder import build_conditional_label_queries
 from cartography.graph.querybuilder import build_create_index_queries
 from cartography.graph.querybuilder import build_ingestion_query
 from cartography.models.core.common import PropertyRef
@@ -66,6 +65,36 @@ VALID_CONDITION = ExtraNodeLabel(
 )
 
 
+def _set_clause(query: str) -> str:
+    """
+    Return the part of an ingestion query that precedes the conditional label clauses.
+
+    Conditional labels are applied with FOREACH clauses that themselves contain `SET i:Label`, so
+    tests that assert on the unconditional SET clause need to look at the query prefix only.
+    """
+    return query.split("FOREACH")[0]
+
+
+def _apply_clause(query: str, label: str) -> str:
+    """Return the FOREACH clause that applies `label`, or "" if there is none."""
+    for line in query.splitlines():
+        if line.strip().startswith("FOREACH") and line.rstrip().endswith(
+            f"| SET i:{label})"
+        ):
+            return line.strip()
+    return ""
+
+
+def _remove_clause(query: str, label: str) -> str:
+    """Return the FOREACH clause that removes `label`, or "" if there is none."""
+    for line in query.splitlines():
+        if line.strip().startswith("FOREACH") and line.rstrip().endswith(
+            f"| REMOVE i:{label})"
+        ):
+            return line.strip()
+    return ""
+
+
 @dataclass(frozen=True)
 class NodeWithConditionalLabelSchema(CartographyNodeSchema):
     """Test schema with a conditional label."""
@@ -117,33 +146,33 @@ class NodeWithNoExtraLabelsSchema(CartographyNodeSchema):
     properties: SimpleNodeProperties = SimpleNodeProperties()
 
 
-def test_build_ingestion_query_excludes_conditional_labels():
+def test_build_ingestion_query_excludes_conditional_labels_from_set_clause():
     """
-    Test that conditional labels are excluded from the main ingestion query.
-    Only string labels should appear in the SET clause.
+    Test that conditional labels are excluded from the unconditional SET clause.
+    Only unconditional labels should appear there.
     """
 
     query = build_ingestion_query(NodeWithConditionalLabelSchema())
 
-    # The query should contain the string label "Resource"
-    assert "i:Resource" in query
-    # The query should NOT contain the conditional label "Critical"
-    assert "i:Critical" not in query
+    # The SET clause should contain the unconditional label "Resource"
+    assert "i:Resource" in _set_clause(query)
+    # The SET clause should NOT contain the conditional label "Critical"
+    assert "Critical" not in _set_clause(query)
     assert "i:Resource:Critical" not in query
 
 
 def test_build_ingestion_query_with_multiple_conditional_labels():
     """
-    Test that only string labels appear in the main query when there are
-    multiple conditional labels mixed with string labels.
+    Test that only unconditional labels appear in the SET clause when there are
+    multiple conditional labels mixed with unconditional ones.
     """
     query = build_ingestion_query(NodeWithMultipleConditionalLabelsSchema())
 
-    # Should contain string labels
-    assert "i:Resource:AWSResource" in query
+    # Should contain unconditional labels
+    assert "i:Resource:AWSResource" in _set_clause(query)
     # Should NOT contain conditional labels
-    assert "Critical" not in query
-    assert "PublicResource" not in query
+    assert "Critical" not in _set_clause(query)
+    assert "PublicResource" not in _set_clause(query)
 
 
 def test_build_ingestion_query_with_only_conditional_labels():
@@ -153,78 +182,100 @@ def test_build_ingestion_query_with_only_conditional_labels():
     """
     query = build_ingestion_query(NodeWithOnlyConditionalLabelSchema())
 
-    # Should NOT contain any extra labels in SET clause
-    # (no "i:SomeLabel" pattern after the property settings)
-    assert "i:Critical" not in query
+    assert "Critical" not in _set_clause(query)
 
 
-def test_build_conditional_label_queries_single_condition():
+def test_conditional_label_single_condition():
     """
-    Test building a conditional label query with a single condition.
-    Each conditional label generates 2 queries: REMOVE then SET.
+    Test that a conditional label with a single condition is applied per row with a
+    matching pair of FOREACH clauses.
     """
-    queries = build_conditional_label_queries(NodeWithConditionalLabelSchema())
+    query = build_ingestion_query(NodeWithConditionalLabelSchema())
 
-    # 1 conditional label = 2 queries (remove + set)
-    assert len(queries) == 2
-
-    # First query should remove the label from all nodes that have it
-    remove_query = queries[0]
-    assert "MATCH (n:TestAsset:Critical)" in remove_query
-    assert "REMOVE n:Critical" in remove_query
-
-    # Second query should set the label on matching nodes
-    set_query = queries[1]
-    assert "MATCH (n:TestAsset)" in set_query
-    assert 'n.severity = "high"' in set_query
-    assert "SET n:Critical" in set_query
+    assert (
+        _apply_clause(query, "Critical")
+        == 'FOREACH (_ IN CASE WHEN i.severity = "high" THEN [1] ELSE [] END | SET i:Critical)'
+    )
+    assert (
+        _remove_clause(query, "Critical")
+        == 'FOREACH (_ IN CASE WHEN i.severity = "high" THEN [] ELSE [1] END | REMOVE i:Critical)'
+    )
+    # 1 conditional label = 1 apply clause + 1 remove clause.
+    assert query.count("FOREACH") == 2
 
 
-def test_build_conditional_label_queries_multiple_conditions():
+def test_conditional_label_multiple_conditions_are_anded():
     """
-    Test building conditional label queries with multiple conditions.
-    Each conditional label generates 2 queries: REMOVE then SET.
+    Test that several conditions on one label declaration are ANDed together, and that each
+    conditional label gets its own FOREACH pair.
     """
-    queries = build_conditional_label_queries(NodeWithMultipleConditionalLabelsSchema())
+    query = build_ingestion_query(NodeWithMultipleConditionalLabelsSchema())
 
-    # 2 conditional labels = 4 queries (2 x (remove + set))
-    assert len(queries) == 4
+    # 2 conditional labels = 4 FOREACH clauses.
+    assert query.count("FOREACH") == 4
 
-    # First conditional label: Critical (queries 0 and 1)
-    critical_remove = queries[0]
-    assert "MATCH (n:TestAsset:Critical)" in critical_remove
-    assert "REMOVE n:Critical" in critical_remove
+    assert (
+        _apply_clause(query, "Critical")
+        == 'FOREACH (_ IN CASE WHEN i.severity = "high" THEN [1] ELSE [] END | SET i:Critical)'
+    )
 
-    critical_set = queries[1]
-    assert "MATCH (n:TestAsset)" in critical_set
-    assert 'n.severity = "high"' in critical_set
-    assert "SET n:Critical" in critical_set
+    public_apply = _apply_clause(query, "PublicResource")
+    assert 'i.is_public = "true"' in public_apply
+    assert 'i.severity = "high"' in public_apply
+    assert " AND " in public_apply
 
-    # Second conditional label: PublicResource (queries 2 and 3)
-    public_remove = queries[2]
-    assert "MATCH (n:TestAsset:PublicResource)" in public_remove
-    assert "REMOVE n:PublicResource" in public_remove
-
-    public_set = queries[3]
-    assert "MATCH (n:TestAsset)" in public_set
-    assert 'n.is_public = "true"' in public_set
-    assert 'n.severity = "high"' in public_set
-    assert "SET n:PublicResource" in public_set
-    # Multiple conditions should be joined with AND
-    assert " AND " in public_set
+    # The remove clause negates the same predicate by swapping the CASE branches, so that a node
+    # whose condition property is missing (null predicate) still loses the stale label.
+    public_remove = _remove_clause(query, "PublicResource")
+    assert public_remove == public_apply.replace(
+        "THEN [1] ELSE [] END | SET i:PublicResource",
+        "THEN [] ELSE [1] END | REMOVE i:PublicResource",
+    )
 
 
-def test_build_conditional_label_queries_no_extra_labels():
+def test_conditional_label_declarations_sharing_a_label_are_ored():
     """
-    Test that an empty list is returned when there are no extra labels.
+    Test that two declarations of the same label produce a single FOREACH pair whose predicate ORs
+    the two condition groups, rather than two pairs that would clobber each other.
     """
-    queries = build_conditional_label_queries(NodeWithNoExtraLabelsSchema())
-    assert queries == []
+
+    @dataclass(frozen=True)
+    class NodeWithSharedLabelSchema(CartographyNodeSchema):
+        label: str = "TestAsset"
+        properties: SimpleNodeProperties = SimpleNodeProperties()
+        extra_node_labels: Optional[ExtraNodeLabels] = ExtraNodeLabels(
+            [
+                CRITICAL.when(severity="high"),
+                CRITICAL.when(severity="urgent"),
+            ]
+        )
+
+    query = build_ingestion_query(NodeWithSharedLabelSchema())
+
+    assert query.count("FOREACH") == 2
+    assert (
+        _apply_clause(query, "Critical")
+        == 'FOREACH (_ IN CASE WHEN (i.severity = "high") OR (i.severity = "urgent") '
+        "THEN [1] ELSE [] END | SET i:Critical)"
+    )
+    assert (
+        _remove_clause(query, "Critical")
+        == 'FOREACH (_ IN CASE WHEN (i.severity = "high") OR (i.severity = "urgent") '
+        "THEN [] ELSE [1] END | REMOVE i:Critical)"
+    )
 
 
-def test_build_conditional_label_queries_only_unconditional_labels():
+def test_no_conditional_clauses_when_no_extra_labels():
     """
-    Test that an empty list is returned when there are only string labels.
+    Test that no FOREACH clauses are emitted when there are no extra labels.
+    """
+    query = build_ingestion_query(NodeWithNoExtraLabelsSchema())
+    assert "FOREACH" not in query
+
+
+def test_no_conditional_clauses_for_only_unconditional_labels():
+    """
+    Test that no FOREACH clauses are emitted when every extra label is unconditional.
     """
 
     @dataclass(frozen=True)
@@ -238,11 +289,12 @@ def test_build_conditional_label_queries_only_unconditional_labels():
             ]
         )
 
-    queries = build_conditional_label_queries(NodeWithOnlyUnconditionalLabelsSchema())
-    assert queries == []
+    query = build_ingestion_query(NodeWithOnlyUnconditionalLabelsSchema())
+    assert "FOREACH" not in query
+    assert "i:Resource:AWSResource" in query
 
 
-def test_build_conditional_label_queries_escapes_special_chars():
+def test_conditional_label_escapes_special_chars():
     """
     Test that special characters in condition values are properly escaped.
     """
@@ -257,15 +309,11 @@ def test_build_conditional_label_queries_escapes_special_chars():
             ]
         )
 
-    queries = build_conditional_label_queries(NodeWithSpecialCharsSchema())
+    query = build_ingestion_query(NodeWithSpecialCharsSchema())
 
-    # 1 conditional label = 2 queries (remove + set)
-    assert len(queries) == 2
-    # Check the SET query (second one) for escaped values
-    set_query = queries[1]
-    # Check that quotes and backslashes are escaped
-    assert r"\"quotes\"" in set_query
-    assert r"\\backslash" in set_query
+    apply_clause = _apply_clause(query, "Special")
+    assert r"\"quotes\"" in apply_clause
+    assert r"\\backslash" in apply_clause
 
 
 def test_build_create_index_queries_includes_conditional_label_indexes():
@@ -306,8 +354,7 @@ def test_build_create_index_queries_with_multiple_conditional_labels():
 
 def test_empty_conditions_apply_label_unconditionally():
     """
-    Test that conditional labels with empty conditions are skipped
-    and don't generate invalid Cypher.
+    Test that labels with empty conditions land in the SET clause and get no FOREACH pair.
     """
 
     @dataclass(frozen=True)
@@ -321,22 +368,45 @@ def test_empty_conditions_apply_label_unconditionally():
             ]
         )
 
-    ingestion_query = build_ingestion_query(NodeWithEmptyConditionsSchema())
-    conditional_queries = build_conditional_label_queries(
-        NodeWithEmptyConditionsSchema()
-    )
+    query = build_ingestion_query(NodeWithEmptyConditionsSchema())
 
-    assert "i:EmptyCondition" in ingestion_query
-    assert len(conditional_queries) == 2
-    assert all("EmptyCondition" not in query for query in conditional_queries)
-    assert "REMOVE n:ValidCondition" in conditional_queries[0]
-    assert "SET n:ValidCondition" in conditional_queries[1]
+    assert "i:EmptyCondition" in _set_clause(query)
+    assert query.count("FOREACH") == 2
+    assert "EmptyCondition" not in query.split(_set_clause(query))[1]
+    assert _apply_clause(query, "ValidCondition")
+    assert _remove_clause(query, "ValidCondition")
 
 
-def test_build_conditional_label_queries_scoped_by_sub_resource():
+def test_label_declared_both_unconditionally_and_conditionally_is_never_removed():
     """
-    Test that conditional label queries are scoped to the sub-resource
-    when a sub_resource_relationship is defined on the schema.
+    Test that a label declared both with and without conditions is applied unconditionally and gets
+    no removal clause. Otherwise the removal clause would strip a label the SET clause just applied.
+    """
+
+    @dataclass(frozen=True)
+    class NodeWithRedundantConditionSchema(CartographyNodeSchema):
+        label: str = "TestAsset"
+        properties: SimpleNodeProperties = SimpleNodeProperties()
+        extra_node_labels: Optional[ExtraNodeLabels] = ExtraNodeLabels(
+            [
+                CRITICAL,
+                CRITICAL.when(severity="high"),
+            ]
+        )
+
+    query = build_ingestion_query(NodeWithRedundantConditionSchema())
+
+    assert "i:Critical" in _set_clause(query)
+    assert "FOREACH" not in query
+
+
+def test_conditional_labels_are_not_scoped_by_sub_resource():
+    """
+    Test that a sub_resource_relationship does not change how conditional labels are applied.
+
+    Conditional labels used to be maintained by post-load queries that had to be scoped to the
+    current tenant to avoid touching other tenants' nodes. Applying them per row makes that scoping
+    unnecessary: only the nodes in the current batch are ever touched.
     """
 
     @dataclass(frozen=True)
@@ -365,65 +435,13 @@ def test_build_conditional_label_queries_scoped_by_sub_resource():
             ]
         )
 
-    queries = build_conditional_label_queries(ScopedNodeSchema())
+    scoped_query = build_ingestion_query(ScopedNodeSchema())
+    unscoped_query = build_ingestion_query(NodeWithConditionalLabelSchema())
 
-    assert len(queries) == 2
-
-    # REMOVE query should be scoped to the sub-resource
-    remove_query = queries[0]
-    assert "MATCH (n:TestAsset:Critical)" in remove_query
-    # Should have the relationship pattern to AWSAccount (INWARD direction)
-    assert "<-[:RESOURCE]-" in remove_query
-    assert "(sub:AWSAccount{" in remove_query
-    assert "id: $AWS_ID" in remove_query
-    assert "REMOVE n:Critical" in remove_query
-
-    # SET query should also be scoped to the sub-resource
-    set_query = queries[1]
-    assert "MATCH (n:TestAsset)" in set_query
-    assert "<-[:RESOURCE]-" in set_query
-    assert "(sub:AWSAccount{" in set_query
-    assert "id: $AWS_ID" in set_query
-    assert 'n.severity = "high"' in set_query
-    assert "SET n:Critical" in set_query
-
-
-def test_build_conditional_label_queries_scoped_outward_direction():
-    """
-    Test that conditional label queries handle OUTWARD direction correctly.
-    """
-
-    @dataclass(frozen=True)
-    class SubResourceRelProperties(CartographyRelProperties):
-        lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
-
-    @dataclass(frozen=True)
-    class TestAssetToTenantRel(CartographyRelSchema):
-        target_node_label: str = "Tenant"
-        target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-            {"id": PropertyRef("tenant_id", set_in_kwargs=True)},
-        )
-        direction: LinkDirection = LinkDirection.OUTWARD
-        rel_label: str = "BELONGS_TO"
-        properties: SubResourceRelProperties = SubResourceRelProperties()
-
-    @dataclass(frozen=True)
-    class OutwardScopedNodeSchema(CartographyNodeSchema):
-        label: str = "TestAsset"
-        properties: SimpleNodeProperties = SimpleNodeProperties()
-        sub_resource_relationship: TestAssetToTenantRel = TestAssetToTenantRel()
-        extra_node_labels: Optional[ExtraNodeLabels] = ExtraNodeLabels(
-            [
-                CRITICAL.when(severity="high"),
-            ]
-        )
-
-    queries = build_conditional_label_queries(OutwardScopedNodeSchema())
-
-    assert len(queries) == 2
-
-    # Both queries should have OUTWARD relationship pattern
-    for query in queries:
-        assert "-[:BELONGS_TO]->" in query
-        assert "(sub:Tenant{" in query
-        assert "id: $tenant_id" in query
+    assert _apply_clause(scoped_query, "Critical") == _apply_clause(
+        unscoped_query, "Critical"
+    )
+    assert _remove_clause(scoped_query, "Critical") == _remove_clause(
+        unscoped_query, "Critical"
+    )
+    assert scoped_query.count("FOREACH") == 2

--- a/tests/unit/cartography/graph/test_querybuilder_conditional_labels.py
+++ b/tests/unit/cartography/graph/test_querybuilder_conditional_labels.py
@@ -318,8 +318,7 @@ def test_conditional_label_escapes_special_chars():
 
 def test_build_create_index_queries_includes_conditional_label_indexes():
     """
-    Test that index creation includes indexes for conditional labels
-    and their condition fields.
+    Test that index creation covers conditional labels but not their condition fields.
     """
     queries = build_create_index_queries(NodeWithConditionalLabelSchema())
 
@@ -333,8 +332,9 @@ def test_build_create_index_queries_includes_conditional_label_indexes():
     # Should have index for the conditional label
     assert any("Critical" in q and "id" in q for q in queries)
 
-    # Should have index for the condition field on the primary label
-    assert any("TestAsset" in q and "severity" in q for q in queries)
+    # Should NOT index the condition field: conditions are evaluated against the already-bound node
+    # of the current row, so there is no lookup for an index to serve.
+    assert not any("severity" in q for q in queries)
 
 
 def test_build_create_index_queries_with_multiple_conditional_labels():
@@ -347,9 +347,9 @@ def test_build_create_index_queries_with_multiple_conditional_labels():
     assert any("Critical" in q and "id" in q for q in queries)
     assert any("PublicResource" in q and "id" in q for q in queries)
 
-    # Should have indexes for all condition fields
-    assert any("TestAsset" in q and "severity" in q for q in queries)
-    assert any("TestAsset" in q and "is_public" in q for q in queries)
+    # Should NOT index any condition field
+    assert not any("severity" in q for q in queries)
+    assert not any("is_public" in q for q in queries)
 
 
 def test_empty_conditions_apply_label_unconditionally():

--- a/tests/unit/cartography/intel/gcp/test_artifact_registry_artifact.py
+++ b/tests/unit/cartography/intel/gcp/test_artifact_registry_artifact.py
@@ -124,10 +124,6 @@ def test_load_docker_images_uses_artifact_registry_batch_size():
 
     assert load_nodes_without_relationships.call_count == 2
     assert (
-        load_nodes_without_relationships.call_args_list[1].kwargs["apply_labels"]
-        is False
-    )
-    assert (
         load_nodes_without_relationships.call_args_list[0].kwargs["batch_size"]
         == ARTIFACT_REGISTRY_LOAD_BATCH_SIZE
     )
@@ -181,7 +177,6 @@ def test_load_nodes_without_relationships_logs_batch_progress(caplog):
             [{"id": "1"}, {"id": "2"}, {"id": "3"}],
             batch_size=2,
             progress_description="test GAR nodes",
-            apply_labels=False,
             lastupdated=123,
         )
 


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Conditional node labels (`ExtraNodeLabel.when(...)`, added in #3032) were maintained by two extra
Cypher queries that `load()` ran *after* every batch write: a blanket `REMOVE` followed by a filtered
`SET`, per conditional label. For a schema with no `sub_resource_relationship` there is nothing to
narrow by, so the pair swept every node carrying the primary label:

```cypher
MATCH (n:GCPArtifactRegistryImage:Image) REMOVE n:Image
MATCH (n:GCPArtifactRegistryImage) WHERE n.type = "image" SET n:Image
```

Since `load()` is typically called in a loop (per project, per report), that whole-label sweep was
repeated once per iteration. Two schemas are in this unscoped bucket today: `aibom/component.py`
(6 conditional labels, so 12 sweeps per `load()`, and `load()` runs once per report) and
`gcp/artifact_registry/image.py` (3 labels, once per project).

This PR folds the conditional label into the ingestion query itself, one pair of `FOREACH` clauses
per row, mirroring how unconditional labels are already folded into the `SET` clause. `FOREACH` over
a one-or-zero element list is the standard pure-Cypher conditional-write idiom, so no APOC dependency
is introduced. The post-load queries and `build_conditional_label_queries()` are deleted;
condition-field index creation is unchanged.

Generated Cypher for `GCPArtifactRegistryImageSchema`:

```cypher
UNWIND $DictList AS item
    MERGE (i:GCPArtifactRegistryImage{id: item.digest})
    ON CREATE SET i.firstseen = timestamp()
    SET
        ...
        i._ont_digest = item.digest
    FOREACH (_ IN CASE WHEN i.type = "image" THEN [1] ELSE [] END | SET i:Image)
    FOREACH (_ IN CASE WHEN i.type = "image" THEN [] ELSE [1] END | REMOVE i:Image)
    FOREACH (_ IN CASE WHEN i.type = "attestation" THEN [1] ELSE [] END | SET i:ImageAttestation)
    FOREACH (_ IN CASE WHEN i.type = "attestation" THEN [] ELSE [1] END | REMOVE i:ImageAttestation)
    ...
```

No cleanup pass is needed. A node holding a stale conditional label is in exactly one of two states:
it is re-loaded during the sync and the negative `FOREACH` strips the label row by row, or it is no
longer reported and cleanup deletes the node outright. The graph converges without ever scanning the
whole label.

GCP Artifact Registry had built its own load helper with an `apply_labels` opt-out to run the sweep
once per sync rather than per batch. That workaround is no longer needed, so
`apply_conditional_labels()` and the flag are removed. `load_nodes_without_relationships()` itself
stays: it has a second, unrelated reason to exist (batch progress logging).

Declarations sharing a label are now ORed together instead of clobbering each other, which removes
the single-condition-per-label limitation that was documented on `AWSInspectorFindingSchema`.


### Related issues or links

Builds on #3032.


### How was this tested?

- `make test_lint` passes.
- `make test_unit` passes (3877 tests).
- `make test_integration` passes (1186 tests), against Neo4j 2025.10.

The strongest signal: the 7 pre-existing integration tests in
`tests/integration/cartography/graph/test_querybuilder_conditional_labels.py` passed **unchanged**
before any test file was touched, including
`test_conditional_labels_updated_when_conditions_change` (which flips a condition and asserts the
old label is gone).

Test changes:
- `tests/unit/.../test_querybuilder_conditional_labels.py`: rewritten to assert on the generated
  ingestion query rather than on the deleted `build_conditional_label_queries()`. Adds coverage for
  OR-ed declarations of one label, and for a label declared both unconditionally and conditionally
  (which must get no removal clause).
- `tests/integration/.../test_querybuilder_conditional_labels.py`: two new cases for the OR-ed
  declaration path (label set from either declaration; label removed once neither holds).
- `tests/unit/cartography/client/core/test_tx.py`: dropped the
  `build_conditional_label_queries` patches.


### Notes for reviewers

**Behavior difference worth knowing.** The old blanket remove-then-set also corrected nodes that were
*not* in the current batch, e.g. one whose condition property was changed by some other code path.
The per-row approach only corrects nodes that are re-loaded. These are equivalent in practice,
because node properties only ever change through `load()` — but it is a real difference and worth a
reviewer's eye rather than being buried.

**Two deliberate choices in the generated Cypher**, both worth a look:

1. **The predicate reads `i.<property>`, not `item.<key>`.** A condition names a *node property*, and
   property names do not always match the source dict key (on `TrivyImageFindingNodeProperties`,
   `name` is fed by `PropertyRef("VulnerabilityID")`). Reading `i.<property>` sidesteps resolving the
   `PropertyRef` source key and preserves the old semantics exactly, since the deleted queries also
   matched on `n.<field>`. It matters concretely: three ECR schemas share the `ECRImage` label, and a
   load through one must not mislabel based on a key another one populates. It works because the
   `SET` clause has already been applied for the current row when the `FOREACH` executes.

2. **The removal clause inverts the branches of the same positive predicate, rather than negating
   it.** `i.x <> "v"` evaluates to `null` when `i.x` is missing, which would silently skip the removal
   and leave a stale label on a node whose condition property disappeared. Swapping `THEN [1] ELSE []`
   for `THEN [] ELSE [1]` is null-safe and keeps one predicate string per label.

**Placement.** The `FOREACH` clauses could not be appended inside `_build_node_properties_statement`:
the ontology statement that follows it starts with `",\n"` and continues the same `SET` clause. They
get their own template slot between the ontology statement and the relationship attach.

**A label declared both unconditionally and conditionally** is left entirely to the unconditional
`SET` clause. `ExtraNodeLabels` does not reject duplicate label names, and a negative `FOREACH` would
otherwise strip a label the `SET` clause had just applied. Guarded and tested.

**Blast radius.** The generated Cypher changes for all 11 schema files that declare conditional
labels, not just the two unscoped ones: `aibom/component.py`, `aws/ecr/image.py`,
`aws/inspector/findings.py`, `aws/ssm/parameters.py`, `gcp/artifact_registry/image.py`,
`github/container_images.py`, `github/dependabot_alerts.py`, `github/personal_access_tokens.py`,
`gitlab/container_images.py`, `semgrep/findings.py`, `tenable/findings.py`.

Docs in `docs/root/dev/writing-intel-modules.md` and the `add-node-type` skill reference both stated
that conditional labels are "applied in a separate query after ingestion"; both are updated.

No schema documentation or schema README changes are needed: which labels each schema declares, and
under what conditions, is unchanged. Only the mechanism that applies them changed.
