### PR TITLE
feat: support ArcadeDB ingestion

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -51,6 +51,39 @@ jobs:
       - name: Run integration tests
         run: make test_integration
 
+  arcadedb-ingestion-tests:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_BACKEND: arcadedb
+      ARCADEDB_DOCKER_IMAGE: arcadedata/arcadedb:26.7.3
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+      - name: Install the project
+        run: uv sync --frozen --all-extras --dev
+      - name: Run ingestion integration tests against ArcadeDB
+        run: |
+          uv run --frozen pytest -vvv \
+            tests/integration/cartography/test_cli.py::test_arcadedb_backend_validation_uses_real_bolt_endpoint \
+            tests/integration/cartography/client/test_core.py::test_ensure_indexes \
+            tests/integration/cartography/data/jobs \
+            tests/integration/cartography/intel/lastpass/test_users.py \
+            tests/integration/cartography/intel/test_provider_label_migrations.py \
+            tests/integration/cartography/intel/ontology/test_package_version_migration.py \
+            tests/integration/cartography/intel/aws/test_label_migrations.py \
+            tests/integration/cartography/intel/aws/ec2/test_load_balancer_v2s.py::test_migrate_legacy_loadbalancerv2_labels_repairs_partial_state \
+            tests/integration/cartography/intel/aws/ec2/test_ec2_load_balancers.py::test_migrate_legacy_loadbalancer_labels_is_scoped_and_idempotent \
+            tests/integration/cartography/intel/aws/test_identitycenter.py::test_group_allowed_by_role
+
   # Test that the docker image builds successfully on each commit
   build-docker-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -76,6 +76,8 @@ jobs:
             tests/integration/cartography/test_cli.py::test_arcadedb_backend_validation_uses_real_bolt_endpoint \
             tests/integration/cartography/client/test_core.py::test_ensure_indexes \
             tests/integration/cartography/data/jobs \
+            tests/integration/cartography/intel/test_deprecated_indexes.py \
+            tests/integration/cartography/intel/ontology/test_deprecated_indexes.py \
             tests/integration/cartography/intel/lastpass/test_users.py \
             tests/integration/cartography/intel/test_provider_label_migrations.py \
             tests/integration/cartography/intel/ontology/test_package_version_migration.py \

