### PR TITLE
fix(tenable): harden ingestion and align conventions

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -2156,8 +2156,8 @@ class CLI:
                     "--tenable-tenant-id",
                     help=(
                         "Identifier used to scope all Tenable nodes in the graph "
-                        "(the TenableTenant node id). Defaults to the hostname of "
-                        "--tenable-url when not set."
+                        "(the TenableTenant node id). When not set, defaults to "
+                        "--tenable-url with a leading http:// or https:// removed."
                     ),
                     rich_help_panel=PANEL_TENABLE,
                     hidden=PANEL_TENABLE not in visible_panels,

--- a/cartography/intel/tenable/api.py
+++ b/cartography/intel/tenable/api.py
@@ -121,6 +121,11 @@ def export_and_download(
             raise RuntimeError(f"Tenable export {export_uuid} was cancelled")
         if status == "FINISHED":
             chunks = status_data["chunks_available"]
+            if not isinstance(chunks, list):
+                raise TypeError(
+                    f"Tenable export {export_uuid} chunks_available returned "
+                    f"{type(chunks).__name__}; expected a list"
+                )
             logger.debug(
                 "Tenable export %s finished; downloading %d chunk(s)",
                 export_uuid,

--- a/cartography/intel/tenable/api.py
+++ b/cartography/intel/tenable/api.py
@@ -126,6 +126,22 @@ def export_and_download(
                     f"Tenable export {export_uuid} chunks_available returned "
                     f"{type(chunks).__name__}; expected a list"
                 )
+            chunks_failed = status_data.get("chunks_failed", [])
+            chunks_cancelled = status_data.get("chunks_cancelled", [])
+            for field_name, incomplete_chunks in (
+                ("chunks_failed", chunks_failed),
+                ("chunks_cancelled", chunks_cancelled),
+            ):
+                if not isinstance(incomplete_chunks, list):
+                    raise TypeError(
+                        f"Tenable export {export_uuid} {field_name} returned "
+                        f"{type(incomplete_chunks).__name__}; expected a list"
+                    )
+            if chunks_failed or chunks_cancelled:
+                raise RuntimeError(
+                    f"Tenable export {export_uuid} finished with incomplete chunks: "
+                    f"failed={chunks_failed}, cancelled={chunks_cancelled}"
+                )
             logger.debug(
                 "Tenable export %s finished; downloading %d chunk(s)",
                 export_uuid,

--- a/cartography/intel/tenable/api.py
+++ b/cartography/intel/tenable/api.py
@@ -77,7 +77,13 @@ def _download_chunk(
     url = f"{base_url}/{result_base}/{export_uuid}/chunks/{chunk_id}"
     response = session.get(url, timeout=(30, 120))
     response.raise_for_status()
-    return response.json()
+    chunk_data = response.json()
+    if not isinstance(chunk_data, list):
+        raise TypeError(
+            f"Tenable export chunk {chunk_id} returned "
+            f"{type(chunk_data).__name__}; expected a list"
+        )
+    return chunk_data
 
 
 def export_and_download(
@@ -103,19 +109,19 @@ def export_and_download(
     :return: Aggregated list of all exported records
     """
     export_uuid = _initiate_export(session, base_url, export_path, export_params)
-    logger.info("Initiated Tenable export %s (endpoint: %s)", export_uuid, export_path)
+    logger.debug("Initiated Tenable export %s (endpoint: %s)", export_uuid, export_path)
 
     for attempt in range(1, _MAX_POLL_ATTEMPTS + 1):
         status_data = _get_export_status(session, base_url, result_base, export_uuid)
-        status = status_data.get("status")
+        status = status_data["status"]
 
         if status == "ERROR":
             raise RuntimeError(f"Tenable export {export_uuid} failed with status ERROR")
         if status == "CANCELLED":
             raise RuntimeError(f"Tenable export {export_uuid} was cancelled")
         if status == "FINISHED":
-            chunks = status_data.get("chunks_available") or []
-            logger.info(
+            chunks = status_data["chunks_available"]
+            logger.debug(
                 "Tenable export %s finished; downloading %d chunk(s)",
                 export_uuid,
                 len(chunks),
@@ -131,15 +137,16 @@ def export_and_download(
                 results.extend(chunk_data)
             return results
 
-        logger.info(
-            "Tenable export %s status: %s (attempt %d/%d) — waiting %ds",
-            export_uuid,
-            status,
-            attempt,
-            _MAX_POLL_ATTEMPTS,
-            _EXPORT_POLL_INTERVAL,
-        )
-        time.sleep(_EXPORT_POLL_INTERVAL)
+        if attempt < _MAX_POLL_ATTEMPTS:
+            logger.debug(
+                "Tenable export %s status: %s (attempt %d/%d); waiting %ds",
+                export_uuid,
+                status,
+                attempt,
+                _MAX_POLL_ATTEMPTS,
+                _EXPORT_POLL_INTERVAL,
+            )
+            time.sleep(_EXPORT_POLL_INTERVAL)
 
     raise TimeoutError(
         f"Tenable export {export_uuid} did not finish after "

--- a/cartography/intel/tenable/assets.py
+++ b/cartography/intel/tenable/assets.py
@@ -29,7 +29,7 @@ def get(
     session: requests.Session,
     base_url: str,
 ) -> list[dict[str, Any]]:
-    logger.info("Initiating Tenable asset export from %s", base_url)
+    logger.debug("Initiating Tenable asset export from %s", base_url)
     return export_and_download(
         session,
         base_url,
@@ -81,7 +81,7 @@ def transform(raw_assets: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 ),
                 "last_licensed_scan_date": scan.get("last_licensed_scan_date"),
                 "last_scan_id": scan.get("last_scan_id"),
-                # Network — name detail in TenableNetwork
+                # Network: name detail in TenableNetwork
                 "network_id": network.get("network_id"),
                 "fqdn": fqdns[0] if fqdns else None,
                 "ipv4s": network.get("ipv4s") or [],
@@ -89,7 +89,7 @@ def transform(raw_assets: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "fqdns": fqdns,
                 "hostnames": network.get("hostnames") or [],
                 "mac_addresses": network.get("mac_addresses") or [],
-                # Cloud identifiers — detail in TenableAssetAWS / TenableAssetAzure / TenableAssetGCP
+                # Cloud identifiers: detail in TenableAssetAWS / TenableAssetAzure / TenableAssetGCP
                 "aws_ec2_instance_id": aws.get("ec2_instance_id"),
                 "azure_vm_id": azure.get("vm_id"),
                 "gcp_instance_id": gcp.get("instance_id"),
@@ -123,7 +123,9 @@ def transform_sources(raw_assets: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for asset in raw_assets:
         asset_id = asset["id"]
         for source in asset.get("sources") or []:
-            name = source.get("name") or ""
+            name = source["name"]
+            if not name:
+                raise ValueError("Tenable asset source requires a non-empty name")
             result.append(
                 {
                     "id": f"{asset_id}::{name}",
@@ -350,3 +352,4 @@ def sync(
         update_tag,
     )
     cleanup(neo4j_session, common_job_parameters)
+    logger.info("Completed Tenable asset sync for tenant %s", tenant_id)

--- a/cartography/intel/tenable/findings.py
+++ b/cartography/intel/tenable/findings.py
@@ -39,7 +39,7 @@ def get(
         "last_found": since_epoch,
         "state": _FINDING_EXPORT_STATES,
     }
-    logger.info(
+    logger.debug(
         "Findings export from %s (last_found >= %d)",
         base_url,
         since_epoch,
@@ -56,19 +56,18 @@ def get(
 def transform(raw_findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
     result = []
     for finding in raw_findings:
-        asset = finding.get("asset") or {}
-        plugin = finding.get("plugin") or {}
+        asset = finding["asset"]
+        plugin = finding["plugin"]
         port_info = finding.get("port") or {}
 
-        asset_uuid = asset.get("uuid")
-        finding_id = finding.get("finding_id")
-        plugin_id = plugin.get("id")
-
+        asset_uuid = asset["uuid"]
+        finding_id = finding["finding_id"]
+        plugin_id = plugin["id"]
         if not asset_uuid or not finding_id or plugin_id is None:
-            logger.warning(
-                "Skipping finding with missing asset_uuid, finding_id, or plugin_id"
+            raise ValueError(
+                "Tenable finding requires non-empty asset.uuid and finding_id, "
+                "and a non-null plugin.id"
             )
-            continue
 
         cve_ids: list[str] = plugin.get("cve") or []
 
@@ -247,3 +246,4 @@ def sync(
     scans = transform_scans(raw_findings)
     load_findings(neo4j_session, findings, plugins, scans, tenant_id, update_tag)
     cleanup(neo4j_session, common_job_parameters)
+    logger.info("Completed Tenable finding sync for tenant %s", tenant_id)

--- a/cartography/models/ontology/mapping/data/cves.py
+++ b/cartography/models/ontology/mapping/data/cves.py
@@ -52,6 +52,13 @@ _S1_SEVERITY = {
     "Critical": "critical",
 }
 
+# Tenable finding state
+_TENABLE_VULN_STATUS = {
+    "OPEN": "open",
+    "REOPENED": "open",
+    "FIXED": "fixed",
+}
+
 # NVD vulnStatus -> resolution state. NVD's values are analysis-workflow states; all
 # non-rejected ones mean the record is live, so they collapse to "open".
 _NVD_VULN_STATUS = {
@@ -381,6 +388,33 @@ sentinelone_mapping = OntologyMapping(
     ],
 )
 
+tenable_mapping = OntologyMapping(
+    module_name="tenable",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="TenableFinding",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="cve_id",
+                    node_field="cve_id",
+                    required=True,
+                ),
+                OntologyFieldMapping(
+                    ontology_field="base_severity",
+                    node_field="severity",
+                ),
+                OntologyFieldMapping(
+                    ontology_field="vuln_status",
+                    node_field="state",
+                    special_handling="mapping",
+                    extra={"map": _TENABLE_VULN_STATUS},
+                ),
+            ],
+        ),
+    ],
+)
+
+
 # SemgrepSCAFinding is a hybrid finding: it carries :CVE when CVE-backed and
 # :SecurityIssue when advisory-only (see cartography/models/semgrep/findings.py).
 # The semantic-label resolver returns a single mapping per primary label regardless
@@ -510,6 +544,7 @@ CVES_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "crowdstrike": crowdstrike_mapping,
     "github": github_mapping,
     "sentinelone": sentinelone_mapping,
+    "tenable": tenable_mapping,
     "semgrep": semgrep_mapping,
     "aws": aws_inspector_mapping,
     "wiz": wiz_mapping,

--- a/cartography/models/ontology/mapping/data/tenants.py
+++ b/cartography/models/ontology/mapping/data/tenants.py
@@ -472,6 +472,21 @@ jumpcloud_mapping = OntologyMapping(
 # Tailscale
 # TailscaleTailnet: No field to map in TailscaleTailnet (minimal properties)
 
+
+# Tenable
+tenable_mapping = OntologyMapping(
+    module_name="tenable",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="TenableTenant",
+            # The configured ID may be an arbitrary scope identifier, so it is not
+            # normalized as a tenant name or domain.
+            fields=[],
+        ),
+    ],
+)
+
+
 # WorkOS Tenant mapping
 workos_tenants_mapping = OntologyMapping(
     module_name="workos",
@@ -803,6 +818,7 @@ TENANTS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "spacelift": spacelift_mapping,
     "subimage": subimage_mapping,
     "socketdev": socketdev_mapping,
+    "tenable": tenable_mapping,
     "workos": workos_tenants_mapping,
     "vercel": vercel_mapping,
     "railway": railway_mapping,

--- a/cartography/models/tenable/tags.py
+++ b/cartography/models/tenable/tags.py
@@ -21,11 +21,11 @@ class TenableAssetTagNodeProperties(CartographyNodeProperties):
         "key", extra_index=True, description="Tag category or key."
     )
     value: PropertyRef = PropertyRef("value", description="Tag value.")
-    # DEPRECATED: will be deleted in version 1.0.0
+    # DEPRECATED: tag_key is a compatibility alias and will be removed in v1.0.0.
     tag_key: PropertyRef = PropertyRef(
         "key", description="Deprecated mirror of key; removed in v1.0.0."
     )
-    # DEPRECATED: will be deleted in version 1.0.0
+    # DEPRECATED: tag_value is a compatibility alias and will be removed in v1.0.0.
     tag_value: PropertyRef = PropertyRef(
         "value", description="Deprecated mirror of value; removed in v1.0.0."
     )

--- a/cartography/models/tenable/tenant.py
+++ b/cartography/models/tenable/tenant.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.ontology.labels import TENANT
 
 
 @dataclass(frozen=True)
@@ -19,3 +21,4 @@ class TenableTenantSchema(CartographyNodeSchema):
 
     label: str = "TenableTenant"
     properties: TenableTenantNodeProperties = TenableTenantNodeProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([TENANT])

--- a/docs/root/modules/tenable/config.md
+++ b/docs/root/modules/tenable/config.md
@@ -4,12 +4,31 @@
 
 Cartography requires Tenable access and secret keys. By default, it reads them
 from the `TENABLE_ACCESS_KEY` and `TENABLE_SECRET_KEY` environment variables.
+Create API keys from the Tenable Vulnerability Management user interface as
+described in Tenable's
+[Generate API Keys](https://docs.tenable.com/vulnerability-management/Content/Settings/my-account/GenerateAPIKey.htm)
+documentation.
+
+## Required Permissions
+
+The Tenable user needs either the Basic role or a custom role with the
+`VM.VM_EXPLORE.VM_EXPLORE.EXPORT` privilege. Vulnerability exports also require
+Can View access to the assets being exported. Administrator users can export
+without explicit Can View access.
+
+See Tenable's API documentation for
+[asset exports](https://developer.tenable.com/reference/export-assets-v2) and
+[vulnerability exports](https://developer.tenable.com/reference/exports-vulns-request-export).
 
 ## Configure Cartography
 
-Use `--tenable-access-key-env-var` and `--tenable-secret-key-env-var` to select
-different environment variable names. `--tenable-url` sets the API base URL and
-defaults to `https://cloud.tenable.com`.
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `--tenable-access-key-env-var` | `TENABLE_ACCESS_KEY` | Environment variable containing the access key. |
+| `--tenable-secret-key-env-var` | `TENABLE_SECRET_KEY` | Environment variable containing the secret key. |
+| `--tenable-url` | `https://cloud.tenable.com` | Tenable API base URL. |
+| `--tenable-tenant-id` | URL without its leading scheme | Stable graph scope for this Tenable tenant. |
+| `--tenable-findings-lookback-days` | `180` | Number of days included in findings exports. |
 
 ## Run Cartography
 
@@ -33,6 +52,13 @@ URL by removing a leading `https://` or `http://`. For the default URL, the ID
 is `cloud.tenable.com`. This is a normalized URL string, not a tenant or
 container UUID discovered from the Tenable API. Any port, path, query, or
 trailing slash in a custom base URL remains part of the derived ID.
+
+```{warning}
+Tenable plugin and cloud-detail identifiers are not currently tenant-qualified.
+Do not import multiple Tenable tenants into the same graph when those identifiers
+may overlap. A future migration will add full tenant isolation without changing
+existing graph identifiers in place.
+```
 
 ### Findings lookback
 

--- a/docs/root/modules/tenable/index.md
+++ b/docs/root/modules/tenable/index.md
@@ -5,10 +5,11 @@ The Tenable module ingests assets and vulnerability findings from the
 It uses the asynchronous bulk export workflow to retrieve assets and findings,
 then models related networks, cloud details, sources, tags, plugins, and scans.
 
-Tenable findings with CVE identifiers also use the `CVE` ontology label so
-Cartography's CVE metadata can enrich them. Tenable asset tags use the shared
-`Tag` label and the `TAGGED` relationship. The deprecated `HAS_TAG`
-compatibility edge is still written in parallel and will be removed in v1.0.0.
+The `TenableTenant` node uses the shared `Tenant` ontology label. Tenable
+findings with CVE identifiers use the `CVE` ontology label so Cartography's CVE
+metadata can enrich them. Tenable asset tags use the shared `Tag` label and the
+`TAGGED` relationship. The deprecated `HAS_TAG` compatibility edge is still
+written in parallel and will be removed in v1.0.0.
 
 See [configuration](config.md) for connection and scoping options, and the
 generated [schema](schema.md) for fields and relationships.

--- a/tests/data/tenable/assets.py
+++ b/tests/data/tenable/assets.py
@@ -2,6 +2,7 @@ TENABLE_TENANT_ID = "cloud.tenable.com"
 
 ASSET_ID_1 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 ASSET_ID_2 = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+GCP_ASSET_ID = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
 
 NETWORK_ID = "00000000-0000-0000-0000-000000000000"
 
@@ -9,6 +10,7 @@ TAG_ID_1 = "cccccccc-cccc-cccc-cccc-cccccccccccc"
 
 AWS_EC2_INSTANCE_ID_1 = "i-1234567890abcdef0"
 AZURE_VM_ID_2 = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+GCP_INSTANCE_ID = "1234567890123456789"
 
 ASSETS_DATA = [
     {
@@ -135,3 +137,14 @@ ASSETS_DATA = [
         "tags": [],
     },
 ]
+
+GCP_ASSET_DATA = {
+    "id": GCP_ASSET_ID,
+    "cloud": {
+        "gcp": {
+            "instance_id": GCP_INSTANCE_ID,
+            "project_id": "example-project",
+            "zone": "us-central1-a",
+        },
+    },
+}

--- a/tests/integration/cartography/intel/tenable/test_assets.py
+++ b/tests/integration/cartography/intel/tenable/test_assets.py
@@ -4,6 +4,9 @@ from tests.data.tenable.assets import ASSET_ID_2
 from tests.data.tenable.assets import ASSETS_DATA
 from tests.data.tenable.assets import AWS_EC2_INSTANCE_ID_1
 from tests.data.tenable.assets import AZURE_VM_ID_2
+from tests.data.tenable.assets import GCP_ASSET_DATA
+from tests.data.tenable.assets import GCP_ASSET_ID
+from tests.data.tenable.assets import GCP_INSTANCE_ID
 from tests.data.tenable.assets import NETWORK_ID
 from tests.data.tenable.assets import TAG_ID_1
 from tests.data.tenable.assets import TENABLE_TENANT_ID
@@ -20,7 +23,7 @@ SOURCE_ID_2 = f"{ASSET_ID_2}::NESSUS_SCAN"
 def _sync_assets(neo4j_session, mocker, data=None):
     """Helper: run assets sync with optional custom data."""
     mocker.patch(
-        "cartography.intel.tenable.assets.export_and_download",
+        "cartography.intel.tenable.assets.get",
         return_value=data if data is not None else ASSETS_DATA,
     )
     cartography.intel.tenable.assets.sync(
@@ -35,8 +38,9 @@ def _sync_assets(neo4j_session, mocker, data=None):
 
 def test_sync_assets(neo4j_session, mocker):
     """Test that asset sync correctly creates TenableAsset nodes and relationships."""
+    # Arrange
     mocker.patch(
-        "cartography.intel.tenable.assets.export_and_download",
+        "cartography.intel.tenable.assets.get",
         return_value=ASSETS_DATA,
     )
 
@@ -45,6 +49,7 @@ def test_sync_assets(neo4j_session, mocker):
         "TENABLE_TENANT_ID": TENABLE_TENANT_ID,
     }
 
+    # Act
     cartography.intel.tenable.assets.sync(
         neo4j_session,
         mocker.MagicMock(),
@@ -54,9 +59,20 @@ def test_sync_assets(neo4j_session, mocker):
         common_job_parameters,
     )
 
+    # Assert
     # Verify tenant node exists
     tenant_nodes = check_nodes(neo4j_session, "TenableTenant", ["id"])
     assert (TENABLE_TENANT_ID,) in tenant_nodes
+    tenant = neo4j_session.run(
+        """
+        MATCH (t:TenableTenant {id: $tenant_id})
+        RETURN t:Tenant AS has_tenant_label,
+               t._ont_source AS ontology_source
+        """,
+        tenant_id=TENABLE_TENANT_ID,
+    ).single()
+    assert tenant["has_tenant_label"] is True
+    assert tenant["ontology_source"] == "tenable"
 
     # Verify asset nodes (cloud detail fields are on sub-nodes, not here)
     actual_nodes = check_nodes(
@@ -124,8 +140,9 @@ def test_sync_assets(neo4j_session, mocker):
 
 def test_sync_networks(neo4j_session, mocker):
     """Test that TenableNetwork nodes are created and linked to assets."""
+    # Arrange
     mocker.patch(
-        "cartography.intel.tenable.assets.export_and_download",
+        "cartography.intel.tenable.assets.get",
         return_value=ASSETS_DATA,
     )
 
@@ -134,6 +151,7 @@ def test_sync_networks(neo4j_session, mocker):
         "TENABLE_TENANT_ID": TENABLE_TENANT_ID,
     }
 
+    # Act
     cartography.intel.tenable.assets.sync(
         neo4j_session,
         mocker.MagicMock(),
@@ -143,6 +161,7 @@ def test_sync_networks(neo4j_session, mocker):
         common_job_parameters,
     )
 
+    # Assert
     # Both assets share the same network; only one node should exist
     actual_networks = check_nodes(neo4j_session, "TenableNetwork", ["id", "name"])
     assert actual_networks == {(NETWORK_ID, "Default")}
@@ -164,8 +183,9 @@ def test_sync_networks(neo4j_session, mocker):
 
 def test_sync_aws_cloud(neo4j_session, mocker):
     """Test that TenableAssetAWS nodes are created and linked to assets."""
+    # Arrange
     mocker.patch(
-        "cartography.intel.tenable.assets.export_and_download",
+        "cartography.intel.tenable.assets.get",
         return_value=ASSETS_DATA,
     )
 
@@ -174,6 +194,7 @@ def test_sync_aws_cloud(neo4j_session, mocker):
         "TENABLE_TENANT_ID": TENABLE_TENANT_ID,
     }
 
+    # Act
     cartography.intel.tenable.assets.sync(
         neo4j_session,
         mocker.MagicMock(),
@@ -183,6 +204,7 @@ def test_sync_aws_cloud(neo4j_session, mocker):
         common_job_parameters,
     )
 
+    # Assert
     actual_aws = check_nodes(
         neo4j_session,
         "TenableAssetAWS",
@@ -206,8 +228,9 @@ def test_sync_aws_cloud(neo4j_session, mocker):
 
 def test_sync_azure_cloud(neo4j_session, mocker):
     """Test that TenableAssetAzure nodes are created and linked to assets."""
+    # Arrange
     mocker.patch(
-        "cartography.intel.tenable.assets.export_and_download",
+        "cartography.intel.tenable.assets.get",
         return_value=ASSETS_DATA,
     )
 
@@ -216,6 +239,7 @@ def test_sync_azure_cloud(neo4j_session, mocker):
         "TENABLE_TENANT_ID": TENABLE_TENANT_ID,
     }
 
+    # Act
     cartography.intel.tenable.assets.sync(
         neo4j_session,
         mocker.MagicMock(),
@@ -225,6 +249,7 @@ def test_sync_azure_cloud(neo4j_session, mocker):
         common_job_parameters,
     )
 
+    # Assert
     actual_azure = check_nodes(
         neo4j_session, "TenableAssetAzure", ["id", "resource_id"]
     )
@@ -247,18 +272,19 @@ def test_sync_azure_cloud(neo4j_session, mocker):
     assert actual_rels == {(ASSET_ID_2, AZURE_VM_ID_2)}
 
 
-def test_sync_sources(neo4j_session, mocker):
-    """Test that TenableAssetSource nodes are created and linked to assets."""
+def test_sync_gcp_cloud(neo4j_session, mocker):
+    """Test that TenableAssetGCP nodes are created and linked to assets and tenants."""
+    # Arrange
     mocker.patch(
-        "cartography.intel.tenable.assets.export_and_download",
-        return_value=ASSETS_DATA,
+        "cartography.intel.tenable.assets.get",
+        return_value=[GCP_ASSET_DATA],
     )
-
     common_job_parameters = {
         "UPDATE_TAG": TEST_UPDATE_TAG,
         "TENABLE_TENANT_ID": TENABLE_TENANT_ID,
     }
 
+    # Act
     cartography.intel.tenable.assets.sync(
         neo4j_session,
         mocker.MagicMock(),
@@ -268,6 +294,58 @@ def test_sync_sources(neo4j_session, mocker):
         common_job_parameters,
     )
 
+    # Assert
+    assert check_nodes(
+        neo4j_session,
+        "TenableAssetGCP",
+        ["id", "project_id", "zone"],
+    ) == {
+        (GCP_INSTANCE_ID, "example-project", "us-central1-a"),
+    }
+    assert check_rels(
+        neo4j_session,
+        "TenableAsset",
+        "id",
+        "TenableAssetGCP",
+        "id",
+        "HAS_GCP_INFO",
+        rel_direction_right=True,
+    ) == {(GCP_ASSET_ID, GCP_INSTANCE_ID)}
+    assert check_rels(
+        neo4j_session,
+        "TenableTenant",
+        "id",
+        "TenableAssetGCP",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {(TENABLE_TENANT_ID, GCP_INSTANCE_ID)}
+
+
+def test_sync_sources(neo4j_session, mocker):
+    """Test that TenableAssetSource nodes are created and linked to assets."""
+    # Arrange
+    mocker.patch(
+        "cartography.intel.tenable.assets.get",
+        return_value=ASSETS_DATA,
+    )
+
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "TENABLE_TENANT_ID": TENABLE_TENANT_ID,
+    }
+
+    # Act
+    cartography.intel.tenable.assets.sync(
+        neo4j_session,
+        mocker.MagicMock(),
+        TEST_BASE_URL,
+        TENABLE_TENANT_ID,
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+
+    # Assert
     actual_sources = check_nodes(neo4j_session, "TenableAssetSource", ["id", "name"])
     assert actual_sources == {
         (SOURCE_ID_1, "NESSUS_AGENT"),
@@ -291,8 +369,9 @@ def test_sync_sources(neo4j_session, mocker):
 
 def test_sync_tags(neo4j_session, mocker):
     """Test that TenableAssetTag nodes are created and linked to assets."""
+    # Arrange
     mocker.patch(
-        "cartography.intel.tenable.assets.export_and_download",
+        "cartography.intel.tenable.assets.get",
         return_value=ASSETS_DATA,
     )
 
@@ -301,6 +380,7 @@ def test_sync_tags(neo4j_session, mocker):
         "TENABLE_TENANT_ID": TENABLE_TENANT_ID,
     }
 
+    # Act
     cartography.intel.tenable.assets.sync(
         neo4j_session,
         mocker.MagicMock(),
@@ -310,6 +390,7 @@ def test_sync_tags(neo4j_session, mocker):
         common_job_parameters,
     )
 
+    # Assert
     actual_tags = check_nodes(neo4j_session, "TenableAssetTag", ["id", "key", "value"])
     assert actual_tags == {(TAG_ID_1, "Environment", "Production")}
 
@@ -337,8 +418,47 @@ def test_sync_tags(neo4j_session, mocker):
     assert tagged_rels == {(ASSET_ID_1, TAG_ID_1)}
 
 
+def test_sync_asset_subresources_have_tenant_ownership(neo4j_session, mocker):
+    """Test that every asset subresource has the RESOURCE edge used for cleanup."""
+    # Arrange
+    mocker.patch(
+        "cartography.intel.tenable.assets.get",
+        return_value=ASSETS_DATA,
+    )
+
+    # Act
+    cartography.intel.tenable.assets.sync(
+        neo4j_session,
+        mocker.MagicMock(),
+        TEST_BASE_URL,
+        TENABLE_TENANT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "TENABLE_TENANT_ID": TENABLE_TENANT_ID},
+    )
+
+    # Assert
+    expected_ids_by_label = {
+        "TenableNetwork": {NETWORK_ID},
+        "TenableAssetAWS": {AWS_EC2_INSTANCE_ID_1},
+        "TenableAssetAzure": {AZURE_VM_ID_2},
+        "TenableAssetSource": {SOURCE_ID_1, SOURCE_ID_2},
+        "TenableAssetTag": {TAG_ID_1},
+    }
+    for label, expected_ids in expected_ids_by_label.items():
+        assert check_rels(
+            neo4j_session,
+            "TenableTenant",
+            "id",
+            label,
+            "id",
+            "RESOURCE",
+            rel_direction_right=True,
+        ) == {(TENABLE_TENANT_ID, resource_id) for resource_id in expected_ids}
+
+
 def test_sync_assets_empty_response(neo4j_session, mocker):
     """Test that asset sync handles an empty export gracefully."""
+    # Arrange
     neo4j_session.run(
         """
         MATCH (n)
@@ -350,7 +470,7 @@ def test_sync_assets_empty_response(neo4j_session, mocker):
     )
 
     mocker.patch(
-        "cartography.intel.tenable.assets.export_and_download",
+        "cartography.intel.tenable.assets.get",
         return_value=[],
     )
 
@@ -359,6 +479,7 @@ def test_sync_assets_empty_response(neo4j_session, mocker):
         "TENABLE_TENANT_ID": TENABLE_TENANT_ID,
     }
 
+    # Act
     cartography.intel.tenable.assets.sync(
         neo4j_session,
         mocker.MagicMock(),
@@ -368,6 +489,7 @@ def test_sync_assets_empty_response(neo4j_session, mocker):
         common_job_parameters,
     )
 
+    # Assert
     assert check_nodes(neo4j_session, "TenableAsset", ["id"]) == set()
     assert check_nodes(neo4j_session, "TenableNetwork", ["id"]) == set()
     assert check_nodes(neo4j_session, "TenableAssetSource", ["id"]) == set()
@@ -379,6 +501,7 @@ def test_sync_assets_empty_response(neo4j_session, mocker):
 
 def test_sync_assets_cleanup(neo4j_session, mocker):
     """Test that stale TenableAsset nodes are deleted after sync."""
+    # Arrange
     old_update_tag = TEST_UPDATE_TAG - 1000
     neo4j_session.run(
         """
@@ -392,7 +515,7 @@ def test_sync_assets_cleanup(neo4j_session, mocker):
     )
 
     mocker.patch(
-        "cartography.intel.tenable.assets.export_and_download",
+        "cartography.intel.tenable.assets.get",
         return_value=[ASSETS_DATA[0]],
     )
 
@@ -401,6 +524,7 @@ def test_sync_assets_cleanup(neo4j_session, mocker):
         "TENABLE_TENANT_ID": TENABLE_TENANT_ID,
     }
 
+    # Act
     cartography.intel.tenable.assets.sync(
         neo4j_session,
         mocker.MagicMock(),
@@ -410,14 +534,101 @@ def test_sync_assets_cleanup(neo4j_session, mocker):
         common_job_parameters,
     )
 
+    # Assert
     result = neo4j_session.run("MATCH (a:TenableAsset) RETURN a.id AS id")
     existing_ids = {r["id"] for r in result}
     assert "stale-asset-id" not in existing_ids
     assert ASSET_ID_1 in existing_ids
 
 
+def test_sync_assets_cleanup_across_update_tags(neo4j_session, mocker):
+    """Test that a second complete sync removes assets absent from the new export."""
+    # Arrange
+    first_update_tag = TEST_UPDATE_TAG
+    second_update_tag = TEST_UPDATE_TAG + 1
+    mocker.patch(
+        "cartography.intel.tenable.assets.get",
+        side_effect=[ASSETS_DATA, [ASSETS_DATA[0]]],
+    )
+
+    # Act
+    cartography.intel.tenable.assets.sync(
+        neo4j_session,
+        mocker.MagicMock(),
+        TEST_BASE_URL,
+        TENABLE_TENANT_ID,
+        first_update_tag,
+        {
+            "UPDATE_TAG": first_update_tag,
+            "TENABLE_TENANT_ID": TENABLE_TENANT_ID,
+        },
+    )
+    cartography.intel.tenable.assets.sync(
+        neo4j_session,
+        mocker.MagicMock(),
+        TEST_BASE_URL,
+        TENABLE_TENANT_ID,
+        second_update_tag,
+        {
+            "UPDATE_TAG": second_update_tag,
+            "TENABLE_TENANT_ID": TENABLE_TENANT_ID,
+        },
+    )
+
+    # Assert
+    assert check_nodes(neo4j_session, "TenableAsset", ["id"]) == {(ASSET_ID_1,)}
+
+
+def test_sync_assets_removes_stale_relationships_across_update_tags(
+    neo4j_session,
+    mocker,
+):
+    """Test that relationships absent from a later export are removed."""
+    # Arrange
+    first_update_tag = TEST_UPDATE_TAG
+    second_update_tag = TEST_UPDATE_TAG + 1
+    mocker.patch(
+        "cartography.intel.tenable.assets.get",
+        side_effect=[[ASSETS_DATA[0]], [{"id": ASSET_ID_1}]],
+    )
+
+    # Act
+    for update_tag in (first_update_tag, second_update_tag):
+        cartography.intel.tenable.assets.sync(
+            neo4j_session,
+            mocker.MagicMock(),
+            TEST_BASE_URL,
+            TENABLE_TENANT_ID,
+            update_tag,
+            {
+                "UPDATE_TAG": update_tag,
+                "TENABLE_TENANT_ID": TENABLE_TENANT_ID,
+            },
+        )
+
+    # Assert
+    for target_label, rel_label in (
+        ("TenableNetwork", "MEMBER_OF_NETWORK"),
+        ("TenableAssetAWS", "HAS_AWS_INFO"),
+        ("TenableAssetTag", "TAGGED"),
+    ):
+        assert (
+            check_rels(
+                neo4j_session,
+                "TenableAsset",
+                "id",
+                target_label,
+                "id",
+                rel_label,
+                rel_direction_right=True,
+            )
+            == set()
+        )
+
+
 def test_sync_networks_cleanup(neo4j_session, mocker):
     """Test that stale TenableNetwork nodes are deleted after sync."""
+    # Arrange
     old_update_tag = TEST_UPDATE_TAG - 1000
     neo4j_session.run(
         """
@@ -430,8 +641,10 @@ def test_sync_networks_cleanup(neo4j_session, mocker):
         old_tag=old_update_tag,
     )
 
+    # Act
     _sync_assets(neo4j_session, mocker)
 
+    # Assert
     result = neo4j_session.run("MATCH (n:TenableNetwork) RETURN n.id AS id")
     existing_ids = {r["id"] for r in result}
     assert "stale-network-id" not in existing_ids
@@ -440,6 +653,7 @@ def test_sync_networks_cleanup(neo4j_session, mocker):
 
 def test_sync_sources_cleanup(neo4j_session, mocker):
     """Test that stale TenableAssetSource nodes are deleted after sync."""
+    # Arrange
     old_update_tag = TEST_UPDATE_TAG - 1000
     neo4j_session.run(
         """
@@ -452,8 +666,10 @@ def test_sync_sources_cleanup(neo4j_session, mocker):
         old_tag=old_update_tag,
     )
 
+    # Act
     _sync_assets(neo4j_session, mocker)
 
+    # Assert
     result = neo4j_session.run("MATCH (s:TenableAssetSource) RETURN s.id AS id")
     existing_ids = {r["id"] for r in result}
     assert "stale-source-id" not in existing_ids
@@ -463,6 +679,7 @@ def test_sync_sources_cleanup(neo4j_session, mocker):
 
 def test_sync_tags_cleanup(neo4j_session, mocker):
     """Test that stale TenableAssetTag nodes are deleted after sync."""
+    # Arrange
     old_update_tag = TEST_UPDATE_TAG - 1000
     neo4j_session.run(
         """
@@ -475,8 +692,10 @@ def test_sync_tags_cleanup(neo4j_session, mocker):
         old_tag=old_update_tag,
     )
 
+    # Act
     _sync_assets(neo4j_session, mocker)
 
+    # Assert
     result = neo4j_session.run("MATCH (tag:TenableAssetTag) RETURN tag.id AS id")
     existing_ids = {r["id"] for r in result}
     assert "stale-tag-id" not in existing_ids
@@ -485,6 +704,7 @@ def test_sync_tags_cleanup(neo4j_session, mocker):
 
 def test_sync_aws_cleanup(neo4j_session, mocker):
     """Test that stale TenableAssetAWS nodes are deleted after sync."""
+    # Arrange
     old_update_tag = TEST_UPDATE_TAG - 1000
     neo4j_session.run(
         """
@@ -497,8 +717,10 @@ def test_sync_aws_cleanup(neo4j_session, mocker):
         old_tag=old_update_tag,
     )
 
+    # Act
     _sync_assets(neo4j_session, mocker)
 
+    # Assert
     result = neo4j_session.run("MATCH (a:TenableAssetAWS) RETURN a.id AS id")
     existing_ids = {r["id"] for r in result}
     assert "stale-aws-id" not in existing_ids
@@ -507,6 +729,7 @@ def test_sync_aws_cleanup(neo4j_session, mocker):
 
 def test_sync_azure_cleanup(neo4j_session, mocker):
     """Test that stale TenableAssetAzure nodes are deleted after sync."""
+    # Arrange
     old_update_tag = TEST_UPDATE_TAG - 1000
     neo4j_session.run(
         """
@@ -519,8 +742,10 @@ def test_sync_azure_cleanup(neo4j_session, mocker):
         old_tag=old_update_tag,
     )
 
+    # Act
     _sync_assets(neo4j_session, mocker)
 
+    # Assert
     result = neo4j_session.run("MATCH (a:TenableAssetAzure) RETURN a.id AS id")
     existing_ids = {r["id"] for r in result}
     assert "stale-azure-id" not in existing_ids
@@ -529,6 +754,7 @@ def test_sync_azure_cleanup(neo4j_session, mocker):
 
 def test_sync_gcp_cleanup(neo4j_session, mocker):
     """Test that stale TenableAssetGCP nodes are deleted after sync."""
+    # Arrange
     old_update_tag = TEST_UPDATE_TAG - 1000
     neo4j_session.run(
         """
@@ -541,9 +767,11 @@ def test_sync_gcp_cleanup(neo4j_session, mocker):
         old_tag=old_update_tag,
     )
 
+    # Act
     # ASSETS_DATA has no GCP assets; the stale node must still be removed
     _sync_assets(neo4j_session, mocker)
 
+    # Assert
     result = neo4j_session.run("MATCH (g:TenableAssetGCP) RETURN g.id AS id")
     existing_ids = {r["id"] for r in result}
     assert "stale-gcp-id" not in existing_ids

--- a/tests/integration/cartography/intel/tenable/test_findings.py
+++ b/tests/integration/cartography/intel/tenable/test_findings.py
@@ -23,7 +23,7 @@ TEST_BASE_URL = "https://cloud.tenable.com"
 def _load_assets(neo4j_session, mocker):
     """Helper: sync assets so TenableAsset nodes exist for relationship tests."""
     mocker.patch(
-        "cartography.intel.tenable.assets.export_and_download",
+        "cartography.intel.tenable.assets.get",
         return_value=ASSETS_DATA,
     )
     cartography.intel.tenable.assets.sync(
@@ -39,7 +39,7 @@ def _load_assets(neo4j_session, mocker):
 def _sync_findings(neo4j_session, mocker, data=None):
     """Helper: run findings sync with optional custom data."""
     mocker.patch(
-        "cartography.intel.tenable.findings.export_and_download",
+        "cartography.intel.tenable.findings.get",
         return_value=data if data is not None else FINDINGS_DATA,
     )
     cartography.intel.tenable.findings.sync(
@@ -54,9 +54,13 @@ def _sync_findings(neo4j_session, mocker, data=None):
 
 def test_sync_findings(neo4j_session, mocker):
     """Test that findings sync creates TenableFinding nodes with correct properties."""
+    # Arrange
     _load_assets(neo4j_session, mocker)
+
+    # Act
     _sync_findings(neo4j_session, mocker)
 
+    # Assert
     actual_nodes = check_nodes(
         neo4j_session,
         "TenableFinding",
@@ -71,18 +75,30 @@ def test_sync_findings(neo4j_session, mocker):
 
 def test_sync_findings_cve_fields(neo4j_session, mocker):
     """Test that cve_id and has_cve are set on findings and the CVE label is applied."""
+    # Arrange
     _load_assets(neo4j_session, mocker)
+
+    # Act
     _sync_findings(neo4j_session, mocker)
 
+    # Assert
     # Finding with CVEs
     record = neo4j_session.run(
         "MATCH (f:TenableFinding {id: $id}) "
-        "RETURN f.cve_id AS cve_id, f.has_cve AS has_cve, f:CVE AS has_cve_label",
+        "RETURN f.cve_id AS cve_id, f.has_cve AS has_cve, "
+        "f:CVE AS has_cve_label, f._ont_cve_id AS ontology_cve_id, "
+        "f._ont_base_severity AS ontology_severity, "
+        "f._ont_vuln_status AS ontology_status, "
+        "f._ont_source AS ontology_source",
         id=FINDING_ID_1,
     ).single()
     assert record["cve_id"] == "CVE-2022-21837"
     assert record["has_cve"] == "true"
     assert record["has_cve_label"] is True
+    assert record["ontology_cve_id"] == "CVE-2022-21837"
+    assert record["ontology_severity"] == "high"
+    assert record["ontology_status"] == "open"
+    assert record["ontology_source"] == "tenable"
 
     # Finding without CVEs
     record = neo4j_session.run(
@@ -96,9 +112,13 @@ def test_sync_findings_cve_fields(neo4j_session, mocker):
 
 def test_sync_findings_affects_asset_rel(neo4j_session, mocker):
     """Test that TenableFinding-[:AFFECTS]->TenableAsset relationships are created."""
+    # Arrange
     _load_assets(neo4j_session, mocker)
+
+    # Act
     _sync_findings(neo4j_session, mocker)
 
+    # Assert
     actual_rels = check_rels(
         neo4j_session,
         "TenableFinding",
@@ -117,9 +137,13 @@ def test_sync_findings_affects_asset_rel(neo4j_session, mocker):
 
 def test_sync_plugins(neo4j_session, mocker):
     """Test that TenablePlugin nodes are created and deduplicated."""
+    # Arrange
     _load_assets(neo4j_session, mocker)
+
+    # Act
     _sync_findings(neo4j_session, mocker)
 
+    # Assert
     actual_plugins = check_nodes(
         neo4j_session,
         "TenablePlugin",
@@ -157,9 +181,13 @@ def test_sync_plugins(neo4j_session, mocker):
 
 def test_sync_findings_detected_by_rel(neo4j_session, mocker):
     """Test that TenableFinding-[:DETECTED_BY]->TenablePlugin relationships are created."""
+    # Arrange
     _load_assets(neo4j_session, mocker)
+
+    # Act
     _sync_findings(neo4j_session, mocker)
 
+    # Assert
     actual_rels = check_rels(
         neo4j_session,
         "TenableFinding",
@@ -178,10 +206,14 @@ def test_sync_findings_detected_by_rel(neo4j_session, mocker):
 
 def test_sync_scans(neo4j_session, mocker):
     """Test that TenableScan nodes are created, deduplicated, and linked to findings."""
+    # Arrange
     _load_assets(neo4j_session, mocker)
+
+    # Act
     _sync_findings(neo4j_session, mocker)
 
-    # FINDING_ID_1 and FINDING_ID_3 share SCAN_UUID_1 — only one scan node should exist
+    # Assert
+    # FINDING_ID_1 and FINDING_ID_3 share SCAN_UUID_1, so only one scan node exists
     actual_scans = check_nodes(neo4j_session, "TenableScan", ["id", "last_scan_target"])
     assert actual_scans == {
         (SCAN_UUID_1, "192.0.2.58"),
@@ -206,9 +238,13 @@ def test_sync_scans(neo4j_session, mocker):
 
 def test_sync_findings_tenant_resource_rel(neo4j_session, mocker):
     """Test that TenableTenant-[:RESOURCE]->TenableFinding relationships are created."""
+    # Arrange
     _load_assets(neo4j_session, mocker)
+
+    # Act
     _sync_findings(neo4j_session, mocker)
 
+    # Assert
     actual_rels = check_rels(
         neo4j_session,
         "TenableTenant",
@@ -218,15 +254,52 @@ def test_sync_findings_tenant_resource_rel(neo4j_session, mocker):
         "RESOURCE",
         rel_direction_right=True,
     )
-    assert {
+    assert actual_rels == {
         (TENABLE_TENANT_ID, FINDING_ID_1),
         (TENABLE_TENANT_ID, FINDING_ID_2),
         (TENABLE_TENANT_ID, FINDING_ID_3),
-    } <= actual_rels
+    }
+
+
+def test_sync_finding_subresources_have_tenant_ownership(neo4j_session, mocker):
+    """Test that plugins and scans have the RESOURCE edge used for cleanup."""
+    # Arrange
+    _load_assets(neo4j_session, mocker)
+
+    # Act
+    _sync_findings(neo4j_session, mocker)
+
+    # Assert
+    assert check_rels(
+        neo4j_session,
+        "TenableTenant",
+        "id",
+        "TenablePlugin",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (TENABLE_TENANT_ID, PLUGIN_ID_1),
+        (TENABLE_TENANT_ID, PLUGIN_ID_2),
+        (TENABLE_TENANT_ID, PLUGIN_ID_3),
+    }
+    assert check_rels(
+        neo4j_session,
+        "TenableTenant",
+        "id",
+        "TenableScan",
+        "id",
+        "RESOURCE",
+        rel_direction_right=True,
+    ) == {
+        (TENABLE_TENANT_ID, SCAN_UUID_1),
+        (TENABLE_TENANT_ID, SCAN_UUID_2),
+    }
 
 
 def test_sync_findings_cleanup(neo4j_session, mocker):
     """Test that stale TenableFinding nodes are deleted after sync."""
+    # Arrange
     old_update_tag = TEST_UPDATE_TAG - 1000
     neo4j_session.run(
         """
@@ -240,16 +313,59 @@ def test_sync_findings_cleanup(neo4j_session, mocker):
     )
 
     _load_assets(neo4j_session, mocker)
+
+    # Act
     _sync_findings(neo4j_session, mocker, data=[FINDINGS_DATA[0]])
 
+    # Assert
     result = neo4j_session.run("MATCH (f:TenableFinding) RETURN f.id AS id")
     existing_ids = {r["id"] for r in result}
     assert "stale-finding-id" not in existing_ids
     assert FINDING_ID_1 in existing_ids
 
 
+def test_sync_findings_cleanup_across_update_tags(neo4j_session, mocker):
+    """Test that a second complete sync removes findings absent from the new export."""
+    # Arrange
+    _load_assets(neo4j_session, mocker)
+    first_update_tag = TEST_UPDATE_TAG
+    second_update_tag = TEST_UPDATE_TAG + 1
+    mocker.patch(
+        "cartography.intel.tenable.findings.get",
+        side_effect=[FINDINGS_DATA, [FINDINGS_DATA[0]]],
+    )
+
+    # Act
+    cartography.intel.tenable.findings.sync(
+        neo4j_session,
+        mocker.MagicMock(),
+        TEST_BASE_URL,
+        TENABLE_TENANT_ID,
+        first_update_tag,
+        {
+            "UPDATE_TAG": first_update_tag,
+            "TENABLE_TENANT_ID": TENABLE_TENANT_ID,
+        },
+    )
+    cartography.intel.tenable.findings.sync(
+        neo4j_session,
+        mocker.MagicMock(),
+        TEST_BASE_URL,
+        TENABLE_TENANT_ID,
+        second_update_tag,
+        {
+            "UPDATE_TAG": second_update_tag,
+            "TENABLE_TENANT_ID": TENABLE_TENANT_ID,
+        },
+    )
+
+    # Assert
+    assert check_nodes(neo4j_session, "TenableFinding", ["id"]) == {(FINDING_ID_1,)}
+
+
 def test_sync_plugins_cleanup(neo4j_session, mocker):
     """Test that stale TenablePlugin nodes are deleted after sync."""
+    # Arrange
     old_update_tag = TEST_UPDATE_TAG - 1000
     neo4j_session.run(
         """
@@ -263,8 +379,11 @@ def test_sync_plugins_cleanup(neo4j_session, mocker):
     )
 
     _load_assets(neo4j_session, mocker)
+
+    # Act
     _sync_findings(neo4j_session, mocker)
 
+    # Assert
     result = neo4j_session.run("MATCH (p:TenablePlugin) RETURN p.id AS id")
     existing_ids = {r["id"] for r in result}
     assert "stale-plugin-id" not in existing_ids
@@ -275,6 +394,7 @@ def test_sync_plugins_cleanup(neo4j_session, mocker):
 
 def test_sync_scans_cleanup(neo4j_session, mocker):
     """Test that stale TenableScan nodes are deleted after sync."""
+    # Arrange
     old_update_tag = TEST_UPDATE_TAG - 1000
     neo4j_session.run(
         """
@@ -288,35 +408,13 @@ def test_sync_scans_cleanup(neo4j_session, mocker):
     )
 
     _load_assets(neo4j_session, mocker)
+
+    # Act
     _sync_findings(neo4j_session, mocker)
 
+    # Assert
     result = neo4j_session.run("MATCH (s:TenableScan) RETURN s.id AS id")
     existing_ids = {r["id"] for r in result}
     assert "stale-scan-id" not in existing_ids
     assert SCAN_UUID_1 in existing_ids
     assert SCAN_UUID_2 in existing_ids
-
-
-def test_sync_findings_export_filter(neo4j_session, mocker):
-    """Every sync sends a last_found filter derived from lookback_days."""
-    _load_assets(neo4j_session, mocker)
-    mock_export = mocker.patch(
-        "cartography.intel.tenable.findings.export_and_download",
-        return_value=FINDINGS_DATA,
-    )
-    lookback_days = 90
-    cartography.intel.tenable.findings.sync(
-        neo4j_session,
-        mocker.MagicMock(),
-        TEST_BASE_URL,
-        TENABLE_TENANT_ID,
-        TEST_UPDATE_TAG,
-        {"UPDATE_TAG": TEST_UPDATE_TAG, "TENABLE_TENANT_ID": TENABLE_TENANT_ID},
-        lookback_days=lookback_days,
-    )
-
-    export_params = mock_export.call_args[0][4]
-    assert export_params["filters"]["last_found"] == TEST_UPDATE_TAG - (
-        lookback_days * 86400
-    )
-    assert export_params["filters"]["state"] == ["OPEN", "REOPENED", "FIXED"]

--- a/tests/unit/cartography/intel/tenable/test_api.py
+++ b/tests/unit/cartography/intel/tenable/test_api.py
@@ -1,0 +1,175 @@
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from cartography.intel.tenable import api
+
+TEST_BASE_URL = "https://cloud.tenable.com"
+TEST_EXPORT_PATH = "assets/v2/export"
+TEST_RESULT_BASE = "assets/export"
+TEST_EXPORT_PARAMS = {"chunk_size": 1000}
+
+
+def test_export_and_download_aggregates_finished_chunks(mocker):
+    # Arrange
+    session = MagicMock()
+    mocker.patch.object(api, "_initiate_export", return_value="export-uuid")
+    mocker.patch.object(
+        api,
+        "_get_export_status",
+        return_value={"status": "FINISHED", "chunks_available": [2, 1]},
+    )
+    mock_download = mocker.patch.object(
+        api,
+        "_download_chunk",
+        side_effect=[[{"id": "asset-2"}], [{"id": "asset-1"}]],
+    )
+
+    # Act
+    result = api.export_and_download(
+        session,
+        TEST_BASE_URL,
+        TEST_EXPORT_PATH,
+        TEST_RESULT_BASE,
+        TEST_EXPORT_PARAMS,
+    )
+
+    # Assert
+    assert result == [{"id": "asset-2"}, {"id": "asset-1"}]
+    assert [call.args[-1] for call in mock_download.call_args_list] == [2, 1]
+
+
+def test_export_and_download_accepts_finished_export_without_chunks(mocker):
+    # Arrange
+    session = MagicMock()
+    mocker.patch.object(api, "_initiate_export", return_value="export-uuid")
+    mocker.patch.object(
+        api,
+        "_get_export_status",
+        return_value={"status": "FINISHED", "chunks_available": []},
+    )
+    mock_download = mocker.patch.object(api, "_download_chunk")
+
+    # Act
+    result = api.export_and_download(
+        session,
+        TEST_BASE_URL,
+        TEST_EXPORT_PATH,
+        TEST_RESULT_BASE,
+        TEST_EXPORT_PARAMS,
+    )
+
+    # Assert
+    assert result == []
+    mock_download.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("status", "message"),
+    [
+        ("ERROR", "failed with status ERROR"),
+        ("CANCELLED", "was cancelled"),
+    ],
+)
+def test_export_and_download_rejects_terminal_failure_statuses(
+    mocker,
+    status,
+    message,
+):
+    # Arrange
+    mocker.patch.object(api, "_initiate_export", return_value="export-uuid")
+    mocker.patch.object(api, "_get_export_status", return_value={"status": status})
+
+    # Act and assert
+    with pytest.raises(RuntimeError, match=message):
+        api.export_and_download(
+            MagicMock(),
+            TEST_BASE_URL,
+            TEST_EXPORT_PATH,
+            TEST_RESULT_BASE,
+            TEST_EXPORT_PARAMS,
+        )
+
+
+@pytest.mark.parametrize(
+    "status_data",
+    [
+        {},
+        {"status": "FINISHED"},
+    ],
+)
+def test_export_and_download_rejects_malformed_status_payloads(
+    mocker,
+    status_data,
+):
+    # Arrange
+    mocker.patch.object(api, "_initiate_export", return_value="export-uuid")
+    mocker.patch.object(api, "_get_export_status", return_value=status_data)
+
+    # Act and assert
+    with pytest.raises(KeyError):
+        api.export_and_download(
+            MagicMock(),
+            TEST_BASE_URL,
+            TEST_EXPORT_PATH,
+            TEST_RESULT_BASE,
+            TEST_EXPORT_PARAMS,
+        )
+
+
+def test_export_and_download_times_out_without_sleeping_after_final_poll(mocker):
+    # Arrange
+    mocker.patch.object(api, "_MAX_POLL_ATTEMPTS", 2)
+    mocker.patch.object(api, "_EXPORT_POLL_INTERVAL", 1)
+    mocker.patch.object(api, "_initiate_export", return_value="export-uuid")
+    mock_status = mocker.patch.object(
+        api,
+        "_get_export_status",
+        return_value={"status": "PROCESSING"},
+    )
+    mock_sleep = mocker.patch.object(api.time, "sleep")
+
+    # Act and assert
+    with pytest.raises(TimeoutError, match="did not finish after 2 polls"):
+        api.export_and_download(
+            MagicMock(),
+            TEST_BASE_URL,
+            TEST_EXPORT_PATH,
+            TEST_RESULT_BASE,
+            TEST_EXPORT_PARAMS,
+        )
+    assert mock_status.call_count == 2
+    mock_sleep.assert_called_once_with(1)
+
+
+def test_initiate_export_propagates_http_errors():
+    # Arrange
+    session = MagicMock()
+    response = session.post.return_value
+    response.raise_for_status.side_effect = requests.HTTPError("forbidden")
+
+    # Act and assert
+    with pytest.raises(requests.HTTPError, match="forbidden"):
+        api._initiate_export(
+            session,
+            TEST_BASE_URL,
+            TEST_EXPORT_PATH,
+            TEST_EXPORT_PARAMS,
+        )
+
+
+def test_download_chunk_rejects_non_list_payload():
+    # Arrange
+    session = MagicMock()
+    session.get.return_value.json.return_value = {"unexpected": "object"}
+
+    # Act and assert
+    with pytest.raises(TypeError, match="expected a list"):
+        api._download_chunk(
+            session,
+            TEST_BASE_URL,
+            TEST_RESULT_BASE,
+            "export-uuid",
+            1,
+        )

--- a/tests/unit/cartography/intel/tenable/test_api.py
+++ b/tests/unit/cartography/intel/tenable/test_api.py
@@ -118,6 +118,33 @@ def test_export_and_download_rejects_malformed_status_payloads(
         )
 
 
+@pytest.mark.parametrize("chunks_available", [{}, "", None])
+def test_export_and_download_rejects_non_list_chunks_available(
+    mocker,
+    chunks_available,
+):
+    # Arrange
+    mocker.patch.object(api, "_initiate_export", return_value="export-uuid")
+    mocker.patch.object(
+        api,
+        "_get_export_status",
+        return_value={
+            "status": "FINISHED",
+            "chunks_available": chunks_available,
+        },
+    )
+
+    # Act and assert
+    with pytest.raises(TypeError, match="chunks_available returned"):
+        api.export_and_download(
+            MagicMock(),
+            TEST_BASE_URL,
+            TEST_EXPORT_PATH,
+            TEST_RESULT_BASE,
+            TEST_EXPORT_PARAMS,
+        )
+
+
 def test_export_and_download_times_out_without_sleeping_after_final_poll(mocker):
     # Arrange
     mocker.patch.object(api, "_MAX_POLL_ATTEMPTS", 2)

--- a/tests/unit/cartography/intel/tenable/test_api.py
+++ b/tests/unit/cartography/intel/tenable/test_api.py
@@ -145,6 +145,71 @@ def test_export_and_download_rejects_non_list_chunks_available(
         )
 
 
+@pytest.mark.parametrize(
+    ("field_name", "chunk_ids"),
+    [
+        ("chunks_failed", [2]),
+        ("chunks_cancelled", [3, 4]),
+    ],
+)
+def test_export_and_download_rejects_incomplete_finished_export(
+    mocker,
+    field_name,
+    chunk_ids,
+):
+    # Arrange
+    mocker.patch.object(api, "_initiate_export", return_value="export-uuid")
+    mocker.patch.object(
+        api,
+        "_get_export_status",
+        return_value={
+            "status": "FINISHED",
+            "chunks_available": [1],
+            field_name: chunk_ids,
+        },
+    )
+    mock_download = mocker.patch.object(api, "_download_chunk")
+
+    # Act and assert
+    with pytest.raises(RuntimeError, match="finished with incomplete chunks"):
+        api.export_and_download(
+            MagicMock(),
+            TEST_BASE_URL,
+            TEST_EXPORT_PATH,
+            TEST_RESULT_BASE,
+            TEST_EXPORT_PARAMS,
+        )
+    mock_download.assert_not_called()
+
+
+@pytest.mark.parametrize("field_name", ["chunks_failed", "chunks_cancelled"])
+def test_export_and_download_rejects_non_list_incomplete_chunks(
+    mocker,
+    field_name,
+):
+    # Arrange
+    mocker.patch.object(api, "_initiate_export", return_value="export-uuid")
+    mocker.patch.object(
+        api,
+        "_get_export_status",
+        return_value={
+            "status": "FINISHED",
+            "chunks_available": [1],
+            field_name: None,
+        },
+    )
+
+    # Act and assert
+    with pytest.raises(TypeError, match=rf"{field_name} returned"):
+        api.export_and_download(
+            MagicMock(),
+            TEST_BASE_URL,
+            TEST_EXPORT_PATH,
+            TEST_RESULT_BASE,
+            TEST_EXPORT_PARAMS,
+        )
+
+
 def test_export_and_download_times_out_without_sleeping_after_final_poll(mocker):
     # Arrange
     mocker.patch.object(api, "_MAX_POLL_ATTEMPTS", 2)

--- a/tests/unit/cartography/intel/tenable/test_assets_transform.py
+++ b/tests/unit/cartography/intel/tenable/test_assets_transform.py
@@ -1,3 +1,5 @@
+import pytest
+
 from cartography.intel.tenable.assets import transform
 from cartography.intel.tenable.assets import transform_aws
 from cartography.intel.tenable.assets import transform_azure
@@ -19,8 +21,10 @@ from tests.data.tenable.assets import TAG_ID_1
 
 
 def test_transform_maps_all_fields():
+    # Act
     result = transform(ASSETS_DATA)
 
+    # Assert
     assert len(result) == 2
 
     asset1 = result[0]
@@ -59,25 +63,40 @@ def test_transform_maps_all_fields():
 
 
 def test_transform_fqdn_is_first_of_fqdns():
+    # Arrange
     raw = [
         {
             "id": "asset-x",
             "network": {"fqdns": ["first.example.com", "second.example.com"]},
         }
     ]
+
+    # Act
     result = transform(raw)
+
+    # Assert
     assert result[0]["fqdn"] == "first.example.com"
 
 
 def test_transform_fqdn_none_when_fqdns_empty():
+    # Arrange
     raw = [{"id": "asset-x", "network": {"fqdns": []}}]
+
+    # Act
     result = transform(raw)
+
+    # Assert
     assert result[0]["fqdn"] is None
 
 
 def test_transform_list_fields_default_to_empty_list():
+    # Arrange
     raw = [{"id": "asset-x"}]
+
+    # Act
     result = transform(raw)
+
+    # Assert
     asset = result[0]
     assert asset["types"] == []
     assert asset["system_types"] == []
@@ -90,8 +109,13 @@ def test_transform_list_fields_default_to_empty_list():
 
 
 def test_transform_optional_scalars_default_to_none():
+    # Arrange
     raw = [{"id": "asset-x"}]
+
+    # Act
     result = transform(raw)
+
+    # Assert
     asset = result[0]
     assert asset["has_agent"] is None
     assert asset["serial_number"] is None
@@ -104,6 +128,7 @@ def test_transform_optional_scalars_default_to_none():
 
 
 def test_transform_empty_input():
+    # Act and assert
     assert transform([]) == []
 
 
@@ -113,35 +138,49 @@ def test_transform_empty_input():
 
 
 def test_transform_networks_basic():
+    # Act
     result = transform_networks(ASSETS_DATA)
-    # Both assets share NETWORK_ID — only one network node produced
+
+    # Assert
+    # Both assets share NETWORK_ID, so only one network node is produced.
     assert len(result) == 1
     assert result[0] == {"id": NETWORK_ID, "name": "Default"}
 
 
 def test_transform_networks_deduplicates():
+    # Arrange
     raw = [
         {"id": "a1", "network": {"network_id": "net-1", "network_name": "Net1"}},
         {"id": "a2", "network": {"network_id": "net-1", "network_name": "Net1"}},
         {"id": "a3", "network": {"network_id": "net-2", "network_name": "Net2"}},
     ]
+
+    # Act
     result = transform_networks(raw)
+
+    # Assert
     ids = [r["id"] for r in result]
     assert ids == ["net-1", "net-2"]
 
 
 def test_transform_networks_skips_missing_network_id():
+    # Arrange
     raw = [
         {"id": "a1", "network": {}},
         {"id": "a2"},
         {"id": "a3", "network": {"network_id": "net-1", "network_name": "N"}},
     ]
+
+    # Act
     result = transform_networks(raw)
+
+    # Assert
     assert len(result) == 1
     assert result[0]["id"] == "net-1"
 
 
 def test_transform_networks_empty_input():
+    # Act and assert
     assert transform_networks([]) == []
 
 
@@ -151,7 +190,10 @@ def test_transform_networks_empty_input():
 
 
 def test_transform_sources_basic():
+    # Act
     result = transform_sources(ASSETS_DATA)
+
+    # Assert
     # ASSET_ID_1 has one source, ASSET_ID_2 has one source
     assert len(result) == 2
 
@@ -167,11 +209,28 @@ def test_transform_sources_basic():
 
 
 def test_transform_sources_no_sources():
+    # Arrange
     raw = [{"id": "asset-x"}]
+
+    # Act and assert
     assert transform_sources(raw) == []
 
 
+def test_transform_sources_rejects_missing_name():
+    # Act and assert
+    with pytest.raises(KeyError):
+        transform_sources([{"id": "asset-x", "sources": [{}]}])
+
+
+@pytest.mark.parametrize("name", [None, ""])
+def test_transform_sources_rejects_null_or_empty_name(name):
+    # Act and assert
+    with pytest.raises(ValueError, match="requires a non-empty name"):
+        transform_sources([{"id": "asset-x", "sources": [{"name": name}]}])
+
+
 def test_transform_sources_multiple_per_asset():
+    # Arrange
     raw = [
         {
             "id": "asset-x",
@@ -189,7 +248,11 @@ def test_transform_sources_multiple_per_asset():
             ],
         }
     ]
+
+    # Act
     result = transform_sources(raw)
+
+    # Assert
     assert len(result) == 2
     ids = {r["id"] for r in result}
     assert ids == {"asset-x::SRC_A", "asset-x::SRC_B"}
@@ -201,7 +264,10 @@ def test_transform_sources_multiple_per_asset():
 
 
 def test_transform_tags_basic():
+    # Act
     result = transform_tags(ASSETS_DATA)
+
+    # Assert
     # Only ASSET_ID_1 has a tag
     assert len(result) == 1
     tag = result[0]
@@ -214,11 +280,15 @@ def test_transform_tags_basic():
 
 
 def test_transform_tags_no_tags():
+    # Arrange
     raw = [{"id": "asset-x", "tags": []}]
+
+    # Act and assert
     assert transform_tags(raw) == []
 
 
 def test_transform_tags_multiple_per_asset():
+    # Arrange
     raw = [
         {
             "id": "asset-x",
@@ -240,7 +310,11 @@ def test_transform_tags_multiple_per_asset():
             ],
         }
     ]
+
+    # Act
     result = transform_tags(raw)
+
+    # Assert
     assert len(result) == 2
     assert {r["id"] for r in result} == {"t1", "t2"}
     assert all(r["asset_id"] == "asset-x" for r in result)
@@ -252,7 +326,10 @@ def test_transform_tags_multiple_per_asset():
 
 
 def test_transform_aws_basic():
+    # Act
     result = transform_aws(ASSETS_DATA)
+
+    # Assert
     assert len(result) == 1
     aws = result[0]
     assert aws["id"] == AWS_EC2_INSTANCE_ID_1
@@ -269,6 +346,7 @@ def test_transform_aws_basic():
 
 
 def test_transform_aws_deduplicates():
+    # Arrange
     raw = [
         {
             "id": "a1",
@@ -283,23 +361,33 @@ def test_transform_aws_deduplicates():
             "cloud": {"aws": {"ec2_instance_id": "i-222", "region": "us-west-2"}},
         },
     ]
+
+    # Act
     result = transform_aws(raw)
+
+    # Assert
     assert len(result) == 2
     assert {r["id"] for r in result} == {"i-111", "i-222"}
 
 
 def test_transform_aws_skips_missing_instance_id():
+    # Arrange
     raw = [
         {"id": "a1", "cloud": {"aws": {}}},
         {"id": "a2"},
         {"id": "a3", "cloud": {"aws": {"ec2_instance_id": "i-999"}}},
     ]
+
+    # Act
     result = transform_aws(raw)
+
+    # Assert
     assert len(result) == 1
     assert result[0]["id"] == "i-999"
 
 
 def test_transform_aws_empty_input():
+    # Act and assert
     assert transform_aws([]) == []
 
 
@@ -309,7 +397,10 @@ def test_transform_aws_empty_input():
 
 
 def test_transform_azure_basic():
+    # Act
     result = transform_azure(ASSETS_DATA)
+
+    # Assert
     assert len(result) == 1
     az = result[0]
     assert az["id"] == AZURE_VM_ID_2
@@ -320,27 +411,38 @@ def test_transform_azure_basic():
 
 
 def test_transform_azure_deduplicates():
+    # Arrange
     raw = [
         {"id": "a1", "cloud": {"azure": {"vm_id": "vm-aaa", "resource_id": "/res/1"}}},
         {"id": "a2", "cloud": {"azure": {"vm_id": "vm-aaa", "resource_id": "/res/1"}}},
         {"id": "a3", "cloud": {"azure": {"vm_id": "vm-bbb", "resource_id": "/res/2"}}},
     ]
+
+    # Act
     result = transform_azure(raw)
+
+    # Assert
     assert len(result) == 2
     assert {r["id"] for r in result} == {"vm-aaa", "vm-bbb"}
 
 
 def test_transform_azure_skips_missing_vm_id():
+    # Arrange
     raw = [
         {"id": "a1", "cloud": {"azure": {}}},
         {"id": "a2", "cloud": {"azure": {"vm_id": "vm-xyz"}}},
     ]
+
+    # Act
     result = transform_azure(raw)
+
+    # Assert
     assert len(result) == 1
     assert result[0]["id"] == "vm-xyz"
 
 
 def test_transform_azure_empty_input():
+    # Act and assert
     assert transform_azure([]) == []
 
 
@@ -350,6 +452,7 @@ def test_transform_azure_empty_input():
 
 
 def test_transform_gcp_basic():
+    # Arrange
     raw = [
         {
             "id": "asset-g",
@@ -362,7 +465,11 @@ def test_transform_gcp_basic():
             },
         }
     ]
