### PR TITLE
feat(gcp): add audit logging coverage

### DIFF
--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -22,6 +22,7 @@ from cartography.config import Config
 from cartography.graph.job import GraphJob
 from cartography.intel.gcp import apikeys
 from cartography.intel.gcp import artifact_registry
+from cartography.intel.gcp import audit_config
 from cartography.intel.gcp import bigquery_connection
 from cartography.intel.gcp import bigquery_dataset
 from cartography.intel.gcp import bigquery_routine
@@ -932,6 +933,22 @@ def start_gcp_ingestion(
             log_sink.sync_gcp_log_sinks(
                 neo4j_session,
                 logging_client,
+                org_resource_name,
+                folders,
+                projects,
+                config.update_tag,
+                common_job_parameters,
+            )
+
+        if requested_syncs is None or "audit_config" in requested_syncs:
+            resourcemanager_client = build_client(
+                "cloudresourcemanager",
+                "v3",
+                credentials=credentials,
+            )
+            audit_config.sync_gcp_audit_configs(
+                neo4j_session,
+                resourcemanager_client,
                 org_resource_name,
                 folders,
                 projects,

--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -42,6 +42,7 @@ from cartography.intel.gcp import gcf
 from cartography.intel.gcp import gke
 from cartography.intel.gcp import iam
 from cartography.intel.gcp import kms
+from cartography.intel.gcp import log_sink
 from cartography.intel.gcp import permission_relationships
 from cartography.intel.gcp import policy_bindings
 from cartography.intel.gcp import secretsmanager
@@ -925,6 +926,18 @@ def start_gcp_ingestion(
             common_job_parameters,
             credentials=credentials,
         )
+
+        if requested_syncs is None or "log_sinks" in requested_syncs:
+            logging_client = build_client("logging", "v2", credentials=credentials)
+            log_sink.sync_gcp_log_sinks(
+                neo4j_session,
+                logging_client,
+                org_resource_name,
+                folders,
+                projects,
+                config.update_tag,
+                common_job_parameters,
+            )
 
         # Sync organization-level IAM (predefined roles + custom org roles) ONCE per org.
         # This is done before project resources so that roles exist when policy bindings are created.

--- a/cartography/intel/gcp/__init__.py
+++ b/cartography/intel/gcp/__init__.py
@@ -928,18 +928,6 @@ def start_gcp_ingestion(
             credentials=credentials,
         )
 
-        if requested_syncs is None or "log_sinks" in requested_syncs:
-            logging_client = build_client("logging", "v2", credentials=credentials)
-            log_sink.sync_gcp_log_sinks(
-                neo4j_session,
-                logging_client,
-                org_resource_name,
-                folders,
-                projects,
-                config.update_tag,
-                common_job_parameters,
-            )
-
         if requested_syncs is None or "audit_config" in requested_syncs:
             resourcemanager_client = build_client(
                 "cloudresourcemanager",
@@ -989,6 +977,20 @@ def start_gcp_ingestion(
             requested_syncs=requested_syncs,
             org_role_permissions_by_name=org_role_permissions_by_name,
         )
+
+        # Run log sinks after project resources so BigQuery dataset destinations
+        # collected in this sync already exist before DELIVERS_TO relationships are matched.
+        if requested_syncs is None or "log_sinks" in requested_syncs:
+            logging_client = build_client("logging", "v2", credentials=credentials)
+            log_sink.sync_gcp_log_sinks(
+                neo4j_session,
+                logging_client,
+                org_resource_name,
+                folders,
+                projects,
+                config.update_tag,
+                common_job_parameters,
+            )
 
         policy_bindings_requested = (
             requested_syncs is None or "policy_bindings" in requested_syncs

--- a/cartography/intel/gcp/audit_config.py
+++ b/cartography/intel/gcp/audit_config.py
@@ -84,15 +84,9 @@ def transform_gcp_audit_configs(
 ) -> list[dict]:
     transformed: list[dict] = []
     for audit_config in audit_configs:
-        service = audit_config.get("service")
-        if not service:
-            continue
+        service = audit_config["service"]
         audit_log_configs = audit_config.get("auditLogConfigs", []) or []
-        log_types = {
-            config.get("logType")
-            for config in audit_log_configs
-            if config.get("logType")
-        }
+        log_types = {config["logType"] for config in audit_log_configs}
         transformed.append(
             {
                 "id": f"{parent_id}/auditConfigs/{service}",

--- a/cartography/intel/gcp/audit_config.py
+++ b/cartography/intel/gcp/audit_config.py
@@ -1,0 +1,255 @@
+# GCP IAM audit configs
+# https://cloud.google.com/resource-manager/reference/rest/v3/Policy#auditconfig
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import neo4j
+from googleapiclient.discovery import Resource
+from googleapiclient.errors import HttpError
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.gcp.util import classify_gcp_http_error
+from cartography.intel.gcp.util import gcp_api_execute_with_retry
+from cartography.intel.gcp.util import summarize_gcp_http_error
+from cartography.models.gcp.audit_config import GCPFolderAuditConfigSchema
+from cartography.models.gcp.audit_config import GCPOrgAuditConfigSchema
+from cartography.models.gcp.audit_config import GCPProjectAuditConfigSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+_EXPECTED_SKIP_CATEGORIES = (
+    "api_disabled",
+    "billing_disabled",
+    "forbidden",
+    "not_found",
+)
+_POLICY_VERSION_BODY = {"options": {"requestedPolicyVersion": 3}}
+
+
+def _get_audit_configs(client_get_iam_policy: Any, resource: str) -> list[dict] | None:
+    try:
+        req = client_get_iam_policy(resource=resource, body=_POLICY_VERSION_BODY)
+        res = gcp_api_execute_with_retry(req)
+        return res.get("auditConfigs", [])
+    except HttpError as e:
+        if classify_gcp_http_error(e) in _EXPECTED_SKIP_CATEGORIES:
+            logger.warning(
+                "GCP: Unable to get IAM audit configs for %s; skipping this scope. %s",
+                resource,
+                summarize_gcp_http_error(e),
+            )
+            return None
+        raise
+
+
+@timeit
+def get_org_audit_config(client: Resource, org_resource_name: str) -> list[dict] | None:
+    return _get_audit_configs(client.organizations().getIamPolicy, org_resource_name)
+
+
+@timeit
+def get_folder_audit_config(client: Resource, folder_name: str) -> list[dict] | None:
+    return _get_audit_configs(client.folders().getIamPolicy, folder_name)
+
+
+@timeit
+def get_project_audit_config(
+    client: Resource,
+    project_id: str,
+    project_number: str | None = None,
+) -> list[dict] | None:
+    try:
+        return _get_audit_configs(
+            client.projects().getIamPolicy, f"projects/{project_id}"
+        )
+    except HttpError as e:
+        if classify_gcp_http_error(e) == "invalid" and project_number:
+            return _get_audit_configs(
+                client.projects().getIamPolicy,
+                f"projects/{project_number}",
+            )
+        raise
+
+
+@timeit
+def transform_gcp_audit_configs(
+    audit_configs: list[dict],
+    parent_type: str,
+    parent_id: str,
+) -> list[dict]:
+    transformed: list[dict] = []
+    for audit_config in audit_configs:
+        service = audit_config.get("service")
+        if not service:
+            continue
+        audit_log_configs = audit_config.get("auditLogConfigs", []) or []
+        log_types = {
+            config.get("logType")
+            for config in audit_log_configs
+            if config.get("logType")
+        }
+        transformed.append(
+            {
+                "id": f"{parent_id}/auditConfigs/{service}",
+                "parent_type": parent_type,
+                "parent_id": parent_id,
+                "service": service,
+                "has_admin_read": "ADMIN_READ" in log_types,
+                "has_data_read": "DATA_READ" in log_types,
+                "has_data_write": "DATA_WRITE" in log_types,
+                "audit_log_configs_json": json.dumps(audit_log_configs),
+            },
+        )
+    return transformed
+
+
+@timeit
+def load_org_audit_configs(
+    neo4j_session: neo4j.Session,
+    audit_configs: list[dict],
+    update_tag: int,
+    org_resource_name: str,
+) -> None:
+    load(
+        neo4j_session,
+        GCPOrgAuditConfigSchema(),
+        audit_configs,
+        lastupdated=update_tag,
+        ORG_RESOURCE_NAME=org_resource_name,
+    )
+
+
+@timeit
+def load_folder_audit_configs(
+    neo4j_session: neo4j.Session,
+    audit_configs: list[dict],
+    update_tag: int,
+    folder_id: str,
+) -> None:
+    load(
+        neo4j_session,
+        GCPFolderAuditConfigSchema(),
+        audit_configs,
+        lastupdated=update_tag,
+        FOLDER_ID=folder_id,
+    )
+
+
+@timeit
+def load_project_audit_configs(
+    neo4j_session: neo4j.Session,
+    audit_configs: list[dict],
+    update_tag: int,
+    project_id: str,
+) -> None:
+    load(
+        neo4j_session,
+        GCPProjectAuditConfigSchema(),
+        audit_configs,
+        lastupdated=update_tag,
+        PROJECT_ID=project_id,
+    )
+
+
+@timeit
+def cleanup_org_audit_configs(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict,
+    org_resource_name: str,
+) -> None:
+    params = common_job_parameters.copy()
+    params["ORG_RESOURCE_NAME"] = org_resource_name
+    GraphJob.from_node_schema(GCPOrgAuditConfigSchema(), params).run(neo4j_session)
+
+
+@timeit
+def cleanup_folder_audit_configs(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict,
+    folder_id: str,
+) -> None:
+    params = common_job_parameters.copy()
+    params["FOLDER_ID"] = folder_id
+    GraphJob.from_node_schema(GCPFolderAuditConfigSchema(), params).run(neo4j_session)
+
+
+@timeit
+def cleanup_project_audit_configs(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict,
+    project_id: str,
+) -> None:
+    params = common_job_parameters.copy()
+    params["PROJECT_ID"] = project_id
+    GraphJob.from_node_schema(GCPProjectAuditConfigSchema(), params).run(neo4j_session)
+
+
+@timeit
+def sync_gcp_audit_configs(
+    neo4j_session: neo4j.Session,
+    client: Resource,
+    org_resource_name: str,
+    folders: list[dict],
+    projects: list[dict],
+    update_tag: int,
+    common_job_parameters: dict,
+) -> None:
+    logger.info("Syncing GCP IAM audit configs for %s", org_resource_name)
+
+    org_configs_raw = get_org_audit_config(client, org_resource_name)
+    if org_configs_raw is not None:
+        org_configs = transform_gcp_audit_configs(
+            org_configs_raw,
+            "organization",
+            org_resource_name,
+        )
+        load_org_audit_configs(
+            neo4j_session, org_configs, update_tag, org_resource_name
+        )
+        cleanup_org_audit_configs(
+            neo4j_session, common_job_parameters, org_resource_name
+        )
+
+    for folder in folders:
+        folder_name = folder.get("name")
+        if not folder_name:
+            continue
+        folder_configs_raw = get_folder_audit_config(client, folder_name)
+        if folder_configs_raw is None:
+            continue
+        folder_configs = transform_gcp_audit_configs(
+            folder_configs_raw,
+            "folder",
+            folder_name,
+        )
+        load_folder_audit_configs(
+            neo4j_session, folder_configs, update_tag, folder_name
+        )
+        cleanup_folder_audit_configs(neo4j_session, common_job_parameters, folder_name)
+
+    for project in projects:
+        project_id = project.get("projectId")
+        if not project_id:
+            continue
+        project_parent = f"projects/{project_id}"
+        project_configs_raw = get_project_audit_config(
+            client,
+            project_id,
+            project.get("projectNumber"),
+        )
+        if project_configs_raw is None:
+            continue
+        project_configs = transform_gcp_audit_configs(
+            project_configs_raw,
+            "project",
+            project_parent,
+        )
+        load_project_audit_configs(
+            neo4j_session, project_configs, update_tag, project_id
+        )
+        cleanup_project_audit_configs(neo4j_session, common_job_parameters, project_id)

--- a/cartography/intel/gcp/cloud_sql_instance.py
+++ b/cartography/intel/gcp/cloud_sql_instance.py
@@ -107,9 +107,15 @@ def transform_sql_instances(instances_data: list[dict], project_id: str) -> list
         if ip_config.get("authorizedNetworks"):
             authorized_networks_json = json.dumps(ip_config.get("authorizedNetworks"))
 
+        database_flags = settings.get("databaseFlags", []) or []
         database_flags_json = None
-        if settings.get("databaseFlags"):
-            database_flags_json = json.dumps(settings.get("databaseFlags"))
+        if database_flags:
+            database_flags_json = json.dumps(database_flags)
+        flags_by_name = {
+            flag["name"]: flag.get("value")
+            for flag in database_flags
+            if flag.get("name")
+        }
 
         # Normalize privateNetwork to match GCPVpc ID format
         # Cloud SQL API returns: /projects/.../global/networks/...
@@ -149,6 +155,13 @@ def transform_sql_instances(instances_data: list[dict], project_id: str) -> list
                 "authorized_networks": authorized_networks_json,
                 "backup_configuration": backup_config_json,
                 "database_flags": database_flags_json,
+                "flag_cloudsql_enable_pgaudit": flags_by_name.get(
+                    "cloudsql.enable_pgaudit"
+                ),
+                "flag_log_checkpoints": flags_by_name.get("log_checkpoints"),
+                "flag_log_connections": flags_by_name.get("log_connections"),
+                "flag_log_disconnections": flags_by_name.get("log_disconnections"),
+                "flag_log_lock_waits": flags_by_name.get("log_lock_waits"),
                 "project_id": project_id,
                 "userLabels": settings.get("userLabels", {}),
             },

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -17,6 +17,7 @@ from cartography.intel.gcp.backendservice import sync_gcp_backend_services
 from cartography.intel.gcp.cloud_armor import sync_gcp_cloud_armor
 from cartography.intel.gcp.instancegroup import sync_gcp_instance_groups
 from cartography.intel.gcp.labels import sync_labels
+from cartography.intel.gcp.router import sync_gcp_routers
 from cartography.intel.gcp.ssl_policy import sync_gcp_ssl_policies
 from cartography.intel.gcp.target_https_proxy import sync_gcp_target_https_proxies
 from cartography.intel.gcp.target_ssl_proxy import sync_gcp_target_ssl_proxies
@@ -2206,6 +2207,13 @@ def sync(
             common_job_parameters,
         )
         sync_gcp_vpn_tunnels(
+            neo4j_session,
+            compute,
+            project_id,
+            gcp_update_tag,
+            common_job_parameters,
+        )
+        sync_gcp_routers(
             neo4j_session,
             compute,
             project_id,

--- a/cartography/intel/gcp/compute.py
+++ b/cartography/intel/gcp/compute.py
@@ -843,6 +843,8 @@ def transform_gcp_firewall(fw_response: Resource) -> list[dict]:
         fw_partial_uri = f"{prefix}/{fw['name']}"
         fw["id"] = fw_partial_uri
         fw["vpc_partial_uri"] = _parse_compute_full_uri_to_partial_uri(fw["network"])
+        fw["log_logging_enabled"] = fw.get("logConfig", {}).get("enable")
+        fw["log_logging_metadata"] = fw.get("logConfig", {}).get("metadata")
 
         fw["transformed_allow_list"] = []
         fw["transformed_deny_list"] = []

--- a/cartography/intel/gcp/log_sink.py
+++ b/cartography/intel/gcp/log_sink.py
@@ -86,6 +86,12 @@ def _sink_short_name(sink_name: str | None) -> str | None:
     return sink_name.split("/sinks/")[-1]
 
 
+def _sink_resource_name(sink_name: str, parent_id: str) -> str:
+    if "/sinks/" in sink_name:
+        return sink_name
+    return f"{parent_id}/sinks/{sink_name}"
+
+
 def _parse_bigquery_dataset_id(destination: str | None) -> str | None:
     if not destination:
         return None
@@ -107,13 +113,12 @@ def transform_gcp_log_sinks(
 ) -> list[dict]:
     transformed: list[dict] = []
     for sink in sinks:
-        name = sink.get("name")
-        if not name:
-            continue
+        name = sink["name"]
+        full_name = _sink_resource_name(name, parent_id)
         transformed.append(
             {
-                "id": name,
-                "name": name,
+                "id": full_name,
+                "name": full_name,
                 "sink_name": _sink_short_name(name),
                 "destination": sink.get("destination"),
                 "bigquery_dataset_id": _parse_bigquery_dataset_id(

--- a/cartography/intel/gcp/log_sink.py
+++ b/cartography/intel/gcp/log_sink.py
@@ -1,0 +1,251 @@
+# GCP Cloud Logging sinks
+# https://cloud.google.com/logging/docs/reference/v2/rest/v2/sinks
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import neo4j
+from googleapiclient.discovery import Resource
+from googleapiclient.errors import HttpError
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.gcp.util import classify_gcp_http_error
+from cartography.intel.gcp.util import gcp_api_execute_with_retry
+from cartography.intel.gcp.util import summarize_gcp_http_error
+from cartography.models.gcp.logging.log_sink import GCPFolderLogSinkSchema
+from cartography.models.gcp.logging.log_sink import GCPOrgLogSinkSchema
+from cartography.models.gcp.logging.log_sink import GCPProjectLogSinkSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+_EXPECTED_SKIP_CATEGORIES = (
+    "api_disabled",
+    "billing_disabled",
+    "forbidden",
+    "not_found",
+)
+
+
+def _list_sinks(
+    list_request: Any,
+    list_next: Any,
+    parent: str,
+) -> list[dict] | None:
+    sinks: list[dict] = []
+    req = list_request(parent=parent)
+    while req is not None:
+        try:
+            res = gcp_api_execute_with_retry(req)
+        except HttpError as e:
+            if classify_gcp_http_error(e) in _EXPECTED_SKIP_CATEGORIES:
+                logger.warning(
+                    "GCP: Unable to list Cloud Logging sinks for %s; skipping this scope. %s",
+                    parent,
+                    summarize_gcp_http_error(e),
+                )
+                return None
+            raise
+        sinks.extend(res.get("sinks", []))
+        req = list_next(previous_request=req, previous_response=res)
+    return sinks
+
+
+@timeit
+def get_org_log_sinks(client: Resource, org_resource_name: str) -> list[dict] | None:
+    return _list_sinks(
+        client.organizations().sinks().list,
+        client.organizations().sinks().list_next,
+        org_resource_name,
+    )
+
+
+@timeit
+def get_folder_log_sinks(client: Resource, folder_name: str) -> list[dict] | None:
+    return _list_sinks(
+        client.folders().sinks().list,
+        client.folders().sinks().list_next,
+        folder_name,
+    )
+
+
+@timeit
+def get_project_log_sinks(client: Resource, project_id: str) -> list[dict] | None:
+    return _list_sinks(
+        client.projects().sinks().list,
+        client.projects().sinks().list_next,
+        f"projects/{project_id}",
+    )
+
+
+def _sink_short_name(sink_name: str | None) -> str | None:
+    if not sink_name:
+        return None
+    return sink_name.split("/sinks/")[-1]
+
+
+@timeit
+def transform_gcp_log_sinks(
+    sinks: list[dict],
+    parent_type: str,
+    parent_id: str,
+) -> list[dict]:
+    transformed: list[dict] = []
+    for sink in sinks:
+        name = sink.get("name")
+        if not name:
+            continue
+        transformed.append(
+            {
+                "id": name,
+                "name": name,
+                "sink_name": _sink_short_name(name),
+                "destination": sink.get("destination"),
+                "filter": sink.get("filter"),
+                "description": sink.get("description"),
+                "disabled": sink.get("disabled", False),
+                "include_children": sink.get("includeChildren", False),
+                "writer_identity": sink.get("writerIdentity"),
+                "output_version_format": sink.get("outputVersionFormat"),
+                "parent_type": parent_type,
+                "parent_id": parent_id,
+            },
+        )
+    return transformed
+
+
+@timeit
+def load_org_log_sinks(
+    neo4j_session: neo4j.Session,
+    sinks: list[dict],
+    update_tag: int,
+    org_resource_name: str,
+) -> None:
+    load(
+        neo4j_session,
+        GCPOrgLogSinkSchema(),
+        sinks,
+        lastupdated=update_tag,
+        ORG_RESOURCE_NAME=org_resource_name,
+    )
+
+
+@timeit
+def load_folder_log_sinks(
+    neo4j_session: neo4j.Session,
+    sinks: list[dict],
+    update_tag: int,
+    folder_id: str,
+) -> None:
+    load(
+        neo4j_session,
+        GCPFolderLogSinkSchema(),
+        sinks,
+        lastupdated=update_tag,
+        FOLDER_ID=folder_id,
+    )
+
+
+@timeit
+def load_project_log_sinks(
+    neo4j_session: neo4j.Session,
+    sinks: list[dict],
+    update_tag: int,
+    project_id: str,
+) -> None:
+    load(
+        neo4j_session,
+        GCPProjectLogSinkSchema(),
+        sinks,
+        lastupdated=update_tag,
+        PROJECT_ID=project_id,
+    )
+
+
+@timeit
+def cleanup_org_log_sinks(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict,
+    org_resource_name: str,
+) -> None:
+    params = common_job_parameters.copy()
+    params["ORG_RESOURCE_NAME"] = org_resource_name
+    GraphJob.from_node_schema(GCPOrgLogSinkSchema(), params).run(neo4j_session)
+
+
+@timeit
+def cleanup_folder_log_sinks(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict,
+    folder_id: str,
+) -> None:
+    params = common_job_parameters.copy()
+    params["FOLDER_ID"] = folder_id
+    GraphJob.from_node_schema(GCPFolderLogSinkSchema(), params).run(neo4j_session)
+
+
+@timeit
+def cleanup_project_log_sinks(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict,
+    project_id: str,
+) -> None:
+    params = common_job_parameters.copy()
+    params["PROJECT_ID"] = project_id
+    GraphJob.from_node_schema(GCPProjectLogSinkSchema(), params).run(neo4j_session)
+
+
+@timeit
+def sync_gcp_log_sinks(
+    neo4j_session: neo4j.Session,
+    client: Resource,
+    org_resource_name: str,
+    folders: list[dict],
+    projects: list[dict],
+    update_tag: int,
+    common_job_parameters: dict,
+) -> None:
+    logger.info("Syncing GCP Cloud Logging sinks for %s", org_resource_name)
+
+    org_sinks_raw = get_org_log_sinks(client, org_resource_name)
+    if org_sinks_raw is not None:
+        org_sinks = transform_gcp_log_sinks(
+            org_sinks_raw,
+            "organization",
+            org_resource_name,
+        )
+        load_org_log_sinks(neo4j_session, org_sinks, update_tag, org_resource_name)
+        cleanup_org_log_sinks(neo4j_session, common_job_parameters, org_resource_name)
+
+    for folder in folders:
+        folder_name = folder.get("name")
+        if not folder_name:
+            continue
+        folder_sinks_raw = get_folder_log_sinks(client, folder_name)
+        if folder_sinks_raw is None:
+            continue
+        folder_sinks = transform_gcp_log_sinks(
+            folder_sinks_raw,
+            "folder",
+            folder_name,
+        )
+        load_folder_log_sinks(neo4j_session, folder_sinks, update_tag, folder_name)
+        cleanup_folder_log_sinks(neo4j_session, common_job_parameters, folder_name)
+
+    for project in projects:
+        project_id = project.get("projectId")
+        if not project_id:
+            continue
+        project_parent = f"projects/{project_id}"
+        project_sinks_raw = get_project_log_sinks(client, project_id)
+        if project_sinks_raw is None:
+            continue
+        project_sinks = transform_gcp_log_sinks(
+            project_sinks_raw,
+            "project",
+            project_parent,
+        )
+        load_project_log_sinks(neo4j_session, project_sinks, update_tag, project_id)
+        cleanup_project_log_sinks(neo4j_session, common_job_parameters, project_id)

--- a/cartography/intel/gcp/log_sink.py
+++ b/cartography/intel/gcp/log_sink.py
@@ -113,7 +113,9 @@ def transform_gcp_log_sinks(
 ) -> list[dict]:
     transformed: list[dict] = []
     for sink in sinks:
-        name = sink["name"]
+        name = sink.get("name")
+        if not name:
+            continue
         full_name = _sink_resource_name(name, parent_id)
         transformed.append(
             {

--- a/cartography/intel/gcp/log_sink.py
+++ b/cartography/intel/gcp/log_sink.py
@@ -86,6 +86,19 @@ def _sink_short_name(sink_name: str | None) -> str | None:
     return sink_name.split("/sinks/")[-1]
 
 
+def _parse_bigquery_dataset_id(destination: str | None) -> str | None:
+    if not destination:
+        return None
+    prefix = "bigquery.googleapis.com/projects/"
+    if not destination.startswith(prefix):
+        return None
+    path = destination[len(prefix) :]
+    parts = path.split("/")
+    if len(parts) != 3 or parts[1] != "datasets" or not parts[0] or not parts[2]:
+        return None
+    return f"{parts[0]}:{parts[2]}"
+
+
 @timeit
 def transform_gcp_log_sinks(
     sinks: list[dict],
@@ -103,6 +116,9 @@ def transform_gcp_log_sinks(
                 "name": name,
                 "sink_name": _sink_short_name(name),
                 "destination": sink.get("destination"),
+                "bigquery_dataset_id": _parse_bigquery_dataset_id(
+                    sink.get("destination")
+                ),
                 "filter": sink.get("filter"),
                 "description": sink.get("description"),
                 "disabled": sink.get("disabled", False),

--- a/cartography/intel/gcp/resources.py
+++ b/cartography/intel/gcp/resources.py
@@ -20,6 +20,7 @@ RESOURCE_FUNCTIONS: list[str] = [
     "bigquery_connection",
     "apikeys",
     "log_sinks",
+    "audit_config",
     "policy_bindings",
     "permission_relationships",
 ]

--- a/cartography/intel/gcp/resources.py
+++ b/cartography/intel/gcp/resources.py
@@ -19,6 +19,7 @@ RESOURCE_FUNCTIONS: list[str] = [
     "bigquery",
     "bigquery_connection",
     "apikeys",
+    "log_sinks",
     "policy_bindings",
     "permission_relationships",
 ]

--- a/cartography/intel/gcp/router.py
+++ b/cartography/intel/gcp/router.py
@@ -11,8 +11,10 @@ from googleapiclient.errors import HttpError
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.gcp.util import aggregated_response_cleanup_safe
 from cartography.intel.gcp.util import classify_gcp_http_error
 from cartography.intel.gcp.util import gcp_api_execute_with_retry
+from cartography.intel.gcp.util import merge_aggregated_scope_items
 from cartography.intel.gcp.util import parse_compute_full_uri_to_partial_uri
 from cartography.intel.gcp.util import summarize_gcp_http_error
 from cartography.models.gcp.compute.cloud_nat import GCPCloudNatSchema
@@ -21,34 +23,7 @@ from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
-_SCOPE_NO_RESULTS_WARNING = "NO_RESULTS_ON_PAGE"
 _EXPECTED_SKIP_CATEGORIES = ("api_disabled", "billing_disabled", "forbidden")
-
-
-def _aggregated_response_cleanup_safe(response: Resource) -> bool:
-    for scoped_list in response.get("items", {}).values():
-        warning = scoped_list.get("warning")
-        if warning and warning.get("code") != _SCOPE_NO_RESULTS_WARNING:
-            return False
-    return True
-
-
-def _merge_aggregated_scope_items(
-    items: dict[str, dict],
-    response: Resource,
-) -> None:
-    for scope, scoped_list in response.get("items", {}).items():
-        target_scoped_list = items.setdefault(scope, {})
-        target_scoped_list.setdefault("routers", []).extend(
-            scoped_list.get("routers", [])
-        )
-        warning = scoped_list.get("warning")
-        existing_warning = target_scoped_list.get("warning")
-        if warning and (
-            not existing_warning
-            or existing_warning.get("code") == _SCOPE_NO_RESULTS_WARNING
-        ):
-            target_scoped_list["warning"] = warning
 
 
 @timeit
@@ -80,7 +55,7 @@ def get_gcp_routers(
                 )
                 return None
             raise
-        _merge_aggregated_scope_items(items, res)
+        merge_aggregated_scope_items(items, res, "routers")
         response_id = res.get("id", response_id)
         req = compute.routers().aggregatedList_next(
             previous_request=req,
@@ -216,5 +191,5 @@ def sync_gcp_routers(
     load_gcp_routers(neo4j_session, routers, gcp_update_tag, project_id)
     load_gcp_cloud_nats(neo4j_session, cloud_nats, gcp_update_tag, project_id)
 
-    if _aggregated_response_cleanup_safe(response):
+    if aggregated_response_cleanup_safe(response):
         cleanup_gcp_routers(neo4j_session, common_job_parameters)

--- a/cartography/intel/gcp/router.py
+++ b/cartography/intel/gcp/router.py
@@ -1,0 +1,220 @@
+# Google Compute Engine Cloud Routers and Cloud NAT configs
+# https://cloud.google.com/compute/docs/reference/rest/v1/routers
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import neo4j
+from googleapiclient.discovery import Resource
+from googleapiclient.errors import HttpError
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.gcp.util import classify_gcp_http_error
+from cartography.intel.gcp.util import gcp_api_execute_with_retry
+from cartography.intel.gcp.util import parse_compute_full_uri_to_partial_uri
+from cartography.intel.gcp.util import summarize_gcp_http_error
+from cartography.models.gcp.compute.cloud_nat import GCPCloudNatSchema
+from cartography.models.gcp.compute.router import GCPRouterSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+_SCOPE_NO_RESULTS_WARNING = "NO_RESULTS_ON_PAGE"
+_EXPECTED_SKIP_CATEGORIES = ("api_disabled", "billing_disabled", "forbidden")
+
+
+def _aggregated_response_cleanup_safe(response: Resource) -> bool:
+    for scoped_list in response.get("items", {}).values():
+        warning = scoped_list.get("warning")
+        if warning and warning.get("code") != _SCOPE_NO_RESULTS_WARNING:
+            return False
+    return True
+
+
+def _merge_aggregated_scope_items(
+    items: dict[str, dict],
+    response: Resource,
+) -> None:
+    for scope, scoped_list in response.get("items", {}).items():
+        target_scoped_list = items.setdefault(scope, {})
+        target_scoped_list.setdefault("routers", []).extend(
+            scoped_list.get("routers", [])
+        )
+        warning = scoped_list.get("warning")
+        existing_warning = target_scoped_list.get("warning")
+        if warning and (
+            not existing_warning
+            or existing_warning.get("code") == _SCOPE_NO_RESULTS_WARNING
+        ):
+            target_scoped_list["warning"] = warning
+
+
+@timeit
+def get_gcp_routers(
+    project_id: str,
+    compute: Resource,
+) -> Resource | None:
+    """
+    Return all Cloud Routers in the given project.
+    :param project_id: The project ID
+    :param compute: The compute resource object created by googleapiclient.discovery.build()
+    :return: Aggregated response object containing Cloud Routers, or None if access is denied
+    """
+    items: dict[str, dict] = {}
+    response_id = f"projects/{project_id}/aggregated/routers"
+    req = compute.routers().aggregatedList(
+        project=project_id,
+        returnPartialSuccess=True,
+    )
+    while req is not None:
+        try:
+            res = gcp_api_execute_with_retry(req)
+        except HttpError as e:
+            if classify_gcp_http_error(e) in _EXPECTED_SKIP_CATEGORIES:
+                logger.warning(
+                    "GCP: Unable to list Cloud Routers for project %s; skipping this collector. %s",
+                    project_id,
+                    summarize_gcp_http_error(e),
+                )
+                return None
+            raise
+        _merge_aggregated_scope_items(items, res)
+        response_id = res.get("id", response_id)
+        req = compute.routers().aggregatedList_next(
+            previous_request=req,
+            previous_response=res,
+        )
+    return {"id": response_id, "items": items}
+
+
+def _scope_to_region(scope: str) -> str | None:
+    if scope == "global":
+        return None
+    return scope.split("regions/")[-1]
+
+
+@timeit
+def transform_gcp_routers(
+    response: Resource,
+    project_id: str,
+) -> tuple[list[dict], list[dict]]:
+    """
+    Transform Cloud Router aggregatedList response into router and Cloud NAT rows.
+    :param response: The response object returned from routers.aggregatedList()
+    :param project_id: The GCP project ID
+    :return: Tuple of router rows and Cloud NAT rows ready for loading
+    """
+    routers: list[dict] = []
+    cloud_nats: list[dict] = []
+
+    for scope, scoped_list in response.get("items", {}).items():
+        region = _scope_to_region(scope)
+        for router in scoped_list.get("routers", []):
+            router_partial_uri = (
+                f"projects/{project_id}/{scope}/routers/{router['name']}"
+            )
+            network = router.get("network")
+            router_row: dict[str, Any] = {
+                "partial_uri": router_partial_uri,
+                "project_id": project_id,
+                "region": region,
+                "name": router.get("name"),
+                "self_link": router.get("selfLink"),
+                "description": router.get("description"),
+                "network_partial_uri": parse_compute_full_uri_to_partial_uri(network),
+            }
+            routers.append(router_row)
+
+            for nat in router.get("nats", []) or []:
+                nat_name = nat.get("name")
+                if not nat_name:
+                    continue
+                log_config = nat.get("logConfig", {})
+                cloud_nats.append(
+                    {
+                        "id": f"{router_partial_uri}/nats/{nat_name}",
+                        "name": nat_name,
+                        "project_id": project_id,
+                        "region": region,
+                        "router_id": router_partial_uri,
+                        "log_enabled": log_config.get("enable"),
+                        "log_filter": log_config.get("filter"),
+                        "nat_ip_allocate_option": nat.get("natIpAllocateOption"),
+                        "source_subnetwork_ip_ranges_to_nat": nat.get(
+                            "sourceSubnetworkIpRangesToNat"
+                        ),
+                    },
+                )
+    return routers, cloud_nats
+
+
+@timeit
+def load_gcp_routers(
+    neo4j_session: neo4j.Session,
+    routers: list[dict],
+    gcp_update_tag: int,
+    project_id: str,
+) -> None:
+    load(
+        neo4j_session,
+        GCPRouterSchema(),
+        routers,
+        lastupdated=gcp_update_tag,
+        PROJECT_ID=project_id,
+    )
+
+
+@timeit
+def load_gcp_cloud_nats(
+    neo4j_session: neo4j.Session,
+    cloud_nats: list[dict],
+    gcp_update_tag: int,
+    project_id: str,
+) -> None:
+    load(
+        neo4j_session,
+        GCPCloudNatSchema(),
+        cloud_nats,
+        lastupdated=gcp_update_tag,
+        PROJECT_ID=project_id,
+    )
+
+
+@timeit
+def cleanup_gcp_routers(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict,
+) -> None:
+    GraphJob.from_node_schema(GCPCloudNatSchema(), common_job_parameters).run(
+        neo4j_session,
+    )
+    GraphJob.from_node_schema(GCPRouterSchema(), common_job_parameters).run(
+        neo4j_session,
+    )
+
+
+@timeit
+def sync_gcp_routers(
+    neo4j_session: neo4j.Session,
+    compute: Resource,
+    project_id: str,
+    gcp_update_tag: int,
+    common_job_parameters: dict,
+) -> None:
+    """
+    Sync GCP Cloud Routers and nested Cloud NAT configs.
+    """
+    logger.info(
+        "Syncing GCP Cloud Routers and Cloud NAT configs for project %s", project_id
+    )
+    response = get_gcp_routers(project_id, compute)
+    if response is None:
+        return
+    routers, cloud_nats = transform_gcp_routers(response, project_id)
+    load_gcp_routers(neo4j_session, routers, gcp_update_tag, project_id)
+    load_gcp_cloud_nats(neo4j_session, cloud_nats, gcp_update_tag, project_id)
+
+    if _aggregated_response_cleanup_safe(response):
+        cleanup_gcp_routers(neo4j_session, common_job_parameters)

--- a/cartography/models/gcp/audit_config.py
+++ b/cartography/models/gcp/audit_config.py
@@ -1,0 +1,125 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GCPAuditConfigNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id", description="Stable identifier for this IAM audit config entry."
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    parent_type: PropertyRef = PropertyRef(
+        "parent_type",
+        description="Audit config parent type: organization, folder, or project.",
+    )
+    parent_id: PropertyRef = PropertyRef(
+        "parent_id", description="Full resource name of the audit config parent."
+    )
+    service: PropertyRef = PropertyRef(
+        "service",
+        extra_index=True,
+        description="Service this audit config applies to, such as `allServices` or `cloudtasks.googleapis.com`.",
+    )
+    has_admin_read: PropertyRef = PropertyRef(
+        "has_admin_read",
+        description="Whether this audit config includes the `ADMIN_READ` log type.",
+    )
+    has_data_read: PropertyRef = PropertyRef(
+        "has_data_read",
+        description="Whether this audit config includes the `DATA_READ` log type.",
+    )
+    has_data_write: PropertyRef = PropertyRef(
+        "has_data_write",
+        description="Whether this audit config includes the `DATA_WRITE` log type.",
+    )
+    audit_log_configs_json: PropertyRef = PropertyRef(
+        "audit_log_configs_json",
+        description="Raw auditLogConfigs array encoded as JSON, including exemptedMembers when present.",
+    )
+
+
+@dataclass(frozen=True)
+class GCPAuditConfigToOrgRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPAuditConfigToOrgRel(CartographyRelSchema):
+    target_node_label: str = "GCPOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ORG_RESOURCE_NAME", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPAuditConfigToOrgRelProperties = GCPAuditConfigToOrgRelProperties()
+
+
+@dataclass(frozen=True)
+class GCPAuditConfigToFolderRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPAuditConfigToFolderRel(CartographyRelSchema):
+    target_node_label: str = "GCPFolder"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("FOLDER_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPAuditConfigToFolderRelProperties = (
+        GCPAuditConfigToFolderRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GCPAuditConfigToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPAuditConfigToProjectRel(CartographyRelSchema):
+    target_node_label: str = "GCPProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPAuditConfigToProjectRelProperties = (
+        GCPAuditConfigToProjectRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class GCPOrgAuditConfigSchema(CartographyNodeSchema):
+    """Representation of an organization-scoped GCP IAM audit config entry."""
+
+    label: str = "GCPAuditConfig"
+    properties: GCPAuditConfigNodeProperties = GCPAuditConfigNodeProperties()
+    sub_resource_relationship: GCPAuditConfigToOrgRel = GCPAuditConfigToOrgRel()
+
+
+@dataclass(frozen=True)
+class GCPFolderAuditConfigSchema(CartographyNodeSchema):
+    """Representation of a folder-scoped GCP IAM audit config entry."""
+
+    label: str = "GCPAuditConfig"
+    properties: GCPAuditConfigNodeProperties = GCPAuditConfigNodeProperties()
+    sub_resource_relationship: GCPAuditConfigToFolderRel = GCPAuditConfigToFolderRel()
+
+
+@dataclass(frozen=True)
+class GCPProjectAuditConfigSchema(CartographyNodeSchema):
+    """Representation of a project-scoped GCP IAM audit config entry."""
+
+    label: str = "GCPAuditConfig"
+    properties: GCPAuditConfigNodeProperties = GCPAuditConfigNodeProperties()
+    sub_resource_relationship: GCPAuditConfigToProjectRel = GCPAuditConfigToProjectRel()

--- a/cartography/models/gcp/cloudsql/instance.py
+++ b/cartography/models/gcp/cloudsql/instance.py
@@ -105,6 +105,26 @@ class GCPSqlInstanceProperties(CartographyNodeProperties):
         "database_flags",
         description="Configured database flags encoded as JSON name-value entries.",
     )
+    flag_cloudsql_enable_pgaudit: PropertyRef = PropertyRef(
+        "flag_cloudsql_enable_pgaudit",
+        description="Value of the Cloud SQL `cloudsql.enable_pgaudit` database flag, when configured.",
+    )
+    flag_log_checkpoints: PropertyRef = PropertyRef(
+        "flag_log_checkpoints",
+        description="Value of the Cloud SQL `log_checkpoints` database flag, when configured.",
+    )
+    flag_log_connections: PropertyRef = PropertyRef(
+        "flag_log_connections",
+        description="Value of the Cloud SQL `log_connections` database flag, when configured.",
+    )
+    flag_log_disconnections: PropertyRef = PropertyRef(
+        "flag_log_disconnections",
+        description="Value of the Cloud SQL `log_disconnections` database flag, when configured.",
+    )
+    flag_log_lock_waits: PropertyRef = PropertyRef(
+        "flag_log_lock_waits",
+        description="Value of the Cloud SQL `log_lock_waits` database flag, when configured.",
+    )
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 

--- a/cartography/models/gcp/compute/cloud_nat.py
+++ b/cartography/models/gcp/compute/cloud_nat.py
@@ -1,0 +1,97 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GCPCloudNatNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id", description="Stable identifier for this Cloud NAT config."
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="The name of the Cloud NAT config."
+    )
+    project_id: PropertyRef = PropertyRef(
+        "project_id", description="The project ID that this Cloud NAT belongs to."
+    )
+    region: PropertyRef = PropertyRef(
+        "region", description="The region where this Cloud NAT is configured."
+    )
+    router_id: PropertyRef = PropertyRef(
+        "router_id",
+        description="The partial URI of the parent Cloud Router that owns this NAT config.",
+    )
+    log_enabled: PropertyRef = PropertyRef(
+        "log_enabled", description="Whether Cloud NAT logging is enabled."
+    )
+    log_filter: PropertyRef = PropertyRef(
+        "log_filter",
+        description="Cloud NAT log filter setting, such as `ERRORS_ONLY`, `TRANSLATIONS_ONLY`, or `ALL`.",
+    )
+    nat_ip_allocate_option: PropertyRef = PropertyRef(
+        "nat_ip_allocate_option",
+        description="Cloud NAT IP allocation mode, such as `AUTO_ONLY` or `MANUAL_ONLY`.",
+    )
+    source_subnetwork_ip_ranges_to_nat: PropertyRef = PropertyRef(
+        "source_subnetwork_ip_ranges_to_nat",
+        description="Source subnetwork IP range selection configured for this Cloud NAT.",
+    )
+
+
+@dataclass(frozen=True)
+class GCPCloudNatToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPCloudNatToProjectRel(CartographyRelSchema):
+    target_node_label: str = "GCPProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("PROJECT_ID", set_in_kwargs=True),
+        },
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPCloudNatToProjectRelProperties = GCPCloudNatToProjectRelProperties()
+
+
+@dataclass(frozen=True)
+class GCPCloudNatToRouterRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPCloudNatToRouterRel(CartographyRelSchema):
+    target_node_label: str = "GCPRouter"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("router_id"),
+        },
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "HAS_NAT"
+    properties: GCPCloudNatToRouterRelProperties = GCPCloudNatToRouterRelProperties()
+
+
+@dataclass(frozen=True)
+class GCPCloudNatSchema(CartographyNodeSchema):
+    """Representation of a GCP [Cloud NAT](https://cloud.google.com/nat/docs/reference/compute/rest/v1/routers)."""
+
+    label: str = "GCPCloudNat"
+    properties: GCPCloudNatNodeProperties = GCPCloudNatNodeProperties()
+    sub_resource_relationship: GCPCloudNatToProjectRel = GCPCloudNatToProjectRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            GCPCloudNatToRouterRel(),
+        ],
+    )

--- a/cartography/models/gcp/compute/firewall.py
+++ b/cartography/models/gcp/compute/firewall.py
@@ -40,6 +40,14 @@ class GCPFirewallNodeProperties(CartographyNodeProperties):
         "has_target_service_accounts",
         description="Set to True if this Firewall has target service accounts defined. This field is currently a placeholder for future functionality to add GCP IAM objects to Cartography. If True, this firewall rule will only apply to GCP instances that use the specified target service account.",
     )
+    log_logging_enabled: PropertyRef = PropertyRef(
+        "log_logging_enabled",
+        description="Whether firewall rule logging is enabled for this firewall rule.",
+    )
+    log_logging_metadata: PropertyRef = PropertyRef(
+        "log_logging_metadata",
+        description="Firewall rule logging metadata setting, such as `INCLUDE_ALL_METADATA` or `EXCLUDE_ALL_METADATA`.",
+    )
 
 
 @dataclass(frozen=True)

--- a/cartography/models/gcp/compute/router.py
+++ b/cartography/models/gcp/compute/router.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GCPRouterNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "partial_uri", description="Stable identifier for this Cloud Router."
+    )
+    partial_uri: PropertyRef = PropertyRef("partial_uri", description="Same as `id`.")
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="The name of the Cloud Router."
+    )
+    self_link: PropertyRef = PropertyRef(
+        "self_link", description="Server-defined URL for the Cloud Router."
+    )
+    project_id: PropertyRef = PropertyRef(
+        "project_id", description="The project ID that this Cloud Router belongs to."
+    )
+    region: PropertyRef = PropertyRef(
+        "region", description="The region where this Cloud Router is configured."
+    )
+    network: PropertyRef = PropertyRef(
+        "network_partial_uri",
+        description="A partial resource URI of the VPC network this Cloud Router belongs to.",
+    )
+    description: PropertyRef = PropertyRef(
+        "description", description="An optional description of this Cloud Router."
+    )
+
+
+@dataclass(frozen=True)
+class GCPRouterToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPRouterToProjectRel(CartographyRelSchema):
+    target_node_label: str = "GCPProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("PROJECT_ID", set_in_kwargs=True),
+        },
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPRouterToProjectRelProperties = GCPRouterToProjectRelProperties()
+
+
+@dataclass(frozen=True)
+class GCPRouterToVpcRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPRouterToVpcRel(CartographyRelSchema):
+    target_node_label: str = "GCPVpc"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "id": PropertyRef("network_partial_uri"),
+        },
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "ASSOCIATED_WITH"
+    properties: GCPRouterToVpcRelProperties = GCPRouterToVpcRelProperties()
+
+
+@dataclass(frozen=True)
+class GCPRouterSchema(CartographyNodeSchema):
+    """Representation of a GCP [Cloud Router](https://cloud.google.com/compute/docs/reference/rest/v1/routers)."""
+
+    label: str = "GCPRouter"
+    properties: GCPRouterNodeProperties = GCPRouterNodeProperties()
+    sub_resource_relationship: GCPRouterToProjectRel = GCPRouterToProjectRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            GCPRouterToVpcRel(),
+        ],
+    )

--- a/cartography/models/gcp/logging/log_sink.py
+++ b/cartography/models/gcp/logging/log_sink.py
@@ -7,6 +7,7 @@ from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
 
 
@@ -24,6 +25,10 @@ class GCPLogSinkNodeProperties(CartographyNodeProperties):
     )
     destination: PropertyRef = PropertyRef(
         "destination", description="Export destination configured for this sink."
+    )
+    bigquery_dataset_id: PropertyRef = PropertyRef(
+        "bigquery_dataset_id",
+        description="GCPBigQueryDataset ID parsed from a BigQuery sink destination, when applicable.",
     )
     filter: PropertyRef = PropertyRef(
         "filter", description="Advanced logs filter configured for this sink."
@@ -102,12 +107,33 @@ class GCPLogSinkToProjectRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class GCPLogSinkToBigQueryDatasetRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPLogSinkToBigQueryDatasetRel(CartographyRelSchema):
+    target_node_label: str = "GCPBigQueryDataset"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("bigquery_dataset_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "DELIVERS_TO"
+    properties: GCPLogSinkToBigQueryDatasetRelProperties = (
+        GCPLogSinkToBigQueryDatasetRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class GCPOrgLogSinkSchema(CartographyNodeSchema):
     """Representation of an organization-scoped GCP [Cloud Logging Sink](https://cloud.google.com/logging/docs/reference/v2/rest/v2/sinks)."""
 
     label: str = "GCPLogSink"
     properties: GCPLogSinkNodeProperties = GCPLogSinkNodeProperties()
     sub_resource_relationship: GCPLogSinkToOrgRel = GCPLogSinkToOrgRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [GCPLogSinkToBigQueryDatasetRel()],
+    )
 
 
 @dataclass(frozen=True)
@@ -117,6 +143,9 @@ class GCPFolderLogSinkSchema(CartographyNodeSchema):
     label: str = "GCPLogSink"
     properties: GCPLogSinkNodeProperties = GCPLogSinkNodeProperties()
     sub_resource_relationship: GCPLogSinkToFolderRel = GCPLogSinkToFolderRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [GCPLogSinkToBigQueryDatasetRel()],
+    )
 
 
 @dataclass(frozen=True)
@@ -126,3 +155,6 @@ class GCPProjectLogSinkSchema(CartographyNodeSchema):
     label: str = "GCPLogSink"
     properties: GCPLogSinkNodeProperties = GCPLogSinkNodeProperties()
     sub_resource_relationship: GCPLogSinkToProjectRel = GCPLogSinkToProjectRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [GCPLogSinkToBigQueryDatasetRel()],
+    )

--- a/cartography/models/gcp/logging/log_sink.py
+++ b/cartography/models/gcp/logging/log_sink.py
@@ -1,0 +1,128 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class GCPLogSinkNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id", description="Full resource name of this Cloud Logging sink."
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    name: PropertyRef = PropertyRef(
+        "name", extra_index=True, description="Full resource name of this sink."
+    )
+    sink_name: PropertyRef = PropertyRef(
+        "sink_name", description="Short sink name without the parent prefix."
+    )
+    destination: PropertyRef = PropertyRef(
+        "destination", description="Export destination configured for this sink."
+    )
+    filter: PropertyRef = PropertyRef(
+        "filter", description="Advanced logs filter configured for this sink."
+    )
+    description: PropertyRef = PropertyRef(
+        "description", description="Optional description of this sink."
+    )
+    disabled: PropertyRef = PropertyRef(
+        "disabled", description="Whether this sink is disabled."
+    )
+    include_children: PropertyRef = PropertyRef(
+        "include_children",
+        description="Whether this sink includes child resources under the parent.",
+    )
+    writer_identity: PropertyRef = PropertyRef(
+        "writer_identity", description="Writer identity used by this sink."
+    )
+    output_version_format: PropertyRef = PropertyRef(
+        "output_version_format",
+        description="Output version format configured for this sink, when present.",
+    )
+    parent_type: PropertyRef = PropertyRef(
+        "parent_type", description="Sink parent type: organization, folder, or project."
+    )
+    parent_id: PropertyRef = PropertyRef(
+        "parent_id", description="Full resource name of the sink parent."
+    )
+
+
+@dataclass(frozen=True)
+class GCPLogSinkToOrgRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPLogSinkToOrgRel(CartographyRelSchema):
+    target_node_label: str = "GCPOrganization"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ORG_RESOURCE_NAME", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPLogSinkToOrgRelProperties = GCPLogSinkToOrgRelProperties()
+
+
+@dataclass(frozen=True)
+class GCPLogSinkToFolderRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPLogSinkToFolderRel(CartographyRelSchema):
+    target_node_label: str = "GCPFolder"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("FOLDER_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPLogSinkToFolderRelProperties = GCPLogSinkToFolderRelProperties()
+
+
+@dataclass(frozen=True)
+class GCPLogSinkToProjectRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class GCPLogSinkToProjectRel(CartographyRelSchema):
+    target_node_label: str = "GCPProject"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("PROJECT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: GCPLogSinkToProjectRelProperties = GCPLogSinkToProjectRelProperties()
+
+
+@dataclass(frozen=True)
+class GCPOrgLogSinkSchema(CartographyNodeSchema):
+    """Representation of an organization-scoped GCP [Cloud Logging Sink](https://cloud.google.com/logging/docs/reference/v2/rest/v2/sinks)."""
+
+    label: str = "GCPLogSink"
+    properties: GCPLogSinkNodeProperties = GCPLogSinkNodeProperties()
+    sub_resource_relationship: GCPLogSinkToOrgRel = GCPLogSinkToOrgRel()
+
+
+@dataclass(frozen=True)
+class GCPFolderLogSinkSchema(CartographyNodeSchema):
+    """Representation of a folder-scoped GCP Cloud Logging Sink."""
+
+    label: str = "GCPLogSink"
+    properties: GCPLogSinkNodeProperties = GCPLogSinkNodeProperties()
+    sub_resource_relationship: GCPLogSinkToFolderRel = GCPLogSinkToFolderRel()
+
+
+@dataclass(frozen=True)
+class GCPProjectLogSinkSchema(CartographyNodeSchema):
+    """Representation of a project-scoped GCP Cloud Logging Sink."""
+
+    label: str = "GCPLogSink"
+    properties: GCPLogSinkNodeProperties = GCPLogSinkNodeProperties()
+    sub_resource_relationship: GCPLogSinkToProjectRel = GCPLogSinkToProjectRel()

--- a/docs/root/modules/gcp/config.md
+++ b/docs/root/modules/gcp/config.md
@@ -75,6 +75,8 @@ Grant only the roles needed for the resource types you want to sync:
 | `roles/run.viewer` | List and get Cloud Run services, jobs, and executions |
 | `roles/notebooks.viewer` | List and get Vertex AI Workbench resources |
 | `roles/serviceusage.apiKeysViewer` | List and get Google Cloud API keys |
+| `roles/logging.viewer` | List organization, folder, and project Cloud Logging sinks |
+| `roles/cloudsql.viewer` | List and get Cloud SQL instances, including database flags |
 
 Enable optional APIs on the host project according to the resources you want
 to sync:
@@ -97,6 +99,7 @@ gcloud services enable aiplatform.googleapis.com --project=YOUR_HOST_PROJECT
 gcloud services enable notebooks.googleapis.com --project=YOUR_HOST_PROJECT
 gcloud services enable cloudasset.googleapis.com --project=YOUR_HOST_PROJECT
 gcloud services enable apikeys.googleapis.com --project=YOUR_HOST_PROJECT
+gcloud services enable logging.googleapis.com --project=YOUR_HOST_PROJECT
 ```
 
 ## Configure Cartography
@@ -140,6 +143,8 @@ cartography --selected-modules gcp
   `roles/cloudasset.viewer`.
 - Permission relationship sync requires policy bindings to refresh
   successfully in the same run.
+- IAM audit config sync uses Resource Manager `getIamPolicy` access on
+  organizations, folders, and projects.
 
 ## References
 

--- a/docs/root/modules/gcp/index.md
+++ b/docs/root/modules/gcp/index.md
@@ -3,10 +3,10 @@
 Cartography supports ingesting Google Cloud Platform resources, including:
 
 - **Cloud Resource Manager**: Organizations, Folders, Projects
-- **Compute**: Instances, VPCs, Subnets, Firewalls, Forwarding Rules, Network Interfaces, SSL Policies, Target HTTPS Proxies, Target SSL Proxies, VPC Peerings, VPN Gateways, VPN Tunnels
+- **Compute**: Instances, VPCs, Subnets, Firewalls, Forwarding Rules, Network Interfaces, SSL Policies, Target HTTPS Proxies, Target SSL Proxies, VPC Peerings, VPN Gateways, VPN Tunnels, Cloud Routers, Cloud NAT configs
 - **Storage**: Buckets
 - **DNS**: Zones, Record Sets
-- **IAM**: Service Accounts, Roles, Policy Bindings
+- **IAM**: Service Accounts, Roles, Policy Bindings, Audit Configs
 - **Bigtable**: Instances, Clusters, Tables, App Profiles, Backups
 - **Google Kubernetes Engine (GKE)**: Clusters
 - **Vertex AI**: Models, Endpoints, Deployed Models, Workbench Instances, Training Pipelines, Feature Groups, Datasets
@@ -14,6 +14,7 @@ Cartography supports ingesting Google Cloud Platform resources, including:
 - **BigQuery**: Datasets, Tables, Routines, Connections
 - **Secret Manager**: Secrets, Secret Versions
 - **Cloud Run**: Services, Revisions, Jobs, Executions
+- **Cloud Logging**: Organization, Folder, and Project sinks
 
 ## VPC peerings and VPN tunnels
 

--- a/tests/data/gcp/audit_config.py
+++ b/tests/data/gcp/audit_config.py
@@ -1,0 +1,51 @@
+ORG_AUDIT_CONFIGS = [
+    {
+        "service": "allServices",
+        "auditLogConfigs": [
+            {"logType": "ADMIN_READ"},
+            {"logType": "DATA_READ"},
+            {"logType": "DATA_WRITE"},
+        ],
+    },
+    {
+        "service": "cloudtasks.googleapis.com",
+        "auditLogConfigs": [
+            {"logType": "DATA_READ"},
+        ],
+    },
+    {
+        "service": "empty.googleapis.com",
+        "auditLogConfigs": [],
+    },
+    {
+        "service": "exempted.googleapis.com",
+        "auditLogConfigs": [
+            {
+                "logType": "DATA_READ",
+                "exemptedMembers": [
+                    "serviceAccount:test@example.iam.gserviceaccount.com",
+                ],
+            },
+        ],
+    },
+]
+
+FOLDER_AUDIT_CONFIGS = [
+    {
+        "service": "allServices",
+        "auditLogConfigs": [
+            {"logType": "ADMIN_READ"},
+            {"logType": "DATA_WRITE"},
+        ],
+    },
+]
+
+PROJECT_AUDIT_CONFIGS = [
+    {
+        "service": "cloudtasks.googleapis.com",
+        "auditLogConfigs": [
+            {"logType": "DATA_READ"},
+            {"logType": "DATA_WRITE"},
+        ],
+    },
+]

--- a/tests/data/gcp/cloud_sql.py
+++ b/tests/data/gcp/cloud_sql.py
@@ -22,6 +22,28 @@ MOCK_INSTANCES = {
                 "dataDiskSizeGb": "100",
                 "dataDiskType": "PD_SSD",
                 "availabilityType": "REGIONAL",
+                "databaseFlags": [
+                    {
+                        "name": "cloudsql.enable_pgaudit",
+                        "value": "on",
+                    },
+                    {
+                        "name": "log_checkpoints",
+                        "value": "on",
+                    },
+                    {
+                        "name": "log_connections",
+                        "value": "on",
+                    },
+                    {
+                        "name": "log_disconnections",
+                        "value": "on",
+                    },
+                    {
+                        "name": "log_lock_waits",
+                        "value": "on",
+                    },
+                ],
                 "backupConfiguration": {
                     "enabled": True,
                     "startTime": "03:00",

--- a/tests/data/gcp/compute.py
+++ b/tests/data/gcp/compute.py
@@ -591,6 +591,7 @@ LIST_FIREWALLS_RESPONSE = {
             "kind": "compute#firewall",
             "logConfig": {
                 "enable": True,
+                "metadata": "INCLUDE_ALL_METADATA",
             },
             "name": "custom-port-incoming",
             "network": "https://www.googleapis.com/compute/v1/projects/project-abc/global/networks/default",

--- a/tests/data/gcp/log_sink.py
+++ b/tests/data/gcp/log_sink.py
@@ -1,0 +1,33 @@
+ORG_LOG_SINKS = [
+    {
+        "name": "organizations/123456789012/sinks/org-audit-sink",
+        "destination": "bigquery.googleapis.com/projects/log-project/datasets/audit_logs",
+        "filter": 'logName:"cloudaudit.googleapis.com/activity"',
+        "description": "Organization audit sink",
+        "disabled": False,
+        "includeChildren": True,
+        "writerIdentity": "serviceAccount:org-writer@gcp-sa-logging.iam.gserviceaccount.com",
+        "outputVersionFormat": "V2",
+    },
+]
+
+FOLDER_LOG_SINKS = [
+    {
+        "name": "folders/987654321098/sinks/folder-disabled-sink",
+        "destination": "storage.googleapis.com/folder-audit-logs",
+        "filter": 'logName:"cloudaudit.googleapis.com/data_access"',
+        "disabled": True,
+        "writerIdentity": "serviceAccount:folder-writer@gcp-sa-logging.iam.gserviceaccount.com",
+    },
+]
+
+PROJECT_LOG_SINKS = [
+    {
+        "name": "projects/test-project/sinks/project-system-event-sink",
+        "destination": "pubsub.googleapis.com/projects/log-project/topics/system-events",
+        "filter": 'logName:"cloudaudit.googleapis.com/system_event"',
+        "disabled": False,
+        "includeChildren": False,
+        "writerIdentity": "serviceAccount:project-writer@gcp-sa-logging.iam.gserviceaccount.com",
+    },
+]

--- a/tests/data/gcp/router.py
+++ b/tests/data/gcp/router.py
@@ -1,0 +1,76 @@
+from typing import Any
+
+ROUTER_AGGREGATED_RESPONSE: dict[str, Any] = {
+    "id": "projects/project-abc/aggregated/routers",
+    "items": {
+        "regions/us-central1": {
+            "routers": [
+                {
+                    "name": "router-no-nats",
+                    "selfLink": "https://www.googleapis.com/compute/v1/projects/"
+                    "project-abc/regions/us-central1/routers/router-no-nats",
+                    "network": "https://www.googleapis.com/compute/v1/projects/"
+                    "project-abc/global/networks/default",
+                },
+                {
+                    "name": "router-with-nats",
+                    "selfLink": "https://www.googleapis.com/compute/v1/projects/"
+                    "project-abc/regions/us-central1/routers/router-with-nats",
+                    "network": "https://www.googleapis.com/compute/v1/projects/"
+                    "project-abc/global/networks/default",
+                    "nats": [
+                        {
+                            "name": "nat-logging-on",
+                            "natIpAllocateOption": "AUTO_ONLY",
+                            "sourceSubnetworkIpRangesToNat": "ALL_SUBNETWORKS_ALL_IP_RANGES",
+                            "logConfig": {
+                                "enable": True,
+                                "filter": "ALL",
+                            },
+                        },
+                        {
+                            "name": "nat-logging-off",
+                            "natIpAllocateOption": "MANUAL_ONLY",
+                            "sourceSubnetworkIpRangesToNat": "LIST_OF_SUBNETWORKS",
+                            "logConfig": {
+                                "enable": False,
+                                "filter": "ERRORS_ONLY",
+                            },
+                        },
+                        {
+                            "name": "nat-no-log-config",
+                            "natIpAllocateOption": "AUTO_ONLY",
+                            "sourceSubnetworkIpRangesToNat": "ALL_SUBNETWORKS_ALL_IP_RANGES",
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+}
+
+ROUTER_PAGE_1_RESPONSE: dict[str, Any] = {
+    "id": "projects/project-abc/aggregated/routers",
+    "items": {
+        "regions/us-central1": {
+            "routers": [
+                {
+                    "name": "router-page-1",
+                },
+            ],
+        },
+    },
+}
+
+ROUTER_PAGE_2_RESPONSE: dict[str, Any] = {
+    "id": "projects/project-abc/aggregated/routers",
+    "items": {
+        "regions/us-central1": {
+            "routers": [
+                {
+                    "name": "router-page-2",
+                },
+            ],
+        },
+    },
+}

--- a/tests/integration/cartography/intel/gcp/test_audit_config.py
+++ b/tests/integration/cartography/intel/gcp/test_audit_config.py
@@ -1,0 +1,184 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.gcp.audit_config
+from tests.data.gcp.audit_config import FOLDER_AUDIT_CONFIGS
+from tests.data.gcp.audit_config import ORG_AUDIT_CONFIGS
+from tests.data.gcp.audit_config import PROJECT_AUDIT_CONFIGS
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = "organizations/123456789012"
+TEST_FOLDER_ID = "folders/987654321098"
+TEST_PROJECT_ID = "test-project"
+TEST_PROJECT_NUMBER = "1234567890"
+
+
+def _create_prerequisite_nodes(neo4j_session):
+    neo4j_session.run(
+        "MERGE (o:GCPOrganization {id: $org_id}) SET o.lastupdated = $tag",
+        org_id=TEST_ORG_ID,
+        tag=TEST_UPDATE_TAG,
+    )
+    neo4j_session.run(
+        "MERGE (f:GCPFolder {id: $folder_id}) SET f.lastupdated = $tag",
+        folder_id=TEST_FOLDER_ID,
+        tag=TEST_UPDATE_TAG,
+    )
+    neo4j_session.run(
+        "MERGE (p:GCPProject {id: $project_id}) SET p.lastupdated = $tag",
+        project_id=TEST_PROJECT_ID,
+        tag=TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.gcp.audit_config,
+    "get_org_audit_config",
+    return_value=ORG_AUDIT_CONFIGS,
+)
+@patch.object(
+    cartography.intel.gcp.audit_config,
+    "get_folder_audit_config",
+    return_value=FOLDER_AUDIT_CONFIGS,
+)
+@patch.object(
+    cartography.intel.gcp.audit_config,
+    "get_project_audit_config",
+    return_value=PROJECT_AUDIT_CONFIGS,
+)
+def test_sync_gcp_audit_configs(
+    mock_get_project_audit_config,
+    mock_get_folder_audit_config,
+    mock_get_org_audit_config,
+    neo4j_session,
+):
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _create_prerequisite_nodes(neo4j_session)
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "ORG_RESOURCE_NAME": TEST_ORG_ID,
+        "PROJECT_ID": TEST_PROJECT_ID,
+    }
+
+    cartography.intel.gcp.audit_config.sync_gcp_audit_configs(
+        neo4j_session,
+        MagicMock(),
+        TEST_ORG_ID,
+        [{"name": TEST_FOLDER_ID}],
+        [{"projectId": TEST_PROJECT_ID, "projectNumber": TEST_PROJECT_NUMBER}],
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "GCPAuditConfig",
+        [
+            "id",
+            "parent_type",
+            "parent_id",
+            "service",
+            "has_admin_read",
+            "has_data_read",
+            "has_data_write",
+        ],
+    ) == {
+        (
+            f"{TEST_ORG_ID}/auditConfigs/allServices",
+            "organization",
+            TEST_ORG_ID,
+            "allServices",
+            True,
+            True,
+            True,
+        ),
+        (
+            f"{TEST_ORG_ID}/auditConfigs/cloudtasks.googleapis.com",
+            "organization",
+            TEST_ORG_ID,
+            "cloudtasks.googleapis.com",
+            False,
+            True,
+            False,
+        ),
+        (
+            f"{TEST_ORG_ID}/auditConfigs/empty.googleapis.com",
+            "organization",
+            TEST_ORG_ID,
+            "empty.googleapis.com",
+            False,
+            False,
+            False,
+        ),
+        (
+            f"{TEST_ORG_ID}/auditConfigs/exempted.googleapis.com",
+            "organization",
+            TEST_ORG_ID,
+            "exempted.googleapis.com",
+            False,
+            True,
+            False,
+        ),
+        (
+            f"{TEST_FOLDER_ID}/auditConfigs/allServices",
+            "folder",
+            TEST_FOLDER_ID,
+            "allServices",
+            True,
+            False,
+            True,
+        ),
+        (
+            f"projects/{TEST_PROJECT_ID}/auditConfigs/cloudtasks.googleapis.com",
+            "project",
+            f"projects/{TEST_PROJECT_ID}",
+            "cloudtasks.googleapis.com",
+            False,
+            True,
+            True,
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "GCPOrganization",
+        "id",
+        "GCPAuditConfig",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (TEST_ORG_ID, f"{TEST_ORG_ID}/auditConfigs/allServices"),
+        (TEST_ORG_ID, f"{TEST_ORG_ID}/auditConfigs/cloudtasks.googleapis.com"),
+        (TEST_ORG_ID, f"{TEST_ORG_ID}/auditConfigs/empty.googleapis.com"),
+        (TEST_ORG_ID, f"{TEST_ORG_ID}/auditConfigs/exempted.googleapis.com"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "GCPFolder",
+        "id",
+        "GCPAuditConfig",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (TEST_FOLDER_ID, f"{TEST_FOLDER_ID}/auditConfigs/allServices"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "GCPProject",
+        "id",
+        "GCPAuditConfig",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (
+            TEST_PROJECT_ID,
+            f"projects/{TEST_PROJECT_ID}/auditConfigs/cloudtasks.googleapis.com",
+        ),
+    }

--- a/tests/integration/cartography/intel/gcp/test_audit_config.py
+++ b/tests/integration/cartography/intel/gcp/test_audit_config.py
@@ -141,6 +141,19 @@ def test_sync_gcp_audit_configs(
         ),
     }
 
+    exempted_config = neo4j_session.run(
+        """
+        MATCH (a:GCPAuditConfig {id: $id})
+        RETURN a.audit_log_configs_json AS audit_log_configs_json
+        """,
+        id=f"{TEST_ORG_ID}/auditConfigs/exempted.googleapis.com",
+    ).single()
+    assert exempted_config is not None
+    assert (
+        "serviceAccount:test@example.iam.gserviceaccount.com"
+        in exempted_config["audit_log_configs_json"]
+    )
+
     assert check_rels(
         neo4j_session,
         "GCPOrganization",

--- a/tests/integration/cartography/intel/gcp/test_cascade_delete.py
+++ b/tests/integration/cartography/intel/gcp/test_cascade_delete.py
@@ -13,10 +13,12 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import cartography.intel.gcp
+import cartography.intel.gcp.audit_config
 import cartography.intel.gcp.crm.folders
 import cartography.intel.gcp.crm.orgs
 import cartography.intel.gcp.crm.projects
 import cartography.intel.gcp.iam
+import cartography.intel.gcp.log_sink
 from cartography.config import Config
 from cartography.graph.job import GraphJob
 from cartography.models.gcp.crm.folders import GCPFolderSchema
@@ -287,6 +289,16 @@ class TestCascadeDeleteIntegration:
         "get_gcp_credentials",
     )
     @patch.object(
+        cartography.intel.gcp.audit_config,
+        "sync_gcp_audit_configs",
+        return_value=None,
+    )
+    @patch.object(
+        cartography.intel.gcp.log_sink,
+        "sync_gcp_log_sinks",
+        return_value=None,
+    )
+    @patch.object(
         cartography.intel.gcp,
         "_sync_project_resources",
         return_value=SKIPPED_PROJECT_RESOURCES_RESULT,
@@ -321,6 +333,8 @@ class TestCascadeDeleteIntegration:
         mock_get_folders,
         mock_get_projects,
         mock_sync_resources,
+        mock_sync_log_sinks,
+        mock_sync_audit_configs,
         mock_get_creds,
         neo4j_session,
     ):

--- a/tests/integration/cartography/intel/gcp/test_cloud_sql.py
+++ b/tests/integration/cartography/intel/gcp/test_cloud_sql.py
@@ -102,8 +102,26 @@ def test_sync_sql(
     )
 
     # Assert: Check all 4 new node types
-    assert check_nodes(neo4j_session, "GCPCloudSQLInstance", ["id"]) == {
-        (TEST_INSTANCE_ID,),
+    assert check_nodes(
+        neo4j_session,
+        "GCPCloudSQLInstance",
+        [
+            "id",
+            "flag_cloudsql_enable_pgaudit",
+            "flag_log_checkpoints",
+            "flag_log_connections",
+            "flag_log_disconnections",
+            "flag_log_lock_waits",
+        ],
+    ) == {
+        (
+            TEST_INSTANCE_ID,
+            "on",
+            "on",
+            "on",
+            "on",
+            "on",
+        ),
     }
     assert check_nodes(neo4j_session, "GCPCloudSQLDatabase", ["id"]) == {
         (f"{TEST_INSTANCE_ID}/databases/carto-db-1",),

--- a/tests/integration/cartography/intel/gcp/test_compute.py
+++ b/tests/integration/cartography/intel/gcp/test_compute.py
@@ -1064,7 +1064,15 @@ def test_sync_gcp_firewall_rules(mock_get_vpcs, mock_get_firewalls, neo4j_sessio
     assert check_nodes(
         neo4j_session,
         "GCPFirewall",
-        ["id", "name", "direction", "priority", "has_target_service_accounts"],
+        [
+            "id",
+            "name",
+            "direction",
+            "priority",
+            "has_target_service_accounts",
+            "log_logging_enabled",
+            "log_logging_metadata",
+        ],
     ) == {
         (
             "projects/project-abc/global/firewalls/default-allow-icmp",
@@ -1072,6 +1080,8 @@ def test_sync_gcp_firewall_rules(mock_get_vpcs, mock_get_firewalls, neo4j_sessio
             "INGRESS",
             65534,
             False,
+            False,
+            None,
         ),
         (
             "projects/project-abc/global/firewalls/default-allow-internal",
@@ -1079,6 +1089,8 @@ def test_sync_gcp_firewall_rules(mock_get_vpcs, mock_get_firewalls, neo4j_sessio
             "INGRESS",
             65534,
             False,
+            False,
+            None,
         ),
         (
             "projects/project-abc/global/firewalls/default-allow-rdp",
@@ -1086,6 +1098,8 @@ def test_sync_gcp_firewall_rules(mock_get_vpcs, mock_get_firewalls, neo4j_sessio
             "INGRESS",
             65534,
             False,
+            False,
+            None,
         ),
         (
             "projects/project-abc/global/firewalls/default-allow-ssh",
@@ -1093,6 +1107,8 @@ def test_sync_gcp_firewall_rules(mock_get_vpcs, mock_get_firewalls, neo4j_sessio
             "INGRESS",
             65534,
             False,
+            False,
+            None,
         ),
         (
             "projects/project-abc/global/firewalls/custom-port-incoming",
@@ -1100,6 +1116,8 @@ def test_sync_gcp_firewall_rules(mock_get_vpcs, mock_get_firewalls, neo4j_sessio
             "INGRESS",
             1000,
             False,
+            True,
+            "INCLUDE_ALL_METADATA",
         ),
     }
 

--- a/tests/integration/cartography/intel/gcp/test_crm_deferred_cleanup.py
+++ b/tests/integration/cartography/intel/gcp/test_crm_deferred_cleanup.py
@@ -7,10 +7,12 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import cartography.intel.gcp
+import cartography.intel.gcp.audit_config
 import cartography.intel.gcp.crm.folders
 import cartography.intel.gcp.crm.orgs
 import cartography.intel.gcp.crm.projects
 import cartography.intel.gcp.iam
+import cartography.intel.gcp.log_sink
 import tests.data.gcp.crm
 from cartography.config import Config
 from cartography.graph.job import GraphJob
@@ -38,6 +40,16 @@ def _make_fake_credentials():
     cartography.intel.gcp,
     "get_gcp_credentials",
     return_value=_make_fake_credentials(),
+)
+@patch.object(
+    cartography.intel.gcp.audit_config,
+    "sync_gcp_audit_configs",
+    return_value=None,  # Skip real cloudresourcemanager calls for these tests
+)
+@patch.object(
+    cartography.intel.gcp.log_sink,
+    "sync_gcp_log_sinks",
+    return_value=None,  # Skip real logging.googleapis.com calls for these tests
 )
 @patch.object(
     cartography.intel.gcp,
@@ -76,6 +88,8 @@ def test_deferred_cleanup_order(
     mock_get_folders,
     mock_get_projects,
     mock_sync_resources,
+    mock_sync_log_sinks,
+    mock_sync_audit_configs,
     mock_get_creds,
     neo4j_session,
 ):
@@ -144,6 +158,16 @@ def test_deferred_cleanup_order(
     return_value=_make_fake_credentials(),
 )
 @patch.object(
+    cartography.intel.gcp.audit_config,
+    "sync_gcp_audit_configs",
+    return_value=None,
+)
+@patch.object(
+    cartography.intel.gcp.log_sink,
+    "sync_gcp_log_sinks",
+    return_value=None,
+)
+@patch.object(
     cartography.intel.gcp,
     "_sync_project_resources",
     return_value=SKIPPED_PROJECT_RESOURCES_RESULT,
@@ -177,6 +201,8 @@ def test_org_deletion_cleanup(
     mock_get_folders,
     mock_get_projects,
     mock_sync_resources,
+    mock_sync_log_sinks,
+    mock_sync_audit_configs,
     mock_get_creds,
     neo4j_session,
 ):
@@ -242,6 +268,16 @@ def test_org_deletion_cleanup(
     return_value=_make_fake_credentials(),
 )
 @patch.object(
+    cartography.intel.gcp.audit_config,
+    "sync_gcp_audit_configs",
+    return_value=None,
+)
+@patch.object(
+    cartography.intel.gcp.log_sink,
+    "sync_gcp_log_sinks",
+    return_value=None,
+)
+@patch.object(
     cartography.intel.gcp,
     "_sync_project_resources",
     return_value=SKIPPED_PROJECT_RESOURCES_RESULT,
@@ -275,6 +311,8 @@ def test_partial_deletion_cleanup(
     mock_get_folders,
     mock_get_projects,
     mock_sync_resources,
+    mock_sync_log_sinks,
+    mock_sync_audit_configs,
     mock_get_creds,
     neo4j_session,
 ):
@@ -324,6 +362,16 @@ def test_partial_deletion_cleanup(
     return_value=_make_fake_credentials(),
 )
 @patch.object(
+    cartography.intel.gcp.audit_config,
+    "sync_gcp_audit_configs",
+    return_value=None,
+)
+@patch.object(
+    cartography.intel.gcp.log_sink,
+    "sync_gcp_log_sinks",
+    return_value=None,
+)
+@patch.object(
     cartography.intel.gcp,
     "_sync_project_resources",
     return_value=SKIPPED_PROJECT_RESOURCES_RESULT,  # Skip project resource sync for these tests
@@ -342,6 +390,8 @@ def test_project_migration_between_orgs(
     mock_get_org_roles,
     mock_get_predefined_roles,
     mock_sync_resources,
+    mock_sync_log_sinks,
+    mock_sync_audit_configs,
     mock_get_creds,
     neo4j_session,
 ):

--- a/tests/integration/cartography/intel/gcp/test_log_sink.py
+++ b/tests/integration/cartography/intel/gcp/test_log_sink.py
@@ -1,0 +1,136 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.gcp.log_sink
+from tests.data.gcp.log_sink import FOLDER_LOG_SINKS
+from tests.data.gcp.log_sink import ORG_LOG_SINKS
+from tests.data.gcp.log_sink import PROJECT_LOG_SINKS
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_ORG_ID = "organizations/123456789012"
+TEST_FOLDER_ID = "folders/987654321098"
+TEST_PROJECT_ID = "test-project"
+
+
+def _create_prerequisite_nodes(neo4j_session):
+    neo4j_session.run(
+        "MERGE (o:GCPOrganization {id: $org_id}) SET o.lastupdated = $tag",
+        org_id=TEST_ORG_ID,
+        tag=TEST_UPDATE_TAG,
+    )
+    neo4j_session.run(
+        "MERGE (f:GCPFolder {id: $folder_id}) SET f.lastupdated = $tag",
+        folder_id=TEST_FOLDER_ID,
+        tag=TEST_UPDATE_TAG,
+    )
+    neo4j_session.run(
+        "MERGE (p:GCPProject {id: $project_id}) SET p.lastupdated = $tag",
+        project_id=TEST_PROJECT_ID,
+        tag=TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.gcp.log_sink,
+    "get_org_log_sinks",
+    return_value=ORG_LOG_SINKS,
+)
+@patch.object(
+    cartography.intel.gcp.log_sink,
+    "get_folder_log_sinks",
+    return_value=FOLDER_LOG_SINKS,
+)
+@patch.object(
+    cartography.intel.gcp.log_sink,
+    "get_project_log_sinks",
+    return_value=PROJECT_LOG_SINKS,
+)
+def test_sync_gcp_log_sinks(
+    mock_get_project_log_sinks,
+    mock_get_folder_log_sinks,
+    mock_get_org_log_sinks,
+    neo4j_session,
+):
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _create_prerequisite_nodes(neo4j_session)
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "ORG_RESOURCE_NAME": TEST_ORG_ID,
+        "PROJECT_ID": TEST_PROJECT_ID,
+    }
+
+    cartography.intel.gcp.log_sink.sync_gcp_log_sinks(
+        neo4j_session,
+        MagicMock(),
+        TEST_ORG_ID,
+        [{"name": TEST_FOLDER_ID}],
+        [{"projectId": TEST_PROJECT_ID}],
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "GCPLogSink",
+        ["id", "parent_type", "parent_id", "disabled", "include_children"],
+    ) == {
+        (
+            "organizations/123456789012/sinks/org-audit-sink",
+            "organization",
+            TEST_ORG_ID,
+            False,
+            True,
+        ),
+        (
+            "folders/987654321098/sinks/folder-disabled-sink",
+            "folder",
+            TEST_FOLDER_ID,
+            True,
+            False,
+        ),
+        (
+            "projects/test-project/sinks/project-system-event-sink",
+            "project",
+            f"projects/{TEST_PROJECT_ID}",
+            False,
+            False,
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "GCPOrganization",
+        "id",
+        "GCPLogSink",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (TEST_ORG_ID, "organizations/123456789012/sinks/org-audit-sink"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "GCPFolder",
+        "id",
+        "GCPLogSink",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (TEST_FOLDER_ID, "folders/987654321098/sinks/folder-disabled-sink"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "GCPProject",
+        "id",
+        "GCPLogSink",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (TEST_PROJECT_ID, "projects/test-project/sinks/project-system-event-sink"),
+    }

--- a/tests/integration/cartography/intel/gcp/test_log_sink.py
+++ b/tests/integration/cartography/intel/gcp/test_log_sink.py
@@ -30,6 +30,11 @@ def _create_prerequisite_nodes(neo4j_session):
         project_id=TEST_PROJECT_ID,
         tag=TEST_UPDATE_TAG,
     )
+    neo4j_session.run(
+        "MERGE (d:GCPBigQueryDataset {id: $dataset_id}) SET d.lastupdated = $tag",
+        dataset_id="log-project:audit_logs",
+        tag=TEST_UPDATE_TAG,
+    )
 
 
 @patch.object(
@@ -74,7 +79,14 @@ def test_sync_gcp_log_sinks(
     assert check_nodes(
         neo4j_session,
         "GCPLogSink",
-        ["id", "parent_type", "parent_id", "disabled", "include_children"],
+        [
+            "id",
+            "parent_type",
+            "parent_id",
+            "disabled",
+            "include_children",
+            "bigquery_dataset_id",
+        ],
     ) == {
         (
             "organizations/123456789012/sinks/org-audit-sink",
@@ -82,6 +94,7 @@ def test_sync_gcp_log_sinks(
             TEST_ORG_ID,
             False,
             True,
+            "log-project:audit_logs",
         ),
         (
             "folders/987654321098/sinks/folder-disabled-sink",
@@ -89,6 +102,7 @@ def test_sync_gcp_log_sinks(
             TEST_FOLDER_ID,
             True,
             False,
+            None,
         ),
         (
             "projects/test-project/sinks/project-system-event-sink",
@@ -96,6 +110,7 @@ def test_sync_gcp_log_sinks(
             f"projects/{TEST_PROJECT_ID}",
             False,
             False,
+            None,
         ),
     }
 
@@ -133,4 +148,19 @@ def test_sync_gcp_log_sinks(
         rel_direction_right=True,
     ) == {
         (TEST_PROJECT_ID, "projects/test-project/sinks/project-system-event-sink"),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "GCPLogSink",
+        "id",
+        "GCPBigQueryDataset",
+        "id",
+        "DELIVERS_TO",
+        rel_direction_right=True,
+    ) == {
+        (
+            "organizations/123456789012/sinks/org-audit-sink",
+            "log-project:audit_logs",
+        ),
     }

--- a/tests/integration/cartography/intel/gcp/test_router.py
+++ b/tests/integration/cartography/intel/gcp/test_router.py
@@ -1,0 +1,157 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.gcp.router
+from tests.data.gcp.router import ROUTER_AGGREGATED_RESPONSE
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+TEST_PROJECT_ID = "project-abc"
+TEST_VPC_ID = f"projects/{TEST_PROJECT_ID}/global/networks/default"
+
+
+def _create_prerequisite_nodes(neo4j_session):
+    neo4j_session.run(
+        "MERGE (p:GCPProject {id: $project_id}) SET p.lastupdated = $tag",
+        project_id=TEST_PROJECT_ID,
+        tag=TEST_UPDATE_TAG,
+    )
+    neo4j_session.run(
+        "MERGE (v:GCPVpc {id: $vpc_id}) SET v.lastupdated = $tag",
+        vpc_id=TEST_VPC_ID,
+        tag=TEST_UPDATE_TAG,
+    )
+
+
+@patch.object(
+    cartography.intel.gcp.router,
+    "get_gcp_routers",
+    return_value=ROUTER_AGGREGATED_RESPONSE,
+)
+def test_sync_gcp_routers(mock_get_routers, neo4j_session):
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _create_prerequisite_nodes(neo4j_session)
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "PROJECT_ID": TEST_PROJECT_ID,
+    }
+
+    cartography.intel.gcp.router.sync_gcp_routers(
+        neo4j_session,
+        MagicMock(),
+        TEST_PROJECT_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "GCPRouter",
+        ["id", "name", "region", "network"],
+    ) == {
+        (
+            f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/router-no-nats",
+            "router-no-nats",
+            "us-central1",
+            TEST_VPC_ID,
+        ),
+        (
+            f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/router-with-nats",
+            "router-with-nats",
+            "us-central1",
+            TEST_VPC_ID,
+        ),
+    }
+
+    assert check_nodes(
+        neo4j_session,
+        "GCPCloudNat",
+        ["id", "name", "log_enabled", "log_filter"],
+    ) == {
+        (
+            f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/"
+            "router-with-nats/nats/nat-logging-on",
+            "nat-logging-on",
+            True,
+            "ALL",
+        ),
+        (
+            f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/"
+            "router-with-nats/nats/nat-logging-off",
+            "nat-logging-off",
+            False,
+            "ERRORS_ONLY",
+        ),
+        (
+            f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/"
+            "router-with-nats/nats/nat-no-log-config",
+            "nat-no-log-config",
+            None,
+            None,
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "GCPProject",
+        "id",
+        "GCPRouter",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (
+            TEST_PROJECT_ID,
+            f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/router-no-nats",
+        ),
+        (
+            TEST_PROJECT_ID,
+            f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/router-with-nats",
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "GCPRouter",
+        "id",
+        "GCPVpc",
+        "id",
+        "ASSOCIATED_WITH",
+        rel_direction_right=True,
+    ) == {
+        (
+            f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/router-no-nats",
+            TEST_VPC_ID,
+        ),
+        (
+            f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/router-with-nats",
+            TEST_VPC_ID,
+        ),
+    }
+
+    assert check_rels(
+        neo4j_session,
+        "GCPRouter",
+        "id",
+        "GCPCloudNat",
+        "id",
+        "HAS_NAT",
+        rel_direction_right=True,
+    ) == {
+        (
+            f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/router-with-nats",
+            f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/"
+            "router-with-nats/nats/nat-logging-on",
+        ),
+        (
+            f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/router-with-nats",
+            f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/"
+            "router-with-nats/nats/nat-logging-off",
+        ),
+        (
+            f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/router-with-nats",
+            f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/"
+            "router-with-nats/nats/nat-no-log-config",
+        ),
+    }

--- a/tests/unit/cartography/intel/gcp/test_audit_config.py
+++ b/tests/unit/cartography/intel/gcp/test_audit_config.py
@@ -1,7 +1,29 @@
 import json
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from googleapiclient.errors import HttpError
 
 import cartography.intel.gcp.audit_config
 from tests.data.gcp.audit_config import ORG_AUDIT_CONFIGS
+
+
+def _make_http_error(
+    status: int,
+    *,
+    reason: str | None = None,
+    message: str | None = None,
+) -> HttpError:
+    payload: dict = {"error": {"code": status}}
+    if message:
+        payload["error"]["message"] = message
+    if reason:
+        payload["error"]["errors"] = [{"reason": reason}]
+
+    mock_resp = MagicMock()
+    mock_resp.status = status
+    return HttpError(mock_resp, json.dumps(payload).encode("utf-8"))
 
 
 def test_transform_gcp_audit_configs_derives_log_type_booleans():
@@ -47,3 +69,73 @@ def test_transform_gcp_audit_configs_preserves_exempted_members():
             ],
         },
     ]
+
+
+def test_get_project_audit_config_falls_back_to_project_number_on_invalid():
+    client = MagicMock()
+    string_request = MagicMock()
+    number_request = MagicMock()
+    client.projects.return_value.getIamPolicy.side_effect = [
+        string_request,
+        number_request,
+    ]
+
+    invalid_error = _make_http_error(400, reason="invalid", message="Invalid resource")
+
+    with patch.object(
+        cartography.intel.gcp.audit_config,
+        "gcp_api_execute_with_retry",
+        side_effect=[invalid_error, {"auditConfigs": [{"service": "allServices"}]}],
+    ):
+        result = cartography.intel.gcp.audit_config.get_project_audit_config(
+            client,
+            "test-project",
+            "1234567890",
+        )
+
+    assert result == [{"service": "allServices"}]
+    assert (
+        client.projects.return_value.getIamPolicy.call_args_list[0].kwargs["resource"]
+        == "projects/test-project"
+    )
+    assert (
+        client.projects.return_value.getIamPolicy.call_args_list[1].kwargs["resource"]
+        == "projects/1234567890"
+    )
+
+
+def test_get_project_audit_config_reraises_invalid_without_project_number():
+    client = MagicMock()
+    client.projects.return_value.getIamPolicy.return_value = MagicMock()
+    invalid_error = _make_http_error(400, reason="invalid", message="Invalid resource")
+
+    with patch.object(
+        cartography.intel.gcp.audit_config,
+        "gcp_api_execute_with_retry",
+        side_effect=invalid_error,
+    ):
+        with pytest.raises(HttpError):
+            cartography.intel.gcp.audit_config.get_project_audit_config(
+                client,
+                "test-project",
+                None,
+            )
+
+
+def test_get_project_audit_config_skips_on_forbidden():
+    client = MagicMock()
+    client.projects.return_value.getIamPolicy.return_value = MagicMock()
+    forbidden_error = _make_http_error(403, reason="forbidden", message="Forbidden")
+
+    with patch.object(
+        cartography.intel.gcp.audit_config,
+        "gcp_api_execute_with_retry",
+        side_effect=forbidden_error,
+    ):
+        result = cartography.intel.gcp.audit_config.get_project_audit_config(
+            client,
+            "test-project",
+            "1234567890",
+        )
+
+    assert result is None

--- a/tests/unit/cartography/intel/gcp/test_audit_config.py
+++ b/tests/unit/cartography/intel/gcp/test_audit_config.py
@@ -1,0 +1,49 @@
+import json
+
+import cartography.intel.gcp.audit_config
+from tests.data.gcp.audit_config import ORG_AUDIT_CONFIGS
+
+
+def test_transform_gcp_audit_configs_derives_log_type_booleans():
+    configs = cartography.intel.gcp.audit_config.transform_gcp_audit_configs(
+        ORG_AUDIT_CONFIGS,
+        "organization",
+        "organizations/123456789012",
+    )
+
+    by_service = {config["service"]: config for config in configs}
+
+    assert by_service["allServices"]["has_admin_read"] is True
+    assert by_service["allServices"]["has_data_read"] is True
+    assert by_service["allServices"]["has_data_write"] is True
+
+    assert by_service["cloudtasks.googleapis.com"]["has_admin_read"] is False
+    assert by_service["cloudtasks.googleapis.com"]["has_data_read"] is True
+    assert by_service["cloudtasks.googleapis.com"]["has_data_write"] is False
+
+    assert by_service["empty.googleapis.com"]["has_admin_read"] is False
+    assert by_service["empty.googleapis.com"]["has_data_read"] is False
+    assert by_service["empty.googleapis.com"]["has_data_write"] is False
+
+
+def test_transform_gcp_audit_configs_preserves_exempted_members():
+    configs = cartography.intel.gcp.audit_config.transform_gcp_audit_configs(
+        ORG_AUDIT_CONFIGS,
+        "organization",
+        "organizations/123456789012",
+    )
+
+    exempted_config = next(
+        config for config in configs if config["service"] == "exempted.googleapis.com"
+    )
+    audit_log_configs = json.loads(exempted_config["audit_log_configs_json"])
+
+    assert exempted_config["has_data_read"] is True
+    assert audit_log_configs == [
+        {
+            "logType": "DATA_READ",
+            "exemptedMembers": [
+                "serviceAccount:test@example.iam.gserviceaccount.com",
+            ],
+        },
+    ]

--- a/tests/unit/cartography/intel/gcp/test_cloud_sql_instance.py
+++ b/tests/unit/cartography/intel/gcp/test_cloud_sql_instance.py
@@ -1,0 +1,56 @@
+from copy import deepcopy
+
+import cartography.intel.gcp.cloud_sql_instance
+from tests.data.gcp.cloud_sql import MOCK_INSTANCES
+
+TEST_PROJECT_ID = "test-project"
+
+
+def test_transform_sql_instances_extracts_audit_logging_flags():
+    instances = cartography.intel.gcp.cloud_sql_instance.transform_sql_instances(
+        MOCK_INSTANCES["items"],
+        TEST_PROJECT_ID,
+    )
+
+    instance = instances[0]
+    assert instance["flag_cloudsql_enable_pgaudit"] == "on"
+    assert instance["flag_log_checkpoints"] == "on"
+    assert instance["flag_log_connections"] == "on"
+    assert instance["flag_log_disconnections"] == "on"
+    assert instance["flag_log_lock_waits"] == "on"
+
+
+def test_transform_sql_instances_handles_missing_database_flags():
+    raw_instances = deepcopy(MOCK_INSTANCES["items"])
+    raw_instances[0]["settings"].pop("databaseFlags")
+
+    instances = cartography.intel.gcp.cloud_sql_instance.transform_sql_instances(
+        raw_instances,
+        TEST_PROJECT_ID,
+    )
+
+    instance = instances[0]
+    assert instance["database_flags"] is None
+    assert instance["flag_cloudsql_enable_pgaudit"] is None
+    assert instance["flag_log_checkpoints"] is None
+    assert instance["flag_log_connections"] is None
+    assert instance["flag_log_disconnections"] is None
+    assert instance["flag_log_lock_waits"] is None
+
+
+def test_transform_sql_instances_handles_empty_database_flags():
+    raw_instances = deepcopy(MOCK_INSTANCES["items"])
+    raw_instances[0]["settings"]["databaseFlags"] = []
+
+    instances = cartography.intel.gcp.cloud_sql_instance.transform_sql_instances(
+        raw_instances,
+        TEST_PROJECT_ID,
+    )
+
+    instance = instances[0]
+    assert instance["database_flags"] is None
+    assert instance["flag_cloudsql_enable_pgaudit"] is None
+    assert instance["flag_log_checkpoints"] is None
+    assert instance["flag_log_connections"] is None
+    assert instance["flag_log_disconnections"] is None
+    assert instance["flag_log_lock_waits"] is None

--- a/tests/unit/cartography/intel/gcp/test_compute.py
+++ b/tests/unit/cartography/intel/gcp/test_compute.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import cartography.intel.gcp.compute
 from tests.data.gcp.compute import LIST_FIREWALLS_RESPONSE
 from tests.data.gcp.compute import VPC_PEERING_RESPONSE
@@ -120,6 +122,21 @@ def test_transform_gcp_firewall():
     assert sample_fw_icmp_rule["fromport"] is None
     assert sample_fw_icmp_rule["toport"] is None
     assert sample_fw_icmp_rule["protocol"] == "icmp"
+
+    assert fw_list[0]["log_logging_enabled"] is False
+    assert fw_list[0]["log_logging_metadata"] is None
+    assert fw_list[4]["log_logging_enabled"] is True
+    assert fw_list[4]["log_logging_metadata"] == "INCLUDE_ALL_METADATA"
+
+
+def test_transform_gcp_firewall_handles_missing_log_config():
+    response = deepcopy(LIST_FIREWALLS_RESPONSE)
+    response["items"][0].pop("logConfig")
+
+    fw_list = cartography.intel.gcp.compute.transform_gcp_firewall(response)
+
+    assert fw_list[0]["log_logging_enabled"] is None
+    assert fw_list[0]["log_logging_metadata"] is None
 
 
 def test_transform_gcp_vpc_peerings():

--- a/tests/unit/cartography/intel/gcp/test_log_sink.py
+++ b/tests/unit/cartography/intel/gcp/test_log_sink.py
@@ -1,3 +1,5 @@
+import pytest
+
 import cartography.intel.gcp.log_sink
 from tests.data.gcp.log_sink import FOLDER_LOG_SINKS
 from tests.data.gcp.log_sink import ORG_LOG_SINKS
@@ -16,6 +18,7 @@ def test_transform_gcp_log_sinks_for_org_scope():
             "name": "organizations/123456789012/sinks/org-audit-sink",
             "sink_name": "org-audit-sink",
             "destination": "bigquery.googleapis.com/projects/log-project/datasets/audit_logs",
+            "bigquery_dataset_id": "log-project:audit_logs",
             "filter": 'logName:"cloudaudit.googleapis.com/activity"',
             "description": "Organization audit sink",
             "disabled": False,
@@ -35,7 +38,35 @@ def test_transform_gcp_log_sinks_defaults_missing_include_children_to_false():
         "folders/987654321098",
     )
 
+    assert sinks[0]["bigquery_dataset_id"] is None
     assert sinks[0]["disabled"] is True
     assert sinks[0]["include_children"] is False
     assert sinks[0]["parent_type"] == "folder"
     assert sinks[0]["parent_id"] == "folders/987654321098"
+
+
+@pytest.mark.parametrize(
+    ("destination", "expected"),
+    [
+        (
+            "bigquery.googleapis.com/projects/log-project/datasets/audit_logs",
+            "log-project:audit_logs",
+        ),
+        (
+            "logging.googleapis.com/projects/log-project/locations/global/buckets/audit",
+            None,
+        ),
+        (
+            "pubsub.googleapis.com/projects/log-project/topics/audit-topic",
+            None,
+        ),
+        ("bigquery.googleapis.com/projects/log-project/topics/not-a-dataset", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_parse_bigquery_dataset_id(destination, expected):
+    assert (
+        cartography.intel.gcp.log_sink._parse_bigquery_dataset_id(destination)
+        == expected
+    )

--- a/tests/unit/cartography/intel/gcp/test_log_sink.py
+++ b/tests/unit/cartography/intel/gcp/test_log_sink.py
@@ -31,6 +31,20 @@ def test_transform_gcp_log_sinks_for_org_scope():
     ]
 
 
+def test_transform_gcp_log_sinks_skips_missing_names():
+    sinks = cartography.intel.gcp.log_sink.transform_gcp_log_sinks(
+        [
+            {
+                "destination": "bigquery.googleapis.com/projects/log-project/datasets/audit_logs"
+            }
+        ],
+        "project",
+        "projects/test-project",
+    )
+
+    assert sinks == []
+
+
 def test_transform_gcp_log_sinks_qualifies_short_sink_names():
     sinks = cartography.intel.gcp.log_sink.transform_gcp_log_sinks(
         [

--- a/tests/unit/cartography/intel/gcp/test_log_sink.py
+++ b/tests/unit/cartography/intel/gcp/test_log_sink.py
@@ -1,0 +1,41 @@
+import cartography.intel.gcp.log_sink
+from tests.data.gcp.log_sink import FOLDER_LOG_SINKS
+from tests.data.gcp.log_sink import ORG_LOG_SINKS
+
+
+def test_transform_gcp_log_sinks_for_org_scope():
+    sinks = cartography.intel.gcp.log_sink.transform_gcp_log_sinks(
+        ORG_LOG_SINKS,
+        "organization",
+        "organizations/123456789012",
+    )
+
+    assert sinks == [
+        {
+            "id": "organizations/123456789012/sinks/org-audit-sink",
+            "name": "organizations/123456789012/sinks/org-audit-sink",
+            "sink_name": "org-audit-sink",
+            "destination": "bigquery.googleapis.com/projects/log-project/datasets/audit_logs",
+            "filter": 'logName:"cloudaudit.googleapis.com/activity"',
+            "description": "Organization audit sink",
+            "disabled": False,
+            "include_children": True,
+            "writer_identity": "serviceAccount:org-writer@gcp-sa-logging.iam.gserviceaccount.com",
+            "output_version_format": "V2",
+            "parent_type": "organization",
+            "parent_id": "organizations/123456789012",
+        },
+    ]
+
+
+def test_transform_gcp_log_sinks_defaults_missing_include_children_to_false():
+    sinks = cartography.intel.gcp.log_sink.transform_gcp_log_sinks(
+        FOLDER_LOG_SINKS,
+        "folder",
+        "folders/987654321098",
+    )
+
+    assert sinks[0]["disabled"] is True
+    assert sinks[0]["include_children"] is False
+    assert sinks[0]["parent_type"] == "folder"
+    assert sinks[0]["parent_id"] == "folders/987654321098"

--- a/tests/unit/cartography/intel/gcp/test_log_sink.py
+++ b/tests/unit/cartography/intel/gcp/test_log_sink.py
@@ -31,6 +31,23 @@ def test_transform_gcp_log_sinks_for_org_scope():
     ]
 
 
+def test_transform_gcp_log_sinks_qualifies_short_sink_names():
+    sinks = cartography.intel.gcp.log_sink.transform_gcp_log_sinks(
+        [
+            {
+                "name": "audit-sink",
+                "destination": "bigquery.googleapis.com/projects/log-project/datasets/audit_logs",
+            },
+        ],
+        "project",
+        "projects/test-project",
+    )
+
+    assert sinks[0]["id"] == "projects/test-project/sinks/audit-sink"
+    assert sinks[0]["name"] == "projects/test-project/sinks/audit-sink"
+    assert sinks[0]["sink_name"] == "audit-sink"
+
+
 def test_transform_gcp_log_sinks_defaults_missing_include_children_to_false():
     sinks = cartography.intel.gcp.log_sink.transform_gcp_log_sinks(
         FOLDER_LOG_SINKS,

--- a/tests/unit/cartography/intel/gcp/test_router.py
+++ b/tests/unit/cartography/intel/gcp/test_router.py
@@ -1,0 +1,106 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import cartography.intel.gcp.router
+from tests.data.gcp.router import ROUTER_AGGREGATED_RESPONSE
+from tests.data.gcp.router import ROUTER_PAGE_1_RESPONSE
+from tests.data.gcp.router import ROUTER_PAGE_2_RESPONSE
+
+TEST_PROJECT_ID = "project-abc"
+
+
+def test_transform_gcp_routers_extracts_routers_and_cloud_nats():
+    routers, cloud_nats = cartography.intel.gcp.router.transform_gcp_routers(
+        ROUTER_AGGREGATED_RESPONSE,
+        TEST_PROJECT_ID,
+    )
+
+    assert len(routers) == 2
+    assert routers[0]["partial_uri"] == (
+        f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/router-no-nats"
+    )
+    assert routers[0]["region"] == "us-central1"
+    assert routers[0]["network_partial_uri"] == (
+        f"projects/{TEST_PROJECT_ID}/global/networks/default"
+    )
+
+    assert len(cloud_nats) == 3
+    assert cloud_nats[0]["id"] == (
+        f"projects/{TEST_PROJECT_ID}/regions/us-central1/routers/"
+        "router-with-nats/nats/nat-logging-on"
+    )
+    assert cloud_nats[0]["log_enabled"] is True
+    assert cloud_nats[0]["log_filter"] == "ALL"
+    assert cloud_nats[1]["log_enabled"] is False
+    assert cloud_nats[1]["log_filter"] == "ERRORS_ONLY"
+    assert cloud_nats[2]["log_enabled"] is None
+    assert cloud_nats[2]["log_filter"] is None
+
+
+def test_get_gcp_routers_merges_same_scope_across_pages():
+    compute = MagicMock()
+    request_1 = MagicMock()
+    request_2 = MagicMock()
+    compute.routers.return_value.aggregatedList.return_value = request_1
+    compute.routers.return_value.aggregatedList_next.side_effect = [
+        request_2,
+        None,
+    ]
+
+    with patch.object(
+        cartography.intel.gcp.router,
+        "gcp_api_execute_with_retry",
+        side_effect=[ROUTER_PAGE_1_RESPONSE, ROUTER_PAGE_2_RESPONSE],
+    ):
+        response = cartography.intel.gcp.router.get_gcp_routers(
+            TEST_PROJECT_ID,
+            compute,
+        )
+
+    assert response is not None
+    assert response["items"]["regions/us-central1"]["routers"] == [
+        {"name": "router-page-1"},
+        {"name": "router-page-2"},
+    ]
+
+
+def test_get_gcp_routers_preserves_unreachable_warning_across_pages():
+    compute = MagicMock()
+    request_1 = MagicMock()
+    request_2 = MagicMock()
+    compute.routers.return_value.aggregatedList.return_value = request_1
+    compute.routers.return_value.aggregatedList_next.side_effect = [
+        request_2,
+        None,
+    ]
+
+    page_1 = {
+        "items": {
+            "regions/us-central1": {
+                "warning": {"code": "UNREACHABLE"},
+            },
+        },
+    }
+    page_2 = {
+        "items": {
+            "regions/us-central1": {
+                "warning": {"code": "NO_RESULTS_ON_PAGE"},
+            },
+        },
+    }
+
+    with patch.object(
+        cartography.intel.gcp.router,
+        "gcp_api_execute_with_retry",
+        side_effect=[page_1, page_2],
+    ):
+        response = cartography.intel.gcp.router.get_gcp_routers(
+            TEST_PROJECT_ID,
+            compute,
+        )
+
+    assert response is not None
+    assert response["items"]["regions/us-central1"]["warning"] == {
+        "code": "UNREACHABLE",
+    }
+    assert not cartography.intel.gcp.router._aggregated_response_cleanup_safe(response)

--- a/tests/unit/cartography/intel/gcp/test_router.py
+++ b/tests/unit/cartography/intel/gcp/test_router.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import cartography.intel.gcp.router
+from cartography.intel.gcp.util import aggregated_response_cleanup_safe
 from tests.data.gcp.router import ROUTER_AGGREGATED_RESPONSE
 from tests.data.gcp.router import ROUTER_PAGE_1_RESPONSE
 from tests.data.gcp.router import ROUTER_PAGE_2_RESPONSE
@@ -103,4 +104,4 @@ def test_get_gcp_routers_preserves_unreachable_warning_across_pages():
     assert response["items"]["regions/us-central1"]["warning"] == {
         "code": "UNREACHABLE",
     }
-    assert not cartography.intel.gcp.router._aggregated_response_cleanup_safe(response)
+    assert not aggregated_response_cleanup_safe(response)


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):


### Summary

Adds GCP audit/logging coverage so Cartography can review common logging and audit-control gaps across GCP orgs, folders, and projects.

This PR adds ingestion for:

- Firewall rule logging status on `GCPFirewall`
- Cloud Router and nested Cloud NAT configs as `GCPRouter` and `GCPCloudNat`
- Cloud NAT logging status (`log_enabled`, `log_filter`)
- Cloud SQL audit-relevant database flags on `GCPSqlInstance`
- Organization, folder, and project Cloud Logging sinks as `GCPLogSink`
- IAM audit configs as `GCPAuditConfig`

It also adds relationships for audit/logging review workflows:

- `(:GCPProject)-[:RESOURCE]->(:GCPRouter)`
- `(:GCPRouter)-[:HAS_NAT]->(:GCPCloudNat)`
- `(:GCPRouter)-[:ASSOCIATED_WITH]->(:GCPVpc)`
- `(:GCPOrganization|GCPFolder|GCPProject)-[:RESOURCE]->(:GCPLogSink)`
- `(:GCPLogSink)-[:DELIVERS_TO]->(:GCPBigQueryDataset)` when the sink destination is a BigQuery dataset already present in the graph
- `(:GCPOrganization|GCPFolder|GCPProject)-[:RESOURCE]->(:GCPAuditConfig)`

The implementation uses GCP aggregated list behavior where applicable and preserves existing data by skipping cleanup when GCP returns partial/unreachable scope results or expected access/API-denial responses.

This enables users to identify missing firewall/NAT logging, missing Cloud SQL audit-related flags, legacy or disabled logging sinks, sink destinations, and IAM Data Access audit-config coverage.


### Related issues or links

- N/A


### Breaking changes

None.


### How was this tested?

Local validation:

```bash
make test_lint
uv run pytest tests/unit/cartography/intel/gcp/test_audit_config.py tests/unit/cartography/intel/gcp/test_log_sink.py tests/unit/cartography/intel/gcp/test_router.py tests/unit/cartography/intel/gcp/test_cloud_sql_instance.py tests/unit/cartography/intel/gcp/test_compute.py -q
uv run pytest tests/integration/cartography/intel/gcp/test_audit_config.py tests/integration/cartography/intel/gcp/test_log_sink.py tests/integration/cartography/intel/gcp/test_router.py tests/integration/cartography/intel/gcp/test_cloud_sql.py tests/integration/cartography/intel/gcp/test_compute.py tests/integration/cartography/intel/gcp/test_crm_deferred_cleanup.py -q
uv run --frozen --group doc ./docs/build.sh
```

Results:

- `make test_lint`: passed
- GCP targeted unit tests: 29 passed
- GCP targeted integration tests: 32 passed
- docs build: succeeded

Real-environment validation:

Ran a full GCP sync against a real GCP environment with this branch enabled. The environment contained 76 projects across 3 organizations. Sanitized validation queries confirmed:

- 7 `GCPCloudNat` configs were collected; all 7 had NAT logging disabled in the observed environment.
- 127 `GCPFirewall` rules were collected; 15 were missing firewall rule logging.
- 5 `GCPSqlInstance` nodes were collected; no audit-relevant database flags were configured in the observed environment.
- 6 Cloud Logging sinks were collected; 4 matched the expected configuration and 2 were legacy/non-compliant.
- Cloud Logging sink to BigQuery dataset traversal resolved for sinks whose destination datasets were visible to the sync identity.
- IAM audit configs were collected across visible organization/folder/project scopes.

Sanitized sync evidence:

```text
INFO:cartography.intel.gcp.router:Syncing GCP Cloud Routers and Cloud NAT configs for project <redacted>
INFO:cartography.intel.gcp.log_sink:Syncing GCP Cloud Logging sinks for organizations/<redacted>
INFO:cartography.intel.gcp.audit_config:Syncing GCP IAM audit configs for organizations/<redacted>
INFO:cartography.graph.job:Finished job GCPRouter
INFO:cartography.graph.job:Finished job GCPCloudNat
INFO:cartography.graph.job:Finished job GCPLogSink
INFO:cartography.graph.job:Finished job GCPAuditConfig
```


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [x] Tested the connector against a real cloud, SaaS, or provider environment.
- [x] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [x] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module
- [x] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

Review focus areas:

- Cleanup safety for aggregated GCP responses: Cloud Router/NAT cleanup is skipped if any scope reports a non-empty/non-benign warning.
- Cloud Logging sink to BigQuery dataset links are best-effort and resolve only when the destination dataset is visible in the graph.
- Log sink sync runs after project resources so same-run BigQuery dataset relationships can resolve.
- IAM audit config nodes preserve the raw `auditLogConfigs` JSON so reviewers can inspect `exemptedMembers` in addition to the boolean log-type coverage fields.
- Cloud SQL audit flag fields intentionally expose selected audit-relevant flags while preserving the existing raw `database_flags` JSON.