### PR TITLE
feat(kubernetes): map container PVC access

### DIFF
--- a/cartography/intel/kubernetes/pods.py
+++ b/cartography/intel/kubernetes/pods.py
@@ -21,6 +21,10 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 
 
+def _claim_id(cluster_name: str, namespace: str, claim_name: str) -> str:
+    return f"{cluster_name}/{namespace}/{claim_name}"
+
+
 def _get_claim_name_by_volume_name(pod: V1Pod) -> dict[str, str]:
     claims = {}
     for volume in pod.spec.volumes or []:
@@ -58,19 +62,23 @@ def _extract_pod_containers(
             "container_ports": json.dumps([]),
             "container_port_numbers": [],
             "persistent_volume_claim_ids": [],
+            "persistent_volume_claim_read_write_ids": [],
             "persistent_volume_claim_mounts": "[]",
             "persistent_volume_claim_device_ids": [],
             "persistent_volume_claim_devices": "[]",
         }
 
         claim_ids = set()
+        read_write_claim_ids = set()
         mount_details = []
         for mount in container.volume_mounts or []:
             claim_name = claim_by_volume_name.get(mount.name)
             if not claim_name:
                 continue
-            claim_id = f"{cluster_name}/{pod.metadata.namespace}/{claim_name}"
+            claim_id = _claim_id(cluster_name, pod.metadata.namespace, claim_name)
             claim_ids.add(claim_id)
