### PR TITLE
perf(github): stop paying full backoff for recovered dependency graph timeouts

### DIFF
--- a/cartography/intel/github/commits.py
+++ b/cartography/intel/github/commits.py
@@ -91,6 +91,16 @@ def get_repo_commits(
             since=since_iso,
         )
 
+        # This caller has no retry path, so it owns the severity of any errors
+        # that call_github_api() logged at DEBUG.
+        if response.get("errors"):
+            logger.warning(
+                "GitHub returned errors fetching commits for %s/%s; results may be incomplete. Errors: %s",
+                organization,
+                repo_name,
+                response["errors"],
+            )
+
         # Navigate to the nested commit history
         repo_data = response.get("data", {}).get("organization", {}).get("repository")
         if not repo_data:

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -454,6 +454,19 @@ def _get_repo_dep_manifests(
             )
             return manifests, False
 
+        # GitHub can return a usable page alongside errors, e.g. a FORBIDDEN or a
+        # timeout on a nested field, which yields a manifest whose dependencies are
+        # silently missing. Keep what we got, but never let cleanup delete the rest.
+        if resp.get("errors"):
+            cleanup_safe = False
+            logger.warning(
+                "GitHub returned errors alongside a usable dependency manifest page "
+                "for repo %s; the page may be incomplete, so manifest cleanup is "
+                "disabled for this repo. Errors: %s",
+                repo,
+                resp["errors"],
+            )
+
         manifest_page_info = dep_manifests.get("pageInfo", {})
         manifest_cursor = manifest_page_info.get("endCursor")
         has_next_manifest = manifest_page_info.get("hasNextPage", False)
@@ -519,6 +532,17 @@ def _get_repo_dep_manifests(
                     len(all_dep_nodes),
                 )
                 break
+
+            if dep_resp.get("errors"):
+                cleanup_safe = False
+                logger.warning(
+                    "GitHub returned errors alongside a usable dependency page for %s "
+                    "in repo %s; the page may be incomplete, so manifest cleanup is "
+                    "disabled for this repo. Errors: %s",
+                    blob_path,
+                    repo,
+                    dep_resp["errors"],
+                )
 
             dep_nodes_list = dep_dep_manifests.get("nodes") or []
             if not dep_nodes_list:

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -2,6 +2,7 @@ import configparser
 import hashlib
 import json
 import logging
+import random
 import time
 from collections import defaultdict
 from collections import namedtuple
@@ -265,6 +266,60 @@ GITHUB_REPO_DEP_MANIFESTS_PAGINATED_GRAPHQL = """
     """
 
 
