### PR TITLE
fix(docs): capitalize OCI schema title

### DIFF
--- a/cartography/models/schema_docs.py
+++ b/cartography/models/schema_docs.py
@@ -806,6 +806,7 @@ def _module_title(module: str) -> str:
         "aibom": "AIBOM",
         "aws": "AWS",
         "gcp": "GCP",
+        "oci": "OCI",
         "sentinelone": "SentinelOne",
         "socketdev": "Socket.dev",
     }

--- a/tests/unit/cartography/models/test_schema_docs.py
+++ b/tests/unit/cartography/models/test_schema_docs.py
@@ -306,6 +306,7 @@ def test_module_titles_use_display_overrides():
         "aibom": "AIBOM",
         "aws": "AWS",
         "gcp": "GCP",
+        "oci": "OCI",
         "sentinelone": "SentinelOne",
         "socketdev": "Socket.dev",
         "docker_scout": "Docker Scout",


### PR DESCRIPTION
### Type of change
- [x] Documentation update

### Summary
Fix the generated OCI schema title so navigation displays `OCI Schema` instead of `Oci Schema`.

### How was this tested?
- `make test_lint`
- `uv run pytest -q tests/unit/cartography/models/test_schema_docs.py`
- `uv run ./docs/build.sh`

### Checklist
- [x] The linter passes locally.
- [x] Added a unit test that proves the fix.
<img width="683" height="387" alt="Screenshot 2026-08-03 at 12 43 48 PM" src="https://github.com/user-attachments/assets/d5955b48-f74f-40af-80da-208247244896" />