+
+    # Act
     result = transform_gcp(raw)
+
+    # Assert
     assert len(result) == 1
     gcp = result[0]
     assert gcp["id"] == "gcp-inst-1"
@@ -371,6 +478,7 @@ def test_transform_gcp_basic():
 
 
 def test_transform_gcp_deduplicates():
+    # Arrange
     raw = [
         {
             "id": "a1",
@@ -391,21 +499,31 @@ def test_transform_gcp_deduplicates():
             },
         },
     ]
+
+    # Act
     result = transform_gcp(raw)
+
+    # Assert
     assert len(result) == 2
     assert {r["id"] for r in result} == {"inst-1", "inst-2"}
 
 
 def test_transform_gcp_skips_missing_instance_id():
+    # Arrange
     raw = [
         {"id": "a1", "cloud": {"gcp": {}}},
         {"id": "a2", "cloud": {"gcp": {"instance_id": "inst-ok"}}},
     ]
+
+    # Act
     result = transform_gcp(raw)
+
+    # Assert
     assert len(result) == 1
     assert result[0]["id"] == "inst-ok"
 
 
 def test_transform_gcp_not_present_in_assets_data():
+    # Act and assert
     # ASSETS_DATA has no GCP assets
     assert transform_gcp(ASSETS_DATA) == []

