### PR TITLE
fix(aws): reduce stale analysis windows

### DIFF
--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -16,6 +16,7 @@ import boto3
 import botocore.exceptions
 import neo4j
 
+from cartography.analysis.aws.analysis import AWS_EC2_ASSET_EXPOSURE_AUTO_SCALING_GROUP
 from cartography.analysis.aws.analysis import AWS_EC2_ASSET_EXPOSURE_JOBS
 from cartography.analysis.aws.analysis import AWS_EC2_IAM_INSTANCE_PROFILE
 from cartography.analysis.aws.analysis import AWS_EC2_KEYPAIR_ANALYSIS_JOBS
@@ -139,6 +140,7 @@ def _sync_one_account(
     module_dependencies = {
         "ssm": ["ec2:instance"],
         "ec2:images": ["ec2:instance"],
+        "ec2:autoscalinggroup": ["ec2:launch_templates", "ec2:instance"],
         "ec2:load_balancer": ["ec2:subnet", "ec2:instance"],
         "ec2:load_balancer_v2": ["ec2:subnet", "ec2:instance"],
         "ec2:load_balancer_v2:expose": [
@@ -146,9 +148,14 @@ def _sync_one_account(
             "ec2:network_interface",
         ],
         "ec2:route_table": ["ec2:vpc_endpoint"],
-        # `ecs` creates IS_INSTANCE rels (AWSECSContainerInstance→AWSEC2Instance) and
-        # TARGETS matchlinks (AWSELBV2TargetGroup→AWSECSService)
-        "ecs": ["ec2:instance", "ec2:load_balancer_v2"],
+        # ECS matches existing roles, images, instances, ENIs, and target groups.
+        "ecs": [
+            "iam",
+            "ecr",
+            "ec2:instance",
+            "ec2:network_interface",
+            "ec2:load_balancer_v2",
+        ],
         "dynamodb": ["kms"],
         # s3/rds/efs create canonical (:...)-[:ENCRYPTED_BY]->(:AWSKMSKey) edges by
         # matching existing AWSKMSKey nodes on their ARN, so kms must sync first.
@@ -212,19 +219,23 @@ def _sync_one_account(
     if "resourcegroupstaggingapi" in aws_requested_syncs:
         RESOURCE_FUNCTIONS["resourcegroupstaggingapi"](**sync_args)
 
-    run_typed_analysis_job(
+    run_typed_analysis_and_ensure_deps(
         AWS_EC2_IAM_INSTANCE_PROFILE,
-        neo4j_session,
+        AWS_EC2_IAM_INSTANCE_PROFILE_DEPS,
+        requested_syncs_set,
         common_job_parameters,
+        neo4j_session,
     )
 
-    run_typed_analysis_job(
+    run_typed_analysis_and_ensure_deps(
         AWS_LAMBDA_ECR,
-        neo4j_session,
+        AWS_LAMBDA_ECR_DEPS,
+        requested_syncs_set,
         common_job_parameters,
+        neo4j_session,
     )
 
-    if {"ec2:network_acls", "ec2:load_balancer_v2"}.issubset(requested_syncs_set):
+    if AWS_LB_NACL_DIRECT_DEPS.issubset(requested_syncs_set):
         run_typed_analysis_job(
             AWS_LB_NACL_DIRECT,
             neo4j_session,
@@ -683,6 +694,19 @@ def _sync_multiple_accounts(
     return False
 
 
+# Per-account analysis jobs must only run when every producer was refreshed.
+AWS_EC2_IAM_INSTANCE_PROFILE_DEPS = {
+    "iam",
+    "iaminstanceprofiles",
+    "ec2:instance",
+}
+AWS_LAMBDA_ECR_DEPS = {"ecr", "lambda_function"}
+AWS_LB_NACL_DIRECT_DEPS = {
+    "ec2:network_acls",
+    "ec2:load_balancer_v2",
+    "ec2:subnet",
+}
+
 # Resource syncs that feed the `exposed_internet` flag: AWS_EC2_ASSET_EXPOSURE_JOBS (which sets it on
 # load balancers, instances, etc.) only runs when all of these were requested this cycle.
 AWS_EC2_ASSET_EXPOSURE_DEPS = {
@@ -690,6 +714,9 @@ AWS_EC2_ASSET_EXPOSURE_DEPS = {
     "ec2:security_group",
     "ec2:load_balancer",
     "ec2:load_balancer_v2",
+}
+AWS_EC2_ASSET_EXPOSURE_AUTO_SCALING_GROUP_DEPS = AWS_EC2_ASSET_EXPOSURE_DEPS | {
+    "ec2:autoscalinggroup"
 }
 # Both the ECS internet-exposure property and the LB->container edge gate on lb.exposed_internet, so
 # they must require the full producer dependency set above: otherwise a partial sync that skips the
@@ -728,9 +755,12 @@ def _perform_aws_analysis(
     )
 
     for job in AWS_EC2_ASSET_EXPOSURE_JOBS:
+        dependencies = AWS_EC2_ASSET_EXPOSURE_DEPS
+        if job is AWS_EC2_ASSET_EXPOSURE_AUTO_SCALING_GROUP:
+            dependencies = AWS_EC2_ASSET_EXPOSURE_AUTO_SCALING_GROUP_DEPS
         run_typed_analysis_and_ensure_deps(
             job,
-            AWS_EC2_ASSET_EXPOSURE_DEPS,
+            dependencies,
             requested_syncs_as_set,
             common_job_parameters,
             neo4j_session,

--- a/cartography/intel/aws/resources.py
+++ b/cartography/intel/aws/resources.py
@@ -86,12 +86,10 @@ RESOURCE_FUNCTIONS: OrderedDict[str, Callable[..., None]] = OrderedDict(
         "s3": s3.sync,
         "dynamodb": dynamodb.sync,
         "ec2:launch_templates": sync_ec2_launch_templates,
-        "ec2:autoscalinggroup": sync_ec2_auto_scaling_groups,
         # `ec2:instance` must be included before `ssm` and `ec2:images`,
         # they rely on AWSEC2Instance data provided by this module.
         "ec2:instance": sync_ec2_instances,
         "ec2:images": sync_ec2_images,
-        "ec2:keypair": sync_ec2_key_pairs,
         # `ec2:security_group` must run before load balancers and network interfaces
         # so that AWSEC2SecurityGroup nodes exist for MEMBER_OF_EC2_SECURITY_GROUP edges.
         "ec2:security_group": sync_ec2_security_groupinfo,
@@ -119,7 +117,6 @@ RESOURCE_FUNCTIONS: OrderedDict[str, Callable[..., None]] = OrderedDict(
         "ec2:snapshots": sync_ebs_snapshots,
         "ecr": ecr.sync,
         "ecr:image_layers": ecr_image_layers.sync,
-        "eks": eks.sync,
         "elasticache": elasticache.sync,
         "elastic_ip_addresses": sync_elastic_ip_addresses,
         "emr": emr.sync,
@@ -160,11 +157,17 @@ RESOURCE_FUNCTIONS: OrderedDict[str, Callable[..., None]] = OrderedDict(
         "cloudtrail_management_events": cloudtrail_management_events.sync,
         "cloudwatch": cloudwatch.sync,
         "efs": efs.sync,
+        # GuardDuty findings match existing EKS clusters.
+        "eks": eks.sync,
         "guardduty": guardduty.sync,
         "codebuild": codebuild.sync,
         "cognito": cognito.sync,
         "eventbridge": eventbridge.sync,
         "glue": glue.sync,
+        # These resources feed final AWS analysis jobs and have no remaining
+        # regular-resource consumers, so keep them close to that analysis.
+        "ec2:autoscalinggroup": sync_ec2_auto_scaling_groups,
+        "ec2:keypair": sync_ec2_key_pairs,
         # Keep ECS last among regular resources. Its tasks and containers are
         # short-lived, so syncing them close to AWS analysis minimizes the period
         # in which replacements lack analysis-derived relationships. EC2 instances

--- a/cartography/intel/aws/resources.py
+++ b/cartography/intel/aws/resources.py
@@ -119,9 +119,6 @@ RESOURCE_FUNCTIONS: OrderedDict[str, Callable[..., None]] = OrderedDict(
         "ec2:snapshots": sync_ebs_snapshots,
         "ecr": ecr.sync,
         "ecr:image_layers": ecr_image_layers.sync,
-        # `ec2:instance` must be synced before `ecs` so that AWSEC2Instance nodes exist
-        # when AWSECSContainerInstance creates IS_INSTANCE relationships.
-        "ecs": ecs.sync,
         "eks": eks.sync,
         "elasticache": elasticache.sync,
         "elastic_ip_addresses": sync_elastic_ip_addresses,
@@ -168,5 +165,10 @@ RESOURCE_FUNCTIONS: OrderedDict[str, Callable[..., None]] = OrderedDict(
         "cognito": cognito.sync,
         "eventbridge": eventbridge.sync,
         "glue": glue.sync,
+        # Keep ECS last among regular resources. Its tasks and containers are
+        # short-lived, so syncing them close to AWS analysis minimizes the period
+        # in which replacements lack analysis-derived relationships. EC2 instances
+        # and load balancers must already exist for ECS relationships.
+        "ecs": ecs.sync,
     }
 )

--- a/tests/integration/cartography/intel/aws/test_init.py
+++ b/tests/integration/cartography/intel/aws/test_init.py
@@ -1140,9 +1140,13 @@ def test_start_aws_ingestion_does_cleanup(
     cartography.intel.aws, "_autodiscover_account_regions", return_value=TEST_REGIONS
 )
 @mock.patch.object(cartography.intel.aws, "run_cleanup_job", return_value=None)
+@mock.patch.object(
+    cartography.intel.aws, "run_typed_analysis_and_ensure_deps", return_value=None
+)
 @mock.patch.object(cartography.intel.aws, "run_typed_analysis_job", return_value=None)
 def test_sync_one_account_all_sync_functions(
     mock_analysis,
+    mock_guarded_analysis,
     mock_cleanup,
     mock_autodiscover,
     mock_perm_rels,
@@ -1182,9 +1186,10 @@ def test_sync_one_account_all_sync_functions(
     # Check that the boilerplate functions get called as expected. Brittle, but a good sanity check.
     assert mock_autodiscover.call_count == 0
     assert mock_cleanup.call_count == 0
-    # Per-account typed analysis jobs: AWS_EC2_IAM_INSTANCE_PROFILE, AWS_LAMBDA_ECR, AWS_LB_NACL_DIRECT.
-    # (AWS_LB_CONTAINER_EXPOSURE runs in the cross-account _perform_aws_analysis phase instead.)
-    assert mock_analysis.call_count == 3
+    # IAM instance-profile and Lambda/ECR analyses are dependency-guarded.
+    assert mock_guarded_analysis.call_count == 2
+    # LB/NACL runs directly after its explicit dependencies are checked.
+    assert mock_analysis.call_count == 1
 
 
 def test_sync_one_account_uses_owned_ecr_session_factory(
@@ -1279,7 +1284,8 @@ def test_sync_one_account_just_iam_rels_and_tags(
     # _sync_one_account() above did not specify regions, so we expect 1 call to _autodiscover_account_regions().
     assert mock_autodiscover.call_count == 1
     assert mock_cleanup.call_count == 0
-    assert mock_analysis.call_count == 2
+    # The selected modules do not satisfy any per-account analysis dependencies.
+    assert mock_analysis.call_count == 0
 
 
 def test_standardize_aws_sync_kwargs():

--- a/tests/integration/cartography/intel/aws/test_init.py
+++ b/tests/integration/cartography/intel/aws/test_init.py
@@ -1140,9 +1140,7 @@ def test_start_aws_ingestion_does_cleanup(
     cartography.intel.aws, "_autodiscover_account_regions", return_value=TEST_REGIONS
 )
 @mock.patch.object(cartography.intel.aws, "run_cleanup_job", return_value=None)
-@mock.patch.object(
-    cartography.intel.aws, "run_typed_analysis_and_ensure_deps", return_value=None
-)
+@mock.patch.object(cartography.util, "run_typed_analysis_job", return_value=None)
 @mock.patch.object(cartography.intel.aws, "run_typed_analysis_job", return_value=None)
 def test_sync_one_account_all_sync_functions(
     mock_analysis,
@@ -1186,9 +1184,9 @@ def test_sync_one_account_all_sync_functions(
     # Check that the boilerplate functions get called as expected. Brittle, but a good sanity check.
     assert mock_autodiscover.call_count == 0
     assert mock_cleanup.call_count == 0
-    # IAM instance-profile and Lambda/ECR analyses are dependency-guarded.
+    # All dependencies are present, so both guarded analyses reach the executor.
     assert mock_guarded_analysis.call_count == 2
-    # LB/NACL runs directly after its explicit dependencies are checked.
+    # LB/NACL runs directly after its explicit dependency check.
     assert mock_analysis.call_count == 1
 
 

--- a/tests/unit/cartography/intel/aws/test_resources.py
+++ b/tests/unit/cartography/intel/aws/test_resources.py
@@ -1,0 +1,14 @@
+from cartography.intel.aws.resources import RESOURCE_FUNCTIONS
+
+
+def test_ecs_syncs_last_to_minimize_stale_analysis_relationships():
+    # Arrange
+    resource_order = list(RESOURCE_FUNCTIONS)
+
+    # Act
+    last_resource = resource_order[-1]
+
+    # Assert
+    assert last_resource == "ecs"
+    assert resource_order.index("ec2:instance") < resource_order.index("ecs")
+    assert resource_order.index("ec2:load_balancer_v2") < resource_order.index("ecs")

--- a/tests/unit/cartography/intel/aws/test_resources.py
+++ b/tests/unit/cartography/intel/aws/test_resources.py
@@ -1,3 +1,7 @@
+from cartography.intel.aws import AWS_EC2_ASSET_EXPOSURE_AUTO_SCALING_GROUP_DEPS
+from cartography.intel.aws import AWS_EC2_IAM_INSTANCE_PROFILE_DEPS
+from cartography.intel.aws import AWS_LAMBDA_ECR_DEPS
+from cartography.intel.aws import AWS_LB_NACL_DIRECT_DEPS
 from cartography.intel.aws.resources import RESOURCE_FUNCTIONS
 
 
@@ -12,3 +16,39 @@ def test_ecs_syncs_last_to_minimize_stale_analysis_relationships():
     assert last_resource == "ecs"
     assert resource_order.index("ec2:instance") < resource_order.index("ecs")
     assert resource_order.index("ec2:load_balancer_v2") < resource_order.index("ecs")
+
+
+def test_analysis_producers_sync_close_to_their_analysis_jobs():
+    # Arrange
+    resource_order = list(RESOURCE_FUNCTIONS)
+
+    # Act
+    analysis_tail = resource_order[-3:]
+
+    # Assert
+    assert analysis_tail == ["ec2:autoscalinggroup", "ec2:keypair", "ecs"]
+    assert resource_order.index("eks") + 1 == resource_order.index("guardduty")
+
+
+def test_analysis_dependency_sets_include_all_required_producers():
+    # Arrange
+    expected_dependencies = {
+        "instance_profile": {"iam", "iaminstanceprofiles", "ec2:instance"},
+        "lambda_ecr": {"ecr", "lambda_function"},
+        "lb_nacl": {
+            "ec2:network_acls",
+            "ec2:load_balancer_v2",
+            "ec2:subnet",
+        },
+    }
+
+    # Act
+    actual_dependencies = {
+        "instance_profile": AWS_EC2_IAM_INSTANCE_PROFILE_DEPS,
+        "lambda_ecr": AWS_LAMBDA_ECR_DEPS,
+        "lb_nacl": AWS_LB_NACL_DIRECT_DEPS,
+    }
+
+    # Assert
+    assert actual_dependencies == expected_dependencies
+    assert "ec2:autoscalinggroup" in AWS_EC2_ASSET_EXPOSURE_AUTO_SCALING_GROUP_DEPS


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

### Summary

- Move ECS, Auto Scaling Groups, EC2 key pairs, and EKS closer to their dependent AWS analysis jobs while preserving resource dependencies.
- Guard per-account and Auto Scaling Group analysis jobs on all required producers so partial syncs do not derive results from stale graph data.
- Expand AWS dependency warnings and add ordering and orchestration regression coverage.

### Related issues or links

None.

### How was this tested?

- `uv run --frozen pytest -q tests/unit/cartography/intel/aws tests/integration/cartography/intel/aws/test_init.py` (368 passed)
- `make test_lint`

### Checklist

#### General
- [ ] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

### Notes for reviewers

This change only adjusts AWS orchestration order and analysis dependency gating. It does not alter AWS schemas or provider API calls. Real-environment connector testing was not performed.