### PR TITLE
fix(vercel): give VercelAccessGroup the UserGroup ontology label

### DIFF
--- a/cartography/data/jobs/analysis/vercel_label_migration.json
+++ b/cartography/data/jobs/analysis/vercel_label_migration.json
@@ -1,0 +1,10 @@
+{
+  "statements": [
+    {
+      "__comment__": "VercelAccessGroup used to carry a vercel-local :Group label instead of the :UserGroup ontology label. Strip stale :Group from pre-migration access groups. Idempotent (REMOVE on a missing label is a no-op).",
+      "query": "MATCH (n:VercelAccessGroup:Group) REMOVE n:Group",
+      "iterative": false
+    }
+  ],
+  "name": "Vercel ontology label migration"
+}

--- a/cartography/intel/vercel/__init__.py
+++ b/cartography/intel/vercel/__init__.py
@@ -25,6 +25,7 @@ import cartography.intel.vercel.teams
 import cartography.intel.vercel.users
 import cartography.intel.vercel.webhooks
 from cartography.config import Config
+from cartography.util import run_analysis_job
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -195,3 +196,11 @@ def start_vercel_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
             ec_job_parameters,
             edge_config_id=ec_id,
         )
+
+    # Phase 8: DEPRECATED: compatibility migration for the vercel-local
+    # :Group label on VercelAccessGroup. Remove in v1.0.0.
+    run_analysis_job(
+        "vercel_label_migration.json",
+        neo4j_session,
+        common_job_parameters,
+    )

--- a/cartography/models/ontology/constraints.py
+++ b/cartography/models/ontology/constraints.py
@@ -197,6 +197,7 @@ from cartography.models.slack.group import SlackGroupToCreatorRel
 from cartography.models.tailscale.group import (
     TailscaleUserToGroupInheritedMemberMatchLink,
 )
+from cartography.models.vercel.accessgroup import VercelAccessGroupToUserRel
 
 
 @dataclass(frozen=True)
