### PR TITLE
feat(GCP): add GCP VPN tunnels and VPC peerings

### DIFF
--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -11,6 +11,7 @@ from googleapiclient.discovery import Resource
 from googleapiclient.errors import HttpError
 
 from cartography.client.core.tx import load
+from cartography.client.core.tx import run_write_query
 from cartography.graph.job import GraphJob
 from cartography.intel.gcp.backendservice import sync_gcp_backend_services
 from cartography.intel.gcp.cloud_armor import sync_gcp_cloud_armor
@@ -230,117 +231,111 @@ def _is_skippable_vpn_list_error(e: HttpError) -> bool:
 
 
 @timeit
-def get_gcp_vpn_gateways(projectid: str, region: str, compute: Resource) -> dict | None:
+def get_gcp_vpn_gateways(projectid: str, compute: Resource) -> tuple[list[dict], bool]:
     """
-    Return list of all HA VPN gateways in the given projectid and region. Returns
-    None if the region is invalid, if the API call times out, or if the call fails
-    with an expected access/configuration error (e.g. the identity lacks the
-    compute.vpnGateways.list permission), so that other Compute resources still
-    sync and cleanup is safely suppressed for the project.
+    Return all HA VPN gateways in the given projectid across all regions using
+    the vpnGateways.aggregatedList endpoint (one request chain instead of one
+    per region) with partial success enabled.
     :param projectid: The project ID
-    :param region: The region to pull VPN gateways from
     :param compute: The compute resource object created by googleapiclient.discovery.build()
-    :return: Response object containing data on all GCP VPN gateways for a given project,
-        or None if the region must be skipped
+    :return: Tuple of (gateway items, incomplete). incomplete is True if the
+        request chain failed partway or any region scope returned an error, in
+        which case cleanup must be suppressed for the project.
     """
-    try:
-        req = compute.vpnGateways().list(project=projectid, region=region)
-    except HttpError as e:
-        if _is_skippable_vpn_list_error(e):
-            logger.warning(
-                "GCP: vpnGateways.list failed for project %s region %s; skipping VPN gateway sync for this region. %s",
-                projectid,
-                region,
-                summarize_gcp_http_error(e),
-            )
-            return None
-        raise
-
-    items: list[dict] = []
-    response_id = f"projects/{projectid}/regions/{region}/vpnGateways"
-    while req is not None:
-        try:
-            res = gcp_api_execute_with_retry(req)
-        except TimeoutError:
-            logger.warning(
-                "GCP: vpnGateways.list for project %s region %s timed out; skipping this region to preserve existing data.",
-                projectid,
-                region,
-            )
-            return None
-        except HttpError as e:
-            if _is_skippable_vpn_list_error(e):
-                logger.warning(
-                    "GCP: vpnGateways.list failed for project %s region %s; skipping VPN gateway sync for this region. %s",
-                    projectid,
-                    region,
-                    summarize_gcp_http_error(e),
-                )
-                return None
-            raise
-        items.extend(res.get("items", []))
-        response_id = res.get("id", response_id)
-        req = compute.vpnGateways().list_next(
-            previous_request=req, previous_response=res
-        )
-    return {"id": response_id, "items": items}
+    return _get_gcp_vpn_aggregated(projectid, compute, "vpnGateways")
 
 
 @timeit
-def get_gcp_vpn_tunnels(projectid: str, region: str, compute: Resource) -> dict | None:
+def get_gcp_vpn_tunnels(projectid: str, compute: Resource) -> tuple[list[dict], bool]:
     """
-    Return list of all VPN tunnels in the given projectid and region. Returns
-    None if the region is invalid, if the API call times out, or if the call fails
-    with an expected access/configuration error (e.g. the identity lacks the
-    compute.vpnTunnels.list permission), so that other Compute resources still
-    sync and cleanup is safely suppressed for the project.
+    Return all VPN tunnels in the given projectid across all regions using the
+    vpnTunnels.aggregatedList endpoint (one request chain instead of one per
+    region) with partial success enabled.
     :param projectid: The project ID
-    :param region: The region to pull VPN tunnels from
     :param compute: The compute resource object created by googleapiclient.discovery.build()
-    :return: Response object containing data on all GCP VPN tunnels for a given project,
-        or None if the region must be skipped
+    :return: Tuple of (tunnel items, incomplete). incomplete is True if the
+        request chain failed partway or any region scope returned an error, in
+        which case cleanup must be suppressed for the project.
     """
+    return _get_gcp_vpn_aggregated(projectid, compute, "vpnTunnels")
+
+
+def _get_gcp_vpn_aggregated(
+    projectid: str,
+    compute: Resource,
+    resource: str,
+) -> tuple[list[dict], bool]:
+    """
+    Fetch all VPN resources of the given type ("vpnGateways" or "vpnTunnels")
+    for a project via the Compute aggregatedList endpoint with
+    returnPartialSuccess=True: a single paginated request chain covers all
+    regions, and a region that fails (e.g. transient location error) reports a
+    per-scope `error` entry in the response instead of failing the whole call.
+
+    Expected access/configuration failures of the whole call (missing list
+    permission, API not enabled, billing disabled, project not found) return
+    ([], True) so that other Compute resources still sync and cleanup is
+    safely suppressed for the project.
+
+    :param projectid: The project ID
+    :param compute: The compute resource object
+    :param resource: "vpnGateways" or "vpnTunnels"
+    :return: Tuple of (items across all regions, incomplete)
+    """
+    api = getattr(compute, resource)()
     try:
-        req = compute.vpnTunnels().list(project=projectid, region=region)
+        req = api.aggregatedList(project=projectid, returnPartialSuccess=True)
     except HttpError as e:
         if _is_skippable_vpn_list_error(e):
             logger.warning(
-                "GCP: vpnTunnels.list failed for project %s region %s; skipping VPN tunnel sync for this region. %s",
+                "GCP: %s.aggregatedList failed for project %s; skipping this resource type for the project. %s",
+                resource,
                 projectid,
-                region,
                 summarize_gcp_http_error(e),
             )
-            return None
+            return [], True
         raise
 
     items: list[dict] = []
-    response_id = f"projects/{projectid}/regions/{region}/vpnTunnels"
+    incomplete = False
     while req is not None:
         try:
             res = gcp_api_execute_with_retry(req)
         except TimeoutError:
             logger.warning(
-                "GCP: vpnTunnels.list for project %s region %s timed out; skipping this region to preserve existing data.",
+                "GCP: %s.aggregatedList for project %s timed out; keeping partial data and suppressing cleanup.",
+                resource,
                 projectid,
-                region,
             )
-            return None
+            incomplete = True
+            break
         except HttpError as e:
             if _is_skippable_vpn_list_error(e):
                 logger.warning(
-                    "GCP: vpnTunnels.list failed for project %s region %s; skipping VPN tunnel sync for this region. %s",
+                    "GCP: %s.aggregatedList failed for project %s; keeping partial data and suppressing cleanup. %s",
+                    resource,
                     projectid,
-                    region,
                     summarize_gcp_http_error(e),
                 )
-                return None
+                incomplete = True
+                break
             raise
-        items.extend(res.get("items", []))
-        response_id = res.get("id", response_id)
-        req = compute.vpnTunnels().list_next(
-            previous_request=req, previous_response=res
-        )
-    return {"id": response_id, "items": items}
+        # Aggregated responses key items by scope ("regions/{region}"). Scopes
+        # with no resources carry only a NO_RESULTS_ON_PAGE warning (complete);
+        # scopes with an `error` entry failed (incomplete).
+        for scope, scope_data in res.get("items", {}).items():
+            if scope_data.get("error"):
+                incomplete = True
+                logger.warning(
+                    "GCP: %s.aggregatedList for project %s returned an error for scope %s; suppressing cleanup for the project.",
+                    resource,
+                    projectid,
+                    scope,
+                )
+                continue
+            items.extend(scope_data.get(resource, []))
+        req = api.aggregatedList_next(previous_request=req, previous_response=res)
+    return items, incomplete
 
 
 @timeit
@@ -600,25 +595,24 @@ def transform_gcp_vpc_peerings(vpc_res: dict) -> list[dict]:
 
 
 @timeit
-def transform_gcp_vpn_gateways(vpn_gateway_res: dict) -> list[dict]:
+def transform_gcp_vpn_gateways(gateways: list[dict], projectid: str) -> list[dict]:
     """
-    Transform the vpnGateways.list response object for Neo4j ingestion.
-    :param vpn_gateway_res: The return data from get_gcp_vpn_gateways()
+    Transform vpnGateways items (from the aggregatedList response) for Neo4j ingestion.
+    :param gateways: Raw vpnGateway items from get_gcp_vpn_gateways()
+    :param projectid: The project ID the gateways belong to
     :return: List of VPN gateways ready for ingestion to Neo4j
     """
-    # prefix has the form `projects/{project}/regions/{region}/vpnGateways`
-    prefix = vpn_gateway_res["id"]
-    projectid = prefix.split("/")[1]
-    region = prefix.split("/")[3]
     gateway_list = []
