### PR TITLE
feat(runpod): add RunPod intel module

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -102,6 +102,7 @@ PANEL_RAILWAY = "Railway Options"
 PANEL_NETLIFY = "Netlify Options"
 PANEL_CIRCLECI = "CircleCI Options"
 PANEL_MODAL = "Modal Options"
+PANEL_RUNPOD = "RunPod Options"
 PANEL_SNOWFLAKE = "Snowflake Options"
 PANEL_STATSD = "StatsD Metrics"
 PANEL_ANALYSIS = "Analysis Options"
@@ -167,6 +168,7 @@ MODULE_PANELS = {
     "netlify": PANEL_NETLIFY,
     "circleci": PANEL_CIRCLECI,
     "modal": PANEL_MODAL,
+    "runpod": PANEL_RUNPOD,
     "snowflake": PANEL_SNOWFLAKE,
     "analysis": PANEL_ANALYSIS,
 }
@@ -2598,6 +2600,39 @@ class CLI:
                 ),
             ] = None,
             # =================================================================
+            # RunPod Options
+            # =================================================================
+            runpod_api_key_env_var: Annotated[
+                str | None,
+                typer.Option(
+                    "--runpod-api-key-env-var",
+                    help="Environment variable name containing a RunPod API key.",
+                    rich_help_panel=PANEL_RUNPOD,
+                    hidden=PANEL_RUNPOD not in visible_panels,
+                ),
+            ] = None,
+            runpod_account_id: Annotated[
+                str | None,
+                typer.Option(
+                    "--runpod-account-id",
+                    help=(
+                        "Stable RunPod account identifier to use as the Cartography "
+                        "tenant root."
+                    ),
+                    rich_help_panel=PANEL_RUNPOD,
+                    hidden=PANEL_RUNPOD not in visible_panels,
+                ),
+            ] = None,
+            runpod_base_url: Annotated[
+                str,
+                typer.Option(
+                    "--runpod-base-url",
+                    help="RunPod API v2 base URL.",
+                    rich_help_panel=PANEL_RUNPOD,
+                    hidden=PANEL_RUNPOD not in visible_panels,
+                ),
+            ] = "https://api.runpod.io/v2",
+            # =================================================================
             # StatsD Metrics Options
             # =================================================================
             statsd_enabled: Annotated[
@@ -3108,6 +3143,15 @@ class CLI:
                 else None
             )
 
+            # Read RunPod API key
+            runpod_api_key = None
+            if runpod_api_key_env_var:
+                logger.debug(
+                    "Reading RunPod API key from environment variable %s",
+                    runpod_api_key_env_var,
+                )
+                runpod_api_key = os.environ.get(runpod_api_key_env_var)
+
             # Read Cloudflare token
             cloudflare_token = None
             if cloudflare_token_env_var:
@@ -3560,6 +3604,9 @@ class CLI:
                 modal_token_id=modal_token_id,
                 modal_token_secret=modal_token_secret,
                 modal_environments=modal_environment_list,
+                runpod_api_key=runpod_api_key,
+                runpod_account_id=runpod_account_id,
+                runpod_base_url=runpod_base_url,
                 cloudflare_token=cloudflare_token,
                 openai_apikey=openai_apikey,
                 openai_org_id=openai_org_id,

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -327,6 +327,13 @@ class Config:
     :type modal_environments: list
     :param modal_environments: Modal environment names whose contents should be synced.
         Defaults to every environment in the workspace. Optional.
+    :type runpod_api_key: str
+    :param runpod_api_key: RunPod API key. Optional.
+    :type runpod_account_id: str
+    :param runpod_account_id: Stable RunPod account identifier to use as the
+        tenant root. Optional.
+    :type runpod_base_url: str
+    :param runpod_base_url: RunPod API v2 base URL. Optional.
     :type cloudflare_token: string
     :param cloudflare_token: Cloudflare API key. Optional.
     :type openai_apikey: string
@@ -617,6 +624,9 @@ class Config:
         modal_token_id=None,
         modal_token_secret=None,
         modal_environments=None,
+        runpod_api_key=None,
+        runpod_account_id=None,
+        runpod_base_url=None,
         cloudflare_token=None,
         openai_apikey=None,
         openai_org_id=None,
@@ -863,6 +873,9 @@ class Config:
         self.modal_token_id = modal_token_id
         self.modal_token_secret = modal_token_secret
         self.modal_environments = modal_environments
+        self.runpod_api_key = runpod_api_key
+        self.runpod_account_id = runpod_account_id
+        self.runpod_base_url = runpod_base_url
         self.cloudflare_token = cloudflare_token
         self.openai_apikey = openai_apikey
         self.openai_org_id = openai_org_id

--- a/cartography/intel/runpod/__init__.py
+++ b/cartography/intel/runpod/__init__.py
@@ -1,0 +1,100 @@
+import logging
+
+import neo4j
+
+import cartography.intel.runpod.account
+import cartography.intel.runpod.catalog
+import cartography.intel.runpod.clusters
+import cartography.intel.runpod.network_volumes
+import cartography.intel.runpod.pods
+import cartography.intel.runpod.registries
+import cartography.intel.runpod.serverless
+import cartography.intel.runpod.sshkeys
+import cartography.intel.runpod.templates
+from cartography.config import Config
+from cartography.intel.runpod.util import BASE_URL
+from cartography.intel.runpod.util import build_session
+from cartography.intel.runpod.util import safe_sync
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def start_runpod_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
+    """
+    If this module is configured, perform ingestion of RunPod inventory. Otherwise skip.
+    """
+    if not config.runpod_api_key or not config.runpod_account_id:
+        logger.info(
+            "RunPod import is not configured - skipping this module. Set "
+            "runpod_api_key and runpod_account_id to enable the RunPod sync stage.",
+        )
+        return
+
+    session = build_session(config.runpod_api_key)
+    base_url = config.runpod_base_url or BASE_URL
+    account_id = config.runpod_account_id
+    common_job_parameters = {
+        "UPDATE_TAG": config.update_tag,
+        "RUNPOD_ACCOUNT_ID": account_id,
+    }
+
+    cartography.intel.runpod.account.sync(
+        neo4j_session,
+        account_id,
+        config.update_tag,
+    )
+
+    sync_kwargs = {
+        "neo4j_session": neo4j_session,
+        "session": session,
+        "base_url": base_url,
+        "account_id": account_id,
+        "update_tag": config.update_tag,
+        "common_job_parameters": common_job_parameters,
+    }
+
+    safe_sync(
+        "SSH keys",
+        cartography.intel.runpod.sshkeys.sync,
+        required=False,
+        **sync_kwargs,
+    )
+    safe_sync(
+        "registry credentials",
+        cartography.intel.runpod.registries.sync,
+        required=False,
+        **sync_kwargs,
+    )
+    safe_sync(
+        "data centers",
+        cartography.intel.runpod.catalog.sync,
+        required=False,
+        **sync_kwargs,
+    )
+    safe_sync(
+        "network volumes",
+        cartography.intel.runpod.network_volumes.sync,
+        required=True,
+        **sync_kwargs,
+    )
+    safe_sync(
+        "templates",
+        cartography.intel.runpod.templates.sync,
+        required=True,
+        **sync_kwargs,
+    )
+    safe_sync("pods", cartography.intel.runpod.pods.sync, required=True, **sync_kwargs)
+    safe_sync(
+        "serverless endpoints",
+        cartography.intel.runpod.serverless.sync,
+        required=True,
+        **sync_kwargs,
+    )
+    safe_sync(
+        "clusters",
+        cartography.intel.runpod.clusters.sync,
+        required=True,
+        **sync_kwargs,
+    )

--- a/cartography/intel/runpod/__init__.py
+++ b/cartography/intel/runpod/__init__.py
@@ -1,6 +1,7 @@
 import logging
 
 import neo4j
+import requests
 
 import cartography.intel.runpod.account
 import cartography.intel.runpod.catalog
@@ -14,7 +15,6 @@ import cartography.intel.runpod.templates
 from cartography.config import Config
 from cartography.intel.runpod.util import BASE_URL
 from cartography.intel.runpod.util import build_session
-from cartography.intel.runpod.util import safe_sync
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -55,46 +55,36 @@ def start_runpod_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
         "common_job_parameters": common_job_parameters,
     }
 
-    safe_sync(
-        "SSH keys",
-        cartography.intel.runpod.sshkeys.sync,
-        required=False,
-        **sync_kwargs,
-    )
-    safe_sync(
-        "registry credentials",
-        cartography.intel.runpod.registries.sync,
-        required=False,
-        **sync_kwargs,
-    )
-    safe_sync(
-        "data centers",
-        cartography.intel.runpod.catalog.sync,
-        required=False,
-        **sync_kwargs,
-    )
-    safe_sync(
-        "network volumes",
-        cartography.intel.runpod.network_volumes.sync,
-        required=True,
-        **sync_kwargs,
-    )
-    safe_sync(
-        "templates",
-        cartography.intel.runpod.templates.sync,
-        required=True,
-        **sync_kwargs,
-    )
-    safe_sync("pods", cartography.intel.runpod.pods.sync, required=True, **sync_kwargs)
-    safe_sync(
-        "serverless endpoints",
-        cartography.intel.runpod.serverless.sync,
-        required=True,
-        **sync_kwargs,
-    )
-    safe_sync(
-        "clusters",
-        cartography.intel.runpod.clusters.sync,
-        required=True,
-        **sync_kwargs,
-    )
+    try:
+        cartography.intel.runpod.sshkeys.sync(**sync_kwargs)
+    except requests.exceptions.RequestException as exc:
+        logger.warning(
+            "RunPod SSH keys sync failed - skipping this resource type and its "
+            "cleanup for this run, continuing with the rest of the account sync: %s",
+            exc,
+        )
+
+    try:
+        cartography.intel.runpod.registries.sync(**sync_kwargs)
+    except requests.exceptions.RequestException as exc:
+        logger.warning(
+            "RunPod registry credentials sync failed - skipping this resource type "
+            "and its cleanup for this run, continuing with the rest of the account "
+            "sync: %s",
+            exc,
+        )
+
+    try:
+        cartography.intel.runpod.catalog.sync(**sync_kwargs)
+    except requests.exceptions.RequestException as exc:
+        logger.warning(
+            "RunPod data centers sync failed - skipping this resource type and its "
+            "cleanup for this run, continuing with the rest of the account sync: %s",
+            exc,
+        )
+
+    cartography.intel.runpod.network_volumes.sync(**sync_kwargs)
+    cartography.intel.runpod.templates.sync(**sync_kwargs)
+    cartography.intel.runpod.pods.sync(**sync_kwargs)
+    cartography.intel.runpod.serverless.sync(**sync_kwargs)
+    cartography.intel.runpod.clusters.sync(**sync_kwargs)

--- a/cartography/intel/runpod/account.py
+++ b/cartography/intel/runpod/account.py
@@ -1,0 +1,15 @@
+import neo4j
+
+from cartography.client.core.tx import load
+from cartography.models.runpod.account import RunPodAccountSchema
+from cartography.util import timeit
+
+
+@timeit
+def sync(neo4j_session: neo4j.Session, account_id: str, update_tag: int) -> None:
+    load(
+        neo4j_session,
+        RunPodAccountSchema(),
+        [{"id": account_id}],
+        lastupdated=update_tag,
+    )

--- a/cartography/intel/runpod/catalog.py
+++ b/cartography/intel/runpod/catalog.py
@@ -5,10 +5,9 @@ import requests
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
-from cartography.intel.runpod.util import first_present
-from cartography.intel.runpod.util import first_present_list
 from cartography.intel.runpod.util import get_list
 from cartography.intel.runpod.util import id_list
+from cartography.intel.runpod.util import require_list_field
 from cartography.intel.runpod.util import require_non_empty
 from cartography.models.runpod.catalog import RunPodDataCenterSchema
 from cartography.util import timeit
@@ -20,33 +19,46 @@ def get(session: requests.Session, base_url: str) -> list[dict[str, Any]]:
 
 
 def _gpu_type_ids(data_center: dict[str, Any]) -> list[str]:
-    return id_list(
-        first_present_list(data_center, "gpuTypes", "gpuAvailability"),
-        "gpuTypes",
-    )
+    if "gpuTypes" in data_center:
+        gpu_types = require_list_field(data_center, "gpuTypes")
+    elif "gpuAvailability" in data_center:
+        gpu_types = require_list_field(data_center, "gpuAvailability")
+    else:
+        gpu_types = []
+    return id_list(gpu_types, "gpuTypes")
 
 
 def transform(
     data_centers: list[dict[str, Any]], account_id: str
 ) -> list[dict[str, Any]]:
-    return [
-        {
-            "id": require_non_empty(data_center.get("id"), "data center id"),
-            "account_id": account_id,
-            "name": data_center.get("name"),
-            "location": data_center.get("location") or data_center.get("region"),
-            "country_code": data_center.get("countryCode"),
-            "gpu_type_ids": _gpu_type_ids(data_center),
-            "compliance": data_center.get("compliance") or [],
-            "volume_types": first_present_list(
-                data_center, "volumeTypes", "networkVolumeTypes"
-            ),
-            "global_networking": first_present(
-                data_center, "globalNetworking", "globalNetwork"
-            ),
-        }
-        for data_center in data_centers
-    ]
+    transformed = []
+    for data_center in data_centers:
+        if "volumeTypes" in data_center:
+            volume_types = require_list_field(data_center, "volumeTypes")
+        elif "networkVolumeTypes" in data_center:
+            volume_types = require_list_field(data_center, "networkVolumeTypes")
+        else:
+            volume_types = []
+        if "globalNetworking" in data_center:
+            global_networking = data_center["globalNetworking"]
+        elif "globalNetwork" in data_center:
+            global_networking = data_center["globalNetwork"]
+        else:
+            global_networking = None
+        transformed.append(
+            {
+                "id": require_non_empty(data_center.get("id"), "data center id"),
+                "account_id": account_id,
+                "name": data_center.get("name"),
+                "location": data_center.get("location") or data_center.get("region"),
+                "country_code": data_center.get("countryCode"),
+                "gpu_type_ids": _gpu_type_ids(data_center),
+                "compliance": data_center.get("compliance") or [],
+                "volume_types": volume_types,
+                "global_networking": global_networking,
+            }
+        )
+    return transformed
 
 
 @timeit

