### PR TITLE
feat(anthropic): add Workload Identity Federation auth and expand Admin API coverage

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -1508,6 +1508,20 @@ class CLI:
                     hidden=PANEL_ANTHROPIC not in visible_panels,
                 ),
             ] = None,
+            anthropic_workspace_federation_rule_id: Annotated[
+                str | None,
+                typer.Option(
+                    "--anthropic-workspace-federation-rule-id",
+                    help=(
+                        "Anthropic federation rule id (fdrl_...) granting the "
+                        "workspace:developer scope. Required to ingest skills, agents "
+                        "and other per-workspace resources, which an org:admin token "
+                        "cannot reach."
+                    ),
+                    rich_help_panel=PANEL_ANTHROPIC,
+                    hidden=PANEL_ANTHROPIC not in visible_panels,
+                ),
+            ] = None,
             anthropic_organization_id: Annotated[
                 str | None,
                 typer.Option(
@@ -3321,6 +3335,7 @@ class CLI:
                 anthropic_identity_token_file=anthropic_identity_token_file,
                 anthropic_identity_token_env_var=anthropic_identity_token_env_var,
                 anthropic_federation_rule_id=anthropic_federation_rule_id,
+                anthropic_workspace_federation_rule_id=anthropic_workspace_federation_rule_id,
                 anthropic_organization_id=anthropic_organization_id,
                 anthropic_service_account_id=anthropic_service_account_id,
                 sentry_token=sentry_token,

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -1471,7 +1471,59 @@ class CLI:
                 str | None,
                 typer.Option(
                     "--anthropic-apikey-env-var",
-                    help="Environment variable name containing Anthropic API key.",
+                    help="Environment variable name containing Anthropic Admin API key.",
+                    rich_help_panel=PANEL_ANTHROPIC,
+                    hidden=PANEL_ANTHROPIC not in visible_panels,
+                ),
+            ] = None,
+            anthropic_identity_token_file: Annotated[
+                str | None,
+                typer.Option(
+                    "--anthropic-identity-token-file",
+                    help=(
+                        "Path to the file containing the OIDC identity token for Anthropic "
+                        "Workload Identity Federation, e.g. a Kubernetes projected service "
+                        "account token."
+                    ),
+                    rich_help_panel=PANEL_ANTHROPIC,
+                    hidden=PANEL_ANTHROPIC not in visible_panels,
+                ),
+            ] = None,
+            anthropic_identity_token_env_var: Annotated[
+                str | None,
+                typer.Option(
+                    "--anthropic-identity-token-env-var",
+                    help=(
+                        "Environment variable name containing the OIDC identity token for "
+                        "Anthropic Workload Identity Federation."
+                    ),
+                    rich_help_panel=PANEL_ANTHROPIC,
+                    hidden=PANEL_ANTHROPIC not in visible_panels,
+                ),
+            ] = None,
+            anthropic_federation_rule_id: Annotated[
+                str | None,
+                typer.Option(
+                    "--anthropic-federation-rule-id",
+                    help="Anthropic federation rule id (fdrl_...) granting the org:admin scope.",
+                    rich_help_panel=PANEL_ANTHROPIC,
+                    hidden=PANEL_ANTHROPIC not in visible_panels,
+                ),
+            ] = None,
+            anthropic_organization_id: Annotated[
+                str | None,
+                typer.Option(
+                    "--anthropic-organization-id",
+                    help="Anthropic organization UUID used for the federated token exchange.",
+                    rich_help_panel=PANEL_ANTHROPIC,
+                    hidden=PANEL_ANTHROPIC not in visible_panels,
+                ),
+            ] = None,
+            anthropic_service_account_id: Annotated[
+                str | None,
+                typer.Option(
+                    "--anthropic-service-account-id",
+                    help="Anthropic service account id (svac_...) that federated tokens act as.",
                     rich_help_panel=PANEL_ANTHROPIC,
                     hidden=PANEL_ANTHROPIC not in visible_panels,
                 ),
@@ -3265,6 +3317,14 @@ class CLI:
                 openai_apikey=openai_apikey,
                 openai_org_id=openai_org_id,
                 anthropic_apikey=anthropic_apikey,
+                # The identity token is deliberately not resolved here: unlike a static
+                # secret it rotates on disk mid-sync, so the env var name (not its value)
+                # is passed through and read at each token exchange.
+                anthropic_identity_token_file=anthropic_identity_token_file,
+                anthropic_identity_token_env_var=anthropic_identity_token_env_var,
+                anthropic_federation_rule_id=anthropic_federation_rule_id,
+                anthropic_organization_id=anthropic_organization_id,
+                anthropic_service_account_id=anthropic_service_account_id,
                 sentry_token=sentry_token,
                 sentry_org=sentry_org,
                 sentry_host=sentry_host,

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -1510,6 +1510,20 @@ class CLI:
                     hidden=PANEL_ANTHROPIC not in visible_panels,
                 ),
             ] = None,