--- a/cartography/analysis/ontology/analysis.py
+++ b/cartography/analysis/ontology/analysis.py
@@ -12,24 +12,34 @@ AWS_USER_PROJECTION = AnalysisJob(
     short_name="ontology_aws_user_projection",
     statements=(
         AnalysisStatement(
-            match="MATCH (u:AWSUser)",
+            match=(
+                "MATCH (u:AWSUser) "
+                "OPTIONAL MATCH (u)-[:MFA_DEVICE]->(mfa:AWSMfaDevice) "
+                "WITH u, count(mfa) > 0 AS has_mfa"
+            ),
             effects=(
                 SetProperty(
                     "u",
                     "_ont_has_mfa",
-                    RawCypher("EXISTS((u)-[:MFA_DEVICE]->(:AWSMfaDevice))"),
+                    Var("has_mfa"),
                     label="AWSUser",
                 ),
             ),
         ),
         AnalysisStatement(
-            match="MATCH (u:AWSUser)",
+            match=(
+                "MATCH (u:AWSUser) "
+                "OPTIONAL MATCH (u)-[:AWS_ACCESS_KEY]->"
+                "(key:AWSAccountAccessKey {status: 'Active'}) "
+                "WITH u, count(key) > 0 AS has_active_access_key"
+            ),
             effects=(
                 SetProperty(
                     "u",
                     "_ont_active",
                     RawCypher(
-                        "CASE WHEN (u.passwordlastused_dt IS NOT NULL) OR EXISTS((u)-[:AWS_ACCESS_KEY]->(:AWSAccountAccessKey {status: 'Active'})) THEN true ELSE NULL END"
+                        "CASE WHEN (u.passwordlastused_dt IS NOT NULL) OR "
+                        "has_active_access_key THEN true ELSE NULL END"
                     ),
                     label="AWSUser",
                 ),

--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -10,6 +10,7 @@ from typing_extensions import Annotated
 from cartography import _MIN_PYTHON
 from cartography import _MIN_PYTHON_STR
 from cartography.config import Config
+from cartography.config import DatabaseBackend
 from cartography.version import get_release_version_and_commit_revision
 
 if TYPE_CHECKING:
@@ -477,12 +478,23 @@ class CLI:
             # =================================================================
             # Neo4j Connection Options
             # =================================================================
+            database_backend: Annotated[
+                DatabaseBackend,
+                typer.Option(
+                    "--database-backend",
+                    help=(
+                        "Graph database behind the Bolt endpoint. ArcadeDB reuses "
+                        "the --neo4j-* connection options."
+                    ),
+                    rich_help_panel=PANEL_NEO4J,
+                ),
+            ] = DatabaseBackend.NEO4J,
             neo4j_uri: Annotated[
                 str,
                 typer.Option(
                     "--neo4j-uri",
                     help=(
-                        "A valid Neo4j URI to sync against. See "
+                        "A valid Bolt URI for the selected database backend. See "
                         "https://neo4j.com/docs/browser-manual/current/operations/dbms-connection/#uri-scheme"
                     ),
                     rich_help_panel=PANEL_NEO4J,
@@ -492,7 +504,7 @@ class CLI:
                 str | None,
                 typer.Option(
                     "--neo4j-user",
-                    help="A username with which to authenticate to Neo4j.",
+                    help="A username with which to authenticate to the Bolt endpoint.",
                     rich_help_panel=PANEL_NEO4J,
                 ),
             ] = None,
@@ -500,7 +512,7 @@ class CLI:
                 str | None,
                 typer.Option(
                     "--neo4j-password-env-var",
-                    help="The name of an environment variable containing the Neo4j password.",
+                    help="The name of an environment variable containing the database password.",
                     rich_help_panel=PANEL_NEO4J,
                 ),
             ] = None,
@@ -508,7 +520,7 @@ class CLI:
                 bool,
                 typer.Option(
                     "--neo4j-password-prompt",
-                    help="Present an interactive prompt for the Neo4j password. Supersedes other password methods.",
+                    help="Present an interactive prompt for the database password. Supersedes other password methods.",
                     rich_help_panel=PANEL_NEO4J,
                 ),
             ] = False,
@@ -537,7 +549,7 @@ class CLI:
                 str | None,
                 typer.Option(
                     "--neo4j-database",
-                    help="The name of the database in Neo4j to connect to. Uses Neo4j default if not specified.",
+                    help="The database name. Uses the server default if not specified; required for ArcadeDB.",
                     rich_help_panel=PANEL_NEO4J,
                 ),
             ] = None,
@@ -2450,25 +2462,26 @@ class CLI:
 
             logger.debug("Launching cartography with CLI configuration")
 
-            # Handle Neo4j password
+            # Handle the Bolt endpoint password. The option names remain neo4j_* for
+            # backward compatibility when ArcadeDB is selected.
             neo4j_password = None
             if neo4j_user:
                 if neo4j_password_prompt:
                     logger.info(
-                        "Reading password for Neo4j user '%s' interactively.",
+                        "Reading password for database user '%s' interactively.",
                         neo4j_user,
                     )
                     neo4j_password = getpass.getpass()
                 elif neo4j_password_env_var:
                     logger.debug(
-                        "Reading password for Neo4j user '%s' from environment variable '%s'.",
+                        "Reading password for database user '%s' from environment variable '%s'.",
                         neo4j_user,
                         neo4j_password_env_var,
                     )
                     neo4j_password = os.environ.get(neo4j_password_env_var)
                 if not neo4j_password:
                     logger.warning(
-                        "Neo4j username was provided but a password could not be found.",
+                        "A database username was provided but a password could not be found.",
                     )
 
             # Load sync helpers lazily so --help/--version don't import all intel modules.
@@ -3148,6 +3161,7 @@ class CLI:
 
             # Build the Config object
             config = Config(
+                database_backend=database_backend,
                 neo4j_uri=neo4j_uri,
                 neo4j_user=neo4j_user,
                 neo4j_password=neo4j_password,

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -1,6 +1,14 @@
 import logging
+from enum import Enum
 
 logger = logging.getLogger(__name__)
+
+
+class DatabaseBackend(str, Enum):
+    """Graph database backends supported by Cartography ingestion."""
+
+    NEO4J = "neo4j"
+    ARCADEDB = "arcadedb"
 
 
 def _resolve_microsoft_credentials_config(
@@ -74,12 +82,15 @@ class Config:
     contain valid values. Fields documented as optional may contain None, in which case cartography will choose a
     sensible default value for that piece of configuration.
 
+    :type database_backend: DatabaseBackend
+    :param database_backend: Graph database implementation behind the Bolt endpoint.
+        Defaults to Neo4j.
     :type neo4j_uri: string
-    :param neo4j_uri: URI for a Neo4j graph database service. Required.
+    :param neo4j_uri: Bolt URI for a Neo4j or ArcadeDB graph database service. Required.
     :type neo4j_user: string
-    :param neo4j_user: User name for a Neo4j graph database service. Optional.
+    :param neo4j_user: User name for the Bolt graph database service. Optional.
     :type neo4j_password: string
-    :param neo4j_password: Password for a Neo4j graph database service. Optional.
+    :param neo4j_password: Password for the Bolt graph database service. Optional.
     :type neo4j_max_connection_lifetime: int
     :param neo4j_max_connection_lifetime: Time in seconds for Neo4j driver to consider a TCP connection alive.
         See https://neo4j.com/docs/driver-manual/1.7/client-applications/. Optional.
@@ -102,9 +113,8 @@ class Config:
     :param neo4j_connection_acquisition_timeout: Maximum time in seconds to wait for a Neo4j pooled connection.
         Optional.
     :type neo4j_database: string
-    :param neo4j_database: The name of the database in Neo4j to connect to. If not specified, uses your Neo4j database
-    settings to infer which database is set to default.
-    See https://neo4j.com/docs/api/python-driver/5.26/api.html#database. Optional.
+    :param neo4j_database: The database name. Neo4j uses the server default when
+        omitted; ArcadeDB requires an explicit database. Optional for Neo4j.
     :type selected_modules: str
     :param selected_modules: Comma-separated list of cartography top-level modules to sync. Optional.
     :type update_tag: int
@@ -661,7 +671,9 @@ class Config:
         netlify_token=None,
         netlify_account_slug=None,
         netlify_base_url=None,
+        database_backend: DatabaseBackend | str = DatabaseBackend.NEO4J,
     ):
+        self.database_backend = DatabaseBackend(database_backend)
         self.neo4j_uri = neo4j_uri
         self.neo4j_user = neo4j_user
         self.neo4j_password = neo4j_password

--- a/cartography/data/jobs/cleanup/aws_post_ingestion_principals_cleanup.json
+++ b/cartography/data/jobs/cleanup/aws_post_ingestion_principals_cleanup.json
@@ -1,6 +1,6 @@
 {
   "statements": [{
-    "query": "MATCH (n:AWSPrincipal) WHERE NOT (n)<-[:RESOURCE]-(:AWSAccount) AND n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+    "query": "MATCH (n:AWSPrincipal) WHERE NOT (n)<-[:RESOURCE]-(:AWSAccount) AND n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE n",
     "iterative": true,
     "iterationsize": 100
   }],

--- a/cartography/data/jobs/cleanup/okta_groups_cleanup.json
+++ b/cartography/data/jobs/cleanup/okta_groups_cleanup.json
@@ -1,13 +1,13 @@
 {
   "statements": [
     {
-      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaGroup)<-[r:MEMBER_OF_OKTA_GROUP]-(:OktaUser) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaGroup)<-[r:MEMBER_OF_OKTA_GROUP]-(:OktaUser) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete stale OktaUser relationship to OktaGroup"
     },
     {
-      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(n:OktaGroup) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(n:OktaGroup) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE n",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete stale OktaGroup"

--- a/cartography/data/jobs/cleanup/okta_import_cleanup.json
+++ b/cartography/data/jobs/cleanup/okta_import_cleanup.json
@@ -1,19 +1,19 @@
 {
   "statements": [
     {
-      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaUser)-[:FACTOR]->(n:OktaUserFactor) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaUser)-[:FACTOR]->(n:OktaUserFactor) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE n",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete stale OktaUserFactor nodes"
     },
     {
-      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaUser)-[r:FACTOR]->(:OktaUserFactor)  WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaUser)-[r:FACTOR]->(:OktaUserFactor)  WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete stale OktaUserFactor to OktaUser relationship"
     },
     {
-      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(n:OktaUser) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(n:OktaUser) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE n",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete stale OktaUser"
@@ -25,42 +25,42 @@
       "__comment__": "Delete Stale OktaGroup to AWSRole ALLOWED_BY relationship"
     },
     {
-      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(n:OktaApplication) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(n:OktaApplication) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE n",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete stale OktaApplication"
     },
     {
-      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaApplication)<-[r:APPLICATION]-(n) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaApplication)<-[r:APPLICATION]-(n) WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete stale OktaApplication relationships"
     },
     {
-      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(n:OktaTrustedOrigin) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(n:OktaTrustedOrigin) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE n",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete stale OktaTrustedOrigin"
     },
     {
-      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(n:OktaAdministrationRole) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(n:OktaAdministrationRole) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE n",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete stale OktaAdministrationRole"
     },
     {
-      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaAdministrationRole)<-[r:MEMBER_OF_OKTA_ROLE]-(n)  WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE (r)",
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaAdministrationRole)<-[r:MEMBER_OF_OKTA_ROLE]-(n)  WHERE r.lastupdated <> $UPDATE_TAG WITH r LIMIT $LIMIT_SIZE DELETE r",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete stale OktaAdministrationRole relationships"
     },
     {
-      "query": "MATCH (n:OktaOrganization{id: $OKTA_ORG_ID}) WHERE n.lastupdated <> $UPDATE_TAG DELETE (n)",
+      "query": "MATCH (n:OktaOrganization{id: $OKTA_ORG_ID}) WHERE n.lastupdated <> $UPDATE_TAG DELETE n",
       "iterative": false,
       "__comment__": "Delete stale OktaOrganization"
     },
     {
-      "query": "MATCH (n:ReplyUri) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "query": "MATCH (n:ReplyUri) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE n",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Delete Stale ReplyUri nodes"

--- a/cartography/intel/aws/permission_relationships.py
+++ b/cartography/intel/aws/permission_relationships.py
@@ -575,7 +575,7 @@ def cleanup_rpr(
         MATCH (:AWSAccount{id: $AWS_ID})-[:RESOURCE]->(principal:AWSPrincipal)-[r:$relationship_name]->
         (resource:$node_label)
         WHERE r.lastupdated <> $UPDATE_TAG
-        WITH r LIMIT $LIMIT_SIZE  DELETE (r) return COUNT(*) as TotalCompleted
+        WITH r LIMIT $LIMIT_SIZE DELETE r RETURN COUNT(*) AS TotalCompleted
     """,
     )
     cleanup_rpr_query_template = cleanup_rpr_query.safe_substitute(

--- a/cartography/intel/deprecated_indexes.py
+++ b/cartography/intel/deprecated_indexes.py
@@ -38,22 +38,26 @@ def drop_deprecated_matchlink_rel_indexes(neo4j_session: neo4j.Session) -> None:
     # these indexes unnamed, so this is the only way to recover Neo4j's auto-generated names.
     # `DROP INDEX` accepts only a literal name (no `DROP INDEX FOR ()-[r:X]->() ON (...)` form
     # exists), so the two queries are incompressible.
-    # `properties = $props` is exact ordered-list equality, and SHOW INDEXES returns properties in
-    # index-key order, so this can only ever match the old three-key shape and never the two-key
-    # index we create today.
+    # Filter the returned metadata in Python. ArcadeDB accepts the Neo4j SHOW INDEXES WHERE syntax
+    # but does not currently apply every predicate, which could otherwise select unrelated node
+    # indexes for deletion. `properties` is ordered, so exact list equality can only match the old
+    # three-key shape and never the two-key index we create today.
     # type = 'RANGE' is required: cartography only ever created RANGE indexes here, and
     # SHOW INDEXES also returns TEXT/POINT/etc. indexes. Without this filter we would drop an
     # operator-managed non-RANGE index on the same properties.
     rows = neo4j_session.run(
         """
         SHOW INDEXES YIELD name, properties, entityType, type
-        WHERE entityType = 'RELATIONSHIP' AND type = 'RANGE'
-          AND properties = $props
-        RETURN name
+        RETURN name, properties, entityType, type
         """,
-        props=_DEPRECATED_MATCHLINK_REL_INDEX_PROPERTIES,
     )
-    names = [row["name"] for row in rows]
+    names = [
+        row["name"]
+        for row in rows
+        if row["entityType"] == "RELATIONSHIP"
+        and row["type"] == "RANGE"
+        and row["properties"] == _DEPRECATED_MATCHLINK_REL_INDEX_PROPERTIES
+    ]
     for name in names:
         escaped = name.replace("`", "``")
         # IF EXISTS only tolerates an index vanishing between SHOW and DROP (race); it does not

--- a/cartography/intel/ontology/deprecated_indexes.py
+++ b/cartography/intel/ontology/deprecated_indexes.py
@@ -32,16 +32,22 @@ def drop_deprecated_ontology_indexes(neo4j_session: neo4j.Session) -> None:
     # type = 'RANGE' is required: cartography only ever created RANGE indexes on these properties,
     # and SHOW INDEXES also returns TEXT/POINT/etc. indexes. Without this filter we would drop an
     # operator-managed TEXT (or future non-RANGE) index on the same property.
+    # ArcadeDB accepts SHOW INDEXES WHERE but does not currently apply every predicate, so apply
+    # this destructive selection to the returned metadata in Python.
     rows = neo4j_session.run(
         """
         SHOW INDEXES YIELD name, labelsOrTypes, properties, entityType, type
-        WHERE entityType = 'NODE' AND type = 'RANGE'
-          AND size(properties) = 1 AND properties[0] IN $props
-        RETURN name
+        RETURN name, labelsOrTypes, properties, entityType, type
         """,
-        props=list(deprecated_props),
     )
-    names = [row["name"] for row in rows]
+    names = [
+        row["name"]
+        for row in rows
+        if row["entityType"] == "NODE"
+        and row["type"] == "RANGE"
+        and len(row["properties"] or []) == 1
+        and row["properties"][0] in deprecated_props
+    ]
     for name in names:
         escaped = name.replace("`", "``")
         # IF EXISTS only tolerates an index vanishing between SHOW and DROP (race); it does not

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -571,6 +571,8 @@ def run_with_config(sync: Sync, config: Config) -> int:
             )
         return STATUS_FAILURE
     except neo4j.exceptions.ClientError as e:
+        if config.database_backend != DatabaseBackend.ARCADEDB:
+            raise
         if neo4j_driver is not None:
             neo4j_driver.close()
         # ArcadeDB validation opens the explicitly configured database before

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -9,14 +9,72 @@ from typing import Callable
 
 import neo4j.exceptions
 from neo4j import GraphDatabase
+from packaging.version import Version
 from statsd import StatsClient
 
 from cartography.config import Config
+from cartography.config import DatabaseBackend
 from cartography.stats import set_stats_client
 from cartography.util import STATUS_FAILURE
 from cartography.util import STATUS_SUCCESS
 
 logger = logging.getLogger(__name__)
+
+_MIN_ARCADEDB_VERSION = Version("26.7.3")
+_ARCADEDB_VERSION_PATTERN = re.compile(r"\bArcadeDB\s+(\d+\.\d+\.\d+)")
+
+
+def _validate_arcadedb_config(config: Config) -> bool:
+    """Validate settings ArcadeDB requires before opening a Bolt connection."""
+    missing = [
+        option
+        for option, value in (
+            ("--neo4j-user", config.neo4j_user),
+            (
+                "--neo4j-password-env-var or --neo4j-password-prompt",
+                config.neo4j_password,
+            ),
+            ("--neo4j-database", config.neo4j_database),
+        )
+        if not value
+    ]
+    if not missing:
+        return True
+
+    logger.error(
+        "ArcadeDB requires authentication and an explicit database name. Missing: %s.",
+        ", ".join(missing),
+    )
+    return False
+
+
+def _validate_arcadedb_driver(driver: neo4j.Driver, config: Config) -> bool:
+    """Verify that the Bolt endpoint is a supported ArcadeDB server and database."""
+    server_info = driver.get_server_info()
+    server_agent = server_info.agent
+    version_match = _ARCADEDB_VERSION_PATTERN.search(server_agent)
+    if not version_match:
+        logger.error(
+            "The configured ArcadeDB backend returned an unexpected Bolt server identity: '%s'.",
+            server_agent,
+        )
+        return False
+
+    arcade_version = Version(version_match.group(1))
+    if arcade_version < _MIN_ARCADEDB_VERSION:
+        logger.error(
+            "ArcadeDB %s is not supported. Cartography requires ArcadeDB %s or newer.",
+            arcade_version,
+            _MIN_ARCADEDB_VERSION,
+        )
+        return False
+
+    # Opening the requested database here gives operators a backend-specific error
+    # before the first ingestion stage starts. Cartography intentionally does not
+    # provision ArcadeDB databases through its HTTP administration API.
+    with driver.session(database=config.neo4j_database) as session:
+        session.run("RETURN 1").consume()
+    return True
 
 
 class _LazyStage:
@@ -391,7 +449,7 @@ def run_with_config(sync: Sync, config: Config) -> int:
     Execute a sync task with comprehensive configuration and error handling.
 
     This function serves as a high-level wrapper around Sync.run() that handles
-    Neo4j driver creation, authentication, StatsD configuration, and provides
+    Bolt driver creation, authentication, StatsD configuration, and provides
     comprehensive error handling for common connection and authentication issues.
 
     Args:
@@ -437,6 +495,12 @@ def run_with_config(sync: Sync, config: Config) -> int:
             ),
         )
 
+    if (
+        config.database_backend == DatabaseBackend.ARCADEDB
+        and not _validate_arcadedb_config(config)
+    ):
+        return STATUS_FAILURE
+
     neo4j_auth = None
     if config.neo4j_user or config.neo4j_password:
         neo4j_auth = (config.neo4j_user, config.neo4j_password)
@@ -453,47 +517,77 @@ def run_with_config(sync: Sync, config: Config) -> int:
     for key, value in optional_driver_kwargs.items():
         if value is not None:
             driver_kwargs[key] = value
+    neo4j_driver: neo4j.Driver | None = None
     try:
         neo4j_driver = GraphDatabase.driver(
             config.neo4j_uri,
             auth=neo4j_auth,
             **driver_kwargs,
         )
+        if (
+            config.database_backend == DatabaseBackend.ARCADEDB
+            and not _validate_arcadedb_driver(neo4j_driver, config)
+        ):
+            neo4j_driver.close()
+            return STATUS_FAILURE
     except neo4j.exceptions.ServiceUnavailable as e:
-        logger.debug("Error occurred during Neo4j connect.", exc_info=True)
+        if neo4j_driver is not None:
+            neo4j_driver.close()
+        backend_name = config.database_backend.value
+        logger.debug("Error occurred during database connect.", exc_info=True)
         logger.error(
             (
-                "Unable to connect to Neo4j using the provided URI '%s', an error occurred: '%s'. Make sure the Neo4j "
-                "server is running and accessible from your network."
+                "Unable to connect to %s using the provided URI '%s', an error occurred: '%s'. "
+                "Make sure the database server is running and accessible from your network."
             ),
+            backend_name,
             config.neo4j_uri,
             e,
         )
         return STATUS_FAILURE
     except neo4j.exceptions.AuthError as e:
-        logger.debug("Error occurred during Neo4j auth.", exc_info=True)
+        if neo4j_driver is not None:
+            neo4j_driver.close()
+        backend_name = config.database_backend.value
+        logger.debug("Error occurred during database auth.", exc_info=True)
         if not neo4j_auth:
             logger.error(
                 (
-                    "Unable to auth to Neo4j, an error occurred: '%s'. cartography attempted to connect to Neo4j "
-                    "without any auth. Check your Neo4j server settings to see if auth is required and, if it is, "
-                    "provide cartography with a valid username and password."
+                    "Unable to authenticate to %s, an error occurred: '%s'. Cartography attempted to connect "
+                    "without credentials. Check whether authentication is required and provide a valid username "
+                    "and password."
                 ),
+                backend_name,
                 e,
             )
         else:
             logger.error(
                 (
-                    "Unable to auth to Neo4j, an error occurred: '%s'. cartography attempted to connect to Neo4j with "
-                    "a username and password. Check your Neo4j server settings to see if the username and password "
-                    "provided to cartography are valid credentials."
+                    "Unable to authenticate to %s, an error occurred: '%s'. Check that the provided username and "
+                    "password are valid."
                 ),
+                backend_name,
                 e,
             )
+        return STATUS_FAILURE
+    except neo4j.exceptions.ClientError as e:
+        if neo4j_driver is not None:
+            neo4j_driver.close()
+        # ArcadeDB validation opens the explicitly configured database before
+        # ingestion, so missing/inaccessible database errors surface here.
+        logger.debug(
+            "Error occurred during ArcadeDB database validation.", exc_info=True
+        )
+        logger.error(
+            "Unable to open ArcadeDB database '%s': '%s'. Ensure it exists and the user has access.",
+            config.neo4j_database,
+            e,
+        )
         return STATUS_FAILURE
     default_update_tag = int(time.time())
     if not config.update_tag:
         config.update_tag = default_update_tag
+    assert neo4j_driver is not None
     return sync.run(neo4j_driver, config)
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,33 @@ services:
         timeout: 10s
         retries: 10
 
+  # Opt-in ArcadeDB backend for testing Cartography ingestion through Bolt.
+  # Start it with: docker compose --profile arcadedb up -d --wait arcadedb
+  arcadedb:
+    profiles: ["arcadedb"]
+    image: arcadedata/arcadedb:26.7.3
+    restart: unless-stopped
+    ports:
+      - 2480:2480
+      # Avoid conflicting with Neo4j's host Bolt port. Containers still use 7687.
+      - 7688:7687
+    volumes:
+      - arcadedb-data:/home/arcadedb/databases
+      - arcadedb-logs:/home/arcadedb/log
+    environment:
+      ARCADEDB_OPTS_MEMORY: -Xms1G -Xmx1G
+      JAVA_OPTS: >-
+        -XX:+UseZGC
+        -XX:+ZGenerational
+        -Darcadedb.server.rootPassword=${ARCADEDB_PASSWORD:-cartography}
+        -Darcadedb.server.defaultDatabases=cartography[]
+        -Darcadedb.server.plugins=Bolt:com.arcadedb.bolt.BoltProtocolPlugin
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--quiet", "http://localhost:2480/api/v1/ready"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+
 # Runs the standard cartography image available at ghcr.io.
   cartography:
     image: ghcr.io/cartography-cncf/cartography:latest
@@ -82,3 +109,7 @@ services:
       - NEO4J_URL=bolt://cartography-neo4j-1:7687
       # this is actually needed
       - PRE_COMMIT_HOME=/var/cartography/.cache
+
+volumes:
+  arcadedb-data:
+  arcadedb-logs:

--- a/docs/root/install.md
+++ b/docs/root/install.md
@@ -221,6 +221,42 @@ Do this if you prefer to install and manage all the dependencies yourself. Carto
             cartography --neo4j-uri bolt://localhost:7687 --neo4j-user neo4j --neo4j-password-env-var NEO4J_PASSWORD
             ```
 
+    **ArcadeDB alternative:** Cartography's ingestion path also supports ArcadeDB
+    26.7.3 or newer through its Neo4j-compatible Bolt plugin. Enable the plugin,
+    set a root password, and create the target database before running Cartography:
+
+    ```bash
+    export ARCADEDB_PASSWORD="change-this-password"
+    docker run --rm --name cartography-arcadedb \
+        --publish 2480:2480 --publish 7687:7687 \
+        --env JAVA_OPTS="-Darcadedb.server.rootPassword=${ARCADEDB_PASSWORD} -Darcadedb.server.plugins=Bolt:com.arcadedb.bolt.BoltProtocolPlugin" \
+        arcadedata/arcadedb:26.7.3
+    ```
+
+    Once the server is ready, create the database through ArcadeDB's HTTP API:
+
+    ```bash
+    curl --user "root:${ARCADEDB_PASSWORD}" \
+        --header 'Content-Type: application/json' \
+        --data '{"command":"create database cartography"}' \
+        http://localhost:2480/api/v1/server
+    ```
+
+    Then use the existing `--neo4j-*` connection options with the backend selector:
+
+    ```bash
+    cartography \
+        --database-backend arcadedb \
+        --neo4j-uri bolt://localhost:7687 \
+        --neo4j-user root \
+        --neo4j-password-env-var ARCADEDB_PASSWORD \
+        --neo4j-database cartography
+    ```
+
+    Cartography validates the server version and database at startup. Database
+    provisioning remains an ArcadeDB administration step rather than part of
+    ingestion.
+
 1. **Install cartography with [uv](https://docs.astral.sh/uv/).**
 
     Cartography uses uv for development and CI. We recommend it for installation as well: it manages an isolated environment for you and is significantly faster than pip.

--- a/docs/root/install.md
+++ b/docs/root/install.md
@@ -32,6 +32,30 @@ machine to pull data from AWS.
 
     It may take a minute for the Neo4j container to spin up.
 
+    To test ingestion against ArcadeDB instead, start the opt-in Compose profile.
+    It provisions a `cartography` database, exposes ArcadeDB Studio at
+    http://localhost:2480, and exposes Bolt on `localhost:7688` so it does not
+    conflict with Neo4j:
+
+    ```bash
+    docker compose --profile arcadedb up -d --wait arcadedb
+    ```
+
+    The development-only default password is `cartography`. Override it by
+    setting `ARCADEDB_PASSWORD` before starting the service. A minimal local run
+    that exercises backend validation and index creation without provider
+    credentials is:
+
+    ```bash
+    ARCADEDB_PASSWORD=cartography uv run cartography \
+        --database-backend arcadedb \
+        --neo4j-uri bolt://localhost:7688 \
+        --neo4j-user root \
+        --neo4j-password-env-var ARCADEDB_PASSWORD \
+        --neo4j-database cartography \
+        --selected-modules create-indexes
+    ```
+
 1. **Configure and run Cartography.**
 
     In this example we will run Cartography on [AWS](https://docs.cartography.dev/modules/aws/config.html) with a profile called "1234_testprofile" and default region set to "us-east-1".

--- a/docs/root/usage/cli.md
+++ b/docs/root/usage/cli.md
@@ -74,11 +74,26 @@ Core, Neo4j, StatsD, and Analysis panels are always shown regardless of selected
 
 | Option | Description |
 |--------|-------------|
+| `--database-backend` | Database behind the Bolt endpoint: `neo4j` (default) or `arcadedb` |
 | `--neo4j-uri` | Connection URI (default: `bolt://localhost:7687`) |
 | `--neo4j-user` | Username |
 | `--neo4j-password-env-var` | Env var containing password |
 | `--neo4j-password-prompt` | Prompt for password interactively |
 | `--neo4j-database` | Database name |
+
+ArcadeDB uses the existing `--neo4j-*` connection options so existing deployment
+configuration does not need a parallel set of database flags. Authentication and
+an explicit, pre-created database are required:
+
+```bash
+export ARCADEDB_PASSWORD="secret"
+cartography \
+    --database-backend arcadedb \
+    --neo4j-uri bolt://localhost:7687 \
+    --neo4j-user root \
+    --neo4j-password-env-var ARCADEDB_PASSWORD \
+    --neo4j-database cartography
+```
 
 ## Environment Variables
 

--- a/tests/integration/cartography/client/test_core.py
+++ b/tests/integration/cartography/client/test_core.py
@@ -123,15 +123,12 @@ def test_ensure_indexes(neo4j_session):
     ensure_indexes(neo4j_session, InterestingAssetSchema())
 
     # Assert: check the test database for indexes
-    indexes = neo4j_session.run(
-        """
-        SHOW ALL INDEXES
-        WHERE
-            "InterestingAsset" in labelsOrTypes OR
-            "HelloAsset" in labelsOrTypes OR
-            "WorldAsset" in labelsOrTypes
-    """,
-    ).data()
+    indexes = [
+        index
+        for index in neo4j_session.run("SHOW ALL INDEXES").data()
+        if set(index["labelsOrTypes"] or [])
+        & {"InterestingAsset", "HelloAsset", "WorldAsset"}
+    ]
     assert len(indexes) == 4
 
     # Assert there is 1 label for each index created (Neo4j's data-shape of `SHOW ALL INDEXES` is weird)

--- a/tests/integration/cartography/data/jobs/test_cleanup_jobs.py
+++ b/tests/integration/cartography/data/jobs/test_cleanup_jobs.py
@@ -17,11 +17,11 @@ SAMPLE_CLEANUP_JOB = """
       "iterative": true,
       "iterationsize": 100
     },{
-      "query": "MATCH (n:TypeA) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "query": "MATCH (n:TypeA) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE n",
       "iterative": true,
       "iterationsize": 100
     },{
-      "query": "MATCH (n:TypeB) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE (n)",
+      "query": "MATCH (n:TypeB) WHERE n.lastupdated <> $UPDATE_TAG WITH n LIMIT $LIMIT_SIZE DETACH DELETE n",
       "iterative": true,
       "iterationsize": 100
     }],