+            if not mount.read_only:
+                read_write_claim_ids.add(claim_id)
             mount_details.append(
                 {
                     "claim_id": claim_id,
@@ -94,6 +102,9 @@ def _extract_pod_containers(
             )
         )
         containers[container.name]["persistent_volume_claim_ids"] = sorted(claim_ids)
+        containers[container.name]["persistent_volume_claim_read_write_ids"] = sorted(
+            read_write_claim_ids
+        )
         containers[container.name]["persistent_volume_claim_mounts"] = json.dumps(
             mount_details,
             sort_keys=True,
@@ -105,7 +116,7 @@ def _extract_pod_containers(
             claim_name = claim_by_volume_name.get(device.name)
             if not claim_name:
                 continue
-            claim_id = f"{cluster_name}/{pod.metadata.namespace}/{claim_name}"
+            claim_id = _claim_id(cluster_name, pod.metadata.namespace, claim_name)
             device_claim_ids.add(claim_id)
             device_details.append(
                 {
@@ -411,7 +422,7 @@ def transform_pods(
                 ),
                 "persistent_volume_claim_names": persistent_volume_claim_names,
                 "persistent_volume_claim_ids": [
-                    f"{cluster_name}/{pod.metadata.namespace}/{claim_name}"
+                    _claim_id(cluster_name, pod.metadata.namespace, claim_name)
                     for claim_name in persistent_volume_claim_names
                 ],
                 "service_account_id": (

--- a/cartography/intel/kubernetes/pods.py
+++ b/cartography/intel/kubernetes/pods.py
@@ -59,6 +59,8 @@ def _extract_pod_containers(
             "container_port_numbers": [],
             "persistent_volume_claim_ids": [],
             "persistent_volume_claim_mounts": "[]",
+            "persistent_volume_claim_device_ids": [],
+            "persistent_volume_claim_devices": "[]",
         }
 
         claim_ids = set()
@@ -94,6 +96,37 @@ def _extract_pod_containers(
         containers[container.name]["persistent_volume_claim_ids"] = sorted(claim_ids)
         containers[container.name]["persistent_volume_claim_mounts"] = json.dumps(
             mount_details,
+            sort_keys=True,
+        )
+
+        device_claim_ids = set()
+        device_details = []
+        for device in getattr(container, "volume_devices", None) or []:
+            claim_name = claim_by_volume_name.get(device.name)
+            if not claim_name:
+                continue
+            claim_id = f"{cluster_name}/{pod.metadata.namespace}/{claim_name}"
+            device_claim_ids.add(claim_id)
+            device_details.append(
+                {
+                    "claim_id": claim_id,
+                    "claim_name": claim_name,
+                    "volume_name": device.name,
+                    "device_path": device.device_path,
+                }
+            )
+        device_details.sort(
+            key=lambda detail: (
+                detail["claim_id"],
+                detail["device_path"],
+                detail["volume_name"],
+            )
+        )
+        containers[container.name]["persistent_volume_claim_device_ids"] = sorted(
+            device_claim_ids
+        )
+        containers[container.name]["persistent_volume_claim_devices"] = json.dumps(
+            device_details,
             sort_keys=True,
         )
 

--- a/cartography/intel/kubernetes/pods.py
+++ b/cartography/intel/kubernetes/pods.py
@@ -21,7 +21,22 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 
 
-def _extract_pod_containers(pod: V1Pod, node_arch: str | None = None) -> dict[str, Any]:
+def _get_claim_name_by_volume_name(pod: V1Pod) -> dict[str, str]:
+    claims = {}
+    for volume in pod.spec.volumes or []:
+        if volume.persistent_volume_claim and volume.persistent_volume_claim.claim_name:
+            claims[volume.name] = volume.persistent_volume_claim.claim_name
+        elif volume.ephemeral:
+            claims[volume.name] = f"{pod.metadata.name}-{volume.name}"
+    return claims
+
+
+def _extract_pod_containers(
+    pod: V1Pod,
+    cluster_name: str,
+    claim_by_volume_name: dict[str, str],
+    node_arch: str | None = None,
+) -> dict[str, Any]:
     pod_containers: list[V1Container] = pod.spec.containers
     containers = dict()
     for container in pod_containers:
@@ -42,7 +57,45 @@ def _extract_pod_containers(pod: V1Pod, node_arch: str | None = None) -> dict[st
             "host_ports": [],
             "container_ports": json.dumps([]),
             "container_port_numbers": [],
+            "persistent_volume_claim_ids": [],
+            "persistent_volume_claim_mounts": "[]",
         }
+
+        claim_ids = set()
+        mount_details = []
+        for mount in container.volume_mounts or []:
+            claim_name = claim_by_volume_name.get(mount.name)
+            if not claim_name:
+                continue
+            claim_id = f"{cluster_name}/{pod.metadata.namespace}/{claim_name}"
+            claim_ids.add(claim_id)
+            mount_details.append(
+                {
+                    "claim_id": claim_id,
+                    "claim_name": claim_name,
+                    "volume_name": mount.name,
+                    "mount_path": mount.mount_path,
+                    "read_only": bool(mount.read_only),
+                    "sub_path": mount.sub_path,
+                    "sub_path_expr": mount.sub_path_expr,
+                    "mount_propagation": mount.mount_propagation,
+                    "recursive_read_only": getattr(mount, "recursive_read_only", None),
+                }
+            )
+        mount_details.sort(
+            key=lambda detail: (
+                detail["claim_id"],
+                detail["mount_path"],
+                detail["volume_name"],
+                detail["sub_path"] or "",
+                detail["sub_path_expr"] or "",
+            )
+        )
+        containers[container.name]["persistent_volume_claim_ids"] = sorted(claim_ids)
+        containers[container.name]["persistent_volume_claim_mounts"] = json.dumps(
+            mount_details,
+            sort_keys=True,
+        )
 
         security_context = getattr(container, "security_context", None)
         if security_context:
@@ -280,26 +333,19 @@ def transform_pods(
 
     for pod in pods:
         node_arch = arch_map.get(pod.spec.node_name or "")
-        containers = _extract_pod_containers(pod, node_arch=node_arch)
+        claim_by_volume_name = _get_claim_name_by_volume_name(pod)
+        containers = _extract_pod_containers(
+            pod,
+            cluster_name,
+            claim_by_volume_name,
+            node_arch=node_arch,
+        )
         volume_secrets, env_secrets = _extract_pod_secrets(pod, cluster_name)
         service_account_name = pod.spec.service_account_name or "default"
         workload_parent = _resolve_pod_workload_parent(
             pod, rs_owner_map, workloads_available=workloads_available
         )
-        persistent_volume_claim_name_set = set()
-        for volume in pod.spec.volumes or []:
-            if (
-                volume.persistent_volume_claim
-                and volume.persistent_volume_claim.claim_name
-            ):
-                persistent_volume_claim_name_set.add(
-                    volume.persistent_volume_claim.claim_name
-                )
-            elif volume.ephemeral:
-                persistent_volume_claim_name_set.add(
-                    f"{pod.metadata.name}-{volume.name}"
-                )
-        persistent_volume_claim_names = sorted(persistent_volume_claim_name_set)
+        persistent_volume_claim_names = sorted(set(claim_by_volume_name.values()))
         transformed_pods.append(
             {
                 **workload_parent,

--- a/cartography/models/kubernetes/containers.py
+++ b/cartography/models/kubernetes/containers.py
@@ -101,6 +101,14 @@ class KubernetesContainerNodeProperties(CartographyNodeProperties):
         extra_index=True,
         description="Total GPU scheduling-unit limit across full-GPU, NVIDIA MIG, and Intel GPU resource keys; heterogeneous units are not normalized to physical GPUs.",
     )
+    persistent_volume_claim_ids: PropertyRef = PropertyRef(
+        "persistent_volume_claim_ids",
+        description="Identifiers of PersistentVolumeClaims mounted by the container.",
+    )
+    persistent_volume_claim_mounts: PropertyRef = PropertyRef(
+        "persistent_volume_claim_mounts",
+        description="Kubernetes PersistentVolumeClaim mount settings stored as a JSON-encoded list.",
+    )
     allow_privilege_escalation: PropertyRef = PropertyRef(
         "allow_privilege_escalation",
         description="Whether the container explicitly allows privilege escalation. Derived from `container.security_context.allow_privilege_escalation`.",
@@ -336,6 +344,24 @@ class KubernetesContainerToGitHubContainerImageRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class KubernetesContainerToPersistentVolumeClaimRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesContainerToPersistentVolumeClaimRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesPersistentVolumeClaim"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("persistent_volume_claim_ids", one_to_many=True)}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MOUNTS"
+    properties: KubernetesContainerToPersistentVolumeClaimRelProperties = (
+        KubernetesContainerToPersistentVolumeClaimRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class KubernetesContainerSchema(CartographyNodeSchema):
     "A container declared by a Kubernetes pod."
 
@@ -354,5 +380,6 @@ class KubernetesContainerSchema(CartographyNodeSchema):
             KubernetesContainerToGitLabContainerImageRel(),
             KubernetesContainerToGCPArtifactRegistryImageRel(),
             KubernetesContainerToGitHubContainerImageRel(),
+            KubernetesContainerToPersistentVolumeClaimRel(),
         ]
     )

--- a/cartography/models/kubernetes/containers.py
+++ b/cartography/models/kubernetes/containers.py
@@ -101,21 +101,17 @@ class KubernetesContainerNodeProperties(CartographyNodeProperties):
         extra_index=True,
         description="Total GPU scheduling-unit limit across full-GPU, NVIDIA MIG, and Intel GPU resource keys; heterogeneous units are not normalized to physical GPUs.",
     )
-    persistent_volume_claim_ids: PropertyRef = PropertyRef(
-        "persistent_volume_claim_ids",
-        description="Identifiers of PersistentVolumeClaims mounted by the container.",
+    persistent_volume_claim_read_write_ids: PropertyRef = PropertyRef(
+        "persistent_volume_claim_read_write_ids",
+        description="Identifiers of PersistentVolumeClaims with at least one read-write entry in `container.volumeMounts[]`.",
     )
     persistent_volume_claim_mounts: PropertyRef = PropertyRef(
         "persistent_volume_claim_mounts",
-        description="Kubernetes PersistentVolumeClaim mount settings stored as a JSON-encoded list.",
-    )
-    persistent_volume_claim_device_ids: PropertyRef = PropertyRef(
-        "persistent_volume_claim_device_ids",
-        description="Identifiers of PersistentVolumeClaims exposed to the container as raw block devices.",
+        description="PersistentVolumeClaim mount settings from `container.volumeMounts[]`, stored as a JSON-encoded list.",
     )
     persistent_volume_claim_devices: PropertyRef = PropertyRef(
         "persistent_volume_claim_devices",
-        description="Kubernetes PersistentVolumeClaim raw block device settings stored as a JSON-encoded list.",
+        description="PersistentVolumeClaim raw block device settings from `container.volumeDevices[]`, stored as a JSON-encoded list.",
     )
     allow_privilege_escalation: PropertyRef = PropertyRef(
         "allow_privilege_escalation",
@@ -358,6 +354,8 @@ class KubernetesContainerToPersistentVolumeClaimRelProperties(CartographyRelProp
 
 @dataclass(frozen=True)
 class KubernetesContainerToPersistentVolumeClaimRel(CartographyRelSchema):
+    """Links a container to a PersistentVolumeClaim mounted as a filesystem."""
+
     target_node_label: str = "KubernetesPersistentVolumeClaim"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("persistent_volume_claim_ids", one_to_many=True)}
@@ -378,6 +376,8 @@ class KubernetesContainerToPersistentVolumeClaimDeviceRelProperties(
 
 @dataclass(frozen=True)
 class KubernetesContainerToPersistentVolumeClaimDeviceRel(CartographyRelSchema):
+    """Links a container to a PersistentVolumeClaim exposed as a block device."""
+
     target_node_label: str = "KubernetesPersistentVolumeClaim"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
         {"id": PropertyRef("persistent_volume_claim_device_ids", one_to_many=True)}

--- a/cartography/models/kubernetes/containers.py
+++ b/cartography/models/kubernetes/containers.py
@@ -109,6 +109,14 @@ class KubernetesContainerNodeProperties(CartographyNodeProperties):
         "persistent_volume_claim_mounts",
         description="Kubernetes PersistentVolumeClaim mount settings stored as a JSON-encoded list.",
     )
+    persistent_volume_claim_device_ids: PropertyRef = PropertyRef(
+        "persistent_volume_claim_device_ids",
+        description="Identifiers of PersistentVolumeClaims exposed to the container as raw block devices.",
+    )
+    persistent_volume_claim_devices: PropertyRef = PropertyRef(
+        "persistent_volume_claim_devices",
+        description="Kubernetes PersistentVolumeClaim raw block device settings stored as a JSON-encoded list.",
+    )
     allow_privilege_escalation: PropertyRef = PropertyRef(
         "allow_privilege_escalation",
         description="Whether the container explicitly allows privilege escalation. Derived from `container.security_context.allow_privilege_escalation`.",
@@ -362,6 +370,26 @@ class KubernetesContainerToPersistentVolumeClaimRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class KubernetesContainerToPersistentVolumeClaimDeviceRelProperties(
+    CartographyRelProperties
+):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesContainerToPersistentVolumeClaimDeviceRel(CartographyRelSchema):
+    target_node_label: str = "KubernetesPersistentVolumeClaim"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("persistent_volume_claim_device_ids", one_to_many=True)}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_BLOCK_DEVICE"
+    properties: KubernetesContainerToPersistentVolumeClaimDeviceRelProperties = (
+        KubernetesContainerToPersistentVolumeClaimDeviceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class KubernetesContainerSchema(CartographyNodeSchema):
     "A container declared by a Kubernetes pod."
 
@@ -381,5 +409,6 @@ class KubernetesContainerSchema(CartographyNodeSchema):
             KubernetesContainerToGCPArtifactRegistryImageRel(),
             KubernetesContainerToGitHubContainerImageRel(),
             KubernetesContainerToPersistentVolumeClaimRel(),
+            KubernetesContainerToPersistentVolumeClaimDeviceRel(),
         ]
     )

--- a/cartography/models/kubernetes/pods.py
+++ b/cartography/models/kubernetes/pods.py
@@ -489,7 +489,7 @@ class KubernetesPodToPersistentVolumeClaimRel(CartographyRelSchema):
         {"id": PropertyRef("persistent_volume_claim_ids", one_to_many=True)}
     )
     direction: LinkDirection = LinkDirection.OUTWARD
-    rel_label: str = "MOUNTS"
+    rel_label: str = "REFERENCES"
     properties: KubernetesPodToPersistentVolumeClaimRelProperties = (
         KubernetesPodToPersistentVolumeClaimRelProperties()
     )

--- a/docs/root/modules/kubernetes/index.md
+++ b/docs/root/modules/kubernetes/index.md
@@ -14,6 +14,11 @@ individual containers. Each container's `persistent_volume_claim_mounts`
 property preserves the claim identifier, mount path, read-only setting, and
 other per-mount Kubernetes configuration as a JSON-encoded list.
 
+For raw block volumes, container `USES_BLOCK_DEVICE` relationships and the
+`persistent_volume_claim_devices` property preserve the claim identifier and
+device path. Pod `REFERENCES` relationships identify claims declared by pod
+volumes, including claims that no container mounts.
+
 Use the configuration guide to grant read-only access and connect one or more
 clusters. The schema reference is generated from the model definitions and is
 included automatically in the built documentation. The query guide contains
@@ -34,9 +39,9 @@ policies use `APPLIES_TO` edges to identify selected pods.
 Until v1.0.0, if the identity cannot list persistent volumes, persistent volume
 claims, or storage classes, Cartography skips persistent storage ingestion and
 cleanup and preserves existing storage nodes. Pods continue to load. On a first
-sync, they have no `MOUNTS` relationships. After an earlier successful storage
-sync, pods can link to the preserved storage snapshot, which may be stale until
-permissions are restored.
+sync, they have no `REFERENCES` relationships. After an earlier successful
+storage sync, pods can link to the preserved storage snapshot, which may be stale
+until permissions are restored.
 
 If the identity cannot list secrets, Cartography skips secret ingestion and
 cleanup and preserves existing `KubernetesSecret` nodes. Cartography stores

--- a/docs/root/modules/kubernetes/index.md
+++ b/docs/root/modules/kubernetes/index.md
@@ -12,12 +12,18 @@ already-ingested cloud disks with `BACKED_BY` relationships.
 Container `MOUNTS` relationships identify the PersistentVolumeClaims used by
 individual containers. Each container's `persistent_volume_claim_mounts`
 property preserves the claim identifier, mount path, read-only setting, and
-other per-mount Kubernetes configuration as a JSON-encoded list.
+other per-mount Kubernetes configuration as a JSON-encoded list. The
+`persistent_volume_claim_read_write_ids` property provides a queryable list of
+claims that have at least one read-write mount.
 
 For raw block volumes, container `USES_BLOCK_DEVICE` relationships and the
 `persistent_volume_claim_devices` property preserve the claim identifier and
 device path. Pod `REFERENCES` relationships identify claims declared by pod
 volumes, including claims that no container mounts.
+
+Container storage relationships currently cover regular application containers
+in `spec.containers`. Init containers and ephemeral containers aren't modeled as
+`KubernetesContainer` nodes.
 
 Use the configuration guide to grant read-only access and connect one or more
 clusters. The schema reference is generated from the model definitions and is
@@ -39,9 +45,10 @@ policies use `APPLIES_TO` edges to identify selected pods.
 Until v1.0.0, if the identity cannot list persistent volumes, persistent volume
 claims, or storage classes, Cartography skips persistent storage ingestion and
 cleanup and preserves existing storage nodes. Pods continue to load. On a first
-sync, they have no `REFERENCES` relationships. After an earlier successful
-storage sync, pods can link to the preserved storage snapshot, which may be stale
-until permissions are restored.
+sync, pods have no `REFERENCES` relationships and containers have no `MOUNTS` or
+`USES_BLOCK_DEVICE` relationships. After an earlier successful storage sync,
+pods and containers can link to the preserved storage snapshot, which may be
+stale until permissions are restored.
 
 If the identity cannot list secrets, Cartography skips secret ingestion and
 cleanup and preserves existing `KubernetesSecret` nodes. Cartography stores

--- a/docs/root/modules/kubernetes/index.md
+++ b/docs/root/modules/kubernetes/index.md
@@ -9,6 +9,11 @@ identity paths can be queried across providers.
 PersistentVolumes managed by the AWS EBS or Azure Disk CSI drivers connect to
 already-ingested cloud disks with `BACKED_BY` relationships.
 
+Container `MOUNTS` relationships identify the PersistentVolumeClaims used by
+individual containers. Each container's `persistent_volume_claim_mounts`
+property preserves the claim identifier, mount path, read-only setting, and
+other per-mount Kubernetes configuration as a JSON-encoded list.
+
 Use the configuration guide to grant read-only access and connect one or more
 clusters. The schema reference is generated from the model definitions and is
 included automatically in the built documentation. The query guide contains

--- a/docs/root/modules/kubernetes/queries.md
+++ b/docs/root/modules/kubernetes/queries.md
@@ -21,20 +21,24 @@ ORDER BY k.name;
 ## Map GPU workloads to persistent storage
 
 Find GPU-requesting containers, their scheduled nodes, and the persistent storage
-mounted by those containers:
+mounted or exposed as a raw block device to those containers:
 
 ```cypher
 MATCH (container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod:KubernetesPod)
 MATCH (pod)-[:RUNS_ON]->(node:KubernetesNode)
 WHERE container.gpu_request > 0 OR container.gpu_limit > 0
-OPTIONAL MATCH (container)-[:MOUNTS]->(claim:KubernetesPersistentVolumeClaim)
+OPTIONAL MATCH (container)
+  -[storage_access:MOUNTS|USES_BLOCK_DEVICE]->
+  (claim:KubernetesPersistentVolumeClaim)
 OPTIONAL MATCH (claim)-[:BOUND_TO]->(volume:KubernetesPersistentVolume)
 OPTIONAL MATCH (volume)-[:BACKED_BY]->(cloud_disk)
 OPTIONAL MATCH (claim)-[:USES_STORAGE_CLASS]->(storage_class:KubernetesStorageClass)
 RETURN pod.namespace, pod.name, container.name,
        container.gpu_request, container.gpu_limit,
        node.name, node.gpu_product, node.gpu_capacity,
-       claim.name, container.persistent_volume_claim_mounts,
+       type(storage_access), claim.name,
+       container.persistent_volume_claim_mounts,
+       container.persistent_volume_claim_devices,
        volume.name, volume.csi_driver,
        labels(cloud_disk), cloud_disk.id, storage_class.name
 ORDER BY pod.namespace, pod.name, container.name;

--- a/docs/root/modules/kubernetes/queries.md
+++ b/docs/root/modules/kubernetes/queries.md
@@ -21,20 +21,21 @@ ORDER BY k.name;
 ## Map GPU workloads to persistent storage
 
 Find GPU-requesting containers, their scheduled nodes, and the persistent storage
-mounted by their pods:
+mounted by those containers:
 
 ```cypher
 MATCH (container:KubernetesContainer)-[:WORKLOAD_PARENT]->(pod:KubernetesPod)
 MATCH (pod)-[:RUNS_ON]->(node:KubernetesNode)
 WHERE container.gpu_request > 0 OR container.gpu_limit > 0
-OPTIONAL MATCH (pod)-[:MOUNTS]->(claim:KubernetesPersistentVolumeClaim)
+OPTIONAL MATCH (container)-[:MOUNTS]->(claim:KubernetesPersistentVolumeClaim)
 OPTIONAL MATCH (claim)-[:BOUND_TO]->(volume:KubernetesPersistentVolume)
 OPTIONAL MATCH (volume)-[:BACKED_BY]->(cloud_disk)
 OPTIONAL MATCH (claim)-[:USES_STORAGE_CLASS]->(storage_class:KubernetesStorageClass)
 RETURN pod.namespace, pod.name, container.name,
        container.gpu_request, container.gpu_limit,
        node.name, node.gpu_product, node.gpu_capacity,
-       claim.name, volume.name, volume.csi_driver,
+       claim.name, container.persistent_volume_claim_mounts,
+       volume.name, volume.csi_driver,
        labels(cloud_disk), cloud_disk.id, storage_class.name
 ORDER BY pod.namespace, pod.name, container.name;
 ```

--- a/docs/root/modules/kubernetes/queries.md
+++ b/docs/root/modules/kubernetes/queries.md
@@ -37,8 +37,11 @@ RETURN pod.namespace, pod.name, container.name,
        container.gpu_request, container.gpu_limit,
        node.name, node.gpu_product, node.gpu_capacity,
        type(storage_access), claim.name,
-       container.persistent_volume_claim_mounts,
-       container.persistent_volume_claim_devices,
+       CASE type(storage_access)
+         WHEN 'MOUNTS' THEN
+           claim.id IN coalesce(container.persistent_volume_claim_read_write_ids, [])
+         ELSE null
+       END AS read_write,
        volume.name, volume.csi_driver,
        labels(cloud_disk), cloud_disk.id, storage_class.name
 ORDER BY pod.namespace, pod.name, container.name;

--- a/tests/data/kubernetes/nodes.py
+++ b/tests/data/kubernetes/nodes.py
@@ -71,6 +71,7 @@ RAW_PODS = [
                     resources=None,
                     env=None,
                     env_from=None,
+                    volume_mounts=None,
                 ),
             ],
             volumes=[],

--- a/tests/data/kubernetes/storage.py
+++ b/tests/data/kubernetes/storage.py
@@ -130,7 +130,13 @@ RAW_GPU_PODS = [
                         },
                     ),
                     volume_mounts=[
-                        V1VolumeMount(name="shared-data", mount_path="/data")
+                        V1VolumeMount(
+                            name="shared-data",
+                            mount_path="/data",
+                            mount_propagation="None",
+                            read_only=False,
+                            sub_path="checkpoints",
+                        )
                     ],
                 )
             ],

--- a/tests/integration/cartography/intel/kubernetes/test_nodes.py
+++ b/tests/integration/cartography/intel/kubernetes/test_nodes.py
@@ -43,6 +43,7 @@ def test_sync_nodes_and_runs_on(neo4j_session, monkeypatch):
                             resources=None,
                             env=None,
                             env_from=None,
+                            volume_mounts=None,
                         ),
                     ],
                     volumes=[],

--- a/tests/integration/cartography/intel/kubernetes/test_storage.py
+++ b/tests/integration/cartography/intel/kubernetes/test_storage.py
@@ -66,6 +66,23 @@ def _mock_storage(monkeypatch):
     )
 
 
+@pytest.fixture
+def _cleanup_block_storage_nodes(neo4j_session):
+    yield
+    neo4j_session.run(
+        """
+        MATCH (node)
+        WHERE node.cluster_name = $cluster_name
+          AND ((node:KubernetesPersistentVolume AND node.name = 'pvc-block-volume')
+            OR (node:KubernetesPersistentVolumeClaim AND node.name = 'block-data')
+            OR (node:KubernetesPod AND node.name = 'block-training-job')
+            OR (node:KubernetesContainer AND node.name = 'block-worker'))
+        DETACH DELETE node
+        """,
+        cluster_name=CLUSTER_NAME,
+    )
+
+
 def test_sync_storage(neo4j_session, monkeypatch, _create_test_cluster):
     # Arrange
     _mock_storage(monkeypatch)
@@ -281,14 +298,18 @@ def test_pod_references_and_container_mounts_persistent_volume_claim(
         MATCH (container:KubernetesContainer {name: $container_name})
               -[:MOUNTS]->
               (:KubernetesPersistentVolumeClaim {name: $claim_name})
-        RETURN container.persistent_volume_claim_ids AS claim_ids,
+        RETURN container.persistent_volume_claim_ids AS internal_claim_ids,
+               container.persistent_volume_claim_read_write_ids AS read_write_claim_ids,
                container.persistent_volume_claim_mounts AS mount_details
         """,
         container_name="worker",
         claim_name=CLAIM_NAME,
     ).single()
     assert container is not None
-    assert container["claim_ids"] == [f"{CLUSTER_NAME}/my-namespace/{CLAIM_NAME}"]
+    assert container["internal_claim_ids"] is None
+    assert container["read_write_claim_ids"] == [
+        f"{CLUSTER_NAME}/my-namespace/{CLAIM_NAME}"
+    ]
     assert json.loads(container["mount_details"]) == [
         {
             "claim_id": f"{CLUSTER_NAME}/my-namespace/{CLAIM_NAME}",
@@ -320,6 +341,7 @@ def test_container_uses_persistent_volume_claim_as_raw_block_device(
     neo4j_session,
     monkeypatch,
     _create_test_cluster,
+    _cleanup_block_storage_nodes,
 ):
     # Arrange
     block_volume = deepcopy(RAW_PERSISTENT_VOLUMES[0])
@@ -365,43 +387,55 @@ def test_container_uses_persistent_volume_claim_as_raw_block_device(
     sync_pods(neo4j_session, client, TEST_UPDATE_TAG, common_job_parameters)
 
     # Assert
-    assert ("block-training-job", "block-data") in check_rels(
-        neo4j_session,
-        "KubernetesPod",
-        "name",
-        "KubernetesPersistentVolumeClaim",
-        "name",
-        "REFERENCES",
-    )
-    assert ("block-worker", "block-data") in check_rels(
-        neo4j_session,
-        "KubernetesContainer",
-        "name",
-        "KubernetesPersistentVolumeClaim",
-        "name",
-        "USES_BLOCK_DEVICE",
-    )
-    assert ("block-worker", "block-data") not in check_rels(
-        neo4j_session,
-        "KubernetesContainer",
-        "name",
-        "KubernetesPersistentVolumeClaim",
-        "name",
-        "MOUNTS",
-    )
+    assert {
+        rel
+        for rel in check_rels(
+            neo4j_session,
+            "KubernetesPod",
+            "name",
+            "KubernetesPersistentVolumeClaim",
+            "name",
+            "REFERENCES",
+        )
+        if rel[0] == "block-training-job"
+    } == {("block-training-job", "block-data")}
+    assert {
+        rel
+        for rel in check_rels(
+            neo4j_session,
+            "KubernetesContainer",
+            "name",
+            "KubernetesPersistentVolumeClaim",
+            "name",
+            "USES_BLOCK_DEVICE",
+        )
+        if rel[0] == "block-worker"
+    } == {("block-worker", "block-data")}
+    assert {
+        rel
+        for rel in check_rels(
+            neo4j_session,
+            "KubernetesContainer",
+            "name",
+            "KubernetesPersistentVolumeClaim",
+            "name",
+            "MOUNTS",
+        )
+        if rel[0] == "block-worker"
+    } == set()
     container = neo4j_session.run(
         """
         MATCH (container:KubernetesContainer {name: $container_name})
               -[:USES_BLOCK_DEVICE]->
               (:KubernetesPersistentVolumeClaim {name: $claim_name})
-        RETURN container.persistent_volume_claim_device_ids AS claim_ids,
+        RETURN container.persistent_volume_claim_device_ids AS internal_claim_ids,
                container.persistent_volume_claim_devices AS device_details
         """,
         container_name="block-worker",
         claim_name="block-data",
     ).single()
     assert container is not None
-    assert container["claim_ids"] == [f"{CLUSTER_NAME}/{NAMESPACE}/block-data"]
+    assert container["internal_claim_ids"] is None
     assert json.loads(container["device_details"]) == [
         {
             "claim_id": f"{CLUSTER_NAME}/{NAMESPACE}/block-data",
@@ -426,27 +460,18 @@ def test_container_uses_persistent_volume_claim_as_raw_block_device(
     )
 
     # Assert
-    assert ("block-worker", "block-data") not in check_rels(
-        neo4j_session,
-        "KubernetesContainer",
-        "name",
-        "KubernetesPersistentVolumeClaim",
-        "name",
-        "USES_BLOCK_DEVICE",
-    )
-    neo4j_session.run(
-        """
-        MATCH (node)
-        WHERE node.uid IN $uids
-        DETACH DELETE node
-        """,
-        uids=[
-            block_volume.metadata.uid,
-            block_claim.metadata.uid,
-            block_pod.metadata.uid,
-            f"{block_pod.metadata.uid}-block-worker",
-        ],
-    )
+    assert {
+        rel
+        for rel in check_rels(
+            neo4j_session,
+            "KubernetesContainer",
+            "name",
+            "KubernetesPersistentVolumeClaim",
+            "name",
+            "USES_BLOCK_DEVICE",
+        )
+        if rel[0] == "block-worker"
+    } == set()
 
 
 def test_sync_pods_cleans_up_removed_container_mount(

--- a/tests/integration/cartography/intel/kubernetes/test_storage.py
+++ b/tests/integration/cartography/intel/kubernetes/test_storage.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from types import SimpleNamespace
 
 import pytest
+from kubernetes.client import V1VolumeDevice
 from kubernetes.client.exceptions import ApiException
 from urllib3.exceptions import MaxRetryError
 
@@ -243,7 +244,7 @@ def test_persistent_volumes_link_to_backing_cloud_disks(
     assert check_nodes(neo4j_session, "AzureDisk", ["id"]) == set()
 
 
-def test_pod_mounts_persistent_volume_claim(
+def test_pod_references_and_container_mounts_persistent_volume_claim(
     neo4j_session,
     monkeypatch,
     _create_test_cluster,
@@ -265,7 +266,7 @@ def test_pod_mounts_persistent_volume_claim(
         "name",
         "KubernetesPersistentVolumeClaim",
         "name",
-        "MOUNTS",
+        "REFERENCES",
     ) == {("training-job-head", CLAIM_NAME)}
     assert check_rels(
         neo4j_session,
@@ -313,6 +314,139 @@ def test_pod_mounts_persistent_volume_claim(
             '{"cpu": "32", "memory": "600Gi", "nvidia.com/gpu": "8"}',
         )
     }
+
+
+def test_container_uses_persistent_volume_claim_as_raw_block_device(
+    neo4j_session,
+    monkeypatch,
+    _create_test_cluster,
+):
+    # Arrange
+    block_volume = deepcopy(RAW_PERSISTENT_VOLUMES[0])
+    block_volume.metadata.name = "pvc-block-volume"
+    block_volume.metadata.uid = "00000000-0000-0000-0000-000000000005"
+    block_volume.spec.volume_mode = "Block"
+    block_volume.spec.claim_ref.name = "block-data"
+    block_claim = deepcopy(RAW_PERSISTENT_VOLUME_CLAIMS[0])
+    block_claim.metadata.name = "block-data"
+    block_claim.metadata.uid = "00000000-0000-0000-0000-000000000006"
+    block_claim.spec.volume_mode = "Block"
+    block_claim.spec.volume_name = block_volume.metadata.name
+    block_pod = deepcopy(RAW_GPU_PODS[0])
+    block_pod.metadata.name = "block-training-job"
+    block_pod.metadata.uid = "00000000-0000-0000-0000-000000000007"
+    block_pod.spec.volumes[0].persistent_volume_claim.claim_name = "block-data"
+    block_pod.spec.containers[0].name = "block-worker"
+    block_pod.spec.containers[0].volume_mounts = []
+    block_pod.spec.containers[0].volume_devices = [
+        V1VolumeDevice(name="shared-data", device_path="/dev/training-data")
+    ]
+    monkeypatch.setattr(
+        storage_module,
+        "get_storage_classes",
+        lambda client: RAW_STORAGE_CLASSES,
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "get_persistent_volumes",
+        lambda client: [block_volume],
+    )
+    monkeypatch.setattr(
+        storage_module,
+        "get_persistent_volume_claims",
+        lambda client: [block_claim],
+    )
+    monkeypatch.setattr(pods_module, "get_pods", lambda client: [block_pod])
+    client = SimpleNamespace(name=CLUSTER_NAME)
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "CLUSTER_ID": CLUSTER_ID}
+    sync_storage(neo4j_session, client, TEST_UPDATE_TAG, common_job_parameters)
+
+    # Act
+    sync_pods(neo4j_session, client, TEST_UPDATE_TAG, common_job_parameters)
+
+    # Assert
+    assert ("block-training-job", "block-data") in check_rels(
+        neo4j_session,
+        "KubernetesPod",
+        "name",
+        "KubernetesPersistentVolumeClaim",
+        "name",
+        "REFERENCES",
+    )
+    assert ("block-worker", "block-data") in check_rels(
+        neo4j_session,
+        "KubernetesContainer",
+        "name",
+        "KubernetesPersistentVolumeClaim",
+        "name",
+        "USES_BLOCK_DEVICE",
+    )
+    assert ("block-worker", "block-data") not in check_rels(
+        neo4j_session,
+        "KubernetesContainer",
+        "name",
+        "KubernetesPersistentVolumeClaim",
+        "name",
+        "MOUNTS",
+    )
+    container = neo4j_session.run(
+        """
+        MATCH (container:KubernetesContainer {name: $container_name})
+              -[:USES_BLOCK_DEVICE]->
+              (:KubernetesPersistentVolumeClaim {name: $claim_name})
+        RETURN container.persistent_volume_claim_device_ids AS claim_ids,
+               container.persistent_volume_claim_devices AS device_details
+        """,
+        container_name="block-worker",
+        claim_name="block-data",
+    ).single()
+    assert container is not None
+    assert container["claim_ids"] == [f"{CLUSTER_NAME}/{NAMESPACE}/block-data"]
+    assert json.loads(container["device_details"]) == [
+        {
+            "claim_id": f"{CLUSTER_NAME}/{NAMESPACE}/block-data",
+            "claim_name": "block-data",
+            "device_path": "/dev/training-data",
+            "volume_name": "shared-data",
+        }
+    ]
+
+    # Arrange
+    pod_without_device = deepcopy(block_pod)
+    pod_without_device.spec.containers[0].volume_devices = []
+    monkeypatch.setattr(pods_module, "get_pods", lambda client: [pod_without_device])
+    next_update_tag = TEST_UPDATE_TAG + 1
+
+    # Act
+    sync_pods(
+        neo4j_session,
+        client,
+        next_update_tag,
+        {"UPDATE_TAG": next_update_tag, "CLUSTER_ID": CLUSTER_ID},
+    )
+
+    # Assert
+    assert ("block-worker", "block-data") not in check_rels(
+        neo4j_session,
+        "KubernetesContainer",
+        "name",
+        "KubernetesPersistentVolumeClaim",
+        "name",
+        "USES_BLOCK_DEVICE",
+    )
+    neo4j_session.run(
+        """
+        MATCH (node)
+        WHERE node.uid IN $uids
+        DETACH DELETE node
+        """,
+        uids=[
+            block_volume.metadata.uid,
+            block_claim.metadata.uid,
+            block_pod.metadata.uid,
+            f"{block_pod.metadata.uid}-block-worker",
+        ],
+    )
 
 
 def test_sync_pods_cleans_up_removed_container_mount(
@@ -376,7 +510,7 @@ def test_sync_pods_cleans_up_removed_container_mount(
         "name",
         "KubernetesPersistentVolumeClaim",
         "name",
-        "MOUNTS",
+        "REFERENCES",
     ) == {("training-job-head", CLAIM_NAME)}
 
 

--- a/tests/integration/cartography/intel/kubernetes/test_storage.py
+++ b/tests/integration/cartography/intel/kubernetes/test_storage.py
@@ -1,3 +1,4 @@
+import json
 from copy import deepcopy
 from types import SimpleNamespace
 
@@ -266,6 +267,40 @@ def test_pod_mounts_persistent_volume_claim(
         "name",
         "MOUNTS",
     ) == {("training-job-head", CLAIM_NAME)}
+    assert check_rels(
+        neo4j_session,
+        "KubernetesContainer",
+        "name",
+        "KubernetesPersistentVolumeClaim",
+        "name",
+        "MOUNTS",
+    ) == {("worker", CLAIM_NAME)}
+    container = neo4j_session.run(
+        """
+        MATCH (container:KubernetesContainer {name: $container_name})
+              -[:MOUNTS]->
+              (:KubernetesPersistentVolumeClaim {name: $claim_name})
+        RETURN container.persistent_volume_claim_ids AS claim_ids,
+               container.persistent_volume_claim_mounts AS mount_details
+        """,
+        container_name="worker",
+        claim_name=CLAIM_NAME,
+    ).single()
+    assert container is not None
+    assert container["claim_ids"] == [f"{CLUSTER_NAME}/my-namespace/{CLAIM_NAME}"]
+    assert json.loads(container["mount_details"]) == [
+        {
+            "claim_id": f"{CLUSTER_NAME}/my-namespace/{CLAIM_NAME}",
+            "claim_name": CLAIM_NAME,
+            "volume_name": "shared-data",
+            "mount_path": "/data",
+            "mount_propagation": "None",
+            "read_only": False,
+            "recursive_read_only": None,
+            "sub_path": "checkpoints",
+            "sub_path_expr": None,
+        }
+    ]
     assert check_nodes(
         neo4j_session,
         "KubernetesContainer",
@@ -278,6 +313,71 @@ def test_pod_mounts_persistent_volume_claim(
             '{"cpu": "32", "memory": "600Gi", "nvidia.com/gpu": "8"}',
         )
     }
+
+
+def test_sync_pods_cleans_up_removed_container_mount(
+    neo4j_session,
+    monkeypatch,
+    _create_test_cluster,
+):
+    # Arrange
+    _mock_storage(monkeypatch)
+    monkeypatch.setattr(pods_module, "get_pods", lambda client: RAW_GPU_PODS)
+    client = SimpleNamespace(name=CLUSTER_NAME)
+    common_job_parameters = {"UPDATE_TAG": TEST_UPDATE_TAG, "CLUSTER_ID": CLUSTER_ID}
+    sync_storage(neo4j_session, client, TEST_UPDATE_TAG, common_job_parameters)
+
+    # Act
+    sync_pods(neo4j_session, client, TEST_UPDATE_TAG, common_job_parameters)
+
+    # Assert
+    assert check_rels(
+        neo4j_session,
+        "KubernetesContainer",
+        "name",
+        "KubernetesPersistentVolumeClaim",
+        "name",
+        "MOUNTS",
+    ) == {("worker", CLAIM_NAME)}
+
+    # Arrange
+    pods_without_container_mounts = deepcopy(RAW_GPU_PODS)
+    pods_without_container_mounts[0].spec.containers[0].volume_mounts = []
+    monkeypatch.setattr(
+        pods_module,
+        "get_pods",
+        lambda client: pods_without_container_mounts,
+    )
+    next_update_tag = TEST_UPDATE_TAG + 1
+
+    # Act
+    sync_pods(
+        neo4j_session,
+        client,
+        next_update_tag,
+        {"UPDATE_TAG": next_update_tag, "CLUSTER_ID": CLUSTER_ID},
+    )
+
+    # Assert
+    assert (
+        check_rels(
+            neo4j_session,
+            "KubernetesContainer",
+            "name",
+            "KubernetesPersistentVolumeClaim",
+            "name",
+            "MOUNTS",
+        )
+        == set()
+    )
+    assert check_rels(
+        neo4j_session,
+        "KubernetesPod",
+        "name",
+        "KubernetesPersistentVolumeClaim",
+        "name",
+        "MOUNTS",
+    ) == {("training-job-head", CLAIM_NAME)}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cartography/intel/kubernetes/test_pods.py
+++ b/tests/unit/cartography/intel/kubernetes/test_pods.py
@@ -6,6 +6,7 @@ from kubernetes.client import V1EphemeralVolumeSource
 from kubernetes.client import V1PersistentVolumeClaimSpec
 from kubernetes.client import V1PersistentVolumeClaimTemplate
 from kubernetes.client import V1Volume
+from kubernetes.client import V1VolumeMount
 
 from cartography.intel.kubernetes.pods import transform_pods
 from tests.data.kubernetes.storage import RAW_GPU_PODS
@@ -82,6 +83,9 @@ def test_transform_pods_maps_generic_ephemeral_volume_to_generated_claim():
             ),
         )
     ]
+    pod.spec.containers[0].volume_mounts = [
+        V1VolumeMount(name="scratch", mount_path="/scratch")
+    ]
 
     transformed = transform_pods([pod], "my-cluster-1")
 
@@ -89,6 +93,13 @@ def test_transform_pods_maps_generic_ephemeral_volume_to_generated_claim():
     assert transformed[0]["persistent_volume_claim_ids"] == [
         "my-cluster-1/my-namespace/ephemeral-pod-scratch"
     ]
+    container = transformed[0]["containers"][0]
+    assert container["persistent_volume_claim_ids"] == [
+        "my-cluster-1/my-namespace/ephemeral-pod-scratch"
+    ]
+    assert json.loads(container["persistent_volume_claim_mounts"])[0]["mount_path"] == (
+        "/scratch"
+    )
 
 
 def _owned_pod(uid: str, name: str, owner_kind: str, owner_uid: str) -> SimpleNamespace:
@@ -201,6 +212,7 @@ def test_transform_pods_propagates_node_architecture_to_pod_and_container():
                     resources=None,
                     env=None,
                     env_from=None,
+                    volume_mounts=None,
                 ),
             ],
             volumes=[],
@@ -240,6 +252,7 @@ def test_transform_pods_extracts_container_ports():
                     resources=None,
                     env=None,
                     env_from=None,
+                    volume_mounts=None,
                     ports=[
                         SimpleNamespace(
                             container_port=8080,
@@ -280,4 +293,56 @@ def test_transform_pods_extracts_container_ports():
         {"container_port": 8080, "protocol": "TCP", "name": "http"},
         {"container_port": 53, "protocol": "UDP", "name": "dns"},
         {"container_port": 9000, "protocol": "SCTP", "name": "sctp"},
+    ]
+
+
+def test_transform_pods_serializes_container_persistent_volume_claim_mounts():
+    # Arrange
+    pod = deepcopy(RAW_GPU_PODS[0])
+    pod.spec.containers[0].volume_mounts = [
+        V1VolumeMount(
+            name="shared-data",
+            mount_path="/data",
+            read_only=False,
+            sub_path="checkpoints",
+        ),
+        V1VolumeMount(
+            name="shared-data",
+            mount_path="/models",
+            read_only=True,
+        ),
+        V1VolumeMount(name="unmatched-volume", mount_path="/ignored"),
+    ]
+
+    # Act
+    transformed = transform_pods([pod], "my-cluster-1")
+
+    # Assert
+    container = transformed[0]["containers"][0]
+    assert container["persistent_volume_claim_ids"] == [
+        "my-cluster-1/my-namespace/shared-data"
+    ]
+    assert json.loads(container["persistent_volume_claim_mounts"]) == [
+        {
+            "claim_id": "my-cluster-1/my-namespace/shared-data",
+            "claim_name": "shared-data",
+            "volume_name": "shared-data",
+            "mount_path": "/data",
+            "mount_propagation": None,
+            "read_only": False,
+            "recursive_read_only": None,
+            "sub_path": "checkpoints",
+            "sub_path_expr": None,
+        },
+        {
+            "claim_id": "my-cluster-1/my-namespace/shared-data",
+            "claim_name": "shared-data",
+            "volume_name": "shared-data",
+            "mount_path": "/models",
+            "mount_propagation": None,
+            "read_only": True,
+            "recursive_read_only": None,
+            "sub_path": None,
+            "sub_path_expr": None,
+        },
     ]

--- a/tests/unit/cartography/intel/kubernetes/test_pods.py
+++ b/tests/unit/cartography/intel/kubernetes/test_pods.py
@@ -6,6 +6,7 @@ from kubernetes.client import V1EphemeralVolumeSource
 from kubernetes.client import V1PersistentVolumeClaimSpec
 from kubernetes.client import V1PersistentVolumeClaimTemplate
 from kubernetes.client import V1Volume
+from kubernetes.client import V1VolumeDevice
 from kubernetes.client import V1VolumeMount
 
 from cartography.intel.kubernetes.pods import transform_pods
@@ -345,4 +346,32 @@ def test_transform_pods_serializes_container_persistent_volume_claim_mounts():
             "sub_path": None,
             "sub_path_expr": None,
         },
+    ]
+
+
+def test_transform_pods_serializes_container_persistent_volume_claim_devices():
+    # Arrange
+    pod = deepcopy(RAW_GPU_PODS[0])
+    pod.spec.containers[0].volume_mounts = []
+    pod.spec.containers[0].volume_devices = [
+        V1VolumeDevice(name="shared-data", device_path="/dev/training-data"),
+        V1VolumeDevice(name="unmatched-volume", device_path="/dev/ignored"),
+    ]
+
+    # Act
+    transformed = transform_pods([pod], "my-cluster-1")
+
+    # Assert
+    container = transformed[0]["containers"][0]
+    assert container["persistent_volume_claim_ids"] == []
+    assert container["persistent_volume_claim_device_ids"] == [
+        "my-cluster-1/my-namespace/shared-data"
+    ]
+    assert json.loads(container["persistent_volume_claim_devices"]) == [
+        {
+            "claim_id": "my-cluster-1/my-namespace/shared-data",
+            "claim_name": "shared-data",
+            "device_path": "/dev/training-data",
+            "volume_name": "shared-data",
+        }
     ]

--- a/tests/unit/cartography/intel/kubernetes/test_pods.py
+++ b/tests/unit/cartography/intel/kubernetes/test_pods.py
@@ -98,6 +98,9 @@ def test_transform_pods_maps_generic_ephemeral_volume_to_generated_claim():
     assert container["persistent_volume_claim_ids"] == [
         "my-cluster-1/my-namespace/ephemeral-pod-scratch"
     ]
+    assert container["persistent_volume_claim_read_write_ids"] == [
+        "my-cluster-1/my-namespace/ephemeral-pod-scratch"
+    ]
     assert json.loads(container["persistent_volume_claim_mounts"])[0]["mount_path"] == (
         "/scratch"
     )
@@ -323,6 +326,9 @@ def test_transform_pods_serializes_container_persistent_volume_claim_mounts():
     assert container["persistent_volume_claim_ids"] == [
         "my-cluster-1/my-namespace/shared-data"
     ]
+    assert container["persistent_volume_claim_read_write_ids"] == [
+        "my-cluster-1/my-namespace/shared-data"
+    ]
     assert json.loads(container["persistent_volume_claim_mounts"]) == [
         {
             "claim_id": "my-cluster-1/my-namespace/shared-data",
@@ -364,6 +370,7 @@ def test_transform_pods_serializes_container_persistent_volume_claim_devices():
     # Assert
     container = transformed[0]["containers"][0]
     assert container["persistent_volume_claim_ids"] == []
+    assert container["persistent_volume_claim_read_write_ids"] == []
     assert container["persistent_volume_claim_device_ids"] == [
         "my-cluster-1/my-namespace/shared-data"
     ]
@@ -375,3 +382,14 @@ def test_transform_pods_serializes_container_persistent_volume_claim_devices():
             "volume_name": "shared-data",
         }
     ]
+
+
+def test_transform_pods_excludes_read_only_claim_from_read_write_ids():
+    pod = deepcopy(RAW_GPU_PODS[0])
+    pod.spec.containers[0].volume_mounts = [
+        V1VolumeMount(name="shared-data", mount_path="/data", read_only=True)
+    ]
+
+    container = transform_pods([pod], "my-cluster-1")[0]["containers"][0]
+
+    assert container["persistent_volume_claim_read_write_ids"] == []


### PR DESCRIPTION
### Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):

### Summary

Map Kubernetes PVC use at the level where each API field is declared.

- Pod `REFERENCES` relationships identify claims referenced by pod volumes.
- Container `MOUNTS` relationships and `persistent_volume_claim_mounts` preserve filesystem mount configuration.
- Container `USES_BLOCK_DEVICE` relationships and `persistent_volume_claim_devices` preserve raw block device mappings.

All relationships are part of the typed Pod and Container schemas, so normal ingestion and cleanup manage them without MatchLinks or a separate relationship-loading path.

### Related issues or links

- Depends on #3187

### How was this tested?

- `make test_lint`
- `uv run --frozen pytest -q tests/unit/cartography/intel/kubernetes tests/integration/cartography/intel/kubernetes` (130 passed)
- `uv run ./docs/build.sh`

The integration tests load sanitized Kubernetes API model objects through the normal storage and pod sync paths. They verify Pod references, container filesystem mounts, raw block device properties and relationships, and stale-edge cleanup after access is removed.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [x] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).

### Notes for reviewers

This PR is intentionally stacked on #3187 because it connects Pods and containers to the PersistentVolumeClaim nodes introduced there.
