### PR TITLE
feat(aws): model trust-policy conditions on the role trust edge (#3078 tier 1)

### DIFF
--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -1,4 +1,5 @@
 import enum
+import fnmatch
 import json
 import logging
 import time
@@ -560,6 +561,50 @@ def transform_access_keys(
     return access_key_data
 
 
+# The sts actions that let a principal actually obtain credentials for a role. A trust
+# statement granting only e.g. sts:TagSession does not make the role assumable.
+ASSUME_ROLE_ACTIONS = (
+    "sts:assumerole",
+    "sts:assumerolewithwebidentity",
+    "sts:assumerolewithsaml",
+)
+
+
+def _action_matches_assume_role(action: str) -> bool:
+    """Whether an Action entry covers at least one assume-role action.
+
+    IAM action names are case-insensitive and may use `*` and `?` wildcards, so
+    "sts:AssumeRole*", "sts:*" and "*" all qualify.
+    """
+    pattern = action.lower()
+    return any(
+        fnmatch.fnmatchcase(assume_action, pattern)
+        for assume_action in ASSUME_ROLE_ACTIONS
+    )
+
+
+def _statement_grants_assume_role(statement: dict[str, Any]) -> bool:
+    """Whether a trust statement's Action element covers an assume-role action.
+
+    NotAction is deliberately treated as matching. Resolving it correctly means
+    enumerating the complement of the action namespace, and guessing wrong here would
+    silently drop a real trust edge, so we keep the edge and let the operator inspect it.
+    """
+    if "NotAction" in statement:
+        logger.warning(
+            "Trust statement uses NotAction, which is not modeled. Treating it as "
+            "granting assume-role rather than dropping the trust edge."
+        )
+        return True
+
+    actions = ensure_list(statement.get("Action") or [])
+    return any(
+        _action_matches_assume_role(action)
+        for action in actions
+        if isinstance(action, str)
+    )
+
+
 def _aggregate_trust_conditions(
     statement_conditions: list[Any],
 ) -> dict[str, Any]:
@@ -631,6 +676,9 @@ def transform_role_trust_policies(
         # A role can trust the same principal from several statements under different
         # conditions, so these are aggregated per (role, principal) below.
         trusted_principal_conditions: dict[str, list[Any]] = {}
+        # Principals named by an explicit Deny. Deny beats Allow in IAM evaluation, so
+        # these draw no trust edge regardless of what the Allow statements say.
+        denied_principals: set[str] = set()
 
         for statement in role["AssumeRolePolicyDocument"]["Statement"]:
             if "Principal" not in statement:
@@ -644,8 +692,26 @@ def transform_role_trust_policies(
                 )
                 continue
 
+            if not _statement_grants_assume_role(statement):
+                # e.g. a statement granting only sts:TagSession. It names a principal but
+                # does not let it obtain credentials for the role.
+                continue
+
+            is_deny = statement.get("Effect") == "Deny"
             condition = statement.get("Condition")
             principal_entries = _parse_principal_entries(statement["Principal"])
+
+            if is_deny:
+                # An unconditional Deny settles the question: that principal cannot
+                # assume the role, so no edge. A conditional Deny only applies when its
+                # condition holds at request time, which we cannot evaluate here, so it
+                # is left to the Allow statements. Either way a Deny is not evidence
+                # that the named principal or its account exists, so no nodes are
+                # created from it.
+                if not condition:
+                    denied_principals.update(arn for _, arn in principal_entries)
+                continue
+
             for principal_type, principal_arn in principal_entries:
                 if principal_type == "Federated":
                     # Add this to list of federated nodes to create
@@ -690,6 +756,8 @@ def transform_role_trust_policies(
                 )
 
         for principal_arn, statement_conditions in trusted_principal_conditions.items():
+            if principal_arn in denied_principals:
+                continue
             trust_relationships.append(
                 {
                     "source_role_arn": role_arn,

--- a/cartography/intel/aws/iam.py
+++ b/cartography/intel/aws/iam.py
@@ -16,6 +16,10 @@ from cartography.client.core.tx import load_matchlinks
 from cartography.client.core.tx import read_list_of_dicts_tx
 from cartography.client.core.tx import read_list_of_values_tx
 from cartography.graph.job import GraphJob
+from cartography.intel.aws.permission_relationships import (
+    extract_condition_context_keys,
+)
+from cartography.intel.aws.permission_relationships import parse_condition_blob
 from cartography.intel.aws.permission_relationships import principal_allowed_on_resource
 from cartography.intel.aws.util.botocore_config import create_boto3_client
 from cartography.intel.aws.util.botocore_config import create_boto3_resource
@@ -32,6 +36,7 @@ from cartography.models.aws.iam.principal_service_access import (
     AWSPrincipalServiceAccessSchema,
 )
 from cartography.models.aws.iam.role import AWSRoleSchema
+from cartography.models.aws.iam.role_trust import AWSRoleTrustsPrincipalMatchLink
 from cartography.models.aws.iam.root_principal import AWSRootPrincipalSchema
 from cartography.models.aws.iam.samlprovider import AWSSAMLProviderSchema
 from cartography.models.aws.iam.server_certificate import AWSServerCertificateSchema
@@ -59,6 +64,7 @@ TransformedRoleData = namedtuple(
     "TransformedRoleData",
     [
         "role_data",
+        "trust_relationships",
         "federated_principals",
         "service_principals",
         "external_aws_accounts",
@@ -554,14 +560,66 @@ def transform_access_keys(
     return access_key_data
 
 
+def _aggregate_trust_conditions(
+    statement_conditions: list[Any],
+) -> dict[str, Any]:
+    """Fold the Condition blocks of every statement trusting one principal into edge properties.
+
+    ``statement_conditions`` holds one entry per statement that trusts the principal, in
+    document order: the statement's raw ``Condition`` value, or None if it had none.
+
+    AWS evaluates conditions at request time against a token that does not exist at sync
+    time, so a conditional trust is annotated rather than resolved. Following the
+    precedent set for permission relationships in
+    cartography.intel.aws.permission_relationships.collect_edge_conditions:
+
+    - If any statement trusts the principal with no Condition, the trust is reachable
+      unconditionally and we report has_condition=False. An unconditional path wins.
+    - Otherwise every path to the trust is gated, so we report has_condition=True with
+      the union of referenced context keys and the raw condition blobs as a JSON string.
+    """
+    conditional_blobs: list[Any] = []
+    condition_keys: set[str] = set()
+
+    for condition in statement_conditions:
+        if not condition:
+            # An unconditional statement trusts this principal; the edge is effectively
+            # unconditional no matter what the other statements say.
+            return {"has_condition": False, "condition_keys": [], "conditions": None}
+        parsed = parse_condition_blob(condition)
+        if parsed:
+            conditional_blobs.extend(parsed)
+            condition_keys.update(extract_condition_context_keys(parsed))
+        else:
+            # Fail safe toward "conditional": if the blob cannot be parsed, keep the edge
+            # flagged and preserve the raw value rather than downgrading it to
+            # unconditional.
+            conditional_blobs.append(
+                condition if isinstance(condition, str) else str(condition)
+            )
+
+    if not conditional_blobs:
+        # Defensive: a principal with no statements at all should not reach here.
+        return {"has_condition": False, "condition_keys": [], "conditions": None}
+
+    return {
+        "has_condition": True,
+        "condition_keys": sorted(condition_keys),
+        "conditions": json.dumps(conditional_blobs),
+    }
+
+
 def transform_role_trust_policies(
     roles: list[dict[str, Any]], current_aws_account_id: str
 ) -> TransformedRoleData:
     """
     Processes AWS role assumption policy documents in the list_roles response.
-    Returns a TransformedRoleData object containing the role data, federated principals, service principals, and external AWS accounts.
+    Returns a TransformedRoleData object containing the role data, the trust
+    relationships to load, federated principals, service principals, and external AWS
+    accounts.
     """
     role_data: list[dict[str, Any]] = []
+    trust_relationships: list[dict[str, Any]] = []
     federated_principals: list[dict[str, Any]] = []
     service_principals: list[dict[str, Any]] = []
     external_aws_accounts: list[dict[str, Any]] = []
@@ -569,12 +627,24 @@ def transform_role_trust_policies(
     for role in roles:
         role_arn = role["Arn"]
 
-        # List of principals of type "AWS" that this role trusts
-        trusted_aws_principals = set()
-        # Process each statement in the assume role policy document
-        # TODO support conditions
-        for statement in role["AssumeRolePolicyDocument"]["Statement"]:
+        # Principal ARN -> the Condition of each statement trusting it, in document order.
+        # A role can trust the same principal from several statements under different
+        # conditions, so these are aggregated per (role, principal) below.
+        trusted_principal_conditions: dict[str, list[Any]] = {}
 
+        for statement in role["AssumeRolePolicyDocument"]["Statement"]:
+            if "Principal" not in statement:
+                # A NotPrincipal-only statement is legal in a trust policy but names no
+                # principal to draw an edge to. Skip it rather than raising KeyError and
+                # aborting the whole account sync.
+                logger.warning(
+                    "Skipping statement with no Principal in the trust policy of %s. "
+                    "NotPrincipal is not currently modeled.",
+                    role_arn,
+                )
+                continue
+
+            condition = statement.get("Condition")
             principal_entries = _parse_principal_entries(statement["Principal"])
             for principal_type, principal_arn in principal_entries:
                 if principal_type == "Federated":
@@ -592,7 +662,6 @@ def transform_role_trust_policies(
                             "role_arn": role_arn,
                         }
                     )
-                    trusted_aws_principals.add(principal_arn)
                 elif principal_type == "Service":
                     # Add to the list of service nodes to create
                     service_principals.append(
@@ -602,7 +671,6 @@ def transform_role_trust_policies(
                         }
                     )
                     # Service principals are global so there is no account id.
-                    trusted_aws_principals.add(principal_arn)
                 elif principal_type == "AWS":
                     if "root" in principal_arn:
                         # The current principal trusts a root principal.
@@ -612,10 +680,23 @@ def transform_role_trust_policies(
                         account_id = get_account_from_arn(principal_arn)
                         if account_id != current_aws_account_id:
                             external_aws_accounts.append({"id": account_id})
-                    trusted_aws_principals.add(principal_arn)
                 else:
                     # This should not happen but who knows.
                     logger.warning(f"Unknown principal type: {principal_type}")
+                    continue
+
+                trusted_principal_conditions.setdefault(principal_arn, []).append(
+                    condition
+                )
+
+        for principal_arn, statement_conditions in trusted_principal_conditions.items():
+            trust_relationships.append(
+                {
+                    "source_role_arn": role_arn,
+                    "target_principal_arn": principal_arn,
+                    **_aggregate_trust_conditions(statement_conditions),
+                }
+            )
 
         role_record = {
             "arn": role["Arn"],
@@ -624,13 +705,13 @@ def transform_role_trust_policies(
             "path": role["Path"],
             "createdate": str(role["CreateDate"]),
             "createdate_dt": role["CreateDate"],
-            "trusted_aws_principals": list(trusted_aws_principals),
             "account_id": get_account_from_arn(role["Arn"]),
         }
         role_data.append(role_record)
 
     return TransformedRoleData(
         role_data=role_data,
+        trust_relationships=trust_relationships,
         federated_principals=federated_principals,
         service_principals=service_principals,
         external_aws_accounts=external_aws_accounts,
@@ -1258,6 +1339,30 @@ def load_federated_principals(
 
 
 @timeit
+def load_role_trust_relationships(
+    neo4j_session: neo4j.Session,
+    trust_relationships: list[dict[str, Any]],
+    current_aws_account_id: str,
+    aws_update_tag: int,
+) -> None:
+    """
+    Load the TRUSTS_AWS_PRINCIPAL edges declared by role trust policies.
+
+    Must be called after the roles and the principals they trust have been loaded: a
+    MatchLink only connects nodes that already exist, so a trust naming a principal in an
+    account outside the sync perimeter draws no edge, same as before.
+    """
+    load_matchlinks(
+        neo4j_session,
+        AWSRoleTrustsPrincipalMatchLink(),
+        trust_relationships,
+        lastupdated=aws_update_tag,
+        _sub_resource_label="AWSAccount",
+        _sub_resource_id=current_aws_account_id,
+    )
+
+
+@timeit
 def sync_role_assumptions(
     neo4j_session: neo4j.Session,
     data: dict[str, Any],
@@ -1284,6 +1389,20 @@ def sync_role_assumptions(
     load_role_data(
         neo4j_session, transformed.role_data, current_aws_account_id, aws_update_tag
     )
+    # The trust edges come last: a MatchLink connects nodes that already exist, so both
+    # the roles and the principals they trust must be in the graph by this point.
+    load_role_trust_relationships(
+        neo4j_session,
+        transformed.trust_relationships,
+        current_aws_account_id,
+        aws_update_tag,
+    )
+    GraphJob.from_matchlink(
+        AWSRoleTrustsPrincipalMatchLink(),
+        sub_resource_label="AWSAccount",
+        sub_resource_id=current_aws_account_id,
+        update_tag=aws_update_tag,
+    ).run(neo4j_session)
 
 
 @timeit

--- a/cartography/models/aws/iam/role.py
+++ b/cartography/models/aws/iam/role.py
@@ -9,7 +9,6 @@ from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
-from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
 from cartography.models.ontology.labels import PERMISSION_ROLE
 
@@ -67,41 +66,15 @@ class AWSRoleToAWSAccountRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
-class AWSRoleToAWSPrincipalTrustRelProperties(CartographyRelProperties):
-    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
-
-
-@dataclass(frozen=True)
-class AWSRoleToAWSPrincipalTrustRel(CartographyRelSchema):
-    """
-    Trust relationship with principals of type "AWS".
-    """
-
-    target_node_label: str = "AWSPrincipal"
-    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {
-            "arn": PropertyRef("trusted_aws_principals", one_to_many=True),
-        },
-    )
-    direction: LinkDirection = LinkDirection.OUTWARD
-    rel_label: str = "TRUSTS_AWS_PRINCIPAL"
-    properties: AWSRoleToAWSPrincipalTrustRelProperties = (
-        AWSRoleToAWSPrincipalTrustRelProperties()
-    )
-
-
-@dataclass(frozen=True)
 class AWSRoleSchema(CartographyNodeSchema):
     """Representation of an AWS [IAM Role](https://docs.aws.amazon.com/IAM/latest/APIReference/API_Role.html). An AWS Role is a type of AWS Principal."""
 
+    # The TRUSTS_AWS_PRINCIPAL relationship is deliberately not declared here. It is
+    # loaded as a MatchLink instead (cartography.models.aws.iam.role_trust) so that each
+    # (role, principal) edge can carry its own trust-condition properties.
     label: str = "AWSRole"
     properties: AWSRoleNodeProperties = AWSRoleNodeProperties()
     sub_resource_relationship: AWSRoleToAWSAccountRel = AWSRoleToAWSAccountRel()
-    other_relationships: OtherRelationships = OtherRelationships(
-        [
-            AWSRoleToAWSPrincipalTrustRel(),
-        ]
-    )
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
         [AWS_PRINCIPAL, PERMISSION_ROLE]
     )

--- a/cartography/models/aws/iam/role.py
+++ b/cartography/models/aws/iam/role.py
@@ -9,7 +9,6 @@ from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
-from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
 from cartography.models.ontology.labels import PERMISSION_ROLE
 
@@ -50,39 +49,13 @@ class AWSRoleToAWSAccountRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
-class AWSRoleToAWSPrincipalTrustRelProperties(CartographyRelProperties):
-    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
-
-
-@dataclass(frozen=True)
-class AWSRoleToAWSPrincipalTrustRel(CartographyRelSchema):
-    """
-    Trust relationship with principals of type "AWS".
-    """
-
-    target_node_label: str = "AWSPrincipal"
-    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {
-            "arn": PropertyRef("trusted_aws_principals", one_to_many=True),
-        },
-    )
-    direction: LinkDirection = LinkDirection.OUTWARD
-    rel_label: str = "TRUSTS_AWS_PRINCIPAL"
-    properties: AWSRoleToAWSPrincipalTrustRelProperties = (
-        AWSRoleToAWSPrincipalTrustRelProperties()
-    )
-
-
-@dataclass(frozen=True)
 class AWSRoleSchema(CartographyNodeSchema):
+    # The TRUSTS_AWS_PRINCIPAL relationship is deliberately not declared here. It is
+    # loaded as a MatchLink instead (cartography.models.aws.iam.role_trust) so that each
+    # (role, principal) edge can carry its own trust-condition properties.
     label: str = "AWSRole"
     properties: AWSRoleNodeProperties = AWSRoleNodeProperties()
     sub_resource_relationship: AWSRoleToAWSAccountRel = AWSRoleToAWSAccountRel()
-    other_relationships: OtherRelationships = OtherRelationships(
-        [
-            AWSRoleToAWSPrincipalTrustRel(),
-        ]
-    )
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
         [AWS_PRINCIPAL, PERMISSION_ROLE]
     )

--- a/cartography/models/aws/iam/role_trust.py
+++ b/cartography/models/aws/iam/role_trust.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import SourceNodeMatcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AWSRoleTrustsPrincipalRelProperties(CartographyRelProperties):
+    """
+    Properties for the TRUSTS_AWS_PRINCIPAL relationship, which represents what a role's
+    assume role policy document declares: the principals permitted to assume it.
+
+    The condition fields mirror the ones set on permission relationships by
+    cartography.intel.aws.permission_relationships, so the two kinds of edge can be
+    filtered the same way. AWS evaluates conditions at request time against a token that
+    does not exist at sync time, so a conditional trust is annotated, never dropped.
+    """
+
+    # Mandatory fields for MatchLinks
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label", set_in_kwargs=True
+    )
+    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
+
+    # Condition metadata, aggregated across every statement that trusts this principal.
+    has_condition: PropertyRef = PropertyRef("has_condition")
+    condition_keys: PropertyRef = PropertyRef("condition_keys")
+    conditions: PropertyRef = PropertyRef("conditions")
+
+
+@dataclass(frozen=True)
+class AWSRoleTrustsPrincipalMatchLink(CartographyRelSchema):
+    """
+    MatchLink schema for (:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal).
+
+    This is a MatchLink rather than a relationship on AWSRoleSchema because a single role
+    can trust several principals under different conditions, and only a per-(role,
+    principal) row can carry per-edge properties. A node-schema relationship using a
+    one_to_many target matcher compiles to a single `principal.arn IN $list` clause, so
+    every edge from a given role would share one set of property values.
+    """
+
+    # Source node (the role whose trust policy declares the trust)
+    source_node_label: str = "AWSRole"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"arn": PropertyRef("source_role_arn")},
+    )
+
+    # Target node (the principal permitted to assume the role)
+    target_node_label: str = "AWSPrincipal"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("target_principal_arn")},
+    )
+
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "TRUSTS_AWS_PRINCIPAL"
+    properties: AWSRoleTrustsPrincipalRelProperties = (
+        AWSRoleTrustsPrincipalRelProperties()
+    )

--- a/cartography/models/aws/iam/role_trust.py
+++ b/cartography/models/aws/iam/role_trust.py
@@ -49,16 +49,19 @@ class AWSRoleTrustsPrincipalRelProperties(CartographyRelProperties):
     )
 
 
+# Modelled per (role, principal) pair rather than as a relationship on AWSRoleSchema: a
+# single role can trust several principals under different conditions, and only a per-pair
+# row can carry its own property values. A node-schema relationship matching many targets
+# at once compiles to a single `principal.arn IN $list` clause, so every edge drawn from a
+# given role would end up sharing one set of properties.
 @dataclass(frozen=True)
 class AWSRoleTrustsPrincipalMatchLink(CartographyRelSchema):
     """
-    MatchLink schema for (:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal).
+    Represents the principals that an AWS role's trust policy permits to assume it, along
+    with any conditions attached to that permission.
 
-    This is a MatchLink rather than a relationship on AWSRoleSchema because a single role
-    can trust several principals under different conditions, and only a per-(role,
-    principal) row can carry per-edge properties. A node-schema relationship using a
-    one_to_many target matcher compiles to a single `principal.arn IN $list` clause, so
-    every edge from a given role would share one set of property values.
+    There is one relationship per role and principal, so a role that trusts the same
+    principal across several statements is represented once with the conditions combined.
     """
 
     # Source node (the role whose trust policy declares the trust)

--- a/cartography/models/aws/iam/role_trust.py
+++ b/cartography/models/aws/iam/role_trust.py
@@ -1,0 +1,80 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import SourceNodeMatcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AWSRoleTrustsPrincipalRelProperties(CartographyRelProperties):
+    """
+    Properties for the TRUSTS_AWS_PRINCIPAL relationship, which represents what a role's
+    assume role policy document declares: the principals permitted to assume it.
+
+    The condition fields mirror the ones set on permission relationships by
+    cartography.intel.aws.permission_relationships, so the two kinds of edge can be
+    filtered the same way. AWS evaluates conditions at request time against a token that
+    does not exist at sync time, so a conditional trust is annotated, never dropped.
+    """
+
+    # Mandatory fields for MatchLinks
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label", set_in_kwargs=True
+    )
+    _sub_resource_id: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
+
+    # Condition metadata, aggregated across every statement that trusts this principal.
+    has_condition: PropertyRef = PropertyRef(
+        "has_condition",
+        description="True if every statement granting this trust carries a Condition "
+        "block; False if at least one statement grants the trust unconditionally.",
+    )
+    condition_keys: PropertyRef = PropertyRef(
+        "condition_keys",
+        description="Sorted union of the IAM condition context keys (e.g. "
+        "`token.actions.githubusercontent.com:sub`) across every conditional "
+        "statement that trusts this principal. Empty if the trust is unconditional.",
+    )
+    conditions: PropertyRef = PropertyRef(
+        "conditions",
+        description="JSON array of the raw Condition blocks from each conditional "
+        "statement trusting this principal, in document order. Null if the trust "
+        "is unconditional.",
+    )
+
+
+@dataclass(frozen=True)
+class AWSRoleTrustsPrincipalMatchLink(CartographyRelSchema):
+    """
+    MatchLink schema for (:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal).
+
+    This is a MatchLink rather than a relationship on AWSRoleSchema because a single role
+    can trust several principals under different conditions, and only a per-(role,
+    principal) row can carry per-edge properties. A node-schema relationship using a
+    one_to_many target matcher compiles to a single `principal.arn IN $list` clause, so
+    every edge from a given role would share one set of property values.
+    """
+
+    # Source node (the role whose trust policy declares the trust)
+    source_node_label: str = "AWSRole"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"arn": PropertyRef("source_role_arn")},
+    )
+
+    # Target node (the principal permitted to assume the role)
+    target_node_label: str = "AWSPrincipal"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("target_principal_arn")},
+    )
+
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "TRUSTS_AWS_PRINCIPAL"
+    properties: AWSRoleTrustsPrincipalRelProperties = (
+        AWSRoleTrustsPrincipalRelProperties()
+    )

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1085,10 +1085,33 @@ Representation of an AWS [IAM Role](https://docs.aws.amazon.com/IAM/latest/APIRe
     (:AWSRole)-[:STS_ASSUMEROLE_ALLOW]->(:AWSRole)
     ```
 
-- Some AWS Roles trust AWS Principals.
+- Some AWS Roles trust AWS Principals. This relationship reflects what the role's assume
+  role policy document declares, and carries the trust statement's `Condition` block:
 
     ```cypher
     (:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal)
+    ```
+
+    | Field | Description |
+    |-------|-------------|
+    | has_condition | `true` only if every statement trusting this principal is gated by a `Condition`. An unconditional statement anywhere in the trust policy wins and sets this to `false`. |
+    | condition_keys | Sorted, de-duplicated list of the condition context keys referenced across those statements, e.g. `["token.actions.githubusercontent.com:aud", "token.actions.githubusercontent.com:sub"]`. |
+    | conditions | The raw condition operator maps as a JSON string. `null` when `has_condition` is `false`. |
+
+    AWS evaluates conditions at request time against a token that does not exist at sync
+    time, so conditional trusts are annotated rather than resolved or filtered out. Note
+    that `condition_keys` is a flattened union: keys within a single condition block are
+    ANDed and values for one key are ORed, and only `conditions` preserves that structure.
+
+    For example, to find roles assumable from any repository in a GitHub organization
+    rather than a pinned repository and ref:
+
+    ```cypher
+    MATCH (r:AWSRole)-[t:TRUSTS_AWS_PRINCIPAL]->(p:AWSFederatedPrincipal)
+    WHERE p.arn ENDS WITH 'oidc-provider/token.actions.githubusercontent.com'
+      AND t.has_condition = true
+      AND t.conditions CONTAINS '*'
+    RETURN r.arn, t.conditions
     ```
 
 - Members of an Okta group can assume associated AWS roles if Okta SAML is configured with AWS.

--- a/docs/root/modules/aws/schema.md
+++ b/docs/root/modules/aws/schema.md
@@ -1103,6 +1103,14 @@ Representation of an AWS [IAM Role](https://docs.aws.amazon.com/IAM/latest/APIRe
     that `condition_keys` is a flattened union: keys within a single condition block are
     ANDed and values for one key are ORed, and only `conditions` preserves that structure.
 
+    The edge is drawn only where the trust statement actually makes the role assumable.
+    A statement whose `Action` covers none of `sts:AssumeRole`,
+    `sts:AssumeRoleWithWebIdentity` or `sts:AssumeRoleWithSAML` draws no edge, and
+    neither does a principal named by an unconditional `Deny`. A `Deny` gated by a
+    `Condition` only applies at request time, so it does not suppress the edge.
+    `NotAction` and `NotPrincipal` are not modeled: statements using them keep, rather
+    than lose, their trust edge.
+
     For example, to find roles assumable from any repository in a GitHub organization
     rather than a pinned repository and ref:
 

--- a/tests/data/aws/iam/__init__.py
+++ b/tests/data/aws/iam/__init__.py
@@ -174,6 +174,100 @@ LIST_ROLES = {
     ],
 }
 
+GITHUB_OIDC_PROVIDER_ARN = (
+    "arn:aws:iam::000000000000:oidc-provider/token.actions.githubusercontent.com"
+)
+
+# Roles trusting the GitHub Actions OIDC provider. The first two are identical apart from
+# the sub condition that scopes them, which is the distinction the trust edge has to
+# preserve. The third trusts the same provider from two statements, one of which is
+# unconditional.
+LIST_ROLES_GITHUB_OIDC = {
+    "Roles": [
+        {
+            # Pinned to one branch of one repo.
+            "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Action": "sts:AssumeRoleWithWebIdentity",
+                        "Effect": "Allow",
+                        "Principal": {"Federated": GITHUB_OIDC_PROVIDER_ARN},
+                        "Condition": {
+                            "StringEquals": {
+                                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                                "token.actions.githubusercontent.com:sub": "repo:octo-org/octo-repo:ref:refs/heads/main",
+                            },
+                        },
+                    },
+                ],
+            },
+            "MaxSessionDuration": 3600,
+            "RoleId": "AROA00000000000000010",
+            "CreateDate": datetime.datetime(2026, 1, 1, 0, 0, 1),
+            "RoleName": "gha-pinned",
+            "Path": "/",
+            "Arn": "arn:aws:iam::000000000000:role/gha-pinned",
+        },
+        {
+            # Org-wide. IAM `*` is not path-aware, so it spans both `/` and `:`: every
+            # repo under octo-org, every ref, and the `pull_request` subject match.
+            "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Action": "sts:AssumeRoleWithWebIdentity",
+                        "Effect": "Allow",
+                        "Principal": {"Federated": GITHUB_OIDC_PROVIDER_ARN},
+                        "Condition": {
+                            "StringLike": {
+                                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                                "token.actions.githubusercontent.com:sub": "repo:octo-org/*",
+                            },
+                        },
+                    },
+                ],
+            },
+            "MaxSessionDuration": 3600,
+            "RoleId": "AROA00000000000000011",
+            "CreateDate": datetime.datetime(2026, 1, 1, 0, 0, 1),
+            "RoleName": "gha-org-wide",
+            "Path": "/",
+            "Arn": "arn:aws:iam::000000000000:role/gha-org-wide",
+        },
+        {
+            # Two statements trusting the same provider. The unconditional one wins, so
+            # the aggregated edge is not conditional.
+            "AssumeRolePolicyDocument": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Action": "sts:AssumeRoleWithWebIdentity",
+                        "Effect": "Allow",
+                        "Principal": {"Federated": GITHUB_OIDC_PROVIDER_ARN},
+                        "Condition": {
+                            "StringEquals": {
+                                "token.actions.githubusercontent.com:sub": "repo:octo-org/octo-repo:ref:refs/heads/main",
+                            },
+                        },
+                    },
+                    {
+                        "Action": "sts:AssumeRoleWithWebIdentity",
+                        "Effect": "Allow",
+                        "Principal": {"Federated": GITHUB_OIDC_PROVIDER_ARN},
+                    },
+                ],
+            },
+            "MaxSessionDuration": 3600,
+            "RoleId": "AROA00000000000000012",
+            "CreateDate": datetime.datetime(2026, 1, 1, 0, 0, 1),
+            "RoleName": "gha-mixed",
+            "Path": "/",
+            "Arn": "arn:aws:iam::000000000000:role/gha-mixed",
+        },
+    ],
+}
+
 LIST_SAML_PROVIDERS = {
     "SAMLProviderList": [
         {

--- a/tests/integration/cartography/intel/aws/iam/test_iam.py
+++ b/tests/integration/cartography/intel/aws/iam/test_iam.py
@@ -236,6 +236,110 @@ def test_load_roles_creates_trust_relationships(neo4j_session):
     assert actual == expected
 
 
+def _trust_edge_properties(neo4j_session, role_arn: str) -> dict:
+    result = neo4j_session.run(
+        """
+        MATCH (r:AWSRole{arn: $role_arn})-[t:TRUSTS_AWS_PRINCIPAL]->(p:AWSPrincipal)
+        RETURN p.arn AS principal_arn,
+               t.has_condition AS has_condition,
+               t.condition_keys AS condition_keys,
+               t.conditions AS conditions
+        """,
+        role_arn=role_arn,
+    )
+    return {record["principal_arn"]: dict(record) for record in result}
+
+
+def test_trust_conditions_are_loaded_onto_the_edge(neo4j_session):
+    """Two roles differing only in sub scoping must not produce identical trust edges."""
+    cartography.intel.aws.iam.sync_role_assumptions(
+        neo4j_session,
+        tests.data.aws.iam.LIST_ROLES_GITHUB_OIDC,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+    provider_arn = tests.data.aws.iam.GITHUB_OIDC_PROVIDER_ARN
+
+    pinned = _trust_edge_properties(
+        neo4j_session, "arn:aws:iam::000000000000:role/gha-pinned"
+    )[provider_arn]
+    org_wide = _trust_edge_properties(
+        neo4j_session, "arn:aws:iam::000000000000:role/gha-org-wide"
+    )[provider_arn]
+
+    assert pinned["has_condition"] is True
+    assert org_wide["has_condition"] is True
+    assert (
+        pinned["condition_keys"]
+        == org_wide["condition_keys"]
+        == [
+            "token.actions.githubusercontent.com:aud",
+            "token.actions.githubusercontent.com:sub",
+        ]
+    )
+    assert "repo:octo-org/octo-repo:ref:refs/heads/main" in pinned["conditions"]
+    assert "repo:octo-org/*" in org_wide["conditions"]
+    assert pinned["conditions"] != org_wide["conditions"]
+
+
+def test_unconditional_trust_edge_is_not_flagged(neo4j_session):
+    """An unconditional Allow anywhere in the trust policy wins for that principal."""
+    cartography.intel.aws.iam.sync_role_assumptions(
+        neo4j_session,
+        tests.data.aws.iam.LIST_ROLES_GITHUB_OIDC,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+    mixed = _trust_edge_properties(
+        neo4j_session, "arn:aws:iam::000000000000:role/gha-mixed"
+    )[tests.data.aws.iam.GITHUB_OIDC_PROVIDER_ARN]
+
+    assert mixed["has_condition"] is False
+    assert mixed["condition_keys"] == []
+    assert mixed["conditions"] is None
+
+
+def test_stale_trust_edges_are_cleaned_up(neo4j_session):
+    """A trust removed from the policy must not survive the next sync."""
+    cartography.intel.aws.iam.sync_role_assumptions(
+        neo4j_session,
+        tests.data.aws.iam.LIST_ROLES_GITHUB_OIDC,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+    assert _trust_edge_properties(
+        neo4j_session, "arn:aws:iam::000000000000:role/gha-pinned"
+    )
+
+    # Re-sync at a later tag with the trust policy emptied out.
+    untrusting = {
+        "Roles": [
+            {
+                **role,
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [],
+                },
+            }
+            for role in tests.data.aws.iam.LIST_ROLES_GITHUB_OIDC["Roles"]
+        ],
+    }
+    cartography.intel.aws.iam.sync_role_assumptions(
+        neo4j_session,
+        untrusting,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG + 1,
+    )
+
+    assert (
+        _trust_edge_properties(
+            neo4j_session, "arn:aws:iam::000000000000:role/gha-pinned"
+        )
+        == {}
+    )
+
+
 def test_sync_saml_providers(neo4j_session):
     _create_base_account(neo4j_session)
 

--- a/tests/unit/cartography/intel/aws/iam/test_role_trust_conditions.py
+++ b/tests/unit/cartography/intel/aws/iam/test_role_trust_conditions.py
@@ -1,0 +1,288 @@
+import datetime
+import json
+
+import pytest
+
+import tests.data.aws.iam
+from cartography.intel.aws.iam import transform_role_trust_policies
+
+TEST_ACCOUNT_ID = "000000000000"
+GITHUB_OIDC_PROVIDER_ARN = tests.data.aws.iam.GITHUB_OIDC_PROVIDER_ARN
+
+
+def _trusts_by_role(transformed):
+    return {
+        (t["source_role_arn"], t["target_principal_arn"]): t
+        for t in transformed.trust_relationships
+    }
+
+
+def test_oidc_trusts_differing_only_in_sub_scoping_are_distinguishable():
+    """Two roles identical apart from their sub condition must not collapse to the same edge."""
+    transformed = transform_role_trust_policies(
+        tests.data.aws.iam.LIST_ROLES_GITHUB_OIDC["Roles"], TEST_ACCOUNT_ID
+    )
+    trusts = _trusts_by_role(transformed)
+
+    pinned = trusts[
+        (
+            "arn:aws:iam::000000000000:role/gha-pinned",
+            GITHUB_OIDC_PROVIDER_ARN,
+        )
+    ]
+    org_wide = trusts[
+        (
+            "arn:aws:iam::000000000000:role/gha-org-wide",
+            GITHUB_OIDC_PROVIDER_ARN,
+        )
+    ]
+
+    # Both are conditional and reference the same context keys...
+    assert pinned["has_condition"] is True
+    assert org_wide["has_condition"] is True
+    assert (
+        pinned["condition_keys"]
+        == org_wide["condition_keys"]
+        == [
+            "token.actions.githubusercontent.com:aud",
+            "token.actions.githubusercontent.com:sub",
+        ]
+    )
+
+    # ...but the retained condition blobs tell them apart, which is the point.
+    assert pinned["conditions"] != org_wide["conditions"]
+    assert json.loads(pinned["conditions"]) == [
+        {
+            "StringEquals": {
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                "token.actions.githubusercontent.com:sub": "repo:octo-org/octo-repo:ref:refs/heads/main",
+            }
+        }
+    ]
+    assert json.loads(org_wide["conditions"]) == [
+        {
+            "StringLike": {
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                "token.actions.githubusercontent.com:sub": "repo:octo-org/*",
+            }
+        }
+    ]
+
+
+def test_unconditional_statement_wins_over_conditional_one():
+    """A role trusting one principal from both a gated and an ungated statement is unconditional."""
+    transformed = transform_role_trust_policies(
+        tests.data.aws.iam.LIST_ROLES_GITHUB_OIDC["Roles"], TEST_ACCOUNT_ID
+    )
+    mixed = _trusts_by_role(transformed)[
+        (
+            "arn:aws:iam::000000000000:role/gha-mixed",
+            GITHUB_OIDC_PROVIDER_ARN,
+        )
+    ]
+
+    assert mixed["has_condition"] is False
+    assert mixed["condition_keys"] == []
+    assert mixed["conditions"] is None
+
+
+def test_one_row_per_role_principal_pair():
+    """A principal trusted by several statements of one role yields a single aggregated row."""
+    transformed = transform_role_trust_policies(
+        tests.data.aws.iam.LIST_ROLES_GITHUB_OIDC["Roles"], TEST_ACCOUNT_ID
+    )
+
+    pairs = [
+        (t["source_role_arn"], t["target_principal_arn"])
+        for t in transformed.trust_relationships
+    ]
+    assert len(pairs) == len(set(pairs))
+    # gha-mixed trusts the provider from two statements but contributes one row.
+    assert (
+        sum(
+            1
+            for role_arn, _ in pairs
+            if role_arn == "arn:aws:iam::000000000000:role/gha-mixed"
+        )
+        == 1
+    )
+
+
+def test_conditions_are_aggregated_across_statements():
+    """Two differently gated statements for one principal keep both blobs and the key union."""
+    role = {
+        "Path": "/",
+        "RoleName": "two-gates",
+        "RoleId": "AROA00000000000000013",
+        "Arn": "arn:aws:iam::000000000000:role/two-gates",
+        "CreateDate": datetime.datetime(2026, 1, 1, 0, 0, 1),
+        "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRoleWithWebIdentity",
+                    "Effect": "Allow",
+                    "Principal": {"Federated": GITHUB_OIDC_PROVIDER_ARN},
+                    "Condition": {
+                        "StringEquals": {
+                            "token.actions.githubusercontent.com:sub": "repo:octo-org/repo-a:ref:refs/heads/main",
+                        },
+                    },
+                },
+                {
+                    "Action": "sts:AssumeRoleWithWebIdentity",
+                    "Effect": "Allow",
+                    "Principal": {"Federated": GITHUB_OIDC_PROVIDER_ARN},
+                    "Condition": {
+                        "StringEquals": {
+                            "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                        },
+                    },
+                },
+            ],
+        },
+    }
+
+    transformed = transform_role_trust_policies([role], TEST_ACCOUNT_ID)
+    (trust,) = transformed.trust_relationships
+
+    assert trust["has_condition"] is True
+    assert trust["condition_keys"] == [
+        "token.actions.githubusercontent.com:aud",
+        "token.actions.githubusercontent.com:sub",
+    ]
+    assert len(json.loads(trust["conditions"])) == 2
+
+
+def test_saml_trust_condition_is_retained():
+    """The SAML:aud condition already present in the shared fixture reaches the edge."""
+    transformed = transform_role_trust_policies(
+        tests.data.aws.iam.LIST_ROLES["Roles"], TEST_ACCOUNT_ID
+    )
+    saml = _trusts_by_role(transformed)[
+        (
+            "arn:aws:iam::000000000000:role/example-role-3",
+            "arn:aws:iam::000000000000:saml-provider/ADFS",
+        )
+    ]
+
+    assert saml["has_condition"] is True
+    assert saml["condition_keys"] == ["SAML:aud"]
+
+
+def test_unconditional_trusts_are_not_flagged():
+    """Trusts with no Condition keep has_condition false and carry no blob."""
+    transformed = transform_role_trust_policies(
+        tests.data.aws.iam.LIST_ROLES["Roles"], TEST_ACCOUNT_ID
+    )
+    root_trust = _trusts_by_role(transformed)[
+        (
+            "arn:aws:iam::000000000000:role/example-role-0",
+            "arn:aws:iam::000000000000:root",
+        )
+    ]
+
+    assert root_trust["has_condition"] is False
+    assert root_trust["condition_keys"] == []
+    assert root_trust["conditions"] is None
+
+
+def test_empty_condition_block_is_not_a_condition():
+    """`"Condition": {}` appears in real policies and must not flag the edge."""
+    role = {
+        "Path": "/",
+        "RoleName": "empty-condition",
+        "RoleId": "AROA00000000000000014",
+        "Arn": "arn:aws:iam::000000000000:role/empty-condition",
+        "CreateDate": datetime.datetime(2026, 1, 1, 0, 0, 1),
+        "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRole",
+                    "Effect": "Allow",
+                    "Principal": {"AWS": "arn:aws:iam::000000000000:root"},
+                    "Condition": {},
+                },
+            ],
+        },
+    }
+
+    transformed = transform_role_trust_policies([role], TEST_ACCOUNT_ID)
+    (trust,) = transformed.trust_relationships
+
+    assert trust["has_condition"] is False
+    assert trust["conditions"] is None
+
+
+def test_not_principal_statement_is_skipped_without_raising(caplog):
+    """A NotPrincipal-only statement is legal and must not abort the account sync."""
+    role = {
+        "Path": "/",
+        "RoleName": "not-principal",
+        "RoleId": "AROA00000000000000015",
+        "Arn": "arn:aws:iam::000000000000:role/not-principal",
+        "CreateDate": datetime.datetime(2026, 1, 1, 0, 0, 1),
+        "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRole",
+                    "Effect": "Allow",
+                    "Principal": {"AWS": "arn:aws:iam::000000000000:root"},
+                },
+                {
+                    "Action": "sts:AssumeRole",
+                    "Effect": "Deny",
+                    "NotPrincipal": {"AWS": "arn:aws:iam::000000000000:root"},
+                },
+            ],
+        },
+    }
+
+    transformed = transform_role_trust_policies([role], TEST_ACCOUNT_ID)
+
+    # The usable statement still produces its edge; the NotPrincipal one is skipped.
+    assert [t["target_principal_arn"] for t in transformed.trust_relationships] == [
+        "arn:aws:iam::000000000000:root"
+    ]
+    assert "NotPrincipal" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "condition_blob",
+    ["not json at all", "{unclosed", ""],
+)
+def test_unparseable_condition_fails_safe(condition_blob):
+    """A Condition we cannot parse keeps the edge flagged rather than downgrading it.
+
+    An empty value is falsy and means "no condition", so only the genuinely malformed
+    blobs stay flagged.
+    """
+    role = {
+        "Path": "/",
+        "RoleName": "weird-condition",
+        "RoleId": "AROA00000000000000016",
+        "Arn": "arn:aws:iam::000000000000:role/weird-condition",
+        "CreateDate": datetime.datetime(2026, 1, 1, 0, 0, 1),
+        "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRole",
+                    "Effect": "Allow",
+                    "Principal": {"AWS": "arn:aws:iam::000000000000:root"},
+                    "Condition": condition_blob,
+                },
+            ],
+        },
+    }
+
+    transformed = transform_role_trust_policies([role], TEST_ACCOUNT_ID)
+    (trust,) = transformed.trust_relationships
+
+    if condition_blob:
+        assert trust["has_condition"] is True
+        assert trust["conditions"] is not None
+    else:
+        assert trust["has_condition"] is False

--- a/tests/unit/cartography/intel/aws/iam/test_role_trust_conditions.py
+++ b/tests/unit/cartography/intel/aws/iam/test_role_trust_conditions.py
@@ -249,6 +249,168 @@ def test_not_principal_statement_is_skipped_without_raising(caplog):
     assert "NotPrincipal" in caplog.text
 
 
+def _role_with_statements(name, statements):
+    return {
+        "Path": "/",
+        "RoleName": name,
+        "RoleId": f"AROA{name.upper().replace('-', '')}",
+        "Arn": f"arn:aws:iam::000000000000:role/{name}",
+        "CreateDate": datetime.datetime(2026, 1, 1, 0, 0, 1),
+        "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": statements,
+        },
+    }
+
+
+ATTACKER_ARN = "arn:aws:iam::999999999999:role/attacker"
+ROOT_ARN = "arn:aws:iam::000000000000:root"
+
+
+def test_unconditional_deny_draws_no_edge():
+    """Deny beats Allow in IAM evaluation, so a denied principal is not trusted."""
+    role = _role_with_statements(
+        "deny-only",
+        [
+            {
+                "Effect": "Deny",
+                "Principal": {"AWS": ATTACKER_ARN},
+                "Action": "sts:AssumeRole",
+            },
+        ],
+    )
+
+    transformed = transform_role_trust_policies([role], TEST_ACCOUNT_ID)
+
+    assert transformed.trust_relationships == []
+    # A Deny is not evidence the account is trusted, so no stub is materialized.
+    assert transformed.external_aws_accounts == []
+
+
+def test_deny_overrides_allow_for_the_same_principal():
+    role = _role_with_statements(
+        "allow-then-deny",
+        [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": [ATTACKER_ARN, ROOT_ARN]},
+                "Action": "sts:AssumeRole",
+            },
+            {
+                "Effect": "Deny",
+                "Principal": {"AWS": ATTACKER_ARN},
+                "Action": "sts:AssumeRole",
+            },
+        ],
+    )
+
+    transformed = transform_role_trust_policies([role], TEST_ACCOUNT_ID)
+
+    assert [t["target_principal_arn"] for t in transformed.trust_relationships] == [
+        ROOT_ARN
+    ]
+
+
+def test_conditional_deny_does_not_suppress_the_edge():
+    """A Deny gated by a Condition only applies at request time, so the edge survives."""
+    role = _role_with_statements(
+        "conditional-deny",
+        [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": ROOT_ARN},
+                "Action": "sts:AssumeRole",
+            },
+            {
+                "Effect": "Deny",
+                "Principal": {"AWS": ROOT_ARN},
+                "Action": "sts:AssumeRole",
+                "Condition": {"Bool": {"aws:MultiFactorAuthPresent": "false"}},
+            },
+        ],
+    )
+
+    transformed = transform_role_trust_policies([role], TEST_ACCOUNT_ID)
+    (trust,) = transformed.trust_relationships
+
+    assert trust["target_principal_arn"] == ROOT_ARN
+    # The Allow is unconditional, and the Deny's condition is not folded into it.
+    assert trust["has_condition"] is False
+
+
+@pytest.mark.parametrize(
+    "action,expected_edge",
+    [
+        ("sts:AssumeRole", True),
+        ("sts:AssumeRoleWithWebIdentity", True),
+        ("sts:AssumeRoleWithSAML", True),
+        ("sts:assumerole", True),  # IAM action names are case-insensitive
+        ("sts:AssumeRole*", True),
+        ("sts:*", True),
+        ("*", True),
+        ("sts:TagSession", False),
+        ("sts:GetCallerIdentity", False),
+        ("s3:GetObject", False),
+    ],
+)
+def test_only_assume_role_actions_draw_an_edge(action, expected_edge):
+    role = _role_with_statements(
+        "action-check",
+        [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": ROOT_ARN},
+                "Action": action,
+            },
+        ],
+    )
+
+    transformed = transform_role_trust_policies([role], TEST_ACCOUNT_ID)
+
+    assert bool(transformed.trust_relationships) is expected_edge
+
+
+def test_action_list_with_one_assume_action_draws_an_edge():
+    """sts:TagSession alongside a real assume action still makes the role assumable."""
+    role = _role_with_statements(
+        "tag-and-assume",
+        [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": ROOT_ARN},
+                "Action": ["sts:AssumeRoleWithSAML", "sts:TagSession"],
+            },
+        ],
+    )
+
+    transformed = transform_role_trust_policies([role], TEST_ACCOUNT_ID)
+
+    assert [t["target_principal_arn"] for t in transformed.trust_relationships] == [
+        ROOT_ARN
+    ]
+
+
+def test_not_action_keeps_the_edge(caplog):
+    """NotAction is not modeled; keep the edge rather than silently dropping a real trust."""
+    role = _role_with_statements(
+        "not-action",
+        [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": ROOT_ARN},
+                "NotAction": "s3:GetObject",
+            },
+        ],
+    )
+
+    transformed = transform_role_trust_policies([role], TEST_ACCOUNT_ID)
+
+    assert [t["target_principal_arn"] for t in transformed.trust_relationships] == [
+        ROOT_ARN
+    ]
+    assert "NotAction" in caplog.text
+
+
 @pytest.mark.parametrize(
     "condition_blob",
     ["not json at all", "{unclosed", ""],


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

### Summary

Tier 1 of #3078, in the shape agreed on the issue: option 3 (MatchLink), one aggregated row per `(role, principal)`, unconditional-allow-wins as in #2891. Tier 2 (the derived `trust_subject_*` / `trust_audiences` properties) is deliberately left for a follow-up.

**The gap.** `transform_role_trust_policies` read only the `Principal` element of each `AssumeRolePolicyDocument` statement, so the trust `Condition` never reached the graph. Two roles differing only in their OIDC `sub` scoping produced isomorphic subgraphs:

| | `gha-pinned` | `gha-org-wide` |
|---|---|---|
| Principal | `oidc-provider/token.actions.githubusercontent.com` | identical |
| `...:sub` | `StringEquals repo:octo-org/octo-repo:ref:refs/heads/main` | `StringLike repo:octo-org/*` |
| Graph before | `(:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSFederatedPrincipal)` | identical |

The second is satisfied by every repository under `octo-org` — IAM's `*` is not path-aware, so it spans both `/` and `:` — including repositories created after the role, and including the `pull_request` subject. Reachability scored them the same.

**Two commits**, deliberately separate:

**1. `feat(aws): model trust-policy conditions on the role trust edge`** — additive. The trust edge now carries the property names #2891 established for permission edges:

- `has_condition` — true only when every statement trusting the principal is gated by a `Condition`; an unconditional statement anywhere wins.
- `condition_keys` — the sorted union of referenced context keys.
- `conditions` — the raw operator maps as a JSON string.

`parse_condition_blob` and `extract_condition_context_keys` are reused as-is. AWS evaluates conditions at request time, so edges are annotated, never resolved.

The relationship moves off `AWSRoleSchema` and becomes a MatchLink. A node-schema relationship with a `one_to_many` target matcher compiles to a single `principal.arn IN $list` clause, so every trust edge from a role would share one set of property values — but conditions are per-statement. The MatchLink emits one aggregated row per `(role, principal)`, matching the shape `STSAssumeRoleAllowMatchLink` and `GitHubRepoAssumeRoleWithWebIdentityMatchLink` already use.

This commit also fixes a crash: `statement["Principal"]` was indexed directly, so a `NotPrincipal`-only statement — legal in a trust policy — raised `KeyError` and aborted the whole account sync.

**2. `fix(aws): only draw role trust edges where the statement grants assume-role`** — this addresses the review point that the transform ignored `Effect` and `Action`. Verified against `master` before writing it:

```python
# Effect ignored: an explicit Deny drew the same edge as an Allow
{"Effect": "Deny", "Principal": {"AWS": ".../attacker"}, "Action": "sts:AssumeRole"}
# -> trusted_aws_principals: ['arn:aws:iam::999999999999:role/attacker']

# Action ignored: sts:TagSession cannot obtain credentials, but was
# indistinguishable from sts:AssumeRoleWithWebIdentity
{"Effect": "Allow", "Principal": {"Federated": "...githubusercontent.com"}, "Action": "sts:TagSession"}
# -> trusted_aws_principals: ['...oidc-provider/token.actions.githubusercontent.com']
```

Unlike conditions, `Effect` is resolvable at sync time, so this filters rather than annotates, following the explicit-deny-wins precedence of `evaluate_policy_for_permissions` (not callable directly here — trust policies match on `Principal`, not `Resource`). Deliberate choices, all covered by tests:

- A `Deny` suppresses the edge only when **unconditional**. A conditional `Deny` applies at request time and cannot be resolved statically, so it is left to the `Allow` statements.
- `Deny` statements no longer materialize federated/service principals or external account stubs, since a `Deny` is not evidence the principal is trusted.
- Action matching is case-insensitive and wildcard-aware: `sts:AssumeRole*`, `sts:*` and `*` all qualify.
- `NotAction` is treated as granting. Resolving it means enumerating the complement of the action namespace, and guessing wrong would silently drop a real trust edge.

**This is the only commit in the series that removes edges**, which is a different review risk from adding properties — hence keeping it separate. Happy to split it into its own PR if you would rather land tier 1 alone. No test fixture in the repo loses an edge.

### Related issues or links

- Addresses #3078 (tier 1; tier 2 tracked there, so this does not auto-close it)
- Follows the condition-annotation precedent from #2891 / #2250
- The immutable-subject interaction raised on #3078 is #3083. Worth noting for whoever takes tier 2: `repo:octo-org/*` does **not** match `repo:octo-org@123456/octo-repo@456789:...`, since the literal prefix `repo:octo-org/` fails against `repo:octo-org@123456/`. The same wildcard is over-broad for legacy-format repos and fail-closed for immutable-format ones, which is why tier 2 should keep the raw pattern rather than reduce it to a single "is wildcard" boolean.

### Breaking changes

No schema-breaking change: the relationship label, direction, and endpoints are unchanged, and existing queries over `(:AWSRole)-[:TRUSTS_AWS_PRINCIPAL]->(:AWSPrincipal)` keep working. Commit 2 does change which edges exist — `Deny`-only and non-assume-action statements no longer produce one — which is the intended correctness fix.

### How was this tested?

Unit — 26 new tests in `tests/unit/cartography/intel/aws/iam/test_role_trust_conditions.py`: the two differently scoped OIDC trusts staying distinguishable, unconditional-allow-wins, one row per `(role, principal)`, cross-statement condition aggregation, the `SAML:aud` condition already present in the shared fixture, `"Condition": {}` not counting as a condition, unparseable blobs failing safe toward "conditional", the `NotPrincipal` skip, Deny precedence, conditional-Deny, and a parametrized action-matching matrix.

Integration — 3 new tests in `tests/integration/cartography/intel/aws/iam/test_iam.py` against Neo4j: the condition properties reaching the edge and telling the two roles apart, `has_condition=false` for the mixed role, and stale trust edges being removed by the MatchLink cleanup on a later update tag.

Suites run locally against Neo4j 5-community:
- `tests/unit` — 4316 passed. (4 failures are pre-existing on `master` on this Windows host: cp1252 decode and path handling in `test_label_migrations`, `test_object_store`, `test_doc`. Confirmed by stashing the branch and re-running.)
- `tests/integration/cartography/intel/aws/` and `tests/integration/rules/` — 327 passed, including `test_iam_role_external_account_trust`, `test_identitycenter` and `test_cloudtrail_management_events`, which are the existing consumers of this edge.
- `pre-commit run` over the changed files — black, isort, flake8, mypy, pyupgrade all pass.

One note on the existing `test_load_roles_creates_trust_relationships`: it passes in file order but fails when run in isolation, on `master` as well as on this branch, because it depends on an earlier test in the file having created the current account's root principal. Left alone here rather than folded into this PR.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the schema documentation (`docs/root/modules/aws/schema.md`: the new edge properties, their aggregation semantics, an example Cypher query for org-wide OIDC trusts, and the Effect/Action rules).
- [ ] Updated the schema README — `docs/schema/README.md` does not exist on `master`; the AWS schema doc above appears to be the current location.
