### PR TITLE
feat(notion): add optional SCIM enrichment

### DIFF
--- a/cartography/intel/notion/__init__.py
+++ b/cartography/intel/notion/__init__.py
@@ -3,9 +3,11 @@ import logging
 import neo4j
 
 from cartography.config import Config
+from cartography.intel.notion import scim
 from cartography.intel.notion import users
 from cartography.intel.notion import workspaces
 from cartography.intel.notion.util import create_api_session
+from cartography.intel.notion.util import create_scim_session
 from cartography.intel.notion.util import parse_config
 from cartography.util import timeit
 
@@ -35,13 +37,26 @@ def start_notion_ingestion(neo4j_session: neo4j.Session, config: Config) -> None
                 "UPDATE_TAG": config.update_tag,
                 "WORKSPACE_ID": workspace.workspace_id,
             }
-            users.sync(
+            public_people = users.sync(
                 neo4j_session,
                 api_session,
                 workspace.workspace_id,
                 config.update_tag,
                 common_job_parameters,
             )
+            if workspace.scim_token:
+                scim_session = create_scim_session(workspace.scim_token)
+                try:
+                    scim.sync(
+                        neo4j_session,
+                        scim_session,
+                        public_people,
+                        workspace.workspace_id,
+                        config.update_tag,
+                        common_job_parameters,
+                    )
+                finally:
+                    scim_session.close()
         finally:
             api_session.close()
         logger.info("Completed Notion sync for workspace %s", workspace.workspace_id)

--- a/cartography/intel/notion/scim.py
+++ b/cartography/intel/notion/scim.py
@@ -1,0 +1,290 @@
+import logging
+from typing import Any
+
+import neo4j
+import requests
+
+from cartography.client.core.tx import load
+from cartography.client.core.tx import load_matchlinks
+from cartography.graph.job import GraphJob
+from cartography.intel.notion.util import get_scim_paginated
+from cartography.intel.notion.util import scoped_id
+from cartography.models.notion.group import NotionGroupSchema
+from cartography.models.notion.manager import NotionUserReportsToMatchLink
+from cartography.models.notion.scim_user import NotionSCIMUserSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+ENTERPRISE_USER_EXTENSION = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+NOTION_USER_EXTENSION = "urn:ietf:params:scim:schemas:extension:notion:2.0:User"
+SCIM_USER_FIELDS = (
+    "active",
+    "workspace_role",
+    "scim_external_id",
+    "title",
+    "user_type",
+    "locale",
+    "preferred_language",
+    "department",
+    "division",
+    "cost_center",
+    "organization",
+    "employee_number",
+    "manager_email",
+    "is_workspace_member",
+)
+
+
+def get(
+    scim_session: requests.Session,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    users = get_scim_paginated(scim_session, "Users")
+    groups = get_scim_paginated(scim_session, "Groups")
+    return users, groups
+
+
+def _object(value: Any, field: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"Notion SCIM {field} must be an object")
+    return value
+
+
+def _required_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Notion SCIM {field} must be a non-empty string")
+    return value.strip()
+
+
+def _optional_string(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"Notion SCIM {field} must be a string")
+    return value.strip() or None
+
+
+def transform_users(
+    scim_users: list[dict[str, Any]],
+    public_people: list[dict[str, Any]],
+    workspace_id: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    enriched_by_id = {
+        person["notion_user_id"]: {
+            **person,
+            **dict.fromkeys(SCIM_USER_FIELDS),
+        }
+        for person in public_people
+    }
+    manager_emails: dict[str, str] = {}
+    email_to_ids: dict[str, list[str]] = {}
+    seen_ids: set[str] = set()
+
+    for user in scim_users:
+        notion_user_id = _required_string(user.get("id"), "user id")
+        if notion_user_id in seen_ids:
+            raise ValueError(
+                f"Notion SCIM returned duplicate user ID {notion_user_id!r}"
+            )
+        seen_ids.add(notion_user_id)
+
+        email = _required_string(user.get("userName"), "userName").lower()
+        name = _object(user.get("name"), "user name")
+        formatted_name = _optional_string(name.get("formatted"), "name.formatted")
+        if formatted_name is None:
+            formatted_name = (
+                " ".join(
+                    part
+                    for part in (
+                        _optional_string(name.get("givenName"), "name.givenName"),
+                        _optional_string(name.get("familyName"), "name.familyName"),
+                    )
+                    if part
+                )
+                or None
+            )
+
+        enterprise = _object(
+            user.get(ENTERPRISE_USER_EXTENSION),
+            "enterprise user extension",
+        )
+        notion = _object(user.get(NOTION_USER_EXTENSION), "Notion user extension")
+        manager = _object(enterprise.get("manager"), "manager")
+        manager_email = _optional_string(manager.get("value"), "manager.value")
+        if manager_email:
+            manager_email = manager_email.lower()
+
+        active = user.get("active")
+        if active is not None and not isinstance(active, bool):
+            raise ValueError("Notion SCIM active must be a boolean")
+
+        existing = enriched_by_id.get(notion_user_id, {})
+        user_id = scoped_id(workspace_id, notion_user_id)
+        enriched_by_id[notion_user_id] = {
+            "id": user_id,
+            "notion_user_id": notion_user_id,
+            "name": formatted_name or existing.get("name"),
+            "email": email,
+            "active": active,
+            "workspace_role": _optional_string(notion.get("role"), "role"),
+            "scim_external_id": _optional_string(
+                user.get("externalId"),
+                "externalId",
+            ),
+            "title": _optional_string(user.get("title"), "title"),
+            "user_type": _optional_string(user.get("userType"), "userType"),
+            "locale": _optional_string(user.get("locale"), "locale"),
+            "preferred_language": _optional_string(
+                user.get("preferredLanguage"),
+                "preferredLanguage",
+            ),
+            "department": _optional_string(
+                enterprise.get("department"),
+                "department",
+            ),
+            "division": _optional_string(enterprise.get("division"), "division"),
+            "cost_center": _optional_string(
+                enterprise.get("costCenter"),
+                "costCenter",
+            ),
+            "organization": _optional_string(
+                enterprise.get("organization"),
+                "organization",
+            ),
+            "employee_number": _optional_string(
+                enterprise.get("employeeNumber"),
+                "employeeNumber",
+            ),
+            "manager_email": manager_email,
+            "is_workspace_member": True,
+        }
+        email_to_ids.setdefault(email, []).append(user_id)
+        if manager_email:
+            manager_emails[user_id] = manager_email
+
+    manager_relationships = [
+        {"source_id": user_id, "target_id": email_to_ids[manager_email][0]}
+        for user_id, manager_email in manager_emails.items()
+        if len(email_to_ids.get(manager_email, [])) == 1
+    ]
+    return list(enriched_by_id.values()), manager_relationships
+
+
+def transform_groups(
+    scim_groups: list[dict[str, Any]],
+    workspace_id: str,
+) -> list[dict[str, Any]]:
+    groups: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for group in scim_groups:
+        notion_group_id = _required_string(group.get("id"), "group id")
+        if notion_group_id in seen_ids:
+            raise ValueError(
+                f"Notion SCIM returned duplicate group ID {notion_group_id!r}"
+            )
+        seen_ids.add(notion_group_id)
+
+        members = group.get("members", [])
+        if not isinstance(members, list) or not all(
+            isinstance(member, dict) for member in members
+        ):
+            raise ValueError("Notion SCIM group members must be a list of objects")
+        member_ids = [
+            scoped_id(
+                workspace_id,
+                _required_string(member.get("value"), "group member value"),
+            )
+            for member in members
+        ]
+        groups.append(
+            {
+                "id": scoped_id(workspace_id, notion_group_id),
+                "notion_group_id": notion_group_id,
+                "name": _required_string(group.get("displayName"), "displayName"),
+                "scim_external_id": _optional_string(
+                    group.get("externalId"),
+                    "externalId",
+                ),
+                "member_ids": list(dict.fromkeys(member_ids)),
+            },
+        )
+    return groups
+
+
+def load_scim_data(
+    neo4j_session: neo4j.Session,
+    users: list[dict[str, Any]],
+    groups: list[dict[str, Any]],
+    manager_relationships: list[dict[str, str]],
+    workspace_id: str,
+    update_tag: int,
+) -> None:
+    load(
+        neo4j_session,
+        NotionSCIMUserSchema(),
+        users,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+    load(
+        neo4j_session,
+        NotionGroupSchema(),
+        groups,
+        lastupdated=update_tag,
+        WORKSPACE_ID=workspace_id,
+    )
+    load_matchlinks(
+        neo4j_session,
+        NotionUserReportsToMatchLink(),
+        manager_relationships,
+        lastupdated=update_tag,
+        _sub_resource_label="NotionWorkspace",
+        _sub_resource_id=workspace_id,
+    )
+
+
+def cleanup(
+    neo4j_session: neo4j.Session,
+    workspace_id: str,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    GraphJob.from_node_schema(NotionGroupSchema(), common_job_parameters).run(
+        neo4j_session,
+    )
+    GraphJob.from_matchlink(
+        NotionUserReportsToMatchLink(),
+        "NotionWorkspace",
+        workspace_id,
+        common_job_parameters["UPDATE_TAG"],
+    ).run(neo4j_session)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    scim_session: requests.Session,
+    public_people: list[dict[str, Any]],
+    workspace_id: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    logger.info("Starting Notion SCIM sync for workspace %s", workspace_id)
+    raw_users, raw_groups = get(scim_session)
+    users, manager_relationships = transform_users(
+        raw_users,
+        public_people,
+        workspace_id,
+    )
+    groups = transform_groups(raw_groups, workspace_id)
+    load_scim_data(
+        neo4j_session,
+        users,
+        groups,
+        manager_relationships,
+        workspace_id,
+        update_tag,
+    )
+    cleanup(neo4j_session, workspace_id, common_job_parameters)
+    logger.info("Completed Notion SCIM sync for workspace %s", workspace_id)

--- a/cartography/intel/notion/users.py
+++ b/cartography/intel/notion/users.py
@@ -130,10 +130,11 @@ def sync(
     workspace_id: str,
     update_tag: int,
     common_job_parameters: dict[str, Any],
-) -> None:
+) -> list[dict[str, Any]]:
     logger.info("Starting Notion identity sync for workspace %s", workspace_id)
     raw_users = get(api_session)
     people, bots = transform(raw_users, workspace_id)
     load_users(neo4j_session, people, bots, workspace_id, update_tag)
     cleanup(neo4j_session, common_job_parameters)
     logger.info("Completed Notion identity sync for workspace %s", workspace_id)
+    return people

--- a/cartography/intel/notion/util.py
+++ b/cartography/intel/notion/util.py
@@ -9,6 +9,7 @@ from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
 NOTION_API_BASE_URL = "https://api.notion.com/v1"
+NOTION_SCIM_BASE_URL = "https://api.notion.com/scim/v2"
 NOTION_API_VERSION = "2026-03-11"
 REQUEST_TIMEOUT = (60, 60)
 
@@ -18,6 +19,7 @@ class NotionWorkspaceConfig:
     workspace_id: str
     workspace_name: str
     api_token: str
+    scim_token: str | None = None
 
 
 def parse_config(encoded_config: str) -> list[NotionWorkspaceConfig]:
@@ -38,7 +40,7 @@ def parse_config(encoded_config: str) -> list[NotionWorkspaceConfig]:
     for workspace in workspaces:
         if not isinstance(workspace, dict):
             raise ValueError("Each Notion workspace config must be a JSON object")
-        values: dict[str, str] = {}
+        values: dict[str, Any] = {}
         for field in ("workspace_id", "workspace_name", "api_token"):
             value = workspace.get(field)
             if not isinstance(value, str) or not value.strip():
@@ -46,6 +48,15 @@ def parse_config(encoded_config: str) -> list[NotionWorkspaceConfig]:
                     f"Notion workspace config field {field!r} must be a non-empty string"
                 )
             values[field] = value.strip()
+
+        scim_token = workspace.get("scim_token")
+        if scim_token is not None and (
+            not isinstance(scim_token, str) or not scim_token.strip()
+        ):
+            raise ValueError(
+                "Notion workspace config field 'scim_token' must be a non-empty string"
+            )
+        values["scim_token"] = scim_token.strip() if scim_token else None
 
         if values["workspace_id"] in seen_ids:
             raise ValueError(
@@ -58,6 +69,20 @@ def parse_config(encoded_config: str) -> list[NotionWorkspaceConfig]:
 
 
 def create_api_session(api_token: str) -> requests.Session:
+    return _create_session(
+        api_token,
+        {
+            "Notion-Version": NOTION_API_VERSION,
+            "Accept": "application/json",
+        },
+    )
+
+
+def create_scim_session(scim_token: str) -> requests.Session:
+    return _create_session(scim_token, {"Accept": "application/scim+json"})
+
+
+def _create_session(api_token: str, headers: dict[str, str]) -> requests.Session:
     retry_policy = Retry(
         total=5,
         backoff_factor=1,
@@ -67,13 +92,7 @@ def create_api_session(api_token: str) -> requests.Session:
     )
     session = requests.Session()
     session.mount("https://", HTTPAdapter(max_retries=retry_policy))
-    session.headers.update(
-        {
-            "Authorization": f"Bearer {api_token}",
-            "Notion-Version": NOTION_API_VERSION,
-            "Accept": "application/json",
-        },
-    )
+    session.headers.update({"Authorization": f"Bearer {api_token}", **headers})
     return session
 
 
@@ -123,3 +142,57 @@ def get_paginated(
 
 def scoped_id(workspace_id: str, notion_id: str) -> str:
     return f"{workspace_id}/{notion_id}"
+
+
+def get_scim_paginated(
+    scim_session: requests.Session,
+    resource: str,
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    start_index = 1
+    expected_total: int | None = None
+
+    while True:
+        response = scim_session.get(
+            f"{NOTION_SCIM_BASE_URL}/{resource}",
+            params={"startIndex": start_index, "count": 100},
+            timeout=REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise ValueError("Notion SCIM response must be a JSON object")
+
+        resources = payload.get("Resources")
+        total = payload.get("totalResults")
+        response_start = payload.get("startIndex")
+        page_size = payload.get("itemsPerPage")
+        if not isinstance(resources, list) or not all(
+            isinstance(item, dict) for item in resources
+        ):
+            raise ValueError("Notion SCIM response must contain object Resources")
+        if not isinstance(total, int) or isinstance(total, bool) or total < 0:
+            raise ValueError("Notion SCIM response has an invalid totalResults")
+        if (
+            not isinstance(response_start, int)
+            or isinstance(response_start, bool)
+            or response_start != start_index
+        ):
+            raise ValueError("Notion SCIM response has an unexpected startIndex")
+        if (
+            not isinstance(page_size, int)
+            or isinstance(page_size, bool)
+            or page_size != len(resources)
+        ):
+            raise ValueError("Notion SCIM response has an invalid itemsPerPage")
+        if expected_total is None:
+            expected_total = total
+        elif total != expected_total:
+            raise ValueError("Notion SCIM totalResults changed during pagination")
+
+        results.extend(resources)
+        if len(results) == expected_total:
+            return results
+        if not resources or len(results) > expected_total:
+            raise ValueError("Notion SCIM pagination did not make valid progress")
+        start_index += len(resources)

--- a/cartography/models/notion/group.py
+++ b/cartography/models/notion/group.py
@@ -1,0 +1,87 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.ontology.labels import USER_GROUP
+
+
+@dataclass(frozen=True)
+class NotionGroupNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id",
+        description="Workspace-scoped Notion group ID.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    notion_group_id: PropertyRef = PropertyRef(
+        "notion_group_id",
+        extra_index=True,
+        description="Notion group UUID returned by SCIM.",
+    )
+    name: PropertyRef = PropertyRef(
+        "name",
+        extra_index=True,
+        description="SCIM group display name.",
+    )
+    scim_external_id: PropertyRef = PropertyRef(
+        "scim_external_id",
+        description="Identity provider group ID supplied through SCIM.",
+    )
+
+
+@dataclass(frozen=True)
+class NotionWorkspaceToGroupRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class NotionWorkspaceToGroupRel(CartographyRelSchema):
+    """A Notion workspace contains a SCIM group."""
+
+    target_node_label: str = "NotionWorkspace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("WORKSPACE_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: NotionWorkspaceToGroupRelProperties = (
+        NotionWorkspaceToGroupRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class NotionUserToGroupRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class NotionUserToGroupRel(CartographyRelSchema):
+    """A Notion user is a member of a SCIM group."""
+
+    target_node_label: str = "NotionUser"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("member_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "MEMBER_OF"
+    properties: NotionUserToGroupRelProperties = NotionUserToGroupRelProperties()
+
+
+@dataclass(frozen=True)
+class NotionGroupSchema(CartographyNodeSchema):
+    """A Notion SCIM group with the canonical UserGroup label."""
+
+    label: str = "NotionGroup"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([USER_GROUP])
+    properties: NotionGroupNodeProperties = NotionGroupNodeProperties()
+    sub_resource_relationship: NotionWorkspaceToGroupRel = NotionWorkspaceToGroupRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [NotionUserToGroupRel()],
+    )

--- a/cartography/models/notion/manager.py
+++ b/cartography/models/notion/manager.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import SourceNodeMatcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class NotionUserReportsToRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label",
+        set_in_kwargs=True,
+    )
+    _sub_resource_id: PropertyRef = PropertyRef(
+        "_sub_resource_id",
+        set_in_kwargs=True,
+    )
+
+
+@dataclass(frozen=True)
+class NotionUserReportsToMatchLink(CartographyRelSchema):
+    """A Notion user reports to another user in the same workspace."""
+
+    source_node_label: str = "NotionUser"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("source_id")},
+    )
+    target_node_label: str = "NotionUser"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("target_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "REPORTS_TO"
+    properties: NotionUserReportsToRelProperties = NotionUserReportsToRelProperties()

--- a/cartography/models/notion/scim_user.py
+++ b/cartography/models/notion/scim_user.py
@@ -1,0 +1,85 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.notion.user import NotionWorkspaceToUserRel
+from cartography.models.ontology.labels import USER_ACCOUNT
+
+
+@dataclass(frozen=True)
+class NotionSCIMUserNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id",
+        description="Workspace-scoped Notion user ID.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    notion_user_id: PropertyRef = PropertyRef(
+        "notion_user_id",
+        extra_index=True,
+        description="Notion's user UUID.",
+    )
+    name: PropertyRef = PropertyRef("name", description="User display name.")
+    email: PropertyRef = PropertyRef(
+        "email",
+        extra_index=True,
+        description="User email when exposed to the connection.",
+    )
+    active: PropertyRef = PropertyRef(
+        "active",
+        description="Whether the SCIM account is active.",
+    )
+    workspace_role: PropertyRef = PropertyRef(
+        "workspace_role",
+        description="Notion workspace role returned by SCIM.",
+    )
+    scim_external_id: PropertyRef = PropertyRef(
+        "scim_external_id",
+        description="Identity provider ID supplied through SCIM.",
+    )
+    title: PropertyRef = PropertyRef("title", description="Job title.")
+    user_type: PropertyRef = PropertyRef(
+        "user_type",
+        description="SCIM user type.",
+    )
+    locale: PropertyRef = PropertyRef("locale", description="SCIM locale.")
+    preferred_language: PropertyRef = PropertyRef(
+        "preferred_language",
+        description="SCIM preferred language.",
+    )
+    department: PropertyRef = PropertyRef(
+        "department",
+        description="SCIM department.",
+    )
+    division: PropertyRef = PropertyRef("division", description="SCIM division.")
+    cost_center: PropertyRef = PropertyRef(
+        "cost_center",
+        description="SCIM cost center.",
+    )
+    organization: PropertyRef = PropertyRef(
+        "organization",
+        description="SCIM organization.",
+    )
+    employee_number: PropertyRef = PropertyRef(
+        "employee_number",
+        description="SCIM employee number.",
+    )
+    manager_email: PropertyRef = PropertyRef(
+        "manager_email",
+        description="Manager email supplied by SCIM.",
+    )
+    is_workspace_member: PropertyRef = PropertyRef(
+        "is_workspace_member",
+        description="True only when SCIM confirms workspace membership.",
+    )
+
+
+@dataclass(frozen=True)
+class NotionSCIMUserSchema(CartographyNodeSchema):
+    """SCIM enrichment for a Notion user account."""
+
+    label: str = "NotionUser"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([USER_ACCOUNT])
+    properties: NotionSCIMUserNodeProperties = NotionSCIMUserNodeProperties()
+    sub_resource_relationship: NotionWorkspaceToUserRel = NotionWorkspaceToUserRel()

--- a/cartography/models/ontology/mapping/data/groups.py
+++ b/cartography/models/ontology/mapping/data/groups.py
@@ -390,6 +390,22 @@ salesforce_mapping = OntologyMapping(
     ],
 )
 
+notion_mapping = OntologyMapping(
+    module_name="notion",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="NotionGroup",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name",
+                    node_field="name",
+                    required=True,
+                ),
+            ],
+        ),
+    ],
+)
+
 GROUPS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws": aws_mapping,
     "circleci": circleci_mapping,
