### PR TITLE
fix(cve_metadata): bound Neo4j transaction memory for the ENRICHES fan-out

### DIFF
--- a/cartography/client/core/tx.py
+++ b/cartography/client/core/tx.py
@@ -40,6 +40,47 @@ _NETWORK_EXCEPTIONS: tuple[type[BaseException], ...] = (
     neo4j.exceptions.TransientError,
 )
 
+# Neo4j reports transaction-memory exhaustion as a retryable TransientError, but replaying an
+# identical payload can never succeed: the batch itself is too large for the pool. Handle these
+# by shrinking the batch (see load_graph_data) rather than by backing off.
+_TRANSACTION_MEMORY_ERROR_CODES = frozenset(
+    {
+        "Neo.TransientError.General.MemoryPoolOutOfMemoryError",
+        "Neo.TransientError.General.OutOfMemoryError",
+    }
+)
+# Below this, halving no longer buys meaningful memory relief: at single-digit batch sizes the
+# per-row fan-out dominates, so shrinking further just converts one failure into thousands of
+# slow transactions. Fail with an actionable message instead.
+_MIN_ADAPTIVE_BATCH_SIZE = 10
+
+
+class Neo4jTransactionMemoryError(Exception):
+    """
+    A write transaction exceeded Neo4j's transaction memory.
+
+    Deliberately NOT a ``neo4j.exceptions.Neo4jError`` subclass. The driver's own managed
+    transaction retry (``Session._run_transaction``) catches ``(DriverError, Neo4jError)`` and
+    replays anything whose ``is_retryable()`` is True, and ``MemoryPoolOutOfMemoryError``
+    reports True. Raising a type the driver does not recognise takes this error out of that
+    retry loop as well as out of ours.
+    """
+
+
+def _is_transaction_memory_error(exc: BaseException) -> bool:
+    """
+    Determine if an exception is Neo4j running out of transaction memory.
+
+    The driver marks every TransientError retryable, so ``_NETWORK_EXCEPTIONS`` would
+    otherwise catch this wholesale and replay the same oversized batch.
+
+    :param exc: The exception to check
+    :return: True if Neo4j exhausted its transaction memory pool or heap, False otherwise
+    """
+    if not isinstance(exc, neo4j.exceptions.Neo4jError):
+        return False
+    return exc.code in _TRANSACTION_MEMORY_ERROR_CODES
+
 
 def _is_retryable_client_error(exc: Exception) -> bool:
     """
@@ -194,6 +235,12 @@ def _run_with_retry(operation: Callable[[], T], target: str) -> T:
                 )
             return result
         except _NETWORK_EXCEPTIONS as exc:
+            if _is_transaction_memory_error(exc):
+                # Same payload, same result. Let the caller shrink the batch instead.
+                # write_list_of_dicts_tx converts execution-time memory errors before the
+                # driver ever sees them; this branch is the backstop for commit-time ones,
+                # which are raised from tx._commit() outside the transaction function.
+                raise Neo4jTransactionMemoryError(str(exc)) from exc
             if network_attempts >= _MAX_NETWORK_RETRIES - 1:
                 raise
             network_attempts += 1
@@ -612,8 +659,18 @@ def write_list_of_dicts_tx(
     Note:
         This function is typically used internally by higher-level functions like
         ``load_graph_data()`` rather than being called directly by user code.
+
+        Transaction-memory exhaustion is re-raised as ``Neo4jTransactionMemoryError``. That
+        type is invisible to the driver's managed-transaction retry, so an oversized batch
+        fails immediately instead of being replayed in full; ``load_graph_data()`` then
+        shrinks the batch and retries.
     """
