### PR TITLE
fix(gcp): stop expanding broad BigQuery grants per table

### DIFF
--- a/cartography/intel/gcp/permission_relationships.py
+++ b/cartography/intel/gcp/permission_relationships.py
@@ -22,8 +22,8 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 
 GCP_PERMISSION_RELATIONSHIP_BATCH_SIZE = 500
-GCP_BIGQUERY_TABLE_PERMISSION_TABLE_BATCH_SIZE = 1000
-GCP_BIGQUERY_TABLE_PERMISSION_PRINCIPAL_BATCH_SIZE = 100
+GCP_PERMISSION_BULK_RESOURCE_BATCH_SIZE = 1000
+GCP_PERMISSION_BULK_PRINCIPAL_BATCH_SIZE = 100
 GCPPrincipalPermissionContext = dict[str, dict[str, dict[str, Any]]]
 
 
@@ -434,8 +434,8 @@ def load_permission_relationships_cartesian_product(
     update_tag: int,
     project_id: str,
     scope_description: str,
-    principal_batch_size: int = GCP_BIGQUERY_TABLE_PERMISSION_PRINCIPAL_BATCH_SIZE,
-    resource_batch_size: int = GCP_BIGQUERY_TABLE_PERMISSION_TABLE_BATCH_SIZE,
+    principal_batch_size: int = GCP_PERMISSION_BULK_PRINCIPAL_BATCH_SIZE,
+    resource_batch_size: int = GCP_PERMISSION_BULK_RESOURCE_BATCH_SIZE,
 ) -> int:
     if not principal_emails or not resource_ids:
         return 0

