### PR TITLE
feat(kubernetes): ingest GPU and persistent storage

### DIFF
--- a/cartography/intel/kubernetes/__init__.py
+++ b/cartography/intel/kubernetes/__init__.py
@@ -17,6 +17,7 @@ from cartography.intel.kubernetes.pods import sync_pods
 from cartography.intel.kubernetes.rbac import sync_kubernetes_rbac
 from cartography.intel.kubernetes.secrets import sync_secrets
 from cartography.intel.kubernetes.services import sync_services
+from cartography.intel.kubernetes.storage import sync_storage
 from cartography.intel.kubernetes.util import get_k8s_clients
 from cartography.intel.kubernetes.workloads import sync_workloads
 from cartography.util import run_typed_analysis_job
@@ -74,6 +75,7 @@ def start_k8s_ingestion(session: Session, config: Config) -> None:
             replicaset_owner_map = sync_workloads(
                 session, client, config.update_tag, common_job_parameters
             )
+            sync_storage(session, client, config.update_tag, common_job_parameters)
 
             # Extract region from cluster ARN (works for EKS; None for non-EKS clusters)
             region: str | None = None

--- a/cartography/intel/kubernetes/nodes.py
+++ b/cartography/intel/kubernetes/nodes.py
@@ -40,9 +40,9 @@ def transform_nodes(nodes: list[V1Node], cluster_name: str) -> list[dict[str, An
     for node in nodes:
         ni = node.status.node_info if node.status else None
         provider_id = getattr(getattr(node, "spec", None), "provider_id", None)
-        labels = getattr(node.metadata, "labels", None) or {}
-        capacity = getattr(node.status, "capacity", None) if node.status else None
-        allocatable = getattr(node.status, "allocatable", None) if node.status else None
+        labels = node.metadata.labels or {}
+        capacity = node.status.capacity if node.status else None
+        allocatable = node.status.allocatable if node.status else None
         transformed.append(
             {
                 "id": f"{cluster_name}/{node.metadata.name}",

--- a/cartography/intel/kubernetes/nodes.py
+++ b/cartography/intel/kubernetes/nodes.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Any
 
@@ -7,6 +8,8 @@ from kubernetes.client.models import V1Node
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.container_arch import normalize_architecture
+from cartography.intel.kubernetes.util import format_resource_quantities
+from cartography.intel.kubernetes.util import get_gpu_quantity
 from cartography.intel.kubernetes.util import k8s_paginate
 from cartography.intel.kubernetes.util import K8sClient
 from cartography.models.kubernetes.nodes import KubernetesNodeSchema
@@ -37,12 +40,22 @@ def transform_nodes(nodes: list[V1Node], cluster_name: str) -> list[dict[str, An
     for node in nodes:
         ni = node.status.node_info if node.status else None
         provider_id = getattr(getattr(node, "spec", None), "provider_id", None)
+        labels = getattr(node.metadata, "labels", None) or {}
+        capacity = getattr(node.status, "capacity", None) if node.status else None
+        allocatable = getattr(node.status, "allocatable", None) if node.status else None
         transformed.append(
             {
                 "id": f"{cluster_name}/{node.metadata.name}",
                 "name": node.metadata.name,
                 "provider_id": provider_id,
                 "instance_id": _ec2_instance_id_from_provider_id(provider_id),
+                "labels": json.dumps(labels, sort_keys=True),
+                "capacity": format_resource_quantities(capacity),
+                "allocatable": format_resource_quantities(allocatable),
+                "gpu_capacity": get_gpu_quantity(capacity),
+                "gpu_allocatable": get_gpu_quantity(allocatable),
+                "gpu_product": labels.get("nvidia.com/gpu.product")
+                or labels.get("cloud.google.com/gke-accelerator"),
                 "architecture": getattr(ni, "architecture", None),
                 "architecture_normalized": normalize_architecture(
                     getattr(ni, "architecture", None),

--- a/cartography/intel/kubernetes/pods.py
+++ b/cartography/intel/kubernetes/pods.py
@@ -8,8 +8,10 @@ from kubernetes.client.models import V1Pod
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.kubernetes.util import format_resource_quantities
 from cartography.intel.kubernetes.util import get_controller_owner_reference
 from cartography.intel.kubernetes.util import get_epoch
+from cartography.intel.kubernetes.util import get_gpu_quantity
 from cartography.intel.kubernetes.util import k8s_paginate
 from cartography.intel.kubernetes.util import K8sClient
 from cartography.models.kubernetes.containers import KubernetesContainerSchema
@@ -103,6 +105,16 @@ def _extract_pod_containers(pod: V1Pod, node_arch: str | None = None) -> dict[st
 
         # Extract resource requests and limits
         if container.resources:
+            requests = container.resources.requests or {}
+            limits = container.resources.limits or {}
+            containers[container.name]["resource_requests"] = (
+                format_resource_quantities(requests)
+            )
+            containers[container.name]["resource_limits"] = format_resource_quantities(
+                limits
+            )
+            containers[container.name]["gpu_request"] = get_gpu_quantity(requests)
+            containers[container.name]["gpu_limit"] = get_gpu_quantity(limits)
             if container.resources.requests:
                 containers[container.name]["memory_request"] = (
                     container.resources.requests.get("memory")
@@ -125,6 +137,10 @@ def _extract_pod_containers(pod: V1Pod, node_arch: str | None = None) -> dict[st
                 containers[container.name]["memory_limit"] = None
                 containers[container.name]["cpu_limit"] = None
         else:
+            containers[container.name]["resource_requests"] = "{}"
+            containers[container.name]["resource_limits"] = "{}"
+            containers[container.name]["gpu_request"] = None
+            containers[container.name]["gpu_limit"] = None
             containers[container.name]["memory_request"] = None
             containers[container.name]["cpu_request"] = None
             containers[container.name]["memory_limit"] = None
@@ -287,6 +303,14 @@ def transform_pods(
         workload_parent = _resolve_pod_workload_parent(
             pod, rs_owner_map, workloads_available=workloads_available
         )
+        persistent_volume_claim_names = sorted(
+            {
+                volume.persistent_volume_claim.claim_name
+                for volume in (pod.spec.volumes or [])
+                if getattr(volume, "persistent_volume_claim", None)
+                and getattr(volume.persistent_volume_claim, "claim_name", None)
+            }
+        )
         transformed_pods.append(
             {
                 **workload_parent,
@@ -317,6 +341,11 @@ def transform_pods(
                         and getattr(volume.host_path, "path", None)
                     ]
                 ),
+                "persistent_volume_claim_names": persistent_volume_claim_names,
+                "persistent_volume_claim_ids": [
+                    f"{cluster_name}/{pod.metadata.namespace}/{claim_name}"
+                    for claim_name in persistent_volume_claim_names
+                ],
                 "service_account_id": (
                     f"{cluster_name}/{pod.metadata.namespace}/{service_account_name}"
                 ),

--- a/cartography/intel/kubernetes/pods.py
+++ b/cartography/intel/kubernetes/pods.py
@@ -303,14 +303,20 @@ def transform_pods(
         workload_parent = _resolve_pod_workload_parent(
             pod, rs_owner_map, workloads_available=workloads_available
         )
-        persistent_volume_claim_names = sorted(
-            {
-                volume.persistent_volume_claim.claim_name
-                for volume in (pod.spec.volumes or [])
-                if volume.persistent_volume_claim
+        persistent_volume_claim_name_set = set()
+        for volume in pod.spec.volumes or []:
+            if (
+                volume.persistent_volume_claim
                 and volume.persistent_volume_claim.claim_name
-            }
-        )
+            ):
+                persistent_volume_claim_name_set.add(
+                    volume.persistent_volume_claim.claim_name
+                )
+            elif volume.ephemeral:
+                persistent_volume_claim_name_set.add(
+                    f"{pod.metadata.name}-{volume.name}"
+                )
+        persistent_volume_claim_names = sorted(persistent_volume_claim_name_set)
         transformed_pods.append(
             {
                 **workload_parent,

--- a/cartography/intel/kubernetes/pods.py
+++ b/cartography/intel/kubernetes/pods.py
@@ -115,27 +115,10 @@ def _extract_pod_containers(pod: V1Pod, node_arch: str | None = None) -> dict[st
             )
             containers[container.name]["gpu_request"] = get_gpu_quantity(requests)
             containers[container.name]["gpu_limit"] = get_gpu_quantity(limits)
-            if container.resources.requests:
-                containers[container.name]["memory_request"] = (
-                    container.resources.requests.get("memory")
-                )
-                containers[container.name]["cpu_request"] = (
-                    container.resources.requests.get("cpu")
-                )
-            else:
-                containers[container.name]["memory_request"] = None
-                containers[container.name]["cpu_request"] = None
-
-            if container.resources.limits:
-                containers[container.name]["memory_limit"] = (
-                    container.resources.limits.get("memory")
-                )
-                containers[container.name]["cpu_limit"] = (
-                    container.resources.limits.get("cpu")
-                )
-            else:
-                containers[container.name]["memory_limit"] = None
-                containers[container.name]["cpu_limit"] = None
+            containers[container.name]["memory_request"] = requests.get("memory")
+            containers[container.name]["cpu_request"] = requests.get("cpu")
+            containers[container.name]["memory_limit"] = limits.get("memory")
+            containers[container.name]["cpu_limit"] = limits.get("cpu")
         else:
             containers[container.name]["resource_requests"] = "{}"
             containers[container.name]["resource_limits"] = "{}"

--- a/cartography/intel/kubernetes/pods.py
+++ b/cartography/intel/kubernetes/pods.py
@@ -307,8 +307,8 @@ def transform_pods(
             {
                 volume.persistent_volume_claim.claim_name
                 for volume in (pod.spec.volumes or [])
-                if getattr(volume, "persistent_volume_claim", None)
-                and getattr(volume.persistent_volume_claim, "claim_name", None)
+                if volume.persistent_volume_claim
+                and volume.persistent_volume_claim.claim_name
             }
         )
         transformed_pods.append(

--- a/cartography/intel/kubernetes/storage.py
+++ b/cartography/intel/kubernetes/storage.py
@@ -66,9 +66,9 @@ def transform_persistent_volumes(
     for volume in volumes:
         spec = volume.spec
         status = volume.status
-        claim_ref = getattr(spec, "claim_ref", None)
-        csi = getattr(spec, "csi", None)
-        storage_class_name = getattr(spec, "storage_class_name", None)
+        claim_ref = spec.claim_ref
+        csi = spec.csi
+        storage_class_name = spec.storage_class_name
         transformed.append(
             {
                 "id": f"{cluster_name}/{volume.metadata.name}",
@@ -86,11 +86,11 @@ def transform_persistent_volumes(
                     else None
                 ),
                 "volume_mode": spec.volume_mode,
-                "phase": getattr(status, "phase", None),
-                "claim_namespace": getattr(claim_ref, "namespace", None),
-                "claim_name": getattr(claim_ref, "name", None),
-                "csi_driver": getattr(csi, "driver", None),
-                "csi_volume_handle": getattr(csi, "volume_handle", None),
+                "phase": status.phase if status else None,
+                "claim_namespace": claim_ref.namespace if claim_ref else None,
+                "claim_name": claim_ref.name if claim_ref else None,
+                "csi_driver": csi.driver if csi else None,
+                "csi_volume_handle": csi.volume_handle if csi else None,
                 "labels": json.dumps(volume.metadata.labels or {}, sort_keys=True),
             }
         )
@@ -107,7 +107,7 @@ def transform_persistent_volume_claims(
         namespace = claim.metadata.namespace
         storage_class_name = spec.storage_class_name
         volume_name = spec.volume_name
-        requests = getattr(spec.resources, "requests", None) or {}
+        requests = spec.resources.requests if spec.resources else {}
         transformed.append(
             {
                 "id": f"{cluster_name}/{namespace}/{claim.metadata.name}",
@@ -127,7 +127,7 @@ def transform_persistent_volume_claims(
                 "access_modes": sorted(spec.access_modes or []),
                 "requested_storage": requests.get("storage"),
                 "volume_mode": spec.volume_mode,
-                "phase": getattr(status, "phase", None),
+                "phase": status.phase if status else None,
                 "labels": json.dumps(claim.metadata.labels or {}, sort_keys=True),
             }
         )

--- a/cartography/intel/kubernetes/storage.py
+++ b/cartography/intel/kubernetes/storage.py
@@ -107,7 +107,7 @@ def transform_persistent_volume_claims(
         namespace = claim.metadata.namespace
         storage_class_name = spec.storage_class_name
         volume_name = spec.volume_name
-        requests = spec.resources.requests if spec.resources else {}
+        requests = (spec.resources.requests if spec.resources else None) or {}
         transformed.append(
             {
                 "id": f"{cluster_name}/{namespace}/{claim.metadata.name}",

--- a/cartography/intel/kubernetes/storage.py
+++ b/cartography/intel/kubernetes/storage.py
@@ -45,6 +45,7 @@ def transform_storage_classes(
     return [
         {
             "id": f"{cluster_name}/{storage_class.metadata.name}",
+            "uid": storage_class.metadata.uid,
             "name": storage_class.metadata.name,
             "creation_timestamp": get_epoch(storage_class.metadata.creation_timestamp),
             "deletion_timestamp": get_epoch(storage_class.metadata.deletion_timestamp),
@@ -68,6 +69,8 @@ def transform_persistent_volumes(
         status = volume.status
         claim_ref = spec.claim_ref
         csi = spec.csi
+        csi_driver = csi.driver if csi else None
+        csi_volume_handle = csi.volume_handle if csi else None
         storage_class_name = spec.storage_class_name
         transformed.append(
             {
@@ -89,8 +92,22 @@ def transform_persistent_volumes(
                 "phase": status.phase if status else None,
                 "claim_namespace": claim_ref.namespace if claim_ref else None,
                 "claim_name": claim_ref.name if claim_ref else None,
-                "csi_driver": csi.driver if csi else None,
-                "csi_volume_handle": csi.volume_handle if csi else None,
+                "csi_driver": csi_driver,
+                "csi_volume_handle": csi_volume_handle,
+                "aws_ebs_volume_id": (
+                    csi_volume_handle
+                    if csi_driver == "ebs.csi.aws.com"
+                    and csi_volume_handle
+                    and csi_volume_handle.startswith("vol-")
+                    else None
+                ),
+                "azure_disk_id": (
+                    csi_volume_handle
+                    if csi_driver == "disk.csi.azure.com"
+                    and csi_volume_handle
+                    and csi_volume_handle.lower().startswith("/subscriptions/")
+                    else None
+                ),
                 "labels": json.dumps(volume.metadata.labels or {}, sort_keys=True),
             }
         )
@@ -213,7 +230,14 @@ def sync_storage(
                 error.status,
             )
             return
-        raise
+        logger.error(
+            "Kubernetes API error listing persistent storage on cluster %s "
+            "(status %s). Skipping storage sync for this run and preserving "
+            "previously synced nodes.",
+            client.name,
+            error.status,
+        )
+        return
 
     load_storage(
         session,

--- a/cartography/intel/kubernetes/storage.py
+++ b/cartography/intel/kubernetes/storage.py
@@ -1,0 +1,220 @@
+import json
+import logging
+from typing import Any
+
+import neo4j
+from kubernetes.client.exceptions import ApiException
+from kubernetes.client.models import V1PersistentVolume
+from kubernetes.client.models import V1PersistentVolumeClaim
+from kubernetes.client.models import V1StorageClass
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.kubernetes.util import k8s_paginate
+from cartography.intel.kubernetes.util import K8sClient
+from cartography.models.kubernetes.storage import KubernetesPersistentVolumeClaimSchema
+from cartography.models.kubernetes.storage import KubernetesPersistentVolumeSchema
+from cartography.models.kubernetes.storage import KubernetesStorageClassSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def get_storage_classes(client: K8sClient) -> list[V1StorageClass]:
+    return k8s_paginate(client.storage.list_storage_class, raise_on_error=True)
+
+
+@timeit
+def get_persistent_volumes(client: K8sClient) -> list[V1PersistentVolume]:
+    return k8s_paginate(client.core.list_persistent_volume, raise_on_error=True)
+
+
+@timeit
+def get_persistent_volume_claims(client: K8sClient) -> list[V1PersistentVolumeClaim]:
+    return k8s_paginate(
+        client.core.list_persistent_volume_claim_for_all_namespaces,
+        raise_on_error=True,
+    )
+
+
+def transform_storage_classes(
+    storage_classes: list[V1StorageClass], cluster_name: str
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": f"{cluster_name}/{storage_class.metadata.name}",
+            "name": storage_class.metadata.name,
+            "provisioner": storage_class.provisioner,
+            "reclaim_policy": storage_class.reclaim_policy,
+            "volume_binding_mode": storage_class.volume_binding_mode,
+            "allow_volume_expansion": storage_class.allow_volume_expansion,
+            "parameters": json.dumps(storage_class.parameters or {}, sort_keys=True),
+            "mount_options": sorted(storage_class.mount_options or []),
+        }
+        for storage_class in storage_classes
+    ]
+
+
+def transform_persistent_volumes(
+    volumes: list[V1PersistentVolume], cluster_name: str
+) -> list[dict[str, Any]]:
+    transformed = []
+    for volume in volumes:
+        spec = volume.spec
+        status = volume.status
+        claim_ref = getattr(spec, "claim_ref", None)
+        csi = getattr(spec, "csi", None)
+        storage_class_name = getattr(spec, "storage_class_name", None)
+        transformed.append(
+            {
+                "id": f"{cluster_name}/{volume.metadata.name}",
+                "uid": volume.metadata.uid,
+                "name": volume.metadata.name,
+                "capacity_storage": (spec.capacity or {}).get("storage"),
+                "access_modes": sorted(spec.access_modes or []),
+                "reclaim_policy": spec.persistent_volume_reclaim_policy,
+                "storage_class_name": storage_class_name,
+                "storage_class_id": (
+                    f"{cluster_name}/{storage_class_name}"
+                    if storage_class_name
+                    else None
+                ),
+                "volume_mode": spec.volume_mode,
+                "phase": getattr(status, "phase", None),
+                "claim_namespace": getattr(claim_ref, "namespace", None),
+                "claim_name": getattr(claim_ref, "name", None),
+                "csi_driver": getattr(csi, "driver", None),
+                "csi_volume_handle": getattr(csi, "volume_handle", None),
+                "labels": json.dumps(volume.metadata.labels or {}, sort_keys=True),
+            }
+        )
+    return transformed
+
+
+def transform_persistent_volume_claims(
+    claims: list[V1PersistentVolumeClaim], cluster_name: str
+) -> list[dict[str, Any]]:
+    transformed = []
+    for claim in claims:
+        spec = claim.spec
+        status = claim.status
+        namespace = claim.metadata.namespace
+        storage_class_name = spec.storage_class_name
+        volume_name = spec.volume_name
+        requests = getattr(spec.resources, "requests", None) or {}
+        transformed.append(
+            {
+                "id": f"{cluster_name}/{namespace}/{claim.metadata.name}",
+                "uid": claim.metadata.uid,
+                "name": claim.metadata.name,
+                "namespace": namespace,
+                "storage_class_name": storage_class_name,
+                "storage_class_id": (
+                    f"{cluster_name}/{storage_class_name}"
+                    if storage_class_name
+                    else None
+                ),
+                "volume_name": volume_name,
+                "volume_id": (f"{cluster_name}/{volume_name}" if volume_name else None),
+                "access_modes": sorted(spec.access_modes or []),
+                "requested_storage": requests.get("storage"),
+                "volume_mode": spec.volume_mode,
+                "phase": getattr(status, "phase", None),
+                "labels": json.dumps(claim.metadata.labels or {}, sort_keys=True),
+            }
+        )
+    return transformed
+
+
+@timeit
+def load_storage(
+    session: neo4j.Session,
+    storage_classes: list[dict[str, Any]],
+    volumes: list[dict[str, Any]],
+    claims: list[dict[str, Any]],
+    update_tag: int,
+    cluster_id: str,
+    cluster_name: str,
+) -> None:
+    load(
+        session,
+        KubernetesStorageClassSchema(),
+        storage_classes,
+        lastupdated=update_tag,
+        CLUSTER_ID=cluster_id,
+        CLUSTER_NAME=cluster_name,
+    )
+    load(
+        session,
+        KubernetesPersistentVolumeSchema(),
+        volumes,
+        lastupdated=update_tag,
+        CLUSTER_ID=cluster_id,
+        CLUSTER_NAME=cluster_name,
+    )
+    load(
+        session,
+        KubernetesPersistentVolumeClaimSchema(),
+        claims,
+        lastupdated=update_tag,
+        CLUSTER_ID=cluster_id,
+        CLUSTER_NAME=cluster_name,
+    )
+
+
+@timeit
+def cleanup(session: neo4j.Session, common_job_parameters: dict[str, Any]) -> None:
+    for schema in (
+        KubernetesPersistentVolumeClaimSchema(),
+        KubernetesPersistentVolumeSchema(),
+        KubernetesStorageClassSchema(),
+    ):
+        logger.debug("Running cleanup job for %s", schema.label)
+        GraphJob.from_node_schema(schema, common_job_parameters).run(session)
+
+
+@timeit
+def sync_storage(
+    session: neo4j.Session,
+    client: K8sClient,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    try:
+        storage_classes = transform_storage_classes(
+            get_storage_classes(client), client.name
+        )
+        volumes = transform_persistent_volumes(
+            get_persistent_volumes(client), client.name
+        )
+        claims = transform_persistent_volume_claims(
+            get_persistent_volume_claims(client), client.name
+        )
+    except ApiException as error:
+        if error.status in (401, 403):
+            # DEPRECATED: missing storage list permissions will become a hard
+            # failure in v1.0.0. Preserve prior data during the migration window.
+            logger.warning(
+                "Cartography lacks permission to list persistent storage on "
+                "cluster %s (status %s). Skipping storage sync and preserving "
+                "previously synced StorageClass/PersistentVolume/"
+                "PersistentVolumeClaim nodes. Grant list on storageclasses, "
+                "persistentvolumes, and persistentvolumeclaims; these permissions "
+                "will be required in v1.0.0.",
+                client.name,
+                error.status,
+            )
+            return
+        raise
+
+    load_storage(
+        session,
+        storage_classes,
+        volumes,
+        claims,
+        update_tag,
+        common_job_parameters["CLUSTER_ID"],
+        client.name,
+    )
+    cleanup(session, common_job_parameters)

--- a/cartography/intel/kubernetes/storage.py
+++ b/cartography/intel/kubernetes/storage.py
@@ -7,10 +7,11 @@ from kubernetes.client.exceptions import ApiException
 from kubernetes.client.models import V1PersistentVolume
 from kubernetes.client.models import V1PersistentVolumeClaim
 from kubernetes.client.models import V1StorageClass
+from kubernetes.utils.quantity import parse_quantity
+from urllib3.exceptions import HTTPError
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
-from cartography.intel.kubernetes.util import get_epoch
 from cartography.intel.kubernetes.util import k8s_paginate
 from cartography.intel.kubernetes.util import K8sClient
 from cartography.models.kubernetes.storage import KubernetesPersistentVolumeClaimSchema
@@ -19,6 +20,10 @@ from cartography.models.kubernetes.storage import KubernetesStorageClassSchema
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
+
+
+def _storage_bytes(quantity: str | None) -> int | None:
+    return int(parse_quantity(quantity)) if quantity is not None else None
 
 
 @timeit
@@ -47,8 +52,8 @@ def transform_storage_classes(
             "id": f"{cluster_name}/{storage_class.metadata.name}",
             "uid": storage_class.metadata.uid,
             "name": storage_class.metadata.name,
-            "creation_timestamp": get_epoch(storage_class.metadata.creation_timestamp),
-            "deletion_timestamp": get_epoch(storage_class.metadata.deletion_timestamp),
+            "creation_timestamp": storage_class.metadata.creation_timestamp,
+            "deletion_timestamp": storage_class.metadata.deletion_timestamp,
             "provisioner": storage_class.provisioner,
             "reclaim_policy": storage_class.reclaim_policy,
             "volume_binding_mode": storage_class.volume_binding_mode,
@@ -77,9 +82,12 @@ def transform_persistent_volumes(
                 "id": f"{cluster_name}/{volume.metadata.name}",
                 "uid": volume.metadata.uid,
                 "name": volume.metadata.name,
-                "creation_timestamp": get_epoch(volume.metadata.creation_timestamp),
-                "deletion_timestamp": get_epoch(volume.metadata.deletion_timestamp),
+                "creation_timestamp": volume.metadata.creation_timestamp,
+                "deletion_timestamp": volume.metadata.deletion_timestamp,
                 "capacity_storage": (spec.capacity or {}).get("storage"),
+                "capacity_storage_bytes": _storage_bytes(
+                    (spec.capacity or {}).get("storage")
+                ),
                 "access_modes": sorted(spec.access_modes or []),
                 "reclaim_policy": spec.persistent_volume_reclaim_policy,
                 "storage_class_name": storage_class_name,
@@ -130,8 +138,8 @@ def transform_persistent_volume_claims(
                 "id": f"{cluster_name}/{namespace}/{claim.metadata.name}",
                 "uid": claim.metadata.uid,
                 "name": claim.metadata.name,
-                "creation_timestamp": get_epoch(claim.metadata.creation_timestamp),
-                "deletion_timestamp": get_epoch(claim.metadata.deletion_timestamp),
+                "creation_timestamp": claim.metadata.creation_timestamp,
+                "deletion_timestamp": claim.metadata.deletion_timestamp,
                 "namespace": namespace,
                 "storage_class_name": storage_class_name,
                 "storage_class_id": (
@@ -143,6 +151,7 @@ def transform_persistent_volume_claims(
                 "volume_id": (f"{cluster_name}/{volume_name}" if volume_name else None),
                 "access_modes": sorted(spec.access_modes or []),
                 "requested_storage": requests.get("storage"),
+                "requested_storage_bytes": _storage_bytes(requests.get("storage")),
                 "volume_mode": spec.volume_mode,
                 "phase": status.phase if status else None,
                 "labels": json.dumps(claim.metadata.labels or {}, sort_keys=True),
@@ -230,12 +239,23 @@ def sync_storage(
                 error.status,
             )
             return
-        logger.error(
-            "Kubernetes API error listing persistent storage on cluster %s "
-            "(status %s). Skipping storage sync for this run and preserving "
-            "previously synced nodes.",
+        status = error.status or 0
+        if status in (0, 429) or 500 <= status < 600:
+            logger.error(
+                "Transient Kubernetes API error listing persistent storage on "
+                "cluster %s (status %s). Skipping storage sync for this run and "
+                "preserving previously synced nodes.",
+                client.name,
+                error.status,
+            )
+            return
+        raise
+    except HTTPError:
+        logger.exception(
+            "Kubernetes transport error listing persistent storage on cluster %s. "
+            "Skipping storage sync for this run and preserving previously synced "
+            "nodes.",
             client.name,
-            error.status,
         )
         return
 

--- a/cartography/intel/kubernetes/storage.py
+++ b/cartography/intel/kubernetes/storage.py
@@ -10,6 +10,7 @@ from kubernetes.client.models import V1StorageClass
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.kubernetes.util import get_epoch
 from cartography.intel.kubernetes.util import k8s_paginate
 from cartography.intel.kubernetes.util import K8sClient
 from cartography.models.kubernetes.storage import KubernetesPersistentVolumeClaimSchema
@@ -45,6 +46,8 @@ def transform_storage_classes(
         {
             "id": f"{cluster_name}/{storage_class.metadata.name}",
             "name": storage_class.metadata.name,
+            "creation_timestamp": get_epoch(storage_class.metadata.creation_timestamp),
+            "deletion_timestamp": get_epoch(storage_class.metadata.deletion_timestamp),
             "provisioner": storage_class.provisioner,
             "reclaim_policy": storage_class.reclaim_policy,
             "volume_binding_mode": storage_class.volume_binding_mode,
@@ -71,6 +74,8 @@ def transform_persistent_volumes(
                 "id": f"{cluster_name}/{volume.metadata.name}",
                 "uid": volume.metadata.uid,
                 "name": volume.metadata.name,
+                "creation_timestamp": get_epoch(volume.metadata.creation_timestamp),
+                "deletion_timestamp": get_epoch(volume.metadata.deletion_timestamp),
                 "capacity_storage": (spec.capacity or {}).get("storage"),
                 "access_modes": sorted(spec.access_modes or []),
                 "reclaim_policy": spec.persistent_volume_reclaim_policy,
@@ -108,6 +113,8 @@ def transform_persistent_volume_claims(
                 "id": f"{cluster_name}/{namespace}/{claim.metadata.name}",
                 "uid": claim.metadata.uid,
                 "name": claim.metadata.name,
+                "creation_timestamp": get_epoch(claim.metadata.creation_timestamp),
+                "deletion_timestamp": get_epoch(claim.metadata.deletion_timestamp),
                 "namespace": namespace,
                 "storage_class_name": storage_class_name,
                 "storage_class_id": (

--- a/cartography/intel/kubernetes/storage.py
+++ b/cartography/intel/kubernetes/storage.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from decimal import ROUND_CEILING
 from typing import Any
 
 import neo4j
@@ -23,7 +24,11 @@ logger = logging.getLogger(__name__)
 
 
 def _storage_bytes(quantity: str | None) -> int | None:
-    return int(parse_quantity(quantity)) if quantity is not None else None
+    return (
+        int(parse_quantity(quantity).to_integral_value(rounding=ROUND_CEILING))
+        if quantity is not None
+        else None
+    )
 
 
 @timeit

--- a/cartography/intel/kubernetes/util.py
+++ b/cartography/intel/kubernetes/util.py
@@ -1,6 +1,8 @@
 import json
 import logging
 from datetime import datetime
+from decimal import Decimal
+from decimal import InvalidOperation
 from typing import Any
 from typing import Callable
 
@@ -34,8 +36,11 @@ def get_gpu_quantity(resources: dict[str, Any] | None) -> int | None:
         if not str(key).endswith("/gpu"):
             continue
         try:
-            quantities.append(int(str(value)))
-        except ValueError:
+            quantity = Decimal(str(value))
+            if quantity != quantity.to_integral_value():
+                raise ValueError
+            quantities.append(int(quantity))
+        except (InvalidOperation, ValueError, OverflowError):
             logger.warning("Ignoring invalid Kubernetes GPU quantity %r", value)
     return sum(quantities) if quantities else None
 

--- a/cartography/intel/kubernetes/util.py
+++ b/cartography/intel/kubernetes/util.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from datetime import datetime
 from typing import Any
@@ -12,11 +13,31 @@ from kubernetes.client import CoreV1Api
 from kubernetes.client import CustomObjectsApi
 from kubernetes.client import NetworkingV1Api
 from kubernetes.client import RbacAuthorizationV1Api
+from kubernetes.client import StorageV1Api
 from kubernetes.client import VersionApi
 from kubernetes.client.exceptions import ApiException
 from kubernetes.config.kube_config import KubeConfigMerger
 
 logger = logging.getLogger(__name__)
+
+
+def format_resource_quantities(resources: dict[str, Any] | None) -> str:
+    return json.dumps(
+        {str(key): str(value) for key, value in (resources or {}).items()},
+        sort_keys=True,
+    )
+
+
+def get_gpu_quantity(resources: dict[str, Any] | None) -> int | None:
+    quantities = []
+    for key, value in (resources or {}).items():
+        if not str(key).endswith("/gpu"):
+            continue
+        try:
+            quantities.append(int(str(value)))
+        except ValueError:
+            logger.warning("Ignoring invalid Kubernetes GPU quantity %r", value)
+    return sum(quantities) if quantities else None
 
 
 class KubernetesContextNotFound(Exception):
@@ -128,6 +149,21 @@ class K8BatchApiClient(BatchV1Api):
         super().__init__(api_client=api_client)
 
 
+class K8StorageApiClient(StorageV1Api):
+    def __init__(
+        self,
+        name: str,
+        config_file: str,
+        api_client: ApiClient | None = None,
+    ) -> None:
+        self.name = name
+        if not api_client:
+            api_client = config.new_client_from_config(
+                context=name, config_file=config_file
+            )
+        super().__init__(api_client=api_client)
+
+
 class K8sClient:
     def __init__(
         self,
@@ -145,6 +181,7 @@ class K8sClient:
         self.custom = K8CustomObjectsApiClient(self.name, self.config_file)
         self.apps = K8AppsApiClient(self.name, self.config_file)
         self.batch = K8BatchApiClient(self.name, self.config_file)
+        self.storage = K8StorageApiClient(self.name, self.config_file)
 
 
 def get_k8s_clients(kubeconfig: str) -> list[K8sClient]:

--- a/cartography/intel/kubernetes/util.py
+++ b/cartography/intel/kubernetes/util.py
@@ -33,7 +33,16 @@ def format_resource_quantities(resources: dict[str, Any] | None) -> str:
 def get_gpu_quantity(resources: dict[str, Any] | None) -> int | None:
     quantities = []
     for key, value in (resources or {}).items():
-        if not str(key).endswith("/gpu"):
+        resource_name = str(key)
+        is_intel_gpu = resource_name in (
+            "gpu.intel.com/i915",
+            "gpu.intel.com/xe",
+        )
+        if not (
+            resource_name.endswith("/gpu")
+            or resource_name.startswith("nvidia.com/mig-")
+            or is_intel_gpu
+        ):
             continue
         try:
             quantity = Decimal(str(value))

--- a/cartography/models/kubernetes/containers.py
+++ b/cartography/models/kubernetes/containers.py
@@ -94,11 +94,12 @@ class KubernetesContainerNodeProperties(CartographyNodeProperties):
     gpu_request: PropertyRef = PropertyRef(
         "gpu_request",
         extra_index=True,
-        description="Total integer request across extended resource keys ending in `/gpu`.",
+        description="Total requested GPU scheduling units across full-GPU, NVIDIA MIG, and Intel GPU resource keys; heterogeneous units are not normalized to physical GPUs.",
     )
     gpu_limit: PropertyRef = PropertyRef(
         "gpu_limit",
-        description="Total integer limit across extended resource keys ending in `/gpu`.",
+        extra_index=True,
+        description="Total GPU scheduling-unit limit across full-GPU, NVIDIA MIG, and Intel GPU resource keys; heterogeneous units are not normalized to physical GPUs.",
     )
     allow_privilege_escalation: PropertyRef = PropertyRef(
         "allow_privilege_escalation",

--- a/cartography/models/kubernetes/containers.py
+++ b/cartography/models/kubernetes/containers.py
@@ -83,6 +83,23 @@ class KubernetesContainerNodeProperties(CartographyNodeProperties):
         "cpu_limit",
         description='Maximum amount of CPU the container is allowed to use (e.g. "500m", "2").',
     )
+    resource_requests: PropertyRef = PropertyRef(
+        "resource_requests",
+        description="All container resource requests, including extended resources, stored as a JSON-encoded object.",
+    )
+    resource_limits: PropertyRef = PropertyRef(
+        "resource_limits",
+        description="All container resource limits, including extended resources, stored as a JSON-encoded object.",
+    )
+    gpu_request: PropertyRef = PropertyRef(
+        "gpu_request",
+        extra_index=True,
+        description="Total integer request across extended resource keys ending in `/gpu`.",
+    )
+    gpu_limit: PropertyRef = PropertyRef(
+        "gpu_limit",
+        description="Total integer limit across extended resource keys ending in `/gpu`.",
+    )
     allow_privilege_escalation: PropertyRef = PropertyRef(
         "allow_privilege_escalation",
         description="Whether the container explicitly allows privilege escalation. Derived from `container.security_context.allow_privilege_escalation`.",

--- a/cartography/models/kubernetes/nodes.py
+++ b/cartography/models/kubernetes/nodes.py
@@ -77,12 +77,11 @@ class KubernetesNodeNodeProperties(CartographyNodeProperties):
     )
     gpu_capacity: PropertyRef = PropertyRef(
         "gpu_capacity",
-        extra_index=True,
-        description="Total integer capacity across extended resource keys ending in `/gpu`.",
+        description="Total GPU scheduling-unit capacity across full-GPU, NVIDIA MIG, and Intel GPU resource keys; heterogeneous units are not normalized to physical GPUs.",
     )
     gpu_allocatable: PropertyRef = PropertyRef(
         "gpu_allocatable",
-        description="Total allocatable integer quantity across extended resource keys ending in `/gpu`.",
+        description="Total allocatable GPU scheduling units across full-GPU, NVIDIA MIG, and Intel GPU resource keys; heterogeneous units are not normalized to physical GPUs.",
     )
     gpu_product: PropertyRef = PropertyRef(
         "gpu_product",

--- a/cartography/models/kubernetes/nodes.py
+++ b/cartography/models/kubernetes/nodes.py
@@ -63,6 +63,32 @@ class KubernetesNodeNodeProperties(CartographyNodeProperties):
         extra_index=True,
         description="EC2 instance id parsed from `provider_id` for EKS nodes (e.g. `i-0123456789abcdef0`); null for non-AWS providers.",
     )
+    labels: PropertyRef = PropertyRef(
+        "labels",
+        description="Node metadata labels stored as a JSON-encoded object.",
+    )
+    capacity: PropertyRef = PropertyRef(
+        "capacity",
+        description="Node resource capacity from `status.capacity`, stored as a JSON-encoded object.",
+    )
+    allocatable: PropertyRef = PropertyRef(
+        "allocatable",
+        description="Node allocatable resources from `status.allocatable`, stored as a JSON-encoded object.",
+    )
+    gpu_capacity: PropertyRef = PropertyRef(
+        "gpu_capacity",
+        extra_index=True,
+        description="Total integer capacity across extended resource keys ending in `/gpu`.",
+    )
+    gpu_allocatable: PropertyRef = PropertyRef(
+        "gpu_allocatable",
+        description="Total allocatable integer quantity across extended resource keys ending in `/gpu`.",
+    )
+    gpu_product: PropertyRef = PropertyRef(
+        "gpu_product",
+        extra_index=True,
+        description="GPU product reported by the standard NVIDIA GPU Feature Discovery or GKE accelerator label.",
+    )
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 

--- a/cartography/models/kubernetes/pods.py
+++ b/cartography/models/kubernetes/pods.py
@@ -65,6 +65,10 @@ class KubernetesPodNodeProperties(CartographyNodeProperties):
         "host_path_volume_paths",
         description="List of host filesystem paths mounted via `hostPath` pod volumes. Derived from `pod.spec.volumes[].host_path.path`.",
     )
+    persistent_volume_claim_names: PropertyRef = PropertyRef(
+        "persistent_volume_claim_names",
+        description="Names of PersistentVolumeClaims referenced by pod volumes.",
+    )
     labels: PropertyRef = PropertyRef(
         "labels",
         description="Labels are key-value pairs contained in the `PodSpec` and fetched from `pod.metadata.labels`. Stored as a JSON-encoded string.",
@@ -472,6 +476,26 @@ class KubernetesPodToServiceAccountRunsAsRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class KubernetesPodToPersistentVolumeClaimRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesPodToPersistentVolumeClaimRel(CartographyRelSchema):
+    """Links a pod to a PersistentVolumeClaim referenced by one of its volumes."""
+
+    target_node_label: str = "KubernetesPersistentVolumeClaim"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("persistent_volume_claim_ids", one_to_many=True)}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MOUNTS"
+    properties: KubernetesPodToPersistentVolumeClaimRelProperties = (
+        KubernetesPodToPersistentVolumeClaimRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class KubernetesPodSchema(CartographyNodeSchema):
     "A Kubernetes pod and its workload security configuration."
 
@@ -493,6 +517,7 @@ class KubernetesPodSchema(CartographyNodeSchema):
             KubernetesPodToKubernetesNodeRel(),
             KubernetesPodToServiceAccountRel(),
             KubernetesPodToServiceAccountRunsAsRel(),
+            KubernetesPodToPersistentVolumeClaimRel(),
             KubernetesPodToSecretVolumeRel(),
             KubernetesPodToSecretEnvRel(),
             KubernetesPodToSecretVolumeUsesSecretRel(),

--- a/cartography/models/kubernetes/storage.py
+++ b/cartography/models/kubernetes/storage.py
@@ -1,0 +1,354 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class KubernetesStorageClassNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id",
+        description="Identifier derived from cluster name and StorageClass name.",
+    )
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="Name of the StorageClass."
+    )
+    cluster_name: PropertyRef = PropertyRef(
+        "CLUSTER_NAME",
+        set_in_kwargs=True,
+        extra_index=True,
+        description="Name of the Kubernetes cluster containing this StorageClass.",
+    )
+    provisioner: PropertyRef = PropertyRef(
+        "provisioner",
+        extra_index=True,
+        description="Volume plugin or CSI driver used to provision volumes.",
+    )
+    reclaim_policy: PropertyRef = PropertyRef(
+        "reclaim_policy",
+        description="Reclaim policy applied to dynamically provisioned volumes.",
+    )
+    volume_binding_mode: PropertyRef = PropertyRef(
+        "volume_binding_mode",
+        description="When volume binding and dynamic provisioning occur.",
+    )
+    allow_volume_expansion: PropertyRef = PropertyRef(
+        "allow_volume_expansion",
+        description="Whether volumes created by this StorageClass can be expanded.",
+    )
+    parameters: PropertyRef = PropertyRef(
+        "parameters",
+        description="Provisioner parameters stored as a JSON-encoded object.",
+    )
+    mount_options: PropertyRef = PropertyRef(
+        "mount_options",
+        description="Mount options applied to dynamically provisioned volumes.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesStorageClassToClusterRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesStorageClassToClusterRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("CLUSTER_ID", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: KubernetesStorageClassToClusterRelProperties = (
+        KubernetesStorageClassToClusterRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesStorageClassSchema(CartographyNodeSchema):
+    "A class used to dynamically provision persistent storage."
+
+    label: str = "KubernetesStorageClass"
+    properties: KubernetesStorageClassNodeProperties = (
+        KubernetesStorageClassNodeProperties()
+    )
+    sub_resource_relationship: KubernetesStorageClassToClusterRel = (
+        KubernetesStorageClassToClusterRel()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id",
+        description="Identifier derived from cluster name and PersistentVolume name.",
+    )
+    uid: PropertyRef = PropertyRef(
+        "uid", description="Kubernetes UID of the PersistentVolume."
+    )
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="Name of the PersistentVolume."
+    )
+    cluster_name: PropertyRef = PropertyRef(
+        "CLUSTER_NAME",
+        set_in_kwargs=True,
+        extra_index=True,
+        description="Name of the Kubernetes cluster containing this PersistentVolume.",
+    )
+    capacity_storage: PropertyRef = PropertyRef(
+        "capacity_storage",
+        description="Storage capacity reported by `spec.capacity.storage`.",
+    )
+    access_modes: PropertyRef = PropertyRef(
+        "access_modes",
+        description="Ways the volume can be mounted, such as ReadWriteOnce or ReadWriteMany.",
+    )
+    reclaim_policy: PropertyRef = PropertyRef(
+        "reclaim_policy",
+        description="What happens to the volume after its claim is released.",
+    )
+    storage_class_name: PropertyRef = PropertyRef(
+        "storage_class_name",
+        extra_index=True,
+        description="Name of the StorageClass associated with the volume.",
+    )
+    volume_mode: PropertyRef = PropertyRef(
+        "volume_mode",
+        description="Whether the volume is exposed as a filesystem or block device.",
+    )
+    phase: PropertyRef = PropertyRef(
+        "phase", extra_index=True, description="Current PersistentVolume phase."
+    )
+    claim_namespace: PropertyRef = PropertyRef(
+        "claim_namespace",
+        description="Namespace of the bound PersistentVolumeClaim, when present.",
+    )
+    claim_name: PropertyRef = PropertyRef(
+        "claim_name",
+        description="Name of the bound PersistentVolumeClaim, when present.",
+    )
+    csi_driver: PropertyRef = PropertyRef(
+        "csi_driver",
+        extra_index=True,
+        description="CSI driver that manages the volume, when the volume uses CSI.",
+    )
+    csi_volume_handle: PropertyRef = PropertyRef(
+        "csi_volume_handle",
+        description="CSI driver volume handle for the backing storage resource.",
+    )
+    labels: PropertyRef = PropertyRef(
+        "labels",
+        description="PersistentVolume metadata labels stored as a JSON-encoded object.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeToClusterRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeToClusterRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("CLUSTER_ID", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: KubernetesPersistentVolumeToClusterRelProperties = (
+        KubernetesPersistentVolumeToClusterRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeToStorageClassRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeToStorageClassRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesStorageClass"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("storage_class_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_STORAGE_CLASS"
+    properties: KubernetesPersistentVolumeToStorageClassRelProperties = (
+        KubernetesPersistentVolumeToStorageClassRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeSchema(CartographyNodeSchema):
+    "Cluster-scoped persistent storage available to Kubernetes workloads."
+
+    label: str = "KubernetesPersistentVolume"
+    properties: KubernetesPersistentVolumeNodeProperties = (
+        KubernetesPersistentVolumeNodeProperties()
+    )
+    sub_resource_relationship: KubernetesPersistentVolumeToClusterRel = (
+        KubernetesPersistentVolumeToClusterRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [KubernetesPersistentVolumeToStorageClassRel()]
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeClaimNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id",
+        description="Identifier derived from cluster name, namespace, and claim name.",
+    )
+    uid: PropertyRef = PropertyRef(
+        "uid", description="Kubernetes UID of the PersistentVolumeClaim."
+    )
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="Name of the PersistentVolumeClaim."
+    )
+    namespace: PropertyRef = PropertyRef(
+        "namespace",
+        extra_index=True,
+        description="Namespace containing the PersistentVolumeClaim.",
+    )
+    cluster_name: PropertyRef = PropertyRef(
+        "CLUSTER_NAME",
+        set_in_kwargs=True,
+        extra_index=True,
+        description="Name of the Kubernetes cluster containing this claim.",
+    )
+    storage_class_name: PropertyRef = PropertyRef(
+        "storage_class_name",
+        extra_index=True,
+        description="Name of the StorageClass requested by the claim.",
+    )
+    volume_name: PropertyRef = PropertyRef(
+        "volume_name",
+        description="Name of the PersistentVolume bound to the claim.",
+    )
+    access_modes: PropertyRef = PropertyRef(
+        "access_modes",
+        description="Requested volume access modes.",
+    )
+    requested_storage: PropertyRef = PropertyRef(
+        "requested_storage",
+        description="Storage quantity requested by the claim.",
+    )
+    volume_mode: PropertyRef = PropertyRef(
+        "volume_mode",
+        description="Whether the claim requests a filesystem or block device.",
+    )
+    phase: PropertyRef = PropertyRef(
+        "phase", extra_index=True, description="Current PersistentVolumeClaim phase."
+    )
+    labels: PropertyRef = PropertyRef(
+        "labels",
+        description="PersistentVolumeClaim metadata labels stored as a JSON-encoded object.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeClaimToClusterRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeClaimToClusterRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("CLUSTER_ID", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: KubernetesPersistentVolumeClaimToClusterRelProperties = (
+        KubernetesPersistentVolumeClaimToClusterRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeClaimToNamespaceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeClaimToNamespaceRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesNamespace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "cluster_name": PropertyRef("CLUSTER_NAME", set_in_kwargs=True),
+            "name": PropertyRef("namespace"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "CONTAINS"
+    properties: KubernetesPersistentVolumeClaimToNamespaceRelProperties = (
+        KubernetesPersistentVolumeClaimToNamespaceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeClaimToVolumeRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeClaimToVolumeRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesPersistentVolume"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("volume_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "BOUND_TO"
+    properties: KubernetesPersistentVolumeClaimToVolumeRelProperties = (
+        KubernetesPersistentVolumeClaimToVolumeRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeClaimToStorageClassRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeClaimToStorageClassRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesStorageClass"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("storage_class_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_STORAGE_CLASS"
+    properties: KubernetesPersistentVolumeClaimToStorageClassRelProperties = (
+        KubernetesPersistentVolumeClaimToStorageClassRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeClaimSchema(CartographyNodeSchema):
+    "A namespace-scoped request for persistent storage."
+
+    label: str = "KubernetesPersistentVolumeClaim"
+    properties: KubernetesPersistentVolumeClaimNodeProperties = (
+        KubernetesPersistentVolumeClaimNodeProperties()
+    )
+    sub_resource_relationship: KubernetesPersistentVolumeClaimToClusterRel = (
+        KubernetesPersistentVolumeClaimToClusterRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            KubernetesPersistentVolumeClaimToNamespaceRel(),
+            KubernetesPersistentVolumeClaimToVolumeRel(),
+            KubernetesPersistentVolumeClaimToStorageClassRel(),
+        ]
+    )

--- a/cartography/models/kubernetes/storage.py
+++ b/cartography/models/kubernetes/storage.py
@@ -17,6 +17,9 @@ class KubernetesStorageClassNodeProperties(CartographyNodeProperties):
         "id",
         description="Identifier derived from cluster name and StorageClass name.",
     )
+    uid: PropertyRef = PropertyRef(
+        "uid", description="Kubernetes UID of the StorageClass."
+    )
     name: PropertyRef = PropertyRef(
         "name", extra_index=True, description="Name of the StorageClass."
     )
@@ -160,6 +163,14 @@ class KubernetesPersistentVolumeNodeProperties(CartographyNodeProperties):
         "csi_volume_handle",
         description="CSI driver volume handle for the backing storage resource.",
     )
+    aws_ebs_volume_id: PropertyRef = PropertyRef(
+        "aws_ebs_volume_id",
+        description="AWS EBS volume ID when managed by the AWS EBS CSI driver.",
+    )
+    azure_disk_id: PropertyRef = PropertyRef(
+        "azure_disk_id",
+        description="Azure managed disk resource ID when managed by the Azure Disk CSI driver.",
+    )
     labels: PropertyRef = PropertyRef(
         "labels",
         description="PersistentVolume metadata labels stored as a JSON-encoded object.",
@@ -204,6 +215,41 @@ class KubernetesPersistentVolumeToStorageClassRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class KubernetesPersistentVolumeToCloudDiskRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeToAWSEBSVolumeRel(CartographyRelSchema):
+    """Links a PersistentVolume to its backing AWS EBS volume."""
+
+    target_node_label: str = "AWSEBSVolume"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("aws_ebs_volume_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "BACKED_BY"
+    properties: KubernetesPersistentVolumeToCloudDiskRelProperties = (
+        KubernetesPersistentVolumeToCloudDiskRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesPersistentVolumeToAzureDiskRel(CartographyRelSchema):
+    """Links a PersistentVolume to its backing Azure managed disk."""
+
+    target_node_label: str = "AzureDisk"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("azure_disk_id")}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "BACKED_BY"
+    properties: KubernetesPersistentVolumeToCloudDiskRelProperties = (
+        KubernetesPersistentVolumeToCloudDiskRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class KubernetesPersistentVolumeSchema(CartographyNodeSchema):
     "Cluster-scoped persistent storage available to Kubernetes workloads."
 
@@ -215,7 +261,11 @@ class KubernetesPersistentVolumeSchema(CartographyNodeSchema):
         KubernetesPersistentVolumeToClusterRel()
     )
     other_relationships: OtherRelationships = OtherRelationships(
-        [KubernetesPersistentVolumeToStorageClassRel()]
+        [
+            KubernetesPersistentVolumeToStorageClassRel(),
+            KubernetesPersistentVolumeToAWSEBSVolumeRel(),
+            KubernetesPersistentVolumeToAzureDiskRel(),
+        ]
     )
 
 

--- a/cartography/models/kubernetes/storage.py
+++ b/cartography/models/kubernetes/storage.py
@@ -20,6 +20,14 @@ class KubernetesStorageClassNodeProperties(CartographyNodeProperties):
     name: PropertyRef = PropertyRef(
         "name", extra_index=True, description="Name of the StorageClass."
     )
+    creation_timestamp: PropertyRef = PropertyRef(
+        "creation_timestamp",
+        description="Timestamp when the StorageClass was created.",
+    )
+    deletion_timestamp: PropertyRef = PropertyRef(
+        "deletion_timestamp",
+        description="Timestamp when the StorageClass was marked for deletion.",
+    )
     cluster_name: PropertyRef = PropertyRef(
         "CLUSTER_NAME",
         set_in_kwargs=True,
@@ -96,6 +104,14 @@ class KubernetesPersistentVolumeNodeProperties(CartographyNodeProperties):
     )
     name: PropertyRef = PropertyRef(
         "name", extra_index=True, description="Name of the PersistentVolume."
+    )
+    creation_timestamp: PropertyRef = PropertyRef(
+        "creation_timestamp",
+        description="Timestamp when the PersistentVolume was created.",
+    )
+    deletion_timestamp: PropertyRef = PropertyRef(
+        "deletion_timestamp",
+        description="Timestamp when the PersistentVolume was marked for deletion.",
     )
     cluster_name: PropertyRef = PropertyRef(
         "CLUSTER_NAME",
@@ -214,6 +230,14 @@ class KubernetesPersistentVolumeClaimNodeProperties(CartographyNodeProperties):
     )
     name: PropertyRef = PropertyRef(
         "name", extra_index=True, description="Name of the PersistentVolumeClaim."
+    )
+    creation_timestamp: PropertyRef = PropertyRef(
+        "creation_timestamp",
+        description="Timestamp when the PersistentVolumeClaim was created.",
+    )
+    deletion_timestamp: PropertyRef = PropertyRef(
+        "deletion_timestamp",
+        description="Timestamp when the PersistentVolumeClaim was marked for deletion.",
     )
     namespace: PropertyRef = PropertyRef(
         "namespace",

--- a/cartography/models/kubernetes/storage.py
+++ b/cartography/models/kubernetes/storage.py
@@ -126,6 +126,10 @@ class KubernetesPersistentVolumeNodeProperties(CartographyNodeProperties):
         "capacity_storage",
         description="Storage capacity reported by `spec.capacity.storage`.",
     )
+    capacity_storage_bytes: PropertyRef = PropertyRef(
+        "capacity_storage_bytes",
+        description="Storage capacity in bytes.",
+    )
     access_modes: PropertyRef = PropertyRef(
         "access_modes",
         description="Ways the volume can be mounted, such as ReadWriteOnce or ReadWriteMany.",
@@ -240,7 +244,7 @@ class KubernetesPersistentVolumeToAzureDiskRel(CartographyRelSchema):
 
     target_node_label: str = "AzureDisk"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
-        {"id": PropertyRef("azure_disk_id")}
+        {"id": PropertyRef("azure_disk_id", ignore_case=True)}
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "BACKED_BY"
@@ -316,6 +320,10 @@ class KubernetesPersistentVolumeClaimNodeProperties(CartographyNodeProperties):
     requested_storage: PropertyRef = PropertyRef(
         "requested_storage",
         description="Storage quantity requested by the claim.",
+    )
+    requested_storage_bytes: PropertyRef = PropertyRef(
+        "requested_storage_bytes",
+        description="Storage requested by the claim in bytes.",
     )
     volume_mode: PropertyRef = PropertyRef(
         "volume_mode",

--- a/docs/root/modules/kubernetes/config.md
+++ b/docs/root/modules/kubernetes/config.md
@@ -17,6 +17,9 @@ Cartography's Kubernetes module requires read-only access to the following Kuber
 - `list pods`
 - `list services`
 - `list serviceaccounts`
+- `list persistentvolumes`
+- `list persistentvolumeclaims`
+- `list storageclasses` in the `storage.k8s.io` group: required to map pod mounts through `PersistentVolumeClaim` and `PersistentVolume` resources to their storage class and CSI driver. Until v1.0.0, if these verbs are missing Cartography logs a warning and skips persistent storage ingestion and cleanup so previously synced storage nodes are preserved; from v1.0.0 a missing verb will be a hard failure.
 - `list roles`
 - `list rolebindings`
 - `list clusterroles`
@@ -61,6 +64,15 @@ rules:
     - pods
     - services
     - serviceaccounts
+    - persistentvolumes
+    - persistentvolumeclaims
+  verbs: ["list"]
+# Persistent storage classes (required). Until v1.0.0 Cartography tolerates this
+# verb being withheld and preserves existing storage nodes; from v1.0.0 a missing
+# verb is a hard failure.
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - storageclasses
   verbs: ["list"]
 # Secrets (optional): omit if you don't want to grant cluster-wide read access
 # to secret contents. Kubernetes RBAC has no metadata-only verb: `list secrets`

--- a/docs/root/modules/kubernetes/config.md
+++ b/docs/root/modules/kubernetes/config.md
@@ -64,12 +64,15 @@ rules:
     - pods
     - services
     - serviceaccounts
+  verbs: ["list"]
+# Persistent storage (required). Until v1.0.0 Cartography tolerates these verbs
+# being withheld and preserves existing storage nodes; from v1.0.0 a missing
+# verb is a hard failure.
+- apiGroups: [""]
+  resources:
     - persistentvolumes
     - persistentvolumeclaims
   verbs: ["list"]
-# Persistent storage classes (required). Until v1.0.0 Cartography tolerates this
-# verb being withheld and preserves existing storage nodes; from v1.0.0 a missing
-# verb is a hard failure.
 - apiGroups: ["storage.k8s.io"]
   resources:
     - storageclasses

--- a/docs/root/modules/kubernetes/index.md
+++ b/docs/root/modules/kubernetes/index.md
@@ -6,6 +6,9 @@ identities and permissions. It also connects Kubernetes resources to cloud
 infrastructure, container images, and shared ontology labels so that workload and
 identity paths can be queried across providers.
 
+PersistentVolumes managed by the AWS EBS or Azure Disk CSI drivers connect to
+already-ingested cloud disks with `BACKED_BY` relationships.
+
 Use the configuration guide to grant read-only access and connect one or more
 clusters. The schema reference is generated from the model definitions and is
 included automatically in the built documentation. The query guide contains

--- a/docs/root/modules/kubernetes/index.md
+++ b/docs/root/modules/kubernetes/index.md
@@ -1,9 +1,10 @@
 # Kubernetes
 
-The Kubernetes module ingests cluster inventory, workloads, networking resources,
-secrets metadata, and RBAC identities and permissions. It also connects Kubernetes
-resources to cloud infrastructure, container images, and shared ontology labels so
-that workload and identity paths can be queried across providers.
+The Kubernetes module ingests cluster inventory, GPU capacity and requests,
+persistent storage, workloads, networking resources, secrets metadata, and RBAC
+identities and permissions. It also connects Kubernetes resources to cloud
+infrastructure, container images, and shared ontology labels so that workload and
+identity paths can be queried across providers.
 
 Use the configuration guide to grant read-only access and connect one or more
 clusters. The schema reference is generated from the model definitions and is
@@ -21,6 +22,11 @@ the `Gateway -[:ROUTES]-> HTTPRoute -[:TARGETS]-> Service` traffic path.
 If the identity cannot list network policies, Cartography skips both ingestion
 and cleanup and preserves existing `KubernetesNetworkPolicy` nodes. Ingested
 policies use `APPLIES_TO` edges to identify selected pods.
+
+Until v1.0.0, if the identity cannot list persistent volumes, persistent volume
+claims, or storage classes, Cartography skips persistent storage ingestion and
+cleanup and preserves existing storage nodes. Pods continue to load without
+`MOUNTS` relationships until the required permissions are granted.
 
 If the identity cannot list secrets, Cartography skips secret ingestion and
 cleanup and preserves existing `KubernetesSecret` nodes. Cartography stores

--- a/docs/root/modules/kubernetes/index.md
+++ b/docs/root/modules/kubernetes/index.md
@@ -25,8 +25,10 @@ policies use `APPLIES_TO` edges to identify selected pods.
 
 Until v1.0.0, if the identity cannot list persistent volumes, persistent volume
 claims, or storage classes, Cartography skips persistent storage ingestion and
-cleanup and preserves existing storage nodes. Pods continue to load without
-`MOUNTS` relationships until the required permissions are granted.
+cleanup and preserves existing storage nodes. Pods continue to load. On a first
+sync, they have no `MOUNTS` relationships. After an earlier successful storage
+sync, pods can link to the preserved storage snapshot, which may be stale until
+permissions are restored.
 
 If the identity cannot list secrets, Cartography skips secret ingestion and
 cleanup and preserves existing `KubernetesSecret` nodes. Cartography stores

--- a/docs/root/modules/kubernetes/queries.md
+++ b/docs/root/modules/kubernetes/queries.md
@@ -24,15 +24,17 @@ Find GPU-requesting containers, their scheduled nodes, and the persistent storag
 mounted by their pods:
 
 ```cypher
-MATCH (container:KubernetesContainer)<-[:CONTAINS]-(pod:KubernetesPod)
+MATCH (container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod:KubernetesPod)
 MATCH (pod)-[:RUNS_ON]->(node:KubernetesNode)
 WHERE container.gpu_request > 0 OR container.gpu_limit > 0
 OPTIONAL MATCH (pod)-[:MOUNTS]->(claim:KubernetesPersistentVolumeClaim)
 OPTIONAL MATCH (claim)-[:BOUND_TO]->(volume:KubernetesPersistentVolume)
+OPTIONAL MATCH (volume)-[:BACKED_BY]->(cloud_disk)
 OPTIONAL MATCH (claim)-[:USES_STORAGE_CLASS]->(storage_class:KubernetesStorageClass)
 RETURN pod.namespace, pod.name, container.name,
        container.gpu_request, container.gpu_limit,
        node.name, node.gpu_product, node.gpu_capacity,
-       claim.name, volume.name, volume.csi_driver, storage_class.name
+       claim.name, volume.name, volume.csi_driver,
+       labels(cloud_disk), cloud_disk.id, storage_class.name
 ORDER BY pod.namespace, pod.name, container.name;
 ```

--- a/docs/root/modules/kubernetes/queries.md
+++ b/docs/root/modules/kubernetes/queries.md
@@ -17,3 +17,22 @@ RETURN k.name, k.api_server_url, k.kubeconfig_tls_configuration_status,
        k.kubeconfig_has_client_key
 ORDER BY k.name;
 ```
+
+## Map GPU workloads to persistent storage
+
+Find GPU-requesting containers, their scheduled nodes, and the persistent storage
+mounted by their pods:
+
+```cypher
+MATCH (container:KubernetesContainer)<-[:CONTAINS]-(pod:KubernetesPod)
+MATCH (pod)-[:RUNS_ON]->(node:KubernetesNode)
+OPTIONAL MATCH (pod)-[:MOUNTS]->(claim:KubernetesPersistentVolumeClaim)
+OPTIONAL MATCH (claim)-[:BOUND_TO]->(volume:KubernetesPersistentVolume)
+OPTIONAL MATCH (claim)-[:USES_STORAGE_CLASS]->(storage_class:KubernetesStorageClass)
+WHERE container.gpu_request > 0 OR container.gpu_limit > 0
+RETURN pod.namespace, pod.name, container.name,
+       container.gpu_request, container.gpu_limit,
+       node.name, node.gpu_product, node.gpu_capacity,
+       claim.name, volume.name, volume.csi_driver, storage_class.name
+ORDER BY pod.namespace, pod.name, container.name;
+```

--- a/docs/root/modules/kubernetes/queries.md
+++ b/docs/root/modules/kubernetes/queries.md
@@ -26,10 +26,10 @@ mounted by their pods:
 ```cypher
 MATCH (container:KubernetesContainer)<-[:CONTAINS]-(pod:KubernetesPod)
 MATCH (pod)-[:RUNS_ON]->(node:KubernetesNode)
+WHERE container.gpu_request > 0 OR container.gpu_limit > 0
 OPTIONAL MATCH (pod)-[:MOUNTS]->(claim:KubernetesPersistentVolumeClaim)
 OPTIONAL MATCH (claim)-[:BOUND_TO]->(volume:KubernetesPersistentVolume)
 OPTIONAL MATCH (claim)-[:USES_STORAGE_CLASS]->(storage_class:KubernetesStorageClass)
-WHERE container.gpu_request > 0 OR container.gpu_limit > 0
 RETURN pod.namespace, pod.name, container.name,
        container.gpu_request, container.gpu_limit,
        node.name, node.gpu_product, node.gpu_capacity,

--- a/tests/data/kubernetes/nodes.py
+++ b/tests/data/kubernetes/nodes.py
@@ -7,11 +7,23 @@ CLUSTER_NAME = KUBERNETES_CLUSTER_NAMES[0]
 
 RAW_NODES = [
     SimpleNamespace(
-        metadata=SimpleNamespace(name="my-node"),
+        metadata=SimpleNamespace(
+            name="my-node",
+            labels={
+                "nvidia.com/gpu.present": "true",
+                "nvidia.com/gpu.product": "NVIDIA-H200",
+            },
+        ),
         spec=SimpleNamespace(
             provider_id="aws:///us-east-1a/i-0123456789abcdef0",
         ),
         status=SimpleNamespace(
+            capacity={"cpu": "128", "memory": "2Ti", "nvidia.com/gpu": "8"},
+            allocatable={
+                "cpu": "127",
+                "memory": "1900Gi",
+                "nvidia.com/gpu": "8",
+            },
             node_info=SimpleNamespace(
                 architecture="amd64",
                 operating_system="linux",
@@ -19,13 +31,15 @@ RAW_NODES = [
                 kernel_version="5.15.0-1034-aws",
                 container_runtime_version="containerd://1.7.0",
                 kubelet_version="v1.27.1",
-            )
+            ),
         ),
     ),
     SimpleNamespace(
-        metadata=SimpleNamespace(name="my-arm-node"),
+        metadata=SimpleNamespace(name="my-arm-node", labels={}),
         spec=SimpleNamespace(provider_id=None),
         status=SimpleNamespace(
+            capacity={"cpu": "4", "memory": "16Gi"},
+            allocatable={"cpu": "3900m", "memory": "15Gi"},
             node_info=SimpleNamespace(
                 architecture="arm64",
                 operating_system="linux",
@@ -33,7 +47,7 @@ RAW_NODES = [
                 kernel_version="5.15.0-1034-aws",
                 container_runtime_version="containerd://1.7.0",
                 kubelet_version="v1.27.1",
-            )
+            ),
         ),
     ),
 ]
@@ -73,6 +87,12 @@ KUBERNETES_NODE_DATA = [
         "name": "my-node",
         "provider_id": "aws:///us-east-1a/i-0123456789abcdef0",
         "instance_id": "i-0123456789abcdef0",
+        "labels": '{"nvidia.com/gpu.present": "true", "nvidia.com/gpu.product": "NVIDIA-H200"}',
+        "capacity": '{"cpu": "128", "memory": "2Ti", "nvidia.com/gpu": "8"}',
+        "allocatable": '{"cpu": "127", "memory": "1900Gi", "nvidia.com/gpu": "8"}',
+        "gpu_capacity": 8,
+        "gpu_allocatable": 8,
+        "gpu_product": "NVIDIA-H200",
         "architecture": "amd64",
         "architecture_normalized": "amd64",
         "os": "linux",
@@ -86,6 +106,12 @@ KUBERNETES_NODE_DATA = [
         "name": "my-arm-node",
         "provider_id": None,
         "instance_id": None,
+        "labels": "{}",
+        "capacity": '{"cpu": "4", "memory": "16Gi"}',
+        "allocatable": '{"cpu": "3900m", "memory": "15Gi"}',
+        "gpu_capacity": None,
+        "gpu_allocatable": None,
+        "gpu_product": None,
         "architecture": "arm64",
         "architecture_normalized": "arm64",
         "os": "linux",

--- a/tests/data/kubernetes/storage.py
+++ b/tests/data/kubernetes/storage.py
@@ -1,0 +1,125 @@
+from kubernetes.client import V1Container
+from kubernetes.client import V1CSIPersistentVolumeSource
+from kubernetes.client import V1ObjectMeta
+from kubernetes.client import V1ObjectReference
+from kubernetes.client import V1PersistentVolume
+from kubernetes.client import V1PersistentVolumeClaim
+from kubernetes.client import V1PersistentVolumeClaimSpec
+from kubernetes.client import V1PersistentVolumeClaimStatus
+from kubernetes.client import V1PersistentVolumeClaimVolumeSource
+from kubernetes.client import V1PersistentVolumeSpec
+from kubernetes.client import V1PersistentVolumeStatus
+from kubernetes.client import V1Pod
+from kubernetes.client import V1PodSpec
+from kubernetes.client import V1PodStatus
+from kubernetes.client import V1ResourceRequirements
+from kubernetes.client import V1StorageClass
+from kubernetes.client import V1Volume
+from kubernetes.client import V1VolumeMount
+from kubernetes.client import V1VolumeResourceRequirements
+
+STORAGE_CLASS_NAME = "shared-csi"
+VOLUME_NAME = "pvc-00000000-0000-0000-0000-000000000001"
+CLAIM_NAME = "shared-data"
+NAMESPACE = "my-namespace"
+
+RAW_STORAGE_CLASSES = [
+    V1StorageClass(
+        metadata=V1ObjectMeta(name=STORAGE_CLASS_NAME),
+        provisioner="csi.example.com",
+        reclaim_policy="Retain",
+        volume_binding_mode="Immediate",
+        allow_volume_expansion=True,
+        parameters={"filesystem": "project-data"},
+        mount_options=["discard"],
+    )
+]
+
+RAW_PERSISTENT_VOLUMES = [
+    V1PersistentVolume(
+        metadata=V1ObjectMeta(
+            name=VOLUME_NAME,
+            uid="00000000-0000-0000-0000-000000000002",
+            labels={"storage.example.com/tier": "performance"},
+        ),
+        spec=V1PersistentVolumeSpec(
+            capacity={"storage": "2Pi"},
+            access_modes=["ReadWriteMany"],
+            persistent_volume_reclaim_policy="Retain",
+            storage_class_name=STORAGE_CLASS_NAME,
+            volume_mode="Filesystem",
+            claim_ref=V1ObjectReference(namespace=NAMESPACE, name=CLAIM_NAME),
+            csi=V1CSIPersistentVolumeSource(
+                driver="csi.example.com",
+                volume_handle="volume-0001",
+            ),
+        ),
+        status=V1PersistentVolumeStatus(phase="Bound"),
+    )
+]
+
+RAW_PERSISTENT_VOLUME_CLAIMS = [
+    V1PersistentVolumeClaim(
+        metadata=V1ObjectMeta(
+            name=CLAIM_NAME,
+            namespace=NAMESPACE,
+            uid="00000000-0000-0000-0000-000000000003",
+            labels={"data.example.com/classification": "restricted"},
+        ),
+        spec=V1PersistentVolumeClaimSpec(
+            access_modes=["ReadWriteMany"],
+            resources=V1VolumeResourceRequirements(requests={"storage": "2Pi"}),
+            storage_class_name=STORAGE_CLASS_NAME,
+            volume_mode="Filesystem",
+            volume_name=VOLUME_NAME,
+        ),
+        status=V1PersistentVolumeClaimStatus(phase="Bound"),
+    )
+]
+
+RAW_GPU_PODS = [
+    V1Pod(
+        metadata=V1ObjectMeta(
+            name="training-job-head",
+            namespace=NAMESPACE,
+            uid="00000000-0000-0000-0000-000000000004",
+            labels={
+                "scheduler.example.com/user": "user-a",
+                "workload.example.com/node-type": "head",
+            },
+        ),
+        spec=V1PodSpec(
+            node_name="gpu-worker-01",
+            service_account_name="workload-scheduler",
+            volumes=[
+                V1Volume(
+                    name="shared-data",
+                    persistent_volume_claim=V1PersistentVolumeClaimVolumeSource(
+                        claim_name=CLAIM_NAME
+                    ),
+                )
+            ],
+            containers=[
+                V1Container(
+                    name="worker",
+                    image="example.com/training@sha256:0000",
+                    resources=V1ResourceRequirements(
+                        requests={
+                            "cpu": "32",
+                            "memory": "600Gi",
+                            "nvidia.com/gpu": "8",
+                        },
+                        limits={
+                            "memory": "1500Gi",
+                            "nvidia.com/gpu": "8",
+                        },
+                    ),
+                    volume_mounts=[
+                        V1VolumeMount(name="shared-data", mount_path="/data")
+                    ],
+                )
+            ],
+        ),
+        status=V1PodStatus(phase="Running", container_statuses=[]),
+    )
+]

--- a/tests/data/kubernetes/storage.py
+++ b/tests/data/kubernetes/storage.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+from datetime import timezone
+
 from kubernetes.client import V1Container
 from kubernetes.client import V1CSIPersistentVolumeSource
 from kubernetes.client import V1ObjectMeta
@@ -16,16 +19,23 @@ from kubernetes.client import V1ResourceRequirements
 from kubernetes.client import V1StorageClass
 from kubernetes.client import V1Volume
 from kubernetes.client import V1VolumeMount
-from kubernetes.client import V1VolumeResourceRequirements
 
 STORAGE_CLASS_NAME = "shared-csi"
 VOLUME_NAME = "pvc-00000000-0000-0000-0000-000000000001"
 CLAIM_NAME = "shared-data"
 NAMESPACE = "my-namespace"
+CREATION_TIMESTAMP = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+CREATION_EPOCH = 1767323045
+DELETION_TIMESTAMP = datetime(2026, 1, 3, 3, 4, 5, tzinfo=timezone.utc)
+DELETION_EPOCH = 1767409445
 
 RAW_STORAGE_CLASSES = [
     V1StorageClass(
-        metadata=V1ObjectMeta(name=STORAGE_CLASS_NAME),
+        metadata=V1ObjectMeta(
+            name=STORAGE_CLASS_NAME,
+            creation_timestamp=CREATION_TIMESTAMP,
+            deletion_timestamp=DELETION_TIMESTAMP,
+        ),
         provisioner="csi.example.com",
         reclaim_policy="Retain",
         volume_binding_mode="Immediate",
@@ -41,6 +51,8 @@ RAW_PERSISTENT_VOLUMES = [
             name=VOLUME_NAME,
             uid="00000000-0000-0000-0000-000000000002",
             labels={"storage.example.com/tier": "performance"},
+            creation_timestamp=CREATION_TIMESTAMP,
+            deletion_timestamp=DELETION_TIMESTAMP,
         ),
         spec=V1PersistentVolumeSpec(
             capacity={"storage": "2Pi"},
@@ -65,10 +77,12 @@ RAW_PERSISTENT_VOLUME_CLAIMS = [
             namespace=NAMESPACE,
             uid="00000000-0000-0000-0000-000000000003",
             labels={"data.example.com/classification": "restricted"},
+            creation_timestamp=CREATION_TIMESTAMP,
+            deletion_timestamp=DELETION_TIMESTAMP,
         ),
         spec=V1PersistentVolumeClaimSpec(
             access_modes=["ReadWriteMany"],
-            resources=V1VolumeResourceRequirements(requests={"storage": "2Pi"}),
+            resources=V1ResourceRequirements(requests={"storage": "2Pi"}),
             storage_class_name=STORAGE_CLASS_NAME,
             volume_mode="Filesystem",
             volume_name=VOLUME_NAME,

--- a/tests/data/kubernetes/storage.py
+++ b/tests/data/kubernetes/storage.py
@@ -33,6 +33,7 @@ RAW_STORAGE_CLASSES = [
     V1StorageClass(
         metadata=V1ObjectMeta(
             name=STORAGE_CLASS_NAME,
+            uid="00000000-0000-0000-0000-000000000000",
             creation_timestamp=CREATION_TIMESTAMP,
             deletion_timestamp=DELETION_TIMESTAMP,
         ),

--- a/tests/integration/cartography/intel/kubernetes/test_nodes.py
+++ b/tests/integration/cartography/intel/kubernetes/test_nodes.py
@@ -81,6 +81,14 @@ def test_sync_nodes_and_runs_on(neo4j_session, monkeypatch):
         ("my-node",),
         ("my-arm-node",),
     }
+    assert check_nodes(
+        neo4j_session,
+        "KubernetesNode",
+        ["name", "gpu_capacity", "gpu_allocatable", "gpu_product"],
+    ) == {
+        ("my-node", 8, 8, "NVIDIA-H200"),
+        ("my-arm-node", None, None, None),
+    }
 
     # Assert: pod is linked to its scheduled node
     assert check_rels(

--- a/tests/integration/cartography/intel/kubernetes/test_storage.py
+++ b/tests/integration/cartography/intel/kubernetes/test_storage.py
@@ -1,0 +1,221 @@
+from types import SimpleNamespace
+
+import pytest
+from kubernetes.client.exceptions import ApiException
+
+import cartography.intel.kubernetes.pods as pods_module
+import cartography.intel.kubernetes.storage as storage_module
+from cartography.intel.kubernetes.clusters import load_kubernetes_cluster
+from cartography.intel.kubernetes.namespaces import load_namespaces
+from cartography.intel.kubernetes.pods import sync_pods
+from cartography.intel.kubernetes.storage import sync_storage
+from tests.data.kubernetes.clusters import KUBERNETES_CLUSTER_DATA
+from tests.data.kubernetes.clusters import KUBERNETES_CLUSTER_IDS
+from tests.data.kubernetes.clusters import KUBERNETES_CLUSTER_NAMES
+from tests.data.kubernetes.namespaces import KUBERNETES_CLUSTER_1_NAMESPACES_DATA
+from tests.data.kubernetes.storage import CLAIM_NAME
+from tests.data.kubernetes.storage import NAMESPACE
+from tests.data.kubernetes.storage import RAW_GPU_PODS
+from tests.data.kubernetes.storage import RAW_PERSISTENT_VOLUME_CLAIMS
+from tests.data.kubernetes.storage import RAW_PERSISTENT_VOLUMES
+from tests.data.kubernetes.storage import RAW_STORAGE_CLASSES
+from tests.data.kubernetes.storage import STORAGE_CLASS_NAME
+from tests.data.kubernetes.storage import VOLUME_NAME
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+CLUSTER_ID = KUBERNETES_CLUSTER_IDS[0]
+CLUSTER_NAME = KUBERNETES_CLUSTER_NAMES[0]
+
+
+@pytest.fixture
+def _create_test_cluster(neo4j_session):
+    # Arrange
+    load_kubernetes_cluster(neo4j_session, KUBERNETES_CLUSTER_DATA, TEST_UPDATE_TAG)
+    load_namespaces(
+        neo4j_session,
+        KUBERNETES_CLUSTER_1_NAMESPACES_DATA,
+        TEST_UPDATE_TAG,
+        CLUSTER_NAME,
+        CLUSTER_ID,
+    )
+
+
+def _mock_storage(monkeypatch):
+    monkeypatch.setattr(
+        storage_module,
+        "get_storage_classes",
+        lambda client: RAW_STORAGE_CLASSES,
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "get_persistent_volumes",
+        lambda client: RAW_PERSISTENT_VOLUMES,
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "get_persistent_volume_claims",
+        lambda client: RAW_PERSISTENT_VOLUME_CLAIMS,
+    )
+
+
+def test_sync_storage(neo4j_session, monkeypatch, _create_test_cluster):
+    # Arrange
+    _mock_storage(monkeypatch)
+    client = SimpleNamespace(name=CLUSTER_NAME)
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "CLUSTER_ID": CLUSTER_ID}
+
+    # Act
+    sync_storage(neo4j_session, client, TEST_UPDATE_TAG, common_job_parameters)
+
+    # Assert
+    assert check_nodes(
+        neo4j_session,
+        "KubernetesPersistentVolume",
+        ["name", "capacity_storage", "csi_driver", "phase"],
+    ) == {(VOLUME_NAME, "2Pi", "csi.example.com", "Bound")}
+    assert check_nodes(
+        neo4j_session,
+        "KubernetesPersistentVolumeClaim",
+        ["name", "requested_storage", "phase"],
+    ) == {(CLAIM_NAME, "2Pi", "Bound")}
+    assert check_rels(
+        neo4j_session,
+        "KubernetesPersistentVolumeClaim",
+        "name",
+        "KubernetesPersistentVolume",
+        "name",
+        "BOUND_TO",
+    ) == {(CLAIM_NAME, VOLUME_NAME)}
+    assert check_rels(
+        neo4j_session,
+        "KubernetesPersistentVolumeClaim",
+        "name",
+        "KubernetesStorageClass",
+        "name",
+        "USES_STORAGE_CLASS",
+    ) == {(CLAIM_NAME, STORAGE_CLASS_NAME)}
+    assert check_rels(
+        neo4j_session,
+        "KubernetesPersistentVolume",
+        "name",
+        "KubernetesStorageClass",
+        "name",
+        "USES_STORAGE_CLASS",
+    ) == {(VOLUME_NAME, STORAGE_CLASS_NAME)}
+    assert check_rels(
+        neo4j_session,
+        "KubernetesNamespace",
+        "name",
+        "KubernetesPersistentVolumeClaim",
+        "name",
+        "CONTAINS",
+    ) == {(NAMESPACE, CLAIM_NAME)}
+
+
+def test_pod_mounts_persistent_volume_claim(
+    neo4j_session,
+    monkeypatch,
+    _create_test_cluster,
+):
+    # Arrange
+    _mock_storage(monkeypatch)
+    monkeypatch.setattr(pods_module, "get_pods", lambda client: RAW_GPU_PODS)
+    client = SimpleNamespace(name=CLUSTER_NAME)
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "CLUSTER_ID": CLUSTER_ID}
+    sync_storage(neo4j_session, client, TEST_UPDATE_TAG, common_job_parameters)
+
+    # Act
+    sync_pods(neo4j_session, client, TEST_UPDATE_TAG, common_job_parameters)
+
+    # Assert
+    assert check_rels(
+        neo4j_session,
+        "KubernetesPod",
+        "name",
+        "KubernetesPersistentVolumeClaim",
+        "name",
+        "MOUNTS",
+    ) == {("training-job-head", CLAIM_NAME)}
+    assert check_nodes(
+        neo4j_session,
+        "KubernetesContainer",
+        ["name", "gpu_request", "gpu_limit", "resource_requests"],
+    ) == {
+        (
+            "worker",
+            8,
+            8,
+            '{"cpu": "32", "memory": "600Gi", "nvidia.com/gpu": "8"}',
+        )
+    }
+
+
+def test_sync_storage_preserves_nodes_when_forbidden(
+    neo4j_session,
+    monkeypatch,
+    _create_test_cluster,
+):
+    # Arrange
+    _mock_storage(monkeypatch)
+    client = SimpleNamespace(name=CLUSTER_NAME)
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "CLUSTER_ID": CLUSTER_ID}
+    sync_storage(neo4j_session, client, TEST_UPDATE_TAG, common_job_parameters)
+    monkeypatch.setattr(
+        storage_module,
+        "get_storage_classes",
+        lambda client: (_ for _ in ()).throw(ApiException(status=403)),
+    )
+
+    # Act
+    sync_storage(
+        neo4j_session,
+        client,
+        TEST_UPDATE_TAG + 1,
+        {"UPDATE_TAG": TEST_UPDATE_TAG + 1, "CLUSTER_ID": CLUSTER_ID},
+    )
+
+    # Assert
+    assert check_nodes(neo4j_session, "KubernetesStorageClass", ["name"]) == {
+        (STORAGE_CLASS_NAME,)
+    }
+
+
+def test_sync_storage_cleans_up_stale_nodes(
+    neo4j_session,
+    monkeypatch,
+    _create_test_cluster,
+):
+    # Arrange
+    _mock_storage(monkeypatch)
+    client = SimpleNamespace(name=CLUSTER_NAME)
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "CLUSTER_ID": CLUSTER_ID}
+    sync_storage(neo4j_session, client, TEST_UPDATE_TAG, common_job_parameters)
+    monkeypatch.setattr(storage_module, "get_storage_classes", lambda client: [])
+    monkeypatch.setattr(storage_module, "get_persistent_volumes", lambda client: [])
+    monkeypatch.setattr(
+        storage_module,
+        "get_persistent_volume_claims",
+        lambda client: [],
+    )
+
+    # Act
+    sync_storage(
+        neo4j_session,
+        client,
+        TEST_UPDATE_TAG + 1,
+        {"UPDATE_TAG": TEST_UPDATE_TAG + 1, "CLUSTER_ID": CLUSTER_ID},
+    )
+
+    # Assert
+    assert check_nodes(neo4j_session, "KubernetesStorageClass", ["name"]) == set()
+    assert check_nodes(neo4j_session, "KubernetesPersistentVolume", ["name"]) == set()
+    assert (
+        check_nodes(
+            neo4j_session,
+            "KubernetesPersistentVolumeClaim",
+            ["name"],
+        )
+        == set()
+    )

--- a/tests/integration/cartography/intel/kubernetes/test_storage.py
+++ b/tests/integration/cartography/intel/kubernetes/test_storage.py
@@ -14,6 +14,8 @@ from tests.data.kubernetes.clusters import KUBERNETES_CLUSTER_IDS
 from tests.data.kubernetes.clusters import KUBERNETES_CLUSTER_NAMES
 from tests.data.kubernetes.namespaces import KUBERNETES_CLUSTER_1_NAMESPACES_DATA
 from tests.data.kubernetes.storage import CLAIM_NAME
+from tests.data.kubernetes.storage import CREATION_EPOCH
+from tests.data.kubernetes.storage import DELETION_EPOCH
 from tests.data.kubernetes.storage import NAMESPACE
 from tests.data.kubernetes.storage import RAW_GPU_PODS
 from tests.data.kubernetes.storage import RAW_PERSISTENT_VOLUME_CLAIMS
@@ -80,6 +82,16 @@ def test_sync_storage(neo4j_session, monkeypatch, _create_test_cluster):
         "KubernetesPersistentVolumeClaim",
         ["name", "requested_storage", "phase"],
     ) == {(CLAIM_NAME, "2Pi", "Bound")}
+    for label, name in (
+        ("KubernetesStorageClass", STORAGE_CLASS_NAME),
+        ("KubernetesPersistentVolume", VOLUME_NAME),
+        ("KubernetesPersistentVolumeClaim", CLAIM_NAME),
+    ):
+        assert check_nodes(
+            neo4j_session,
+            label,
+            ["name", "creation_timestamp", "deletion_timestamp"],
+        ) == {(name, CREATION_EPOCH, DELETION_EPOCH)}
     assert check_rels(
         neo4j_session,
         "KubernetesPersistentVolumeClaim",
@@ -152,10 +164,23 @@ def test_pod_mounts_persistent_volume_claim(
     }
 
 
-def test_sync_storage_preserves_nodes_when_forbidden(
+@pytest.mark.parametrize(
+    ("getter_name", "status"),
+    (
+        ("get_storage_classes", 401),
+        ("get_storage_classes", 403),
+        ("get_persistent_volumes", 401),
+        ("get_persistent_volumes", 403),
+        ("get_persistent_volume_claims", 401),
+        ("get_persistent_volume_claims", 403),
+    ),
+)
+def test_sync_storage_preserves_nodes_when_unauthorized_or_forbidden(
     neo4j_session,
     monkeypatch,
     _create_test_cluster,
+    getter_name,
+    status,
 ):
     # Arrange
     _mock_storage(monkeypatch)
@@ -164,8 +189,8 @@ def test_sync_storage_preserves_nodes_when_forbidden(
     sync_storage(neo4j_session, client, TEST_UPDATE_TAG, common_job_parameters)
     monkeypatch.setattr(
         storage_module,
-        "get_storage_classes",
-        lambda client: (_ for _ in ()).throw(ApiException(status=403)),
+        getter_name,
+        lambda client: (_ for _ in ()).throw(ApiException(status=status)),
     )
 
     # Act
@@ -177,9 +202,12 @@ def test_sync_storage_preserves_nodes_when_forbidden(
     )
 
     # Assert
-    assert check_nodes(neo4j_session, "KubernetesStorageClass", ["name"]) == {
-        (STORAGE_CLASS_NAME,)
-    }
+    for label, name in (
+        ("KubernetesStorageClass", STORAGE_CLASS_NAME),
+        ("KubernetesPersistentVolume", VOLUME_NAME),
+        ("KubernetesPersistentVolumeClaim", CLAIM_NAME),
+    ):
+        assert check_nodes(neo4j_session, label, ["name"]) == {(name,)}
 
 
 def test_sync_storage_cleans_up_stale_nodes(

--- a/tests/integration/cartography/intel/kubernetes/test_storage.py
+++ b/tests/integration/cartography/intel/kubernetes/test_storage.py
@@ -148,6 +148,15 @@ def test_transform_persistent_volume_claim_without_requests():
     assert result[0]["requested_storage"] is None
 
 
+def test_transform_persistent_volume_claim_rounds_fractional_bytes_up():
+    claim = deepcopy(RAW_PERSISTENT_VOLUME_CLAIMS[0])
+    claim.spec.resources.requests = {"storage": "400m"}
+
+    result = storage_module.transform_persistent_volume_claims([claim], CLUSTER_NAME)
+
+    assert result[0]["requested_storage_bytes"] == 1
+
+
 def test_persistent_volumes_link_to_backing_cloud_disks(
     neo4j_session,
     monkeypatch,

--- a/tests/integration/cartography/intel/kubernetes/test_storage.py
+++ b/tests/integration/cartography/intel/kubernetes/test_storage.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from types import SimpleNamespace
 
 import pytest
@@ -124,6 +125,15 @@ def test_sync_storage(neo4j_session, monkeypatch, _create_test_cluster):
         "name",
         "CONTAINS",
     ) == {(NAMESPACE, CLAIM_NAME)}
+
+
+def test_transform_persistent_volume_claim_without_requests():
+    claim = deepcopy(RAW_PERSISTENT_VOLUME_CLAIMS[0])
+    claim.spec.resources.requests = None
+
+    result = storage_module.transform_persistent_volume_claims([claim], CLUSTER_NAME)
+
+    assert result[0]["requested_storage"] is None
 
 
 def test_pod_mounts_persistent_volume_claim(

--- a/tests/integration/cartography/intel/kubernetes/test_storage.py
+++ b/tests/integration/cartography/intel/kubernetes/test_storage.py
@@ -83,6 +83,11 @@ def test_sync_storage(neo4j_session, monkeypatch, _create_test_cluster):
         "KubernetesPersistentVolumeClaim",
         ["name", "requested_storage", "phase"],
     ) == {(CLAIM_NAME, "2Pi", "Bound")}
+    assert check_nodes(
+        neo4j_session,
+        "KubernetesStorageClass",
+        ["name", "uid"],
+    ) == {(STORAGE_CLASS_NAME, "00000000-0000-0000-0000-000000000000")}
     for label, name in (
         ("KubernetesStorageClass", STORAGE_CLASS_NAME),
         ("KubernetesPersistentVolume", VOLUME_NAME),
@@ -136,6 +141,80 @@ def test_transform_persistent_volume_claim_without_requests():
     assert result[0]["requested_storage"] is None
 
 
+def test_persistent_volumes_link_to_backing_cloud_disks(
+    neo4j_session,
+    monkeypatch,
+    _create_test_cluster,
+):
+    # Arrange
+    aws_volume = deepcopy(RAW_PERSISTENT_VOLUMES[0])
+    aws_volume.metadata.name = "aws-volume"
+    aws_volume.metadata.uid = "aws-volume-uid"
+    aws_volume.spec.csi.driver = "ebs.csi.aws.com"
+    aws_volume.spec.csi.volume_handle = "vol-0123456789abcdef0"
+
+    azure_volume = deepcopy(RAW_PERSISTENT_VOLUMES[0])
+    azure_volume.metadata.name = "azure-volume"
+    azure_volume.metadata.uid = "azure-volume-uid"
+    azure_volume.spec.csi.driver = "disk.csi.azure.com"
+    azure_volume.spec.csi.volume_handle = (
+        "/subscriptions/00000000-0000-0000-0000-000000000000/"
+        "resourceGroups/example/providers/Microsoft.Compute/disks/data"
+    )
+
+    monkeypatch.setattr(
+        storage_module,
+        "get_storage_classes",
+        lambda client: RAW_STORAGE_CLASSES,
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "get_persistent_volumes",
+        lambda client: [aws_volume, azure_volume],
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "get_persistent_volume_claims",
+        lambda client: [],
+    )
+    neo4j_session.run("MERGE (:AWSEBSVolume {id: 'vol-0123456789abcdef0'})")
+    neo4j_session.run(
+        "MERGE (:AzureDisk {id: $id})",
+        id=azure_volume.spec.csi.volume_handle,
+    )
+    client = SimpleNamespace(name=CLUSTER_NAME)
+
+    # Act
+    sync_storage(
+        neo4j_session,
+        client,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "CLUSTER_ID": CLUSTER_ID},
+    )
+
+    # Assert
+    assert check_rels(
+        neo4j_session,
+        "KubernetesPersistentVolume",
+        "name",
+        "AWSEBSVolume",
+        "id",
+        "BACKED_BY",
+    ) == {("aws-volume", "vol-0123456789abcdef0")}
+    assert check_rels(
+        neo4j_session,
+        "KubernetesPersistentVolume",
+        "name",
+        "AzureDisk",
+        "id",
+        "BACKED_BY",
+    ) == {("azure-volume", azure_volume.spec.csi.volume_handle)}
+    neo4j_session.run(
+        "MATCH (v:KubernetesPersistentVolume) "
+        "WHERE v.name IN ['aws-volume', 'azure-volume'] DETACH DELETE v"
+    )
+
+
 def test_pod_mounts_persistent_volume_claim(
     neo4j_session,
     monkeypatch,
@@ -179,13 +258,16 @@ def test_pod_mounts_persistent_volume_claim(
     (
         ("get_storage_classes", 401),
         ("get_storage_classes", 403),
+        ("get_storage_classes", 500),
         ("get_persistent_volumes", 401),
         ("get_persistent_volumes", 403),
+        ("get_persistent_volumes", 500),
         ("get_persistent_volume_claims", 401),
         ("get_persistent_volume_claims", 403),
+        ("get_persistent_volume_claims", 500),
     ),
 )
-def test_sync_storage_preserves_nodes_when_unauthorized_or_forbidden(
+def test_sync_storage_preserves_nodes_on_api_error(
     neo4j_session,
     monkeypatch,
     _create_test_cluster,

--- a/tests/integration/cartography/intel/kubernetes/test_storage.py
+++ b/tests/integration/cartography/intel/kubernetes/test_storage.py
@@ -210,9 +210,16 @@ def test_persistent_volumes_link_to_backing_cloud_disks(
         "BACKED_BY",
     ) == {("azure-volume", azure_volume.spec.csi.volume_handle)}
     neo4j_session.run(
-        "MATCH (v:KubernetesPersistentVolume) "
-        "WHERE v.name IN ['aws-volume', 'azure-volume'] DETACH DELETE v"
+        "MATCH (v) "
+        "WHERE (v:KubernetesPersistentVolume AND "
+        "v.name IN ['aws-volume', 'azure-volume']) "
+        "OR (v:AWSEBSVolume AND v.id = 'vol-0123456789abcdef0') "
+        "OR (v:AzureDisk AND v.id = $azure_disk_id) "
+        "DETACH DELETE v",
+        azure_disk_id=azure_volume.spec.csi.volume_handle,
     )
+    assert check_nodes(neo4j_session, "AWSEBSVolume", ["id"]) == set()
+    assert check_nodes(neo4j_session, "AzureDisk", ["id"]) == set()
 
 
 def test_pod_mounts_persistent_volume_claim(

--- a/tests/integration/cartography/intel/kubernetes/test_storage.py
+++ b/tests/integration/cartography/intel/kubernetes/test_storage.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 from kubernetes.client.exceptions import ApiException
+from urllib3.exceptions import MaxRetryError
 
 import cartography.intel.kubernetes.pods as pods_module
 import cartography.intel.kubernetes.storage as storage_module
@@ -15,8 +16,8 @@ from tests.data.kubernetes.clusters import KUBERNETES_CLUSTER_IDS
 from tests.data.kubernetes.clusters import KUBERNETES_CLUSTER_NAMES
 from tests.data.kubernetes.namespaces import KUBERNETES_CLUSTER_1_NAMESPACES_DATA
 from tests.data.kubernetes.storage import CLAIM_NAME
-from tests.data.kubernetes.storage import CREATION_EPOCH
-from tests.data.kubernetes.storage import DELETION_EPOCH
+from tests.data.kubernetes.storage import CREATION_TIMESTAMP
+from tests.data.kubernetes.storage import DELETION_TIMESTAMP
 from tests.data.kubernetes.storage import NAMESPACE
 from tests.data.kubernetes.storage import RAW_GPU_PODS
 from tests.data.kubernetes.storage import RAW_PERSISTENT_VOLUME_CLAIMS
@@ -76,13 +77,19 @@ def test_sync_storage(neo4j_session, monkeypatch, _create_test_cluster):
     assert check_nodes(
         neo4j_session,
         "KubernetesPersistentVolume",
-        ["name", "capacity_storage", "csi_driver", "phase"],
-    ) == {(VOLUME_NAME, "2Pi", "csi.example.com", "Bound")}
+        [
+            "name",
+            "capacity_storage",
+            "capacity_storage_bytes",
+            "csi_driver",
+            "phase",
+        ],
+    ) == {(VOLUME_NAME, "2Pi", 2251799813685248, "csi.example.com", "Bound")}
     assert check_nodes(
         neo4j_session,
         "KubernetesPersistentVolumeClaim",
-        ["name", "requested_storage", "phase"],
-    ) == {(CLAIM_NAME, "2Pi", "Bound")}
+        ["name", "requested_storage", "requested_storage_bytes", "phase"],
+    ) == {(CLAIM_NAME, "2Pi", 2251799813685248, "Bound")}
     assert check_nodes(
         neo4j_session,
         "KubernetesStorageClass",
@@ -97,7 +104,7 @@ def test_sync_storage(neo4j_session, monkeypatch, _create_test_cluster):
             neo4j_session,
             label,
             ["name", "creation_timestamp", "deletion_timestamp"],
-        ) == {(name, CREATION_EPOCH, DELETION_EPOCH)}
+        ) == {(name, CREATION_TIMESTAMP, DELETION_TIMESTAMP)}
     assert check_rels(
         neo4j_session,
         "KubernetesPersistentVolumeClaim",
@@ -157,9 +164,13 @@ def test_persistent_volumes_link_to_backing_cloud_disks(
     azure_volume.metadata.name = "azure-volume"
     azure_volume.metadata.uid = "azure-volume-uid"
     azure_volume.spec.csi.driver = "disk.csi.azure.com"
-    azure_volume.spec.csi.volume_handle = (
+    azure_disk_id = (
         "/subscriptions/00000000-0000-0000-0000-000000000000/"
         "resourceGroups/example/providers/Microsoft.Compute/disks/data"
+    )
+    azure_volume.spec.csi.volume_handle = (
+        "/subscriptions/00000000-0000-0000-0000-000000000000/"
+        "resourcegroups/example/providers/microsoft.compute/disks/data"
     )
 
     monkeypatch.setattr(
@@ -180,7 +191,7 @@ def test_persistent_volumes_link_to_backing_cloud_disks(
     neo4j_session.run("MERGE (:AWSEBSVolume {id: 'vol-0123456789abcdef0'})")
     neo4j_session.run(
         "MERGE (:AzureDisk {id: $id})",
-        id=azure_volume.spec.csi.volume_handle,
+        id=azure_disk_id,
     )
     client = SimpleNamespace(name=CLUSTER_NAME)
 
@@ -208,7 +219,7 @@ def test_persistent_volumes_link_to_backing_cloud_disks(
         "AzureDisk",
         "id",
         "BACKED_BY",
-    ) == {("azure-volume", azure_volume.spec.csi.volume_handle)}
+    ) == {("azure-volume", azure_disk_id)}
     neo4j_session.run(
         "MATCH (v) "
         "WHERE (v:KubernetesPersistentVolume AND "
@@ -216,7 +227,7 @@ def test_persistent_volumes_link_to_backing_cloud_disks(
         "OR (v:AWSEBSVolume AND v.id = 'vol-0123456789abcdef0') "
         "OR (v:AzureDisk AND v.id = $azure_disk_id) "
         "DETACH DELETE v",
-        azure_disk_id=azure_volume.spec.csi.volume_handle,
+        azure_disk_id=azure_disk_id,
     )
     assert check_nodes(neo4j_session, "AWSEBSVolume", ["id"]) == set()
     assert check_nodes(neo4j_session, "AzureDisk", ["id"]) == set()
@@ -307,6 +318,57 @@ def test_sync_storage_preserves_nodes_on_api_error(
         ("KubernetesPersistentVolumeClaim", CLAIM_NAME),
     ):
         assert check_nodes(neo4j_session, label, ["name"]) == {(name,)}
+
+
+def test_sync_storage_raises_unexpected_api_error(
+    neo4j_session,
+    monkeypatch,
+    _create_test_cluster,
+):
+    monkeypatch.setattr(
+        storage_module,
+        "get_storage_classes",
+        lambda client: (_ for _ in ()).throw(ApiException(status=400)),
+    )
+
+    with pytest.raises(ApiException):
+        sync_storage(
+            neo4j_session,
+            SimpleNamespace(name=CLUSTER_NAME),
+            TEST_UPDATE_TAG,
+            {"UPDATE_TAG": TEST_UPDATE_TAG, "CLUSTER_ID": CLUSTER_ID},
+        )
+
+
+def test_sync_storage_preserves_nodes_on_transport_error(
+    neo4j_session,
+    monkeypatch,
+    _create_test_cluster,
+):
+    _mock_storage(monkeypatch)
+    client = SimpleNamespace(name=CLUSTER_NAME)
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "CLUSTER_ID": CLUSTER_ID}
+    sync_storage(neo4j_session, client, TEST_UPDATE_TAG, common_job_parameters)
+    monkeypatch.setattr(
+        storage_module,
+        "get_storage_classes",
+        lambda client: (_ for _ in ()).throw(
+            MaxRetryError(None, "/api/v1/persistentvolumes", "connection refused")
+        ),
+    )
+
+    sync_storage(
+        neo4j_session,
+        client,
+        TEST_UPDATE_TAG + 1,
+        {"UPDATE_TAG": TEST_UPDATE_TAG + 1, "CLUSTER_ID": CLUSTER_ID},
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "KubernetesPersistentVolume",
+        ["name"],
+    ) == {(VOLUME_NAME,)}
 
 
 def test_sync_storage_cleans_up_stale_nodes(

--- a/tests/unit/cartography/intel/kubernetes/test_init.py
+++ b/tests/unit/cartography/intel/kubernetes/test_init.py
@@ -32,6 +32,7 @@ def test_start_k8s_ingestion_uses_external_id_for_eks_region(monkeypatch):
         kubernetes, "sync_kubernetes_rbac", lambda *args, **kwargs: None
     )
     monkeypatch.setattr(kubernetes, "sync_workloads", lambda *args, **kwargs: {})
+    monkeypatch.setattr(kubernetes, "sync_storage", lambda *args, **kwargs: None)
     monkeypatch.setattr(kubernetes, "sync_pods", lambda *args, **kwargs: [])
     monkeypatch.setattr(kubernetes, "sync_secrets", lambda *args, **kwargs: None)
     monkeypatch.setattr(kubernetes, "sync_services", lambda *args, **kwargs: None)

--- a/tests/unit/cartography/intel/kubernetes/test_pods.py
+++ b/tests/unit/cartography/intel/kubernetes/test_pods.py
@@ -48,6 +48,8 @@ def test_transform_pods_defaults_service_account_name():
             "host_network": None,
             "seccomp_profile_type": None,
             "host_path_volume_paths": [],
+            "persistent_volume_claim_names": [],
+            "persistent_volume_claim_ids": [],
             "service_account_id": "my-cluster-1/my-namespace/default",
             "node": "node-a",
             "node_id": "my-cluster-1/node-a",

--- a/tests/unit/cartography/intel/kubernetes/test_pods.py
+++ b/tests/unit/cartography/intel/kubernetes/test_pods.py
@@ -1,7 +1,14 @@
 import json
+from copy import deepcopy
 from types import SimpleNamespace
 
+from kubernetes.client import V1EphemeralVolumeSource
+from kubernetes.client import V1PersistentVolumeClaimSpec
+from kubernetes.client import V1PersistentVolumeClaimTemplate
+from kubernetes.client import V1Volume
+
 from cartography.intel.kubernetes.pods import transform_pods
+from tests.data.kubernetes.storage import RAW_GPU_PODS
 
 
 def test_transform_pods_defaults_service_account_name():
@@ -59,6 +66,28 @@ def test_transform_pods_defaults_service_account_name():
             "secret_volume_ids": [],
             "secret_env_ids": [],
         },
+    ]
+
+
+def test_transform_pods_maps_generic_ephemeral_volume_to_generated_claim():
+    pod = deepcopy(RAW_GPU_PODS[0])
+    pod.metadata.name = "ephemeral-pod"
+    pod.spec.volumes = [
+        V1Volume(
+            name="scratch",
+            ephemeral=V1EphemeralVolumeSource(
+                volume_claim_template=V1PersistentVolumeClaimTemplate(
+                    spec=V1PersistentVolumeClaimSpec()
+                )
+            ),
+        )
+    ]
+
+    transformed = transform_pods([pod], "my-cluster-1")
+
+    assert transformed[0]["persistent_volume_claim_names"] == ["ephemeral-pod-scratch"]
+    assert transformed[0]["persistent_volume_claim_ids"] == [
+        "my-cluster-1/my-namespace/ephemeral-pod-scratch"
     ]
 
 

--- a/tests/unit/cartography/intel/kubernetes/test_util.py
+++ b/tests/unit/cartography/intel/kubernetes/test_util.py
@@ -35,7 +35,7 @@ def test_k8s_paginate_raise_on_forbidden_is_status_scoped():
 
 def test_get_gpu_quantity_sums_extended_gpu_resources():
     assert (
-        get_gpu_quantity({"cpu": "32", "nvidia.com/gpu": "8", "example.com/gpu": "2"})
+        get_gpu_quantity({"cpu": "32", "nvidia.com/gpu": "8", "example.com/gpu": "2e0"})
         == 10
     )
     assert get_gpu_quantity({"example.com/gpu": "not-a-number"}) is None

--- a/tests/unit/cartography/intel/kubernetes/test_util.py
+++ b/tests/unit/cartography/intel/kubernetes/test_util.py
@@ -1,6 +1,7 @@
 import pytest
 from kubernetes.client.exceptions import ApiException
 
+from cartography.intel.kubernetes.util import get_gpu_quantity
 from cartography.intel.kubernetes.util import k8s_paginate
 
 
@@ -30,3 +31,11 @@ def test_k8s_paginate_raise_on_forbidden_is_status_scoped():
     with pytest.raises(ApiException):
         k8s_paginate(_raiser(403), raise_on_forbidden=True)
     assert k8s_paginate(_raiser(500), raise_on_forbidden=True) == []
+
+
+def test_get_gpu_quantity_sums_extended_gpu_resources():
+    assert (
+        get_gpu_quantity({"cpu": "32", "nvidia.com/gpu": "8", "example.com/gpu": "2"})
+        == 10
+    )
+    assert get_gpu_quantity({"example.com/gpu": "not-a-number"}) is None

--- a/tests/unit/cartography/intel/kubernetes/test_util.py
+++ b/tests/unit/cartography/intel/kubernetes/test_util.py
@@ -35,7 +35,16 @@ def test_k8s_paginate_raise_on_forbidden_is_status_scoped():
 
 def test_get_gpu_quantity_sums_extended_gpu_resources():
     assert (
-        get_gpu_quantity({"cpu": "32", "nvidia.com/gpu": "8", "example.com/gpu": "2e0"})
-        == 10
+        get_gpu_quantity(
+            {
+                "cpu": "32",
+                "nvidia.com/gpu": "8",
+                "nvidia.com/mig-1g.10gb": "7",
+                "gpu.intel.com/i915": "2",
+                "example.com/gpu": "2e0",
+                "gpu.intel.com/monitoring": "1",
+            }
+        )
+        == 19
     )
     assert get_gpu_quantity({"example.com/gpu": "not-a-number"}) is None


### PR DESCRIPTION
### Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

### Summary

Expose Kubernetes GPU capacity, allocatable GPU count, product labels, and container GPU requests and limits without adding vendor-specific node types. Preserve complete resource request, limit, capacity, and allocatable maps as sorted JSON so other extended resources remain queryable.

Ingest StorageClasses, PersistentVolumes, and PersistentVolumeClaims. Connect pods to claims with `MOUNTS`, claims to volumes with `BOUND_TO`, and volumes and claims to storage classes with `USES_STORAGE_CLASS`. During the pre-1.0 permission migration, a 401 or 403 skips storage ingestion and cleanup so an upgraded deployment does not erase previously synced storage data.



### How was this tested?

- Added relevant tests 
- Ran the modified connector against a live Kubernetes 1.34 API and loaded the result into a new isolated Neo4j database. The redacted result was:

  ```text
  live Kubernetes sync completed
  {"claims": 0, "nodes": 2, "pods": 18, "storage_classes": 1, "volumes": 0}
  ```

- Loaded anonymized Kubernetes SDK response shapes into the isolated database to exercise the complete GPU pod to PVC to PV to StorageClass path:

  ```text
  {"claims": 1, "gpu_pods": 1, "max_gpu_limit": 8, "max_gpu_request": 8, "storage_classes": 1, "volumes": 1}
  ```

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [x] Tested the connector against a real cloud, SaaS, or provider environment.
- [x] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [x] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).

### Notes for reviewers

The fixtures use synthetic UIDs, example domains, and generic scheduler labels. They contain no customer names, cluster identifiers, storage handles, or credentials.