@@ -409,6 +425,7 @@ GROUPS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "slack": slack_mapping,
     "tailscale": tailscale_mapping,
     "kubernetes": kubernetes_mapping,
+    "notion": notion_mapping,
     "vercel": vercel_mapping,
     "databricks": OntologyMapping(
         module_name="databricks",

--- a/cartography/models/ontology/mapping/data/useraccounts.py
+++ b/cartography/models/ontology/mapping/data/useraccounts.py
@@ -440,6 +440,7 @@ notion_mapping = OntologyMapping(
                 ),
                 OntologyFieldMapping(ontology_field="username", node_field="email"),
                 OntologyFieldMapping(ontology_field="fullname", node_field="name"),
+                OntologyFieldMapping(ontology_field="active", node_field="active"),
             ],
         ),
     ],

--- a/docs/root/modules/notion/config.md
+++ b/docs/root/modules/notion/config.md
@@ -33,6 +33,7 @@ config = {
             "workspace_id": "stable-workspace-id",
             "workspace_name": "Engineering",
             "api_token": "ntn_your_token_here",
+            "scim_token": "optional_enterprise_scim_token",
         },
     ],
 }
@@ -50,6 +51,12 @@ Workspace IDs must be unique within the configuration. User and bot node IDs
 are scoped by this value so the same Notion identity can safely appear in more
 than one workspace.
 
