### PR TITLE
fix(aws): handle null groups in aws-auth mappings

### DIFF
--- a/cartography/intel/kubernetes/eks.py
+++ b/cartography/intel/kubernetes/eks.py
@@ -271,7 +271,7 @@ def transform_aws_auth_mappings(
         for mapping in auth_mappings.get("roles", []):
             role_arn = mapping.get("rolearn")
             username = mapping.get("username")
-            group_names = mapping.get("groups", [])
+            group_names = mapping.get("groups") or []
 
             if not role_arn:
                 continue
@@ -328,7 +328,7 @@ def transform_aws_auth_mappings(
         for mapping in auth_mappings.get("users", []):
             user_arn = mapping.get("userarn")
             username = mapping.get("username")
-            group_names = mapping.get("groups", [])
+            group_names = mapping.get("groups") or []
 
             if not user_arn:
                 continue
@@ -553,7 +553,7 @@ def transform_access_entries(
     for entry in access_entries:
         principal_arn = entry["principalArn"]
         username = entry["username"]
-        group_names = entry.get("kubernetesGroups", [])
+        group_names = entry.get("kubernetesGroups") or []
 
         is_role = ":role/" in principal_arn
         is_user = ":user/" in principal_arn

--- a/tests/unit/cartography/intel/kubernetes/test_eks.py
+++ b/tests/unit/cartography/intel/kubernetes/test_eks.py
@@ -64,6 +64,40 @@ def test_parse_aws_auth_map_handles_missing_map_accounts():
     assert result["accounts"] == []
 
 
+def test_transform_aws_auth_mappings_handles_null_groups():
+    # A mapRoles/mapUsers entry may set `groups: null` (valid aws-auth: the
+    # principal maps to a username with no extra RBAC groups). YAML null becomes
+    # None, so `.get("groups", [])` returns None and iterating it used to raise
+    # TypeError, aborting the whole kubernetes sync stage.
+    auth_mappings = {
+        "roles": [
+            {
+                "rolearn": "arn:aws:iam::000000000000:role/AdminSSO",
+                "username": "admin",
+                "groups": None,
+            },
+        ],
+        "users": [
+            {
+                "userarn": "arn:aws:iam::000000000000:user/dev",
+                "username": "dev",
+                "groups": None,
+            },
+        ],
+        "accounts": [],
+    }
+
+    result = eks.transform_aws_auth_mappings(
+        MagicMock(),
+        auth_mappings,
+        EXAMPLE_CLUSTER_NAME,
+    )
+
+    # The usernames are still ingested; the null groups simply add nothing.
+    assert {user["name"] for user in result["users"]} == {"admin", "dev"}
+    assert result["groups"] == []
+
+
 def test_list_access_entry_principal_arns_skips_config_map_auth_mode(caplog):
     error = _list_access_entries_client_error(
         "InvalidRequestException",


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary

A `mapRoles`/`mapUsers` entry in the `aws-auth` ConfigMap can set `groups: null`. A principal mapped to a username with no additional RBAC groups is valid. `parse_aws_auth_map` preserves that as `None`, and `transform_aws_auth_mappings` read it with `mapping.get("groups", [])`, whose default only applies when the key is missing. A present-but-null value returns `None`, so `for group_name in group_names:` raised `TypeError: 'NoneType' object is not iterable`.

Because the exception is unhandled, it aborts the entire `kubernetes` sync stage when `--managed-kubernetes eks` is set, so no Kubernetes resources are ingested.

Coercing with `mapping.get("groups") or []` treats null the same as an empty list. The same guard is applied to `kubernetesGroups` on EKS access entries, which has the identical pattern.

### How was this tested?

Added a unit test (`test_transform_aws_auth_mappings_handles_null_groups`) covering `groups: null` on both a role and a user mapping; it reproduces the `TypeError` on `master` and passes with the fix. `make test_unit` and `make test_lint` pass locally.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.