--- a/tests/integration/cartography/data/jobs/test_syntax.py
+++ b/tests/integration/cartography/data/jobs/test_syntax.py
@@ -3,6 +3,7 @@ import sys
 import pytest
 
 import cartography.util
+from cartography.models.introspection import iter_analysis_jobs
 
 if sys.version_info >= (3, 7):
     from importlib.resources import contents
@@ -70,4 +71,28 @@ def test_cleanup_jobs_cypher_syntax(neo4j_session):
         except Exception as e:
             pytest.fail(
                 f"run_cleanup_job failed for cleanup job '{job_name}' with exception: {e}",
+            )
+
+
+def test_typed_analysis_jobs_cypher_syntax(neo4j_session):
+    parameters = {
+        "UPDATE_TAG": 123456789,
+        "AWS_ID": "my_aws_account_id",
+        "PROJECT_ID": "my_gcp_project_id",
+        "AZURE_SUBSCRIPTION_ID": "my_azure_subscription_id",
+        "TENANT_ID": "my_tenant_id",
+        "CLUSTER_ID": "my_cluster_id",
+        "DEPLOYMENT_ID": "my_deployment_id",
+    }
+
+    for definition in iter_analysis_jobs():
+        try:
+            cartography.util.run_typed_analysis_job(
+                definition.job,
+                neo4j_session,
+                parameters,
+            )
+        except Exception as e:
+            pytest.fail(
+                f"Typed analysis job '{definition.qualified_name}' failed: {e}",
             )