--- a/tests/unit/cartography/intel/tenable/test_findings_transform.py
+++ b/tests/unit/cartography/intel/tenable/test_findings_transform.py
@@ -1,3 +1,6 @@
+import pytest
+
+from cartography.intel.tenable.findings import get
 from cartography.intel.tenable.findings import transform
 from cartography.intel.tenable.findings import transform_plugins
 from cartography.intel.tenable.findings import transform_scans
@@ -12,14 +15,38 @@ from tests.data.tenable.findings import PLUGIN_ID_3
 from tests.data.tenable.findings import SCAN_UUID_1
 from tests.data.tenable.findings import SCAN_UUID_2
 
+
+def test_get_builds_findings_export_filter(mocker):
+    # Arrange
+    mock_export = mocker.patch(
+        "cartography.intel.tenable.findings.export_and_download",
+        return_value=FINDINGS_DATA,
+    )
+
+    # Act
+    result = get(mocker.MagicMock(), "https://cloud.tenable.com", 123456789)
+
+    # Assert
+    assert result == FINDINGS_DATA
+    assert mock_export.call_args.args[4] == {
+        "num_assets": 500,
+        "filters": {
+            "last_found": 123456789,
+            "state": ["OPEN", "REOPENED", "FIXED"],
+        },
+    }
+
+
 # ---------------------------------------------------------------------------
 # transform()
 # ---------------------------------------------------------------------------
 
 
 def test_transform_maps_all_fields():
