### PR TITLE
feat(aws:inspector): add fixAvailable, exploitAvailable, EPSS score to Inspector findings

### DIFF
--- a/cartography/intel/aws/inspector.py
+++ b/cartography/intel/aws/inspector.py
@@ -179,6 +179,14 @@ def transform_inspector_findings(
         finding["description"] = f["description"]
         finding["type"] = f["type"]
         finding["status"] = f["status"]
+        finding["fixavailable"] = f.get("fixAvailable")
+        finding["exploitavailable"] = f.get("exploitAvailable")
+        if f.get("exploitabilityDetails"):
+            finding["lastknownexploitat"] = f["exploitabilityDetails"].get(
+                "lastKnownExploitAt",
+            )
+        if f.get("epss"):
+            finding["epss_score_inspector"] = f["epss"].get("score")
         if f.get("inspectorScoreDetails"):
             finding["cvssscore"] = f["inspectorScoreDetails"]["adjustedCvss"]["score"]
         if f["resources"][0]["type"] == "AWS_EC2_INSTANCE":

--- a/cartography/models/aws/inspector/findings.py
+++ b/cartography/models/aws/inspector/findings.py
@@ -130,6 +130,22 @@ class AWSInspectorNodeProperties(CartographyNodeProperties):
         "vulnerablepackageids",
         description="Identifiers of packages affected by the vulnerability.",
     )
+    fixavailable: PropertyRef = PropertyRef(
+        "fixavailable",
+        description="Whether a fix is available through a version update: `YES`, `NO`, or `PARTIAL`.",
+    )
+    exploitavailable: PropertyRef = PropertyRef(
+        "exploitavailable",
+        description="Whether an exploit is available for the finding: `YES` or `NO`.",
+    )
+    lastknownexploitat: PropertyRef = PropertyRef(
+        "lastknownexploitat",
+        description="Timestamp of the last known exploit associated with the finding.",
+    )
+    epss_score_inspector: PropertyRef = PropertyRef(
+        "epss_score_inspector",
+        description="Exploit Prediction Scoring System (EPSS) score for the finding, as reported by Inspector.",
+    )
     region: PropertyRef = PropertyRef(
         "Region",
         set_in_kwargs=True,

--- a/tests/data/aws/inspector.py
+++ b/tests/data/aws/inspector.py
@@ -4,8 +4,16 @@ LIST_FINDINGS_NETWORK = [
     {
         "awsAccountId": "123456789011",
         "description": "string",
+        "epss": {
+            "score": 123.0,
+        },
+        "exploitAvailable": "NO",
+        "exploitabilityDetails": {
+            "lastKnownExploitAt": datetime(2015, 1, 1),
+        },
         "findingArn": "arn:aws:test123",
         "firstObservedAt": datetime(2015, 1, 1),
+        "fixAvailable": "YES",
         "inspectorScore": 123.0,
         "inspectorScoreDetails": {
             "adjustedCvss": {
@@ -101,8 +109,16 @@ LIST_FINDINGS_EC2_PACKAGE = [
         "(resource consumption) by leveraging improper channel "
         "callback shutdown when unmounting an NFSv4 filesystem, aka "
         'a "module reference and kernel daemon" leak.',
+        "epss": {
+            "score": 0.42,
+        },
+        "exploitAvailable": "YES",
+        "exploitabilityDetails": {
+            "lastKnownExploitAt": datetime(2022, 5, 4, 16, 23, 3, 692000),
+        },
         "findingArn": "arn:aws:test456",
         "firstObservedAt": datetime(2022, 5, 4, 16, 23, 3, 692000),
+        "fixAvailable": "PARTIAL",
         "inspectorScore": 5.5,
         "inspectorScoreDetails": {
             "adjustedCvss": {

--- a/tests/unit/cartography/intel/aws/test_inspector.py
+++ b/tests/unit/cartography/intel/aws/test_inspector.py
@@ -29,6 +29,10 @@ def test_transform_inspector_findings_network():
             "portrangebegin": 123,
             "type": "NETWORK_REACHABILITY",
             "status": "ACTIVE",
+            "fixavailable": "YES",
+            "exploitavailable": "NO",
+            "lastknownexploitat": datetime(2015, 1, 1, 0, 0),
+            "epss_score_inspector": 123.0,
         },
     ]
 
@@ -69,6 +73,10 @@ def test_transform_inspector_findings_package():
                 "kernel-tools|0:4.9.17-6.29.amzn1.X86_64",
                 "kernel|0:4.9.17-6.29.amzn1.X86_64",
             ],
+            "fixavailable": "PARTIAL",
+            "exploitavailable": "YES",
+            "lastknownexploitat": datetime(2022, 5, 4, 16, 23, 3, 692000),
+            "epss_score_inspector": 0.42,
         },
         {
             "id": "arn:aws:test789",
@@ -97,6 +105,8 @@ def test_transform_inspector_findings_package():
             "vulnerablepackageids": [
                 "openssl|0:1.0.2k-1.amzn2.X86_64",
             ],
+            "fixavailable": None,
+            "exploitavailable": None,
         },
     ]
     # The order of packages is not guaranteed because it comes from a set.


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
Adds four new flattened properties to `AWSInspectorFinding` nodes, sourced from the Inspector2 `list_findings` API (per the [boto3 reference](https://docs.aws.amazon.com/boto3/latest/reference/services/inspector2/client/list_findings.html)):

- `fixavailable` ← `fixAvailable` (`YES` / `NO` / `PARTIAL`)
- `exploitavailable` ← `exploitAvailable` (`YES` / `NO`)
- `lastknownexploitat` ← `exploitabilityDetails.lastKnownExploitAt`
- `epss_score_inspector` ← `epss.score`

These give visibility into remediation availability and exploit risk directly on the finding node. The EPSS score is named `epss_score_inspector` (rather than `epss_score`) to avoid colliding with the existing `epss_score` property on the CVE metadata ontology schema (`cartography/models/cve_metadata/cve_metadata.py`), which is populated from a different source.

### Related issues or links


### How was this tested?
- Updated `tests/data/aws/inspector.py` fixtures to include the new API fields (including one finding that omits them, to exercise the missing-field path).
- Updated and ran `tests/unit/cartography/intel/aws/test_inspector.py::test_transform_inspector_findings_network` and `::test_transform_inspector_findings_package` — both pass.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [ ] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [ ] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

### Notes for reviewers
Schema docs / README updates for the new properties are still outstanding — flagging for reviewer awareness.

Supersedes #3114 (recreated from an up-to-date `master` with a properly signed-off commit).