### PR TITLE
perf(gitlab): resolve tag digests before fetching container manifests

### DIFF
--- a/cartography/intel/gitlab/__init__.py
+++ b/cartography/intel/gitlab/__init__.py
@@ -203,6 +203,21 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         )
     )
 
+    # Resolve tags once for the whole container phase. The tag detail endpoint is
+    # the only GitLab API that reports a tag's manifest digest, and it costs one
+    # request per tag, so both the image sync (which needs the digests to decide
+    # what to fetch) and the tag sync (which ingests them) share this one fetch.
+    all_container_tags = cartography.intel.gitlab.container_repository_tags.get_all_container_repository_tags(
+        gitlab_url,
+        token,
+        all_container_repositories,
+    )
+    container_tags_by_repository = (
+        cartography.intel.gitlab.container_repository_tags.group_tags_by_repository(
+            all_container_tags,
+        )
+    )
+
     # Sync container images before tags since tags have REFERENCES relationship to images
     # Returns raw manifests and manifest lists for downstream attestation sync
     all_image_manifests, manifest_lists = (
@@ -214,6 +229,7 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
             all_container_repositories,
             config.update_tag,
             common_job_parameters,
+            tags_by_repository=container_tags_by_repository,
         )
     )
 
@@ -226,6 +242,7 @@ def start_gitlab_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         all_container_repositories,
         config.update_tag,
         common_job_parameters,
+        raw_tags=all_container_tags,
     )
 
     # Sync container image attestations (includes cleanup since it's org-scoped)

--- a/cartography/intel/gitlab/container_images.py
+++ b/cartography/intel/gitlab/container_images.py
@@ -10,8 +10,10 @@ from typing import Any
 from urllib.parse import urlparse
 
 import neo4j
+import requests
 
 from cartography.client.core.tx import load
+from cartography.client.core.tx import read_list_of_values_tx
 from cartography.graph.job import GraphJob
 from cartography.helpers import batch
 from cartography.intel.container_image_layers import ContainerImageLayerGraphShape