+# GitHub computes the dependency graph lazily, so the first request for a given
+# manifest position often times out while priming the resolver and the retry then
+# hits a warm result. Retrying that case straight away instead of paying the
+# transport-level backoff saves minutes of pure sleep across a large org.
+_MANIFEST_RESOLVER_RETRY_DELAYS = (0.0, 1.0)
+# Add up to +25% to every non-zero retry delay so a large org does not retry in
+# lockstep against the same resolver.
+_RETRY_JITTER_RATIO = 0.25
+
+
+class DependencyGraphForbiddenError(Exception):
+    """
+    Raised when GitHub refuses the dependency graph outright, e.g. when the org has
+    an IP allow list that does not cover this sync's source address. This is
+    permanent for the run, so callers must not retry it.
+    """
+
+
+def _sleep_with_jitter(delay: float) -> None:
+    """
+    Sleep for `delay` seconds plus jitter. A delay of 0 skips the sleep entirely.
+    """
+    if delay <= 0:
+        return
+    time.sleep(delay * (1 + random.random() * _RETRY_JITTER_RATIO))
+
+
+def _is_org_wide_forbidden(message: str) -> bool:
+    """
+    Return True if a FORBIDDEN message is the org-wide IP allow list refusal, which
+    every other repo in the org would hit identically.
+
+    Any other FORBIDDEN is repo-scoped: the dependency graph is enabled per
+    repository (see
+    https://docs.github.com/en/code-security/concepts/supply-chain-security/dependency-graph)
+    and token permissions can differ per repo, so it must not stop the batch. GitHub
+    does not document the refusal wording, so a miss here only means we keep walking
+    the batch, which is the safe behavior anyway.
+    """
+    return "ip allow list" in message.lower()
+
+
+def _get_forbidden_error_message(errors: list[Any]) -> str | None:
+    """
+    Return the message of the first FORBIDDEN error in `errors`, or None if there
+    is none.
+    """
+    for error in errors:
+        if isinstance(error, dict) and error.get("type") == "FORBIDDEN":
+            message = error.get("message")
+            return message if isinstance(message, str) else "FORBIDDEN"
+    return None
+
+
 def _fetch_manifest_page(
     token: str,
     api_url: str,
@@ -279,6 +334,8 @@ def _fetch_manifest_page(
     Retries on both HTTP errors and GraphQL-level timeouts (where GitHub returns
     HTTP 200 but with errors and null data in the response body).
     Returns the raw response dict, or None if all retries failed.
+    :raises DependencyGraphForbiddenError: if GitHub refuses the dependency graph,
+        which no amount of retrying can fix.
     """
     for attempt in range(retries):
         try:
@@ -300,7 +357,7 @@ def _fetch_manifest_page(
         ):
             if attempt + 1 >= retries:
                 return None
-            time.sleep(2 ** (attempt + 1))
+            _sleep_with_jitter(2 ** (attempt + 1))
             continue
 
         # Check for GraphQL-level timeout: HTTP 200 but dependencyGraphManifests is null
@@ -308,7 +365,13 @@ def _fetch_manifest_page(
         dep_manifests = (
             repository.get("dependencyGraphManifests") if repository else None
         )
-        if dep_manifests is None and resp.get("errors"):
+        errors = resp.get("errors") or []
+        if dep_manifests is None and errors:
+            forbidden_message = _get_forbidden_error_message(errors)
+            if forbidden_message:
+                # Permanent for this run; retrying only burns wall time and would
+                # report itself as a timeout, which it is not.
+                raise DependencyGraphForbiddenError(forbidden_message)
             if attempt + 1 >= retries:
                 logger.warning(
                     "GraphQL timeout fetching dependency manifests for repo %s after %d retries.",
@@ -322,7 +385,11 @@ def _fetch_manifest_page(
                 attempt + 1,
                 retries,
             )
-            time.sleep(2 ** (attempt + 1))
+            _sleep_with_jitter(
+                _MANIFEST_RESOLVER_RETRY_DELAYS[
+                    min(attempt, len(_MANIFEST_RESOLVER_RETRY_DELAYS) - 1)
+                ],
+            )
             continue
 
         return resp
@@ -511,9 +578,13 @@ def _get_dep_manifests_for_repos(
     )
     result: dict[str, dict[str, Any]] = {}
     failed_count = 0
+    forbidden_count = 0
+    forbidden_message: str | None = None
+    org_wide_forbidden = False
+    not_attempted_count = 0
     cleanup_safe = True
 
-    for repo in repo_raw_data:
+    for index, repo in enumerate(repo_raw_data):
         if repo is None:
             continue
         repo_name = repo.get("name")
@@ -536,6 +607,16 @@ def _get_dep_manifests_for_repos(
                     len(manifests),
                     repo_name,
                 )
+        except DependencyGraphForbiddenError as err:
+            forbidden_count += 1
+            forbidden_message = str(err)
+            cleanup_safe = False
+            if _is_org_wide_forbidden(forbidden_message):
+                # Every remaining repo would spend a GraphQL request only to be
+                # refused too, so stop and report what we did not attempt.
+                org_wide_forbidden = True
+                not_attempted_count = len(repo_raw_data) - index - 1
+                break
         except requests.exceptions.RequestException:
             failed_count += 1
             cleanup_safe = False
@@ -545,6 +626,26 @@ def _get_dep_manifests_for_repos(
                 exc_info=True,
             )
 
+    if org_wide_forbidden:
+        logger.warning(
+            "GitHub refused the dependency graph for org %s with an org-wide IP allow "
+            "list error: %s. No retry can succeed, so the remaining %d of %d repos in "
+            "this batch were not attempted.",
+            org,
+            forbidden_message,
+            not_attempted_count,
+            len(repo_raw_data),
+        )
+    elif forbidden_count > 0:
+        logger.warning(
+            "GitHub refused the dependency graph for %d of %d repos in org %s; the "
+            "dependency graph is enabled per repository and token permissions can "
+            "differ per repo, so the other repos were still synced. Last message: %s",
+            forbidden_count,
+            len(repo_raw_data),
+            org,
+            forbidden_message,
+        )
     if failed_count > 0:
         logger.warning(
             "Skipped dependency manifests for %d of %d repos in org %s due to fetch errors.",

--- a/cartography/intel/github/util.py
+++ b/cartography/intel/github/util.py
@@ -165,9 +165,14 @@ def call_github_api(query: str, variables: str, token: str, api_url: str) -> dic
     response.raise_for_status()
     response_json = response.json()
     if "errors" in response_json:
-        logger.warning(
-            f'call_github_api() response has errors, please investigate. Raw response: {response_json["errors"]}; '
-            f"continuing sync.",
+        # Severity belongs to the caller: a caller with a retry path (see
+        # `fetch_all()` and `_fetch_manifest_page()`) recovers from most of these,
+        # and warning here would bury the one line that does warrant investigation
+        # under hundreds of recovered ones. Callers with no retry path warn
+        # themselves.
+        logger.debug(
+            "call_github_api() response has errors: %s",
+            response_json["errors"],
         )
     return response_json  # type: ignore
 
@@ -344,6 +349,18 @@ def fetch_all(
 
         # Successful non-null resource; reset null-resource retry counter.
         null_resource_retry = 0
+
+        # The page is usable, so nothing above retries it. Any errors GitHub still
+        # reported are therefore terminal for this page and may mean it is
+        # incomplete, so surface them here rather than in call_github_api().
+        if resp.get("errors"):
+            logger.warning(
+                "GitHub returned errors alongside a usable page of resource `%s` for org `%s`; "
+                "the page may be incomplete. Errors: %s",
+                resource_type,
+                organization,
+                resp["errors"],
+            )
 
         # Allow for paginating both nodes and edges fields of the GitHub GQL structure.
         data.nodes.extend(resource.get("nodes", []))

--- a/tests/unit/cartography/intel/github/test_repos.py
+++ b/tests/unit/cartography/intel/github/test_repos.py
@@ -701,6 +701,66 @@ def test_fetch_manifest_page_does_not_retry_forbidden():
     mock_sleep.assert_not_called()
 
 
+def test_get_repo_dep_manifests_marks_errors_on_usable_page_unsafe_for_cleanup(
+    caplog,
+):
+    """
+    GitHub can refuse or time out a nested field while still returning a usable
+    page, which yields a manifest whose dependencies are silently missing. Keep the
+    partial data but never let cleanup delete what we could not read.
+    """
+    # Arrange
+    partial_page = {
+        "data": {
+            "organization": {
+                "repository": {
+                    "dependencyGraphManifests": {
+                        "pageInfo": {"endCursor": None, "hasNextPage": False},
+                        "nodes": [
+                            {
+                                "blobPath": "/package.json",
+                                "dependencies": {
+                                    "pageInfo": {
+                                        "endCursor": None,
+                                        "hasNextPage": False,
+                                    },
+                                    "nodes": [],
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+        "errors": [
+            {
+                "type": "FORBIDDEN",
+                "message": "Resource not accessible by integration",
+                "path": ["organization", "repository", "dependencyGraphManifests"],
+            },
+        ],
+    }
+
+    with patch.object(
+        cartography.intel.github.repos,
+        "_fetch_manifest_page",
+        return_value=partial_page,
+    ):
+        # Act
+        with caplog.at_level(logging.WARNING, logger="cartography.intel.github.repos"):
+            result, cleanup_safe = _get_repo_dep_manifests(
+                "token",
+                "https://api.github.com/graphql",
+                "test-org",
+                "test-repo",
+            )
+
+    # Assert: the partial manifest is kept, but cleanup must not run.
+    assert result == [{"blobPath": "/package.json", "dependencies": {"nodes": []}}]
+    assert cleanup_safe is False
+    assert "the page may be incomplete" in caplog.text
+
+
 def test_get_dep_manifests_for_repos_keeps_going_after_repo_scoped_forbidden(caplog):
     """
     The dependency graph is enabled per repository and token permissions can differ

--- a/tests/unit/cartography/intel/github/test_repos.py
+++ b/tests/unit/cartography/intel/github/test_repos.py
@@ -7,6 +7,7 @@ import pytest
 import cartography.intel.github.repos
 from cartography.intel.github.repos import _build_branch_data
 from cartography.intel.github.repos import _create_git_url_from_ssh_url
+from cartography.intel.github.repos import _fetch_manifest_page
 from cartography.intel.github.repos import _get_repo_dep_manifests
 from cartography.intel.github.repos import _get_repo_rulesets_by_url
 from cartography.intel.github.repos import _merge_repos_with_privileged_details
@@ -16,6 +17,7 @@ from cartography.intel.github.repos import _transform_dependency_graph
 from cartography.intel.github.repos import _transform_dependency_manifests
 from cartography.intel.github.repos import _transform_python_requirements
 from cartography.intel.github.repos import _transform_rulesets
+from cartography.intel.github.repos import DependencyGraphForbiddenError
 from cartography.intel.github.repos import enrich_dependencies_with_lockfile_versions
 from cartography.intel.github.repos import reconcile_dependency_version_conflicts
 from cartography.intel.github.repos import transform
@@ -614,6 +616,178 @@ def test_get_dep_manifests_for_repos_marks_request_exception_unsafe_for_cleanup(
         "test-repo",
     )
     assert "Skipped dependency manifests for 1 of 1 repos" in caplog.text
+
+
+def test_fetch_manifest_page_retries_resolver_timeout_without_paying_backoff(caplog):
+    """
+    The first request for a manifest position primes GitHub's lazily-computed
+    dependency graph and the retry hits a warm result, so the first retry must not
+    sleep. Across a large org that first sleep is the bulk of the retry overhead.
+    """
+    # Arrange
+    timeout_page = {
+        "data": {"organization": {"repository": {"dependencyGraphManifests": None}}},
+        "errors": [{"message": "timedout"}],
+    }
+    success_page = {
+        "data": {
+            "organization": {
+                "repository": {
+                    "dependencyGraphManifests": {
+                        "pageInfo": {"endCursor": None, "hasNextPage": False},
+                        "nodes": [],
+                    },
+                },
+            },
+        },
+    }
+
+    with (
+        patch.object(
+            cartography.intel.github.repos,
+            "fetch_page",
+            side_effect=[timeout_page, success_page],
+        ),
+        patch.object(cartography.intel.github.repos, "handle_rate_limit_sleep"),
+        patch.object(cartography.intel.github.repos.time, "sleep") as mock_sleep,
+    ):
+        # Act
+        resp = _fetch_manifest_page(
+            "token",
+            "https://api.github.com/graphql",
+            "test-org",
+            "test-repo",
+            None,
+        )
+
+    # Assert
+    assert resp == success_page
+    mock_sleep.assert_not_called()
+
+
+def test_fetch_manifest_page_does_not_retry_forbidden():
+    # Arrange
+    forbidden_page = {
+        "data": {"organization": {"repository": {"dependencyGraphManifests": None}}},
+        "errors": [
+            {
+                "type": "FORBIDDEN",
+                "message": "Although you appear to have the correct authorization "
+                "credentials, the `test-org` organization has an IP allow list enabled.",
+            },
+        ],
+    }
+
+    with (
+        patch.object(
+            cartography.intel.github.repos,
+            "fetch_page",
+            return_value=forbidden_page,
+        ) as mock_fetch_page,
+        patch.object(cartography.intel.github.repos, "handle_rate_limit_sleep"),
+        patch.object(cartography.intel.github.repos.time, "sleep") as mock_sleep,
+    ):
+        # Act + Assert
+        with pytest.raises(DependencyGraphForbiddenError, match="IP allow list"):
+            _fetch_manifest_page(
+                "token",
+                "https://api.github.com/graphql",
+                "test-org",
+                "test-repo",
+                None,
+            )
+
+    mock_fetch_page.assert_called_once()
+    mock_sleep.assert_not_called()
+
+
+def test_get_dep_manifests_for_repos_keeps_going_after_repo_scoped_forbidden(caplog):
+    """
+    The dependency graph is enabled per repository and token permissions can differ
+    per repo, so one refusal must not cost the following repos their dependencies.
+    """
+    # Arrange
+    manifests = [{"blobPath": "/package.json", "dependencies": {"nodes": []}}]
+    repos = [
+        {"name": "repo-a", "url": "https://github.com/test-org/repo-a"},
+        {"name": "repo-b", "url": "https://github.com/test-org/repo-b"},
+        {"name": "repo-c", "url": "https://github.com/test-org/repo-c"},
+    ]
+    with patch.object(
+        cartography.intel.github.repos,
+        "_get_repo_dep_manifests",
+        side_effect=[
+            (manifests, True),
+            DependencyGraphForbiddenError("Resource not accessible by integration"),
+            (manifests, True),
+        ],
+    ) as mock_get_repo_dep_manifests:
+        # Act
+        with caplog.at_level(logging.WARNING, logger="cartography.intel.github.repos"):
+            result, cleanup_safe = (
+                cartography.intel.github.repos._get_dep_manifests_for_repos(
+                    repos,
+                    "test-org",
+                    "https://api.github.com/graphql",
+                    "token",
+                )
+            )
+
+    # Assert
+    assert mock_get_repo_dep_manifests.call_count == 3
+    assert result == {
+        "https://github.com/test-org/repo-a": {"nodes": manifests},
+        "https://github.com/test-org/repo-c": {"nodes": manifests},
+    }
+    # We could not read repo-b, so its manifests must not be cleaned up.
+    assert cleanup_safe is False
+    assert (
+        "refused the dependency graph for 1 of 3 repos in org test-org" in caplog.text
+    )
+    assert "not attempted" not in caplog.text
+
+
+def test_get_dep_manifests_for_repos_stops_the_org_on_ip_allow_list_forbidden(caplog):
+    """
+    An org-wide IP allow list refuses every repo identically, so walking the rest of
+    the batch only spends a GraphQL request per repo to be refused again.
+    """
+    # Arrange
+    manifests = [{"blobPath": "/package.json", "dependencies": {"nodes": []}}]
+    repos = [
+        {"name": "repo-a", "url": "https://github.com/test-org/repo-a"},
+        {"name": "repo-b", "url": "https://github.com/test-org/repo-b"},
+        {"name": "repo-c", "url": "https://github.com/test-org/repo-c"},
+    ]
+    with patch.object(
+        cartography.intel.github.repos,
+        "_get_repo_dep_manifests",
+        side_effect=[
+            (manifests, True),
+            DependencyGraphForbiddenError(
+                "Although you appear to have the correct authorization credentials, "
+                "the `test-org` organization has an IP allow list enabled, and "
+                "203.0.113.1 is not permitted to access this resource.",
+            ),
+        ],
+    ) as mock_get_repo_dep_manifests:
+        # Act
+        with caplog.at_level(logging.WARNING, logger="cartography.intel.github.repos"):
+            result, cleanup_safe = (
+                cartography.intel.github.repos._get_dep_manifests_for_repos(
+                    repos,
+                    "test-org",
+                    "https://api.github.com/graphql",
+                    "token",
+                )
+            )
+
+    # Assert
+    assert mock_get_repo_dep_manifests.call_count == 2
+    assert result == {"https://github.com/test-org/repo-a": {"nodes": manifests}}
+    assert cleanup_safe is False
+    assert "the remaining 1 of 3 repos in this batch were not attempted" in caplog.text
+    assert "Skipped dependency manifests" not in caplog.text
 
 
 def test_enrich_dependencies_with_lockfile_versions():


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

On a large organization, roughly a fifth of the `github.repos` sync is spent retrying GraphQL calls that then succeed. Measured over one 6.24 h sync by summing the wall time following each error response in the run's own log stream:

| error class | occurrences | wall time | share of run |
|---|---|---|---|
| `dependencyGraphManifests` `timedout` | 270 | 0.86 h | 13.9% |
| `Something went wrong while executing your query` | 106 | 0.38 h | 6.1% |
| `FORBIDDEN` (org with an IP allow list) | 4 | 0.02 h | 0.2% |
| **total** | **380** | **1.26 h** | **20.2%** |

This is a performance issue rather than a correctness one. The run contained no `GraphQL timeout ... after N retries` line, so every timeout was recovered within the 3 allowed attempts and no data was lost. The median 4.3 s gap matches the `time.sleep(2 ** (attempt + 1))` schedule in `_fetch_manifest_page()`, which confirms the time is retry overhead rather than slow-but-useful work.

GitHub computes the dependency graph lazily, so the first request for a given manifest position frequently returns HTTP 200 with null data and an error, and the retry hits a warm result. `dependencyGraphManifests(first: 1)` is already the minimum page size, so "ask for less per page" is not available: the fix is to reprice the retry, not the retry budget, which the data shows is never exhausted.

**Retry pricing** in `_fetch_manifest_page()`:

- The two retry paths no longer share one schedule. Transport errors (`Timeout`, `ConnectionError`, ...) keep the 2s/4s exponential backoff, since those are genuine network problems.
- The GraphQL resolver-timeout path uses delays of `0s` then `1s`. The retry that primes the resolver no longer waits 2 s first. Across the 376 recovered timeouts in the measured run that is roughly 12 minutes of pure sleep, and it caps the worst case per manifest position at 1 s instead of 6 s.
- Every non-zero delay gets up to +25% jitter, so a large org stops retrying in lockstep against the same resolver.
- `retries=3` is unchanged.

**FORBIDDEN handling.** A `FORBIDDEN` error was retried three times and then reported as a timeout, which it is not. It is now raised as `DependencyGraphForbiddenError` and not retried. The dependency graph is [enabled per repository](https://docs.github.com/en/code-security/concepts/supply-chain-security/dependency-graph) and token permissions can differ per repo, so a refusal skips that repo and the batch continues, with `cleanup_safe` disabled so the skipped repo's manifests are never deleted. Only the org-wide IP allow list refusal, which every repo in the org would hit identically, stops the batch early and reports how many repos went unattempted.

**Log severity.** `call_github_api()` warned on every GraphQL error before any caller had decided whether it mattered. A healthy run that recovered from every timeout still emitted several hundred `please investigate` lines, drowning the one line that actually warrants investigation. It now logs at DEBUG and returns the errors, leaving severity to the caller that knows whether the error is terminal:

- `_fetch_manifest_page()` already had the right split (DEBUG per retry, WARNING on give-up) and is unchanged in that respect.
- `fetch_all()` now warns when errors arrive alongside a usable page. Nothing retries that case, so those errors are terminal for the page and may mean it is incomplete. The null-resource case was already retried by the existing `null_resource_retry` loop.
- `get_repo_commits()` uses `fetch_page()` directly with no retry path, so it now warns for itself.


### Related issues or links

- https://docs.github.com/en/code-security/concepts/supply-chain-security/dependency-graph


### How was this tested?

- `make test_lint` passes.
- Full unit suite passes: 5092 tests.
- Three new unit tests in `tests/unit/cartography/intel/github/test_repos.py`:
  - `test_fetch_manifest_page_retries_resolver_timeout_without_paying_backoff` asserts `time.sleep` is never called when the first attempt times out and the retry succeeds.
  - `test_fetch_manifest_page_does_not_retry_forbidden` asserts one request and no sleep on a `FORBIDDEN` response.
  - `test_get_dep_manifests_for_repos_keeps_going_after_repo_scoped_forbidden` asserts a refusal on `repo-b` still lets `repo-a` and `repo-c` load their manifests, with `cleanup_safe` false.
  - `test_get_dep_manifests_for_repos_stops_the_org_on_ip_allow_list_forbidden` asserts the batch stops after the IP allow list error and reports the unattempted repos.

No real-environment sync evidence is attached: reproducing this needs an org large enough that a meaningful number of repos have an uncomputed dependency graph, which I cannot stand up on demand. The measurements above come from a production sync of such an org, and the behavior change is covered by the unit tests.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.


### Notes for reviewers

Two things worth a look:

1. **The IP allow list matcher is best-effort.** `_is_org_wide_forbidden()` tests for `"ip allow list"` in the error message. GitHub does not document the refusal wording anywhere I could find, so this rests on the message observed in practice rather than a guarantee. The failure mode is the safe one: if the wording changes, the predicate returns `False` and we fall back to walking the whole batch, which is exactly the behavior for every other `FORBIDDEN`. No data loss is possible through that path. If reviewers would rather not depend on a message string at all, dropping the short-circuit costs one fast failing request per repo in the IP-allow-list case and nothing else.

2. **Scope.** This does not address the structural cost: one GraphQL round trip per manifest per repo. The REST [SBOM endpoint](https://docs.github.com/en/rest/dependency-graph/sboms) returns a repo's whole dependency set in one response and would remove this retry path entirely, but SPDX has no per-manifest `blobPath` equivalent, so it would require redesigning `DependencyGraphManifestSchema` rather than being a drop-in swap. Left for a separate PR.

Also unaddressed: the 106 `Something went wrong while executing your query` occurrences are a GitHub server-side error distinct from the resolver timeout. They benefit from the repriced backoff here because they reach the same branch in `_fetch_manifest_page()`, but if that class can arrive on other paginated queries it may deserve a shared retry in `fetch_all()`. I did not confirm which queries produce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