+`scim_token` is optional and requires a Notion Enterprise workspace. Organization
+owners generate one token per workspace under **Manage organization** →
+**General** → **SCIM provisioning**. When omitted, Cartography does not modify or
+clean previously ingested SCIM properties, groups, memberships, or reporting
+relationships.
+
 ## Run Cartography
 
 ```bash
@@ -63,6 +70,7 @@ cartography \
 | Issue | Resolution |
 |-------|------------|
 | `403 Forbidden` from `/v1/users` | Enable the connection's read-user capability, including email access if ontology mapping is required. |
+| `401 Unauthorized` from `/scim/v2` | Replace the revoked or invalid workspace-specific Enterprise SCIM token. |
 | Missing email properties | Notion omits email unless the connection has the appropriate user capability. |
 | Invalid configuration error | Confirm the environment variable contains base64-encoded JSON with a non-empty `workspaces` list. |
 
@@ -70,4 +78,5 @@ cartography \
 
 - [Notion list users API](https://developers.notion.com/reference/get-users)
 - [Notion user object](https://developers.notion.com/reference/user)
+- [Notion SCIM provisioning](https://www.notion.com/help/provision-users-and-groups-with-scim)
 - [Notion token security](https://developers.notion.com/guides/get-started/handling-api-keys)

--- a/docs/root/modules/notion/index.md
+++ b/docs/root/modules/notion/index.md
@@ -1,12 +1,14 @@
 # Notion
 
 The Notion module inventories people and bot connections in one or more Notion
-workspaces through the public Notion API. People are mapped to Cartography's
-`UserAccount` ontology and bot connections are mapped to `ThirdPartyApp`.
+workspaces through the public Notion API. Optional Enterprise SCIM credentials
+enrich people with membership and profile data and add groups, memberships, and
+reporting relationships. People, groups, and bot connections map to the
+`UserAccount`, `UserGroup`, and `ThirdPartyApp` ontologies.
 
 The public API does not distinguish workspace members from guests and does not
-expose roles, account status, or groups. The module therefore leaves those
-attributes unknown rather than inferring them.
+expose roles, account status, or groups. Without SCIM, the module therefore
+leaves those attributes unknown rather than inferring them.
 
 ```{toctree}
 config

