### PR TITLE
feat(railway): model filesystem snapshots

### DIFF
--- a/cartography/intel/railway/deployments.py
+++ b/cartography/intel/railway/deployments.py
@@ -10,6 +10,9 @@ from cartography.intel.railway.serviceinstances import iter_service_instances
 from cartography.intel.railway.utils import unwrap_edges
 from cartography.models.railway.deployment import RailwayDeploymentSchema
 from cartography.models.railway.deploymenttrigger import RailwayDeploymentTriggerSchema
+from cartography.models.railway.filesystem_snapshot import (
+    RailwayFilesystemSnapshotSchema,
+)
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
@@ -22,28 +25,36 @@ def sync(
     bundles: dict[str, dict[str, Any]],
     update_tag: int,
 ) -> None:
-    deployments, triggers = transform(bundles)
+    deployments, snapshots, triggers = transform(bundles)
     load_deployments(neo4j_session, deployments, update_tag)
+    load_filesystem_snapshots(neo4j_session, snapshots, update_tag)
     load_deployment_triggers(neo4j_session, triggers, update_tag)
     cleanup(neo4j_session, list(bundles), common_job_parameters)
 
 
 def transform(
     bundles: dict[str, dict[str, Any]],
-) -> tuple[dict[str, list[dict[str, Any]]], dict[str, list[dict[str, Any]]]]:
+) -> tuple[
+    dict[str, list[dict[str, Any]]],
+    dict[str, list[dict[str, Any]]],
+    dict[str, list[dict[str, Any]]],
+]:
     deployments: dict[str, list[dict[str, Any]]] = {}
+    snapshots: dict[str, list[dict[str, Any]]] = {}
     triggers: dict[str, list[dict[str, Any]]] = {}
 
     for project_id, bundle in bundles.items():
         # The deployment each service instance is currently serving. Everything else in the
         # window is a superseded revision.
-        current_ids = {
-            (instance.get("latestDeployment") or {}).get("id")
-            for instance in iter_service_instances(bundle)
-        }
-        current_ids.discard(None)
+        current_instances: dict[str, dict[str, Any]] = {}
+        for instance in iter_service_instances(bundle):
+            latest_deployment = instance.get("latestDeployment") or {}
+            if latest_deployment.get("id"):
+                current_instances[latest_deployment["id"]] = instance
+        current_ids = set(current_instances)
 
         project_deployments: list[dict[str, Any]] = []
+        project_snapshots: list[dict[str, Any]] = []
         project_triggers: list[dict[str, Any]] = []
         for environment in unwrap_edges(bundle["environments"]):
             for deployment in unwrap_edges(environment["deployments"]):
@@ -66,11 +77,26 @@ def transform(
                         ),
                     },
                 )
+                current_instance = current_instances.get(deployment["id"])
+                source = (current_instance or {}).get("source") or {}
+                if source_revision and source.get("repo"):
+                    project_snapshots.append(
+                        {
+                            "id": deployment["id"],
+                            "kind": "source",
+                            "source_revision": source_revision,
+                            "source_repo": source["repo"],
+                            "root_directory": (current_instance or {}).get(
+                                "rootDirectory"
+                            ),
+                        },
+                    )
             project_triggers.extend(unwrap_edges(environment["deploymentTriggers"]))
         deployments[project_id] = project_deployments
+        snapshots[project_id] = project_snapshots
         triggers[project_id] = project_triggers
 
-    return deployments, triggers
+    return deployments, snapshots, triggers
 
 
 @timeit
@@ -84,6 +110,22 @@ def load_deployments(
             neo4j_session,
             RailwayDeploymentSchema(),
             deployments,
+            lastupdated=update_tag,
+            PROJECT_ID=project_id,
+        )
+
+
+@timeit
+def load_filesystem_snapshots(
+    neo4j_session: neo4j.Session,
+    by_project: dict[str, list[dict[str, Any]]],
+    update_tag: int,
+) -> None:
+    for project_id, snapshots in by_project.items():
+        load(
+            neo4j_session,
+            RailwayFilesystemSnapshotSchema(),
+            snapshots,
             lastupdated=update_tag,
             PROJECT_ID=project_id,
         )