+    # Act
     result = transform(FINDINGS_DATA)
 
+    # Assert
     assert len(result) == 3
 
     f1 = next(r for r in result if r["id"] == FINDING_ID_1)
@@ -45,7 +72,7 @@ def test_transform_maps_all_fields():
     assert f1["port"] == 445
     assert f1["protocol"] == "TCP"
     assert f1["service"] == "cifs"
-    # CVE fields — finding has CVEs
+    # CVE fields: finding has CVEs
     assert f1["cve_id"] == "CVE-2022-21837"
     assert set(f1["cve_list"]) == {
         "CVE-2022-21837",
@@ -56,7 +83,10 @@ def test_transform_maps_all_fields():
 
 
 def test_transform_cve_fields_no_cves():
+    # Act
     result = transform(FINDINGS_DATA)
+
+    # Assert
     f2 = next(r for r in result if r["id"] == FINDING_ID_2)
     assert f2["cve_id"] is None
     assert f2["cve_list"] == []
@@ -64,52 +94,59 @@ def test_transform_cve_fields_no_cves():
 
 
 def test_transform_port_zero_and_null_service():
+    # Act
     result = transform(FINDINGS_DATA)
+
+    # Assert
     f3 = next(r for r in result if r["id"] == FINDING_ID_3)
     assert f3["port"] == 0
     assert f3["protocol"] == "TCP"
     assert f3["service"] is None
 
 
-def test_transform_skips_missing_asset_uuid():
-    raw = [
+@pytest.mark.parametrize(
+    "raw_finding",
+    [
         {"finding_id": "f1", "asset": {}, "plugin": {"id": 1}},
-        {"finding_id": "f2", "asset": {"uuid": "a-uuid"}, "plugin": {"id": 2}},
-    ]
-    result = transform(raw)
-    assert len(result) == 1
-    assert result[0]["id"] == "f2"
-
-
-def test_transform_skips_missing_finding_id():
-    raw = [
         {"asset": {"uuid": "a-uuid"}, "plugin": {"id": 1}},
-        {"finding_id": "f2", "asset": {"uuid": "a-uuid"}, "plugin": {"id": 2}},
-    ]
-    result = transform(raw)
-    assert len(result) == 1
-    assert result[0]["id"] == "f2"
-
-
-def test_transform_skips_missing_plugin_id():
-    raw = [
         {"finding_id": "f1", "asset": {"uuid": "a-uuid"}, "plugin": {}},
-        {"finding_id": "f2", "asset": {"uuid": "a-uuid"}, "plugin": {"id": 99}},
-    ]
-    result = transform(raw)
-    assert len(result) == 1
-    assert result[0]["id"] == "f2"
+    ],
+)
+def test_transform_rejects_missing_required_identifiers(raw_finding):
+    # Act and assert
+    with pytest.raises(KeyError):
+        transform([raw_finding])
+
+
+@pytest.mark.parametrize(
+    "raw_finding",
+    [
+        {"finding_id": "f1", "asset": {"uuid": None}, "plugin": {"id": 1}},
+        {"finding_id": "", "asset": {"uuid": "a-uuid"}, "plugin": {"id": 1}},
+        {"finding_id": "f1", "asset": {"uuid": "a-uuid"}, "plugin": {"id": None}},
+    ],
+)
+def test_transform_rejects_null_or_empty_required_identifiers(raw_finding):
+    # Act and assert
+    with pytest.raises(ValueError, match="Tenable finding requires"):
+        transform([raw_finding])
 
 
 def test_transform_null_scan_uuid_allowed():
     """A finding with no scan block should still be included; scan_uuid will be None."""
+    # Arrange
     raw = [{"finding_id": "f1", "asset": {"uuid": "a-uuid"}, "plugin": {"id": 1}}]
+
+    # Act
     result = transform(raw)
+
+    # Assert
     assert len(result) == 1
     assert result[0]["scan_uuid"] is None
 
 
 def test_transform_empty_input():
+    # Act and assert
     assert transform([]) == []
 
 
@@ -119,7 +156,10 @@ def test_transform_empty_input():
 
 
 def test_transform_plugins_basic():
+    # Act
     result = transform_plugins(FINDINGS_DATA)
+
+    # Assert
     assert len(result) == 3
 
     p1 = next(r for r in result if r["id"] == PLUGIN_ID_1)
@@ -136,18 +176,25 @@ def test_transform_plugins_basic():
 
 
 def test_transform_plugins_vpr_none_when_missing():
+    # Act
     result = transform_plugins(FINDINGS_DATA)
+
+    # Assert
     p2 = next(r for r in result if r["id"] == PLUGIN_ID_2)
     assert p2["vpr_score"] is None
 
 
 def test_transform_plugins_empty_cve_list():
+    # Act
     result = transform_plugins(FINDINGS_DATA)
+
+    # Assert
     p3 = next(r for r in result if r["id"] == PLUGIN_ID_3)
     assert p3["cve_list"] == []
 
 
 def test_transform_plugins_deduplicates():
+    # Arrange
     raw = [
         {
             "finding_id": "f1",
@@ -165,22 +212,32 @@ def test_transform_plugins_deduplicates():
             "plugin": {"id": 99, "name": "Plugin B"},
         },
     ]
+
+    # Act
     result = transform_plugins(raw)
+
+    # Assert
     assert len(result) == 2
     assert {r["id"] for r in result} == {42, 99}
 
 
 def test_transform_plugins_skips_missing_id():
+    # Arrange
     raw = [
         {"finding_id": "f1", "asset": {"uuid": "a"}, "plugin": {}},
         {"finding_id": "f2", "asset": {"uuid": "b"}, "plugin": {"id": 7}},
     ]
+
+    # Act
     result = transform_plugins(raw)
+
+    # Assert
     assert len(result) == 1
     assert result[0]["id"] == 7
 
 
 def test_transform_plugins_empty_input():
+    # Act and assert
     assert transform_plugins([]) == []
 
 
@@ -190,8 +247,11 @@ def test_transform_plugins_empty_input():
 
 
 def test_transform_scans_basic():
+    # Act
     result = transform_scans(FINDINGS_DATA)
-    # FINDING_ID_1 and FINDING_ID_3 share SCAN_UUID_1 — only two scan nodes
+
+    # Assert
+    # FINDING_ID_1 and FINDING_ID_3 share SCAN_UUID_1, so only two scan nodes exist
     assert len(result) == 2
 
     s1 = next(r for r in result if r["id"] == SCAN_UUID_1)
@@ -204,6 +264,7 @@ def test_transform_scans_basic():
 
 
 def test_transform_scans_deduplicates():
+    # Arrange
     raw = [
         {
             "finding_id": "f1",
@@ -218,21 +279,31 @@ def test_transform_scans_deduplicates():
             "scan": {"uuid": "scan-bbb", "last_scan_target": "10.0.0.2"},
         },
     ]
+
+    # Act
     result = transform_scans(raw)
+
+    # Assert
     assert len(result) == 2
     assert {r["id"] for r in result} == {"scan-aaa", "scan-bbb"}
 
 
 def test_transform_scans_skips_missing_uuid():
+    # Arrange
     raw = [
         {"finding_id": "f1", "scan": {}},
         {"finding_id": "f2"},
         {"finding_id": "f3", "scan": {"uuid": "scan-xyz"}},
     ]
+
+    # Act
     result = transform_scans(raw)
+
+    # Assert
     assert len(result) == 1
     assert result[0]["id"] == "scan-xyz"
 
 
 def test_transform_scans_empty_input():
+    # Act and assert
     assert transform_scans([]) == []

--- a/tests/unit/cartography/intel/tenable/test_init.py
+++ b/tests/unit/cartography/intel/tenable/test_init.py
@@ -1,0 +1,127 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import cartography.intel.tenable as tenable
+
+TEST_UPDATE_TAG = 123456789
+
+
+def _config(**overrides):
+    values = {
+        "tenable_access_key": "access-key",
+        "tenable_secret_key": "secret-key",
+        "tenable_findings_lookback_days": 180,
+        "tenable_url": None,
+        "tenable_tenant_id": None,
+        "update_tag": TEST_UPDATE_TAG,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_start_tenable_ingestion_skips_when_credentials_are_missing(mocker):
+    # Arrange
+    mock_session = mocker.patch.object(tenable, "get_tenable_session")
+    mock_assets_sync = mocker.patch.object(tenable.assets, "sync")
+    mock_findings_sync = mocker.patch.object(tenable.findings, "sync")
+
+    # Act
+    tenable.start_tenable_ingestion(
+        MagicMock(),
+        _config(tenable_access_key=None),
+    )
+
+    # Assert
+    mock_session.assert_not_called()
+    mock_assets_sync.assert_not_called()
+    mock_findings_sync.assert_not_called()
+
+
+def test_start_tenable_ingestion_skips_when_lookback_is_invalid(mocker):
+    # Arrange
+    mock_session = mocker.patch.object(tenable, "get_tenable_session")
+    mock_assets_sync = mocker.patch.object(tenable.assets, "sync")
+    mock_findings_sync = mocker.patch.object(tenable.findings, "sync")
+
+    # Act
+    tenable.start_tenable_ingestion(
+        MagicMock(),
+        _config(tenable_findings_lookback_days=0),
+    )
+
+    # Assert
+    mock_session.assert_not_called()
+    mock_assets_sync.assert_not_called()
+    mock_findings_sync.assert_not_called()
+
+
+def test_start_tenable_ingestion_derives_tenant_id_from_default_url(mocker):
+    # Arrange
+    neo4j_session = MagicMock()
+    api_session = MagicMock()
+    mocker.patch.object(tenable, "get_tenable_session", return_value=api_session)
+    mock_assets_sync = mocker.patch.object(tenable.assets, "sync")
+    mock_findings_sync = mocker.patch.object(tenable.findings, "sync")
+    mock_metadata = mocker.patch.object(tenable, "merge_module_sync_metadata")
+
+    # Act
+    tenable.start_tenable_ingestion(neo4j_session, _config())
+
+    # Assert
+    common_job_parameters = {
+        "UPDATE_TAG": TEST_UPDATE_TAG,
+        "TENABLE_TENANT_ID": "cloud.tenable.com",
+    }
+    mock_assets_sync.assert_called_once_with(
+        neo4j_session,
+        api_session,
+        tenable.TENABLE_DEFAULT_URL,
+        "cloud.tenable.com",
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+    )
+    mock_findings_sync.assert_called_once_with(
+        neo4j_session,
+        api_session,
+        tenable.TENABLE_DEFAULT_URL,
+        "cloud.tenable.com",
+        TEST_UPDATE_TAG,
+        common_job_parameters,
+        lookback_days=180,
+    )
+    mock_metadata.assert_called_once_with(
+        neo4j_session,
+        group_type="TenableTenant",
+        group_id="cloud.tenable.com",
+        synced_type="TenableData",
+        update_tag=TEST_UPDATE_TAG,
+        stat_handler=tenable.stat_handler,
+    )
+
+
+def test_start_tenable_ingestion_uses_explicit_url_and_tenant_id(mocker):
+    # Arrange
+    neo4j_session = MagicMock()
+    api_session = MagicMock()
+    mock_session_factory = mocker.patch.object(
+        tenable,
+        "get_tenable_session",
+        return_value=api_session,
+    )
+    mock_assets_sync = mocker.patch.object(tenable.assets, "sync")
+    mock_findings_sync = mocker.patch.object(tenable.findings, "sync")
+    mocker.patch.object(tenable, "merge_module_sync_metadata")
+    config = _config(
+        tenable_url="https://tenable.example.test/api",
+        tenable_tenant_id="tenant-1",
+        tenable_findings_lookback_days=30,
+    )
+
+    # Act
+    tenable.start_tenable_ingestion(neo4j_session, config)
+
+    # Assert
+    mock_session_factory.assert_called_once_with("access-key", "secret-key")
+    assert mock_assets_sync.call_args.args[3] == "tenant-1"
+    assert mock_findings_sync.call_args.args[3] == "tenant-1"
+    assert mock_findings_sync.call_args.kwargs["lookback_days"] == 30


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

- Fail before load and cleanup when Tenable export status, chunks, finding identifiers, or source names are malformed.
- Add additive Tenant and CVE ontology enrichment without changing existing node IDs, labels, properties, or relationships.
- Align CLI help and configuration documentation, then expand API, orchestration, graph, cleanup, GCP, and ontology coverage.
- Preserve historical IDs and compatibility fields. Tenant-qualified IDs remain deferred because they require a graph migration.


### Related issues or links

None.


### How was this tested?

- `uv run pytest tests/unit/cartography/intel/tenable tests/unit/cartography/intel/ontology/test_ontology_mapping.py -q` (81 passed)
- `uv run pytest tests/integration/cartography/intel/tenable -q` (30 passed)
- `uv run pre-commit run --files ...` (all hooks passed)
- `uv sync --group doc && uv run ./docs/build.sh` (succeeded with pre-existing warnings)


### Checklist

#### General
- [ ] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

Connector pull requests without real-environment evidence are labeled `needs-tests`, are not reviewed, and may be closed after 30 days.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [x] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers

The remaining multi-tenant ID isolation issue is intentionally excluded. Qualifying existing plugin and cloud-detail IDs would change public graph identifiers and requires a separate migration plan. The configuration documentation now calls out this limitation.