### PR TITLE
perf(graph): drop lastupdated from the MatchLink relationship index key

### DIFF
--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -1472,7 +1472,7 @@ def build_create_index_queries_for_matchlink(
         >>> # Returns:
         >>> # - CREATE INDEX FOR (n:User) ON (n.id)
         >>> # - CREATE INDEX FOR (n:Role) ON (n.name)
-        >>> # - CREATE INDEX FOR ()-[r:HAS_ROLE]->() ON (r._sub_resource_label, r._sub_resource_id, r.lastupdated)
+        >>> # - CREATE INDEX FOR ()-[r:HAS_ROLE]->() ON (r._sub_resource_label, r._sub_resource_id)
 
         >>> # Missing source node matcher
         >>> incomplete_rel = CartographyRelSchema(target_node_label='Role', ...)
@@ -1528,12 +1528,14 @@ def build_create_index_queries_for_matchlink(
                 target_sub_resource_key,
             )
 
-    # Create a composite relationship index that matches the cleanup predicate shape.
-    # Matchlink cleanup filters by sub-resource equality first and then uses lastupdated
-    # as a trailing inequality, so that order avoids broad scans under parallel sync load.
+    # Create a composite relationship index on the two stable keys of the cleanup predicate.
+    # `lastupdated` is deliberately excluded: it is rewritten on every sync, so including it in
+    # the composite key made Neo4j delete and reinsert every index entry on every run (37.2s vs
+    # 17.8s on a 2.79M-relationship warm load). It could not help the cleanup anyway, since `<>`
+    # is not a seekable predicate.
     rel_index_template = Template(
         "CREATE INDEX IF NOT EXISTS FOR ()$rel_direction[r:$RelLabel]$rel_direction_end() "
-        "ON (r._sub_resource_label, r._sub_resource_id, r.lastupdated);",
+        "ON (r._sub_resource_label, r._sub_resource_id);",
     )
     if rel_schema.direction == LinkDirection.INWARD:
         result.append(
@@ -1709,6 +1711,12 @@ def build_matchlink_cartesian_product_query(rel_schema: CartographyRelSchema) ->
     else:
         rel = f"(from)-[r:{rel_schema.rel_label}]->(to)"
 
+    # `_module_name` identifies the module that owns this relationship's schema, so it is set once on
+    # create rather than rewritten on every sync. Everything else stays in the unconditional SET:
+    # `lastupdated` is the cleanup's liveness marker, `_module_version` tracks the cartography version
+    # that last wrote the relationship (as build_ingestion_query() does for nodes), and
+    # `_sub_resource_label`/`_sub_resource_id` must keep following the last writer, since a MatchLink
+    # is keyed only on its endpoints and label and so can be shared by several sub-resources.
     matchlink_cartesian_product_query_template = Template(
         """
         UNWIND $SourceValues AS source_value
@@ -1719,9 +1727,10 @@ def build_matchlink_cartesian_product_query(rel_schema: CartographyRelSchema) ->
         WITH sources, to
         UNWIND sources AS from
             MERGE $rel
-            ON CREATE SET r.firstseen = timestamp()
+            ON CREATE SET
+                r.firstseen = timestamp(),
+                r._module_name = "$module_name"
             SET
-                r._module_name = "$module_name",
                 r._module_version = "$module_version",
                 $set_rel_properties_statement
         RETURN count(r) AS rel_count;
@@ -1782,7 +1791,7 @@ def build_matchlink_query(rel_schema: CartographyRelSchema) -> str:
         >>> #     MATCH (from:User{id: item.user_id})
         >>> #     MATCH (to:Role{name: item.role_name})
         >>> #     MERGE (from)-[r:HAS_ROLE]->(to)
-        >>> #     ON CREATE SET r.firstseen = timestamp()
+        >>> #     ON CREATE SET r.firstseen = timestamp(), r._module_name = "cartography:..."
         >>> #     SET r._sub_resource_label = $_sub_resource_label, ...
 
     Note:
@@ -1817,6 +1826,7 @@ def build_matchlink_query(rel_schema: CartographyRelSchema) -> str:
     target_sub_resource_var: str | None = None
     sub_resource_match_statements: list[str] = []
 
+    # See build_matchlink_cartesian_product_query() for why only `_module_name` is set on create.
     if source_sub_resource or target_sub_resource:
         matchlink_query_template = Template(
             """
@@ -1825,9 +1835,10 @@ def build_matchlink_query(rel_schema: CartographyRelSchema) -> str:
             $source_match
             $target_match
             MERGE $rel
-            ON CREATE SET r.firstseen = timestamp()
+            ON CREATE SET
+                r.firstseen = timestamp(),
+                r._module_name = "$module_name"
             SET
-                r._module_name = "$module_name",
                 r._module_version = "$module_version",
                 $set_rel_properties_statement;
         """
@@ -1868,9 +1879,10 @@ def build_matchlink_query(rel_schema: CartographyRelSchema) -> str:
             $source_match
             $target_match
             MERGE $rel
-            ON CREATE SET r.firstseen = timestamp()
+            ON CREATE SET
+                r.firstseen = timestamp(),
+                r._module_name = "$module_name"
             SET
-                r._module_name = "$module_name",
                 r._module_version = "$module_version",
                 $set_rel_properties_statement;
         """

--- a/cartography/intel/create_indexes.py
+++ b/cartography/intel/create_indexes.py
@@ -5,6 +5,7 @@ import neo4j
 
 from cartography.client.core.tx import run_write_query
 from cartography.config import Config
+from cartography.intel.deprecated_indexes import drop_deprecated_matchlink_rel_indexes
 from cartography.util import load_resource_binary
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,12 @@ def get_index_statements() -> List[str]:
 
 
 def run(neo4j_session: neo4j.Session, config: Config) -> None:
+    # DEPRECATED: drop this call (and cartography.intel.deprecated_indexes) in v1.0.0. MatchLink
+    # relationship indexes are created lazily by ensure_indexes_for_matchlinks() rather than from
+    # indexes.cypher, but this stage runs first and exactly once, so it is the only place where we
+    # can drop the old churning index shape without racing a module that recreates the new one.
+    drop_deprecated_matchlink_rel_indexes(neo4j_session)
+
     logger.info("Creating indexes for cartography node types.")
     for statement in get_index_statements():
         logger.debug("Executing statement: %s", statement)

--- a/cartography/intel/deprecated_indexes.py
+++ b/cartography/intel/deprecated_indexes.py
@@ -1,0 +1,67 @@
+"""DEPRECATED: temporary backward-compatibility cleanup. Remove this whole module in v1.0.0.
+
+MatchLink relationship indexes used to be keyed on
+`(_sub_resource_label, _sub_resource_id, lastupdated)`. Because `lastupdated` is rewritten on
+every sync, every relationship's index entry was deleted and reinserted on every run, which
+roughly halved warm write throughput on large MatchLink loads. The trailing key never helped
+anyway: the only consumer is the MatchLink cleanup, whose `lastupdated <> $UPDATE_TAG` is not a
+seekable predicate.
+
+`build_create_index_queries_for_matchlink()` now creates the two-key index only, but
+`CREATE INDEX IF NOT EXISTS` does not replace an index with a different property list, so graphs
+synced before that change keep the churning three-key index alongside the new one. This module
+drops those deprecated indexes if they exist.
+"""
+
+import logging
+
+import neo4j
+
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+_DEPRECATED_MATCHLINK_REL_INDEX_PROPERTIES = [
+    "_sub_resource_label",
+    "_sub_resource_id",
+    "lastupdated",
+]
+
+
+@timeit
+def drop_deprecated_matchlink_rel_indexes(neo4j_session: neo4j.Session) -> None:
+    """DEPRECATED: drop the three-key MatchLink relationship indexes that
+    `build_create_index_queries_for_matchlink()` no longer creates. Only needed for graphs synced
+    before that change; remove in v1.0.0.
+    """
+    # SHOW INDEXES is NOT an existence check we could skip with try/except: cartography creates
+    # these indexes unnamed, so this is the only way to recover Neo4j's auto-generated names.
+    # `DROP INDEX` accepts only a literal name (no `DROP INDEX FOR ()-[r:X]->() ON (...)` form
+    # exists), so the two queries are incompressible.
+    # `properties = $props` is exact ordered-list equality, and SHOW INDEXES returns properties in
+    # index-key order, so this can only ever match the old three-key shape and never the two-key
+    # index we create today.
+    # type = 'RANGE' is required: cartography only ever created RANGE indexes here, and
+    # SHOW INDEXES also returns TEXT/POINT/etc. indexes. Without this filter we would drop an
+    # operator-managed non-RANGE index on the same properties.
+    rows = neo4j_session.run(
+        """
+        SHOW INDEXES YIELD name, properties, entityType, type
+        WHERE entityType = 'RELATIONSHIP' AND type = 'RANGE'
+          AND properties = $props
+        RETURN name
+        """,
+        props=_DEPRECATED_MATCHLINK_REL_INDEX_PROPERTIES,
+    )
+    names = [row["name"] for row in rows]
+    for name in names:
+        escaped = name.replace("`", "``")
+        # IF EXISTS only tolerates an index vanishing between SHOW and DROP (race); it does not
+        # replace the SHOW above.
+        neo4j_session.run(f"DROP INDEX `{escaped}` IF EXISTS")
+    if names:
+        logger.info(
+            "Dropped %d deprecated MatchLink relationship index(es) keyed on lastupdated: %s",
+            len(names),
+            names,
+        )

--- a/docs/root/dev/matchlinks.md
+++ b/docs/root/dev/matchlinks.md
@@ -102,6 +102,10 @@ Let's say we have the following data that maps principals with the S3Buckets the
 - `_sub_resource_label`: PropertyRef = PropertyRef("_sub_resource_label", set_in_kwargs=True)
 - `_sub_resource_id`: PropertyRef = PropertyRef("_sub_resource_id", set_in_kwargs=True)
 
+All three are rewritten on every sync. A MatchLink is keyed only on its two endpoints and its label,
+so two sub-resources reporting the same edge between the same nodes converge on one relationship, and
+the most recent writer owns it for cleanup purposes.
+
 1. Load the matchlinks to the graph
     ```python
     load_matchlinks(
@@ -114,7 +118,10 @@ Let's say we have the following data that maps principals with the S3Buckets the
     )
     ```
     This function automatically creates indexes for the nodes involved, as well for the relationship between
-    them (specifically, on the update tag, the sub-resource label, and the sub-resource id fields).
+    them (specifically, on the sub-resource label and the sub-resource id fields). `lastupdated` is
+    deliberately not part of that index key: it is rewritten on every sync, so including it made Neo4j
+    delete and reinsert every index entry on every run, and it could not help the cleanup anyway because
+    `<>` is not a seekable predicate.
 
 1. Run the cleanup to remove stale matchlinks
     ```python

--- a/tests/integration/cartography/intel/test_deprecated_indexes.py
+++ b/tests/integration/cartography/intel/test_deprecated_indexes.py
@@ -1,0 +1,80 @@
+from cartography.intel.deprecated_indexes import drop_deprecated_matchlink_rel_indexes
+
+# Relationship types this test creates indexes on. The integration Neo4j is shared across test
+# modules and only nodes (not indexes) are wiped between them, so we drop these before and after to
+# stay hermetic and to avoid EquivalentSchemaRuleAlreadyExists on CREATE.
+TEST_REL_TYPES = ("TEST_DEPRECATED_INDEX_A", "TEST_DEPRECATED_INDEX_B")
+
+
+def _rel_indexes(neo4j_session, rel_type: str) -> set[tuple[str, tuple[str, ...]]]:
+    rows = neo4j_session.run(
+        """
+        SHOW INDEXES YIELD name, labelsOrTypes, properties, entityType
+        WHERE entityType = 'RELATIONSHIP' AND $rel_type IN labelsOrTypes
+        RETURN name, properties
+        """,
+        rel_type=rel_type,
+    )
+    return {(row["name"], tuple(row["properties"])) for row in rows}
+
+
+def _drop_all_rel_indexes(neo4j_session, rel_types) -> None:
+    for rel_type in rel_types:
+        for name, _ in _rel_indexes(neo4j_session, rel_type):
+            neo4j_session.run(f"DROP INDEX `{name}` IF EXISTS")
+
+
+def test_drop_deprecated_matchlink_rel_indexes(neo4j_session):
+    """The old three-key MatchLink relationship index is dropped; every other one survives."""
+    _drop_all_rel_indexes(neo4j_session, TEST_REL_TYPES)
+    try:
+        # Deprecated: the three-key shape cartography used to create, whose trailing `lastupdated`
+        # made Neo4j rewrite every index entry on every sync.
+        neo4j_session.run(
+            "CREATE INDEX deprecated_three_key IF NOT EXISTS "
+            "FOR ()-[r:TEST_DEPRECATED_INDEX_A]->() "
+            "ON (r._sub_resource_label, r._sub_resource_id, r.lastupdated)"
+        )
+        # Must be kept: the two-key shape cartography creates today.
+        neo4j_session.run(
+            "CREATE INDEX current_two_key IF NOT EXISTS "
+            "FOR ()-[r:TEST_DEPRECATED_INDEX_A]->() "
+            "ON (r._sub_resource_label, r._sub_resource_id)"
+        )
+        # Must be kept: same properties in a different order is a different index shape, and is not
+        # something cartography ever created.
+        neo4j_session.run(
+            "CREATE INDEX reordered_three_key IF NOT EXISTS "
+            "FOR ()-[r:TEST_DEPRECATED_INDEX_B]->() "
+            "ON (r.lastupdated, r._sub_resource_label, r._sub_resource_id)"
+        )
+
+        assert _rel_indexes(neo4j_session, "TEST_DEPRECATED_INDEX_A") == {
+            (
+                "deprecated_three_key",
+                ("_sub_resource_label", "_sub_resource_id", "lastupdated"),
+            ),
+            ("current_two_key", ("_sub_resource_label", "_sub_resource_id")),
+        }
+
+        drop_deprecated_matchlink_rel_indexes(neo4j_session)
+
+        # Only the three-key index in cartography's own key order is gone.
+        assert _rel_indexes(neo4j_session, "TEST_DEPRECATED_INDEX_A") == {
+            ("current_two_key", ("_sub_resource_label", "_sub_resource_id")),
+        }
+        assert _rel_indexes(neo4j_session, "TEST_DEPRECATED_INDEX_B") == {
+            (
+                "reordered_three_key",
+                ("lastupdated", "_sub_resource_label", "_sub_resource_id"),
+            ),
+        }
+
+        # Idempotent: a second run with nothing left to drop is a no-op.
+        drop_deprecated_matchlink_rel_indexes(neo4j_session)
+        assert _rel_indexes(neo4j_session, "TEST_DEPRECATED_INDEX_A") == {
+            ("current_two_key", ("_sub_resource_label", "_sub_resource_id")),
+        }
+    finally:
+        # Don't leak schema into other test modules sharing this Neo4j instance.
+        _drop_all_rel_indexes(neo4j_session, TEST_REL_TYPES)

--- a/tests/unit/cartography/graph/test_matchlink.py
+++ b/tests/unit/cartography/graph/test_matchlink.py
@@ -119,9 +119,10 @@ def test_build_matchlink_query(_mock_get_cartography_version):
             MATCH (from:AWSPrincipal{principal_arn: item.principal_arn})
             MATCH (to:AWSS3Bucket{name: item.BucketName})
             MERGE (from)-[r:CAN_ACCESS]->(to)
-            ON CREATE SET r.firstseen = timestamp()
+            ON CREATE SET
+                r.firstseen = timestamp(),
+                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions"
             SET
-                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions",
                 r._module_version = "3.14.16",
                 r.lastupdated = $UPDATE_TAG,
                 r.permission_action = item.permission_action,
@@ -153,9 +154,10 @@ def test_build_matchlink_cartesian_product_query(_mock_get_cartography_version):
         WITH sources, to
         UNWIND sources AS from
             MERGE (from)-[r:CAN_BULK_ACCESS]->(to)
-            ON CREATE SET r.firstseen = timestamp()
+            ON CREATE SET
+                r.firstseen = timestamp(),
+                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions"
             SET
-                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions",
                 r._module_version = "3.14.16",
                 r.lastupdated = $UPDATE_TAG,
                 r._sub_resource_label = $_sub_resource_label,
@@ -247,9 +249,10 @@ def test_build_source_scoped_matchlink_query(_mock_get_cartography_version):
             MATCH (from:AWSPrincipal{principal_arn: item.principal_arn})<-[:RESOURCE]-(source_sub_resource)
             MATCH (to:AWSS3Bucket{name: item.BucketName})
             MERGE (from)-[r:CAN_ACCESS]->(to)
-            ON CREATE SET r.firstseen = timestamp()
+            ON CREATE SET
+                r.firstseen = timestamp(),
+                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions"
             SET
-                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions",
                 r._module_version = "3.14.16",
                 r.lastupdated = $UPDATE_TAG,
                 r.permission_action = item.permission_action,
@@ -273,9 +276,10 @@ def test_build_target_scoped_matchlink_query(_mock_get_cartography_version):
             MATCH (from:AWSPrincipal{principal_arn: item.principal_arn})
             MATCH (to:AWSS3Bucket{name: item.BucketName})<-[:RESOURCE]-(target_sub_resource)
             MERGE (from)-[r:CAN_ACCESS]->(to)
-            ON CREATE SET r.firstseen = timestamp()
+            ON CREATE SET
+                r.firstseen = timestamp(),
+                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions"
             SET
-                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions",
                 r._module_version = "3.14.16",
                 r.lastupdated = $UPDATE_TAG,
                 r.permission_action = item.permission_action,
@@ -299,9 +303,10 @@ def test_build_scoped_matchlink_query(_mock_get_cartography_version):
             MATCH (from:AWSPrincipal{principal_arn: item.principal_arn})<-[:RESOURCE]-(sub_resource)
             MATCH (to:AWSS3Bucket{name: item.BucketName})<-[:RESOURCE]-(sub_resource)
             MERGE (from)-[r:CAN_ACCESS]->(to)
-            ON CREATE SET r.firstseen = timestamp()
+            ON CREATE SET
+                r.firstseen = timestamp(),
+                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions"
             SET
-                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions",
                 r._module_version = "3.14.16",
                 r.lastupdated = $UPDATE_TAG,
                 r.permission_action = item.permission_action,
@@ -326,9 +331,10 @@ def test_build_unequal_scoped_matchlink_query(_mock_get_cartography_version):
             MATCH (from:AWSPrincipal{principal_arn: item.principal_arn})<-[:RESOURCE]-(source_sub_resource)
             MATCH (to:AWSS3Bucket{name: item.BucketName})<-[:RESOURCE]-(target_sub_resource)
             MERGE (from)-[r:CAN_ACCESS]->(to)
-            ON CREATE SET r.firstseen = timestamp()
+            ON CREATE SET
+                r.firstseen = timestamp(),
+                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions"
             SET
-                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions",
                 r._module_version = "3.14.16",
                 r.lastupdated = $UPDATE_TAG,
                 r.permission_action = item.permission_action,
@@ -352,9 +358,10 @@ def test_build_outward_scoped_matchlink_query(_mock_get_cartography_version):
             MATCH (from:AWSPrincipal{principal_arn: item.principal_arn})
             MATCH (to:AWSS3Bucket{name: item.BucketName})-[:RESOURCE]->(target_sub_resource)
             MERGE (from)-[r:CAN_ACCESS]->(to)
-            ON CREATE SET r.firstseen = timestamp()
+            ON CREATE SET
+                r.firstseen = timestamp(),
+                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions"
             SET
-                r._module_name = "unknown:tests.data.graph.matchlink.iam_permissions",
                 r._module_version = "3.14.16",
                 r.lastupdated = $UPDATE_TAG,
                 r.permission_action = item.permission_action,
@@ -399,7 +406,7 @@ def test_build_create_index_queries_for_matchlink():
     expected_queries = {
         "CREATE INDEX IF NOT EXISTS FOR (n:AWSPrincipal) ON (n.principal_arn);",
         "CREATE INDEX IF NOT EXISTS FOR (n:AWSS3Bucket) ON (n.name);",
-        "CREATE INDEX IF NOT EXISTS FOR ()-[r:CAN_ACCESS]->() ON (r._sub_resource_label, r._sub_resource_id, r.lastupdated);",
+        "CREATE INDEX IF NOT EXISTS FOR ()-[r:CAN_ACCESS]->() ON (r._sub_resource_label, r._sub_resource_id);",
     }
 
     # Assert: compare the list of index queries
@@ -414,7 +421,7 @@ def test_build_create_index_queries_for_scoped_matchlink():
         "CREATE INDEX IF NOT EXISTS FOR (n:AWSPrincipal) ON (n.principal_arn);",
         "CREATE INDEX IF NOT EXISTS FOR (n:AWSS3Bucket) ON (n.name);",
         "CREATE INDEX IF NOT EXISTS FOR (n:AWSAccount) ON (n.id);",
-        "CREATE INDEX IF NOT EXISTS FOR ()-[r:CAN_ACCESS]->() ON (r._sub_resource_label, r._sub_resource_id, r.lastupdated);",
+        "CREATE INDEX IF NOT EXISTS FOR ()-[r:CAN_ACCESS]->() ON (r._sub_resource_label, r._sub_resource_id);",
     }
 
     assert set(index_queries) == expected_queries


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

`build_create_index_queries_for_matchlink()` created, for every MatchLink, a composite relationship index keyed on `(_sub_resource_label, _sub_resource_id, lastupdated)`. `lastupdated` is rewritten on every sync, so the composite key changed on every run and Neo4j deleted and reinserted every index entry each time.

On the workload described in the issue (2.79M relationships), a warm pass cost **37.2s against 22.8s for the cold pass that created the relationships from scratch**. Updating existing relationships was 63% more expensive than creating them. Dropping the trailing key brings the warm pass to 17.8s, roughly doubling throughput.

The trailing key bought nothing. The only consumer is the MatchLink cleanup, whose `r.lastupdated <> $UPDATE_TAG` is not a seekable predicate, and measured cleanup latency is identical with the three-key index, the two-key index, and no relationship index at all.

This PR:

1. **Drops `lastupdated` from the composite key**, keeping the two stable ones. Not removing the index entirely: the two stable keys cost essentially nothing to maintain, and the planner does use them (see below).
2. **Adds a one-time drop of the stale three-key index.** `CREATE INDEX IF NOT EXISTS` does not replace an index with a different property list, so without this every existing graph would keep the churning index *alongside* the new one and see no improvement. New `cartography/intel/deprecated_indexes.py`, mirroring the existing `cartography/intel/ontology/deprecated_indexes.py` precedent and marked for removal in v1.0.0. It runs from the `create-indexes` stage, which is first and runs exactly once, so nothing can race it while recreating the new shape.
3. **Moves `_module_name` into `ON CREATE SET`** in the three generated MatchLink write queries. It identifies the module that owns the relationship's schema and never changes.

### Related issues or links

- Fixes #3103

### Breaking changes

None. Ownership and cleanup semantics are unchanged.

The issue proposed moving four properties into `ON CREATE SET`; only `_module_name` moved. The other three were deliberately left unconditional:

- **`lastupdated`** cannot move: the cleanup uses it as the liveness marker, so an unstamped relationship would be deleted. (The issue says this too.)
- **`_module_version`** would freeze at the version that first created the relationship, so it would mean something different on relationships than on nodes, where `build_ingestion_query()` sets it unconditionally. It would go permanently stale on upgraded graphs.
- **`_sub_resource_label` / `_sub_resource_id`** turned out to be load-bearing. A MatchLink is keyed only on `(from, to, rel_label)`, so an edge between two nodes that several sub-resources can see converges on one relationship, and ownership currently follows the last writer. Freezing it at creation broke `test_load_manifests_large_parent_relationships_are_idempotent`, and not as a test-isolation artifact: `GCPArtifactRegistryImage` nodes are keyed on the bare digest with no project scoping, so a `CONTAINS_IMAGE` edge is genuinely shared across GCP projects. Under first-creator-owns, if the owning project later leaves the sync while another still reports the edge, nothing can ever clean it up.

The measured value of the full `ON CREATE SET` split is +0.9% standalone, against +52.3% for the index fix, and Neo4j skips a property write entirely when the value is unchanged, so keeping these unconditional costs a compare rather than an index touch. The index is the whole story here.

### How was this tested?

- `make test_lint` passes.
- Unit suite: 4470 passed. Expected Cypher updated in `tests/unit/cartography/graph/test_matchlink.py` for both index shapes and all seven generated-query assertions.
- Integration suite: 1287 passed, including the existing MatchLink load/cleanup coverage in `tests/integration/cartography/graph/test_matchlink.py`.
- New `tests/integration/cartography/intel/test_deprecated_indexes.py`: creates the old three-key index, the new two-key index, and a same-properties-different-order index; asserts only the three-key one in cartography's own key order is dropped, and that a second run is a no-op.
- Manually verified against a local Neo4j 2025.10 that had been synced by the old code: the migration found and dropped 8 real three-key relationship indexes (`RESOURCE`, `HAS_ROLE`, `MEMBER_OF`, `PACKAGED_FROM`, `CAN_READ`, `CAN_ACCESS`, `EXPOSE`, `HAS_PRIVILEGE`), and the next `load_matchlinks()` created the two-key shape.
- `EXPLAIN` on the cleanup query with the new index:

  ```
  ProduceResults -> EmptyResult -> Delete -> Eager -> Limit -> Filter
    -> DirectedRelationshipIndexSeek
  ```

  Better than expected: the planner seeks the two-key index on the two equality predicates. Worth noting that this was measured on a small graph, where cardinality estimates favor a seek; the issue reports the `NodeByLabelScan -> Expand(All)` plan on a 71k-node graph. Either shape is a non-regression, and this is a further argument for keeping the two stable keys rather than removing the index.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

### Notes for reviewers

Two spots worth a close look:

- **The `SHOW INDEXES` predicate in `drop_deprecated_matchlink_rel_indexes()`.** It uses exact ordered-list equality on `properties` plus `type = 'RANGE'`, so it can only ever match the shape cartography itself used to create, never the new two-key index and never an operator-managed non-RANGE index on the same properties. `SHOW INDEXES` is unavoidable here: cartography creates these indexes unnamed and `DROP INDEX` accepts only a literal name.
- **The migration's placement** in `create_indexes.run()`. MatchLink relationship indexes are created lazily by `ensure_indexes_for_matchlinks()` rather than from `indexes.cypher`, so `create_indexes` otherwise knows nothing about them; it is used here purely because it is the one stage guaranteed to run first and once.

On rebuild cost: dropping these indexes is cheap, but the two-key index is recreated lazily on the first `load_matchlinks()` of the next sync, so operators of large graphs should expect one build per MatchLink label on the first run after upgrading.
