### PR TITLE
perf(ontology): add an index on PackageVersion.name

### DIFF
--- a/cartography/models/ontology/package_version.py
+++ b/cartography/models/ontology/package_version.py
@@ -20,7 +20,11 @@ class PackageVersionNodeProperties(CartographyNodeProperties):
         description="Normalized identifier for this specific package version.",
     )
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
-    name: PropertyRef = PropertyRef("name", description="Package name.")
+    name: PropertyRef = PropertyRef(
+        "name",
+        extra_index=True,
+        description="Package name.",
+    )
     version: PropertyRef = PropertyRef("version", description="Package version.")
     type: PropertyRef = PropertyRef(
         "type",


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Other (please describe): performance (adds a Neo4j index)


### Summary
`PackageVersion` only had the auto-generated indexes on `id` and `lastupdated` (plus `id`/`lastupdated` on its `Ontology` extra label). No `TargetNodeMatcher` matches on `PackageVersion.name` either: every relationship pointing at the label matches on `id` or `normalized_id`. As a result, any lookup by package name over the canonical package graph fell back to a label scan.

Marking the `name` `PropertyRef` with `extra_index=True` makes `build_create_index_queries()` emit:

```
CREATE INDEX IF NOT EXISTS FOR (n:PackageVersion) ON (n.name);
```

Looking up a package by name is a common entry point into the package/vulnerability part of the graph (for example "which images run this dependency"), so it is worth an index. The cost is one extra range index maintained on write.


### Related issues or links

N/A


### How was this tested?
- `make test_lint` passes.
- `uv run --frozen pytest tests/unit` passes (5146 passed).

Index generation is already covered generically by the querybuilder unit tests: `extra_index=True` is the documented mechanism in `build_create_index_queries()` for emitting an extra `CREATE INDEX` on a node property, so this is a declarative one-property change with no new code path.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation. (No description changes: only the index flag; generated schema docs do not render indexes.)
- [ ] Built the documentation with `uv run ./docs/build.sh`. Ran it: the schema-doc generation stage completed and left no diff on tracked files (this change touches no `description`), but the final `sphinx-build` stage could not run locally (`sphinx-build: command not found`).


### Notes for reviewers
Scoped deliberately to `PackageVersion.name`. `Package.name` is in the same situation (indexed only through `id`/`lastupdated`); happy to add it in this PR if reviewers want the two kept symmetric.
