### PR TITLE
docs: define parallelism and incremental sync policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,6 +36,7 @@
 - [ ] The linter passes locally (`make test_lint`).
 - [ ] I have added/updated tests that prove my fix is effective or my feature works.
 - [ ] Every commit includes a DCO `Signed-off-by` trailer.
+- [ ] If this change adds parallel or incremental ingestion, I followed the [parallelism guide](https://docs.cartography.dev/dev/parallelism.html) and documented worker limits, partial results, cleanup, and checkpoints.
 
 #### Proof of functionality
 <!-- Provide at least one of the following to help reviewers verify your changes: -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,15 @@ Procedures for building and extending Cartography intel modules ship as Claude s
 - **Update Tag**: Timestamp used for cleanup jobs to remove stale data
 - **Analysis Jobs**: Post-ingestion queries that enrich the graph (e.g., internet exposure, permission inheritance). When a job manages relationships, put `MERGE` statements before the stale-edge `DELETE`; iterative deletion exposes a window where concurrent readers see those edges missing. See the `analysis-jobs` skill.
 
+**Parallelism and incremental sync:**
+- Keep top-level account, organization, project, and module pipelines sequential.
+- Limit in-process concurrency to bounded, independent provider reads.
+- Workers must not write to Neo4j or run cleanup, analysis, or checkpoint updates.
+- Prefer provider bulk or aggregated APIs before adding workers.
+- Treat a worker failure as incomplete input and suppress cleanup.
+- Review incremental sync separately from parallelism.
+- Follow `docs/root/dev/parallelism.md`.
+
 **Critical Files to Know:**
 - `cartography/config.py` - Configuration object definitions
 - `cartography/cli.py` - Typer-based CLI with organized help panels

--- a/docs/root/dev/index.md
+++ b/docs/root/dev/index.md
@@ -4,5 +4,6 @@
 developer-guide
 writing-analysis-jobs
 writing-intel-modules
+parallelism
 matchlinks
 ```

--- a/docs/root/dev/parallelism.md
+++ b/docs/root/dev/parallelism.md
@@ -1,0 +1,172 @@
+# Parallelism and incremental sync
+
+Cartography writes provider data to a shared graph. Parallel execution can
+change API usage, graph identity, cleanup, retries, and checkpoints. Review it
+as a data correctness change, not only as a performance change.
+
+## Favor predictable behavior
+
+Cartography favors correctness, repeatable cleanup, and deterministic graph
+output over maximum throughput. Recent project changes support this direction:
+
+- Declarative data models define graph identity and relationships in one place.
+- Generated schema documentation stays aligned with those models.
+- Typed analysis jobs make graph enrichment explicit and testable.
+
+AI-assisted development can increase the pace of change. It also makes explicit
+contracts more important. Security teams must be able to trust that the same
+provider state produces the same graph and that a partial failure does not
+remove valid data.
+
+Use built-in parallelism only when it preserves these guarantees. Performance
+improvements must not make the default execution model harder to understand or
+operate.
+
+## Keep top-level syncs sequential
+
+Keep account, organization, project, and module sync pipelines sequential by
+default. Do not run complete `get` → `transform` → `load` → `cleanup` pipelines
+in parallel inside Cartography.
+
+Complete pipelines can share:
+
+- Provider API quotas.
+- Neo4j connection pools.
+- Nodes and relationships.
+- Cleanup scopes.
+- Analysis jobs.
+- Incremental checkpoints.
+- Mutable sync state.
+
+Fixing one known race does not prove that a complete pipeline is safe. A new
+top-level concurrency model requires a separate design discussion.
+
+Cartography is also a library. Advanced operators can build parallel execution
+around it when they understand their environment and can control:
+
+- Provider API quotas and rate limits.
+- The connection and transaction capacity of their Neo4j deployment.
+- Network, storage, memory, and compute limits.
+- Retry, cancellation, and failure isolation.
+- Graph ownership and cleanup scopes.
+
+Concurrent runs against the same graph must not own overlapping cleanup scopes.
+The operator, not the library, owns this deployment-level concurrency policy.
+
+## Limit parallelism to provider reads
+
+Parallelism can be appropriate in a narrow provider fetch function. Use it only
+when all of the following conditions apply:
+
+- Measurements show that provider reads are the bottleneck.
+- The provider does not offer a suitable bulk or aggregated API.
+- Each work item is independent.
+- Workers only call the provider and return data.
+- Workers do not write to Neo4j or run cleanup, analysis, or checkpoint updates.
+- The worker count has a small, explicit upper bound.
+- A worker count of one uses the sequential path.
+- The call path does not create nested worker pools.
+- Results are combined deterministically before Cartography loads them.
+- A failed worker makes the fetch incomplete.
+
+Use this execution boundary:
+
+```text
+bounded provider reads → combine results → load → cleanup → analysis/checkpoint
+```
+
+Run `load`, cleanup, analysis, and checkpoint updates on the calling thread after
+all required fetches succeed.
+
+## Bound the worker count
+
+Do not set the worker count based only on the number of accounts, organizations,
+projects, regions, or resources. Use a conservative maximum and clamp it to the
+number of work items:
+
+```python
+worker_count = max(1, min(max_workers, len(items)))
+```
+
+If `worker_count` is one, use the sequential path. This behavior makes the
+module easier to test and lets operators disable concurrency without using a
+different implementation.
+
+Add a configurable worker count in a dedicated pull request. Document its
+default, maximum, provider quota impact, and interaction with other concurrent
+work.
+
+## Keep Neo4j writes sequential
+
+Do not share a Neo4j session between threads. The Neo4j driver can be shared,
+but [sessions are not thread-safe](https://neo4j.com/docs/python-manual/current/transactions/).
+
+Separate sessions do not make concurrent writes safe. Workers can still write
+the same graph identity or run overlapping cleanup jobs. In addition,
+concurrent `MERGE` operations do not guarantee node uniqueness without a
+[uniqueness constraint](https://neo4j.com/docs/cypher-manual/current/clauses/merge/).
+
+Keep graph writes sequential unless a dedicated design proves that:
+
+- Write scopes do not overlap.
+- Shared node identities cannot race.
+- Cleanup scopes do not overlap.
+- Failure and retry behavior is deterministic.
+- Integration tests cover the behavior against Neo4j.
+
+## Fail before cleanup
+
+Parallel fetching must preserve Cartography's fail-before-cleanup contract. If
+any required worker fails:
+
+1. Mark the fetch as incomplete.
+2. Do not treat the collected data as a complete inventory.
+3. Do not run cleanup for the affected scope.
+4. Do not advance an incremental checkpoint.
+5. Preserve enough context to retry the failed work.
+
+Do not return partial data unless the caller receives an explicit completeness
+signal and suppresses cleanup.
+
+## Review incremental sync separately
+
+Incremental sync reduces the data fetched while preserving one execution flow.
+It is not a concurrency model. Review incremental sync and parallelism in
+separate pull requests.
+
+An incremental sync must:
+
+- Advance its checkpoint only after every dependent stage succeeds.
+- Preserve nodes and relationships skipped because they are unchanged.
+- Distinguish unchanged data from missing or failed data.
+- Suppress cleanup after partial provider responses.
+- Retry safely after interruption.
+- Produce the same graph as a complete sync for the same provider state.
+
+## Test the execution boundary
+
+Add the smallest tests that prove the new behavior:
+
+- One worker and multiple workers return equivalent results.
+- The worker count does not exceed its configured limit.
+- Results remain deterministic when workers finish in a different order.
+- A worker failure produces an incomplete result.
+- Incomplete results do not run cleanup or advance checkpoints.
+- Two update tags preserve unchanged data and remove stale data.
+- Shared provider identities do not create duplicate graph nodes.
+- The sequential path remains covered.
+
+Use an integration test when the behavior affects graph writes, identity,
+relationships, cleanup, or checkpoints.
+
+## Keep the pull request focused
+
+Submit concurrency changes separately from incremental sync, unrelated features,
+and bug fixes. Include the following information in the pull request:
+
+- Measurements that identify the bottleneck.
+- The proposed concurrency boundary.
+- The worker limit and default.
+- Provider quota and rate-limit considerations.
+- Failure, cancellation, cleanup, and checkpoint behavior.
+- Focused test evidence.

--- a/docs/root/dev/writing-intel-modules.md
+++ b/docs/root/dev/writing-intel-modules.md
@@ -104,6 +104,10 @@ docstrings and `PropertyRef.description`, which Sphinx uses to generate
 
 A cartography intel module consists of one `sync` function. `sync` should call `get`, then `load`, and finally `cleanup`.
 
+Before adding concurrent or incremental ingestion, read
+[Parallelism and incremental sync](parallelism). Keep graph writes and cleanup
+outside provider fetch workers.
+
 ### Get
 
 The `get` function [returns data as a list of dicts](https://github.com/cartography-cncf/cartography/blob/8d60311a10156cd8aa16de7e1fe3e109cc3eca0f/cartography/intel/gcp/compute.py#L98)

--- a/docs/root/llms.txt
+++ b/docs/root/llms.txt
@@ -26,6 +26,7 @@ Use these resources to install Cartography, configure integrations, query the gr
 - [Developer guide](https://docs.cartography.dev/dev/developer-guide.html): Set up a development environment and contribute.
 - [Write an intel module](https://docs.cartography.dev/dev/writing-intel-modules.html): Build a new data ingestion module.
 - [Write an analysis job](https://docs.cartography.dev/dev/writing-analysis-jobs.html): Add graph enrichment and analysis.
+- [Parallelism and incremental sync](https://docs.cartography.dev/dev/parallelism.html): Choose safe concurrency boundaries and preserve cleanup correctness.
 - [Source code](https://github.com/cartography-cncf/cartography): Cartography's GitHub repository.
 
 ## Optional

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -73,6 +73,12 @@ test-specific expectations.
   current-data path, usually with at least two update tags.
 - For scoped cleanup or partial-failure behavior, test that successful scopes are
   cleaned up and incomplete scopes preserve prior data when that is the contract.
+- For concurrent fetches, prove that sequential and concurrent execution return
+  equivalent results and that the worker limit is enforced.
+- Test worker failures through the complete caller path. Verify that cleanup and
+  incremental checkpoints do not advance after incomplete input.
+- Use an integration test for concurrent behavior that can affect graph identity,
+  relationships, cleanup scope, or checkpoints.
 - For generated IDs or canonicalization, include cases that would collide or
   drift without the intended stable identity input.
 - For rule tests, keep `cypher_query`, `cypher_count_query`, and any visual query


### PR DESCRIPTION
### Type of change

- [x] Documentation update

### Summary

Cartography has received two independent proposals in the last five weeks to add library-managed parallelism: per-repository GitHub workers in #3057 and complete per-organization GCP pipelines in #3177. The GCP approach first appeared in #3172.

Recent project work has moved Cartography toward simpler, more explicit, and deterministic behavior through declarative graph models, generated schema documentation, and typed analysis jobs. As AI-assisted development increases the pace of change, these contracts matter more. Security teams need Cartography to produce repeatable graph state and preserve valid data after partial failures.

This PR defines the project boundary: top-level sync pipelines stay sequential by default; bounded, independent provider reads may run concurrently; and Neo4j writes, cleanup, analysis, and checkpoints stay on the calling thread. Incremental sync and parallelism require separate reviews. Advanced operators may compose the library into parallel deployments when they own provider quotas, Neo4j capacity, infrastructure constraints, failure isolation, and cleanup scope.

### Related issues or links

- #3057
- #3177
- #3172

### How was this tested?

- `uv run --frozen --group doc ./docs/build.sh`
- `uv run --frozen pre-commit run --files .github/pull_request_template.md AGENTS.md docs/root/dev/index.md docs/root/dev/parallelism.md docs/root/dev/writing-intel-modules.md docs/root/llms.txt tests/AGENTS.md`
- `git diff --check`

The documentation build succeeds. It reports 55 existing Cypher syntax-highlighting warnings in unchanged query documentation and no warnings from the new page.

### Checklist

#### General

- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] Relevant pre-commit checks pass locally.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

### Notes for reviewers

Please focus on whether the boundary is strict enough to keep default syncs predictable without preventing advanced operators from composing Cartography for their own environment.