+            anthropic_workspace_federation_rule_id: Annotated[
+                str | None,
+                typer.Option(
+                    "--anthropic-workspace-federation-rule-id",
+                    help=(
+                        "Anthropic federation rule id (fdrl_...) granting the "
+                        "workspace:developer scope. Required to ingest skills, agents "
+                        "and other per-workspace resources, which an org:admin token "
+                        "cannot reach."
+                    ),
+                    rich_help_panel=PANEL_ANTHROPIC,
+                    hidden=PANEL_ANTHROPIC not in visible_panels,
+                ),
+            ] = None,
             anthropic_organization_id: Annotated[
                 str | None,
                 typer.Option(
@@ -3323,6 +3337,7 @@ class CLI:
                 anthropic_identity_token_file=anthropic_identity_token_file,
                 anthropic_identity_token_env_var=anthropic_identity_token_env_var,
                 anthropic_federation_rule_id=anthropic_federation_rule_id,
+                anthropic_workspace_federation_rule_id=anthropic_workspace_federation_rule_id,
                 anthropic_organization_id=anthropic_organization_id,
                 anthropic_service_account_id=anthropic_service_account_id,
                 sentry_token=sentry_token,

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -1469,7 +1469,59 @@ class CLI:
                 str | None,
                 typer.Option(
                     "--anthropic-apikey-env-var",
-                    help="Environment variable name containing Anthropic API key.",
+                    help="Environment variable name containing Anthropic Admin API key.",
+                    rich_help_panel=PANEL_ANTHROPIC,
+                    hidden=PANEL_ANTHROPIC not in visible_panels,
+                ),
+            ] = None,
+            anthropic_identity_token_file: Annotated[
+                str | None,
+                typer.Option(
+                    "--anthropic-identity-token-file",
+                    help=(
+                        "Path to the file containing the OIDC identity token for Anthropic "
+                        "Workload Identity Federation, e.g. a Kubernetes projected service "
+                        "account token."
+                    ),
+                    rich_help_panel=PANEL_ANTHROPIC,
+                    hidden=PANEL_ANTHROPIC not in visible_panels,
+                ),
+            ] = None,
+            anthropic_identity_token_env_var: Annotated[
+                str | None,
+                typer.Option(
+                    "--anthropic-identity-token-env-var",
+                    help=(
+                        "Environment variable name containing the OIDC identity token for "
+                        "Anthropic Workload Identity Federation."
+                    ),
+                    rich_help_panel=PANEL_ANTHROPIC,
+                    hidden=PANEL_ANTHROPIC not in visible_panels,
+                ),
+            ] = None,
+            anthropic_federation_rule_id: Annotated[
+                str | None,
+                typer.Option(
+                    "--anthropic-federation-rule-id",
+                    help="Anthropic federation rule id (fdrl_...) granting the org:admin scope.",
+                    rich_help_panel=PANEL_ANTHROPIC,
+                    hidden=PANEL_ANTHROPIC not in visible_panels,
+                ),
+            ] = None,
+            anthropic_organization_id: Annotated[
+                str | None,
+                typer.Option(
+                    "--anthropic-organization-id",
+                    help="Anthropic organization UUID used for the federated token exchange.",
+                    rich_help_panel=PANEL_ANTHROPIC,
+                    hidden=PANEL_ANTHROPIC not in visible_panels,
+                ),
+            ] = None,
+            anthropic_service_account_id: Annotated[
+                str | None,
+                typer.Option(
+                    "--anthropic-service-account-id",
+                    help="Anthropic service account id (svac_...) that federated tokens act as.",
                     rich_help_panel=PANEL_ANTHROPIC,
                     hidden=PANEL_ANTHROPIC not in visible_panels,
                 ),
@@ -3263,6 +3315,14 @@ class CLI:
                 openai_apikey=openai_apikey,
                 openai_org_id=openai_org_id,
                 anthropic_apikey=anthropic_apikey,
+                # The identity token is deliberately not resolved here: unlike a static
+                # secret it rotates on disk mid-sync, so the env var name (not its value)
+                # is passed through and read at each token exchange.
+                anthropic_identity_token_file=anthropic_identity_token_file,
+                anthropic_identity_token_env_var=anthropic_identity_token_env_var,
+                anthropic_federation_rule_id=anthropic_federation_rule_id,
+                anthropic_organization_id=anthropic_organization_id,
+                anthropic_service_account_id=anthropic_service_account_id,
                 sentry_token=sentry_token,
                 sentry_org=sentry_org,
                 sentry_host=sentry_host,

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -341,6 +341,9 @@ class Config:
     :type anthropic_organization_id: string
     :param anthropic_organization_id: Anthropic organization UUID used during the Workload Identity
         Federation token exchange. Optional.
+    :type anthropic_workspace_federation_rule_id: string
+    :param anthropic_workspace_federation_rule_id: Anthropic federation rule id (fdrl_...) granting
+        the workspace:developer scope, used to reach per-workspace resources. Optional.
     :type anthropic_service_account_id: string
     :param anthropic_service_account_id: Anthropic service account id (svac_...) that federated
         tokens act as. Optional.
@@ -592,6 +595,7 @@ class Config:
         anthropic_identity_token_file=None,
         anthropic_identity_token_env_var=None,
         anthropic_federation_rule_id=None,
+        anthropic_workspace_federation_rule_id=None,
         anthropic_organization_id=None,
         anthropic_service_account_id=None,
         subimage_client_id=None,
@@ -823,6 +827,9 @@ class Config:
         self.anthropic_identity_token_file = anthropic_identity_token_file
         self.anthropic_identity_token_env_var = anthropic_identity_token_env_var
         self.anthropic_federation_rule_id = anthropic_federation_rule_id
+        self.anthropic_workspace_federation_rule_id = (
+            anthropic_workspace_federation_rule_id
+        )
         self.anthropic_organization_id = anthropic_organization_id
         self.anthropic_service_account_id = anthropic_service_account_id
         self.subimage_client_id = subimage_client_id

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -333,8 +333,9 @@ class Config:
     :param anthropic_identity_token_file: Path to a file holding the OIDC identity token used for
         Anthropic Workload Identity Federation. Optional.
     :type anthropic_identity_token_env_var: string
-    :param anthropic_identity_token_env_var: OIDC identity token used for Anthropic Workload
-        Identity Federation. Optional.
+    :param anthropic_identity_token_env_var: Name of the environment variable holding the OIDC
+        identity token used for Anthropic Workload Identity Federation. This is the variable name,
+        not the token value. Optional.
     :type anthropic_federation_rule_id: string
     :param anthropic_federation_rule_id: Anthropic federation rule id (fdrl_...) to exchange the
         identity token against. Optional.
@@ -592,12 +593,6 @@ class Config:
         openai_apikey=None,
         openai_org_id=None,
         anthropic_apikey=None,
-        anthropic_identity_token_file=None,
-        anthropic_identity_token_env_var=None,
-        anthropic_federation_rule_id=None,
-        anthropic_workspace_federation_rule_id=None,
-        anthropic_organization_id=None,
-        anthropic_service_account_id=None,
         subimage_client_id=None,
         subimage_client_secret=None,
         subimage_tenant_url=None,
@@ -685,6 +680,14 @@ class Config:
         netlify_token=None,
         netlify_account_slug=None,
         netlify_base_url=None,
+        # Appended rather than grouped next to anthropic_apikey: inserting parameters
+        # mid-signature would shift the position of every later argument.
+        anthropic_identity_token_file=None,
+        anthropic_identity_token_env_var=None,
+        anthropic_federation_rule_id=None,
+        anthropic_workspace_federation_rule_id=None,
+        anthropic_organization_id=None,
+        anthropic_service_account_id=None,
     ):
         self.neo4j_uri = neo4j_uri
         self.neo4j_user = neo4j_user

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -328,7 +328,22 @@ class Config:
     :type openai_org_id: string
     :param openai_org_id: OpenAI organization id. Optional.
     :type anthropic_apikey: string
-    :param anthropic_apikey: Anthropic API key. Optional.
+    :param anthropic_apikey: Anthropic Admin API key. Optional.
+    :type anthropic_identity_token_file: string
+    :param anthropic_identity_token_file: Path to a file holding the OIDC identity token used for
+        Anthropic Workload Identity Federation. Optional.
+    :type anthropic_identity_token_env_var: string
+    :param anthropic_identity_token_env_var: OIDC identity token used for Anthropic Workload
+        Identity Federation. Optional.
+    :type anthropic_federation_rule_id: string
+    :param anthropic_federation_rule_id: Anthropic federation rule id (fdrl_...) to exchange the
+        identity token against. Optional.
+    :type anthropic_organization_id: string
+    :param anthropic_organization_id: Anthropic organization UUID used during the Workload Identity
+        Federation token exchange. Optional.
+    :type anthropic_service_account_id: string
+    :param anthropic_service_account_id: Anthropic service account id (svac_...) that federated
+        tokens act as. Optional.
     :type socketdev_token: str
     :param socketdev_token: Socket.dev API token. Optional.
     :type airbyte_client_id: str
@@ -574,6 +589,11 @@ class Config:
         openai_apikey=None,
         openai_org_id=None,
         anthropic_apikey=None,
+        anthropic_identity_token_file=None,
+        anthropic_identity_token_env_var=None,
+        anthropic_federation_rule_id=None,
+        anthropic_organization_id=None,
+        anthropic_service_account_id=None,
         subimage_client_id=None,
         subimage_client_secret=None,
         subimage_tenant_url=None,
@@ -800,6 +820,11 @@ class Config:
         self.openai_apikey = openai_apikey
         self.openai_org_id = openai_org_id
         self.anthropic_apikey = anthropic_apikey
+        self.anthropic_identity_token_file = anthropic_identity_token_file
+        self.anthropic_identity_token_env_var = anthropic_identity_token_env_var
+        self.anthropic_federation_rule_id = anthropic_federation_rule_id
+        self.anthropic_organization_id = anthropic_organization_id
+        self.anthropic_service_account_id = anthropic_service_account_id
         self.subimage_client_id = subimage_client_id
         self.subimage_client_secret = subimage_client_secret
         self.subimage_tenant_url = subimage_tenant_url

--- a/cartography/intel/anthropic/__init__.py
+++ b/cartography/intel/anthropic/__init__.py
@@ -6,6 +6,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
+import cartography.intel.anthropic.agents
 import cartography.intel.anthropic.apikeys
 import cartography.intel.anthropic.federation
 import cartography.intel.anthropic.invites
@@ -13,16 +14,80 @@ import cartography.intel.anthropic.organization
 import cartography.intel.anthropic.ratelimits
 import cartography.intel.anthropic.rbac
 import cartography.intel.anthropic.serviceaccounts
+import cartography.intel.anthropic.skills
 import cartography.intel.anthropic.users
 import cartography.intel.anthropic.workspaces
 from cartography.config import Config
 from cartography.intel.anthropic.auth import AnthropicAuth
+from cartography.intel.anthropic.auth import AnthropicCredential
 from cartography.intel.anthropic.auth import is_federated
 from cartography.intel.anthropic.auth import make_assertion_source
 from cartography.intel.anthropic.auth import make_credential
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
+
+
+def _build_api_session(credential: AnthropicCredential) -> requests.Session:
+    api_session = requests.session()
+    retry_policy = Retry(
+        total=5,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
+    api_session.mount("https://", HTTPAdapter(max_retries=retry_policy))
+    api_session.auth = AnthropicAuth(credential)
+    api_session.headers.update({"anthropic-version": "2023-06-01"})
+    return api_session
+
+
+def _sync_workspace_plane(
+    neo4j_session: neo4j.Session,
+    config: Config,
+    common_job_parameters: dict[str, Any],
+    workspaces: list[dict[str, Any]],
+) -> None:
+    """Sync the per-workspace resources, one federated token per workspace.
+
+    Skills, agents and the rest have no organization-wide listing and are out of
+    reach of an org:admin token, so each workspace needs its own exchange against a
+    workspace:developer federation rule. There is no way to downscope the org:admin
+    token already in hand: the only grant type the token endpoint accepts is
+    jwt-bearer, so every workspace re-presents the original identity token.
+    """
+    for workspace in workspaces:
+        workspace_id = workspace["id"]
+        try:
+            credential = make_credential(
+                identity_token_file=config.anthropic_identity_token_file,
+                identity_token_env_var=config.anthropic_identity_token_env_var,
+                federation_rule_id=config.anthropic_workspace_federation_rule_id,
+                organization_id=config.anthropic_organization_id,
+                service_account_id=config.anthropic_service_account_id,
+                workspace_id=workspace_id,
+            )
+            api_session = _build_api_session(credential)
+            workspace_job_parameters = {
+                **common_job_parameters,
+                "WORKSPACE_ID": workspace_id,
+            }
+            cartography.intel.anthropic.skills.sync(
+                neo4j_session, api_session, workspace_job_parameters
+            )
+            cartography.intel.anthropic.agents.sync(
+                neo4j_session, api_session, workspace_job_parameters
+            )
+        except requests.exceptions.HTTPError as exc:
+            # A failed exchange is expected and undiagnosable: the service account
+            # may not be a member of this workspace, or replay protection may have
+            # rejected a reused assertion. Both surface as an opaque 400
+            # invalid_grant. Skip the workspace rather than abandon the others.
+            logger.warning(
+                "Skipping the workspace plane for Anthropic workspace %s: %s",
+                workspace_id,
+                exc,
+            )
 
 
 def _sync_enterprise_rbac(
@@ -80,17 +145,7 @@ def start_anthropic_ingestion(neo4j_session: neo4j.Session, config: Config) -> N
         service_account_id=config.anthropic_service_account_id,
     )
 
-    # Create requests sessions
-    api_session = requests.session()
-    retry_policy = Retry(
-        total=5,
-        backoff_factor=1,
-        status_forcelist=[429, 500, 502, 503, 504],
-        allowed_methods=["GET"],
-    )
-    api_session.mount("https://", HTTPAdapter(max_retries=retry_policy))
-    api_session.auth = AnthropicAuth(credential)
-    api_session.headers.update({"anthropic-version": "2023-06-01"})
+    api_session = _build_api_session(credential)
 
     common_job_parameters = {
         "UPDATE_TAG": config.update_tag,
@@ -161,3 +216,12 @@ def start_anthropic_ingestion(neo4j_session: neo4j.Session, config: Config) -> N
         api_session,
         common_job_parameters,
     )
+
+    if config.anthropic_workspace_federation_rule_id:
+        _sync_workspace_plane(neo4j_session, config, common_job_parameters, workspaces)
+    else:
+        logger.info(
+            "Skipping Anthropic skills, agents and other per-workspace resources: "
+            "they need a workspace:developer credential. Set "
+            "--anthropic-workspace-federation-rule-id to ingest them.",
+        )

--- a/cartography/intel/anthropic/__init__.py
+++ b/cartography/intel/anthropic/__init__.py
@@ -6,6 +6,7 @@ from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
 import cartography.intel.anthropic.apikeys
+import cartography.intel.anthropic.organization
 import cartography.intel.anthropic.users
 import cartography.intel.anthropic.workspaces
 from cartography.config import Config
@@ -66,7 +67,14 @@ def start_anthropic_ingestion(neo4j_session: neo4j.Session, config: Config) -> N
         "BASE_URL": "https://api.anthropic.com/v1",
     }
 
-    # Organization node is created during the users sync
+    # Must run first: it creates the organization node that scopes every other node,
+    # and resolves the ORG_ID the remaining syncs read from common_job_parameters.
+    cartography.intel.anthropic.organization.sync(
+        neo4j_session,
+        api_session,
+        common_job_parameters,
+    )
+
     cartography.intel.anthropic.users.sync(
         neo4j_session,
         api_session,

--- a/cartography/intel/anthropic/__init__.py
+++ b/cartography/intel/anthropic/__init__.py
@@ -20,6 +20,7 @@ import cartography.intel.anthropic.workspaces
 from cartography.config import Config
 from cartography.intel.anthropic.auth import AnthropicAuth
 from cartography.intel.anthropic.auth import AnthropicCredential
+from cartography.intel.anthropic.auth import assertion_has_jti
 from cartography.intel.anthropic.auth import is_federated
 from cartography.intel.anthropic.auth import make_assertion_source
 from cartography.intel.anthropic.auth import make_credential
@@ -68,6 +69,8 @@ def _sync_workspace_plane(
     token already in hand: the only grant type the token endpoint accepts is
     jwt-bearer, so every workspace re-presents the original identity token.
     """
+    _warn_if_assertion_is_single_use(config, len(workspaces))
+
     for workspace in workspaces:
         workspace_id = workspace["id"]
         try:
@@ -90,16 +93,51 @@ def _sync_workspace_plane(
             cartography.intel.anthropic.agents.sync(
                 neo4j_session, api_session, workspace_job_parameters
             )
-        except requests.exceptions.HTTPError as exc:
+        except (requests.exceptions.RequestException, ValueError) as exc:
             # A failed exchange is expected and undiagnosable: the service account
             # may not be a member of this workspace, or replay protection may have
             # rejected a reused assertion. Both surface as an opaque 400
             # invalid_grant. Skip the workspace rather than abandon the others.
+            #
+            # RequestException rather than HTTPError alone: a timeout, a connection
+            # reset or an exhausted retry policy would otherwise escape the loop and
+            # deny every remaining workspace a sync over one workspace's bad luck.
             logger.warning(
                 "Skipping the workspace plane for Anthropic workspace %s: %s",
                 workspace_id,
                 exc,
             )
+
+
+def _warn_if_assertion_is_single_use(config: Config, workspace_count: int) -> None:
+    """Warn up front when the assertion cannot serve more than one exchange.
+
+    The workspace plane needs one exchange per workspace, all presenting the same
+    identity token, because the token endpoint accepts no grant that downscopes the
+    org:admin token already in hand. A federation issuer enforces single-use per `jti`
+    by default, so an assertion carrying that claim mints exactly one token and every
+    later workspace fails with the same opaque 400 invalid_grant as a genuine
+    misconfiguration. Say so before the fan-out; the remedy is on the issuer
+    (`check_jti: false`) or the token source, and cartography cannot apply either.
+    """
+    if workspace_count < 2:
+        return
+    assertion_source = make_assertion_source(
+        config.anthropic_identity_token_file,
+        config.anthropic_identity_token_env_var,
+    )
+    if assertion_source is None:
+        return
+    if not assertion_has_jti(assertion_source.read()):
+        return
+    logger.warning(
+        "The Anthropic identity token carries a jti claim and %d workspaces need one "
+        "token exchange each. Federation issuers enforce single-use per jti by "
+        "default, so every workspace after the first is likely to be rejected as a "
+        "replay. Set check_jti to false on the federation issuer, or supply a token "
+        "source that yields a fresh assertion per read.",
+        workspace_count,
+    )
 
 
 def _cleanup_detached_workspace_resources(

--- a/cartography/intel/anthropic/__init__.py
+++ b/cartography/intel/anthropic/__init__.py
@@ -9,6 +9,9 @@ import cartography.intel.anthropic.apikeys
 import cartography.intel.anthropic.users
 import cartography.intel.anthropic.workspaces
 from cartography.config import Config
+from cartography.intel.anthropic.auth import AnthropicAuth
+from cartography.intel.anthropic.auth import make_assertion_source
+from cartography.intel.anthropic.auth import make_credential
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -23,12 +26,28 @@ def start_anthropic_ingestion(neo4j_session: neo4j.Session, config: Config) -> N
     :return: None
     """
 
-    if not config.anthropic_apikey:
+    # Resolve the identity token source first: a Workload Identity Federation setup
+    # missing one of its parts is an operator mistake (typo in the flag, unpopulated
+    # environment variable) and must fail loudly rather than silently skip the module.
+    assertion_source = make_assertion_source(
+        config.anthropic_identity_token_file,
+        config.anthropic_identity_token_env_var,
+    )
+    if not config.anthropic_apikey and assertion_source is None:
         logger.info(
             "Anthropic import is not configured - skipping this module. "
             "See docs to configure.",
         )
         return
+
+    credential = make_credential(
+        apikey=config.anthropic_apikey,
+        identity_token_file=config.anthropic_identity_token_file,
+        identity_token_env_var=config.anthropic_identity_token_env_var,
+        federation_rule_id=config.anthropic_federation_rule_id,
+        organization_id=config.anthropic_organization_id,
+        service_account_id=config.anthropic_service_account_id,
+    )
 
     # Create requests sessions
     api_session = requests.session()
@@ -39,12 +58,8 @@ def start_anthropic_ingestion(neo4j_session: neo4j.Session, config: Config) -> N
         allowed_methods=["GET"],
     )
     api_session.mount("https://", HTTPAdapter(max_retries=retry_policy))
-    api_session.headers.update(
-        {
-            "X-Api-Key": config.anthropic_apikey,
-            "anthropic-version": "2023-06-01",
-        }
-    )
+    api_session.auth = AnthropicAuth(credential)
+    api_session.headers.update({"anthropic-version": "2023-06-01"})
 
     common_job_parameters = {
         "UPDATE_TAG": config.update_tag,

--- a/cartography/intel/anthropic/__init__.py
+++ b/cartography/intel/anthropic/__init__.py
@@ -27,6 +27,18 @@ from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
+# Nodes scoped to an AnthropicWorkspace rather than to the organization. Their cleanup
+# runs per workspace, so they need a sweep for the workspaces that vanished entirely.
+_WORKSPACE_PLANE_LABELS = (
+    "AnthropicDeployment",
+    "AnthropicAgent",
+    "AnthropicSkillVersion",
+    "AnthropicSkill",
+    "AnthropicMemoryStore",
+    "AnthropicVault",
+    "AnthropicEnvironment",
+)
+
 
 def _build_api_session(credential: AnthropicCredential) -> requests.Session:
     api_session = requests.session()
@@ -90,12 +102,56 @@ def _sync_workspace_plane(
             )
 
 
+def _cleanup_detached_workspace_resources(
+    neo4j_session: neo4j.Session,
+    update_tag: int,
+) -> None:
+    """Delete workspace-plane nodes whose workspace is gone from the graph.
+
+    Every workspace-plane node is scoped to its own workspace, so its cleanup job only
+    ever considers the workspaces present in the current listing. A workspace that was
+    deleted, or that the credential can no longer see, has its own node removed by the
+    workspace cleanup and leaves its skills, agents and deployments behind, attached to
+    nothing.
+
+    Keyed on the missing parent rather than on a list of removed ids, so a workspace
+    whose token exchange merely failed this run keeps its resources: its node is still
+    there.
+    """
+    for label in _WORKSPACE_PLANE_LABELS:
+        result = neo4j_session.run(
+            f"""
+            MATCH (n:{label})
+            WHERE NOT (n)<-[:RESOURCE]-(:AnthropicWorkspace)
+              AND n.lastupdated <> $UPDATE_TAG
+            WITH n LIMIT $LIMIT_SIZE
+            DETACH DELETE n
+            RETURN COUNT(*) AS deleted
+            """,
+            UPDATE_TAG=update_tag,
+            LIMIT_SIZE=100000,
+        ).single()
+        deleted = result["deleted"] if result else 0
+        if deleted:
+            logger.info(
+                "Deleted %d %s node(s) left detached by a removed Anthropic workspace.",
+                deleted,
+                label,
+            )
+
+
 def _sync_enterprise_rbac(
     neo4j_session: neo4j.Session,
     api_session: requests.Session,
     common_job_parameters: dict[str, Any],
 ) -> None:
-    """Sync the Claude Enterprise RBAC beta, tolerating organizations without it."""
+    """Sync the Claude Enterprise RBAC beta, tolerating organizations without it.
+
+    RBAC is optional enrichment on top of the core inventory, so an organization that
+    is refused the endpoint, or a beta that is briefly unavailable, must not take the
+    module down. The sync returns before its cleanup in that case, leaving the roles
+    and groups from the last healthy run in place rather than converging them to empty.
+    """
     try:
         cartography.intel.anthropic.rbac.sync(
             neo4j_session,
@@ -104,12 +160,31 @@ def _sync_enterprise_rbac(
         )
     except requests.exceptions.HTTPError as exc:
         status_code = exc.response.status_code if exc.response is not None else None
-        if status_code not in (403, 404):
+        if status_code in (403, 404):
+            logger.info(
+                "Skipping Anthropic RBAC groups and roles (HTTP %s): the RBAC API is a "
+                "Claude Enterprise beta and is not available to this organization.",
+                status_code,
+            )
+            return
+        if status_code is not None and status_code < 500:
+            # A 4xx other than the two above is a real defect on our side (a malformed
+            # request, a missing beta header) and must not be hidden.
             raise
-        logger.info(
-            "Skipping Anthropic RBAC groups and roles (HTTP %s): the RBAC API is a "
-            "Claude Enterprise beta and is not available to this organization.",
+        logger.warning(
+            "Skipping Anthropic RBAC groups and roles: the RBAC API failed with "
+            "HTTP %s. Existing RBAC data is left untouched. Error: %s",
             status_code,
+            exc,
+        )
+    except (
+        requests.exceptions.ConnectionError,
+        requests.exceptions.Timeout,
+    ) as exc:
+        logger.warning(
+            "Skipping Anthropic RBAC groups and roles: the RBAC API was unreachable. "
+            "Existing RBAC data is left untouched. Error: %s",
+            exc,
         )
 
 
@@ -129,12 +204,31 @@ def start_anthropic_ingestion(neo4j_session: neo4j.Session, config: Config) -> N
         config.anthropic_identity_token_file,
         config.anthropic_identity_token_env_var,
     )
-    if not config.anthropic_apikey and assertion_source is None:
+    # A half-configured federation must reach make_credential() so it raises. Skipping
+    # on the token source alone would turn an unset token variable into a silent
+    # no-op when an API key is also present, or into a silent skip when it is not.
+    federation_configured = any(
+        (
+            assertion_source is not None,
+            config.anthropic_federation_rule_id,
+            config.anthropic_workspace_federation_rule_id,
+            config.anthropic_organization_id,
+            config.anthropic_service_account_id,
+        )
+    )
+    if not config.anthropic_apikey and not federation_configured:
         logger.info(
             "Anthropic import is not configured - skipping this module. "
             "See docs to configure.",
         )
         return
+
+    if config.anthropic_workspace_federation_rule_id and assertion_source is None:
+        raise ValueError(
+            "--anthropic-workspace-federation-rule-id needs an identity token source: "
+            "set --anthropic-identity-token-file or "
+            "--anthropic-identity-token-env-var.",
+        )
 
     credential = make_credential(
         apikey=config.anthropic_apikey,
@@ -219,6 +313,7 @@ def start_anthropic_ingestion(neo4j_session: neo4j.Session, config: Config) -> N
 
     if config.anthropic_workspace_federation_rule_id:
         _sync_workspace_plane(neo4j_session, config, common_job_parameters, workspaces)
+        _cleanup_detached_workspace_resources(neo4j_session, config.update_tag)
     else:
         logger.info(
             "Skipping Anthropic skills, agents and other per-workspace resources: "

--- a/cartography/intel/anthropic/__init__.py
+++ b/cartography/intel/anthropic/__init__.py
@@ -6,11 +6,14 @@ from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
 import cartography.intel.anthropic.apikeys
+import cartography.intel.anthropic.federation
 import cartography.intel.anthropic.organization
+import cartography.intel.anthropic.serviceaccounts
 import cartography.intel.anthropic.users
 import cartography.intel.anthropic.workspaces
 from cartography.config import Config
 from cartography.intel.anthropic.auth import AnthropicAuth
+from cartography.intel.anthropic.auth import is_federated
 from cartography.intel.anthropic.auth import make_assertion_source
 from cartography.intel.anthropic.auth import make_credential
 from cartography.util import timeit
@@ -86,6 +89,28 @@ def start_anthropic_ingestion(neo4j_session: neo4j.Session, config: Config) -> N
         api_session,
         common_job_parameters,
     )
+
+    # Service accounts and federation resources reject Admin API keys with a 403;
+    # they are only readable with an org:admin OAuth token. Must run before the API
+    # key sync, which edges service-account-owned keys to their principal.
+    if is_federated(credential):
+        cartography.intel.anthropic.serviceaccounts.sync(
+            neo4j_session,
+            api_session,
+            common_job_parameters,
+        )
+
+        cartography.intel.anthropic.federation.sync(
+            neo4j_session,
+            api_session,
+            common_job_parameters,
+        )
+    else:
+        logger.info(
+            "Skipping Anthropic service accounts and federation resources: those "
+            "endpoints reject Admin API keys. Configure Workload Identity "
+            "Federation to ingest them.",
+        )
 
     cartography.intel.anthropic.apikeys.sync(
         neo4j_session,

--- a/cartography/intel/anthropic/__init__.py
+++ b/cartography/intel/anthropic/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 import neo4j
 import requests
@@ -7,7 +8,10 @@ from urllib3 import Retry
 
 import cartography.intel.anthropic.apikeys
 import cartography.intel.anthropic.federation
+import cartography.intel.anthropic.invites
 import cartography.intel.anthropic.organization
+import cartography.intel.anthropic.ratelimits
+import cartography.intel.anthropic.rbac
 import cartography.intel.anthropic.serviceaccounts
 import cartography.intel.anthropic.users
 import cartography.intel.anthropic.workspaces
@@ -19,6 +23,29 @@ from cartography.intel.anthropic.auth import make_credential
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
+
+
+def _sync_enterprise_rbac(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    """Sync the Claude Enterprise RBAC beta, tolerating organizations without it."""
+    try:
+        cartography.intel.anthropic.rbac.sync(
+            neo4j_session,
+            api_session,
+            common_job_parameters,
+        )
+    except requests.exceptions.HTTPError as exc:
+        status_code = exc.response.status_code if exc.response is not None else None
+        if status_code not in (403, 404):
+            raise
+        logger.info(
+            "Skipping Anthropic RBAC groups and roles (HTTP %s): the RBAC API is a "
+            "Claude Enterprise beta and is not available to this organization.",
+            status_code,
+        )
 
 
 @timeit
@@ -84,10 +111,27 @@ def start_anthropic_ingestion(neo4j_session: neo4j.Session, config: Config) -> N
         common_job_parameters,
     )
 
-    cartography.intel.anthropic.workspaces.sync(
+    workspaces = cartography.intel.anthropic.workspaces.sync(
         neo4j_session,
         api_session,
         common_job_parameters,
+    )
+
+    # Enterprise-only beta. A non-Enterprise organization is refused rather than
+    # returned an empty list, so this must not fail the module.
+    _sync_enterprise_rbac(neo4j_session, api_session, common_job_parameters)
+
+    cartography.intel.anthropic.invites.sync(
+        neo4j_session,
+        api_session,
+        common_job_parameters,
+    )
+
+    cartography.intel.anthropic.ratelimits.sync(
+        neo4j_session,
+        api_session,
+        common_job_parameters,
+        [workspace["id"] for workspace in workspaces],
     )
 
     # Service accounts and federation resources reject Admin API keys with a 403;

--- a/cartography/intel/anthropic/agents.py
+++ b/cartography/intel/anthropic/agents.py
@@ -132,7 +132,9 @@ def transform_agent(agent: dict[str, Any]) -> None:
         server["url"] for server in agent.get("mcp_servers") or [] if server.get("url")
     ]
     agent["skill_ids"] = [
-        skill["skill_id"] for skill in agent.get("skills") or [] if skill.get("skill_id")
+        skill["skill_id"]
+        for skill in agent.get("skills") or []
+        if skill.get("skill_id")
     ]
     always_allow: list[str] = []
     always_ask: list[str] = []

--- a/cartography/intel/anthropic/agents.py
+++ b/cartography/intel/anthropic/agents.py
@@ -1,0 +1,260 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.anthropic.util import paginated_get_by_page
+from cartography.models.anthropic.agent import AnthropicAgentSchema
+from cartography.models.anthropic.deployment import AnthropicDeploymentSchema
+from cartography.models.anthropic.environment import AnthropicEnvironmentSchema
+from cartography.models.anthropic.memorystore import AnthropicMemoryStoreSchema
+from cartography.models.anthropic.vault import AnthropicVaultSchema
+from cartography.util import timeit
+
+# Connect and read timeouts of 60 seconds each; see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
+_TIMEOUT = (60, 60)
+
+# Beta headers are sent per request, not on the session: managed-agents and
+# agent-memory are mutually exclusive and sending both returns a 400.
+_MANAGED_AGENTS_HEADERS = {"anthropic-beta": "managed-agents-2026-04-01"}
+_AGENT_MEMORY_HEADERS = {"anthropic-beta": "agent-memory-2026-07-22"}
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    base_url = common_job_parameters["BASE_URL"]
+    workspace_id = common_job_parameters["WORKSPACE_ID"]
+    update_tag = common_job_parameters["UPDATE_TAG"]
+
+    # Load in dependency order: deployments reference agents, environments and
+    # vaults, and agents reference skills loaded by the skills sync.
+    environments = get_environments(api_session, base_url)
+    for environment in environments:
+        transform_environment(environment)
+    load_environments(neo4j_session, environments, workspace_id, update_tag)
+
+    vaults = get_vaults(api_session, base_url)
+    load_vaults(neo4j_session, vaults, workspace_id, update_tag)
+
+    memory_stores = get_memory_stores(api_session, base_url)
+    load_memory_stores(neo4j_session, memory_stores, workspace_id, update_tag)
+
+    agents = get_agents(api_session, base_url)
+    for agent in agents:
+        transform_agent(agent)
+    load_agents(neo4j_session, agents, workspace_id, update_tag)
+
+    deployments = get_deployments(api_session, base_url)
+    load_deployments(neo4j_session, deployments, workspace_id, update_tag)
+
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get_agents(
+    api_session: requests.Session,
+    base_url: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/agents",
+        timeout=_TIMEOUT,
+        headers=_MANAGED_AGENTS_HEADERS,
+    )
+
+
+@timeit
+def get_environments(
+    api_session: requests.Session,
+    base_url: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/environments",
+        timeout=_TIMEOUT,
+        headers=_MANAGED_AGENTS_HEADERS,
+    )
+
+
+@timeit
+def get_deployments(
+    api_session: requests.Session,
+    base_url: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/deployments",
+        timeout=_TIMEOUT,
+        headers=_MANAGED_AGENTS_HEADERS,
+    )
+
+
+@timeit
+def get_vaults(
+    api_session: requests.Session,
+    base_url: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/vaults",
+        timeout=_TIMEOUT,
+        headers=_MANAGED_AGENTS_HEADERS,
+    )
+
+
+@timeit
+def get_memory_stores(
+    api_session: requests.Session,
+    base_url: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/memory_stores",
+        timeout=_TIMEOUT,
+        headers=_AGENT_MEMORY_HEADERS,
+    )
+
+
+def transform_agent(agent: dict[str, Any]) -> None:
+    """Flatten the agent's nested MCP server, tool and skill lists.
+
+    Tools are split by permission policy rather than kept as one list: the ones an
+    agent may invoke without asking run unsupervised, which is the part worth
+    querying on.
+    """
+    agent["mcp_server_urls"] = [
+        server["url"] for server in agent.get("mcp_servers") or [] if server.get("url")
+    ]
+    agent["skill_ids"] = [
+        skill["skill_id"] for skill in agent.get("skills") or [] if skill.get("skill_id")
+    ]
+    always_allow: list[str] = []
+    always_ask: list[str] = []
+    for tool in agent.get("tools") or []:
+        name = tool.get("name") or tool.get("type")
+        if not name:
+            continue
+        if tool.get("permission_policy") == "always_allow":
+            always_allow.append(name)
+        else:
+            always_ask.append(name)
+    agent["always_allow_tools"] = sorted(always_allow)
+    agent["always_ask_tools"] = sorted(always_ask)
+
+
+def transform_environment(environment: dict[str, Any]) -> None:
+    """Flatten the environment's config union into the egress policy it encodes."""
+    config = environment.pop("config", None) or {}
+    environment["config_type"] = config.get("type", "cloud")
+    networking = config.get("networking")
+    if isinstance(networking, str):
+        # The unrestricted case is the bare string rather than an object.
+        environment["networking_type"] = networking
+        networking = {}
+    else:
+        networking = networking or {}
+        environment["networking_type"] = networking.get("type")
+    environment["allowed_hosts"] = networking.get("allowed_hosts")
+    environment["allow_mcp_servers"] = networking.get("allow_mcp_servers")
+    environment["allow_package_managers"] = networking.get("allow_package_managers")
+
+
+@timeit
+def load_agents(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    WORKSPACE_ID: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicAgentSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=WORKSPACE_ID,
+    )
+
+
+@timeit
+def load_environments(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    WORKSPACE_ID: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicEnvironmentSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=WORKSPACE_ID,
+    )
+
+
+@timeit
+def load_deployments(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    WORKSPACE_ID: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicDeploymentSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=WORKSPACE_ID,
+    )
+
+
+@timeit
+def load_vaults(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    WORKSPACE_ID: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicVaultSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=WORKSPACE_ID,
+    )
+
+
+@timeit
+def load_memory_stores(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    WORKSPACE_ID: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicMemoryStoreSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=WORKSPACE_ID,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    # Reverse of the load order: dependants first.
+    for schema in (
+        AnthropicDeploymentSchema(),
+        AnthropicAgentSchema(),
+        AnthropicMemoryStoreSchema(),
+        AnthropicVaultSchema(),
+        AnthropicEnvironmentSchema(),
+    ):
+        GraphJob.from_node_schema(schema, common_job_parameters).run(neo4j_session)

--- a/cartography/intel/anthropic/apikeys.py
+++ b/cartography/intel/anthropic/apikeys.py
@@ -7,6 +7,7 @@ import requests
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.anthropic.util import paginated_get
+from cartography.intel.anthropic.util import resolve_org_id
 from cartography.models.anthropic.apikey import AnthropicApiKeySchema
 from cartography.util import timeit
 
@@ -20,10 +21,11 @@ def sync(
     api_session: requests.Session,
     common_job_parameters: dict[str, Any],
 ) -> None:
-    org_id, apikeys = get(
+    header_org_id, apikeys = get(
         api_session,
         common_job_parameters["BASE_URL"],
     )
+    org_id = resolve_org_id(common_job_parameters, header_org_id)
     common_job_parameters["ORG_ID"] = org_id
     load_apikeys(
         neo4j_session,

--- a/cartography/intel/anthropic/apikeys.py
+++ b/cartography/intel/anthropic/apikeys.py
@@ -27,6 +27,8 @@ def sync(
     )
     org_id = resolve_org_id(common_job_parameters, header_org_id)
     common_job_parameters["ORG_ID"] = org_id
+    for apikey in apikeys:
+        transform_apikey(apikey)
     load_apikeys(
         neo4j_session,
         apikeys,
@@ -44,6 +46,26 @@ def get(
     return paginated_get(
         api_session, f"{base_url}/organizations/api_keys", timeout=_TIMEOUT
     )
+
+
+def transform_apikey(apikey: dict[str, Any]) -> None:
+    """Resolve the single owner the canonical OWNED_BY edge points at.
+
+    A key acting as a service account still records the human who created it, so
+    deriving ownership from `created_by` alone would attribute the key to both a user
+    and a service account and make ownership queries double-count. The principal is
+    what the key acts as, so it wins; `created_by` remains the fallback, and stays on
+    the deprecated OWNS edge either way as creation attribution.
+    """
+    principal = apikey.get("principal") or {}
+    if principal.get("type") == "service_account":
+        apikey["owner_user_id"] = None
+        apikey["owner_service_account_id"] = principal.get("id")
+        return
+    apikey["owner_user_id"] = principal.get("id") or (
+        apikey.get("created_by") or {}
+    ).get("id")
+    apikey["owner_service_account_id"] = None
 
 
 @timeit

--- a/cartography/intel/anthropic/auth.py
+++ b/cartography/intel/anthropic/auth.py
@@ -36,6 +36,11 @@ _JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 _EXCHANGE_MAX_ATTEMPTS = 4
 _EXCHANGE_BACKOFF_SECONDS = 2
 
+# Retried because a later attempt can plausibly succeed: throttling and the gateway
+# family. A 4xx other than 429 means the federation configuration itself is wrong, so
+# retrying only delays the error.
+_RETRYABLE_EXCHANGE_STATUSES = frozenset({429, 500, 502, 503, 504})
+
 
 class AssertionSource:
     """Base class for reading the OIDC JWT that proves the workload's identity."""
@@ -159,19 +164,40 @@ class WorkloadIdentityCredential(AnthropicCredential):
         logger.debug("Anthropic access token minted with scope %s", data.get("scope"))
 
     def _exchange(self, body: dict[str, Any]) -> dict[str, Any]:
+        """POST the assertion to the token endpoint, retrying only what can succeed later.
+
+        Throttling, gateway errors and connection failures are retried: they say
+        nothing about whether the federation setup is valid. Every other 4xx is
+        raised on the first attempt, so a wrong rule id, an expired assertion or a
+        service account that is not a member of the workspace fails fast instead of
+        being buried under a minute of backoff.
+        """
         for attempt in range(_EXCHANGE_MAX_ATTEMPTS):
-            response = requests.post(
-                f"{self._base_url}/oauth/token",
-                json=body,
-                timeout=_TIMEOUT,
-            )
-            if response.status_code != 429 or attempt == _EXCHANGE_MAX_ATTEMPTS - 1:
-                response.raise_for_status()
-                result: dict[str, Any] = response.json()
-                return result
+            last_attempt = attempt == _EXCHANGE_MAX_ATTEMPTS - 1
+            try:
+                response = requests.post(
+                    f"{self._base_url}/oauth/token",
+                    json=body,
+                    timeout=_TIMEOUT,
+                )
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
+            ) as exc:
+                if last_attempt:
+                    raise
+                reason: str = f"failed to reach the token endpoint ({exc})"
+            else:
+                if response.status_code not in _RETRYABLE_EXCHANGE_STATUSES:
+                    response.raise_for_status()
+                    result: dict[str, Any] = response.json()
+                    return result
+                if last_attempt:
+                    response.raise_for_status()
+                reason = f"returned HTTP {response.status_code}"
             delay = (_EXCHANGE_BACKOFF_SECONDS**attempt) + random.uniform(0, 1)
-            logger.debug(
-                "Anthropic token exchange was throttled, retrying in %.1fs", delay
+            logger.warning(
+                "Anthropic token exchange %s, retrying in %.1fs", reason, delay
             )
             time.sleep(delay)
         raise AssertionError("unreachable: the loop returns or raises on every path")
@@ -241,6 +267,27 @@ def make_credential(
             organization_id=organization_id,
             service_account_id=service_account_id,
             workspace_id=workspace_id,
+        )
+
+    # The inverse of the check above: the federation ids are set but the identity token
+    # source is not. Silently falling back to the API key (or skipping the module) would
+    # hide the very operator mistake this is most likely to be, an unset token variable.
+    configured_federation_ids = [
+        name
+        for name, value in (
+            ("--anthropic-federation-rule-id", federation_rule_id),
+            ("--anthropic-organization-id", organization_id),
+            ("--anthropic-service-account-id", service_account_id),
+        )
+        if value
+    ]
+    if configured_federation_ids:
+        raise ValueError(
+            "Anthropic Workload Identity Federation is partially configured: "
+            f"{', '.join(configured_federation_ids)} set without an identity token "
+            "source. Set --anthropic-identity-token-file or "
+            "--anthropic-identity-token-env-var, and check that the token file exists "
+            "and the environment variable is populated.",
         )
 
     if apikey:

--- a/cartography/intel/anthropic/auth.py
+++ b/cartography/intel/anthropic/auth.py
@@ -1,0 +1,263 @@
+"""
+Anthropic authentication support for Admin API keys and Workload Identity Federation.
+
+Workload Identity Federation flow:
+1. The platform running cartography (Kubernetes, EKS, GKE, GitHub Actions) issues an
+   OIDC JWT that proves the workload's identity, as a file on disk or an environment
+   variable.
+2. That JWT is POSTed to /v1/oauth/token using the RFC 7523 jwt-bearer grant, along
+   with the federation rule, organization and service account it should act as.
+3. Anthropic returns a short-lived bearer token, used for API calls and transparently
+   refreshed when it nears expiry.
+
+The two credential types use different headers: an Admin API key goes in `X-Api-Key`,
+a federated token in `Authorization: Bearer`.
+"""
+
+import logging
+import os
+import time
+from typing import Any
+
+import requests
+from requests.auth import AuthBase
+
+logger = logging.getLogger(__name__)
+
+# Federated tokens live for the federation rule's token_lifetime_seconds (3600 by
+# default). Refresh well before expiry so a long sync never presents a stale token.
+_TOKEN_REFRESH_BUFFER_SECONDS = 300
+_TIMEOUT = (60, 60)
+_JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+
+class AssertionSource:
+    """Base class for reading the OIDC JWT that proves the workload's identity."""
+
+    def read(self) -> str:
+        """Return the current OIDC JWT."""
+        raise NotImplementedError
+
+
+class FileAssertionSource(AssertionSource):
+    """
+    Reads the OIDC JWT from a file, e.g. a Kubernetes projected service account token.
+
+    The file is re-read on every call: Kubernetes rotates projected tokens on disk
+    before they expire, so a value cached at startup goes stale mid-sync.
+    """
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+
+    def read(self) -> str:
+        with open(self._path) as f:
+            return f.read().strip()
+
+
+class EnvVarAssertionSource(AssertionSource):
+    """Reads the OIDC JWT from an environment variable."""
+
+    def __init__(self, env_var: str) -> None:
+        self._env_var = env_var
+
+    def read(self) -> str:
+        token = os.environ.get(self._env_var)
+        if not token:
+            raise ValueError(
+                f"Environment variable {self._env_var} does not contain an identity token.",
+            )
+        return token.strip()
+
+
+class AnthropicCredential:
+    """Base class for Anthropic authentication credentials."""
+
+    def get_headers(self) -> dict[str, str]:
+        """Return the authentication headers to attach to a request."""
+        raise NotImplementedError
+
+
+class ApiKeyCredential(AnthropicCredential):
+    """Admin API key credential - a static key sent in the X-Api-Key header."""
+
+    def __init__(self, apikey: str) -> None:
+        self._apikey = apikey
+
+    def get_headers(self) -> dict[str, str]:
+        return {"X-Api-Key": self._apikey}
+
+
+class WorkloadIdentityCredential(AnthropicCredential):
+    """
+    Workload Identity Federation credential with automatic token refresh.
+
+    Exchanges the workload's OIDC JWT for a short-lived Anthropic bearer token and
+    transparently re-exchanges when the token nears expiry.
+
+    The scope of the minted token is fixed by the federation rule, not chosen here:
+    a rule carrying `org:admin` yields an Admin API token, a rule carrying
+    `workspace:developer` yields a token for a single workspace. Anthropic exposes no
+    way to downscope one token into another, so reaching a different scope or a
+    different workspace means constructing another credential against another rule.
+    """
+
+    def __init__(
+        self,
+        assertion_source: AssertionSource,
+        federation_rule_id: str,
+        organization_id: str,
+        service_account_id: str,
+        workspace_id: str | None = None,
+        base_url: str = "https://api.anthropic.com/v1",
+    ) -> None:
+        self._assertion_source = assertion_source
+        self._federation_rule_id = federation_rule_id
+        self._organization_id = organization_id
+        self._service_account_id = service_account_id
+        self._workspace_id = workspace_id
+        self._base_url = base_url
+        self._token: str | None = None
+        self._token_expires_at: float = 0
+
+    def get_headers(self) -> dict[str, str]:
+        if self._token is None or self._is_near_expiry():
+            self._refresh_token()
+        assert self._token is not None
+        return {"Authorization": f"Bearer {self._token}"}
+
+    def _is_near_expiry(self) -> bool:
+        return time.time() >= (self._token_expires_at - _TOKEN_REFRESH_BUFFER_SECONDS)
+
+    def _refresh_token(self) -> None:
+        logger.debug(
+            "Exchanging identity token for an Anthropic access token (rule %s, workspace %s)",
+            self._federation_rule_id,
+            self._workspace_id or "default",
+        )
+        body: dict[str, Any] = {
+            "grant_type": _JWT_BEARER_GRANT,
+            "assertion": self._assertion_source.read(),
+            "federation_rule_id": self._federation_rule_id,
+            "organization_id": self._organization_id,
+            "service_account_id": self._service_account_id,
+        }
+        # Required when the federation rule is enabled for more than one workspace;
+        # rejected as unnecessary otherwise, so only send it when we have one.
+        if self._workspace_id:
+            body["workspace_id"] = self._workspace_id
+
+        response = requests.post(
+            f"{self._base_url}/oauth/token",
+            json=body,
+            timeout=_TIMEOUT,
+        )
+        response.raise_for_status()
+        data = response.json()
+        self._token = data["access_token"]
+        self._token_expires_at = time.time() + data["expires_in"]
+        logger.debug("Anthropic access token minted with scope %s", data.get("scope"))
+
+
+class AnthropicAuth(AuthBase):
+    """
+    Applies an AnthropicCredential to every request on a session.
+
+    Attached as `session.auth` rather than baked into `session.headers` so that a
+    federated token refreshes itself mid-sync without the callers knowing.
+    """
+
+    def __init__(self, credential: AnthropicCredential) -> None:
+        self.credential = credential
+
+    def __call__(self, request: requests.PreparedRequest) -> requests.PreparedRequest:
+        request.headers.update(self.credential.get_headers())
+        return request
+
+
+def make_credential(
+    apikey: str | None = None,
+    identity_token_file: str | None = None,
+    identity_token_env_var: str | None = None,
+    federation_rule_id: str | None = None,
+    organization_id: str | None = None,
+    service_account_id: str | None = None,
+    workspace_id: str | None = None,
+) -> AnthropicCredential:
+    """
+    Build the credential implied by the supplied configuration.
+
+    Workload Identity Federation wins when both it and an Admin API key are
+    configured: it reaches strictly more endpoints (service accounts and federation
+    resources reject Admin API keys) and involves no long-lived secret.
+    """
+    assertion_source = make_assertion_source(
+        identity_token_file,
+        identity_token_env_var,
+    )
+    if assertion_source is not None:
+        missing = [
+            name
+            for name, value in (
+                ("--anthropic-federation-rule-id", federation_rule_id),
+                ("--anthropic-organization-id", organization_id),
+                ("--anthropic-service-account-id", service_account_id),
+            )
+            if not value
+        ]
+        if missing:
+            raise ValueError(
+                "Anthropic Workload Identity Federation is partially configured: "
+                f"missing {', '.join(missing)}.",
+            )
+        # The guard above proves these are set; mypy cannot see through the list.
+        assert federation_rule_id and organization_id and service_account_id
+        if apikey:
+            logger.warning(
+                "Both an Anthropic API key and Workload Identity Federation are "
+                "configured; using Workload Identity Federation.",
+            )
+        return WorkloadIdentityCredential(
+            assertion_source=assertion_source,
+            federation_rule_id=federation_rule_id,
+            organization_id=organization_id,
+            service_account_id=service_account_id,
+            workspace_id=workspace_id,
+        )
+
+    if apikey:
+        return ApiKeyCredential(apikey)
+
+    raise ValueError(
+        "Anthropic authentication is not configured. Set either "
+        "--anthropic-apikey-env-var or --anthropic-identity-token-file / "
+        "--anthropic-identity-token-env-var plus --anthropic-federation-rule-id, "
+        "--anthropic-organization-id and --anthropic-service-account-id.",
+    )
+
+
+def make_assertion_source(
+    identity_token_file: str | None,
+    identity_token_env_var: str | None,
+) -> AssertionSource | None:
+    """Return the configured identity token source, or None if there is none."""
+    if identity_token_file and identity_token_env_var:
+        raise ValueError(
+            "--anthropic-identity-token-file and --anthropic-identity-token-env-var "
+            "are mutually exclusive; set only one.",
+        )
+    if identity_token_file:
+        return FileAssertionSource(identity_token_file)
+    if identity_token_env_var:
+        return EnvVarAssertionSource(identity_token_env_var)
+    return None
+
+
+def is_federated(credential: AnthropicCredential) -> bool:
+    """
+    Whether this credential can reach the endpoints that reject Admin API keys.
+
+    Service accounts, federation issuers and federation rules are only readable with
+    an org:admin OAuth token.
+    """
+    return isinstance(credential, WorkloadIdentityCredential)

--- a/cartography/intel/anthropic/auth.py
+++ b/cartography/intel/anthropic/auth.py
@@ -16,6 +16,7 @@ a federated token in `Authorization: Bearer`.
 
 import logging
 import os
+import random
 import time
 from typing import Any
 
@@ -29,6 +30,11 @@ logger = logging.getLogger(__name__)
 _TOKEN_REFRESH_BUFFER_SECONDS = 300
 _TIMEOUT = (60, 60)
 _JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+# The token endpoint publishes no rate limit, and enumerating a large organization
+# means one exchange per workspace. Back off with jitter rather than assume a budget.
+_EXCHANGE_MAX_ATTEMPTS = 4
+_EXCHANGE_BACKOFF_SECONDS = 2
 
 
 class AssertionSource:
@@ -147,16 +153,28 @@ class WorkloadIdentityCredential(AnthropicCredential):
         if self._workspace_id:
             body["workspace_id"] = self._workspace_id
 
-        response = requests.post(
-            f"{self._base_url}/oauth/token",
-            json=body,
-            timeout=_TIMEOUT,
-        )
-        response.raise_for_status()
-        data = response.json()
+        data = self._exchange(body)
         self._token = data["access_token"]
         self._token_expires_at = time.time() + data["expires_in"]
         logger.debug("Anthropic access token minted with scope %s", data.get("scope"))
+
+    def _exchange(self, body: dict[str, Any]) -> dict[str, Any]:
+        for attempt in range(_EXCHANGE_MAX_ATTEMPTS):
+            response = requests.post(
+                f"{self._base_url}/oauth/token",
+                json=body,
+                timeout=_TIMEOUT,
+            )
+            if response.status_code != 429 or attempt == _EXCHANGE_MAX_ATTEMPTS - 1:
+                response.raise_for_status()
+                result: dict[str, Any] = response.json()
+                return result
+            delay = (_EXCHANGE_BACKOFF_SECONDS**attempt) + random.uniform(0, 1)
+            logger.debug(
+                "Anthropic token exchange was throttled, retrying in %.1fs", delay
+            )
+            time.sleep(delay)
+        raise AssertionError("unreachable: the loop returns or raises on every path")
 
 
 class AnthropicAuth(AuthBase):

--- a/cartography/intel/anthropic/auth.py
+++ b/cartography/intel/anthropic/auth.py
@@ -14,6 +14,9 @@ The two credential types use different headers: an Admin API key goes in `X-Api-
 a federated token in `Authorization: Bearer`.
 """
 
+import base64
+import binascii
+import json
 import logging
 import os
 import random
@@ -25,9 +28,13 @@ from requests.auth import AuthBase
 
 logger = logging.getLogger(__name__)
 
-# Federated tokens live for the federation rule's token_lifetime_seconds (3600 by
-# default). Refresh well before expiry so a long sync never presents a stale token.
-_TOKEN_REFRESH_BUFFER_SECONDS = 300
+# Federated tokens live for the federation rule's token_lifetime_seconds, which ranges
+# from 60 seconds to 24 hours (3600 by default). Anthropic prescribes a two-tier refresh
+# rather than one fixed buffer: attempt a refresh at expiry minus 120s but keep serving
+# the cached token if it fails, then force one at expiry minus 30s. A single buffer
+# wider than the shortest allowed token would mark every such token expired on arrival.
+_ADVISORY_REFRESH_SECONDS = 120
+_MANDATORY_REFRESH_SECONDS = 30
 _TIMEOUT = (60, 60)
 _JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 
@@ -132,13 +139,36 @@ class WorkloadIdentityCredential(AnthropicCredential):
         self._token_expires_at: float = 0
 
     def get_headers(self) -> dict[str, str]:
-        if self._token is None or self._is_near_expiry():
+        """Return the Authorization header, refreshing the token on Anthropic's schedule.
+
+        The refresh happens in two tiers rather than at one fixed offset. A federation
+        rule may mint a token as short as 60 seconds, and a single buffer wider than
+        the token's own lifetime would make every token look expired the moment it
+        arrives, re-exchanging on every request.
+        """
+        if self._token is None:
             self._refresh_token()
+            assert self._token is not None
+            return {"Authorization": f"Bearer {self._token}"}
+
+        remaining = self._token_expires_at - time.time()
+        if remaining <= _MANDATORY_REFRESH_SECONDS:
+            # Too close to expiry to keep serving: a failure here has to surface.
+            self._refresh_token()
+        elif remaining <= _ADVISORY_REFRESH_SECONDS:
+            try:
+                self._refresh_token()
+            except requests.exceptions.RequestException as exc:
+                # The cached token is still valid for a while. Serve it and let the
+                # mandatory tier raise if the endpoint is still down by then.
+                logger.warning(
+                    "Advisory refresh of the Anthropic access token failed, continuing "
+                    "with the cached token for another %.0fs. Error: %s",
+                    remaining - _MANDATORY_REFRESH_SECONDS,
+                    exc,
+                )
         assert self._token is not None
         return {"Authorization": f"Bearer {self._token}"}
-
-    def _is_near_expiry(self) -> bool:
-        return time.time() >= (self._token_expires_at - _TOKEN_REFRESH_BUFFER_SECONDS)
 
     def _refresh_token(self) -> None:
         logger.debug(
@@ -316,6 +346,30 @@ def make_assertion_source(
     if identity_token_env_var:
         return EnvVarAssertionSource(identity_token_env_var)
     return None
+
+
+def assertion_has_jti(assertion: str) -> bool:
+    """Report whether the assertion carries a `jti` claim.
+
+    Read-only inspection of the payload segment: the signature is Anthropic's to
+    verify, not ours. A malformed assertion returns False rather than raising, since
+    the token exchange is the right place to reject it with the server's own diagnosis.
+
+    This matters because a federation issuer enforces single-use per `jti` by default
+    (`check_jti`), and only for assertions that carry one. Reusing one assertion across
+    several exchanges is fine without the claim and rejected as a replay with it.
+    """
+    segments = assertion.split(".")
+    if len(segments) != 3:
+        return False
+    payload = segments[1]
+    # base64url without padding, which b64decode requires.
+    payload += "=" * (-len(payload) % 4)
+    try:
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+    except (ValueError, binascii.Error):
+        return False
+    return isinstance(claims, dict) and "jti" in claims
 
 
 def is_federated(credential: AnthropicCredential) -> bool:

--- a/cartography/intel/anthropic/federation.py
+++ b/cartography/intel/anthropic/federation.py
@@ -1,0 +1,155 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.anthropic.util import paginated_get_by_page
+from cartography.models.anthropic.federationissuer import (
+    AnthropicFederationIssuerSchema,
+)
+from cartography.models.anthropic.federationrule import AnthropicFederationRuleSchema
+from cartography.util import timeit
+
+# Connect and read timeouts of 60 seconds each; see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
+_TIMEOUT = (60, 60)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    issuers = get_issuers(api_session, common_job_parameters["BASE_URL"])
+    for issuer in issuers:
+        transform_issuer(issuer)
+    load_issuers(
+        neo4j_session,
+        issuers,
+        common_job_parameters["ORG_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+
+    rules = get_rules(api_session, common_job_parameters["BASE_URL"])
+    for rule in rules:
+        enablements = get_rule_workspaces(
+            api_session,
+            common_job_parameters["BASE_URL"],
+            rule["id"],
+        )
+        transform_rule(rule, enablements)
+    load_rules(
+        neo4j_session,
+        rules,
+        common_job_parameters["ORG_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get_issuers(
+    api_session: requests.Session,
+    base_url: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/organizations/federation_issuers",
+        timeout=_TIMEOUT,
+    )
+
+
+@timeit
+def get_rules(
+    api_session: requests.Session,
+    base_url: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/organizations/federation_rules",
+        timeout=_TIMEOUT,
+    )
+
+
+@timeit
+def get_rule_workspaces(
+    api_session: requests.Session,
+    base_url: str,
+    federation_rule_id: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/organizations/federation_rules/{federation_rule_id}/workspaces",
+        timeout=_TIMEOUT,
+    )
+
+
+def transform_issuer(issuer: dict[str, Any]) -> None:
+    """Flatten the jwks discriminated union into scalar properties."""
+    jwks = issuer.pop("jwks", None) or {}
+    issuer["jwks_type"] = jwks.get("type")
+    # Only the explicit_url variant carries a url; discovery derives it from the
+    # issuer, and inline embeds the keys directly.
+    issuer["jwks_url"] = jwks.get("url")
+
+
+def transform_rule(rule: dict[str, Any], enablements: list[dict[str, Any]]) -> None:
+    """Flatten the claims matcher and collect every workspace the rule is enabled on."""
+    claims = (rule.get("match") or {}).get("claims") or {}
+    rule["match_claims"] = sorted(f"{key}={value}" for key, value in claims.items())
+
+    workspace_ids = {e["workspace_id"] for e in enablements}
+    workspace_ids.update(rule.get("workspace_ids") or [])
+    # Rules predating the multi-workspace sub-resource carry a single legacy binding.
+    legacy_workspace_id = rule.get("workspace_id")
+    if legacy_workspace_id:
+        workspace_ids.add(legacy_workspace_id)
+    rule["workspace_ids"] = sorted(workspace_ids)
+
+
+@timeit
+def load_issuers(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    ORG_ID: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicFederationIssuerSchema(),
+        data,
+        lastupdated=update_tag,
+        ORG_ID=ORG_ID,
+    )
+
+
+@timeit
+def load_rules(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    ORG_ID: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicFederationRuleSchema(),
+        data,
+        lastupdated=update_tag,
+        ORG_ID=ORG_ID,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    # Rules first: they reference the issuers.
+    GraphJob.from_node_schema(
+        AnthropicFederationRuleSchema(), common_job_parameters
+    ).run(neo4j_session)
+    GraphJob.from_node_schema(
+        AnthropicFederationIssuerSchema(), common_job_parameters
+    ).run(neo4j_session)

--- a/cartography/intel/anthropic/invites.py
+++ b/cartography/intel/anthropic/invites.py
@@ -1,0 +1,68 @@
+from typing import Any
+from typing import Tuple
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.anthropic.util import paginated_get
+from cartography.intel.anthropic.util import resolve_org_id
+from cartography.models.anthropic.invite import AnthropicInviteSchema
+from cartography.util import timeit
+
+# Connect and read timeouts of 60 seconds each; see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
+_TIMEOUT = (60, 60)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    header_org_id, invites = get(
+        api_session,
+        common_job_parameters["BASE_URL"],
+    )
+    org_id = resolve_org_id(common_job_parameters, header_org_id)
+    common_job_parameters["ORG_ID"] = org_id
+    load_invites(
+        neo4j_session, invites, org_id, common_job_parameters["UPDATE_TAG"]
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+) -> Tuple[str, list[dict[str, Any]]]:
+    return paginated_get(
+        api_session, f"{base_url}/organizations/invites", timeout=_TIMEOUT
+    )
+
+
+@timeit
+def load_invites(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    ORG_ID: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicInviteSchema(),
+        data,
+        lastupdated=update_tag,
+        ORG_ID=ORG_ID,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(AnthropicInviteSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/anthropic/invites.py
+++ b/cartography/intel/anthropic/invites.py
@@ -27,9 +27,7 @@ def sync(
     )
     org_id = resolve_org_id(common_job_parameters, header_org_id)
     common_job_parameters["ORG_ID"] = org_id
-    load_invites(
-        neo4j_session, invites, org_id, common_job_parameters["UPDATE_TAG"]
-    )
+    load_invites(neo4j_session, invites, org_id, common_job_parameters["UPDATE_TAG"])
     cleanup(neo4j_session, common_job_parameters)
 
 

--- a/cartography/intel/anthropic/organization.py
+++ b/cartography/intel/anthropic/organization.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.models.anthropic.organization import AnthropicOrganizationSchema
+from cartography.util import timeit
+
+# Connect and read timeouts of 60 seconds each; see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
+_TIMEOUT = (60, 60)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+) -> str:
+    """Load the organization node and return its id, which scopes every other sync."""
+    organization = get(api_session, common_job_parameters["BASE_URL"])
+    common_job_parameters["ORG_ID"] = organization["id"]
+    load_organization(
+        neo4j_session, organization, common_job_parameters["UPDATE_TAG"]
+    )
+    # No cleanup: the organization is the sub-resource every other node hangs off, so
+    # it has no parent to scope a cleanup job to.
+    return organization["id"]
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+) -> dict[str, Any]:
+    req = api_session.get(f"{base_url}/organizations/me", timeout=_TIMEOUT)
+    req.raise_for_status()
+    result: dict[str, Any] = req.json()
+    return result
+
+
+@timeit
+def load_organization(
+    neo4j_session: neo4j.Session,
+    data: dict[str, Any],
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicOrganizationSchema(),
+        [data],
+        lastupdated=update_tag,
+    )

--- a/cartography/intel/anthropic/organization.py
+++ b/cartography/intel/anthropic/organization.py
@@ -20,9 +20,7 @@ def sync(
     """Load the organization node and return its id, which scopes every other sync."""
     organization = get(api_session, common_job_parameters["BASE_URL"])
     common_job_parameters["ORG_ID"] = organization["id"]
-    load_organization(
-        neo4j_session, organization, common_job_parameters["UPDATE_TAG"]
-    )
+    load_organization(neo4j_session, organization, common_job_parameters["UPDATE_TAG"])
     # No cleanup: the organization is the sub-resource every other node hangs off, so
     # it has no parent to scope a cleanup job to.
     return organization["id"]

--- a/cartography/intel/anthropic/ratelimits.py
+++ b/cartography/intel/anthropic/ratelimits.py
@@ -1,0 +1,127 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.anthropic.util import paginated_get_by_page
+from cartography.models.anthropic.ratelimit import AnthropicRateLimitSchema
+from cartography.util import timeit
+
+# Connect and read timeouts of 60 seconds each; see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
+_TIMEOUT = (60, 60)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+    workspace_ids: list[str],
+) -> None:
+    rate_limits = transform_rate_limits(
+        get(api_session, common_job_parameters["BASE_URL"]),
+        workspace_id=None,
+    )
+    for workspace_id in workspace_ids:
+        rate_limits.extend(
+            transform_rate_limits(
+                get_workspace_rate_limits(
+                    api_session,
+                    common_job_parameters["BASE_URL"],
+                    workspace_id,
+                ),
+                workspace_id=workspace_id,
+            )
+        )
+    load_rate_limits(
+        neo4j_session,
+        rate_limits,
+        common_job_parameters["ORG_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/organizations/rate_limits",
+        timeout=_TIMEOUT,
+    )
+
+
+@timeit
+def get_workspace_rate_limits(
+    api_session: requests.Session,
+    base_url: str,
+    workspace_id: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/organizations/workspaces/{workspace_id}/rate_limits",
+        timeout=_TIMEOUT,
+    )
+
+
+def transform_rate_limits(
+    groups: list[dict[str, Any]],
+    workspace_id: str | None,
+) -> list[dict[str, Any]]:
+    """Explode each group's list of limits into one node per individual limit.
+
+    The API returns limits as a nested list of objects, which Neo4j cannot store as
+    a node property, and gives no identifier for either the group or the individual
+    limit. The id is synthesised from the fields that make a limit unique: its scope,
+    group type, models and limit type.
+    """
+    results: list[dict[str, Any]] = []
+    for group in groups:
+        group_type = group.get("group_type")
+        models = group.get("models") or []
+        scope = workspace_id or "organization"
+        model_key = ",".join(sorted(models)) if models else "all"
+        for limit in group.get("limits") or []:
+            limit_type = limit.get("type")
+            results.append(
+                {
+                    "id": f"{scope}/{group_type}/{model_key}/{limit_type}",
+                    "group_type": group_type,
+                    "limit_type": limit_type,
+                    "value": limit.get("value"),
+                    "org_limit": limit.get("org_limit"),
+                    "models": models,
+                    "workspace_id": workspace_id,
+                }
+            )
+    return results
+
+
+@timeit
+def load_rate_limits(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    ORG_ID: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicRateLimitSchema(),
+        data,
+        lastupdated=update_tag,
+        ORG_ID=ORG_ID,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(AnthropicRateLimitSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/anthropic/ratelimits.py
+++ b/cartography/intel/anthropic/ratelimits.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import neo4j
@@ -8,6 +9,8 @@ from cartography.graph.job import GraphJob
 from cartography.intel.anthropic.util import paginated_get_by_page
 from cartography.models.anthropic.ratelimit import AnthropicRateLimitSchema
 from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
 
 # Connect and read timeouts of 60 seconds each; see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
 _TIMEOUT = (60, 60)
@@ -24,16 +27,26 @@ def sync(
         get(api_session, common_job_parameters["BASE_URL"]),
         workspace_id=None,
     )
+    skipped_workspace_ids: list[str] = []
     for workspace_id in workspace_ids:
-        rate_limits.extend(
-            transform_rate_limits(
-                get_workspace_rate_limits(
-                    api_session,
-                    common_job_parameters["BASE_URL"],
-                    workspace_id,
-                ),
-                workspace_id=workspace_id,
+        try:
+            workspace_limits = get_workspace_rate_limits(
+                api_session,
+                common_job_parameters["BASE_URL"],
+                workspace_id,
             )
+        except requests.exceptions.HTTPError as exc:
+            # A workspace the credential cannot read must not take the whole module
+            # down, nor let cleanup converge its previously ingested limits to empty.
+            logger.warning(
+                "Skipping rate limits for Anthropic workspace %s: %s",
+                workspace_id,
+                exc,
+            )
+            skipped_workspace_ids.append(workspace_id)
+            continue
+        rate_limits.extend(
+            transform_rate_limits(workspace_limits, workspace_id=workspace_id)
         )
     load_rate_limits(
         neo4j_session,
@@ -41,6 +54,16 @@ def sync(
         common_job_parameters["ORG_ID"],
         common_job_parameters["UPDATE_TAG"],
     )
+    if skipped_workspace_ids:
+        # Cleanup is organization-scoped, so running it now would delete the limits of
+        # every workspace that was skipped. Keep the last known good state instead.
+        logger.warning(
+            "Skipping Anthropic rate limit cleanup: %d workspace(s) could not be read "
+            "(%s), and organization-scoped cleanup would delete their existing limits.",
+            len(skipped_workspace_ids),
+            ", ".join(skipped_workspace_ids),
+        )
+        return
     cleanup(neo4j_session, common_job_parameters)
 
 

--- a/cartography/intel/anthropic/ratelimits.py
+++ b/cartography/intel/anthropic/ratelimits.py
@@ -23,9 +23,11 @@ def sync(
     common_job_parameters: dict[str, Any],
     workspace_ids: list[str],
 ) -> None:
+    org_id = common_job_parameters["ORG_ID"]
     rate_limits = transform_rate_limits(
         get(api_session, common_job_parameters["BASE_URL"]),
         workspace_id=None,
+        org_id=org_id,
     )
     skipped_workspace_ids: list[str] = []
     for workspace_id in workspace_ids:
@@ -46,7 +48,9 @@ def sync(
             skipped_workspace_ids.append(workspace_id)
             continue
         rate_limits.extend(
-            transform_rate_limits(workspace_limits, workspace_id=workspace_id)
+            transform_rate_limits(
+                workspace_limits, workspace_id=workspace_id, org_id=org_id
+            )
         )
     load_rate_limits(
         neo4j_session,
@@ -95,13 +99,18 @@ def get_workspace_rate_limits(
 def transform_rate_limits(
     groups: list[dict[str, Any]],
     workspace_id: str | None,
+    org_id: str,
 ) -> list[dict[str, Any]]:
     """Explode each group's list of limits into one node per individual limit.
 
     The API returns limits as a nested list of objects, which Neo4j cannot store as
     a node property, and gives no identifier for either the group or the individual
-    limit. The id is synthesised from the fields that make a limit unique: its scope,
-    group type, models and limit type.
+    limit. The id is synthesised from the fields that make a limit unique: the
+    organization, the scope, the group type, the models and the limit type.
+
+    The organization has to be part of it. An organization-wide limit has no workspace
+    to distinguish it, so two organizations in the same graph would otherwise both
+    produce `organization/...` and merge into a single node.
     """
     results: list[dict[str, Any]] = []
     for group in groups:
@@ -113,7 +122,7 @@ def transform_rate_limits(
             limit_type = limit.get("type")
             results.append(
                 {
-                    "id": f"{scope}/{group_type}/{model_key}/{limit_type}",
+                    "id": f"{org_id}/{scope}/{group_type}/{model_key}/{limit_type}",
                     "group_type": group_type,
                     "limit_type": limit_type,
                     "value": limit.get("value"),

--- a/cartography/intel/anthropic/rbac.py
+++ b/cartography/intel/anthropic/rbac.py
@@ -148,7 +148,13 @@ def transform_permissions(
         resource = permission.get("resource") or {}
         resource_key = "/".join(
             str(resource[field])
-            for field in ("type", "organization_id", "connector_id", "tool_name", "scope")
+            for field in (
+                "type",
+                "organization_id",
+                "connector_id",
+                "tool_name",
+                "scope",
+            )
             if resource.get(field)
         )
         results.append(

--- a/cartography/intel/anthropic/rbac.py
+++ b/cartography/intel/anthropic/rbac.py
@@ -61,6 +61,10 @@ def sync(
     )
 
     groups = get_groups(api_session, common_job_parameters["BASE_URL"])
+    known_roles = get_known_role_ids(
+        neo4j_session,
+        [group["id"] for group in groups if group.get("roles") is None],
+    )
     for group in groups:
         transform_group(
             group,
@@ -69,6 +73,7 @@ def sync(
                 common_job_parameters["BASE_URL"],
                 group["id"],
             ),
+            known_roles.get(group["id"]),
         )
     load_groups(
         neo4j_session,
@@ -167,23 +172,53 @@ def transform_permissions(
     return results
 
 
-def transform_group(group: dict[str, Any], members: list[dict[str, Any]]) -> None:
+@timeit
+def get_known_role_ids(
+    neo4j_session: neo4j.Session,
+    group_ids: list[str],
+) -> dict[str, list[str]]:
+    """Read back the roles the graph already holds for these groups.
+
+    Used only when the API reports a group's roles as unavailable. Re-writing the
+    known ids keeps the existing edges and refreshes their lastupdated, which is what
+    stops the cleanup job from deleting them.
+    """
+    if not group_ids:
+        return {}
+    records = neo4j_session.run(
+        """
+        MATCH (g:AnthropicRbacGroup)-[:HAS_ROLE]->(r:AnthropicRbacRole)
+        WHERE g.id IN $group_ids
+        RETURN g.id AS group_id, collect(r.id) AS role_ids
+        """,
+        group_ids=group_ids,
+    )
+    return {record["group_id"]: record["role_ids"] for record in records}
+
+
+def transform_group(
+    group: dict[str, Any],
+    members: list[dict[str, Any]],
+    known_role_ids: list[str] | None = None,
+) -> None:
     """Attach member ids, and normalise the roles field.
 
     A null `roles` means the role data was temporarily unavailable, not that the
-    group holds no roles. Treating it as empty would let the cleanup job delete the
-    group's real HAS_ROLE edges, so warn loudly when it happens: the edges will be
-    dropped until a sync reads the field successfully.
+    group holds no roles. Writing an empty list would let the cleanup job delete the
+    group's real HAS_ROLE edges, turning a transient API failure into an
+    under-reported set of permissions. Carry forward what the graph already knows
+    instead, so the edges survive until a sync reads the field successfully.
     """
     group["members"] = [m["user_id"] for m in members]
     if group.get("roles") is None:
         logger.warning(
             "Anthropic RBAC group %s returned null roles, meaning the role data was "
-            "temporarily unavailable. Its HAS_ROLE edges will be removed until a "
-            "later sync reads them.",
+            "temporarily unavailable. Carrying forward the %d role(s) already in the "
+            "graph.",
             group["id"],
+            len(known_role_ids or []),
         )
-        group["roles"] = []
+        group["roles"] = known_role_ids or []
 
 
 @timeit

--- a/cartography/intel/anthropic/rbac.py
+++ b/cartography/intel/anthropic/rbac.py
@@ -1,0 +1,244 @@
+import logging
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.anthropic.util import paginated_get_by_page
+from cartography.models.anthropic.rbac import AnthropicRbacGroupSchema
+from cartography.models.anthropic.rbac import AnthropicRbacRolePermissionSchema
+from cartography.models.anthropic.rbac import AnthropicRbacRoleSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+# Connect and read timeouts of 60 seconds each; see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
+_TIMEOUT = (60, 60)
+
+# Every RBAC endpoint requires this opt-in. It must be sent per request rather than
+# on the session: other Anthropic betas are mutually exclusive with each other.
+_BETA_HEADERS = {"anthropic-beta": "ce-user-management-2026-07-13"}
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    """Sync RBAC groups, roles and role permissions.
+
+    The RBAC API is a Claude Enterprise beta. A non-Enterprise organization gets a
+    403 or 404 rather than an empty list, so the whole sync is best-effort: it logs
+    and returns instead of failing the module.
+    """
+    roles = get_roles(api_session, common_job_parameters["BASE_URL"])
+    permissions: list[dict[str, Any]] = []
+    for role in roles:
+        permissions.extend(
+            transform_permissions(
+                role["id"],
+                get_role_permissions(
+                    api_session,
+                    common_job_parameters["BASE_URL"],
+                    role["id"],
+                ),
+            )
+        )
+    load_roles(
+        neo4j_session,
+        roles,
+        common_job_parameters["ORG_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    load_role_permissions(
+        neo4j_session,
+        permissions,
+        common_job_parameters["ORG_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+
+    groups = get_groups(api_session, common_job_parameters["BASE_URL"])
+    for group in groups:
+        transform_group(
+            group,
+            get_group_members(
+                api_session,
+                common_job_parameters["BASE_URL"],
+                group["id"],
+            ),
+        )
+    load_groups(
+        neo4j_session,
+        groups,
+        common_job_parameters["ORG_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get_roles(
+    api_session: requests.Session,
+    base_url: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/organizations/rbac_roles",
+        timeout=_TIMEOUT,
+        headers=_BETA_HEADERS,
+    )
+
+
+@timeit
+def get_role_permissions(
+    api_session: requests.Session,
+    base_url: str,
+    role_id: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/organizations/rbac_roles/{role_id}/permissions",
+        timeout=_TIMEOUT,
+        headers=_BETA_HEADERS,
+    )
+
+
+@timeit
+def get_groups(
+    api_session: requests.Session,
+    base_url: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/organizations/rbac_groups",
+        timeout=_TIMEOUT,
+        headers=_BETA_HEADERS,
+    )
+
+
+@timeit
+def get_group_members(
+    api_session: requests.Session,
+    base_url: str,
+    group_id: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/organizations/rbac_groups/{group_id}/members",
+        timeout=_TIMEOUT,
+        headers=_BETA_HEADERS,
+    )
+
+
+def transform_permissions(
+    role_id: str,
+    permissions: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Give each permission a stable id.
+
+    The API returns none, so it is synthesised from the fields that make a grant
+    unique: the role, the action, and the resource it applies to.
+    """
+    results: list[dict[str, Any]] = []
+    for permission in permissions:
+        resource = permission.get("resource") or {}
+        resource_key = "/".join(
+            str(resource[field])
+            for field in ("type", "organization_id", "connector_id", "tool_name", "scope")
+            if resource.get(field)
+        )
+        results.append(
+            {
+                **permission,
+                "id": f"{role_id}/{permission.get('action')}/{resource_key}",
+                "role_id": role_id,
+            }
+        )
+    return results
+
+
+def transform_group(group: dict[str, Any], members: list[dict[str, Any]]) -> None:
+    """Attach member ids, and normalise the roles field.
+
+    A null `roles` means the role data was temporarily unavailable, not that the
+    group holds no roles. Treating it as empty would let the cleanup job delete the
+    group's real HAS_ROLE edges, so warn loudly when it happens: the edges will be
+    dropped until a sync reads the field successfully.
+    """
+    group["members"] = [m["user_id"] for m in members]
+    if group.get("roles") is None:
+        logger.warning(
+            "Anthropic RBAC group %s returned null roles, meaning the role data was "
+            "temporarily unavailable. Its HAS_ROLE edges will be removed until a "
+            "later sync reads them.",
+            group["id"],
+        )
+        group["roles"] = []
+
+
+@timeit
+def load_roles(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    ORG_ID: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicRbacRoleSchema(),
+        data,
+        lastupdated=update_tag,
+        ORG_ID=ORG_ID,
+    )
+
+
+@timeit
+def load_role_permissions(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    ORG_ID: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicRbacRolePermissionSchema(),
+        data,
+        lastupdated=update_tag,
+        ORG_ID=ORG_ID,
+    )
+
+
+@timeit
+def load_groups(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    ORG_ID: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicRbacGroupSchema(),
+        data,
+        lastupdated=update_tag,
+        ORG_ID=ORG_ID,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(AnthropicRbacGroupSchema(), common_job_parameters).run(
+        neo4j_session
+    )
+    # Permissions before roles: they hang off the roles.
+    GraphJob.from_node_schema(
+        AnthropicRbacRolePermissionSchema(), common_job_parameters
+    ).run(neo4j_session)
+    GraphJob.from_node_schema(AnthropicRbacRoleSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/anthropic/serviceaccounts.py
+++ b/cartography/intel/anthropic/serviceaccounts.py
@@ -1,0 +1,99 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.anthropic.util import paginated_get_by_page
+from cartography.models.anthropic.serviceaccount import AnthropicServiceAccountSchema
+from cartography.util import timeit
+
+# Connect and read timeouts of 60 seconds each; see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
+_TIMEOUT = (60, 60)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    service_accounts = get(api_session, common_job_parameters["BASE_URL"])
+    for service_account in service_accounts:
+        memberships = get_service_account_workspaces(
+            api_session,
+            common_job_parameters["BASE_URL"],
+            service_account["id"],
+        )
+        transform_service_account(service_account, memberships)
+    load_service_accounts(
+        neo4j_session,
+        service_accounts,
+        common_job_parameters["ORG_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/organizations/service_accounts",
+        timeout=_TIMEOUT,
+    )
+
+
+@timeit
+def get_service_account_workspaces(
+    api_session: requests.Session,
+    base_url: str,
+    service_account_id: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/organizations/service_accounts/{service_account_id}/workspaces",
+        timeout=_TIMEOUT,
+    )
+
+
+def transform_service_account(
+    service_account: dict[str, Any],
+    memberships: list[dict[str, Any]],
+) -> None:
+    """Fold workspace memberships into id lists the relationships match on."""
+    service_account["workspaces"] = [m["workspace_id"] for m in memberships]
+    service_account["workspace_admins"] = [
+        m["workspace_id"]
+        for m in memberships
+        if m["workspace_role"] == "workspace_admin"
+    ]
+
+
+@timeit
+def load_service_accounts(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    ORG_ID: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicServiceAccountSchema(),
+        data,
+        lastupdated=update_tag,
+        ORG_ID=ORG_ID,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    GraphJob.from_node_schema(
+        AnthropicServiceAccountSchema(), common_job_parameters
+    ).run(neo4j_session)

--- a/cartography/intel/anthropic/skills.py
+++ b/cartography/intel/anthropic/skills.py
@@ -112,9 +112,9 @@ def cleanup(
     neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
 ) -> None:
     # Versions before skills: they hang off the skills.
-    GraphJob.from_node_schema(
-        AnthropicSkillVersionSchema(), common_job_parameters
-    ).run(neo4j_session)
+    GraphJob.from_node_schema(AnthropicSkillVersionSchema(), common_job_parameters).run(
+        neo4j_session
+    )
     GraphJob.from_node_schema(AnthropicSkillSchema(), common_job_parameters).run(
         neo4j_session
     )

--- a/cartography/intel/anthropic/skills.py
+++ b/cartography/intel/anthropic/skills.py
@@ -1,0 +1,120 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.anthropic.util import paginated_get_by_page
+from cartography.models.anthropic.skill import AnthropicSkillSchema
+from cartography.models.anthropic.skill import AnthropicSkillVersionSchema
+from cartography.util import timeit
+
+# Connect and read timeouts of 60 seconds each; see https://requests.readthedocs.io/en/master/user/advanced/#timeouts
+_TIMEOUT = (60, 60)
+
+# Sent per request rather than on the session: other Anthropic betas are mutually
+# exclusive with each other.
+_BETA_HEADERS = {"anthropic-beta": "skills-2025-10-02"}
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    api_session: requests.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    skills = get(api_session, common_job_parameters["BASE_URL"])
+    versions: list[dict[str, Any]] = []
+    for skill in skills:
+        for version in get_skill_versions(
+            api_session,
+            common_job_parameters["BASE_URL"],
+            skill["id"],
+        ):
+            versions.append({**version, "skill_id": skill["id"]})
+    load_skills(
+        neo4j_session,
+        skills,
+        common_job_parameters["WORKSPACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    load_skill_versions(
+        neo4j_session,
+        versions,
+        common_job_parameters["WORKSPACE_ID"],
+        common_job_parameters["UPDATE_TAG"],
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get(
+    api_session: requests.Session,
+    base_url: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/skills",
+        timeout=_TIMEOUT,
+        headers=_BETA_HEADERS,
+    )
+
+
+@timeit
+def get_skill_versions(
+    api_session: requests.Session,
+    base_url: str,
+    skill_id: str,
+) -> list[dict[str, Any]]:
+    return paginated_get_by_page(
+        api_session,
+        f"{base_url}/skills/{skill_id}/versions",
+        timeout=_TIMEOUT,
+        headers=_BETA_HEADERS,
+    )
+
+
+@timeit
+def load_skills(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    WORKSPACE_ID: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicSkillSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=WORKSPACE_ID,
+    )
+
+
+@timeit
+def load_skill_versions(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    WORKSPACE_ID: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        AnthropicSkillVersionSchema(),
+        data,
+        lastupdated=update_tag,
+        WORKSPACE_ID=WORKSPACE_ID,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session, common_job_parameters: dict[str, Any]
+) -> None:
+    # Versions before skills: they hang off the skills.
+    GraphJob.from_node_schema(
+        AnthropicSkillVersionSchema(), common_job_parameters
+    ).run(neo4j_session)
+    GraphJob.from_node_schema(AnthropicSkillSchema(), common_job_parameters).run(
+        neo4j_session
+    )

--- a/cartography/intel/anthropic/users.py
+++ b/cartography/intel/anthropic/users.py
@@ -7,7 +7,7 @@ import requests
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.anthropic.util import paginated_get
-from cartography.models.anthropic.organization import AnthropicOrganizationSchema
+from cartography.intel.anthropic.util import resolve_org_id
 from cartography.models.anthropic.user import AnthropicUserSchema
 from cartography.util import timeit
 
@@ -21,10 +21,11 @@ def sync(
     api_session: requests.Session,
     common_job_parameters: dict[str, Any],
 ) -> str:
-    org_id, users = get(
+    header_org_id, users = get(
         api_session,
         common_job_parameters["BASE_URL"],
     )
+    org_id = resolve_org_id(common_job_parameters, header_org_id)
     common_job_parameters["ORG_ID"] = org_id
     load_users(neo4j_session, users, org_id, common_job_parameters["UPDATE_TAG"])
     cleanup(neo4j_session, common_job_parameters)
@@ -48,12 +49,6 @@ def load_users(
     ORG_ID: str,
     update_tag: int,
 ) -> None:
-    load(
-        neo4j_session,
-        AnthropicOrganizationSchema(),
-        [{"id": ORG_ID}],
-        lastupdated=update_tag,
-    )
     load(
         neo4j_session,
         AnthropicUserSchema(),

--- a/cartography/intel/anthropic/util.py
+++ b/cartography/intel/anthropic/util.py
@@ -16,6 +16,41 @@ def resolve_org_id(
     return common_job_parameters.get("ORG_ID") or header_org_id
 
 
+def paginated_get_by_page(
+    api_session: requests.Session,
+    url: str,
+    timeout: tuple[int, int],
+    headers: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Helper function to get data from the Anthropic API's page-cursor endpoints.
+
+    The Anthropic API has two pagination families. The older organization endpoints
+    use the `after_id` cursor handled by `paginated_get`; service accounts,
+    federation resources and the workspace-scoped endpoints use an opaque `page`
+    cursor instead, returning the next one in `next_page`.
+
+    Args:
+        api_session (requests.Session): The requests session to use for making API calls.
+        url (str): The URL to make the API call to.
+        timeout (tuple[int, int]): The timeout for the API call.
+        headers (dict[str, str] | None): Extra headers for this call, e.g. a beta
+            opt-in. Beta headers are per-call because some are mutually exclusive.
+    Returns:
+        list[dict[str, Any]]: The results across every page.
+    """
+    results: list[dict[str, Any]] = []
+    page: str | None = None
+    while True:
+        params = {"page": page} if page else {}
+        req = api_session.get(url, params=params, timeout=timeout, headers=headers)
+        req.raise_for_status()
+        result = req.json()
+        results.extend(result.get("data", []))
+        page = result.get("next_page")
+        if not page:
+            return results
+
+
 def paginated_get(
     api_session: requests.Session,
     url: str,

--- a/cartography/intel/anthropic/util.py
+++ b/cartography/intel/anthropic/util.py
@@ -89,11 +89,19 @@ def paginated_get(
     result = req.json()
     results.extend(result.get("data", []))
     if result.get("has_more"):
+        last_id = result.get("last_id")
+        if not last_id:
+            # Without a cursor the next call would re-request the first page, looping
+            # until the recursion limit. Report the malformed response instead.
+            raise ValueError(
+                f"Anthropic API reported has_more for {url} but returned no usable "
+                "last_id cursor."
+            )
         _, next_results = paginated_get(
             api_session,
             url,
             timeout=timeout,
-            after=result.get("last_id"),
+            after=last_id,
         )
         results.extend(next_results)
     return organization_id, results

--- a/cartography/intel/anthropic/util.py
+++ b/cartography/intel/anthropic/util.py
@@ -3,6 +3,19 @@ from typing import Any
 import requests
 
 
+def resolve_org_id(
+    common_job_parameters: dict[str, Any],
+    header_org_id: str,
+) -> str:
+    """Prefer the organization id resolved by the organization sync.
+
+    That id comes from GET /organizations/me and is authoritative. The
+    `anthropic-organization-id` response header is only a fallback, for syncs run in
+    isolation (tests, seeds) where the organization sync has not populated ORG_ID.
+    """
+    return common_job_parameters.get("ORG_ID") or header_org_id
+
+
 def paginated_get(
     api_session: requests.Session,
     url: str,

--- a/cartography/intel/anthropic/workspaces.py
+++ b/cartography/intel/anthropic/workspaces.py
@@ -7,6 +7,7 @@ import requests
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.anthropic.util import paginated_get
+from cartography.intel.anthropic.util import resolve_org_id
 from cartography.models.anthropic.workspace import AnthropicWorkspaceSchema
 from cartography.util import timeit
 
@@ -20,12 +21,14 @@ def sync(
     api_session: requests.Session,
     common_job_parameters: dict[str, Any],
 ) -> list[dict]:
-    org_id, workspaces = get(
+    header_org_id, workspaces = get(
         api_session,
         common_job_parameters["BASE_URL"],
     )
+    org_id = resolve_org_id(common_job_parameters, header_org_id)
     common_job_parameters["ORG_ID"] = org_id
     for workspace in workspaces:
+        transform_workspace(workspace)
         workspace["users"] = []
         workspace["admins"] = []
         for user in get_workspace_users(
@@ -65,6 +68,24 @@ def get_workspace_users(
         timeout=_TIMEOUT,
     )
     return result
+
+
+def transform_workspace(workspace: dict[str, Any]) -> None:
+    """Flatten the nested data_residency object into scalar properties.
+
+    Neo4j node properties cannot hold maps. `tags` is dropped for the same reason:
+    it is an arbitrary string map with no fixed keys to flatten onto.
+    """
+    data_residency = workspace.pop("data_residency", None) or {}
+    workspace["workspace_geo"] = data_residency.get("workspace_geo")
+    workspace["default_inference_geo"] = data_residency.get("default_inference_geo")
+    # Either a list of geo names or the literal string "unrestricted"; normalise both
+    # to a list so the property has a single type in the graph.
+    allowed = data_residency.get("allowed_inference_geos")
+    if isinstance(allowed, str):
+        allowed = [allowed]
+    workspace["allowed_inference_geos"] = allowed
+    workspace.pop("tags", None)
 
 
 @timeit

--- a/cartography/models/anthropic/agent.py
+++ b/cartography/models/anthropic/agent.py
@@ -1,0 +1,118 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AnthropicAgentNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Anthropic managed agent ID.")
+    name: PropertyRef = PropertyRef("name", description="Agent name.")
+    description: PropertyRef = PropertyRef(
+        "description", description="What the agent is for."
+    )
+    version: PropertyRef = PropertyRef(
+        "version", description="Monotonic version of the agent definition."
+    )
+    model_id: PropertyRef = PropertyRef(
+        "model.id", description="Model the agent runs on."
+    )
+    model_effort: PropertyRef = PropertyRef(
+        "model.effort", description="Reasoning effort the agent runs at."
+    )
+    mcp_server_urls: PropertyRef = PropertyRef(
+        "mcp_server_urls",
+        description=(
+            "URLs of the MCP servers the agent connects to. Each one is an external "
+            "system the agent can reach."
+        ),
+    )
+    always_allow_tools: PropertyRef = PropertyRef(
+        "always_allow_tools",
+        description=(
+            "Tools the agent may invoke without asking. These run unsupervised, so "
+            "they carry the agent's full blast radius."
+        ),
+    )
+    always_ask_tools: PropertyRef = PropertyRef(
+        "always_ask_tools",
+        description="Tools the agent must get confirmation for before invoking.",
+    )
+    archived_at: PropertyRef = PropertyRef(
+        "archived_at",
+        description=(
+            "RFC 3339 timestamp when the agent was archived. Empty while it is live."
+        ),
+    )
+    created_at: PropertyRef = PropertyRef(
+        "created_at", description="RFC 3339 timestamp when the agent was created."
+    )
+    updated_at: PropertyRef = PropertyRef(
+        "updated_at", description="RFC 3339 timestamp when the agent was last updated."
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AnthropicAgentToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicWorkspace)-[:RESOURCE]->(:AnthropicAgent)
+class AnthropicAgentToWorkspaceRel(CartographyRelSchema):
+    """The workspace the agent belongs to."""
+
+    target_node_label: str = "AnthropicWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AnthropicAgentToWorkspaceRelProperties = (
+        AnthropicAgentToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicAgentToSkillRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicAgent)-[:USES_SKILL]->(:AnthropicSkill)
+class AnthropicAgentToSkillRel(CartographyRelSchema):
+    """A skill the agent has loaded."""
+
+    target_node_label: str = "AnthropicSkill"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("skill_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_SKILL"
+    properties: AnthropicAgentToSkillRelProperties = (
+        AnthropicAgentToSkillRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicAgentSchema(CartographyNodeSchema):
+    """A managed agent defined in an Anthropic workspace."""
+
+    label: str = "AnthropicAgent"
+    properties: AnthropicAgentNodeProperties = AnthropicAgentNodeProperties()
+    sub_resource_relationship: AnthropicAgentToWorkspaceRel = (
+        AnthropicAgentToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AnthropicAgentToSkillRel(),
+        ],
+    )

--- a/cartography/models/anthropic/apikey.py
+++ b/cartography/models/anthropic/apikey.py
@@ -109,6 +109,31 @@ class AnthropicApiKeyToUserOwnedByRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class AnthropicApiKeyToServiceAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# Canonical ontology edge: (:APIKey)-[:OWNED_BY]->(:ServiceAccount)
+class AnthropicApiKeyToServiceAccountRel(CartographyRelSchema):
+    """An API key is owned by a service account.
+
+    Only set when the key's principal is a service account; keys bound to a human
+    edge to an AnthropicUser instead.
+    """
+
+    target_node_label: str = "AnthropicServiceAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("principal.id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "OWNED_BY"
+    properties: AnthropicApiKeyToServiceAccountRelProperties = (
+        AnthropicApiKeyToServiceAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class AnthropicApiKeyToWorkspaceRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
@@ -145,6 +170,7 @@ class AnthropicApiKeySchema(CartographyNodeSchema):
         [
             AnthropicApiKeyToUserRel(),
             AnthropicApiKeyToUserOwnedByRel(),
+            AnthropicApiKeyToServiceAccountRel(),
             AnthropicApiKeyToWorkspaceRel(),
         ],
     )

--- a/cartography/models/anthropic/apikey.py
+++ b/cartography/models/anthropic/apikey.py
@@ -95,11 +95,16 @@ class AnthropicApiKeyToUserOwnedByRelProperties(CartographyRelProperties):
 @dataclass(frozen=True)
 # Canonical ontology edge: (:APIKey)-[:OWNED_BY]->(:UserAccount)
 class AnthropicApiKeyToUserOwnedByRel(CartographyRelSchema):
-    """An API key is owned by a user account."""
+    """An API key is owned by a user account.
+
+    Mutually exclusive with AnthropicApiKeyToServiceAccountRel: `owner_user_id` is left
+    unset for a key whose principal is a service account, so a key never reports two
+    owners.
+    """
 
     target_node_label: str = "AnthropicUser"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("created_by.id")},
+        {"id": PropertyRef("owner_user_id")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "OWNED_BY"
@@ -124,7 +129,7 @@ class AnthropicApiKeyToServiceAccountRel(CartographyRelSchema):
 
     target_node_label: str = "AnthropicServiceAccount"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("principal.id")},
+        {"id": PropertyRef("owner_service_account_id")},
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "OWNED_BY"

--- a/cartography/models/anthropic/apikey.py
+++ b/cartography/models/anthropic/apikey.py
@@ -25,6 +25,20 @@ class AnthropicApiKeyNodeProperties(CartographyNodeProperties):
         "created_at",
         description="RFC 3339 timestamp when the API key was created.",
     )
+    expires_at: PropertyRef = PropertyRef(
+        "expires_at",
+        description=(
+            "RFC 3339 timestamp when the API key expires. Empty when the key never "
+            "expires."
+        ),
+    )
+    principal_type: PropertyRef = PropertyRef(
+        "principal.type",
+        description=(
+            "Type of principal the API key acts as: user or service_account. Empty "
+            "when the key is not bound to a principal."
+        ),
+    )
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 

--- a/cartography/models/anthropic/deployment.py
+++ b/cartography/models/anthropic/deployment.py
@@ -1,0 +1,161 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AnthropicDeploymentNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Anthropic deployment ID.")
+    status: PropertyRef = PropertyRef(
+        "status",
+        description="Whether the deployment is active or paused.",
+    )
+    paused_reason: PropertyRef = PropertyRef(
+        "paused_reason", description="Why the deployment was paused."
+    )
+    schedule_type: PropertyRef = PropertyRef(
+        "schedule.type", description="Trigger type, currently always cron."
+    )
+    schedule_expression: PropertyRef = PropertyRef(
+        "schedule.expression",
+        description="Cron expression the agent is run on.",
+    )
+    schedule_timezone: PropertyRef = PropertyRef(
+        "schedule.timezone", description="Timezone the cron expression is read in."
+    )
+    schedule_last_run_at: PropertyRef = PropertyRef(
+        "schedule.last_run_at",
+        description="RFC 3339 timestamp of the most recent scheduled run.",
+    )
+    agent_id: PropertyRef = PropertyRef(
+        "agent.id", description="Agent this deployment runs."
+    )
+    agent_version: PropertyRef = PropertyRef(
+        "agent.version", description="Pinned version of the agent definition."
+    )
+    environment_id: PropertyRef = PropertyRef(
+        "environment_id", description="Environment the deployment runs in."
+    )
+    created_at: PropertyRef = PropertyRef(
+        "created_at", description="RFC 3339 timestamp when the deployment was created."
+    )
+    updated_at: PropertyRef = PropertyRef(
+        "updated_at",
+        description="RFC 3339 timestamp when the deployment was last updated.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AnthropicDeploymentToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicWorkspace)-[:RESOURCE]->(:AnthropicDeployment)
+class AnthropicDeploymentToWorkspaceRel(CartographyRelSchema):
+    """The workspace the deployment belongs to."""
+
+    target_node_label: str = "AnthropicWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AnthropicDeploymentToWorkspaceRelProperties = (
+        AnthropicDeploymentToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicDeploymentToAgentRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicDeployment)-[:RUNS]->(:AnthropicAgent)
+class AnthropicDeploymentToAgentRel(CartographyRelSchema):
+    """The agent this deployment runs on a schedule."""
+
+    target_node_label: str = "AnthropicAgent"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("agent.id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RUNS"
+    properties: AnthropicDeploymentToAgentRelProperties = (
+        AnthropicDeploymentToAgentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicDeploymentToEnvironmentRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicDeployment)-[:RUNS_IN]->(:AnthropicEnvironment)
+class AnthropicDeploymentToEnvironmentRel(CartographyRelSchema):
+    """The sandbox the deployment executes in, and so the egress policy it inherits."""
+
+    target_node_label: str = "AnthropicEnvironment"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("environment_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RUNS_IN"
+    properties: AnthropicDeploymentToEnvironmentRelProperties = (
+        AnthropicDeploymentToEnvironmentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicDeploymentToVaultRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicDeployment)-[:USES_VAULT]->(:AnthropicVault)
+class AnthropicDeploymentToVaultRel(CartographyRelSchema):
+    """A vault the deployment can draw credentials from."""
+
+    target_node_label: str = "AnthropicVault"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("vault_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_VAULT"
+    properties: AnthropicDeploymentToVaultRelProperties = (
+        AnthropicDeploymentToVaultRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicDeploymentSchema(CartographyNodeSchema):
+    """A scheduled, unattended run of an agent.
+
+    An active deployment is standing execution: the agent runs on its cron
+    expression with the credentials of its vaults and the egress of its environment,
+    with nobody watching.
+    """
+
+    label: str = "AnthropicDeployment"
+    properties: AnthropicDeploymentNodeProperties = AnthropicDeploymentNodeProperties()
+    sub_resource_relationship: AnthropicDeploymentToWorkspaceRel = (
+        AnthropicDeploymentToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AnthropicDeploymentToAgentRel(),
+            AnthropicDeploymentToEnvironmentRel(),
+            AnthropicDeploymentToVaultRel(),
+        ],
+    )

--- a/cartography/models/anthropic/environment.py
+++ b/cartography/models/anthropic/environment.py
@@ -1,0 +1,96 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AnthropicEnvironmentNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Anthropic environment ID.")
+    name: PropertyRef = PropertyRef("name", description="Environment name.")
+    description: PropertyRef = PropertyRef(
+        "description", description="What the environment is for."
+    )
+    config_type: PropertyRef = PropertyRef(
+        "config_type",
+        description="Where agents run: cloud, or self_hosted on your own infrastructure.",
+    )
+    networking_type: PropertyRef = PropertyRef(
+        "networking_type",
+        description=(
+            "Egress posture of the sandbox: unrestricted, or limited to an explicit "
+            "allowlist. Empty for self-hosted environments, whose egress is governed "
+            "by your own infrastructure."
+        ),
+    )
+    allowed_hosts: PropertyRef = PropertyRef(
+        "allowed_hosts",
+        description="Hosts the sandbox may reach when networking is limited.",
+    )
+    allow_mcp_servers: PropertyRef = PropertyRef(
+        "allow_mcp_servers",
+        description="Whether a limited sandbox may still reach MCP servers.",
+    )
+    allow_package_managers: PropertyRef = PropertyRef(
+        "allow_package_managers",
+        description="Whether a limited sandbox may still reach package registries.",
+    )
+    scope: PropertyRef = PropertyRef(
+        "scope",
+        description="Whether the environment is shared organization-wide or per account.",
+    )
+    archived_at: PropertyRef = PropertyRef(
+        "archived_at",
+        description=(
+            "RFC 3339 timestamp when the environment was archived. Empty while it is "
+            "live."
+        ),
+    )
+    created_at: PropertyRef = PropertyRef(
+        "created_at", description="RFC 3339 timestamp when the environment was created."
+    )
+    updated_at: PropertyRef = PropertyRef(
+        "updated_at",
+        description="RFC 3339 timestamp when the environment was last updated.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AnthropicEnvironmentToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicWorkspace)-[:RESOURCE]->(:AnthropicEnvironment)
+class AnthropicEnvironmentToWorkspaceRel(CartographyRelSchema):
+    """The workspace the environment belongs to."""
+
+    target_node_label: str = "AnthropicWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AnthropicEnvironmentToWorkspaceRelProperties = (
+        AnthropicEnvironmentToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicEnvironmentSchema(CartographyNodeSchema):
+    """A sandbox agents execute in, and the egress policy that bounds them."""
+
+    label: str = "AnthropicEnvironment"
+    properties: AnthropicEnvironmentNodeProperties = (
+        AnthropicEnvironmentNodeProperties()
+    )
+    sub_resource_relationship: AnthropicEnvironmentToWorkspaceRel = (
+        AnthropicEnvironmentToWorkspaceRel()
+    )

--- a/cartography/models/anthropic/federationissuer.py
+++ b/cartography/models/anthropic/federationissuer.py
@@ -1,0 +1,118 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.ontology.labels import IDENTITY_PROVIDER
+
+
+@dataclass(frozen=True)
+class AnthropicFederationIssuerNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Anthropic federation issuer ID.")
+    name: PropertyRef = PropertyRef("name", description="Federation issuer name.")
+    issuer_url: PropertyRef = PropertyRef(
+        "issuer_url",
+        extra_index=True,
+        description="URL of the OIDC identity provider whose tokens this issuer trusts.",
+    )
+    check_jti: PropertyRef = PropertyRef(
+        "check_jti",
+        description=(
+            "Whether the token exchange enforces single use per jti claim (replay "
+            "protection). Defaults to true, and only applies to assertions that "
+            "carry a jti."
+        ),
+    )
+    max_jwt_lifetime_seconds: PropertyRef = PropertyRef(
+        "max_jwt_lifetime_seconds",
+        description="Longest lifetime accepted on an assertion from this issuer.",
+    )
+    jwks_type: PropertyRef = PropertyRef(
+        "jwks_type",
+        description=(
+            "How the signing keys are obtained: discovery, explicit_url, or inline. "
+            "Inline keys are never refreshed automatically."
+        ),
+    )
+    jwks_url: PropertyRef = PropertyRef(
+        "jwks_url",
+        description=(
+            "URL the signing keys are fetched from. Empty for inline keys, and for "
+            "discovery unless a non-default discovery base is configured."
+        ),
+    )
+    jwks_polling_disabled_at: PropertyRef = PropertyRef(
+        "jwks_polling_disabled_at",
+        description=(
+            "RFC 3339 timestamp when key polling was disabled. A live issuer with "
+            "polling disabled will not pick up a key rotation."
+        ),
+    )
+    poll_status_consecutive_failures: PropertyRef = PropertyRef(
+        "poll_status.consecutive_failures",
+        description="Number of consecutive failed attempts to fetch the signing keys.",
+    )
+    poll_status_last_fetched_at: PropertyRef = PropertyRef(
+        "poll_status.last_fetched_at",
+        description="RFC 3339 timestamp when the signing keys were last fetched.",
+    )
+    created_at: PropertyRef = PropertyRef(
+        "created_at",
+        description="RFC 3339 timestamp when the issuer was registered.",
+    )
+    updated_at: PropertyRef = PropertyRef(
+        "updated_at",
+        description="RFC 3339 timestamp when the issuer was last updated.",
+    )
+    archived_at: PropertyRef = PropertyRef(
+        "archived_at",
+        description=(
+            "RFC 3339 timestamp when the issuer was archived. Empty while the "
+            "issuer is live."
+        ),
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AnthropicFederationIssuerToOrganizationRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicOrganization)-[:RESOURCE]->(:AnthropicFederationIssuer)
+class AnthropicFederationIssuerToOrganizationRel(CartographyRelSchema):
+    """The organization contains the federation issuer."""
+
+    target_node_label: str = "AnthropicOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ORG_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AnthropicFederationIssuerToOrganizationRelProperties = (
+        AnthropicFederationIssuerToOrganizationRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicFederationIssuerSchema(CartographyNodeSchema):
+    """An external OIDC identity provider trusted for Workload Identity Federation.
+
+    Only readable with an org:admin OAuth token, never with an Admin API key.
+    """
+
+    label: str = "AnthropicFederationIssuer"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([IDENTITY_PROVIDER])
+    properties: AnthropicFederationIssuerNodeProperties = (
+        AnthropicFederationIssuerNodeProperties()
+    )
+    sub_resource_relationship: AnthropicFederationIssuerToOrganizationRel = (
+        AnthropicFederationIssuerToOrganizationRel()
+    )

--- a/cartography/models/anthropic/federationrule.py
+++ b/cartography/models/anthropic/federationrule.py
@@ -1,0 +1,198 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AnthropicFederationRuleNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Anthropic federation rule ID.")
+    name: PropertyRef = PropertyRef("name", description="Federation rule name.")
+    description: PropertyRef = PropertyRef(
+        "description",
+        description="Free-text description of the federation rule.",
+    )
+    oauth_scope: PropertyRef = PropertyRef(
+        "oauth_scope",
+        description=(
+            "Scope ceiling for tokens minted through this rule: org:admin, "
+            "workspace:developer, workspace:inference, or workspace:manage_tunnels. "
+            "Effective permissions are the intersection of this scope and the target "
+            "service account's role."
+        ),
+    )
+    token_lifetime_seconds: PropertyRef = PropertyRef(
+        "token_lifetime_seconds",
+        description="Lifetime of tokens minted through this rule, in seconds.",
+    )
+    applies_to_all_workspaces: PropertyRef = PropertyRef(
+        "applies_to_all_workspaces",
+        description=(
+            "Whether the rule is enabled for every workspace in the organization, "
+            "including workspaces created after it. Ignored for org:admin rules, "
+            "which span the whole organization regardless."
+        ),
+    )
+    match_subject_prefix: PropertyRef = PropertyRef(
+        "match.subject_prefix",
+        description=(
+            "Prefix the assertion's sub claim must match. A trailing '*' makes it a "
+            "prefix match, which can be far broader than intended: a GitHub Actions "
+            "prefix ending in '*' also matches pull_request runs from forks."
+        ),
+    )
+    match_audience: PropertyRef = PropertyRef(
+        "match.audience",
+        description=(
+            "Value the assertion's aud claim must match. When empty, aud must equal "
+            "Anthropic's default expected audience for the issuer."
+        ),
+    )
+    match_condition: PropertyRef = PropertyRef(
+        "match.condition",
+        description="CEL expression evaluated against the assertion's claims.",
+    )
+    match_claims: PropertyRef = PropertyRef(
+        "match_claims",
+        description=(
+            "Claims the assertion must carry exactly, as sorted 'key=value' entries. "
+            "Flattened from a map, which Neo4j cannot store as a node property."
+        ),
+    )
+    created_at: PropertyRef = PropertyRef(
+        "created_at",
+        description="RFC 3339 timestamp when the rule was created.",
+    )
+    updated_at: PropertyRef = PropertyRef(
+        "updated_at",
+        description="RFC 3339 timestamp when the rule was last updated.",
+    )
+    archived_at: PropertyRef = PropertyRef(
+        "archived_at",
+        description=(
+            "RFC 3339 timestamp when the rule was archived. Empty while the rule is "
+            "live."
+        ),
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AnthropicFederationRuleToOrganizationRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicOrganization)-[:RESOURCE]->(:AnthropicFederationRule)
+class AnthropicFederationRuleToOrganizationRel(CartographyRelSchema):
+    """The organization contains the federation rule."""
+
+    target_node_label: str = "AnthropicOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ORG_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AnthropicFederationRuleToOrganizationRelProperties = (
+        AnthropicFederationRuleToOrganizationRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicFederationRuleToIssuerRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicFederationRule)-[:AUTHENTICATED_BY]->(:AnthropicFederationIssuer)
+class AnthropicFederationRuleToIssuerRel(CartographyRelSchema):
+    """The rule only accepts assertions signed by this issuer."""
+
+    target_node_label: str = "AnthropicFederationIssuer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("issuer_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "AUTHENTICATED_BY"
+    properties: AnthropicFederationRuleToIssuerRelProperties = (
+        AnthropicFederationRuleToIssuerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicFederationRuleToServiceAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicFederationRule)-[:ASSUMES]->(:AnthropicServiceAccount)
+class AnthropicFederationRuleToServiceAccountRel(CartographyRelSchema):
+    """Tokens minted through this rule act as this service account."""
+
+    target_node_label: str = "AnthropicServiceAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("target.service_account_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "ASSUMES"
+    properties: AnthropicFederationRuleToServiceAccountRelProperties = (
+        AnthropicFederationRuleToServiceAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicFederationRuleToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicFederationRule)-[:ENABLED_ON]->(:AnthropicWorkspace)
+class AnthropicFederationRuleToWorkspaceRel(CartographyRelSchema):
+    """The rule can mint tokens scoped to this workspace.
+
+    Only the explicitly enabled workspaces are edged. A rule with
+    applies_to_all_workspaces set covers every workspace without enumerating them,
+    so read that property rather than counting these edges.
+    """
+
+    target_node_label: str = "AnthropicWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("workspace_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "ENABLED_ON"
+    properties: AnthropicFederationRuleToWorkspaceRelProperties = (
+        AnthropicFederationRuleToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicFederationRuleSchema(CartographyNodeSchema):
+    """A rule binding external OIDC identities to an Anthropic service account.
+
+    A federation rule states which assertions, from which issuer, may mint a token
+    acting as which service account, and with which scope. Only readable with an
+    org:admin OAuth token, never with an Admin API key.
+    """
+
+    label: str = "AnthropicFederationRule"
+    properties: AnthropicFederationRuleNodeProperties = (
+        AnthropicFederationRuleNodeProperties()
+    )
+    sub_resource_relationship: AnthropicFederationRuleToOrganizationRel = (
+        AnthropicFederationRuleToOrganizationRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AnthropicFederationRuleToIssuerRel(),
+            AnthropicFederationRuleToServiceAccountRel(),
+            AnthropicFederationRuleToWorkspaceRel(),
+        ],
+    )

--- a/cartography/models/anthropic/invite.py
+++ b/cartography/models/anthropic/invite.py
@@ -1,0 +1,114 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AnthropicInviteNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Anthropic invite ID.")
+    email: PropertyRef = PropertyRef(
+        "email",
+        extra_index=True,
+        description="Email address the invite was sent to.",
+    )
+    role: PropertyRef = PropertyRef(
+        "role",
+        description="Organization role the invitee will hold once they accept.",
+    )
+    status: PropertyRef = PropertyRef(
+        "status",
+        description="Invite status: pending, accepted, expired, or deleted.",
+    )
+    invited_at: PropertyRef = PropertyRef(
+        "invited_at",
+        description="RFC 3339 timestamp when the invite was sent.",
+    )
+    expires_at: PropertyRef = PropertyRef(
+        "expires_at",
+        description=(
+            "RFC 3339 timestamp when the invite expires. Invites hard-expire after "
+            "21 days and the window is not configurable."
+        ),
+    )
+    accepted_at: PropertyRef = PropertyRef(
+        "accepted_at",
+        description=(
+            "RFC 3339 timestamp when the invite was accepted. Empty while the invite "
+            "is outstanding."
+        ),
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AnthropicInviteToOrganizationRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicOrganization)-[:RESOURCE]->(:AnthropicInvite)
+class AnthropicInviteToOrganizationRel(CartographyRelSchema):
+    """The organization issued the invite."""
+
+    target_node_label: str = "AnthropicOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ORG_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AnthropicInviteToOrganizationRelProperties = (
+        AnthropicInviteToOrganizationRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicInviteToRbacGroupRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicInvite)-[:GRANTS_MEMBERSHIP_OF]->(:AnthropicRbacGroup)
+class AnthropicInviteToRbacGroupRel(CartographyRelSchema):
+    """The group the invitee joins on acceptance.
+
+    Distinct from MEMBER_OF: nobody is in the group yet. This is a pending grant,
+    and it only appears on Claude Enterprise organizations.
+    """
+
+    target_node_label: str = "AnthropicRbacGroup"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("rbac_group_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "GRANTS_MEMBERSHIP_OF"
+    properties: AnthropicInviteToRbacGroupRelProperties = (
+        AnthropicInviteToRbacGroupRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicInviteSchema(CartographyNodeSchema):
+    """A pending or historical invitation to join an Anthropic organization.
+
+    An outstanding invite is an un-redeemed grant of the role it carries: whoever
+    controls the invited mailbox can claim it.
+    """
+
+    label: str = "AnthropicInvite"
+    properties: AnthropicInviteNodeProperties = AnthropicInviteNodeProperties()
+    sub_resource_relationship: AnthropicInviteToOrganizationRel = (
+        AnthropicInviteToOrganizationRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AnthropicInviteToRbacGroupRel(),
+        ],
+    )

--- a/cartography/models/anthropic/memorystore.py
+++ b/cartography/models/anthropic/memorystore.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AnthropicMemoryStoreNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Anthropic memory store ID.")
+    name: PropertyRef = PropertyRef("name", description="Memory store name.")
+    description: PropertyRef = PropertyRef(
+        "description", description="What the memory store holds."
+    )
+    archived_at: PropertyRef = PropertyRef(
+        "archived_at",
+        description=(
+            "RFC 3339 timestamp when the memory store was archived. Empty while live."
+        ),
+    )
+    created_at: PropertyRef = PropertyRef(
+        "created_at",
+        description="RFC 3339 timestamp when the memory store was created.",
+    )
+    updated_at: PropertyRef = PropertyRef(
+        "updated_at",
+        description="RFC 3339 timestamp when the memory store was last updated.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AnthropicMemoryStoreToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicWorkspace)-[:RESOURCE]->(:AnthropicMemoryStore)
+class AnthropicMemoryStoreToWorkspaceRel(CartographyRelSchema):
+    """The workspace the memory store belongs to."""
+
+    target_node_label: str = "AnthropicWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AnthropicMemoryStoreToWorkspaceRelProperties = (
+        AnthropicMemoryStoreToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicMemoryStoreSchema(CartographyNodeSchema):
+    """Persistent memory an agent carries between sessions."""
+
+    label: str = "AnthropicMemoryStore"
+    properties: AnthropicMemoryStoreNodeProperties = (
+        AnthropicMemoryStoreNodeProperties()
+    )
+    sub_resource_relationship: AnthropicMemoryStoreToWorkspaceRel = (
+        AnthropicMemoryStoreToWorkspaceRel()
+    )

--- a/cartography/models/anthropic/organization.py
+++ b/cartography/models/anthropic/organization.py
@@ -10,6 +10,7 @@ from cartography.models.ontology.labels import TENANT
 @dataclass(frozen=True)
 class AnthropicOrganizationNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef("id", description="Anthropic organization ID.")
+    name: PropertyRef = PropertyRef("name", description="Organization name.")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 

--- a/cartography/models/anthropic/ratelimit.py
+++ b/cartography/models/anthropic/ratelimit.py
@@ -1,0 +1,115 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AnthropicRateLimitNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id",
+        description=(
+            "Synthesised from the scope, group type, models and limit type. The API "
+            "returns no identifier for a rate limit."
+        ),
+    )
+    group_type: PropertyRef = PropertyRef(
+        "group_type",
+        description=(
+            "Family the limit applies to: batch, files, model_group, skills, "
+            "token_count, or web_search."
+        ),
+    )
+    limit_type: PropertyRef = PropertyRef(
+        "limit_type",
+        description="Quantity being limited, e.g. requests or tokens per minute.",
+    )
+    value: PropertyRef = PropertyRef("value", description="The configured limit.")
+    org_limit: PropertyRef = PropertyRef(
+        "org_limit",
+        description=(
+            "Organization-level value this workspace limit overrides. Empty on "
+            "organization-level limits."
+        ),
+    )
+    models: PropertyRef = PropertyRef(
+        "models",
+        description="Models the limit applies to. Empty when it applies to all.",
+    )
+    workspace_id: PropertyRef = PropertyRef(
+        "workspace_id",
+        description=(
+            "Workspace this limit overrides, or empty for an organization-level "
+            "limit."
+        ),
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AnthropicRateLimitToOrganizationRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicOrganization)-[:RESOURCE]->(:AnthropicRateLimit)
+class AnthropicRateLimitToOrganizationRel(CartographyRelSchema):
+    """The organization the rate limit belongs to."""
+
+    target_node_label: str = "AnthropicOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ORG_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AnthropicRateLimitToOrganizationRelProperties = (
+        AnthropicRateLimitToOrganizationRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicRateLimitToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicWorkspace)-[:CONTAINS]->(:AnthropicRateLimit)
+class AnthropicRateLimitToWorkspaceRel(CartographyRelSchema):
+    """The workspace this limit overrides. Absent on organization-level limits."""
+
+    target_node_label: str = "AnthropicWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("workspace_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "CONTAINS"
+    properties: AnthropicRateLimitToWorkspaceRelProperties = (
+        AnthropicRateLimitToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicRateLimitSchema(CartographyNodeSchema):
+    """A configured rate limit on an Anthropic organization or workspace.
+
+    Only overrides are returned: a group with no node here inherits the
+    organization's limit, which is not the same as being unlimited.
+    """
+
+    label: str = "AnthropicRateLimit"
+    properties: AnthropicRateLimitNodeProperties = AnthropicRateLimitNodeProperties()
+    sub_resource_relationship: AnthropicRateLimitToOrganizationRel = (
+        AnthropicRateLimitToOrganizationRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AnthropicRateLimitToWorkspaceRel(),
+        ],
+    )

--- a/cartography/models/anthropic/rbac.py
+++ b/cartography/models/anthropic/rbac.py
@@ -1,0 +1,277 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.ontology.labels import PERMISSION_ROLE
+from cartography.models.ontology.labels import USER_GROUP
+
+
+@dataclass(frozen=True)
+class AnthropicRbacRoleNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Anthropic RBAC role ID.")
+    name: PropertyRef = PropertyRef("name", description="RBAC role name.")
+    created_at: PropertyRef = PropertyRef(
+        "created_at",
+        description="RFC 3339 timestamp when the role was created.",
+    )
+    updated_at: PropertyRef = PropertyRef(
+        "updated_at",
+        description="RFC 3339 timestamp when the role was last updated.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AnthropicRbacRoleToOrganizationRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicOrganization)-[:RESOURCE]->(:AnthropicRbacRole)
+class AnthropicRbacRoleToOrganizationRel(CartographyRelSchema):
+    """The organization defines the RBAC role."""
+
+    target_node_label: str = "AnthropicOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ORG_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AnthropicRbacRoleToOrganizationRelProperties = (
+        AnthropicRbacRoleToOrganizationRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicRbacRoleSchema(CartographyNodeSchema):
+    """A custom role in a Claude Enterprise organization."""
+
+    label: str = "AnthropicRbacRole"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([PERMISSION_ROLE])
+    properties: AnthropicRbacRoleNodeProperties = AnthropicRbacRoleNodeProperties()
+    sub_resource_relationship: AnthropicRbacRoleToOrganizationRel = (
+        AnthropicRbacRoleToOrganizationRel()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicRbacRolePermissionNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id",
+        description=(
+            "Synthesised from the role, action and resource. The API returns no "
+            "identifier for a permission."
+        ),
+    )
+    action: PropertyRef = PropertyRef(
+        "action",
+        description=(
+            "Action the permission grants on the resource. Free-form: the API "
+            "declares no enumeration. The blanket values capability_access_all and "
+            "capability_access_all_ga each stand for every product-feature "
+            "entitlement they cover, so reading a role's grants literally will "
+            "under-report its effective access."
+        ),
+    )
+    resource_type: PropertyRef = PropertyRef(
+        "resource.type",
+        description=(
+            "Kind of resource granted on: organization, connector, connector_tool, "
+            "connector_scope, or all_connectors."
+        ),
+    )
+    resource_organization_id: PropertyRef = PropertyRef(
+        "resource.organization_id",
+        description="Organization granted on, for organization-type resources.",
+    )
+    resource_connector_id: PropertyRef = PropertyRef(
+        "resource.connector_id",
+        description="Connector granted on, for connector-type resources.",
+    )
+    resource_tool_name: PropertyRef = PropertyRef(
+        "resource.tool_name",
+        description=(
+            "Tool granted on. Names containing characters outside [a-zA-Z0-9_-] are "
+            "server-encoded to a stable {prefix}_{32-hex} form the original name "
+            "cannot be recovered from; treat this as an opaque identifier."
+        ),
+    )
+    resource_scope: PropertyRef = PropertyRef(
+        "resource.scope",
+        description=(
+            "OAuth scope granted. Scopes routinely contain ':' and '/', so most "
+            "arrive in the server-encoded opaque form."
+        ),
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AnthropicRbacRolePermissionToOrganizationRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicOrganization)-[:RESOURCE]->(:AnthropicRbacRolePermission)
+class AnthropicRbacRolePermissionToOrganizationRel(CartographyRelSchema):
+    """The organization the permission belongs to."""
+
+    target_node_label: str = "AnthropicOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ORG_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AnthropicRbacRolePermissionToOrganizationRelProperties = (
+        AnthropicRbacRolePermissionToOrganizationRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicRbacRolePermissionToRoleRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicRbacRole)-[:GRANTS]->(:AnthropicRbacRolePermission)
+class AnthropicRbacRolePermissionToRoleRel(CartographyRelSchema):
+    """The role grants this permission."""
+
+    target_node_label: str = "AnthropicRbacRole"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("role_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "GRANTS"
+    properties: AnthropicRbacRolePermissionToRoleRelProperties = (
+        AnthropicRbacRolePermissionToRoleRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicRbacRolePermissionSchema(CartographyNodeSchema):
+    """A single action-on-resource grant carried by an RBAC role."""
+
+    label: str = "AnthropicRbacRolePermission"
+    properties: AnthropicRbacRolePermissionNodeProperties = (
+        AnthropicRbacRolePermissionNodeProperties()
+    )
+    sub_resource_relationship: AnthropicRbacRolePermissionToOrganizationRel = (
+        AnthropicRbacRolePermissionToOrganizationRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AnthropicRbacRolePermissionToRoleRel(),
+        ],
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicRbacGroupNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Anthropic RBAC group ID.")
+    name: PropertyRef = PropertyRef("name", description="RBAC group name.")
+    source_type: PropertyRef = PropertyRef(
+        "source_type",
+        description=(
+            "How the group is provisioned: direct, or scim when it is synced from an "
+            "external directory."
+        ),
+    )
+    created_at: PropertyRef = PropertyRef(
+        "created_at",
+        description="RFC 3339 timestamp when the group was created.",
+    )
+    updated_at: PropertyRef = PropertyRef(
+        "updated_at",
+        description="RFC 3339 timestamp when the group was last updated.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AnthropicRbacGroupToOrganizationRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicOrganization)-[:RESOURCE]->(:AnthropicRbacGroup)
+class AnthropicRbacGroupToOrganizationRel(CartographyRelSchema):
+    """The organization contains the RBAC group."""
+
+    target_node_label: str = "AnthropicOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ORG_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AnthropicRbacGroupToOrganizationRelProperties = (
+        AnthropicRbacGroupToOrganizationRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicRbacGroupToRoleRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicRbacGroup)-[:HAS_ROLE]->(:AnthropicRbacRole)
+class AnthropicRbacGroupToRoleRel(CartographyRelSchema):
+    """The group holds the role; its members inherit the role's permissions."""
+
+    target_node_label: str = "AnthropicRbacRole"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("roles", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_ROLE"
+    properties: AnthropicRbacGroupToRoleRelProperties = (
+        AnthropicRbacGroupToRoleRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicRbacGroupToUserRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicUser)-[:MEMBER_OF]->(:AnthropicRbacGroup)
+class AnthropicRbacGroupToUserRel(CartographyRelSchema):
+    """A user is a member of the group."""
+
+    target_node_label: str = "AnthropicUser"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("members", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "MEMBER_OF"
+    properties: AnthropicRbacGroupToUserRelProperties = (
+        AnthropicRbacGroupToUserRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicRbacGroupSchema(CartographyNodeSchema):
+    """A group in a Claude Enterprise organization, holding roles its members inherit."""
+
+    label: str = "AnthropicRbacGroup"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([USER_GROUP])
+    properties: AnthropicRbacGroupNodeProperties = AnthropicRbacGroupNodeProperties()
+    sub_resource_relationship: AnthropicRbacGroupToOrganizationRel = (
+        AnthropicRbacGroupToOrganizationRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AnthropicRbacGroupToRoleRel(),
+            AnthropicRbacGroupToUserRel(),
+        ],
+    )

--- a/cartography/models/anthropic/serviceaccount.py
+++ b/cartography/models/anthropic/serviceaccount.py
@@ -1,0 +1,138 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.ontology.labels import SERVICE_ACCOUNT
+
+
+@dataclass(frozen=True)
+class AnthropicServiceAccountNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Anthropic service account ID.")
+    name: PropertyRef = PropertyRef("name", description="Service account name.")
+    description: PropertyRef = PropertyRef(
+        "description",
+        description="Free-text description of the service account.",
+    )
+    organization_role: PropertyRef = PropertyRef(
+        "organization_role",
+        description=(
+            "Organization-level role: admin or developer. Only an admin service "
+            "account can back a federation rule carrying the org:admin scope."
+        ),
+    )
+    created_at: PropertyRef = PropertyRef(
+        "created_at",
+        description="RFC 3339 timestamp when the service account was created.",
+    )
+    updated_at: PropertyRef = PropertyRef(
+        "updated_at",
+        description="RFC 3339 timestamp when the service account was last updated.",
+    )
+    archived_at: PropertyRef = PropertyRef(
+        "archived_at",
+        description=(
+            "RFC 3339 timestamp when the service account was archived. Empty while "
+            "the service account is live."
+        ),
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AnthropicServiceAccountToOrganizationRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicOrganization)-[:RESOURCE]->(:AnthropicServiceAccount)
+class AnthropicServiceAccountToOrganizationRel(CartographyRelSchema):
+    """The organization contains the service account."""
+
+    target_node_label: str = "AnthropicOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ORG_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AnthropicServiceAccountToOrganizationRelProperties = (
+        AnthropicServiceAccountToOrganizationRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicServiceAccountToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicServiceAccount)-[:MEMBER_OF]->(:AnthropicWorkspace)
+class AnthropicServiceAccountToWorkspaceRel(CartographyRelSchema):
+    """A service account is a member of a workspace.
+
+    Membership is what lets a federated token act in a workspace: enabling a
+    federation rule for a workspace does not grant it.
+    """
+
+    target_node_label: str = "AnthropicWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("workspaces", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MEMBER_OF"
+    properties: AnthropicServiceAccountToWorkspaceRelProperties = (
+        AnthropicServiceAccountToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicServiceAccountToWorkspaceAdminRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicServiceAccount)-[:ADMIN_OF]->(:AnthropicWorkspace)
+class AnthropicServiceAccountToWorkspaceAdminRel(CartographyRelSchema):
+    """A service account administers a workspace."""
+
+    target_node_label: str = "AnthropicWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("workspace_admins", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "ADMIN_OF"
+    properties: AnthropicServiceAccountToWorkspaceAdminRelProperties = (
+        AnthropicServiceAccountToWorkspaceAdminRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicServiceAccountSchema(CartographyNodeSchema):
+    """A non-human principal in an Anthropic organization.
+
+    Service accounts are the target of Workload Identity Federation: a federated
+    token exchange mints a token that acts as one. Only readable with an org:admin
+    OAuth token, never with an Admin API key.
+    """
+
+    label: str = "AnthropicServiceAccount"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([SERVICE_ACCOUNT])
+    properties: AnthropicServiceAccountNodeProperties = (
+        AnthropicServiceAccountNodeProperties()
+    )
+    sub_resource_relationship: AnthropicServiceAccountToOrganizationRel = (
+        AnthropicServiceAccountToOrganizationRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AnthropicServiceAccountToWorkspaceRel(),
+            AnthropicServiceAccountToWorkspaceAdminRel(),
+        ],
+    )

--- a/cartography/models/anthropic/skill.py
+++ b/cartography/models/anthropic/skill.py
@@ -1,0 +1,164 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AnthropicSkillNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Anthropic skill ID.")
+    display_title: PropertyRef = PropertyRef(
+        "display_title",
+        description="Skill title shown in the Console.",
+    )
+    source: PropertyRef = PropertyRef(
+        "source",
+        description=(
+            "Who authored the skill: custom for one uploaded to this workspace, or "
+            "anthropic for a first-party one available organization-wide."
+        ),
+    )
+    latest_version: PropertyRef = PropertyRef(
+        "latest_version",
+        description="Version identifier of the most recent version.",
+    )
+    created_at: PropertyRef = PropertyRef(
+        "created_at",
+        description="RFC 3339 timestamp when the skill was created.",
+    )
+    updated_at: PropertyRef = PropertyRef(
+        "updated_at",
+        description="RFC 3339 timestamp when the skill was last updated.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AnthropicSkillToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicWorkspace)-[:RESOURCE]->(:AnthropicSkill)
+class AnthropicSkillToWorkspaceRel(CartographyRelSchema):
+    """The workspace the skill is available in."""
+
+    target_node_label: str = "AnthropicWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AnthropicSkillToWorkspaceRelProperties = (
+        AnthropicSkillToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicSkillSchema(CartographyNodeSchema):
+    """A skill available to agents in an Anthropic workspace.
+
+    Custom skills are private to the workspace that uploaded them. There is no
+    organization-wide listing, so reaching them means a workspace-scoped credential
+    per workspace.
+    """
+
+    label: str = "AnthropicSkill"
+    properties: AnthropicSkillNodeProperties = AnthropicSkillNodeProperties()
+    sub_resource_relationship: AnthropicSkillToWorkspaceRel = (
+        AnthropicSkillToWorkspaceRel()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicSkillVersionNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Anthropic skill version ID.")
+    name: PropertyRef = PropertyRef("name", description="Skill version name.")
+    description: PropertyRef = PropertyRef(
+        "description",
+        description="What the skill does, as declared by this version.",
+    )
+    directory: PropertyRef = PropertyRef(
+        "directory",
+        description="Directory the skill's files are rooted at.",
+    )
+    version: PropertyRef = PropertyRef(
+        "version",
+        description="Version identifier, a microsecond epoch rendered as a string.",
+    )
+    skill_id: PropertyRef = PropertyRef(
+        "skill_id",
+        description="Skill this version belongs to.",
+    )
+    created_at: PropertyRef = PropertyRef(
+        "created_at",
+        description="RFC 3339 timestamp when the version was created.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AnthropicSkillVersionToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicWorkspace)-[:RESOURCE]->(:AnthropicSkillVersion)
+class AnthropicSkillVersionToWorkspaceRel(CartographyRelSchema):
+    """The workspace the skill version is available in."""
+
+    target_node_label: str = "AnthropicWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AnthropicSkillVersionToWorkspaceRelProperties = (
+        AnthropicSkillVersionToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicSkillVersionToSkillRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicSkill)-[:HAS_VERSION]->(:AnthropicSkillVersion)
+class AnthropicSkillVersionToSkillRel(CartographyRelSchema):
+    """The skill this version belongs to."""
+
+    target_node_label: str = "AnthropicSkill"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("skill_id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_VERSION"
+    properties: AnthropicSkillVersionToSkillRelProperties = (
+        AnthropicSkillVersionToSkillRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicSkillVersionSchema(CartographyNodeSchema):
+    """A published version of an Anthropic skill."""
+
+    label: str = "AnthropicSkillVersion"
+    properties: AnthropicSkillVersionNodeProperties = (
+        AnthropicSkillVersionNodeProperties()
+    )
+    sub_resource_relationship: AnthropicSkillVersionToWorkspaceRel = (
+        AnthropicSkillVersionToWorkspaceRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            AnthropicSkillVersionToSkillRel(),
+        ],
+    )

--- a/cartography/models/anthropic/vault.py
+++ b/cartography/models/anthropic/vault.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class AnthropicVaultNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Anthropic vault ID.")
+    display_name: PropertyRef = PropertyRef(
+        "display_name", description="Vault name shown in the Console."
+    )
+    archived_at: PropertyRef = PropertyRef(
+        "archived_at",
+        description="RFC 3339 timestamp when the vault was archived. Empty while live.",
+    )
+    created_at: PropertyRef = PropertyRef(
+        "created_at", description="RFC 3339 timestamp when the vault was created."
+    )
+    updated_at: PropertyRef = PropertyRef(
+        "updated_at", description="RFC 3339 timestamp when the vault was last updated."
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class AnthropicVaultToWorkspaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:AnthropicWorkspace)-[:RESOURCE]->(:AnthropicVault)
+class AnthropicVaultToWorkspaceRel(CartographyRelSchema):
+    """The workspace the vault belongs to."""
+
+    target_node_label: str = "AnthropicWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: AnthropicVaultToWorkspaceRelProperties = (
+        AnthropicVaultToWorkspaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AnthropicVaultSchema(CartographyNodeSchema):
+    """A container of credentials that agent sessions and deployments can draw on.
+
+    Only the vault itself is enumerable; the secrets inside it are not exposed by
+    the API, so the graph records which workloads can reach a vault, not what is in
+    it.
+    """
+
+    label: str = "AnthropicVault"
+    properties: AnthropicVaultNodeProperties = AnthropicVaultNodeProperties()
+    sub_resource_relationship: AnthropicVaultToWorkspaceRel = (
+        AnthropicVaultToWorkspaceRel()
+    )

--- a/cartography/models/anthropic/workspace.py
+++ b/cartography/models/anthropic/workspace.py
@@ -30,6 +30,35 @@ class AnthropicWorkspaceNodeProperties(CartographyNodeProperties):
         "display_color",
         description="Hex color representing the workspace in the Anthropic Console.",
     )
+    compartment_id: PropertyRef = PropertyRef(
+        "compartment_id",
+        description=(
+            "ID of the compartment the workspace belongs to, referenced by "
+            "customer-managed encryption key policy conditions."
+        ),
+    )
+    external_key_id: PropertyRef = PropertyRef(
+        "external_key_id",
+        description=(
+            "ID of the customer-managed encryption key bound to the workspace. "
+            "Write-once; empty when the workspace uses Anthropic-managed encryption."
+        ),
+    )
+    workspace_geo: PropertyRef = PropertyRef(
+        "workspace_geo",
+        description="Geography the workspace's data is resident in.",
+    )
+    default_inference_geo: PropertyRef = PropertyRef(
+        "default_inference_geo",
+        description="Geography inference runs in by default for this workspace.",
+    )
+    allowed_inference_geos: PropertyRef = PropertyRef(
+        "allowed_inference_geos",
+        description=(
+            "Geographies inference is allowed to run in, or a single entry "
+            "'unrestricted' when the workspace places no restriction."
+        ),
+    )
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 

--- a/cartography/models/anthropic/workspace.py
+++ b/cartography/models/anthropic/workspace.py
@@ -39,6 +39,7 @@ class AnthropicWorkspaceNodeProperties(CartographyNodeProperties):
     )
     external_key_id: PropertyRef = PropertyRef(
         "external_key_id",
+        extra_index=True,
         description=(
             "ID of the customer-managed encryption key bound to the workspace. "
             "Write-once; empty when the workspace uses Anthropic-managed encryption."

--- a/cartography/models/ontology/mapping/data/groups.py
+++ b/cartography/models/ontology/mapping/data/groups.py
@@ -390,7 +390,25 @@ salesforce_mapping = OntologyMapping(
     ],
 )
 
+# Anthropic
+anthropic_mapping = OntologyMapping(
+    module_name="anthropic",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="AnthropicRbacGroup",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                # description: Not available
+                # email: Not available
+            ],
+        ),
+    ],
+)
+
 GROUPS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
+    "anthropic": anthropic_mapping,
     "aws": aws_mapping,
     "circleci": circleci_mapping,
     "salesforce": salesforce_mapping,

--- a/cartography/models/ontology/mapping/data/identityproviders.py
+++ b/cartography/models/ontology/mapping/data/identityproviders.py
@@ -159,7 +159,33 @@ supabase_mapping = OntologyMapping(
     ],
 )
 
+anthropic_mapping = OntologyMapping(
+    module_name="anthropic",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="AnthropicFederationIssuer",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                # A federation issuer is an OIDC issuer by construction: Anthropic
+                # verifies assertions against a JWKS and accepts no other protocol.
+                OntologyFieldMapping(
+                    ontology_field="protocol",
+                    node_field="",
+                    special_handling="static_value",
+                    extra={"value": "OIDC"},
+                ),
+                OntologyFieldMapping(ontology_field="issuer", node_field="issuer_url"),
+                # enabled: An issuer has no enable/disable state; it is either live
+                # or archived, and `archived_at` already carries that.
+            ],
+        ),
+    ],
+)
+
 IDENTITYPROVIDERS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
+    "anthropic": anthropic_mapping,
     "aws": aws_mapping,
     "kubernetes": kubernetes_mapping,
     "keycloak": keycloak_mapping,

--- a/cartography/models/ontology/mapping/data/roles.py
+++ b/cartography/models/ontology/mapping/data/roles.py
@@ -395,7 +395,37 @@ modal_mapping = OntologyMapping(
     ],
 )
 
+# Anthropic
+anthropic_mapping = OntologyMapping(
+    module_name="anthropic",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="AnthropicRbacRole",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                # The RBAC roles endpoint only returns custom roles; Anthropic's
+                # built-in organization roles are a separate enum on the user object.
+                OntologyFieldMapping(
+                    ontology_field="type",
+                    node_field="",
+                    special_handling="static_value",
+                    extra={"value": "custom"},
+                ),
+                OntologyFieldMapping(
+                    ontology_field="scope",
+                    node_field="",
+                    special_handling="static_value",
+                    extra={"value": "org"},
+                ),
+            ],
+        ),
+    ],
+)
+
 ROLES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
+    "anthropic": anthropic_mapping,
     "aws": aws_mapping,
     "azure": azure_mapping,
     "gcp": gcp_mapping,

--- a/cartography/models/ontology/mapping/data/serviceaccounts.py
+++ b/cartography/models/ontology/mapping/data/serviceaccounts.py
@@ -132,7 +132,25 @@ modal_mapping = OntologyMapping(
     ],
 )
 
+anthropic_mapping = OntologyMapping(
+    module_name="anthropic",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="AnthropicServiceAccount",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                # email: Not available
+                # active: Not available. Archival is exposed as `archived_at`, but a
+                # timestamp is not the boolean this field expects.
+            ],
+        ),
+    ],
+)
+
 SERVICEACCOUNTS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
+    "anthropic": anthropic_mapping,
     "gcp": gcp_mapping,
     "kubernetes": kubernetes_mapping,
     "openai": openai_mapping,

--- a/cartography/models/ontology/mapping/data/tenants.py
+++ b/cartography/models/ontology/mapping/data/tenants.py
@@ -80,7 +80,22 @@ airbyte_mapping = OntologyMapping(
     ],
 )
 
-# Anthropic: No field to map in AnthropicOrganization (minimal properties)
+# Anthropic
+anthropic_mapping = OntologyMapping(
+    module_name="anthropic",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="AnthropicOrganization",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                # status: Not available
+                # domain: Not available
+            ],
+        ),
+    ],
+)
 
 # AWS
 aws_mapping = OntologyMapping(
@@ -722,6 +737,7 @@ modal_mapping = OntologyMapping(
 
 TENANTS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "airbyte": airbyte_mapping,
+    "anthropic": anthropic_mapping,
     "aws": aws_mapping,
     "circleci": circleci_mapping,
     "azure": azure_mapping,

--- a/demo/seeds/anthropic.py
+++ b/demo/seeds/anthropic.py
@@ -2,9 +2,11 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 import cartography.intel.anthropic.apikeys
+import cartography.intel.anthropic.organization
 import cartography.intel.anthropic.users
 import cartography.intel.anthropic.workspaces
 import tests.data.anthropic.apikeys
+import tests.data.anthropic.organization
 import tests.data.anthropic.users
 import tests.data.anthropic.workspaces
 from demo.seeds.base import Seed
@@ -33,11 +35,27 @@ class AnthropicSeed(Seed):
         "get",
         return_value=(ORG_ID, tests.data.anthropic.apikeys.ANTHROPIC_APIKEYS),
     )
+    @patch.object(
+        cartography.intel.anthropic.organization,
+        "get",
+        return_value=tests.data.anthropic.organization.ANTHROPIC_ORGANIZATION,
+    )
     def seed(self, *args) -> None:
         api_session = Mock()
+        self._seed_organization(api_session)
         self._seed_users(api_session)
         self._seed_workspaces(api_session)
         self._seed_apikeys(api_session)
+
+    def _seed_organization(self, api_session: Mock) -> None:
+        cartography.intel.anthropic.organization.sync(
+            self.neo4j_session,
+            api_session,
+            common_job_parameters={
+                "UPDATE_TAG": self.update_tag,
+                "BASE_URL": "https://api.anthropic.com/v1",
+            },
+        )
 
     def _seed_users(self, api_session: Mock) -> None:
         cartography.intel.anthropic.users.sync(

--- a/demo/seeds/anthropic.py
+++ b/demo/seeds/anthropic.py
@@ -2,11 +2,15 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 import cartography.intel.anthropic.apikeys
+import cartography.intel.anthropic.federation
 import cartography.intel.anthropic.organization
+import cartography.intel.anthropic.serviceaccounts
 import cartography.intel.anthropic.users
 import cartography.intel.anthropic.workspaces
 import tests.data.anthropic.apikeys
+import tests.data.anthropic.federation
 import tests.data.anthropic.organization
+import tests.data.anthropic.serviceaccounts
 import tests.data.anthropic.users
 import tests.data.anthropic.workspaces
 from demo.seeds.base import Seed
@@ -40,12 +44,69 @@ class AnthropicSeed(Seed):
         "get",
         return_value=tests.data.anthropic.organization.ANTHROPIC_ORGANIZATION,
     )
+    @patch.object(
+        cartography.intel.anthropic.serviceaccounts,
+        "get_service_account_workspaces",
+        side_effect=lambda _session, _url, service_account_id: (
+            tests.data.anthropic.serviceaccounts.ANTHROPIC_SERVICE_ACCOUNT_WORKSPACES[
+                service_account_id
+            ]
+        ),
+    )
+    @patch.object(
+        cartography.intel.anthropic.serviceaccounts,
+        "get",
+        return_value=tests.data.anthropic.serviceaccounts.ANTHROPIC_SERVICE_ACCOUNTS,
+    )
+    @patch.object(
+        cartography.intel.anthropic.federation,
+        "get_rule_workspaces",
+        side_effect=lambda _session, _url, rule_id: (
+            tests.data.anthropic.federation.ANTHROPIC_FEDERATION_RULE_WORKSPACES[
+                rule_id
+            ]
+        ),
+    )
+    @patch.object(
+        cartography.intel.anthropic.federation,
+        "get_rules",
+        return_value=tests.data.anthropic.federation.ANTHROPIC_FEDERATION_RULES,
+    )
+    @patch.object(
+        cartography.intel.anthropic.federation,
+        "get_issuers",
+        return_value=tests.data.anthropic.federation.ANTHROPIC_FEDERATION_ISSUERS,
+    )
     def seed(self, *args) -> None:
         api_session = Mock()
         self._seed_organization(api_session)
         self._seed_users(api_session)
         self._seed_workspaces(api_session)
+        self._seed_service_accounts(api_session)
+        self._seed_federation(api_session)
         self._seed_apikeys(api_session)
+
+    def _seed_service_accounts(self, api_session: Mock) -> None:
+        cartography.intel.anthropic.serviceaccounts.sync(
+            self.neo4j_session,
+            api_session,
+            common_job_parameters={
+                "UPDATE_TAG": self.update_tag,
+                "BASE_URL": "https://api.anthropic.com/v1",
+                "ORG_ID": ORG_ID,
+            },
+        )
+
+    def _seed_federation(self, api_session: Mock) -> None:
+        cartography.intel.anthropic.federation.sync(
+            self.neo4j_session,
+            api_session,
+            common_job_parameters={
+                "UPDATE_TAG": self.update_tag,
+                "BASE_URL": "https://api.anthropic.com/v1",
+                "ORG_ID": ORG_ID,
+            },
+        )
 
     def _seed_organization(self, api_session: Mock) -> None:
         cartography.intel.anthropic.organization.sync(

--- a/demo/seeds/anthropic.py
+++ b/demo/seeds/anthropic.py
@@ -3,17 +3,25 @@ from unittest.mock import patch
 
 import cartography.intel.anthropic.apikeys
 import cartography.intel.anthropic.federation
+import cartography.intel.anthropic.invites
 import cartography.intel.anthropic.organization
+import cartography.intel.anthropic.ratelimits
+import cartography.intel.anthropic.rbac
 import cartography.intel.anthropic.serviceaccounts
 import cartography.intel.anthropic.users
 import cartography.intel.anthropic.workspaces
 import tests.data.anthropic.apikeys
 import tests.data.anthropic.federation
+import tests.data.anthropic.invites
 import tests.data.anthropic.organization
+import tests.data.anthropic.ratelimits
+import tests.data.anthropic.rbac
 import tests.data.anthropic.serviceaccounts
 import tests.data.anthropic.users
 import tests.data.anthropic.workspaces
 from demo.seeds.base import Seed
+
+WORKSPACE_ID = "wrkspc_01JwQvzr7rXLA5AGx3HKfFUJ"
 
 ORG_ID = "8834c225-ea27-405a-aea9-5ed5f07f4858"
 
@@ -77,14 +85,94 @@ class AnthropicSeed(Seed):
         "get_issuers",
         return_value=tests.data.anthropic.federation.ANTHROPIC_FEDERATION_ISSUERS,
     )
+    @patch.object(
+        cartography.intel.anthropic.ratelimits,
+        "get_workspace_rate_limits",
+        side_effect=lambda _session, _url, workspace_id: (
+            tests.data.anthropic.ratelimits.ANTHROPIC_WORKSPACE_RATE_LIMITS[
+                workspace_id
+            ]
+        ),
+    )
+    @patch.object(
+        cartography.intel.anthropic.ratelimits,
+        "get",
+        return_value=tests.data.anthropic.ratelimits.ANTHROPIC_RATE_LIMITS,
+    )
+    @patch.object(
+        cartography.intel.anthropic.invites,
+        "get",
+        return_value=(ORG_ID, tests.data.anthropic.invites.ANTHROPIC_INVITES),
+    )
+    @patch.object(
+        cartography.intel.anthropic.rbac,
+        "get_group_members",
+        side_effect=lambda _session, _url, group_id: (
+            tests.data.anthropic.rbac.ANTHROPIC_RBAC_GROUP_MEMBERS[group_id]
+        ),
+    )
+    @patch.object(
+        cartography.intel.anthropic.rbac,
+        "get_groups",
+        return_value=tests.data.anthropic.rbac.ANTHROPIC_RBAC_GROUPS,
+    )
+    @patch.object(
+        cartography.intel.anthropic.rbac,
+        "get_role_permissions",
+        side_effect=lambda _session, _url, role_id: (
+            tests.data.anthropic.rbac.ANTHROPIC_RBAC_ROLE_PERMISSIONS[role_id]
+        ),
+    )
+    @patch.object(
+        cartography.intel.anthropic.rbac,
+        "get_roles",
+        return_value=tests.data.anthropic.rbac.ANTHROPIC_RBAC_ROLES,
+    )
     def seed(self, *args) -> None:
         api_session = Mock()
         self._seed_organization(api_session)
         self._seed_users(api_session)
         self._seed_workspaces(api_session)
+        self._seed_rbac(api_session)
+        self._seed_invites(api_session)
+        self._seed_rate_limits(api_session)
         self._seed_service_accounts(api_session)
         self._seed_federation(api_session)
         self._seed_apikeys(api_session)
+
+    def _seed_rbac(self, api_session: Mock) -> None:
+        cartography.intel.anthropic.rbac.sync(
+            self.neo4j_session,
+            api_session,
+            common_job_parameters={
+                "UPDATE_TAG": self.update_tag,
+                "BASE_URL": "https://api.anthropic.com/v1",
+                "ORG_ID": ORG_ID,
+            },
+        )
+
+    def _seed_invites(self, api_session: Mock) -> None:
+        cartography.intel.anthropic.invites.sync(
+            self.neo4j_session,
+            api_session,
+            common_job_parameters={
+                "UPDATE_TAG": self.update_tag,
+                "BASE_URL": "https://api.anthropic.com/v1",
+                "ORG_ID": ORG_ID,
+            },
+        )
+
+    def _seed_rate_limits(self, api_session: Mock) -> None:
+        cartography.intel.anthropic.ratelimits.sync(
+            self.neo4j_session,
+            api_session,
+            common_job_parameters={
+                "UPDATE_TAG": self.update_tag,
+                "BASE_URL": "https://api.anthropic.com/v1",
+                "ORG_ID": ORG_ID,
+            },
+            workspace_ids=[WORKSPACE_ID],
+        )
 
     def _seed_service_accounts(self, api_session: Mock) -> None:
         cartography.intel.anthropic.serviceaccounts.sync(

--- a/demo/seeds/anthropic.py
+++ b/demo/seeds/anthropic.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 from unittest.mock import patch
 
+import cartography.intel.anthropic.agents
 import cartography.intel.anthropic.apikeys
 import cartography.intel.anthropic.federation
 import cartography.intel.anthropic.invites
@@ -8,8 +9,10 @@ import cartography.intel.anthropic.organization
 import cartography.intel.anthropic.ratelimits
 import cartography.intel.anthropic.rbac
 import cartography.intel.anthropic.serviceaccounts
+import cartography.intel.anthropic.skills
 import cartography.intel.anthropic.users
 import cartography.intel.anthropic.workspaces
+import tests.data.anthropic.agents
 import tests.data.anthropic.apikeys
 import tests.data.anthropic.federation
 import tests.data.anthropic.invites
@@ -17,6 +20,7 @@ import tests.data.anthropic.organization
 import tests.data.anthropic.ratelimits
 import tests.data.anthropic.rbac
 import tests.data.anthropic.serviceaccounts
+import tests.data.anthropic.skills
 import tests.data.anthropic.users
 import tests.data.anthropic.workspaces
 from demo.seeds.base import Seed
@@ -128,6 +132,43 @@ class AnthropicSeed(Seed):
         "get_roles",
         return_value=tests.data.anthropic.rbac.ANTHROPIC_RBAC_ROLES,
     )
+    @patch.object(
+        cartography.intel.anthropic.agents,
+        "get_deployments",
+        return_value=tests.data.anthropic.agents.ANTHROPIC_DEPLOYMENTS,
+    )
+    @patch.object(
+        cartography.intel.anthropic.agents,
+        "get_agents",
+        return_value=tests.data.anthropic.agents.ANTHROPIC_AGENTS,
+    )
+    @patch.object(
+        cartography.intel.anthropic.agents,
+        "get_memory_stores",
+        return_value=tests.data.anthropic.agents.ANTHROPIC_MEMORY_STORES,
+    )
+    @patch.object(
+        cartography.intel.anthropic.agents,
+        "get_vaults",
+        return_value=tests.data.anthropic.agents.ANTHROPIC_VAULTS,
+    )
+    @patch.object(
+        cartography.intel.anthropic.agents,
+        "get_environments",
+        return_value=tests.data.anthropic.agents.ANTHROPIC_ENVIRONMENTS,
+    )
+    @patch.object(
+        cartography.intel.anthropic.skills,
+        "get_skill_versions",
+        side_effect=lambda _session, _url, skill_id: (
+            tests.data.anthropic.skills.ANTHROPIC_SKILL_VERSIONS[skill_id]
+        ),
+    )
+    @patch.object(
+        cartography.intel.anthropic.skills,
+        "get",
+        return_value=tests.data.anthropic.skills.ANTHROPIC_SKILLS,
+    )
     def seed(self, *args) -> None:
         api_session = Mock()
         self._seed_organization(api_session)
@@ -139,6 +180,20 @@ class AnthropicSeed(Seed):
         self._seed_service_accounts(api_session)
         self._seed_federation(api_session)
         self._seed_apikeys(api_session)
+        self._seed_workspace_plane(api_session)
+
+    def _seed_workspace_plane(self, api_session: Mock) -> None:
+        common_job_parameters = {
+            "UPDATE_TAG": self.update_tag,
+            "BASE_URL": "https://api.anthropic.com/v1",
+            "WORKSPACE_ID": WORKSPACE_ID,
+        }
+        cartography.intel.anthropic.skills.sync(
+            self.neo4j_session, api_session, common_job_parameters
+        )
+        cartography.intel.anthropic.agents.sync(
+            self.neo4j_session, api_session, common_job_parameters
+        )
 
     def _seed_rbac(self, api_session: Mock) -> None:
         cartography.intel.anthropic.rbac.sync(

--- a/docs/root/modules/anthropic/config.md
+++ b/docs/root/modules/anthropic/config.md
@@ -67,6 +67,37 @@ If both an Admin API key and a federation configuration are supplied, cartograph
 federation and logs a warning. A federation configuration missing one of its three ids
 is treated as an operator mistake and fails loudly rather than silently falling back.
 
+### Per-workspace resources
+
+Skills, agents, environments, deployments, vaults and memory stores are scoped to a
+workspace and have no organization-wide listing. An `org:admin` token cannot reach
+them, and there is no way to downscope one: the token endpoint accepts only the
+`jwt-bearer` grant, so each workspace needs its own exchange.
+
+Set up a second federation rule to ingest them:
+
+1. Create a rule with `oauth_scope: workspace:developer` and
+   `applies_to_all_workspaces: true`. One rule covers every workspace; cartography
+   varies the workspace on each exchange.
+2. Add its target service account as an explicit member of every workspace you want
+   covered. Enabling a rule for a workspace does not create that membership, and
+   `applies_to_all_workspaces` does not either. Every service account is implicitly a
+   member of the default workspace only.
+
+Then pass the rule with `--anthropic-workspace-federation-rule-id`, alongside the
+`org:admin` configuration above. Without it, cartography syncs the organization plane
+and logs that it is skipping the rest.
+
+Cartography never writes, so it will not add those workspace memberships for you even
+though the Admin API can.
+
+A workspace whose exchange fails is skipped with a warning and the sync continues.
+Consider giving the workspace rule its own federation issuer with `check_jti: false`:
+otherwise, replay protection can reject the second and later exchanges when your
+identity token carries a `jti` and does not rotate between them. A dedicated issuer
+also keeps it updatable through the API, which an issuer backing an `org:admin` rule
+is not.
+
 ### Troubleshooting
 
 Every credential-level rejection from the token exchange returns an opaque

--- a/docs/root/modules/anthropic/config.md
+++ b/docs/root/modules/anthropic/config.md
@@ -1,20 +1,85 @@
 # Anthropic Configuration
 
-## Authentication
+The Anthropic module supports two authentication methods: a static Admin API key, or
+Workload Identity Federation. Federation is recommended: it involves no long-lived
+secret, and it reaches endpoints that Admin API keys are refused on.
+
+## Option 1: Admin API key
 
 Create an Admin API key in the
-[Anthropic Console](https://console.anthropic.com/settings/admin-keys) and store
-it in an environment variable.
-
-## Configure Cartography
-
-Pass the name of the environment variable containing the Admin API key with
+[Anthropic Console](https://console.anthropic.com/settings/admin-keys) and store it in
+an environment variable. Pass the name of that variable with
 `--anthropic-apikey-env-var`.
-
-## Run Cartography
 
 ```bash
 cartography \
   --selected-modules anthropic \
   --anthropic-apikey-env-var ANTHROPIC_API_KEY
 ```
+
+An Admin API key covers organization members, workspaces, workspace members and API
+keys. It is rejected with a 403 on service accounts, federation issuers and federation
+rules, so those resources will not appear in the graph.
+
+## Option 2: Workload Identity Federation
+
+Cartography presents the OIDC token that its own platform issues (a Kubernetes
+projected service account token, a GitHub Actions identity token) and exchanges it for
+a short-lived Anthropic access token. Nothing long-lived is stored.
+
+### Prerequisites
+
+Set these up once in the Anthropic Console:
+
+1. A **service account** with `organization_role: admin`.
+2. A **federation issuer** registered for your identity provider.
+3. A **federation rule** with `oauth_scope: org:admin` targeting that service account.
+   This rule must be created in the Console. Granting a workload organization-admin
+   access is a deliberate human action, and the API will not let automation bootstrap
+   it.
+
+Note the rule's `subject_prefix` matcher. A trailing `*` is a prefix match, so a
+GitHub Actions rule like `repo:my-org/my-repo:*` also matches `pull_request` runs,
+including ones triggered from forks: anyone who can open a pull request against the
+repository could then mint an `org:admin` token. Pin the prefix to a specific ref, for
+example `repo:my-org/my-repo:ref:refs/heads/main`.
+
+### Configure Cartography
+
+Point cartography at the identity token and at the three ids that identify the
+exchange. The token is read fresh on every exchange, so a projected token that rotates
+on disk is always current.
+
+```bash
+cartography \
+  --selected-modules anthropic \
+  --anthropic-identity-token-file /var/run/secrets/anthropic/token \
+  --anthropic-federation-rule-id fdrl_xxx \
+  --anthropic-organization-id 00000000-0000-0000-0000-000000000000 \
+  --anthropic-service-account-id svac_xxx
+```
+
+Use `--anthropic-identity-token-env-var` instead of `--anthropic-identity-token-file`
+when the identity token arrives in an environment variable rather than on disk. The
+two are mutually exclusive.
+
+If both an Admin API key and a federation configuration are supplied, cartography uses
+federation and logs a warning. A federation configuration missing one of its three ids
+is treated as an operator mistake and fails loudly rather than silently falling back.
+
+### Troubleshooting
+
+Every credential-level rejection from the token exchange returns an opaque
+`400 invalid_grant`; the specific cause is only logged on Anthropic's side. The
+Console's authentication history page
+(`platform.claude.com/settings/workload-identity-federation?tab=history`) shows which
+validation step failed.
+
+Two causes worth checking first:
+
+- **Replay protection.** A federation issuer's `check_jti` defaults to `true`, which
+  makes each assertion carrying a `jti` claim single-use. Kubernetes projected tokens
+  carry one.
+- **Workspace membership.** For rules enabled on more than the default workspace, the
+  target service account must be an explicit member of the workspace being requested.
+  Enabling a rule for a workspace does not create that membership.

--- a/docs/root/modules/anthropic/config.md
+++ b/docs/root/modules/anthropic/config.md
@@ -60,8 +60,8 @@ cartography \
 ```
 
 Use `--anthropic-identity-token-env-var` instead of `--anthropic-identity-token-file`
-when the identity token arrives in an environment variable rather than on disk. The
-two are mutually exclusive.
+when the identity token arrives in an environment variable rather than on disk. Pass the
+name of the variable, not the token itself. The two are mutually exclusive.
 
 If both an Admin API key and a federation configuration are supplied, cartography uses
 federation and logs a warning. A federation configuration missing one of its three ids

--- a/tests/data/anthropic/agents.py
+++ b/tests/data/anthropic/agents.py
@@ -1,0 +1,107 @@
+ANTHROPIC_ENVIRONMENTS = [
+    {
+        "id": "env_01Kd7Rt2Nm5Bq8Vx3Wy6Pz9L",
+        "type": "environment",
+        "name": "locked-down",
+        "description": "Allowlisted egress only.",
+        "config": {
+            "networking": {
+                "type": "limited",
+                "allowed_hosts": ["api.springfield.corp"],
+                "allow_mcp_servers": True,
+                "allow_package_managers": False,
+            },
+            "packages": {"pip": ["requests"]},
+        },
+        "scope": "organization",
+        "archived_at": None,
+        "created_at": "2025-06-01T09:00:00.000000Z",
+        "updated_at": "2025-06-01T09:00:00.000000Z",
+    },
+    {
+        "id": "env_02Wq4Jm9Zn6Rt1Cx8Bv5Hd3K",
+        "type": "environment",
+        "name": "wide-open",
+        "description": "No egress restriction.",
+        "config": {"networking": "unrestricted", "packages": {}},
+        "scope": "account",
+        "archived_at": None,
+        "created_at": "2025-06-02T09:00:00.000000Z",
+        "updated_at": "2025-06-02T09:00:00.000000Z",
+    },
+]
+
+ANTHROPIC_VAULTS = [
+    {
+        "id": "vlt_01Tz6Nb3Kw8Qm2Xr5Jd9Pc4V",
+        "type": "vault",
+        "display_name": "plant-credentials",
+        "archived_at": None,
+        "created_at": "2025-06-03T09:00:00.000000Z",
+        "updated_at": "2025-06-03T09:00:00.000000Z",
+    },
+]
+
+ANTHROPIC_MEMORY_STORES = [
+    {
+        "id": "memstore_01Bd8Vq5Rk2Wn7Tj4Lm6Zx3C",
+        "type": "memory_store",
+        "name": "shift-handover",
+        "description": "What the previous shift left running.",
+        "archived_at": None,
+        "created_at": "2025-06-04T09:00:00.000000Z",
+        "updated_at": "2025-06-04T09:00:00.000000Z",
+    },
+]
+
+ANTHROPIC_AGENTS = [
+    {
+        "id": "agent_01Rn5Wx9Kt3Bm7Qd2Vz8Lp6J",
+        "type": "agent",
+        "name": "reactor-monitor",
+        "description": "Watches reactor telemetry and files incidents.",
+        "system": "You watch the reactor.",
+        "version": 3,
+        "model": {"id": "claude-opus-5", "effort": "high", "speed": "standard"},
+        "mcp_servers": [
+            {"name": "telemetry", "type": "url", "url": "https://mcp.springfield.corp"},
+        ],
+        "skills": [
+            {
+                "skill_id": "skill_01Mv4Zq7Nr2Ks8Ld3Tp6Wx9B",
+                "type": "skill",
+                "version": "1738240000000000",
+            },
+        ],
+        "tools": [
+            {"name": "read_sensor", "permission_policy": "always_allow"},
+            {"name": "scram_reactor", "permission_policy": "always_ask"},
+        ],
+        "metadata": {},
+        "archived_at": None,
+        "created_at": "2025-06-05T09:00:00.000000Z",
+        "updated_at": "2025-06-06T09:00:00.000000Z",
+    },
+]
+
+ANTHROPIC_DEPLOYMENTS = [
+    {
+        "id": "depl_01Ym2Qc7Jx4Nv9Rb5Kd8Tw3P",
+        "type": "deployment",
+        "agent": {"id": "agent_01Rn5Wx9Kt3Bm7Qd2Vz8Lp6J", "version": 3},
+        "environment_id": "env_01Kd7Rt2Nm5Bq8Vx3Wy6Pz9L",
+        "schedule": {
+            "type": "cron",
+            "expression": "0 * * * *",
+            "timezone": "UTC",
+            "last_run_at": "2025-06-10T09:00:00.000000Z",
+            "upcoming_runs_at": ["2025-06-10T10:00:00.000000Z"],
+        },
+        "status": "active",
+        "paused_reason": None,
+        "vault_ids": ["vlt_01Tz6Nb3Kw8Qm2Xr5Jd9Pc4V"],
+        "metadata": {},
+        "created_at": "2025-06-07T09:00:00.000000Z",
+        "updated_at": "2025-06-07T09:00:00.000000Z",
+    },
+]

--- a/tests/data/anthropic/apikeys.py
+++ b/tests/data/anthropic/apikeys.py
@@ -8,5 +8,19 @@ ANTHROPIC_APIKEYS = [
         "created_by": {"id": "user_EneequohSheesh3Ohtaefu8we2aite", "type": "user"},
         "partial_key_hint": "sk-ant-api03-R2D...igAA",
         "status": "active",
-    }
+        "expires_at": None,
+        "principal": {"id": "user_EneequohSheesh3Ohtaefu8we2aite", "type": "user"},
+    },
+    {
+        "id": "apikey_01Wq7X2ZTbn4LcVpM8sKdYhE",
+        "type": "api_key",
+        "name": "Reactor Telemetry Collector",
+        "workspace_id": "wrkspc_01JwQvzr7rXLA5AGx3HKfFUJ",
+        "created_at": "2025-01-14T08:12:03.114509Z",
+        "created_by": {"id": "user_Oov3aYewo6ZuoGh8thaiV1uNoy1aXe", "type": "user"},
+        "partial_key_hint": "sk-ant-api03-K9F...twQA",
+        "status": "active",
+        "expires_at": "2026-01-14T08:12:03.114509Z",
+        "principal": {"id": "svac_01Nb5RtYuIoPaSdFgHjKlZxC", "type": "service_account"},
+    },
 ]

--- a/tests/data/anthropic/federation.py
+++ b/tests/data/anthropic/federation.py
@@ -1,0 +1,118 @@
+ANTHROPIC_FEDERATION_ISSUERS = [
+    {
+        "id": "fdis_01Ab2Cd3Ef4Gh5Ij6Kl7Mn8Op",
+        "type": "federation_issuer",
+        "name": "github-actions",
+        "issuer_url": "https://token.actions.githubusercontent.com",
+        "check_jti": True,
+        "max_jwt_lifetime_seconds": 900,
+        "jwks": {"type": "discovery"},
+        "jwks_polling_disabled_at": None,
+        "poll_status": {
+            "consecutive_failures": 0,
+            "last_fetched_at": "2025-02-01T10:00:00.000000Z",
+            "next_poll_at": "2025-02-01T10:05:00.000000Z",
+        },
+        "created_at": "2025-01-20T08:00:00.000000Z",
+        "updated_at": "2025-01-20T08:00:00.000000Z",
+        "archived_at": None,
+        "created_by_actor_id": "user_EneequohSheesh3Ohtaefu8we2aite",
+    },
+    {
+        "id": "fdis_01Zy9Xw8Vu7Ts6Rq5Po4Nm3Lk",
+        "type": "federation_issuer",
+        "name": "springfield-k8s",
+        "issuer_url": "https://kubernetes.springfield.corp",
+        "check_jti": False,
+        "max_jwt_lifetime_seconds": 3600,
+        "jwks": {
+            "type": "explicit_url",
+            "url": "https://kubernetes.springfield.corp/openid/v1/jwks",
+        },
+        "jwks_polling_disabled_at": "2025-03-02T11:00:00.000000Z",
+        "poll_status": {
+            "consecutive_failures": 3,
+            "last_fetched_at": "2025-03-02T10:00:00.000000Z",
+            "next_poll_at": None,
+        },
+        "created_at": "2025-01-22T08:00:00.000000Z",
+        "updated_at": "2025-03-02T11:00:00.000000Z",
+        "archived_at": None,
+        "created_by_actor_id": "user_EneequohSheesh3Ohtaefu8we2aite",
+    },
+]
+
+ANTHROPIC_FEDERATION_RULES = [
+    {
+        "id": "fdrl_01Qw2Er3Ty4Ui5Op6As7Df8Gh",
+        "type": "federation_rule",
+        "name": "cartography-collector",
+        "description": "Lets the cartography collector read the whole organization.",
+        "issuer_id": "fdis_01Zy9Xw8Vu7Ts6Rq5Po4Nm3Lk",
+        "issuer_name": "springfield-k8s",
+        "match": {
+            "subject_prefix": "system:serviceaccount:security:cartography",
+            "audience": "https://api.anthropic.com",
+            "claims": {"namespace": "security"},
+            "condition": None,
+        },
+        "target": {
+            "type": "service_account",
+            "service_account_id": "svac_01Pq8WeRtYuIoPaSdFgHjKlM",
+            "service_account_name": "cartography-collector",
+        },
+        "oauth_scope": "org:admin",
+        "token_lifetime_seconds": 3600,
+        "attributes": None,
+        "applies_to_all_workspaces": False,
+        "workspace_id": None,
+        "workspace_ids": [],
+        "created_at": "2025-02-01T10:30:00.000000Z",
+        "updated_at": "2025-02-01T10:30:00.000000Z",
+        "archived_at": None,
+    },
+    {
+        "id": "fdrl_01Hj2Kl3Zx4Cv5Bn6Mq7Wt8Ry",
+        "type": "federation_rule",
+        "name": "ci-inference",
+        "description": "Wildcard prefix: also matches fork pull request runs.",
+        "issuer_id": "fdis_01Ab2Cd3Ef4Gh5Ij6Kl7Mn8Op",
+        "issuer_name": "github-actions",
+        "match": {
+            "subject_prefix": "repo:springfield/reactor-control:*",
+            "audience": None,
+            "claims": {},
+            "condition": None,
+        },
+        "target": {
+            "type": "service_account",
+            "service_account_id": "svac_01Nb5RtYuIoPaSdFgHjKlZxC",
+            "service_account_name": "reactor-telemetry",
+        },
+        "oauth_scope": "workspace:developer",
+        "token_lifetime_seconds": 900,
+        "attributes": None,
+        "applies_to_all_workspaces": True,
+        "workspace_id": None,
+        "workspace_ids": [],
+        "created_at": "2025-02-03T14:00:00.000000Z",
+        "updated_at": "2025-02-03T14:00:00.000000Z",
+        "archived_at": None,
+    },
+]
+
+# Keyed by federation rule id, as returned by
+# GET /organizations/federation_rules/{id}/workspaces
+ANTHROPIC_FEDERATION_RULE_WORKSPACES = {
+    "fdrl_01Qw2Er3Ty4Ui5Op6As7Df8Gh": [],
+    "fdrl_01Hj2Kl3Zx4Cv5Bn6Mq7Wt8Ry": [
+        {
+            "type": "federation_rule_workspace",
+            "federation_rule_id": "fdrl_01Hj2Kl3Zx4Cv5Bn6Mq7Wt8Ry",
+            "workspace_id": "wrkspc_01JwQvzr7rXLA5AGx3HKfFUJ",
+            "workspace_name": "Springfield Nuclear Power Plant",
+            "created_at": "2025-02-03T14:00:00.000000Z",
+            "created_by_actor_id": "user_EneequohSheesh3Ohtaefu8we2aite",
+        },
+    ],
+}

--- a/tests/data/anthropic/invites.py
+++ b/tests/data/anthropic/invites.py
@@ -1,0 +1,24 @@
+ANTHROPIC_INVITES = [
+    {
+        "id": "invite_015gWxCN9Hfg2QhZwTK7Mdeu",
+        "type": "invite",
+        "email": "lisa@simpson.corp",
+        "role": "developer",
+        "status": "pending",
+        "invited_at": "2025-05-01T09:00:00.000000Z",
+        "expires_at": "2025-05-22T09:00:00.000000Z",
+        "accepted_at": None,
+        "rbac_group_ids": ["rbac_group_012rppKaSVsmTo6NqRDXQXNF"],
+    },
+    {
+        "id": "invite_026hXyDO0Igh3RiAxUL8Nefv",
+        "type": "invite",
+        "email": "bart@simpson.corp",
+        "role": "admin",
+        "status": "accepted",
+        "invited_at": "2025-04-10T09:00:00.000000Z",
+        "expires_at": "2025-05-01T09:00:00.000000Z",
+        "accepted_at": "2025-04-11T10:15:00.000000Z",
+        "rbac_group_ids": [],
+    },
+]

--- a/tests/data/anthropic/organization.py
+++ b/tests/data/anthropic/organization.py
@@ -1,0 +1,5 @@
+ANTHROPIC_ORGANIZATION = {
+    "id": "8834c225-ea27-405a-aea9-5ed5f07f4858",
+    "type": "organization",
+    "name": "Springfield Nuclear Power Plant",
+}

--- a/tests/data/anthropic/ratelimits.py
+++ b/tests/data/anthropic/ratelimits.py
@@ -1,0 +1,40 @@
+ANTHROPIC_RATE_LIMITS = [
+    {
+        "type": "rate_limit",
+        "group_type": "model_group",
+        "models": ["claude-opus-5"],
+        "limits": [
+            {"type": "requests_per_minute", "value": 4000},
+            {"type": "input_tokens_per_minute", "value": 400000},
+        ],
+    },
+    {
+        "type": "rate_limit",
+        "group_type": "web_search",
+        "models": None,
+        "limits": [
+            {"type": "requests_per_minute", "value": 1000},
+        ],
+    },
+]
+
+# Keyed by workspace id, as returned by
+# GET /organizations/workspaces/{id}/rate_limits. Only overrides are returned; a
+# group with no entry here inherits the organization limit rather than being
+# unlimited.
+ANTHROPIC_WORKSPACE_RATE_LIMITS = {
+    "wrkspc_01JwQvzr7rXLA5AGx3HKfFUJ": [
+        {
+            "type": "workspace_rate_limit",
+            "group_type": "model_group",
+            "models": ["claude-opus-5"],
+            "limits": [
+                {
+                    "type": "requests_per_minute",
+                    "value": 500,
+                    "org_limit": 4000,
+                },
+            ],
+        },
+    ],
+}

--- a/tests/data/anthropic/rbac.py
+++ b/tests/data/anthropic/rbac.py
@@ -1,0 +1,98 @@
+ANTHROPIC_RBAC_ROLES = [
+    {
+        "id": "rbac_role_016J8xVtKpDq3Wy9ZmN2hR4s",
+        "type": "rbac_role",
+        "name": "Project Editor",
+        "created_at": "2025-04-01T09:00:00.000000Z",
+        "updated_at": "2025-04-01T09:00:00.000000Z",
+    },
+    {
+        "id": "rbac_role_02Tf7NqWrBz5Xk1LcPd8Ju6M",
+        "type": "rbac_role",
+        "name": "Plant Supervisor",
+        "created_at": "2025-04-02T09:00:00.000000Z",
+        "updated_at": "2025-04-02T09:00:00.000000Z",
+    },
+]
+
+# Keyed by role id, as returned by
+# GET /organizations/rbac_roles/{id}/permissions
+ANTHROPIC_RBAC_ROLE_PERMISSIONS = {
+    "rbac_role_016J8xVtKpDq3Wy9ZmN2hR4s": [
+        {
+            "type": "rbac_role_permission",
+            "action": "chat",
+            "resource": {
+                "type": "organization",
+                "organization_id": "8834c225-ea27-405a-aea9-5ed5f07f4858",
+            },
+        },
+        {
+            "type": "rbac_role_permission",
+            "action": "use",
+            "resource": {
+                "type": "connector_tool",
+                "connector_id": "conn_01ReactorTelemetry",
+                "tool_name": "read_sensor",
+            },
+        },
+    ],
+    # capability_access_all is a blanket grant: it stands for every product-feature
+    # entitlement, so it must not be read as a single narrow permission.
+    "rbac_role_02Tf7NqWrBz5Xk1LcPd8Ju6M": [
+        {
+            "type": "rbac_role_permission",
+            "action": "capability_access_all",
+            "resource": {
+                "type": "organization",
+                "organization_id": "8834c225-ea27-405a-aea9-5ed5f07f4858",
+            },
+        },
+    ],
+}
+
+ANTHROPIC_RBAC_GROUPS = [
+    {
+        "id": "rbac_group_012rppKaSVsmTo6NqRDXQXNF",
+        "type": "rbac_group",
+        "name": "Engineering",
+        "source_type": "direct",
+        "roles": ["rbac_role_016J8xVtKpDq3Wy9ZmN2hR4s"],
+        "created_at": "2025-04-03T09:00:00.000000Z",
+        "updated_at": "2025-04-03T09:00:00.000000Z",
+    },
+    # A null roles field means the role data was temporarily unavailable, not that
+    # the group holds no roles.
+    {
+        "id": "rbac_group_03Yh4MjXsQe7Rv2BnKt9Wz5D",
+        "type": "rbac_group",
+        "name": "Safety Inspectors",
+        "source_type": "scim",
+        "roles": None,
+        "created_at": "2025-04-04T09:00:00.000000Z",
+        "updated_at": "2025-04-04T09:00:00.000000Z",
+    },
+]
+
+# Keyed by group id, as returned by
+# GET /organizations/rbac_groups/{id}/members
+ANTHROPIC_RBAC_GROUP_MEMBERS = {
+    "rbac_group_012rppKaSVsmTo6NqRDXQXNF": [
+        {
+            "type": "rbac_group_member",
+            "group_id": "rbac_group_012rppKaSVsmTo6NqRDXQXNF",
+            "user_id": "user_EneequohSheesh3Ohtaefu8we2aite",
+            "email": "hjsimpson@simpson.corp",
+            "created_at": "2025-04-03T09:00:00.000000Z",
+        },
+    ],
+    "rbac_group_03Yh4MjXsQe7Rv2BnKt9Wz5D": [
+        {
+            "type": "rbac_group_member",
+            "group_id": "rbac_group_03Yh4MjXsQe7Rv2BnKt9Wz5D",
+            "user_id": "user_Oov3aYewo6ZuoGh8thaiV1uNoy1aXe",
+            "email": "mbsimpson@simpson.corp",
+            "created_at": "2025-04-04T09:00:00.000000Z",
+        },
+    ],
+}

--- a/tests/data/anthropic/serviceaccounts.py
+++ b/tests/data/anthropic/serviceaccounts.py
@@ -1,0 +1,47 @@
+ANTHROPIC_SERVICE_ACCOUNTS = [
+    {
+        "id": "svac_01Nb5RtYuIoPaSdFgHjKlZxC",
+        "type": "service_account",
+        "name": "reactor-telemetry",
+        "description": "Collects reactor telemetry from the plant floor.",
+        "organization_role": "developer",
+        "created_at": "2025-01-10T09:00:00.000000Z",
+        "updated_at": "2025-01-12T09:00:00.000000Z",
+        "archived_at": None,
+    },
+    {
+        "id": "svac_01Pq8WeRtYuIoPaSdFgHjKlM",
+        "type": "service_account",
+        "name": "cartography-collector",
+        "description": "Read-only org:admin collector.",
+        "organization_role": "admin",
+        "created_at": "2025-02-01T10:30:00.000000Z",
+        "updated_at": "2025-02-01T10:30:00.000000Z",
+        "archived_at": None,
+    },
+]
+
+# Keyed by service account id, as returned by
+# GET /organizations/service_accounts/{id}/workspaces
+ANTHROPIC_SERVICE_ACCOUNT_WORKSPACES = {
+    "svac_01Nb5RtYuIoPaSdFgHjKlZxC": [
+        {
+            "type": "service_account_workspace_member",
+            "service_account_id": "svac_01Nb5RtYuIoPaSdFgHjKlZxC",
+            "workspace_id": "wrkspc_01JwQvzr7rXLA5AGx3HKfFUJ",
+            "workspace_role": "workspace_developer",
+            "implicit": False,
+            "created_by_actor_id": "user_EneequohSheesh3Ohtaefu8we2aite",
+        },
+    ],
+    "svac_01Pq8WeRtYuIoPaSdFgHjKlM": [
+        {
+            "type": "service_account_workspace_member",
+            "service_account_id": "svac_01Pq8WeRtYuIoPaSdFgHjKlM",
+            "workspace_id": "wrkspc_01JwQvzr7rXLA5AGx3HKfFUJ",
+            "workspace_role": "workspace_admin",
+            "implicit": False,
+            "created_by_actor_id": "user_EneequohSheesh3Ohtaefu8we2aite",
+        },
+    ],
+}

--- a/tests/data/anthropic/skills.py
+++ b/tests/data/anthropic/skills.py
@@ -1,0 +1,36 @@
+ANTHROPIC_SKILLS = [
+    {
+        "id": "skill_01Mv4Zq7Nr2Ks8Ld3Tp6Wx9B",
+        "type": "skill",
+        "display_title": "Reactor Runbook",
+        "source": "custom",
+        "latest_version": "1738240000000000",
+        "created_at": "2025-01-30T12:00:00.000000Z",
+        "updated_at": "2025-01-30T12:00:00.000000Z",
+    },
+    {
+        "id": "skill_02Hb5Yn8Pq3Jt7Mc4Rd1Vz6A",
+        "type": "skill",
+        "display_title": "pptx",
+        "source": "anthropic",
+        "latest_version": "1730000000000000",
+        "created_at": "2024-10-27T00:00:00.000000Z",
+        "updated_at": "2024-10-27T00:00:00.000000Z",
+    },
+]
+
+# Keyed by skill id, as returned by GET /skills/{id}/versions
+ANTHROPIC_SKILL_VERSIONS = {
+    "skill_01Mv4Zq7Nr2Ks8Ld3Tp6Wx9B": [
+        {
+            "id": "skillver_01Qt9Wr4Ym6Nb2Kd8Lp3Xc7F",
+            "type": "skill_version",
+            "name": "reactor-runbook",
+            "description": "Emergency procedures for the Springfield reactor.",
+            "directory": "skills/reactor-runbook",
+            "version": "1738240000000000",
+            "created_at": "2025-01-30T12:00:00.000000Z",
+        },
+    ],
+    "skill_02Hb5Yn8Pq3Jt7Mc4Rd1Vz6A": [],
+}

--- a/tests/data/anthropic/workspaces.py
+++ b/tests/data/anthropic/workspaces.py
@@ -6,6 +6,14 @@ ANTHROPIC_WORKSPACES = [
         "created_at": "2024-10-30T23:58:27.427722Z",
         "archived_at": "2024-11-01T23:59:27.427722Z",
         "display_color": "#6C5BB9",
+        "compartment_id": "3f2b1c8e-9d4a-4f6b-8c1e-2a7d5b9e0f3c",
+        "external_key_id": "ekey_01HxYzAbCdEfGhIjKlMnOpQr",
+        "data_residency": {
+            "workspace_geo": "us",
+            "default_inference_geo": "us",
+            "allowed_inference_geos": ["us", "eu"],
+        },
+        "tags": {"env": "prod"},
     }
 ]
 

--- a/tests/integration/cartography/intel/anthropic/test_agents.py
+++ b/tests/integration/cartography/intel/anthropic/test_agents.py
@@ -1,0 +1,181 @@
+import copy
+from unittest.mock import patch
+
+import requests
+
+import cartography.intel.anthropic.agents
+import tests.data.anthropic.agents
+from tests.integration.cartography.intel.anthropic.test_organization import (
+    _ensure_local_neo4j_has_test_organization,
+)
+from tests.integration.cartography.intel.anthropic.test_skills import (
+    _ensure_local_neo4j_has_test_skills,
+)
+from tests.integration.cartography.intel.anthropic.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspaces,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_WORKSPACE_ID = "wrkspc_01JwQvzr7rXLA5AGx3HKfFUJ"
+
+
+@patch.object(
+    cartography.intel.anthropic.agents,
+    "get_deployments",
+    return_value=copy.deepcopy(tests.data.anthropic.agents.ANTHROPIC_DEPLOYMENTS),
+)
+@patch.object(
+    cartography.intel.anthropic.agents,
+    "get_agents",
+    return_value=copy.deepcopy(tests.data.anthropic.agents.ANTHROPIC_AGENTS),
+)
+@patch.object(
+    cartography.intel.anthropic.agents,
+    "get_memory_stores",
+    return_value=copy.deepcopy(tests.data.anthropic.agents.ANTHROPIC_MEMORY_STORES),
+)
+@patch.object(
+    cartography.intel.anthropic.agents,
+    "get_vaults",
+    return_value=copy.deepcopy(tests.data.anthropic.agents.ANTHROPIC_VAULTS),
+)
+@patch.object(
+    cartography.intel.anthropic.agents,
+    "get_environments",
+    return_value=copy.deepcopy(tests.data.anthropic.agents.ANTHROPIC_ENVIRONMENTS),
+)
+def test_load_anthropic_agents(
+    mock_envs, mock_vaults, mock_memory, mock_agents, mock_deployments, neo4j_session
+):
+    """
+    Ensure agents, environments, vaults, memory stores and deployments get loaded
+    """
+    # Arrange
+    api_session = requests.Session()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "BASE_URL": "https://api.anthropic.com/v1",
+        "WORKSPACE_ID": TEST_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_organization(neo4j_session)
+    _ensure_local_neo4j_has_test_workspaces(neo4j_session)
+    _ensure_local_neo4j_has_test_skills(neo4j_session)
+
+    # Act
+    cartography.intel.anthropic.agents.sync(
+        neo4j_session,
+        api_session,
+        common_job_parameters,
+    )
+
+    # Assert environments exist with the egress policy flattened out of the config
+    # union. The unrestricted case arrives as a bare string rather than an object.
+    assert check_nodes(
+        neo4j_session,
+        "AnthropicEnvironment",
+        ["id", "networking_type", "allow_package_managers"],
+    ) == {
+        ("env_01Kd7Rt2Nm5Bq8Vx3Wy6Pz9L", "limited", False),
+        ("env_02Wq4Jm9Zn6Rt1Cx8Bv5Hd3K", "unrestricted", None),
+    }
+
+    # Assert vaults and memory stores exist
+    assert check_nodes(neo4j_session, "AnthropicVault", ["id", "display_name"]) == {
+        ("vlt_01Tz6Nb3Kw8Qm2Xr5Jd9Pc4V", "plant-credentials"),
+    }
+    assert check_nodes(neo4j_session, "AnthropicMemoryStore", ["id", "name"]) == {
+        ("memstore_01Bd8Vq5Rk2Wn7Tj4Lm6Zx3C", "shift-handover"),
+    }
+
+    # Assert the agent exists with its tools split by permission policy: the
+    # always_allow ones run unsupervised
+    assert check_nodes(
+        neo4j_session, "AnthropicAgent", ["id", "name", "model_id"]
+    ) == {
+        ("agent_01Rn5Wx9Kt3Bm7Qd2Vz8Lp6J", "reactor-monitor", "claude-opus-5"),
+    }
+    agent = neo4j_session.run(
+        "MATCH (a:AnthropicAgent) RETURN a.always_allow_tools AS allow, "
+        "a.always_ask_tools AS ask, a.mcp_server_urls AS mcp"
+    ).single()
+    assert agent["allow"] == ["read_sensor"]
+    assert agent["ask"] == ["scram_reactor"]
+    assert agent["mcp"] == ["https://mcp.springfield.corp"]
+
+    # Assert the agent is linked to the skill it loads
+    assert check_rels(
+        neo4j_session,
+        "AnthropicAgent",
+        "id",
+        "AnthropicSkill",
+        "id",
+        "USES_SKILL",
+        rel_direction_right=True,
+    ) == {
+        (
+            "agent_01Rn5Wx9Kt3Bm7Qd2Vz8Lp6J",
+            "skill_01Mv4Zq7Nr2Ks8Ld3Tp6Wx9B",
+        ),
+    }
+
+    # Assert the deployment exists and carries its schedule
+    assert check_nodes(
+        neo4j_session,
+        "AnthropicDeployment",
+        ["id", "status", "schedule_expression"],
+    ) == {
+        ("depl_01Ym2Qc7Jx4Nv9Rb5Kd8Tw3P", "active", "0 * * * *"),
+    }
+
+    # Assert the deployment wires the agent to the sandbox and credentials it runs
+    # with: this is the standing-execution blast radius
+    assert check_rels(
+        neo4j_session,
+        "AnthropicDeployment",
+        "id",
+        "AnthropicAgent",
+        "id",
+        "RUNS",
+        rel_direction_right=True,
+    ) == {("depl_01Ym2Qc7Jx4Nv9Rb5Kd8Tw3P", "agent_01Rn5Wx9Kt3Bm7Qd2Vz8Lp6J")}
+    assert check_rels(
+        neo4j_session,
+        "AnthropicDeployment",
+        "id",
+        "AnthropicEnvironment",
+        "id",
+        "RUNS_IN",
+        rel_direction_right=True,
+    ) == {("depl_01Ym2Qc7Jx4Nv9Rb5Kd8Tw3P", "env_01Kd7Rt2Nm5Bq8Vx3Wy6Pz9L")}
+    assert check_rels(
+        neo4j_session,
+        "AnthropicDeployment",
+        "id",
+        "AnthropicVault",
+        "id",
+        "USES_VAULT",
+        rel_direction_right=True,
+    ) == {("depl_01Ym2Qc7Jx4Nv9Rb5Kd8Tw3P", "vlt_01Tz6Nb3Kw8Qm2Xr5Jd9Pc4V")}
+
+    # Assert every workspace-plane node is scoped to its workspace
+    for label in (
+        "AnthropicAgent",
+        "AnthropicEnvironment",
+        "AnthropicDeployment",
+        "AnthropicVault",
+        "AnthropicMemoryStore",
+    ):
+        assert {
+            workspace_id
+            for _, workspace_id in check_rels(
+                neo4j_session,
+                label,
+                "id",
+                "AnthropicWorkspace",
+                "id",
+                "RESOURCE",
+                rel_direction_right=False,
+            )
+        } == {TEST_WORKSPACE_ID}

--- a/tests/integration/cartography/intel/anthropic/test_agents.py
+++ b/tests/integration/cartography/intel/anthropic/test_agents.py
@@ -91,9 +91,7 @@ def test_load_anthropic_agents(
 
     # Assert the agent exists with its tools split by permission policy: the
     # always_allow ones run unsupervised
-    assert check_nodes(
-        neo4j_session, "AnthropicAgent", ["id", "name", "model_id"]
-    ) == {
+    assert check_nodes(neo4j_session, "AnthropicAgent", ["id", "name", "model_id"]) == {
         ("agent_01Rn5Wx9Kt3Bm7Qd2Vz8Lp6J", "reactor-monitor", "claude-opus-5"),
     }
     agent = neo4j_session.run(

--- a/tests/integration/cartography/intel/anthropic/test_apikeys.py
+++ b/tests/integration/cartography/intel/anthropic/test_apikeys.py
@@ -107,19 +107,19 @@ def test_load_anthropic_apikeys(mock_api, neo4j_session):
         )
         == expected_rels
     )
-    # Canonical ontology edge: (:APIKey)-[:OWNED_BY]->(:UserAccount)
-    assert (
-        check_rels(
-            neo4j_session,
-            "AnthropicApiKey",
-            "id",
-            "AnthropicUser",
-            "id",
-            "OWNED_BY",
-            rel_direction_right=True,
-        )
-        == expected_rels
-    )
+    # Canonical ontology edge: (:APIKey)-[:OWNED_BY]->(:UserAccount). Only the
+    # human-owned key gets one: a key acting as a service account is owned by that
+    # service account, not by the human who happened to create it, so it must not
+    # report two owners.
+    assert check_rels(
+        neo4j_session,
+        "AnthropicApiKey",
+        "id",
+        "AnthropicUser",
+        "id",
+        "OWNED_BY",
+        rel_direction_right=True,
+    ) == {("apikey_01Rj2N8SVvo6BePZj99NhmiT", "user_EneequohSheesh3Ohtaefu8we2aite")}
 
     # Assert the service-account-owned key edges to its principal, and the
     # human-owned one does not

--- a/tests/integration/cartography/intel/anthropic/test_apikeys.py
+++ b/tests/integration/cartography/intel/anthropic/test_apikeys.py
@@ -44,15 +44,34 @@ def test_load_anthropic_apikeys(mock_api, neo4j_session):
         common_job_parameters,
     )
 
-    # Assert AdminApiKeys exist
-    expected_nodes = {("apikey_01Rj2N8SVvo6BePZj99NhmiT", "Homer Assistant")}
+    # Assert AdminApiKeys exist, carrying expiry and the principal they act as
+    expected_nodes = {
+        (
+            "apikey_01Rj2N8SVvo6BePZj99NhmiT",
+            "Homer Assistant",
+            None,
+            "user",
+        ),
+        (
+            "apikey_01Wq7X2ZTbn4LcVpM8sKdYhE",
+            "Reactor Telemetry Collector",
+            "2026-01-14T08:12:03.114509Z",
+            "service_account",
+        ),
+    }
     assert (
-        check_nodes(neo4j_session, "AnthropicApiKey", ["id", "name"]) == expected_nodes
+        check_nodes(
+            neo4j_session,
+            "AnthropicApiKey",
+            ["id", "name", "expires_at", "principal_type"],
+        )
+        == expected_nodes
     )
 
     # Assert apikey are linked to the correct org
     expected_rels = {
         ("apikey_01Rj2N8SVvo6BePZj99NhmiT", TEST_ORG_ID),
+        ("apikey_01Wq7X2ZTbn4LcVpM8sKdYhE", TEST_ORG_ID),
     }
     assert (
         check_rels(
@@ -69,7 +88,8 @@ def test_load_anthropic_apikeys(mock_api, neo4j_session):
 
     # Assert apikeys are linked to the correct user
     expected_rels = {
-        ("apikey_01Rj2N8SVvo6BePZj99NhmiT", "user_EneequohSheesh3Ohtaefu8we2aite")
+        ("apikey_01Rj2N8SVvo6BePZj99NhmiT", "user_EneequohSheesh3Ohtaefu8we2aite"),
+        ("apikey_01Wq7X2ZTbn4LcVpM8sKdYhE", "user_Oov3aYewo6ZuoGh8thaiV1uNoy1aXe"),
     }
     assert (
         check_rels(
@@ -101,6 +121,10 @@ def test_load_anthropic_apikeys(mock_api, neo4j_session):
     expected_rels = {
         (
             "apikey_01Rj2N8SVvo6BePZj99NhmiT",
+            "wrkspc_01JwQvzr7rXLA5AGx3HKfFUJ",
+        ),
+        (
+            "apikey_01Wq7X2ZTbn4LcVpM8sKdYhE",
             "wrkspc_01JwQvzr7rXLA5AGx3HKfFUJ",
         ),
     }

--- a/tests/integration/cartography/intel/anthropic/test_apikeys.py
+++ b/tests/integration/cartography/intel/anthropic/test_apikeys.py
@@ -4,6 +4,9 @@ import requests
 
 import cartography.intel.anthropic.apikeys
 import tests.data.anthropic.apikeys
+from tests.integration.cartography.intel.anthropic.test_serviceaccounts import (
+    _ensure_local_neo4j_has_test_service_accounts,
+)
 from tests.integration.cartography.intel.anthropic.test_users import (
     _ensure_local_neo4j_has_test_users,
 )
@@ -36,6 +39,7 @@ def test_load_anthropic_apikeys(mock_api, neo4j_session):
     }
     _ensure_local_neo4j_has_test_users(neo4j_session)
     _ensure_local_neo4j_has_test_workspaces(neo4j_session)
+    _ensure_local_neo4j_has_test_service_accounts(neo4j_session)
 
     # Act
     cartography.intel.anthropic.apikeys.sync(
@@ -116,6 +120,18 @@ def test_load_anthropic_apikeys(mock_api, neo4j_session):
         )
         == expected_rels
     )
+
+    # Assert the service-account-owned key edges to its principal, and the
+    # human-owned one does not
+    assert check_rels(
+        neo4j_session,
+        "AnthropicApiKey",
+        "id",
+        "AnthropicServiceAccount",
+        "id",
+        "OWNED_BY",
+        rel_direction_right=True,
+    ) == {("apikey_01Wq7X2ZTbn4LcVpM8sKdYhE", "svac_01Nb5RtYuIoPaSdFgHjKlZxC")}
 
     # Assert apikeys are linked to the correct workspaces
     expected_rels = {

--- a/tests/integration/cartography/intel/anthropic/test_federation.py
+++ b/tests/integration/cartography/intel/anthropic/test_federation.py
@@ -1,0 +1,220 @@
+import copy
+from unittest.mock import patch
+
+import requests
+
+import cartography.intel.anthropic.federation
+import tests.data.anthropic.federation
+from tests.integration.cartography.intel.anthropic.test_organization import (
+    _ensure_local_neo4j_has_test_organization,
+)
+from tests.integration.cartography.intel.anthropic.test_serviceaccounts import (
+    _ensure_local_neo4j_has_test_service_accounts,
+)
+from tests.integration.cartography.intel.anthropic.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspaces,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = "8834c225-ea27-405a-aea9-5ed5f07f4858"
+TEST_WORKSPACE_ID = "wrkspc_01JwQvzr7rXLA5AGx3HKfFUJ"
+
+
+@patch.object(
+    cartography.intel.anthropic.federation,
+    "get_rule_workspaces",
+    side_effect=lambda _session, _url, rule_id: (
+        tests.data.anthropic.federation.ANTHROPIC_FEDERATION_RULE_WORKSPACES[rule_id]
+    ),
+)
+@patch.object(
+    cartography.intel.anthropic.federation,
+    "get_rules",
+    return_value=copy.deepcopy(
+        tests.data.anthropic.federation.ANTHROPIC_FEDERATION_RULES
+    ),
+)
+@patch.object(
+    cartography.intel.anthropic.federation,
+    "get_issuers",
+    return_value=copy.deepcopy(
+        tests.data.anthropic.federation.ANTHROPIC_FEDERATION_ISSUERS
+    ),
+)
+def test_load_anthropic_federation(
+    mock_issuers, mock_rules, mock_rule_workspaces, neo4j_session
+):
+    """
+    Ensure that federation issuers and rules get loaded and wired to each other
+    """
+    # Arrange
+    api_session = requests.Session()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "BASE_URL": "https://api.anthropic.com/v1",
+        "ORG_ID": TEST_ORG_ID,
+    }
+    _ensure_local_neo4j_has_test_organization(neo4j_session)
+    _ensure_local_neo4j_has_test_workspaces(neo4j_session)
+    _ensure_local_neo4j_has_test_service_accounts(neo4j_session)
+
+    # Act
+    cartography.intel.anthropic.federation.sync(
+        neo4j_session,
+        api_session,
+        common_job_parameters,
+    )
+
+    # Assert issuers exist, with the jwks union flattened. The second issuer has key
+    # polling disabled and failing fetches, which is the interesting posture.
+    expected_nodes = {
+        (
+            "fdis_01Ab2Cd3Ef4Gh5Ij6Kl7Mn8Op",
+            "github-actions",
+            True,
+            "discovery",
+            None,
+            0,
+        ),
+        (
+            "fdis_01Zy9Xw8Vu7Ts6Rq5Po4Nm3Lk",
+            "springfield-k8s",
+            False,
+            "explicit_url",
+            "https://kubernetes.springfield.corp/openid/v1/jwks",
+            3,
+        ),
+    }
+    assert (
+        check_nodes(
+            neo4j_session,
+            "AnthropicFederationIssuer",
+            [
+                "id",
+                "name",
+                "check_jti",
+                "jwks_type",
+                "jwks_url",
+                "poll_status_consecutive_failures",
+            ],
+        )
+        == expected_nodes
+    )
+
+    # Assert rules exist, with the matchers flattened. The wildcard subject_prefix on
+    # the second rule is what makes fork pull requests able to mint a token.
+    expected_nodes = {
+        (
+            "fdrl_01Qw2Er3Ty4Ui5Op6As7Df8Gh",
+            "cartography-collector",
+            "org:admin",
+            "system:serviceaccount:security:cartography",
+            False,
+        ),
+        (
+            "fdrl_01Hj2Kl3Zx4Cv5Bn6Mq7Wt8Ry",
+            "ci-inference",
+            "workspace:developer",
+            "repo:springfield/reactor-control:*",
+            True,
+        ),
+    }
+    assert (
+        check_nodes(
+            neo4j_session,
+            "AnthropicFederationRule",
+            [
+                "id",
+                "name",
+                "oauth_scope",
+                "match_subject_prefix",
+                "applies_to_all_workspaces",
+            ],
+        )
+        == expected_nodes
+    )
+
+    # Assert the claims map was flattened onto the rule that carries one. Queried
+    # directly because check_nodes cannot hash a list-valued property.
+    claims_by_rule = {
+        record["id"]: record["match_claims"]
+        for record in neo4j_session.run(
+            "MATCH (r:AnthropicFederationRule) RETURN r.id AS id, "
+            "r.match_claims AS match_claims"
+        )
+    }
+    assert claims_by_rule == {
+        "fdrl_01Qw2Er3Ty4Ui5Op6As7Df8Gh": ["namespace=security"],
+        "fdrl_01Hj2Kl3Zx4Cv5Bn6Mq7Wt8Ry": [],
+    }
+
+    # Assert issuers and rules are linked to the correct org
+    for label in ("AnthropicFederationIssuer", "AnthropicFederationRule"):
+        assert {
+            org_id
+            for _, org_id in check_rels(
+                neo4j_session,
+                label,
+                "id",
+                "AnthropicOrganization",
+                "id",
+                "RESOURCE",
+                rel_direction_right=False,
+            )
+        } == {TEST_ORG_ID}
+
+    # Assert each rule trusts the right issuer
+    expected_rels = {
+        ("fdrl_01Qw2Er3Ty4Ui5Op6As7Df8Gh", "fdis_01Zy9Xw8Vu7Ts6Rq5Po4Nm3Lk"),
+        ("fdrl_01Hj2Kl3Zx4Cv5Bn6Mq7Wt8Ry", "fdis_01Ab2Cd3Ef4Gh5Ij6Kl7Mn8Op"),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "AnthropicFederationRule",
+            "id",
+            "AnthropicFederationIssuer",
+            "id",
+            "AUTHENTICATED_BY",
+            rel_direction_right=True,
+        )
+        == expected_rels
+    )
+
+    # Assert each rule mints tokens acting as the right service account. This is the
+    # escalation path: rule -> service account -> organization_role.
+    expected_rels = {
+        ("fdrl_01Qw2Er3Ty4Ui5Op6As7Df8Gh", "svac_01Pq8WeRtYuIoPaSdFgHjKlM"),
+        ("fdrl_01Hj2Kl3Zx4Cv5Bn6Mq7Wt8Ry", "svac_01Nb5RtYuIoPaSdFgHjKlZxC"),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "AnthropicFederationRule",
+            "id",
+            "AnthropicServiceAccount",
+            "id",
+            "ASSUMES",
+            rel_direction_right=True,
+        )
+        == expected_rels
+    )
+
+    # Assert only the explicitly enabled workspace is edged
+    expected_rels = {
+        ("fdrl_01Hj2Kl3Zx4Cv5Bn6Mq7Wt8Ry", TEST_WORKSPACE_ID),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "AnthropicFederationRule",
+            "id",
+            "AnthropicWorkspace",
+            "id",
+            "ENABLED_ON",
+            rel_direction_right=True,
+        )
+        == expected_rels
+    )

--- a/tests/integration/cartography/intel/anthropic/test_invites.py
+++ b/tests/integration/cartography/intel/anthropic/test_invites.py
@@ -1,0 +1,92 @@
+from unittest.mock import patch
+
+import requests
+
+import cartography.intel.anthropic.invites
+import tests.data.anthropic.invites
+from tests.integration.cartography.intel.anthropic.test_organization import (
+    _ensure_local_neo4j_has_test_organization,
+)
+from tests.integration.cartography.intel.anthropic.test_rbac import (
+    _ensure_local_neo4j_has_test_rbac_groups,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = "8834c225-ea27-405a-aea9-5ed5f07f4858"
+
+
+@patch.object(
+    cartography.intel.anthropic.invites,
+    "get",
+    return_value=(TEST_ORG_ID, tests.data.anthropic.invites.ANTHROPIC_INVITES),
+)
+def test_load_anthropic_invites(mock_api, neo4j_session):
+    """
+    Ensure that invites get loaded, including the groups they grant on acceptance
+    """
+    # Arrange
+    api_session = requests.Session()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "BASE_URL": "https://api.anthropic.com/v1",
+        "ORG_ID": TEST_ORG_ID,
+    }
+    _ensure_local_neo4j_has_test_organization(neo4j_session)
+    _ensure_local_neo4j_has_test_rbac_groups(neo4j_session)
+
+    # Act
+    cartography.intel.anthropic.invites.sync(
+        neo4j_session,
+        api_session,
+        common_job_parameters,
+    )
+
+    # Assert invites exist. A pending one is an un-redeemed grant of its role.
+    assert check_nodes(
+        neo4j_session, "AnthropicInvite", ["id", "email", "role", "status"]
+    ) == {
+        (
+            "invite_015gWxCN9Hfg2QhZwTK7Mdeu",
+            "lisa@simpson.corp",
+            "developer",
+            "pending",
+        ),
+        (
+            "invite_026hXyDO0Igh3RiAxUL8Nefv",
+            "bart@simpson.corp",
+            "admin",
+            "accepted",
+        ),
+    }
+
+    # Assert invites are linked to the correct org
+    assert check_rels(
+        neo4j_session,
+        "AnthropicInvite",
+        "id",
+        "AnthropicOrganization",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        ("invite_015gWxCN9Hfg2QhZwTK7Mdeu", TEST_ORG_ID),
+        ("invite_026hXyDO0Igh3RiAxUL8Nefv", TEST_ORG_ID),
+    }
+
+    # Assert only the invite carrying a group id edges to it
+    assert check_rels(
+        neo4j_session,
+        "AnthropicInvite",
+        "id",
+        "AnthropicRbacGroup",
+        "id",
+        "GRANTS_MEMBERSHIP_OF",
+        rel_direction_right=True,
+    ) == {
+        (
+            "invite_015gWxCN9Hfg2QhZwTK7Mdeu",
+            "rbac_group_012rppKaSVsmTo6NqRDXQXNF",
+        ),
+    }

--- a/tests/integration/cartography/intel/anthropic/test_organization.py
+++ b/tests/integration/cartography/intel/anthropic/test_organization.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+
+import requests
+
+import cartography.intel.anthropic.organization
+import tests.data.anthropic.organization
+from tests.integration.util import check_nodes
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = "8834c225-ea27-405a-aea9-5ed5f07f4858"
+
+
+def _ensure_local_neo4j_has_test_organization(neo4j_session):
+    cartography.intel.anthropic.organization.load_organization(
+        neo4j_session,
+        tests.data.anthropic.organization.ANTHROPIC_ORGANIZATION,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.anthropic.organization,
+    "get",
+    return_value=tests.data.anthropic.organization.ANTHROPIC_ORGANIZATION,
+)
+def test_load_anthropic_organization(mock_api, neo4j_session):
+    """
+    Ensure that the organization gets loaded and its id is published for other syncs
+    """
+    # Arrange
+    api_session = requests.Session()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "BASE_URL": "https://api.anthropic.com/v1",
+    }
+
+    # Act
+    org_id = cartography.intel.anthropic.organization.sync(
+        neo4j_session,
+        api_session,
+        common_job_parameters,
+    )
+
+    # Assert the org id is returned and published for the other syncs to scope on
+    assert org_id == TEST_ORG_ID
+    assert common_job_parameters["ORG_ID"] == TEST_ORG_ID
+
+    # Assert Organization exists, with the name that only /organizations/me exposes
+    assert check_nodes(neo4j_session, "AnthropicOrganization", ["id", "name"]) == {
+        (TEST_ORG_ID, "Springfield Nuclear Power Plant"),
+    }

--- a/tests/integration/cartography/intel/anthropic/test_ratelimits.py
+++ b/tests/integration/cartography/intel/anthropic/test_ratelimits.py
@@ -1,0 +1,121 @@
+from unittest.mock import patch
+
+import requests
+
+import cartography.intel.anthropic.ratelimits
+import tests.data.anthropic.ratelimits
+from tests.integration.cartography.intel.anthropic.test_organization import (
+    _ensure_local_neo4j_has_test_organization,
+)
+from tests.integration.cartography.intel.anthropic.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspaces,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = "8834c225-ea27-405a-aea9-5ed5f07f4858"
+TEST_WORKSPACE_ID = "wrkspc_01JwQvzr7rXLA5AGx3HKfFUJ"
+
+
+@patch.object(
+    cartography.intel.anthropic.ratelimits,
+    "get_workspace_rate_limits",
+    side_effect=lambda _session, _url, workspace_id: (
+        tests.data.anthropic.ratelimits.ANTHROPIC_WORKSPACE_RATE_LIMITS[workspace_id]
+    ),
+)
+@patch.object(
+    cartography.intel.anthropic.ratelimits,
+    "get",
+    return_value=tests.data.anthropic.ratelimits.ANTHROPIC_RATE_LIMITS,
+)
+def test_load_anthropic_rate_limits(mock_api, mock_api_workspace, neo4j_session):
+    """
+    Ensure org and workspace rate limits get exploded into one node per limit
+    """
+    # Arrange
+    api_session = requests.Session()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "BASE_URL": "https://api.anthropic.com/v1",
+        "ORG_ID": TEST_ORG_ID,
+    }
+    _ensure_local_neo4j_has_test_organization(neo4j_session)
+    _ensure_local_neo4j_has_test_workspaces(neo4j_session)
+
+    # Act
+    cartography.intel.anthropic.ratelimits.sync(
+        neo4j_session,
+        api_session,
+        common_job_parameters,
+        [TEST_WORKSPACE_ID],
+    )
+
+    # Assert each entry in a group's limits list became its own node, with an id
+    # synthesised from scope, group type, models and limit type
+    assert check_nodes(
+        neo4j_session,
+        "AnthropicRateLimit",
+        ["id", "group_type", "limit_type", "value", "org_limit"],
+    ) == {
+        (
+            "organization/model_group/claude-opus-5/requests_per_minute",
+            "model_group",
+            "requests_per_minute",
+            4000,
+            None,
+        ),
+        (
+            "organization/model_group/claude-opus-5/input_tokens_per_minute",
+            "model_group",
+            "input_tokens_per_minute",
+            400000,
+            None,
+        ),
+        (
+            "organization/web_search/all/requests_per_minute",
+            "web_search",
+            "requests_per_minute",
+            1000,
+            None,
+        ),
+        # The workspace override records the org value it displaces
+        (
+            f"{TEST_WORKSPACE_ID}/model_group/claude-opus-5/requests_per_minute",
+            "model_group",
+            "requests_per_minute",
+            500,
+            4000,
+        ),
+    }
+
+    # Assert only the workspace-scoped limit edges to a workspace
+    assert check_rels(
+        neo4j_session,
+        "AnthropicRateLimit",
+        "id",
+        "AnthropicWorkspace",
+        "id",
+        "CONTAINS",
+        rel_direction_right=False,
+    ) == {
+        (
+            f"{TEST_WORKSPACE_ID}/model_group/claude-opus-5/requests_per_minute",
+            TEST_WORKSPACE_ID,
+        ),
+    }
+
+    # Assert every limit is scoped to the org
+    assert {
+        org_id
+        for _, org_id in check_rels(
+            neo4j_session,
+            "AnthropicRateLimit",
+            "id",
+            "AnthropicOrganization",
+            "id",
+            "RESOURCE",
+            rel_direction_right=False,
+        )
+    } == {TEST_ORG_ID}

--- a/tests/integration/cartography/intel/anthropic/test_ratelimits.py
+++ b/tests/integration/cartography/intel/anthropic/test_ratelimits.py
@@ -53,28 +53,28 @@ def test_load_anthropic_rate_limits(mock_api, mock_api_workspace, neo4j_session)
     )
 
     # Assert each entry in a group's limits list became its own node, with an id
-    # synthesised from scope, group type, models and limit type
+    # synthesised from the organization, scope, group type, models and limit type
     assert check_nodes(
         neo4j_session,
         "AnthropicRateLimit",
         ["id", "group_type", "limit_type", "value", "org_limit"],
     ) == {
         (
-            "organization/model_group/claude-opus-5/requests_per_minute",
+            f"{TEST_ORG_ID}/organization/model_group/claude-opus-5/requests_per_minute",
             "model_group",
             "requests_per_minute",
             4000,
             None,
         ),
         (
-            "organization/model_group/claude-opus-5/input_tokens_per_minute",
+            f"{TEST_ORG_ID}/organization/model_group/claude-opus-5/input_tokens_per_minute",
             "model_group",
             "input_tokens_per_minute",
             400000,
             None,
         ),
         (
-            "organization/web_search/all/requests_per_minute",
+            f"{TEST_ORG_ID}/organization/web_search/all/requests_per_minute",
             "web_search",
             "requests_per_minute",
             1000,
@@ -82,7 +82,7 @@ def test_load_anthropic_rate_limits(mock_api, mock_api_workspace, neo4j_session)
         ),
         # The workspace override records the org value it displaces
         (
-            f"{TEST_WORKSPACE_ID}/model_group/claude-opus-5/requests_per_minute",
+            f"{TEST_ORG_ID}/{TEST_WORKSPACE_ID}/model_group/claude-opus-5/requests_per_minute",
             "model_group",
             "requests_per_minute",
             500,
@@ -101,7 +101,7 @@ def test_load_anthropic_rate_limits(mock_api, mock_api_workspace, neo4j_session)
         rel_direction_right=False,
     ) == {
         (
-            f"{TEST_WORKSPACE_ID}/model_group/claude-opus-5/requests_per_minute",
+            f"{TEST_ORG_ID}/{TEST_WORKSPACE_ID}/model_group/claude-opus-5/requests_per_minute",
             TEST_WORKSPACE_ID,
         ),
     }

--- a/tests/integration/cartography/intel/anthropic/test_rbac.py
+++ b/tests/integration/cartography/intel/anthropic/test_rbac.py
@@ -136,8 +136,7 @@ def test_load_anthropic_rbac(
     }
 
     # Assert the group with roles holds them. The group whose roles came back null
-    # gets no edge: null means the data was unavailable, and inventing an edge would
-    # be worse than reporting none.
+    # has none in the graph to carry forward, so it gets no edge.
     assert check_rels(
         neo4j_session,
         "AnthropicRbacGroup",
@@ -191,3 +190,93 @@ def test_load_anthropic_rbac(
                 rel_direction_right=False,
             )
         } == {TEST_ORG_ID}
+
+
+def _sync_rbac(neo4j_session, groups, update_tag):
+    """Run a full RBAC sync against the given group payload."""
+    common_job_parameters = {
+        "UPDATE_TAG": update_tag,
+        "BASE_URL": "https://api.anthropic.com/v1",
+        "ORG_ID": TEST_ORG_ID,
+    }
+    with (
+        patch.object(
+            cartography.intel.anthropic.rbac,
+            "get_roles",
+            return_value=copy.deepcopy(tests.data.anthropic.rbac.ANTHROPIC_RBAC_ROLES),
+        ),
+        patch.object(
+            cartography.intel.anthropic.rbac,
+            "get_role_permissions",
+            side_effect=lambda _session, _url, role_id: (
+                tests.data.anthropic.rbac.ANTHROPIC_RBAC_ROLE_PERMISSIONS[role_id]
+            ),
+        ),
+        patch.object(
+            cartography.intel.anthropic.rbac, "get_groups", return_value=groups
+        ),
+        patch.object(
+            cartography.intel.anthropic.rbac,
+            "get_group_members",
+            side_effect=lambda _session, _url, group_id: (
+                tests.data.anthropic.rbac.ANTHROPIC_RBAC_GROUP_MEMBERS[group_id]
+            ),
+        ),
+    ):
+        cartography.intel.anthropic.rbac.sync(
+            neo4j_session,
+            requests.Session(),
+            common_job_parameters,
+        )
+
+
+def _has_role_rels(neo4j_session):
+    return check_rels(
+        neo4j_session,
+        "AnthropicRbacGroup",
+        "id",
+        "AnthropicRbacRole",
+        "id",
+        "HAS_ROLE",
+        rel_direction_right=True,
+    )
+
+
+def test_null_roles_preserves_known_role_edges(neo4j_session):
+    """
+    A transient null roles field must not silently drop a group's known roles.
+
+    The API returns null when role data was momentarily unavailable, which is not
+    the same as the group holding no roles. Writing an empty list would let the
+    cleanup job delete the real edges, under-reporting the group's permissions until
+    the next healthy sync.
+    """
+    # Arrange: a first sync where both groups report their roles
+    _ensure_local_neo4j_has_test_organization(neo4j_session)
+    _ensure_local_neo4j_has_test_users(neo4j_session)
+
+    healthy_groups = copy.deepcopy(tests.data.anthropic.rbac.ANTHROPIC_RBAC_GROUPS)
+    healthy_groups[1]["roles"] = ["rbac_role_02Tf7NqWrBz5Xk1LcPd8Ju6M"]
+    _sync_rbac(neo4j_session, healthy_groups, TEST_UPDATE_TAG)
+
+    expected_rels = {
+        (
+            "rbac_group_012rppKaSVsmTo6NqRDXQXNF",
+            "rbac_role_016J8xVtKpDq3Wy9ZmN2hR4s",
+        ),
+        (
+            "rbac_group_03Yh4MjXsQe7Rv2BnKt9Wz5D",
+            "rbac_role_02Tf7NqWrBz5Xk1LcPd8Ju6M",
+        ),
+    }
+    assert _has_role_rels(neo4j_session) == expected_rels
+
+    # Act: a second sync at a new update tag where the second group's roles are
+    # unavailable. The cleanup job runs against the new tag, so an edge that is not
+    # rewritten is deleted.
+    degraded_groups = copy.deepcopy(tests.data.anthropic.rbac.ANTHROPIC_RBAC_GROUPS)
+    assert degraded_groups[1]["roles"] is None
+    _sync_rbac(neo4j_session, degraded_groups, TEST_UPDATE_TAG + 1)
+
+    # Assert: the edge survived the outage
+    assert _has_role_rels(neo4j_session) == expected_rels

--- a/tests/integration/cartography/intel/anthropic/test_rbac.py
+++ b/tests/integration/cartography/intel/anthropic/test_rbac.py
@@ -1,0 +1,193 @@
+import copy
+from unittest.mock import patch
+
+import requests
+
+import cartography.intel.anthropic.rbac
+import tests.data.anthropic.rbac
+from tests.integration.cartography.intel.anthropic.test_organization import (
+    _ensure_local_neo4j_has_test_organization,
+)
+from tests.integration.cartography.intel.anthropic.test_users import (
+    _ensure_local_neo4j_has_test_users,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = "8834c225-ea27-405a-aea9-5ed5f07f4858"
+
+
+def _ensure_local_neo4j_has_test_rbac_groups(neo4j_session):
+    groups = copy.deepcopy(tests.data.anthropic.rbac.ANTHROPIC_RBAC_GROUPS)
+    for group in groups:
+        cartography.intel.anthropic.rbac.transform_group(
+            group,
+            tests.data.anthropic.rbac.ANTHROPIC_RBAC_GROUP_MEMBERS[group["id"]],
+        )
+    cartography.intel.anthropic.rbac.load_groups(
+        neo4j_session,
+        groups,
+        TEST_ORG_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.anthropic.rbac,
+    "get_group_members",
+    side_effect=lambda _session, _url, group_id: (
+        tests.data.anthropic.rbac.ANTHROPIC_RBAC_GROUP_MEMBERS[group_id]
+    ),
+)
+@patch.object(
+    cartography.intel.anthropic.rbac,
+    "get_groups",
+    return_value=copy.deepcopy(tests.data.anthropic.rbac.ANTHROPIC_RBAC_GROUPS),
+)
+@patch.object(
+    cartography.intel.anthropic.rbac,
+    "get_role_permissions",
+    side_effect=lambda _session, _url, role_id: (
+        tests.data.anthropic.rbac.ANTHROPIC_RBAC_ROLE_PERMISSIONS[role_id]
+    ),
+)
+@patch.object(
+    cartography.intel.anthropic.rbac,
+    "get_roles",
+    return_value=copy.deepcopy(tests.data.anthropic.rbac.ANTHROPIC_RBAC_ROLES),
+)
+def test_load_anthropic_rbac(
+    mock_roles, mock_permissions, mock_groups, mock_members, neo4j_session
+):
+    """
+    Ensure that RBAC roles, their permissions, and groups get loaded and linked
+    """
+    # Arrange
+    api_session = requests.Session()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "BASE_URL": "https://api.anthropic.com/v1",
+        "ORG_ID": TEST_ORG_ID,
+    }
+    _ensure_local_neo4j_has_test_organization(neo4j_session)
+    _ensure_local_neo4j_has_test_users(neo4j_session)
+
+    # Act
+    cartography.intel.anthropic.rbac.sync(
+        neo4j_session,
+        api_session,
+        common_job_parameters,
+    )
+
+    # Assert roles exist
+    assert check_nodes(neo4j_session, "AnthropicRbacRole", ["id", "name"]) == {
+        ("rbac_role_016J8xVtKpDq3Wy9ZmN2hR4s", "Project Editor"),
+        ("rbac_role_02Tf7NqWrBz5Xk1LcPd8Ju6M", "Plant Supervisor"),
+    }
+
+    # Assert groups exist, with source_type distinguishing SCIM-synced groups
+    assert check_nodes(
+        neo4j_session, "AnthropicRbacGroup", ["id", "name", "source_type"]
+    ) == {
+        ("rbac_group_012rppKaSVsmTo6NqRDXQXNF", "Engineering", "direct"),
+        ("rbac_group_03Yh4MjXsQe7Rv2BnKt9Wz5D", "Safety Inspectors", "scim"),
+    }
+
+    # Assert permissions get a synthetic id built from role, action and resource,
+    # since the API returns none
+    assert check_nodes(
+        neo4j_session,
+        "AnthropicRbacRolePermission",
+        ["id", "action", "resource_type"],
+    ) == {
+        (
+            f"rbac_role_016J8xVtKpDq3Wy9ZmN2hR4s/chat/organization/{TEST_ORG_ID}",
+            "chat",
+            "organization",
+        ),
+        (
+            "rbac_role_016J8xVtKpDq3Wy9ZmN2hR4s/use/connector_tool/"
+            "conn_01ReactorTelemetry/read_sensor",
+            "use",
+            "connector_tool",
+        ),
+        (
+            "rbac_role_02Tf7NqWrBz5Xk1LcPd8Ju6M/capability_access_all/"
+            f"organization/{TEST_ORG_ID}",
+            "capability_access_all",
+            "organization",
+        ),
+    }
+
+    # Assert each permission hangs off its role
+    assert check_rels(
+        neo4j_session,
+        "AnthropicRbacRole",
+        "id",
+        "AnthropicRbacRolePermission",
+        "action",
+        "GRANTS",
+        rel_direction_right=True,
+    ) == {
+        ("rbac_role_016J8xVtKpDq3Wy9ZmN2hR4s", "chat"),
+        ("rbac_role_016J8xVtKpDq3Wy9ZmN2hR4s", "use"),
+        ("rbac_role_02Tf7NqWrBz5Xk1LcPd8Ju6M", "capability_access_all"),
+    }
+
+    # Assert the group with roles holds them. The group whose roles came back null
+    # gets no edge: null means the data was unavailable, and inventing an edge would
+    # be worse than reporting none.
+    assert check_rels(
+        neo4j_session,
+        "AnthropicRbacGroup",
+        "id",
+        "AnthropicRbacRole",
+        "id",
+        "HAS_ROLE",
+        rel_direction_right=True,
+    ) == {
+        (
+            "rbac_group_012rppKaSVsmTo6NqRDXQXNF",
+            "rbac_role_016J8xVtKpDq3Wy9ZmN2hR4s",
+        ),
+    }
+
+    # Assert members are linked
+    assert check_rels(
+        neo4j_session,
+        "AnthropicUser",
+        "id",
+        "AnthropicRbacGroup",
+        "id",
+        "MEMBER_OF",
+        rel_direction_right=True,
+    ) == {
+        (
+            "user_EneequohSheesh3Ohtaefu8we2aite",
+            "rbac_group_012rppKaSVsmTo6NqRDXQXNF",
+        ),
+        (
+            "user_Oov3aYewo6ZuoGh8thaiV1uNoy1aXe",
+            "rbac_group_03Yh4MjXsQe7Rv2BnKt9Wz5D",
+        ),
+    }
+
+    # Assert everything is scoped to the org
+    for label in (
+        "AnthropicRbacRole",
+        "AnthropicRbacGroup",
+        "AnthropicRbacRolePermission",
+    ):
+        assert {
+            org_id
+            for _, org_id in check_rels(
+                neo4j_session,
+                label,
+                "id",
+                "AnthropicOrganization",
+                "id",
+                "RESOURCE",
+                rel_direction_right=False,
+            )
+        } == {TEST_ORG_ID}

--- a/tests/integration/cartography/intel/anthropic/test_serviceaccounts.py
+++ b/tests/integration/cartography/intel/anthropic/test_serviceaccounts.py
@@ -1,0 +1,144 @@
+import copy
+from unittest.mock import patch
+
+import requests
+
+import cartography.intel.anthropic.serviceaccounts
+import tests.data.anthropic.serviceaccounts
+from tests.integration.cartography.intel.anthropic.test_organization import (
+    _ensure_local_neo4j_has_test_organization,
+)
+from tests.integration.cartography.intel.anthropic.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspaces,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = "8834c225-ea27-405a-aea9-5ed5f07f4858"
+TEST_WORKSPACE_ID = "wrkspc_01JwQvzr7rXLA5AGx3HKfFUJ"
+
+
+def _ensure_local_neo4j_has_test_service_accounts(neo4j_session):
+    service_accounts = copy.deepcopy(
+        tests.data.anthropic.serviceaccounts.ANTHROPIC_SERVICE_ACCOUNTS
+    )
+    for service_account in service_accounts:
+        cartography.intel.anthropic.serviceaccounts.transform_service_account(
+            service_account,
+            tests.data.anthropic.serviceaccounts.ANTHROPIC_SERVICE_ACCOUNT_WORKSPACES[
+                service_account["id"]
+            ],
+        )
+    cartography.intel.anthropic.serviceaccounts.load_service_accounts(
+        neo4j_session,
+        service_accounts,
+        TEST_ORG_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.anthropic.serviceaccounts,
+    "get_service_account_workspaces",
+    side_effect=lambda _session, _url, service_account_id: (
+        tests.data.anthropic.serviceaccounts.ANTHROPIC_SERVICE_ACCOUNT_WORKSPACES[
+            service_account_id
+        ]
+    ),
+)
+@patch.object(
+    cartography.intel.anthropic.serviceaccounts,
+    "get",
+    return_value=copy.deepcopy(
+        tests.data.anthropic.serviceaccounts.ANTHROPIC_SERVICE_ACCOUNTS
+    ),
+)
+def test_load_anthropic_service_accounts(mock_api, mock_api_workspaces, neo4j_session):
+    """
+    Ensure that service accounts and their workspace memberships get loaded
+    """
+    # Arrange
+    api_session = requests.Session()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "BASE_URL": "https://api.anthropic.com/v1",
+        "ORG_ID": TEST_ORG_ID,
+    }
+    _ensure_local_neo4j_has_test_organization(neo4j_session)
+    _ensure_local_neo4j_has_test_workspaces(neo4j_session)
+
+    # Act
+    cartography.intel.anthropic.serviceaccounts.sync(
+        neo4j_session,
+        api_session,
+        common_job_parameters,
+    )
+
+    # Assert service accounts exist. organization_role is the privilege signal: only
+    # an admin service account can back an org:admin federation rule.
+    expected_nodes = {
+        ("svac_01Nb5RtYuIoPaSdFgHjKlZxC", "reactor-telemetry", "developer"),
+        ("svac_01Pq8WeRtYuIoPaSdFgHjKlM", "cartography-collector", "admin"),
+    }
+    assert (
+        check_nodes(
+            neo4j_session,
+            "AnthropicServiceAccount",
+            ["id", "name", "organization_role"],
+        )
+        == expected_nodes
+    )
+
+    # Assert service accounts are linked to the correct org
+    expected_rels = {
+        ("svac_01Nb5RtYuIoPaSdFgHjKlZxC", TEST_ORG_ID),
+        ("svac_01Pq8WeRtYuIoPaSdFgHjKlM", TEST_ORG_ID),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "AnthropicServiceAccount",
+            "id",
+            "AnthropicOrganization",
+            "id",
+            "RESOURCE",
+            rel_direction_right=False,
+        )
+        == expected_rels
+    )
+
+    # Assert both are members of the workspace
+    expected_rels = {
+        ("svac_01Nb5RtYuIoPaSdFgHjKlZxC", TEST_WORKSPACE_ID),
+        ("svac_01Pq8WeRtYuIoPaSdFgHjKlM", TEST_WORKSPACE_ID),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "AnthropicServiceAccount",
+            "id",
+            "AnthropicWorkspace",
+            "id",
+            "MEMBER_OF",
+            rel_direction_right=True,
+        )
+        == expected_rels
+    )
+
+    # Assert only the workspace_admin member administers it
+    expected_rels = {
+        ("svac_01Pq8WeRtYuIoPaSdFgHjKlM", TEST_WORKSPACE_ID),
+    }
+    assert (
+        check_rels(
+            neo4j_session,
+            "AnthropicServiceAccount",
+            "id",
+            "AnthropicWorkspace",
+            "id",
+            "ADMIN_OF",
+            rel_direction_right=True,
+        )
+        == expected_rels
+    )

--- a/tests/integration/cartography/intel/anthropic/test_skills.py
+++ b/tests/integration/cartography/intel/anthropic/test_skills.py
@@ -1,0 +1,112 @@
+import copy
+from unittest.mock import patch
+
+import requests
+
+import cartography.intel.anthropic.skills
+import tests.data.anthropic.skills
+from tests.integration.cartography.intel.anthropic.test_organization import (
+    _ensure_local_neo4j_has_test_organization,
+)
+from tests.integration.cartography.intel.anthropic.test_workspaces import (
+    _ensure_local_neo4j_has_test_workspaces,
+)
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_WORKSPACE_ID = "wrkspc_01JwQvzr7rXLA5AGx3HKfFUJ"
+
+
+def _ensure_local_neo4j_has_test_skills(neo4j_session):
+    cartography.intel.anthropic.skills.load_skills(
+        neo4j_session,
+        copy.deepcopy(tests.data.anthropic.skills.ANTHROPIC_SKILLS),
+        TEST_WORKSPACE_ID,
+        TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.anthropic.skills,
+    "get_skill_versions",
+    side_effect=lambda _session, _url, skill_id: (
+        tests.data.anthropic.skills.ANTHROPIC_SKILL_VERSIONS[skill_id]
+    ),
+)
+@patch.object(
+    cartography.intel.anthropic.skills,
+    "get",
+    return_value=copy.deepcopy(tests.data.anthropic.skills.ANTHROPIC_SKILLS),
+)
+def test_load_anthropic_skills(mock_api, mock_api_versions, neo4j_session):
+    """
+    Ensure that skills and their versions get loaded, scoped to their workspace
+    """
+    # Arrange
+    api_session = requests.Session()
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "BASE_URL": "https://api.anthropic.com/v1",
+        "WORKSPACE_ID": TEST_WORKSPACE_ID,
+    }
+    _ensure_local_neo4j_has_test_organization(neo4j_session)
+    _ensure_local_neo4j_has_test_workspaces(neo4j_session)
+
+    # Act
+    cartography.intel.anthropic.skills.sync(
+        neo4j_session,
+        api_session,
+        common_job_parameters,
+    )
+
+    # Assert skills exist. source distinguishes a skill uploaded to this workspace
+    # from a first-party one available everywhere.
+    assert check_nodes(
+        neo4j_session, "AnthropicSkill", ["id", "display_title", "source"]
+    ) == {
+        ("skill_01Mv4Zq7Nr2Ks8Ld3Tp6Wx9B", "Reactor Runbook", "custom"),
+        ("skill_02Hb5Yn8Pq3Jt7Mc4Rd1Vz6A", "pptx", "anthropic"),
+    }
+
+    # Assert versions exist
+    assert check_nodes(
+        neo4j_session, "AnthropicSkillVersion", ["id", "name", "version"]
+    ) == {
+        (
+            "skillver_01Qt9Wr4Ym6Nb2Kd8Lp3Xc7F",
+            "reactor-runbook",
+            "1738240000000000",
+        ),
+    }
+
+    # Assert skills are scoped to the workspace, not the organization: there is no
+    # org-wide skill listing
+    assert check_rels(
+        neo4j_session,
+        "AnthropicSkill",
+        "id",
+        "AnthropicWorkspace",
+        "id",
+        "RESOURCE",
+        rel_direction_right=False,
+    ) == {
+        ("skill_01Mv4Zq7Nr2Ks8Ld3Tp6Wx9B", TEST_WORKSPACE_ID),
+        ("skill_02Hb5Yn8Pq3Jt7Mc4Rd1Vz6A", TEST_WORKSPACE_ID),
+    }
+
+    # Assert the version hangs off its skill
+    assert check_rels(
+        neo4j_session,
+        "AnthropicSkill",
+        "id",
+        "AnthropicSkillVersion",
+        "id",
+        "HAS_VERSION",
+        rel_direction_right=True,
+    ) == {
+        (
+            "skill_01Mv4Zq7Nr2Ks8Ld3Tp6Wx9B",
+            "skillver_01Qt9Wr4Ym6Nb2Kd8Lp3Xc7F",
+        ),
+    }

--- a/tests/integration/cartography/intel/anthropic/test_users.py
+++ b/tests/integration/cartography/intel/anthropic/test_users.py
@@ -4,6 +4,9 @@ import requests
 
 import cartography.intel.anthropic.users
 import tests.data.anthropic.users
+from tests.integration.cartography.intel.anthropic.test_organization import (
+    _ensure_local_neo4j_has_test_organization,
+)
 from tests.integration.util import check_nodes
 from tests.integration.util import check_rels
 
@@ -12,6 +15,8 @@ TEST_ORG_ID = "8834c225-ea27-405a-aea9-5ed5f07f4858"
 
 
 def _ensure_local_neo4j_has_test_users(neo4j_session):
+    # The organization sync owns the org node that users hang off.
+    _ensure_local_neo4j_has_test_organization(neo4j_session)
     cartography.intel.anthropic.users.load_users(
         neo4j_session,
         tests.data.anthropic.users.ANTHROPIC_USERS,
@@ -37,16 +42,12 @@ def test_load_anthropic_users(mock_api, neo4j_session):
     }
 
     # Act
+    _ensure_local_neo4j_has_test_organization(neo4j_session)
     cartography.intel.anthropic.users.sync(
         neo4j_session,
         api_session,
         common_job_parameters,
     )
-
-    # Assert Organization exists
-    assert check_nodes(neo4j_session, "AnthropicOrganization", ["id"]) == {
-        (TEST_ORG_ID,)
-    }
 
     # Assert Users exist
     expected_nodes = {

--- a/tests/integration/cartography/intel/anthropic/test_workspaces.py
+++ b/tests/integration/cartography/intel/anthropic/test_workspaces.py
@@ -1,3 +1,4 @@
+import copy
 from unittest.mock import patch
 
 import requests
@@ -15,9 +16,12 @@ TEST_ORG_ID = "8834c225-ea27-405a-aea9-5ed5f07f4858"
 
 
 def _ensure_local_neo4j_has_test_workspaces(neo4j_session):
+    workspaces = copy.deepcopy(tests.data.anthropic.workspaces.ANTHROPIC_WORKSPACES)
+    for workspace in workspaces:
+        cartography.intel.anthropic.workspaces.transform_workspace(workspace)
     cartography.intel.anthropic.workspaces.load_workspaces(
         neo4j_session,
-        tests.data.anthropic.workspaces.ANTHROPIC_WORKSPACES,
+        workspaces,
         TEST_ORG_ID,
         TEST_UPDATE_TAG,
     )
@@ -53,15 +57,23 @@ def test_load_anthropic_workspaces(mock_api, mock_api_members, neo4j_session):
         common_job_parameters,
     )
 
-    # Assert Workspaces exist
+    # Assert Workspaces exist, with the CMEK binding and residency posture flattened
+    # out of the nested data_residency object
     expected_nodes = {
         (
             "wrkspc_01JwQvzr7rXLA5AGx3HKfFUJ",
             "Springfield Nuclear Power Plant",
+            "3f2b1c8e-9d4a-4f6b-8c1e-2a7d5b9e0f3c",
+            "ekey_01HxYzAbCdEfGhIjKlMnOpQr",
+            "us",
         ),
     }
     assert (
-        check_nodes(neo4j_session, "AnthropicWorkspace", ["id", "name"])
+        check_nodes(
+            neo4j_session,
+            "AnthropicWorkspace",
+            ["id", "name", "compartment_id", "external_key_id", "workspace_geo"],
+        )
         == expected_nodes
     )
 

--- a/tests/unit/cartography/intel/anthropic/test_auth.py
+++ b/tests/unit/cartography/intel/anthropic/test_auth.py
@@ -1,0 +1,186 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from cartography.intel.anthropic.auth import AnthropicAuth
+from cartography.intel.anthropic.auth import ApiKeyCredential
+from cartography.intel.anthropic.auth import EnvVarAssertionSource
+from cartography.intel.anthropic.auth import FileAssertionSource
+from cartography.intel.anthropic.auth import is_federated
+from cartography.intel.anthropic.auth import make_assertion_source
+from cartography.intel.anthropic.auth import make_credential
+from cartography.intel.anthropic.auth import WorkloadIdentityCredential
+
+
+def _token_response(access_token: str = "sk-ant-oat01-abc", expires_in: int = 3600):
+    response = MagicMock()
+    response.json.return_value = {
+        "access_token": access_token,
+        "token_type": "Bearer",
+        "expires_in": expires_in,
+        "scope": "org:admin",
+    }
+    return response
+
+
+def _wif_credential(assertion_source, workspace_id: str | None = None):
+    return WorkloadIdentityCredential(
+        assertion_source=assertion_source,
+        federation_rule_id="fdrl_123",
+        organization_id="8834c225-ea27-405a-aea9-5ed5f07f4858",
+        service_account_id="svac_456",
+        workspace_id=workspace_id,
+    )
+
+
+def test_apikey_credential_uses_x_api_key_header() -> None:
+    cred = ApiKeyCredential("sk-ant-admin01-abc")
+    assert cred.get_headers() == {"X-Api-Key": "sk-ant-admin01-abc"}
+
+
+def test_file_assertion_source_is_reread_on_each_call(tmp_path: Path) -> None:
+    # Kubernetes rotates projected service account tokens on disk, so a value cached
+    # at startup goes stale mid-sync.
+    token_file = tmp_path / "token"
+    token_file.write_text("first-jwt\n")
+    source = FileAssertionSource(str(token_file))
+    assert source.read() == "first-jwt"
+
+    token_file.write_text("rotated-jwt\n")
+    assert source.read() == "rotated-jwt"
+
+
+def test_env_var_assertion_source_reads_and_strips(monkeypatch) -> None:
+    monkeypatch.setenv("MY_IDENTITY_TOKEN", "  a-jwt  ")
+    assert EnvVarAssertionSource("MY_IDENTITY_TOKEN").read() == "a-jwt"
+
+
+def test_env_var_assertion_source_raises_when_unset(monkeypatch) -> None:
+    monkeypatch.delenv("MY_IDENTITY_TOKEN", raising=False)
+    with pytest.raises(ValueError, match="does not contain an identity token"):
+        EnvVarAssertionSource("MY_IDENTITY_TOKEN").read()
+
+
+@patch("cartography.intel.anthropic.auth.requests.post")
+def test_wif_exchange_posts_jwt_bearer_grant(mock_post: MagicMock) -> None:
+    mock_post.return_value = _token_response()
+    source = MagicMock()
+    source.read.return_value = "the-oidc-jwt"
+
+    headers = _wif_credential(source).get_headers()
+
+    assert headers == {"Authorization": "Bearer sk-ant-oat01-abc"}
+    assert "X-Api-Key" not in headers
+    url = mock_post.call_args[0][0]
+    assert url == "https://api.anthropic.com/v1/oauth/token"
+    assert mock_post.call_args.kwargs["json"] == {
+        "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        "assertion": "the-oidc-jwt",
+        "federation_rule_id": "fdrl_123",
+        "organization_id": "8834c225-ea27-405a-aea9-5ed5f07f4858",
+        "service_account_id": "svac_456",
+    }
+
+
+@patch("cartography.intel.anthropic.auth.requests.post")
+def test_wif_exchange_sends_workspace_id_when_set(mock_post: MagicMock) -> None:
+    mock_post.return_value = _token_response()
+    source = MagicMock()
+    source.read.return_value = "the-oidc-jwt"
+
+    _wif_credential(source, workspace_id="wrkspc_789").get_headers()
+
+    assert mock_post.call_args.kwargs["json"]["workspace_id"] == "wrkspc_789"
+
+
+@patch("cartography.intel.anthropic.auth.requests.post")
+def test_wif_token_is_cached_until_near_expiry(mock_post: MagicMock) -> None:
+    mock_post.return_value = _token_response()
+    source = MagicMock()
+    source.read.return_value = "the-oidc-jwt"
+    cred = _wif_credential(source)
+
+    cred.get_headers()
+    cred.get_headers()
+
+    mock_post.assert_called_once()
+
+
+@patch("cartography.intel.anthropic.auth.requests.post")
+def test_wif_token_refreshes_and_rereads_assertion(mock_post: MagicMock) -> None:
+    # A token inside the refresh buffer must be re-exchanged, and the exchange must
+    # pull a fresh assertion rather than replaying the one used the first time.
+    mock_post.side_effect = [
+        _token_response("first-token", expires_in=10),
+        _token_response("second-token"),
+    ]
+    source = MagicMock()
+    source.read.side_effect = ["first-jwt", "second-jwt"]
+    cred = _wif_credential(source)
+
+    assert cred.get_headers() == {"Authorization": "Bearer first-token"}
+    assert cred.get_headers() == {"Authorization": "Bearer second-token"}
+
+    assert source.read.call_count == 2
+    assert mock_post.call_args_list[1].kwargs["json"]["assertion"] == "second-jwt"
+
+
+@patch("cartography.intel.anthropic.auth.requests.post")
+def test_auth_applies_headers_to_request(mock_post: MagicMock) -> None:
+    mock_post.return_value = _token_response()
+    source = MagicMock()
+    source.read.return_value = "the-oidc-jwt"
+
+    auth = AnthropicAuth(_wif_credential(source))
+    request = requests.Request("GET", "https://api.anthropic.com/v1/organizations/me")
+    prepared = auth(request.prepare())
+
+    assert prepared.headers["Authorization"] == "Bearer sk-ant-oat01-abc"
+
+
+def test_make_credential_returns_apikey_credential() -> None:
+    cred = make_credential(apikey="sk-ant-admin01-abc")
+    assert isinstance(cred, ApiKeyCredential)
+    assert not is_federated(cred)
+
+
+def test_make_credential_prefers_wif_over_apikey(tmp_path: Path) -> None:
+    # Federation reaches strictly more endpoints than an Admin API key, so it wins.
+    token_file = tmp_path / "token"
+    token_file.write_text("a-jwt")
+    cred = make_credential(
+        apikey="sk-ant-admin01-abc",
+        identity_token_file=str(token_file),
+        federation_rule_id="fdrl_123",
+        organization_id="org-uuid",
+        service_account_id="svac_456",
+    )
+    assert isinstance(cred, WorkloadIdentityCredential)
+    assert is_federated(cred)
+
+
+def test_make_credential_raises_on_partial_wif_config(tmp_path: Path) -> None:
+    token_file = tmp_path / "token"
+    token_file.write_text("a-jwt")
+    with pytest.raises(ValueError, match="partially configured"):
+        make_credential(
+            identity_token_file=str(token_file),
+            federation_rule_id="fdrl_123",
+        )
+
+
+def test_make_credential_raises_when_nothing_configured() -> None:
+    with pytest.raises(ValueError, match="not configured"):
+        make_credential()
+
+
+def test_make_assertion_source_returns_none_when_unconfigured() -> None:
+    assert make_assertion_source(None, None) is None
+
+
+def test_make_assertion_source_rejects_both_sources() -> None:
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        make_assertion_source("/path/to/token", "MY_IDENTITY_TOKEN")


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Adds Workload Identity Federation as an authentication method for the Anthropic module, and expands coverage from 4 node types to 19.

Two things changed on Anthropic's side since the module was written:

1. **The Admin API now accepts OAuth bearer tokens** with the `org:admin` scope alongside `sk-ant-admin` keys, and Workload Identity Federation (GA) mints them. A collector running in Kubernetes, EKS, GKE or GitHub Actions can now drive the API with no long-lived secret.
2. **Some endpoints refuse Admin API keys outright.** Service accounts, federation issuers and federation rules return 403 to a `sk-ant-admin` key and are only readable with an `org:admin` OAuth token, so cartography could not see them at all. Those are exactly the IAM primitives a security graph should carry.

Both auth methods are supported. Federation wins when both are configured; a partially configured federation triple raises rather than silently falling back to skipping the module.

**New node types** (15): `AnthropicServiceAccount`, `AnthropicFederationIssuer`, `AnthropicFederationRule`, `AnthropicInvite`, `AnthropicRbacGroup`, `AnthropicRbacRole`, `AnthropicRbacRolePermission`, `AnthropicRateLimit`, `AnthropicSkill`, `AnthropicSkillVersion`, `AnthropicAgent`, `AnthropicEnvironment`, `AnthropicDeployment`, `AnthropicVault`, `AnthropicMemoryStore`.

**Enriched existing nodes**: `AnthropicOrganization` gains a real `name` from `GET /organizations/me` (the id was previously scraped from a response header and defaulted to `""`), which lets it map onto the Tenant ontology. `AnthropicApiKey` gains `expires_at` and the `principal` it acts as, which is what distinguishes a machine credential from a human's. `AnthropicWorkspace` gains its customer-managed encryption key binding and data-residency posture.

The federation subgraph makes the trust chain queryable end to end: a rule declares which assertions from which issuer may mint a token, `ASSUMES` the service account that token acts as, and that service account carries the `organization_role` the token inherits. An over-broad matcher becomes a visible escalation path, such as a GitHub Actions `subject_prefix` ending in a wildcard, which also matches fork pull requests.

Six commits, one per logical change.


### Related issues or links

- [Workload Identity Federation](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation)
- [WIF reference](https://platform.claude.com/docs/en/manage-claude/wif-reference)
- [Manage WIF with the Admin API](https://platform.claude.com/docs/en/manage-claude/wif-admin-api)


### How was this tested?

- **Unit** (`tests/unit/cartography/intel/anthropic/test_auth.py`, 15 new tests): the exchange request body, that the resulting header is `Authorization: Bearer` and not `X-Api-Key`, that a near-expiry token triggers exactly one refresh, that the assertion is re-read from disk on every exchange, and the configuration guards.
- **Integration** (11 test files under `tests/integration/cartography/intel/anthropic/`): one per node type, asserting nodes and every relationship.
- One regression test runs two syncs at different update tags so it exercises cleanup for real, and was confirmed to fail without its fix.
- Full suites green locally: 4572 unit, 1347 integration. `pre-commit run --all-files` clean.

**Not tested**: the live token exchange. It needs a real organization with a Console-created `org:admin` federation rule, a service account with `organization_role: admin`, and an OIDC assertion, none of which a fixture can stand in for. Flagging this explicitly rather than checking the sync-logs box below.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment. **Not provided**: see the note above. The syncs are covered by integration tests against a real Neo4j instead.

#### If you are changing a node or relationship
- [x] Updated the schema documentation. Node and relationship descriptions live in the dataclasses and render into the generated schema page; `docs/root/modules/anthropic/config.md` was rewritten for both auth methods.
- [ ] Updated the schema README. Not applicable: no new module.

#### If you are implementing a new intel module
- [x] Used the NodeSchema data model.


### Notes for reviewers

Three decisions worth a look:

1. **`requests.auth.AuthBase`** is a new idiom for this repo, used so a federated token can refresh itself mid-sync without callers knowing. The closest precedent for the problem is Tailscale, which solves it with a 401 response hook instead.

2. **Per-workspace failures are warnings, not fatal.** Skills, agents and the rest have no organization-wide listing and are out of reach of an `org:admin` token, and there is no way to downscope one: the token endpoint accepts only the `jwt-bearer` grant, with no RFC 8693 exchange and no request-side scope. So each workspace needs its own exchange, and a failed one is expected rather than exceptional. The service account may not be a member of that workspace, or replay protection may have rejected a reused assertion, and both come back as an opaque `400 invalid_grant` that gives no way to tell them apart. Workspace-plane nodes therefore hang off their workspace rather than the organization, so one workspace failing to exchange cannot delete another's resources at cleanup.

3. **A transient `null` on an RBAC group's `roles`** is carried forward from the graph rather than written as empty. Skipping the load would not have been enough, because cleanup deletes any relationship whose `lastupdated` misses the current tag. The residual tradeoff: a role legitimately removed during an outage leaves a stale edge until the next healthy sync. That direction is deliberate, since over-declaring a permission is visible and self-correcting while under-declaring it is silent.

Deliberately out of scope, all noted in the code or docs: `/v1/models` (a static public catalog), `/v1/files`, `/v1/sessions`, `/v1/messages/batches` (high-volume transient records that would dominate the graph), `/v1/tunnels` (needs a third federation rule with `workspace:manage_tunnels`, which cannot share a rule with `workspace:developer`), and the Compliance API (a fourth credential family that does not accept `org:admin` tokens). No security rules either; the data is in place to write them in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
