### PR TITLE
fix(s3): tolerate transport errors when a bucket's region is unreachable

### DIFF
--- a/cartography/intel/aws/s3.py
+++ b/cartography/intel/aws/s3.py
@@ -14,9 +14,8 @@ import boto3
 import botocore
 import neo4j
 from botocore.exceptions import ClientError
-from botocore.exceptions import ConnectTimeoutError
-from botocore.exceptions import EndpointConnectionError
-from botocore.exceptions import ReadTimeoutError
+from botocore.exceptions import ConnectionError as BotoCoreConnectionError
+from botocore.exceptions import HTTPClientError
 from policyuniverse.policy import Policy
 
 from cartography.analysis.aws.s3.analysis import AWS_S3ACL_ANALYSIS
@@ -49,10 +48,20 @@ stat_handler = get_stats_client(__name__)
 
 BUCKET_BATCH_SIZE = 50
 
-S3_DETAIL_TRANSPORT_ERRORS = (
-    ConnectTimeoutError,
-    EndpointConnectionError,
-    ReadTimeoutError,
+# Transport-level failures where the endpoint could not be reached at all, as
+# opposed to AWS answering with an error. These are caught rather than raised so
+# that one unreachable bucket cannot abort an entire account's sync.
+#
+# The two botocore base classes are used deliberately in place of an enumeration
+# of leaf classes. Enumerating leaves silently misses siblings: ProxyConnectionError
+# (raised when an egress proxy cannot reach a bucket's regional endpoint) is a
+# sibling of EndpointConnectionError, not a subclass of it, so listing the latter
+# does not cover the former.
+S3_TRANSPORT_ERRORS = (
+    # ConnectTimeoutError, EndpointConnectionError, ProxyConnectionError, SSLError
+    BotoCoreConnectionError,
+    # ReadTimeoutError, ConnectionClosedError, ResponseStreamingError
+    HTTPClientError,
 )
 
 
@@ -126,11 +135,20 @@ def get_s3_bucket_list(boto3_session: boto3.session.Session) -> List[Dict]:
                 continue
             else:
                 raise
-        except (ConnectTimeoutError, EndpointConnectionError, ReadTimeoutError):
+        except S3_TRANSPORT_ERRORS as error:
             bucket["Region"] = None
+            # Suffixed with the exception class so a proxy or DNS failure is
+            # distinguishable from a plain timeout. Cardinality is bounded by the
+            # leaf classes under S3_TRANSPORT_ERRORS.
+            stat_handler.incr(
+                f"bucket_region_discovery_transport_error.{error.__class__.__name__}",
+            )
             logger.warning(
-                "skipping bucket='%s' region discovery due to transport timeout/connection error.",
+                "Failed to discover the region for bucket %s due to transient %s: %s. "
+                "Leaving its region unset.",
                 bucket["Name"],
+                error.__class__.__name__,
+                error,
             )
     return buckets
 
@@ -237,7 +255,7 @@ def get_policy(bucket: Dict, client: botocore.client.BaseClient) -> MaybeFailed:
             return FETCH_FAILED if is_failure else None
         else:
             raise
-    except S3_DETAIL_TRANSPORT_ERRORS as error:
+    except S3_TRANSPORT_ERRORS as error:
         return _handle_s3_detail_transport_error(bucket["Name"], "policy", error)
 
 
@@ -254,7 +272,7 @@ def get_acl(bucket: Dict, client: botocore.client.BaseClient) -> MaybeFailed:
             return FETCH_FAILED if is_failure else None
         else:
             raise
-    except S3_DETAIL_TRANSPORT_ERRORS as error:
+    except S3_TRANSPORT_ERRORS as error:
         return _handle_s3_detail_transport_error(bucket["Name"], "ACL", error)
 
 
@@ -271,7 +289,7 @@ def get_encryption(bucket: Dict, client: botocore.client.BaseClient) -> MaybeFai
             return FETCH_FAILED if is_failure else None
         else:
             raise
-    except S3_DETAIL_TRANSPORT_ERRORS as error:
+    except S3_TRANSPORT_ERRORS as error:
         return _handle_s3_detail_transport_error(bucket["Name"], "encryption", error)
 
 
@@ -288,7 +306,7 @@ def get_versioning(bucket: Dict, client: botocore.client.BaseClient) -> MaybeFai
             return FETCH_FAILED if is_failure else None
         else:
             raise
-    except S3_DETAIL_TRANSPORT_ERRORS as error:
+    except S3_TRANSPORT_ERRORS as error:
         return _handle_s3_detail_transport_error(bucket["Name"], "versioning", error)
 
 
@@ -308,7 +326,7 @@ def get_public_access_block(
             return FETCH_FAILED if is_failure else None
         else:
             raise
-    except S3_DETAIL_TRANSPORT_ERRORS as error:
+    except S3_TRANSPORT_ERRORS as error:
         return _handle_s3_detail_transport_error(
             bucket["Name"],
             "public access block",
@@ -331,7 +349,7 @@ def get_bucket_ownership_controls(
             return FETCH_FAILED if is_failure else None
         else:
             raise
-    except S3_DETAIL_TRANSPORT_ERRORS as error:
+    except S3_TRANSPORT_ERRORS as error:
         return _handle_s3_detail_transport_error(
             bucket["Name"],
             "ownership controls",
@@ -352,7 +370,7 @@ def get_bucket_logging(bucket: Dict, client: botocore.client.BaseClient) -> Mayb
             return FETCH_FAILED if is_failure else None
         else:
             raise
-    except S3_DETAIL_TRANSPORT_ERRORS as error:
+    except S3_TRANSPORT_ERRORS as error:
         return _handle_s3_detail_transport_error(
             bucket["Name"],
             "logging status",
@@ -1340,6 +1358,21 @@ def _sync_s3_notifications(
         except ClientError as e:
             logger.warning(
                 f"Failed to retrieve notification configuration for bucket {bucket['Name']}: {e}"
+            )
+            continue
+        except S3_TRANSPORT_ERRORS as error:
+            # Reached for a bucket whose region is unreachable from this network:
+            # the request is redirected to the bucket's regional endpoint, which
+            # never answers. Without this the whole account's sync would abort.
+            stat_handler.incr(
+                f"bucket_notification_transport_error.{error.__class__.__name__}",
+            )
+            logger.warning(
+                "Failed to retrieve the notification configuration for bucket %s due to "
+                "transient %s: %s. Skipping it.",
+                bucket["Name"],
+                error.__class__.__name__,
+                error,
             )
             continue
 

--- a/tests/unit/cartography/intel/aws/test_s3.py
+++ b/tests/unit/cartography/intel/aws/test_s3.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 import pytest
 from botocore.exceptions import ClientError
 from botocore.exceptions import ConnectTimeoutError
+from botocore.exceptions import ProxyConnectionError
 
+from cartography.intel.aws.s3 import _sync_s3_notifications
 from cartography.intel.aws.s3 import FETCH_FAILED
 from cartography.intel.aws.s3 import get_acl
 from cartography.intel.aws.s3 import get_bucket_logging
@@ -129,6 +131,66 @@ def test_get_s3_bucket_list_connect_timeout_preserves_other_buckets():
         {"Name": "slow-bucket", "Region": None},
         {"Name": "last-bucket", "Region": "eu-west-1"},
     ]
+
+
+def test_get_s3_bucket_list_proxy_error_preserves_other_buckets():
+    """An egress proxy that cannot reach a bucket's region must not abort discovery.
+
+    ProxyConnectionError is a sibling of EndpointConnectionError rather than a
+    subclass of it, so enumerating leaf exception classes does not catch it. This
+    covers the case where a bucket lives in a region unreachable from the network
+    the sync runs on, and the proxy answers the CONNECT with a 5xx.
+    """
+    mock_session = MagicMock()
+    mock_client = mock_session.client.return_value
+
+    mock_client.list_buckets.return_value = {
+        "Buckets": [
+            {"Name": "reachable-bucket"},
+            {"Name": "unreachable-region-bucket"},
+        ],
+    }
+    mock_client.head_bucket.side_effect = [
+        {
+            "BucketRegion": "us-east-1",
+            "ResponseMetadata": {"HTTPHeaders": {}},
+        },
+        ProxyConnectionError(proxy_url="http://127.0.0.1:12002"),
+    ]
+
+    result = get_s3_bucket_list(mock_session)
+    assert result["Buckets"] == [
+        {"Name": "reachable-bucket", "Region": "us-east-1"},
+        {"Name": "unreachable-region-bucket", "Region": None},
+    ]
+
+
+@patch("cartography.intel.aws.s3._cleanup_s3_notifications")
+@patch("cartography.intel.aws.s3._load_s3_notifications")
+def test_sync_s3_notifications_survives_a_transport_error(_mock_load, _mock_cleanup):
+    """An unreachable bucket must not abort the notification sync for the rest.
+
+    This path only caught ClientError, so a transport failure here aborted the
+    whole account's sync even once region discovery tolerated it.
+    """
+    mock_session = MagicMock()
+    mock_client = mock_session.client.return_value
+    mock_client.get_bucket_notification_configuration.side_effect = [
+        ProxyConnectionError(proxy_url="http://127.0.0.1:12002"),
+        {"TopicConfigurations": []},
+    ]
+
+    bucket_data = {
+        "Buckets": [
+            {"Name": "unreachable-region-bucket", "Region": None},
+            {"Name": "reachable-bucket", "Region": "us-east-1"},
+        ],
+    }
+
+    # Must not raise, and must still reach the second bucket.
+    _sync_s3_notifications(MagicMock(), mock_session, bucket_data, update_tag=1)
+
+    assert mock_client.get_bucket_notification_configuration.call_count == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

`get_s3_bucket_list` catches transport errors during per-bucket region discovery so that one
unreachable bucket cannot abort an entire account's sync. The handler enumerated three leaf
exception classes:

```python
except (ConnectTimeoutError, EndpointConnectionError, ReadTimeoutError):
```

`botocore.exceptions.ProxyConnectionError` is a **sibling** of `EndpointConnectionError` — both
inherit from `botocore.exceptions.ConnectionError` — not a subclass of it, so it was never caught.

Any deployment that egresses through an HTTP proxy hits this. If a bucket lives in a region the
proxy cannot reach, `head_bucket` raises `ProxyConnectionError`, which propagates out of
`get_s3_bucket_list` and aborts the whole account's sync.

How it arises is worth spelling out, because it is not visible in the source. The client built in
`get_s3_bucket_list` has no `region_name`, so `head_bucket` first goes to the *global* endpoint.
S3 answers with a redirect carrying `x-amz-bucket-region`, and **botocore transparently follows it**
to the bucket's regional endpoint. That redirect target is what fails. No line of cartography code
names the regional endpoint.

### Breaking changes

None.

### How was this tested?

**Unit tests.** Two added, both failing before the change and passing after:

- `test_get_s3_bucket_list_proxy_error_preserves_other_buckets`
- `test_sync_s3_notifications_survives_a_transport_error`

`tests/unit/cartography/intel/aws/test_s3.py`: 14 passed.

**Against live AWS.** A local HTTP CONNECT proxy returned `503` for one region's S3 endpoint while
tunnelling everything else, reproducing:

```
OSError: Tunnel connection failed: 503 Service Unavailable
  -> urllib3.exceptions.ProxyError
  -> botocore.exceptions.ProxyConnectionError
```

The proxy log confirmed only the *regional* endpoint was rejected while the global endpoint
tunnelled normally, i.e. botocore genuinely followed the region redirect before failing.

`get_s3_bucket_list` against identical live traffic, with only the exception tuple swapped:

| | Result |
|---|---|
| Before | `RAISED botocore.exceptions.ProxyConnectionError` — the account's sync aborts |
| After | completes; unreachable bucket gets `Region=None`, control bucket gets `Region='us-west-2'` |

`_sync_s3_notifications`, same setup:

| | Result |
|---|---|
| Before | `RAISED ProxyConnectionError` — the account's sync aborts |
| After | completes, every bucket handled |

Also verified that a `Region=None` bucket in a *reachable* region still returns all seven property
groups, since boto3 falls back to the default region and follows S3's redirect. This is why such
buckets are deliberately not skipped.

**Production-scale sync.** A full run across **48 AWS accounts**, six of which contained a bucket in
a region unreachable from the host network:

```
WARNING cartography.intel.aws.s3: Failed to discover the region for bucket <redacted> due to
  transient ProxyConnectionError: Failed to connect to proxy URL: "<redacted>". Leaving its
  region unset.
WARNING cartography.intel.aws.s3: Failed to retrieve S3 bucket ACL for <redacted> due to
  transient ProxyConnectionError: ... Skipping this detail group.
WARNING cartography.intel.aws.s3: Failed to retrieve the notification configuration for bucket
  <redacted> due to transient ProxyConnectionError: ... Skipping it.
INFO  Finishing sync stage 'aws'
INFO  Recorded SyncMetadata for cron with update_tag=<redacted>
```

Totals for the run:

| Signal | Count |
|---|---|
| Accounts synced | 48 |
| Region-discovery skips (new handler) | 6 |
| Detail-group skips (7 groups x 6 buckets) | 42 |
| Notification-config skips (new handler) | 6 |
| Unhandled exceptions | **0** |
| Failed accounts | **0** |

The sync recorded successful completion, and downstream stages that had never run against these
accounts completed too (`aws_s3acl_analysis`, permission relationships).

Before this change the same workload failed on **every** run, aborting at the first unreachable
bucket. That also meant five of the six bad buckets were never discovered at all — the sync died
before enumerating them.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [ ] The linter passes locally (`make test_lint`).
- [ ] I have added/updated tests that prove my fix is effective or my feature works.
- [ ] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [x] Tested the connector against a real cloud, SaaS, or provider environment.
- [x] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

Connector pull requests without real-environment evidence are labeled `needs-tests`, are not reviewed, and may be closed after 30 days.

#### If you are changing a node or relationship
- [ ] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [ ] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->
