### PR TITLE
feat(railway): ingest deployment source revision

### DIFF
--- a/cartography/intel/railway/deployments.py
+++ b/cartography/intel/railway/deployments.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Any
 
 import neo4j
@@ -46,9 +47,18 @@ def transform(
         project_triggers: list[dict[str, Any]] = []
         for environment in unwrap_edges(bundle["environments"]):
             for deployment in unwrap_edges(environment["deployments"]):
+                meta = deployment.get("meta")
+                commit_hash = meta.get("commitHash") if isinstance(meta, dict) else None
+                source_revision = (
+                    commit_hash.lower()
+                    if isinstance(commit_hash, str)
+                    and re.fullmatch(r"[0-9a-fA-F]{40}", commit_hash)
+                    else None
+                )
                 project_deployments.append(
                     {
                         **deployment,
+                        "source_revision": source_revision,
                         "lifecycle": (
                             "current"
                             if deployment["id"] in current_ids

--- a/cartography/intel/railway/queries.py
+++ b/cartography/intel/railway/queries.py
@@ -146,6 +146,7 @@ _SERVICE_INSTANCE_FIELDS = """
 
 _DEPLOYMENT_FIELDS = """
     id
+    meta
     status
     statusUpdatedAt
     createdAt

--- a/cartography/models/railway/deployment.py
+++ b/cartography/models/railway/deployment.py
@@ -27,6 +27,11 @@ class RailwayDeploymentNodeProperties(CartographyNodeProperties):
         extra_index=True,
         description="Whether this deployment is the current or a historical revision.",
     )
+    source_revision: PropertyRef = PropertyRef(
+        "source_revision",
+        extra_index=True,
+        description="Full source commit SHA reported for this deployment.",
+    )
     status_updated_at: PropertyRef = PropertyRef(
         "statusUpdatedAt", description="Time when the deployment status last changed."
     )

--- a/tests/data/railway/bundles.py
+++ b/tests/data/railway/bundles.py
@@ -5,9 +5,10 @@ cartography/intel/railway/queries.py), with identifiers replaced by stable fakes
 Kept in raw GraphQL shape - Relay `edges`/`node` wrappers and nested `source` / `status`
 objects intact - because unwrapping and flattening those is what the transforms do.
 
-Three things are hand-added, since a throwaway Hobby project cannot produce them:
+Four things are hand-added, since a throwaway Hobby project cannot produce them:
   * custom domains, which need a real domain plus DNS verification (one verified, one not);
-  * a git source on one service instance, to exercise the DEPLOYED_FROM edge;
+  * a git source and root directory on one service instance, to exercise source context;
+  * deployment commit metadata, including a malformed value to exercise validation;
   * a deployment trigger, which requires a linked GitHub account.
 Everything else is exactly what the live API returned.
 """
@@ -75,6 +76,9 @@ RAILWAY_PROJECT_BUNDLE: dict[str, Any] = {
                                     "createdAt": "2026-07-27T18:02:21.021Z",
                                     "environmentId": "44444444-4444-4444-4444-444444444444",
                                     "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                                    "meta": {
+                                        "commitHash": "0123456789ABCDEF0123456789ABCDEF01234567",
+                                    },
                                     "projectId": "33333333-3333-3333-3333-333333333333",
                                     "serviceId": "77777777-7777-7777-7777-777777777777",
                                     "staticUrl": None,
@@ -89,6 +93,7 @@ RAILWAY_PROJECT_BUNDLE: dict[str, Any] = {
                                     "createdAt": "2026-07-27T18:01:57.350Z",
                                     "environmentId": "44444444-4444-4444-4444-444444444444",
                                     "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                                    "meta": {"commitHash": "main"},
                                     "projectId": "33333333-3333-3333-3333-333333333333",
                                     "serviceId": "66666666-6666-6666-6666-666666666666",
                                     "staticUrl": "web-production-abcde.up.railway.app",
@@ -129,7 +134,7 @@ RAILWAY_PROJECT_BUNDLE: dict[str, Any] = {
                                     "region": None,
                                     "restartPolicyMaxRetries": 10,
                                     "restartPolicyType": "ON_FAILURE",
-                                    "rootDirectory": None,
+                                    "rootDirectory": "/backend",
                                     "serviceId": "77777777-7777-7777-7777-777777777777",
                                     "serviceName": "Postgres",
                                     "sleepApplication": False,

--- a/tests/integration/cartography/intel/railway/test_deployments.py
+++ b/tests/integration/cartography/intel/railway/test_deployments.py
@@ -29,6 +29,7 @@ from tests.integration.util import check_rels
 WEB_DEPLOYMENT_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 POSTGRES_DEPLOYMENT_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 TRIGGER_ID = "dt111111-1111-1111-1111-111111111111"
+SOURCE_REVISION = "0123456789abcdef0123456789abcdef01234567"
 
 
 def test_load_railway_deployments(neo4j_session):
@@ -47,10 +48,10 @@ def test_load_railway_deployments(neo4j_session):
     assert check_nodes(
         neo4j_session,
         "RailwayDeployment",
-        ["id", "status", "static_url"],
+        ["id", "status", "static_url", "source_revision"],
     ) == {
-        (WEB_DEPLOYMENT_ID, "SUCCESS", "web-production-abcde.up.railway.app"),
-        (POSTGRES_DEPLOYMENT_ID, "SUCCESS", None),
+        (WEB_DEPLOYMENT_ID, "SUCCESS", "web-production-abcde.up.railway.app", None),
+        (POSTGRES_DEPLOYMENT_ID, "SUCCESS", None, SOURCE_REVISION),
     }
 
     # Assert the canonical ontology edge required for Container -> ComputeService
@@ -85,6 +86,45 @@ def test_load_railway_deployments(neo4j_session):
     ) == {
         (TEST_PROJECT_ID, WEB_DEPLOYMENT_ID),
         (TEST_PROJECT_ID, POSTGRES_DEPLOYMENT_ID),
+    }
+
+
+def test_git_backed_deployment_resolves_exact_source_context(neo4j_session):
+    # Arrange
+    neo4j_session.run(
+        """
+        MERGE (r:GitHubRepository {id: "https://github.com/acme/api"})
+        SET r.fullname = "acme/api", r.lastupdated = $update_tag
+        """,
+        update_tag=TEST_UPDATE_TAG,
+    )
+    _sync_compute_tier(neo4j_session)
+
+    # Act
+    cartography.intel.railway.deployments.sync(
+        neo4j_session,
+        _common_job_parameters(),
+        BUNDLES,
+        TEST_UPDATE_TAG,
+    )
+
+    # Assert
+    result = neo4j_session.run(
+        """
+        MATCH (d:RailwayDeployment {id: $deployment_id})
+              -[:WORKLOAD_PARENT]->(s:RailwayServiceInstance)
+              -[:DEPLOYED_FROM]->(r:GitHubRepository)
+        RETURN d.source_revision AS revision,
+               s.root_directory AS root_directory,
+               r.fullname AS repository
+        """,
+        deployment_id=POSTGRES_DEPLOYMENT_ID,
+    ).single()
+    assert result is not None
+    assert result.data() == {
+        "revision": SOURCE_REVISION,
+        "root_directory": "/backend",
+        "repository": "acme/api",
     }
 
 


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Railway can report the exact Git commit associated with a deployment in its `meta` field. Cartography currently ingests the repository configured on the service instance, but not the immutable revision that was deployed.

This change requests deployment metadata and stores a normalized `source_revision` on `RailwayDeployment` when `meta.commitHash` is a full 40-character hexadecimal SHA. Invalid or mutable values are ignored. The repository and root directory remain on the parent `RailwayServiceInstance`, preserving the existing graph shape.


### Related issues or links

- Related to #3118, which covers the separate image-backed Railway path.


### How was this tested?

- `make test_lint`
- `uv run pytest tests/unit/cartography/intel/railway tests/integration/cartography/intel/railway tests/unit/cartography/models/test_schema_docs.py -q` (75 passed)
- `uv run --group doc ./docs/build.sh`
- Integration coverage verifies that a Git-backed deployment resolves to its repository, exact revision, and configured root directory, and rejects a mutable value as a revision.
- Real Railway API validation has not been run because no provider token is available in this environment. This PR remains a draft pending sanitized real-environment evidence.


### Checklist

#### General

- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality

- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector

- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [ ] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

#### If you are changing a node or relationship

- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [x] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module

- [x] Not applicable; this extends the existing Railway module.


### Notes for reviewers

This is intentionally limited to capturing immutable deployment provenance. It does not add a new scan target or change image-resolution behavior.
