### PR TITLE
fix(rules): simplify SOC 2 framework name

### DIFF
--- a/cartography/rules/data/frameworks/soc2.py
+++ b/cartography/rules/data/frameworks/soc2.py
@@ -8,7 +8,7 @@ edition while the criteria identifiers stay those of 2017.
 
 from cartography.rules.spec.model import Framework
 
-SOC2_FRAMEWORK_NAME = "SOC 2: Trust Services Critera"
+SOC2_FRAMEWORK_NAME = "SOC 2: Trust Services Criteria"
 SOC2_SHORT_NAME = "SOC2"
 SOC2_SCOPE = "TSC"
 SOC2_REVISION = "2022"

--- a/cartography/rules/data/frameworks/soc2.py
+++ b/cartography/rules/data/frameworks/soc2.py
@@ -8,9 +8,7 @@ edition while the criteria identifiers stay those of 2017.
 
 from cartography.rules.spec.model import Framework
 
-SOC2_FRAMEWORK_NAME = (
-    "AICPA 2017 Trust Services Criteria (With Revised Points of Focus - 2022)"
-)
+SOC2_FRAMEWORK_NAME = "SOC 2: Trust Services Critera"
 SOC2_SHORT_NAME = "SOC2"
 SOC2_SCOPE = "TSC"
 SOC2_REVISION = "2022"

--- a/tests/unit/rules/test_framework_helpers.py
+++ b/tests/unit/rules/test_framework_helpers.py
@@ -65,8 +65,7 @@ def test_framework_helpers_preserve_framework_metadata():
         ),
         (
             soc2_tsc("CC6.6"),
-            "aicpa 2017 trust services criteria "
-            "(with revised points of focus - 2022)",
+            "soc 2: trust services critera",
             "soc2",
             "tsc",
             "2022",

--- a/tests/unit/rules/test_framework_helpers.py
+++ b/tests/unit/rules/test_framework_helpers.py
@@ -65,7 +65,7 @@ def test_framework_helpers_preserve_framework_metadata():
         ),
         (
             soc2_tsc("CC6.6"),
-            "soc 2: trust services critera",
+            "soc 2: trust services criteria",
             "soc2",
             "tsc",
             "2022",


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

### Summary
Rename the verbose AICPA SOC 2 framework display name to `SOC 2: Trust Services Critera` for clearer presentation. Update the framework helper test to cover the new name.

### Related issues or links

None.

### How was this tested?

`uv run --group dev python -m pytest tests/unit/rules/test_framework_helpers.py`

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [ ] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).

### Notes for reviewers

This only changes the framework display name. Its short name, scope, revision, requirements, and mappings are unchanged.