@@ -117,6 +119,47 @@ def _get_manifest(
     return manifest
 
 
+def _get_manifest_digest(
+    gitlab_url: str,
+    registry_url: str,
+    repository_name: str,
+    reference: str,
+    token: str,
+) -> str | None:
+    """
+    Resolve the manifest digest for a reference with a HEAD request.
+
+    The OCI distribution spec requires HEAD on /v2/<name>/manifests/<reference>
+    to return the same Docker-Content-Digest header as GET, so this learns the
+    digest without transferring or parsing a manifest body.
+
+    Returns None when the reference is gone (404), the registry omits the
+    header, or the probe fails outright, leaving the caller to fall back to a
+    full manifest fetch.
+    """
+    try:
+        response = fetch_registry_manifest(
+            gitlab_url,
+            registry_url,
+            repository_name,
+            reference,
+            token,
+            accept_header=MANIFEST_ACCEPT_HEADER,
+            method="HEAD",
+        )
+    except requests.exceptions.RequestException as e:
+        logger.debug(
+            f"HEAD digest probe failed for {repository_name}:{reference}: {e}. "
+            f"Falling back to a full manifest fetch."
+        )
+        return None
+
+    if response.status_code != 200:
+        return None
+
+    return response.headers.get("Docker-Content-Digest")
+
+
 def get_container_images(
     gitlab_url: str,
     token: str,
@@ -125,12 +168,21 @@ def get_container_images(
     skip_digests: set[str] | None = None,
     observed_and_skipped: set[str] | None = None,
     skipped_attestation_manifests: list[dict[str, Any]] | None = None,
+    tags_by_repository: dict[str, list[dict[str, Any]]] | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """
     Fetch container image manifests for all repositories via the Registry V2 API.
 
-    For each repository, fetches tags and then retrieves the manifest for each tag.
-    Returns raw manifest data for transformation, plus manifest lists for attestation discovery.
+    For each repository, resolves each tag to a manifest digest and then fetches
+    the manifests that are not already known. Returns raw manifest data for
+    transformation, plus manifest lists for attestation discovery.
+
+    ``tags_by_repository`` maps a repository location to the tag records resolved
+    by the tag sync, which already carry the manifest ``digest``. Passing it lets
+    both dedup checks run before any registry request, so an already-enriched
+    digest costs zero HTTP. Without it this falls back to the tag list endpoint,
+    which reports names only, and resolves digests with HEAD probes when there is
+    something to skip against.
 
     Deduplication is scoped per repository to ensure complete attestation discovery.
     If the same digest appears in multiple repositories, each will be processed separately.
@@ -166,17 +218,63 @@ def get_container_images(
         if repository_name not in seen_digests:
             seen_digests[repository_name] = set()
 
-        # Fetch tags for this repository
-        tags = get_paginated(
-            gitlab_url,
-            token,
-            f"/api/v4/projects/{project_id}/registry/repositories/{repository_id}/tags",
-        )
+        # Prefer tag records resolved by the tag sync: they already carry the
+        # manifest digest, so both dedup checks below cost no HTTP at all. Fall
+        # back to the tag list endpoint, which reports names only.
+        if tags_by_repository is not None:
+            tags = tags_by_repository.get(location, [])
+        else:
+            tags = get_paginated(
+                gitlab_url,
+                token,
+                f"/api/v4/projects/{project_id}/registry/repositories/{repository_id}/tags",
+            )
 
         for tag in tags:
             tag_name = tag.get("name")
             if not tag_name:
                 continue
+
+            # Resolve the digest before spending a manifest GET. Without this the
+            # dedup below can only run on the response of the fetch it is meant
+            # to avoid, so every tag costs a full manifest body on every run.
+            known_digest = tag.get("digest")
+            if not known_digest and skip_digests:
+                # No digest on the tag record. A HEAD returns it in
+                # Docker-Content-Digest without a body, which is only worth a
+                # round trip when there are digests to skip against - on a first
+                # run skip_digests is empty and a HEAD would be pure overhead.
+                known_digest = _get_manifest_digest(
+                    gitlab_url, registry_url, repository_name, tag_name, token
+                )
+
+            if known_digest:
+                if known_digest in seen_digests[repository_name]:
+                    # Another tag in this repository already resolved to this
+                    # digest (e.g. "latest" and "v1.0.0" on one image).
+                    continue
+                if known_digest in skip_digests:
+                    # Cross-run dedup: a previous sync already enriched this
+                    # image and its layer closure. Record it so the caller
+                    # refreshes lastupdated and cleanup leaves it alone, and
+                    # keep it in the attestation discovery set - which only
+                    # needs these three keys.
+                    #
+                    # Only single images reach here. skip_digests comes from
+                    # get_complete_layer_digests, which requires layer_diff_ids
+                    # to be set, and manifest lists have no layers, so a
+                    # manifest list is never skipped and its children are always
+                    # walked.
+                    seen_digests[repository_name].add(known_digest)
+                    observed_and_skipped.add(str(known_digest))
+                    skipped_attestation_manifests.append(
+                        {
+                            "_digest": known_digest,
+                            "_registry_url": registry_url,
+                            "_repository_name": repository_name,
+                        }
+                    )
+                    continue
 
             manifest = _get_manifest(
                 gitlab_url, registry_url, repository_name, tag_name, token
@@ -186,7 +284,8 @@ def get_container_images(
             if manifest is None:
                 continue
 
-            # Deduplicate by digest within this repository (multiple tags can point to same image)
+            # Re-check against the digest the registry actually served: the tag
+            # may have moved since its digest was resolved above.
             digest = manifest.get("_digest")
             if not digest or digest in seen_digests[repository_name]:
                 continue
@@ -194,6 +293,10 @@ def get_container_images(
 
             media_type = manifest.get("mediaType")
             is_manifest_list = media_type in MANIFEST_LIST_MEDIA_TYPES
+            # Manifest lists are deliberately excluded from the skip: they carry
+            # no layers, so get_complete_layer_digests never reports one as
+            # complete, and short-circuiting here would drop the child walk that
+            # discovers their platform images.
             if not is_manifest_list and digest in skip_digests:
                 observed_and_skipped.add(digest)
                 skipped_attestation_manifests.append(manifest)
@@ -571,6 +674,42 @@ def cleanup_container_image_layers(
     ).run(neo4j_session)
 
 
+def _get_manifest_list_digests(
+    neo4j_session: neo4j.Session,
+    org_id: int,
+    gitlab_url: str,
+    digests: set[str],
+) -> set[str]:
+    """
+    Return the subset of ``digests`` the graph records as manifest lists.
+
+    Callers use this to keep manifest lists out of the skip set. A manifest list
+    carries no layers of its own, so it should never be reported as having a
+    complete layer closure, but skipping one would drop the child walk that
+    discovers its platform images. Enforcing that here keeps the guarantee local
+    to this module instead of resting on how the shared layer-closure query
+    happens to treat images without layers.
+    """
+    if not digests:
+        return set()
+
+    query = """
+    MATCH (org:GitLabOrganization {id: $org_id, gitlab_url: $gitlab_url})
+          -[:RESOURCE]->(img:GitLabContainerImage)
+    WHERE img.digest IN $digests
+      AND (img.type = 'manifest_list' OR img.child_image_digests IS NOT NULL)
+    RETURN img.digest
+    """
+    values = neo4j_session.execute_read(
+        read_list_of_values_tx,
+        query,
+        digests=sorted(digests),
+        org_id=org_id,
+        gitlab_url=gitlab_url,
+    )
+    return {str(value) for value in values if value}
+
+
 @timeit
 def sync_container_images(
     neo4j_session: neo4j.Session,
@@ -580,12 +719,16 @@ def sync_container_images(
     repositories: list[dict[str, Any]],
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    tags_by_repository: dict[str, list[dict[str, Any]]] | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """
     Sync GitLab container images for an organization.
 
     Returns attestation-discovery manifests and manifest lists. Cached images
     remain in the discovery set without being sent through image/layer transforms.
+
+    ``tags_by_repository`` is the tag-sync output grouped by repository location;
+    see get_container_images for how it removes the per-tag manifest fetch.
     """
     all_raw_manifests: list[dict[str, Any]] = []
     all_attestation_manifests: list[dict[str, Any]] = []
@@ -596,10 +739,24 @@ def sync_container_images(
         None,
         {"id": org_id, "gitlab_url": gitlab_url},
     )
+    manifest_list_digests = _get_manifest_list_digests(
+        neo4j_session,
+        org_id,
+        gitlab_url,
+        complete_digests,
+    )
+    if manifest_list_digests:
+        logger.warning(
+            "Excluding %d manifest list digest(s) from the GitLab image skip set: "
+            "skipping a manifest list would drop its platform images.",
+            len(manifest_list_digests),
+        )
+        complete_digests -= manifest_list_digests
+
     observed_and_skipped: set[str] = set()
     if complete_digests:
         logger.info(
-            "Skipping config fetches for %d already-enriched GitLab digests",
+            "Skipping manifest/config fetches for %d already-enriched GitLab digests",
             len(complete_digests),
         )
     total_repositories = len(repositories)
@@ -625,6 +782,7 @@ def sync_container_images(
             skip_digests=complete_digests,
             observed_and_skipped=observed_and_skipped,
             skipped_attestation_manifests=skipped_attestation_manifests,
+            tags_by_repository=tags_by_repository,
         )
         all_raw_manifests.extend(raw_manifests)
         all_attestation_manifests.extend(raw_manifests)

--- a/cartography/intel/gitlab/container_images.py
+++ b/cartography/intel/gitlab/container_images.py
@@ -149,8 +149,10 @@ def _get_manifest_digest(
         )
     except requests.exceptions.RequestException as e:
         logger.debug(
-            f"HEAD digest probe failed for {repository_name}:{reference}: {e}. "
-            f"Falling back to a full manifest fetch."
+            "HEAD digest probe failed for %s:%s: %s. Falling back to a full manifest fetch.",
+            repository_name,
+            reference,
+            e,
         )
         return None
 

--- a/cartography/intel/gitlab/container_repository_tags.py
+++ b/cartography/intel/gitlab/container_repository_tags.py
@@ -68,6 +68,7 @@ def get_container_repository_tags(
     return detailed_tags
 
 
+@timeit
 def get_all_container_repository_tags(
     gitlab_url: str,
     token: str,

--- a/cartography/intel/gitlab/container_repository_tags.py
+++ b/cartography/intel/gitlab/container_repository_tags.py
@@ -99,6 +99,26 @@ def get_all_container_repository_tags(
     return all_tags
 
 
+def group_tags_by_repository(
+    raw_tags: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """
+    Group raw tag records by their parent repository location.
+
+    The image sync consumes this to resolve each tag's manifest digest without a
+    registry round trip: get_container_repository_tags already paid for the tag
+    detail endpoint, which reports the digest, so re-deriving it from a manifest
+    fetch is wasted work.
+    """
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for tag in raw_tags:
+        repository_location = tag.get("_repository_location")
+        if not repository_location:
+            continue
+        grouped.setdefault(str(repository_location), []).append(tag)
+    return grouped
+
+
 def transform_container_repository_tags(
     raw_tags: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -169,13 +189,19 @@ def sync_container_repository_tags(
     repositories: list[dict[str, Any]],
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    raw_tags: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """
     Sync GitLab container repository tags for an organization.
+
+    Pass ``raw_tags`` to reuse records already fetched by the caller. The tag
+    detail endpoint costs one request per tag, so the container phase fetches
+    them once and shares them with the image sync rather than fetching twice.
     """
     logger.info(f"Syncing container repository tags for organization {org_id}")
 
-    raw_tags = get_all_container_repository_tags(gitlab_url, token, repositories)
+    if raw_tags is None:
+        raw_tags = get_all_container_repository_tags(gitlab_url, token, repositories)
 
     transformed = transform_container_repository_tags(raw_tags)
     load_container_repository_tags(

--- a/cartography/intel/gitlab/util.py
+++ b/cartography/intel/gitlab/util.py
@@ -125,11 +125,18 @@ def fetch_registry_manifest(
     reference: str,
     token: str,
     accept_header: str | None = None,
+    method: str = "GET",
 ) -> requests.Response:
     """
     Fetch a manifest from the registry with 401 retry handling.
 
     Returns the full response object so callers can access headers (e.g., Docker-Content-Digest).
+
+    Pass method="HEAD" to learn a reference's digest without transferring or
+    parsing the manifest body. The OCI distribution spec requires HEAD on
+    /v2/<name>/manifests/<reference> to answer with the same
+    Docker-Content-Digest header as GET, so callers can resolve a digest and
+    only spend a full GET when the body is actually needed.
     """
     jwt_token = get_registry_token(gitlab_url, registry_url, repository_name, token)
     url = f"{registry_url}/v2/{repository_name}/manifests/{reference}"
@@ -139,7 +146,7 @@ def fetch_registry_manifest(
         headers["Accept"] = accept_header
 
     response = make_request_with_retry(
-        "GET",
+        method,
         url,
         headers=headers,
         timeout=DEFAULT_TIMEOUT,
@@ -153,7 +160,7 @@ def fetch_registry_manifest(
         )
         headers["Authorization"] = f"Bearer {jwt_token}"
         response = make_request_with_retry(
-            "GET",
+            method,
             url,
             headers=headers,
             timeout=DEFAULT_TIMEOUT,

--- a/tests/integration/cartography/intel/gitlab/test_container_registry.py
+++ b/tests/integration/cartography/intel/gitlab/test_container_registry.py
@@ -643,3 +643,142 @@ def test_sync_container_registry(
         )
         >= expected_built_from_rels
     )
+
+
+DEDUP_REPO = {
+    "id": 91,
+    "project_id": 92,
+    "location": "registry.gitlab.example.com/myorg/awesome-project/dedup",
+}
+DEDUP_IMAGE_DIGEST = (
+    "sha256:dedup1111111111111111111111111111111111111111111111111111111111"
+)
+DEDUP_CONFIG_DIGEST = (
+    "sha256:dedupcfg11111111111111111111111111111111111111111111111111111111"
+)
+DEDUP_DIFF_IDS = [
+    "sha256:dedupdiff1111111111111111111111111111111111111111111111111111111",
+    "sha256:dedupdiff2222222222222222222222222222222222222222222222222222222",
+]
+# Two tags pointing at one image: the sync must resolve both to the same digest
+# and fetch that manifest once.
+DEDUP_TAGS_BY_REPOSITORY = {
+    DEDUP_REPO["location"]: [
+        {"name": "latest", "digest": DEDUP_IMAGE_DIGEST},
+        {"name": "v1.0.0", "digest": DEDUP_IMAGE_DIGEST},
+    ],
+}
+DEDUP_MANIFEST = {
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+    "config": {"digest": DEDUP_CONFIG_DIGEST},
+    "layers": [
+        {
+            "digest": "sha256:deduplayer111111111111111111111111111111111111111111111111111111",
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "size": 100,
+        },
+        {
+            "digest": "sha256:deduplayer222222222222222222222222222222222222222222222222222222",
+            "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "size": 200,
+        },
+    ],
+    "_digest": DEDUP_IMAGE_DIGEST,
+    "_registry_url": "https://registry.gitlab.example.com",
+    "_repository_name": "myorg/awesome-project/dedup",
+    "_reference": "latest",
+}
+DEDUP_CONFIG_BLOB = {
+    "architecture": "amd64",
+    "os": "linux",
+    "rootfs": {"type": "layers", "diff_ids": DEDUP_DIFF_IDS},
+}
+
+
+@patch(
+    "cartography.intel.gitlab.container_images.fetch_registry_blob",
+    return_value=DEDUP_CONFIG_BLOB,
+)
+@patch(
+    "cartography.intel.gitlab.container_images._get_manifest",
+    return_value=DEDUP_MANIFEST,
+)
+def test_sync_container_images_skips_manifest_fetch_on_second_run(
+    mock_get_manifest,
+    mock_fetch_blob,
+    neo4j_session,
+):
+    """
+    A second sync must not re-fetch manifests for digests it already enriched,
+    and must not let cleanup reap the images it skipped.
+    """
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _create_test_org(neo4j_session)
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "ORGANIZATION_ID": TEST_ORG_ID,
+        "org_id": TEST_ORG_ID,
+        "gitlab_url": TEST_GITLAB_URL,
+    }
+
+    # Act: first sync populates the image and its layer closure.
+    sync_container_images(
+        neo4j_session,
+        TEST_GITLAB_URL,
+        "fake-token",
+        TEST_ORG_ID,
+        [DEDUP_REPO],
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+        tags_by_repository=DEDUP_TAGS_BY_REPOSITORY,
+    )
+
+    # Assert: two tags, one digest, one manifest fetch.
+    assert mock_get_manifest.call_count == 1
+    assert check_nodes(neo4j_session, "GitLabContainerImage", ["digest"]) == {
+        (DEDUP_IMAGE_DIGEST,),
+    }
+    assert check_nodes(neo4j_session, "GitLabContainerImageLayer", ["diff_id"]) == {
+        (DEDUP_DIFF_IDS[0],),
+        (DEDUP_DIFF_IDS[1],),
+    }
+
+    # Act: second sync at a later update tag.
+    mock_get_manifest.reset_mock()
+    mock_fetch_blob.reset_mock()
+    second_update_tag = TEST_UPDATE_TAG + 1
+    common_job_parameters["UPDATE_TAG"] = second_update_tag
+    sync_container_images(
+        neo4j_session,
+        TEST_GITLAB_URL,
+        "fake-token",
+        TEST_ORG_ID,
+        [DEDUP_REPO],
+        second_update_tag,
+        common_job_parameters,
+        tags_by_repository=DEDUP_TAGS_BY_REPOSITORY,
+    )
+
+    # Assert: no registry traffic at all for the already-enriched digest.
+    mock_get_manifest.assert_not_called()
+    mock_fetch_blob.assert_not_called()
+
+    # Assert: the skipped image and its layers survived cleanup at the new tag.
+    assert check_nodes(neo4j_session, "GitLabContainerImage", ["digest"]) == {
+        (DEDUP_IMAGE_DIGEST,),
+    }
+    assert check_nodes(neo4j_session, "GitLabContainerImageLayer", ["diff_id"]) == {
+        (DEDUP_DIFF_IDS[0],),
+        (DEDUP_DIFF_IDS[1],),
+    }
+    assert check_rels(
+        neo4j_session,
+        "GitLabOrganization",
+        "id",
+        "GitLabContainerImage",
+        "digest",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {(TEST_ORG_ID, DEDUP_IMAGE_DIGEST)}

--- a/tests/unit/cartography/intel/gitlab/test_container_images.py
+++ b/tests/unit/cartography/intel/gitlab/test_container_images.py
@@ -320,3 +320,291 @@ def test_get_container_images_skips_config_for_complete_digest(monkeypatch):
         },
     ]
     fetch_blob.assert_not_called()
+
+
+def _repo():
+    return {
+        "id": 1,
+        "project_id": 2,
+        "location": "registry.gitlab.example.com/group/project",
+    }
+
+
+def test_get_container_images_skips_manifest_fetch_for_known_complete_digest(
+    monkeypatch,
+):
+    # Arrange: the tag record already carries the digest, and that digest is
+    # already enriched in the graph, so no registry request should be issued.
+    digest = "sha256:complete"
+    get_manifest = Mock()
+    get_paginated = Mock()
+    head_digest = Mock()
+    observed_and_skipped: set[str] = set()
+    skipped_attestation_manifests: list[dict] = []
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_images.get_paginated",
+        get_paginated,
+    )
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_images._get_manifest",
+        get_manifest,
+    )
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_images._get_manifest_digest",
+        head_digest,
+    )
+
+    # Act
+    manifests, manifest_lists = get_container_images(
+        "https://gitlab.example.com",
+        "token",
+        [_repo()],
+        skip_digests={digest},
+        observed_and_skipped=observed_and_skipped,
+        skipped_attestation_manifests=skipped_attestation_manifests,
+        tags_by_repository={
+            "registry.gitlab.example.com/group/project": [
+                {"name": "latest", "digest": digest},
+            ],
+        },
+    )
+
+    # Assert
+    assert manifests == []
+    assert manifest_lists == []
+    assert observed_and_skipped == {digest}
+    assert skipped_attestation_manifests == [
+        {
+            "_digest": digest,
+            "_registry_url": "https://registry.gitlab.example.com",
+            "_repository_name": "group/project",
+        },
+    ]
+    get_manifest.assert_not_called()
+    head_digest.assert_not_called()
+    # The tag records were supplied, so the tag list endpoint is not re-paginated.
+    get_paginated.assert_not_called()
+
+
+def test_get_container_images_fetches_shared_digest_once(monkeypatch):
+    # Arrange: two tags point at the same digest and none is already enriched.
+    digest = "sha256:shared"
+    manifest = {
+        "_digest": digest,
+        "_registry_url": "https://registry.gitlab.example.com",
+        "_repository_name": "group/project",
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    }
+    get_manifest = Mock(return_value=manifest)
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_images._get_manifest",
+        get_manifest,
+    )
+
+    # Act
+    manifests, _ = get_container_images(
+        "https://gitlab.example.com",
+        "token",
+        [_repo()],
+        tags_by_repository={
+            "registry.gitlab.example.com/group/project": [
+                {"name": "latest", "digest": digest},
+                {"name": "v1.0.0", "digest": digest},
+            ],
+        },
+    )
+
+    # Assert: one manifest fetch, not one per tag.
+    assert get_manifest.call_count == 1
+    assert manifests == [manifest]
+
+
+def test_get_container_images_head_probes_when_tag_digest_unknown(monkeypatch):
+    # Arrange: the tag record has no digest (tag detail fetch fell back to basic
+    # info), so the digest is resolved with a HEAD before any body is fetched.
+    digest = "sha256:complete"
+    get_manifest = Mock()
+    head_digest = Mock(return_value=digest)
+    observed_and_skipped: set[str] = set()
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_images._get_manifest",
+        get_manifest,
+    )
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_images._get_manifest_digest",
+        head_digest,
+    )
+
+    # Act
+    manifests, _ = get_container_images(
+        "https://gitlab.example.com",
+        "token",
+        [_repo()],
+        skip_digests={digest},
+        observed_and_skipped=observed_and_skipped,
+        tags_by_repository={
+            "registry.gitlab.example.com/group/project": [{"name": "latest"}],
+        },
+    )
+
+    # Assert
+    assert manifests == []
+    assert observed_and_skipped == {digest}
+    head_digest.assert_called_once_with(
+        "https://gitlab.example.com",
+        "https://registry.gitlab.example.com",
+        "group/project",
+        "latest",
+        "token",
+    )
+    get_manifest.assert_not_called()
+
+
+def test_get_container_images_skips_head_probe_on_first_run(monkeypatch):
+    # Arrange: nothing is enriched yet, so a HEAD would only add a round trip on
+    # top of the GET that has to happen anyway.
+    manifest = {
+        "_digest": "sha256:new",
+        "_registry_url": "https://registry.gitlab.example.com",
+        "_repository_name": "group/project",
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    }
+    get_manifest = Mock(return_value=manifest)
+    head_digest = Mock()
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_images._get_manifest",
+        get_manifest,
+    )
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_images._get_manifest_digest",
+        head_digest,
+    )
+
+    # Act
+    manifests, _ = get_container_images(
+        "https://gitlab.example.com",
+        "token",
+        [_repo()],
+        skip_digests=set(),
+        tags_by_repository={
+            "registry.gitlab.example.com/group/project": [{"name": "latest"}],
+        },
+    )
+
+    # Assert
+    head_digest.assert_not_called()
+    assert manifests == [manifest]
+
+
+def test_get_container_images_walks_manifest_list_when_child_is_skipped(monkeypatch):
+    # Arrange: a manifest list with two children, one of which is already
+    # enriched. The already-enriched child must be skipped without a fetch while
+    # the parent and the new child are still ingested.
+    parent_digest = "sha256:parent"
+    known_child = "sha256:knownchild"
+    new_child = "sha256:newchild"
+    parent = {
+        "_digest": parent_digest,
+        "_registry_url": "https://registry.gitlab.example.com",
+        "_repository_name": "group/project",
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [{"digest": known_child}, {"digest": new_child}],
+    }
+    child = {
+        "_digest": new_child,
+        "_registry_url": "https://registry.gitlab.example.com",
+        "_repository_name": "group/project",
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    }
+    get_manifest = Mock(side_effect=[parent, child])
+    observed_and_skipped: set[str] = set()
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_images._get_manifest",
+        get_manifest,
+    )
+
+    # Act
+    manifests, manifest_lists = get_container_images(
+        "https://gitlab.example.com",
+        "token",
+        [_repo()],
+        skip_digests={known_child},
+        observed_and_skipped=observed_and_skipped,
+        tags_by_repository={
+            "registry.gitlab.example.com/group/project": [
+                {"name": "latest", "digest": parent_digest},
+            ],
+        },
+    )
+
+    # Assert
+    assert manifest_lists == [parent]
+    assert manifests == [parent, child]
+    assert observed_and_skipped == {known_child}
+    assert get_manifest.call_count == 2
+
+
+def test_sync_container_images_excludes_manifest_lists_from_skip_set(monkeypatch):
+    # Arrange: the layer-closure query reports a manifest list digest alongside a
+    # regular image. Skipping the manifest list would drop the child walk that
+    # discovers its platform images, so it must not reach get_container_images.
+    parent_digest = "sha256:parent"
+    image_digest = "sha256:image"
+    get_images = Mock(return_value=([], []))
+    mocks = _patch_sync_container_images_dependencies(
+        monkeypatch,
+        get_images_mock=get_images,
+        complete_digests_mock=Mock(return_value={parent_digest, image_digest}),
+    )
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_images._get_manifest_list_digests",
+        Mock(return_value={parent_digest}),
+    )
+
+    # Act
+    sync_container_images(
+        neo4j_session=Mock(),
+        gitlab_url="https://gitlab.example.com",
+        token="token",
+        org_id=123,
+        repositories=[_repo()],
+        update_tag=1,
+        common_job_parameters={},
+    )
+
+    # Assert
+    assert get_images.call_args.kwargs["skip_digests"] == {image_digest}
+    assert mocks["cleanup_images"].called
+
+
+def test_sync_container_images_forwards_tags_by_repository(monkeypatch):
+    # Arrange
+    tags_by_repository = {
+        "registry.gitlab.example.com/group/project": [
+            {"name": "latest", "digest": "sha256:image"},
+        ],
+    }
+    get_images = Mock(return_value=([], []))
+    _patch_sync_container_images_dependencies(
+        monkeypatch,
+        get_images_mock=get_images,
+    )
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_images._get_manifest_list_digests",
+        Mock(return_value=set()),
+    )
+
+    # Act
+    sync_container_images(
+        neo4j_session=Mock(),
+        gitlab_url="https://gitlab.example.com",
+        token="token",
+        org_id=123,
+        repositories=[_repo()],
+        update_tag=1,
+        common_job_parameters={},
+        tags_by_repository=tags_by_repository,
+    )
+
+    # Assert
+    assert get_images.call_args.kwargs["tags_by_repository"] is tags_by_repository

--- a/tests/unit/cartography/intel/gitlab/test_container_repository_tags.py
+++ b/tests/unit/cartography/intel/gitlab/test_container_repository_tags.py
@@ -1,0 +1,103 @@
+from unittest.mock import Mock
+
+from cartography.intel.gitlab.container_repository_tags import group_tags_by_repository
+from cartography.intel.gitlab.container_repository_tags import (
+    sync_container_repository_tags,
+)
+
+
+def test_group_tags_by_repository_groups_and_drops_unattributed_tags():
+    # Arrange
+    tags = [
+        {"name": "latest", "_repository_location": "reg.example.com/group/app"},
+        {"name": "v1.0.0", "_repository_location": "reg.example.com/group/app"},
+        {"name": "v0.9.0", "_repository_location": "reg.example.com/group/worker"},
+        {"name": "orphan"},
+    ]
+
+    # Act
+    grouped = group_tags_by_repository(tags)
+
+    # Assert
+    assert grouped == {
+        "reg.example.com/group/app": [tags[0], tags[1]],
+        "reg.example.com/group/worker": [tags[2]],
+    }
+
+
+def test_sync_container_repository_tags_reuses_prefetched_tags(monkeypatch):
+    # Arrange: the caller already paid for the per-tag detail requests, so the
+    # tag sync must not fetch them a second time.
+    fetch_tags = Mock()
+    transform = Mock(return_value=[])
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_repository_tags.get_all_container_repository_tags",
+        fetch_tags,
+    )
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_repository_tags.transform_container_repository_tags",
+        transform,
+    )
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_repository_tags.load_container_repository_tags",
+        Mock(),
+    )
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_repository_tags.cleanup_container_repository_tags",
+        Mock(),
+    )
+    raw_tags = [{"name": "latest", "_repository_location": "reg.example.com/group/app"}]
+
+    # Act
+    returned = sync_container_repository_tags(
+        neo4j_session=Mock(),
+        gitlab_url="https://gitlab.example.com",
+        token="token",
+        org_id=123,
+        repositories=[{"id": 1, "project_id": 2}],
+        update_tag=1,
+        common_job_parameters={},
+        raw_tags=raw_tags,
+    )
+
+    # Assert
+    fetch_tags.assert_not_called()
+    transform.assert_called_once_with(raw_tags)
+    assert returned is raw_tags
+
+
+def test_sync_container_repository_tags_fetches_when_not_prefetched(monkeypatch):
+    # Arrange
+    raw_tags = [{"name": "latest", "_repository_location": "reg.example.com/group/app"}]
+    fetch_tags = Mock(return_value=raw_tags)
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_repository_tags.get_all_container_repository_tags",
+        fetch_tags,
+    )
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_repository_tags.transform_container_repository_tags",
+        Mock(return_value=[]),
+    )
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_repository_tags.load_container_repository_tags",
+        Mock(),
+    )
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.container_repository_tags.cleanup_container_repository_tags",
+        Mock(),
+    )
+
+    # Act
+    returned = sync_container_repository_tags(
+        neo4j_session=Mock(),
+        gitlab_url="https://gitlab.example.com",
+        token="token",
+        org_id=123,
+        repositories=[{"id": 1, "project_id": 2}],
+        update_tag=1,
+        common_job_parameters={},
+    )
+
+    # Assert
+    fetch_tags.assert_called_once()
+    assert returned is raw_tags

--- a/tests/unit/cartography/intel/gitlab/test_util.py
+++ b/tests/unit/cartography/intel/gitlab/test_util.py
@@ -112,3 +112,43 @@ def test_fetch_registry_manifest_refreshes_token_after_401(monkeypatch):
 
     assert response.status_code == 200
     assert token_calls == [False, True]
+
+
+def test_fetch_registry_manifest_forwards_head_method(monkeypatch):
+    # Arrange: a HEAD probe must reach the registry as HEAD, including on the
+    # post-401 retry, so a digest can be resolved without a body transfer.
+    methods = []
+    responses = iter(
+        [
+            _make_response(401),
+            _make_response(200, {}),
+        ],
+    )
+
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.util.get_registry_token",
+        lambda *args, **kwargs: "jwt-token",
+    )
+
+    def _request(method, *args, **kwargs):
+        methods.append(method)
+        return next(responses)
+
+    monkeypatch.setattr(
+        "cartography.intel.gitlab.util.requests.request",
+        _request,
+    )
+
+    # Act
+    response = fetch_registry_manifest(
+        "https://gitlab.example.com",
+        "https://registry.example.com",
+        "group/project",
+        "latest",
+        "pat",
+        method="HEAD",
+    )
+
+    # Assert
+    assert response.status_code == 200
+    assert methods == ["HEAD", "HEAD"]


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Other (please describe): performance fix, no schema or functional change


### Summary

The GitLab container image sync fetched a full manifest for **every tag of every
container repository on every run**. The cross-run dedup helper
(`get_complete_layer_digests`) was already wired in and worked for child manifests
and config blobs, but it could not prevent the parent fetch, because the digest was
only learned from the response of the fetch itself:

```python
manifest = _get_manifest(gitlab_url, registry_url, repository_name, tag_name, token)
...
digest = manifest.get("_digest")
if not digest or digest in seen_digests[repository_name]:
    continue
```

On a root group with roughly 1000 container repositories and roughly 177k tags, this
phase took about 10.4 hours out of a 12.3 hour module run while the graph already
knew about 38k enriched digests. All other phases in that run totalled under 1.8
hours, and the Neo4j writes for this phase were about 0.04 hours, so the cost was
essentially all outbound HTTP.

The GHCR implementation of the same feature does not have this problem because the
package-versions API reports the digest up front, so it can test `skip_digests`
before issuing any request.

**The digest was already being paid for on the GitLab side too.**
`get_container_repository_tags` calls the REST tag detail endpoint for every tag,
and that response reports the manifest digest. So the module was making ~177k tag
detail calls and then ~177k manifest GETs to rediscover the same values.

This PR resolves tags once per container phase and shares the records with both
syncs, so `get_container_images` can test `seen_digests` and `skip_digests` before
issuing any registry request. That makes the GitLab path structurally equivalent to
GHCR without adding a new API dependency.

Two wins, not one:

- **Warm runs**: an already-enriched digest now costs zero HTTP instead of a full
  manifest body.
- **Cold runs**: tags sharing a digest previously cost one manifest fetch *each*,
  because dedup ran after the fetch. With ~177k tags over ~38k digests that alone is
  roughly a 4x reduction on a first run.

Secondary changes:

- **HEAD before GET.** Where a tag record carries no digest (the tag detail call fell
  back to basic info, or a self-managed instance does not report one), the digest is
  resolved with a HEAD on the manifest reference, which the OCI distribution spec
  requires to return `Docker-Content-Digest` without a body. `fetch_registry_manifest`
  takes the HTTP method instead of hardcoding `"GET"`. This is gated on `skip_digests`
  being non-empty, because on a first run there is nothing to skip against and a HEAD
  would only add a round trip on top of the GET that has to happen anyway.
- **Manifest lists are excluded from the skip set explicitly.**
  `get_complete_layer_digests` requires `layer_diff_ids IS NOT NULL` and
  `transform_container_images` only sets that for single images, so a manifest list
  should never be reported as complete. The pre-fetch skip has no media type to check,
  so rather than rely on that invariant holding forever, `sync_container_images` now
  filters manifest lists out of the skip set at the boundary. Skipping a manifest list
  would drop the child walk that discovers its platform images.
- The log line now reads `Skipping manifest/config fetches for N already-enriched
  GitLab digests`, matching the GHCR wording so the two modules are comparable.

The `not is_manifest_list` clause on the existing post-fetch guard is left in place
and now carries a comment explaining why the exclusion is intentional, since it reads
like an oversight otherwise.


### Related issues or links

- GitLab REST container registry API (tag list has no digest, tag detail does):
  https://docs.gitlab.com/api/container_registry/
- OCI distribution spec, HEAD on manifests and required headers:
  https://github.com/opencontainers/distribution-spec/blob/main/spec.md


### How was this tested?

- `uv run --frozen pytest tests/unit` : 5099 passed
- `uv run --frozen pytest tests/integration` : 1545 passed (against `neo4j:5-community`
  from the repo's `docker-compose.yml`)
- `uv run --frozen pre-commit run --all-files` : all hooks pass

New integration test `test_sync_container_images_skips_manifest_fetch_on_second_run`
is the regression guard for the reported behavior. It runs `sync_container_images`
twice against a real Neo4j and asserts:

1. First run: two tags pointing at one digest cost **one** manifest fetch, not two.
2. Second run at a higher update tag: **zero** manifest fetches and **zero** config
   fetches.
3. The skipped image and its layers survive cleanup at the new update tag, so the
   optimization does not cause data loss.

New unit tests cover the pre-fetch cross-run skip, the shared-digest fetch-once path,
the HEAD probe, the first-run HEAD suppression, the manifest-list boundary filter,
`tags_by_repository` forwarding, tag grouping, tag reuse in the tag sync, and HEAD
method forwarding through the 401 refresh retry.

Not tested against a live GitLab instance. The change consumes a field the module was
already reading (`digest` from the tag detail endpoint), and the repo's own fixtures
in `tests/data/gitlab/container_registry.py` already assert that this field equals the
manifest's `Docker-Content-Digest`, including for a manifest list.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

No new real-environment evidence is attached: the request counts and phase timings in
the Summary come from an existing production sync of the current code, and the change
adds no new provider API call. Happy to attach sanitized logs from a before/after
sync if reviewers want them.

#### If you are changing a node or relationship
- [ ] Not applicable: no schema, node, or relationship changes. No `PropertyRef` or
  model docstring was touched, so the generated schema docs are unaffected.


### Notes for reviewers

Areas worth a close look:

- **`sync_container_images` boundary filter** (`_get_manifest_list_digests`). This adds
  one indexed read per sync. It defends a state that should be unreachable today. I
  added it because the first version of the pre-fetch skip did silently drop a manifest
  list's children in test, and I would rather enforce the invariant than document it.
  Reasonable to argue it is unnecessary.
- **Post-fetch checks are retained** as the authoritative net. A tag can move between
  digest resolution and the fetch, so the pre-fetch checks are a fast path only, and the
  digest the registry actually served still decides what gets ingested.
- **Sync ordering** in `cartography/intel/gitlab/__init__.py`. Tags are now fetched
  before the image sync, but still *loaded* after it, so the `REFERENCES` edge from tag
  to image still resolves. `sync_container_repository_tags` takes an optional `raw_tags`
  and falls back to fetching when it is not supplied.

Deliberately left out of scope:

- **The container registry's own bulk tag list endpoint**
  (`GET /gitlab/v1/repositories/<path>/tags/list/`), which returns `digest`,
  `config_digest` and `media_type` for up to 1000 tags per call. That would collapse the
  remaining ~177k per-tag REST detail calls into roughly one paginated call per
  repository, but it targets the *tags* phase rather than this one, and it requires the
  registry metadata database, so it needs a probe-and-fallback path. Worth its own PR.
- **Bounded concurrency** for the image phase, following the
  `asyncio.Semaphore(DEFAULT_MAX_CONCURRENT_REQUESTS)` pattern already in
  `cartography/intel/gitlab/projects.py`. It attacks the round-trip floor, which now
  only applies to genuinely new digests.
