### PR TITLE
fix(cve_metadata): bound Neo4j transaction memory for the ENRICHES fan-out

### DIFF
--- a/cartography/intel/cve_metadata/__init__.py
+++ b/cartography/intel/cve_metadata/__init__.py
@@ -29,6 +29,14 @@ stat_handler = get_stats_client(__name__)
 CVE_METADATA_FEED_ID = "CVE_METADATA"
 ALL_SOURCES = {"nvd", "epss"}
 
+# Each CVEMetadata row fans out to every node carrying the :CVE label with the same cve_id
+# (the deprecated CVE node plus AWSInspectorFinding / SemgrepSCAFinding / TrivyImageFinding /
+# ...), and all of those ENRICHES MERGEs land in one transaction. Yearly batches alone stay
+# under the 10000-row default, so without this a whole CVE year is one transaction: on a large
+# container-scanning graph a ~2400-row transaction exhausted a 3.5 GiB
+# dbms.memory.transaction.total.max pool.
+CVE_METADATA_BATCH_SIZE = 500
+
 
 def _get_cve_feed_year(cve_id: str) -> str | None:
     parts = cve_id.split("-")
@@ -100,6 +108,7 @@ def load_cve_metadata(
         neo4j_session,
         CVEMetadataSchema(),
         data,
+        batch_size=CVE_METADATA_BATCH_SIZE,
         lastupdated=update_tag,
         FEED_ID=CVE_METADATA_FEED_ID,
     )

--- a/tests/unit/cartography/intel/cve_metadata/test_init.py
+++ b/tests/unit/cartography/intel/cve_metadata/test_init.py
@@ -25,6 +25,18 @@ def test_build_yearly_cve_batches_groups_by_feed_year():
     ]
 
 
+@patch.object(cve_metadata, "load")
+def test_load_cve_metadata_bounds_batch_size(mock_load):
+    """Each row fans out to every :CVE-labelled node, so transactions must stay small."""
+    cve_metadata.load_cve_metadata(MagicMock(), [{"id": "CVE-2024-0001"}], 123)
+
+    assert (
+        mock_load.call_args.kwargs["batch_size"] == cve_metadata.CVE_METADATA_BATCH_SIZE
+    )
+    # Guard against someone raising this back toward the 10000-row load() default.
+    assert cve_metadata.CVE_METADATA_BATCH_SIZE <= 500
+
+
 @patch.object(cve_metadata, "merge_module_sync_metadata")
 @patch.object(GraphJob, "from_node_schema")
 @patch.object(cve_metadata, "run_analysis_job")


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

The `cve_metadata` sync fails reproducibly on large graphs with
`Neo.TransientError.General.MemoryPoolOutOfMemoryError` ("the allocation of an extra 2.0 MiB would
use more than the limit 3.5 GiB ... `dbms.memory.transaction.total.max` threshold reached"), because
a whole CVE year is written in a single Neo4j transaction.

**No per-transaction row bound.** `load_cve_metadata` calls `load()` with no `batch_size`, so it uses
the default of 10000. The only upstream batching is `_build_yearly_cve_batches`, which buckets CVE ids
by publication year, and every bucket lands below 10000. The chunker in `load_graph_data` therefore
never splits anything: one CVE year is one Neo4j transaction. The existing "keep memory bounded"
comment in the sync loop refers to the Python heap, not to Neo4j transaction memory.

**Rows are not cheap, because the `ENRICHES` edge fans out.** `CVEMetadataToCVERel` matches
`target_node_label="CVE"` on `{"cve_id": PropertyRef("id")}`, deliberately loose so it reaches every
node carrying the `:CVE` semantic label: the deprecated CVE node plus every finding node that now
carries that label (`AWSInspectorFinding`, `SemgrepSCAFinding`, `TrivyImageFinding`, and so on). Each
input row therefore expands to one relationship MERGE per match, and that count is unbounded and
graph-dependent. Rows times fan-out is what exhausts the pool. The fan-out is intentional and covered
by a regression test, so batch size is the lever here.

On the observed run, 22144 CVE nodes were enriched year by year. The 3016-row bucket took about six
minutes to commit, and a later 2400-row bucket exhausted the pool.

This PR bounds the loader to 500 rows per transaction, following the existing convention of a named
per-module constant with a comment explaining why (`ECR_LAYER_BATCH_SIZE`,
`CONTAINER_IMAGE_BATCH_SIZE`, `GITLAB_CONTAINER_IMAGE_BATCH_SIZE`).

Sizing: about 2400 rows exhausted a 3.5 GiB pool, roughly 1.5 MB of transaction memory per row on
that graph, so 500 sits well under the observed failure point while keeping the number of round trips
reasonable on a sync that is already serialized per year.

#### Known limitation

This bounds rows, not fan-out. If a single `cve_id` matches a very large number of `:CVE`-labelled
findings, even 500 rows could exhaust the pool on a graph with a heavier scanning surface than the one
observed. The durable fix would be to move `CVEMetadataToCVERel` out of the node ingestion query into
its own `load_matchlinks` with an independent batch size, which is a larger change and out of scope
here.


### Related issues or links

Supersedes #3144, which paired this change with a broader adaptive-batch-sizing change in the shared
write path (`cartography/client/core/tx.py`). Per review feedback there, that shared-layer change
deserves its own discussion, so this PR is narrowed to the module-scoped fix that resolves the
reported failure on its own.


### How was this tested?

- `make test_lint` passes.
- `uv run --frozen pytest tests/unit/cartography/intel/cve_metadata/`: 29 passed.
- `uv run --frozen pytest tests/integration/cartography/intel/cve_metadata/`: 4 passed, against a
  local Neo4j.

New unit test `test_load_cve_metadata_bounds_batch_size` asserts that `load_cve_metadata` passes the
bounded `batch_size`, and guards against the constant drifting back up toward the 10000-row `load()`
default. This follows the existing precedent in
`tests/unit/cartography/intel/test_container_image_layers.py`.

The existing `test_start_cve_metadata_ingestion_loads_one_year_at_a_time` is unaffected: it patches
`load_cve_metadata` itself, and that function's signature is unchanged.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
<!-- No node or relationship definition changed; no PropertyRef added or modified. -->


### Notes for reviewers

The diff is two files and 21 added lines. No shared code path is touched, so the blast radius is
limited to the `cve_metadata` module.