--- a/tests/data/notion/scim.py
+++ b/tests/data/notion/scim.py
@@ -1,0 +1,57 @@
+from cartography.intel.notion.scim import ENTERPRISE_USER_EXTENSION
+from cartography.intel.notion.scim import NOTION_USER_EXTENSION
+
+SCIM_USERS = [
+    {
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "id": "person-1",
+        "externalId": "employee-alice",
+        "userName": "ALICE@example.com",
+        "name": {
+            "formatted": "Alice Example",
+            "givenName": "Alice",
+            "familyName": "Example",
+        },
+        "active": True,
+        "title": "Security Engineer",
+        "userType": "Employee",
+        "locale": "en-US",
+        "preferredLanguage": "en",
+        ENTERPRISE_USER_EXTENSION: {
+            "department": "Security",
+            "division": "Engineering",
+            "costCenter": "CC-42",
+            "organization": "Example Corp",
+            "employeeNumber": "E-1",
+        },
+        NOTION_USER_EXTENSION: {"role": "owner"},
+    },
+    {
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "id": "person-2",
+        "externalId": "employee-bob",
+        "userName": "bob@example.com",
+        "name": {"givenName": "Bob", "familyName": "Example"},
+        "active": True,
+        ENTERPRISE_USER_EXTENSION: {
+            "manager": {
+                "value": "ALICE@example.com",
+                "displayName": "Alice Example",
+            },
+        },
+        NOTION_USER_EXTENSION: {"role": "member"},
+    },
+]
+
+SCIM_GROUPS = [
+    {
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "id": "group-1",
+        "externalId": "security-team",
+        "displayName": "Security",
+        "members": [
+            {"value": "person-1", "display": "Alice Example"},
+            {"value": "person-2", "display": "Bob Example"},
+        ],
+    },
+]

