### PR TITLE
docs: correct docstring parameter names that do not match signatures

### DIFF
--- a/cartography/intel/aws/cloudtrail_management_events.py
+++ b/cartography/intel/aws/cloudtrail_management_events.py
@@ -708,8 +708,8 @@ def sync_assume_role_events(
     :param regions: List of AWS regions to sync
     :type current_aws_account_id: str
     :param current_aws_account_id: The AWS account ID being synced
-    :type aws_update_tag: int
-    :param aws_update_tag: Timestamp tag for tracking data freshness
+    :type update_tag: int
+    :param update_tag: Timestamp tag for tracking data freshness
     :rtype: None
     """
     # Extract lookback hours from common_job_parameters (set by CLI parameter)

--- a/cartography/intel/aws/resourcegroupstaggingapi.py
+++ b/cartography/intel/aws/resourcegroupstaggingapi.py
@@ -43,7 +43,7 @@ def get_bucket_name_from_arn(bucket_arn: str) -> str:
     """
     Return the bucket name from an S3 bucket ARN.
     For example, for "arn:aws:s3:::bucket_name", return 'bucket_name'.
-    :param arn: The S3 bucket's full ARN
+    :param bucket_arn: The S3 bucket's full ARN
     :return: The S3 bucket's name
     """
     return bucket_arn.split(":")[-1]
@@ -53,7 +53,7 @@ def get_short_id_from_elb_arn(alb_arn: str) -> str:
     """
     Return the ELB name from the ARN
     For example, for arn:aws:elasticloadbalancing:::loadbalancer/foo", return 'foo'.
-    :param arn: The ELB's full ARN
+    :param alb_arn: The ELB's full ARN
     :return: The ELB's name
     """
     return alb_arn.split("/")[-1]
@@ -64,7 +64,7 @@ def get_short_id_from_lb2_arn(alb_arn: str) -> str:
     Return the (A|N)LB name from the ARN
     For example, for arn:aws:elasticloadbalancing:::loadbalancer/app/foo/ab123", return 'foo'.
     For example, for arn:aws:elasticloadbalancing:::loadbalancer/net/foo/ab123", return 'foo'.
-    :param arn: The (N|A)LB's full ARN
+    :param alb_arn: The (N|A)LB's full ARN
     :return: The (N|A)LB's name
     """
     return alb_arn.split("/")[-2]

--- a/cartography/intel/okta/awssaml.py
+++ b/cartography/intel/okta/awssaml.py
@@ -272,10 +272,9 @@ def sync_okta_aws_saml(
     https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-Amazon-Web-Service#scenarioC
     If an organization does not use okta as a SAML provider for AWS the query will not return any results
     and nothing will be added to the graph
-    :param mapping_regex: session from the Neo4j server
+    :param neo4j_session: session from the Neo4j server
     :param okta_org_id: okta organization id
     :param okta_update_tag: The timestamp value to set our new Neo4j resources with
-    :param okta_api_key: Okta api key
     :return: Nothing
     """
     logger.info("Syncing Okta SAML Integration")


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary
Five docstring entries name parameters that their functions do not accept, so the
rendered docs describe arguments a caller cannot pass. Each was verified against the
function signature before changing.

**`intel/aws/resourcegroupstaggingapi.py`** — `get_bucket_name_from_arn`,
`get_short_id_from_elb_arn` and `get_short_id_from_lb2_arn` each document
`:param arn:`, but their parameters are `bucket_arn` and `alb_arn`. The two
neighbouring helpers in the same file, `get_short_id_from_ec2_arn` and
`get_resource_type_from_arn`, genuinely do take `arn` — which is what shows these
three to be stale copies rather than a house convention.

**`intel/aws/cloudtrail_management_events.py`** — `sync_assume_role_events`
documents `aws_update_tag`, but its parameter is `update_tag`. Note that
`load_role_assumptions`, `load_saml_role_assumptions` and
`load_web_identity_role_assumptions` in the same module really do take
`aws_update_tag`; their docstrings are correct and are left untouched.

**`intel/okta/awssaml.py`** — `sync_okta_aws_saml` documents `okta_api_key`, which
has never been a parameter of this function (the docstring arrived in its current
shape in 80908b67, when the signature was
`sync_okta_aws_saml(neo4j_session, mapping_regex, okta_update_tag)`). The same
docstring attaches the description "session from the Neo4j server" to
`mapping_regex`, which is a regex string; that description belongs to
`neo4j_session`, a real parameter that was left undocumented. The line is relabelled
rather than rewritten, so no new prose is invented.

Scope was kept deliberately narrow: parameters that were never documented are left
undocumented rather than newly described, and no wording is changed beyond the
incorrect names.


### Related issues or links
No related issue. Found by comparing `:param` entries against actual function
signatures with an AST scan, then reading each hit — most candidates were
`Raises:`/`Returns:` entries and were discarded.


### How was this tested?
Docstring-only, so there is no behaviour to exercise; correctness was established by
reading each signature and by `git log` for the Okta case. Both required suites were
run locally on macOS (arm64, Python 3.13):

- `uv run --frozen pre-commit run --all-files` — **all 14 hooks pass**, including
  `flake8`, `black`, `isort` and `mypy`.
- `COVERAGE_CORE=sysmon uv run --frozen pytest tests/unit` — **5202 passed** in 33.75s.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.
      No test is added: the change alters only docstring text, which no test asserts on.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [ ] New or updated unit/integration tests.

There is no functional change to demonstrate — the diff touches only `:param` and
`:type` lines inside docstrings, and no executable statement is modified. The full
unit suite result above is included as evidence that nothing regressed.

#### If you are adding or modifying an intel connector
Not applicable. No connector behaviour, API call, or data model is changed, so there
is no sync to run and no real-environment evidence to capture. Flagging this
explicitly because the files live under `cartography/intel/` — please let me know if
you would still like this treated as a connector change.

#### If you are changing a node or relationship
Not applicable. No node schema, relationship schema, or `PropertyRef.description` is
touched, so the generated schema documentation is unaffected.

#### If you are implementing a new intel module
Not applicable.


### Notes for reviewers
The three `aws_update_tag` docstrings in `cloudtrail_management_events.py` that are
*correct* are deliberately untouched; only `sync_assume_role_events` had the mismatch.
Worth a glance to confirm that read.

AI-assisted per CONTRIBUTING's "AI-Assisted Contributions": every changed line was
checked against the function signature by hand, and the two test suites above were
run and their output inspected before opening this.
