### PR TITLE
refactor(microsoft): build the Graph credential in one place

### DIFF
--- a/cartography/intel/microsoft/credentials.py
+++ b/cartography/intel/microsoft/credentials.py
@@ -1,0 +1,37 @@
+"""
+Credential construction for the Microsoft intel modules.
+
+Every Microsoft sync authenticates the same way: a service principal built from
+a tenant ID, a client ID, and a client secret. That construction used to be
+copy-pasted into each sync module; it lives here instead, so the Microsoft
+modules have a single auth path the way ``cartography.intel.azure.util.credentials``
+does for Azure.
+
+Call sites import this module and call ``credentials.make_credential(...)``
+rather than importing the function itself, which keeps the construction
+reachable as a single attribute for tests and for anything that needs to
+substitute the credential.
+"""
+
+from azure.core.credentials import TokenCredential
+from azure.identity import ClientSecretCredential
+
+
+def make_credential(
+    tenant_id: str,
+    client_id: str,
+    client_secret: str,
+) -> TokenCredential:
+    """
+    Build the credential used to authenticate against Microsoft Graph.
+
+    :param tenant_id: Microsoft Entra tenant ID
+    :param client_id: Application (client) ID of the registered application
+    :param client_secret: Client secret of the registered application
+    :return: A credential the Graph clients can authenticate with
+    """
+    return ClientSecretCredential(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        client_secret=client_secret,
+    )

--- a/cartography/intel/microsoft/entra/__init__.py
+++ b/cartography/intel/microsoft/entra/__init__.py
@@ -2,11 +2,11 @@ import asyncio
 import logging
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from kiota_abstractions.api_error import APIError
 from msgraph import GraphServiceClient
 
 from cartography.config import Config
+from cartography.intel.microsoft import credentials
 from cartography.intel.microsoft.entra.app_role_assignments import (
     sync_app_role_assignments,
 )