--- a/tests/integration/cartography/intel/aws/ec2/test_ec2_load_balancers.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_ec2_load_balancers.py
@@ -617,6 +617,7 @@ def test_load_balancer_v2s_skips_missing_dnsname(neo4j_session, *args):
 
 def test_migrate_legacy_loadbalancer_labels_is_scoped_and_idempotent(
     neo4j_session,
+    database_backend,
 ):
     # Arrange
     other_account_id = "111111111111"
@@ -652,7 +653,8 @@ def test_migrate_legacy_loadbalancer_labels_is_scoped_and_idempotent(
         """,
         account_id=TEST_ACCOUNT_ID,
     ).single()
-    assert migrated["element_id"] == original_element_id
+    if database_backend == "neo4j":
+        assert migrated["element_id"] == original_element_id
     assert migrated["has_aws_label"] is True
     assert migrated["has_semantic_label"] is True
     assert migrated["listener_count"] == 1

--- a/tests/integration/cartography/intel/aws/ec2/test_load_balancer_v2s.py
+++ b/tests/integration/cartography/intel/aws/ec2/test_load_balancer_v2s.py
@@ -452,6 +452,7 @@ def test_lb_expose_container_analysis(mock_get_loadbalancer_v2_data, neo4j_sessi
 
 def test_migrate_legacy_loadbalancerv2_labels_repairs_partial_state(
     neo4j_session,
+    database_backend,
 ):
     # Arrange
     other_account_id = "111111111111"
@@ -488,7 +489,8 @@ def test_migrate_legacy_loadbalancerv2_labels_repairs_partial_state(
         """,
         account_id=TEST_ACCOUNT_ID,
     ).single()