--- a/tests/integration/cartography/intel/notion/test_scim.py
+++ b/tests/integration/cartography/intel/notion/test_scim.py
@@ -1,0 +1,287 @@
+from copy import deepcopy
+from unittest.mock import MagicMock
+
+import pytest
+
+import cartography.intel.notion.scim
+import cartography.intel.notion.users
+import cartography.intel.notion.workspaces
+from cartography.intel.notion.scim import ENTERPRISE_USER_EXTENSION
+from cartography.intel.notion.scim import NOTION_USER_EXTENSION
+from tests.data.notion.scim import SCIM_GROUPS
+from tests.data.notion.scim import SCIM_USERS
+from tests.data.notion.users import USERS
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 223456789
+
+
+def _response(payload):
+    response = MagicMock()
+    response.json.return_value = payload
+    return response
+
+
+def _public_session(raw_users=USERS):
+    session = MagicMock()
+    session.get.return_value = _response(
+        {"results": raw_users, "has_more": False, "next_cursor": None},
+    )
+    return session
+
+
+def _scim_response(resources):
+    return _response(
+        {
+            "Resources": resources,
+            "totalResults": len(resources),
+            "startIndex": 1,
+            "itemsPerPage": len(resources),
+        },
+    )
+
+
+def _scim_session(scim_users=SCIM_USERS, scim_groups=SCIM_GROUPS):
+    session = MagicMock()
+    session.get.side_effect = [
+        _scim_response(scim_users),
+        _scim_response(scim_groups),
+    ]
+    return session
+
+
+def _sync_core(neo4j_session, workspace_id, update_tag):
+    cartography.intel.notion.workspaces.sync(
+        neo4j_session,
+        workspace_id,
+        workspace_id,
+        update_tag,
+    )
+    return cartography.intel.notion.users.sync(
+        neo4j_session,
+        _public_session(),
+        workspace_id,
+        update_tag,
+        {"UPDATE_TAG": update_tag, "WORKSPACE_ID": workspace_id},
+    )
+
+
+def _sync_scim(
+    neo4j_session,
+    workspace_id,
+    update_tag,
+    scim_users=SCIM_USERS,
+    scim_groups=SCIM_GROUPS,
+):
+    public_people = _sync_core(neo4j_session, workspace_id, update_tag)
+    cartography.intel.notion.scim.sync(
+        neo4j_session,
+        _scim_session(scim_users, scim_groups),
+        public_people,
+        workspace_id,
+        update_tag,
+        {"UPDATE_TAG": update_tag, "WORKSPACE_ID": workspace_id},
+    )
+
+
+def test_sync_scim_users_groups_memberships_and_reporting(neo4j_session):
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+
+    # Act
+    _sync_scim(neo4j_session, "workspace-1", TEST_UPDATE_TAG)
+
+    # Assert
+    assert check_nodes(
+        neo4j_session,
+        "NotionUser",
+        ["id", "active", "workspace_role", "department", "is_workspace_member"],
+    ) == {
+        ("workspace-1/person-1", True, "owner", "Security", True),
+        ("workspace-1/person-2", True, "member", None, True),
+    }
+    assert check_nodes(
+        neo4j_session,
+        "NotionGroup",
+        ["id", "name", "scim_external_id"],
+    ) == {("workspace-1/group-1", "Security", "security-team")}
+    assert check_rels(
+        neo4j_session,
+        "NotionUser",
+        "id",
+        "NotionGroup",
+        "id",
+        "MEMBER_OF",
+        rel_direction_right=True,
+    ) == {
+        ("workspace-1/person-1", "workspace-1/group-1"),
+        ("workspace-1/person-2", "workspace-1/group-1"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "NotionUser",
+        "id",
+        "NotionUser",
+        "id",
+        "REPORTS_TO",
+        rel_direction_right=True,
+    ) == {("workspace-1/person-2", "workspace-1/person-1")}
+    ontology = neo4j_session.run(
+        """
+        MATCH (u:NotionUser {id: 'workspace-1/person-1'})
+        MATCH (g:NotionGroup {id: 'workspace-1/group-1'})
+        RETURN u._ont_active AS active, g._ont_name AS group_name
+        """,
+    ).single()
+    assert ontology == {"active": True, "group_name": "Security"}
+
+
+def test_scim_refresh_cleans_stale_groups_memberships_and_manager(neo4j_session):
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _sync_scim(neo4j_session, "workspace-1", TEST_UPDATE_TAG)
+    updated_users = deepcopy(SCIM_USERS)
+    updated_users[1]["active"] = False
+    updated_users[1][NOTION_USER_EXTENSION]["role"] = "restricted_member"
+    updated_users[1][ENTERPRISE_USER_EXTENSION].pop("manager")
+
+    # Act
+    _sync_scim(
+        neo4j_session,
+        "workspace-1",
+        TEST_UPDATE_TAG + 1,
+        updated_users,
+        [],
+    )
+
+    # Assert
+    assert check_nodes(neo4j_session, "NotionGroup", ["id"]) == set()
+    assert (
+        check_rels(
+            neo4j_session,
+            "NotionUser",
+            "id",
+            "NotionGroup",
+            "id",
+            "MEMBER_OF",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+    assert (
+        check_rels(
+            neo4j_session,
+            "NotionUser",
+            "id",
+            "NotionUser",
+            "id",
+            "REPORTS_TO",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+    bob = neo4j_session.run(
+        """
+        MATCH (u:NotionUser {id: 'workspace-1/person-2'})
+        RETURN u.active AS active, u.workspace_role AS role,
+               u.manager_email AS manager_email
+        """,
+    ).single()
+    assert bob == {
+        "active": False,
+        "role": "restricted_member",
+        "manager_email": None,
+    }
+
+
+def test_no_scim_run_preserves_existing_scim_data(neo4j_session):
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _sync_scim(neo4j_session, "workspace-1", TEST_UPDATE_TAG)
+
+    # Act: this is the exact path used when scim_token is omitted.
+    _sync_core(neo4j_session, "workspace-1", TEST_UPDATE_TAG + 1)
+
+    # Assert
+    assert check_nodes(
+        neo4j_session,
+        "NotionUser",
+        ["id", "workspace_role", "is_workspace_member", "active", "_ont_active"],
+    ) == {
+        ("workspace-1/person-1", "owner", True, True, True),
+        ("workspace-1/person-2", "member", True, True, True),
+    }
+    assert check_nodes(neo4j_session, "NotionGroup", ["id"]) == {
+        ("workspace-1/group-1",),
+    }
+
+
+def test_failed_scim_enumeration_suppresses_all_scim_updates_and_cleanup(
+    neo4j_session,
+):
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _sync_scim(neo4j_session, "workspace-1", TEST_UPDATE_TAG)
+    public_people = _sync_core(neo4j_session, "workspace-1", TEST_UPDATE_TAG + 1)
+    failed_session = MagicMock()
+    failed_session.get.side_effect = [
+        _scim_response([]),
+        _response(
+            {
+                "Resources": "malformed",
+                "totalResults": 0,
+                "startIndex": 1,
+                "itemsPerPage": 0,
+            },
+        ),
+    ]
+
+    # Act and assert
+    with pytest.raises(ValueError):
+        cartography.intel.notion.scim.sync(
+            neo4j_session,
+            failed_session,
+            public_people,
+            "workspace-1",
+            TEST_UPDATE_TAG + 1,
+            {"UPDATE_TAG": TEST_UPDATE_TAG + 1, "WORKSPACE_ID": "workspace-1"},
+        )
+    assert check_nodes(
+        neo4j_session,
+        "NotionUser",
+        ["id", "workspace_role"],
+    ) == {
+        ("workspace-1/person-1", "owner"),
+        ("workspace-1/person-2", "member"),
+    }
+    assert check_nodes(neo4j_session, "NotionGroup", ["id"]) == {
+        ("workspace-1/group-1",),
+    }
+
+
+def test_scim_cleanup_is_scoped_to_workspace(neo4j_session):
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _sync_scim(neo4j_session, "workspace-1", TEST_UPDATE_TAG)
+    _sync_scim(neo4j_session, "workspace-2", TEST_UPDATE_TAG)
+
+    # Act
+    _sync_scim(neo4j_session, "workspace-1", TEST_UPDATE_TAG + 1, SCIM_USERS, [])
+
+    # Assert
+    assert check_nodes(neo4j_session, "NotionGroup", ["id"]) == {
+        ("workspace-2/group-1",),
+    }
+    assert check_rels(
+        neo4j_session,
+        "NotionUser",
+        "id",
+        "NotionGroup",
+        "id",
+        "MEMBER_OF",
+        rel_direction_right=True,
+    ) == {
+        ("workspace-2/person-1", "workspace-2/group-1"),
+        ("workspace-2/person-2", "workspace-2/group-1"),
+    }

--- a/tests/unit/cartography/intel/notion/test_scim.py
+++ b/tests/unit/cartography/intel/notion/test_scim.py
@@ -1,0 +1,109 @@
+import pytest
+
+from cartography.intel.notion.scim import transform_groups
+from cartography.intel.notion.scim import transform_users
+from tests.data.notion.scim import SCIM_GROUPS
+from tests.data.notion.scim import SCIM_USERS
+
+PUBLIC_PEOPLE = [
+    {
+        "id": "workspace-1/person-1",
+        "notion_user_id": "person-1",
+        "name": "Public Alice",
+        "email": "alice@example.com",
+    },
+    {
+        "id": "workspace-1/person-2",
+        "notion_user_id": "person-2",
+        "name": "Public Bob",
+        "email": "bob@example.com",
+    },
+]
+
+
+def test_transform_users_merges_fields_and_resolves_manager():
+    # Act
+    users, managers = transform_users(SCIM_USERS, PUBLIC_PEOPLE, "workspace-1")
+
+    # Assert
+    alice = next(user for user in users if user["notion_user_id"] == "person-1")
+    bob = next(user for user in users if user["notion_user_id"] == "person-2")
+    assert alice == {
+        "id": "workspace-1/person-1",
+        "notion_user_id": "person-1",
+        "name": "Alice Example",
+        "email": "alice@example.com",
+        "active": True,
+        "workspace_role": "owner",
+        "scim_external_id": "employee-alice",
+        "title": "Security Engineer",
+        "user_type": "Employee",
+        "locale": "en-US",
+        "preferred_language": "en",
+        "department": "Security",
+        "division": "Engineering",
+        "cost_center": "CC-42",
+        "organization": "Example Corp",
+        "employee_number": "E-1",
+        "manager_email": None,
+        "is_workspace_member": True,
+    }
+    assert bob["name"] == "Bob Example"
+    assert bob["manager_email"] == "alice@example.com"
+    assert managers == [
+        {
+            "source_id": "workspace-1/person-2",
+            "target_id": "workspace-1/person-1",
+        },
+    ]
+
+
+def test_transform_users_leaves_public_only_people_unconfirmed_and_clears_scim_fields():
+    # Act
+    users, managers = transform_users(SCIM_USERS[:1], PUBLIC_PEOPLE, "workspace-1")
+
+    # Assert
+    bob = next(user for user in users if user["notion_user_id"] == "person-2")
+    assert bob["name"] == "Public Bob"
+    assert bob["email"] == "bob@example.com"
+    assert bob["is_workspace_member"] is None
+    assert bob["workspace_role"] is None
+    assert managers == []
+
+
+def test_transform_groups_scopes_memberships():
+    # Act
+    groups = transform_groups(SCIM_GROUPS, "workspace-1")
+
+    # Assert
+    assert groups == [
+        {
+            "id": "workspace-1/group-1",
+            "notion_group_id": "group-1",
+            "name": "Security",
+            "scim_external_id": "security-team",
+            "member_ids": ["workspace-1/person-1", "workspace-1/person-2"],
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    "users",
+    [
+        [{"id": "person-1", "userName": None}],
+        SCIM_USERS + [SCIM_USERS[0]],
+    ],
+)
+def test_transform_users_rejects_malformed_or_duplicate_resources(users):
+    # Act and assert
+    with pytest.raises(ValueError):
+        transform_users(users, PUBLIC_PEOPLE, "workspace-1")
+
+
+def test_transform_groups_rejects_malformed_members():
+    # Act and assert
+    with pytest.raises(ValueError):
+        transform_groups(
+            [{"id": "group-1", "displayName": "Group", "members": [1]}],
+            "workspace-1",
+        )

--- a/tests/unit/cartography/intel/notion/test_util.py
+++ b/tests/unit/cartography/intel/notion/test_util.py
@@ -3,9 +3,12 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 
 from cartography.intel.notion.util import create_api_session
+from cartography.intel.notion.util import create_scim_session
 from cartography.intel.notion.util import get_paginated
+from cartography.intel.notion.util import get_scim_paginated
 from cartography.intel.notion.util import NOTION_API_VERSION
 from cartography.intel.notion.util import parse_config
 
@@ -40,6 +43,25 @@ def test_parse_config_accepts_multiple_workspaces():
     assert [workspace.workspace_id for workspace in workspaces] == ["ws-1", "ws-2"]
 
 
+def test_parse_config_accepts_optional_scim_token():
+    # Arrange
+    encoded = _encode(
+        {
+            "workspaces": [
+                {
+                    "workspace_id": "ws-1",
+                    "workspace_name": "One",
+                    "api_token": "ntn_one",
+                    "scim_token": "scim_one",
+                },
+            ],
+        },
+    )
+
+    # Act and assert
+    assert parse_config(encoded)[0].scim_token == "scim_one"
+
+
 @pytest.mark.parametrize(
     "encoded",
     [
@@ -48,6 +70,18 @@ def test_parse_config_accepts_multiple_workspaces():
         _encode({}),
         _encode({"workspaces": []}),
         _encode({"workspaces": [{"workspace_id": "ws-1"}]}),
+        _encode(
+            {
+                "workspaces": [
+                    {
+                        "workspace_id": "ws-1",
+                        "workspace_name": "One",
+                        "api_token": "ntn_one",
+                        "scim_token": "",
+                    },
+                ],
+            },
+        ),
         _encode(
             {
                 "workspaces": [
@@ -92,6 +126,17 @@ def test_create_api_session_configures_version_and_bounded_get_retries():
     session.close()
 
 
+def test_create_scim_session_uses_scim_media_type_and_same_retry_policy():
+    # Act
+    session = create_scim_session("scim-token")
+
+    # Assert
+    assert session.headers["Authorization"] == "Bearer scim-token"
+    assert session.headers["Accept"] == "application/scim+json"
+    assert session.adapters["https://"].max_retries.total == 5
+    session.close()
+
+
 def test_get_paginated_reads_every_page():
     # Arrange
     session = MagicMock()
@@ -129,3 +174,81 @@ def test_get_paginated_rejects_malformed_or_nonprogressing_responses(payloads):
     # Act and assert
     with pytest.raises(ValueError):
         get_paginated(session, "users")
+
+
+def test_get_scim_paginated_reads_every_page():
+    # Arrange
+    session = MagicMock()
+    session.get.side_effect = [
+        _response(
+            {
+                "Resources": [{"id": "one"}],
+                "totalResults": 2,
+                "startIndex": 1,
+                "itemsPerPage": 1,
+            },
+        ),
+        _response(
+            {
+                "Resources": [{"id": "two"}],
+                "totalResults": 2,
+                "startIndex": 2,
+                "itemsPerPage": 1,
+            },
+        ),
+    ]
+
+    # Act
+    result = get_scim_paginated(session, "Users")
+
+    # Assert
+    assert result == [{"id": "one"}, {"id": "two"}]
+    assert session.get.call_args_list[1].kwargs["params"] == {
+        "startIndex": 2,
+        "count": 100,
+    }
+
+
+def test_get_scim_paginated_propagates_authentication_failure():
+    # Arrange
+    session = MagicMock()
+    response = MagicMock()
+    response.raise_for_status.side_effect = requests.HTTPError("401 Unauthorized")
+    session.get.return_value = response
+
+    # Act and assert
+    with pytest.raises(requests.HTTPError, match="401 Unauthorized"):
+        get_scim_paginated(session, "Users")
+
+
+@pytest.mark.parametrize(
+    "payloads",
+    [
+        [[{"id": "not-an-object"}]],
+        [{"Resources": {}, "totalResults": 0, "startIndex": 1, "itemsPerPage": 0}],
+        [{"Resources": [], "totalResults": True, "startIndex": 1, "itemsPerPage": 0}],
+        [{"Resources": [], "totalResults": 1, "startIndex": 1, "itemsPerPage": 0}],
+        [
+            {
+                "Resources": [{"id": "one"}],
+                "totalResults": 2,
+                "startIndex": 1,
+                "itemsPerPage": 1,
+            },
+            {
+                "Resources": [{"id": "two"}],
+                "totalResults": 3,
+                "startIndex": 2,
+                "itemsPerPage": 1,
+            },
+        ],
+    ],
+)
+def test_get_scim_paginated_rejects_malformed_or_nonprogressing_responses(payloads):
+    # Arrange
+    session = MagicMock()
+    session.get.side_effect = [_response(payload) for payload in payloads]
+
+    # Act and assert
+    with pytest.raises(ValueError):
+        get_scim_paginated(session, "Users")


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):

### Summary

Adds optional Enterprise SCIM enrichment on top of the regular Notion API connector in #3193. SCIM users merge onto the existing workspace-scoped `NotionUser` nodes by Notion user ID and contribute account state, workspace role, identity-provider metadata, organization fields, confirmed membership, groups, group membership, and reporting relationships.

Both SCIM Users and Groups are completely enumerated and validated before any SCIM-derived graph write or cleanup. Omitting `scim_token` leaves prior SCIM data untouched; authentication, malformed-response, and pagination failures abort enrichment without converting the failed inventory into an empty one.

### Related issues or links

- Stacked on #3193
- [Notion SCIM provisioning](https://www.notion.com/help/provision-users-and-groups-with-scim)
- [SCIM protocol RFC 7644](https://www.rfc-editor.org/rfc/rfc7644)

### How was this tested?

- `make test_lint`
- `make test_unit` — 5,238 passed
- `make test_integration` — 1,575 passed
- `uv run ./docs/build.sh` — succeeded
- Focused Notion unit tests — 36 passed
- Focused Notion integration tests — 7 passed

The integration fixtures verify aggregate graph shape for one workspace: 2 enriched users, 1 group, 2 memberships, and 1 reporting relationship. They also verify field refresh, stale group/member/manager cleanup, cleanup suppression after malformed enumeration, no-SCIM preservation, and cross-workspace isolation.

No Enterprise SCIM token was supplied, so no live SCIM logs or live graph counts are included. This PR remains a draft and must not be marked ready until a real Enterprise workspace produces sanitized successful sync logs and aggregate counts.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [x] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module
- [x] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).

### Notes for reviewers

The four current Notion workspace roles remain properties rather than role nodes. Public-API-only people remain unconfirmed instead of being assumed to be guests. Reporting edges are created only when a manager email uniquely resolves to another SCIM-returned user in the same configured workspace.