@@ -116,6 +158,10 @@ def cleanup(
         scoped_job_parameters["PROJECT_ID"] = project_id
         GraphJob.from_node_schema(
             RailwayDeploymentSchema(),
+            scoped_job_parameters,
+        ).run(neo4j_session)
+        GraphJob.from_node_schema(
+            RailwayFilesystemSnapshotSchema(),
             scoped_job_parameters,
         ).run(neo4j_session)
         GraphJob.from_node_schema(

--- a/cartography/intel/railway/deployments.py
+++ b/cartography/intel/railway/deployments.py
@@ -82,7 +82,8 @@ def transform(
                 if source_revision and source.get("repo"):
                     project_snapshots.append(
                         {
-                            "id": deployment["id"],
+                            "id": f"railway:filesystem-snapshot:{deployment['id']}",
+                            "deployment_id": deployment["id"],
                             "kind": "source",
                             "source_revision": source_revision,
                             "source_repo": source["repo"],

--- a/cartography/intel/railway/deployments.py
+++ b/cartography/intel/railway/deployments.py
@@ -17,6 +17,8 @@ from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
+_SERVING_DEPLOYMENT_STATUSES = {"SUCCESS", "SLEEPING"}
+
 
 @timeit
 def sync(
@@ -44,19 +46,41 @@ def transform(
     triggers: dict[str, list[dict[str, Any]]] = {}
 
     for project_id, bundle in bundles.items():
-        # The deployment each service instance is currently serving. Everything else in the
-        # window is a superseded revision.
+        environments = unwrap_edges(bundle["environments"])
+        project_deployment_nodes = [
+            deployment
+            for environment in environments
+            for deployment in unwrap_edges(environment["deployments"])
+        ]
+        serving_by_instance: dict[tuple[str, str], dict[str, Any]] = {}
+        for deployment in project_deployment_nodes:
+            if deployment.get("status") not in _SERVING_DEPLOYMENT_STATUSES:
+                continue
+            key = (deployment["environmentId"], deployment["serviceId"])
+            previous = serving_by_instance.get(key)
+            if previous is None or deployment["createdAt"] > previous["createdAt"]:
+                serving_by_instance[key] = deployment
+
+        # latestDeployment is the newest attempt, not necessarily the revision serving
+        # traffic. If it failed, Railway keeps the previous healthy deployment active.
         current_instances: dict[str, dict[str, Any]] = {}
         for instance in iter_service_instances(bundle):
             latest_deployment = instance.get("latestDeployment") or {}
-            if latest_deployment.get("id"):
-                current_instances[latest_deployment["id"]] = instance
+            serving_deployment = (
+                latest_deployment
+                if latest_deployment.get("status") in _SERVING_DEPLOYMENT_STATUSES
+                else serving_by_instance.get(
+                    (instance["environmentId"], instance["serviceId"]),
+                )
+            )
+            if serving_deployment and serving_deployment.get("id"):
+                current_instances[serving_deployment["id"]] = instance
         current_ids = set(current_instances)
 
         project_deployments: list[dict[str, Any]] = []
         project_snapshots: list[dict[str, Any]] = []
         project_triggers: list[dict[str, Any]] = []
-        for environment in unwrap_edges(bundle["environments"]):
+        for environment in environments:
             for deployment in unwrap_edges(environment["deployments"]):
                 meta = deployment.get("meta")
                 commit_hash = meta.get("commitHash") if isinstance(meta, dict) else None
@@ -78,18 +102,27 @@ def transform(
                     },
                 )
                 current_instance = current_instances.get(deployment["id"])
-                source = (current_instance or {}).get("source") or {}
-                if source_revision and source.get("repo"):
+                source_repo = meta.get("repo") if isinstance(meta, dict) else None
+                root_directory = (
+                    meta.get("rootDirectory") if isinstance(meta, dict) else None
+                )
+                if (
+                    current_instance
+                    and source_revision
+                    and isinstance(meta, dict)
+                    and isinstance(source_repo, str)
+                    and source_repo
+                    and "rootDirectory" in meta
+                    and (root_directory is None or isinstance(root_directory, str))
+                ):
                     project_snapshots.append(
                         {
                             "id": f"railway:filesystem-snapshot:{deployment['id']}",
                             "deployment_id": deployment["id"],
                             "kind": "source",
                             "source_revision": source_revision,
-                            "source_repo": source["repo"],
-                            "root_directory": (current_instance or {}).get(
-                                "rootDirectory"
-                            ),
+                            "source_repo": source_repo,
+                            "root_directory": root_directory,
                         },
                     )
             project_triggers.extend(unwrap_edges(environment["deploymentTriggers"]))

--- a/cartography/intel/railway/deployments.py
+++ b/cartography/intel/railway/deployments.py
@@ -17,8 +17,6 @@ from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
-_SERVING_DEPLOYMENT_STATUSES = {"SUCCESS", "SLEEPING"}
-
 
 @timeit
 def sync(
@@ -47,84 +45,69 @@ def transform(
 
     for project_id, bundle in bundles.items():
         environments = unwrap_edges(bundle["environments"])
-        project_deployment_nodes = [
-            deployment
+        project_deployments_by_id = {
+            deployment["id"]: deployment
             for environment in environments
             for deployment in unwrap_edges(environment["deployments"])
-        ]
-        serving_by_instance: dict[tuple[str, str], dict[str, Any]] = {}
-        for deployment in project_deployment_nodes:
-            if deployment.get("status") not in _SERVING_DEPLOYMENT_STATUSES:
-                continue
-            key = (deployment["environmentId"], deployment["serviceId"])
-            previous = serving_by_instance.get(key)
-            if previous is None or deployment["createdAt"] > previous["createdAt"]:
-                serving_by_instance[key] = deployment
+        }
 
-        # latestDeployment is the newest attempt, not necessarily the revision serving
-        # traffic. If it failed, Railway keeps the previous healthy deployment active.
         current_instances: dict[str, dict[str, Any]] = {}
         for instance in iter_service_instances(bundle):
             latest_deployment = instance.get("latestDeployment") or {}
-            serving_deployment = (
-                latest_deployment
-                if latest_deployment.get("status") in _SERVING_DEPLOYMENT_STATUSES
-                else serving_by_instance.get(
-                    (instance["environmentId"], instance["serviceId"]),
-                )
-            )
-            if serving_deployment and serving_deployment.get("id"):
-                current_instances[serving_deployment["id"]] = instance
+            current_deployments = list(instance.get("activeDeployments") or [])
+            if latest_deployment.get("status") == "SLEEPING":
+                current_deployments.append(latest_deployment)
+            for deployment in current_deployments:
+                project_deployments_by_id[deployment["id"]] = deployment
+                current_instances[deployment["id"]] = instance
         current_ids = set(current_instances)
 
         project_deployments: list[dict[str, Any]] = []
         project_snapshots: list[dict[str, Any]] = []
         project_triggers: list[dict[str, Any]] = []
-        for environment in environments:
-            for deployment in unwrap_edges(environment["deployments"]):
-                meta = deployment.get("meta")
-                commit_hash = meta.get("commitHash") if isinstance(meta, dict) else None
-                source_revision = (
-                    commit_hash.lower()
-                    if isinstance(commit_hash, str)
-                    and re.fullmatch(r"[0-9a-fA-F]{40}", commit_hash)
-                    else None
-                )
-                project_deployments.append(
+        for deployment in project_deployments_by_id.values():
+            meta = deployment.get("meta")
+            commit_hash = meta.get("commitHash") if isinstance(meta, dict) else None
+            source_revision = (
+                commit_hash.lower()
+                if isinstance(commit_hash, str)
+                and re.fullmatch(r"[0-9a-fA-F]{40}", commit_hash)
+                else None
+            )
+            project_deployments.append(
+                {
+                    **deployment,
+                    "source_revision": source_revision,
+                    "lifecycle": (
+                        "current" if deployment["id"] in current_ids else "historical"
+                    ),
+                },
+            )
+            current_instance = current_instances.get(deployment["id"])
+            source_repo = meta.get("repo") if isinstance(meta, dict) else None
+            root_directory = (
+                meta.get("rootDirectory") if isinstance(meta, dict) else None
+            )
+            if (
+                current_instance
+                and source_revision
+                and isinstance(meta, dict)
+                and isinstance(source_repo, str)
+                and source_repo
+                and "rootDirectory" in meta
+                and (root_directory is None or isinstance(root_directory, str))
+            ):
+                project_snapshots.append(
                     {
-                        **deployment,
+                        "id": f"railway:filesystem-snapshot:{deployment['id']}",
+                        "deployment_id": deployment["id"],
+                        "kind": "source",
                         "source_revision": source_revision,
-                        "lifecycle": (
-                            "current"
-                            if deployment["id"] in current_ids
-                            else "historical"
-                        ),
+                        "source_repo": source_repo,
+                        "root_directory": root_directory,
                     },
                 )
-                current_instance = current_instances.get(deployment["id"])
-                source_repo = meta.get("repo") if isinstance(meta, dict) else None
-                root_directory = (
-                    meta.get("rootDirectory") if isinstance(meta, dict) else None
-                )
-                if (
-                    current_instance
-                    and source_revision
-                    and isinstance(meta, dict)
-                    and isinstance(source_repo, str)
-                    and source_repo
-                    and "rootDirectory" in meta
-                    and (root_directory is None or isinstance(root_directory, str))
-                ):
-                    project_snapshots.append(
-                        {
-                            "id": f"railway:filesystem-snapshot:{deployment['id']}",
-                            "deployment_id": deployment["id"],
-                            "kind": "source",
-                            "source_revision": source_revision,
-                            "source_repo": source_repo,
-                            "root_directory": root_directory,
-                        },
-                    )
+        for environment in environments:
             project_triggers.extend(unwrap_edges(environment["deploymentTriggers"]))
         deployments[project_id] = project_deployments
         snapshots[project_id] = project_snapshots

--- a/cartography/intel/railway/queries.py
+++ b/cartography/intel/railway/queries.py
@@ -92,58 +92,6 @@ _PAGE_INFO = """
     }
 """
 
-_SERVICE_INSTANCE_FIELDS = """
-    id
-    serviceId
-    serviceName
-    environmentId
-    createdAt
-    updatedAt
-    source {
-      image
-      repo
-    }
-    builder
-    buildCommand
-    startCommand
-    rootDirectory
-    dockerfilePath
-    region
-    numReplicas
-    sleepApplication
-    cronSchedule
-    healthcheckPath
-    restartPolicyType
-    restartPolicyMaxRetries
-    ipv6EgressEnabled
-    latestDeployment {
-      id
-      status
-    }
-    domains {
-      serviceDomains {
-        id
-        domain
-        suffix
-        targetPort
-        syncStatus
-        createdAt
-      }
-      customDomains {
-        id
-        domain
-        targetPort
-        isRailwayDomain
-        syncStatus
-        status {
-          verified
-          certificateStatus
-          verificationDnsHost
-        }
-      }
-    }
-"""
-
 _DEPLOYMENT_FIELDS = """
     id
     meta
@@ -157,6 +105,63 @@ _DEPLOYMENT_FIELDS = """
     staticUrl
     canRedeploy
 """
+
+_SERVICE_INSTANCE_FIELDS = """
+    id
+    serviceId
+    serviceName
+    environmentId
+    createdAt
+    updatedAt
+    source {{
+      image
+      repo
+    }}
+    builder
+    buildCommand
+    startCommand
+    rootDirectory
+    dockerfilePath
+    region
+    numReplicas
+    sleepApplication
+    cronSchedule
+    healthcheckPath
+    restartPolicyType
+    restartPolicyMaxRetries
+    ipv6EgressEnabled
+    activeDeployments {{
+      {}
+    }}
+    latestDeployment {{
+      {}
+    }}
+    domains {{
+      serviceDomains {{
+        id
+        domain
+        suffix
+        targetPort
+        syncStatus
+        createdAt
+      }}
+      customDomains {{
+        id
+        domain
+        targetPort
+        isRailwayDomain
+        syncStatus
+        status {{
+          verified
+          certificateStatus
+          verificationDnsHost
+        }}
+      }}
+    }}
+""".format(
+    _DEPLOYMENT_FIELDS,
+    _DEPLOYMENT_FIELDS,
+)
 
 _VOLUME_INSTANCE_FIELDS = """
     id

--- a/cartography/models/ontology/constraints.py
+++ b/cartography/models/ontology/constraints.py
@@ -76,6 +76,10 @@ ONTOLOGY_REL_CONSTRAINTS: tuple[RelConstraint, ...] = (
     # semantic.
     RelConstraint(src="Container", dst="Image", label="RESOLVED_IMAGE"),
     RelConstraint(src="Function", dst="Image", label="RESOLVED_IMAGE"),
+    # A running workload can be assessed through an immutable filesystem view.
+    RelConstraint(src="Container", dst="FilesystemSnapshot", label="SCANNED_AS"),
+    # A source snapshot identifies the repository whose exact revision it represents.
+    RelConstraint(src="FilesystemSnapshot", dst="CodeRepository", label="SNAPSHOT_OF"),
     # An image/function is built from a source code repository (CI provenance).
     RelConstraint(src="Image", dst="CodeRepository", label="PACKAGED_FROM"),
     # NOTE: no UserAccount->CodeRepository constraint. Several distinct edges

--- a/cartography/models/ontology/labels.py
+++ b/cartography/models/ontology/labels.py
@@ -134,6 +134,13 @@ FILE_STORAGE = ExtraNodeLabel(
 )
 
 
+FILESYSTEM_SNAPSHOT = ExtraNodeLabel(
+    label="FilesystemSnapshot",
+    description="An immutable filesystem view used as a software scan target.",
+    kind=LabelKind.ONTOLOGY,
+)
+
+
 FUNCTION = ExtraNodeLabel(
     label="Function",
     description="A cross-provider Function resource in Cartography's ontology.",

--- a/cartography/models/ontology/mapping/__init__.py
+++ b/cartography/models/ontology/mapping/__init__.py
@@ -22,6 +22,7 @@ from cartography.models.ontology.labels import DNS_RECORD
 from cartography.models.ontology.labels import DNS_ZONE
 from cartography.models.ontology.labels import ENCRYPTION_KEY
 from cartography.models.ontology.labels import FILE_STORAGE
+from cartography.models.ontology.labels import FILESYSTEM_SNAPSHOT
 from cartography.models.ontology.labels import FUNCTION
 from cartography.models.ontology.labels import IDENTITY_PROVIDER
 from cartography.models.ontology.labels import IMAGE
@@ -87,6 +88,9 @@ from cartography.models.ontology.mapping.data.encryptionkeys import (
 )
 from cartography.models.ontology.mapping.data.file_storage import (
     FILE_STORAGE_ONTOLOGY_MAPPING,
+)
+from cartography.models.ontology.mapping.data.filesystem_snapshots import (
+    FILESYSTEM_SNAPSHOTS_ONTOLOGY_MAPPING,
 )
 from cartography.models.ontology.mapping.data.firewalls import (
     FIREWALLS_ONTOLOGY_MAPPING,
@@ -171,6 +175,7 @@ SEMANTIC_LABELS_MAPPING: dict[str, dict[str, OntologyMapping]] = {
     "dnszones": DNSZONES_ONTOLOGY_MAPPING,
     "encryptionkeys": ENCRYPTIONKEYS_ONTOLOGY_MAPPING,
     "filestorage": FILE_STORAGE_ONTOLOGY_MAPPING,
+    "filesystemsnapshots": FILESYSTEM_SNAPSHOTS_ONTOLOGY_MAPPING,
     "firewalls": FIREWALLS_ONTOLOGY_MAPPING,
     "functions": FUNCTIONS_ONTOLOGY_MAPPING,
     "groups": GROUPS_ONTOLOGY_MAPPING,
@@ -216,6 +221,7 @@ SEMANTIC_LABEL_BY_CATEGORY: dict[str, ExtraNodeLabel] = {
     "dnszones": DNS_ZONE,
     "encryptionkeys": ENCRYPTION_KEY,
     "filestorage": FILE_STORAGE,
+    "filesystemsnapshots": FILESYSTEM_SNAPSHOT,
     "firewalls": NETWORK_ACCESS_CONTROL,
     "functions": FUNCTION,
     "groups": USER_GROUP,

--- a/cartography/models/ontology/mapping/data/filesystem_snapshots.py
+++ b/cartography/models/ontology/mapping/data/filesystem_snapshots.py
@@ -1,0 +1,32 @@
+from cartography.models.ontology.mapping.specs import OntologyFieldMapping
+from cartography.models.ontology.mapping.specs import OntologyMapping
+from cartography.models.ontology.mapping.specs import OntologyNodeMapping
+
+# FilesystemSnapshot fields:
+# _ont_kind - Snapshot type, initially `source`; future host snapshots may use `rootfs`.
+# _ont_source_revision - Immutable source revision represented by the snapshot.
+# _ont_root_directory - Repository-relative directory represented by the snapshot.
+
+railway_mapping = OntologyMapping(
+    module_name="railway",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="RailwayFilesystemSnapshot",
+            fields=[
+                OntologyFieldMapping(ontology_field="kind", node_field="kind"),
+                OntologyFieldMapping(
+                    ontology_field="source_revision",
+                    node_field="source_revision",
+                    required=True,
+                ),
+                OntologyFieldMapping(
+                    ontology_field="root_directory", node_field="root_directory"
+                ),
+            ],
+        ),
+    ],
+)
+
+FILESYSTEM_SNAPSHOTS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
+    "railway": railway_mapping,
+}

--- a/cartography/models/railway/filesystem_snapshot.py
+++ b/cartography/models/railway/filesystem_snapshot.py
@@ -16,7 +16,11 @@ from cartography.models.ontology.labels import FILESYSTEM_SNAPSHOT
 @dataclass(frozen=True)
 class RailwayFilesystemSnapshotNodeProperties(CartographyNodeProperties):
     id: PropertyRef = PropertyRef(
-        "id", description="ID of the Railway deployment represented by this snapshot."
+        "id", description="Cartography ID for this Railway filesystem snapshot."
+    )
+    deployment_id: PropertyRef = PropertyRef(
+        "deployment_id",
+        description="ID of the Railway deployment represented by this snapshot.",
     )
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
     kind: PropertyRef = PropertyRef(
@@ -71,7 +75,7 @@ class RailwayFilesystemSnapshotToDeploymentRel(CartographyRelSchema):
 
     target_node_label: str = "RailwayDeployment"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("id")},
+        {"id": PropertyRef("deployment_id")},
     )
     direction: LinkDirection = LinkDirection.INWARD
     rel_label: str = "SCANNED_AS"

--- a/cartography/models/railway/filesystem_snapshot.py
+++ b/cartography/models/railway/filesystem_snapshot.py
@@ -1,0 +1,120 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.ontology.labels import FILESYSTEM_SNAPSHOT
+
+
+@dataclass(frozen=True)
+class RailwayFilesystemSnapshotNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id", description="ID of the Railway deployment represented by this snapshot."
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    kind: PropertyRef = PropertyRef(
+        "kind",
+        extra_index=True,
+        description="Snapshot type. Currently always `source`.",
+    )
+    source_revision: PropertyRef = PropertyRef(
+        "source_revision",
+        extra_index=True,
+        description="Full source commit SHA represented by this snapshot.",
+    )
+    source_repo: PropertyRef = PropertyRef(
+        "source_repo",
+        extra_index=True,
+        description="Source repository in owner/name form.",
+    )
+    root_directory: PropertyRef = PropertyRef(
+        "root_directory",
+        description="Repository subdirectory represented by this snapshot.",
+    )
+
+
+@dataclass(frozen=True)
+class RailwayFilesystemSnapshotToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class RailwayFilesystemSnapshotToProjectRel(CartographyRelSchema):
+    """Connects a Railway project to a filesystem snapshot that it contains."""
+
+    target_node_label: str = "RailwayProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: RailwayFilesystemSnapshotToProjectRelProperties = (
+        RailwayFilesystemSnapshotToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class RailwayFilesystemSnapshotToDeploymentRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class RailwayFilesystemSnapshotToDeploymentRel(CartographyRelSchema):
+    """Identifies the filesystem snapshot used to assess a Railway deployment."""
+
+    target_node_label: str = "RailwayDeployment"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("id")},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "SCANNED_AS"
+    properties: RailwayFilesystemSnapshotToDeploymentRelProperties = (
+        RailwayFilesystemSnapshotToDeploymentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class RailwayFilesystemSnapshotToRepositoryRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class RailwayFilesystemSnapshotToRepositoryRel(CartographyRelSchema):
+    """Identifies the repository revision represented by a source snapshot."""
+
+    target_node_label: str = "GitHubRepository"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"fullname": PropertyRef("source_repo")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "SNAPSHOT_OF"
+    properties: RailwayFilesystemSnapshotToRepositoryRelProperties = (
+        RailwayFilesystemSnapshotToRepositoryRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class RailwayFilesystemSnapshotSchema(CartographyNodeSchema):
+    """An immutable source filesystem used to assess a Railway deployment."""
+
+    label: str = "RailwayFilesystemSnapshot"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([FILESYSTEM_SNAPSHOT])
+    properties: RailwayFilesystemSnapshotNodeProperties = (
+        RailwayFilesystemSnapshotNodeProperties()
+    )
+    sub_resource_relationship: RailwayFilesystemSnapshotToProjectRel = (
+        RailwayFilesystemSnapshotToProjectRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            RailwayFilesystemSnapshotToDeploymentRel(),
+            RailwayFilesystemSnapshotToRepositoryRel(),
+        ],
+    )

--- a/tests/data/railway/bundles.py
+++ b/tests/data/railway/bundles.py
@@ -78,6 +78,8 @@ RAILWAY_PROJECT_BUNDLE: dict[str, Any] = {
                                     "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
                                     "meta": {
                                         "commitHash": "0123456789ABCDEF0123456789ABCDEF01234567",
+                                        "repo": "acme/api",
+                                        "rootDirectory": "/backend",
                                     },
                                     "projectId": "33333333-3333-3333-3333-333333333333",
                                     "serviceId": "77777777-7777-7777-7777-777777777777",

--- a/tests/data/railway/bundles.py
+++ b/tests/data/railway/bundles.py
@@ -128,6 +128,25 @@ RAILWAY_PROJECT_BUNDLE: dict[str, Any] = {
                                     "healthcheckPath": None,
                                     "id": "99999999-9999-9999-9999-999999999999",
                                     "ipv6EgressEnabled": False,
+                                    "activeDeployments": [
+                                        {
+                                            "canRedeploy": True,
+                                            "createdAt": "2026-07-27T18:02:21.021Z",
+                                            "environmentId": "44444444-4444-4444-4444-444444444444",
+                                            "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                                            "meta": {
+                                                "commitHash": "0123456789ABCDEF0123456789ABCDEF01234567",
+                                                "repo": "acme/api",
+                                                "rootDirectory": "/backend",
+                                            },
+                                            "projectId": "33333333-3333-3333-3333-333333333333",
+                                            "serviceId": "77777777-7777-7777-7777-777777777777",
+                                            "staticUrl": None,
+                                            "status": "SUCCESS",
+                                            "statusUpdatedAt": "2026-07-27T18:02:26.300Z",
+                                            "url": None,
+                                        }
+                                    ],
                                     "latestDeployment": {
                                         "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
                                         "status": "SUCCESS",
@@ -194,6 +213,21 @@ RAILWAY_PROJECT_BUNDLE: dict[str, Any] = {
                                     "healthcheckPath": None,
                                     "id": "88888888-8888-8888-8888-888888888888",
                                     "ipv6EgressEnabled": False,
+                                    "activeDeployments": [
+                                        {
+                                            "canRedeploy": True,
+                                            "createdAt": "2026-07-27T18:01:57.350Z",
+                                            "environmentId": "44444444-4444-4444-4444-444444444444",
+                                            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                                            "meta": {"commitHash": "main"},
+                                            "projectId": "33333333-3333-3333-3333-333333333333",
+                                            "serviceId": "66666666-6666-6666-6666-666666666666",
+                                            "staticUrl": "web-production-abcde.up.railway.app",
+                                            "status": "SUCCESS",
+                                            "statusUpdatedAt": "2026-07-27T18:02:04.313Z",
+                                            "url": None,
+                                        }
+                                    ],
                                     "latestDeployment": {
                                         "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                                         "status": "SUCCESS",

--- a/tests/integration/cartography/intel/railway/test_deployments.py
+++ b/tests/integration/cartography/intel/railway/test_deployments.py
@@ -166,7 +166,7 @@ def test_git_backed_deployment_resolves_exact_source_context(neo4j_session):
     ) == {(TEST_PROJECT_ID, POSTGRES_SNAPSHOT_ID)}
 
 
-def test_failed_latest_deployment_keeps_previous_snapshot_current(neo4j_session):
+def test_active_deployment_outside_history_keeps_snapshot_current(neo4j_session):
     # Arrange
     failed_deployment_id = "dddd0000-dddd-dddd-dddd-dddddddddddd"
     bundles = copy.deepcopy(BUNDLES)
@@ -183,6 +183,11 @@ def test_failed_latest_deployment_keeps_previous_snapshot_current(neo4j_session)
         environment = env_edge["node"]
         if environment["id"] != PRODUCTION_ENV_ID:
             continue
+        environment["deployments"]["edges"] = [
+            edge
+            for edge in environment["deployments"]["edges"]
+            if edge["node"]["id"] != POSTGRES_DEPLOYMENT_ID
+        ]
         environment["deployments"]["edges"].append(
             {
                 "node": {
@@ -241,6 +246,11 @@ def test_filesystem_snapshot_is_removed_without_an_exact_revision(neo4j_session)
     }
 
     bundles = copy.deepcopy(BUNDLES)
+    for instance in cartography.intel.railway.serviceinstances.iter_service_instances(
+        bundles[TEST_PROJECT_ID]
+    ):
+        if instance["id"] == POSTGRES_INSTANCE_ID:
+            instance["activeDeployments"][0]["meta"] = {"commitHash": "main"}
     for environment in bundles[TEST_PROJECT_ID]["environments"]["edges"]:
         for deployment in environment["node"]["deployments"]["edges"]:
             if deployment["node"]["id"] == POSTGRES_DEPLOYMENT_ID:

--- a/tests/integration/cartography/intel/railway/test_deployments.py
+++ b/tests/integration/cartography/intel/railway/test_deployments.py
@@ -112,20 +112,74 @@ def test_git_backed_deployment_resolves_exact_source_context(neo4j_session):
     result = neo4j_session.run(
         """
         MATCH (d:RailwayDeployment {id: $deployment_id})
-              -[:WORKLOAD_PARENT]->(s:RailwayServiceInstance)
-              -[:DEPLOYED_FROM]->(r:GitHubRepository)
-        RETURN d.source_revision AS revision,
-               s.root_directory AS root_directory,
+              -[:SCANNED_AS]->(snapshot:RailwayFilesystemSnapshot:FilesystemSnapshot)
+              -[:SNAPSHOT_OF]->(r:GitHubRepository)
+        RETURN snapshot.kind AS kind,
+               snapshot._ont_kind AS ontology_kind,
+               snapshot.source_revision AS revision,
+               snapshot._ont_source_revision AS ontology_revision,
+               snapshot.root_directory AS root_directory,
+               snapshot._ont_root_directory AS ontology_root_directory,
+               snapshot._ont_source AS ontology_source,
                r.fullname AS repository
         """,
         deployment_id=POSTGRES_DEPLOYMENT_ID,
     ).single()
     assert result is not None
     assert result.data() == {
+        "kind": "source",
+        "ontology_kind": "source",
         "revision": SOURCE_REVISION,
+        "ontology_revision": SOURCE_REVISION,
         "root_directory": "/backend",
+        "ontology_root_directory": "/backend",
+        "ontology_source": "railway",
         "repository": "acme/api",
     }
+
+    assert check_nodes(neo4j_session, "FilesystemSnapshot", ["id"]) == {
+        (POSTGRES_DEPLOYMENT_ID,),
+    }
+    assert check_rels(
+        neo4j_session,
+        "RailwayProject",
+        "id",
+        "RailwayFilesystemSnapshot",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {(TEST_PROJECT_ID, POSTGRES_DEPLOYMENT_ID)}
+
+
+def test_filesystem_snapshot_is_removed_without_an_exact_revision(neo4j_session):
+    # Arrange
+    _sync_compute_tier(neo4j_session)
+    cartography.intel.railway.deployments.sync(
+        neo4j_session,
+        _common_job_parameters(),
+        BUNDLES,
+        TEST_UPDATE_TAG,
+    )
+    assert check_nodes(neo4j_session, "FilesystemSnapshot", ["id"]) == {
+        (POSTGRES_DEPLOYMENT_ID,),
+    }
+
+    bundles = copy.deepcopy(BUNDLES)
+    for environment in bundles[TEST_PROJECT_ID]["environments"]["edges"]:
+        for deployment in environment["node"]["deployments"]["edges"]:
+            if deployment["node"]["id"] == POSTGRES_DEPLOYMENT_ID:
+                deployment["node"]["meta"] = {"commitHash": "main"}
+
+    # Act
+    cartography.intel.railway.deployments.sync(
+        neo4j_session,
+        _common_job_parameters(TEST_UPDATE_TAG + 1),
+        bundles,
+        TEST_UPDATE_TAG + 1,
+    )
+
+    # Assert
+    assert check_nodes(neo4j_session, "FilesystemSnapshot", ["id"]) == set()
 
 
 def test_load_railway_deployment_triggers(neo4j_session):

--- a/tests/integration/cartography/intel/railway/test_deployments.py
+++ b/tests/integration/cartography/intel/railway/test_deployments.py
@@ -15,6 +15,9 @@ from tests.integration.cartography.intel.railway.test_serviceinstances import (
     POSTGRES_INSTANCE_ID,
 )
 from tests.integration.cartography.intel.railway.test_serviceinstances import (
+    POSTGRES_SERVICE_ID,
+)
+from tests.integration.cartography.intel.railway.test_serviceinstances import (
     PRODUCTION_ENV_ID,
 )
 from tests.integration.cartography.intel.railway.test_serviceinstances import (
@@ -92,6 +95,13 @@ def test_load_railway_deployments(neo4j_session):
 
 def test_git_backed_deployment_resolves_exact_source_context(neo4j_session):
     # Arrange
+    bundles = copy.deepcopy(BUNDLES)
+    for instance in cartography.intel.railway.serviceinstances.iter_service_instances(
+        bundles[TEST_PROJECT_ID]
+    ):
+        if instance["id"] == POSTGRES_INSTANCE_ID:
+            instance["source"] = {"image": None, "repo": "acme/other"}
+            instance["rootDirectory"] = "/other"
     neo4j_session.run(
         """
         MERGE (r:GitHubRepository {id: "https://github.com/acme/api"})
@@ -105,7 +115,7 @@ def test_git_backed_deployment_resolves_exact_source_context(neo4j_session):
     cartography.intel.railway.deployments.sync(
         neo4j_session,
         _common_job_parameters(),
-        BUNDLES,
+        bundles,
         TEST_UPDATE_TAG,
     )
 
@@ -154,6 +164,67 @@ def test_git_backed_deployment_resolves_exact_source_context(neo4j_session):
         "RESOURCE",
         rel_direction_right=True,
     ) == {(TEST_PROJECT_ID, POSTGRES_SNAPSHOT_ID)}
+
+
+def test_failed_latest_deployment_keeps_previous_snapshot_current(neo4j_session):
+    # Arrange
+    failed_deployment_id = "dddd0000-dddd-dddd-dddd-dddddddddddd"
+    bundles = copy.deepcopy(BUNDLES)
+    bundle = bundles[TEST_PROJECT_ID]
+    for instance in cartography.intel.railway.serviceinstances.iter_service_instances(
+        bundle
+    ):
+        if instance["id"] == POSTGRES_INSTANCE_ID:
+            instance["latestDeployment"] = {
+                "id": failed_deployment_id,
+                "status": "FAILED",
+            }
+    for env_edge in bundle["environments"]["edges"]:
+        environment = env_edge["node"]
+        if environment["id"] != PRODUCTION_ENV_ID:
+            continue
+        environment["deployments"]["edges"].append(
+            {
+                "node": {
+                    "id": failed_deployment_id,
+                    "status": "FAILED",
+                    "statusUpdatedAt": "2026-07-27T19:00:05.000Z",
+                    "createdAt": "2026-07-27T19:00:00.000Z",
+                    "projectId": TEST_PROJECT_ID,
+                    "environmentId": PRODUCTION_ENV_ID,
+                    "serviceId": POSTGRES_SERVICE_ID,
+                    "url": None,
+                    "staticUrl": None,
+                    "canRedeploy": True,
+                    "meta": {
+                        "commitHash": "fedcba9876543210fedcba9876543210fedcba98",
+                        "repo": "acme/api",
+                        "rootDirectory": "/backend",
+                    },
+                },
+            },
+        )
+    _sync_compute_tier(neo4j_session)
+
+    # Act
+    cartography.intel.railway.deployments.sync(
+        neo4j_session,
+        _common_job_parameters(),
+        bundles,
+        TEST_UPDATE_TAG,
+    )
+
+    # Assert
+    assert check_nodes(neo4j_session, "RailwayDeployment", ["id", "lifecycle"]) == {
+        (WEB_DEPLOYMENT_ID, "current"),
+        (POSTGRES_DEPLOYMENT_ID, "current"),
+        (failed_deployment_id, "historical"),
+    }
+    assert check_nodes(
+        neo4j_session,
+        "RailwayFilesystemSnapshot",
+        ["deployment_id", "source_revision"],
+    ) == {(POSTGRES_DEPLOYMENT_ID, SOURCE_REVISION)}
 
 
 def test_filesystem_snapshot_is_removed_without_an_exact_revision(neo4j_session):

--- a/tests/integration/cartography/intel/railway/test_deployments.py
+++ b/tests/integration/cartography/intel/railway/test_deployments.py
@@ -28,6 +28,7 @@ from tests.integration.util import check_rels
 
 WEB_DEPLOYMENT_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 POSTGRES_DEPLOYMENT_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+POSTGRES_SNAPSHOT_ID = f"railway:filesystem-snapshot:{POSTGRES_DEPLOYMENT_ID}"
 TRIGGER_ID = "dt111111-1111-1111-1111-111111111111"
 SOURCE_REVISION = "0123456789abcdef0123456789abcdef01234567"
 
@@ -115,6 +116,8 @@ def test_git_backed_deployment_resolves_exact_source_context(neo4j_session):
               -[:SCANNED_AS]->(snapshot:RailwayFilesystemSnapshot:FilesystemSnapshot)
               -[:SNAPSHOT_OF]->(r:GitHubRepository)
         RETURN snapshot.kind AS kind,
+               snapshot.id AS id,
+               snapshot.deployment_id AS deployment_id,
                snapshot._ont_kind AS ontology_kind,
                snapshot.source_revision AS revision,
                snapshot._ont_source_revision AS ontology_revision,
@@ -128,6 +131,8 @@ def test_git_backed_deployment_resolves_exact_source_context(neo4j_session):
     assert result is not None
     assert result.data() == {
         "kind": "source",
+        "id": POSTGRES_SNAPSHOT_ID,
+        "deployment_id": POSTGRES_DEPLOYMENT_ID,
         "ontology_kind": "source",
         "revision": SOURCE_REVISION,
         "ontology_revision": SOURCE_REVISION,
@@ -138,7 +143,7 @@ def test_git_backed_deployment_resolves_exact_source_context(neo4j_session):
     }
 
     assert check_nodes(neo4j_session, "FilesystemSnapshot", ["id"]) == {
-        (POSTGRES_DEPLOYMENT_ID,),
+        (POSTGRES_SNAPSHOT_ID,),
     }
     assert check_rels(
         neo4j_session,
@@ -148,7 +153,7 @@ def test_git_backed_deployment_resolves_exact_source_context(neo4j_session):
         "id",
         "RESOURCE",
         rel_direction_right=True,
-    ) == {(TEST_PROJECT_ID, POSTGRES_DEPLOYMENT_ID)}
+    ) == {(TEST_PROJECT_ID, POSTGRES_SNAPSHOT_ID)}
 
 
 def test_filesystem_snapshot_is_removed_without_an_exact_revision(neo4j_session):
@@ -161,7 +166,7 @@ def test_filesystem_snapshot_is_removed_without_an_exact_revision(neo4j_session)
         TEST_UPDATE_TAG,
     )
     assert check_nodes(neo4j_session, "FilesystemSnapshot", ["id"]) == {
-        (POSTGRES_DEPLOYMENT_ID,),
+        (POSTGRES_SNAPSHOT_ID,),
     }
 
     bundles = copy.deepcopy(BUNDLES)

--- a/tests/unit/cartography/models/test_introspection.py
+++ b/tests/unit/cartography/models/test_introspection.py
@@ -403,9 +403,11 @@ def test_build_data_model_exposes_ontology_catalog_metadata():
         )
         for constraint in model.ontology_relationship_constraints
     }
-    assert len(constraints) == 42
+    assert len(constraints) == 44
     assert ("ComputePod", "USES_SECRET", "Secret") in constraints
     assert ("Container", "RESOLVED_IMAGE", "Image") in constraints
+    assert ("Container", "SCANNED_AS", "FilesystemSnapshot") in constraints
+    assert ("FilesystemSnapshot", "SNAPSHOT_OF", "CodeRepository") in constraints
     assert ("CVE", "AFFECTS", "PackageVersion") in constraints
     assert ("LoadBalancer", "EXPOSE", "ComputeInstance") in constraints
 


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

### Summary

Adds a Railway-specific filesystem snapshot node with the cross-provider `FilesystemSnapshot` ontology label. It represents the exact repository revision backing a current Git-based Railway deployment. The snapshot uses a namespaced Cartography ID and retains the Railway deployment ID separately for the `SCANNED_AS` relationship.

Current deployments link to snapshots with `SCANNED_AS`, snapshots link to matching GitHub repositories with `SNAPSHOT_OF`, and snapshots remain scoped to their Railway project. Snapshots are only created when Railway supplies both a repository and a full commit SHA; scoped cleanup removes stale snapshots.

### Related issues or links

- Depends on #3179

### How was this tested?

- `uv run pytest tests/unit/cartography/intel/ontology/test_ontology_mapping.py tests/unit/cartography/graph/test_ontology_rel_constraints.py tests/unit/cartography/models/test_schema_docs.py tests/integration/cartography/intel/railway -q` (72 passed)
- `make test_lint`
- `uv run --group doc ./docs/build.sh`

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [ ] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [x] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).

### Notes for reviewers

This PR is intentionally stacked on #3179, which adds the exact Railway source revision used here. Trivy result ingestion is outside this PR.