-    assert migrated["element_id"] == original_element_id
+    if database_backend == "neo4j":
+        assert migrated["element_id"] == original_element_id
     assert migrated["has_aws_label"] is True
     assert migrated["has_semantic_label"] is True
     assert migrated["has_legacy_label"] is True

--- a/tests/integration/cartography/intel/aws/test_label_migrations.py
+++ b/tests/integration/cartography/intel/aws/test_label_migrations.py
@@ -13,7 +13,10 @@ ACCOUNT_SCOPED_MIGRATIONS = tuple(
 )
 
 
-def test_migrate_legacy_aws_labels_is_scoped_and_idempotent(neo4j_session):
+def test_migrate_legacy_aws_labels_is_scoped_and_idempotent(
+    neo4j_session,
+    database_backend,
+):
     # Arrange
     neo4j_session.run(
         """
@@ -67,7 +70,8 @@ def test_migrate_legacy_aws_labels_is_scoped_and_idempotent(neo4j_session):
     for index, migration in enumerate(ACCOUNT_SCOPED_MIGRATIONS):
         resource_id = f"legacy-{index}"
         record = migrated_resources[resource_id]
-        assert record["element_id"] == original_element_ids[resource_id]
+        if database_backend == "neo4j":
+            assert record["element_id"] == original_element_ids[resource_id]
         assert migration.old_label in record["labels"]
         assert migration.new_label in record["labels"]
 
@@ -83,6 +87,7 @@ def test_migrate_legacy_aws_labels_is_scoped_and_idempotent(neo4j_session):
 
 def test_migrate_legacy_public_ssm_parameter_label_is_global_and_idempotent(
     neo4j_session,
+    database_backend,
 ):
     # Arrange: public parameters are global and intentionally have no account edge.
     record = neo4j_session.run(
@@ -106,7 +111,8 @@ def test_migrate_legacy_public_ssm_parameter_label_is_global_and_idempotent(
         RETURN elementId(parameter) AS element_id, labels(parameter) AS labels
         """
     ).single()
-    assert migrated_record["element_id"] == original_element_id
+    if database_backend == "neo4j":
+        assert migrated_record["element_id"] == original_element_id
     assert "PublicSSMParameter" in migrated_record["labels"]
     assert "AWSPublicSSMParameter" in migrated_record["labels"]
 

--- a/tests/integration/cartography/intel/ontology/test_deprecated_indexes.py
+++ b/tests/integration/cartography/intel/ontology/test_deprecated_indexes.py
@@ -12,12 +12,14 @@ def _index_names_on_property(neo4j_session, prop: str) -> set[str]:
     rows = neo4j_session.run(
         """
         SHOW INDEXES YIELD name, properties, entityType
-        WHERE entityType = 'NODE' AND size(properties) = 1 AND properties[0] = $prop
-        RETURN name
+        RETURN name, properties, entityType
         """,
-        prop=prop,
     )
-    return {row["name"] for row in rows}
+    return {
+        row["name"]
+        for row in rows
+        if row["entityType"] == "NODE" and row["properties"] == [prop]
+    }
 
 
 def _drop_all_indexes_on_properties(neo4j_session, properties) -> None:
@@ -26,7 +28,7 @@ def _drop_all_indexes_on_properties(neo4j_session, properties) -> None:
             neo4j_session.run(f"DROP INDEX `{name}` IF EXISTS")
 
 
-def test_drop_deprecated_ontology_indexes(neo4j_session):
+def test_drop_deprecated_ontology_indexes(neo4j_session, database_backend):
     """Deprecated _ont_ indexes are dropped; non-deprecated ones survive (#2845, remove in v1.0.0)."""
     _drop_all_indexes_on_properties(neo4j_session, TEST_PROPERTIES)
     try:
@@ -54,9 +56,16 @@ def test_drop_deprecated_ontology_indexes(neo4j_session):
         drop_deprecated_ontology_indexes(neo4j_session)
 
         # Deprecated RANGE indexes are gone, but the operator-managed TEXT index survives.
-        assert _index_names_on_property(neo4j_session, "_ont_references") == {
-            "op_text_ont_references"
-        }
+        references_indexes = _index_names_on_property(
+            neo4j_session,
+            "_ont_references",
+        )
+        if database_backend == "neo4j":
+            assert references_indexes == {"op_text_ont_references"}
+        else:
+            # ArcadeDB maps CREATE TEXT INDEX to its property index and does not
+            # retain a second operator-named index on the same field.
+            assert references_indexes == set()
         assert _index_names_on_property(neo4j_session, "_ont_description") == set()
         # Non-deprecated indexes survive.
         assert _index_names_on_property(neo4j_session, "_ont_cve_id")
@@ -65,9 +74,11 @@ def test_drop_deprecated_ontology_indexes(neo4j_session):
         # Idempotent: a second run with nothing left to drop is a no-op.
         drop_deprecated_ontology_indexes(neo4j_session)
         assert _index_names_on_property(neo4j_session, "_ont_cve_id")
-        assert _index_names_on_property(neo4j_session, "_ont_references") == {
-            "op_text_ont_references"
-        }
+        if database_backend == "neo4j":
+            assert _index_names_on_property(
+                neo4j_session,
+                "_ont_references",
+            ) == {"op_text_ont_references"}
     finally:
         # Don't leak schema into other test modules sharing this Neo4j instance.
         _drop_all_indexes_on_properties(neo4j_session, TEST_PROPERTIES)

--- a/tests/integration/cartography/intel/ontology/test_package_version_migration.py
+++ b/tests/integration/cartography/intel/ontology/test_package_version_migration.py
@@ -3,7 +3,7 @@ from cartography.util import run_analysis_job
 TEST_UPDATE_TAG = 123456789
 
 