--- a/cartography/intel/runpod/catalog.py
+++ b/cartography/intel/runpod/catalog.py
@@ -1,0 +1,90 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.runpod.util import first_present
+from cartography.intel.runpod.util import first_present_list
+from cartography.intel.runpod.util import get_list
+from cartography.intel.runpod.util import id_list
+from cartography.intel.runpod.util import require_non_empty
+from cartography.models.runpod.catalog import RunPodDataCenterSchema
+from cartography.util import timeit
+
+
+@timeit
+def get(session: requests.Session, base_url: str) -> list[dict[str, Any]]:
+    return get_list(session, base_url, "/catalog/datacenters", ("dataCenters", "data"))
+
+
+def _gpu_type_ids(data_center: dict[str, Any]) -> list[str]:
+    return id_list(
+        first_present_list(data_center, "gpuTypes", "gpuAvailability"),
+        "gpuTypes",
+    )
+
+
+def transform(
+    data_centers: list[dict[str, Any]], account_id: str
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": require_non_empty(data_center.get("id"), "data center id"),
+            "account_id": account_id,
+            "name": data_center.get("name"),
+            "location": data_center.get("location") or data_center.get("region"),
+            "country_code": data_center.get("countryCode"),
+            "gpu_type_ids": _gpu_type_ids(data_center),
+            "compliance": data_center.get("compliance") or [],
+            "volume_types": first_present_list(
+                data_center, "volumeTypes", "networkVolumeTypes"
+            ),
+            "global_networking": first_present(
+                data_center, "globalNetworking", "globalNetwork"
+            ),
+        }
+        for data_center in data_centers
+    ]
+
+
+@timeit
+def load_data_centers(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    account_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        RunPodDataCenterSchema(),
+        data,
+        lastupdated=update_tag,
+        RUNPOD_ACCOUNT_ID=account_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(RunPodDataCenterSchema(), common_job_parameters).run(
+        neo4j_session
+    )
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    session: requests.Session,
+    base_url: str,
+    account_id: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    data_centers = get(session, base_url)
+    transformed = transform(data_centers, account_id)
+    load_data_centers(neo4j_session, transformed, account_id, update_tag)
+    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/runpod/clusters.py
+++ b/cartography/intel/runpod/clusters.py
@@ -5,7 +5,6 @@ import requests
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
-from cartography.intel.runpod.util import first_present
 from cartography.intel.runpod.util import get_list
 from cartography.intel.runpod.util import require_non_empty
 from cartography.models.runpod.cluster import RunPodClusterSchema
@@ -28,7 +27,7 @@ def _cluster_gpu_count(
     cluster: dict[str, Any],
 ) -> Any:
     if "count" in gpu:
-        return first_present(gpu, "count")
+        return gpu["count"]
     if "gpuCount" in cluster:
         return cluster.get("gpuCount")
     if "gpuCountPerPod" in compute and isinstance(pod_count, int | float):
@@ -53,15 +52,16 @@ def transform(clusters: list[dict[str, Any]], account_id: str) -> list[dict[str,
         primary_pod = _dict_or_empty(
             cluster.get("primaryPod") or cluster.get("primary")
         )
-        pod_count = (
-            first_present(pods, "count", "total")
-            if any(key in pods for key in ("count", "total"))
-            else cluster.get("podCount")
-        )
+        if "count" in pods:
+            pod_count = pods["count"]
+        elif "total" in pods:
+            pod_count = pods["total"]
+        else:
+            pod_count = cluster.get("podCount")
         if "running" in pods:
-            running_pod_count = first_present(pods, "running")
+            running_pod_count = pods["running"]
         elif "RUNNING" in by_status:
-            running_pod_count = first_present(by_status, "RUNNING")
+            running_pod_count = by_status["RUNNING"]
         else:
             running_pod_count = cluster.get("runningPodCount")
         transformed.append(

--- a/cartography/intel/runpod/clusters.py
+++ b/cartography/intel/runpod/clusters.py
@@ -63,7 +63,6 @@ def transform(clusters: list[dict[str, Any]], account_id: str) -> list[dict[str,
                 "id": require_non_empty(cluster.get("id"), "cluster id"),
                 "account_id": account_id,
                 "name": cluster.get("name"),
-                "status": cluster.get("status"),
                 "data_center_id": cluster.get("dataCenterId"),
                 "gpu_type_id": gpu.get("id")
                 or compute.get("gpuTypeId")

--- a/cartography/intel/runpod/clusters.py
+++ b/cartography/intel/runpod/clusters.py
@@ -58,6 +58,12 @@ def transform(clusters: list[dict[str, Any]], account_id: str) -> list[dict[str,
             if any(key in pods for key in ("count", "total"))
             else cluster.get("podCount")
         )
+        if "running" in pods:
+            running_pod_count = first_present(pods, "running")
+        elif "RUNNING" in by_status:
+            running_pod_count = first_present(by_status, "RUNNING")
+        else:
+            running_pod_count = cluster.get("runningPodCount")
         transformed.append(
             {
                 "id": require_non_empty(cluster.get("id"), "cluster id"),
@@ -69,11 +75,7 @@ def transform(clusters: list[dict[str, Any]], account_id: str) -> list[dict[str,
                 or cluster.get("gpuTypeId"),
                 "gpu_count": _cluster_gpu_count(gpu, compute, pod_count, cluster),
                 "pod_count": pod_count,
-                "running_pod_count": (
-                    first_present(pods, "running")
-                    if "running" in pods
-                    else by_status.get("RUNNING") or cluster.get("runningPodCount")
-                ),
+                "running_pod_count": running_pod_count,
                 "primary_pod_id": primary_pod.get("id")
                 or primary_pod.get("podId")
                 or cluster.get("primaryPodId"),

--- a/cartography/intel/runpod/clusters.py
+++ b/cartography/intel/runpod/clusters.py
@@ -1,0 +1,126 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.runpod.util import first_present
+from cartography.intel.runpod.util import get_list
+from cartography.intel.runpod.util import require_non_empty
+from cartography.models.runpod.cluster import RunPodClusterSchema
+from cartography.util import timeit
+
+
+@timeit
+def get(session: requests.Session, base_url: str) -> list[dict[str, Any]]:
+    return get_list(session, base_url, "/clusters", ("clusters", "data"))
+
+
+def _dict_or_empty(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _cluster_gpu_count(
+    gpu: dict[str, Any],
+    compute: dict[str, Any],
+    pod_count: Any,
+    cluster: dict[str, Any],
+) -> Any:
+    if "count" in gpu:
+        return first_present(gpu, "count")
+    if "gpuCount" in cluster:
+        return cluster.get("gpuCount")
+    if "gpuCountPerPod" in compute and isinstance(pod_count, int | float):
+        return compute["gpuCountPerPod"] * pod_count
+    return compute.get("gpuCountPerPod")
+
+
+def _template_id(record: dict[str, Any]) -> Any:
+    template = record.get("template")
+    if isinstance(template, dict):
+        return template.get("id")
+    return record.get("templateId") or template
+
+
+def transform(clusters: list[dict[str, Any]], account_id: str) -> list[dict[str, Any]]:
+    transformed = []
+    for cluster in clusters:
+        compute = _dict_or_empty(cluster.get("compute"))
+        gpu = _dict_or_empty(cluster.get("gpu"))
+        pods = _dict_or_empty(cluster.get("pods"))
+        by_status = _dict_or_empty(pods.get("byStatus"))
+        primary_pod = _dict_or_empty(
+            cluster.get("primaryPod") or cluster.get("primary")
+        )
+        pod_count = (
+            first_present(pods, "count", "total")
+            if any(key in pods for key in ("count", "total"))
+            else cluster.get("podCount")
+        )
+        transformed.append(
+            {
+                "id": require_non_empty(cluster.get("id"), "cluster id"),
+                "account_id": account_id,
+                "name": cluster.get("name"),
+                "status": cluster.get("status"),
+                "data_center_id": cluster.get("dataCenterId"),
+                "gpu_type_id": gpu.get("id")
+                or compute.get("gpuTypeId")
+                or cluster.get("gpuTypeId"),
+                "gpu_count": _cluster_gpu_count(gpu, compute, pod_count, cluster),
+                "pod_count": pod_count,
+                "running_pod_count": (
+                    first_present(pods, "running")
+                    if "running" in pods
+                    else by_status.get("RUNNING") or cluster.get("runningPodCount")
+                ),
+                "primary_pod_id": primary_pod.get("id")
+                or primary_pod.get("podId")
+                or cluster.get("primaryPodId"),
+                "template_id": _template_id(cluster),
+                "created_at": cluster.get("createdAt"),
+            }
+        )
+    return transformed
+
+
+@timeit
+def load_clusters(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    account_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        RunPodClusterSchema(),
+        data,
+        lastupdated=update_tag,
+        RUNPOD_ACCOUNT_ID=account_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(RunPodClusterSchema(), common_job_parameters).run(
+        neo4j_session
+    )
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    session: requests.Session,
+    base_url: str,
+    account_id: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    clusters = get(session, base_url)
+    transformed = transform(clusters, account_id)
+    load_clusters(neo4j_session, transformed, account_id, update_tag)
+    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/runpod/network_volumes.py
+++ b/cartography/intel/runpod/network_volumes.py
@@ -1,0 +1,72 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.runpod.util import get_list
+from cartography.intel.runpod.util import require_non_empty
+from cartography.models.runpod.network_volume import RunPodNetworkVolumeSchema
+from cartography.util import timeit
+
+
+@timeit
+def get(session: requests.Session, base_url: str) -> list[dict[str, Any]]:
+    return get_list(session, base_url, "/network-volumes", ("networkVolumes", "data"))
+
+
+def transform(volumes: list[dict[str, Any]], account_id: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": require_non_empty(volume.get("id"), "network volume id"),
+            "account_id": account_id,
+            "name": volume.get("name"),
+            "size": volume.get("size"),
+            "volume_type": volume.get("type"),
+            "data_center_id": volume.get("dataCenterId") or volume.get("dataCenter"),
+            "created_at": volume.get("createdAt"),
+        }
+        for volume in volumes
+    ]
+
+
+@timeit
+def load_network_volumes(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    account_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        RunPodNetworkVolumeSchema(),
+        data,
+        lastupdated=update_tag,
+        RUNPOD_ACCOUNT_ID=account_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(RunPodNetworkVolumeSchema(), common_job_parameters).run(
+        neo4j_session
+    )
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    session: requests.Session,
+    base_url: str,
+    account_id: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    volumes = get(session, base_url)
+    transformed = transform(volumes, account_id)
+    load_network_volumes(neo4j_session, transformed, account_id, update_tag)
+    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/runpod/pods.py
+++ b/cartography/intel/runpod/pods.py
@@ -5,8 +5,6 @@ import requests
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
-from cartography.intel.runpod.util import first_not_none
-from cartography.intel.runpod.util import first_present
 from cartography.intel.runpod.util import get_list
 from cartography.intel.runpod.util import require_non_empty
 from cartography.models.runpod.pod import RunPodPodSchema
@@ -75,13 +73,32 @@ def _template_id(record: dict[str, Any]) -> Any:
     return record.get("templateId") or template
 
 
-def _cpu_value(pod: dict[str, Any], *keys: str) -> Any:
+def _vcpu_count(pod: dict[str, Any]) -> Any:
     cpu = pod.get("cpu")
     if isinstance(cpu, dict):
-        value = first_not_none(cpu, *keys)
+        value = cpu.get("vcpuCount")
+        if value is None:
+            value = cpu.get("vcpu")
         if value is not None:
             return value
-    return first_not_none(pod, *keys)
+    value = pod.get("vcpuCount")
+    if value is None:
+        value = pod.get("vcpu")
+    return value
+
+
+def _memory_in_gb(pod: dict[str, Any]) -> Any:
+    cpu = pod.get("cpu")
+    if isinstance(cpu, dict):
+        value = cpu.get("memoryInGb")
+        if value is None:
+            value = cpu.get("memory")
+        if value is not None:
+            return value
+    value = pod.get("memoryInGb")
+    if value is None:
+        value = pod.get("memory")
+    return value
 
 
 @timeit
@@ -105,9 +122,21 @@ def transform(pods: list[dict[str, Any]], account_id: str) -> list[dict[str, Any
         runtime = pod.get("runtime") or {}
         global_networking = pod.get("globalNetworking") or {}
         persistent_mount = _persistent_mount(pod)
-        volume_in_gb = first_not_none(pod, "volumeInGb", "volume")
+
+        volume_in_gb = pod.get("volumeInGb")
+        if volume_in_gb is None:
+            volume_in_gb = pod.get("volume")
         if volume_in_gb is None:
             volume_in_gb = persistent_mount.get("size")
+
+        container_disk_in_gb = pod.get("containerDiskInGb")
+        if container_disk_in_gb is None:
+            container_disk_in_gb = pod.get("containerDisk")
+        if container_disk_in_gb is None:
+            container_disk_in_gb = pod.get("disk")
+
+        gpu_count = gpu["count"] if "count" in gpu else pod.get("gpuCount")
+
         transformed.append(
             {
                 "id": require_non_empty(pod.get("id"), "pod id"),
@@ -118,16 +147,10 @@ def transform(pods: list[dict[str, Any]], account_id: str) -> list[dict[str, Any
                 "machine_id": pod.get("machineId"),
                 "data_center_id": pod.get("dataCenterId"),
                 "gpu_type_id": gpu.get("id") or pod.get("gpuTypeId"),
-                "gpu_count": (
-                    first_present(gpu, "count")
-                    if "count" in gpu
-                    else pod.get("gpuCount")
-                ),
-                "vcpu_count": _cpu_value(pod, "vcpuCount", "vcpu"),
-                "memory_in_gb": _cpu_value(pod, "memoryInGb", "memory"),
-                "container_disk_in_gb": first_not_none(
-                    pod, "containerDiskInGb", "containerDisk", "disk"
-                ),
+                "gpu_count": gpu_count,
+                "vcpu_count": _vcpu_count(pod),
+                "memory_in_gb": _memory_in_gb(pod),
+                "container_disk_in_gb": container_disk_in_gb,
                 "volume_in_gb": volume_in_gb,
                 "volume_mount_path": pod.get("volumeMountPath")
                 or persistent_mount.get("path"),

--- a/cartography/intel/runpod/pods.py
+++ b/cartography/intel/runpod/pods.py
@@ -1,0 +1,186 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.runpod.util import first_not_none
+from cartography.intel.runpod.util import first_present
+from cartography.intel.runpod.util import get_list
+from cartography.intel.runpod.util import require_non_empty
+from cartography.models.runpod.pod import RunPodPodSchema
+from cartography.util import timeit
+
+
+def _port_summaries(ports: Any) -> list[str]:
+    if not isinstance(ports, list):
+        return []
+    summaries = []
+    for port in ports:
+        if isinstance(port, dict):
+            private_port = (
+                port.get("privatePort") or port.get("private") or port.get("port")
+            )
+            public_port = port.get("publicPort") or port.get("public")
+            protocol = port.get("protocol") or port.get("type")
+            summary = ":".join(
+                str(part)
+                for part in (protocol, private_port, public_port)
+                if part is not None
+            )
+            if summary:
+                summaries.append(summary)
+        elif port is not None:
+            summaries.append(str(port))
+    return summaries
+
+
+def _persistent_mount(pod: dict[str, Any]) -> dict[str, Any]:
+    mounts = pod.get("mounts") or {}
+    persistent = mounts.get("persistent") if isinstance(mounts, dict) else {}
+    return persistent if isinstance(persistent, dict) else {}
+
+
+def _network_mounts(pod: dict[str, Any]) -> list[dict[str, Any]]:
+    mounts = pod.get("mounts") or {}
+    network_mounts = mounts.get("network") if isinstance(mounts, dict) else []
+    if not isinstance(network_mounts, list):
+        return []
+    return [mount for mount in network_mounts if isinstance(mount, dict)]
+
+
+def _network_volume_id(pod: dict[str, Any]) -> Any:
+    for mount in _network_mounts(pod):
+        volume_id = mount.get("volumeId")
+        if volume_id:
+            return volume_id
+    network_volume = pod.get("networkVolume")
+    if isinstance(network_volume, dict):
+        return network_volume.get("id")
+    return pod.get("networkVolumeId")
+
+
+def _registry_id(pod: dict[str, Any]) -> Any:
+    registry = pod.get("registry")
+    if isinstance(registry, dict):
+        return registry.get("id")
+    return pod.get("containerRegistryId") or pod.get("registryId") or registry
+
+
+def _template_id(record: dict[str, Any]) -> Any:
+    template = record.get("template")
+    if isinstance(template, dict):
+        return template.get("id")
+    return record.get("templateId") or template
+
+
+def _cpu_value(pod: dict[str, Any], *keys: str) -> Any:
+    cpu = pod.get("cpu")
+    if isinstance(cpu, dict):
+        value = first_not_none(cpu, *keys)
+        if value is not None:
+            return value
+    return first_not_none(pod, *keys)
+
+
+@timeit
+def get(
+    session: requests.Session,
+    base_url: str,
+) -> list[dict[str, Any]]:
+    return get_list(
+        session,
+        base_url,
+        "/pods",
+        ("pods", "data"),
+        params={"includeClusterPods": "true"},
+    )
+
+
+def transform(pods: list[dict[str, Any]], account_id: str) -> list[dict[str, Any]]:
+    transformed = []
+    for pod in pods:
+        gpu = pod.get("gpu") or {}
+        runtime = pod.get("runtime") or {}
+        global_networking = pod.get("globalNetworking") or {}
+        persistent_mount = _persistent_mount(pod)
+        volume_in_gb = first_not_none(pod, "volumeInGb", "volume")
+        if volume_in_gb is None:
+            volume_in_gb = persistent_mount.get("size")
+        transformed.append(
+            {
+                "id": require_non_empty(pod.get("id"), "pod id"),
+                "account_id": account_id,
+                "name": pod.get("name"),
+                "status": pod.get("status"),
+                "image_name": pod.get("imageName") or pod.get("image"),
+                "machine_id": pod.get("machineId"),
+                "data_center_id": pod.get("dataCenterId"),
+                "gpu_type_id": gpu.get("id") or pod.get("gpuTypeId"),
+                "gpu_count": (
+                    first_present(gpu, "count")
+                    if "count" in gpu
+                    else pod.get("gpuCount")
+                ),
+                "vcpu_count": _cpu_value(pod, "vcpuCount", "vcpu"),
+                "memory_in_gb": _cpu_value(pod, "memoryInGb", "memory"),
+                "container_disk_in_gb": first_not_none(
+                    pod, "containerDiskInGb", "containerDisk", "disk"
+                ),
+                "volume_in_gb": volume_in_gb,
+                "volume_mount_path": pod.get("volumeMountPath")
+                or persistent_mount.get("path"),
+                "network_volume_id": _network_volume_id(pod),
+                "template_id": _template_id(pod),
+                "registry_id": _registry_id(pod),
+                "global_networking_enabled": global_networking.get("enabled"),
+                "public_ip": pod.get("publicIp") or runtime.get("publicIp"),
+                "exposed_ports": _port_summaries(pod.get("ports")),
+                "runtime_ports": _port_summaries(runtime.get("ports")),
+                "created_at": pod.get("createdAt"),
+                "started_at": pod.get("startedAt"),
+            }
+        )
+    return transformed
+
+
+@timeit
+def load_pods(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    account_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        RunPodPodSchema(),
+        data,
+        lastupdated=update_tag,
+        RUNPOD_ACCOUNT_ID=account_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(RunPodPodSchema(), common_job_parameters).run(
+        neo4j_session
+    )
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    session: requests.Session,
+    base_url: str,
+    account_id: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    pods = get(session, base_url)
+    transformed = transform(pods, account_id)
+    load_pods(neo4j_session, transformed, account_id, update_tag)
+    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/runpod/registries.py
+++ b/cartography/intel/runpod/registries.py
@@ -1,0 +1,70 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.runpod.util import get_list
+from cartography.intel.runpod.util import require_non_empty
+from cartography.models.runpod.registry import RunPodRegistryCredentialSchema
+from cartography.util import timeit
+
+
+@timeit
+def get(session: requests.Session, base_url: str) -> list[dict[str, Any]]:
+    return get_list(session, base_url, "/registries", ("registries", "data"))
+
+
+def transform(
+    registries: list[dict[str, Any]], account_id: str
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": require_non_empty(registry.get("id"), "registry credential id"),
+            "account_id": account_id,
+            "name": registry.get("name"),
+        }
+        for registry in registries
+    ]
+
+
+@timeit
+def load_registries(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    account_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        RunPodRegistryCredentialSchema(),
+        data,
+        lastupdated=update_tag,
+        RUNPOD_ACCOUNT_ID=account_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(
+        RunPodRegistryCredentialSchema(), common_job_parameters
+    ).run(neo4j_session)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    session: requests.Session,
+    base_url: str,
+    account_id: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    registries = get(session, base_url)
+    transformed = transform(registries, account_id)
+    load_registries(neo4j_session, transformed, account_id, update_tag)
+    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/runpod/serverless.py
+++ b/cartography/intel/runpod/serverless.py
@@ -6,10 +6,9 @@ import requests
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.runpod.pods import _port_summaries
-from cartography.intel.runpod.util import first_present
-from cartography.intel.runpod.util import first_present_list
 from cartography.intel.runpod.util import get_list
 from cartography.intel.runpod.util import id_list
+from cartography.intel.runpod.util import require_list_field
 from cartography.intel.runpod.util import require_non_empty
 from cartography.models.runpod.serverless import RunPodServerlessEndpointSchema
 from cartography.util import timeit
@@ -21,7 +20,12 @@ def get(session: requests.Session, base_url: str) -> list[dict[str, Any]]:
 
 
 def _gpu_type_ids(endpoint: dict[str, Any]) -> list[str]:
-    gpu_ids = first_present_list(endpoint, "gpuTypeIds", "gpuIds")
+    if "gpuTypeIds" in endpoint:
+        gpu_ids = require_list_field(endpoint, "gpuTypeIds")
+    elif "gpuIds" in endpoint:
+        gpu_ids = require_list_field(endpoint, "gpuIds")
+    else:
+        gpu_ids = []
     if gpu_ids:
         return id_list(gpu_ids, "gpuTypeIds")
     gpu = endpoint.get("gpu") or {}
@@ -33,10 +37,23 @@ def _gpu_type_ids(endpoint: dict[str, Any]) -> list[str]:
 
 
 def _network_volume_ids(endpoint: dict[str, Any]) -> list[str]:
-    return id_list(
-        first_present_list(endpoint, "networkVolumeIds", "networkVolumes"),
-        "networkVolumeIds",
-    )
+    if "networkVolumeIds" in endpoint:
+        network_volume_ids = require_list_field(endpoint, "networkVolumeIds")
+    elif "networkVolumes" in endpoint:
+        network_volume_ids = require_list_field(endpoint, "networkVolumes")
+    else:
+        network_volume_ids = []
+    return id_list(network_volume_ids, "networkVolumeIds")
+
+
+def _scaler_value(scaler: dict[str, Any], endpoint: dict[str, Any]) -> Any:
+    if "value" in scaler:
+        return scaler["value"]
+    if "queueDelay" in scaler:
+        return scaler["queueDelay"]
+    if "requestCount" in scaler:
+        return scaler["requestCount"]
+    return endpoint.get("scalerValue")
 
 
 def transform(endpoints: list[dict[str, Any]], account_id: str) -> list[dict[str, Any]]:
@@ -55,32 +72,20 @@ def transform(endpoints: list[dict[str, Any]], account_id: str) -> list[dict[str
                 "data_center_ids": endpoint.get("dataCenterIds") or [],
                 "network_volume_ids": _network_volume_ids(endpoint),
                 "workers_min": (
-                    first_present(workers, "min")
-                    if "min" in workers
-                    else endpoint.get("workersMin")
+                    workers["min"] if "min" in workers else endpoint.get("workersMin")
                 ),
                 "workers_max": (
-                    first_present(workers, "max")
-                    if "max" in workers
-                    else endpoint.get("workersMax")
+                    workers["max"] if "max" in workers else endpoint.get("workersMax")
                 ),
                 "idle_timeout": (
-                    first_present(workers, "idleTimeout")
+                    workers["idleTimeout"]
                     if "idleTimeout" in workers
                     else endpoint.get("idleTimeout")
                 ),
                 "scaler_type": (
-                    first_present(scaler, "type")
-                    if "type" in scaler
-                    else endpoint.get("scalerType")
+                    scaler["type"] if "type" in scaler else endpoint.get("scalerType")
                 ),
-                "scaler_value": (
-                    first_present(scaler, "value", "queueDelay", "requestCount")
-                    if any(
-                        key in scaler for key in ("value", "queueDelay", "requestCount")
-                    )
-                    else endpoint.get("scalerValue")
-                ),
+                "scaler_value": _scaler_value(scaler, endpoint),
                 "timeout": endpoint.get("timeout"),
                 "created_at": endpoint.get("createdAt"),
                 "ports": _port_summaries(endpoint.get("ports")),

--- a/cartography/intel/runpod/serverless.py
+++ b/cartography/intel/runpod/serverless.py
@@ -1,0 +1,130 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.runpod.pods import _port_summaries
+from cartography.intel.runpod.util import first_present
+from cartography.intel.runpod.util import first_present_list
+from cartography.intel.runpod.util import get_list
+from cartography.intel.runpod.util import id_list
+from cartography.intel.runpod.util import require_non_empty
+from cartography.models.runpod.serverless import RunPodServerlessEndpointSchema
+from cartography.util import timeit
+
+
+@timeit
+def get(session: requests.Session, base_url: str) -> list[dict[str, Any]]:
+    return get_list(session, base_url, "/serverless", ("endpoints", "data"))
+
+
+def _gpu_type_ids(endpoint: dict[str, Any]) -> list[str]:
+    gpu_ids = first_present_list(endpoint, "gpuTypeIds", "gpuIds")
+    if gpu_ids:
+        return id_list(gpu_ids, "gpuTypeIds")
+    gpu = endpoint.get("gpu") or {}
+    gpu_pools = gpu.get("pools") if isinstance(gpu, dict) else None
+    if gpu_pools:
+        return id_list(gpu_pools, "gpu.pools")
+    gpu_type_id = endpoint.get("gpuTypeId")
+    return [str(gpu_type_id)] if gpu_type_id else []
+
+
+def _network_volume_ids(endpoint: dict[str, Any]) -> list[str]:
+    return id_list(
+        first_present_list(endpoint, "networkVolumeIds", "networkVolumes"),
+        "networkVolumeIds",
+    )
+
+
+def transform(endpoints: list[dict[str, Any]], account_id: str) -> list[dict[str, Any]]:
+    transformed = []
+    for endpoint in endpoints:
+        workers = endpoint.get("workers") or {}
+        scaler = endpoint.get("scaler") or endpoint.get("scaling") or {}
+        transformed.append(
+            {
+                "id": require_non_empty(endpoint.get("id"), "serverless endpoint id"),
+                "account_id": account_id,
+                "name": endpoint.get("name"),
+                "endpoint_type": endpoint.get("type"),
+                "image_name": endpoint.get("imageName") or endpoint.get("image"),
+                "gpu_type_ids": _gpu_type_ids(endpoint),
+                "data_center_ids": endpoint.get("dataCenterIds") or [],
+                "network_volume_ids": _network_volume_ids(endpoint),
+                "workers_min": (
+                    first_present(workers, "min")
+                    if "min" in workers
+                    else endpoint.get("workersMin")
+                ),
+                "workers_max": (
+                    first_present(workers, "max")
+                    if "max" in workers
+                    else endpoint.get("workersMax")
+                ),
+                "idle_timeout": (
+                    first_present(workers, "idleTimeout")
+                    if "idleTimeout" in workers
+                    else endpoint.get("idleTimeout")
+                ),
+                "scaler_type": (
+                    first_present(scaler, "type")
+                    if "type" in scaler
+                    else endpoint.get("scalerType")
+                ),
+                "scaler_value": (
+                    first_present(scaler, "value", "queueDelay", "requestCount")
+                    if any(
+                        key in scaler for key in ("value", "queueDelay", "requestCount")
+                    )
+                    else endpoint.get("scalerValue")
+                ),
+                "timeout": endpoint.get("timeout"),
+                "created_at": endpoint.get("createdAt"),
+                "ports": _port_summaries(endpoint.get("ports")),
+            }
+        )
+    return transformed
+
+
+@timeit
+def load_serverless(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    account_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        RunPodServerlessEndpointSchema(),
+        data,
+        lastupdated=update_tag,
+        RUNPOD_ACCOUNT_ID=account_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(
+        RunPodServerlessEndpointSchema(), common_job_parameters
+    ).run(neo4j_session)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    session: requests.Session,
+    base_url: str,
+    account_id: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    endpoints = get(session, base_url)
+    transformed = transform(endpoints, account_id)
+    load_serverless(neo4j_session, transformed, account_id, update_tag)
+    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/runpod/sshkeys.py
+++ b/cartography/intel/runpod/sshkeys.py
@@ -1,0 +1,112 @@
+import base64
+import hashlib
+from collections.abc import Sequence
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.runpod.util import get_string_list
+from cartography.intel.runpod.util import require_non_empty
+from cartography.models.runpod.sshkey import RunPodSSHKeySchema
+from cartography.util import timeit
+
+
+def _fingerprint(public_key: str | None) -> str | None:
+    if not public_key:
+        return None
+    parts = public_key.split()
+    if len(parts) < 2:
+        return None
+    try:
+        raw_key = base64.b64decode(parts[1].encode("ascii"), validate=True)
+    except (ValueError, TypeError):
+        return None
+    digest = (
+        base64.b64encode(hashlib.sha256(raw_key).digest()).decode("ascii").rstrip("=")
+    )
+    return f"SHA256:{digest}"
+
+
+@timeit
+def get(session: requests.Session, base_url: str) -> list[str]:
+    return get_string_list(session, base_url, "/account/ssh-keys", ("keys",))
+
+
+def transform(
+    keys: Sequence[str | dict[str, Any]], account_id: str
+) -> list[dict[str, Any]]:
+    transformed = []
+    for key in keys:
+        public_key: str | None
+        if isinstance(key, str):
+            public_key = key
+            name = None
+            fingerprint = _fingerprint(public_key)
+            key_id = fingerprint
+            created_at = None
+        elif isinstance(key, dict):
+            public_key = key.get("publicKey")
+            name = key.get("name")
+            fingerprint = key.get("fingerprint") or _fingerprint(public_key)
+            key_id = key.get("id") or fingerprint
+            created_at = key.get("createdAt")
+        else:
+            raise ValueError(
+                f"RunPod SSH key entry must be a string or object, got "
+                f"{type(key).__name__}."
+            )
+
+        transformed.append(
+            {
+                "id": require_non_empty(key_id, "SSH key id or fingerprint"),
+                "account_id": account_id,
+                "name": name,
+                "fingerprint": fingerprint,
+                "created_at": created_at,
+            }
+        )
+    return transformed
+
+
+@timeit
+def load_ssh_keys(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    account_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        RunPodSSHKeySchema(),
+        data,
+        lastupdated=update_tag,
+        RUNPOD_ACCOUNT_ID=account_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(RunPodSSHKeySchema(), common_job_parameters).run(
+        neo4j_session
+    )
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    session: requests.Session,
+    base_url: str,
+    account_id: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    keys = get(session, base_url)
+    transformed = transform(keys, account_id)
+    load_ssh_keys(neo4j_session, transformed, account_id, update_tag)
+    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/runpod/templates.py
+++ b/cartography/intel/runpod/templates.py
@@ -6,8 +6,6 @@ import requests
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.runpod.pods import _port_summaries
-from cartography.intel.runpod.util import first_not_none
-from cartography.intel.runpod.util import first_present
 from cartography.intel.runpod.util import get_list
 from cartography.intel.runpod.util import require_non_empty
 from cartography.models.runpod.template import RunPodTemplateSchema
@@ -36,24 +34,41 @@ def transform(templates: list[dict[str, Any]], account_id: str) -> list[dict[str
     transformed = []
     for template in templates:
         persistent_mount = _persistent_mount(template)
-        volume_in_gb = first_not_none(template, "volumeInGb", "volume")
+
+        volume_in_gb = template.get("volumeInGb")
+        if volume_in_gb is None:
+            volume_in_gb = template.get("volume")
         if volume_in_gb is None:
             volume_in_gb = persistent_mount.get("size")
+
+        container_disk_in_gb = template.get("containerDiskInGb")
+        if container_disk_in_gb is None:
+            container_disk_in_gb = template.get("containerDisk")
+        if container_disk_in_gb is None:
+            container_disk_in_gb = template.get("disk")
+
+        is_public = (
+            template["isPublic"] if "isPublic" in template else template.get("public")
+        )
+        is_serverless = (
+            template["isServerless"]
+            if "isServerless" in template
+            else template.get("serverless")
+        )
+
         transformed.append(
             {
                 "id": require_non_empty(template.get("id"), "template id"),
                 "account_id": account_id,
                 "name": template.get("name"),
                 "image_name": template.get("imageName") or template.get("image"),
-                "container_disk_in_gb": first_not_none(
-                    template, "containerDiskInGb", "containerDisk", "disk"
-                ),
+                "container_disk_in_gb": container_disk_in_gb,
                 "volume_in_gb": volume_in_gb,
                 "volume_mount_path": template.get("volumeMountPath")
                 or persistent_mount.get("path"),
                 "registry_id": _registry_id(template),
-                "is_public": first_present(template, "isPublic", "public"),
-                "is_serverless": first_present(template, "isServerless", "serverless"),
+                "is_public": is_public,
+                "is_serverless": is_serverless,
                 "category": template.get("category"),
                 "start_ssh": template.get("startSsh"),
                 "start_jupyter": template.get("startJupyter"),

--- a/cartography/intel/runpod/templates.py
+++ b/cartography/intel/runpod/templates.py
@@ -1,0 +1,104 @@
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.runpod.pods import _port_summaries
+from cartography.intel.runpod.util import first_not_none
+from cartography.intel.runpod.util import first_present
+from cartography.intel.runpod.util import get_list
+from cartography.intel.runpod.util import require_non_empty
+from cartography.models.runpod.template import RunPodTemplateSchema
+from cartography.util import timeit
+
+
+def _persistent_mount(template: dict[str, Any]) -> dict[str, Any]:
+    mounts = template.get("mounts") or {}
+    persistent = mounts.get("persistent") if isinstance(mounts, dict) else {}
+    return persistent if isinstance(persistent, dict) else {}
+
+
+def _registry_id(template: dict[str, Any]) -> Any:
+    registry = template.get("registry")
+    if isinstance(registry, dict):
+        return registry.get("id")
+    return template.get("containerRegistryId") or template.get("registryId") or registry
+
+
+@timeit
+def get(session: requests.Session, base_url: str) -> list[dict[str, Any]]:
+    return get_list(session, base_url, "/templates", ("templates", "data"))
+
+
+def transform(templates: list[dict[str, Any]], account_id: str) -> list[dict[str, Any]]:
+    transformed = []
+    for template in templates:
+        persistent_mount = _persistent_mount(template)
+        volume_in_gb = first_not_none(template, "volumeInGb", "volume")
+        if volume_in_gb is None:
+            volume_in_gb = persistent_mount.get("size")
+        transformed.append(
+            {
+                "id": require_non_empty(template.get("id"), "template id"),
+                "account_id": account_id,
+                "name": template.get("name"),
+                "image_name": template.get("imageName") or template.get("image"),
+                "container_disk_in_gb": first_not_none(
+                    template, "containerDiskInGb", "containerDisk", "disk"
+                ),
+                "volume_in_gb": volume_in_gb,
+                "volume_mount_path": template.get("volumeMountPath")
+                or persistent_mount.get("path"),
+                "registry_id": _registry_id(template),
+                "is_public": first_present(template, "isPublic", "public"),
+                "is_serverless": first_present(template, "isServerless", "serverless"),
+                "category": template.get("category"),
+                "start_ssh": template.get("startSsh"),
+                "start_jupyter": template.get("startJupyter"),
+                "ports": _port_summaries(template.get("ports")),
+            }
+        )
+    return transformed
+
+
+@timeit
+def load_templates(
+    neo4j_session: neo4j.Session,
+    data: list[dict[str, Any]],
+    account_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        RunPodTemplateSchema(),
+        data,
+        lastupdated=update_tag,
+        RUNPOD_ACCOUNT_ID=account_id,
+    )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(RunPodTemplateSchema(), common_job_parameters).run(
+        neo4j_session
+    )
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    session: requests.Session,
+    base_url: str,
+    account_id: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    templates = get(session, base_url)
+    transformed = transform(templates, account_id)
+    load_templates(neo4j_session, transformed, account_id, update_tag)
+    cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/runpod/util.py
+++ b/cartography/intel/runpod/util.py
@@ -77,7 +77,7 @@ def id_list(value: Any, field_name: str) -> list[str]:
                 str(require_non_empty(entry.get("id"), f"{field_name} entry id"))
             )
         else:
-            ids.append(str(entry))
+            ids.append(str(require_non_empty(entry, f"{field_name} entry id")))
     return ids
 
 

--- a/cartography/intel/runpod/util.py
+++ b/cartography/intel/runpod/util.py
@@ -1,15 +1,10 @@
-import logging
 from typing import Any
-from typing import Callable
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
-logger = logging.getLogger(__name__)
-
 BASE_URL = "https://api.runpod.io/v2"
-SKIPPED_SYNC = object()
 
 
 def build_session(api_key: str) -> requests.Session:
@@ -31,33 +26,15 @@ def require_non_empty(value: Any, field_name: str) -> Any:
     return value
 
 
-def first_present(record: dict[str, Any], *keys: str) -> Any:
-    for key in keys:
-        if key in record:
-            return record[key]
-    return None
-
-
-def first_not_none(record: dict[str, Any], *keys: str) -> Any:
-    for key in keys:
-        value = record.get(key)
-        if value is not None:
-            return value
-    return None
-
-
-def first_present_list(record: dict[str, Any], *keys: str) -> list[Any]:
-    for key in keys:
-        if key in record:
-            value = record[key]
-            if value is None:
-                return []
-            if not isinstance(value, list):
-                raise ValueError(
-                    f"RunPod field {key!r} must be a list, got {type(value).__name__}."
-                )
-            return value
-    return []
+def require_list_field(record: dict[str, Any], key: str) -> list[Any]:
+    value = record.get(key)
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(
+            f"RunPod field {key!r} must be a list, got {type(value).__name__}."
+        )
+    return value
 
 
 def id_list(value: Any, field_name: str) -> list[str]:
@@ -171,23 +148,3 @@ def compact_json(value: Any) -> Any:
     if isinstance(value, list):
         return [compact_json(v) for v in value]
     return value
-
-
-def safe_sync(
-    name: str,
-    sync_fn: Callable[..., Any],
-    required: bool,
-    **kwargs: Any,
-) -> Any:
-    try:
-        return sync_fn(**kwargs)
-    except requests.exceptions.RequestException as exc:
-        if required:
-            raise
-        logger.warning(
-            "RunPod %s sync failed - skipping this resource type and its cleanup "
-            "for this run, continuing with the rest of the account sync: %s",
-            name,
-            exc,
-        )
-        return SKIPPED_SYNC

--- a/cartography/intel/runpod/util.py
+++ b/cartography/intel/runpod/util.py
@@ -1,0 +1,193 @@
+import logging
+from typing import Any
+from typing import Callable
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://api.runpod.io/v2"
+SKIPPED_SYNC = object()
+
+
+def build_session(api_key: str) -> requests.Session:
+    session = requests.session()
+    retry_policy = Retry(
+        total=5,
+        backoff_factor=1,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
+    session.mount("https://", HTTPAdapter(max_retries=retry_policy))
+    session.headers.update({"Authorization": f"Bearer {api_key}"})
+    return session
+
+
+def require_non_empty(value: Any, field_name: str) -> Any:
+    if value is None or value == "":
+        raise ValueError(f"RunPod record is missing required non-empty {field_name}.")
+    return value
+
+
+def first_present(record: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in record:
+            return record[key]
+    return None
+
+
+def first_not_none(record: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = record.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def first_present_list(record: dict[str, Any], *keys: str) -> list[Any]:
+    for key in keys:
+        if key in record:
+            value = record[key]
+            if value is None:
+                return []
+            if not isinstance(value, list):
+                raise ValueError(
+                    f"RunPod field {key!r} must be a list, got {type(value).__name__}."
+                )
+            return value
+    return []
+
+
+def id_list(value: Any, field_name: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(
+            f"RunPod field {field_name!r} must be a list, got {type(value).__name__}."
+        )
+
+    ids = []
+    for entry in value:
+        if entry is None:
+            continue
+        if isinstance(entry, dict):
+            ids.append(
+                str(require_non_empty(entry.get("id"), f"{field_name} entry id"))
+            )
+        else:
+            ids.append(str(entry))
+    return ids
+
+
+def _unwrap_list_response(
+    body: Any,
+    path: str,
+    list_keys: tuple[str, ...],
+) -> list[Any]:
+    if isinstance(body, list):
+        return body
+    if isinstance(body, dict):
+        for key in list_keys:
+            value = body.get(key)
+            if isinstance(value, list):
+                return value
+        raise ValueError(
+            f"RunPod API returned an object response for {path} without one of "
+            f"the expected list keys {sorted(list_keys)!r}; got keys "
+            f"{sorted(body.keys())!r}."
+        )
+    raise ValueError(
+        f"RunPod API returned a non-list response for {path}: {type(body).__name__}."
+    )
+
+
+def get_list(
+    session: requests.Session,
+    base_url: str,
+    path: str,
+    list_keys: tuple[str, ...],
+    params: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """
+    Fetch a RunPod v2 list endpoint.
+
+    RunPod's documented v2 list endpoints used by this module return a single object
+    wrapper such as {"pods": [...]} or {"networkVolumes": [...]}, with no documented
+    cursor, next-page token, or total count. Keep this as one GET until the API docs
+    expose a supported pagination contract; guessing from response keys like "cursor"
+    or "next" would risk skipped or duplicated inventory before scoped cleanup.
+    """
+    response = session.get(f"{base_url}{path}", params=params, timeout=(60, 60))
+    response.raise_for_status()
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise ValueError(f"RunPod API returned malformed JSON for {path}.") from exc
+
+    records = _unwrap_list_response(body, path, list_keys)
+
+    for record in records:
+        if not isinstance(record, dict):
+            raise ValueError(
+                f"RunPod API returned a malformed entry for {path}: expected an "
+                f"object, got {type(record).__name__}."
+            )
+    return records
+
+
+def get_string_list(
+    session: requests.Session,
+    base_url: str,
+    path: str,
+    list_keys: tuple[str, ...],
+) -> list[str]:
+    response = session.get(f"{base_url}{path}", timeout=(60, 60))
+    response.raise_for_status()
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise ValueError(f"RunPod API returned malformed JSON for {path}.") from exc
+
+    records = _unwrap_list_response(body, path, list_keys)
+
+    for record in records:
+        if not isinstance(record, str):
+            raise ValueError(
+                f"RunPod API returned a malformed entry for {path}: expected a "
+                f"string, got {type(record).__name__}."
+            )
+    return records
+
+
+def _compact_dict(value: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in value.items() if v is not None}
+
+
+def compact_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        return _compact_dict({k: compact_json(v) for k, v in value.items()})
+    if isinstance(value, list):
+        return [compact_json(v) for v in value]
+    return value
+
+
+def safe_sync(
+    name: str,
+    sync_fn: Callable[..., Any],
+    required: bool,
+    **kwargs: Any,
+) -> Any:
+    try:
+        return sync_fn(**kwargs)
+    except requests.exceptions.RequestException as exc:
+        if required:
+            raise
+        logger.warning(
+            "RunPod %s sync failed - skipping this resource type and its cleanup "
+            "for this run, continuing with the rest of the account sync: %s",
+            name,
+            exc,
+        )
+        return SKIPPED_SYNC

--- a/cartography/models/ontology/constraints_whitelist.py
+++ b/cartography/models/ontology/constraints_whitelist.py
@@ -191,6 +191,7 @@ from cartography.models.openai.adminapikey import OpenAIAdminApiKeyToSARel
 from cartography.models.openai.adminapikey import OpenAIAdminApiKeyToUserRel
 from cartography.models.openai.apikey import OpenAIApiKeyToSARel
 from cartography.models.openai.apikey import OpenAIApiKeyToUserRel
+from cartography.models.runpod.pod import RunPodPodToRegistryCredentialRel
 from cartography.models.scaleway.iam.apikey import ScalewayApiKeyToApplicationRel
 from cartography.models.scaleway.iam.apikey import ScalewayApiKeyToUserRel
 from cartography.models.scaleway.serverless.container import (
@@ -280,6 +281,9 @@ LEGACY_REL_WHITELIST: frozenset[type] = frozenset(
         # mount_method property), will be removed in v1.0.0.
         KubernetesPodToSecretVolumeRel,
         KubernetesPodToSecretEnvRel,
+        # DEPRECATED: replaced by USES_SECRET for ontology queries. Kept to
+        # preserve the provider-specific RunPod registry credential edge.
+        RunPodPodToRegistryCredentialRel,
         # DEPRECATED: replaced by MEMBER_OF, will be removed in v1.0.0.
         AWSGroupToAWSUserRel,
         AWSSSOUserToSSOGroupRel,

--- a/cartography/models/ontology/mapping/data/clusters.py
+++ b/cartography/models/ontology/mapping/data/clusters.py
@@ -271,6 +271,21 @@ CLUSTERS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "gcp_gke": gcp_gke_mapping,
     "kubernetes": kubernetes_mapping,
     "scaleway_kapsule": scaleway_kapsule_mapping,
+    "runpod": OntologyMapping(
+        module_name="runpod",
+        nodes=[
+            OntologyNodeMapping(
+                node_label="RunPodCluster",
+                fields=[
+                    OntologyFieldMapping(
+                        ontology_field="name", node_field="name", required=True
+                    ),
+                    # status: RunPod's v2 Cluster schema does not expose a
+                    # cluster lifecycle/status field.
+                ],
+            ),
+        ],
+    ),
     "snowflake": OntologyMapping(
         module_name="snowflake",
         nodes=[

--- a/cartography/models/ontology/mapping/data/computeinstance.py
+++ b/cartography/models/ontology/mapping/data/computeinstance.py
@@ -313,6 +313,15 @@ _NETLIFY_DEV_SERVER_STATE = {
     "error": "error",
 }
 
+_RUNPOD_POD_STATUS = {
+    "PROVISIONING": "pending",
+    "STARTING": "starting",
+    "RUNNING": "running",
+    "EXITED": "stopped",
+    "ERROR": "error",
+    "TERMINATED": "terminated",
+}
+
 netlify_mapping = OntologyMapping(
     module_name="netlify",
     nodes=[
@@ -341,6 +350,36 @@ netlify_mapping = OntologyMapping(
     ],
 )
 
+runpod_mapping = OntologyMapping(
+    module_name="runpod",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="RunPodPod",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                OntologyFieldMapping(
+                    ontology_field="region", node_field="data_center_id"
+                ),
+                OntologyFieldMapping(
+                    ontology_field="public_ip_address", node_field="public_ip"
+                ),
+                OntologyFieldMapping(
+                    ontology_field="created_at", node_field="created_at"
+                ),
+                OntologyFieldMapping(ontology_field="type", node_field="gpu_type_id"),
+                OntologyFieldMapping(
+                    ontology_field="state",
+                    node_field="status",
+                    special_handling="mapping",
+                    extra={"map": _RUNPOD_POD_STATUS},
+                ),
+            ],
+        ),
+    ],
+)
+
 COMPUTE_INSTANCE_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws": aws_mapping,
     "scaleway": scaleway_mapping,
@@ -348,4 +387,5 @@ COMPUTE_INSTANCE_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "gcp": gcp_mapping,
     "azure": azure_mapping,
     "netlify": netlify_mapping,
+    "runpod": runpod_mapping,
 }

--- a/cartography/models/ontology/mapping/data/computeservices.py
+++ b/cartography/models/ontology/mapping/data/computeservices.py
@@ -272,6 +272,20 @@ _SNOWFLAKE_SERVICE_STATUS = {
     "DONE": "active",
 }
 
+runpod_mapping = OntologyMapping(
+    module_name="runpod",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="RunPodServerlessEndpoint",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+            ],
+        ),
+    ],
+)
+
 COMPUTESERVICES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws_ecs": aws_ecs_mapping,
     "gcp_cloudrun_service": gcp_cloudrun_service_mapping,
@@ -281,6 +295,7 @@ COMPUTESERVICES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "railway": railway_mapping,
     "modal": modal_mapping,
     "netlify": netlify_mapping,
+    "runpod": runpod_mapping,
     "snowflake": OntologyMapping(
         module_name="snowflake",
         nodes=[

--- a/cartography/models/ontology/mapping/data/file_storage.py
+++ b/cartography/models/ontology/mapping/data/file_storage.py
@@ -83,11 +83,29 @@ modal_mapping = OntologyMapping(
     ],
 )
 
+runpod_mapping = OntologyMapping(
+    module_name="runpod",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="RunPodNetworkVolume",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+                OntologyFieldMapping(
+                    ontology_field="location", node_field="data_center_id"
+                ),
+            ],
+        ),
+    ],
+)
+
 FILE_STORAGE_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws": aws_mapping,
     "azure": azure_mapping,
     "scaleway": scaleway_mapping,
     "modal": modal_mapping,
+    "runpod": runpod_mapping,
     "snowflake": OntologyMapping(
         module_name="snowflake",
         nodes=[

--- a/cartography/models/ontology/mapping/data/secrets.py
+++ b/cartography/models/ontology/mapping/data/secrets.py
@@ -200,6 +200,20 @@ netlify_mapping = OntologyMapping(
     ],
 )
 
+runpod_mapping = OntologyMapping(
+    module_name="runpod",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="RunPodRegistryCredential",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name", node_field="name", required=True
+                ),
+            ],
+        ),
+    ],
+)
+
 SECRETS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws": aws_mapping,
     "gcp": gcp_mapping,
@@ -210,6 +224,7 @@ SECRETS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "supabase": supabase_mapping,
     "modal": modal_mapping,
     "netlify": netlify_mapping,
+    "runpod": runpod_mapping,
     "snowflake": OntologyMapping(
         module_name="snowflake",
         nodes=[

--- a/cartography/models/ontology/mapping/data/tenants.py
+++ b/cartography/models/ontology/mapping/data/tenants.py
@@ -791,6 +791,19 @@ TENANTS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     ),
     "supabase": supabase_mapping,
     "modal": modal_mapping,
+    "runpod": OntologyMapping(
+        module_name="runpod",
+        nodes=[
+            OntologyNodeMapping(
+                node_label="RunPodAccount",
+                fields=[
+                    OntologyFieldMapping(
+                        ontology_field="name", node_field="id", required=True
+                    ),
+                ],
+            ),
+        ],
+    ),
     "snowflake": OntologyMapping(
         module_name="snowflake",
         nodes=[

--- a/cartography/models/runpod/_relationships.py
+++ b/cartography/models/runpod/_relationships.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class RunPodToAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class RunPodResourceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class RunPodToAccountRel(CartographyRelSchema):
+    """Connects a RunPod account to a resource it contains."""
+
+    target_node_label: str = "RunPodAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("RUNPOD_ACCOUNT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: RunPodToAccountRelProperties = RunPodToAccountRelProperties()

--- a/cartography/models/runpod/account.py
+++ b/cartography/models/runpod/account.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+
+
+@dataclass(frozen=True)
+class RunPodAccountNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id", description="Configured stable RunPod account identifier."
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class RunPodAccountSchema(CartographyNodeSchema):
+    """
+    A RunPod account or team used as the tenant and security boundary for RunPod
+    resources.
+    """
+
+    label: str = "RunPodAccount"
+    properties: RunPodAccountNodeProperties = RunPodAccountNodeProperties()

--- a/cartography/models/runpod/account.py
+++ b/cartography/models/runpod/account.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.ontology.labels import TENANT
 
 
 @dataclass(frozen=True)
@@ -22,3 +24,4 @@ class RunPodAccountSchema(CartographyNodeSchema):
 
     label: str = "RunPodAccount"
     properties: RunPodAccountNodeProperties = RunPodAccountNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([TENANT])

--- a/cartography/models/runpod/catalog.py
+++ b/cartography/models/runpod/catalog.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.runpod._relationships import RunPodToAccountRel
+
+
+@dataclass(frozen=True)
+class RunPodDataCenterNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="ID of the RunPod data center.")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    account_id: PropertyRef = PropertyRef(
+        "account_id", description="Configured RunPod account identifier."
+    )
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="Display name of the data center."
+    )
+    location: PropertyRef = PropertyRef("location", description="Data center location.")
+    country_code: PropertyRef = PropertyRef("country_code", description="Country code.")
+    gpu_type_ids: PropertyRef = PropertyRef(
+        "gpu_type_ids", description="GPU type IDs available in this data center."
+    )
+    compliance: PropertyRef = PropertyRef(
+        "compliance", description="Compliance programs advertised for this data center."
+    )
+    volume_types: PropertyRef = PropertyRef(
+        "volume_types", description="Supported network volume types."
+    )
+    global_networking: PropertyRef = PropertyRef(
+        "global_networking", description="Whether global networking is supported."
+    )
+
+
+@dataclass(frozen=True)
+class RunPodDataCenterSchema(CartographyNodeSchema):
+    """A RunPod catalog data center visible to the configured account."""
+
+    label: str = "RunPodDataCenter"
+    properties: RunPodDataCenterNodeProperties = RunPodDataCenterNodeProperties()
+    sub_resource_relationship: RunPodToAccountRel = RunPodToAccountRel()

--- a/cartography/models/runpod/cluster.py
+++ b/cartography/models/runpod/cluster.py
@@ -1,0 +1,96 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.runpod._relationships import RunPodResourceRelProperties
+from cartography.models.runpod._relationships import RunPodToAccountRel
+
+
+@dataclass(frozen=True)
+class RunPodClusterNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="ID of the RunPod cluster.")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    account_id: PropertyRef = PropertyRef(
+        "account_id", description="Configured RunPod account identifier."
+    )
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="Display name of the cluster."
+    )
+    status: PropertyRef = PropertyRef("status", description="Current cluster status.")
+    data_center_id: PropertyRef = PropertyRef(
+        "data_center_id", extra_index=True, description="RunPod data center ID."
+    )
+    gpu_type_id: PropertyRef = PropertyRef("gpu_type_id", description="GPU type ID.")
+    gpu_count: PropertyRef = PropertyRef("gpu_count", description="Total GPU count.")
+    pod_count: PropertyRef = PropertyRef("pod_count", description="Cluster pod count.")
+    running_pod_count: PropertyRef = PropertyRef(
+        "running_pod_count", description="Running pod count."
+    )
+    primary_pod_id: PropertyRef = PropertyRef(
+        "primary_pod_id", extra_index=True, description="Primary pod ID."
+    )
+    template_id: PropertyRef = PropertyRef(
+        "template_id", extra_index=True, description="Template used by the cluster."
+    )
+    created_at: PropertyRef = PropertyRef("created_at", description="Creation time.")
+
+
+@dataclass(frozen=True)
+class RunPodClusterToPrimaryPodRel(CartographyRelSchema):
+    """Connects a cluster to its primary pod."""
+
+    target_node_label: str = "RunPodPod"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("primary_pod_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_PRIMARY"
+    properties: RunPodResourceRelProperties = RunPodResourceRelProperties()
+
+
+@dataclass(frozen=True)
+class RunPodClusterToTemplateRel(CartographyRelSchema):
+    """Connects a cluster to the template used by its pods."""
+
+    target_node_label: str = "RunPodTemplate"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("template_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_TEMPLATE"
+    properties: RunPodResourceRelProperties = RunPodResourceRelProperties()
+
+
+@dataclass(frozen=True)
+class RunPodClusterToDataCenterRel(CartographyRelSchema):
+    """Connects a cluster to the data center where it runs."""
+
+    target_node_label: str = "RunPodDataCenter"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("data_center_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RUNS_IN"
+    properties: RunPodResourceRelProperties = RunPodResourceRelProperties()
+
+
+@dataclass(frozen=True)
+class RunPodClusterSchema(CartographyNodeSchema):
+    """A RunPod cluster grouping multiple pods."""
+
+    label: str = "RunPodCluster"
+    properties: RunPodClusterNodeProperties = RunPodClusterNodeProperties()
+    sub_resource_relationship: RunPodToAccountRel = RunPodToAccountRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            RunPodClusterToPrimaryPodRel(),
+            RunPodClusterToTemplateRel(),
+            RunPodClusterToDataCenterRel(),
+        ],
+    )

--- a/cartography/models/runpod/cluster.py
+++ b/cartography/models/runpod/cluster.py
@@ -3,11 +3,13 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
 from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.ontology.labels import COMPUTE_CLUSTER
 from cartography.models.runpod._relationships import RunPodResourceRelProperties
 from cartography.models.runpod._relationships import RunPodToAccountRel
 
@@ -22,7 +24,6 @@ class RunPodClusterNodeProperties(CartographyNodeProperties):
     name: PropertyRef = PropertyRef(
         "name", extra_index=True, description="Display name of the cluster."
     )
-    status: PropertyRef = PropertyRef("status", description="Current cluster status.")
     data_center_id: PropertyRef = PropertyRef(
         "data_center_id", extra_index=True, description="RunPod data center ID."
     )
@@ -86,6 +87,7 @@ class RunPodClusterSchema(CartographyNodeSchema):
 
     label: str = "RunPodCluster"
     properties: RunPodClusterNodeProperties = RunPodClusterNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([COMPUTE_CLUSTER])
     sub_resource_relationship: RunPodToAccountRel = RunPodToAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [

--- a/cartography/models/runpod/network_volume.py
+++ b/cartography/models/runpod/network_volume.py
@@ -3,11 +3,13 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
 from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.ontology.labels import FILE_STORAGE
 from cartography.models.runpod._relationships import RunPodResourceRelProperties
 from cartography.models.runpod._relationships import RunPodToAccountRel
 
@@ -49,6 +51,7 @@ class RunPodNetworkVolumeSchema(CartographyNodeSchema):
 
     label: str = "RunPodNetworkVolume"
     properties: RunPodNetworkVolumeNodeProperties = RunPodNetworkVolumeNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([FILE_STORAGE])
     sub_resource_relationship: RunPodToAccountRel = RunPodToAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [RunPodNetworkVolumeToDataCenterRel()],

--- a/cartography/models/runpod/network_volume.py
+++ b/cartography/models/runpod/network_volume.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.runpod._relationships import RunPodResourceRelProperties
+from cartography.models.runpod._relationships import RunPodToAccountRel
+
+
+@dataclass(frozen=True)
+class RunPodNetworkVolumeNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="ID of the RunPod network volume.")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    account_id: PropertyRef = PropertyRef(
+        "account_id", description="Configured RunPod account identifier."
+    )
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="Display name of the network volume."
+    )
+    size: PropertyRef = PropertyRef("size", description="Volume size in GiB.")
+    volume_type: PropertyRef = PropertyRef("volume_type", description="Volume type.")
+    data_center_id: PropertyRef = PropertyRef(
+        "data_center_id", extra_index=True, description="RunPod data center ID."
+    )
+    created_at: PropertyRef = PropertyRef("created_at", description="Creation time.")
+
+
+@dataclass(frozen=True)
+class RunPodNetworkVolumeToDataCenterRel(CartographyRelSchema):
+    """Connects a network volume to the data center where it is available."""
+
+    target_node_label: str = "RunPodDataCenter"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("data_center_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "LOCATED_IN"
+    properties: RunPodResourceRelProperties = RunPodResourceRelProperties()
+
+
+@dataclass(frozen=True)
+class RunPodNetworkVolumeSchema(CartographyNodeSchema):
+    """A RunPod persistent network volume."""
+
+    label: str = "RunPodNetworkVolume"
+    properties: RunPodNetworkVolumeNodeProperties = RunPodNetworkVolumeNodeProperties()
+    sub_resource_relationship: RunPodToAccountRel = RunPodToAccountRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [RunPodNetworkVolumeToDataCenterRel()],
+    )

--- a/cartography/models/runpod/pod.py
+++ b/cartography/models/runpod/pod.py
@@ -3,12 +3,14 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
 from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.ontology.labels import COMPUTE_INSTANCE
 from cartography.models.runpod._relationships import RunPodResourceRelProperties
 from cartography.models.runpod._relationships import RunPodToAccountRel
 
@@ -119,6 +121,19 @@ class RunPodPodToRegistryCredentialRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class RunPodPodToSecretRel(CartographyRelSchema):
+    """Canonical ontology edge for a pod consuming a registry credential secret."""
+
+    target_node_label: str = "RunPodRegistryCredential"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("registry_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_SECRET"
+    properties: RunPodResourceRelProperties = RunPodResourceRelProperties()
+
+
+@dataclass(frozen=True)
 class RunPodPodToDataCenterRel(CartographyRelSchema):
     """Connects a pod to the data center where it runs."""
 
@@ -137,12 +152,14 @@ class RunPodPodSchema(CartographyNodeSchema):
 
     label: str = "RunPodPod"
     properties: RunPodPodNodeProperties = RunPodPodNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([COMPUTE_INSTANCE])
     sub_resource_relationship: RunPodToAccountRel = RunPodToAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [
             RunPodPodToNetworkVolumeRel(),
             RunPodPodToTemplateRel(),
             RunPodPodToRegistryCredentialRel(),
+            RunPodPodToSecretRel(),
             RunPodPodToDataCenterRel(),
         ],
     )

--- a/cartography/models/runpod/pod.py
+++ b/cartography/models/runpod/pod.py
@@ -1,0 +1,148 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.runpod._relationships import RunPodResourceRelProperties
+from cartography.models.runpod._relationships import RunPodToAccountRel
+
+
+@dataclass(frozen=True)
+class RunPodPodNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="ID of the RunPod pod.")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    account_id: PropertyRef = PropertyRef(
+        "account_id", description="Configured RunPod account identifier."
+    )
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="Display name of the pod."
+    )
+    status: PropertyRef = PropertyRef("status", description="Current pod status.")
+    image_name: PropertyRef = PropertyRef("image_name", description="Container image.")
+    machine_id: PropertyRef = PropertyRef(
+        "machine_id", description="RunPod machine ID."
+    )
+    data_center_id: PropertyRef = PropertyRef(
+        "data_center_id", extra_index=True, description="RunPod data center ID."
+    )
+    gpu_type_id: PropertyRef = PropertyRef("gpu_type_id", description="GPU type ID.")
+    gpu_count: PropertyRef = PropertyRef("gpu_count", description="Number of GPUs.")
+    vcpu_count: PropertyRef = PropertyRef("vcpu_count", description="Number of vCPUs.")
+    memory_in_gb: PropertyRef = PropertyRef(
+        "memory_in_gb", description="Memory in GiB."
+    )
+    container_disk_in_gb: PropertyRef = PropertyRef(
+        "container_disk_in_gb", description="Container disk size in GiB."
+    )
+    volume_in_gb: PropertyRef = PropertyRef(
+        "volume_in_gb", description="Persistent volume size in GiB."
+    )
+    volume_mount_path: PropertyRef = PropertyRef(
+        "volume_mount_path", description="Persistent volume mount path."
+    )
+    network_volume_id: PropertyRef = PropertyRef(
+        "network_volume_id",
+        extra_index=True,
+        description="Attached RunPod network volume ID, if any.",
+    )
+    template_id: PropertyRef = PropertyRef(
+        "template_id", extra_index=True, description="Template used by this pod."
+    )
+    registry_id: PropertyRef = PropertyRef(
+        "registry_id", extra_index=True, description="Registry credential ID, if any."
+    )
+    global_networking_enabled: PropertyRef = PropertyRef(
+        "global_networking_enabled",
+        description="Whether RunPod global networking is enabled for the pod.",
+    )
+    public_ip: PropertyRef = PropertyRef("public_ip", description="Public IP address.")
+    exposed_ports: PropertyRef = PropertyRef(
+        "exposed_ports", description="Configured exposed port summaries."
+    )
+    runtime_ports: PropertyRef = PropertyRef(
+        "runtime_ports", description="Runtime exposed port summaries."
+    )
+    created_at: PropertyRef = PropertyRef("created_at", description="Creation time.")
+    started_at: PropertyRef = PropertyRef("started_at", description="Start time.")
+
+
+@dataclass(frozen=True)
+class RunPodPodToNetworkVolumeRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class RunPodPodToNetworkVolumeRel(CartographyRelSchema):
+    """Connects a pod to its attached network volume, if any."""
+
+    target_node_label: str = "RunPodNetworkVolume"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("network_volume_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_VOLUME"
+    properties: RunPodPodToNetworkVolumeRelProperties = (
+        RunPodPodToNetworkVolumeRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class RunPodPodToTemplateRel(CartographyRelSchema):
+    """Connects a pod to the template used to create or configure it."""
+
+    target_node_label: str = "RunPodTemplate"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("template_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_TEMPLATE"
+    properties: RunPodResourceRelProperties = RunPodResourceRelProperties()
+
+
+@dataclass(frozen=True)
+class RunPodPodToRegistryCredentialRel(CartographyRelSchema):
+    """Connects a pod to the registry credential used for its image."""
+
+    target_node_label: str = "RunPodRegistryCredential"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("registry_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_REGISTRY_CREDENTIAL"
+    properties: RunPodResourceRelProperties = RunPodResourceRelProperties()
+
+
+@dataclass(frozen=True)
+class RunPodPodToDataCenterRel(CartographyRelSchema):
+    """Connects a pod to the data center where it runs."""
+
+    target_node_label: str = "RunPodDataCenter"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("data_center_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RUNS_IN"
+    properties: RunPodResourceRelProperties = RunPodResourceRelProperties()
+
+
+@dataclass(frozen=True)
+class RunPodPodSchema(CartographyNodeSchema):
+    """A RunPod pod: a GPU container workload running in a RunPod account."""
+
+    label: str = "RunPodPod"
+    properties: RunPodPodNodeProperties = RunPodPodNodeProperties()
+    sub_resource_relationship: RunPodToAccountRel = RunPodToAccountRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            RunPodPodToNetworkVolumeRel(),
+            RunPodPodToTemplateRel(),
+            RunPodPodToRegistryCredentialRel(),
+            RunPodPodToDataCenterRel(),
+        ],
+    )

--- a/cartography/models/runpod/registry.py
+++ b/cartography/models/runpod/registry.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.runpod._relationships import RunPodToAccountRel
+
+
+@dataclass(frozen=True)
+class RunPodRegistryCredentialNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id", description="ID of the RunPod registry credential."
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    account_id: PropertyRef = PropertyRef(
+        "account_id", description="Configured RunPod account identifier."
+    )
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="Display name of the registry credential."
+    )
+
+
+@dataclass(frozen=True)
+class RunPodRegistryCredentialSchema(CartographyNodeSchema):
+    """
+    A RunPod container registry credential.
+
+    Only metadata is ingested. The credential secret value is not stored.
+    """
+
+    label: str = "RunPodRegistryCredential"
+    properties: RunPodRegistryCredentialNodeProperties = (
+        RunPodRegistryCredentialNodeProperties()
+    )
+    sub_resource_relationship: RunPodToAccountRel = RunPodToAccountRel()

--- a/cartography/models/runpod/registry.py
+++ b/cartography/models/runpod/registry.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.ontology.labels import SECRET
 from cartography.models.runpod._relationships import RunPodToAccountRel
 
 
@@ -32,4 +34,5 @@ class RunPodRegistryCredentialSchema(CartographyNodeSchema):
     properties: RunPodRegistryCredentialNodeProperties = (
         RunPodRegistryCredentialNodeProperties()
     )
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([SECRET])
     sub_resource_relationship: RunPodToAccountRel = RunPodToAccountRel()

--- a/cartography/models/runpod/serverless.py
+++ b/cartography/models/runpod/serverless.py
@@ -3,11 +3,13 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
 from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.ontology.labels import COMPUTE_SERVICE
 from cartography.models.runpod._relationships import RunPodResourceRelProperties
 from cartography.models.runpod._relationships import RunPodToAccountRel
 
@@ -85,6 +87,7 @@ class RunPodServerlessEndpointSchema(CartographyNodeSchema):
     properties: RunPodServerlessEndpointNodeProperties = (
         RunPodServerlessEndpointNodeProperties()
     )
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([COMPUTE_SERVICE])
     sub_resource_relationship: RunPodToAccountRel = RunPodToAccountRel()
     other_relationships: OtherRelationships = OtherRelationships(
         [

--- a/cartography/models/runpod/serverless.py
+++ b/cartography/models/runpod/serverless.py
@@ -1,0 +1,94 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.runpod._relationships import RunPodResourceRelProperties
+from cartography.models.runpod._relationships import RunPodToAccountRel
+
+
+@dataclass(frozen=True)
+class RunPodServerlessEndpointNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id", description="ID of the RunPod serverless endpoint."
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    account_id: PropertyRef = PropertyRef(
+        "account_id", description="Configured RunPod account identifier."
+    )
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="Display name of the endpoint."
+    )
+    endpoint_type: PropertyRef = PropertyRef(
+        "endpoint_type", description="Endpoint type."
+    )
+    image_name: PropertyRef = PropertyRef("image_name", description="Container image.")
+    gpu_type_ids: PropertyRef = PropertyRef("gpu_type_ids", description="GPU type IDs.")
+    data_center_ids: PropertyRef = PropertyRef(
+        "data_center_ids", description="Allowed data center IDs."
+    )
+    network_volume_ids: PropertyRef = PropertyRef(
+        "network_volume_ids", description="Attached network volume IDs."
+    )
+    workers_min: PropertyRef = PropertyRef(
+        "workers_min", description="Minimum worker count."
+    )
+    workers_max: PropertyRef = PropertyRef(
+        "workers_max", description="Maximum worker count."
+    )
+    idle_timeout: PropertyRef = PropertyRef(
+        "idle_timeout", description="Worker idle timeout in seconds."
+    )
+    scaler_type: PropertyRef = PropertyRef("scaler_type", description="Scaler type.")
+    scaler_value: PropertyRef = PropertyRef("scaler_value", description="Scaler value.")
+    timeout: PropertyRef = PropertyRef("timeout", description="Request timeout.")
+    created_at: PropertyRef = PropertyRef("created_at", description="Creation time.")
+    ports: PropertyRef = PropertyRef("ports", description="Configured port summaries.")
+
+
+@dataclass(frozen=True)
+class RunPodServerlessEndpointToNetworkVolumeRel(CartographyRelSchema):
+    """Connects a serverless endpoint to attached network volumes."""
+
+    target_node_label: str = "RunPodNetworkVolume"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("network_volume_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_VOLUME"
+    properties: RunPodResourceRelProperties = RunPodResourceRelProperties()
+
+
+@dataclass(frozen=True)
+class RunPodServerlessEndpointToDataCenterRel(CartographyRelSchema):
+    """Connects a serverless endpoint to its allowed data centers."""
+
+    target_node_label: str = "RunPodDataCenter"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("data_center_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "RUNS_IN"
+    properties: RunPodResourceRelProperties = RunPodResourceRelProperties()
+
+
+@dataclass(frozen=True)
+class RunPodServerlessEndpointSchema(CartographyNodeSchema):
+    """A RunPod serverless endpoint and its scaling/runtime configuration."""
+
+    label: str = "RunPodServerlessEndpoint"
+    properties: RunPodServerlessEndpointNodeProperties = (
+        RunPodServerlessEndpointNodeProperties()
+    )
+    sub_resource_relationship: RunPodToAccountRel = RunPodToAccountRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            RunPodServerlessEndpointToNetworkVolumeRel(),
+            RunPodServerlessEndpointToDataCenterRel(),
+        ],
+    )

--- a/cartography/models/runpod/sshkey.py
+++ b/cartography/models/runpod/sshkey.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.runpod._relationships import RunPodToAccountRel
+
+
+@dataclass(frozen=True)
+class RunPodSSHKeyNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="Stable SSH key fingerprint or ID.")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    account_id: PropertyRef = PropertyRef(
+        "account_id", description="Configured RunPod account identifier."
+    )
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="Display name for the SSH key."
+    )
+    fingerprint: PropertyRef = PropertyRef(
+        "fingerprint", extra_index=True, description="SSH public key fingerprint."
+    )
+    created_at: PropertyRef = PropertyRef("created_at", description="Creation time.")
+
+
+@dataclass(frozen=True)
+class RunPodSSHKeySchema(CartographyNodeSchema):
+    """An SSH public key registered on a RunPod account."""
+
+    label: str = "RunPodSSHKey"
+    properties: RunPodSSHKeyNodeProperties = RunPodSSHKeyNodeProperties()
+    sub_resource_relationship: RunPodToAccountRel = RunPodToAccountRel()

--- a/cartography/models/runpod/template.py
+++ b/cartography/models/runpod/template.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.runpod._relationships import RunPodResourceRelProperties
+from cartography.models.runpod._relationships import RunPodToAccountRel
+
+
+@dataclass(frozen=True)
+class RunPodTemplateNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("id", description="ID of the RunPod template.")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    account_id: PropertyRef = PropertyRef(
+        "account_id", description="Configured RunPod account identifier."
+    )
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="Display name of the template."
+    )
+    image_name: PropertyRef = PropertyRef("image_name", description="Container image.")
+    container_disk_in_gb: PropertyRef = PropertyRef(
+        "container_disk_in_gb", description="Container disk size in GiB."
+    )
+    volume_in_gb: PropertyRef = PropertyRef(
+        "volume_in_gb", description="Persistent volume size in GiB."
+    )
+    volume_mount_path: PropertyRef = PropertyRef(
+        "volume_mount_path", description="Persistent volume mount path."
+    )
+    registry_id: PropertyRef = PropertyRef(
+        "registry_id", extra_index=True, description="Registry credential ID, if any."
+    )
+    is_public: PropertyRef = PropertyRef(
+        "is_public", description="Whether the template is public."
+    )
+    is_serverless: PropertyRef = PropertyRef(
+        "is_serverless", description="Whether the template is serverless-compatible."
+    )
+    category: PropertyRef = PropertyRef("category", description="Template category.")
+    start_ssh: PropertyRef = PropertyRef(
+        "start_ssh", description="Whether the template starts SSH."
+    )
+    start_jupyter: PropertyRef = PropertyRef(
+        "start_jupyter", description="Whether the template starts Jupyter."
+    )
+    ports: PropertyRef = PropertyRef("ports", description="Configured port summaries.")
+
+
+@dataclass(frozen=True)
+class RunPodTemplateToRegistryCredentialRel(CartographyRelSchema):
+    """Connects a template to the registry credential used for its image."""
+
+    target_node_label: str = "RunPodRegistryCredential"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("registry_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_REGISTRY_CREDENTIAL"
+    properties: RunPodResourceRelProperties = RunPodResourceRelProperties()
+
+
+@dataclass(frozen=True)
+class RunPodTemplateSchema(CartographyNodeSchema):
+    """A RunPod template used to configure pods or serverless endpoints."""
+
+    label: str = "RunPodTemplate"
+    properties: RunPodTemplateNodeProperties = RunPodTemplateNodeProperties()
+    sub_resource_relationship: RunPodToAccountRel = RunPodToAccountRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [RunPodTemplateToRegistryCredentialRel()],
+    )

--- a/cartography/sync.py
+++ b/cartography/sync.py
@@ -147,6 +147,7 @@ TOP_LEVEL_MODULES: OrderedDict[str, Callable[..., None]] = OrderedDict(
             "cartography.intel.circleci", "start_circleci_ingestion"
         ),
         "modal": _LazyStage("cartography.intel.modal", "start_modal_ingestion"),
+        "runpod": _LazyStage("cartography.intel.runpod", "start_runpod_ingestion"),
         "miradore": _LazyStage(
             "cartography.intel.miradore", "start_miradore_ingestion"
         ),

--- a/docs/root/module-list.md
+++ b/docs/root/module-list.md
@@ -43,6 +43,7 @@ modules/ontology/index
 modules/openai/index
 modules/pagerduty/index
 modules/railway/index
+modules/runpod/index
 modules/salesforce/index
 modules/scaleway/index
 modules/semgrep/index

--- a/docs/root/modules/runpod/config.md
+++ b/docs/root/modules/runpod/config.md
@@ -1,0 +1,41 @@
+# RunPod Configuration
+
+Configure a RunPod API key and a stable account identifier before running this module.
+
+## Authentication
+
+Create a RunPod API key in the RunPod console, store it in an environment variable,
+and pass the environment variable name to Cartography.
+
+## Required Permissions
+
+The configured key needs read access to the RunPod API v2 resources you want to sync.
+RunPod scoped keys can deny individual endpoints. Core inventory resources fail loudly
+on HTTP authorization or transport errors so Cartography does not clean up from an
+incomplete snapshot. Optional resources such as SSH keys, registry credentials, and
+catalog data centers skip their cleanup for that run and preserve previous graph data.
+
+## Configure Cartography
+
+| Option | Required | Description |
+| --- | --- | --- |
+| `--runpod-api-key-env-var` | Yes | Environment variable name containing the RunPod API key. |
+| `--runpod-account-id` | Yes | Stable identifier to use as the `RunPodAccount` tenant root. |
+| `--runpod-base-url` | No | RunPod API v2 base URL. Defaults to `https://api.runpod.io/v2`. |
+
+`--runpod-account-id` does not need to be a provider-internal ID. It must be stable
+and unique in your Cartography graph, for example `prod-runpod` or your RunPod team
+name.
+
+## Run Cartography
+
+```bash
+RUNPOD_API_KEY=<your-api-key> cartography \
+  --runpod-api-key-env-var RUNPOD_API_KEY \
+  --runpod-account-id prod-runpod
+```
+
+## References
+
+- [RunPod API keys](https://docs.runpod.io/get-started/api-keys)
+- [RunPod API v2 documentation](https://docs.runpod.io/api-reference-v2/overview)

--- a/docs/root/modules/runpod/index.md
+++ b/docs/root/modules/runpod/index.md
@@ -1,0 +1,14 @@
+# RunPod
+
+```{toctree}
+config
+schema
+```
+
+The RunPod module ingests account-scoped infrastructure inventory from the RunPod API
+v2. It uses `RunPodAccount` as the tenant and security boundary, with pods,
+serverless endpoints, network volumes, templates, registry credentials, clusters, SSH
+keys, and catalog data centers modeled as resources under that account.
+
+Billing and cost-center data are intentionally out of scope for the first RunPod
+module implementation.

--- a/docs/root/usage/schema.md
+++ b/docs/root/usage/schema.md
@@ -65,6 +65,7 @@ Cartography metadata schema, which is attached here to keep it out of the orphan
 - [Openai](../modules/openai/schema.md)
 - [Pagerduty](../modules/pagerduty/schema.md)
 - [Railway](../modules/railway/schema.md)
+- [RunPod](../modules/runpod/schema.md)
 - [Salesforce](../modules/salesforce/schema.md)
 - [Scaleway](../modules/scaleway/schema.md)
 - [Semgrep](../modules/semgrep/schema.md)

--- a/tests/data/runpod/data.py
+++ b/tests/data/runpod/data.py
@@ -93,7 +93,6 @@ CLUSTERS_RESPONSE = [
     {
         "id": "cluster-1",
         "name": "training-cluster",
-        "status": "RUNNING",
         "dataCenterId": "EU-SE-1",
         "gpu": {"id": "NVIDIA A100", "count": 8},
         "pods": {"count": 4, "running": 4},

--- a/tests/data/runpod/data.py
+++ b/tests/data/runpod/data.py
@@ -1,0 +1,117 @@
+TEST_ACCOUNT_ID = "runpod-test-account"
+TEST_UPDATE_TAG = 123456789
+
+SSH_KEYS_RESPONSE = [
+    "ssh-rsa AQID laptop@example",
+]
+
+REGISTRIES_RESPONSE = [
+    {
+        "id": "registry-1",
+        "name": "private-registry",
+    }
+]
+
+NETWORK_VOLUMES_RESPONSE = [
+    {
+        "id": "volume-1",
+        "name": "models",
+        "size": 100,
+        "type": "network",
+        "dataCenterId": "EU-SE-1",
+        "createdAt": "2026-08-01T00:00:00Z",
+    }
+]
+
+TEMPLATES_RESPONSE = [
+    {
+        "id": "template-1",
+        "name": "pytorch-ssh",
+        "imageName": "runpod/pytorch:latest",
+        "containerDiskInGb": 40,
+        "volumeInGb": 10,
+        "volumeMountPath": "/workspace",
+        "containerRegistryId": "registry-1",
+        "isPublic": False,
+        "serverless": False,
+        "category": "gpu",
+        "startSsh": True,
+        "startJupyter": False,
+        "ports": [{"privatePort": 22, "protocol": "tcp"}],
+        "env": {"HF_TOKEN": "discarded"},
+    }
+]
+
+PODS_RESPONSE = [
+    {
+        "id": "pod-1",
+        "name": "training-pod",
+        "status": "RUNNING",
+        "imageName": "runpod/pytorch:latest",
+        "machineId": "machine-1",
+        "dataCenterId": "EU-SE-1",
+        "gpu": {"id": "NVIDIA A100", "count": 1},
+        "cpu": {"vcpuCount": 8, "memory": 64},
+        "containerDiskInGb": 40,
+        "volumeInGb": 10,
+        "volumeMountPath": "/workspace",
+        "mounts": {"network": [{"volumeId": "volume-1", "path": "/models"}]},
+        "template": "template-1",
+        "registry": "registry-1",
+        "globalNetworking": {"enabled": True},
+        "ports": [{"privatePort": 8888, "publicPort": 12345, "protocol": "http"}],
+        "runtime": {
+            "publicIp": "203.0.113.10",
+            "ports": [{"privatePort": 22, "publicPort": 30022, "protocol": "tcp"}],
+            "ssh": {"proxy": "ssh.runpod.io:22", "direct": "203.0.113.10:30022"},
+        },
+        "createdAt": "2026-08-01T00:00:00Z",
+        "startedAt": "2026-08-01T00:05:00Z",
+    }
+]
+
+SERVERLESS_RESPONSE = [
+    {
+        "id": "endpoint-1",
+        "name": "inference",
+        "type": "serverless",
+        "imageName": "registry.example.com/inference:latest",
+        "gpuTypeIds": ["NVIDIA A40"],
+        "dataCenterIds": ["EU-SE-1"],
+        "networkVolumeIds": ["volume-1"],
+        "workers": {"min": 0, "max": 3, "idleTimeout": 5},
+        "scaler": {"type": "QUEUE_DELAY", "value": 4},
+        "timeout": 60,
+        "requestUrl": "https://api.runpod.ai/v2/endpoint-1/runsync",
+        "requestUrls": ["https://api.runpod.ai/v2/endpoint-1/run"],
+        "ports": [{"privatePort": 8080, "protocol": "http"}],
+        "createdAt": "2026-08-01T00:00:00Z",
+    }
+]
+
+CLUSTERS_RESPONSE = [
+    {
+        "id": "cluster-1",
+        "name": "training-cluster",
+        "status": "RUNNING",
+        "dataCenterId": "EU-SE-1",
+        "gpu": {"id": "NVIDIA A100", "count": 8},
+        "pods": {"count": 4, "running": 4},
+        "primaryPod": {"id": "pod-1", "sshEndpoint": "ssh.runpod.io:2200"},
+        "templateId": "template-1",
+        "createdAt": "2026-08-01T00:00:00Z",
+    }
+]
+
+DATA_CENTERS_RESPONSE = [
+    {
+        "id": "EU-SE-1",
+        "name": "EU Sweden 1",
+        "location": "Sweden",
+        "countryCode": "SE",
+        "gpuTypes": [{"id": "NVIDIA A100"}],
+        "compliance": ["ISO27001"],
+        "volumeTypes": ["network"],
+        "globalNetworking": True,
+    }
+]

--- a/tests/integration/cartography/intel/runpod/test_runpod.py
+++ b/tests/integration/cartography/intel/runpod/test_runpod.py
@@ -100,6 +100,38 @@ def test_start_runpod_ingestion(neo4j_session):
     assert check_nodes(neo4j_session, "RunPodDataCenter", ["id", "country_code"]) == {
         ("EU-SE-1", "SE"),
     }
+    assert check_nodes(neo4j_session, "Tenant", ["id", "_ont_name", "_ont_source"]) == {
+        (TEST_ACCOUNT_ID, TEST_ACCOUNT_ID, "runpod"),
+    }
+    assert check_nodes(
+        neo4j_session,
+        "ComputeInstance",
+        ["id", "_ont_name", "_ont_state", "_ont_region", "_ont_type", "_ont_source"],
+    ) == {
+        ("pod-1", "training-pod", "running", "EU-SE-1", "NVIDIA A100", "runpod"),
+    }
+    assert check_nodes(
+        neo4j_session,
+        "ComputeCluster",
+        ["id", "_ont_name", "_ont_source"],
+    ) == {
+        ("cluster-1", "training-cluster", "runpod"),
+    }
+    assert check_nodes(
+        neo4j_session,
+        "FileStorage",
+        ["id", "_ont_name", "_ont_location", "_ont_source"],
+    ) == {
+        ("volume-1", "models", "EU-SE-1", "runpod"),
+    }
+    assert check_nodes(neo4j_session, "Secret", ["id", "_ont_name", "_ont_source"]) == {
+        ("registry-1", "private-registry", "runpod"),
+    }
+    assert check_nodes(
+        neo4j_session, "ComputeService", ["id", "_ont_name", "_ont_source"]
+    ) == {
+        ("endpoint-1", "inference", "runpod"),
+    }
 
     assert check_rels(
         neo4j_session,
@@ -132,6 +164,14 @@ def test_start_runpod_ingestion(neo4j_session):
         "RunPodRegistryCredential",
         "id",
         "USES_REGISTRY_CREDENTIAL",
+    ) == {("pod-1", "registry-1")}
+    assert check_rels(
+        neo4j_session,
+        "RunPodPod",
+        "id",
+        "RunPodRegistryCredential",
+        "id",
+        "USES_SECRET",
     ) == {("pod-1", "registry-1")}
     assert check_rels(
         neo4j_session,

--- a/tests/integration/cartography/intel/runpod/test_runpod.py
+++ b/tests/integration/cartography/intel/runpod/test_runpod.py
@@ -1,0 +1,217 @@
+from unittest.mock import patch
+
+import cartography.intel.runpod
+import cartography.intel.runpod.catalog
+import cartography.intel.runpod.clusters
+import cartography.intel.runpod.network_volumes
+import cartography.intel.runpod.pods
+import cartography.intel.runpod.registries
+import cartography.intel.runpod.serverless
+import cartography.intel.runpod.sshkeys
+import cartography.intel.runpod.templates
+from cartography.config import Config
+from tests.data.runpod.data import CLUSTERS_RESPONSE
+from tests.data.runpod.data import DATA_CENTERS_RESPONSE
+from tests.data.runpod.data import NETWORK_VOLUMES_RESPONSE
+from tests.data.runpod.data import PODS_RESPONSE
+from tests.data.runpod.data import REGISTRIES_RESPONSE
+from tests.data.runpod.data import SERVERLESS_RESPONSE
+from tests.data.runpod.data import SSH_KEYS_RESPONSE
+from tests.data.runpod.data import TEMPLATES_RESPONSE
+from tests.data.runpod.data import TEST_ACCOUNT_ID
+from tests.data.runpod.data import TEST_UPDATE_TAG
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+
+def _config(update_tag: int = TEST_UPDATE_TAG) -> Config:
+    return Config(
+        neo4j_uri="bolt://localhost:7687",
+        runpod_api_key="test-api-key",
+        runpod_account_id=TEST_ACCOUNT_ID,
+        update_tag=update_tag,
+    )
+
+
+RUNPOD_PATCHES = [
+    (cartography.intel.runpod.sshkeys, "get", SSH_KEYS_RESPONSE),
+    (cartography.intel.runpod.registries, "get", REGISTRIES_RESPONSE),
+    (cartography.intel.runpod.network_volumes, "get", NETWORK_VOLUMES_RESPONSE),
+    (cartography.intel.runpod.templates, "get", TEMPLATES_RESPONSE),
+    (cartography.intel.runpod.pods, "get", PODS_RESPONSE),
+    (cartography.intel.runpod.serverless, "get", SERVERLESS_RESPONSE),
+    (cartography.intel.runpod.clusters, "get", CLUSTERS_RESPONSE),
+    (cartography.intel.runpod.catalog, "get", DATA_CENTERS_RESPONSE),
+]
+
+
+def _run_with_patches(neo4j_session, patches, update_tag: int = TEST_UPDATE_TAG):
+    patchers = [
+        patch.object(module, attr, return_value=value)
+        for module, attr, value in patches
+    ]
+    for patcher in patchers:
+        patcher.start()
+    try:
+        cartography.intel.runpod.start_runpod_ingestion(
+            neo4j_session, _config(update_tag)
+        )
+    finally:
+        for patcher in reversed(patchers):
+            patcher.stop()
+
+
+def test_start_runpod_ingestion(neo4j_session):
+    _run_with_patches(neo4j_session, RUNPOD_PATCHES)
+
+    assert check_nodes(neo4j_session, "RunPodAccount", ["id"]) == {
+        (TEST_ACCOUNT_ID,),
+    }
+    assert check_nodes(neo4j_session, "RunPodPod", ["id", "name", "status"]) == {
+        ("pod-1", "training-pod", "RUNNING"),
+    }
+    assert check_nodes(
+        neo4j_session, "RunPodServerlessEndpoint", ["id", "name", "workers_max"]
+    ) == {
+        ("endpoint-1", "inference", 3),
+    }
+    assert check_nodes(
+        neo4j_session, "RunPodNetworkVolume", ["id", "name", "size"]
+    ) == {
+        ("volume-1", "models", 100),
+    }
+    assert check_nodes(
+        neo4j_session, "RunPodTemplate", ["id", "name", "start_ssh"]
+    ) == {
+        ("template-1", "pytorch-ssh", True),
+    }
+    assert check_nodes(neo4j_session, "RunPodRegistryCredential", ["id", "name"]) == {
+        ("registry-1", "private-registry"),
+    }
+    assert check_nodes(neo4j_session, "RunPodCluster", ["id", "name", "pod_count"]) == {
+        ("cluster-1", "training-cluster", 4),
+    }
+    assert check_nodes(neo4j_session, "RunPodSSHKey", ["id", "fingerprint"]) == {
+        (
+            "SHA256:A5BYxvLAy0ksUzsKTRTvd8wPeKvMztUofYShogEc+4E",
+            "SHA256:A5BYxvLAy0ksUzsKTRTvd8wPeKvMztUofYShogEc+4E",
+        ),
+    }
+    assert check_nodes(neo4j_session, "RunPodDataCenter", ["id", "country_code"]) == {
+        ("EU-SE-1", "SE"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "RunPodAccount",
+        "id",
+        "RunPodPod",
+        "id",
+        "RESOURCE",
+    ) == {(TEST_ACCOUNT_ID, "pod-1")}
+    assert check_rels(
+        neo4j_session,
+        "RunPodPod",
+        "id",
+        "RunPodNetworkVolume",
+        "id",
+        "USES_VOLUME",
+    ) == {("pod-1", "volume-1")}
+    assert check_rels(
+        neo4j_session,
+        "RunPodPod",
+        "id",
+        "RunPodTemplate",
+        "id",
+        "USES_TEMPLATE",
+    ) == {("pod-1", "template-1")}
+    assert check_rels(
+        neo4j_session,
+        "RunPodPod",
+        "id",
+        "RunPodRegistryCredential",
+        "id",
+        "USES_REGISTRY_CREDENTIAL",
+    ) == {("pod-1", "registry-1")}
+    assert check_rels(
+        neo4j_session,
+        "RunPodPod",
+        "id",
+        "RunPodDataCenter",
+        "id",
+        "RUNS_IN",
+    ) == {("pod-1", "EU-SE-1")}
+    assert check_rels(
+        neo4j_session,
+        "RunPodTemplate",
+        "id",
+        "RunPodRegistryCredential",
+        "id",
+        "USES_REGISTRY_CREDENTIAL",
+    ) == {("template-1", "registry-1")}
+    assert check_rels(
+        neo4j_session,
+        "RunPodNetworkVolume",
+        "id",
+        "RunPodDataCenter",
+        "id",
+        "LOCATED_IN",
+    ) == {("volume-1", "EU-SE-1")}
+    assert check_rels(
+        neo4j_session,
+        "RunPodServerlessEndpoint",
+        "id",
+        "RunPodNetworkVolume",
+        "id",
+        "USES_VOLUME",
+    ) == {("endpoint-1", "volume-1")}
+    assert check_rels(
+        neo4j_session,
+        "RunPodServerlessEndpoint",
+        "id",
+        "RunPodDataCenter",
+        "id",
+        "RUNS_IN",
+    ) == {("endpoint-1", "EU-SE-1")}
+    assert check_rels(
+        neo4j_session,
+        "RunPodCluster",
+        "id",
+        "RunPodPod",
+        "id",
+        "HAS_PRIMARY",
+    ) == {("cluster-1", "pod-1")}
+    assert check_rels(
+        neo4j_session,
+        "RunPodCluster",
+        "id",
+        "RunPodTemplate",
+        "id",
+        "USES_TEMPLATE",
+    ) == {("cluster-1", "template-1")}
+    assert check_rels(
+        neo4j_session,
+        "RunPodCluster",
+        "id",
+        "RunPodDataCenter",
+        "id",
+        "RUNS_IN",
+    ) == {("cluster-1", "EU-SE-1")}
+
+
+def test_runpod_cleanup_removes_stale_resources(neo4j_session):
+    _run_with_patches(neo4j_session, RUNPOD_PATCHES)
+    empty_patches = [(module, attr, []) for module, attr, _ in RUNPOD_PATCHES]
+    _run_with_patches(neo4j_session, empty_patches, TEST_UPDATE_TAG + 1)
+
+    assert check_nodes(neo4j_session, "RunPodAccount", ["id"]) == {
+        (TEST_ACCOUNT_ID,),
+    }
+    assert check_nodes(neo4j_session, "RunPodPod", ["id"]) == set()
+    assert check_nodes(neo4j_session, "RunPodServerlessEndpoint", ["id"]) == set()
+    assert check_nodes(neo4j_session, "RunPodNetworkVolume", ["id"]) == set()
+    assert check_nodes(neo4j_session, "RunPodTemplate", ["id"]) == set()
+    assert check_nodes(neo4j_session, "RunPodRegistryCredential", ["id"]) == set()
+    assert check_nodes(neo4j_session, "RunPodCluster", ["id"]) == set()
+    assert check_nodes(neo4j_session, "RunPodSSHKey", ["id"]) == set()
+    assert check_nodes(neo4j_session, "RunPodDataCenter", ["id"]) == set()

--- a/tests/unit/cartography/intel/runpod/test_sshkeys.py
+++ b/tests/unit/cartography/intel/runpod/test_sshkeys.py
@@ -1,0 +1,73 @@
+from unittest.mock import Mock
+
+import pytest
+
+from cartography.intel.runpod.sshkeys import get
+from cartography.intel.runpod.sshkeys import transform
+
+ACCOUNT_ID = "runpod-test-account"
+PUBLIC_KEY = "ssh-rsa AQID laptop@example"
+FINGERPRINT = "SHA256:A5BYxvLAy0ksUzsKTRTvd8wPeKvMztUofYShogEc+4E"
+
+
+def _response(body):
+    mock_response = Mock()
+    mock_response.json.return_value = body
+    mock_response.raise_for_status.return_value = None
+    return mock_response
+
+
+def test_get_unwraps_documented_keys_response():
+    session = Mock()
+    session.get.return_value = _response({"keys": [PUBLIC_KEY]})
+
+    rows = get(session, "https://api.runpod.io/v2")
+
+    assert rows == [PUBLIC_KEY]
+    session.get.assert_called_once_with(
+        "https://api.runpod.io/v2/account/ssh-keys",
+        timeout=(60, 60),
+    )
+
+
+def test_transform_uses_stable_fingerprint_for_documented_string_key():
+    rows = transform([PUBLIC_KEY], ACCOUNT_ID)
+
+    assert rows == [
+        {
+            "id": FINGERPRINT,
+            "account_id": ACCOUNT_ID,
+            "name": None,
+            "fingerprint": FINGERPRINT,
+            "created_at": None,
+        }
+    ]
+
+
+def test_transform_uses_stable_fingerprint_when_object_id_is_missing():
+    rows = transform([{"publicKey": PUBLIC_KEY, "comment": "laptop"}], ACCOUNT_ID)
+
+    assert rows[0]["id"] == FINGERPRINT
+    assert rows[0]["name"] is None
+    assert rows[0]["fingerprint"] == FINGERPRINT
+
+
+def test_transform_prefers_provider_id_when_present():
+    rows = transform(
+        [
+            {
+                "id": "sshkey-1",
+                "publicKey": PUBLIC_KEY,
+                "comment": "laptop",
+            }
+        ],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["id"] == "sshkey-1"
+    assert rows[0]["fingerprint"] == FINGERPRINT
+
+
+def test_transform_rejects_key_without_id_or_valid_fingerprint():
+    with pytest.raises(ValueError):
+        transform(["not-valid"], ACCOUNT_ID)

--- a/tests/unit/cartography/intel/runpod/test_transforms.py
+++ b/tests/unit/cartography/intel/runpod/test_transforms.py
@@ -142,6 +142,13 @@ def test_serverless_transform_rejects_malformed_object_id_lists():
         transform_serverless([endpoint], ACCOUNT_ID)
 
 
+def test_serverless_transform_rejects_empty_scalar_id_lists():
+    endpoint = {"id": "endpoint-1", "gpuTypeIds": [""]}
+
+    with pytest.raises(ValueError):
+        transform_serverless([endpoint], ACCOUNT_ID)
+
+
 def test_serverless_transform_preserves_intentionally_empty_new_field():
     rows = transform_serverless(
         [
@@ -255,6 +262,36 @@ def test_cluster_transform_handles_non_object_pods_block():
     assert rows[0]["gpu_count"] == 8
     assert rows[0]["pod_count"] == 4
     assert rows[0]["running_pod_count"] == 3
+
+
+def test_cluster_transform_preserves_zero_running_pod_count():
+    rows = transform_clusters(
+        [
+            {
+                "id": "cluster-1",
+                "pods": {"total": 4, "byStatus": {"RUNNING": 0}},
+                "runningPodCount": 3,
+            }
+        ],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["running_pod_count"] == 0
+
+
+def test_cluster_transform_preserves_zero_top_level_running_pod_count():
+    rows = transform_clusters(
+        [
+            {
+                "id": "cluster-1",
+                "pods": {"total": 4, "running": 0},
+                "runningPodCount": 3,
+            }
+        ],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["running_pod_count"] == 0
 
 
 def test_catalog_transform_accepts_documented_v2_shape():

--- a/tests/unit/cartography/intel/runpod/test_transforms.py
+++ b/tests/unit/cartography/intel/runpod/test_transforms.py
@@ -226,6 +226,7 @@ def test_cluster_transform_accepts_documented_v2_shape():
     assert rows[0]["running_pod_count"] == 3
     assert rows[0]["primary_pod_id"] == "pod-1"
     assert rows[0]["template_id"] == "template-1"
+    assert "status" not in rows[0]
 
 
 def test_cluster_transform_unwraps_nested_template():

--- a/tests/unit/cartography/intel/runpod/test_transforms.py
+++ b/tests/unit/cartography/intel/runpod/test_transforms.py
@@ -1,0 +1,296 @@
+import pytest
+
+from cartography.intel.runpod.catalog import transform as transform_data_centers
+from cartography.intel.runpod.clusters import transform as transform_clusters
+from cartography.intel.runpod.pods import transform as transform_pods
+from cartography.intel.runpod.serverless import transform as transform_serverless
+from cartography.intel.runpod.templates import transform as transform_templates
+
+ACCOUNT_ID = "runpod-test-account"
+
+
+def test_pod_transform_accepts_documented_v2_shape():
+    rows = transform_pods(
+        [
+            {
+                "id": "pod-1",
+                "name": "pytorch-training",
+                "image": "runpod/pytorch:latest",
+                "disk": 50,
+                "ports": ["8888/http", "22/tcp"],
+                "registry": {"id": "registry-1"},
+                "status": "RUNNING",
+                "mounts": {
+                    "persistent": {"size": 20, "path": "/workspace"},
+                    "network": [{"volumeId": "volume-1", "path": "/models"}],
+                },
+                "gpu": {"id": "NVIDIA GeForce RTX 4090", "count": 1},
+                "cpu": {"vcpuCount": 8, "memory": 64},
+                "dataCenterId": "US-KS-2",
+                "ssh": {
+                    "proxy": {"host": "ssh.runpod.io", "command": "ssh pod"},
+                    "direct": {"host": "195.26.233.3", "command": "ssh root"},
+                },
+                "template": "template-1",
+                "runtime": {"ports": [{"private": 22, "public": 34446, "type": "tcp"}]},
+            }
+        ],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["container_disk_in_gb"] == 50
+    assert rows[0]["volume_in_gb"] == 20
+    assert rows[0]["vcpu_count"] == 8
+    assert rows[0]["memory_in_gb"] == 64
+    assert rows[0]["volume_mount_path"] == "/workspace"
+    assert rows[0]["network_volume_id"] == "volume-1"
+    assert rows[0]["registry_id"] == "registry-1"
+    assert rows[0]["runtime_ports"] == ["tcp:22:34446"]
+    assert "ssh_proxy" not in rows[0]
+    assert "ssh_direct" not in rows[0]
+
+
+def test_pod_transform_preserves_zero_numeric_values_and_unwraps_template():
+    rows = transform_pods(
+        [
+            {
+                "id": "pod-1",
+                "cpu": {"vcpuCount": 0, "memory": 0},
+                "containerDiskInGb": 0,
+                "volumeInGb": 0,
+                "template": {"id": "template-1", "name": "ignored"},
+            }
+        ],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["vcpu_count"] == 0
+    assert rows[0]["memory_in_gb"] == 0
+    assert rows[0]["container_disk_in_gb"] == 0
+    assert rows[0]["volume_in_gb"] == 0
+    assert rows[0]["template_id"] == "template-1"
+
+
+def test_pod_transform_uses_openapi_network_mount_volume_id():
+    rows = transform_pods(
+        [
+            {
+                "id": "pod-1",
+                "mounts": {
+                    "network": [{"volumeId": "volume-1", "path": "/models"}],
+                },
+            }
+        ],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["network_volume_id"] == "volume-1"
+
+
+def test_serverless_transform_accepts_documented_v2_shape():
+    rows = transform_serverless(
+        [
+            {
+                "id": "endpoint-1",
+                "name": "image-generator",
+                "type": "QUEUE",
+                "requestUrls": {
+                    "run": "https://api.runpod.ai/v2/endpoint-1/run",
+                    "runSync": "https://api.runpod.ai/v2/endpoint-1/runsync",
+                },
+                "image": "runpod/pytorch:latest",
+                "gpu": {"pools": ["ADA_24"], "count": 1},
+                "workers": {"min": 0, "max": 5, "idleTimeout": 5},
+                "scaling": {"type": "QUEUE_DELAY", "queueDelay": 4},
+                "dataCenterIds": ["US-KS-2"],
+                "networkVolumes": ["volume-1"],
+                "ports": ["8000/http"],
+            }
+        ],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["image_name"] == "runpod/pytorch:latest"
+    assert rows[0]["gpu_type_ids"] == ["ADA_24"]
+    assert rows[0]["network_volume_ids"] == ["volume-1"]
+    assert rows[0]["scaler_type"] == "QUEUE_DELAY"
+    assert rows[0]["scaler_value"] == 4
+    assert "request_url" not in rows[0]
+    assert "request_urls" not in rows[0]
+
+
+def test_serverless_transform_accepts_object_id_lists():
+    rows = transform_serverless(
+        [
+            {
+                "id": "endpoint-1",
+                "gpuTypeIds": [{"id": "ADA_24"}],
+                "networkVolumeIds": [{"id": "volume-1"}],
+            }
+        ],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["gpu_type_ids"] == ["ADA_24"]
+    assert rows[0]["network_volume_ids"] == ["volume-1"]
+
+
+def test_serverless_transform_rejects_malformed_object_id_lists():
+    endpoint = {"id": "endpoint-1", "gpuTypeIds": [{"name": "ADA_24"}]}
+
+    with pytest.raises(ValueError):
+        transform_serverless([endpoint], ACCOUNT_ID)
+
+
+def test_serverless_transform_preserves_intentionally_empty_new_field():
+    rows = transform_serverless(
+        [
+            {
+                "id": "endpoint-1",
+                "gpuTypeIds": [],
+                "gpuIds": ["legacy-gpu-id"],
+                "networkVolumeIds": [],
+                "networkVolumes": ["legacy-volume-id"],
+            }
+        ],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["gpu_type_ids"] == []
+    assert rows[0]["network_volume_ids"] == []
+
+
+def test_template_transform_accepts_documented_v2_shape():
+    rows = transform_templates(
+        [
+            {
+                "id": "template-1",
+                "name": "PyTorch GPU Template",
+                "image": "runpod/pytorch:latest",
+                "disk": 50,
+                "mounts": {"persistent": {"size": 20, "path": "/workspace"}},
+                "ports": ["8888/http"],
+                "env": {"JUPYTER_ENABLE_LAB": "yes"},
+                "registry": {"id": "registry-1"},
+                "serverless": False,
+                "public": False,
+            }
+        ],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["image_name"] == "runpod/pytorch:latest"
+    assert rows[0]["container_disk_in_gb"] == 50
+    assert rows[0]["volume_in_gb"] == 20
+    assert rows[0]["volume_mount_path"] == "/workspace"
+    assert rows[0]["registry_id"] == "registry-1"
+    assert "env_keys" not in rows[0]
+
+
+def test_template_transform_preserves_zero_numeric_values():
+    rows = transform_templates(
+        [
+            {
+                "id": "template-1",
+                "containerDiskInGb": 0,
+                "volumeInGb": 0,
+                "mounts": {"persistent": {"size": 20}},
+            }
+        ],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["container_disk_in_gb"] == 0
+    assert rows[0]["volume_in_gb"] == 0
+
+
+def test_cluster_transform_accepts_documented_v2_shape():
+    rows = transform_clusters(
+        [
+            {
+                "id": "cluster-1",
+                "name": "training-cluster",
+                "compute": {"gpuTypeId": "NVIDIA A100", "gpuCountPerPod": 2},
+                "pods": {"total": 4, "byStatus": {"RUNNING": 3}},
+                "primary": {"podId": "pod-1", "sshEndpoint": "ssh.runpod.io:2200"},
+                "template": "template-1",
+                "dataCenterId": "US-KS-2",
+            }
+        ],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["gpu_type_id"] == "NVIDIA A100"
+    assert rows[0]["gpu_count"] == 8
+    assert rows[0]["pod_count"] == 4
+    assert rows[0]["running_pod_count"] == 3
+    assert rows[0]["primary_pod_id"] == "pod-1"
+    assert rows[0]["template_id"] == "template-1"
+
+
+def test_cluster_transform_unwraps_nested_template():
+    rows = transform_clusters(
+        [{"id": "cluster-1", "template": {"id": "template-1", "name": "ignored"}}],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["template_id"] == "template-1"
+
+
+def test_cluster_transform_handles_non_object_pods_block():
+    rows = transform_clusters(
+        [
+            {
+                "id": "cluster-1",
+                "compute": {"gpuTypeId": "NVIDIA A100", "gpuCountPerPod": 2},
+                "pods": [],
+                "podCount": 4,
+                "runningPodCount": 3,
+            }
+        ],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["gpu_count"] == 8
+    assert rows[0]["pod_count"] == 4
+    assert rows[0]["running_pod_count"] == 3
+
+
+def test_catalog_transform_accepts_documented_v2_shape():
+    rows = transform_data_centers(
+        [
+            {
+                "id": "US-KS-2",
+                "name": "US Kansas 2",
+                "region": "NORTH_AMERICA",
+                "globalNetwork": True,
+                "networkVolumeTypes": ["STANDARD", "HIGH_PERFORMANCE"],
+                "compliance": ["SOC_2_TYPE_2"],
+                "gpuAvailability": [{"id": "NVIDIA GeForce RTX 4090"}],
+            }
+        ],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["location"] == "NORTH_AMERICA"
+    assert rows[0]["global_networking"] is True
+    assert rows[0]["volume_types"] == ["STANDARD", "HIGH_PERFORMANCE"]
+    assert rows[0]["gpu_type_ids"] == ["NVIDIA GeForce RTX 4090"]
+
+
+def test_catalog_transform_preserves_intentionally_empty_new_field():
+    rows = transform_data_centers(
+        [
+            {
+                "id": "US-KS-2",
+                "gpuTypes": [],
+                "gpuAvailability": [{"id": "NVIDIA GeForce RTX 4090"}],
+                "volumeTypes": [],
+                "networkVolumeTypes": ["STANDARD"],
+            }
+        ],
+        ACCOUNT_ID,
+    )
+
+    assert rows[0]["gpu_type_ids"] == []
+    assert rows[0]["volume_types"] == []

--- a/tests/unit/cartography/intel/runpod/test_util.py
+++ b/tests/unit/cartography/intel/runpod/test_util.py
@@ -1,0 +1,140 @@
+import logging
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from cartography.intel.runpod.util import get_list
+from cartography.intel.runpod.util import get_string_list
+from cartography.intel.runpod.util import require_non_empty
+from cartography.intel.runpod.util import safe_sync
+from cartography.intel.runpod.util import SKIPPED_SYNC
+
+
+def _response(body, json_exception=None):
+    mock_response = Mock()
+    if json_exception:
+        mock_response.json.side_effect = json_exception
+    else:
+        mock_response.json.return_value = body
+    mock_response.raise_for_status.return_value = None
+    return mock_response
+
+
+def test_get_list_unwraps_documented_object_list_key():
+    session = Mock()
+    session.get.return_value = _response({"pods": [{"id": "pod-1"}]})
+
+    records = get_list(session, "https://api.runpod.io/v2", "/pods", ("pods",))
+
+    assert records == [{"id": "pod-1"}]
+
+
+def test_get_list_accepts_legacy_plain_array_response():
+    session = Mock()
+    session.get.return_value = _response([{"id": "pod-1"}])
+
+    records = get_list(session, "https://api.runpod.io/v2", "/pods", ("pods",))
+
+    assert records == [{"id": "pod-1"}]
+
+
+def test_get_list_raises_on_unexpected_object_shape():
+    session = Mock()
+    session.get.return_value = _response({"error": "not a list"})
+
+    with pytest.raises(ValueError):
+        get_list(session, "https://api.runpod.io/v2", "/pods", ("pods",))
+
+
+def test_get_list_raises_on_non_object_entry():
+    session = Mock()
+    session.get.return_value = _response({"pods": ["not-an-object"]})
+
+    with pytest.raises(ValueError):
+        get_list(session, "https://api.runpod.io/v2", "/pods", ("pods",))
+
+
+def test_get_list_raises_on_malformed_json():
+    session = Mock()
+    session.get.return_value = _response(None, ValueError("bad json"))
+
+    with pytest.raises(ValueError, match="malformed JSON"):
+        get_list(session, "https://api.runpod.io/v2", "/pods", ("pods",))
+
+
+def test_get_string_list_unwraps_documented_object_string_list_key():
+    session = Mock()
+    session.get.return_value = _response({"keys": ["ssh-rsa AQID laptop@example"]})
+
+    records = get_string_list(
+        session,
+        "https://api.runpod.io/v2",
+        "/account/ssh-keys",
+        ("keys",),
+    )
+
+    assert records == ["ssh-rsa AQID laptop@example"]
+
+
+def test_get_string_list_raises_on_non_string_entry():
+    session = Mock()
+    session.get.return_value = _response({"keys": [{"id": "sshkey-1"}]})
+
+    with pytest.raises(ValueError):
+        get_string_list(
+            session,
+            "https://api.runpod.io/v2",
+            "/account/ssh-keys",
+            ("keys",),
+        )
+
+
+def test_require_non_empty_rejects_none_and_empty_string():
+    with pytest.raises(ValueError):
+        require_non_empty(None, "pod id")
+    with pytest.raises(ValueError):
+        require_non_empty("", "pod id")
+
+
+def test_safe_sync_swallows_request_exception_and_skips_cleanup(caplog):
+    def sync_fn():
+        raise requests.exceptions.HTTPError("boom")
+
+    with caplog.at_level(logging.WARNING):
+        result = safe_sync("SSH keys", sync_fn, required=False)
+
+    assert result is SKIPPED_SYNC
+    assert "SSH keys" in caplog.text
+
+
+def test_safe_sync_required_reraises_request_exception():
+    def sync_fn():
+        raise requests.exceptions.HTTPError("boom")
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        safe_sync("pods", sync_fn, required=True)
+
+
+def test_safe_sync_still_raises_on_value_error():
+    def sync_fn():
+        raise ValueError("RunPod record is missing required non-empty pod id.")
+
+    with pytest.raises(ValueError):
+        safe_sync("pods", sync_fn, required=False)
+
+
+def test_get_list_does_not_invent_undocumented_pagination():
+    session = Mock()
+    session.get.return_value = _response(
+        {
+            "pods": [{"id": "pod-1"}],
+            "cursor": "opaque",
+            "next": "https://api.runpod.io/v2/pods?page=2",
+        }
+    )
+
+    records = get_list(session, "https://api.runpod.io/v2", "/pods", ("pods",))
+
+    assert records == [{"id": "pod-1"}]
+    assert session.get.call_count == 1

--- a/tests/unit/cartography/intel/runpod/test_util.py
+++ b/tests/unit/cartography/intel/runpod/test_util.py
@@ -1,14 +1,10 @@
-import logging
 from unittest.mock import Mock
 
 import pytest
-import requests
 
 from cartography.intel.runpod.util import get_list
 from cartography.intel.runpod.util import get_string_list
 from cartography.intel.runpod.util import require_non_empty
-from cartography.intel.runpod.util import safe_sync
-from cartography.intel.runpod.util import SKIPPED_SYNC
 
 
 def _response(body, json_exception=None):
@@ -95,33 +91,6 @@ def test_require_non_empty_rejects_none_and_empty_string():
         require_non_empty(None, "pod id")
     with pytest.raises(ValueError):
         require_non_empty("", "pod id")
-
-
-def test_safe_sync_swallows_request_exception_and_skips_cleanup(caplog):
-    def sync_fn():
-        raise requests.exceptions.HTTPError("boom")
-
-    with caplog.at_level(logging.WARNING):
-        result = safe_sync("SSH keys", sync_fn, required=False)
-
-    assert result is SKIPPED_SYNC
-    assert "SSH keys" in caplog.text
-
-
-def test_safe_sync_required_reraises_request_exception():
-    def sync_fn():
-        raise requests.exceptions.HTTPError("boom")
-
-    with pytest.raises(requests.exceptions.HTTPError):
-        safe_sync("pods", sync_fn, required=True)
-
-
-def test_safe_sync_still_raises_on_value_error():
-    def sync_fn():
-        raise ValueError("RunPod record is missing required non-empty pod id.")
-
-    with pytest.raises(ValueError):
-        safe_sync("pods", sync_fn, required=False)
 
 
 def test_get_list_does_not_invent_undocumented_pagination():

--- a/tests/unit/cartography/models/test_schema_docs.py
+++ b/tests/unit/cartography/models/test_schema_docs.py
@@ -286,6 +286,23 @@ def test_every_generated_module_renders_documented_content():
         assert "No description provided." not in page, module
 
 
+def test_runpod_generated_schema_documents_ontology_mappings():
+    # Arrange
+    model = inspect_data_model()
+
+    # Act
+    generated = render_module_schema(model, "runpod")
+
+    # Assert
+    assert "> **Ontology Mapping**: This node uses the ontology label" in generated
+    assert "RunPodPod" in generated
+    assert "[`ComputeInstance`](#ontology-computeinstance)" in generated
+    assert "RunPodRegistryCredential" in generated
+    assert "[`Secret`](#ontology-secret)" in generated
+    assert "RunPodServerlessEndpoint" in generated
+    assert "[`ComputeService`](#ontology-computeservice)" in generated
+
+
 def test_write_schema_docs_overwrites_every_generated_page(tmp_path: Path):
     # Arrange
     model = inspect_data_model(lastpass_models)


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Adds a `runpod` intel module for ingesting RunPod inventory from the RunPod v2 REST API (`https://api.runpod.io/v2`). The module authenticates with a RunPod API key supplied via `--runpod-api-key-env-var` and scopes ingestion to a stable account label supplied via `--runpod-account-id`.

`--runpod-account-id` is intentionally configured by the operator rather than fetched from RunPod. The public RunPod v2 docs do not expose a reliable current-account/team endpoint, so the configured value is used as the `RunPodAccount` tenant root and cleanup scope.

Synced nodes:

| Area | Nodes |
| --- | --- |
| Tenant root | `RunPodAccount` |
| Access / identity-adjacent metadata | `RunPodSSHKey`, `RunPodRegistryCredential` |
| Catalog / placement | `RunPodDataCenter` |
| Storage | `RunPodNetworkVolume` |
| Runtime definitions | `RunPodTemplate` |
| Compute workloads | `RunPodPod`, `RunPodCluster` |
| Serverless | `RunPodServerlessEndpoint` |

Graph relationships include:

- `RunPodAccount -[:RESOURCE]->` every RunPod resource type.
- `RunPodPod -[:USES_VOLUME]-> RunPodNetworkVolume`.
- `RunPodServerlessEndpoint -[:USES_VOLUME]-> RunPodNetworkVolume`.
- `RunPodPod -[:USES_TEMPLATE]-> RunPodTemplate`.
- `RunPodCluster -[:USES_TEMPLATE]-> RunPodTemplate`.
- `RunPodPod -[:USES_REGISTRY_CREDENTIAL]-> RunPodRegistryCredential`.
- `RunPodPod -[:USES_SECRET]-> RunPodRegistryCredential` for canonical ontology secret-consumption queries.
- `RunPodTemplate -[:USES_REGISTRY_CREDENTIAL]-> RunPodRegistryCredential`.
- `RunPodPod -[:RUNS_IN]-> RunPodDataCenter`.
- `RunPodCluster -[:RUNS_IN]-> RunPodDataCenter`.
- `RunPodServerlessEndpoint -[:RUNS_IN]-> RunPodDataCenter`.
- `RunPodNetworkVolume -[:LOCATED_IN]-> RunPodDataCenter`.
- `RunPodCluster -[:HAS_PRIMARY]-> RunPodPod`.

Core resources (`network volumes`, `templates`, `pods`, `serverless endpoints`, `clusters`) fail loudly on fetch errors so Cartography does not clean up from an incomplete inventory snapshot. Optional/enrichment resources (`SSH keys`, `registry credentials`, `catalog data centers`) preserve previous graph data by skipping cleanup when those endpoints are unavailable or denied by a scoped key.

Secret material is intentionally not ingested:

- `RunPodSSHKey` stores a deterministic SHA-256 fingerprint only; raw public keys, private keys, and authorized-keys comments are not stored.
- `RunPodRegistryCredential` stores only metadata returned by the list endpoint; password/credential values are not returned by the API and are not modeled.
- Template env var names and values are not stored.
- Pod SSH command/proxy endpoint strings and cluster SSH endpoint strings are not stored.
- Serverless invocation URLs are not stored.


### Ontology / Schema Notes

This RunPod module uses Cartography declarative `CartographyNodeSchema` / `CartographyRelSchema` models with `RunPodAccount` as the tenant cleanup root.

It also adds shared semantic ontology labels and mappings for the RunPod resources that have clear cross-provider equivalents:

| RunPod node | Semantic ontology label | Notes |
| --- | --- | --- |
| `RunPodAccount` | `Tenant` | Configured account/tenant root for cleanup and scoping. |
| `RunPodPod` | `ComputeInstance` | A concrete RunPod pod workload; status is normalized to `_ont_state`. |
| `RunPodCluster` | `ComputeCluster` | Cluster/pod-group resource; RunPod v2 does not expose a cluster lifecycle status field. |
| `RunPodNetworkVolume` | `FileStorage` | Network volume that can be mounted by workloads and shared across pods/workers. |
| `RunPodRegistryCredential` | `Secret` | Metadata-only registry credential; no secret value is ingested. |
| `RunPodServerlessEndpoint` | `ComputeService` | Managed serverless endpoint/workload surface. |

The provider-specific `USES_REGISTRY_CREDENTIAL` edge is preserved for backward compatibility, and `RunPodPod -[:USES_SECRET]-> RunPodRegistryCredential` is added as the canonical ontology edge for `ComputeInstance -> Secret` queries.


### Related issues or links

- RunPod API keys: https://docs.runpod.io/get-started/api-keys
- RunPod API v2 documentation: https://docs.runpod.io/api-reference-v2/overview


### Breaking changes

None.


### How was this tested?

Automated checks:

```bash
uv run pytest tests/unit/cartography/intel/runpod
uv run pytest tests/unit/cartography/graph/test_model.py::test_sub_resource_relationship tests/unit/cartography/graph/test_ontology_rel_constraints.py tests/unit/cartography/intel/ontology
NEO4J_URL=bolt://localhost:7687 uv run pytest tests/integration/cartography/intel/runpod
uv run python -m compileall cartography/intel/runpod cartography/models/runpod cartography/models/ontology tests/unit/cartography/intel/runpod tests/integration/cartography/intel/runpod
uv run --group doc ./docs/build.sh
git diff --check
```

Recent local results:

```text
tests/unit/cartography/intel/runpod: 31 passed
tests/unit/cartography/intel/runpod + test_sub_resource_relationship + test_ontology_rel_constraints + test_ontology: 58 passed
RunPod Cubic follow-up unit/schema/ontology checks: 36 passed
tests/integration/cartography/intel/runpod/test_runpod.py: 2 passed against a fresh neo4j:5-community container
compileall: passed
docs/build.sh: succeeded (pre-existing unrelated Cypher-highlighting warnings only)
git diff --check: passed
isort / flake8 / pyupgrade / mypy: passed
black --check --fast: printed "4 files would be left unchanged"; local timeout wrapper exited during shutdown
```

Latest Cubic follow-up also added focused regression coverage for preserving an
explicit `0` cluster running-pod count, rejecting empty scalar IDs in RunPod ID
lists, and proving the generated RunPod schema documents the ontology mappings for
`RunPodPod`, `RunPodRegistryCredential`, and `RunPodServerlessEndpoint`.

Production proof was run against a real RunPod account with sanitized output. The proof command synced live RunPod resources into a disposable Neo4j instance and queried the graph by the run's update tag. The semantic ontology mappings are covered by the automated integration test above; the production proof below demonstrates live provider sync shape, relationship population, and sensitive-data exclusion.

Selected sync log excerpt:

```text
INFO:cartography.client.core.tx:Loaded 1 RunPodAccount nodes
INFO:cartography.client.core.tx:Loaded 1 RunPodSSHKey nodes
INFO:cartography.client.core.tx:Loaded 1 RunPodRegistryCredential nodes
INFO:cartography.client.core.tx:Loaded 32 RunPodDataCenter nodes
INFO:cartography.client.core.tx:Loaded 1 RunPodNetworkVolume nodes
INFO:cartography.client.core.tx:Loaded 1 RunPodTemplate nodes
INFO:cartography.client.core.tx:Loaded 3 RunPodPod nodes
INFO:cartography.client.core.tx:Loaded 1 RunPodServerlessEndpoint nodes
INFO:cartography.client.core.tx:Loaded 1 RunPodCluster nodes
```

Graph-derived production proof:

```text
Production graph node counts for update tag 1787177538:
RunPodAccount: 1
RunPodSSHKey: 1
RunPodRegistryCredential: 1
RunPodDataCenter: 32
RunPodNetworkVolume: 1
RunPodTemplate: 1
RunPodPod: 3
RunPodServerlessEndpoint: 1
RunPodCluster: 1

Production graph relationship counts for update tag 1787177538:
RunPodAccount-[:RESOURCE]->RunPodSSHKey: 1
RunPodAccount-[:RESOURCE]->RunPodRegistryCredential: 1
RunPodAccount-[:RESOURCE]->RunPodDataCenter: 32
RunPodAccount-[:RESOURCE]->RunPodNetworkVolume: 1
RunPodAccount-[:RESOURCE]->RunPodTemplate: 1
RunPodAccount-[:RESOURCE]->RunPodPod: 3
RunPodAccount-[:RESOURCE]->RunPodServerlessEndpoint: 1
RunPodAccount-[:RESOURCE]->RunPodCluster: 1
RunPodPod-[:USES_VOLUME]->RunPodNetworkVolume: 1
RunPodServerlessEndpoint-[:USES_VOLUME]->RunPodNetworkVolume: 1
RunPodPod-[:USES_TEMPLATE]->RunPodTemplate: 0
RunPodCluster-[:USES_TEMPLATE]->RunPodTemplate: 0
RunPodPod-[:USES_REGISTRY_CREDENTIAL]->RunPodRegistryCredential: 1
RunPodTemplate-[:USES_REGISTRY_CREDENTIAL]->RunPodRegistryCredential: 1
RunPodPod-[:RUNS_IN]->RunPodDataCenter: 3
RunPodCluster-[:RUNS_IN]->RunPodDataCenter: 1
RunPodServerlessEndpoint-[:RUNS_IN]->RunPodDataCenter: 1
RunPodNetworkVolume-[:LOCATED_IN]->RunPodDataCenter: 1
RunPodCluster-[:HAS_PRIMARY]->RunPodPod: 1
```

Selected resource proof:

```text
RunPodPod details for update tag 1787177538:
- status=RUNNING, data_center_id=US-MD-1, gpu_type_id=NVIDIA A100-SXM4-80GB, gpu_count=1, vcpu_count=None, memory_in_gb=None, network_volume_id=None, template_id=None, registry_id=None
- status=RUNNING, data_center_id=US-MD-1, gpu_type_id=NVIDIA A100-SXM4-80GB, gpu_count=1, vcpu_count=None, memory_in_gb=None, network_volume_id=None, template_id=None, registry_id=None
- status=RUNNING, data_center_id=EU-RO-1, gpu_type_id=None, gpu_count=None, vcpu_count=2, memory_in_gb=4, network_volume_id=<redacted>, template_id=None, registry_id=<redacted>

RunPodCluster details for update tag 1787177538:
- data_center_id=US-MD-1, gpu_type_id=NVIDIA A100-SXM4-80GB, gpu_count=2, pod_count=2, running_pod_count=2, primary_pod_id=<redacted>

RunPodServerlessEndpoint details for update tag 1787177538:
- endpoint_type=QUEUE, workers_min=0, workers_max=1, gpu_type_ids=[], network_volume_ids=['<redacted>']

RunPodNetworkVolume details for update tag 1787177538:
- size=10, data_center_id=EU-RO-1, volume_type=STANDARD

RunPodTemplate details for update tag 1787177538:
- image_name=ubuntu:22.04, container_disk_in_gb=10, registry_id=<redacted>
```

Secret-value safety check:

```text
OK: no RunPodSSHKey node has a public_key/private_key property, no RunPodRegistryCredential node has a username/password property.
```


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [x] Tested the connector against a real cloud, SaaS, or provider environment.
- [x] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [x] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module
- [x] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

Areas worth reviewing closely:

- `cartography/intel/runpod/__init__.py`: orchestration, core-vs-enrichment classification, and cleanup behavior.
- `cartography/intel/runpod/util.py`: response unwrapping, required-ID validation, and `safe_sync()`.
- `cartography/intel/runpod/pods.py`: OpenAPI-backed pod shape handling, including nested `cpu` values and `mounts.network[].volumeId`.
- `cartography/intel/runpod/sshkeys.py`: fingerprint-only SSH key modeling. Raw public keys and authorized-keys comments are not persisted.
- `cartography/models/runpod/*`: declarative node and relationship schemas. In particular, check `RESOURCE` scoping to `RunPodAccount` and the relationships between pods/serverless endpoints/clusters, templates, registry credentials, network volumes, and data centers.
- `docs/root/modules/runpod/schema.md` is generated from the declarative data model and should not be committed manually.
