### PR TITLE
Add Railway deployments to the image ontology

### DIFF
--- a/cartography/intel/railway/deployments.py
+++ b/cartography/intel/railway/deployments.py
@@ -5,6 +5,7 @@ import neo4j
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.container_image import parse_image_uri
 from cartography.intel.railway.serviceinstances import iter_service_instances
 from cartography.intel.railway.utils import unwrap_edges
 from cartography.models.railway.deployment import RailwayDeploymentSchema
@@ -34,26 +35,46 @@ def transform(
     triggers: dict[str, list[dict[str, Any]]] = {}
 
     for project_id, bundle in bundles.items():
+        instances = iter_service_instances(bundle)
         # The deployment each service instance is currently serving. Everything else in the
         # window is a superseded revision.
         current_ids = {
-            (instance.get("latestDeployment") or {}).get("id")
-            for instance in iter_service_instances(bundle)
+            (instance.get("latestDeployment") or {}).get("id") for instance in instances
         }
         current_ids.discard(None)
+        # The image reference lives on the parent service instance, not the deployment. Key it
+        # by the same (service, environment) pair the WORKLOAD_PARENT edge joins on so we can
+        # copy it onto the current revision.
+        source_image_by_instance = {
+            (instance.get("serviceId"), instance.get("environmentId")): (
+                instance.get("source") or {}
+            ).get("image")
+            for instance in instances
+        }
 
         project_deployments: list[dict[str, Any]] = []
         project_triggers: list[dict[str, Any]] = []
         for environment in unwrap_edges(bundle["environments"]):
             for deployment in unwrap_edges(environment["deployments"]):
+                is_current = deployment["id"] in current_ids
+                # Only the current revision is guaranteed to run the instance's current source
+                # image; a superseded revision may have run something else, so leave it null.
+                image_uri, image_digest = (None, None)
+                if is_current:
+                    image_uri, image_digest = parse_image_uri(
+                        source_image_by_instance.get(
+                            (
+                                deployment.get("serviceId"),
+                                deployment.get("environmentId"),
+                            ),
+                        ),
+                    )
                 project_deployments.append(
                     {
                         **deployment,
-                        "lifecycle": (
-                            "current"
-                            if deployment["id"] in current_ids
-                            else "historical"
-                        ),
+                        "lifecycle": "current" if is_current else "historical",
+                        "image_uri": image_uri,
+                        "image_digest": image_digest,
                     },
                 )
             project_triggers.extend(unwrap_edges(environment["deploymentTriggers"]))

--- a/cartography/models/ontology/constraints_whitelist.py
+++ b/cartography/models/ontology/constraints_whitelist.py
@@ -191,6 +191,16 @@ from cartography.models.openai.adminapikey import OpenAIAdminApiKeyToSARel
 from cartography.models.openai.adminapikey import OpenAIAdminApiKeyToUserRel
 from cartography.models.openai.apikey import OpenAIApiKeyToSARel
 from cartography.models.openai.apikey import OpenAIApiKeyToUserRel
+from cartography.models.railway.deployment import RailwayDeploymentToECRImageRel
+from cartography.models.railway.deployment import (
+    RailwayDeploymentToGCPArtifactRegistryImageRel,
+)
+from cartography.models.railway.deployment import (
+    RailwayDeploymentToGitHubContainerImageRel,
+)
+from cartography.models.railway.deployment import (
+    RailwayDeploymentToGitLabContainerImageRel,
+)
 from cartography.models.scaleway.iam.apikey import ScalewayApiKeyToApplicationRel
 from cartography.models.scaleway.iam.apikey import ScalewayApiKeyToUserRel
 from cartography.models.scaleway.serverless.container import (
@@ -361,6 +371,10 @@ LEGACY_REL_WHITELIST: frozenset[type] = frozenset(
         AzureContainerInstanceToGitLabContainerImageRel,
         AzureContainerInstanceToGCPArtifactRegistryImageRel,
         AzureContainerInstanceToGitHubContainerImageRel,
+        RailwayDeploymentToECRImageRel,
+        RailwayDeploymentToGitLabContainerImageRel,
+        RailwayDeploymentToGCPArtifactRegistryImageRel,
+        RailwayDeploymentToGitHubContainerImageRel,
         ScalewayServerlessContainerToImageRel,
         SnowflakeServiceContainerToImageRel,
         AWSLambdaToECRImageRel,

--- a/cartography/models/railway/deployment.py
+++ b/cartography/models/railway/deployment.py
@@ -53,6 +53,18 @@ class RailwayDeploymentNodeProperties(CartographyNodeProperties):
     created_at: PropertyRef = PropertyRef(
         "createdAt", description="Time when the deployment was created."
     )
+    # Copied from the parent RailwayServiceInstance.source_image onto the current revision so
+    # the image ontology can reach it. Railway only exposes an image reference for the current
+    # deployment, so historical revisions leave these null.
+    image_uri: PropertyRef = PropertyRef(
+        "image_uri",
+        extra_index=True,
+        description="Container image reference this deployment runs, when deployed from a registry.",
+    )
+    image_digest: PropertyRef = PropertyRef(
+        "image_digest",
+        description="Digest (e.g. `sha256:...`) when `image_uri` is pinned by digest; `None` for tag-based references.",
+    )
 
 
 @dataclass(frozen=True)
@@ -102,6 +114,92 @@ class RailwayDeploymentToServiceInstanceRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class RailwayDeploymentToECRImageRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:RailwayDeployment)-[:HAS_IMAGE]->(:AWSECRImage), joined on digest.
+class RailwayDeploymentToECRImageRel(CartographyRelSchema):
+    """Links a deployment to the image it runs, hosted in Amazon ECR."""
+
+    target_node_label: str = "AWSECRImage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"digest": PropertyRef("image_digest")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_IMAGE"
+    properties: RailwayDeploymentToECRImageRelProperties = (
+        RailwayDeploymentToECRImageRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class RailwayDeploymentToGitLabContainerImageRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:RailwayDeployment)-[:HAS_IMAGE]->(:GitLabContainerImage), joined on digest.
+class RailwayDeploymentToGitLabContainerImageRel(CartographyRelSchema):
+    """Links a deployment to the image it runs, hosted in the GitLab registry."""
+
+    target_node_label: str = "GitLabContainerImage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"digest": PropertyRef("image_digest")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_IMAGE"
+    properties: RailwayDeploymentToGitLabContainerImageRelProperties = (
+        RailwayDeploymentToGitLabContainerImageRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class RailwayDeploymentToGCPArtifactRegistryImageRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:RailwayDeployment)-[:HAS_IMAGE]->(:GCPArtifactRegistryImage), joined on digest.
+class RailwayDeploymentToGCPArtifactRegistryImageRel(CartographyRelSchema):
+    """Links a deployment to the image it runs, hosted in Artifact Registry."""
+
+    target_node_label: str = "GCPArtifactRegistryImage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"digest": PropertyRef("image_digest")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_IMAGE"
+    properties: RailwayDeploymentToGCPArtifactRegistryImageRelProperties = (
+        RailwayDeploymentToGCPArtifactRegistryImageRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class RailwayDeploymentToGitHubContainerImageRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+# (:RailwayDeployment)-[:HAS_IMAGE]->(:GitHubContainerImage), joined on digest.
+class RailwayDeploymentToGitHubContainerImageRel(CartographyRelSchema):
+    """Links a deployment to the image it runs, hosted in GitHub Container Registry."""
+
+    target_node_label: str = "GitHubContainerImage"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"digest": PropertyRef("image_digest")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_IMAGE"
+    properties: RailwayDeploymentToGitHubContainerImageRelProperties = (
+        RailwayDeploymentToGitHubContainerImageRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 # A deployment is one concrete revision of a service instance, so the revision that is
 # actually running plays the Container role to the instance's ComputeService - the same split
 # GCP Cloud Run uses for Service and ServiceContainer.
@@ -124,5 +222,9 @@ class RailwayDeploymentSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             RailwayDeploymentToServiceInstanceRel(),
+            RailwayDeploymentToECRImageRel(),
+            RailwayDeploymentToGitLabContainerImageRel(),
+            RailwayDeploymentToGCPArtifactRegistryImageRel(),
+            RailwayDeploymentToGitHubContainerImageRel(),
         ],
     )

--- a/tests/integration/cartography/intel/railway/test_deployments.py
+++ b/tests/integration/cartography/intel/railway/test_deployments.py
@@ -73,6 +73,18 @@ def test_load_railway_deployments(neo4j_session):
         (POSTGRES_DEPLOYMENT_ID,),
     }
 
+    # Assert the current deployment carries the image reference from its service instance so
+    # the image ontology can reach it. The web instance runs a registry image; the Postgres
+    # instance is git-backed and has none.
+    assert check_nodes(
+        neo4j_session,
+        "RailwayDeployment",
+        ["id", "image_uri", "image_digest"],
+    ) == {
+        (WEB_DEPLOYMENT_ID, "nginxdemos/hello", None),
+        (POSTGRES_DEPLOYMENT_ID, None, None),
+    }
+
     # And the project tenant edge
     assert check_rels(
         neo4j_session,

--- a/tests/unit/cartography/intel/railway/test_deployments.py
+++ b/tests/unit/cartography/intel/railway/test_deployments.py
@@ -1,0 +1,76 @@
+import copy
+
+from cartography.intel.railway.deployments import transform
+from tests.data.railway.bundles import RAILWAY_PROJECT_BUNDLE
+
+PROJECT_ID = "33333333-3333-3333-3333-333333333333"
+WEB_DEPLOYMENT_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+POSTGRES_DEPLOYMENT_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+
+def _deployments_by_id(bundle):
+    deployments, _ = transform({PROJECT_ID: bundle})
+    return {d["id"]: d for d in deployments[PROJECT_ID]}
+
+
+def test_current_deployment_copies_registry_image_from_instance():
+    by_id = _deployments_by_id(copy.deepcopy(RAILWAY_PROJECT_BUNDLE))
+
+    # The web instance runs a registry image, so its current deployment gets it.
+    web = by_id[WEB_DEPLOYMENT_ID]
+    assert web["lifecycle"] == "current"
+    assert web["image_uri"] == "nginxdemos/hello"
+    # A bare tag reference is not digest-pinned.
+    assert web["image_digest"] is None
+
+
+def test_git_backed_deployment_has_no_image():
+    by_id = _deployments_by_id(copy.deepcopy(RAILWAY_PROJECT_BUNDLE))
+
+    # The Postgres instance is deployed from git (source.image is null), so no image ref.
+    postgres = by_id[POSTGRES_DEPLOYMENT_ID]
+    assert postgres["lifecycle"] == "current"
+    assert postgres["image_uri"] is None
+    assert postgres["image_digest"] is None
+
+
+def test_digest_pinned_image_is_parsed():
+    bundle = copy.deepcopy(RAILWAY_PROJECT_BUNDLE)
+    digest = "sha256:" + "a" * 64
+    for env_edge in bundle["environments"]["edges"]:
+        for inst_edge in env_edge["node"]["serviceInstances"]["edges"]:
+            source = inst_edge["node"].get("source") or {}
+            if source.get("image") == "nginxdemos/hello":
+                source["image"] = f"nginxdemos/hello@{digest}"
+
+    web = _deployments_by_id(bundle)[WEB_DEPLOYMENT_ID]
+    assert web["image_uri"] == f"nginxdemos/hello@{digest}"
+    assert web["image_digest"] == digest
+
+
+def test_superseded_deployment_has_no_image():
+    bundle = copy.deepcopy(RAILWAY_PROJECT_BUNDLE)
+    for env_edge in bundle["environments"]["edges"]:
+        if env_edge["node"]["name"] != "production":
+            continue
+        env_edge["node"]["deployments"]["edges"].append(
+            {
+                "node": {
+                    "id": "cccc0000-cccc-cccc-cccc-cccccccccccc",
+                    "status": "CRASHED",
+                    "statusUpdatedAt": "2026-07-27T17:00:00.000Z",
+                    "createdAt": "2026-07-27T17:00:00.000Z",
+                    "projectId": PROJECT_ID,
+                    "environmentId": "44444444-4444-4444-4444-444444444444",
+                    "serviceId": "66666666-6666-6666-6666-666666666666",
+                    "url": None,
+                    "staticUrl": None,
+                    "canRedeploy": True,
+                },
+            },
+        )
+
+    superseded = _deployments_by_id(bundle)["cccc0000-cccc-cccc-cccc-cccccccccccc"]
+    assert superseded["lifecycle"] == "historical"
+    assert superseded["image_uri"] is None
+    assert superseded["image_digest"] is None


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Wire `RailwayDeployment` into the container image ontology so image consumers can actually reach Railway workloads.

A Railway deployment already gets the `Container` label on its current revision, but the image it runs only lives on the parent `RailwayServiceInstance.source_image`. So the deployment had no image reference of its own, no `HAS_IMAGE`, and never picked up `RESOLVED_IMAGE` — vuln/SBOM consumers that walk the image ontology couldn't see it.

This copies `source_image` onto the current deployment as `image_uri` (parsing out the digest when the reference is digest-pinned via the shared `parse_image_uri` helper) and attaches the same `HAS_IMAGE` edges to the ECR / GitLab / Artifact Registry / GHCR image nodes that the other `Container` modules (Cloud Run, ECS, Kubernetes) already use. Matching is by digest, so an existing provider-owned `Image` gets reused rather than duplicated. Once `HAS_IMAGE` is present the existing `CONTAINER_RESOLVED_IMAGE` analysis derives `RESOLVED_IMAGE` with no extra work.

Only the current revision gets the image copied onto it. Railway keeps a row for every past deploy attempt, and a superseded revision may well have run a different image than the instance's current source — same reason the `Container` label is already conditional on `lifecycle="current"`.

Nothing new is pulled from the Railway API here — `source.image` is already ingested onto the service instance. This is purely a graph-modeling change over data the connector already syncs.

Scope note: this is the deployment-side ontology wiring from #3118. The generic Trivy path in that issue (scanning pullable references that don't yet resolve to a provider image, and loading a digest-keyed fallback `Image` when Trivy learns a concrete digest) is a separate, larger change and isn't part of this PR.

### Related issues or links

- Refs #3118


### How was this tested?

- `pytest tests/unit/cartography/intel/railway/` — added `test_deployments.py` covering the transform: a registry-backed current deployment gets `image_uri`, a git-backed one (`source.image = null`) stays empty, a digest-pinned reference splits into `image_uri` + `image_digest`, and a superseded revision gets nothing. 24 passed.
- `pytest tests/unit/cartography/graph/test_ontology_rel_constraints.py tests/unit/cartography/graph/test_ontology_fields.py` — the four new `HAS_IMAGE` rels are whitelisted alongside the existing container modules. 29 passed.
- Extended `tests/integration/.../test_deployments.py` to assert the current deployment carries `image_uri` from its instance (the existing fixture already has an `nginxdemos/hello` service and a git-backed one). This needs Neo4j to run and I don't have a live instance here, so I haven't executed it — flagging that for a reviewer.
- `flake8` clean, `mypy` clean on the changed files, `black` + `isort` applied.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (flake8 / black / isort / mypy on the changed files).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [ ] Built the documentation with `uv run ./docs/build.sh` (didn't run the docs build locally).


### Notes for reviewers

The change lives entirely in the transform + model — no new Railway API surface — so it shouldn't need real-environment sync evidence the way a new connector would. The one thing worth a look is the `(serviceId, environmentId)` join I use to find each deployment's parent instance; it's the same key the existing `WORKLOAD_PARENT` edge matches on.
