### PR TITLE
fix(rules): return webhook_resources as a list and include the wildcard

### DIFF
--- a/cartography/rules/data/rules/cis_kubernetes_rbac.py
+++ b/cartography/rules/data/rules/cis_kubernetes_rbac.py
@@ -1199,7 +1199,7 @@ class WebhookConfigAccessOutput(Finding):
     role_name: str | None = None
     role_id: str | None = None
     role_type: str | None = None
-    webhook_resources: str | None = None
+    webhook_resources: list[str] | None = None
     cluster_name: str | None = None
 
 
@@ -1226,7 +1226,8 @@ _k8s_webhook_config_clusterroles = Fact(
         'ClusterRole' AS role_type,
         [r IN cr.resources WHERE r IN [
             'validatingwebhookconfigurations',
-            'mutatingwebhookconfigurations'
+            'mutatingwebhookconfigurations',
+            '*'
         ]] AS webhook_resources,
         cluster.name AS cluster_name
     """,


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

The CIS Kubernetes 5.1.12 rule `kubernetes_webhook_configuration_access` raised a
`ValidationError` on every ClusterRole it matched, so it produced no findings at all.
Two independent defects in its fact `k8s_webhook_config_clusterroles` caused this.

**1. A Cypher list was projected into a scalar field.** The fact projects
`webhook_resources` with a list comprehension, which always yields a list, while
`WebhookConfigAccessOutput.webhook_resources` was declared `str | None`.
`Finding.coerce_to_string` does not rescue this: it joins list values only when the
annotation is exactly `str`, so `str | None` is skipped and the list reaches Pydantic
unconverted:

```
ValidationError: 1 validation error for WebhookConfigAccessOutput
webhook_resources
  Input should be a valid string [type=string_type, input_value=[...], input_type=list]
```

This fired for every matched row, not only the empty-list case.

**2. The wildcard matched but was dropped from the output.** The `WHERE` clause accepts
`'*'` as a match; the projection filtered it out. A ClusterRole with `resources: ['*']`,
which is the `cluster-admin` shape that ships with every conformant cluster and arguably
the most important match the rule can make, selected the row and then reported an empty
list of resources.

Both changes follow the sibling fact in the same file: `_k8s_escalation_clusterroles`
uses the identical comprehension shape, keeps `'*'` in both the predicate and the
projection, and declares `dangerous_verbs: list[str] | None`. `list[str] | None` is the
convention for every other multi-valued projection in the rules tree (`trail_names`,
`direct_policy_arns`, `access_key_ids`, `pod_names`); this field was the only outlier in
the directory.

All rules were checked for the same list-into-scalar mismatch by comparing each
top-level `RETURN` projection against its output model field type. This was the only
instance. Four other projections look similar but are correct: the three Azure
`principal_type` fields index the comprehension with `[0]`, and
`workload_identity_admin_capabilities.workload_id` is projected from `lambda.arn`.


### Related issues or links

None.


### How was this tested?

`make test_lint` passes, and the 2521 tests under `tests/unit/rules` pass.

Verified end to end against a throwaway `neo4j:5-community` container: seeded five
ClusterRoles under one cluster, ran the fact's real `cypher_query`, and passed the rows
through `Rule.parse_results`.

```
--- raw rows ---
  cluster-admin        webhook_resources=['*']
  webhook-both         webhook_resources=['validatingwebhookconfigurations', 'mutatingwebhookconfigurations']
  webhook-editor       webhook_resources=['validatingwebhookconfigurations']
--- parsed findings ---
  cluster-admin        ['*']
  webhook-both         ['validatingwebhookconfigurations', 'mutatingwebhookconfigurations']
  webhook-editor       ['validatingwebhookconfigurations']
```

Before this change the same fixture raised `ValidationError` on the first row, and
`cluster-admin` projected `[]`. `cypher_visual_query` and `cypher_count_query` were also
executed and still run.

The two negative cases are still excluded correctly: a `system:`-prefixed ClusterRole
with `resources: ['*']`, and a ClusterRole holding only read-only verbs
(`get`, `list`) on `validatingwebhookconfigurations`.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://docs.cartography.dev/dev/developer-guide.html).
- [x] The linter passes locally (`make test_lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

Neither box is checked: this ships as a code-only fix, with the manual reproduction above
standing in for automated coverage.


### Notes for reviewers

Two things deliberately left out of scope:

- **No new tests.** Worth flagging the coverage gap that let this ship: the registry-wide
  guards in `tests/unit/rules/test_asset_anchor.py` and `test_identity_fields.py` check
  only that a field *exists* on the output model, and the rule integration tests under
  `tests/integration/rules/` assert raw Cypher rows without ever calling `parse_results`.
  So nothing in CI catches a projection whose Cypher type contradicts its output model
  annotation. A registry-wide guard for that class of bug would need static analysis of
  the Cypher projections, which is a larger and more fragile change than this fix.
- **The fact's count query denominator** excludes only `system:`-prefixed ClusterRoles,
  so it counts roles that cannot match the rule (4 against 3 findings in the fixture
  above). That behavior is pre-existing and consistent with the sibling facts in this
  file, so it is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