@@ -44,11 +44,7 @@ async def sync_tenant(
     :param client_secret: Azure application client secret
     :param update_tag: Update tag for tracking data freshness
     """
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id,
-        client_id=client_id,
-        client_secret=client_secret,
-    )
+    credential = credentials.make_credential(tenant_id, client_id, client_secret)
     client = GraphServiceClient(
         credential, scopes=["https://graph.microsoft.com/.default"]
     )

--- a/cartography/intel/microsoft/entra/app_role_assignments.py
+++ b/cartography/intel/microsoft/entra/app_role_assignments.py
@@ -3,7 +3,6 @@ from typing import Any
 from typing import AsyncGenerator
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from kiota_abstractions.api_error import APIError
 from msgraph import GraphServiceClient
 from msgraph.generated.models.app_role_assignment_collection_response import (
@@ -14,6 +13,7 @@ from cartography.client.core.tx import load
 from cartography.client.core.tx import read_list_of_values_tx
 from cartography.client.core.tx import read_single_value_tx
 from cartography.graph.job import GraphJob
+from cartography.intel.microsoft import credentials
 from cartography.intel.microsoft.entra.applications import (
     APP_ROLE_ASSIGNMENTS_PAGE_SIZE,
 )
@@ -262,11 +262,7 @@ async def sync_app_role_assignments(
     :param common_job_parameters: Common job parameters for cleanup
     """
     # Create credentials and client
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id,
-        client_id=client_id,
-        client_secret=client_secret,
-    )
+    credential = credentials.make_credential(tenant_id, client_id, client_secret)
 
     client = GraphServiceClient(
         credential,

--- a/cartography/intel/microsoft/entra/applications.py
+++ b/cartography/intel/microsoft/entra/applications.py
@@ -5,12 +5,12 @@ from typing import AsyncGenerator
 from typing import Generator
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from msgraph.generated.models.application import Application
 from msgraph.graph_service_client import GraphServiceClient
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.microsoft import credentials
 from cartography.intel.microsoft.entra.utils import call_with_retries
 from cartography.models.microsoft.entra.application import EntraApplicationSchema
 from cartography.util import timeit
@@ -155,11 +155,7 @@ async def sync_entra_applications(
     :param common_job_parameters: Common job parameters containing UPDATE_TAG and TENANT_ID
     """
     # Create credentials and client
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id,
-        client_id=client_id,
-        client_secret=client_secret,
-    )
+    credential = credentials.make_credential(tenant_id, client_id, client_secret)
 
     client = GraphServiceClient(
         credential,

--- a/cartography/intel/microsoft/entra/directory_roles.py
+++ b/cartography/intel/microsoft/entra/directory_roles.py
@@ -2,13 +2,13 @@ import logging
 from typing import Any
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from msgraph import GraphServiceClient
 from msgraph.generated.models.unified_role_assignment import UnifiedRoleAssignment
 from msgraph.generated.models.unified_role_definition import UnifiedRoleDefinition
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.microsoft import credentials
 from cartography.intel.microsoft.entra.utils import (
     get_paginated_values_with_expired_page_retry,
 )
@@ -159,11 +159,7 @@ async def sync_entra_directory_roles(
     :param update_tag: Update tag for tracking data freshness
     :param common_job_parameters: Common job parameters for cleanup
     """
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id,
-        client_id=client_id,
-        client_secret=client_secret,
-    )
+    credential = credentials.make_credential(tenant_id, client_id, client_secret)
     client = GraphServiceClient(
         credential,
         scopes=["https://graph.microsoft.com/.default"],

--- a/cartography/intel/microsoft/entra/groups.py
+++ b/cartography/intel/microsoft/entra/groups.py
@@ -4,7 +4,6 @@ from typing import AsyncGenerator
 from typing import Generator
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from kiota_abstractions.api_error import APIError
 from msgraph import GraphServiceClient
 from msgraph.generated.models.directory_object import DirectoryObject
@@ -12,6 +11,7 @@ from msgraph.generated.models.group import Group
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.microsoft import credentials
 from cartography.intel.microsoft.entra.utils import call_with_retries
 from cartography.intel.microsoft.entra.utils import (
     get_paginated_values_with_expired_page_retry,
@@ -140,9 +140,7 @@ async def sync_entra_groups(
     common_job_parameters: dict[str, Any],
 ) -> None:
     """Sync Entra groups."""
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id, client_id=client_id, client_secret=client_secret
-    )
+    credential = credentials.make_credential(tenant_id, client_id, client_secret)
     client = GraphServiceClient(
         credential, scopes=["https://graph.microsoft.com/.default"]
     )

--- a/cartography/intel/microsoft/entra/ou.py
+++ b/cartography/intel/microsoft/entra/ou.py
@@ -5,12 +5,12 @@ from typing import AsyncGenerator
 from typing import Generator
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from msgraph import GraphServiceClient
 from msgraph.generated.models.administrative_unit import AdministrativeUnit
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.microsoft import credentials
 from cartography.intel.microsoft.entra.utils import call_with_retries
 from cartography.models.microsoft.entra.ou import EntraOUSchema
 from cartography.util import timeit
@@ -104,11 +104,7 @@ async def sync_entra_ous(
     Sync Entra OUs
     """
     # Initialize Graph client
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id,
-        client_id=client_id,
-        client_secret=client_secret,
-    )
+    credential = credentials.make_credential(tenant_id, client_id, client_secret)
     client = GraphServiceClient(
         credential, scopes=["https://graph.microsoft.com/.default"]
     )

--- a/cartography/intel/microsoft/entra/service_principals.py
+++ b/cartography/intel/microsoft/entra/service_principals.py
@@ -4,13 +4,13 @@ from typing import Any
 from typing import AsyncGenerator
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from msgraph import GraphServiceClient
 from msgraph.generated.models.service_principal import ServicePrincipal
 
 from cartography.analysis.microsoft.entra.analysis import ENTRA_APPLICATION_PROJECTION
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.microsoft import credentials
 from cartography.intel.microsoft.entra.utils import call_with_retries
 from cartography.models.microsoft.entra.service_principal import (
     EntraServicePrincipalSchema,
@@ -190,11 +190,7 @@ async def sync_service_principals(
     :param common_job_parameters: Common job parameters for cleanup
     """
     # Create credentials and client
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id,
-        client_id=client_id,
-        client_secret=client_secret,
-    )
+    credential = credentials.make_credential(tenant_id, client_id, client_secret)
 
     client = GraphServiceClient(
         credential,

--- a/cartography/intel/microsoft/entra/users.py
+++ b/cartography/intel/microsoft/entra/users.py
@@ -4,13 +4,13 @@ from typing import AsyncGenerator
 from typing import Generator
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from msgraph import GraphServiceClient
 from msgraph.generated.models.organization import Organization
 from msgraph.generated.models.user import User
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.microsoft import credentials
 from cartography.intel.microsoft.entra.utils import call_with_retries
 from cartography.models.microsoft.entra.tenant import EntraTenantSchema
 from cartography.models.microsoft.entra.user import EntraUserSchema
@@ -237,11 +237,7 @@ async def sync_entra_users(
     :return: None
     """
     # Initialize Graph client
-    credential = ClientSecretCredential(
-        tenant_id=tenant_id,
-        client_id=client_id,
-        client_secret=client_secret,
-    )
+    credential = credentials.make_credential(tenant_id, client_id, client_secret)
     client = GraphServiceClient(
         credential, scopes=["https://graph.microsoft.com/.default"]
     )

--- a/cartography/intel/microsoft/intune/__init__.py
+++ b/cartography/intel/microsoft/intune/__init__.py
@@ -2,13 +2,13 @@ import asyncio
 import logging
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from kiota_abstractions.api_error import APIError
 
 from cartography.analysis.microsoft.intune.analysis import (
     INTUNE_COMPLIANCE_POLICY_DEVICE,
 )
 from cartography.config import Config
+from cartography.intel.microsoft import credentials
 from cartography.intel.microsoft.client import create_graph_service_client
 from cartography.intel.microsoft.intune.compliance_policies import (
     sync_compliance_policies,
@@ -51,11 +51,7 @@ def start_intune_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
     }
 
     async def main() -> None:
-        credential = ClientSecretCredential(
-            tenant_id=tenant_id,
-            client_id=client_id,
-            client_secret=client_secret,
-        )
+        credential = credentials.make_credential(tenant_id, client_id, client_secret)
         intune_client = create_graph_service_client(credential)
 
         managed_devices_synced = False

--- a/cartography/intel/microsoft/o365/__init__.py
+++ b/cartography/intel/microsoft/o365/__init__.py
@@ -2,10 +2,10 @@ import asyncio
 import logging
 
 import neo4j
-from azure.identity import ClientSecretCredential
 from kiota_abstractions.api_error import APIError
 
 from cartography.config import Config
+from cartography.intel.microsoft import credentials
 from cartography.intel.microsoft.client import create_graph_service_client
 from cartography.intel.microsoft.o365.license_details import (
     cleanup_user_license_assignments,
@@ -49,11 +49,7 @@ def start_o365_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     }
 
     async def main() -> None:
-        credential = ClientSecretCredential(
-            tenant_id=tenant_id,
-            client_id=client_id,
-            client_secret=client_secret,
-        )
+        credential = credentials.make_credential(tenant_id, client_id, client_secret)
         o365_client = create_graph_service_client(credential)
 
         try:

--- a/tests/unit/cartography/intel/microsoft/intune/test_init.py
+++ b/tests/unit/cartography/intel/microsoft/intune/test_init.py
@@ -31,9 +31,9 @@ def _build_config() -> MagicMock:
     new_callable=AsyncMock,
 )
 @patch("cartography.intel.microsoft.intune.create_graph_service_client")
-@patch("cartography.intel.microsoft.intune.ClientSecretCredential")
+@patch("cartography.intel.microsoft.credentials.make_credential")
 def test_detected_app_export_failure_does_not_fail_microsoft_sync(
-    mock_credential,
+    mock_make_credential,
     mock_create_client,
     mock_sync_managed_devices,
     mock_sync_detected_apps,
@@ -69,9 +69,9 @@ def test_detected_app_export_failure_does_not_fail_microsoft_sync(
     new_callable=AsyncMock,
 )
 @patch("cartography.intel.microsoft.intune.create_graph_service_client")
-@patch("cartography.intel.microsoft.intune.ClientSecretCredential")
+@patch("cartography.intel.microsoft.credentials.make_credential")
 def test_unrelated_detected_app_error_still_fails_microsoft_sync(
-    mock_credential,
+    mock_make_credential,
     mock_create_client,
     mock_sync_managed_devices,
     mock_sync_detected_apps,

--- a/tests/unit/cartography/intel/microsoft/test_credentials.py
+++ b/tests/unit/cartography/intel/microsoft/test_credentials.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+
+from azure.identity import ClientSecretCredential
+
+from cartography.intel.microsoft import credentials
+
+
+def test_make_credential_returns_service_principal_credential() -> None:
+    credential = credentials.make_credential(
+        "tenant-id",
+        "client-id",
+        "client-secret",
+    )
+
+    assert isinstance(credential, ClientSecretCredential)
+
+
+@patch("cartography.intel.microsoft.credentials.ClientSecretCredential")
+def test_make_credential_maps_positional_args(mock_client_secret_credential) -> None:
+    # Call sites pass the three values positionally, so pin the order: swapping
+    # client_id and client_secret would otherwise fail only at auth time.
+    credential = credentials.make_credential(
+        "tenant-id",
+        "client-id",
+        "client-secret",
+    )
+
+    mock_client_secret_credential.assert_called_once_with(
+        tenant_id="tenant-id",
+        client_id="client-id",
+        client_secret="client-secret",
+    )
+    assert credential is mock_client_secret_credential.return_value


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
The Microsoft intel modules build their service principal credential in ten
different places. Every sync entry point takes `tenant_id`, `client_id` and
`client_secret` as strings and does the same three lines:

```python
credential = ClientSecretCredential(
    tenant_id=tenant_id,
    client_id=client_id,
    client_secret=client_secret,
)
```

The Azure side of this codebase already does the opposite: every Azure
credential is built by `Authenticator` in
`cartography/intel/azure/util/credentials.py`, so there is exactly one place
that knows how Azure authenticates. This makes the Microsoft modules match.

Adds `cartography/intel/microsoft/credentials.py`:

```python
def make_credential(tenant_id: str, client_id: str, client_secret: str) -> TokenCredential:
    return ClientSecretCredential(
        tenant_id=tenant_id, client_id=client_id, client_secret=client_secret,
    )
```

and routes all ten construction sites through it:

- `intel/microsoft/entra/__init__.py` (`sync_tenant`)
- `intel/microsoft/entra/users.py`
- `intel/microsoft/entra/groups.py`
- `intel/microsoft/entra/ou.py`
- `intel/microsoft/entra/applications.py`
- `intel/microsoft/entra/service_principals.py`
- `intel/microsoft/entra/directory_roles.py`
- `intel/microsoft/entra/app_role_assignments.py`
- `intel/microsoft/o365/__init__.py`
- `intel/microsoft/intune/__init__.py`

No function signatures change, no configuration changes, and the credential
handed to `GraphServiceClient` / `create_graph_service_client` is the same
object it was before.

One deliberate detail: call sites do
`from cartography.intel.microsoft import credentials` and then
`credentials.make_credential(...)`, instead of importing the function by name.
`from x import name` binds at import time, so a call site written that way can
only be substituted in its own module, which puts us back at ten places to
touch. Going through the module keeps `credentials.make_credential` a single
attribute, which is what the updated Intune test patches. This is the same
shape as `cartography.intel.github.make_credential`, which has to be patched at
`cartography.intel.github` rather than at `cartography.intel.github.app_auth`.

The deeper cut is available if you would prefer it: build the credential once in
`start_entra_ingestion` and pass the credential (or the `GraphServiceClient`)
down, rather than threading three strings through ten async functions so each
one can rebuild the same object and keep its own token cache. That changes
signatures across the Entra sync functions, so I kept it out of this PR. Happy
to follow up with it.


### Related issues or links

None.


### How was this tested?

- `make test_lint` passes.
- `uv run pytest tests/unit`: 5106 passed.
- `uv run pytest tests/integration/cartography/intel/microsoft`: 14 passed
  against a local Neo4j.
- Added `tests/unit/cartography/intel/microsoft/test_credentials.py`, which pins
  the argument order (the call sites pass the three values positionally, so a
  swap of `client_id` and `client_secret` would otherwise only surface at auth
  time).
- Updated `tests/unit/cartography/intel/microsoft/intune/test_init.py` to patch
  `cartography.intel.microsoft.credentials.make_credential` instead of the
  per-module `ClientSecretCredential` name.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [ ] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

#### If you are changing a node or relationship
Not applicable: no node, relationship, or schema changes.


### Notes for reviewers

This touches connector files but does not touch any provider interaction: no
Graph call, scope, pagination path, or model changes. The only behavior-bearing
line moved is the `ClientSecretCredential(...)` construction, which is
unchanged, so there are no new sync logs to show that the existing ones would
not already cover. Say the word if you want a real-tenant sync run attached
anyway and I will add it.