-    for g in vpn_gateway_res.get("items", []):
+    for g in gateways:
         gateway: dict[str, Any] = {
-            "partial_uri": f"{prefix}/{g['name']}",
+            # selfLink has the form
+            # `https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/vpnGateways/{name}`
+            "partial_uri": _parse_compute_full_uri_to_partial_uri(g["selfLink"]),
             "self_link": g["selfLink"],
             "name": g["name"],
             "project_id": projectid,
             # Region looks like "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region name}"
-            "region": g.get("region", "").split("/")[-1] or region,
+            "region": g.get("region", "").split("/")[-1],
             "description": g.get("description"),
             "gateway_ip_version": g.get("gatewayIpVersion"),
             "stack_type": g.get("stackType"),
@@ -633,27 +627,24 @@ def transform_gcp_vpn_gateways(vpn_gateway_res: dict) -> list[dict]:
 
 
 @timeit
-def transform_gcp_vpn_tunnels(vpn_tunnel_res: dict) -> list[dict]:
+def transform_gcp_vpn_tunnels(tunnels: list[dict], projectid: str) -> list[dict]:
     """
-    Transform the vpnTunnels.list response object for Neo4j ingestion.
+    Transform vpnTunnels items (from the aggregatedList response) for Neo4j ingestion.
     NOTE: The API response contains `sharedSecret` and `sharedSecretHash` (the
     IKE pre-shared key). We deliberately never copy these fields into the
     transformed output so that VPN secrets are never written to Neo4j.
-    :param vpn_tunnel_res: The return data from get_gcp_vpn_tunnels()
+    :param tunnels: Raw vpnTunnel items from get_gcp_vpn_tunnels()
+    :param projectid: The project ID the tunnels belong to
     :return: List of VPN tunnels ready for ingestion to Neo4j
     """
-    # prefix has the form `projects/{project}/regions/{region}/vpnTunnels`
-    prefix = vpn_tunnel_res["id"]
-    projectid = prefix.split("/")[1]
-    region = prefix.split("/")[3]
     tunnel_list = []
-    for t in vpn_tunnel_res.get("items", []):
+    for t in tunnels:
         tunnel: dict[str, Any] = {
-            "partial_uri": f"{prefix}/{t['name']}",
+            "partial_uri": _parse_compute_full_uri_to_partial_uri(t["selfLink"]),
             "self_link": t["selfLink"],
             "name": t["name"],
             "project_id": projectid,
-            "region": t.get("region", "").split("/")[-1] or region,
+            "region": t.get("region", "").split("/")[-1],
             "description": t.get("description"),
             "status": t.get("status"),
             "detailed_status": t.get("detailedStatus"),
@@ -1713,6 +1704,52 @@ def cleanup_gcp_subnets(
 
 
 @timeit
+def cleanup_orphan_gcp_vpc_stubs(neo4j_session: neo4j.Session) -> None:
+    """
+    Delete GCPVpc stub nodes that are no longer referenced by anything.
+
+    Stubs are created for peering peer networks whose project is not synced, so
+    they have no owning `(:GCPProject)-[:RESOURCE]->` edge and are invisible to
+    project-scoped cleanup. Once the last peering referencing a stub disappears
+    (or the stub never belonged to a synced project), it would otherwise stay
+    in the graph forever. Real VPCs always carry a RESOURCE edge from their
+    project and are never matched.
+    """
+    run_write_query(
+        neo4j_session,
+        """
+        MATCH (v:GCPVpc)
+        WHERE NOT (:GCPProject)-[:RESOURCE]->(v)
+        AND NOT (:GCPVpcPeering)-[:PEER_NETWORK]->(v)
+        DETACH DELETE v
+        """,
+    )
+
+
+@timeit
+def cleanup_orphan_gcp_vpn_gateway_stubs(neo4j_session: neo4j.Session) -> None:
+    """
+    Delete GCPVpnGateway stub nodes that are no longer referenced by anything.
+
+    Stubs are created for tunnel peer gateways whose project is not synced, so
+    they have no owning `(:GCPProject)-[:RESOURCE]->` edge and are invisible to
+    project-scoped cleanup. Once the last tunnel referencing a stub disappears,
+    it would otherwise stay in the graph forever. Real gateways always carry a
+    RESOURCE edge from their project and are never matched.
+    """
+    run_write_query(
+        neo4j_session,
+        """
+        MATCH (g:GCPVpnGateway)
+        WHERE NOT (:GCPProject)-[:RESOURCE]->(g)
+        AND NOT (:GCPVpnTunnel)-[:CONNECTS_TO_GATEWAY]->(g)
+        AND NOT (:GCPVpnTunnel)-[:USES_GATEWAY]->(g)
+        DETACH DELETE g
+        """,
+    )
+
+
+@timeit
 def cleanup_gcp_forwarding_rules(
     neo4j_session: neo4j.Session,
     common_job_parameters: dict,
@@ -1876,6 +1913,9 @@ def sync_gcp_vpc_peerings(
     )
     load_gcp_vpc_peerings(neo4j_session, peerings, gcp_update_tag, project_id)
     cleanup_gcp_vpc_peerings(neo4j_session, common_job_parameters)
+    # Remove stub VPCs left behind by peerings that no longer exist. Runs after
+    # peering cleanup so stale peerings release their references first.
+    cleanup_orphan_gcp_vpc_stubs(neo4j_session)
 
 
 @timeit
@@ -1883,34 +1923,27 @@ def sync_gcp_vpn_gateways(
     neo4j_session: neo4j.Session,
     compute: Resource,
     project_id: str,
-    regions: list[str],
     gcp_update_tag: int,
     common_job_parameters: dict,
 ) -> None:
     """
-    Sync GCP HA VPN gateways across all regions, ingest to Neo4j, and clean up old data.
+    Sync GCP HA VPN gateways across all regions via one aggregatedList call
+    chain, ingest to Neo4j, and clean up old data.
     Must run after sync_gcp_vpcs so PART_OF_VPC relationships resolve in the same cycle.
     :param neo4j_session: The Neo4j session
     :param compute: The GCP Compute resource object
     :param project_id: The project ID to sync
-    :param regions: List of regions
     :param gcp_update_tag: The timestamp value to set our new Neo4j nodes with
     :param common_job_parameters: dict of other job parameters to pass to Neo4j
     :return: Nothing
     """
-    incomplete = False
-    for r in regions:
-        vpn_gateway_res = get_gcp_vpn_gateways(project_id, r, compute)
-        if vpn_gateway_res is None:
-            # Invalid region or timeout, skip this one
-            incomplete = True
-            continue
-        gateways = transform_gcp_vpn_gateways(vpn_gateway_res)
-        load_gcp_vpn_gateways(neo4j_session, gateways, gcp_update_tag, project_id)
+    gateway_items, incomplete = get_gcp_vpn_gateways(project_id, compute)
+    gateways = transform_gcp_vpn_gateways(gateway_items, project_id)
+    load_gcp_vpn_gateways(neo4j_session, gateways, gcp_update_tag, project_id)
     if incomplete:
         logger.warning(
-            "Skipping VPN gateway cleanup for project %s because one or more regions "
-            "returned incomplete data. Existing gateway data will be preserved.",
+            "Skipping VPN gateway cleanup for project %s because the aggregated "
+            "list returned incomplete data. Existing gateway data will be preserved.",
             project_id,
         )
     else:
@@ -1922,47 +1955,44 @@ def sync_gcp_vpn_tunnels(
     neo4j_session: neo4j.Session,
     compute: Resource,
     project_id: str,
-    regions: list[str],
     gcp_update_tag: int,
     common_job_parameters: dict,
 ) -> None:
     """
-    Sync GCP VPN tunnels across all regions, ingest to Neo4j, and clean up old data.
+    Sync GCP VPN tunnels across all regions via one aggregatedList call chain,
+    ingest to Neo4j, and clean up old data.
     Must run after sync_gcp_vpn_gateways so USES_GATEWAY relationships resolve in
     the same cycle. Creates stub GCPVpnGateway nodes for peer gateways whose
     projects have not been synced.
     :param neo4j_session: The Neo4j session
     :param compute: The GCP Compute resource object
     :param project_id: The project ID to sync
-    :param regions: List of regions
     :param gcp_update_tag: The timestamp value to set our new Neo4j nodes with
     :param common_job_parameters: dict of other job parameters to pass to Neo4j
     :return: Nothing
     """
-    incomplete = False
-    for r in regions:
-        vpn_tunnel_res = get_gcp_vpn_tunnels(project_id, r, compute)
-        if vpn_tunnel_res is None:
-            # Invalid region or timeout, skip this one
-            incomplete = True
-            continue
-        tunnels = transform_gcp_vpn_tunnels(vpn_tunnel_res)
-        # Create peer gateway stubs first so that CONNECTS_TO_GATEWAY
-        # relationships resolve even when the peer project is not synced.
-        _create_vpn_gateway_stubs(
-            neo4j_session,
-            _get_vpn_gateway_stubs_from_tunnels(tunnels),
-            gcp_update_tag,
-        )
-        load_gcp_vpn_tunnels(neo4j_session, tunnels, gcp_update_tag, project_id)
+    tunnel_items, incomplete = get_gcp_vpn_tunnels(project_id, compute)
+    tunnels = transform_gcp_vpn_tunnels(tunnel_items, project_id)
+    # Create peer gateway stubs first so that CONNECTS_TO_GATEWAY
+    # relationships resolve even when the peer project is not synced.
+    _create_vpn_gateway_stubs(
+        neo4j_session,
+        _get_vpn_gateway_stubs_from_tunnels(tunnels),
+        gcp_update_tag,
+    )
+    load_gcp_vpn_tunnels(neo4j_session, tunnels, gcp_update_tag, project_id)
     if incomplete:
         logger.warning(
-            "Skipping VPN tunnel cleanup for project %s because one or more regions "
-            "returned incomplete data. Existing tunnel data will be preserved.",
+            "Skipping VPN tunnel cleanup for project %s because the aggregated "
+            "list returned incomplete data. Existing tunnel data will be preserved.",
             project_id,
         )
     else:
         cleanup_gcp_vpn_tunnels(neo4j_session, common_job_parameters)
+    # Remove stub gateways left behind by tunnels that no longer exist. Safe
+    # even when cleanup was suppressed: stale tunnels still reference their
+    # stubs, so only truly unreferenced stubs are deleted.
+    cleanup_orphan_gcp_vpn_gateway_stubs(neo4j_session)
 
 
 @timeit
@@ -2146,7 +2176,6 @@ def sync(
             neo4j_session,
             compute,
             project_id,
-            regions,
             gcp_update_tag,
             common_job_parameters,
         )
@@ -2154,7 +2183,6 @@ def sync(
             neo4j_session,
             compute,
             project_id,
-            regions,
             gcp_update_tag,
             common_job_parameters,
         )

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -213,26 +213,45 @@ def get_gcp_vpcs(projectid: str, compute: Resource) -> Resource:
     return gcp_api_execute_with_retry(req)
 
 
+def _is_skippable_vpn_list_error(e: HttpError) -> bool:
+    """
+    Return True if a vpnGateways/vpnTunnels list HttpError is an expected
+    access or configuration failure (invalid region, missing list permission,
+    API not enabled, billing disabled, or project not found) for which the
+    region should be skipped rather than aborting the whole project sync.
+    """
+    return classify_gcp_http_error(e) in (
+        "invalid",
+        "forbidden",
+        "api_disabled",
+        "billing_disabled",
+        "not_found",
+    )
+
+
 @timeit
 def get_gcp_vpn_gateways(projectid: str, region: str, compute: Resource) -> dict | None:
     """
     Return list of all HA VPN gateways in the given projectid and region. Returns
-    None if the region is invalid or if the API call times out (to prevent partial
-    data from triggering cleanup that would delete valid nodes).
+    None if the region is invalid, if the API call times out, or if the call fails
+    with an expected access/configuration error (e.g. the identity lacks the
+    compute.vpnGateways.list permission), so that other Compute resources still
+    sync and cleanup is safely suppressed for the project.
     :param projectid: The project ID
     :param region: The region to pull VPN gateways from
     :param compute: The compute resource object created by googleapiclient.discovery.build()
     :return: Response object containing data on all GCP VPN gateways for a given project,
-        or None if region is invalid or the request times out
+        or None if the region must be skipped
     """
     try:
         req = compute.vpnGateways().list(project=projectid, region=region)
     except HttpError as e:
-        if classify_gcp_http_error(e) == "invalid":
+        if _is_skippable_vpn_list_error(e):
             logger.warning(
-                "GCP: Invalid region %s for project %s; skipping VPN gateway sync for this region.",
-                region,
+                "GCP: vpnGateways.list failed for project %s region %s; skipping VPN gateway sync for this region. %s",
                 projectid,
+                region,
+                summarize_gcp_http_error(e),
             )
             return None
         raise
@@ -250,11 +269,12 @@ def get_gcp_vpn_gateways(projectid: str, region: str, compute: Resource) -> dict
             )
             return None
         except HttpError as e:
-            if classify_gcp_http_error(e) == "invalid":
+            if _is_skippable_vpn_list_error(e):
                 logger.warning(
-                    "GCP: Invalid region %s for project %s; skipping VPN gateway sync for this region.",
-                    region,
+                    "GCP: vpnGateways.list failed for project %s region %s; skipping VPN gateway sync for this region. %s",
                     projectid,
+                    region,
+                    summarize_gcp_http_error(e),
                 )
                 return None
             raise
@@ -270,22 +290,25 @@ def get_gcp_vpn_gateways(projectid: str, region: str, compute: Resource) -> dict
 def get_gcp_vpn_tunnels(projectid: str, region: str, compute: Resource) -> dict | None:
     """
     Return list of all VPN tunnels in the given projectid and region. Returns
-    None if the region is invalid or if the API call times out (to prevent partial
-    data from triggering cleanup that would delete valid nodes).
+    None if the region is invalid, if the API call times out, or if the call fails
+    with an expected access/configuration error (e.g. the identity lacks the
+    compute.vpnTunnels.list permission), so that other Compute resources still
+    sync and cleanup is safely suppressed for the project.
     :param projectid: The project ID
     :param region: The region to pull VPN tunnels from
     :param compute: The compute resource object created by googleapiclient.discovery.build()
     :return: Response object containing data on all GCP VPN tunnels for a given project,
-        or None if region is invalid or the request times out
+        or None if the region must be skipped
     """
     try:
         req = compute.vpnTunnels().list(project=projectid, region=region)
     except HttpError as e:
-        if classify_gcp_http_error(e) == "invalid":
+        if _is_skippable_vpn_list_error(e):
             logger.warning(
-                "GCP: Invalid region %s for project %s; skipping VPN tunnel sync for this region.",
-                region,
+                "GCP: vpnTunnels.list failed for project %s region %s; skipping VPN tunnel sync for this region. %s",
                 projectid,
+                region,
+                summarize_gcp_http_error(e),
             )
             return None
         raise
@@ -303,11 +326,12 @@ def get_gcp_vpn_tunnels(projectid: str, region: str, compute: Resource) -> dict 
             )
             return None
         except HttpError as e:
-            if classify_gcp_http_error(e) == "invalid":
+            if _is_skippable_vpn_list_error(e):
                 logger.warning(
-                    "GCP: Invalid region %s for project %s; skipping VPN tunnel sync for this region.",
-                    region,
+                    "GCP: vpnTunnels.list failed for project %s region %s; skipping VPN tunnel sync for this region. %s",
                     projectid,
+                    region,
+                    summarize_gcp_http_error(e),
                 )
                 return None
             raise

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -320,19 +320,23 @@ def _get_gcp_vpn_aggregated(
                 incomplete = True
                 break
             raise
-        # Aggregated responses key items by scope ("regions/{region}"). Scopes
-        # with no resources carry only a NO_RESULTS_ON_PAGE warning (complete);
-        # scopes with an `error` entry failed (incomplete).
+        # Aggregated responses key items by scope ("regions/{region}"). A scope
+        # is incomplete if it carries an `error` entry, or a `warning` with any
+        # code other than the benign NO_RESULTS_ON_PAGE (e.g. UNREACHABLE means
+        # the region could not be queried, so its data is missing).
         for scope, scope_data in res.get("items", {}).items():
-            if scope_data.get("error"):
+            warning_code = (scope_data.get("warning") or {}).get("code")
+            if scope_data.get("error") or (
+                warning_code and warning_code != "NO_RESULTS_ON_PAGE"
+            ):
                 incomplete = True
                 logger.warning(
-                    "GCP: %s.aggregatedList for project %s returned an error for scope %s; suppressing cleanup for the project.",
+                    "GCP: %s.aggregatedList for project %s reported a problem for scope %s (warning: %s); suppressing cleanup for the project.",
                     resource,
                     projectid,
                     scope,
+                    warning_code or scope_data.get("error"),
                 )
-                continue
             items.extend(scope_data.get(resource, []))
         req = api.aggregatedList_next(previous_request=req, previous_response=res)
     return items, incomplete

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -338,6 +338,26 @@ def _get_gcp_vpn_aggregated(
                     warning_code or scope_data.get("error"),
                 )
             items.extend(scope_data.get(resource, []))
+        # Missing data can also be reported at the page level, outside items:
+        # a non-empty `unreachables` list, or a top-level `warning` whose code
+        # is not the benign NO_RESULTS_ON_PAGE (e.g. UNREACHABLE).
+        if res.get("unreachables"):
+            incomplete = True
+            logger.warning(
+                "GCP: %s.aggregatedList for project %s reported unreachable scopes %s; suppressing cleanup for the project.",
+                resource,
+                projectid,
+                res["unreachables"],
+            )
+        page_warning_code = (res.get("warning") or {}).get("code")
+        if page_warning_code and page_warning_code != "NO_RESULTS_ON_PAGE":
+            incomplete = True
+            logger.warning(
+                "GCP: %s.aggregatedList for project %s returned warning %s; suppressing cleanup for the project.",
+                resource,
+                projectid,
+                page_warning_code,
+            )
         req = api.aggregatedList_next(previous_request=req, previous_response=res)
     return items, incomplete
 

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -46,6 +46,11 @@ from cartography.models.gcp.compute.project import GCPProjectComputeMetadataSche
 from cartography.models.gcp.compute.subnet import GCPSubnetSchema
 from cartography.models.gcp.compute.subnet_stub import GCPSubnetStubSchema
 from cartography.models.gcp.compute.vpc import GCPVpcSchema
+from cartography.models.gcp.compute.vpc_peering import GCPVpcPeeringSchema
+from cartography.models.gcp.compute.vpc_stub import GCPVpcStubSchema
+from cartography.models.gcp.compute.vpn_gateway import GCPVpnGatewaySchema
+from cartography.models.gcp.compute.vpn_gateway_stub import GCPVpnGatewayStubSchema
+from cartography.models.gcp.compute.vpn_tunnel import GCPVpnTunnelSchema
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -146,13 +151,14 @@ def get_gcp_instance_responses(
 @timeit
 def get_gcp_subnets(projectid: str, region: str, compute: Resource) -> dict | None:
     """
-    Return list of all subnets in the given projectid and region.  If the API
-    call times out mid-pagination, return any subnets gathered so far rather than
-    bubbling the error up to the caller. Returns None if the region is invalid.
+    Return list of all subnets in the given projectid and region. Returns None
+    if the region is invalid or if the API call times out (to prevent partial
+    data from triggering cleanup that would delete valid nodes).
     :param projectid: The project ID
     :param region: The region to pull subnets from
     :param compute: The compute resource object created by googleapiclient.discovery.build()
-    :return: Response object containing data on all GCP subnets for a given project, or None if region is invalid
+    :return: Response object containing data on all GCP subnets for a given project,
+        or None if region is invalid or the request times out
     """
     try:
         req = compute.subnetworks().list(project=projectid, region=region)
@@ -173,11 +179,11 @@ def get_gcp_subnets(projectid: str, region: str, compute: Resource) -> dict | No
             res = gcp_api_execute_with_retry(req)
         except TimeoutError:
             logger.warning(
-                "GCP: subnetworks.list for project %s region %s timed out; continuing with partial data.",
+                "GCP: subnetworks.list for project %s region %s timed out; skipping this region to preserve existing data.",
                 projectid,
                 region,
             )
-            break
+            return None
         except HttpError as e:
             if classify_gcp_http_error(e) == "invalid":
                 logger.warning(
@@ -205,6 +211,112 @@ def get_gcp_vpcs(projectid: str, compute: Resource) -> Resource:
     """
     req = compute.networks().list(project=projectid)
     return gcp_api_execute_with_retry(req)
+
+
+@timeit
+def get_gcp_vpn_gateways(projectid: str, region: str, compute: Resource) -> dict | None:
+    """
+    Return list of all HA VPN gateways in the given projectid and region. Returns
+    None if the region is invalid or if the API call times out (to prevent partial
+    data from triggering cleanup that would delete valid nodes).
+    :param projectid: The project ID
+    :param region: The region to pull VPN gateways from
+    :param compute: The compute resource object created by googleapiclient.discovery.build()
+    :return: Response object containing data on all GCP VPN gateways for a given project,
+        or None if region is invalid or the request times out
+    """
+    try:
+        req = compute.vpnGateways().list(project=projectid, region=region)
+    except HttpError as e:
+        if classify_gcp_http_error(e) == "invalid":
+            logger.warning(
+                "GCP: Invalid region %s for project %s; skipping VPN gateway sync for this region.",
+                region,
+                projectid,
+            )
+            return None
+        raise
+
+    items: list[dict] = []
+    response_id = f"projects/{projectid}/regions/{region}/vpnGateways"
+    while req is not None:
+        try:
+            res = gcp_api_execute_with_retry(req)
+        except TimeoutError:
+            logger.warning(
+                "GCP: vpnGateways.list for project %s region %s timed out; skipping this region to preserve existing data.",
+                projectid,
+                region,
+            )
+            return None
+        except HttpError as e:
+            if classify_gcp_http_error(e) == "invalid":
+                logger.warning(
+                    "GCP: Invalid region %s for project %s; skipping VPN gateway sync for this region.",
+                    region,
+                    projectid,
+                )
+                return None
+            raise
+        items.extend(res.get("items", []))
+        response_id = res.get("id", response_id)
+        req = compute.vpnGateways().list_next(
+            previous_request=req, previous_response=res
+        )
+    return {"id": response_id, "items": items}
+
+
+@timeit
+def get_gcp_vpn_tunnels(projectid: str, region: str, compute: Resource) -> dict | None:
+    """
+    Return list of all VPN tunnels in the given projectid and region. Returns
+    None if the region is invalid or if the API call times out (to prevent partial
+    data from triggering cleanup that would delete valid nodes).
+    :param projectid: The project ID
+    :param region: The region to pull VPN tunnels from
+    :param compute: The compute resource object created by googleapiclient.discovery.build()
+    :return: Response object containing data on all GCP VPN tunnels for a given project,
+        or None if region is invalid or the request times out
+    """
+    try:
+        req = compute.vpnTunnels().list(project=projectid, region=region)
+    except HttpError as e:
+        if classify_gcp_http_error(e) == "invalid":
+            logger.warning(
+                "GCP: Invalid region %s for project %s; skipping VPN tunnel sync for this region.",
+                region,
+                projectid,
+            )
+            return None
+        raise
+
+    items: list[dict] = []
+    response_id = f"projects/{projectid}/regions/{region}/vpnTunnels"
+    while req is not None:
+        try:
+            res = gcp_api_execute_with_retry(req)
+        except TimeoutError:
+            logger.warning(
+                "GCP: vpnTunnels.list for project %s region %s timed out; skipping this region to preserve existing data.",
+                projectid,
+                region,
+            )
+            return None
+        except HttpError as e:
+            if classify_gcp_http_error(e) == "invalid":
+                logger.warning(
+                    "GCP: Invalid region %s for project %s; skipping VPN tunnel sync for this region.",
+                    region,
+                    projectid,
+                )
+                return None
+            raise
+        items.extend(res.get("items", []))
+        response_id = res.get("id", response_id)
+        req = compute.vpnTunnels().list_next(
+            previous_request=req, previous_response=res
+        )
+    return {"id": response_id, "items": items}
 
 
 @timeit
@@ -409,6 +521,136 @@ def transform_gcp_vpcs(vpc_res: dict) -> list[dict]:
 
         vpc_list.append(vpc)
     return vpc_list
+
+
+@timeit
+def transform_gcp_vpc_peerings(vpc_res: dict) -> list[dict]:
+    """
+    Extract VPC Network Peering connections from the networks.list response and
+    transform them for Neo4j ingestion. Peerings are embedded in each network's
+    `peerings` field, so no extra API call is needed. Each side of a peering is
+    reported by its own project's networks.list response, so this yields one
+    peering object per (local network, peering name) pair.
+    :param vpc_res: The return data from get_gcp_vpcs()
+    :return: List of VPC peerings ready for ingestion to Neo4j
+    """
+    # prefix has the form `projects/{project ID}/global/networks`
+    prefix = vpc_res["id"]
+    peering_list = []
+    for v in vpc_res.get("items", []):
+        network_partial_uri = f"{prefix}/{v['name']}"
+        for p in v.get("peerings", []):
+            peering: dict[str, Any] = {
+                # The API exposes no resource URI for peerings, so construct a
+                # stable ID from the local network and the peering name.
+                "id": f"{network_partial_uri}/networkPeerings/{p['name']}",
+                "name": p["name"],
+                "network_partial_uri": network_partial_uri,
+                "state": p.get("state"),
+                "state_details": p.get("stateDetails"),
+                "peer_mtu": p.get("peerMtu"),
+                "stack_type": p.get("stackType"),
+                "update_strategy": p.get("updateStrategy"),
+                "auto_create_routes": p.get("autoCreateRoutes"),
+                "exchange_subnet_routes": p.get("exchangeSubnetRoutes"),
+                "import_custom_routes": p.get("importCustomRoutes"),
+                "export_custom_routes": p.get("exportCustomRoutes"),
+                "import_subnet_routes_with_public_ip": p.get(
+                    "importSubnetRoutesWithPublicIp"
+                ),
+                "export_subnet_routes_with_public_ip": p.get(
+                    "exportSubnetRoutesWithPublicIp"
+                ),
+            }
+            peer_network = p.get("peerNetwork")
+            if peer_network:
+                peer_partial_uri = _parse_compute_full_uri_to_partial_uri(peer_network)
+                peering["peer_network_partial_uri"] = peer_partial_uri
+                # Partial URIs have the form `projects/{project}/global/networks/{name}`
+                peering["peer_project_id"] = peer_partial_uri.split("/")[1]
+            else:
+                peering["peer_network_partial_uri"] = None
+                peering["peer_project_id"] = None
+            peering_list.append(peering)
+    return peering_list
+
+
+@timeit
+def transform_gcp_vpn_gateways(vpn_gateway_res: dict) -> list[dict]:
+    """
+    Transform the vpnGateways.list response object for Neo4j ingestion.
+    :param vpn_gateway_res: The return data from get_gcp_vpn_gateways()
+    :return: List of VPN gateways ready for ingestion to Neo4j
+    """
+    # prefix has the form `projects/{project}/regions/{region}/vpnGateways`
+    prefix = vpn_gateway_res["id"]
+    projectid = prefix.split("/")[1]
+    region = prefix.split("/")[3]
+    gateway_list = []
+    for g in vpn_gateway_res.get("items", []):
+        gateway: dict[str, Any] = {
+            "partial_uri": f"{prefix}/{g['name']}",
+            "self_link": g["selfLink"],
+            "name": g["name"],
+            "project_id": projectid,
+            # Region looks like "https://www.googleapis.com/compute/v1/projects/{project}/regions/{region name}"
+            "region": g.get("region", "").split("/")[-1] or region,
+            "description": g.get("description"),
+            "gateway_ip_version": g.get("gatewayIpVersion"),
+            "stack_type": g.get("stackType"),
+            "creation_timestamp": g.get("creationTimestamp"),
+        }
+        network = g.get("network")
+        gateway["network_partial_uri"] = (
+            _parse_compute_full_uri_to_partial_uri(network) if network else None
+        )
+        gateway_list.append(gateway)
+    return gateway_list
+
+
+@timeit
+def transform_gcp_vpn_tunnels(vpn_tunnel_res: dict) -> list[dict]:
+    """
+    Transform the vpnTunnels.list response object for Neo4j ingestion.
+    NOTE: The API response contains `sharedSecret` and `sharedSecretHash` (the
+    IKE pre-shared key). We deliberately never copy these fields into the
+    transformed output so that VPN secrets are never written to Neo4j.
+    :param vpn_tunnel_res: The return data from get_gcp_vpn_tunnels()
+    :return: List of VPN tunnels ready for ingestion to Neo4j
+    """
+    # prefix has the form `projects/{project}/regions/{region}/vpnTunnels`
+    prefix = vpn_tunnel_res["id"]
+    projectid = prefix.split("/")[1]
+    region = prefix.split("/")[3]
+    tunnel_list = []
+    for t in vpn_tunnel_res.get("items", []):
+        tunnel: dict[str, Any] = {
+            "partial_uri": f"{prefix}/{t['name']}",
+            "self_link": t["selfLink"],
+            "name": t["name"],
+            "project_id": projectid,
+            "region": t.get("region", "").split("/")[-1] or region,
+            "description": t.get("description"),
+            "status": t.get("status"),
+            "detailed_status": t.get("detailedStatus"),
+            "peer_ip": t.get("peerIp"),
+            "ike_version": t.get("ikeVersion"),
+            "local_traffic_selector": t.get("localTrafficSelector"),
+            "remote_traffic_selector": t.get("remoteTrafficSelector"),
+            "creation_timestamp": t.get("creationTimestamp"),
+        }
+        for field, out_field in (
+            ("vpnGateway", "vpn_gateway_partial_uri"),
+            ("peerGcpGateway", "peer_gcp_gateway_partial_uri"),
+            ("targetVpnGateway", "target_vpn_gateway_partial_uri"),
+            ("router", "router_partial_uri"),
+        ):
+            full_uri = t.get(field)
+            tunnel[out_field] = (
+                _parse_compute_full_uri_to_partial_uri(full_uri) if full_uri else None
+            )
+        tunnel_list.append(tunnel)
+    return tunnel_list
 
 
 @timeit
@@ -918,6 +1160,174 @@ def load_gcp_vpcs(
     )
 
 
+def _get_vpc_stubs_from_peerings(peerings: list[dict]) -> list[dict]:
+    """
+    Extract unique peer VPC stubs from peering objects so that PEER_NETWORK
+    relationships can be established even if the peer VPC's project has not been
+    synced. Mirrors the subnet-stub pattern used by the instance sync.
+    :param peerings: List of transformed GCPVpcPeering objects
+    :return: List of VPC stub objects with partial_uri and project_id
+    """
+    seen_vpcs: set[str] = set()
+    vpc_stubs: list[dict] = []
+    for peering in peerings:
+        peer_uri = peering.get("peer_network_partial_uri")
+        if peer_uri and peer_uri not in seen_vpcs:
+            seen_vpcs.add(peer_uri)
+            vpc_stubs.append(
+                {
+                    "partial_uri": peer_uri,
+                    "project_id": peering["peer_project_id"],
+                }
+            )
+    return vpc_stubs
+
+
+def _create_vpc_stubs(
+    neo4j_session: neo4j.Session,
+    vpc_stubs: list[dict],
+    gcp_update_tag: int,
+) -> None:
+    """
+    Create GCPVpc stub nodes if they don't exist. If the peer project is synced
+    in the same run, the full VPC sync MERGEs on the same id and fills in all
+    properties and labels.
+    :param neo4j_session: The Neo4j session
+    :param vpc_stubs: List of VPC stub objects
+    :param gcp_update_tag: The timestamp
+    """
+    if not vpc_stubs:
+        return
+    load(
+        neo4j_session,
+        GCPVpcStubSchema(),
+        vpc_stubs,
+        lastupdated=gcp_update_tag,
+    )
+
+
+@timeit
+def load_gcp_vpc_peerings(
+    neo4j_session: neo4j.Session,
+    peerings: list[dict],
+    gcp_update_tag: int,
+    project_id: str,
+) -> None:
+    """
+    Ingest GCP VPC peering data to Neo4j
+    :param neo4j_session: The Neo4j session
+    :param peerings: List of the VPC peerings
+    :param gcp_update_tag: The timestamp to set these Neo4j nodes with
+    :param project_id: The project ID
+    :return: Nothing
+    """
+    if not peerings:
+        return
+    load(
+        neo4j_session,
+        GCPVpcPeeringSchema(),
+        peerings,
+        lastupdated=gcp_update_tag,
+        PROJECT_ID=project_id,
+    )
+
+
+def _get_vpn_gateway_stubs_from_tunnels(tunnels: list[dict]) -> list[dict]:
+    """
+    Extract unique peer VPN gateway stubs from tunnel objects so that
+    CONNECTS_TO_GATEWAY relationships can be established even if the peer
+    gateway's project has not been synced.
+    :param tunnels: List of transformed GCPVpnTunnel objects
+    :return: List of VPN gateway stub objects with partial_uri and project_id
+    """
+    seen_gateways: set[str] = set()
+    gateway_stubs: list[dict] = []
+    for tunnel in tunnels:
+        peer_uri = tunnel.get("peer_gcp_gateway_partial_uri")
+        if peer_uri and peer_uri not in seen_gateways:
+            seen_gateways.add(peer_uri)
+            gateway_stubs.append(
+                {
+                    "partial_uri": peer_uri,
+                    # Partial URIs have the form
+                    # `projects/{project}/regions/{region}/vpnGateways/{name}`
+                    "project_id": peer_uri.split("/")[1],
+                }
+            )
+    return gateway_stubs
+
+
+def _create_vpn_gateway_stubs(
+    neo4j_session: neo4j.Session,
+    gateway_stubs: list[dict],
+    gcp_update_tag: int,
+) -> None:
+    """
+    Create GCPVpnGateway stub nodes if they don't exist. If the peer project is
+    synced in the same run, the full gateway sync MERGEs on the same id and
+    fills in all properties.
+    :param neo4j_session: The Neo4j session
+    :param gateway_stubs: List of VPN gateway stub objects
+    :param gcp_update_tag: The timestamp
+    """
+    if not gateway_stubs:
+        return
+    load(
+        neo4j_session,
+        GCPVpnGatewayStubSchema(),
+        gateway_stubs,
+        lastupdated=gcp_update_tag,
+    )
+
+
+@timeit
+def load_gcp_vpn_gateways(
+    neo4j_session: neo4j.Session,
+    gateways: list[dict],
+    gcp_update_tag: int,
+    project_id: str,
+) -> None:
+    """
+    Ingest GCP HA VPN gateway data to Neo4j
+    :param neo4j_session: The Neo4j session
+    :param gateways: List of the VPN gateways
+    :param gcp_update_tag: The timestamp to set these Neo4j nodes with
+    :param project_id: The project ID
+    :return: Nothing
+    """
+    load(
+        neo4j_session,
+        GCPVpnGatewaySchema(),
+        gateways,
+        lastupdated=gcp_update_tag,
+        PROJECT_ID=project_id,
+    )
+
+
+@timeit
+def load_gcp_vpn_tunnels(
+    neo4j_session: neo4j.Session,
+    tunnels: list[dict],
+    gcp_update_tag: int,
+    project_id: str,
+) -> None:
+    """
+    Ingest GCP VPN tunnel data to Neo4j
+    :param neo4j_session: The Neo4j session
+    :param tunnels: List of the VPN tunnels
+    :param gcp_update_tag: The timestamp to set these Neo4j nodes with
+    :param project_id: The project ID
+    :return: Nothing
+    """
+    load(
+        neo4j_session,
+        GCPVpnTunnelSchema(),
+        tunnels,
+        lastupdated=gcp_update_tag,
+        PROJECT_ID=project_id,
+    )
+
+
 @timeit
 def load_gcp_subnets(
     neo4j_session: neo4j.Session,
@@ -1212,6 +1622,57 @@ def cleanup_gcp_vpcs(neo4j_session: neo4j.Session, common_job_parameters: dict) 
 
 
 @timeit
+def cleanup_gcp_vpc_peerings(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict,
+) -> None:
+    """
+    Delete out-of-date GCP VPC peering nodes and relationships
+    :param neo4j_session: The Neo4j session
+    :param common_job_parameters: dict of other job parameters to pass to Neo4j
+    :return: Nothing
+    """
+    GraphJob.from_node_schema(
+        GCPVpcPeeringSchema(),
+        common_job_parameters,
+    ).run(neo4j_session)
+
+
+@timeit
+def cleanup_gcp_vpn_gateways(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict,
+) -> None:
+    """
+    Delete out-of-date GCP VPN gateway nodes and relationships
+    :param neo4j_session: The Neo4j session
+    :param common_job_parameters: dict of other job parameters to pass to Neo4j
+    :return: Nothing
+    """
+    GraphJob.from_node_schema(
+        GCPVpnGatewaySchema(),
+        common_job_parameters,
+    ).run(neo4j_session)
+
+
+@timeit
+def cleanup_gcp_vpn_tunnels(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict,
+) -> None:
+    """
+    Delete out-of-date GCP VPN tunnel nodes and relationships
+    :param neo4j_session: The Neo4j session
+    :param common_job_parameters: dict of other job parameters to pass to Neo4j
+    :return: Nothing
+    """
+    GraphJob.from_node_schema(
+        GCPVpnTunnelSchema(),
+        common_job_parameters,
+    ).run(neo4j_session)
+
+
+@timeit
 def cleanup_gcp_subnets(
     neo4j_session: neo4j.Session,
     common_job_parameters: dict,
@@ -1351,7 +1812,133 @@ def sync_gcp_vpcs(
     vpc_res = get_gcp_vpcs(project_id, compute)
     vpcs = transform_gcp_vpcs(vpc_res)
     load_gcp_vpcs(neo4j_session, vpcs, gcp_update_tag, project_id)
+    sync_gcp_vpc_peerings(
+        neo4j_session,
+        vpc_res,
+        project_id,
+        gcp_update_tag,
+        common_job_parameters,
+    )
     cleanup_gcp_vpcs(neo4j_session, common_job_parameters)
+
+
+@timeit
+def sync_gcp_vpc_peerings(
+    neo4j_session: neo4j.Session,
+    vpc_res: dict,
+    project_id: str,
+    gcp_update_tag: int,
+    common_job_parameters: dict,
+) -> None:
+    """
+    Extract VPC Network Peerings from the networks.list response, ingest to
+    Neo4j, and clean up old data. Peerings are embedded in the VPC response, so
+    this reuses the data already fetched by get_gcp_vpcs(). Creates stub GCPVpc
+    nodes for peer networks whose projects have not been synced.
+    :param neo4j_session: The Neo4j session
+    :param vpc_res: The return data from get_gcp_vpcs()
+    :param project_id: The project ID to sync
+    :param gcp_update_tag: The timestamp value to set our new Neo4j nodes with
+    :param common_job_parameters: dict of other job parameters to pass to Neo4j
+    :return: Nothing
+    """
+    peerings = transform_gcp_vpc_peerings(vpc_res)
+    # Create peer VPC stubs first so that PEER_NETWORK relationships resolve
+    # even when the peer project is not synced.
+    _create_vpc_stubs(
+        neo4j_session,
+        _get_vpc_stubs_from_peerings(peerings),
+        gcp_update_tag,
+    )
+    load_gcp_vpc_peerings(neo4j_session, peerings, gcp_update_tag, project_id)
+    cleanup_gcp_vpc_peerings(neo4j_session, common_job_parameters)
+
+
+@timeit
+def sync_gcp_vpn_gateways(
+    neo4j_session: neo4j.Session,
+    compute: Resource,
+    project_id: str,
+    regions: list[str],
+    gcp_update_tag: int,
+    common_job_parameters: dict,
+) -> None:
+    """
+    Sync GCP HA VPN gateways across all regions, ingest to Neo4j, and clean up old data.
+    Must run after sync_gcp_vpcs so PART_OF_VPC relationships resolve in the same cycle.
+    :param neo4j_session: The Neo4j session
+    :param compute: The GCP Compute resource object
+    :param project_id: The project ID to sync
+    :param regions: List of regions
+    :param gcp_update_tag: The timestamp value to set our new Neo4j nodes with
+    :param common_job_parameters: dict of other job parameters to pass to Neo4j
+    :return: Nothing
+    """
+    incomplete = False
+    for r in regions:
+        vpn_gateway_res = get_gcp_vpn_gateways(project_id, r, compute)
+        if vpn_gateway_res is None:
+            # Invalid region or timeout, skip this one
+            incomplete = True
+            continue
+        gateways = transform_gcp_vpn_gateways(vpn_gateway_res)
+        load_gcp_vpn_gateways(neo4j_session, gateways, gcp_update_tag, project_id)
+    if incomplete:
+        logger.warning(
+            "Skipping VPN gateway cleanup for project %s because one or more regions "
+            "returned incomplete data. Existing gateway data will be preserved.",
+            project_id,
+        )
+    else:
+        cleanup_gcp_vpn_gateways(neo4j_session, common_job_parameters)
+
+
+@timeit
+def sync_gcp_vpn_tunnels(
+    neo4j_session: neo4j.Session,
+    compute: Resource,
+    project_id: str,
+    regions: list[str],
+    gcp_update_tag: int,
+    common_job_parameters: dict,
+) -> None:
+    """
+    Sync GCP VPN tunnels across all regions, ingest to Neo4j, and clean up old data.
+    Must run after sync_gcp_vpn_gateways so USES_GATEWAY relationships resolve in
+    the same cycle. Creates stub GCPVpnGateway nodes for peer gateways whose
+    projects have not been synced.
+    :param neo4j_session: The Neo4j session
+    :param compute: The GCP Compute resource object
+    :param project_id: The project ID to sync
+    :param regions: List of regions
+    :param gcp_update_tag: The timestamp value to set our new Neo4j nodes with
+    :param common_job_parameters: dict of other job parameters to pass to Neo4j
+    :return: Nothing
+    """
+    incomplete = False
+    for r in regions:
+        vpn_tunnel_res = get_gcp_vpn_tunnels(project_id, r, compute)
+        if vpn_tunnel_res is None:
+            # Invalid region or timeout, skip this one
+            incomplete = True
+            continue
+        tunnels = transform_gcp_vpn_tunnels(vpn_tunnel_res)
+        # Create peer gateway stubs first so that CONNECTS_TO_GATEWAY
+        # relationships resolve even when the peer project is not synced.
+        _create_vpn_gateway_stubs(
+            neo4j_session,
+            _get_vpn_gateway_stubs_from_tunnels(tunnels),
+            gcp_update_tag,
+        )
+        load_gcp_vpn_tunnels(neo4j_session, tunnels, gcp_update_tag, project_id)
+    if incomplete:
+        logger.warning(
+            "Skipping VPN tunnel cleanup for project %s because one or more regions "
+            "returned incomplete data. Existing tunnel data will be preserved.",
+            project_id,
+        )
+    else:
+        cleanup_gcp_vpn_tunnels(neo4j_session, common_job_parameters)
 
 
 @timeit
@@ -1363,14 +1950,23 @@ def sync_gcp_subnets(
     gcp_update_tag: int,
     common_job_parameters: dict,
 ) -> None:
+    incomplete = False
     for r in regions:
         subnet_res = get_gcp_subnets(project_id, r, compute)
         if subnet_res is None:
-            # Invalid region, skip this one
+            # Invalid region or timeout, skip this one
+            incomplete = True
             continue
         subnets = transform_gcp_subnets(subnet_res)
         load_gcp_subnets(neo4j_session, subnets, gcp_update_tag, project_id)
-    cleanup_gcp_subnets(neo4j_session, common_job_parameters)
+    if incomplete:
+        logger.warning(
+            "Skipping subnet cleanup for project %s because one or more regions "
+            "returned incomplete data. Existing subnet data will be preserved.",
+            project_id,
+        )
+    else:
+        cleanup_gcp_subnets(neo4j_session, common_job_parameters)
 
 
 @timeit
@@ -1513,6 +2109,24 @@ def sync(
             common_job_parameters,
         )
         sync_gcp_subnets(
+            neo4j_session,
+            compute,
+            project_id,
+            regions,
+            gcp_update_tag,
+            common_job_parameters,
+        )
+        # VPN gateways must exist before tunnels so USES_GATEWAY rels resolve
+        # in the same sync cycle; both need VPCs already loaded (PART_OF_VPC).
+        sync_gcp_vpn_gateways(
+            neo4j_session,
+            compute,
+            project_id,
+            regions,
+            gcp_update_tag,
+            common_job_parameters,
+        )
+        sync_gcp_vpn_tunnels(
             neo4j_session,
             compute,
             project_id,

--- a/cartography/models/gcp/compute/vpc_peering.py
+++ b/cartography/models/gcp/compute/vpc_peering.py
@@ -1,0 +1,173 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GCPVpcPeeringNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id",
+        extra_index=True,
+        description="A constructed unique ID for this VPC peering of the form `projects/{project}/global/networks/{network name}/networkPeerings/{peering name}`. "
+        "The GCP API does not expose a resource URI for peerings, so Cartography derives one from the local network and peering name.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    name: PropertyRef = PropertyRef(
+        "name",
+        extra_index=True,
+        description="The name of this VPC Network Peering connection.",
+    )
+    project_id: PropertyRef = PropertyRef(
+        "PROJECT_ID",
+        set_in_kwargs=True,
+        description="The project ID of the local side of this peering (the project whose network the peering is configured on).",
+    )
+    network_partial_uri: PropertyRef = PropertyRef(
+        "network_partial_uri",
+        description="The partial URI of the local VPC network this peering is configured on, e.g. `projects/{project}/global/networks/{network name}`.",
+    )
+    peer_network_partial_uri: PropertyRef = PropertyRef(
+        "peer_network_partial_uri",
+        description="The partial URI of the peer VPC network, e.g. `projects/{peer project}/global/networks/{peer network name}`. The peer network may belong to a different project.",
+    )
+    peer_project_id: PropertyRef = PropertyRef(
+        "peer_project_id",
+        description="The project ID of the peer VPC network, parsed from the peer network URI.",
+    )
+    state: PropertyRef = PropertyRef(
+        "state",
+        description="The peering state, either ACTIVE or INACTIVE. A peering becomes ACTIVE only when both sides are connected.",
+    )
+    state_details: PropertyRef = PropertyRef(
+        "state_details",
+        description="Additional details about the current peering state.",
+    )
+    peer_mtu: PropertyRef = PropertyRef(
+        "peer_mtu",
+        description="Maximum Transmission Unit in bytes of the peer network.",
+    )
+    stack_type: PropertyRef = PropertyRef(
+        "stack_type",
+        description="Which IP stack(s) are allowed to be used by the peering, e.g. IPV4_ONLY or IPV4_IPV6.",
+    )
+    update_strategy: PropertyRef = PropertyRef(
+        "update_strategy",
+        description="The update strategy of the peering, e.g. INDEPENDENT or CONSERVATIVE.",
+    )
+    auto_create_routes: PropertyRef = PropertyRef(
+        "auto_create_routes",
+        description="Whether to automatically create routes for the peer network's subnets.",
+    )
+    exchange_subnet_routes: PropertyRef = PropertyRef(
+        "exchange_subnet_routes",
+        description="Whether subnet routes are exchanged with the peer network.",
+    )
+    import_custom_routes: PropertyRef = PropertyRef(
+        "import_custom_routes",
+        description="Whether custom routes are imported from the peer network.",
+    )
+    export_custom_routes: PropertyRef = PropertyRef(
+        "export_custom_routes",
+        description="Whether custom routes are exported to the peer network.",
+    )
+    import_subnet_routes_with_public_ip: PropertyRef = PropertyRef(
+        "import_subnet_routes_with_public_ip",
+        description="Whether subnet routes with public IP ranges are imported from the peer network.",
+    )
+    export_subnet_routes_with_public_ip: PropertyRef = PropertyRef(
+        "export_subnet_routes_with_public_ip",
+        description="Whether subnet routes with public IP ranges are exported to the peer network.",
+    )
+
+
+@dataclass(frozen=True)
+class GCPVpcPeeringToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPVpcPeeringToProjectRel(CartographyRelSchema):
+    target_node_label: str = "GCPProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("PROJECT_ID", set_in_kwargs=True),
+        }
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPVpcPeeringToProjectRelProperties = (
+        GCPVpcPeeringToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GCPVpcPeeringToLocalVpcRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPVpcPeeringToLocalVpcRel(CartographyRelSchema):
+    """Points from the peering to the local VPC network it is configured on."""
+
+    target_node_label: str = "GCPVpc"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("network_partial_uri"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "LOCAL_NETWORK"
+    properties: GCPVpcPeeringToLocalVpcRelProperties = (
+        GCPVpcPeeringToLocalVpcRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GCPVpcPeeringToPeerVpcRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPVpcPeeringToPeerVpcRel(CartographyRelSchema):
+    """Points from the peering to the peer VPC network. The peer VPC may live in a
+    different project; if that project has not been synced, the target is a stub
+    GCPVpc node holding only its partial URI."""
+
+    target_node_label: str = "GCPVpc"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("peer_network_partial_uri"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "PEER_NETWORK"
+    properties: GCPVpcPeeringToPeerVpcRelProperties = (
+        GCPVpcPeeringToPeerVpcRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GCPVpcPeeringSchema(CartographyNodeSchema):
+    """Representation of one side of a GCP [VPC Network Peering](https://cloud.google.com/vpc/docs/vpc-peering)
+    connection. GCP reports each peering from each participating network's perspective, so Cartography
+    creates one GCPVpcPeering node per side; the two sides are joined through their shared
+    LOCAL_NETWORK / PEER_NETWORK edges to GCPVpc nodes, which may belong to different projects.
+    """
+
+    label: str = "GCPVpcPeering"
+    properties: GCPVpcPeeringNodeProperties = GCPVpcPeeringNodeProperties()
+    sub_resource_relationship: GCPVpcPeeringToProjectRel = GCPVpcPeeringToProjectRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            GCPVpcPeeringToLocalVpcRel(),
+            GCPVpcPeeringToPeerVpcRel(),
+        ]
+    )

--- a/cartography/models/gcp/compute/vpc_stub.py
+++ b/cartography/models/gcp/compute/vpc_stub.py
@@ -1,0 +1,71 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GCPVpcStubNodeProperties(CartographyNodeProperties):
+    """
+    Minimal properties for GCPVpc stub nodes.
+    These are created from VPC peering `peerNetwork` references so that
+    PEER_NETWORK relationships can be established even when the peer VPC's
+    project is not synced.
+    """
+
+    id: PropertyRef = PropertyRef(
+        "partial_uri",
+        description="The partial resource URI representing this VPC.  Has the form `projects/{project_name}/global/networks/{vpc name}`.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    partial_uri: PropertyRef = PropertyRef(
+        "partial_uri", extra_index=True, description="Same as `id`."
+    )
+    # NOTE: descriptions for properties shared with GCPVpcSchema must match it
+    # exactly; the schema-docs generator rejects conflicting descriptions for
+    # the same (label, property) pair.
+    project_id: PropertyRef = PropertyRef(
+        "project_id",
+        description="The project ID that this VPC belongs to.",
+    )
+
+
+@dataclass(frozen=True)
+class GCPVpcStubToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPVpcStubToProjectRel(CartographyRelSchema):
+    target_node_label: str = "GCPProject"
+    # Matched on the peer project parsed from the stub's own partial URI (data
+    # field), not on the PROJECT_ID kwarg of the syncing project: the stub
+    # represents a VPC owned by the *peer* project.
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("project_id"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPVpcStubToProjectRelProperties = GCPVpcStubToProjectRelProperties()
+
+
+@dataclass(frozen=True)
+class GCPVpcStubSchema(CartographyNodeSchema):
+    """Representation of a GCP [VPC](https://cloud.google.com/compute/docs/reference/rest/v1/networks/) placeholder."""
+
+    label: str = "GCPVpc"
+    properties: GCPVpcStubNodeProperties = GCPVpcStubNodeProperties()
+    # Deliberately no `VirtualNetwork` semantic label here: stubs only carry
+    # partial_uri and would surface in cross-cloud `(:VirtualNetwork)` queries
+    # with a null _ont_name (the GCP mapping resolves the ontology name from the
+    # `name` field, which the stub lacks). The full GCPVpcSchema attaches the
+    # VirtualNetwork label and _ont_* fields once the real VPC data is synced.
+    sub_resource_relationship: GCPVpcStubToProjectRel = GCPVpcStubToProjectRel()

--- a/cartography/models/gcp/compute/vpn_gateway.py
+++ b/cartography/models/gcp/compute/vpn_gateway.py
@@ -1,0 +1,108 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GCPVpnGatewayNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "partial_uri",
+        extra_index=True,
+        description="A partial resource URI representing this HA VPN Gateway. Has the form `projects/{project}/regions/{region}/vpnGateways/{gateway name}`.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    partial_uri: PropertyRef = PropertyRef("partial_uri", description="Same as `id`.")
+    self_link: PropertyRef = PropertyRef(
+        "self_link",
+        description="The full resource URI representing this VPN Gateway. Has the form `https://www.googleapis.com/compute/v1/{partial_uri}`.",
+    )
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="The name of this VPN Gateway."
+    )
+    project_id: PropertyRef = PropertyRef(
+        "project_id", description="The project ID that this VPN Gateway belongs to."
+    )
+    region: PropertyRef = PropertyRef(
+        "region", description="The region of this VPN Gateway."
+    )
+    description: PropertyRef = PropertyRef(
+        "description", description="A description for this VPN Gateway."
+    )
+    gateway_ip_version: PropertyRef = PropertyRef(
+        "gateway_ip_version",
+        description="The IP family of the gateway, e.g. IPV4 or IPV6.",
+    )
+    stack_type: PropertyRef = PropertyRef(
+        "stack_type",
+        description="The stack type of the gateway, e.g. IPV4_ONLY or IPV4_IPV6.",
+    )
+    network_partial_uri: PropertyRef = PropertyRef(
+        "network_partial_uri",
+        description="The partial URI of the VPC network this VPN Gateway is attached to, e.g. `projects/{project}/global/networks/{network name}`.",
+    )
+    creation_timestamp: PropertyRef = PropertyRef(
+        "creation_timestamp",
+        description="The creation timestamp of this VPN Gateway.",
+    )
+
+
+@dataclass(frozen=True)
+class GCPVpnGatewayToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPVpnGatewayToProjectRel(CartographyRelSchema):
+    target_node_label: str = "GCPProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("PROJECT_ID", set_in_kwargs=True),
+        }
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPVpnGatewayToProjectRelProperties = (
+        GCPVpnGatewayToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GCPVpnGatewayToVpcRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPVpnGatewayToVpcRel(CartographyRelSchema):
+    """Points from the VPN gateway to the VPC network it is attached to."""
+
+    target_node_label: str = "GCPVpc"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("network_partial_uri"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "PART_OF_VPC"
+    properties: GCPVpnGatewayToVpcRelProperties = GCPVpnGatewayToVpcRelProperties()
+
+
+@dataclass(frozen=True)
+class GCPVpnGatewaySchema(CartographyNodeSchema):
+    """Representation of a GCP [HA VPN Gateway](https://cloud.google.com/compute/docs/reference/rest/v1/vpnGateways)."""
+
+    label: str = "GCPVpnGateway"
+    properties: GCPVpnGatewayNodeProperties = GCPVpnGatewayNodeProperties()
+    sub_resource_relationship: GCPVpnGatewayToProjectRel = GCPVpnGatewayToProjectRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            GCPVpnGatewayToVpcRel(),
+        ]
+    )

--- a/cartography/models/gcp/compute/vpn_gateway_stub.py
+++ b/cartography/models/gcp/compute/vpn_gateway_stub.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GCPVpnGatewayStubNodeProperties(CartographyNodeProperties):
+    """
+    Minimal properties for GCPVpnGateway stub nodes.
+    These are created from VPN tunnel `peerGcpGateway` references so that
+    CONNECTS_TO_GATEWAY relationships can be established even when the peer
+    gateway's project is not synced.
+    """
+
+    id: PropertyRef = PropertyRef(
+        "partial_uri",
+        description="A partial resource URI representing this HA VPN Gateway. Has the form `projects/{project}/regions/{region}/vpnGateways/{gateway name}`.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    partial_uri: PropertyRef = PropertyRef(
+        "partial_uri", extra_index=True, description="Same as `id`."
+    )
+    # NOTE: descriptions for properties shared with GCPVpnGatewaySchema must
+    # match it exactly; the schema-docs generator rejects conflicting
+    # descriptions for the same (label, property) pair.
+    project_id: PropertyRef = PropertyRef(
+        "project_id",
+        description="The project ID that this VPN Gateway belongs to.",
+    )
+
+
+@dataclass(frozen=True)
+class GCPVpnGatewayStubToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPVpnGatewayStubToProjectRel(CartographyRelSchema):
+    target_node_label: str = "GCPProject"
+    # Matched on the peer project parsed from the stub's own partial URI (data
+    # field), not on the PROJECT_ID kwarg of the syncing project: the stub
+    # represents a gateway owned by the *peer* project.
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("project_id"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPVpnGatewayStubToProjectRelProperties = (
+        GCPVpnGatewayStubToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GCPVpnGatewayStubSchema(CartographyNodeSchema):
+    """Representation of a GCP [HA VPN Gateway](https://cloud.google.com/compute/docs/reference/rest/v1/vpnGateways)
+    placeholder for gateways whose owning project has not been synced."""
+
+    label: str = "GCPVpnGateway"
+    properties: GCPVpnGatewayStubNodeProperties = GCPVpnGatewayStubNodeProperties()
+    # No extra fields are set on purpose: a later full sync of the owning project
+    # MERGEs on the same id and fills in the complete gateway properties.
+    sub_resource_relationship: GCPVpnGatewayStubToProjectRel = (
+        GCPVpnGatewayStubToProjectRel()
+    )

--- a/cartography/models/gcp/compute/vpn_tunnel.py
+++ b/cartography/models/gcp/compute/vpn_tunnel.py
@@ -1,0 +1,167 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GCPVpnTunnelNodeProperties(CartographyNodeProperties):
+    # NOTE: The GCP API returns `sharedSecret`/`sharedSecretHash` (the IKE
+    # pre-shared key) on tunnel resources. These are deliberately NOT modeled
+    # here so that Cartography never ingests VPN secrets.
+    id: PropertyRef = PropertyRef(
+        "partial_uri",
+        extra_index=True,
+        description="A partial resource URI representing this VPN Tunnel. Has the form `projects/{project}/regions/{region}/vpnTunnels/{tunnel name}`.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    partial_uri: PropertyRef = PropertyRef("partial_uri", description="Same as `id`.")
+    self_link: PropertyRef = PropertyRef(
+        "self_link",
+        description="The full resource URI representing this VPN Tunnel. Has the form `https://www.googleapis.com/compute/v1/{partial_uri}`.",
+    )
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="The name of this VPN Tunnel."
+    )
+    project_id: PropertyRef = PropertyRef(
+        "project_id", description="The project ID that this VPN Tunnel belongs to."
+    )
+    region: PropertyRef = PropertyRef(
+        "region", description="The region of this VPN Tunnel."
+    )
+    description: PropertyRef = PropertyRef(
+        "description", description="A description for this VPN Tunnel."
+    )
+    status: PropertyRef = PropertyRef(
+        "status",
+        description="The status of the VPN tunnel, e.g. ESTABLISHED, WAITING_FOR_FULL_CONFIG, or FAILED.",
+    )
+    detailed_status: PropertyRef = PropertyRef(
+        "detailed_status",
+        description="A detailed human-readable status message for the VPN tunnel.",
+    )
+    peer_ip: PropertyRef = PropertyRef(
+        "peer_ip",
+        description="The IP address of the peer VPN gateway. Set for tunnels to non-GCP peers.",
+    )
+    ike_version: PropertyRef = PropertyRef(
+        "ike_version",
+        description="The IKE protocol version of the tunnel (1 or 2).",
+    )
+    local_traffic_selector: PropertyRef = PropertyRef(
+        "local_traffic_selector",
+        description="Local traffic selector CIDR ranges to use when establishing the VPN tunnel.",
+    )
+    remote_traffic_selector: PropertyRef = PropertyRef(
+        "remote_traffic_selector",
+        description="Remote traffic selector CIDR ranges to use when establishing the VPN tunnel.",
+    )
+    vpn_gateway_partial_uri: PropertyRef = PropertyRef(
+        "vpn_gateway_partial_uri",
+        description="The partial URI of the HA VPN gateway on the local side of this tunnel. Unset for classic VPN tunnels.",
+    )
+    peer_gcp_gateway_partial_uri: PropertyRef = PropertyRef(
+        "peer_gcp_gateway_partial_uri",
+        description="The partial URI of the peer HA VPN gateway, when the tunnel connects to another GCP VPN gateway. The peer gateway may belong to a different project.",
+    )
+    target_vpn_gateway_partial_uri: PropertyRef = PropertyRef(
+        "target_vpn_gateway_partial_uri",
+        description="The partial URI of the classic (legacy) target VPN gateway this tunnel is attached to, if any.",
+    )
+    router_partial_uri: PropertyRef = PropertyRef(
+        "router_partial_uri",
+        description="The partial URI of the Cloud Router associated with this tunnel, if any.",
+    )
+    creation_timestamp: PropertyRef = PropertyRef(
+        "creation_timestamp",
+        description="The creation timestamp of this VPN Tunnel.",
+    )
+
+
+@dataclass(frozen=True)
+class GCPVpnTunnelToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPVpnTunnelToProjectRel(CartographyRelSchema):
+    target_node_label: str = "GCPProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("PROJECT_ID", set_in_kwargs=True),
+        }
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPVpnTunnelToProjectRelProperties = (
+        GCPVpnTunnelToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GCPVpnTunnelToGatewayRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPVpnTunnelToGatewayRel(CartographyRelSchema):
+    """Points from the VPN tunnel to the local HA VPN gateway it runs on."""
+
+    target_node_label: str = "GCPVpnGateway"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("vpn_gateway_partial_uri"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_GATEWAY"
+    properties: GCPVpnTunnelToGatewayRelProperties = (
+        GCPVpnTunnelToGatewayRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GCPVpnTunnelToPeerGatewayRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPVpnTunnelToPeerGatewayRel(CartographyRelSchema):
+    """Points from the VPN tunnel to the peer HA VPN gateway on the remote side.
+    The peer gateway may live in a different project; if that project has not been
+    synced, the target is a stub GCPVpnGateway node holding only its partial URI."""
+
+    target_node_label: str = "GCPVpnGateway"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("peer_gcp_gateway_partial_uri"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "CONNECTS_TO_GATEWAY"
+    properties: GCPVpnTunnelToPeerGatewayRelProperties = (
+        GCPVpnTunnelToPeerGatewayRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GCPVpnTunnelSchema(CartographyNodeSchema):
+    """Representation of a GCP [Cloud VPN Tunnel](https://cloud.google.com/compute/docs/reference/rest/v1/vpnTunnels).
+    Cartography never ingests the tunnel's `sharedSecret`/`sharedSecretHash` fields."""
+
+    label: str = "GCPVpnTunnel"
+    properties: GCPVpnTunnelNodeProperties = GCPVpnTunnelNodeProperties()
+    sub_resource_relationship: GCPVpnTunnelToProjectRel = GCPVpnTunnelToProjectRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            GCPVpnTunnelToGatewayRel(),
+            GCPVpnTunnelToPeerGatewayRel(),
+        ]
+    )

--- a/docs/root/modules/gcp/index.md
+++ b/docs/root/modules/gcp/index.md
@@ -3,7 +3,7 @@
 Cartography supports ingesting Google Cloud Platform resources, including:
 
 - **Cloud Resource Manager**: Organizations, Folders, Projects
-- **Compute**: Instances, VPCs, Subnets, Firewalls, Forwarding Rules, Network Interfaces, SSL Policies, Target HTTPS Proxies, Target SSL Proxies
+- **Compute**: Instances, VPCs, Subnets, Firewalls, Forwarding Rules, Network Interfaces, SSL Policies, Target HTTPS Proxies, Target SSL Proxies, VPC Peerings, VPN Gateways, VPN Tunnels
 - **Storage**: Buckets
 - **DNS**: Zones, Record Sets
 - **IAM**: Service Accounts, Roles, Policy Bindings

--- a/docs/root/modules/gcp/index.md
+++ b/docs/root/modules/gcp/index.md
@@ -23,11 +23,16 @@ call) and modeled as `GCPVpcPeering` nodes linked to the local VPC via
 synced, Cartography creates a `GCPVpc` stub node so the `PEER_NETWORK`
 relationship still resolves.
 
-VPN tunnels (`GCPVpnTunnel`) are synced per region along with their VPN
-gateways (`GCPVpnGateway`). Gateways are synced before tunnels so that
-`USES_GATEWAY` relationships resolve in the same sync cycle; peer gateways
-outside the synced project are represented as stub nodes linked via
-`CONNECTS_TO_GATEWAY`.
+VPN tunnels (`GCPVpnTunnel`) and VPN gateways (`GCPVpnGateway`) are fetched
+with the Compute aggregated list endpoints (one request chain per project,
+with partial success enabled; cleanup is skipped whenever any region scope
+returns an error). Gateways are synced before tunnels so that `USES_GATEWAY`
+relationships resolve in the same sync cycle; peer gateways outside the synced
+project are represented as stub nodes linked via `CONNECTS_TO_GATEWAY`.
+
+Stub nodes are reference-counted by their relationships, not by a sync scope:
+once no peering or tunnel references a stub (and no synced project owns it),
+it is removed automatically on the next sync.
 
 ## Cloud Asset Inventory behavior
 

--- a/docs/root/modules/gcp/index.md
+++ b/docs/root/modules/gcp/index.md
@@ -15,6 +15,20 @@ Cartography supports ingesting Google Cloud Platform resources, including:
 - **Secret Manager**: Secrets, Secret Versions
 - **Cloud Run**: Services, Revisions, Jobs, Executions
 
+## VPC peerings and VPN tunnels
+
+VPC peerings are extracted from each network's `peerings` field (no extra API
+call) and modeled as `GCPVpcPeering` nodes linked to the local VPC via
+`LOCAL_NETWORK`. When the peer network belongs to a project that has not been
+synced, Cartography creates a `GCPVpc` stub node so the `PEER_NETWORK`
+relationship still resolves.
+
+VPN tunnels (`GCPVpnTunnel`) are synced per region along with their VPN
+gateways (`GCPVpnGateway`). Gateways are synced before tunnels so that
+`USES_GATEWAY` relationships resolve in the same sync cycle; peer gateways
+outside the synced project are represented as stub nodes linked via
+`CONNECTS_TO_GATEWAY`.
+
 ## Cloud Asset Inventory behavior
 
 Cartography uses the Cloud Asset Inventory API as a fallback for service

--- a/tests/data/gcp/compute.py
+++ b/tests/data/gcp/compute.py
@@ -897,3 +897,289 @@ LIST_GLOBAL_FORWARDING_RULES_RESPONSE = {
     "selfLink": "https://www.googleapis.com/compute/v1/projects/project-abc/global/forwardingRules",
     "kind": "compute#forwardingRuleList",
 }
+
+# VPC response for project-abc containing two peerings on network vpc-a:
+# - peering-a-to-b: peer network lives in project-def (synced in some tests)
+# - peering-a-to-ext: peer network lives in project-xyz (never synced -> stub)
+VPC_PEERING_RESPONSE = {
+    "id": "projects/project-abc/global/networks",
+    "items": [
+        {
+            "autoCreateSubnetworks": False,
+            "creationTimestamp": "2024-01-10T10:00:00.000-08:00",
+            "description": "Peered network in project-abc",
+            "id": "345678",
+            "kind": "compute#network",
+            "name": "vpc-a",
+            "routingConfig": {
+                "routingMode": "GLOBAL",
+            },
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/project-abc/global/networks/vpc-a",
+            "peerings": [
+                {
+                    "name": "peering-a-to-b",
+                    "network": "https://www.googleapis.com/compute/v1/projects/project-abc/global/networks/vpc-a",
+                    "peerNetwork": "https://www.googleapis.com/compute/v1/projects/project-def/global/networks/vpc-b",
+                    "state": "ACTIVE",
+                    "stateDetails": "[2024-01-10T10:05:00]: Connected.",
+                    "peerMtu": 1460,
+                    "stackType": "IPV4_ONLY",
+                    "updateStrategy": "CONSERVATIVE",
+                    "autoCreateRoutes": True,
+                    "exchangeSubnetRoutes": True,
+                    "importCustomRoutes": False,
+                    "exportCustomRoutes": True,
+                    "importSubnetRoutesWithPublicIp": False,
+                    "exportSubnetRoutesWithPublicIp": False,
+                },
+                {
+                    "name": "peering-a-to-ext",
+                    "network": "https://www.googleapis.com/compute/v1/projects/project-abc/global/networks/vpc-a",
+                    "peerNetwork": "https://www.googleapis.com/compute/v1/projects/project-xyz/global/networks/vpc-ext",
+                    "state": "INACTIVE",
+                    "stateDetails": "[2024-01-11T09:00:00]: Waiting for peer network to connect.",
+                    "peerMtu": 1460,
+                    "stackType": "IPV4_ONLY",
+                    "updateStrategy": "CONSERVATIVE",
+                    "autoCreateRoutes": True,
+                    "exchangeSubnetRoutes": True,
+                    "importCustomRoutes": True,
+                    "exportCustomRoutes": False,
+                    "importSubnetRoutesWithPublicIp": False,
+                    "exportSubnetRoutesWithPublicIp": False,
+                },
+            ],
+        },
+    ],
+    "kind": "compute#networkList",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-abc/global/networks",
+}
+
+# The other side of peering-a-to-b, as reported by project-def's networks.list.
+VPC_PEERING_PEER_RESPONSE = {
+    "id": "projects/project-def/global/networks",
+    "items": [
+        {
+            "autoCreateSubnetworks": False,
+            "creationTimestamp": "2024-01-10T10:01:00.000-08:00",
+            "description": "Peered network in project-def",
+            "id": "456789",
+            "kind": "compute#network",
+            "name": "vpc-b",
+            "routingConfig": {
+                "routingMode": "GLOBAL",
+            },
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/project-def/global/networks/vpc-b",
+            "peerings": [
+                {
+                    "name": "peering-b-to-a",
+                    "network": "https://www.googleapis.com/compute/v1/projects/project-def/global/networks/vpc-b",
+                    "peerNetwork": "https://www.googleapis.com/compute/v1/projects/project-abc/global/networks/vpc-a",
+                    "state": "ACTIVE",
+                    "stateDetails": "[2024-01-10T10:05:00]: Connected.",
+                    "peerMtu": 1460,
+                    "stackType": "IPV4_ONLY",
+                    "updateStrategy": "CONSERVATIVE",
+                    "autoCreateRoutes": True,
+                    "exchangeSubnetRoutes": True,
+                    "importCustomRoutes": True,
+                    "exportCustomRoutes": False,
+                    "importSubnetRoutesWithPublicIp": False,
+                    "exportSubnetRoutesWithPublicIp": False,
+                },
+            ],
+        },
+    ],
+    "kind": "compute#networkList",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-def/global/networks",
+}
+
+# Same project/network as VPC_PEERING_RESPONSE but with all peerings removed
+# (used for stale-peering cleanup tests).
+VPC_PEERING_RESPONSE_NO_PEERINGS = {
+    "id": "projects/project-abc/global/networks",
+    "items": [
+        {
+            "autoCreateSubnetworks": False,
+            "creationTimestamp": "2024-01-10T10:00:00.000-08:00",
+            "description": "Peered network in project-abc",
+            "id": "345678",
+            "kind": "compute#network",
+            "name": "vpc-a",
+            "routingConfig": {
+                "routingMode": "GLOBAL",
+            },
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/project-abc/global/networks/vpc-a",
+        },
+    ],
+    "kind": "compute#networkList",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-abc/global/networks",
+}
+
+VPN_GATEWAYS_RESPONSE = {
+    "id": "projects/project-abc/regions/us-central1/vpnGateways",
+    "items": [
+        {
+            "creationTimestamp": "2024-02-01T08:00:00.000-08:00",
+            "description": "HA VPN gateway in project-abc",
+            "id": "111222333",
+            "kind": "compute#vpnGateway",
+            "name": "gw-a",
+            "network": "https://www.googleapis.com/compute/v1/projects/project-abc/global/networks/vpc-a",
+            "region": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1/vpnGateways/gw-a",
+            "stackType": "IPV4_ONLY",
+            "gatewayIpVersion": "IPV4",
+            "vpnInterfaces": [
+                {
+                    "id": 0,
+                    "ipAddress": "203.0.113.10",
+                    "interconnectAttachment": None,
+                },
+                {
+                    "id": 1,
+                    "ipAddress": "203.0.113.11",
+                    "interconnectAttachment": None,
+                },
+            ],
+        },
+    ],
+    "kind": "compute#vpnGatewayList",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1/vpnGateways",
+}
+
+# project-abc's tunnels: one HA tunnel to project-def's gw-b, one HA tunnel to
+# project-xyz's gw-ext (never synced -> stub), and one classic tunnel with no
+# vpnGateway. Includes sharedSecret to prove it is never ingested.
+VPN_TUNNELS_RESPONSE = {
+    "id": "projects/project-abc/regions/us-central1/vpnTunnels",
+    "items": [
+        {
+            "creationTimestamp": "2024-02-01T08:05:00.000-08:00",
+            "description": "HA VPN tunnel to project-def",
+            "detailedStatus": "Tunnel is up and running.",
+            "id": "222333444",
+            "ikeVersion": 2,
+            "kind": "compute#vpnTunnel",
+            "localTrafficSelector": ["0.0.0.0/0"],
+            "remoteTrafficSelector": ["0.0.0.0/0"],
+            "name": "tunnel-a-to-b",
+            "peerGcpGateway": "https://www.googleapis.com/compute/v1/projects/project-def/regions/us-central1/vpnGateways/gw-b",
+            "region": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1/vpnTunnels/tunnel-a-to-b",
+            "sharedSecret": "mock-psk-do-not-ingest",
+            "sharedSecretHash": "HASHED:abc123",
+            "status": "ESTABLISHED",
+            "vpnGateway": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1/vpnGateways/gw-a",
+            "vpnGatewayInterface": 0,
+        },
+        {
+            "creationTimestamp": "2024-02-01T08:06:00.000-08:00",
+            "description": "HA VPN tunnel to project-xyz",
+            "detailedStatus": "Tunnel is up and running.",
+            "id": "333444555",
+            "ikeVersion": 2,
+            "kind": "compute#vpnTunnel",
+            "localTrafficSelector": ["10.0.0.0/8"],
+            "remoteTrafficSelector": ["172.16.0.0/12"],
+            "name": "tunnel-a-to-ext",
+            "peerGcpGateway": "https://www.googleapis.com/compute/v1/projects/project-xyz/regions/us-central1/vpnGateways/gw-ext",
+            "region": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1/vpnTunnels/tunnel-a-to-ext",
+            "sharedSecret": "mock-psk-do-not-ingest-2",
+            "sharedSecretHash": "HASHED:def456",
+            "status": "ESTABLISHED",
+            "vpnGateway": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1/vpnGateways/gw-a",
+            "vpnGatewayInterface": 1,
+        },
+        {
+            "creationTimestamp": "2024-02-01T08:07:00.000-08:00",
+            "description": "Classic VPN tunnel to on-prem",
+            "detailedStatus": "Tunnel is up and running.",
+            "id": "444555666",
+            "ikeVersion": 2,
+            "kind": "compute#vpnTunnel",
+            "localTrafficSelector": ["0.0.0.0/0"],
+            "remoteTrafficSelector": ["0.0.0.0/0"],
+            "name": "tunnel-classic",
+            "peerIp": "198.51.100.1",
+            "region": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1",
+            "router": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1/routers/router-a",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1/vpnTunnels/tunnel-classic",
+            "sharedSecret": "mock-psk-do-not-ingest-3",
+            "sharedSecretHash": "HASHED:ghi789",
+            "status": "ESTABLISHED",
+            "targetVpnGateway": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1/targetVpnGateways/classic-gw",
+        },
+    ],
+    "kind": "compute#vpnTunnelList",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1/vpnTunnels",
+}
+
+# project-def's side of the HA VPN: gateway gw-b and tunnel back to gw-a.
+VPN_GATEWAYS_PEER_RESPONSE = {
+    "id": "projects/project-def/regions/us-central1/vpnGateways",
+    "items": [
+        {
+            "creationTimestamp": "2024-02-01T08:01:00.000-08:00",
+            "description": "HA VPN gateway in project-def",
+            "id": "555666777",
+            "kind": "compute#vpnGateway",
+            "name": "gw-b",
+            "network": "https://www.googleapis.com/compute/v1/projects/project-def/global/networks/vpc-b",
+            "region": "https://www.googleapis.com/compute/v1/projects/project-def/regions/us-central1",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/project-def/regions/us-central1/vpnGateways/gw-b",
+            "stackType": "IPV4_ONLY",
+            "gatewayIpVersion": "IPV4",
+            "vpnInterfaces": [
+                {
+                    "id": 0,
+                    "ipAddress": "203.0.113.20",
+                    "interconnectAttachment": None,
+                },
+            ],
+        },
+    ],
+    "kind": "compute#vpnGatewayList",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-def/regions/us-central1/vpnGateways",
+}
+
+VPN_TUNNELS_PEER_RESPONSE = {
+    "id": "projects/project-def/regions/us-central1/vpnTunnels",
+    "items": [
+        {
+            "creationTimestamp": "2024-02-01T08:08:00.000-08:00",
+            "description": "HA VPN tunnel to project-abc",
+            "detailedStatus": "Tunnel is up and running.",
+            "id": "666777888",
+            "ikeVersion": 2,
+            "kind": "compute#vpnTunnel",
+            "localTrafficSelector": ["0.0.0.0/0"],
+            "remoteTrafficSelector": ["0.0.0.0/0"],
+            "name": "tunnel-b-to-a",
+            "peerGcpGateway": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1/vpnGateways/gw-a",
+            "region": "https://www.googleapis.com/compute/v1/projects/project-def/regions/us-central1",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/project-def/regions/us-central1/vpnTunnels/tunnel-b-to-a",
+            "sharedSecret": "mock-psk-do-not-ingest-4",
+            "sharedSecretHash": "HASHED:jkl012",
+            "status": "ESTABLISHED",
+            "vpnGateway": "https://www.googleapis.com/compute/v1/projects/project-def/regions/us-central1/vpnGateways/gw-b",
+            "vpnGatewayInterface": 0,
+        },
+    ],
+    "kind": "compute#vpnTunnelList",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-def/regions/us-central1/vpnTunnels",
+}
+
+# Empty regional responses (used for cleanup tests).
+VPN_GATEWAYS_RESPONSE_EMPTY = {
+    "id": "projects/project-abc/regions/us-central1/vpnGateways",
+    "kind": "compute#vpnGatewayList",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1/vpnGateways",
+}
+
+VPN_TUNNELS_RESPONSE_EMPTY = {
+    "id": "projects/project-abc/regions/us-central1/vpnTunnels",
+    "kind": "compute#vpnTunnelList",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/project-abc/regions/us-central1/vpnTunnels",
+}

--- a/tests/integration/cartography/intel/gcp/test_compute.py
+++ b/tests/integration/cartography/intel/gcp/test_compute.py
@@ -1364,3 +1364,716 @@ def test_vpc_cleanup_scoped_to_project(mock_get_vpcs, neo4j_session):
         ("project-abc", "projects/project-abc/global/networks/default"),
         ("project-def", "projects/project-def/global/networks/default2"),
     }, "Second project->vpc rels are not created"
+
+
+@patch.object(
+    cartography.intel.gcp.compute,
+    "get_gcp_vpcs",
+    return_value=tests.data.gcp.compute.VPC_PEERING_RESPONSE,
+)
+def test_sync_gcp_vpc_peerings(mock_get_vpcs, neo4j_session):
+    """Test that sync_gcp_vpcs() extracts peerings from the VPC response, loads
+    one GCPVpcPeering node per side, links them to local and peer VPCs, and
+    creates stub GCPVpc nodes for peer networks in unsynced projects."""
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "PROJECT_ID": TEST_PROJECT_ID,
+    }
+    _create_test_project(neo4j_session, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+
+    # Act
+    cartography.intel.gcp.compute.sync_gcp_vpcs(
+        neo4j_session,
+        MagicMock(),
+        TEST_PROJECT_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    # Assert - Peering nodes created with correct properties
+    assert check_nodes(
+        neo4j_session,
+        "GCPVpcPeering",
+        ["id", "name", "state", "peer_project_id", "export_custom_routes"],
+    ) == {
+        (
+            "projects/project-abc/global/networks/vpc-a/networkPeerings/peering-a-to-b",
+            "peering-a-to-b",
+            "ACTIVE",
+            "project-def",
+            True,
+        ),
+        (
+            "projects/project-abc/global/networks/vpc-a/networkPeerings/peering-a-to-ext",
+            "peering-a-to-ext",
+            "INACTIVE",
+            "project-xyz",
+            False,
+        ),
+    }
+
+    # Assert - Project to Peering RESOURCE relationships created
+    assert check_rels(
+        neo4j_session,
+        "GCPProject",
+        "id",
+        "GCPVpcPeering",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (
+            "project-abc",
+            "projects/project-abc/global/networks/vpc-a/networkPeerings/peering-a-to-b",
+        ),
+        (
+            "project-abc",
+            "projects/project-abc/global/networks/vpc-a/networkPeerings/peering-a-to-ext",
+        ),
+    }
+
+    # Assert - Peering to local VPC relationships created
+    assert check_rels(
+        neo4j_session,
+        "GCPVpcPeering",
+        "id",
+        "GCPVpc",
+        "id",
+        "LOCAL_NETWORK",
+        rel_direction_right=True,
+    ) == {
+        (
+            "projects/project-abc/global/networks/vpc-a/networkPeerings/peering-a-to-b",
+            "projects/project-abc/global/networks/vpc-a",
+        ),
+        (
+            "projects/project-abc/global/networks/vpc-a/networkPeerings/peering-a-to-ext",
+            "projects/project-abc/global/networks/vpc-a",
+        ),
+    }
+
+    # Assert - Peering to peer VPC relationships created, including stubs in
+    # unsynced projects
+    assert check_rels(
+        neo4j_session,
+        "GCPVpcPeering",
+        "id",
+        "GCPVpc",
+        "id",
+        "PEER_NETWORK",
+        rel_direction_right=True,
+    ) == {
+        (
+            "projects/project-abc/global/networks/vpc-a/networkPeerings/peering-a-to-b",
+            "projects/project-def/global/networks/vpc-b",
+        ),
+        (
+            "projects/project-abc/global/networks/vpc-a/networkPeerings/peering-a-to-ext",
+            "projects/project-xyz/global/networks/vpc-ext",
+        ),
+    }
+
+    # Assert - Peer VPC stubs exist, carry no name, and deliberately do NOT have
+    # the VirtualNetwork ontology label (mirrors the GCPSubnet stub rationale:
+    # stubs lack the data needed for _ont_* fields).
+    stub_nodes = neo4j_session.run(
+        """
+        MATCH (v:GCPVpc)
+        WHERE v.id IN $stub_ids
+        RETURN v.id AS id, labels(v) AS labels, v.name AS name
+        """,
+        stub_ids=[
+            "projects/project-def/global/networks/vpc-b",
+            "projects/project-xyz/global/networks/vpc-ext",
+        ],
+    )
+    stub_results = {r["id"]: r for r in stub_nodes}
+    assert set(stub_results) == {
+        "projects/project-def/global/networks/vpc-b",
+        "projects/project-xyz/global/networks/vpc-ext",
+    }
+    for r in stub_results.values():
+        assert r["labels"] == ["GCPVpc"]
+        assert r["name"] is None
+
+
+def test_sync_gcp_vpc_peerings_both_sides(neo4j_session):
+    """Test that syncing both projects of a peering creates one peering node per
+    side, and that the real VPC sync upgrades the stub node with full data and
+    the VirtualNetwork label."""
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "PROJECT_ID": TEST_PROJECT_ID,
+    }
+    _create_test_project(neo4j_session, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+    _create_test_project(neo4j_session, "project-def", TEST_UPDATE_TAG)
+
+    def _vpc_response_for_project(projectid, compute):
+        if projectid == "project-def":
+            return tests.data.gcp.compute.VPC_PEERING_PEER_RESPONSE
+        return tests.data.gcp.compute.VPC_PEERING_RESPONSE
+
+    # Act - sync project-abc first (creates a stub for project-def's vpc-b),
+    # then project-def (upgrades the stub with real data).
+    with patch.object(
+        cartography.intel.gcp.compute,
+        "get_gcp_vpcs",
+        side_effect=_vpc_response_for_project,
+    ):
+        cartography.intel.gcp.compute.sync_gcp_vpcs(
+            neo4j_session,
+            MagicMock(),
+            TEST_PROJECT_ID,
+            TEST_UPDATE_TAG,
+            common_job_parameters,
+        )
+        common_job_parameters["PROJECT_ID"] = "project-def"
+        cartography.intel.gcp.compute.sync_gcp_vpcs(
+            neo4j_session,
+            MagicMock(),
+            "project-def",
+            TEST_UPDATE_TAG,
+            common_job_parameters,
+        )
+
+    # Assert - one peering node per side
+    assert check_nodes(
+        neo4j_session,
+        "GCPVpcPeering",
+        ["id", "project_id"],
+    ) == {
+        (
+            "projects/project-abc/global/networks/vpc-a/networkPeerings/peering-a-to-b",
+            "project-abc",
+        ),
+        (
+            "projects/project-abc/global/networks/vpc-a/networkPeerings/peering-a-to-ext",
+            "project-abc",
+        ),
+        (
+            "projects/project-def/global/networks/vpc-b/networkPeerings/peering-b-to-a",
+            "project-def",
+        ),
+    }
+
+    # Assert - the second side's LOCAL_NETWORK/PEER_NETWORK edges point the
+    # other way, joining the two sides through the same VPC nodes
+    assert check_rels(
+        neo4j_session,
+        "GCPVpcPeering",
+        "id",
+        "GCPVpc",
+        "id",
+        "LOCAL_NETWORK",
+        rel_direction_right=True,
+    ) >= {
+        (
+            "projects/project-def/global/networks/vpc-b/networkPeerings/peering-b-to-a",
+            "projects/project-def/global/networks/vpc-b",
+        ),
+    }
+    assert check_rels(
+        neo4j_session,
+        "GCPVpcPeering",
+        "id",
+        "GCPVpc",
+        "id",
+        "PEER_NETWORK",
+        rel_direction_right=True,
+    ) >= {
+        (
+            "projects/project-def/global/networks/vpc-b/networkPeerings/peering-b-to-a",
+            "projects/project-abc/global/networks/vpc-a",
+        ),
+    }
+
+    # Assert - the stub for project-def's vpc-b was upgraded by the real sync:
+    # full properties, RESOURCE edge from project-def, and VirtualNetwork label.
+    vpc_b = neo4j_session.run(
+        """
+        MATCH (v:GCPVpc {id: $id})
+        RETURN labels(v) AS labels, v.name AS name, v.description AS description
+        """,
+        id="projects/project-def/global/networks/vpc-b",
+    ).single()
+    assert vpc_b["name"] == "vpc-b"
+    assert vpc_b["description"] == "Peered network in project-def"
+    assert "VirtualNetwork" in vpc_b["labels"]
+    assert check_rels(
+        neo4j_session,
+        "GCPProject",
+        "id",
+        "GCPVpc",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) >= {
+        ("project-def", "projects/project-def/global/networks/vpc-b"),
+    }
+
+
+def test_sync_gcp_vpc_peerings_cleanup(neo4j_session):
+    """Test that peerings removed from the VPC response are deleted on the next sync."""
+    # Arrange - sync once with peerings present
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "PROJECT_ID": TEST_PROJECT_ID,
+    }
+    _create_test_project(neo4j_session, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+    with patch.object(
+        cartography.intel.gcp.compute,
+        "get_gcp_vpcs",
+        return_value=tests.data.gcp.compute.VPC_PEERING_RESPONSE,
+    ):
+        cartography.intel.gcp.compute.sync_gcp_vpcs(
+            neo4j_session,
+            MagicMock(),
+            TEST_PROJECT_ID,
+            TEST_UPDATE_TAG,
+            common_job_parameters,
+        )
+    assert check_nodes(neo4j_session, "GCPVpcPeering", ["id"]) != set()
+
+    # Act - sync again with the peerings removed at a later update tag
+    new_tag = TEST_UPDATE_TAG + 1
+    common_job_parameters["UPDATE_TAG"] = new_tag
+    with patch.object(
+        cartography.intel.gcp.compute,
+        "get_gcp_vpcs",
+        return_value=tests.data.gcp.compute.VPC_PEERING_RESPONSE_NO_PEERINGS,
+    ):
+        cartography.intel.gcp.compute.sync_gcp_vpcs(
+            neo4j_session,
+            MagicMock(),
+            TEST_PROJECT_ID,
+            new_tag,
+            common_job_parameters,
+        )
+
+    # Assert - peering nodes are deleted; the VPC itself remains
+    assert check_nodes(neo4j_session, "GCPVpcPeering", ["id"]) == set()
+    assert check_nodes(neo4j_session, "GCPVpc", ["id"]) >= {
+        ("projects/project-abc/global/networks/vpc-a",),
+    }
+
+
+@patch.object(
+    cartography.intel.gcp.compute,
+    "get_gcp_vpn_tunnels",
+    return_value=tests.data.gcp.compute.VPN_TUNNELS_RESPONSE,
+)
+@patch.object(
+    cartography.intel.gcp.compute,
+    "get_gcp_vpn_gateways",
+    return_value=tests.data.gcp.compute.VPN_GATEWAYS_RESPONSE,
+)
+@patch.object(
+    cartography.intel.gcp.compute,
+    "get_gcp_vpcs",
+    return_value=tests.data.gcp.compute.VPC_PEERING_RESPONSE_NO_PEERINGS,
+)
+def test_sync_gcp_vpn_gateways_and_tunnels(
+    mock_get_vpcs, mock_get_gateways, mock_get_tunnels, neo4j_session
+):
+    """Test that VPN gateways and tunnels are loaded with their project, VPC,
+    and gateway relationships, that cross-project peer gateways become stubs,
+    and that shared secrets are never ingested."""
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "PROJECT_ID": TEST_PROJECT_ID,
+    }
+    _create_test_project(neo4j_session, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+
+    # Act
+    cartography.intel.gcp.compute.sync_gcp_vpcs(
+        neo4j_session,
+        MagicMock(),
+        TEST_PROJECT_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+    cartography.intel.gcp.compute.sync_gcp_vpn_gateways(
+        neo4j_session,
+        MagicMock(),
+        TEST_PROJECT_ID,
+        ["us-central1"],
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+    cartography.intel.gcp.compute.sync_gcp_vpn_tunnels(
+        neo4j_session,
+        MagicMock(),
+        TEST_PROJECT_ID,
+        ["us-central1"],
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    # Assert - VPN gateway node created with correct properties
+    assert check_nodes(
+        neo4j_session,
+        "GCPVpnGateway",
+        ["id", "name", "region", "project_id", "stack_type"],
+    ) == {
+        (
+            "projects/project-abc/regions/us-central1/vpnGateways/gw-a",
+            "gw-a",
+            "us-central1",
+            "project-abc",
+            "IPV4_ONLY",
+        ),
+        # Stub for the peer gateway in unsynced project-xyz: only id and
+        # project_id are set, all other checked fields are None.
+        (
+            "projects/project-xyz/regions/us-central1/vpnGateways/gw-ext",
+            None,
+            None,
+            "project-xyz",
+            None,
+        ),
+        # Stub for the peer gateway in unsynced project-def.
+        (
+            "projects/project-def/regions/us-central1/vpnGateways/gw-b",
+            None,
+            None,
+            "project-def",
+            None,
+        ),
+    }
+
+    # Assert - Gateway to project and VPC relationships created
+    assert check_rels(
+        neo4j_session,
+        "GCPProject",
+        "id",
+        "GCPVpnGateway",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) >= {
+        ("project-abc", "projects/project-abc/regions/us-central1/vpnGateways/gw-a"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "GCPVpnGateway",
+        "id",
+        "GCPVpc",
+        "id",
+        "PART_OF_VPC",
+        rel_direction_right=True,
+    ) == {
+        (
+            "projects/project-abc/regions/us-central1/vpnGateways/gw-a",
+            "projects/project-abc/global/networks/vpc-a",
+        ),
+    }
+
+    # Assert - VPN tunnel nodes created with correct properties
+    assert check_nodes(
+        neo4j_session,
+        "GCPVpnTunnel",
+        ["id", "name", "status", "ike_version", "peer_ip"],
+    ) == {
+        (
+            "projects/project-abc/regions/us-central1/vpnTunnels/tunnel-a-to-b",
+            "tunnel-a-to-b",
+            "ESTABLISHED",
+            2,
+            None,
+        ),
+        (
+            "projects/project-abc/regions/us-central1/vpnTunnels/tunnel-a-to-ext",
+            "tunnel-a-to-ext",
+            "ESTABLISHED",
+            2,
+            None,
+        ),
+        (
+            "projects/project-abc/regions/us-central1/vpnTunnels/tunnel-classic",
+            "tunnel-classic",
+            "ESTABLISHED",
+            2,
+            "198.51.100.1",
+        ),
+    }
+
+    # Assert - Tunnel to project relationships created
+    assert check_rels(
+        neo4j_session,
+        "GCPProject",
+        "id",
+        "GCPVpnTunnel",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (
+            "project-abc",
+            "projects/project-abc/regions/us-central1/vpnTunnels/tunnel-a-to-b",
+        ),
+        (
+            "project-abc",
+            "projects/project-abc/regions/us-central1/vpnTunnels/tunnel-a-to-ext",
+        ),
+        (
+            "project-abc",
+            "projects/project-abc/regions/us-central1/vpnTunnels/tunnel-classic",
+        ),
+    }
+
+    # Assert - HA tunnels connect to their local gateway (classic tunnel does not)
+    assert check_rels(
+        neo4j_session,
+        "GCPVpnTunnel",
+        "id",
+        "GCPVpnGateway",
+        "id",
+        "USES_GATEWAY",
+        rel_direction_right=True,
+    ) == {
+        (
+            "projects/project-abc/regions/us-central1/vpnTunnels/tunnel-a-to-b",
+            "projects/project-abc/regions/us-central1/vpnGateways/gw-a",
+        ),
+        (
+            "projects/project-abc/regions/us-central1/vpnTunnels/tunnel-a-to-ext",
+            "projects/project-abc/regions/us-central1/vpnGateways/gw-a",
+        ),
+    }
+
+    # Assert - Cross-project CONNECTS_TO_GATEWAY edges land on stub gateways
+    assert check_rels(
+        neo4j_session,
+        "GCPVpnTunnel",
+        "id",
+        "GCPVpnGateway",
+        "id",
+        "CONNECTS_TO_GATEWAY",
+        rel_direction_right=True,
+    ) == {
+        (
+            "projects/project-abc/regions/us-central1/vpnTunnels/tunnel-a-to-b",
+            "projects/project-def/regions/us-central1/vpnGateways/gw-b",
+        ),
+        (
+            "projects/project-abc/regions/us-central1/vpnTunnels/tunnel-a-to-ext",
+            "projects/project-xyz/regions/us-central1/vpnGateways/gw-ext",
+        ),
+    }
+
+    # Assert - the IKE shared secret from the API response was never ingested
+    tunnels = neo4j_session.run("MATCH (t:GCPVpnTunnel) RETURN keys(t) AS keys")
+    for record in tunnels:
+        assert "sharedSecret" not in record["keys"]
+        assert "sharedSecretHash" not in record["keys"]
+        assert "shared_secret" not in record["keys"]
+
+
+def test_sync_gcp_vpn_tunnels_both_sides(neo4j_session):
+    """Test that syncing both projects of a cross-project HA VPN yields gateway
+    and tunnel nodes on both sides, with CONNECTS_TO_GATEWAY edges crossing the
+    project boundary in both directions, and the peer-side stub upgraded."""
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "PROJECT_ID": TEST_PROJECT_ID,
+    }
+    _create_test_project(neo4j_session, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+    _create_test_project(neo4j_session, "project-def", TEST_UPDATE_TAG)
+
+    def _vpc_response_for_project(projectid, compute):
+        if projectid == "project-def":
+            return tests.data.gcp.compute.VPC_PEERING_PEER_RESPONSE
+        return tests.data.gcp.compute.VPC_PEERING_RESPONSE
+
+    def _gateway_response_for_project(projectid, region, compute):
+        if projectid == "project-def":
+            return tests.data.gcp.compute.VPN_GATEWAYS_PEER_RESPONSE
+        return tests.data.gcp.compute.VPN_GATEWAYS_RESPONSE
+
+    def _tunnel_response_for_project(projectid, region, compute):
+        if projectid == "project-def":
+            return tests.data.gcp.compute.VPN_TUNNELS_PEER_RESPONSE
+        return tests.data.gcp.compute.VPN_TUNNELS_RESPONSE
+
+    # Act - sync project-abc first (creates a stub for project-def's gw-b),
+    # then project-def (upgrades the stub with real data).
+    with (
+        patch.object(
+            cartography.intel.gcp.compute,
+            "get_gcp_vpcs",
+            side_effect=_vpc_response_for_project,
+        ),
+        patch.object(
+            cartography.intel.gcp.compute,
+            "get_gcp_vpn_gateways",
+            side_effect=_gateway_response_for_project,
+        ),
+        patch.object(
+            cartography.intel.gcp.compute,
+            "get_gcp_vpn_tunnels",
+            side_effect=_tunnel_response_for_project,
+        ),
+    ):
+        for project in (TEST_PROJECT_ID, "project-def"):
+            common_job_parameters["PROJECT_ID"] = project
+            cartography.intel.gcp.compute.sync_gcp_vpcs(
+                neo4j_session,
+                MagicMock(),
+                project,
+                TEST_UPDATE_TAG,
+                common_job_parameters,
+            )
+            cartography.intel.gcp.compute.sync_gcp_vpn_gateways(
+                neo4j_session,
+                MagicMock(),
+                project,
+                ["us-central1"],
+                TEST_UPDATE_TAG,
+                common_job_parameters,
+            )
+            cartography.intel.gcp.compute.sync_gcp_vpn_tunnels(
+                neo4j_session,
+                MagicMock(),
+                project,
+                ["us-central1"],
+                TEST_UPDATE_TAG,
+                common_job_parameters,
+            )
+
+    # Assert - the stub for project-def's gw-b was upgraded by the real sync
+    gw_b = neo4j_session.run(
+        """
+        MATCH (g:GCPVpnGateway {id: $id})
+        RETURN g.name AS name, g.description AS description
+        """,
+        id="projects/project-def/regions/us-central1/vpnGateways/gw-b",
+    ).single()
+    assert gw_b["name"] == "gw-b"
+    assert gw_b["description"] == "HA VPN gateway in project-def"
+
+    # Assert - both tunnel directions exist with cross-project
+    # CONNECTS_TO_GATEWAY edges pointing at real gateway nodes
+    assert check_rels(
+        neo4j_session,
+        "GCPVpnTunnel",
+        "id",
+        "GCPVpnGateway",
+        "id",
+        "CONNECTS_TO_GATEWAY",
+        rel_direction_right=True,
+    ) >= {
+        (
+            "projects/project-abc/regions/us-central1/vpnTunnels/tunnel-a-to-b",
+            "projects/project-def/regions/us-central1/vpnGateways/gw-b",
+        ),
+        (
+            "projects/project-def/regions/us-central1/vpnTunnels/tunnel-b-to-a",
+            "projects/project-abc/regions/us-central1/vpnGateways/gw-a",
+        ),
+    }
+
+    # Assert - gateway gw-b links to its own project's VPC
+    assert check_rels(
+        neo4j_session,
+        "GCPVpnGateway",
+        "id",
+        "GCPVpc",
+        "id",
+        "PART_OF_VPC",
+        rel_direction_right=True,
+    ) >= {
+        (
+            "projects/project-def/regions/us-central1/vpnGateways/gw-b",
+            "projects/project-def/global/networks/vpc-b",
+        ),
+    }
+
+
+def test_sync_gcp_vpn_tunnels_cleanup(neo4j_session):
+    """Test that gateways and tunnels removed from the API responses are deleted
+    on the next sync."""
+    # Arrange - sync once with gateways and tunnels present
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "PROJECT_ID": TEST_PROJECT_ID,
+    }
+    _create_test_project(neo4j_session, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+    with (
+        patch.object(
+            cartography.intel.gcp.compute,
+            "get_gcp_vpn_gateways",
+            return_value=tests.data.gcp.compute.VPN_GATEWAYS_RESPONSE,
+        ),
+        patch.object(
+            cartography.intel.gcp.compute,
+            "get_gcp_vpn_tunnels",
+            return_value=tests.data.gcp.compute.VPN_TUNNELS_RESPONSE,
+        ),
+    ):
+        cartography.intel.gcp.compute.sync_gcp_vpn_gateways(
+            neo4j_session,
+            MagicMock(),
+            TEST_PROJECT_ID,
+            ["us-central1"],
+            TEST_UPDATE_TAG,
+            common_job_parameters,
+        )
+        cartography.intel.gcp.compute.sync_gcp_vpn_tunnels(
+            neo4j_session,
+            MagicMock(),
+            TEST_PROJECT_ID,
+            ["us-central1"],
+            TEST_UPDATE_TAG,
+            common_job_parameters,
+        )
+    assert check_nodes(neo4j_session, "GCPVpnTunnel", ["id"]) != set()
+
+    # Act - sync again with empty responses at a later update tag
+    new_tag = TEST_UPDATE_TAG + 1
+    common_job_parameters["UPDATE_TAG"] = new_tag
+    with (
+        patch.object(
+            cartography.intel.gcp.compute,
+            "get_gcp_vpn_gateways",
+            return_value=tests.data.gcp.compute.VPN_GATEWAYS_RESPONSE_EMPTY,
+        ),
+        patch.object(
+            cartography.intel.gcp.compute,
+            "get_gcp_vpn_tunnels",
+            return_value=tests.data.gcp.compute.VPN_TUNNELS_RESPONSE_EMPTY,
+        ),
+    ):
+        cartography.intel.gcp.compute.sync_gcp_vpn_gateways(
+            neo4j_session,
+            MagicMock(),
+            TEST_PROJECT_ID,
+            ["us-central1"],
+            new_tag,
+            common_job_parameters,
+        )
+        cartography.intel.gcp.compute.sync_gcp_vpn_tunnels(
+            neo4j_session,
+            MagicMock(),
+            TEST_PROJECT_ID,
+            ["us-central1"],
+            new_tag,
+            common_job_parameters,
+        )
+
+    # Assert - project-abc's gateways and tunnels are deleted; peer gateway
+    # stubs in unsynced projects remain (their owning projects never clean up).
+    assert check_nodes(neo4j_session, "GCPVpnTunnel", ["id"]) == set()
+    assert check_nodes(neo4j_session, "GCPVpnGateway", ["id"]) == {
+        ("projects/project-def/regions/us-central1/vpnGateways/gw-b",),
+        ("projects/project-xyz/regions/us-central1/vpnGateways/gw-ext",),
+    }

--- a/tests/integration/cartography/intel/gcp/test_compute.py
+++ b/tests/integration/cartography/intel/gcp/test_compute.py
@@ -1665,12 +1665,12 @@ def test_sync_gcp_vpc_peerings_cleanup(neo4j_session):
 @patch.object(
     cartography.intel.gcp.compute,
     "get_gcp_vpn_tunnels",
-    return_value=tests.data.gcp.compute.VPN_TUNNELS_RESPONSE,
+    return_value=(tests.data.gcp.compute.VPN_TUNNELS_RESPONSE["items"], False),
 )
 @patch.object(
     cartography.intel.gcp.compute,
     "get_gcp_vpn_gateways",
-    return_value=tests.data.gcp.compute.VPN_GATEWAYS_RESPONSE,
+    return_value=(tests.data.gcp.compute.VPN_GATEWAYS_RESPONSE["items"], False),
 )
 @patch.object(
     cartography.intel.gcp.compute,
@@ -1703,7 +1703,6 @@ def test_sync_gcp_vpn_gateways_and_tunnels(
         neo4j_session,
         MagicMock(),
         TEST_PROJECT_ID,
-        ["us-central1"],
         TEST_UPDATE_TAG,
         common_job_parameters,
     )
@@ -1711,7 +1710,6 @@ def test_sync_gcp_vpn_gateways_and_tunnels(
         neo4j_session,
         MagicMock(),
         TEST_PROJECT_ID,
-        ["us-central1"],
         TEST_UPDATE_TAG,
         common_job_parameters,
     )
@@ -1894,15 +1892,15 @@ def test_sync_gcp_vpn_tunnels_both_sides(neo4j_session):
             return tests.data.gcp.compute.VPC_PEERING_PEER_RESPONSE
         return tests.data.gcp.compute.VPC_PEERING_RESPONSE
 
-    def _gateway_response_for_project(projectid, region, compute):
+    def _gateway_response_for_project(projectid, compute):
         if projectid == "project-def":
-            return tests.data.gcp.compute.VPN_GATEWAYS_PEER_RESPONSE
-        return tests.data.gcp.compute.VPN_GATEWAYS_RESPONSE
+            return (tests.data.gcp.compute.VPN_GATEWAYS_PEER_RESPONSE["items"], False)
+        return (tests.data.gcp.compute.VPN_GATEWAYS_RESPONSE["items"], False)
 
-    def _tunnel_response_for_project(projectid, region, compute):
+    def _tunnel_response_for_project(projectid, compute):
         if projectid == "project-def":
-            return tests.data.gcp.compute.VPN_TUNNELS_PEER_RESPONSE
-        return tests.data.gcp.compute.VPN_TUNNELS_RESPONSE
+            return (tests.data.gcp.compute.VPN_TUNNELS_PEER_RESPONSE["items"], False)
+        return (tests.data.gcp.compute.VPN_TUNNELS_RESPONSE["items"], False)
 
     # Act - sync project-abc first (creates a stub for project-def's gw-b),
     # then project-def (upgrades the stub with real data).
@@ -1936,7 +1934,6 @@ def test_sync_gcp_vpn_tunnels_both_sides(neo4j_session):
                 neo4j_session,
                 MagicMock(),
                 project,
-                ["us-central1"],
                 TEST_UPDATE_TAG,
                 common_job_parameters,
             )
@@ -1944,7 +1941,6 @@ def test_sync_gcp_vpn_tunnels_both_sides(neo4j_session):
                 neo4j_session,
                 MagicMock(),
                 project,
-                ["us-central1"],
                 TEST_UPDATE_TAG,
                 common_job_parameters,
             )
@@ -2000,7 +1996,8 @@ def test_sync_gcp_vpn_tunnels_both_sides(neo4j_session):
 
 def test_sync_gcp_vpn_tunnels_cleanup(neo4j_session):
     """Test that gateways and tunnels removed from the API responses are deleted
-    on the next sync."""
+    on the next sync, and that peer gateway stubs in unsynced projects are
+    removed once no tunnel references them anymore."""
     # Arrange - sync once with gateways and tunnels present
     neo4j_session.run("MATCH (n) DETACH DELETE n")
     common_job_parameters = {
@@ -2012,19 +2009,18 @@ def test_sync_gcp_vpn_tunnels_cleanup(neo4j_session):
         patch.object(
             cartography.intel.gcp.compute,
             "get_gcp_vpn_gateways",
-            return_value=tests.data.gcp.compute.VPN_GATEWAYS_RESPONSE,
+            return_value=(tests.data.gcp.compute.VPN_GATEWAYS_RESPONSE["items"], False),
         ),
         patch.object(
             cartography.intel.gcp.compute,
             "get_gcp_vpn_tunnels",
-            return_value=tests.data.gcp.compute.VPN_TUNNELS_RESPONSE,
+            return_value=(tests.data.gcp.compute.VPN_TUNNELS_RESPONSE["items"], False),
         ),
     ):
         cartography.intel.gcp.compute.sync_gcp_vpn_gateways(
             neo4j_session,
             MagicMock(),
             TEST_PROJECT_ID,
-            ["us-central1"],
             TEST_UPDATE_TAG,
             common_job_parameters,
         )
@@ -2032,7 +2028,6 @@ def test_sync_gcp_vpn_tunnels_cleanup(neo4j_session):
             neo4j_session,
             MagicMock(),
             TEST_PROJECT_ID,
-            ["us-central1"],
             TEST_UPDATE_TAG,
             common_job_parameters,
         )
@@ -2045,19 +2040,24 @@ def test_sync_gcp_vpn_tunnels_cleanup(neo4j_session):
         patch.object(
             cartography.intel.gcp.compute,
             "get_gcp_vpn_gateways",
-            return_value=tests.data.gcp.compute.VPN_GATEWAYS_RESPONSE_EMPTY,
+            return_value=(
+                tests.data.gcp.compute.VPN_GATEWAYS_RESPONSE_EMPTY.get("items", []),
+                False,
+            ),
         ),
         patch.object(
             cartography.intel.gcp.compute,
             "get_gcp_vpn_tunnels",
-            return_value=tests.data.gcp.compute.VPN_TUNNELS_RESPONSE_EMPTY,
+            return_value=(
+                tests.data.gcp.compute.VPN_TUNNELS_RESPONSE_EMPTY.get("items", []),
+                False,
+            ),
         ),
     ):
         cartography.intel.gcp.compute.sync_gcp_vpn_gateways(
             neo4j_session,
             MagicMock(),
             TEST_PROJECT_ID,
-            ["us-central1"],
             new_tag,
             common_job_parameters,
         )
@@ -2065,15 +2065,69 @@ def test_sync_gcp_vpn_tunnels_cleanup(neo4j_session):
             neo4j_session,
             MagicMock(),
             TEST_PROJECT_ID,
-            ["us-central1"],
             new_tag,
             common_job_parameters,
         )
 
-    # Assert - project-abc's gateways and tunnels are deleted; peer gateway
-    # stubs in unsynced projects remain (their owning projects never clean up).
+    # Assert - project-abc's gateways and tunnels are deleted, and the peer
+    # gateway stubs are gone too: with no tunnel referencing them, the orphan
+    # stub cleanup removes them even though their owning projects never sync.
     assert check_nodes(neo4j_session, "GCPVpnTunnel", ["id"]) == set()
-    assert check_nodes(neo4j_session, "GCPVpnGateway", ["id"]) == {
-        ("projects/project-def/regions/us-central1/vpnGateways/gw-b",),
-        ("projects/project-xyz/regions/us-central1/vpnGateways/gw-ext",),
+    assert check_nodes(neo4j_session, "GCPVpnGateway", ["id"]) == set()
+
+
+def test_sync_gcp_vpc_peerings_orphan_stub_cleanup(neo4j_session):
+    """Two-sync test: peer VPC stubs created for unsynced projects must be
+    removed once the peerings referencing them disappear, while the real local
+    VPC is untouched."""
+    # Arrange - sync 1: vpc-a has peerings to vpc-b (project-def) and vpc-c
+    # (project-xyz), both unsynced, so stubs are created for both.
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "PROJECT_ID": TEST_PROJECT_ID,
+    }
+    _create_test_project(neo4j_session, TEST_PROJECT_ID, TEST_UPDATE_TAG)
+
+    with patch.object(
+        cartography.intel.gcp.compute,
+        "get_gcp_vpcs",
+        return_value=tests.data.gcp.compute.VPC_PEERING_RESPONSE,
+    ):
+        cartography.intel.gcp.compute.sync_gcp_vpcs(
+            neo4j_session,
+            MagicMock(),
+            TEST_PROJECT_ID,
+            TEST_UPDATE_TAG,
+            common_job_parameters,
+        )
+
+    assert check_nodes(neo4j_session, "GCPVpc", ["id"]) == {
+        ("projects/project-abc/global/networks/vpc-a",),
+        ("projects/project-def/global/networks/vpc-b",),
+        ("projects/project-xyz/global/networks/vpc-ext",),
+    }
+    assert check_nodes(neo4j_session, "GCPVpcPeering", ["id"]) != set()
+
+    # Act - sync 2: all peerings are gone from the API response.
+    new_tag = TEST_UPDATE_TAG + 1
+    common_job_parameters["UPDATE_TAG"] = new_tag
+    with patch.object(
+        cartography.intel.gcp.compute,
+        "get_gcp_vpcs",
+        return_value=tests.data.gcp.compute.VPC_PEERING_RESPONSE_NO_PEERINGS,
+    ):
+        cartography.intel.gcp.compute.sync_gcp_vpcs(
+            neo4j_session,
+            MagicMock(),
+            TEST_PROJECT_ID,
+            new_tag,
+            common_job_parameters,
+        )
+
+    # Assert - peerings and their orphan stub VPCs are deleted; the real local
+    # VPC (owned by the synced project via RESOURCE) remains.
+    assert check_nodes(neo4j_session, "GCPVpcPeering", ["id"]) == set()
+    assert check_nodes(neo4j_session, "GCPVpc", ["id"]) == {
+        ("projects/project-abc/global/networks/vpc-a",),
     }

--- a/tests/unit/cartography/intel/gcp/test_compute.py
+++ b/tests/unit/cartography/intel/gcp/test_compute.py
@@ -167,7 +167,8 @@ def test_transform_gcp_vpn_gateways():
     parses the network reference.
     """
     gateways = cartography.intel.gcp.compute.transform_gcp_vpn_gateways(
-        VPN_GATEWAYS_RESPONSE
+        VPN_GATEWAYS_RESPONSE["items"],
+        "project-abc",
     )
     assert len(gateways) == 1
 
@@ -190,7 +191,8 @@ def test_transform_gcp_vpn_tunnels():
     gateway references, and never copies the shared secret fields.
     """
     tunnels = cartography.intel.gcp.compute.transform_gcp_vpn_tunnels(
-        VPN_TUNNELS_RESPONSE
+        VPN_TUNNELS_RESPONSE["items"],
+        "project-abc",
     )
     assert len(tunnels) == 3
 

--- a/tests/unit/cartography/intel/gcp/test_compute.py
+++ b/tests/unit/cartography/intel/gcp/test_compute.py
@@ -1,7 +1,10 @@
 import cartography.intel.gcp.compute
 from tests.data.gcp.compute import LIST_FIREWALLS_RESPONSE
+from tests.data.gcp.compute import VPC_PEERING_RESPONSE
 from tests.data.gcp.compute import VPC_RESPONSE
 from tests.data.gcp.compute import VPC_SUBNET_RESPONSE
+from tests.data.gcp.compute import VPN_GATEWAYS_RESPONSE
+from tests.data.gcp.compute import VPN_TUNNELS_RESPONSE
 
 
 def test_transform_gcp_vpcs():
@@ -117,3 +120,104 @@ def test_transform_gcp_firewall():
     assert sample_fw_icmp_rule["fromport"] is None
     assert sample_fw_icmp_rule["toport"] is None
     assert sample_fw_icmp_rule["protocol"] == "icmp"
+
+
+def test_transform_gcp_vpc_peerings():
+    """
+    Ensure that transform_gcp_vpc_peerings() extracts peerings from a
+    networks.list response, builds stable IDs, and parses peer project IDs.
+    """
+    peerings = cartography.intel.gcp.compute.transform_gcp_vpc_peerings(
+        VPC_PEERING_RESPONSE
+    )
+    assert len(peerings) == 2
+
+    peering = peerings[0]
+    assert (
+        peering["id"]
+        == "projects/project-abc/global/networks/vpc-a/networkPeerings/peering-a-to-b"
+    )
+    assert peering["network_partial_uri"] == (
+        "projects/project-abc/global/networks/vpc-a"
+    )
+    assert peering["peer_network_partial_uri"] == (
+        "projects/project-def/global/networks/vpc-b"
+    )
+    assert peering["peer_project_id"] == "project-def"
+    assert peering["state"] == "ACTIVE"
+    assert peering["peer_mtu"] == 1460
+    assert peering["export_custom_routes"] is True
+    assert peering["import_custom_routes"] is False
+
+    peering2 = peerings[1]
+    assert peering2["peer_project_id"] == "project-xyz"
+
+
+def test_transform_gcp_vpc_peerings_no_peerings():
+    """
+    Ensure that transform_gcp_vpc_peerings() returns an empty list when no
+    network has peerings.
+    """
+    assert cartography.intel.gcp.compute.transform_gcp_vpc_peerings(VPC_RESPONSE) == []
+
+
+def test_transform_gcp_vpn_gateways():
+    """
+    Ensure that transform_gcp_vpn_gateways() builds correct partial URIs and
+    parses the network reference.
+    """
+    gateways = cartography.intel.gcp.compute.transform_gcp_vpn_gateways(
+        VPN_GATEWAYS_RESPONSE
+    )
+    assert len(gateways) == 1
+
+    gateway = gateways[0]
+    assert (
+        gateway["partial_uri"]
+        == "projects/project-abc/regions/us-central1/vpnGateways/gw-a"
+    )
+    assert gateway["project_id"] == "project-abc"
+    assert gateway["region"] == "us-central1"
+    assert gateway["network_partial_uri"] == (
+        "projects/project-abc/global/networks/vpc-a"
+    )
+    assert gateway["gateway_ip_version"] == "IPV4"
+
+
+def test_transform_gcp_vpn_tunnels():
+    """
+    Ensure that transform_gcp_vpn_tunnels() builds correct partial URIs, parses
+    gateway references, and never copies the shared secret fields.
+    """
+    tunnels = cartography.intel.gcp.compute.transform_gcp_vpn_tunnels(
+        VPN_TUNNELS_RESPONSE
+    )
+    assert len(tunnels) == 3
+
+    tunnel = tunnels[0]
+    assert (
+        tunnel["partial_uri"]
+        == "projects/project-abc/regions/us-central1/vpnTunnels/tunnel-a-to-b"
+    )
+    assert tunnel["vpn_gateway_partial_uri"] == (
+        "projects/project-abc/regions/us-central1/vpnGateways/gw-a"
+    )
+    assert tunnel["peer_gcp_gateway_partial_uri"] == (
+        "projects/project-def/regions/us-central1/vpnGateways/gw-b"
+    )
+    assert tunnel["target_vpn_gateway_partial_uri"] is None
+    assert tunnel["status"] == "ESTABLISHED"
+
+    classic = tunnels[2]
+    assert classic["vpn_gateway_partial_uri"] is None
+    assert classic["peer_gcp_gateway_partial_uri"] is None
+    assert classic["target_vpn_gateway_partial_uri"] == (
+        "projects/project-abc/regions/us-central1/targetVpnGateways/classic-gw"
+    )
+    assert classic["peer_ip"] == "198.51.100.1"
+
+    # sharedSecret / sharedSecretHash must never be copied to the graph.
+    for t in tunnels:
+        assert "sharedSecret" not in t
+        assert "sharedSecretHash" not in t
+        assert "shared_secret" not in t

--- a/tests/unit/cartography/intel/gcp/test_compute_http_errors.py
+++ b/tests/unit/cartography/intel/gcp/test_compute_http_errors.py
@@ -302,59 +302,116 @@ class TestGetGcpVpnGatewaysHttpErrors:
                 message="Compute Engine API has not been used in project",
             ),
             _make_http_error(404, reason="notFound", message="Project not found"),
-            _make_http_error(
-                400,
-                reason="invalid",
-                message="Invalid value for field 'region'",
-            ),
+            _make_http_error(400, reason="invalid", message="Invalid request"),
         ],
     )
-    def test_returns_none_for_expected_skip_categories(self, error):
+    def test_returns_empty_incomplete_for_expected_skip_categories(self, error):
         """
-        A 403 on vpnGateways.list (e.g. identity has compute.zones.list but not
-        compute.vpnGateways.list) must not abort the whole project sync; the
-        region is skipped instead so cleanup is suppressed via `incomplete`.
+        A whole-call 403 on vpnGateways.aggregatedList (e.g. identity has
+        compute.zones.list but not compute.vpnGateways.list) must not abort the
+        project sync; return ([], incomplete=True) so cleanup is suppressed.
         """
         mock_compute = MagicMock()
-        request = _make_request(error=error)
-        mock_compute.vpnGateways.return_value.list.return_value = request
-
-        assert get_gcp_vpn_gateways("test-project", "us-central1", mock_compute) is None
-
-    def test_returns_none_for_forbidden_during_request_creation(self):
-        mock_compute = MagicMock()
-        mock_compute.vpnGateways.return_value.list.side_effect = _make_http_error(
-            403,
-            reason="forbidden",
-            message="Required 'compute.vpnGateways.list' permission",
+        mock_compute.vpnGateways.return_value.aggregatedList.return_value = (
+            _make_request(error=error)
         )
 
-        assert get_gcp_vpn_gateways("test-project", "us-central1", mock_compute) is None
+        assert get_gcp_vpn_gateways("test-project", mock_compute) == ([], True)
 
-    @pytest.mark.parametrize(
-        "error",
-        [
-            _make_http_error(418, message="Unexpected response"),
-        ],
-    )
-    def test_reraises_unexpected_http_errors(self, error):
+    def test_returns_empty_incomplete_for_forbidden_during_request_creation(self):
         mock_compute = MagicMock()
-        request = _make_request(error=error)
-        mock_compute.vpnGateways.return_value.list.return_value = request
-
-        with pytest.raises(HttpError):
-            get_gcp_vpn_gateways("test-project", "us-central1", mock_compute)
-
-    def test_sync_skips_cleanup_on_forbidden(self):
-        mock_compute = MagicMock()
-        request = _make_request(
-            error=_make_http_error(
+        mock_compute.vpnGateways.return_value.aggregatedList.side_effect = (
+            _make_http_error(
                 403,
                 reason="forbidden",
                 message="Required 'compute.vpnGateways.list' permission",
-            ),
+            )
         )
-        mock_compute.vpnGateways.return_value.list.return_value = request
+
+        assert get_gcp_vpn_gateways("test-project", mock_compute) == ([], True)
+
+    def test_aggregates_items_across_region_scopes(self):
+        mock_compute = MagicMock()
+        mock_compute.vpnGateways.return_value.aggregatedList.return_value = _make_request(
+            response={
+                "items": {
+                    "regions/us-central1": {"vpnGateways": [{"name": "gw-a"}]},
+                    # Empty scopes carry only a NO_RESULTS_ON_PAGE warning.
+                    "regions/europe-west1": {"warning": {"code": "NO_RESULTS_ON_PAGE"}},
+                    "regions/asia-east1": {"vpnGateways": [{"name": "gw-b"}]},
+                }
+            }
+        )
+        mock_compute.vpnGateways.return_value.aggregatedList_next.return_value = None
+
+        items, incomplete = get_gcp_vpn_gateways("test-project", mock_compute)
+
+        assert items == [{"name": "gw-a"}, {"name": "gw-b"}]
+        assert incomplete is False
+
+    def test_scope_error_keeps_partial_data_and_marks_incomplete(self):
+        """With returnPartialSuccess, failed scopes carry an `error` entry."""
+        mock_compute = MagicMock()
+        mock_compute.vpnGateways.return_value.aggregatedList.return_value = (
+            _make_request(
+                response={
+                    "items": {
+                        "regions/us-central1": {"vpnGateways": [{"name": "gw-a"}]},
+                        "regions/europe-west1": {
+                            "error": {"errors": [{"message": "Location unavailable"}]}
+                        },
+                    }
+                }
+            )
+        )
+        mock_compute.vpnGateways.return_value.aggregatedList_next.return_value = None
+
+        items, incomplete = get_gcp_vpn_gateways("test-project", mock_compute)
+
+        assert items == [{"name": "gw-a"}]
+        assert incomplete is True
+
+    def test_timeout_mid_pagination_keeps_partial_data_and_marks_incomplete(self):
+        mock_compute = MagicMock()
+        first_request = _make_request(
+            response={
+                "items": {"regions/us-central1": {"vpnGateways": [{"name": "gw-a"}]}}
+            }
+        )
+        second_request = _make_request(error=TimeoutError())
+        mock_compute.vpnGateways.return_value.aggregatedList.return_value = (
+            first_request
+        )
+        mock_compute.vpnGateways.return_value.aggregatedList_next.side_effect = [
+            second_request,
+            None,
+        ]
+
+        items, incomplete = get_gcp_vpn_gateways("test-project", mock_compute)
+
+        assert items == [{"name": "gw-a"}]
+        assert incomplete is True
+
+    def test_reraises_unexpected_http_errors(self):
+        mock_compute = MagicMock()
+        mock_compute.vpnGateways.return_value.aggregatedList.return_value = (
+            _make_request(error=_make_http_error(418, message="Unexpected response"))
+        )
+
+        with pytest.raises(HttpError):
+            get_gcp_vpn_gateways("test-project", mock_compute)
+
+    def test_sync_skips_cleanup_on_forbidden(self):
+        mock_compute = MagicMock()
+        mock_compute.vpnGateways.return_value.aggregatedList.return_value = (
+            _make_request(
+                error=_make_http_error(
+                    403,
+                    reason="forbidden",
+                    message="Required 'compute.vpnGateways.list' permission",
+                )
+            )
+        )
 
         with patch(
             "cartography.intel.gcp.compute.cleanup_gcp_vpn_gateways",
@@ -363,12 +420,31 @@ class TestGetGcpVpnGatewaysHttpErrors:
                 MagicMock(),
                 mock_compute,
                 "test-project",
-                ["us-central1"],
                 123,
                 {"PROJECT_ID": "test-project", "UPDATE_TAG": 123},
             )
 
         mock_cleanup.assert_not_called()
+
+    def test_sync_runs_cleanup_when_complete(self):
+        mock_compute = MagicMock()
+        mock_compute.vpnGateways.return_value.aggregatedList.return_value = (
+            _make_request(response={"items": {}})
+        )
+        mock_compute.vpnGateways.return_value.aggregatedList_next.return_value = None
+
+        with patch(
+            "cartography.intel.gcp.compute.cleanup_gcp_vpn_gateways",
+        ) as mock_cleanup:
+            sync_gcp_vpn_gateways(
+                MagicMock(),
+                mock_compute,
+                "test-project",
+                123,
+                {"PROJECT_ID": "test-project", "UPDATE_TAG": 123},
+            )
+
+        mock_cleanup.assert_called_once()
 
 
 class TestGetGcpVpnTunnelsHttpErrors:
@@ -382,54 +458,70 @@ class TestGetGcpVpnTunnelsHttpErrors:
                 message="Compute Engine API has not been used in project",
             ),
             _make_http_error(404, reason="notFound", message="Project not found"),
-            _make_http_error(
-                400,
-                reason="invalid",
-                message="Invalid value for field 'region'",
-            ),
+            _make_http_error(400, reason="invalid", message="Invalid request"),
         ],
     )
-    def test_returns_none_for_expected_skip_categories(self, error):
+    def test_returns_empty_incomplete_for_expected_skip_categories(self, error):
         mock_compute = MagicMock()
-        request = _make_request(error=error)
-        mock_compute.vpnTunnels.return_value.list.return_value = request
-
-        assert get_gcp_vpn_tunnels("test-project", "us-central1", mock_compute) is None
-
-    def test_returns_none_for_forbidden_during_request_creation(self):
-        mock_compute = MagicMock()
-        mock_compute.vpnTunnels.return_value.list.side_effect = _make_http_error(
-            403,
-            reason="forbidden",
-            message="Required 'compute.vpnTunnels.list' permission",
+        mock_compute.vpnTunnels.return_value.aggregatedList.return_value = (
+            _make_request(error=error)
         )
 
-        assert get_gcp_vpn_tunnels("test-project", "us-central1", mock_compute) is None
+        assert get_gcp_vpn_tunnels("test-project", mock_compute) == ([], True)
 
-    @pytest.mark.parametrize(
-        "error",
-        [
-            _make_http_error(418, message="Unexpected response"),
-        ],
-    )
-    def test_reraises_unexpected_http_errors(self, error):
+    def test_returns_empty_incomplete_for_forbidden_during_request_creation(self):
         mock_compute = MagicMock()
-        request = _make_request(error=error)
-        mock_compute.vpnTunnels.return_value.list.return_value = request
-
-        with pytest.raises(HttpError):
-            get_gcp_vpn_tunnels("test-project", "us-central1", mock_compute)
-
-    def test_sync_skips_cleanup_on_forbidden(self):
-        mock_compute = MagicMock()
-        request = _make_request(
-            error=_make_http_error(
+        mock_compute.vpnTunnels.return_value.aggregatedList.side_effect = (
+            _make_http_error(
                 403,
                 reason="forbidden",
                 message="Required 'compute.vpnTunnels.list' permission",
-            ),
+            )
         )
-        mock_compute.vpnTunnels.return_value.list.return_value = request
+
+        assert get_gcp_vpn_tunnels("test-project", mock_compute) == ([], True)
+
+    def test_scope_error_keeps_partial_data_and_marks_incomplete(self):
+        mock_compute = MagicMock()
+        mock_compute.vpnTunnels.return_value.aggregatedList.return_value = (
+            _make_request(
+                response={
+                    "items": {
+                        "regions/us-central1": {"vpnTunnels": [{"name": "tun-a"}]},
+                        "regions/europe-west1": {
+                            "error": {"errors": [{"message": "Location unavailable"}]}
+                        },
+                    }
+                }
+            )
+        )
+        mock_compute.vpnTunnels.return_value.aggregatedList_next.return_value = None
+
+        items, incomplete = get_gcp_vpn_tunnels("test-project", mock_compute)
+
+        assert items == [{"name": "tun-a"}]
+        assert incomplete is True
+
+    def test_reraises_unexpected_http_errors(self):
+        mock_compute = MagicMock()
+        mock_compute.vpnTunnels.return_value.aggregatedList.return_value = (
+            _make_request(error=_make_http_error(418, message="Unexpected response"))
+        )
+
+        with pytest.raises(HttpError):
+            get_gcp_vpn_tunnels("test-project", mock_compute)
+
+    def test_sync_skips_cleanup_on_forbidden(self):
+        mock_compute = MagicMock()
+        mock_compute.vpnTunnels.return_value.aggregatedList.return_value = (
+            _make_request(
+                error=_make_http_error(
+                    403,
+                    reason="forbidden",
+                    message="Required 'compute.vpnTunnels.list' permission",
+                )
+            )
+        )
 
         with patch(
             "cartography.intel.gcp.compute.cleanup_gcp_vpn_tunnels",
@@ -438,7 +530,6 @@ class TestGetGcpVpnTunnelsHttpErrors:
                 MagicMock(),
                 mock_compute,
                 "test-project",
-                ["us-central1"],
                 123,
                 {"PROJECT_ID": "test-project", "UPDATE_TAG": 123},
             )

--- a/tests/unit/cartography/intel/gcp/test_compute_http_errors.py
+++ b/tests/unit/cartography/intel/gcp/test_compute_http_errors.py
@@ -588,3 +588,46 @@ class TestGetGcpVpnTunnelsHttpErrors:
             )
 
         mock_cleanup.assert_not_called()
+
+
+class TestGcpVpnAggregatedListPageLevelSignals:
+    """
+    Both VPN getters share _get_gcp_vpn_aggregated, so one parametrized test
+    covers the page-level (outside `items`) partial-result signals for both.
+    """
+
+    @pytest.mark.parametrize(
+        "getter,api_attr,items_key",
+        [
+            (get_gcp_vpn_gateways, "vpnGateways", "vpnGateways"),
+            (get_gcp_vpn_tunnels, "vpnTunnels", "vpnTunnels"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "page_fields",
+        [
+            # Non-empty unreachables list: regions that could not be queried.
+            {"unreachables": ["regions/europe-west1"]},
+            # Top-level warning indicating partial results.
+            {"warning": {"code": "UNREACHABLE", "message": "Some scopes failed."}},
+        ],
+    )
+    def test_page_level_partial_result_signals_mark_incomplete(
+        self, getter, api_attr, items_key, page_fields
+    ):
+        mock_compute = MagicMock()
+        response = {
+            "items": {
+                "regions/us-central1": {items_key: [{"name": "res-a"}]},
+            },
+            **page_fields,
+        }
+        api = getattr(mock_compute, api_attr)
+        api.return_value.aggregatedList.return_value = _make_request(response=response)
+        api.return_value.aggregatedList_next.return_value = None
+
+        items, incomplete = getter("test-project", mock_compute)
+
+        # Returned scopes are still ingested, but cleanup must be suppressed.
+        assert items == [{"name": "res-a"}]
+        assert incomplete is True

--- a/tests/unit/cartography/intel/gcp/test_compute_http_errors.py
+++ b/tests/unit/cartography/intel/gcp/test_compute_http_errors.py
@@ -8,9 +8,13 @@ from googleapiclient.errors import HttpError
 from cartography.intel.gcp.compute import get_gcp_instance_responses
 from cartography.intel.gcp.compute import get_gcp_regional_forwarding_rules
 from cartography.intel.gcp.compute import get_gcp_subnets
+from cartography.intel.gcp.compute import get_gcp_vpn_gateways
+from cartography.intel.gcp.compute import get_gcp_vpn_tunnels
 from cartography.intel.gcp.compute import get_zones_in_project
 from cartography.intel.gcp.compute import sync
 from cartography.intel.gcp.compute import sync_gcp_forwarding_rules
+from cartography.intel.gcp.compute import sync_gcp_vpn_gateways
+from cartography.intel.gcp.compute import sync_gcp_vpn_tunnels
 
 
 def _make_http_error(
@@ -283,5 +287,160 @@ class TestGetGcpRegionalForwardingRulesHttpErrors:
                     123,
                     {"PROJECT_ID": "test-project", "UPDATE_TAG": 123},
                 )
+
+        mock_cleanup.assert_not_called()
+
+
+class TestGetGcpVpnGatewaysHttpErrors:
+    @pytest.mark.parametrize(
+        "error",
+        [
+            _make_http_error(403, reason="forbidden", message="Permission denied"),
+            _make_http_error(
+                403,
+                reason="accessNotConfigured",
+                message="Compute Engine API has not been used in project",
+            ),
+            _make_http_error(404, reason="notFound", message="Project not found"),
+            _make_http_error(
+                400,
+                reason="invalid",
+                message="Invalid value for field 'region'",
+            ),
+        ],
+    )
+    def test_returns_none_for_expected_skip_categories(self, error):
+        """
+        A 403 on vpnGateways.list (e.g. identity has compute.zones.list but not
+        compute.vpnGateways.list) must not abort the whole project sync; the
+        region is skipped instead so cleanup is suppressed via `incomplete`.
+        """
+        mock_compute = MagicMock()
+        request = _make_request(error=error)
+        mock_compute.vpnGateways.return_value.list.return_value = request
+
+        assert get_gcp_vpn_gateways("test-project", "us-central1", mock_compute) is None
+
+    def test_returns_none_for_forbidden_during_request_creation(self):
+        mock_compute = MagicMock()
+        mock_compute.vpnGateways.return_value.list.side_effect = _make_http_error(
+            403,
+            reason="forbidden",
+            message="Required 'compute.vpnGateways.list' permission",
+        )
+
+        assert get_gcp_vpn_gateways("test-project", "us-central1", mock_compute) is None
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            _make_http_error(418, message="Unexpected response"),
+        ],
+    )
+    def test_reraises_unexpected_http_errors(self, error):
+        mock_compute = MagicMock()
+        request = _make_request(error=error)
+        mock_compute.vpnGateways.return_value.list.return_value = request
+
+        with pytest.raises(HttpError):
+            get_gcp_vpn_gateways("test-project", "us-central1", mock_compute)
+
+    def test_sync_skips_cleanup_on_forbidden(self):
+        mock_compute = MagicMock()
+        request = _make_request(
+            error=_make_http_error(
+                403,
+                reason="forbidden",
+                message="Required 'compute.vpnGateways.list' permission",
+            ),
+        )
+        mock_compute.vpnGateways.return_value.list.return_value = request
+
+        with patch(
+            "cartography.intel.gcp.compute.cleanup_gcp_vpn_gateways",
+        ) as mock_cleanup:
+            sync_gcp_vpn_gateways(
+                MagicMock(),
+                mock_compute,
+                "test-project",
+                ["us-central1"],
+                123,
+                {"PROJECT_ID": "test-project", "UPDATE_TAG": 123},
+            )
+
+        mock_cleanup.assert_not_called()
+
+
+class TestGetGcpVpnTunnelsHttpErrors:
+    @pytest.mark.parametrize(
+        "error",
+        [
+            _make_http_error(403, reason="forbidden", message="Permission denied"),
+            _make_http_error(
+                403,
+                reason="accessNotConfigured",
+                message="Compute Engine API has not been used in project",
+            ),
+            _make_http_error(404, reason="notFound", message="Project not found"),
+            _make_http_error(
+                400,
+                reason="invalid",
+                message="Invalid value for field 'region'",
+            ),
+        ],
+    )
+    def test_returns_none_for_expected_skip_categories(self, error):
+        mock_compute = MagicMock()
+        request = _make_request(error=error)
+        mock_compute.vpnTunnels.return_value.list.return_value = request
+
+        assert get_gcp_vpn_tunnels("test-project", "us-central1", mock_compute) is None
+
+    def test_returns_none_for_forbidden_during_request_creation(self):
+        mock_compute = MagicMock()
+        mock_compute.vpnTunnels.return_value.list.side_effect = _make_http_error(
+            403,
+            reason="forbidden",
+            message="Required 'compute.vpnTunnels.list' permission",
+        )
+
+        assert get_gcp_vpn_tunnels("test-project", "us-central1", mock_compute) is None
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            _make_http_error(418, message="Unexpected response"),
+        ],
+    )
+    def test_reraises_unexpected_http_errors(self, error):
+        mock_compute = MagicMock()
+        request = _make_request(error=error)
+        mock_compute.vpnTunnels.return_value.list.return_value = request
+
+        with pytest.raises(HttpError):
+            get_gcp_vpn_tunnels("test-project", "us-central1", mock_compute)
+
+    def test_sync_skips_cleanup_on_forbidden(self):
+        mock_compute = MagicMock()
+        request = _make_request(
+            error=_make_http_error(
+                403,
+                reason="forbidden",
+                message="Required 'compute.vpnTunnels.list' permission",
+            ),
+        )
+        mock_compute.vpnTunnels.return_value.list.return_value = request
+
+        with patch(
+            "cartography.intel.gcp.compute.cleanup_gcp_vpn_tunnels",
+        ) as mock_cleanup:
+            sync_gcp_vpn_tunnels(
+                MagicMock(),
+                mock_compute,
+                "test-project",
+                ["us-central1"],
+                123,
+                {"PROJECT_ID": "test-project", "UPDATE_TAG": 123},
+            )
 
         mock_cleanup.assert_not_called()

--- a/tests/unit/cartography/intel/gcp/test_compute_http_errors.py
+++ b/tests/unit/cartography/intel/gcp/test_compute_http_errors.py
@@ -144,7 +144,7 @@ class TestGetGcpSubnetsHttpErrors:
 
         assert get_gcp_subnets("test-project", "bad-region", mock_compute) is None
 
-    def test_preserves_partial_data_on_timeout(self):
+    def test_returns_none_on_timeout(self):
         mock_compute = MagicMock()
         first_request = _make_request(
             response={"id": "subnet-page", "items": [{"name": "subnet-a"}]},
@@ -156,10 +156,7 @@ class TestGetGcpSubnetsHttpErrors:
             None,
         ]
 
-        assert get_gcp_subnets("test-project", "us-central1", mock_compute) == {
-            "id": "subnet-page",
-            "items": [{"name": "subnet-a"}],
-        }
+        assert get_gcp_subnets("test-project", "us-central1", mock_compute) is None
 
     @pytest.mark.parametrize(
         "error",

--- a/tests/unit/cartography/intel/gcp/test_compute_http_errors.py
+++ b/tests/unit/cartography/intel/gcp/test_compute_http_errors.py
@@ -371,6 +371,35 @@ class TestGetGcpVpnGatewaysHttpErrors:
         assert items == [{"name": "gw-a"}]
         assert incomplete is True
 
+    def test_non_benign_scope_warning_marks_incomplete(self):
+        """
+        A scope warning other than NO_RESULTS_ON_PAGE (e.g. UNREACHABLE) means
+        the region's data is missing; the result must be marked incomplete so
+        cleanup does not delete that region's gateways.
+        """
+        mock_compute = MagicMock()
+        mock_compute.vpnGateways.return_value.aggregatedList.return_value = (
+            _make_request(
+                response={
+                    "items": {
+                        "regions/us-central1": {"vpnGateways": [{"name": "gw-a"}]},
+                        "regions/europe-west1": {
+                            "warning": {
+                                "code": "UNREACHABLE",
+                                "message": "The region could not be reached.",
+                            }
+                        },
+                    }
+                }
+            )
+        )
+        mock_compute.vpnGateways.return_value.aggregatedList_next.return_value = None
+
+        items, incomplete = get_gcp_vpn_gateways("test-project", mock_compute)
+
+        assert items == [{"name": "gw-a"}]
+        assert incomplete is True
+
     def test_timeout_mid_pagination_keeps_partial_data_and_marks_incomplete(self):
         mock_compute = MagicMock()
         first_request = _make_request(
@@ -490,6 +519,30 @@ class TestGetGcpVpnTunnelsHttpErrors:
                         "regions/us-central1": {"vpnTunnels": [{"name": "tun-a"}]},
                         "regions/europe-west1": {
                             "error": {"errors": [{"message": "Location unavailable"}]}
+                        },
+                    }
+                }
+            )
+        )
+        mock_compute.vpnTunnels.return_value.aggregatedList_next.return_value = None
+
+        items, incomplete = get_gcp_vpn_tunnels("test-project", mock_compute)
+
+        assert items == [{"name": "tun-a"}]
+        assert incomplete is True
+
+    def test_non_benign_scope_warning_marks_incomplete(self):
+        mock_compute = MagicMock()
+        mock_compute.vpnTunnels.return_value.aggregatedList.return_value = (
+            _make_request(
+                response={
+                    "items": {
+                        "regions/us-central1": {"vpnTunnels": [{"name": "tun-a"}]},
+                        "regions/europe-west1": {
+                            "warning": {
+                                "code": "UNREACHABLE",
+                                "message": "The region could not be reached.",
+                            }
                         },
                     }
                 }


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->
Adds three new GCP Compute resources to the graph: **VPC peerings** (`GCPVpcPeering`), **VPN gateways** (`GCPVpnGateway`), and **VPN tunnels (`GCPVpnTunnel`). These are needed to model cross-network and cross-project connectivity: which VPCs peer with each other, and which VPN tunnels connect which gateways.

- VPC peerings are extracted from each network's existing `peerings` field (no extra API call). Each peering links to its local VPC via `LOCAL_NETWORK` and to the peer VPC via `PEER_NETWORK`. When the peer VPC lives in a project that hasn't been synced, a `GCPVpc` stub node is created so the relationship still resolves.
- VPN gateways and tunnels are synced per region. Gateways sync before tunnels so `USES_GATEWAY` relationships resolve in the same sync cycle; peer gateways outside the synced project are represented as `GCPVpnGateway` stub nodes linked via `CONNECTS_TO_GATEWAY`.
- Also hardens subnet sync: if any region returns incomplete data (timeout/invalid region), subnet cleanup is skipped for that project so existing `GCPSubnet` nodes are preserved instead of being deleted based on partial data.

### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

- Fixes #


### Breaking changes
<!-- If this PR introduces breaking changes, describe the impact and migration path. Otherwise, delete this section. -->

### How was this tested?
- Unit tests: `tests/unit/cartography/intel/gcp/test_compute.py` (transform logic for peerings, gateways, tunnels, stub extraction) and `test_compute_http_errors.py` (subnet timeout now returns None so cleanup is skipped). `uv run pytest tests/unit/cartography/intel/gcp/ -q` → all pass.
- Integration tests: `tests/integration/cartography/intel/gcp/test_compute.py` covers node creation, all new relationships (RESOURCE, LOCAL_NETWORK, PEER_NETWORK, PART_OF_VPC, USES_GATEWAY, CONNECTS_TO_GATEWAY), stub creation, and scoped cleanup against Neo4j.
- `pre-commit run` (isort/black/flake8/pyupgrade/mypy) passes on all changed files.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [x] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

Connector pull requests without real-environment evidence are labeled `needs-tests`, are not reviewed, and may be closed after 30 days.

#### If you are changing a node or relationship
- [ ] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [ ] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->
