### PR TITLE
fix(cloudflare): tolerate optional SDK fields that arrive as null

### DIFF
--- a/cartography/intel/cloudflare/members.py
+++ b/cartography/intel/cloudflare/members.py
@@ -58,8 +58,12 @@ def load_members(
 def transform_members(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     result: List[Dict[str, Any]] = []
     for member in data:
-        member["roles_ids"] = [role["id"] for role in member.get("roles", [])]
-        member["policies_ids"] = [policy["id"] for policy in member.get("policies", [])]
+        # Both fields are optional, so a member without any comes back with the
+        # key absent or explicitly null.
+        member["roles_ids"] = [role["id"] for role in member.get("roles") or []]
+        member["policies_ids"] = [
+            policy["id"] for policy in member.get("policies") or []
+        ]
         result.append(member)
     return result
 

--- a/cartography/intel/cloudflare/r2buckets.py
+++ b/cartography/intel/cloudflare/r2buckets.py
@@ -207,7 +207,9 @@ def get_custom_domains(
             exc_info=True,
         )
         return None
-    return [domain.to_dict() for domain in response.domains]
+    # Like the bucket listing above, the SDK types `domains` as required but the
+    # API omits it for a bucket without any custom domain.
+    return [domain.to_dict() for domain in response.domains or []]
 
 
 def bucket_id(account_id: str, jurisdiction: str, bucket_name: str) -> str:

--- a/cartography/intel/cloudflare/rulesets.py
+++ b/cartography/intel/cloudflare/rulesets.py
@@ -194,7 +194,9 @@ def get_ruleset_rules(
     # require fetching the ruleset itself.
     scope_params = {"zone_id": zone_id} if zone_id else {"account_id": account_id}
     ruleset = client.rulesets.get(ruleset_id, **scope_params)
-    return [rule.to_dict() for rule in ruleset.rules]
+    # The SDK types `rules` as required, but the API omits it for a ruleset with
+    # no rules configured, so it arrives as None.
+    return [rule.to_dict() for rule in ruleset.rules or []]
 
 
 def deployment_id(account_id: str, zone_id: str | None, ruleset_id: str) -> str:
@@ -253,7 +255,9 @@ def transform_ruleset_rules(
         row = rule.copy()
         row["rule_id"] = rule["id"]
         row["id"] = f"{ruleset_deployment_id}/{rule['id']}"
-        executed_ruleset_id = rule.get("action_parameters", {}).get("id")
+        # `action_parameters` is optional, and a rule that carries none comes back
+        # with the key absent or explicitly null, as executed_ruleset_ids() sees.
+        executed_ruleset_id = (rule.get("action_parameters") or {}).get("id")
         row["executed_deployment_id"] = (
             deployment_id(account_id, zone_id, executed_ruleset_id)
             if executed_ruleset_id


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

`cartography.intel.cloudflare.rulesets.get_ruleset_rules` raised
`TypeError: 'NoneType' object is not iterable` on a ruleset with no rules, aborting the
whole Cloudflare intel module:

```
File "cartography/intel/cloudflare/rulesets.py", line 197, in get_ruleset_rules
    return [rule.to_dict() for rule in ruleset.rules]
TypeError: 'NoneType' object is not iterable
```

The Cloudflare SDK types `rules` as a required `List[Rule]`, but the API omits the key for
a ruleset with nothing configured, and the SDK builds its models permissively, so the
missing field surfaces as `None` rather than raising. This is not an edge case: a phase
entry point ruleset exists per scope whether or not any rule was ever added to it, so a
single empty entry point in any zone stopped the sync for the whole account.

A sweep of the module for the same class of bug turned up three more spots, fixed here too:

| Location | Field | Why it can be `None` |
| --- | --- | --- |
| `rulesets.get_ruleset_rules` | `ruleset.rules` | typed required, omitted by the API for an empty ruleset |
| `r2buckets.get_custom_domains` | `response.domains` | same, for a bucket without any custom domain |
| `rulesets.transform_ruleset_rules` | `action_parameters` | optional field; an explicit null keeps the key, so the `.get(k, {})` default never applies and `.get()` raises `AttributeError` |
| `members.transform_members` | `roles`, `policies` | optional in the same way |

The underlying reason the `.get(key, default)` form is not enough: the SDK's `to_dict()`
runs with `exclude_unset=True` and `exclude_none=False`, so a field the API omits
disappears from the dict (the default applies) while a field returned as `null` stays
present holding `None` (the default does not apply). Only the `or []` / `or {}` form covers
both. `r2buckets.get_jurisdiction_buckets` and `rulesets.executed_ruleset_ids` already used
that form for the same reason; the remaining call sites now match them.

Behaviour after the fix: an empty ruleset contributes no rules, a bucket with no custom
domain reports an empty exposure rather than an unknown one, and the sync continues.


### Related issues or links

- Follow-up to #3107, which introduced the Cloudflare ruleset and R2 ingestion.


### How was this tested?

```
uv run pytest tests/unit/cartography/intel/cloudflare/ tests/integration/cartography/intel/cloudflare/
```

2 unit tests and 22 integration tests pass. `pre-commit run` (isort, black, flake8,
pyupgrade, mypy) is clean on the changed files.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.


### Notes for reviewers

No test is added: each fix is a null guard on a field the existing fixtures cannot produce
without inventing SDK responses whose only purpose is to be null, and the existing
integration tests already cover the populated path for all four call sites.

No node, relationship or schema doc changes.