--- a/cartography/intel/gcp/permission_relationships.py
+++ b/cartography/intel/gcp/permission_relationships.py
@@ -359,14 +359,6 @@ def iter_permission_relationship_batches(
         yield batch
 
 
-def _bigquery_dataset_id_from_table_id(table_id: str) -> str | None:
-    if ":" not in table_id or "." not in table_id:
-        return None
-    project_id, rest = table_id.split(":", 1)
-    dataset_id, _ = rest.split(".", 1)
-    return f"{project_id}:{dataset_id}"
-
-
 def _match_bigquery_dataset_scope(scope_pattern: str, project_id: str) -> str | None:
     match = re.fullmatch(
         rf"project/{re.escape(project_id)}/resource/projects/([^/]+)/datasets/([^/]+)",
@@ -378,67 +370,59 @@ def _match_bigquery_dataset_scope(scope_pattern: str, project_id: str) -> str | 
     return f"{scope_project_id}:{dataset_id}"
 
 
-def split_bigquery_table_broad_scope_principals(
+def _is_broad_scope_for_bigquery_table(
+    assignment_data: dict[str, Any],
+    project_id: str,
+) -> bool:
+    """
+    Return True if this binding covers more than one specific BigQuery table.
+
+    A project scope covers every table in the project; organization and folder
+    scopes resolve to it too (see resolve_gcp_scope). A dataset scope covers every
+    table in that dataset.
+    """
+    scope_pattern = assignment_data["scope"].pattern
+    if scope_pattern == f"project/{project_id}/.*":
+        return True
+    return _match_bigquery_dataset_scope(scope_pattern, project_id) is not None
+
+
+def filter_bigquery_table_broad_scope_bindings(
     principals: GCPPrincipalPermissionContext,
     permissions: list[str],
     project_id: str,
-) -> tuple[set[str], dict[str, set[str]], GCPPrincipalPermissionContext]:
+) -> GCPPrincipalPermissionContext:
     """
-    Split BigQuery table permissions into broad scopes and exact residual work.
+    Keep only the bindings placed directly on a BigQuery table.
 
-    Project- and dataset-scope BigQuery grants can apply to every table in a
-    project or dataset. Group those principals up front so they can be loaded
-    through the core MatchLink Cartesian product helper instead of repeatedly
-    evaluating the same broad scope for every table.
+    Expanding a project- or dataset-scope grant into one relationship per table
+    wrote millions of relationships that carried no information: the permission
+    engine consults no table-level property (no table ACL, no row or column level
+    security, no authorized view), and the same grant always also produces the
+    GCPBigQueryDataset relationship. Consumers reach the tables in one hop:
+
+        (:GCPPrincipal)-[:CAN_READ]->(:GCPBigQueryDataset)-[:HAS_TABLE]->(:GCPBigQueryTable)
+
+    What survives here is the signal that cannot be derived from the dataset
+    relationship: an IAM binding placed directly on a single table. Conditional
+    bindings follow the same rule; the dataset relationship carries their
+    condition metadata.
     """
-    project_scope_principals, residual_principals = _split_project_scope_principals(
-        principals,
-        permissions,
-        project_id,
-    )
-    dataset_scope_principals, residual_principals = (
-        _split_bigquery_table_dataset_scope_principals(
-            residual_principals,
-            permissions,
-            project_id,
-        )
-    )
-    return project_scope_principals, dataset_scope_principals, residual_principals
-
-
-def _split_bigquery_table_dataset_scope_principals(
-    principals: GCPPrincipalPermissionContext,
-    permissions: list[str],
-    project_id: str,
-) -> tuple[dict[str, set[str]], GCPPrincipalPermissionContext]:
-    dataset_scope_principals: dict[str, set[str]] = {}
-    residual_principals: GCPPrincipalPermissionContext = {}
+    direct_principals: GCPPrincipalPermissionContext = {}
 
     for principal_email, policy_bindings in principals.items():
         for binding_id, assignment_data in policy_bindings.items():
             if not _assignment_allows_permissions(assignment_data, permissions):
                 continue
 
-            # As with project scope, conditional grants cannot ride the bulk loader.
-            if assignment_data.get("has_condition"):
-                residual_principals.setdefault(principal_email, {})[
-                    binding_id
-                ] = assignment_data
+            if _is_broad_scope_for_bigquery_table(assignment_data, project_id):
                 continue
 
-            scope_pattern = assignment_data["scope"].pattern
-            dataset_id = _match_bigquery_dataset_scope(scope_pattern, project_id)
-            if dataset_id is not None:
-                dataset_scope_principals.setdefault(dataset_id, set()).add(
-                    principal_email
-                )
-                continue
-
-            residual_principals.setdefault(principal_email, {})[
+            direct_principals.setdefault(principal_email, {})[
                 binding_id
             ] = assignment_data
 
-    return dataset_scope_principals, residual_principals
+    return direct_principals
 
 
 @timeit
@@ -480,71 +464,54 @@ def load_permission_relationships_cartesian_product(
     )
 
 
-@timeit
-def _load_bigquery_dataset_scope_bulk(
+_BroadScopeFilter = Callable[
+    [GCPPrincipalPermissionContext, list[str], str],
+    GCPPrincipalPermissionContext,
+]
+
+# Labels whose broad-scope grants are deliberately not materialized per resource:
+# a container node already carries the relationship and consumers traverse one hop
+# to the members. Only bindings placed directly on the resource are written, so
+# these labels have no bulk Cartesian phase at all.
+_BROAD_SCOPE_FILTERS: dict[str, _BroadScopeFilter] = {
+    "GCPBigQueryTable": filter_bigquery_table_broad_scope_bindings,
+}
+
+
+def _load_residual_permission_relationships(
     neo4j_session: neo4j.Session,
-    dataset_scope_principals: dict[str, set[str]],
+    residual_principals: GCPPrincipalPermissionContext,
     resource_dict: dict[str, str],
+    permissions: list[str],
     matchlink_schema: GCPPermissionMatchLink,
     update_tag: int,
     project_id: str,
+    batch_size: int,
 ) -> int:
-    relationships_loaded = 0
-    table_ids_by_dataset: dict[str, list[str]] = {}
-    for table_id in resource_dict:
-        dataset_id = _bigquery_dataset_id_from_table_id(table_id)
-        if dataset_id in dataset_scope_principals:
-            table_ids_by_dataset.setdefault(dataset_id, []).append(table_id)
+    """
+    Load the row-by-row path, the only one that carries per-edge condition metadata.
 
-    for dataset_id, dataset_table_ids in table_ids_by_dataset.items():
-        dataset_principals = dataset_scope_principals[dataset_id]
-        logger.info(
-            "Bulk loading relationship '%s' for %d dataset-scope principals across %d BigQuery tables in dataset '%s'",
-            matchlink_schema.rel_label,
-            len(dataset_principals),
-            len(dataset_table_ids),
-            dataset_id,
-        )
-        relationships_loaded += load_permission_relationships_cartesian_product(
-            neo4j_session,
-            matchlink_schema,
-            dataset_principals,
-            dataset_table_ids,
-            update_tag,
-            project_id,
-            f"dataset {dataset_id}",
-        )
+    Every pair is evaluated against the binding scope, so this handles exact and
+    partially wildcarded scopes alike.
+    """
+    if not residual_principals:
+        return 0
 
-    return relationships_loaded
-
-
-_ContainerScopeSplitter = Callable[
-    [GCPPrincipalPermissionContext, list[str], str],
-    tuple[dict[str, set[str]], GCPPrincipalPermissionContext],
-]
-_ContainerScopeBulkLoader = Callable[
-    [
-        neo4j.Session,
-        dict[str, set[str]],
-        dict[str, str],
-        GCPPermissionMatchLink,
-        int,
-        str,
-    ],
-    int,
-]
-
-# Container scopes (e.g. a BigQuery dataset covering all its tables) are handled
-# in two phases: a splitter separates broad-scope principals from exact residual
-# work, then a bulk loader Cartesian-writes the broad grants.
-_CONTAINER_SCOPE_HANDLERS: dict[
-    str, tuple[_ContainerScopeSplitter, _ContainerScopeBulkLoader]
-] = {
-    "GCPBigQueryTable": (
-        _split_bigquery_table_dataset_scope_principals,
-        _load_bigquery_dataset_scope_bulk,
-    ),
-}
+    residual_matchlink_schema = GCPConditionalPermissionMatchLink(
+        source_node_label=matchlink_schema.source_node_label,
+        target_node_label=matchlink_schema.target_node_label,
+        rel_label=matchlink_schema.rel_label,
+    )
+    return evaluate_and_load_permission_relationships(
+        neo4j_session,
+        residual_principals,
+        resource_dict,
+        permissions,
+        residual_matchlink_schema,
+        update_tag,
+        project_id,
+        batch_size=batch_size,
+    )
 
 
 @timeit
@@ -558,59 +525,56 @@ def evaluate_and_load_scope_aware_permission_relationships(
     project_id: str,
     batch_size: int = GCP_PERMISSION_RELATIONSHIP_BATCH_SIZE,
 ) -> int:
+    broad_scope_filter = _BROAD_SCOPE_FILTERS.get(matchlink_schema.target_node_label)
+    if broad_scope_filter is not None:
+        # This label represents broad grants on a container node instead of
+        # expanding them per resource, so there is no bulk Cartesian phase and
+        # _split_project_scope_principals must not run: it drops a project-scope
+        # principal from the residual entirely, which would discard the direct
+        # binding of a principal that also holds project-wide access.
+        direct_principals = broad_scope_filter(principals, permissions, project_id)
+        logger.info(
+            "Loading relationship '%s' for %d %s resources in project '%s' from direct "
+            "bindings only: %d of %d principals hold one, broader grants stay on the container node",
+            matchlink_schema.rel_label,
+            len(resource_dict),
+            matchlink_schema.target_node_label,
+            project_id,
+            len(direct_principals),
+            len(principals),
+        )
+        return _load_residual_permission_relationships(
+            neo4j_session,
+            direct_principals,
+            resource_dict,
+            permissions,
+            matchlink_schema,
+            update_tag,
+            project_id,
+            batch_size,
+        )
+
     project_scope_principals, residual_principals = _split_project_scope_principals(
         principals,
         permissions,
         project_id,
     )
 
-    # Split container-scope (e.g. BigQuery dataset) broad grants out of the residual
-    # up front so we know the final residual before loading anything.
-    dataset_scope_principals: dict[str, set[str]] = {}
-    handler = _CONTAINER_SCOPE_HANDLERS.get(matchlink_schema.target_node_label)
-    if handler is not None:
-        splitter, _ = handler
-        dataset_scope_principals, residual_principals = splitter(
-            residual_principals,
-            permissions,
-            project_id,
-        )
-
-    relationships_loaded = 0
     resource_ids = list(resource_dict)
 
     # Load the residual (row-by-row) path FIRST. It may write conditional edges, and
-    # the bulk unconditional loads below must overwrite any overlapping edge so that
+    # the bulk unconditional load below must overwrite any overlapping edge so that
     # broader unconditional access always wins (has_condition=false). See #2891 review.
-    if residual_principals:
-        residual_matchlink_schema = GCPConditionalPermissionMatchLink(
-            source_node_label=matchlink_schema.source_node_label,
-            target_node_label=matchlink_schema.target_node_label,
-            rel_label=matchlink_schema.rel_label,
-        )
-        relationships_loaded += evaluate_and_load_permission_relationships(
-            neo4j_session,
-            residual_principals,
-            resource_dict,
-            permissions,
-            residual_matchlink_schema,
-            update_tag,
-            project_id,
-            batch_size=batch_size,
-        )
-
-    # Container (dataset) bulk: overwrites overlapping residual edges with
-    # has_condition=false.
-    if handler is not None and dataset_scope_principals:
-        _, bulk_loader = handler
-        relationships_loaded += bulk_loader(
-            neo4j_session,
-            dataset_scope_principals,
-            resource_dict,
-            matchlink_schema,
-            update_tag,
-            project_id,
-        )
+    relationships_loaded = _load_residual_permission_relationships(
+        neo4j_session,
+        residual_principals,
+        resource_dict,
+        permissions,
+        matchlink_schema,
+        update_tag,
+        project_id,
+        batch_size,
+    )
 
     # Project bulk is the broadest scope, so it runs last and wins over everything.
     if project_scope_principals:

--- a/docs/root/modules/gcp/schema.md
+++ b/docs/root/modules/gcp/schema.md
@@ -2512,18 +2512,40 @@ Represents a GCP BigQuery Table, View, or Materialized View.
     ```
     (GCPBigQueryTable)-[:USES_CONNECTION]->(GCPBigQueryConnection)
     ```
-  - GCPPrincipals with appropriate permissions can read data from a table. Created from [gcp_permission_relationships.yaml](https://github.com/cartography-cncf/cartography/blob/master/cartography/data/gcp_permission_relationships.yaml).
+  - GCPPrincipals with an IAM binding placed directly on this table can read its data. Created from [gcp_permission_relationships.yaml](https://github.com/cartography-cncf/cartography/blob/master/cartography/data/gcp_permission_relationships.yaml).
     ```
     (GCPPrincipal)-[:CAN_READ]->(GCPBigQueryTable)
     ```
-  - GCPPrincipals with appropriate permissions can write data to a table.
+  - GCPPrincipals with an IAM binding placed directly on this table can write its data.
     ```
     (GCPPrincipal)-[:CAN_WRITE]->(GCPBigQueryTable)
     ```
-  - GCPPrincipals with appropriate permissions can delete a table.
+  - GCPPrincipals with an IAM binding placed directly on this table can delete it.
     ```
     (GCPPrincipal)-[:CAN_DELETE]->(GCPBigQueryTable)
     ```
+
+```{note}
+A permission relationship on a `GCPBigQueryTable` means an IAM binding placed
+**directly on that table**. Grants held at the project, folder, organization or
+dataset level are not expanded into one relationship per table: they land on the
+`GCPBigQueryDataset` and reach the tables through `HAS_TABLE`. Nothing table-level
+is consulted when evaluating them (no table ACL, no row or column level security,
+no authorized view), so expanding them per table added no information while writing
+millions of relationships on large projects.
+
+Query effective access as the union of the two grains:
+
+    MATCH (p:GCPPrincipal)-[:CAN_READ]->(t:GCPBigQueryTable)
+    RETURN p.email AS principal, t.id AS table, 'table binding' AS grain
+    UNION
+    MATCH (p:GCPPrincipal)-[:CAN_READ]->(:GCPBigQueryDataset)-[:HAS_TABLE]->(t:GCPBigQueryTable)
+    RETURN p.email AS principal, t.id AS table, 'dataset grant' AS grain
+
+Each relationship carries its own `has_condition`, `condition_title` and
+`condition_expression`, so a conditional binding on one table and an unconditional
+grant on its dataset are both represented, each on its own grain.
+```
 
 ### GCPBigQueryRoutine
 

--- a/tests/integration/cartography/intel/gcp/test_permission_relationships.py
+++ b/tests/integration/cartography/intel/gcp/test_permission_relationships.py
@@ -338,10 +338,12 @@ def test_sync_gcp_permission_relationships(
         ("alice@example.com", "projects/project-abc/datasets/test_dataset"),
     }
 
-    # alice@example.com gets project-level access to every table.
-    # bob@example.com is bound at resource scope to a SPECIFIC events table
-    # in dataset_a; the engine must NOT extend that to the homonymous events
-    # table in dataset_b — we expose that regression here.
+    # A table relationship means an IAM binding placed directly on that table.
+    # alice@example.com holds project-level access, which stays on the dataset and
+    # is read through HAS_TABLE, so she gets no table relationship at all.
+    # bob@example.com is bound at resource scope to a SPECIFIC events table in
+    # dataset_a; the engine must NOT extend that to the homonymous events table in
+    # dataset_b — we expose that regression here.
     assert check_rels(
         neo4j_session,
         "GCPPrincipal",
@@ -351,18 +353,6 @@ def test_sync_gcp_permission_relationships(
         "CAN_READ",
         rel_direction_right=True,
     ) == {
-        (
-            "alice@example.com",
-            "projects/project-abc/datasets/test_dataset/tables/test_table",
-        ),
-        (
-            "alice@example.com",
-            "projects/project-abc/datasets/dataset_a/tables/events",
-        ),
-        (
-            "alice@example.com",
-            "projects/project-abc/datasets/dataset_b/tables/events",
-        ),
         (
             "bob@example.com",
             "projects/project-abc/datasets/dataset_a/tables/events",
@@ -433,12 +423,29 @@ def test_sync_gcp_permission_relationships(
             "permissions": ["bigquery.tables.delete"],
             "relationship_name": "CAN_DELETE",
         },
+        {
+            "target_label": "GCPBigQueryDataset",
+            "permissions": ["bigquery.tables.getData"],
+            "relationship_name": "CAN_READ",
+        },
+        {
+            "target_label": "GCPBigQueryDataset",
+            "permissions": ["bigquery.tables.updateData"],
+            "relationship_name": "CAN_WRITE",
+        },
     ],
 )
-def test_sync_bigquery_table_permission_relationship_fast_paths(
+def test_sync_bigquery_broad_grants_stay_on_the_dataset(
     mock_parse_yaml,
     neo4j_session,
 ):
+    """
+    Project- and dataset-scope BigQuery grants are represented on the dataset and
+    are never expanded into one relationship per table: that expansion carried no
+    information (nothing table-level is consulted) and cost millions of MERGEs.
+    Only a binding placed directly on a table produces a table relationship, and
+    the tables covered by a broad grant stay reachable in one HAS_TABLE hop.
+    """
     # Arrange
     neo4j_session.run("MATCH (n) DETACH DELETE n")
     _create_test_project(neo4j_session)
@@ -554,31 +561,57 @@ def test_sync_bigquery_table_permission_relationship_fast_paths(
     )
 
     # Assert
+    # The project-wide reader gets its dataset relationships and NO table
+    # relationship: the broad grant is not expanded per table.
     assert check_rels(
         neo4j_session,
         "GCPPrincipal",
         "email",
-        "GCPBigQueryTable",
+        "GCPBigQueryDataset",
         "id",
         "CAN_READ",
         rel_direction_right=True,
     ) == {
-        ("project-reader@example.com", "project-abc:analytics.events"),
-        ("project-reader@example.com", "project-abc:analytics.orders"),
-        ("project-reader@example.com", "project-abc:logs.audit"),
+        ("project-reader@example.com", "project-abc:analytics"),
+        ("project-reader@example.com", "project-abc:logs"),
     }
+    # Same for the dataset-scoped writer, on its dataset only.
     assert check_rels(
         neo4j_session,
         "GCPPrincipal",
         "email",
-        "GCPBigQueryTable",
+        "GCPBigQueryDataset",
         "id",
         "CAN_WRITE",
         rel_direction_right=True,
     ) == {
-        ("dataset-writer@example.com", "project-abc:analytics.events"),
-        ("dataset-writer@example.com", "project-abc:analytics.orders"),
+        ("dataset-writer@example.com", "project-abc:analytics"),
     }
+    assert (
+        check_rels(
+            neo4j_session,
+            "GCPPrincipal",
+            "email",
+            "GCPBigQueryTable",
+            "id",
+            "CAN_READ",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+    assert (
+        check_rels(
+            neo4j_session,
+            "GCPPrincipal",
+            "email",
+            "GCPBigQueryTable",
+            "id",
+            "CAN_WRITE",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+    # Only the binding placed directly on a table produces a table relationship.
     assert check_rels(
         neo4j_session,
         "GCPPrincipal",
@@ -590,6 +623,27 @@ def test_sync_bigquery_table_permission_relationship_fast_paths(
     ) == {
         ("table-deleter@example.com", "project-abc:analytics.events"),
     }
+
+    # Losslessness: the one HAS_TABLE hop recovers exactly the tables the per-table
+    # expansion used to write for each broad grant.
+    reachable_tables = {
+        (record["email"], record["table_id"])
+        for record in neo4j_session.run(
+            """
+            MATCH (p:GCPPrincipal)-[:CAN_READ]->(:GCPBigQueryDataset)
+                  -[:HAS_TABLE]->(t:GCPBigQueryTable)
+            RETURN p.email AS email, t.id AS table_id
+            """,
+        )
+    }
+    assert reachable_tables == {
+        ("project-reader@example.com", "project-abc:analytics.events"),
+        ("project-reader@example.com", "project-abc:analytics.orders"),
+        ("project-reader@example.com", "project-abc:logs.audit"),
+    }
+
+    # The fan-out relationships written by a previous sync are still cleaned up:
+    # cleanup_rpr runs per YAML entry regardless of which load path ran.
     stale_count = neo4j_session.run(
         """
         MATCH (:GCPPrincipal{email: "stale@example.com"})-[r:CAN_READ]->(:GCPBigQueryTable)
@@ -832,17 +886,25 @@ def test_sync_gcp_permission_relationships_clears_stale_condition_on_transition(
             "permissions": ["bigquery.tables.getData"],
             "relationship_name": "CAN_READ",
         },
+        {
+            "target_label": "GCPBigQueryDataset",
+            "permissions": ["bigquery.tables.getData"],
+            "relationship_name": "CAN_READ",
+        },
     ],
 )
-def test_sync_gcp_permission_relationships_unconditional_dataset_beats_conditional_table(
+def test_sync_gcp_permission_relationships_separates_dataset_and_table_grains(
     mock_parse_yaml,
     neo4j_session,
 ):
     """
-    A principal with an unconditional dataset-scope grant AND a conditional binding on
-    a table in that dataset must end up with an unconditional edge (has_condition=false):
-    the broad unconditional grant wins over the conditional table binding for the same
-    principal/table. Regression for PR #2891 review (kunaals).
+    A principal with an unconditional dataset-scope grant AND a conditional binding
+    on one table in that dataset gets both grains, each stating its own truth:
+    an unconditional dataset relationship, and a table relationship flagged
+    has_condition=true because the binding on that table IS conditional. Effective
+    access is the union of the two paths, so the broad grant no longer overwrites
+    the condition metadata of the narrow one (contrast PR #2891, when both grains
+    landed on the same table edge).
     """
     # Arrange
     neo4j_session.run("MATCH (n) DETACH DELETE n")
@@ -855,13 +917,15 @@ def test_sync_gcp_permission_relationships_unconditional_dataset_beats_condition
         SET ds.lastupdated = $update_tag
         MERGE (project)-[dr:RESOURCE]->(ds)
         SET dr.lastupdated = $update_tag
-        WITH project
+        WITH project, ds
         UNWIND ["project-abc:analytics.events", "project-abc:analytics.orders"] AS tid
             MERGE (t:GCPBigQueryTable{id: tid})
             ON CREATE SET t.firstseen = timestamp()
             SET t.lastupdated = $update_tag
             MERGE (project)-[tr:RESOURCE]->(t)
             SET tr.lastupdated = $update_tag
+            MERGE (ds)-[hr:HAS_TABLE]->(t)
+            SET hr.lastupdated = $update_tag
         WITH project
         MERGE (p:GCPPrincipal{email: "dev@example.com"})
         ON CREATE SET p.firstseen = timestamp()
@@ -905,11 +969,158 @@ def test_sync_gcp_permission_relationships_unconditional_dataset_beats_condition
         },
     )
 
-    # Assert: the events edge is unconditional (dataset grant wins), not conditional.
-    events_has_condition = neo4j_session.run(
+    # Assert: the dataset relationship carries the unconditional grant.
+    dataset_edge = neo4j_session.run(
+        """
+        MATCH (:GCPPrincipal{email: "dev@example.com"})-[r:CAN_READ]->(:GCPBigQueryDataset{id: "project-abc:analytics"})
+        RETURN r.has_condition AS has_condition,
+               r.condition_title AS condition_title
+        """,
+    ).single()
+    assert dataset_edge["has_condition"] is False
+    assert dataset_edge["condition_title"] is None
+
+    # Only the table carrying a direct binding gets a table relationship, and it
+    # keeps its own condition metadata.
+    assert check_rels(
+        neo4j_session,
+        "GCPPrincipal",
+        "email",
+        "GCPBigQueryTable",
+        "id",
+        "CAN_READ",
+        rel_direction_right=True,
+    ) == {
+        ("dev@example.com", "project-abc:analytics.events"),
+    }
+    events_edge = neo4j_session.run(
         """
         MATCH (:GCPPrincipal{email: "dev@example.com"})-[r:CAN_READ]->(:GCPBigQueryTable{id: "project-abc:analytics.events"})
-        RETURN r.has_condition AS has_condition
+        RETURN r.has_condition AS has_condition,
+               r.condition_title AS condition_title
         """,
-    ).single()["has_condition"]
-    assert events_has_condition is False
+    ).single()
+    assert events_edge["has_condition"] is True
+    assert events_edge["condition_title"] == "business-hours"
+
+    # Unconditional access to every table in the dataset remains readable in one hop.
+    reachable_tables = {
+        record["table_id"]
+        for record in neo4j_session.run(
+            """
+            MATCH (:GCPPrincipal{email: "dev@example.com"})-[r:CAN_READ]->(:GCPBigQueryDataset)
+                  -[:HAS_TABLE]->(t:GCPBigQueryTable)
+            WHERE r.has_condition = false
+            RETURN t.id AS table_id
+            """,
+        )
+    }
+    assert reachable_tables == {
+        "project-abc:analytics.events",
+        "project-abc:analytics.orders",
+    }
+
+
+@patch.object(
+    cartography.intel.gcp.permission_relationships,
+    "parse_permission_relationships_file",
+    return_value=[
+        {
+            "target_label": "GCPBigQueryTable",
+            "permissions": ["bigquery.tables.getData"],
+            "relationship_name": "CAN_READ",
+        },
+        {
+            "target_label": "GCPBigQueryDataset",
+            "permissions": ["bigquery.tables.getData"],
+            "relationship_name": "CAN_READ",
+        },
+    ],
+)
+def test_sync_conditional_project_wide_grant_writes_no_table_relationships(
+    mock_parse_yaml,
+    neo4j_session,
+):
+    """
+    A conditional project-wide binding is broad too. Its scope pattern ends in a
+    wildcard, so it matches every table scope and used to be expanded per table by
+    the row-by-row path. It must now stop at the dataset like any other broad grant.
+    """
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _create_test_project(neo4j_session)
+    neo4j_session.run(
+        """
+        MATCH (project:GCPProject{id: $project_id})
+        MERGE (ds:GCPBigQueryDataset{id: "project-abc:analytics"})
+        ON CREATE SET ds.firstseen = timestamp()
+        SET ds.lastupdated = $update_tag
+        MERGE (project)-[dr:RESOURCE]->(ds)
+        SET dr.lastupdated = $update_tag
+        WITH project, ds
+        UNWIND ["project-abc:analytics.events", "project-abc:analytics.orders"] AS tid
+            MERGE (t:GCPBigQueryTable{id: tid})
+            ON CREATE SET t.firstseen = timestamp()
+            SET t.lastupdated = $update_tag
+            MERGE (project)-[tr:RESOURCE]->(t)
+            SET tr.lastupdated = $update_tag
+            MERGE (ds)-[hr:HAS_TABLE]->(t)
+            SET hr.lastupdated = $update_tag
+        WITH project
+        MERGE (p:GCPPrincipal{email: "oncall@example.com"})
+        ON CREATE SET p.firstseen = timestamp()
+        SET p.lastupdated = $update_tag
+        """,
+        project_id=TEST_PROJECT_ID,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    # Act
+    cartography.intel.gcp.permission_relationships.sync(
+        neo4j_session,
+        TEST_PROJECT_ID,
+        TEST_UPDATE_TAG,
+        COMMON_JOB_PARAMS,
+        {
+            "oncall@example.com": {
+                "binding-project-conditional": {
+                    "permissions": cartography.intel.gcp.permission_relationships.compile_permissions(
+                        {
+                            "permissions": ["bigquery.tables.getData"],
+                            "denied_permissions": [],
+                        }
+                    ),
+                    "scope": cartography.intel.gcp.permission_relationships.compile_gcp_regex(
+                        "project/project-abc/*"
+                    ),
+                    "has_condition": True,
+                    "condition_title": "incident-only",
+                    "condition_expression": "request.time.getHours() < 18",
+                },
+            },
+        },
+    )
+
+    # Assert
+    assert (
+        check_rels(
+            neo4j_session,
+            "GCPPrincipal",
+            "email",
+            "GCPBigQueryTable",
+            "id",
+            "CAN_READ",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+    # The dataset relationship still carries the grant, with its condition.
+    dataset_edge = neo4j_session.run(
+        """
+        MATCH (:GCPPrincipal{email: "oncall@example.com"})-[r:CAN_READ]->(:GCPBigQueryDataset{id: "project-abc:analytics"})
+        RETURN r.has_condition AS has_condition,
+               r.condition_title AS condition_title
+        """,
+    ).single()
+    assert dataset_edge["has_condition"] is True
+    assert dataset_edge["condition_title"] == "incident-only"

--- a/tests/unit/cartography/intel/gcp/test_permission_relationships.py
+++ b/tests/unit/cartography/intel/gcp/test_permission_relationships.py
@@ -408,7 +408,13 @@ def test_iter_permission_relationship_batches_preserves_matches():
     assert all(mapping["has_condition"] is False for mapping in flattened)
 
 
-def test_split_bigquery_table_broad_scope_principals():
+def test_filter_bigquery_table_broad_scope_bindings():
+    """
+    Only bindings placed directly on a table survive. Project scope (which org and
+    folder scopes resolve to) and dataset scope are dropped whether or not they
+    carry a condition: the GCPBigQueryDataset relationship covers them and the
+    tables are one HAS_TABLE hop away.
+    """
     # Arrange
     principals = {
         "project-viewer@example.com": _build_policy_bindings(
@@ -423,11 +429,31 @@ def test_split_bigquery_table_broad_scope_principals():
             ["bigquery.tables.getData"],
             "project/project-abc/resource/projects/project-abc/datasets/analytics/tables/events",
         ),
+        # Conditional broad grants follow the same rule as unconditional ones.
+        "conditional-project-viewer@example.com": {
+            "binding-1": _build_assignment(
+                ["bigquery.tables.getData"],
+                "project/project-abc/*",
+                has_condition=True,
+                condition_title="business-hours",
+            ),
+        },
+        "conditional-dataset-viewer@example.com": {
+            "binding-1": _build_assignment(
+                ["bigquery.tables.getData"],
+                "project/project-abc/resource/projects/project-abc/datasets/analytics",
+                has_condition=True,
+                condition_title="business-hours",
+            ),
+        },
+        # Holds the permission through a different verb only.
         "writer@example.com": _build_policy_bindings(
             ["bigquery.tables.updateData"],
-            "project/project-abc/*",
+            "project/project-abc/resource/projects/project-abc/datasets/analytics/tables/events",
         ),
     }
+    # A project-wide principal that ALSO holds a direct table binding must keep it:
+    # that surgical access is the whole point of the table-level relationship.
     principals["project-viewer@example.com"]["binding-exact-table"] = (
         _build_policy_bindings(
             ["bigquery.tables.getData"],
@@ -437,8 +463,8 @@ def test_split_bigquery_table_broad_scope_principals():
     )
 
     # Act
-    project_principals, dataset_principals, residual_principals = (
-        permission_relationships.split_bigquery_table_broad_scope_principals(
+    direct_principals = (
+        permission_relationships.filter_bigquery_table_broad_scope_bindings(
             principals,
             ["bigquery.tables.getData"],
             TEST_PROJECT_ID,
@@ -446,11 +472,52 @@ def test_split_bigquery_table_broad_scope_principals():
     )
 
     # Assert
-    assert project_principals == {"project-viewer@example.com"}
-    assert dataset_principals == {
-        "project-abc:analytics": {"dataset-viewer@example.com"},
+    assert set(direct_principals) == {
+        "project-viewer@example.com",
+        "table-viewer@example.com",
     }
-    assert set(residual_principals) == {"table-viewer@example.com"}
+    assert set(direct_principals["project-viewer@example.com"]) == {
+        "binding-exact-table",
+    }
+    assert set(direct_principals["table-viewer@example.com"]) == {"binding-1"}
+
+
+def test_filter_bigquery_table_broad_scope_bindings_drops_org_and_folder_scope():
+    """
+    Organization- and folder-level grants resolve to the project scope pattern
+    (resolve_gcp_scope), so they are dropped like any other project-wide grant.
+    """
+    # Arrange
+    org_scope = permission_relationships.resolve_gcp_scope(
+        "//cloudresourcemanager.googleapis.com/organizations/1337",
+        TEST_PROJECT_ID,
+    )
+    folder_scope = permission_relationships.resolve_gcp_scope(
+        "//cloudresourcemanager.googleapis.com/folders/42",
+        TEST_PROJECT_ID,
+    )
+    principals = {
+        "org-viewer@example.com": _build_policy_bindings(
+            ["bigquery.tables.getData"],
+            org_scope,
+        ),
+        "folder-viewer@example.com": _build_policy_bindings(
+            ["bigquery.tables.getData"],
+            folder_scope,
+        ),
+    }
+
+    # Act
+    direct_principals = (
+        permission_relationships.filter_bigquery_table_broad_scope_bindings(
+            principals,
+            ["bigquery.tables.getData"],
+            TEST_PROJECT_ID,
+        )
+    )
+
+    # Assert
+    assert direct_principals == {}
 
 
 def test_load_permission_relationships_cartesian_product_uses_core_cartesian_product_loader():
@@ -559,12 +626,20 @@ def test_scope_aware_loader_uses_cartesian_product_for_project_scope():
     mock_calculate.assert_not_called()
 
 
-def test_bigquery_table_fast_path_keeps_exact_table_scope_on_residual_path():
+def test_bigquery_table_loader_writes_direct_bindings_only():
+    """
+    The GCPBigQueryTable label never uses the bulk Cartesian path: a project-wide
+    grant writes nothing, and only the direct table binding is loaded row by row.
+    """
     # Arrange
     principals = {
         "project-viewer@example.com": _build_policy_bindings(
             ["bigquery.tables.getData"],
             "project/project-abc/*",
+        ),
+        "dataset-viewer@example.com": _build_policy_bindings(
+            ["bigquery.tables.getData"],
+            "project/project-abc/resource/projects/project-abc/datasets/analytics",
         ),
         "table-viewer@example.com": _build_policy_bindings(
             ["bigquery.tables.getData"],
@@ -592,7 +667,7 @@ def test_bigquery_table_fast_path_keeps_exact_table_scope_on_residual_path():
             permission_relationships,
             "load_permission_relationships_cartesian_product",
             return_value=2,
-        ),
+        ) as mock_bulk_load,
         patch.object(
             permission_relationships,
             "load_principal_mappings",
@@ -609,7 +684,8 @@ def test_bigquery_table_fast_path_keeps_exact_table_scope_on_residual_path():
         )
 
     # Assert
-    assert loaded_count == 3
+    assert loaded_count == 1
+    mock_bulk_load.assert_not_called()
     mock_load_principal_mappings.assert_called_once()
     assert mock_load_principal_mappings.call_args.args[1] == [
         {


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

A project-, folder-, organization- or dataset-scope IAM grant was expanded into one relationship per BigQuery table. On a project with 71,453 tables and 39 project-wide principals that is 2,786,847 relationships for `CAN_READ`, and as many again for `CAN_WRITE` and `CAN_DELETE`. At a measured ~375 MERGE/s, the three bulk loads take nearly 8 hours per night on a single sync worker while the others idle.

**The expansion carries no information.** The only two criteria for creating one of these relationships are that the principal holds the permission through a role, and that the binding scope covers the resource (`evaluate_policy_binding_for_permissions`, `principal_allowed_on_resource`). Nothing table-level is consulted: no table ACL, no row or column level security, no authorized view, and `GCPBigQueryTableSchema` carries no policy field at all. A broad grant always also produces the `GCPBigQueryDataset` relationship, and every ingested table is attached to its dataset by `HAS_TABLE`, so the same facts are one hop away at query time.

A `GCPBigQueryTable` permission relationship now means the one thing that cannot be derived from the dataset relationship: **an IAM binding placed directly on that table**. That is the "surgical access to one sensitive table" signal, and it is fully preserved.

| Case | Before | After |
|---|---|---|
| Project / folder / org grant | dataset relationship + N table relationships | dataset relationship only |
| Dataset-scope grant | dataset relationship + N table relationships | dataset relationship only |
| Binding placed on a table | table relationship | unchanged |

Two things a reviewer should look at closely, both of which are why this is not a one-line deletion:

1. **`_split_project_scope_principals` is skipped for this label.** It drops a project-scope principal from the residual path entirely, which was only safe because the bulk load covered every resource afterwards. Keeping it would silently discard the direct table binding of a principal that *also* holds project-wide access, i.e. exactly the signal this change sets out to preserve. Covered by `test_filter_bigquery_table_broad_scope_bindings`.
2. **A conditional project-wide binding was fanning out too**, through the row-by-row path rather than the bulk one: its scope pattern ends in a wildcard, so it `fullmatch`es every table scope. It is now filtered like any other broad grant. This case had no test at all; there is one now.

Also fixed as a side effect: a dataset-scope *conditional* binding used to produce the dataset relationship and zero table relationships, silently, because `_split_bigquery_table_dataset_scope_principals` early-returned to the residual path where `project/p/resource/projects/p/datasets/d` does not `fullmatch` a table scope. The new grain makes that behaviour intentional and documented rather than an accident.

The second commit renames `GCP_BIGQUERY_TABLE_PERMISSION_{TABLE,PRINCIPAL}_BATCH_SIZE`: they are the defaults of `load_permission_relationships_cartesian_product`, used by every target label and never overridden by a call site, so the BigQuery-table naming was already misleading and is now plainly wrong.


### Related issues or links

- Fixes #


### Breaking changes

Consumers reading `(:GCPPrincipal)-[:CAN_READ]->(:GCPBigQueryTable)` as *effective* access must now read the union of the two grains:

```cypher
MATCH (p:GCPPrincipal)-[:CAN_READ]->(t:GCPBigQueryTable)
RETURN p.email AS principal, t.id AS table, 'table binding' AS grain
UNION
MATCH (p:GCPPrincipal)-[:CAN_READ]->(:GCPBigQueryDataset)-[:HAS_TABLE]->(t:GCPBigQueryTable)
RETURN p.email AS principal, t.id AS table, 'dataset grant' AS grain
```

One consequence is visible in an existing test, rewritten here: a principal holding an unconditional dataset grant *and* a conditional binding on one table in that dataset now keeps `has_condition=true` on the table relationship, because the broad grant no longer overwrites it. Each relationship states its own truth, and the unconditional dataset relationship still states the broader one.

**No migration is required** for the relationships already in the graph. `cleanup_rpr` runs per YAML entry regardless of which load path ran, and matches on `rel_label` + endpoint labels + `_sub_resource_*` with `lastupdated <> $UPDATE_TAG`, which the fan-out relationships all carry. The first sync after this change removes them. The integration test asserts this by pre-seeding a stale relationship.

Known limit, unchanged by this PR: `get_bigquery_tables` returns `None` and logs a warning on 403 / API disabled / not found for a dataset, leaving it with zero tables in the graph. Both the direct relationship and the traversal return nothing in that case, so there is no relative divergence, but both are incomplete.


### How was this tested?

```
uv run --frozen python -m pytest tests/unit/cartography/intel/gcp        # 328 passed
uv run --frozen python -m pytest tests/integration/cartography/intel/gcp # 110 passed
uv run --frozen pre-commit run --all-files                               # clean
```

The 110 passing GCP integration tests are the guard for the acceptance criterion that `GCPBucket`, `GCPSecretManagerSecret`, `GCPBigQueryDataset` and `GCPArtifactRegistryRepository` are unaffected; two unit tests pin the bulk Cartesian path for those labels specifically.

New and rewritten coverage:

- `test_sync_bigquery_broad_grants_stay_on_the_dataset` (integration) exercises both grains in a single sync: the project-wide reader and the dataset-scope writer get their dataset relationships and **zero** table relationships, the principal bound directly to a table keeps its relationship, and the `HAS_TABLE` hop recovers *exactly* the three tables the fan-out used to write. That last assertion is the losslessness proof.
- `test_sync_conditional_project_wide_grant_writes_no_table_relationships` (integration) covers the conditional broad grant that previously fanned out via the residual path.
- `test_sync_gcp_permission_relationships_separates_dataset_and_table_grains` (integration) replaces the #2891 regression test with the new grain semantics.
- `test_filter_bigquery_table_broad_scope_bindings` and `..._drops_org_and_folder_scope` (unit) pin the filter, including that org/folder scopes resolve to the project pattern and that a project-wide principal keeps its direct table binding.
- `test_bigquery_table_loader_writes_direct_bindings_only` (unit) asserts the bulk Cartesian loader is never called for this label.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).


### Notes for reviewers

The relationship *labels* are unchanged; what changed is which of them get written, so the review question is whether the new grain is the right one rather than whether the schema is right. Worth knowing while reading: BigQuery legacy `access_entries` exist only on the dataset and are stored as a raw property, never consumed by the permission engine. That is not a source of divergence introduced here, but it is a fidelity blind spot in the same area.

The expected gain on the deployment that motivated this is the removal of 7h54 per night, taking a 17h45 total run down to roughly 7 to 8 hours by making the parallel phase the limiting factor again instead of one single-threaded project.