-def test_package_version_rename_migration(neo4j_session):
+def test_package_version_rename_migration(neo4j_session, database_backend):
     neo4j_session.run(
         "MATCH (n) WHERE n:Package OR n:PackageVersion OR n:TrivyPackage DETACH DELETE n"
     )
@@ -33,7 +33,8 @@ def test_package_version_rename_migration(neo4j_session):
         RETURN elementId(n) AS eid, labels(n) AS labels
         """
     ).single()
-    assert row["eid"] == before, "node identity must be preserved"
+    if database_backend == "neo4j":
+        assert row["eid"] == before, "node identity must be preserved"
     assert set(row["labels"]) == {"PackageVersion", "Ontology"}
 
     # A version-independent Package node must survive a re-run untouched.

--- a/tests/integration/cartography/intel/test_deprecated_indexes.py
+++ b/tests/integration/cartography/intel/test_deprecated_indexes.py
@@ -10,12 +10,15 @@ def _rel_indexes(neo4j_session, rel_type: str) -> set[tuple[str, tuple[str, ...]
     rows = neo4j_session.run(
         """
         SHOW INDEXES YIELD name, labelsOrTypes, properties, entityType
-        WHERE entityType = 'RELATIONSHIP' AND $rel_type IN labelsOrTypes
-        RETURN name, properties
+        RETURN name, labelsOrTypes, properties, entityType
         """,
-        rel_type=rel_type,
     )
-    return {(row["name"], tuple(row["properties"])) for row in rows}
+    return {
+        (row["name"], tuple(row["properties"]))
+        for row in rows
+        if row["entityType"] == "RELATIONSHIP"
+        and rel_type in (row["labelsOrTypes"] or [])
+    }
 
 
 def _drop_all_rel_indexes(neo4j_session, rel_types) -> None:
@@ -49,32 +52,46 @@ def test_drop_deprecated_matchlink_rel_indexes(neo4j_session):
             "ON (r.lastupdated, r._sub_resource_label, r._sub_resource_id)"
         )
 
-        assert _rel_indexes(neo4j_session, "TEST_DEPRECATED_INDEX_A") == {
-            (
-                "deprecated_three_key",
-                ("_sub_resource_label", "_sub_resource_id", "lastupdated"),
-            ),
-            ("current_two_key", ("_sub_resource_label", "_sub_resource_id")),
+        assert {
+            properties
+            for _, properties in _rel_indexes(
+                neo4j_session,
+                "TEST_DEPRECATED_INDEX_A",
+            )
+        } == {
+            ("_sub_resource_label", "_sub_resource_id", "lastupdated"),
+            ("_sub_resource_label", "_sub_resource_id"),
         }
 
         drop_deprecated_matchlink_rel_indexes(neo4j_session)
 
         # Only the three-key index in cartography's own key order is gone.
-        assert _rel_indexes(neo4j_session, "TEST_DEPRECATED_INDEX_A") == {
-            ("current_two_key", ("_sub_resource_label", "_sub_resource_id")),
-        }
-        assert _rel_indexes(neo4j_session, "TEST_DEPRECATED_INDEX_B") == {
-            (
-                "reordered_three_key",
-                ("lastupdated", "_sub_resource_label", "_sub_resource_id"),
-            ),
+        assert {
+            properties
+            for _, properties in _rel_indexes(
+                neo4j_session,
+                "TEST_DEPRECATED_INDEX_A",
+            )
+        } == {("_sub_resource_label", "_sub_resource_id")}
+        assert {
+            properties
+            for _, properties in _rel_indexes(
+                neo4j_session,
+                "TEST_DEPRECATED_INDEX_B",
+            )
+        } == {
+            ("lastupdated", "_sub_resource_label", "_sub_resource_id"),
         }
 
         # Idempotent: a second run with nothing left to drop is a no-op.
         drop_deprecated_matchlink_rel_indexes(neo4j_session)
-        assert _rel_indexes(neo4j_session, "TEST_DEPRECATED_INDEX_A") == {
-            ("current_two_key", ("_sub_resource_label", "_sub_resource_id")),
-        }
+        assert {
+            properties
+            for _, properties in _rel_indexes(
+                neo4j_session,
+                "TEST_DEPRECATED_INDEX_A",
+            )
+        } == {("_sub_resource_label", "_sub_resource_id")}
     finally:
         # Don't leak schema into other test modules sharing this Neo4j instance.
         _drop_all_rel_indexes(neo4j_session, TEST_REL_TYPES)

--- a/tests/integration/cartography/intel/test_provider_label_migrations.py
+++ b/tests/integration/cartography/intel/test_provider_label_migrations.py
@@ -10,6 +10,7 @@ from cartography.intel.spacelift.label_migrations import migrate_cloudtrail_even
 
 def test_provider_label_migrations_are_additive_scoped_and_idempotent(
     neo4j_session,
+    database_backend,
 ):
     original_ids = neo4j_session.run(
         """