@@ -387,6 +388,7 @@ LEGACY_REL_WHITELIST: frozenset[type] = frozenset(
         GitHubTeamChildTeamRel,
         KeycloakGroupToGroupRel,
         OCIGroupToOCIUserRel,
+        VercelAccessGroupToUserRel,
         # Group "owner"/"maintainer"/"admin" edges mark a privileged role held
         # within the group, a distinct semantic from plain membership. The
         # principals remain reachable through these edges; MEMBER_OF is reserved

--- a/cartography/models/ontology/mapping/__init__.py
+++ b/cartography/models/ontology/mapping/__init__.py
@@ -1,7 +1,45 @@
 import logging
 
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabel
 from cartography.models.ontology.device import DeviceSchema
+from cartography.models.ontology.labels import AI_MODEL
+from cartography.models.ontology.labels import API_KEY
+from cartography.models.ontology.labels import BLOCK_STORAGE
+from cartography.models.ontology.labels import CERTIFICATE
+from cartography.models.ontology.labels import CICD_PIPELINE
+from cartography.models.ontology.labels import CODE_REPOSITORY
+from cartography.models.ontology.labels import COMPUTE_CLUSTER
+from cartography.models.ontology.labels import COMPUTE_INSTANCE
+from cartography.models.ontology.labels import COMPUTE_NAMESPACE
+from cartography.models.ontology.labels import COMPUTE_POD
+from cartography.models.ontology.labels import COMPUTE_SERVICE
+from cartography.models.ontology.labels import CONTAINER
+from cartography.models.ontology.labels import CONTAINER_REGISTRY
+from cartography.models.ontology.labels import CVE
+from cartography.models.ontology.labels import DATABASE
+from cartography.models.ontology.labels import DNS_RECORD
+from cartography.models.ontology.labels import DNS_ZONE
+from cartography.models.ontology.labels import ENCRYPTION_KEY
+from cartography.models.ontology.labels import FILE_STORAGE
+from cartography.models.ontology.labels import FUNCTION
+from cartography.models.ontology.labels import IDENTITY_PROVIDER
+from cartography.models.ontology.labels import IMAGE
+from cartography.models.ontology.labels import LOAD_BALANCER
+from cartography.models.ontology.labels import NETWORK_ACCESS_CONTROL
+from cartography.models.ontology.labels import OBJECT_STORAGE
+from cartography.models.ontology.labels import PERMISSION_ROLE
+from cartography.models.ontology.labels import SECRET
+from cartography.models.ontology.labels import SECURITY_ISSUE
+from cartography.models.ontology.labels import SERVICE_ACCOUNT
+from cartography.models.ontology.labels import SNAPSHOT
+from cartography.models.ontology.labels import SUBNET
+from cartography.models.ontology.labels import TAG
+from cartography.models.ontology.labels import TENANT
+from cartography.models.ontology.labels import THIRD_PARTY_APP
+from cartography.models.ontology.labels import USER_ACCOUNT
+from cartography.models.ontology.labels import USER_GROUP
+from cartography.models.ontology.labels import VIRTUAL_NETWORK
 from cartography.models.ontology.mapping.data.aimodels import AIMODELS_ONTOLOGY_MAPPING
 from cartography.models.ontology.mapping.data.apikeys import APIKEYS_ONTOLOGY_MAPPING
 from cartography.models.ontology.mapping.data.blockstorage import (
@@ -152,6 +190,50 @@ SEMANTIC_LABELS_MAPPING: dict[str, dict[str, OntologyMapping]] = {
     "serviceaccounts": SERVICEACCOUNTS_ONTOLOGY_MAPPING,
     "certificates": CERTIFICATES_ONTOLOGY_MAPPING,
     "cves": CVES_ONTOLOGY_MAPPING,
+}
+
+# The ontology extra label carried by every node mapped in a given semantic category.
+# Provider schemas mapped into a category must declare that label (enforced by
+# tests/unit/cartography/intel/ontology/test_ontology_mapping.py), otherwise their nodes get
+# normalized `_ont_*` properties while staying invisible to `MATCH (n:<Label>)` queries.
+SEMANTIC_LABEL_BY_CATEGORY: dict[str, ExtraNodeLabel] = {
+    "aimodels": AI_MODEL,
+    "apikeys": API_KEY,
+    "blockstorage": BLOCK_STORAGE,
+    "certificates": CERTIFICATE,
+    "cicdpipelines": CICD_PIPELINE,
+    "coderepositories": CODE_REPOSITORY,
+    "computeclusters": COMPUTE_CLUSTER,
+    "computeinstance": COMPUTE_INSTANCE,
+    "computenamespaces": COMPUTE_NAMESPACE,
+    "computepods": COMPUTE_POD,
+    "computeservices": COMPUTE_SERVICE,
+    "containerregistries": CONTAINER_REGISTRY,
+    "containers": CONTAINER,
+    "cves": CVE,
+    "databases": DATABASE,
+    "dnsrecords": DNS_RECORD,
+    "dnszones": DNS_ZONE,
+    "encryptionkeys": ENCRYPTION_KEY,
+    "filestorage": FILE_STORAGE,
+    "firewalls": NETWORK_ACCESS_CONTROL,
+    "functions": FUNCTION,
+    "groups": USER_GROUP,
+    "identityproviders": IDENTITY_PROVIDER,
+    "images": IMAGE,
+    "loadbalancers": LOAD_BALANCER,
+    "objectstorage": OBJECT_STORAGE,
+    "roles": PERMISSION_ROLE,
+    "secrets": SECRET,
+    "securityissues": SECURITY_ISSUE,
+    "serviceaccounts": SERVICE_ACCOUNT,
+    "snapshots": SNAPSHOT,
+    "subnets": SUBNET,
+    "tags": TAG,
+    "tenants": TENANT,
+    "thirdpartyapps": THIRD_PARTY_APP,
+    "useraccounts": USER_ACCOUNT,
+    "vpcs": VIRTUAL_NETWORK,
 }
 
 ONTOLOGY_MODELS: dict[str, type[CartographyNodeSchema] | None] = {

--- a/cartography/models/vercel/accessgroup.py
+++ b/cartography/models/vercel/accessgroup.py
@@ -12,7 +12,7 @@ from cartography.models.core.relationships import make_target_node_matcher
 from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import SourceNodeMatcher
 from cartography.models.core.relationships import TargetNodeMatcher
-from cartography.models.vercel.extra_labels import GROUP
+from cartography.models.ontology.labels import USER_GROUP
 
 
 @dataclass(frozen=True)
@@ -54,6 +54,8 @@ class VercelAccessGroupToUserRelProperties(CartographyRelProperties):
 
 @dataclass(frozen=True)
 # (:VercelAccessGroup)-[:HAS_MEMBER]->(:VercelUser)
+# DEPRECATED: replaced by the canonical MEMBER_OF edge created by
+# VercelAccessGroupToMemberRel. Will be removed in v1.0.0.
 class VercelAccessGroupToUserRel(CartographyRelSchema):
     target_node_label: str = "VercelUser"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
@@ -63,6 +65,25 @@ class VercelAccessGroupToUserRel(CartographyRelSchema):
     rel_label: str = "HAS_MEMBER"
     properties: VercelAccessGroupToUserRelProperties = (
         VercelAccessGroupToUserRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class VercelAccessGroupToMemberRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:VercelUser)-[:MEMBER_OF]->(:VercelAccessGroup)
+class VercelAccessGroupToMemberRel(CartographyRelSchema):
+    target_node_label: str = "VercelUser"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("member_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "MEMBER_OF"
+    properties: VercelAccessGroupToMemberRelProperties = (
+        VercelAccessGroupToMemberRelProperties()
     )
 
 
@@ -98,8 +119,8 @@ class VercelAccessGroupToProjectRel(CartographyRelSchema):
 class VercelAccessGroupSchema(CartographyNodeSchema):
     label: str = "VercelAccessGroup"
     properties: VercelAccessGroupNodeProperties = VercelAccessGroupNodeProperties()
-    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([GROUP])
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([USER_GROUP])
     sub_resource_relationship: VercelAccessGroupToTeamRel = VercelAccessGroupToTeamRel()
     other_relationships: OtherRelationships = OtherRelationships(
-        [VercelAccessGroupToUserRel()],
+        [VercelAccessGroupToUserRel(), VercelAccessGroupToMemberRel()],
     )

--- a/cartography/models/vercel/extra_labels.py
+++ b/cartography/models/vercel/extra_labels.py
@@ -1,6 +1,0 @@
-from cartography.models.core.nodes import ExtraNodeLabel
-
-GROUP = ExtraNodeLabel(
-    label="Group",
-    description="A vercel node participating in the shared Group graph interface.",
-)

--- a/docs/root/modules/ontology/schema.md
+++ b/docs/root/modules/ontology/schema.md
@@ -212,7 +212,7 @@ Unlike the abstract `User` node, `UserGroup` is a semantic label applied to conc
 Common group concepts across platforms include:
 - **Cloud IAM**: AWS IAM Groups, AWS SSO Groups, OCI Groups, Scaleway Groups
 - **Identity Providers**: Entra Groups, Okta Groups, Keycloak Groups, Google Workspace Groups, GSuite Groups
-- **Collaboration**: GitHub Teams, GitLab Groups, Slack Groups, PagerDuty Teams
+- **Collaboration**: GitHub Teams, GitLab Groups, Slack Groups, PagerDuty Teams, Vercel Access Groups
 - **Network/Device**: Duo Groups, Tailscale Groups
 
 | Field | Description |

--- a/docs/root/modules/vercel/schema.md
+++ b/docs/root/modules/vercel/schema.md
@@ -27,6 +27,7 @@ DP -- CREATED_BY --> U
 FBR -- CREATED_BY --> U
 EV -- REFERENCES --> EC
 I -- CONFIGURED_FOR --> P
+U -- MEMBER_OF --> AG
 AG -- HAS_MEMBER --> U
 AG -- HAS_ACCESS_TO --> P
 W -- WATCHES --> P

--- a/docs/root/modules/vercel/schema.md
+++ b/docs/root/modules/vercel/schema.md
@@ -327,7 +327,7 @@ Represents a third-party integration installed on the team.
 
 Represents a team access group used for RBAC.
 
-> **Ontology Mapping**: This node has the extra label `Group` to enable cross-platform queries for user groups across different systems (e.g., OktaGroup, GoogleWorkspaceGroup, AWSGroup).
+> **Ontology Mapping**: This node has the extra label `UserGroup` to enable cross-platform queries for user groups across different systems (e.g., AWSGroup, EntraGroup, GoogleWorkspaceGroup).
 
 | Field | Description |
 |-------|-------------|
@@ -343,9 +343,12 @@ Represents a team access group used for RBAC.
 | member_ids | List of user IDs. |
 
 #### Relationships
-- An access group groups users.
+- An access group groups users. Membership is exposed through the canonical ontology edge; the
+  reverse `HAS_MEMBER` edge is deprecated and will be removed in v1.0.0.
     ```
-    (:VercelTeam)-[:RESOURCE]->(:VercelAccessGroup)-[:HAS_MEMBER]->(:VercelUser)
+    (:VercelTeam)-[:RESOURCE]->(:VercelAccessGroup)
+    (:VercelUser)-[:MEMBER_OF]->(:VercelAccessGroup)
+    (:VercelAccessGroup)-[:HAS_MEMBER]->(:VercelUser)
     ```
 - An access group grants access to projects. The `HAS_ACCESS_TO` relationship carries a `role` property (`ADMIN`, `PROJECT_DEVELOPER`, `PROJECT_VIEWER`, or `PROJECT_GUEST`) describing the per-project privilege level.
     ```

--- a/tests/integration/cartography/intel/vercel/test_accessgroups.py
+++ b/tests/integration/cartography/intel/vercel/test_accessgroups.py
@@ -66,6 +66,17 @@ def test_load_vercel_access_groups(mock_api, neo4j_session):
     }
     assert check_nodes(neo4j_session, "VercelAccessGroup", ["id"]) == expected_nodes
 
+    # Assert Access Groups carry the UserGroup ontology label and its normalized properties
+    record = neo4j_session.run(
+        """
+        MATCH (g:VercelAccessGroup:UserGroup {id: $id})
+        RETURN g._ont_name AS name, g._ont_source AS source
+        """,
+        id="ag_123",
+    ).single()
+    assert record["name"] == "Engineering"
+    assert record["source"] == "vercel"
+
     # Assert Access Groups are connected to VercelTeam via RESOURCE
     expected_team_rels = {
         ("ag_123", TEST_TEAM_ID),
@@ -102,6 +113,17 @@ def test_load_vercel_access_groups(mock_api, neo4j_session):
         )
         == expected_user_rels
     )
+
+    # Assert the canonical MEMBER_OF edge mirrors HAS_MEMBER in the ontology direction
+    assert check_rels(
+        neo4j_session,
+        "VercelUser",
+        "id",
+        "VercelAccessGroup",
+        "id",
+        "MEMBER_OF",
+        rel_direction_right=True,
+    ) == {(user_id, group_id) for group_id, user_id in expected_user_rels}
 
     # Assert Access Groups are connected to VercelProject via HAS_ACCESS_TO,
     # and the per-project role is captured on the relationship.

--- a/tests/unit/cartography/intel/ontology/test_ontology_mapping.py
+++ b/tests/unit/cartography/intel/ontology/test_ontology_mapping.py
@@ -4,10 +4,12 @@ from typing import Type
 
 import cartography.models
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import LabelKind
 from cartography.models.ontology.mapping import get_deprecated_ontology_index_properties
 from cartography.models.ontology.mapping import ONTOLOGY_CANONICAL_SCHEMAS
 from cartography.models.ontology.mapping import ONTOLOGY_MODELS
 from cartography.models.ontology.mapping import ONTOLOGY_NODES_MAPPING
+from cartography.models.ontology.mapping import SEMANTIC_LABEL_BY_CATEGORY
 from cartography.models.ontology.mapping import SEMANTIC_LABELS_MAPPING
 from cartography.models.ontology.mapping.data.cves import CVES_ONTOLOGY_MAPPING
 from cartography.models.ontology.mapping.data.tenants import TENANTS_ONTOLOGY_MAPPING
@@ -160,6 +162,68 @@ def test_ontology_primary_labels_are_reserved_for_ontology_models():
     assert (
         not violations
     ), "Ontology primary labels are reserved for ontology schemas only.\n" + "\n".join(
+        sorted(violations)
+    )
+
+
+def test_semantic_label_by_category_is_complete():
+    # Every semantic category must declare the ontology label its nodes carry, and that
+    # label must actually be an ontology label.
+    assert set(SEMANTIC_LABEL_BY_CATEGORY) == set(SEMANTIC_LABELS_MAPPING), (
+        "SEMANTIC_LABEL_BY_CATEGORY is out of sync with SEMANTIC_LABELS_MAPPING: "
+        f"missing {sorted(set(SEMANTIC_LABELS_MAPPING) - set(SEMANTIC_LABEL_BY_CATEGORY))}, "
+        f"extra {sorted(set(SEMANTIC_LABEL_BY_CATEGORY) - set(SEMANTIC_LABELS_MAPPING))}."
+    )
+
+    for category, extra_label in SEMANTIC_LABEL_BY_CATEGORY.items():
+        assert extra_label.kind is LabelKind.ONTOLOGY, (
+            f"Semantic category '{category}' maps to '{extra_label.label}', "
+            f"which is a {extra_label.kind.value} label, not an ontology one."
+        )
+
+
+def test_semantically_mapped_nodes_declare_their_ontology_label():
+    # A node mapped into a semantic category gets normalized `_ont_*` properties written by
+    # the query builder. If it does not also carry the category's ontology label, it stays
+    # invisible to every cross-provider `MATCH (n:<Label>)` query.
+    violations: set[str] = set()
+
+    for category, mappings in SEMANTIC_LABELS_MAPPING.items():
+        ontology_label = SEMANTIC_LABEL_BY_CATEGORY[category].label
+        for module_name, mapping in mappings.items():
+            for node in mapping.nodes:
+                # TODO: Remove that uggly exception once all models are migrated to the new data model system
+                if node.node_label in OLD_FORMAT_NODES:
+                    continue
+                model_classes = _get_model_by_node_label(node.node_label)
+                assert len(model_classes) > 0, (
+                    f"Model class for node label '{node.node_label}' "
+                    f"in module '{module_name}' not found."
+                )
+                # A canonical ontology schema owns the label as its primary label (e.g. CVE).
+                if node.node_label == ontology_label:
+                    continue
+                declared = any(
+                    ontology_label
+                    in {
+                        extra_label.label
+                        for extra_label in (
+                            model_class().extra_node_labels.labels
+                            if model_class().extra_node_labels
+                            else ()
+                        )
+                    }
+                    for model_class in model_classes
+                )
+                if not declared:
+                    violations.add(
+                        f"{node.node_label} is mapped into the '{category}' ontology category "
+                        f"but does not declare the '{ontology_label}' extra node label.",
+                    )
+
+    assert (
+        not violations
+    ), "Semantically mapped nodes must declare their ontology label.\n" + "\n".join(
         sorted(violations)
     )
 


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

`VercelAccessGroup` is registered in the `groups` semantic mapping, so the query builder writes normalized `_ont_*` properties onto it. But the schema declared a vercel-local `Group` extra label instead of the ontology `UserGroup`:

```python
extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([GROUP])  # label="Group", kind=STANDARD
```

So `MATCH (n:UserGroup)` never returned Vercel access groups, and the `_ont_*` range indexes landed on `:Group`, a label nothing else in the repo declares or queries. Any cross-provider report over user groups silently under-reported Vercel.

This PR:

1. **Swaps the label.** `ExtraNodeLabels([USER_GROUP])` on `VercelAccessGroupSchema`. The vercel-local `Group` label had no other consumer (`cartography/models/vercel/extra_labels.py` had exactly one importer, and `label="Group"` appeared nowhere else), so it is removed rather than kept as a compatibility alias.
2. **Strips the stale label.** New `vercel_label_migration.json` analysis job (`MATCH (n:VercelAccessGroup:Group) REMOVE n:Group`), run at the end of `start_vercel_ingestion`, so already-synced graphs do not keep a dangling `:Group`.
3. **Promotes membership to the canonical edge.** With both endpoints now carrying ontology labels, `(:VercelAccessGroup)-[:HAS_MEMBER]->(:VercelUser)` violates `RelConstraint(src="UserAccount", dst="UserGroup", label="MEMBER_OF")`, so the label could not land on its own. Membership is promoted the same way AWS, GSuite, GitHub, Keycloak and OCI groups did it: a parallel `MEMBER_OF` relationship producing `(:VercelUser)-[:MEMBER_OF]->(:VercelAccessGroup)`, with `HAS_MEMBER` kept, marked deprecated, and added to `LEGACY_REL_WHITELIST` until v1.0.0.
4. **Adds the guard that would have caught this.** `SEMANTIC_LABEL_BY_CATEGORY` records the ontology label carried by each of the 37 semantic categories, and a new unit test requires every semantically mapped node schema to declare it (either as its primary label, e.g. `CVE`, or as an ontology extra label). A second test keeps the table in sync with `SEMANTIC_LABELS_MAPPING`.

`VercelAccessGroup` was the **only** declarative offender across all 37 categories. The remaining gaps are the legacy raw-Cypher nodes already listed in `OLD_FORMAT_NODES` (`OktaGroup`, `OktaUser`, ...), which have no loadable model class and are skipped by the guard as they are by the sibling tests.


### Related issues or links

None.


### Breaking changes

None in the API sense, but the graph shape changes on the next sync:

- `VercelAccessGroup` nodes gain `:UserGroup` and lose `:Group`. Any custom query selecting `:Group` must switch to `:UserGroup`. Nothing in cartography itself referenced `:Group`.
- A new `(:VercelUser)-[:MEMBER_OF]->(:VercelAccessGroup)` edge appears. `HAS_MEMBER` still exists and is unchanged; it is scheduled for removal in v1.0.0.


### How was this tested?

- `uv run pytest tests/unit` — 4472 passed.
- `uv run pytest tests/integration/cartography/intel/vercel tests/integration/cartography/intel/ontology` — 68 passed.
- **Guard verified to actually fail.** Restoring the old vercel-local label makes the new test fail with exactly:
  ```
  AssertionError: Semantically mapped nodes must declare their ontology label.
    VercelAccessGroup is mapped into the 'groups' ontology category but does not declare the 'UserGroup' extra node label.
  ```
- **Migration job verified against a live Neo4j** with a throwaway test (not committed): it strips `:Group` from `VercelAccessGroup`, is idempotent across two consecutive runs, and leaves an unrelated `:OtherThing:Group` node untouched.
- `uv run --frozen pre-commit run --all-files` — clean.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

  No new entity is synced: this changes labels and one relationship on an existing node, covered by the integration test above.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

Two things worth a look:

- **The docs claim was already wrong before this PR.** `docs/root/modules/vercel/schema.md` said the extra label `Group` enabled "cross-platform queries for user groups", which was never true since no other node carried `Group`. It now matches the sentence used by the other 18 group modules.
- **`Group` is deleted, not deprecated.** `LabelKind.COMPATIBILITY` (with `remove_in` / `replacement_label`) exists and would have been the conservative choice, but `:Group` was never a functioning query surface, so keeping it seemed like preserving a bug. The migration job removes it from existing graphs instead. Happy to switch to a compatibility alias if you would rather not touch existing labels in a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
