### PR TITLE
fix(netlify): tolerate a DNS zone whose apex domain was registered through Netlify

### DIFF
--- a/cartography/intel/netlify/dns.py
+++ b/cartography/intel/netlify/dns.py
@@ -14,6 +14,18 @@ from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
+# Keys lifted off the domain registration object onto the zone, mapped to the property they land
+# in. `auth_code` is deliberately absent: it is the EPP transfer authorization code, so ingesting
+# it would put a domain-takeover credential in the graph. `renewal_price`, `failure_reason`,
+# `transferred_at`, `deleted` and `auto_renew_at` are dropped as well; they add no signal that
+# `status` and `expires_at` do not already carry.
+_DOMAIN_REGISTRATION_FIELDS = {
+    "registered_at": "domain_registered_at",
+    "expires_at": "domain_expires_at",
+    "auto_renew": "domain_auto_renew",
+    "status": "domain_registration_status",
+}
+
 
 @timeit
 def sync_netlify_dns(
@@ -25,7 +37,9 @@ def sync_netlify_dns(
     update_tag: int,
     common_job_parameters: dict[str, Any],
 ) -> None:
-    zones = get_netlify_dns_zones(api_session, base_url, account_slug)
+    zones = transform_netlify_dns_zones(
+        get_netlify_dns_zones(api_session, base_url, account_slug),
+    )
     records = []
     for zone in zones:
         records.extend(get_netlify_dns_records(api_session, base_url, zone["id"]))
@@ -68,6 +82,40 @@ def get_netlify_dns_records(
     zone_id: str,
 ) -> list[dict[str, Any]]:
     return get_list(api_session, f"{base_url}/dns_zones/{zone_id}/dns_records")
+
+
+def transform_netlify_dns_zones(
+    zones: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    Normalize `domain` to a string and flatten the domain registration onto the zone.
+
+    The API documents `domain` as a string, and that is what a zone whose apex domain is
+    registered elsewhere and delegated to Netlify DNS returns. A domain bought through Netlify
+    carries the whole domain registration object there instead, which Neo4j cannot store as a
+    property value.
+
+    Only the renewal fields are kept: a domain close to expiry, with auto-renew off, or with a
+    failed payment is a hijack candidate.
+    """
+    transformed = []
+    for zone in zones:
+        domain = zone.get("domain")
+        registration = domain if isinstance(domain, dict) else {}
+        transformed.append(
+            {
+                **zone,
+                "domain": registration.get("name") if registration else domain,
+                # Copied field by field rather than spread: the registration carries its own
+                # `id`, `name`, `account_id`, `user_id`, `created_at` and `updated_at`, which
+                # would otherwise overwrite the zone's.
+                **{
+                    prop: registration.get(key)
+                    for key, prop in _DOMAIN_REGISTRATION_FIELDS.items()
+                },
+            },
+        )
+    return transformed
 
 
 def transform_netlify_dns_records(

--- a/cartography/intel/netlify/dns.py
+++ b/cartography/intel/netlify/dns.py
@@ -101,11 +101,16 @@ def transform_netlify_dns_zones(
     transformed = []
     for zone in zones:
         domain = zone.get("domain")
-        registration = domain if isinstance(domain, dict) else {}
+        registration: dict[str, Any] = {}
+        # Every object-shaped `domain` takes this branch, including an empty or partial one:
+        # falling back to the raw value for those would put the map back into the property.
+        if isinstance(domain, dict):
+            registration = domain
+            domain = registration.get("name")
         transformed.append(
             {
                 **zone,
-                "domain": registration.get("name") if registration else domain,
+                "domain": domain,
                 # Copied field by field rather than spread: the registration carries its own
                 # `id`, `name`, `account_id`, `user_id`, `created_at` and `updated_at`, which
                 # would otherwise overwrite the zone's.

--- a/cartography/models/netlify/dnszone.py
+++ b/cartography/models/netlify/dnszone.py
@@ -19,7 +19,29 @@ class NetlifyDNSZoneNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef("id", description="The Netlify DNS zone id.")
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
     name: PropertyRef = PropertyRef("name", extra_index=True, description="Zone name.")
-    domain: PropertyRef = PropertyRef("domain", description="Apex domain of the zone.")
+    domain: PropertyRef = PropertyRef(
+        "domain",
+        description="Apex domain of the zone. Taken from the domain registration's name when the domain was bought through Netlify.",
+    )
+    # Set only for a domain bought through Netlify, where the API returns the whole domain
+    # registration on `domain` and transform() flattens the renewal fields onto the zone. A
+    # domain near expiry, with auto-renew off, or with a failed payment is a hijack candidate.
+    domain_registered_at: PropertyRef = PropertyRef(
+        "domain_registered_at",
+        description="When the apex domain was registered, for a domain bought through Netlify.",
+    )
+    domain_expires_at: PropertyRef = PropertyRef(
+        "domain_expires_at",
+        description="When the domain registration expires. A near expiry is a hijack candidate.",
+    )
+    domain_auto_renew: PropertyRef = PropertyRef(
+        "domain_auto_renew",
+        description="Whether the registration renews automatically. A false value is a hijack candidate.",
+    )
+    domain_registration_status: PropertyRef = PropertyRef(
+        "domain_registration_status",
+        description="Registration status Netlify reports, e.g. `payment_succeeded`.",
+    )
     # Set when the zone is attached to a specific site rather than held at team level.
     site_id: PropertyRef = PropertyRef(
         "site_id",

--- a/tests/data/netlify/dns.py
+++ b/tests/data/netlify/dns.py
@@ -5,6 +5,10 @@ Hand-written from https://open-api.netlify.com/ rather than captured live: creat
 returns HTTP 500 on a Free-plan team, so this shape could not be observed against the real API
 the way the rest of the Netlify fixtures were. Ids and domains are stable fakes matching the
 other fixtures in this package.
+
+The one exception is the domain registration object on the first zone's `domain`, which is
+transcribed from a production traceback. The spec declares `domain` as a string and does not
+describe that object at all, so the spec alone could not have produced it.
 """
 
 from typing import Any
@@ -20,7 +24,28 @@ NETLIFY_DNS_ZONES: list[dict[str, Any]] = [
             "dns1.p05.nsone.net",
             "dns2.p05.nsone.net",
         ],
-        "domain": "example-site.dev",
+        # A domain bought through Netlify: `domain` holds the whole domain registration object
+        # instead of the string the spec documents. Its `id`, `name`, `created_at` and
+        # `updated_at` deliberately differ from the zone's own, so a transform that spread the
+        # object onto the zone would clobber them and fail the node assertions.
+        "domain": {
+            "account_id": "5f5a5d7053c60b4be4c8784d",
+            "auth_code": "super-secret-epp-transfer-code",
+            "auto_renew": True,
+            "auto_renew_at": "2027-06-28T16:18:52.098Z",
+            "created_at": "2025-07-30T16:18:52.098Z",
+            "deleted": False,
+            "expires_at": "2027-07-30T16:18:52.098Z",
+            "failure_reason": None,
+            "id": "6b6b6d7053c60b4be4c87301",
+            "name": "example-site.dev",
+            "registered_at": "2025-07-30T16:18:52.098Z",
+            "renewal_price": "19.99",
+            "status": "payment_succeeded",
+            "transferred_at": None,
+            "updated_at": "2026-07-01T03:00:05.303Z",
+            "user_id": "5f5a5d7053c60b4be4c8784b",
+        },
         "errors": [],
         "id": "7c7c7d7053c60b4be4c87001",
         "ipv6_enabled": True,
@@ -54,6 +79,8 @@ NETLIFY_DNS_ZONES: list[dict[str, Any]] = [
             "dns1.p05.nsone.net",
             "dns2.p05.nsone.net",
         ],
+        # Registered elsewhere and merely delegated to Netlify DNS, so `domain` is the plain
+        # string the spec documents: the other branch of the zone transform.
         "domain": "orphan.example",
         "errors": ["NS records for orphan.example do not point to Netlify DNS"],
         "id": "7c7c7d7053c60b4be4c87002",

--- a/tests/integration/cartography/intel/netlify/test_network.py
+++ b/tests/integration/cartography/intel/netlify/test_network.py
@@ -20,6 +20,7 @@ from tests.integration.cartography.intel.netlify.common import common_job_parame
 from tests.integration.cartography.intel.netlify.common import (
     create_test_netlify_account,
 )
+from tests.integration.cartography.intel.netlify.common import find_secret_in_graph
 from tests.integration.cartography.intel.netlify.common import TEST_ACCOUNT_ID
 from tests.integration.cartography.intel.netlify.common import TEST_ACCOUNT_SLUG
 from tests.integration.cartography.intel.netlify.common import TEST_BASE_URL
@@ -85,6 +86,29 @@ def test_sync_netlify_dns(
     ) == {
         (_ZONE_SITE, "example-site.dev", False, True),
         (_ZONE_ORPHAN, "orphan.example", False, False),
+    }
+
+    # Assert Nodes: the domain registration object was flattened onto the zone that carries one,
+    # and the zone whose apex domain is registered elsewhere keeps its plain `domain` string
+    assert check_nodes(
+        neo4j_session,
+        "NetlifyDNSZone",
+        [
+            "id",
+            "domain",
+            "domain_expires_at",
+            "domain_auto_renew",
+            "domain_registration_status",
+        ],
+    ) == {
+        (
+            _ZONE_SITE,
+            "example-site.dev",
+            "2027-07-30T16:18:52.098Z",
+            True,
+            "payment_succeeded",
+        ),
+        (_ZONE_ORPHAN, "orphan.example", None, None, None),
     }
 
     # Netlify reports delegation problems on the zone, which is the dangling-delegation signal
@@ -183,6 +207,55 @@ def test_dns_zones_are_scoped_to_the_requested_team() -> None:
 
     _, kwargs = api_session.get.call_args
     assert kwargs["params"]["account_slug"] == TEST_ACCOUNT_SLUG
+
+
+def test_transform_netlify_dns_zones_flattens_a_registered_domain() -> None:
+    """
+    A domain bought through Netlify comes back with the whole domain registration object on
+    `domain`, where the spec documents a string, and Neo4j rejects a map as a property value.
+    """
+    transformed = cartography.intel.netlify.dns.transform_netlify_dns_zones(
+        tests.data.netlify.dns.NETLIFY_DNS_ZONES,
+    )
+    by_id = {zone["id"]: zone for zone in transformed}
+
+    registered = by_id[_ZONE_SITE]
+    assert registered["domain"] == "example-site.dev"
+    assert registered["domain_registered_at"] == "2025-07-30T16:18:52.098Z"
+    assert registered["domain_expires_at"] == "2027-07-30T16:18:52.098Z"
+    assert registered["domain_auto_renew"] is True
+    assert registered["domain_registration_status"] == "payment_succeeded"
+    # The registration carries its own id, name and timestamps; the zone keeps its own
+    assert registered["name"] == "example-site.dev"
+    assert registered["created_at"] == "2026-07-30T16:18:52.098Z"
+    assert registered["updated_at"] == "2026-07-30T16:20:20.019Z"
+
+    # A domain registered elsewhere already matches the spec, so it passes through untouched
+    delegated = by_id[_ZONE_ORPHAN]
+    assert delegated["domain"] == "orphan.example"
+    assert delegated["domain_expires_at"] is None
+    assert delegated["domain_auto_renew"] is None
+    assert delegated["domain_registration_status"] is None
+
+
+def test_netlify_dns_zone_never_stores_the_domain_auth_code(
+    neo4j_session: neo4j.Session,
+) -> None:
+    """
+    `auth_code` on the domain registration is the EPP transfer authorization code: whoever holds
+    it can move the domain to another registrar, so it must never reach the graph.
+    """
+    create_test_netlify_account(neo4j_session)
+    cartography.intel.netlify.dns.load_netlify_dns_zones(
+        neo4j_session,
+        cartography.intel.netlify.dns.transform_netlify_dns_zones(
+            tests.data.netlify.dns.NETLIFY_DNS_ZONES,
+        ),
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+    assert find_secret_in_graph(neo4j_session, "super-secret-epp-transfer-code") == []
 
 
 @patch.object(


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

`sync_netlify_dns` transformed records but not zones, so the raw `dns_zones` payload went straight into `load()`.

The OpenAPI spec declares `dns_zones[].domain` as a string, and that is what a zone whose apex domain is registered elsewhere and delegated to Netlify DNS returns. A domain **bought through Netlify** carries the whole domain registration object in that field instead, which Neo4j rejects as a property value:

```
neo4j.exceptions.CypherTypeError: {code: Neo.ClientError.Statement.TypeError}
Property values can only be of primitive types or arrays thereof.
Encountered: Map{registered_at -> ..., auto_renew -> ..., status -> String("payment_succeeded"), ...}
```

The registration object is not described in `swagger.yml` at all (`registered_at`, `renewal_price`, `auto_renew`, `auth_code` and `transferred_at` appear nowhere in it), which is why the shape was never modeled. This is the same class of defect as #3116: the declared contract does not match what the API actually returns.

Impact before this fix: the raise aborts `_sync_one_account` before `merge_module_sync_metadata`, so the entire Netlify module reports failure and no `NetlifyDNSZone` or `NetlifyDNSRecord` node lands. It is not intermittent, it reproduces on every sync for any team owning at least one Netlify-registered domain.

**The fix** adds `transform_netlify_dns_zones`, mirroring the existing `transform_netlify_sites`, which:

1. Normalizes `domain` to a string, taking the registration's `name` when the field holds an object.
2. Flattens the registration's renewal fields onto the zone as four new scalar properties: `domain_registered_at`, `domain_expires_at`, `domain_auto_renew` and `domain_registration_status`. A domain close to expiry, with auto-renew off, or with a failed payment is a genuine hijack candidate, so this is useful signal rather than incidental metadata.

Two deliberate choices worth calling out:

- **`auth_code` is excluded.** It is the EPP transfer authorization code, so ingesting it would put a domain-takeover credential in the graph. This follows the precedent in `sites.py`, which replaces `jwt_secret` with a `has_jwt_secret` boolean. `renewal_price`, `failure_reason`, `transferred_at`, `deleted` and `auto_renew_at` are dropped as well, since they add no signal that `status` and `expires_at` do not already carry.
- **Fields are copied one by one, not spread.** The registration object carries its own `id`, `name`, `account_id`, `user_id`, `created_at` and `updated_at`. A `{**zone, **registration}` spread would silently overwrite the zone's identity and timestamps.

Timestamps are stored as the ISO 8601 strings the API returns, matching the zone's existing `created_at` and `updated_at`. Converting the Netlify module to native temporal types would be a separate migration.


### Related issues or links

None. Reported directly against a team owning a Netlify-registered domain.

Same class of defect as #3116 (`fix(cloudflare): tolerate optional SDK fields that arrive as null`).


### How was this tested?

The regression was proven before the fix was written: with the amended fixture and the old code, `test_sync_netlify_dns` fails with the same `CypherTypeError`, so the test demonstrably covers the bug rather than merely passing afterwards.

`tests/data/netlify/dns.py` now carries both shapes side by side, so the ordinary integration test exercises both branches:

- the first zone's `domain` is the registration object, transcribed from an observed payload;
- the second zone's `domain` stays the plain string the spec documents.

The registration's `id`, `created_at` and `updated_at` are deliberately different from the zone's own, so a future change that spread the object onto the zone would fail the existing node assertions.

Three test additions in `tests/integration/cartography/intel/netlify/test_network.py`:

- an assertion in `test_sync_netlify_dns` that the registered zone gets the flattened scalars and the delegated zone keeps its `domain` string with all four properties null;
- `test_transform_netlify_dns_zones_flattens_a_registered_domain`, covering both branches and asserting the zone's own `id`, `name` and timestamps survive;
- `test_netlify_dns_zone_never_stores_the_domain_auth_code`, which scans every property of every node in the graph using the existing `find_secret_in_graph` helper, mirroring `test_netlify_site_never_stores_the_jwt_secret`. This assertion survives someone later adding a `PropertyRef` for `auth_code`.

Commands run locally:

```
uv run --frozen pre-commit run --all-files   # 14/14 hooks pass
uv run --frozen pytest tests/unit            # 4584 passed
uv run --frozen pytest tests/integration/cartography/intel/netlify/   # 43 passed
```


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [ ] Included Cartography sync logs from a real environment demonstrating successful synchronization of the new/modified entity.

#### If you are changing a node or relationship
- [x] Updated the [schema documentation](https://github.com/cartography-cncf/cartography/tree/master/docs/root/modules).
- [ ] Updated the [schema README](https://github.com/cartography-cncf/cartography/blob/master/docs/schema/README.md).

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

**On the schema documentation checkbox.** The Netlify schema page is generated from the data model at Sphinx build time, and `test_only_legacy_modules_keep_a_hand_written_schema_page` fails if a `docs/root/modules/netlify/schema.md` is committed. The documentation for the four new properties is therefore the `description=` kwarg on each `PropertyRef`, which is what the generator renders. Verified with:

```
uv run --frozen python -c "from cartography.models.introspection import inspect_data_model; from cartography.models.schema_docs import render_module_schema; print(render_module_schema(inspect_data_model(), 'netlify'))"
```

The `domain` description was also extended to record the normalization, following the `NetlifyDNSRecord.name` convention of documenting the transform inline.

**On the missing sync logs.** Reproducing this requires a team that owns a domain purchased through Netlify, and creating a DNS zone returns HTTP 500 on a Free-plan team, which is why `tests/data/netlify/dns.py` was hand-written from the spec in the first place and why this shape was missed. The integration test standing in for those logs is described above.

**Scope check performed.** I cross-referenced all 20 Netlify node schemas against `swagger.yml` v2.57.0 looking for a second instance of this bug. Every field the spec types as `object` or `array of object` (`capabilities`, `records`, `build_settings`, `published_deploy`, `default_hooks_data`, `processing_settings`, `function_schedules`, `functions_region_overrides`, `updated_by`, `values`, `fields`, `data`, `config`, `env`, `external_attributes`, `snippets`) is undeclared, so none of them reach Neo4j. `domain` was the only declared property that could be non-primitive.

That said, the spec is precisely what was wrong here, so spec conformance does not rule out another deviation. `accounts.py` and `devservers.py` have no transform at all, so they are the two spots in this module with no normalization layer if Netlify deviates again. I left both alone rather than adding speculative guards.

**Possible follow-up, out of scope here.** `write_list_of_dicts_tx` runs the query bare, so a non-primitive property value surfaces as a `CypherTypeError` that names neither the node label, nor the property, nor the offending record. Diagnosing this one meant reading the map contents out of the traceback. A validation pass in `load()` that names node label, property and record id would turn this whole class of failure into a quick diagnosis across every module. Happy to open that separately if reviewers agree it is worth it.