-    tx.run(query, kwargs).consume()
+    try:
+        tx.run(query, kwargs).consume()
+    except neo4j.exceptions.Neo4jError as exc:
+        if _is_transaction_memory_error(exc):
+            raise Neo4jTransactionMemoryError(str(exc)) from exc
+        raise
 
 
 def write_matchlink_cartesian_product_tx(
@@ -652,13 +709,23 @@ def load_graph_data(
     This function handles retries for:
     - Network errors (ConnectionResetError)
     - Service unavailability (ServiceUnavailable, SessionExpired)
-    - Transient database errors (TransientError)
+    - Transient database errors (TransientError), except transaction-memory exhaustion
     - EntityNotFound errors during concurrent operations (ClientError with specific code)
     - BufferError with "cannot be re-sized" during concurrent multi-threaded operations
 
     EntityNotFound errors are retried because they commonly occur during concurrent
     write operations when multiple threads access the same node space. This is expected
     behavior in Neo4j's query execution pipeline, not a permanent failure.
+
+    Transaction-memory exhaustion is handled by shrinking rather than retrying, because
+    replaying an identical oversized payload can never succeed. A single row can fan out to
+    an unbounded number of relationship MERGEs (for example ``(:CVEMetadata)-[:ENRICHES]->``
+    every node carrying the ``:CVE`` label), so a batch size that is safe on one graph can
+    exhaust ``dbms.memory.transaction.total.max`` on another. On such an error the batch size
+    is halved and the same rows are retried; the reduced size then persists for the rest of
+    the load so the cost of discovering it is paid once. Shrinking is safe because a failed
+    transaction commits nothing and the generated queries are idempotent MERGEs. Modules with
+    known heavy rows should still pass an explicit ``batch_size`` rather than rely on this.
 
     Args:
         neo4j_session (neo4j.Session): The Neo4j session for database operations.
@@ -679,8 +746,13 @@ def load_graph_data(
         ... ]
         >>> load_graph_data(session, query, data, lastupdated=current_time)
 
+    Raises:
+        ValueError: If ``batch_size`` is not greater than 0.
+        Neo4jTransactionMemoryError: If Neo4j still runs out of transaction memory once the
+            batch size has been reduced to ``_MIN_ADAPTIVE_BATCH_SIZE``.
+
     Note:
-        - Data is processed in batches of 10,000 records to optimize memory usage
+        - Data is processed in batches of 10,000 records by default to optimize memory usage
           and transaction performance.
         - This function is typically called by higher-level functions like ``load()``
           rather than directly by user code.
@@ -688,14 +760,44 @@ def load_graph_data(
     if batch_size <= 0:
         raise ValueError(f"batch_size must be greater than 0, got {batch_size}")
 
-    for data_batch in batch(dict_list, size=batch_size):
-        execute_write_with_retry(
-            neo4j_session,
-            write_list_of_dicts_tx,
-            query,
-            DictList=data_batch,
-            **kwargs,
-        )
+    # Materialise so we can re-slice the same rows after shrinking the batch size. Every
+    # in-repo caller already passes a list; this guards a generator caller from silent loss.
+    rows = dict_list if isinstance(dict_list, list) else list(dict_list)
+    effective_batch_size = batch_size
+    index = 0
+    while index < len(rows):
+        data_batch = rows[index : index + effective_batch_size]
+        try:
+            execute_write_with_retry(
+                neo4j_session,
+                write_list_of_dicts_tx,
+                query,
+                DictList=data_batch,
+                **kwargs,
+            )
+        except Neo4jTransactionMemoryError as exc:
+            if effective_batch_size <= _MIN_ADAPTIVE_BATCH_SIZE:
+                raise Neo4jTransactionMemoryError(
+                    f"Neo4j ran out of transaction memory even at batch_size="
+                    f"{effective_batch_size}. Each input row likely fans out to many matched "
+                    f"nodes; reduce the fan-out of this query or raise the transaction "
+                    f"memory limit named in the causing error."
+                ) from exc
+            effective_batch_size = max(
+                _MIN_ADAPTIVE_BATCH_SIZE, effective_batch_size // 2
+            )
+            logger.warning(
+                "Neo4j transaction memory exceeded. Halving batch size to %d and retrying "
+                "from row %d of %d. Consider setting an explicit batch_size constant for "
+                "this module. Error: %s",
+                effective_batch_size,
+                index,
+                len(rows),
+                exc,
+            )
+            # Retry the same offset with a smaller slice; nothing was committed.
+            continue
+        index += len(data_batch)
 
 
 def ensure_indexes(

--- a/cartography/intel/cve_metadata/__init__.py
+++ b/cartography/intel/cve_metadata/__init__.py
@@ -29,6 +29,14 @@ stat_handler = get_stats_client(__name__)
 CVE_METADATA_FEED_ID = "CVE_METADATA"
 ALL_SOURCES = {"nvd", "epss"}
 
+# Each CVEMetadata row fans out to every node carrying the :CVE label with the same cve_id
+# (the deprecated CVE node plus AWSInspectorFinding / SemgrepSCAFinding / TrivyImageFinding /
+# ...), and all of those ENRICHES MERGEs land in one transaction. Yearly batches alone stay
+# under the 10000-row default, so without this a whole CVE year is one transaction: on a large
+# container-scanning graph a ~2400-row transaction exhausted a 3.5 GiB
+# dbms.memory.transaction.total.max pool.
+CVE_METADATA_BATCH_SIZE = 500
+
 
 def _get_cve_feed_year(cve_id: str) -> str | None:
     parts = cve_id.split("-")
@@ -100,6 +108,7 @@ def load_cve_metadata(
         neo4j_session,
         CVEMetadataSchema(),
         data,
+        batch_size=CVE_METADATA_BATCH_SIZE,
         lastupdated=update_tag,
         FEED_ID=CVE_METADATA_FEED_ID,
     )

--- a/tests/unit/cartography/client/core/test_tx.py
+++ b/tests/unit/cartography/client/core/test_tx.py
@@ -9,10 +9,15 @@ from cartography.client.core.tx import _buffer_error_backoff_handler
 from cartography.client.core.tx import _entity_not_found_backoff_handler
 from cartography.client.core.tx import _is_retryable_buffer_error
 from cartography.client.core.tx import _is_retryable_client_error
+from cartography.client.core.tx import _is_transaction_memory_error
+from cartography.client.core.tx import _MIN_ADAPTIVE_BATCH_SIZE
 from cartography.client.core.tx import _run_index_query_with_retry
 from cartography.client.core.tx import _run_with_retry
 from cartography.client.core.tx import execute_write_with_retry
+from cartography.client.core.tx import load_graph_data
 from cartography.client.core.tx import load_matchlinks_cartesian_product
+from cartography.client.core.tx import Neo4jTransactionMemoryError
+from cartography.client.core.tx import write_list_of_dicts_tx
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
@@ -55,6 +60,24 @@ def _create_client_error(
     # Set the code attribute (this is how Neo4j driver sets it internally)
     object.__setattr__(exc, "_neo4j_code", code)
     return exc
+
+
+def _create_transient_error(
+    code: str, message: str = "Test error"
+) -> neo4j.exceptions.TransientError:
+    """Helper to create a TransientError with a specific code."""
+    exc = neo4j.exceptions.TransientError(message)
+    object.__setattr__(exc, "_neo4j_code", code)
+    return exc
+
+
+def _create_memory_pool_error(
+    message: str = "Test error",
+) -> neo4j.exceptions.TransientError:
+    """Helper to create the transaction memory pool exhaustion error."""
+    return _create_transient_error(
+        "Neo.TransientError.General.MemoryPoolOutOfMemoryError", message
+    )
 
 
 def _cartesian_product_rel_schema() -> PrincipalToS3BucketCartesianProductRel:
@@ -270,6 +293,172 @@ def test_handles_none_wait_time_gracefully(mock_logger, mock_sleep):
     assert len(error_logs) == 1
     # Should still sleep (with fallback 1.0 second)
     mock_sleep.assert_called_once_with(1.0)
+
+
+# Tests for transaction memory errors
+
+
+def test_memory_pool_error_is_classified():
+    """Should recognise Neo4j transaction memory exhaustion, and nothing else."""
+    assert _is_transaction_memory_error(_create_memory_pool_error()) is True
+    assert (
+        _is_transaction_memory_error(
+            _create_transient_error("Neo.TransientError.General.OutOfMemoryError")
+        )
+        is True
+    )
+    assert (
+        _is_transaction_memory_error(
+            _create_transient_error("Neo.TransientError.Transaction.LockClientStopped")
+        )
+        is False
+    )
+    assert (
+        _is_transaction_memory_error(
+            _create_client_error("Neo.ClientError.Statement.EntityNotFound")
+        )
+        is False
+    )
+    assert _is_transaction_memory_error(ValueError("nope")) is False
+
+
+def test_raises_transaction_memory_error_without_retry():
+    """Should not retry transaction memory errors: the same payload cannot succeed."""
+    operation = MagicMock()
+    operation.side_effect = _create_memory_pool_error("pool exhausted")
+
+    with pytest.raises(Neo4jTransactionMemoryError) as exc_info:
+        _run_with_retry(operation, "test_target")
+
+    # Should only be called once (no retries, no backoff sleep)
+    operation.assert_called_once()
+    # The original error is carried by the exception chain, not copied into the message
+    assert isinstance(exc_info.value.__cause__, neo4j.exceptions.TransientError)
+    assert exc_info.value.__cause__.code == (
+        "Neo.TransientError.General.MemoryPoolOutOfMemoryError"
+    )
+
+
+@patch("cartography.client.core.tx.time.sleep")
+def test_still_retries_non_memory_transient_errors(mock_sleep):
+    """Should keep retrying TransientErrors that are not memory exhaustion."""
+    operation = MagicMock()
+    operation.side_effect = [
+        _create_transient_error("Neo.TransientError.Transaction.LockClientStopped"),
+        "success",
+    ]
+
+    result = _run_with_retry(operation, "test_target")
+
+    assert result == "success"
+    assert operation.call_count == 2
+
+
+def test_write_list_of_dicts_tx_converts_memory_error():
+    """Should convert memory errors to a type the neo4j driver will not retry."""
+    mock_tx = MagicMock()
+    mock_tx.run.return_value.consume.side_effect = _create_memory_pool_error()
+
+    with pytest.raises(Neo4jTransactionMemoryError) as exc_info:
+        write_list_of_dicts_tx(mock_tx, "MERGE (n:Test)", DictList=[{"id": 1}])
+
+    # Session._run_transaction only retries (DriverError, Neo4jError), so raising a type
+    # outside that hierarchy is what keeps the driver from replaying the oversized batch.
+    assert not isinstance(exc_info.value, neo4j.exceptions.Neo4jError)
+
+
+def test_write_list_of_dicts_tx_reraises_other_neo4j_errors():
+    """Should leave non-memory Neo4j errors untouched."""
+    mock_tx = MagicMock()
+    mock_tx.run.return_value.consume.side_effect = _create_client_error(
+        "Neo.ClientError.Statement.SyntaxError"
+    )
+
+    with pytest.raises(neo4j.exceptions.ClientError):
+        write_list_of_dicts_tx(mock_tx, "MERGE (n:Test)", DictList=[{"id": 1}])
+
+
+# Tests for load_graph_data adaptive batch sizing
+
+
+def _rows(count: int) -> list:
+    return [{"id": i} for i in range(count)]
+
+
+@patch("cartography.client.core.tx.execute_write_with_retry")
+def test_load_graph_data_halves_batch_on_memory_error(mock_execute):
+    """Should halve the batch and retry the same rows when memory is exhausted."""
+    rows = _rows(100)
+    calls = []
+
+    def side_effect(session, tx_func, query, **kwargs):
+        batch_rows = kwargs["DictList"]
+        calls.append(batch_rows)
+        if len(batch_rows) > 50:
+            raise Neo4jTransactionMemoryError("pool exhausted")
+
+    mock_execute.side_effect = side_effect
+
+    load_graph_data(MagicMock(), "MERGE (n:Test)", rows, batch_size=100)
+
+    # First attempt at 100 fails, then two successful halves of 50
+    assert [len(c) for c in calls] == [100, 50, 50]
+    # Every row is written exactly once, in order, with nothing dropped
+    written = [row for c in calls[1:] for row in c]
+    assert written == rows
+
+
+@patch("cartography.client.core.tx.execute_write_with_retry")
+def test_load_graph_data_keeps_reduced_batch_size(mock_execute):
+    """Should not re-grow the batch size after a memory error."""
+    rows = _rows(80)
+    calls = []
+
+    def side_effect(session, tx_func, query, **kwargs):
+        batch_rows = kwargs["DictList"]
+        calls.append(batch_rows)
+        if len(batch_rows) > 20:
+            raise Neo4jTransactionMemoryError("pool exhausted")
+
+    mock_execute.side_effect = side_effect
+
+    load_graph_data(MagicMock(), "MERGE (n:Test)", rows, batch_size=80)
+
+    # 80 fails, 40 fails, then 20 succeeds and stays at 20 for the rest of the load
+    assert [len(c) for c in calls] == [80, 40, 20, 20, 20, 20]
+    written = [row for c in calls[2:] for row in c]
+    assert written == rows
+
+
+@patch("cartography.client.core.tx.execute_write_with_retry")
+def test_load_graph_data_raises_at_floor(mock_execute):
+    """Should give up with an actionable message once shrinking stops helping."""
+    mock_execute.side_effect = Neo4jTransactionMemoryError("pool exhausted")
+
+    with pytest.raises(Neo4jTransactionMemoryError) as exc_info:
+        load_graph_data(MagicMock(), "MERGE (n:Test)", _rows(100), batch_size=100)
+
+    # The actionable guidance lives here, at the one point where we actually give up
+    assert "fans out" in str(exc_info.value)
+    assert "batch_size" in str(exc_info.value)
+    assert "transaction memory limit" in str(exc_info.value)
+    # Halving is bounded: 100 -> 50 -> 25 -> 12 -> 10, then raise. Guards against a
+    # regression that loops forever.
+    assert mock_execute.call_count <= 8
+    assert len(mock_execute.call_args_list[-1].kwargs["DictList"]) == (
+        _MIN_ADAPTIVE_BATCH_SIZE
+    )
+
+
+@patch("cartography.client.core.tx.execute_write_with_retry")
+def test_load_graph_data_does_not_shrink_for_other_errors(mock_execute):
+    """Should not shrink the batch for failures unrelated to transaction memory."""
+    mock_execute.side_effect = neo4j.exceptions.ServiceUnavailable("Connection lost")
+
+    with pytest.raises(neo4j.exceptions.ServiceUnavailable):
+        load_graph_data(MagicMock(), "MERGE (n:Test)", _rows(100), batch_size=100)
+
+    mock_execute.assert_called_once()
 
 
 # Tests for execute_write_with_retry

--- a/tests/unit/cartography/intel/cve_metadata/test_init.py
+++ b/tests/unit/cartography/intel/cve_metadata/test_init.py
@@ -25,6 +25,18 @@ def test_build_yearly_cve_batches_groups_by_feed_year():
     ]
 
 
+@patch.object(cve_metadata, "load")
+def test_load_cve_metadata_bounds_batch_size(mock_load):
+    """Each row fans out to every :CVE-labelled node, so transactions must stay small."""
+    cve_metadata.load_cve_metadata(MagicMock(), [{"id": "CVE-2024-0001"}], 123)
+
+    assert (
+        mock_load.call_args.kwargs["batch_size"] == cve_metadata.CVE_METADATA_BATCH_SIZE
+    )
+    # Guard against someone raising this back toward the 10000-row load() default.
+    assert cve_metadata.CVE_METADATA_BATCH_SIZE <= 500
+
+
 @patch.object(cve_metadata, "merge_module_sync_metadata")
 @patch.object(GraphJob, "from_node_schema")
 @patch.object(cve_metadata, "run_analysis_job")


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

The `cve_metadata` sync fails reproducibly on large graphs with
`Neo.TransientError.General.MemoryPoolOutOfMemoryError` ("the allocation of an extra 2.0 MiB would
use more than the limit 3.5 GiB ... `dbms.memory.transaction.total.max` threshold reached"), and then
burns roughly an hour retrying before it gives up. On the observed run, 22144 CVE nodes were enriched
year by year: the 3016-row bucket took about six minutes to commit, and the following 2400-row bucket
raised after a full hour.

There are three causes.

**1. No per-transaction row bound.** `load_cve_metadata` called `load()` with no `batch_size`, so it
used the default of 10000. The only upstream batching is `_build_yearly_cve_batches`, which buckets
CVE ids by publication year, and every bucket lands below 10000. The chunker in `load_graph_data`
therefore never split anything: **one CVE year was one Neo4j transaction**. The existing "keep memory
bounded" comment in the sync loop is about the Python heap, not Neo4j transaction memory.

**2. The `ENRICHES` edge fans out per row.** `CVEMetadataToCVERel` matches `target_node_label="CVE"`
on `{"cve_id": PropertyRef("id")}`, deliberately loose so it reaches every node carrying the `:CVE`
semantic label (the deprecated CVE node plus `AWSInspectorFinding`, `SemgrepSCAFinding`,
`TrivyImageFinding`, and so on). Each input row expands to one relationship MERGE per match, and that
count is unbounded and graph-dependent. Rows times fan-out is what exhausts the pool. The fan-out is
intentional and covered by a regression test, so batch size is the only lever available here.

**3. The oversized payload was replayed, not shrunk.** `MemoryPoolOutOfMemoryError` maps to
`neo4j.exceptions.TransientError`, which carries `_retryable = True`. It was therefore in
`_NETWORK_EXCEPTIONS` and `_run_with_retry` replayed it up to five times with exponential backoff,
re-sending the same `DictList` each time. The neo4j driver's own managed-transaction retry
(`Session._run_transaction`) adds another layer: it catches `(DriverError, Neo4jError)` and retries
anything whose `is_retryable()` is true, and its retry timer starts only *after* the first attempt, so
a slow transaction is always replayed in full at least once. Replaying a batch that is too large for
the pool can never succeed. That is the wasted hour.

#### What this PR changes

**`cartography/intel/cve_metadata/__init__.py`**: adds `CVE_METADATA_BATCH_SIZE = 500`, passed to
`load()`, following the existing convention of a named per-module constant with a why-comment
(`ECR_LAYER_BATCH_SIZE`, `CONTAINER_IMAGE_BATCH_SIZE`). Sizing: about 2400 rows exhausted a 3.5 GiB
pool, roughly 1.5 MB of transaction memory per row on that graph, so 500 leaves about 3x headroom.

**`cartography/client/core/tx.py`**: treats transaction-memory exhaustion as a signal to shrink
rather than to back off. This is deliberately at the shared layer: the retry classification is
generic, not specific to this module.

- `_is_transaction_memory_error` classifies the two Neo4j memory error codes.
- A new `Neo4jTransactionMemoryError`, deliberately **not** a `neo4j.exceptions.Neo4jError` subclass.
  `write_list_of_dicts_tx` converts at the transaction-function boundary, so the error is invisible to
  the driver's managed-transaction retry and an oversized batch is no longer replayed in full before
  our code sees it.
- `_run_with_retry` re-raises immediately instead of consuming five network retries. This is the
  backstop for commit-time errors, which are raised from `tx._commit()` outside the transaction
  function.
- `load_graph_data` halves the batch and retries the same rows. The reduced size then persists for the
  rest of the load, so the cost of discovering it is paid once rather than per chunk. Below a floor of
  10 rows it fails with an actionable message, because at single-digit batch sizes the per-row fan-out
  dominates and shrinking further just converts one failure into thousands of slow transactions.

Shrinking is safe because a failed transaction commits nothing and the generated queries are
idempotent MERGEs. `load_matchlinks` inherits the behavior for free, since it delegates to
`load_graph_data`.

#### Note on blast radius

Cause 3 is a shared-layer fix, so it changes behavior for every module that writes through `load()`,
`load_matchlinks()`, or `load_graph_data()`. The one realistic downside is a genuinely transient pool
exhaustion caused by a concurrent sync, which today sometimes succeeds on a plain retry and would now
shrink instead. Shrinking still completes the load, so this should be strictly better, but it is worth
a reviewer's attention.

`load_matchlinks_cartesian_product` keeps its own two-dimensional batching and is not converted to
adaptive shrinking. It still benefits from the classification change: an out-of-memory error there now
fails in seconds instead of after five replays.

This bounds rows, not fan-out. If a single `cve_id` matches a very large number of `:CVE`-labelled
findings, even 500 rows can exhaust the pool; the adaptive shrink absorbs that. A durable follow-up
would be to move `CVEMetadataToCVERel` out of the node ingestion query into its own `load_matchlinks`
with an independent batch size. That is out of scope here.


### Related issues or links

<!-- No tracking issue; reported from a production sync failure. -->


### How was this tested?

- `make test_lint` passes.
- `uv run --frozen pytest tests/unit`: 4594 passed.
- `uv run --frozen pytest tests/integration`: 1402 passed, against a local Neo4j. The shared write
  path is on every module's load path, so the full suites were run rather than just the touched
  modules.
- **End-to-end against a real Neo4j, using the driver's real error rather than a synthetic one.**
  `db.memory.transaction.max` was temporarily capped at 2 MiB and a 2000-row load was driven through
  `load_graph_data`. This confirmed the error code is
  `Neo.TransientError.General.MemoryPoolOutOfMemoryError`, that it surfaces at execution time (so the
  driver never replays it), that the batch size walked 2000 → 1000 → 500 → 250 → 125 → 62 → 31, and
  that **all 2000 rows were written** with no loss. The setting was restored afterward.

  ```
  WARNING cartography.client.core.tx Neo4j transaction memory exceeded. Halving batch size to 1000
  and retrying from row 0 of 2000. Consider setting an explicit batch_size constant for this module.
  Error: Neo4j ran out of transaction memory. This is not retryable: replaying the same payload will
  fail again. Lower the batch_size passed to load()/load_matchlinks() for this module, or raise the
  transaction memory limit named in the original error below. Original error:
  {neo4j_code: Neo.TransientError.General.MemoryPoolOutOfMemoryError} {message: The allocation of an
  extra 4.9 MiB would use more than the limit 2.0 MiB. Currently using 2.0 MiB.
  db.memory.transaction.max threshold reached} {gql_status: 51N72}
  ...
  >>> rows written: 2000 (expected 2000)
  ```

New unit tests:

- `tests/unit/cartography/client/core/test_tx.py`: error classification, no retry on memory errors,
  other `TransientError` codes still retried, conversion in `write_list_of_dicts_tx` (asserting the
  raised type is outside the `Neo4jError` hierarchy, which is the regression guard for the
  driver-retry bypass), batch halving, sticky reduced size, the floor, and no shrinking for unrelated
  errors.
- `tests/unit/cartography/intel/cve_metadata/test_init.py`: `load_cve_metadata` passes a bounded
  `batch_size`.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
<!-- No node or relationship definitions changed; no PropertyRef added or modified. -->


### Notes for reviewers

The two parts are separable if you would prefer them split: the `cve_metadata` batch size alone
resolves the reported failure, and the `tx.py` change is the generic hardening that keeps any module
with heavy per-row fan-out from burning an hour on a payload that can never succeed. Happy to split
them into two PRs if you would rather review them independently.

Two design choices worth a second opinion:

- **The reduced batch size is sticky for the rest of the load** rather than being re-derived per
  chunk. A stack-of-halves design rediscovers the failure once per chunk, which with the 10000-row
  default over a large list means many wasted attempts. It never re-grows, which is the conservative
  choice.
- **The floor is 10, not 1.** Below that the per-row fan-out dominates, so failing with a message that
  points at the fan-out is more actionable than crawling through thousands of single-row transactions.
