### PR TITLE
feat(trivy): ingest filesystem scan reports

### DIFF
--- a/cartography/analysis/ontology/analysis.py
+++ b/cartography/analysis/ontology/analysis.py
@@ -345,6 +345,24 @@ PACKAGE_DEPLOYED_IMAGE_JOBS = (
         ),
     ),
 )
+PACKAGE_DEPLOYED_FILESYSTEM_SNAPSHOT = AnalysisJob(
+    name="Ontology - Trivy PackageVersion DEPLOYED FilesystemSnapshot linking",
+    short_name="ontology_packages_trivy_deployed_filesystem_snapshot",
+    statements=(
+        AnalysisStatement(
+            match="MATCH (p:PackageVersion)-[:DETECTED_AS]->(tp:TrivyPackage)-[:DEPLOYED]->(snapshot:FilesystemSnapshot)",
+            effects=(
+                AddRelationship(
+                    "p",
+                    "DEPLOYED",
+                    "snapshot",
+                    source_label="PackageVersion",
+                    target_label="FilesystemSnapshot",
+                ),
+            ),
+        ),
+    ),
+)
 PACKAGE_AFFECTS_LINKING = AnalysisJob(
     name="Ontology - TrivyImageFinding AFFECTS PackageVersion linking",
     short_name="ontology_packages_affects",
@@ -419,6 +437,7 @@ PACKAGE_DEPENDS_ON_LINKING = AnalysisJob(
 )
 PACKAGE_LINKING_JOBS = (
     *PACKAGE_DEPLOYED_IMAGE_JOBS,
+    PACKAGE_DEPLOYED_FILESYSTEM_SNAPSHOT,
     PACKAGE_AFFECTS_LINKING,
     PACKAGE_AFFECTS_SEMGREP_SCA_LINKING,
     PACKAGE_SHOULD_UPDATE_TO_LINKING,

--- a/cartography/intel/trivy/__init__.py
+++ b/cartography/intel/trivy/__init__.py
@@ -173,8 +173,8 @@ def _normalize_repository(value: str) -> str:
 
 def _get_filesystem_scan_targets(
     neo4j_session: Session,
-) -> dict[tuple[str, str], list[str]]:
-    """Return source repository and revision pairs mapped to snapshot IDs."""
+) -> dict[tuple[str, str, str | None], list[str]]:
+    """Return source repository, revision, and root mapped to snapshot IDs."""
     result = neo4j_session.run(
         """
         MATCH (snapshot:FilesystemSnapshot)
@@ -182,14 +182,18 @@ def _get_filesystem_scan_targets(
           AND snapshot.source_revision IS NOT NULL
         RETURN snapshot.id AS id,
                snapshot.source_repo AS repository,
-               snapshot.source_revision AS revision
+               snapshot.source_revision AS revision,
+               snapshot.root_directory AS root_directory
         """,
     )
-    targets: dict[tuple[str, str], list[str]] = {}
+    targets: dict[tuple[str, str, str | None], list[str]] = {}
     for record in result:
         repository = _normalize_repository(record["repository"])
         revision = record["revision"].lower()
-        targets.setdefault((repository, revision), []).append(record["id"])
+        root_directory = (record["root_directory"] or "").strip("/") or None
+        targets.setdefault((repository, revision, root_directory), []).append(
+            record["id"]
+        )
     return targets
 
 
@@ -209,7 +213,7 @@ def _prepare_trivy_data(
     trivy_data: dict[str, Any],
     image_uris: set[str],
     digest_aliases: dict[str, str],
-    filesystem_targets: dict[tuple[str, str], list[str]],
+    filesystem_targets: dict[tuple[str, str, str | None], list[str]],
     source: str,
 ) -> tuple[dict[str, Any], str | None, list[str]] | None:
     """
@@ -249,16 +253,30 @@ def _prepare_trivy_data(
     artifact_type = trivy_data.get("ArtifactType")
     repo_url = metadata.get("RepoURL")
     revision = metadata.get("Commit")
+    root_directory = metadata.get("RootDirectory")
     if (
         artifact_type in {"filesystem", "repository"}
         and isinstance(repo_url, str)
         and isinstance(revision, str)
         and re.fullmatch(r"[0-9a-fA-F]{40}", revision)
     ):
-        snapshot_ids = filesystem_targets.get(
-            (_normalize_repository(repo_url), revision.lower()),
-            [],
-        )
+        repository_key = _normalize_repository(repo_url)
+        revision_key = revision.lower()
+        if isinstance(root_directory, str):
+            root_key = root_directory.strip("/") or None
+            snapshot_ids = filesystem_targets.get(
+                (repository_key, revision_key, root_key),
+                [],
+            )
+        else:
+            # Reports without a root predate this discriminator and represent
+            # the whole repository, so retain the existing broad match.
+            snapshot_ids = [
+                snapshot_id
+                for (repository, commit, _), ids in filesystem_targets.items()
+                if repository == repository_key and commit == revision_key
+                for snapshot_id in ids
+            ]
         if snapshot_ids:
             return trivy_data, None, snapshot_ids
 

--- a/cartography/intel/trivy/__init__.py
+++ b/cartography/intel/trivy/__init__.py
@@ -24,6 +24,7 @@ from cartography.intel.common.report_reader_builder import (
 from cartography.intel.common.report_source import parse_report_source
 from cartography.intel.trivy.scanner import cleanup
 from cartography.intel.trivy.scanner import cleanup_filesystem_snapshot_relationships
+from cartography.intel.trivy.scanner import cleanup_image_relationships
 from cartography.intel.trivy.scanner import sync_single_filesystem_snapshot
 from cartography.intel.trivy.scanner import sync_single_image
 from cartography.stats import get_stats_client
@@ -326,6 +327,7 @@ def sync_trivy_from_report_reader(
     logger.info("Processing %d Trivy result files from report source", len(json_files))
     failed_report_count = 0
     processed_reports = 0
+    processed_filesystem_reports = 0
     processed_image_reports = 0
     for ref in json_files:
         logger.debug(
@@ -366,6 +368,7 @@ def sync_trivy_from_report_reader(
                 ref.uri,
                 update_tag,
             )
+            processed_filesystem_reports += 1
         processed_reports += 1
 
     if failed_report_count:
@@ -387,6 +390,14 @@ def sync_trivy_from_report_reader(
             "source contained only filesystem reports while image scan targets exist.",
         )
         cleanup_filesystem_snapshot_relationships(neo4j_session, update_tag)
+        return
+
+    if filesystem_targets and processed_filesystem_reports == 0:
+        logger.warning(
+            "Limiting Trivy cleanup to image relationships because the report source "
+            "contained only image reports while filesystem scan targets exist.",
+        )
+        cleanup_image_relationships(neo4j_session, update_tag)
         return
 
     cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/trivy/__init__.py
+++ b/cartography/intel/trivy/__init__.py
@@ -325,6 +325,7 @@ def sync_trivy_from_report_reader(
     logger.info("Processing %d Trivy result files from report source", len(json_files))
     failed_report_count = 0
     processed_reports = 0
+    processed_image_reports = 0
     for ref in json_files:
         logger.debug(
             "Reading scan results from report source: %s",
@@ -355,6 +356,7 @@ def sync_trivy_from_report_reader(
                 display_uri,
                 update_tag,
             )
+            processed_image_reports += 1
         else:
             sync_single_filesystem_snapshot(
                 neo4j_session,
@@ -375,6 +377,13 @@ def sync_trivy_from_report_reader(
     if processed_reports == 0:
         logger.warning(
             "Skipping Trivy cleanup because no reports were ingested.",
+        )
+        return
+
+    if image_uris and processed_image_reports == 0:
+        logger.warning(
+            "Skipping Trivy cleanup because the report source contained only "
+            "filesystem reports while image scan targets exist.",
         )
         return
 

--- a/cartography/intel/trivy/__init__.py
+++ b/cartography/intel/trivy/__init__.py
@@ -1,5 +1,7 @@
 import logging
+import re
 from typing import Any
+from urllib.parse import urlparse
 
 import boto3
 from neo4j import Session
@@ -21,6 +23,7 @@ from cartography.intel.common.report_reader_builder import (
 )
 from cartography.intel.common.report_source import parse_report_source
 from cartography.intel.trivy.scanner import cleanup
+from cartography.intel.trivy.scanner import sync_single_filesystem_snapshot
 from cartography.intel.trivy.scanner import sync_single_image
 from cartography.stats import get_stats_client
 from cartography.util import timeit
@@ -155,6 +158,41 @@ def _get_scan_targets_and_aliases(
     return image_uris, digest_aliases
 
 
+def _normalize_repository(value: str) -> str:
+    repository = value.strip().rstrip("/")
+    if repository.endswith(".git"):
+        repository = repository[:-4]
+
+    if "://" in repository:
+        repository = urlparse(repository).path
+    elif repository.startswith("git@") and ":" in repository:
+        repository = repository.split(":", 1)[1]
+
+    return repository.strip("/").lower()
+
+
+def _get_filesystem_scan_targets(
+    neo4j_session: Session,
+) -> dict[tuple[str, str], list[str]]:
+    """Return source repository and revision pairs mapped to snapshot IDs."""
+    result = neo4j_session.run(
+        """
+        MATCH (snapshot:FilesystemSnapshot)
+        WHERE snapshot.source_repo IS NOT NULL
+          AND snapshot.source_revision IS NOT NULL
+        RETURN snapshot.id AS id,
+               snapshot.source_repo AS repository,
+               snapshot.source_revision AS revision
+        """,
+    )
+    targets: dict[tuple[str, str], list[str]] = {}
+    for record in result:
+        repository = _normalize_repository(record["repository"])
+        revision = record["revision"].lower()
+        targets.setdefault((repository, revision), []).append(record["id"])
+    return targets
+
+
 @timeit
 def get_scan_targets(
     neo4j_session: Session,
@@ -171,13 +209,13 @@ def _prepare_trivy_data(
     trivy_data: dict[str, Any],
     image_uris: set[str],
     digest_aliases: dict[str, str],
+    filesystem_targets: dict[tuple[str, str], list[str]],
     source: str,
-) -> tuple[dict[str, Any], str] | None:
+) -> tuple[dict[str, Any], str | None, list[str]] | None:
     """
     Determine the tag URI that corresponds to this Trivy payload.
 
-    Returns (trivy_data, display_uri) if the payload can be linked to an image present
-    in the graph; otherwise returns None so the caller can skip ingestion.
+    Returns the report and its matching image or filesystem snapshot targets.
     """
 
     artifact_name = (trivy_data.get("ArtifactName") or "").strip()
@@ -205,14 +243,30 @@ def _prepare_trivy_data(
             display_uri = alias
             break
 
-    if not display_uri:
-        logger.debug(
-            "Skipping Trivy results for %s because no matching image URI was found in the graph",
-            source,
-        )
-        return None
+    if display_uri:
+        return trivy_data, display_uri, []
 
-    return trivy_data, display_uri
+    artifact_type = trivy_data.get("ArtifactType")
+    repo_url = metadata.get("RepoURL")
+    revision = metadata.get("Commit")
+    if (
+        artifact_type in {"filesystem", "repository"}
+        and isinstance(repo_url, str)
+        and isinstance(revision, str)
+        and re.fullmatch(r"[0-9a-fA-F]{40}", revision)
+    ):
+        snapshot_ids = filesystem_targets.get(
+            (_normalize_repository(repo_url), revision.lower()),
+            [],
+        )
+        if snapshot_ids:
+            return trivy_data, None, snapshot_ids
+
+    logger.debug(
+        "Skipping Trivy results for %s because no matching scan target was found in the graph",
+        source,
+    )
+    return None
 
 
 @timeit
@@ -234,6 +288,7 @@ def sync_trivy_from_report_reader(
     logger.info("Using Trivy scan results from %s", reader.source_uri)
 
     image_uris, digest_aliases = _get_scan_targets_and_aliases(neo4j_session)
+    filesystem_targets = _get_filesystem_scan_targets(neo4j_session)
     json_files = filter_report_refs(
         reader.list_reports(),
         suffix=".json",
@@ -268,18 +323,28 @@ def sync_trivy_from_report_reader(
             trivy_data,
             image_uris=image_uris,
             digest_aliases=digest_aliases,
+            filesystem_targets=filesystem_targets,
             source=ref.uri,
         )
         if prepared is None:
             continue
 
-        prepared_data, display_uri = prepared
-        sync_single_image(
-            neo4j_session,
-            prepared_data,
-            display_uri,
-            update_tag,
-        )
+        prepared_data, display_uri, filesystem_snapshot_ids = prepared
+        if display_uri:
+            sync_single_image(
+                neo4j_session,
+                prepared_data,
+                display_uri,
+                update_tag,
+            )
+        else:
+            sync_single_filesystem_snapshot(
+                neo4j_session,
+                prepared_data,
+                filesystem_snapshot_ids,
+                ref.uri,
+                update_tag,
+            )
         processed_reports += 1
 
     if failed_report_count:

--- a/cartography/intel/trivy/__init__.py
+++ b/cartography/intel/trivy/__init__.py
@@ -23,6 +23,7 @@ from cartography.intel.common.report_reader_builder import (
 )
 from cartography.intel.common.report_source import parse_report_source
 from cartography.intel.trivy.scanner import cleanup
+from cartography.intel.trivy.scanner import cleanup_filesystem_snapshot_relationships
 from cartography.intel.trivy.scanner import sync_single_filesystem_snapshot
 from cartography.intel.trivy.scanner import sync_single_image
 from cartography.stats import get_stats_client
@@ -382,9 +383,10 @@ def sync_trivy_from_report_reader(
 
     if image_uris and processed_image_reports == 0:
         logger.warning(
-            "Skipping Trivy cleanup because the report source contained only "
-            "filesystem reports while image scan targets exist.",
+            "Limiting Trivy cleanup to filesystem relationships because the report "
+            "source contained only filesystem reports while image scan targets exist.",
         )
+        cleanup_filesystem_snapshot_relationships(neo4j_session, update_tag)
         return
 
     cleanup(neo4j_session, common_job_parameters)

--- a/cartography/intel/trivy/scanner.py
+++ b/cartography/intel/trivy/scanner.py
@@ -363,7 +363,7 @@ def sync_single_filesystem_snapshot(
 
         results = trivy_data.get("Results", [])
         if not results:
-            logger.info("No vulnerabilities found for %s", source)
+            logger.debug("No vulnerabilities found for %s", source)
 
         num_findings = _sync_scan_results(
             neo4j_session,

--- a/cartography/intel/trivy/scanner.py
+++ b/cartography/intel/trivy/scanner.py
@@ -515,6 +515,33 @@ def cleanup_filesystem_snapshot_relationships(
     )
 
 
+@timeit
+def cleanup_image_relationships(
+    neo4j_session: Session,
+    update_tag: int,
+) -> None:
+    """Remove stale image edges without touching filesystem-scoped scan data."""
+    run_write_query(
+        neo4j_session,
+        """
+        CALL {
+          MATCH (:TrivyImageFinding)-[r:AFFECTS]->(:Image)
+          WHERE r.lastupdated IS NULL OR r.lastupdated <> $UPDATE_TAG
+          DELETE r
+          RETURN count(*) AS removed_findings
+        }
+        CALL {
+          MATCH (:TrivyPackage)-[r:DEPLOYED]->(:Image)
+          WHERE r.lastupdated IS NULL OR r.lastupdated <> $UPDATE_TAG
+          DELETE r
+          RETURN count(*) AS removed_packages
+        }
+        RETURN removed_findings, removed_packages
+        """,
+        UPDATE_TAG=update_tag,
+    )
+
+
 # DEPRECATED: legacy Package label migration will be removed in v1.0.0.
 def _migrate_legacy_package_labels(neo4j_session: Session) -> None:
     """One-time migration: relabel legacy Package → TrivyPackage for nodes created before the rename."""

--- a/cartography/intel/trivy/scanner.py
+++ b/cartography/intel/trivy/scanner.py
@@ -45,7 +45,9 @@ def _validate_packages(package_list: list[dict]) -> list[dict]:
 
 
 def transform_scan_results(
-    results: list[dict], image_digest: str
+    results: list[dict],
+    image_digest: str | None,
+    filesystem_snapshot_ids: list[str] | None = None,
 ) -> tuple[list[dict], list[dict], list[dict]]:
     """
     Transform raw Trivy scan results into a format suitable for loading into Neo4j.
@@ -118,6 +120,7 @@ def transform_scan_results(
                     "Class": scan_class["Class"],
                     "Type": scan_class["Type"],
                     "ImageDigest": image_digest,  # For AFFECTS relationship
+                    "FilesystemSnapshotIds": filesystem_snapshot_ids or [],
                     # Additional fields
                     "CweIDs": result.get("CweIDs"),
                     "Status": result.get("Status"),
@@ -172,6 +175,7 @@ def transform_scan_results(
                         "Class": scan_class["Class"],
                         "Type": scan_class["Type"],
                         "ImageDigest": image_digest,  # For DEPLOYED relationship
+                        "FilesystemSnapshotIds": filesystem_snapshot_ids or [],
                         "FindingId": finding["id"],  # For AFFECTS relationship
                         # Additional fields
                         "PURL": purl,
@@ -198,8 +202,9 @@ def transform_scan_results(
 
 def transform_all_packages(
     results: list[dict],
-    image_digest: str,
+    image_digest: str | None,
     seen_ids: set[str],
+    filesystem_snapshot_ids: list[str] | None = None,
 ) -> list[dict]:
     """
     Transform Trivy Packages arrays into package dicts for loading.
@@ -255,6 +260,7 @@ def transform_all_packages(
                     "Class": class_name,
                     "Type": pkg_type,
                     "ImageDigest": image_digest,
+                    "FilesystemSnapshotIds": filesystem_snapshot_ids or [],
                     "FindingId": None,
                     "PURL": purl,
                     "PkgID": pkg.get("ID"),
@@ -322,35 +328,92 @@ def sync_single_image(
     """
     try:
         _, results, image_digest = _parse_trivy_data(trivy_data, source)
-
-        # Transform all data in one pass
-        findings_list, packages_list, fixes_list = transform_scan_results(
+        num_findings = _sync_scan_results(
+            neo4j_session,
             results,
-            image_digest,
+            source,
+            update_tag,
+            image_digest=image_digest,
         )
-
-        num_findings = len(findings_list)
         stat_handler.incr("image_scan_cve_count", num_findings)
-
-        # Load the transformed data
-        load_scan_vulns(neo4j_session, findings_list, update_tag=update_tag)
-        load_scan_packages(neo4j_session, packages_list, update_tag=update_tag)
-        load_scan_fixes(neo4j_session, fixes_list, update_tag=update_tag)
-
-        # Load non-vulnerable packages from the Packages arrays (requires --list-all-pkgs)
-        seen_ids = {pkg["id"] for pkg in packages_list}
-        all_packages = transform_all_packages(results, image_digest, seen_ids)
-        if all_packages:
-            logger.info(
-                f"Loading {len(all_packages)} additional non-vulnerable packages for {source}",
-            )
-            load_scan_packages(neo4j_session, all_packages, update_tag=update_tag)
-
         stat_handler.incr("images_processed_count")
 
     except Exception as e:
         logger.error(f"Failed to process scan results for {source}: {e}")
         raise
+
+
+@timeit
+def sync_single_filesystem_snapshot(
+    neo4j_session: Session,
+    trivy_data: dict,
+    filesystem_snapshot_ids: list[str],
+    source: str,
+    update_tag: int,
+) -> None:
+    """Sync one Trivy filesystem or repository report to matching snapshots."""
+    try:
+        artifact_type = trivy_data.get("ArtifactType")
+        if artifact_type not in {"filesystem", "repository"}:
+            raise ValueError(
+                f"Expected a filesystem or repository Trivy report for {source}",
+            )
+        if not filesystem_snapshot_ids:
+            raise ValueError(f"No filesystem snapshot targets for {source}")
+
+        results = trivy_data.get("Results", [])
+        if not results:
+            logger.info("No vulnerabilities found for %s", source)
+
+        num_findings = _sync_scan_results(
+            neo4j_session,
+            results,
+            source,
+            update_tag,
+            filesystem_snapshot_ids=filesystem_snapshot_ids,
+        )
+        stat_handler.incr("filesystem_scan_cve_count", num_findings)
+        stat_handler.incr("filesystem_scans_processed_count")
+    except Exception as exc:
+        logger.error("Failed to process scan results for %s: %s", source, exc)
+        raise
+
+
+def _sync_scan_results(
+    neo4j_session: Session,
+    results: list[dict],
+    source: str,
+    update_tag: int,
+    *,
+    image_digest: str | None = None,
+    filesystem_snapshot_ids: list[str] | None = None,
+) -> int:
+    findings_list, packages_list, fixes_list = transform_scan_results(
+        results,
+        image_digest,
+        filesystem_snapshot_ids,
+    )
+
+    load_scan_vulns(neo4j_session, findings_list, update_tag=update_tag)
+    load_scan_packages(neo4j_session, packages_list, update_tag=update_tag)
+    load_scan_fixes(neo4j_session, fixes_list, update_tag=update_tag)
+
+    seen_ids = {pkg["id"] for pkg in packages_list}
+    all_packages = transform_all_packages(
+        results,
+        image_digest,
+        seen_ids,
+        filesystem_snapshot_ids,
+    )
+    if all_packages:
+        logger.info(
+            "Loading %d additional non-vulnerable packages for %s",
+            len(all_packages),
+            source,
+        )
+        load_scan_packages(neo4j_session, all_packages, update_tag=update_tag)
+
+    return len(findings_list)
 
 
 @timeit

--- a/cartography/intel/trivy/scanner.py
+++ b/cartography/intel/trivy/scanner.py
@@ -7,6 +7,7 @@ import boto3
 from neo4j import Session
 
 from cartography.client.core.tx import load
+from cartography.client.core.tx import run_write_query
 from cartography.graph.job import GraphJob
 from cartography.intel.common.object_store import filter_report_refs
 from cartography.intel.common.object_store import read_text_report
@@ -361,7 +362,7 @@ def sync_single_filesystem_snapshot(
         if not filesystem_snapshot_ids:
             raise ValueError(f"No filesystem snapshot targets for {source}")
 
-        results = trivy_data.get("Results", [])
+        results = trivy_data.get("Results") or []
         if not results:
             logger.debug("No vulnerabilities found for %s", source)
 
@@ -484,6 +485,33 @@ def cleanup(neo4j_session: Session, common_job_parameters: dict[str, Any]) -> No
     )
     GraphJob.from_node_schema(TrivyFixSchema(), common_job_parameters).run(
         neo4j_session
+    )
+
+
+@timeit
+def cleanup_filesystem_snapshot_relationships(
+    neo4j_session: Session,
+    update_tag: int,
+) -> None:
+    """Remove stale filesystem edges without touching image-scoped scan data."""
+    run_write_query(
+        neo4j_session,
+        """
+        CALL {
+          MATCH (:TrivyImageFinding)-[r:AFFECTS]->(:FilesystemSnapshot)
+          WHERE r.lastupdated IS NULL OR r.lastupdated <> $UPDATE_TAG
+          DELETE r
+          RETURN count(*) AS removed_findings
+        }
+        CALL {
+          MATCH (:TrivyPackage)-[r:DEPLOYED]->(:FilesystemSnapshot)
+          WHERE r.lastupdated IS NULL OR r.lastupdated <> $UPDATE_TAG
+          DELETE r
+          RETURN count(*) AS removed_packages
+        }
+        RETURN removed_findings, removed_packages
+        """,
+        UPDATE_TAG=update_tag,
     )
 
 

--- a/cartography/models/ontology/constraints.py
+++ b/cartography/models/ontology/constraints.py
@@ -78,6 +78,8 @@ ONTOLOGY_REL_CONSTRAINTS: tuple[RelConstraint, ...] = (
     RelConstraint(src="Function", dst="Image", label="RESOLVED_IMAGE"),
     # A running workload can be assessed through an immutable filesystem view.
     RelConstraint(src="Container", dst="FilesystemSnapshot", label="SCANNED_AS"),
+    RelConstraint(src="CVE", dst="FilesystemSnapshot", label="AFFECTS"),
+    RelConstraint(src="PackageVersion", dst="FilesystemSnapshot", label="DEPLOYED"),
     # A source snapshot identifies the repository whose exact revision it represents.
     RelConstraint(src="FilesystemSnapshot", dst="CodeRepository", label="SNAPSHOT_OF"),
     # An image/function is built from a source code repository (CI provenance).

--- a/cartography/models/ontology/package_version.py
+++ b/cartography/models/ontology/package_version.py
@@ -135,6 +135,19 @@ class PackageVersionToOntologyImageRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class PackageVersionToFilesystemSnapshotRel(CartographyRelSchema):
+    """A canonical package version is deployed in a filesystem snapshot."""
+
+    target_node_label: str = "FilesystemSnapshot"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("_unused_cleanup_matcher")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "DEPLOYED"
+    properties: PackageVersionToNodeRelProperties = PackageVersionToNodeRelProperties()
+
+
+@dataclass(frozen=True)
 class PackageVersionToTrivyFixRel(CartographyRelSchema):
     """A canonical package version should be updated to an available Trivy fix."""
 
@@ -192,6 +205,7 @@ class PackageVersionSchema(CartographyNodeSchema):
             PackageVersionToGitHubDependencyRel(),
             PackageVersionToSemgrepDependencyRel(),
             PackageVersionToOntologyImageRel(),
+            PackageVersionToFilesystemSnapshotRel(),
             PackageVersionToTrivyFixRel(),
             PackageVersionToPackageVersionDependsOnRel(),
             TrivyImageFindingToPackageVersionRel(),

--- a/cartography/models/trivy/findings.py
+++ b/cartography/models/trivy/findings.py
@@ -156,8 +156,21 @@ class TrivyFindingToOntologyImageRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class TrivyFindingToFilesystemSnapshotRel(CartographyRelSchema):
+    """Links a Trivy finding to the filesystem snapshots it affects."""
+
+    target_node_label: str = "FilesystemSnapshot"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("FilesystemSnapshotIds", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "AFFECTS"
+    properties: TrivyFindingToImageRelProperties = TrivyFindingToImageRelProperties()
+
+
+@dataclass(frozen=True)
 class TrivyImageFindingSchema(CartographyNodeSchema):
-    """A vulnerability finding detected by Trivy in a container image."""
+    """A vulnerability finding detected by Trivy in a scan target."""
 
     label: str = "TrivyImageFinding"
     scoped_cleanup: bool = False
@@ -173,5 +186,6 @@ class TrivyImageFindingSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             TrivyFindingToOntologyImageRel(),
+            TrivyFindingToFilesystemSnapshotRel(),
         ],
     )

--- a/cartography/models/trivy/package.py
+++ b/cartography/models/trivy/package.py
@@ -69,6 +69,19 @@ class TrivyPackageToOntologyImageRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class TrivyPackageToFilesystemSnapshotRel(CartographyRelSchema):
+    """Links a Trivy package to the filesystem snapshots where it is installed."""
+
+    target_node_label: str = "FilesystemSnapshot"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("FilesystemSnapshotIds", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "DEPLOYED"
+    properties: TrivyPackageToImageRelProperties = TrivyPackageToImageRelProperties()
+
+
+@dataclass(frozen=True)
 class TrivyPackageToFindingRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
@@ -90,7 +103,7 @@ class TrivyPackageToFindingRel(CartographyRelSchema):
 
 @dataclass(frozen=True)
 class TrivyPackageSchema(CartographyNodeSchema):
-    """A package detected by Trivy in a container image."""
+    """A package detected by Trivy in a scan target."""
 
     label: str = "TrivyPackage"
     scoped_cleanup: bool = False
@@ -98,6 +111,7 @@ class TrivyPackageSchema(CartographyNodeSchema):
     other_relationships: OtherRelationships = OtherRelationships(
         [
             TrivyPackageToOntologyImageRel(),
+            TrivyPackageToFilesystemSnapshotRel(),
             TrivyPackageToFindingRel(),
         ],
     )

--- a/docs/root/modules/trivy/config.md
+++ b/docs/root/modules/trivy/config.md
@@ -4,8 +4,8 @@
 
 Install Trivy by following the [official Trivy installation
 guide](https://aquasecurity.github.io/trivy/latest/getting-started/installation/).
-Populate the graph with the registry resources that you want to scan before
-running the Trivy module. For AWS ECR:
+Populate the graph with the image or filesystem snapshot resources that you want
+to scan before running the Trivy module. For AWS ECR:
 
 ```bash
 cartography --selected-modules aws --aws-requested-syncs ecr
@@ -13,6 +13,16 @@ cartography --selected-modules aws --aws-requested-syncs ecr
 
 Trivy scans ECR repository images, while Cartography attaches findings to
 their underlying `AWSECRImage` nodes.
+
+For a source filesystem snapshot, check out the exact commit while retaining
+the repository's Git metadata, then run:
+
+```bash
+trivy fs --format json --scanners vuln --list-all-pkgs /path/to/repository
+```
+
+Cartography uses `Metadata.RepoURL` and the full SHA in `Metadata.Commit` to
+match the report to every `FilesystemSnapshot` for that repository revision.
 
 ## Required Permissions
 
@@ -49,8 +59,9 @@ cartography --selected-modules trivy --trivy-source /path/to/trivy-results
 
 ### Generate Input Artifacts
 
-Scan images with Trivy and put the JSON results in a local directory or
-supported object store. Cartography requires these Trivy arguments:
+Scan images or checked-out repositories with Trivy and put the JSON results in
+a local directory or supported object store. Cartography requires these Trivy
+arguments:
 
 - `--format json`: Cartography only accepts JSON, including the useful
   `fixed_version` field.
@@ -70,9 +81,9 @@ Optional Trivy arguments include:
 
 ### Input Format
 
-JSON files can use any naming convention. Cartography determines which image a
-scan belongs to from the scan content, not the filename. You can use an object
-prefix to organize cloud results. For example:
+JSON files can use any naming convention. Cartography determines which scan
+target a report belongs to from the scan content, not the filename. You can use
+an object prefix to organize cloud results. For example:
 
 - `s3://my-bucket/trivy-scans/123456789012.dkr.ecr.us-east-1.amazonaws.com/test-app:v1.2.3.json`
 - `s3://my-bucket/trivy-scans/scan-12345.json`
@@ -81,6 +92,10 @@ Cartography supports scans identified by tag URIs such as `repo:tag` and digest
 URIs such as `repo@sha256:abc123...`. Digest-qualified URIs support
 multi-architecture images where each platform has its own digest. Cartography
 matches scans to canonical images using the digest in `Metadata.RepoDigests`.
+
+Filesystem reports must use `ArtifactType` `filesystem` or `repository` and
+include `Metadata.RepoURL` plus a 40-character `Metadata.Commit`. Reports without
+an exact graph match are skipped.
 
 ## Advanced Configuration
 

--- a/docs/root/modules/trivy/index.md
+++ b/docs/root/modules/trivy/index.md
@@ -1,13 +1,17 @@
 # Trivy
 
 The Trivy module ingests vulnerability, package, and fix data from Trivy JSON
-container image scan reports. Findings and packages attach to canonical
-ontology `Image` nodes by image digest, independent of the source registry.
+container image and source filesystem scan reports. Findings and packages attach
+to canonical ontology `Image` or `FilesystemSnapshot` nodes.
 
 Cartography currently supports matching Trivy reports to images ingested from
 AWS ECR, Google Artifact Registry, and GitLab Container Registry. Load the
 registry's Cartography module before Trivy so the corresponding canonical image
 nodes exist.
+
+Git repository scans match `FilesystemSnapshot` nodes by the repository URL and
+exact commit recorded in Trivy metadata. The corresponding provider module must
+create the snapshot before Trivy ingestion runs.
 
 ## Finding Identifiers
 

--- a/tests/integration/cartography/intel/ontology/test_packages.py
+++ b/tests/integration/cartography/intel/ontology/test_packages.py
@@ -24,6 +24,8 @@ def _setup_trivy_graph(neo4j_session):
         MERGE (ont_img:Image {id: 'ont-img-abc123'})
         SET ont_img._ont_digest = 'sha256:abc123'
         MERGE (p)-[:DEPLOYED]->(ont_img)
+        MERGE (snapshot:FilesystemSnapshot {id: 'filesystem-snapshot-1'})
+        MERGE (p)-[:DEPLOYED]->(snapshot)
         MERGE (f:TrivyImageFinding {id: 'TIF|CVE-2024-00001'})
         SET f.name = 'CVE-2024-00001'
         MERGE (f)-[:AFFECTS]->(p)
@@ -178,6 +180,16 @@ def test_load_ontology_packages(_mock_get_source_nodes, neo4j_session):
         rel_direction_right=True,
     )
     assert actual_trivy_rels == expected_trivy_rels
+
+    assert check_rels(
+        neo4j_session,
+        "PackageVersion",
+        "id",
+        "FilesystemSnapshot",
+        "id",
+        "DEPLOYED",
+        rel_direction_right=True,
+    ) == {("npm|express|4.18.2", "filesystem-snapshot-1")}
 
     # Assert - Check DETECTED_AS relationships to SyftPackage
     expected_syft_rels = {

--- a/tests/integration/cartography/intel/trivy/test_trivy_filesystem_snapshot.py
+++ b/tests/integration/cartography/intel/trivy/test_trivy_filesystem_snapshot.py
@@ -1,0 +1,91 @@
+import json
+
+import cartography.intel.trivy
+from cartography.intel.common.object_store import ListedReportReader
+from cartography.intel.common.object_store import ReportRef
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+SNAPSHOT_IDS = ["railway-deployment-1", "railway-deployment-2"]
+SOURCE_REVISION = "0123456789abcdef0123456789abcdef01234567"
+
+
+def test_sync_trivy_repository_report_to_filesystem_snapshot(neo4j_session):
+    # Arrange
+    neo4j_session.run(
+        """
+        UNWIND $ids AS id
+        MERGE (snapshot:RailwayFilesystemSnapshot:FilesystemSnapshot {id: id})
+        SET snapshot.source_repo = "acme/api",
+            snapshot.source_revision = $revision,
+            snapshot.lastupdated = $update_tag
+        """,
+        ids=SNAPSHOT_IDS,
+        revision=SOURCE_REVISION,
+        update_tag=TEST_UPDATE_TAG,
+    )
+    payload = {
+        "SchemaVersion": 2,
+        "ArtifactName": "/tmp/api",
+        "ArtifactType": "repository",
+        "Metadata": {
+            "RepoURL": "git@github.com:acme/api.git",
+            "Commit": SOURCE_REVISION.upper(),
+        },
+        "Results": [
+            {
+                "Target": "requirements.txt",
+                "Class": "lang-pkgs",
+                "Type": "pip",
+                "Vulnerabilities": [
+                    {
+                        "VulnerabilityID": "CVE-2026-12345",
+                        "PkgName": "example-package",
+                        "InstalledVersion": "1.0.0",
+                        "FixedVersion": "1.0.1",
+                        "Severity": "HIGH",
+                    },
+                ],
+            },
+        ],
+    }
+    ref = ReportRef(uri="memory://filesystem.json", name="filesystem.json")
+    reader = ListedReportReader(
+        "memory://trivy-reports",
+        [ref],
+        lambda _ref: json.dumps(payload).encode(),
+    )
+
+    # Act
+    cartography.intel.trivy.sync_trivy_from_report_reader(
+        neo4j_session,
+        reader,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    # Assert
+    assert check_rels(
+        neo4j_session,
+        "TrivyImageFinding",
+        "id",
+        "FilesystemSnapshot",
+        "id",
+        "AFFECTS",
+        rel_direction_right=True,
+    ) == {
+        ("TIF|CVE-2026-12345", SNAPSHOT_IDS[0]),
+        ("TIF|CVE-2026-12345", SNAPSHOT_IDS[1]),
+    }
+    assert check_rels(
+        neo4j_session,
+        "TrivyPackage",
+        "id",
+        "FilesystemSnapshot",
+        "id",
+        "DEPLOYED",
+        rel_direction_right=True,
+    ) == {
+        ("1.0.0|example-package", SNAPSHOT_IDS[0]),
+        ("1.0.0|example-package", SNAPSHOT_IDS[1]),
+    }

--- a/tests/integration/cartography/intel/trivy/test_trivy_filesystem_snapshot.py
+++ b/tests/integration/cartography/intel/trivy/test_trivy_filesystem_snapshot.py
@@ -3,6 +3,7 @@ import json
 import cartography.intel.trivy
 from cartography.intel.common.object_store import ListedReportReader
 from cartography.intel.common.object_store import ReportRef
+from cartography.intel.trivy.scanner import cleanup_filesystem_snapshot_relationships
 from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
@@ -89,3 +90,63 @@ def test_sync_trivy_repository_report_to_filesystem_snapshot(neo4j_session):
         ("1.0.0|example-package", SNAPSHOT_IDS[0]),
         ("1.0.0|example-package", SNAPSHOT_IDS[1]),
     }
+
+
+def test_filesystem_cleanup_preserves_image_relationships(neo4j_session):
+    neo4j_session.run(
+        """
+        MERGE (snapshot:FilesystemSnapshot {id: "cleanup-snapshot"})
+        MERGE (image:Image {id: "cleanup-image"})
+        MERGE (finding:TrivyImageFinding {id: "cleanup-finding"})
+        MERGE (package:TrivyPackage {id: "cleanup-package"})
+        MERGE (finding)-[:AFFECTS {lastupdated: 1}]->(snapshot)
+        MERGE (finding)-[:AFFECTS {lastupdated: 1}]->(image)
+        MERGE (package)-[:DEPLOYED {lastupdated: 1}]->(snapshot)
+        MERGE (package)-[:DEPLOYED {lastupdated: 1}]->(image)
+        """
+    )
+
+    cleanup_filesystem_snapshot_relationships(neo4j_session, update_tag=2)
+
+    assert (
+        check_rels(
+            neo4j_session,
+            "TrivyImageFinding",
+            "id",
+            "FilesystemSnapshot",
+            "id",
+            "AFFECTS",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+    assert check_rels(
+        neo4j_session,
+        "TrivyImageFinding",
+        "id",
+        "Image",
+        "id",
+        "AFFECTS",
+        rel_direction_right=True,
+    ) == {("cleanup-finding", "cleanup-image")}
+    assert (
+        check_rels(
+            neo4j_session,
+            "TrivyPackage",
+            "id",
+            "FilesystemSnapshot",
+            "id",
+            "DEPLOYED",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+    assert check_rels(
+        neo4j_session,
+        "TrivyPackage",
+        "id",
+        "Image",
+        "id",
+        "DEPLOYED",
+        rel_direction_right=True,
+    ) == {("cleanup-package", "cleanup-image")}

--- a/tests/integration/cartography/intel/trivy/test_trivy_filesystem_snapshot.py
+++ b/tests/integration/cartography/intel/trivy/test_trivy_filesystem_snapshot.py
@@ -4,6 +4,7 @@ import cartography.intel.trivy
 from cartography.intel.common.object_store import ListedReportReader
 from cartography.intel.common.object_store import ReportRef
 from cartography.intel.trivy.scanner import cleanup_filesystem_snapshot_relationships
+from cartography.intel.trivy.scanner import cleanup_image_relationships
 from tests.integration.util import check_rels
 
 TEST_UPDATE_TAG = 123456789
@@ -150,3 +151,66 @@ def test_filesystem_cleanup_preserves_image_relationships(neo4j_session):
         "DEPLOYED",
         rel_direction_right=True,
     ) == {("cleanup-package", "cleanup-image")}
+
+
+def test_image_cleanup_preserves_filesystem_relationships(neo4j_session):
+    # Arrange
+    neo4j_session.run(
+        """
+        MERGE (snapshot:FilesystemSnapshot {id: "cleanup-snapshot"})
+        MERGE (image:Image {id: "cleanup-image"})
+        MERGE (finding:TrivyImageFinding {id: "cleanup-finding"})
+        MERGE (package:TrivyPackage {id: "cleanup-package"})
+        MERGE (finding)-[:AFFECTS {lastupdated: 1}]->(snapshot)
+        MERGE (finding)-[:AFFECTS {lastupdated: 1}]->(image)
+        MERGE (package)-[:DEPLOYED {lastupdated: 1}]->(snapshot)
+        MERGE (package)-[:DEPLOYED {lastupdated: 1}]->(image)
+        """
+    )
+
+    # Act
+    cleanup_image_relationships(neo4j_session, update_tag=2)
+
+    # Assert
+    assert (
+        check_rels(
+            neo4j_session,
+            "TrivyImageFinding",
+            "id",
+            "Image",
+            "id",
+            "AFFECTS",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+    assert check_rels(
+        neo4j_session,
+        "TrivyImageFinding",
+        "id",
+        "FilesystemSnapshot",
+        "id",
+        "AFFECTS",
+        rel_direction_right=True,
+    ) == {("cleanup-finding", "cleanup-snapshot")}
+    assert (
+        check_rels(
+            neo4j_session,
+            "TrivyPackage",
+            "id",
+            "Image",
+            "id",
+            "DEPLOYED",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+    assert check_rels(
+        neo4j_session,
+        "TrivyPackage",
+        "id",
+        "FilesystemSnapshot",
+        "id",
+        "DEPLOYED",
+        rel_direction_right=True,
+    ) == {("cleanup-package", "cleanup-snapshot")}

--- a/tests/unit/cartography/intel/trivy/test_scanner.py
+++ b/tests/unit/cartography/intel/trivy/test_scanner.py
@@ -6,11 +6,36 @@ import pytest
 
 from cartography.intel.common.object_store import ObjectStoreError
 from cartography.intel.common.object_store import ReportRef
+from cartography.intel.trivy import _prepare_trivy_data
 from cartography.intel.trivy import sync_trivy_from_report_reader
 from cartography.intel.trivy import sync_trivy_from_s3
 from cartography.intel.trivy.scanner import get_json_files_in_s3
 from cartography.intel.trivy.scanner import sync_single_image_from_s3
 from cartography.intel.trivy.scanner import transform_scan_results
+
+
+def test_prepare_trivy_data_rejects_non_exact_filesystem_revision():
+    # Arrange
+    revision = "0123456789abcdef0123456789abcdef01234567"
+    trivy_data = {
+        "ArtifactType": "repository",
+        "Metadata": {
+            "RepoURL": "https://github.com/acme/api",
+            "Commit": "main",
+        },
+    }
+
+    # Act
+    prepared = _prepare_trivy_data(
+        trivy_data,
+        image_uris=set(),
+        digest_aliases={},
+        filesystem_targets={("acme/api", revision): ["snapshot-1"]},
+        source="repository.json",
+    )
+
+    # Assert
+    assert prepared is None
 
 
 @patch("boto3.Session")

--- a/tests/unit/cartography/intel/trivy/test_scanner.py
+++ b/tests/unit/cartography/intel/trivy/test_scanner.py
@@ -10,6 +10,7 @@ from cartography.intel.trivy import _prepare_trivy_data
 from cartography.intel.trivy import sync_trivy_from_report_reader
 from cartography.intel.trivy import sync_trivy_from_s3
 from cartography.intel.trivy.scanner import get_json_files_in_s3
+from cartography.intel.trivy.scanner import sync_single_filesystem_snapshot
 from cartography.intel.trivy.scanner import sync_single_image_from_s3
 from cartography.intel.trivy.scanner import transform_scan_results
 
@@ -705,15 +706,35 @@ def test_filesystem_only_reports_preserve_existing_image_scan_data(
         }
     ).encode()
 
-    sync_trivy_from_report_reader(
-        neo4j_session=MagicMock(),
-        reader=reader,
-        update_tag=123,
-        common_job_parameters={"UPDATE_TAG": 123},
-    )
+    neo4j_session = MagicMock()
+    with patch(
+        "cartography.intel.trivy.cleanup_filesystem_snapshot_relationships"
+    ) as mock_filesystem_cleanup:
+        sync_trivy_from_report_reader(
+            neo4j_session=neo4j_session,
+            reader=reader,
+            update_tag=123,
+            common_job_parameters={"UPDATE_TAG": 123},
+        )
 
     mock_sync_filesystem.assert_called_once()
     mock_cleanup.assert_not_called()
+    mock_filesystem_cleanup.assert_called_once_with(neo4j_session, 123)
+
+
+@patch("cartography.intel.trivy.scanner._sync_scan_results")
+def test_filesystem_scan_accepts_null_results(mock_sync_scan_results):
+    mock_sync_scan_results.return_value = 0
+
+    sync_single_filesystem_snapshot(
+        MagicMock(),
+        {"ArtifactType": "repository", "Results": None},
+        ["snapshot-1"],
+        "memory://clean.json",
+        123,
+    )
+
+    assert mock_sync_scan_results.call_args.args[1] == []
 
 
 def test_transform_scan_results_only_sets_cve_id_for_cves():

--- a/tests/unit/cartography/intel/trivy/test_scanner.py
+++ b/tests/unit/cartography/intel/trivy/test_scanner.py
@@ -674,6 +674,48 @@ def test_sync_trivy_skips_cleanup_when_no_reports_match_graph(
     mock_cleanup.assert_not_called()
 
 
+@patch("cartography.intel.trivy.sync_single_filesystem_snapshot")
+@patch("cartography.intel.trivy.cleanup")
+@patch("cartography.intel.trivy._get_filesystem_scan_targets")
+@patch("cartography.intel.trivy._get_scan_targets_and_aliases")
+def test_filesystem_only_reports_preserve_existing_image_scan_data(
+    mock_get_targets_and_aliases,
+    mock_get_filesystem_targets,
+    mock_cleanup,
+    mock_sync_filesystem,
+):
+    revision = "a" * 40
+    mock_get_targets_and_aliases.return_value = ({"registry.example/app:latest"}, {})
+    mock_get_filesystem_targets.return_value = {
+        ("owner/repo", revision, None): ["snapshot-1"]
+    }
+    reader = MagicMock()
+    reader.source_uri = "memory://trivy"
+    reader.list_reports.return_value = [
+        ReportRef(uri="memory://filesystem.json", name="filesystem.json")
+    ]
+    reader.read_bytes.return_value = json.dumps(
+        {
+            "ArtifactType": "repository",
+            "Metadata": {
+                "RepoURL": "https://github.com/owner/repo",
+                "Commit": revision,
+            },
+            "Results": [],
+        }
+    ).encode()
+
+    sync_trivy_from_report_reader(
+        neo4j_session=MagicMock(),
+        reader=reader,
+        update_tag=123,
+        common_job_parameters={"UPDATE_TAG": 123},
+    )
+
+    mock_sync_filesystem.assert_called_once()
+    mock_cleanup.assert_not_called()
+
+
 def test_transform_scan_results_only_sets_cve_id_for_cves():
     """Only CVE-prefixed ids populate cve_id; GHSA ids land in ghsa_id."""
     # Arrange

--- a/tests/unit/cartography/intel/trivy/test_scanner.py
+++ b/tests/unit/cartography/intel/trivy/test_scanner.py
@@ -30,12 +30,37 @@ def test_prepare_trivy_data_rejects_non_exact_filesystem_revision():
         trivy_data,
         image_uris=set(),
         digest_aliases={},
-        filesystem_targets={("acme/api", revision): ["snapshot-1"]},
+        filesystem_targets={("acme/api", revision, None): ["snapshot-1"]},
         source="repository.json",
     )
 
     # Assert
     assert prepared is None
+
+
+def test_prepare_trivy_data_matches_filesystem_root_directory():
+    revision = "0123456789abcdef0123456789abcdef01234567"
+    trivy_data = {
+        "ArtifactType": "repository",
+        "Metadata": {
+            "RepoURL": "https://github.com/acme/api",
+            "Commit": revision,
+            "RootDirectory": "services/api",
+        },
+    }
+
+    prepared = _prepare_trivy_data(
+        trivy_data,
+        image_uris=set(),
+        digest_aliases={},
+        filesystem_targets={
+            ("acme/api", revision, "services/api"): ["snapshot-api"],
+            ("acme/api", revision, "services/web"): ["snapshot-web"],
+        },
+        source="repository.json",
+    )
+
+    assert prepared == (trivy_data, None, ["snapshot-api"])
 
 
 @patch("boto3.Session")

--- a/tests/unit/cartography/intel/trivy/test_scanner.py
+++ b/tests/unit/cartography/intel/trivy/test_scanner.py
@@ -722,6 +722,53 @@ def test_filesystem_only_reports_preserve_existing_image_scan_data(
     mock_filesystem_cleanup.assert_called_once_with(neo4j_session, 123)
 
 
+@patch("cartography.intel.trivy.sync_single_image")
+@patch("cartography.intel.trivy.cleanup")
+@patch("cartography.intel.trivy._get_filesystem_scan_targets")
+@patch("cartography.intel.trivy._get_scan_targets_and_aliases")
+def test_image_only_reports_preserve_existing_filesystem_scan_data(
+    mock_get_targets_and_aliases,
+    mock_get_filesystem_targets,
+    mock_cleanup,
+    mock_sync_image,
+):
+    # Arrange
+    image_uri = "registry.example/app:latest"
+    mock_get_targets_and_aliases.return_value = ({image_uri}, {})
+    mock_get_filesystem_targets.return_value = {
+        ("owner/repo", "a" * 40, None): ["snapshot-1"]
+    }
+    reader = MagicMock()
+    reader.source_uri = "memory://trivy"
+    reader.list_reports.return_value = [
+        ReportRef(uri="memory://image.json", name="image.json")
+    ]
+    reader.read_bytes.return_value = json.dumps(
+        {
+            "ArtifactName": image_uri,
+            "Metadata": {"RepoTags": [image_uri]},
+            "Results": [],
+        }
+    ).encode()
+    neo4j_session = MagicMock()
+
+    # Act
+    with patch(
+        "cartography.intel.trivy.cleanup_image_relationships"
+    ) as mock_image_cleanup:
+        sync_trivy_from_report_reader(
+            neo4j_session=neo4j_session,
+            reader=reader,
+            update_tag=123,
+            common_job_parameters={"UPDATE_TAG": 123},
+        )
+
+    # Assert
+    mock_sync_image.assert_called_once()
+    mock_cleanup.assert_not_called()
+    mock_image_cleanup.assert_called_once_with(neo4j_session, 123)
+
+
 @patch("cartography.intel.trivy.scanner._sync_scan_results")
 def test_filesystem_scan_accepts_null_results(mock_sync_scan_results):
     mock_sync_scan_results.return_value = 0

--- a/tests/unit/cartography/models/test_introspection.py
+++ b/tests/unit/cartography/models/test_introspection.py
@@ -403,11 +403,13 @@ def test_build_data_model_exposes_ontology_catalog_metadata():
         )
         for constraint in model.ontology_relationship_constraints
     }
-    assert len(constraints) == 44
+    assert len(constraints) == 46
     assert ("ComputePod", "USES_SECRET", "Secret") in constraints
     assert ("Container", "RESOLVED_IMAGE", "Image") in constraints
     assert ("Container", "SCANNED_AS", "FilesystemSnapshot") in constraints
+    assert ("CVE", "AFFECTS", "FilesystemSnapshot") in constraints
     assert ("FilesystemSnapshot", "SNAPSHOT_OF", "CodeRepository") in constraints
+    assert ("PackageVersion", "DEPLOYED", "FilesystemSnapshot") in constraints
     assert ("CVE", "AFFECTS", "PackageVersion") in constraints
     assert ("LoadBalancer", "EXPOSE", "ComputeInstance") in constraints
 


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):

### Summary

Extends Trivy ingestion to accept source filesystem and repository reports in addition to container image reports.

Cartography matches a report to `FilesystemSnapshot` nodes using the repository URL and exact 40-character commit from Trivy metadata. Findings attach with `AFFECTS`, packages attach with `DEPLOYED`, and canonical `PackageVersion` relationships are propagated by the existing ontology package sync. One report can attach to multiple snapshots representing the same repository revision.

Existing image report matching and ingestion remain unchanged.

### Related issues or links

- Depends on #3180

### How was this tested?

- `uv run pytest tests/unit/cartography/intel/trivy tests/integration/cartography/intel/trivy tests/integration/cartography/intel/ontology/test_packages.py tests/unit/cartography/graph/test_ontology_rel_constraints.py tests/unit/cartography/models/test_schema_docs.py -q` (69 passed)
- `make test_lint`
- `uv run --group doc ./docs/build.sh`
- Trivy 0.69.3 against a normal clone with a public remote produced `ArtifactType: repository`, the public repository URL in `Metadata.RepoURL`, and the exact commit in `Metadata.Commit`.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [x] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).

### Notes for reviewers

Trivy emits Git metadata only when it can identify the scan target as a repository. The documentation therefore requires scanning the checked-out repository root while retaining its Git metadata. Reports without an exact graph match are skipped, and cleanup is skipped when no reports match.