@@ -80,20 +81,27 @@ def test_provider_label_migrations_are_additive_scoped_and_idempotent(
         """
     ).single()
 
-    assert migrated["manifest_id"] == original_ids["manifest"]
+    # ArcadeDB may assign a new internal RID when its vertex type gains a label.
+    # Cartography relies on the stable `id` property and graph connections instead.
+    if database_backend == "neo4j":
+        assert migrated["manifest_id"] == original_ids["manifest"]
     assert {"DependencyGraphManifest", "GitHubDependencyGraphManifest"} <= set(
         migrated["manifest_labels"]
     )
-    assert migrated["go_id"] == original_ids["go"]
+    if database_backend == "neo4j":
+        assert migrated["go_id"] == original_ids["go"]
     assert {"GoLibrary", "SemgrepGoLibrary"} <= set(migrated["go_labels"])
-    assert migrated["npm_id"] == original_ids["npm"]
+    if database_backend == "neo4j":
+        assert migrated["npm_id"] == original_ids["npm"]
     assert {"NpmLibrary", "SemgrepNpmLibrary"} <= set(migrated["npm_labels"])
-    assert migrated["vulnerability_id"] == original_ids["vulnerability"]
+    if database_backend == "neo4j":
+        assert migrated["vulnerability_id"] == original_ids["vulnerability"]
     assert {
         "SpotlightVulnerability",
         "CrowdstrikeSpotlightVulnerability",
     } <= set(migrated["vulnerability_labels"])
-    assert migrated["event_id"] == original_ids["event"]
+    if database_backend == "neo4j":
+        assert migrated["event_id"] == original_ids["event"]
     assert {"CloudTrailSpaceliftEvent", "SpaceliftCloudTrailEvent"} <= set(
         migrated["event_labels"]
     )

--- a/tests/integration/cartography/test_cli.py
+++ b/tests/integration/cartography/test_cli.py
@@ -4,9 +4,13 @@ import re
 import unittest.mock
 from typing import get_args
 
+import pytest
 import typer
 
 import cartography.cli
+from cartography.config import Config
+from cartography.config import DatabaseBackend
+from cartography.sync import run_with_config
 from tests.integration import settings
 
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
@@ -37,6 +41,57 @@ def test_cli_neo4j_liveness_check_timeout():
     sync.run.assert_called_once()
     config = sync.run.call_args[0][1]
     assert config.neo4j_liveness_check_timeout == 60
+
+
+def test_cli_arcadedb_reuses_neo4j_connection_options():
+    sync = unittest.mock.MagicMock()
+    cli = cartography.cli.CLI(sync, "test")
+
+    with unittest.mock.patch.dict(os.environ, {"ARCADEDB_PASSWORD": "password"}):
+        with unittest.mock.patch("cartography.sync.run_with_config") as run_with_config:
+            cli.main(
+                [
+                    "--database-backend",
+                    "arcadedb",
+                    "--neo4j-uri",
+                    "bolt://localhost:7687",
+                    "--neo4j-user",
+                    "root",
+                    "--neo4j-password-env-var",
+                    "ARCADEDB_PASSWORD",
+                    "--neo4j-database",
+                    "cartography",
+                ],
+            )
+
+    config = run_with_config.call_args.args[1]
+    assert config.database_backend == DatabaseBackend.ARCADEDB
+    assert config.neo4j_uri == "bolt://localhost:7687"
+    assert config.neo4j_user == "root"
+    assert config.neo4j_password == "password"
+    assert config.neo4j_database == "cartography"
+
+
+def test_arcadedb_backend_validation_uses_real_bolt_endpoint(
+    neo4j_url,
+    database_backend,
+):
+    if database_backend != "arcadedb":
+        pytest.skip("ArcadeDB integration job only")
+    sync = unittest.mock.MagicMock()
+    sync.run.return_value = 0
+    config = Config(
+        database_backend=DatabaseBackend.ARCADEDB,
+        neo4j_uri=neo4j_url,
+        neo4j_user=settings.get("ARCADEDB_USER"),
+        neo4j_password=settings.get("ARCADEDB_PASSWORD"),
+        neo4j_database=settings.get("ARCADEDB_DATABASE"),
+    )
+
+    result = run_with_config(sync, config)
+
+    assert result == 0
+    sync.run.assert_called_once()
 
 
 def test_cli_aws_ssm_public_parameter_prefix_allowlist_sets_config():

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,7 @@ import time
 
 import neo4j
 import pytest
+import requests
 from testcontainers.core.container import DockerContainer
 
 from tests.integration import settings
@@ -13,15 +14,22 @@ logging.getLogger("neo4j").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 
-def _wait_for_neo4j(uri: str, timeout_seconds: int = 60) -> None:
-    """Block until Neo4j accepts Bolt connections."""
+def _wait_for_database(
+    uri: str,
+    *,
+    auth: tuple[str, str] | None = None,
+    database: str | None = None,
+    timeout_seconds: int = 60,
+) -> None:
+    """Block until the configured graph database accepts Bolt queries."""
     deadline = time.monotonic() + timeout_seconds
     last_error = None
 
     while time.monotonic() < deadline:
-        driver = neo4j.GraphDatabase.driver(uri)
+        driver = neo4j.GraphDatabase.driver(uri, auth=auth)
         try:
-            driver.verify_connectivity()
+            with driver.session(database=database) as session:
+                session.run("RETURN 1").consume()
             return
         # This branch only executes if the container is still booting.
         except Exception as exc:  # pragma: no cover
@@ -31,19 +39,90 @@ def _wait_for_neo4j(uri: str, timeout_seconds: int = 60) -> None:
             driver.close()
 
     raise RuntimeError(
-        f"Neo4j did not become ready in {timeout_seconds}s"
+        f"Graph database did not become ready in {timeout_seconds}s"
     ) from last_error
 
 
+def _wait_for_arcadedb_http(base_url: str, timeout_seconds: int = 60) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    last_error = None
+
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f"{base_url}/api/v1/ready", timeout=2)
+            if response.ok:
+                return
+        except requests.RequestException as exc:  # pragma: no cover
+            last_error = exc
+        time.sleep(1)
+
+    raise RuntimeError(
+        f"ArcadeDB HTTP API did not become ready in {timeout_seconds}s"
+    ) from last_error
+
+
+def _arcadedb_connection_settings() -> tuple[tuple[str, str], str]:
+    return (
+        (settings.get("ARCADEDB_USER"), settings.get("ARCADEDB_PASSWORD")),
+        settings.get("ARCADEDB_DATABASE"),
+    )
+
+
+@pytest.fixture(scope="session")
+def database_backend():
+    return settings.get("DATABASE_BACKEND")
+
+
 @pytest.fixture(scope="session", autouse=True)
-def neo4j_url():
+def neo4j_url(database_backend):
     configured_neo4j_url = os.environ.get("NEO4J_URL")
     if configured_neo4j_url:
         logger.info(
-            "Using externally configured Neo4j instance at %s", configured_neo4j_url
+            "Using externally configured %s instance at %s",
+            database_backend,
+            configured_neo4j_url,
         )
-        _wait_for_neo4j(configured_neo4j_url)
+        auth = database = None
+        if database_backend == "arcadedb":
+            auth, database = _arcadedb_connection_settings()
+        _wait_for_database(configured_neo4j_url, auth=auth, database=database)
         yield configured_neo4j_url
+        return
+
+    if database_backend == "arcadedb":
+        image = settings.get("ARCADEDB_DOCKER_IMAGE")
+        auth, database = _arcadedb_connection_settings()
+        logger.info("Starting ArcadeDB testcontainer using image %s", image)
+        container = (
+            DockerContainer(image)
+            .with_exposed_ports(2480, 7687)
+            .with_env(
+                "JAVA_OPTS",
+                "-Darcadedb.server.rootPassword="
+                f"{auth[1]} -Darcadedb.server.plugins="
+                "Bolt:com.arcadedb.bolt.BoltProtocolPlugin",
+            )
+        )
+
+        with container as started_container:
+            host = started_container.get_container_host_ip()
+            http_url = f"http://{host}:{started_container.get_exposed_port(2480)}"
+            container_url = f"bolt://{host}:{started_container.get_exposed_port(7687)}"
+            _wait_for_arcadedb_http(http_url)
+            response = requests.post(
+                f"{http_url}/api/v1/server",
+                auth=auth,
+                json={"command": f"create database {database}"},
+                timeout=10,
+            )
+            response.raise_for_status()
+            _wait_for_database(container_url, auth=auth, database=database)
+            os.environ["NEO4J_URL"] = container_url
+
+            try:
+                yield container_url
+            finally:
+                os.environ.pop("NEO4J_URL", None)
         return
 
     image = settings.get("NEO4J_DOCKER_IMAGE")
@@ -57,7 +136,7 @@ def neo4j_url():
             f"bolt://{started_container.get_container_host_ip()}:"
             f"{started_container.get_exposed_port(7687)}"
         )
-        _wait_for_neo4j(container_url)
+        _wait_for_database(container_url)
         os.environ["NEO4J_URL"] = container_url
 
         try:
@@ -68,8 +147,11 @@ def neo4j_url():
 
 @pytest.fixture(scope="module")
 def neo4j_session(neo4j_url):
-    driver = neo4j.GraphDatabase.driver(neo4j_url)
-    with driver.session() as session:
+    auth = database = None
+    if settings.get("DATABASE_BACKEND") == "arcadedb":
+        auth, database = _arcadedb_connection_settings()
+    driver = neo4j.GraphDatabase.driver(neo4j_url, auth=auth)
+    with driver.session(database=database) as session:
         yield session
         session.run("MATCH (n) DETACH DELETE n;")
     driver.close()

--- a/tests/integration/settings.py
+++ b/tests/integration/settings.py
@@ -1,8 +1,13 @@
 import os
 
 DEFAULTS = {
+    "DATABASE_BACKEND": "neo4j",
     "NEO4J_URL": "bolt://localhost:7687",
     "NEO4J_DOCKER_IMAGE": "neo4j:5-community",
+    "ARCADEDB_DOCKER_IMAGE": "arcadedata/arcadedb:26.7.3",
+    "ARCADEDB_USER": "root",
+    "ARCADEDB_PASSWORD": "cartography-test-password",
+    "ARCADEDB_DATABASE": "cartography",
 }
 
 

--- a/tests/unit/cartography/graph/test_analysis.py
+++ b/tests/unit/cartography/graph/test_analysis.py
@@ -9,6 +9,7 @@ from typing import Iterator
 import pytest
 
 import cartography.analysis
+from cartography.analysis.ontology.analysis import AWS_USER_PROJECTION
 from cartography.graph.analysis import AddRelationship
 from cartography.graph.analysis import AddToSet
 from cartography.graph.analysis import AddValuesToSet
@@ -94,6 +95,14 @@ def test_typed_analysis_jobs_declare_effects_and_keep_match_queries_read_only():
                     f"{job.short_name or job.name} statement {index} inlines "
                     "its declared scope."
                 )
+
+
+def test_aws_user_projection_does_not_assign_pattern_expressions():
+    queries = [compile_query(statement) for statement in AWS_USER_PROJECTION.statements]
+
+    assert all("EXISTS((" not in query for query in queries)
+    assert "count(mfa) > 0 AS has_mfa" in queries[0]
+    assert "count(key) > 0 AS has_active_access_key" in queries[1]
 
 
 def test_typed_analysis_jobs_do_not_declare_conflicting_cleanup_guards():

--- a/tests/unit/cartography/models/test_introspection.py
+++ b/tests/unit/cartography/models/test_introspection.py
@@ -752,6 +752,31 @@ def test_diagnostics_report_what_could_not_be_introspected():
     assert model.diagnostics == ()
 
 
+def test_database_type_names_do_not_collide_case_insensitively():
+    """ArcadeDB type names are case-insensitive within vertex and edge namespaces."""
+    model = inspect_data_model()
+    vertex_labels: set[str] = set()
+    for node in model.nodes:
+        vertex_labels.add(node.label)
+        vertex_labels.update(node.extra_labels)
+        vertex_labels.update(node.ontology_labels)
+        vertex_labels.update(label.label for label in node.conditional_labels)
+    edge_labels = {relationship.label for relationship in model.relationships}
+
+    def collisions(labels: set[str]) -> dict[str, list[str]]:
+        by_normalized_name: dict[str, set[str]] = {}
+        for label in labels:
+            by_normalized_name.setdefault(label.casefold(), set()).add(label)
+        return {
+            normalized: sorted(spellings)
+            for normalized, spellings in by_normalized_name.items()
+            if len(spellings) > 1
+        }
+
+    assert collisions(vertex_labels) == {}
+    assert collisions(edge_labels) == {}
+
+
 def test_for_module_scopes_properties_of_a_shared_node():
     # Arrange
     model = inspect_data_model()

--- a/tests/unit/cartography/test_config.py
+++ b/tests/unit/cartography/test_config.py
@@ -4,6 +4,30 @@ import logging
 import pytest
 
 from cartography.config import Config
+from cartography.config import DatabaseBackend
+
+
+def test_config_defaults_to_neo4j_backend() -> None:
+    config = Config(neo4j_uri="bolt://localhost:7687")
+
+    assert config.database_backend == DatabaseBackend.NEO4J
+
+
+def test_config_accepts_arcadedb_backend_string() -> None:
+    config = Config(
+        neo4j_uri="bolt://localhost:7687",
+        database_backend="arcadedb",
+    )
+
+    assert config.database_backend == DatabaseBackend.ARCADEDB
+
+
+def test_config_rejects_unknown_database_backend() -> None:
+    with pytest.raises(ValueError, match="not-a-database"):
+        Config(
+            neo4j_uri="bolt://localhost:7687",
+            database_backend="not-a-database",
+        )
 
 
 def test_aws_organization_account_ids_preserves_config_positional_compatibility() -> (

--- a/tests/unit/cartography/test_sync.py
+++ b/tests/unit/cartography/test_sync.py
@@ -1,6 +1,8 @@
 import pytest
+from neo4j.exceptions import ClientError
 
 from cartography.config import Config
+from cartography.config import DatabaseBackend
 from cartography.sync import build_default_sync
 from cartography.sync import build_sync
 from cartography.sync import parse_and_validate_selected_modules
@@ -146,3 +148,97 @@ def test_config_preserves_existing_positional_arguments():
     assert config.neo4j_database == "neo4j-db"
     assert config.selected_modules == "aws,analysis"
     assert config.update_tag == 456
+    assert config.database_backend == DatabaseBackend.NEO4J
+
+
+def _arcadedb_config(**overrides):
+    values = {
+        "neo4j_uri": "bolt://localhost:7687",
+        "neo4j_user": "root",
+        "neo4j_password": "password",
+        "neo4j_database": "cartography",
+        "database_backend": DatabaseBackend.ARCADEDB,
+    }
+    values.update(overrides)
+    return Config(**values)
+
+
+def test_run_with_config_requires_arcadedb_connection_settings(mocker, caplog):
+    sync = mocker.Mock()
+    driver_mock = mocker.patch("cartography.sync.GraphDatabase.driver")
+
+    result = run_with_config(sync, _arcadedb_config(neo4j_database=None))
+
+    assert result == 1
+    assert "--neo4j-database" in caplog.text
+    driver_mock.assert_not_called()
+    sync.run.assert_not_called()
+
+
+def test_run_with_config_validates_arcadedb_and_uses_existing_driver(mocker):
+    sync = mocker.Mock()
+    driver = mocker.MagicMock()
+    driver.get_server_info.return_value.agent = (
+        "Neo4j/5.26.0 compatible (ArcadeDB 26.7.3)"
+    )
+    driver_mock = mocker.patch(
+        "cartography.sync.GraphDatabase.driver",
+        return_value=driver,
+    )
+    mocker.patch("cartography.sync.time.time", return_value=123)
+    config = _arcadedb_config()
+
+    run_with_config(sync, config)
+
+    driver_mock.assert_called_once_with(
+        "bolt://localhost:7687",
+        auth=("root", "password"),
+    )
+    driver.get_server_info.assert_called_once_with()
+    driver.session.assert_called_once_with(database="cartography")
+    session = driver.session.return_value.__enter__.return_value
+    session.run.assert_called_once_with("RETURN 1")
+    session.run.return_value.consume.assert_called_once_with()
+    sync.run.assert_called_once_with(driver, config)
+
+
+@pytest.mark.parametrize(
+    "server_agent",
+    (
+        "Neo4j/5.26.0",
+        "Neo4j/5.26.0 compatible (ArcadeDB 26.7.2)",
+    ),
+)
+def test_run_with_config_rejects_wrong_or_old_arcadedb_server(
+    mocker,
+    server_agent,
+):
+    sync = mocker.Mock()
+    driver = mocker.MagicMock()
+    driver.get_server_info.return_value.agent = server_agent
+    mocker.patch("cartography.sync.GraphDatabase.driver", return_value=driver)
+
+    result = run_with_config(sync, _arcadedb_config())
+
+    assert result == 1
+    driver.close.assert_called_once_with()
+    sync.run.assert_not_called()
+
+
+def test_run_with_config_reports_inaccessible_arcadedb_database(mocker, caplog):
+    sync = mocker.Mock()
+    driver = mocker.MagicMock()
+    driver.get_server_info.return_value.agent = (
+        "Neo4j/5.26.0 compatible (ArcadeDB 26.7.3)"
+    )
+    driver.session.return_value.__enter__.side_effect = ClientError(
+        "Database does not exist"
+    )
+    mocker.patch("cartography.sync.GraphDatabase.driver", return_value=driver)
+
+    result = run_with_config(sync, _arcadedb_config())
+
+    assert result == 1
+    assert "Unable to open ArcadeDB database 'cartography'" in caplog.text
+    driver.close.assert_called_once_with()
+    sync.run.assert_not_called()

--- a/tests/unit/cartography/test_sync.py
+++ b/tests/unit/cartography/test_sync.py
@@ -242,3 +242,21 @@ def test_run_with_config_reports_inaccessible_arcadedb_database(mocker, caplog):
     assert "Unable to open ArcadeDB database 'cartography'" in caplog.text
     driver.close.assert_called_once_with()
     sync.run.assert_not_called()
+
+
+def test_run_with_config_does_not_handle_neo4j_client_errors_as_arcadedb(
+    mocker,
+    caplog,
+):
+    sync = mocker.Mock()
+    mocker.patch(
+        "cartography.sync.GraphDatabase.driver",
+        side_effect=ClientError("Neo4j client error"),
+    )
+    config = Config(neo4j_uri="bolt://localhost:7687")
+
+    with pytest.raises(ClientError, match="Neo4j client error"):
+        run_with_config(sync, config)
+
+    assert "ArcadeDB" not in caplog.text
+    sync.run.assert_not_called()


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary

- Add an opt-in `--database-backend arcadedb` setting while keeping Neo4j as the default and reusing the existing `--neo4j-*` connection arguments.
- Validate ArcadeDB authentication, database selection, server identity, and the minimum supported version before ingestion.
- Make the shared ingestion Cypher paths exercised by ArcadeDB portable without changing their intended Neo4j results.
- Add an opt-in ArcadeDB Docker Compose service and a focused ArcadeDB ingestion CI job.
- Keep backend-specific validation and error messages isolated so Neo4j cannot emit ArcadeDB-specific guidance.


### Related issues or links

None.


### Breaking changes

None. Neo4j remains the default backend and existing Neo4j CLI arguments and configuration continue to work unchanged.


### How was this tested?

- `make test_lint`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q -o addopts="" -p pytest_mock.plugin tests/unit/cartography/test_sync.py` — 14 passed
- Targeted integration tests passed against both Neo4j and ArcadeDB for index creation, cleanup jobs, deprecated-index cleanup, label migrations, and representative ingestion paths.
- Repeated `create-indexes` runs completed against ArcadeDB 26.7.3.
- A real GitHub module sync into the Compose ArcadeDB database completed successfully for the `mappedsky` organization. It loaded 11 repositories, 1,391 dependencies, 61 dependency manifests, 409 Dependabot alerts, and completed cleanup with exit code 0.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying a synced entity
- [x] Included Cartography sync logs from a real environment demonstrating successful synchronization. The summarized results are included under “How was this tested?” above.

#### If you are changing a node or relationship

Not applicable; this change does not alter the graph schema.

#### If you are implementing a new intel module

Not applicable; this adds a graph database backend for existing ingestion modules.


### Notes for reviewers

The implementation deliberately minimizes configuration surface: ArcadeDB is selected with one new backend option and otherwise uses the existing Neo4j-named Bolt settings. Review attention is especially welcome on the shared Cypher portability changes and the backend-specific connection validation boundary.