### PR TITLE
feat(github): add opt-in incremental sync using repository pushedAt

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -941,6 +941,22 @@ class CLI:
                     hidden=PANEL_GITHUB not in visible_panels,
                 ),
             ] = 30,
+            github_incremental_sync: Annotated[
+                bool,
+                typer.Option(
+                    "--github-incremental-sync",
+                    help=(
+                        "Enable incremental sync for GitHub repos. "
+                        "Skips archived/disabled repos in Actions, commits, and manifest syncs. "
+                        "Skips commits for repos with no push in the lookback window. "
+                        "Skips re-fetching workflow YAML and dependency manifests for repos "
+                        "whose pushedAt is unchanged since the last sync. "
+                        "Secrets, variables, and environments are always refreshed regardless."
+                    ),
+                    rich_help_panel=PANEL_GITHUB,
+                    hidden=PANEL_GITHUB not in visible_panels,
+                ),
+            ] = False,
             # =================================================================
             # GitLab Options
             # =================================================================
@@ -3583,6 +3599,7 @@ class CLI:
                 okta_saml_role_regex=okta_saml_role_regex,
                 github_config=github_config,
                 github_commit_lookback_days=github_commit_lookback_days,
+                github_incremental_sync=github_incremental_sync,
                 digitalocean_token=digitalocean_token,
                 permission_relationships_file=permission_relationships_file,
                 azure_permission_relationships_file=azure_permission_relationships_file,

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -180,6 +180,10 @@ class Config:
     :param github_config: Base64 encoded config object for GitHub ingestion. Optional.
     :type github_commit_lookback_days: int
     :param github_commit_lookback_days: Number of days to look back for GitHub commit tracking. Optional.
+    :type github_incremental_sync: bool
+    :param github_incremental_sync: Enable incremental sync for GitHub repos. Skips archived/disabled repos,
+        skips commits for repos with no push in the lookback window, and skips re-fetching workflow YAML and
+        dependency manifests for repos whose pushedAt is unchanged since the last sync. Optional.
     :type digitalocean_token: str
     :param digitalocean_token: DigitalOcean access token. Optional.
     :type permission_relationships_file: str
@@ -743,6 +747,8 @@ class Config:
         gcp_excluded_org_ids=None,
         gcp_excluded_folder_ids=None,
         gcp_exclude_org_root_projects=False,
+        # Appended last to preserve positional-arg compatibility for existing callers.
+        github_incremental_sync=False,
     ):
         self.neo4j_uri = neo4j_uri
         self.neo4j_user = neo4j_user
@@ -803,6 +809,7 @@ class Config:
         self.okta_saml_role_regex = okta_saml_role_regex
         self.github_config = github_config
         self.github_commit_lookback_days = github_commit_lookback_days
+        self.github_incremental_sync = github_incremental_sync
         self.digitalocean_token = digitalocean_token
         self.permission_relationships_file = permission_relationships_file
         self.azure_permission_relationships_file = azure_permission_relationships_file

--- a/cartography/intel/github/__init__.py
+++ b/cartography/intel/github/__init__.py
@@ -22,22 +22,29 @@ import cartography.intel.github.users
 from cartography.client.core.tx import read_list_of_values_tx
 from cartography.config import Config
 from cartography.intel.github.app_auth import make_credential
+from cartography.intel.github.repos import _write_synced_pushedat
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
 
 
-def _get_repos_from_graph(neo4j_session: neo4j.Session, organization: str) -> list[str]:
+def _get_repos_from_graph(
+    neo4j_session: neo4j.Session,
+    organization: str,
+    skip_archived: bool = False,
+) -> list[str]:
     """
     Get repository names for an organization from the graph instead of making an API call.
 
     :param neo4j_session: Neo4j session for database interface
     :param organization: GitHub organization name
+    :param skip_archived: If True, exclude archived/disabled repos.
     :return: List of repository names
     """
     org_url = f"https://github.com/{organization}"
     query = """
     MATCH (org:GitHubOrganization {id: $org_url})<-[:OWNER]-(repo:GitHubRepository)
+    WHERE NOT $skip_archived OR (repo.archived = false AND repo.disabled = false)
     RETURN repo.name
     ORDER BY repo.name
     """
@@ -47,6 +54,7 @@ def _get_repos_from_graph(neo4j_session: neo4j.Session, organization: str) -> li
             read_list_of_values_tx,
             query,
             org_url=org_url,
+            skip_archived=skip_archived,
         ),
     )
 
@@ -127,6 +135,7 @@ def start_github_ingestion(
             token,
             api_url,
             org_name,
+            incremental_sync=config.github_incremental_sync,
         )
         cartography.intel.github.personal_access_tokens.sync(
             neo4j_session,
@@ -169,11 +178,17 @@ def start_github_ingestion(
             token,
             api_url,
             org_name,
+            skip_archived_repos=config.github_incremental_sync,
+            skip_unchanged_repos=config.github_incremental_sync,
         )
 
-        # Sync commit relationships for the configured lookback period
-        # Get repo names from the graph instead of making another API call
-        repo_names = _get_repos_from_graph(neo4j_session, org_name)
+        # Sync commit relationships for the configured lookback period.
+        # Get repo names from the graph instead of making another API call.
+        repo_names = _get_repos_from_graph(
+            neo4j_session,
+            org_name,
+            skip_archived=config.github_incremental_sync,
+        )
 
         cartography.intel.github.commits.sync_github_commits(
             neo4j_session,
@@ -183,6 +198,7 @@ def start_github_ingestion(
             repo_names,
             common_job_parameters["UPDATE_TAG"],
             config.github_commit_lookback_days,
+            skip_stale_repos=config.github_incremental_sync,
         )
 
         repos_json = cartography.intel.github.repos.get(
@@ -251,6 +267,14 @@ def start_github_ingestion(
                 common_job_parameters,
                 valid_repos,
                 workflows=all_workflows,
+            )
+
+        # Write synced_pushedat now that all downstream stages have completed.
+        # This ensures the bookmark reflects the previous run's pushedat when
+        # the next run's skip comparisons read it, not the current run's value.
+        if config.github_incremental_sync:
+            _write_synced_pushedat(
+                neo4j_session, repo_sync_result.repo_pushedat_updates
             )
 
         processed_any_org = True

--- a/cartography/intel/github/actions.py
+++ b/cartography/intel/github/actions.py
@@ -8,6 +8,8 @@ Supports three levels:
 """
 
 import logging
+from dataclasses import dataclass
+from dataclasses import field
 from typing import Any
 from urllib.parse import quote
 
@@ -739,6 +741,133 @@ def _get_repos_from_graph(neo4j_session: neo4j.Session, organization: str) -> li
 # =============================================================================
 
 
+@dataclass
+class _RepoActionsData:
+    """All fetched-and-transformed data for a single repo's Actions resources.
+    Populated by _fetch_actions_for_repo(); consumed by sync() for Neo4j
+    writes. Separating fetch/transform from load keeps every API call in one
+    place and every graph write in another."""
+
+    repo_name: str
+    enriched_workflows: list[dict[str, Any]] = field(default_factory=list)
+    repo_actions: list[dict[str, Any]] = field(default_factory=list)
+    transformed_environments: list[dict[str, Any]] = field(default_factory=list)
+    transformed_repo_secrets: list[dict[str, Any]] = field(default_factory=list)
+    transformed_repo_variables: list[dict[str, Any]] = field(default_factory=list)
+    env_secrets: list[dict[str, Any]] = field(default_factory=list)
+    env_variables: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _fetch_actions_for_repo(
+    repo_name: str,
+    organization: str,
+    github_api_key: str,
+    github_url: str,
+) -> _RepoActionsData:
+    """
+    Fetch and transform all Actions data for a single repo.
+    Returns a _RepoActionsData bundle; no Neo4j writes are performed here.
+    """
+    data = _RepoActionsData(repo_name=repo_name)
+
+    # Workflows
+    workflows = get_repo_workflows(github_api_key, github_url, organization, repo_name)
+    if workflows:
+        transformed_workflows = transform_workflows(workflows, organization, repo_name)
+        for wf in transformed_workflows:
+            content = None
+            workflow_path = wf.get("path")
+            if workflow_path:
+                content = get_workflow_content(
+                    github_api_key,
+                    github_url,
+                    organization,
+                    repo_name,
+                    workflow_path,
+                )
+            parsed = parse_workflow_yaml(content) if content else None
+            enriched_wf = enrich_workflow_with_parsed_content(
+                wf,
+                parsed,
+                organization,
+                repo_name,
+            )
+            data.enriched_workflows.append(enriched_wf)
+            if parsed and wf.get("id") is not None:
+                data.repo_actions.extend(
+                    transform_actions(parsed, wf["id"], organization, repo_name)
+                )
+
+    # Environments
+    environments = get_repo_environments(
+        github_api_key,
+        github_url,
+        organization,
+        repo_name,
+    )
+    if environments:
+        data.transformed_environments = transform_environments(
+            environments,
+            organization,
+            repo_name,
+        )
+
+    # Repo secrets and variables
+    repo_secrets = get_repo_secrets(github_api_key, github_url, organization, repo_name)
+    if repo_secrets:
+        data.transformed_repo_secrets = transform_repo_secrets(
+            repo_secrets,
+            organization,
+            repo_name,
+        )
+
+    repo_variables = get_repo_variables(
+        github_api_key,
+        github_url,
+        organization,
+        repo_name,
+    )
+    if repo_variables:
+        data.transformed_repo_variables = transform_repo_variables(
+            repo_variables,
+            organization,
+            repo_name,
+        )
+
+    # Environment-level secrets and variables
+    for env in environments or []:
+        env_name = env["name"]
+        env_id = env["id"]
+
+        env_s = get_env_secrets(
+            github_api_key,
+            github_url,
+            organization,
+            repo_name,
+            env_name,
+        )
+        if env_s:
+            data.env_secrets.extend(
+                transform_env_secrets(env_s, organization, repo_name, env_name, env_id)
+            )
+
+        env_v = get_env_variables(
+            github_api_key,
+            github_url,
+            organization,
+            repo_name,
+            env_name,
+        )
+        if env_v:
+            data.env_variables.extend(
+                transform_env_variables(
+                    env_v, organization, repo_name, env_name, env_id
+                )
+            )
+
+    return data
+
+
 @timeit
 def sync(
     neo4j_session: neo4j.Session,
@@ -782,130 +911,36 @@ def sync(
     logger.info(f"Syncing GitHub Actions for {len(repo_names)} repositories")
 
     for repo_name in repo_names:
-        # Sync workflows
-        workflows = get_repo_workflows(
-            github_api_key, github_url, organization, repo_name
+        # Fetch and transform all Actions data for this repo (no writes), then
+        # load sequentially on this thread.
+        d = _fetch_actions_for_repo(
+            repo_name,
+            organization,
+            github_api_key,
+            github_url,
         )
-        if workflows:
-            transformed_workflows = transform_workflows(
-                workflows, organization, repo_name
-            )
 
-            # Fetch and parse workflow content for each workflow
-            repo_actions: list[dict[str, Any]] = []
-            enriched_workflows = []
-
-            for wf in transformed_workflows:
-                workflow_path = wf.get("path")
-                workflow_id = wf.get("id")
-
-                # Fetch workflow YAML content
-                content = None
-                if workflow_path:
-                    content = get_workflow_content(
-                        github_api_key,
-                        github_url,
-                        organization,
-                        repo_name,
-                        workflow_path,
-                    )
-
-                # Parse the workflow content
-                parsed = None
-                if content:
-                    parsed = parse_workflow_yaml(content)
-
-                # Enrich workflow with parsed data
-                enriched_wf = enrich_workflow_with_parsed_content(
-                    wf, parsed, organization, repo_name
-                )
-                enriched_workflows.append(enriched_wf)
-
-                # Extract actions for loading
-                if parsed and workflow_id is not None:
-                    actions = transform_actions(
-                        parsed, workflow_id, organization, repo_name
-                    )
-                    repo_actions.extend(actions)
-
-            # Load enriched workflows
-            load_workflows(neo4j_session, enriched_workflows, update_tag, org_url)
-            all_workflows.extend(enriched_workflows)
-
-            # Load actions
-            if repo_actions:
-                load_actions(neo4j_session, repo_actions, update_tag, org_url)
-
-        # Sync environments (must come before env secrets/variables)
-        environments = get_repo_environments(
-            github_api_key, github_url, organization, repo_name
-        )
-        if environments:
-            transformed_environments = transform_environments(
-                environments, organization, repo_name
-            )
+        if d.enriched_workflows:
+            load_workflows(neo4j_session, d.enriched_workflows, update_tag, org_url)
+            all_workflows.extend(d.enriched_workflows)
+        if d.repo_actions:
+            load_actions(neo4j_session, d.repo_actions, update_tag, org_url)
+        if d.transformed_environments:
             load_environments(
-                neo4j_session, transformed_environments, update_tag, org_url
+                neo4j_session, d.transformed_environments, update_tag, org_url
             )
-
-        # Sync repo-level secrets
-        repo_secrets = get_repo_secrets(
-            github_api_key, github_url, organization, repo_name
-        )
-        if repo_secrets:
-            transformed_repo_secrets = transform_repo_secrets(
-                repo_secrets, organization, repo_name
-            )
+        if d.transformed_repo_secrets:
             load_repo_secrets(
-                neo4j_session, transformed_repo_secrets, update_tag, org_url
+                neo4j_session, d.transformed_repo_secrets, update_tag, org_url
             )
-
-        # Sync repo-level variables
-        repo_variables = get_repo_variables(
-            github_api_key, github_url, organization, repo_name
-        )
-        if repo_variables:
-            transformed_repo_variables = transform_repo_variables(
-                repo_variables, organization, repo_name
-            )
+        if d.transformed_repo_variables:
             load_repo_variables(
-                neo4j_session, transformed_repo_variables, update_tag, org_url
+                neo4j_session, d.transformed_repo_variables, update_tag, org_url
             )
-
-        # 3. Sync environment-level secrets and variables
-        for env in environments or []:
-            env_name = env["name"]
-            env_id = env["id"]
-
-            env_secrets = get_env_secrets(
-                github_api_key, github_url, organization, repo_name, env_name
-            )
-            if env_secrets:
-                transformed_env_secrets = transform_env_secrets(
-                    env_secrets,
-                    organization,
-                    repo_name,
-                    env_name,
-                    env_id,
-                )
-                load_env_secrets(
-                    neo4j_session, transformed_env_secrets, update_tag, org_url
-                )
-
-            env_variables = get_env_variables(
-                github_api_key, github_url, organization, repo_name, env_name
-            )
-            if env_variables:
-                transformed_env_variables = transform_env_variables(
-                    env_variables,
-                    organization,
-                    repo_name,
-                    env_name,
-                    env_id,
-                )
-                load_env_variables(
-                    neo4j_session, transformed_env_variables, update_tag, org_url
-                )
+        if d.env_secrets:
+            load_env_secrets(neo4j_session, d.env_secrets, update_tag, org_url)
+        if d.env_variables:
+            load_env_variables(neo4j_session, d.env_variables, update_tag, org_url)
 
     # 4. Cleanup all stale nodes scoped to the organization. Repo-level secrets
     # and variables are now scoped to the org as well, so cleanup_org_level

--- a/cartography/intel/github/actions.py
+++ b/cartography/intel/github/actions.py
@@ -16,7 +16,8 @@ from urllib.parse import quote
 import neo4j
 
 from cartography.client.core.tx import load
-from cartography.client.core.tx import read_list_of_values_tx
+from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.client.core.tx import run_write_query
 from cartography.graph.job import GraphJob
 from cartography.intel.github.util import _get_rest_api_base_url
 from cartography.intel.github.util import fetch_all_rest_api_pages
@@ -718,20 +719,30 @@ def cleanup_org_level(
 # =============================================================================
 
 
-def _get_repos_from_graph(neo4j_session: neo4j.Session, organization: str) -> list[str]:
+def _get_repos_from_graph(
+    neo4j_session: neo4j.Session,
+    organization: str,
+    skip_archived_repos: bool = False,
+) -> list[dict[str, Any]]:
     """
-    Get repository names for an organization from the graph.
+    Get repository name/url/pushedat/synced_pushedat metadata for an
+    organization from the graph.
+
+    :param skip_archived_repos: If True, exclude archived/disabled repos.
     """
     org_url = f"https://github.com/{organization}"
     query = """
     MATCH (org:GitHubOrganization {id: $org_url})<-[:OWNER]-(repo:GitHubRepository)
-    RETURN repo.name
+    WHERE NOT $skip_archived_repos OR (repo.archived = false AND repo.disabled = false)
+    RETURN repo.name AS name, repo.id AS url, repo.pushedat AS pushedat,
+           repo.synced_pushedat AS synced_pushedat
     ORDER BY repo.name
     """
-    result: list[str] = neo4j_session.execute_read(
-        read_list_of_values_tx,
+    result: list[dict[str, Any]] = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
         query,
         org_url=org_url,
+        skip_archived_repos=skip_archived_repos,
     )
     return result
 
@@ -749,6 +760,9 @@ class _RepoActionsData:
     place and every graph write in another."""
 
     repo_name: str
+    repo_url: str = ""
+    pushedat: str | None = None
+    workflows_skipped: bool = False
     enriched_workflows: list[dict[str, Any]] = field(default_factory=list)
     repo_actions: list[dict[str, Any]] = field(default_factory=list)
     transformed_environments: list[dict[str, Any]] = field(default_factory=list)
@@ -763,40 +777,63 @@ def _fetch_actions_for_repo(
     organization: str,
     github_api_key: str,
     github_url: str,
+    repo_url: str = "",
+    pushedat: str | None = None,
+    synced_pushedat: str | None = None,
+    skip_unchanged_repos: bool = False,
 ) -> _RepoActionsData:
     """
     Fetch and transform all Actions data for a single repo.
     Returns a _RepoActionsData bundle; no Neo4j writes are performed here.
+
+    :param skip_unchanged_repos: If True, skip re-fetching/re-parsing workflow
+        YAML content when `pushedat` matches `synced_pushedat` (written after
+        the last successful repos sync). Secrets, variables, and environments
+        are always fetched regardless.
     """
-    data = _RepoActionsData(repo_name=repo_name)
+    data = _RepoActionsData(repo_name=repo_name, repo_url=repo_url, pushedat=pushedat)
+
+    skip_workflows = (
+        skip_unchanged_repos
+        and pushedat is not None
+        and synced_pushedat is not None
+        and pushedat == synced_pushedat
+    )
 
     # Workflows
-    workflows = get_repo_workflows(github_api_key, github_url, organization, repo_name)
-    if workflows:
-        transformed_workflows = transform_workflows(workflows, organization, repo_name)
-        for wf in transformed_workflows:
-            content = None
-            workflow_path = wf.get("path")
-            if workflow_path:
-                content = get_workflow_content(
-                    github_api_key,
-                    github_url,
+    if skip_workflows:
+        data.workflows_skipped = True
+    else:
+        workflows = get_repo_workflows(
+            github_api_key, github_url, organization, repo_name
+        )
+        if workflows:
+            transformed_workflows = transform_workflows(
+                workflows, organization, repo_name
+            )
+            for wf in transformed_workflows:
+                content = None
+                workflow_path = wf.get("path")
+                if workflow_path:
+                    content = get_workflow_content(
+                        github_api_key,
+                        github_url,
+                        organization,
+                        repo_name,
+                        workflow_path,
+                    )
+                parsed = parse_workflow_yaml(content) if content else None
+                enriched_wf = enrich_workflow_with_parsed_content(
+                    wf,
+                    parsed,
                     organization,
                     repo_name,
-                    workflow_path,
                 )
-            parsed = parse_workflow_yaml(content) if content else None
-            enriched_wf = enrich_workflow_with_parsed_content(
-                wf,
-                parsed,
-                organization,
-                repo_name,
-            )
-            data.enriched_workflows.append(enriched_wf)
-            if parsed and wf.get("id") is not None:
-                data.repo_actions.extend(
-                    transform_actions(parsed, wf["id"], organization, repo_name)
-                )
+                data.enriched_workflows.append(enriched_wf)
+                if parsed and wf.get("id") is not None:
+                    data.repo_actions.extend(
+                        transform_actions(parsed, wf["id"], organization, repo_name)
+                    )
 
     # Environments
     environments = get_repo_environments(
@@ -868,6 +905,84 @@ def _fetch_actions_for_repo(
     return data
 
 
+def _touch_skipped_actions_workflows(
+    neo4j_session: neo4j.Session,
+    skipped_repo_urls: list[str],
+    update_tag: int,
+) -> None:
+    """
+    Refresh `lastupdated` on the existing GitHubWorkflow/GitHubAction subgraph
+    for repos whose workflow-content fetch was skipped this run (pushedat
+    unchanged), so the stale-tag cleanups don't delete it. Cleanup also deletes
+    stale relationships by their own `lastupdated`, so every relationship reaped
+    by the workflow and action cleanups is touched too.
+    """
+    if not skipped_repo_urls:
+        return
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[hw:HAS_WORKFLOW]->(wf:GitHubWorkflow)
+        SET wf.lastupdated = $update_tag, hw.lastupdated = $update_tag
+        WITH DISTINCT wf
+        MATCH (:GitHubOrganization)-[res:RESOURCE]->(wf)
+        SET res.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_WORKFLOW]->(:GitHubWorkflow)
+              -[rs:REFERENCES_SECRET]->(:GitHubActionsSecret)
+        SET rs.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_WORKFLOW]->(:GitHubWorkflow)
+              -[ua:USES_ACTION]->(a:GitHubAction)
+        SET a.lastupdated = $update_tag, ua.lastupdated = $update_tag
+        WITH DISTINCT a
+        MATCH (:GitHubOrganization)-[res:RESOURCE]->(a)
+        SET res.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+
+
+def _get_skipped_repo_workflows(
+    neo4j_session: neo4j.Session,
+    skipped_repo_urls: list[str],
+) -> list[dict[str, Any]]:
+    """
+    Return {repo_url, path} rows for the existing workflows of skipped repos so
+    supply_chain.sync refreshes their PACKAGED_BY matchlinks instead of its
+    cleanup deleting them as stale.
+    """
+    if not skipped_repo_urls:
+        return []
+    rows: list[dict[str, Any]] = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_WORKFLOW]->(wf:GitHubWorkflow)
+        WHERE wf.repo_url IS NOT NULL AND wf.path IS NOT NULL
+        RETURN wf.repo_url AS repo_url, wf.path AS path
+        """,
+        repo_urls=skipped_repo_urls,
+    )
+    return rows
+
+
 @timeit
 def sync(
     neo4j_session: neo4j.Session,
@@ -875,16 +990,23 @@ def sync(
     github_api_key: str,
     github_url: str,
     organization: str,
+    skip_archived_repos: bool = False,
+    skip_unchanged_repos: bool = False,
 ) -> list[dict[str, Any]]:
     """
     Sync GitHub Actions data (workflows, secrets, variables, environments) for an organization.
 
     Sync order:
     1. Organization-level secrets and variables
-    2. For each repo: workflows, environments, repo secrets/variables
-    3. For each environment: env secrets/variables
-    4. Cleanup stale nodes
+    2. For each repo: workflows, environments, repo secrets/variables,
+       env secrets/variables
+    3. Cleanup stale nodes
 
+    :param skip_archived_repos: If True, skip archived/disabled repos entirely.
+    :param skip_unchanged_repos: If True, skip re-fetching/re-parsing workflow
+        YAML content for repos whose `pushedat` is unchanged since the last
+        successful Actions sync. Secrets/variables/environments are always
+        still fetched for every repo.
     :return: List of all transformed workflows (with repo_url and path) for supply chain sync.
     """
     org_url = f"https://github.com/{organization}"
@@ -907,17 +1029,27 @@ def sync(
         )
 
     # 2. Get repos from graph and sync repo-level resources
-    repo_names = _get_repos_from_graph(neo4j_session, organization)
-    logger.info(f"Syncing GitHub Actions for {len(repo_names)} repositories")
+    repos = _get_repos_from_graph(
+        neo4j_session,
+        organization,
+        skip_archived_repos=skip_archived_repos,
+    )
+    logger.info(f"Syncing GitHub Actions for {len(repos)} repositories")
 
-    for repo_name in repo_names:
+    skipped_repo_urls: list[str] = []
+
+    for repo in repos:
         # Fetch and transform all Actions data for this repo (no writes), then
         # load sequentially on this thread.
         d = _fetch_actions_for_repo(
-            repo_name,
+            repo["name"],
             organization,
             github_api_key,
             github_url,
+            repo_url=repo["url"],
+            pushedat=repo.get("pushedat"),
+            synced_pushedat=repo.get("synced_pushedat"),
+            skip_unchanged_repos=skip_unchanged_repos,
         )
 
         if d.enriched_workflows:
@@ -942,7 +1074,23 @@ def sync(
         if d.env_variables:
             load_env_variables(neo4j_session, d.env_variables, update_tag, org_url)
 
-    # 4. Cleanup all stale nodes scoped to the organization. Repo-level secrets
+        if skip_unchanged_repos and d.workflows_skipped:
+            skipped_repo_urls.append(d.repo_url)
+
+    if skip_unchanged_repos:
+        _touch_skipped_actions_workflows(neo4j_session, skipped_repo_urls, update_tag)
+        all_workflows.extend(
+            _get_skipped_repo_workflows(neo4j_session, skipped_repo_urls)
+        )
+        logger.info(
+            "GitHub Actions incremental sync for org %s: skipped workflow refetch "
+            "for %d/%d unchanged repos.",
+            organization,
+            len(skipped_repo_urls),
+            len(repos),
+        )
+
+    # 3. Cleanup all stale nodes scoped to the organization. Repo-level secrets
     # and variables are now scoped to the org as well, so cleanup_org_level
     # picks them up here.
     org_cleanup_params = {**common_job_parameters, "org_url": org_url}

--- a/cartography/intel/github/actions.py
+++ b/cartography/intel/github/actions.py
@@ -17,6 +17,7 @@ import neo4j
 
 from cartography.client.core.tx import load
 from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.client.core.tx import read_list_of_values_tx
 from cartography.client.core.tx import run_write_query
 from cartography.graph.job import GraphJob
 from cartography.intel.github.util import _get_rest_api_base_url
@@ -983,6 +984,100 @@ def _get_skipped_repo_workflows(
     return rows
 
 
+def _get_archived_repo_urls(
+    neo4j_session: neo4j.Session,
+    organization: str,
+) -> list[str]:
+    """
+    Return the URLs of archived/disabled repos for the org. These are excluded
+    from the Actions fetch loop under incremental sync, so their existing
+    Actions subgraph must be touched separately to survive stale-tag cleanup.
+    """
+    org_url = f"https://github.com/{organization}"
+    result: list[str] = neo4j_session.execute_read(
+        read_list_of_values_tx,
+        """
+        MATCH (:GitHubOrganization {id: $org_url})<-[:OWNER]-(repo:GitHubRepository)
+        WHERE repo.archived = true OR repo.disabled = true
+        RETURN repo.id
+        """,
+        org_url=org_url,
+    )
+    return result
+
+
+def _touch_archived_repo_actions(
+    neo4j_session: neo4j.Session,
+    archived_repo_urls: list[str],
+    update_tag: int,
+) -> None:
+    """
+    Refresh `lastupdated` on the full existing Actions subgraph of archived/
+    disabled repos that incremental sync skipped entirely. Unlike the
+    pushedat-unchanged path (where secrets/variables/environments are still
+    re-fetched every run and only workflow content is skipped), archived repos
+    are not fetched at all, so every org-scoped Actions resource they own must be
+    touched here or `cleanup_org_level` will delete it as stale: workflows,
+    actions, environments, and repo-level & env-level secrets/variables.
+    """
+    if not archived_repo_urls:
+        return
+    # Workflows + their org RESOURCE edge, plus REFERENCES_SECRET and USES_ACTION.
+    _touch_skipped_actions_workflows(neo4j_session, archived_repo_urls, update_tag)
+    # Environments + org RESOURCE edge.
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[he:HAS_ENVIRONMENT]->(e:GitHubEnvironment)
+        SET e.lastupdated = $update_tag, he.lastupdated = $update_tag
+        WITH DISTINCT e
+        MATCH (:GitHubOrganization)-[res:RESOURCE]->(e)
+        SET res.lastupdated = $update_tag
+        """,
+        repo_urls=archived_repo_urls,
+        update_tag=update_tag,
+    )
+    # Repo-level secrets and variables (org-scoped RESOURCE).
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (r:GitHubRepository {id: repo_url})
+        OPTIONAL MATCH (r)-[hrs:HAS_SECRET]->(rs:GitHubActionsSecret)
+        SET rs.lastupdated = $update_tag, hrs.lastupdated = $update_tag
+        WITH r
+        OPTIONAL MATCH (r)-[hrv:HAS_VARIABLE]->(rv:GitHubActionsVariable)
+        SET rv.lastupdated = $update_tag, hrv.lastupdated = $update_tag
+        """,
+        repo_urls=archived_repo_urls,
+        update_tag=update_tag,
+    )
+    # Environment-level secrets and variables.
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_ENVIRONMENT]->(:GitHubEnvironment)
+              -[hes:HAS_SECRET]->(es:GitHubActionsSecret)
+        SET es.lastupdated = $update_tag, hes.lastupdated = $update_tag
+        """,
+        repo_urls=archived_repo_urls,
+        update_tag=update_tag,
+    )
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_ENVIRONMENT]->(:GitHubEnvironment)
+              -[hev:HAS_VARIABLE]->(ev:GitHubActionsVariable)
+        SET ev.lastupdated = $update_tag, hev.lastupdated = $update_tag
+        """,
+        repo_urls=archived_repo_urls,
+        update_tag=update_tag,
+    )
+
+
 @timeit
 def sync(
     neo4j_session: neo4j.Session,
@@ -1088,6 +1183,23 @@ def sync(
             organization,
             len(skipped_repo_urls),
             len(repos),
+        )
+
+    if skip_archived_repos:
+        # Archived/disabled repos were excluded from the fetch loop entirely, so
+        # their existing Actions subgraph is never re-tagged this run. Touch it
+        # (and re-feed their workflows into all_workflows for supply_chain) so
+        # cleanup_org_level does not delete valid historical data.
+        archived_repo_urls = _get_archived_repo_urls(neo4j_session, organization)
+        _touch_archived_repo_actions(neo4j_session, archived_repo_urls, update_tag)
+        all_workflows.extend(
+            _get_skipped_repo_workflows(neo4j_session, archived_repo_urls)
+        )
+        logger.info(
+            "GitHub Actions incremental sync for org %s: preserved existing "
+            "Actions subgraph for %d skipped archived/disabled repos.",
+            organization,
+            len(archived_repo_urls),
         )
 
     # 3. Cleanup all stale nodes scoped to the organization. Repo-level secrets

--- a/cartography/intel/github/commits.py
+++ b/cartography/intel/github/commits.py
@@ -7,6 +7,8 @@ from typing import Any
 import neo4j
 
 from cartography.client.core.tx import load_matchlinks
+from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.client.core.tx import run_write_query
 from cartography.graph.job import GraphJob
 from cartography.intel.github.util import fetch_page
 from cartography.models.github.commits import GitHubUserCommittedToRepoRel
@@ -136,6 +138,38 @@ def get_repo_commits(
     return all_commits
 
 
+def _get_repo_pushedat_map(
+    neo4j_session: neo4j.Session,
+    organization: str,
+    repo_names: list[str],
+) -> dict[str, str | None]:
+    """
+    Fetch the current `pushedat` value for the given repos from the graph.
+
+    :param neo4j_session: Neo4j session for database interface.
+    :param organization: The Github organization name.
+    :param repo_names: List of repository names to look up.
+    :return: A dict mapping repo_name to its `pushedat` value (or None if
+        missing/never fetched).
+    """
+    repo_urls = {
+        repo_name: f"https://github.com/{organization}/{repo_name}"
+        for repo_name in repo_names
+    }
+    query = """
+    UNWIND $repo_urls AS url
+    MATCH (r:GitHubRepository {id: url})
+    RETURN r.id AS url, r.pushedat AS pushedat
+    """
+    rows = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        query,
+        repo_urls=list(repo_urls.values()),
+    )
+    pushedat_by_url = {row["url"]: row["pushedat"] for row in rows}
+    return {repo_name: pushedat_by_url.get(url) for repo_name, url in repo_urls.items()}
+
+
 def process_repo_commits_batch(
     neo4j_session: neo4j.Session,
     token: str,
@@ -145,7 +179,8 @@ def process_repo_commits_batch(
     update_tag: int,
     lookback_days: int = 30,
     batch_size: int = 10,
-) -> None:
+    skip_stale_repos: bool = False,
+) -> list[str]:
     """
     Process repository commits in batches to save memory and API quota.
 
@@ -157,9 +192,49 @@ def process_repo_commits_batch(
     :param update_tag: Timestamp used to determine data freshness.
     :param lookback_days: Number of days to look back for commits.
     :param batch_size: Number of repositories to process in each batch.
+    :param skip_stale_repos: If True, skip repos whose `pushedat` (last known
+        push, from a prior GitHub repos sync) is older than the lookback
+        window; such repos cannot have any commits within that window. Repos
+        with no `pushedat` on record (e.g. never seen by a repos sync yet)
+        are never skipped.
+    :return: List of repo names skipped this run (empty unless
+        skip_stale_repos is True). The caller touches their existing
+        COMMITTED_TO edges so the stale-tag cleanup doesn't delete them.
     """
     # Calculate lookback date based on configured days
     lookback_date = datetime.now(timezone.utc) - timedelta(days=lookback_days)
+
+    skipped_repo_names: list[str] = []
+    if skip_stale_repos:
+        pushedat_by_repo = _get_repo_pushedat_map(
+            neo4j_session, organization, repo_names
+        )
+        eligible_repo_names = []
+        skipped_count = 0
+        for repo_name in repo_names:
+            pushedat = pushedat_by_repo.get(repo_name)
+            if pushedat is None:
+                eligible_repo_names.append(repo_name)
+                continue
+            try:
+                pushed_dt = datetime.fromisoformat(pushedat.replace("Z", "+00:00"))
+            except (ValueError, AttributeError):
+                eligible_repo_names.append(repo_name)
+                continue
+            if pushed_dt < lookback_date:
+                skipped_count += 1
+                skipped_repo_names.append(repo_name)
+            else:
+                eligible_repo_names.append(repo_name)
+        logger.info(
+            "Skipping commits fetch for %d/%d repos in org %s with no push in the "
+            "last %d days.",
+            skipped_count,
+            len(repo_names),
+            organization,
+            lookback_days,
+        )
+        repo_names = eligible_repo_names
 
     logger.info(f"Processing {len(repo_names)} repositories in batches of {batch_size}")
 
@@ -212,6 +287,8 @@ def process_repo_commits_batch(
 
         # Clear memory for next batch
         batch_relationships.clear()
+
+    return skipped_repo_names
 
 
 def transform_single_repo_commits_to_relationships(
@@ -359,6 +436,45 @@ def load_github_commit_relationships(
     )
 
 
+def _touch_skipped_commit_relationships(
+    neo4j_session: neo4j.Session,
+    organization: str,
+    skipped_repo_names: list[str],
+    update_tag: int,
+) -> None:
+    """
+    Refresh `lastupdated` on the existing COMMITTED_TO edges for repos whose
+    commit fetch was skipped this run (no push within the lookback window), so
+    the org-scoped matchlink cleanup doesn't delete them as stale.
+
+    A skipped repo had no push in the lookback window, so a full sync would
+    normally produce no new in-window commit edges for it. But GitHub's
+    `pushedat` is imprecise (it doesn't always bump on every ref update, and
+    can lag a real push), so a repo with genuine in-window commits can be
+    skipped. Touching keeps those live edges instead of silently deleting
+    them; symmetric with the actions/manifests incremental-skip paths.
+    """
+    if not skipped_repo_names:
+        return
+    org_url = f"https://github.com/{organization}"
+    repo_urls = [
+        f"https://github.com/{organization}/{repo_name}"
+        for repo_name in skipped_repo_names
+    ]
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubUser)-[c:COMMITTED_TO]->(:GitHubRepository {id: repo_url})
+        WHERE c._sub_resource_id = $org_url
+        SET c.lastupdated = $update_tag
+        """,
+        repo_urls=repo_urls,
+        org_url=org_url,
+        update_tag=update_tag,
+    )
+
+
 @timeit
 def cleanup_github_commit_relationships(
     neo4j_session: neo4j.Session,
@@ -393,6 +509,7 @@ def sync_github_commits(
     repo_names: list[str],
     update_tag: int,
     lookback_days: int = 30,
+    skip_stale_repos: bool = False,
 ) -> None:
     """
     Sync GitHub commit relationships for the specified lookback period.
@@ -405,12 +522,14 @@ def sync_github_commits(
     :param repo_names: List of repository names to sync commits for.
     :param update_tag: Timestamp used to determine data freshness.
     :param lookback_days: Number of days to look back for commits.
+    :param skip_stale_repos: If True, skip repos with no push in the lookback
+        window (see process_repo_commits_batch).
     """
     logger.info(f"Starting GitHub commits sync for organization: {organization}")
 
     # Process repositories in batches to save memory and API quota
     # This approach processes repos in batches, transforms immediately, and loads in batches
-    process_repo_commits_batch(
+    skipped_repo_names = process_repo_commits_batch(
         neo4j_session,
         token,
         api_url,
@@ -418,7 +537,15 @@ def sync_github_commits(
         repo_names,
         update_tag,
         lookback_days=lookback_days,
+        skip_stale_repos=skip_stale_repos,
         batch_size=10,  # Process 10 repos at a time
+    )
+
+    # Touch COMMITTED_TO edges of skipped repos before cleanup so the
+    # org-scoped matchlink cleanup doesn't delete live edges on repos whose
+    # commit fetch was skipped this run (symmetric with actions/manifests).
+    _touch_skipped_commit_relationships(
+        neo4j_session, organization, skipped_repo_names, update_tag
     )
 
     # Cleanup stale relationships after all batches are processed

--- a/cartography/intel/github/commits.py
+++ b/cartography/intel/github/commits.py
@@ -475,6 +475,34 @@ def _touch_skipped_commit_relationships(
     )
 
 
+def _touch_archived_commit_relationships(
+    neo4j_session: neo4j.Session,
+    organization: str,
+    update_tag: int,
+) -> None:
+    """
+    Refresh `lastupdated` on the existing COMMITTED_TO edges of archived/disabled
+    repos. Under incremental sync these repos are excluded from `repo_names`
+    entirely (filtered in start_github_ingestion), so they never reach the
+    stale-skip touch above. Their existing commit edges are still valid, so the
+    org-scoped matchlink cleanup would otherwise delete them. Touched by matching
+    archived/disabled repos directly in the graph rather than by name list.
+    """
+    org_url = f"https://github.com/{organization}"
+    run_write_query(
+        neo4j_session,
+        """
+        MATCH (org:GitHubOrganization {id: $org_url})<-[:OWNER]-(repo:GitHubRepository)
+        WHERE repo.archived = true OR repo.disabled = true
+        MATCH (:GitHubUser)-[c:COMMITTED_TO]->(repo)
+        WHERE c._sub_resource_id = $org_url
+        SET c.lastupdated = $update_tag
+        """,
+        org_url=org_url,
+        update_tag=update_tag,
+    )
+
+
 @timeit
 def cleanup_github_commit_relationships(
     neo4j_session: neo4j.Session,
@@ -547,6 +575,12 @@ def sync_github_commits(
     _touch_skipped_commit_relationships(
         neo4j_session, organization, skipped_repo_names, update_tag
     )
+
+    # Archived/disabled repos are excluded from `repo_names` before this sync, so
+    # they never reach the stale-skip touch above. Preserve their existing commit
+    # edges too, or the org-scoped cleanup would delete valid historical data.
+    if skip_stale_repos:
+        _touch_archived_commit_relationships(neo4j_session, organization, update_tag)
 
     # Cleanup stale relationships after all batches are processed
     cleanup_github_commit_relationships(neo4j_session, organization, update_tag)

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from collections import namedtuple
 from collections.abc import Callable
 from dataclasses import dataclass
+from dataclasses import field
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -23,6 +24,8 @@ from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 
 from cartography.client.core.tx import load as load_data
+from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.client.core.tx import run_write_query
 from cartography.graph.job import GraphJob
 from cartography.helpers import backoff_handler
 from cartography.intel.github.codeowners import normalize_repo_relative_path
@@ -82,6 +85,7 @@ class GitHubRepoSyncResult:
     repos: list[dict[str, Any]]
     manifests: list[dict[str, Any]]
     manifests_cleanup_safe: bool
+    repo_pushedat_updates: list[dict[str, str]] = field(default_factory=list)
 
 
 GITHUB_ORG_REPOS_PAGINATED_GRAPHQL = """
@@ -106,6 +110,7 @@ GITHUB_ORG_REPOS_PAGINATED_GRAPHQL = """
                     createdAt
                     description
                     updatedAt
+                    pushedAt
                     homepageUrl
                     languages(first: 25){
                         totalCount
@@ -578,11 +583,147 @@ def _get_repo_dep_manifests(
     return manifests, cleanup_safe
 
 
+def _touch_skipped_dependency_manifests(
+    neo4j_session: neo4j.Session,
+    skipped_repo_urls: list[str],
+    update_tag: int,
+) -> None:
+    """
+    Refresh `lastupdated` on the existing manifest/dependency subgraph for repos
+    whose manifest fetch was skipped this run (pushedat unchanged), so the
+    stale-tag cleanups don't delete it. Cleanup also deletes stale relationships
+    by their own `lastupdated`, so every relationship reaped by the manifest,
+    dependency, and CODEOWNERS-matchlink cleanups is touched too.
+    """
+    if not skipped_repo_urls:
+        return
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[hm:HAS_MANIFEST]->(m:DependencyGraphManifest)
+        SET m.lastupdated = $update_tag, hm.lastupdated = $update_tag
+        WITH DISTINCT m
+        MATCH (:GitHubOrganization)-[res:RESOURCE]->(m)
+        SET res.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_MANIFEST]->(:DependencyGraphManifest)
+              -[hd:HAS_DEP]->(d:Dependency)
+        SET d.lastupdated = $update_tag, hd.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[req:REQUIRES]->(:Dependency)
+        SET req.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (:GitHubRepository {id: repo_url})-[:HAS_MANIFEST]->(:DependencyGraphManifest)
+              -[mc:MATCHES_CODEOWNER_RULE]->(:GitHubCodeOwnerRule)
+        SET mc.lastupdated = $update_tag
+        """,
+        repo_urls=skipped_repo_urls,
+        update_tag=update_tag,
+    )
+
+
+def _update_manifests_synced_bookmarks(
+    neo4j_session: neo4j.Session,
+    synced_bookmarks: list[dict[str, str]],
+) -> None:
+    """
+    Record the `pushedat` value seen at the time of a successful (i.e. not
+    skipped) dependency manifest fetch, so future runs can compare against it
+    to decide whether to skip.
+    """
+    if not synced_bookmarks:
+        return
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $updates AS u
+        MATCH (repo:GitHubRepository {id: u.repo_url})
+        SET repo.manifests_synced_pushedat = u.pushedat
+        """,
+        updates=synced_bookmarks,
+    )
+
+
+def _write_synced_pushedat(
+    neo4j_session: neo4j.Session,
+    updates: list[dict[str, str]],
+) -> None:
+    """
+    Write the ``synced_pushedat`` bookmark on each ``GitHubRepository`` node.
+
+    This single bookmark is written once after a successful repos sync and is
+    shared by all downstream incremental-skip stages (Actions, manifests,
+    commits). A stage skips re-fetching a repo when its current ``pushedat``
+    matches ``synced_pushedat``, meaning nothing has been pushed since the last
+    time the repos sync ran.
+    """
+    if not updates:
+        return
+    run_write_query(
+        neo4j_session,
+        """
+        UNWIND $updates AS u
+        MATCH (repo:GitHubRepository {id: u.repo_url})
+        SET repo.synced_pushedat = u.pushedat
+        """,
+        updates=updates,
+    )
+
+
+def _get_manifests_synced_bookmarks(
+    neo4j_session: neo4j.Session,
+    repo_urls: list[str],
+) -> dict[str, str | None]:
+    """
+    Fetch the ``synced_pushedat`` bookmark for the given repo URLs from the
+    graph. This is the value written after the last successful repos sync and
+    is used by the manifests incremental-skip logic.
+    """
+    if not repo_urls:
+        return {}
+    rows = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        """
+        UNWIND $repo_urls AS repo_url
+        MATCH (r:GitHubRepository {id: repo_url})
+        RETURN r.id AS url, r.synced_pushedat AS synced_pushedat
+        """,
+        repo_urls=repo_urls,
+    )
+    return {row["url"]: row["synced_pushedat"] for row in rows}
+
+
 def _get_dep_manifests_for_repos(
     repo_raw_data: list[dict[str, Any] | None],
     org: str,
     api_url: str,
     token: str,
+    skip_archived_repos: bool = False,
+    skip_unchanged_repos: bool = False,
+    neo4j_session: neo4j.Session | None = None,
+    update_tag: int | None = None,
 ) -> tuple[dict[str, dict[str, Any]], bool]:
     """
     For every repo in the given list, retrieve its dependency graph manifests individually.
@@ -592,9 +733,24 @@ def _get_dep_manifests_for_repos(
     :param org: The name of the target Github organization as string.
     :param api_url: The Github v4 API endpoint as string.
     :param token: The Github API token as string.
+    :param skip_archived_repos: Skip archived/disabled repos if True.
+    :param skip_unchanged_repos: Skip repos whose pushedAt is unchanged since
+        the last successful manifest fetch, if True. Requires neo4j_session.
+    :param neo4j_session: Neo4j session, required when skip_unchanged_repos is True
+        (used to look up prior sync bookmarks and to touch/update them).
     :return: A tuple of repo URL to dependencyGraphManifests structure and
         whether manifest cleanup is safe.
     """
+    non_null_repos = [repo for repo in repo_raw_data if repo is not None]
+
+    if skip_unchanged_repos and neo4j_session is not None:
+        bookmarks = _get_manifests_synced_bookmarks(
+            neo4j_session,
+            [repo["url"] for repo in non_null_repos if repo.get("url")],
+        )
+        for r in non_null_repos:
+            r["manifests_synced_pushedat"] = bookmarks.get(r.get("url", ""))
+
     logger.info(
         "Fetching dependency graph manifests for %d repos in org %s.",
         len(repo_raw_data),
@@ -607,6 +763,8 @@ def _get_dep_manifests_for_repos(
     org_wide_forbidden = False
     not_attempted_count = 0
     cleanup_safe = True
+    skipped_unchanged_repo_urls: list[str] = []
+    synced_bookmarks: list[dict[str, str]] = []
 
     for index, repo in enumerate(repo_raw_data):
         if repo is None:
@@ -614,6 +772,30 @@ def _get_dep_manifests_for_repos(
         repo_name = repo.get("name")
         repo_url = repo.get("url")
         if not repo_name or not repo_url:
+            continue
+
+        # Incremental skips: archived/disabled repos and repos whose pushedAt is
+        # unchanged since the last successful manifest fetch.
+        if skip_archived_repos and (repo.get("isArchived") or repo.get("isDisabled")):
+            logger.debug(
+                "Skipping dependency manifest fetch for archived/disabled repo %s.",
+                repo_name,
+            )
+            continue
+
+        pushedat = repo.get("pushedAt")
+        synced_pushedat = repo.get("manifests_synced_pushedat")
+        if (
+            skip_unchanged_repos
+            and pushedat is not None
+            and synced_pushedat is not None
+            and pushedat == synced_pushedat
+        ):
+            logger.debug(
+                "Skipping dependency manifest fetch for unchanged repo %s (pushedat unchanged).",
+                repo_name,
+            )
+            skipped_unchanged_repo_urls.append(repo_url)
             continue
 
         try:
@@ -631,6 +813,8 @@ def _get_dep_manifests_for_repos(
                     len(manifests),
                     repo_name,
                 )
+            if skip_unchanged_repos and pushedat is not None:
+                synced_bookmarks.append({"repo_url": repo_url, "pushedat": pushedat})
         except DependencyGraphForbiddenError as err:
             forbidden_count += 1
             forbidden_message = str(err)
@@ -678,6 +862,22 @@ def _get_dep_manifests_for_repos(
             org,
         )
     logger.debug("Fetched dependency manifests for %d repos.", len(result))
+
+    if skip_unchanged_repos and neo4j_session is not None and update_tag is not None:
+        _touch_skipped_dependency_manifests(
+            neo4j_session,
+            skipped_unchanged_repo_urls,
+            update_tag,
+        )
+        _update_manifests_synced_bookmarks(neo4j_session, synced_bookmarks)
+        logger.info(
+            "Dependency manifest incremental sync for org %s: skipped refetch "
+            "for %d/%d unchanged repos.",
+            org,
+            len(skipped_unchanged_repo_urls),
+            len(non_null_repos),
+        )
+
     return result, cleanup_safe
 
 
@@ -1336,6 +1536,7 @@ def _transform_repo_objects(input_repo_object: Dict, out_repo_list: List[Dict]) 
             "url": input_repo_object["url"],
             "sshurl": ssh_url,
             "updatedat": input_repo_object["updatedAt"],
+            "pushedat": input_repo_object.get("pushedAt"),
             "owner_org_id": owner["url"] if owner_type == "Organization" else None,
             "owner_user_id": owner["url"] if owner_type == "User" else None,
         },
@@ -2670,6 +2871,7 @@ def sync(
     github_api_key: str,
     github_url: str,
     organization: str,
+    incremental_sync: bool = False,
 ) -> GitHubRepoSyncResult:
     """
     Performs the sequential tasks to collect, transform, and sync github data
@@ -2678,6 +2880,8 @@ def sync(
     :param github_api_key: The API key to access the GitHub v4 API
     :param github_url: The URL for the GitHub v4 endpoint to use
     :param organization: The organization to query GitHub for
+    :param incremental_sync: Skip archived/disabled repos and skip re-fetching
+        manifests for repos whose pushedAt is unchanged since the last sync.
     :return: Repository and dependency manifest data fetched for this org.
     """
     logger.info("Syncing GitHub repos")
@@ -2746,6 +2950,10 @@ def sync(
         organization,
         github_url,
         github_api_key,
+        skip_archived_repos=incremental_sync,
+        skip_unchanged_repos=incremental_sync,
+        neo4j_session=neo4j_session,
+        update_tag=common_job_parameters["UPDATE_TAG"],
     )
     for repo in repos_json:
         if repo is not None and repo.get("url") in dep_manifests_by_url:
@@ -2757,6 +2965,18 @@ def sync(
         github_api_key,
         github_url,
     )
+
+    # Build the pushedat update list to be written by the caller
+    # (start_github_ingestion) AFTER all downstream stages (actions, manifests,
+    # commits) have completed. Writing synced_pushedat here would immediately
+    # overwrite the bookmark with the current run's pushedat before the skip
+    # comparisons have a chance to use it.
+    repo_pushedat_updates = [
+        {"repo_url": repo["url"], "pushedat": repo["pushedat"]}
+        for repo in repo_data["repos"]
+        if repo.get("pushedat")
+    ]
+
     owner_org_id = next(
         (
             repo["owner_org_id"]
@@ -2806,4 +3026,5 @@ def sync(
         repos=repo_data["repos"],
         manifests=repo_data["manifests"],
         manifests_cleanup_safe=dep_manifests_cleanup_safe,
+        repo_pushedat_updates=repo_pushedat_updates,
     )

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -764,6 +764,7 @@ def _get_dep_manifests_for_repos(
     not_attempted_count = 0
     cleanup_safe = True
     skipped_unchanged_repo_urls: list[str] = []
+    skipped_archived_repo_urls: list[str] = []
     synced_bookmarks: list[dict[str, str]] = []
 
     for index, repo in enumerate(repo_raw_data):
@@ -781,6 +782,12 @@ def _get_dep_manifests_for_repos(
                 "Skipping dependency manifest fetch for archived/disabled repo %s.",
                 repo_name,
             )
+            # We chose not to re-fetch this repo, but its existing manifest
+            # subgraph is still valid; touch it so stale-tag cleanup keeps it.
+            # Kept separate from the unchanged list so the archived repo does not
+            # get a synced_pushedat bookmark advance (it was skipped by policy,
+            # not because pushedAt was unchanged).
+            skipped_archived_repo_urls.append(repo_url)
             continue
 
         pushedat = repo.get("pushedAt")
@@ -875,6 +882,28 @@ def _get_dep_manifests_for_repos(
             "for %d/%d unchanged repos.",
             org,
             len(skipped_unchanged_repo_urls),
+            len(non_null_repos),
+        )
+
+    if (
+        skip_archived_repos
+        and neo4j_session is not None
+        and update_tag is not None
+        and skipped_archived_repo_urls
+    ):
+        # Archived/disabled repos are skipped by policy, not because their data
+        # changed. Their existing manifest subgraph is still valid, so touch it
+        # to keep the stale-tag cleanup from deleting it. No bookmark advance.
+        _touch_skipped_dependency_manifests(
+            neo4j_session,
+            skipped_archived_repo_urls,
+            update_tag,
+        )
+        logger.info(
+            "Dependency manifest incremental sync for org %s: preserved existing "
+            "manifests for %d/%d skipped archived/disabled repos.",
+            org,
+            len(skipped_archived_repo_urls),
             len(non_null_repos),
         )
 

--- a/cartography/models/github/repos.py
+++ b/cartography/models/github/repos.py
@@ -76,6 +76,9 @@ class GitHubRepositoryNodeProperties(CartographyNodeProperties):
         "parent",
         description="Web URL of the repository this repository was forked from.",
     )
+    pushedat: PropertyRef = PropertyRef(
+        "pushedat", description="Timestamp when the repository was last pushed to."
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/integration/cartography/intel/github/test_actions.py
+++ b/tests/integration/cartography/intel/github/test_actions.py
@@ -1237,3 +1237,135 @@ def test_sync_github_actions_incremental_skip_preserves_workflows(
     ).data()
     assert len(uses_action_rows) >= 2
     assert all(row["lastupdated"] == second_update_tag for row in uses_action_rows)
+
+
+@patch.object(
+    cartography.intel.github.actions,
+    "get_org_secrets",
+    return_value=GET_ORG_SECRETS,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_org_variables",
+    return_value=GET_ORG_VARIABLES,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_repo_workflows",
+    return_value=GET_REPO_WORKFLOWS,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_repo_environments",
+    return_value=GET_REPO_ENVIRONMENTS,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_repo_secrets",
+    return_value=GET_REPO_SECRETS,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_repo_variables",
+    return_value=GET_REPO_VARIABLES,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_env_secrets",
+    side_effect=lambda *args, **kwargs: (
+        GET_ENV_SECRETS_PRODUCTION
+        if args[4] == "production"
+        else GET_ENV_SECRETS_STAGING
+    ),
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_env_variables",
+    side_effect=lambda *args, **kwargs: (
+        GET_ENV_VARIABLES_PRODUCTION
+        if args[4] == "production"
+        else GET_ENV_VARIABLES_STAGING
+    ),
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_workflow_content",
+    return_value=WORKFLOW_CI_CONTENT,
+)
+def test_sync_github_actions_archived_skip_preserves_workflows(
+    mock_workflow_content,
+    mock_env_variables,
+    mock_env_secrets,
+    mock_repo_variables,
+    mock_repo_secrets,
+    mock_repo_environments,
+    mock_repo_workflows,
+    mock_org_variables,
+    mock_org_secrets,
+    neo4j_session,
+):
+    """
+    Regression (cubic PR #3200): when skip_archived_repos is enabled and a repo
+    is archived, it is excluded from the Actions fetch loop entirely. Its
+    existing GitHubWorkflow/GitHubAction subgraph must still be preserved
+    (touched, not stale-cleaned) across a new update tag, since a full sync
+    would have re-fetched and re-tagged it.
+    """
+    # Arrange - first sync (repo not archived) populates the workflow subgraph.
+    _ensure_repo_exists(neo4j_session)
+    neo4j_session.run(
+        'MATCH (r:GitHubRepository{id: "https://github.com/simpsoncorp/sample_repo"}) '
+        "SET r.archived = false, r.disabled = false",
+    )
+
+    cartography.intel.github.actions.sync(
+        neo4j_session,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+        FAKE_API_KEY,
+        TEST_GITHUB_URL,
+        TEST_ORGANIZATION,
+    )
+    assert mock_repo_workflows.call_count == 1
+    first_workflow_ids = {
+        row[0] for row in check_nodes(neo4j_session, "GitHubWorkflow", ["id"])
+    }
+    assert first_workflow_ids
+    first_action_ids = {
+        row[0] for row in check_nodes(neo4j_session, "GitHubAction", ["id"])
+    }
+    assert first_action_ids
+
+    # Now mark the repo archived so the next incremental sync excludes it.
+    neo4j_session.run(
+        'MATCH (r:GitHubRepository{id: "https://github.com/simpsoncorp/sample_repo"}) '
+        "SET r.archived = true",
+    )
+
+    # Act - second sync with skip_archived_repos; the archived repo is excluded
+    # from the fetch loop, so its workflow fetch must NOT be called again.
+    second_update_tag = TEST_UPDATE_TAG + 1
+    cartography.intel.github.actions.sync(
+        neo4j_session,
+        {"UPDATE_TAG": second_update_tag},
+        FAKE_API_KEY,
+        TEST_GITHUB_URL,
+        TEST_ORGANIZATION,
+        skip_archived_repos=True,
+    )
+
+    # Assert - archived repo's workflows were NOT re-fetched...
+    assert mock_repo_workflows.call_count == 1
+
+    # ...yet its existing GitHubWorkflow subgraph survived AND was touched to the
+    # new update tag, instead of being deleted as stale by cleanup_org_level.
+    workflow_rows = neo4j_session.run(
+        "MATCH (w:GitHubWorkflow) RETURN w.id AS id, w.lastupdated AS lastupdated",
+    ).data()
+    assert {row["id"] for row in workflow_rows} == first_workflow_ids
+    assert all(row["lastupdated"] == second_update_tag for row in workflow_rows)
+
+    action_rows = neo4j_session.run(
+        "MATCH (a:GitHubAction) RETURN a.id AS id, a.lastupdated AS lastupdated",
+    ).data()
+    assert {row["id"] for row in action_rows} == first_action_ids
+    assert all(row["lastupdated"] == second_update_tag for row in action_rows)

--- a/tests/integration/cartography/intel/github/test_actions.py
+++ b/tests/integration/cartography/intel/github/test_actions.py
@@ -37,6 +37,17 @@ def _ensure_repo_exists(neo4j_session):
     )
 
 
+def _set_repo_pushedat(neo4j_session, pushedat, synced_pushedat=None):
+    neo4j_session.run(
+        """
+        MATCH (repo:GitHubRepository{id: "https://github.com/simpsoncorp/sample_repo"})
+        SET repo.pushedat = $pushedat, repo.synced_pushedat = $synced_pushedat
+        """,
+        pushedat=pushedat,
+        synced_pushedat=synced_pushedat,
+    )
+
+
 @patch.object(
     cartography.intel.github.actions,
     "get_org_secrets",
@@ -1078,3 +1089,151 @@ def test_sync_github_actions_workflow_parsing(
         "MATCH (:GitHubWorkflow)-[r:REFERENCES_SECRET]->(:GitHubActionsSecret) RETURN count(r) as count",
     ).single()["count"]
     assert refs_secret_rels >= 1
+
+
+@patch.object(
+    cartography.intel.github.actions,
+    "get_org_secrets",
+    return_value=GET_ORG_SECRETS,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_org_variables",
+    return_value=GET_ORG_VARIABLES,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_repo_workflows",
+    return_value=GET_REPO_WORKFLOWS,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_repo_environments",
+    return_value=GET_REPO_ENVIRONMENTS,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_repo_secrets",
+    return_value=GET_REPO_SECRETS,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_repo_variables",
+    return_value=GET_REPO_VARIABLES,
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_env_secrets",
+    side_effect=lambda *args, **kwargs: (
+        GET_ENV_SECRETS_PRODUCTION
+        if args[4] == "production"
+        else GET_ENV_SECRETS_STAGING
+    ),
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_env_variables",
+    side_effect=lambda *args, **kwargs: (
+        GET_ENV_VARIABLES_PRODUCTION
+        if args[4] == "production"
+        else GET_ENV_VARIABLES_STAGING
+    ),
+)
+@patch.object(
+    cartography.intel.github.actions,
+    "get_workflow_content",
+    return_value=WORKFLOW_CI_CONTENT,
+)
+def test_sync_github_actions_incremental_skip_preserves_workflows(
+    mock_workflow_content,
+    mock_env_variables,
+    mock_env_secrets,
+    mock_repo_variables,
+    mock_repo_secrets,
+    mock_repo_environments,
+    mock_repo_workflows,
+    mock_org_variables,
+    mock_org_secrets,
+    neo4j_session,
+):
+    """
+    Test that when skip_unchanged_repos is enabled and a repo's pushedat is
+    unchanged since the last successful Actions sync, the workflow fetch is
+    skipped but the existing GitHubWorkflow/GitHubAction subgraph is preserved
+    (nodes AND relationships touched, not stale-cleaned) across a new update tag.
+    Uses WORKFLOW_CI_CONTENT so GitHubAction nodes actually exist and the
+    action-preservation branch is exercised.
+    """
+    # Arrange - repo exists, no prior pushedat/bookmark (first sync should fetch normally)
+    _ensure_repo_exists(neo4j_session)
+    _set_repo_pushedat(neo4j_session, pushedat="2024-01-01T00:00:00Z")
+
+    # Act - first sync populates workflows and records the pushedat bookmark
+    cartography.intel.github.actions.sync(
+        neo4j_session,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+        FAKE_API_KEY,
+        TEST_GITHUB_URL,
+        TEST_ORGANIZATION,
+        skip_unchanged_repos=True,
+    )
+
+    # Assert - first sync fetched workflows; synced_pushedat is set externally
+    # (by repos.sync() in a real run) — simulate that by setting it now so the
+    # second sync can use it as the bookmark.
+    assert mock_repo_workflows.call_count == 1
+    assert check_nodes(neo4j_session, "GitHubWorkflow", ["id"]) == {
+        (12345678,),
+        (12345679,),
+        (12345680,),
+    }
+    # WORKFLOW_CI_CONTENT references 2 distinct actions
+    first_action_nodes = check_nodes(neo4j_session, "GitHubAction", ["id"])
+    assert len(first_action_nodes) == 2
+    first_uses_action = neo4j_session.run(
+        "MATCH (:GitHubWorkflow)-[r:USES_ACTION]->(:GitHubAction) RETURN count(r) AS c",
+    ).single()["c"]
+    assert first_uses_action >= 2
+    # Simulate repos.sync() writing synced_pushedat after repos fetch
+    neo4j_session.run(
+        'MATCH (r:GitHubRepository{id: "https://github.com/simpsoncorp/sample_repo"}) '
+        "SET r.synced_pushedat = $pushedat",
+        pushedat="2024-01-01T00:00:00Z",
+    )
+
+    # Act - second sync, pushedat matches synced_pushedat, new update tag
+    second_update_tag = TEST_UPDATE_TAG + 1
+    cartography.intel.github.actions.sync(
+        neo4j_session,
+        {"UPDATE_TAG": second_update_tag},
+        FAKE_API_KEY,
+        TEST_GITHUB_URL,
+        TEST_ORGANIZATION,
+        skip_unchanged_repos=True,
+    )
+
+    # Assert - workflow fetch was NOT called again (still just the 1 call from before)
+    assert mock_repo_workflows.call_count == 1
+
+    # Assert - GitHubWorkflow nodes still exist and were touched to the new update tag,
+    # i.e. NOT deleted by stale-tag cleanup despite not being re-fetched.
+    workflow_rows = neo4j_session.run(
+        "MATCH (w:GitHubWorkflow) RETURN w.id AS id, w.lastupdated AS lastupdated",
+    ).data()
+    assert {row["id"] for row in workflow_rows} == {12345678, 12345679, 12345680}
+    assert all(row["lastupdated"] == second_update_tag for row in workflow_rows)
+
+    # Assert - GitHubAction nodes were preserved and touched too
+    action_rows = neo4j_session.run(
+        "MATCH (a:GitHubAction) RETURN a.id AS id, a.lastupdated AS lastupdated",
+    ).data()
+    assert {row["id"] for row in action_rows} == {row[0] for row in first_action_nodes}
+    assert all(row["lastupdated"] == second_update_tag for row in action_rows)
+
+    # Assert - the USES_ACTION relationships were preserved and touched too
+    uses_action_rows = neo4j_session.run(
+        "MATCH (:GitHubWorkflow)-[r:USES_ACTION]->(:GitHubAction) "
+        "RETURN r.lastupdated AS lastupdated",
+    ).data()
+    assert len(uses_action_rows) >= 2
+    assert all(row["lastupdated"] == second_update_tag for row in uses_action_rows)

--- a/tests/integration/cartography/intel/github/test_commits.py
+++ b/tests/integration/cartography/intel/github/test_commits.py
@@ -234,10 +234,12 @@ def test_sync_github_commits_skip_stale_repos_touches_existing_rels(
         "https://github.com/testorg/repo1",
     ) in actual_rels
 
-    touched = neo4j_session.run("""
+    touched = neo4j_session.run(
+        """
         MATCH (:GitHubUser {id: "https://github.com/alice"})
               -[c:COMMITTED_TO]->
               (:GitHubRepository {id: "https://github.com/testorg/repo1"})
         RETURN c.lastupdated AS lastupdated
-        """).single()
+        """
+    ).single()
     assert touched["lastupdated"] == TEST_UPDATE_TAG

--- a/tests/integration/cartography/intel/github/test_commits.py
+++ b/tests/integration/cartography/intel/github/test_commits.py
@@ -102,3 +102,142 @@ def test_sync_github_commits(mock_get_commits, neo4j_session):
     }
     actual_repos = check_nodes(neo4j_session, "GitHubRepository", ["id"])
     assert expected_repos.issubset(actual_repos)
+
+
+@patch.object(
+    cartography.intel.github.commits,
+    "get_repo_commits",
+)
+def test_sync_github_commits_skip_stale_repos(mock_get_commits, neo4j_session):
+    """
+    Test that when skip_stale_repos is enabled, repos with no push within the
+    lookback window are skipped entirely (no commits API call), while repos
+    with no known pushedat (never seen by a repos sync) are still processed.
+    """
+    # Arrange - wipe state left by earlier tests in this module (the session
+    # fixture is module-scoped), then seed repo1 pushed outside the lookback window.
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _ensure_test_users_exist(neo4j_session)
+    _ensure_test_repos_exist(neo4j_session)
+    neo4j_session.run(
+        """
+        MATCH (r1:GitHubRepository {id: "https://github.com/testorg/repo1"})
+        SET r1.pushedat = "2000-01-01T00:00:00Z"
+        """,
+    )
+    # repo2 has no pushedat set at all (simulates a repo the repos-sync hasn't
+    # recorded pushedat for yet) — should never be skipped.
+
+    def side_effect(token, api_url, organization, repo_name, since_date):
+        return MOCK_COMMITS_BY_REPO.get(repo_name, [])
+
+    mock_get_commits.side_effect = side_effect
+
+    # Act
+    cartography.intel.github.commits.sync_github_commits(
+        neo4j_session,
+        "fake-token",
+        TEST_GITHUB_URL,
+        TEST_GITHUB_ORG,
+        TEST_REPO_NAMES,
+        TEST_UPDATE_TAG,
+        skip_stale_repos=True,
+    )
+
+    # Assert - only repo2 (no pushedat on record) had its commits fetched
+    fetched_repos = {call.args[3] for call in mock_get_commits.call_args_list}
+    assert fetched_repos == {"repo2"}
+
+    # Assert - only repo2's commit relationship was written to the graph
+    actual_rels = check_rels(
+        neo4j_session,
+        "GitHubUser",
+        "id",
+        "GitHubRepository",
+        "id",
+        "COMMITTED_TO",
+        rel_direction_right=True,
+    )
+    assert actual_rels == {
+        ("https://github.com/bob", "https://github.com/testorg/repo2"),
+    }
+
+
+@patch.object(
+    cartography.intel.github.commits,
+    "get_repo_commits",
+)
+def test_sync_github_commits_skip_stale_repos_touches_existing_rels(
+    mock_get_commits, neo4j_session
+):
+    """
+    Regression: a repo skipped by skip_stale_repos (pushedat outside the
+    lookback window) whose existing COMMITTED_TO edge carries a prior
+    update_tag must have that edge touched forward — not deleted by the
+    org-scoped matchlink cleanup. `pushedat` is imprecise, so a stale-by-
+    pushedat repo can still hold live commit edges; incremental sync must not
+    silently delete them.
+    """
+    # Arrange - reset, seed nodes, and create a pre-existing COMMITTED_TO edge
+    # on the to-be-skipped repo1 carrying an OLD update tag.
+    old_update_tag = TEST_UPDATE_TAG - 1
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _ensure_test_users_exist(neo4j_session)
+    _ensure_test_repos_exist(neo4j_session)
+    neo4j_session.run(
+        """
+        MATCH (r1:GitHubRepository {id: "https://github.com/testorg/repo1"})
+        SET r1.pushedat = "2000-01-01T00:00:00Z"
+        WITH r1
+        MATCH (u:GitHubUser {id: "https://github.com/alice"})
+        MERGE (u)-[c:COMMITTED_TO]->(r1)
+        SET c.lastupdated = $old_update_tag,
+            c._sub_resource_label = "GitHubOrganization",
+            c._sub_resource_id = "https://github.com/testorg"
+        """,
+        old_update_tag=old_update_tag,
+    )
+
+    def side_effect(token, api_url, organization, repo_name, since_date):
+        return MOCK_COMMITS_BY_REPO.get(repo_name, [])
+
+    mock_get_commits.side_effect = side_effect
+
+    # Act - incremental sync with a NEW update tag; repo1 is skipped.
+    cartography.intel.github.commits.sync_github_commits(
+        neo4j_session,
+        "fake-token",
+        TEST_GITHUB_URL,
+        TEST_GITHUB_ORG,
+        TEST_REPO_NAMES,
+        TEST_UPDATE_TAG,
+        skip_stale_repos=True,
+    )
+
+    # Assert - repo1 was skipped (no commits API call)...
+    fetched_repos = {call.args[3] for call in mock_get_commits.call_args_list}
+    assert fetched_repos == {"repo2"}
+
+    # ...yet repo1's pre-existing edge survived AND was touched to the new tag,
+    # instead of being deleted as stale by the cleanup.
+    actual_rels = check_rels(
+        neo4j_session,
+        "GitHubUser",
+        "id",
+        "GitHubRepository",
+        "id",
+        "COMMITTED_TO",
+        rel_direction_right=True,
+    )
+    assert (
+        "https://github.com/alice",
+        "https://github.com/testorg/repo1",
+    ) in actual_rels
+
+    touched = neo4j_session.run("""
+        MATCH (:GitHubUser {id: "https://github.com/alice"})
+              -[c:COMMITTED_TO]->
+              (:GitHubRepository {id: "https://github.com/testorg/repo1"})
+        RETURN c.lastupdated AS lastupdated
+        """).single()
+    assert touched["lastupdated"] == TEST_UPDATE_TAG

--- a/tests/integration/cartography/intel/github/test_commits.py
+++ b/tests/integration/cartography/intel/github/test_commits.py
@@ -243,3 +243,86 @@ def test_sync_github_commits_skip_stale_repos_touches_existing_rels(
         """
     ).single()
     assert touched["lastupdated"] == TEST_UPDATE_TAG
+
+
+@patch.object(
+    cartography.intel.github.commits,
+    "get_repo_commits",
+)
+def test_sync_github_commits_archived_repo_touches_existing_rels(
+    mock_get_commits, neo4j_session
+):
+    """
+    Regression (cubic PR #3200): an archived/disabled repo is excluded from
+    `repo_names` before commits sync (filtered in start_github_ingestion), so it
+    never reaches the stale-skip touch. Its existing COMMITTED_TO edge must still
+    be touched forward, not deleted by the org-scoped matchlink cleanup.
+    """
+    # Arrange - repo1 is archived and NOT in the repo_names passed to sync, yet
+    # it holds a pre-existing COMMITTED_TO edge carrying an OLD update tag.
+    old_update_tag = TEST_UPDATE_TAG - 1
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    _ensure_test_users_exist(neo4j_session)
+    _ensure_test_repos_exist(neo4j_session)
+    neo4j_session.run(
+        """
+        MATCH (r1:GitHubRepository {id: "https://github.com/testorg/repo1"})
+        SET r1.archived = true, r1.disabled = false
+        WITH r1
+        MATCH (org:GitHubOrganization {id: "https://github.com/testorg"})
+        MERGE (r1)-[:OWNER]->(org)
+        WITH r1
+        MATCH (u:GitHubUser {id: "https://github.com/alice"})
+        MERGE (u)-[c:COMMITTED_TO]->(r1)
+        SET c.lastupdated = $old_update_tag,
+            c._sub_resource_label = "GitHubOrganization",
+            c._sub_resource_id = "https://github.com/testorg"
+        """,
+        old_update_tag=old_update_tag,
+    )
+
+    def side_effect(token, api_url, organization, repo_name, since_date):
+        return MOCK_COMMITS_BY_REPO.get(repo_name, [])
+
+    mock_get_commits.side_effect = side_effect
+
+    # Act - incremental sync; repo1 is archived so it is not in repo_names.
+    cartography.intel.github.commits.sync_github_commits(
+        neo4j_session,
+        "fake-token",
+        TEST_GITHUB_URL,
+        TEST_GITHUB_ORG,
+        ["repo2"],
+        TEST_UPDATE_TAG,
+        skip_stale_repos=True,
+    )
+
+    # Assert - repo1's commits were never fetched (excluded entirely)...
+    fetched_repos = {call.args[3] for call in mock_get_commits.call_args_list}
+    assert fetched_repos == {"repo2"}
+
+    # ...yet repo1's pre-existing edge survived AND was touched to the new tag,
+    # instead of being deleted as stale by the org-scoped cleanup.
+    actual_rels = check_rels(
+        neo4j_session,
+        "GitHubUser",
+        "id",
+        "GitHubRepository",
+        "id",
+        "COMMITTED_TO",
+        rel_direction_right=True,
+    )
+    assert (
+        "https://github.com/alice",
+        "https://github.com/testorg/repo1",
+    ) in actual_rels
+
+    touched = neo4j_session.run(
+        """
+        MATCH (:GitHubUser {id: "https://github.com/alice"})
+              -[c:COMMITTED_TO]->
+              (:GitHubRepository {id: "https://github.com/testorg/repo1"})
+        RETURN c.lastupdated AS lastupdated
+        """
+    ).single()
+    assert touched["lastupdated"] == TEST_UPDATE_TAG

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -1334,3 +1334,83 @@ def test_get_dep_manifests_for_repos_incremental_skip_preserves_manifests(
         id=repo_url,
     ).single()
     assert bookmark_row["bookmark"] == "2024-01-01T00:00:00Z"
+
+
+@patch.object(
+    cartography.intel.github.repos,
+    "_get_repo_dep_manifests",
+)
+def test_get_dep_manifests_for_repos_archived_skip_preserves_manifests(
+    mock_get_repo_dep_manifests, neo4j_session
+):
+    """
+    When skip_archived_repos is enabled and a repo is archived/disabled, its
+    per-repo manifest fetch is skipped. The existing manifest/dependency
+    subgraph must still be preserved (touched, not stale-cleaned) across a new
+    update tag, because a full sync would have re-fetched and re-tagged it.
+    Regression for cubic PR #3200 finding on repos.py.
+    """
+    # Arrange - seed an archived repo with an existing manifest + dependency
+    repo_url = "https://github.com/simpsoncorp/archived_repo"
+    manifest_id = f"{repo_url}#/requirements.txt"
+    neo4j_session.run(
+        """
+        MERGE (org:GitHubOrganization{id: "https://github.com/simpsoncorp"})
+        MERGE (repo:GitHubRepository{id: $repo_url})
+        SET repo.name = "archived_repo", repo.lastupdated = $update_tag,
+            repo.archived = true, repo.disabled = false
+        MERGE (repo)-[:OWNER]->(org)
+        MERGE (repo)-[:HAS_MANIFEST]->(m:DependencyGraphManifest{id: $manifest_id})
+        SET m.lastupdated = $update_tag
+        MERGE (m)-[:HAS_DEP]->(d:Dependency{id: "django"})
+        SET d.lastupdated = $update_tag
+        """,
+        repo_url=repo_url,
+        manifest_id=manifest_id,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    repo_raw_data = [
+        {
+            "name": "archived_repo",
+            "url": repo_url,
+            "pushedAt": "2024-06-01T00:00:00Z",
+            "isArchived": True,
+            "isDisabled": False,
+        }
+    ]
+
+    # Act - run with a new update tag; repo is archived so the fetch is skipped
+    new_update_tag = TEST_UPDATE_TAG + 1
+    result, cleanup_safe = cartography.intel.github.repos._get_dep_manifests_for_repos(
+        repo_raw_data,
+        TEST_GITHUB_ORG,
+        TEST_GITHUB_URL,
+        FAKE_API_KEY,
+        skip_archived_repos=True,
+        neo4j_session=neo4j_session,
+        update_tag=new_update_tag,
+    )
+
+    # Assert - the per-repo fetch was never called (skipped as archived)
+    mock_get_repo_dep_manifests.assert_not_called()
+    assert result == {}
+
+    # Assert - existing manifest/dependency nodes were touched to the new tag,
+    # not deleted by stale-tag cleanup, despite the repo being skipped.
+    manifest_row = neo4j_session.run(
+        "MATCH (m:DependencyGraphManifest {id: $id}) RETURN m.lastupdated AS lastupdated",
+        id=manifest_id,
+    ).single()
+    assert manifest_row is not None
+    assert manifest_row["lastupdated"] == new_update_tag
+
+    dep_row = neo4j_session.run(
+        """
+        MATCH (:DependencyGraphManifest {id: $manifest_id})-[:HAS_DEP]->(d:Dependency {id: "django"})
+        RETURN d.lastupdated AS lastupdated
+        """,
+        manifest_id=manifest_id,
+    ).single()
+    assert dep_row is not None
+    assert dep_row["lastupdated"] == new_update_tag

--- a/tests/integration/cartography/intel/github/test_repos.py
+++ b/tests/integration/cartography/intel/github/test_repos.py
@@ -1226,3 +1226,111 @@ def test_sync_github_python_requirements(
         "REQUIRES",
     )
     assert expected_requires_rels.issubset(actual_requires_rels)
+
+
+@patch.object(
+    cartography.intel.github.repos,
+    "_get_repo_dep_manifests",
+)
+def test_get_dep_manifests_for_repos_incremental_skip_preserves_manifests(
+    mock_get_repo_dep_manifests, neo4j_session
+):
+    """
+    Test that when skip_unchanged_repos is enabled and a repo's pushedAt is
+    unchanged since the last successful manifest sync, the per-repo manifest
+    fetch is skipped, but existing DependencyGraphManifest/Dependency nodes
+    are preserved (touched, not stale-cleaned) across a new update tag. Also
+    verifies the DependencyGraphManifest-[:MATCHES_CODEOWNER_RULE]->
+    GitHubCodeOwnerRule matchlink is preserved, since codeowners.sync's
+    cleanup is scoped to the whole org and would otherwise delete matchlinks
+    for repos whose manifest fetch was skipped this run.
+    """
+    # Arrange - seed a repo with an existing manifest+dependency, a CODEOWNERS
+    # rule match, and a matching bookmark
+    repo_url = "https://github.com/simpsoncorp/sample_repo"
+    manifest_id = f"{repo_url}#/requirements.txt"
+    rule_id = f"{repo_url}#CODEOWNERS:.github/CODEOWNERS:1:deadbeef"
+    neo4j_session.run(
+        """
+        MERGE (org:GitHubOrganization{id: "https://github.com/simpsoncorp"})
+        MERGE (repo:GitHubRepository{id: $repo_url})
+        SET repo.name = "sample_repo", repo.lastupdated = $update_tag,
+            repo.synced_pushedat = "2024-01-01T00:00:00Z"
+        MERGE (repo)-[:OWNER]->(org)
+        MERGE (repo)-[:HAS_MANIFEST]->(m:DependencyGraphManifest{id: $manifest_id})
+        SET m.lastupdated = $update_tag
+        MERGE (m)-[:HAS_DEP]->(d:Dependency{id: "django"})
+        SET d.lastupdated = $update_tag
+        MERGE (rule:GitHubCodeOwnerRule{id: $rule_id})
+        SET rule.lastupdated = $update_tag
+        MERGE (m)-[mc:MATCHES_CODEOWNER_RULE]->(rule)
+        SET mc.lastupdated = $update_tag
+        """,
+        repo_url=repo_url,
+        manifest_id=manifest_id,
+        rule_id=rule_id,
+        update_tag=TEST_UPDATE_TAG,
+    )
+
+    repo_raw_data = [
+        {
+            "name": "sample_repo",
+            "url": repo_url,
+            "pushedAt": "2024-01-01T00:00:00Z",
+            "isArchived": False,
+        }
+    ]
+
+    # Act - run with a new update tag; pushedAt matches the recorded bookmark
+    new_update_tag = TEST_UPDATE_TAG + 1
+    result, cleanup_safe = cartography.intel.github.repos._get_dep_manifests_for_repos(
+        repo_raw_data,
+        TEST_GITHUB_ORG,
+        TEST_GITHUB_URL,
+        FAKE_API_KEY,
+        skip_unchanged_repos=True,
+        neo4j_session=neo4j_session,
+        update_tag=new_update_tag,
+    )
+
+    # Assert - the per-repo fetch was never called (skipped as unchanged)
+    mock_get_repo_dep_manifests.assert_not_called()
+    assert cleanup_safe is True
+    assert result == {}
+
+    # Assert - existing manifest/dependency nodes were touched to the new tag,
+    # not deleted by stale-tag cleanup, despite not being re-fetched.
+    manifest_row = neo4j_session.run(
+        "MATCH (m:DependencyGraphManifest {id: $id}) RETURN m.lastupdated AS lastupdated",
+        id=manifest_id,
+    ).single()
+    assert manifest_row is not None
+    assert manifest_row["lastupdated"] == new_update_tag
+
+    dep_row = neo4j_session.run(
+        'MATCH (d:Dependency {id: "django"}) RETURN d.lastupdated AS lastupdated',
+    ).single()
+    assert dep_row is not None
+    assert dep_row["lastupdated"] == new_update_tag
+
+    # Assert - the MATCHES_CODEOWNER_RULE matchlink was touched too, so
+    # codeowners.sync's org-scoped cleanup won't delete it even though this
+    # repo's manifest fetch was skipped this run.
+    matchlink_row = neo4j_session.run(
+        """
+        MATCH (:DependencyGraphManifest {id: $manifest_id})
+              -[mc:MATCHES_CODEOWNER_RULE]->(:GitHubCodeOwnerRule {id: $rule_id})
+        RETURN mc.lastupdated AS lastupdated
+        """,
+        manifest_id=manifest_id,
+        rule_id=rule_id,
+    ).single()
+    assert matchlink_row is not None
+    assert matchlink_row["lastupdated"] == new_update_tag
+
+    # Assert - bookmark unchanged (still valid for next comparison)
+    bookmark_row = neo4j_session.run(
+        "MATCH (r:GitHubRepository {id: $id}) RETURN r.synced_pushedat AS bookmark",
+        id=repo_url,
+    ).single()
+    assert bookmark_row["bookmark"] == "2024-01-01T00:00:00Z"


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary

Adds an opt-in **incremental sync** mode for the GitHub intel module, enabled by
a new `--github-incremental-sync` flag (config attribute `github_incremental_sync`,
default `False`). When disabled, GitHub sync behaves exactly as today.

When enabled, incremental sync reduces GitHub API quota and wall-clock time on
large orgs by skipping work that provably cannot have changed since the last run,
using the repository's `pushedAt` timestamp as the change signal:

- **Archived/disabled repos** are excluded from the Actions, commits, and
  dependency-manifest stages.
- **Commits**: repos whose last known `pushedat` is older than the commit
  lookback window are skipped — they cannot have in-window commits. Repos with no
  recorded `pushedat` are never skipped.
- **Actions (workflow YAML)** and **dependency manifests** are not re-fetched for
  a repo whose current `pushedAt` matches the `synced_pushedat` bookmark written
  after the previous successful repos sync (i.e. nothing has been pushed since).
  Secrets, variables, and environments are always refreshed regardless.

To support this, the sync now:

- Fetches `pushedAt` from the repos GraphQL query and stores it as `pushedat` on
  `GitHubRepository` (new `PropertyRef` in `models/github/repos.py`).
- Writes a single shared `synced_pushedat` bookmark on each `GitHubRepository`
  once, **after all downstream stages complete** (`_write_synced_pushedat`,
  called from `start_github_ingestion`). Writing it earlier would overwrite the
  value the skip comparisons need to read.

This branch is the **S + I** slice of the internal PR #3057. It deliberately
**excludes** the parallelism (P) slice (`ThreadPoolExecutor`/`parallel_workers`
per-repo fetch fan-out); every stage here remains sequential. The shared "S"
refactor — extracting each repo's Actions fetch/transform into
`_fetch_actions_for_repo()` / `_RepoActionsData` — is the base this builds on.

#### Silent-deletion fix for skipped commits (included deliberately)

Skipping the fetch for a repo means its resources are not re-loaded this run, so
the normal stale-tag cleanup would **delete** the existing subgraph as stale.
Each skip path therefore *touches* (`SET lastupdated = $update_tag`) the existing
nodes and relationships it chose not to re-fetch, so cleanup preserves them:

- `_touch_skipped_actions_workflows` (workflows, actions, secret refs)
- `_touch_skipped_dependency_manifests` (manifests, dependencies, REQUIRES,
  CODEOWNER-rule matchlinks)
- `_touch_skipped_commit_relationships` (org-scoped `COMMITTED_TO` matchlinks)

The **commits** touch (`_touch_skipped_commit_relationships`) fixes a genuine
silent-data-loss bug rather than merely mirroring the other paths. GitHub's
`pushedat` is imprecise — it does not always bump on every ref update and can lag
a real push — so a repo can be skipped by the lookback filter yet still hold
genuine in-window commit edges. Without the touch, the org-scoped matchlink
cleanup would silently delete those live `COMMITTED_TO` edges. The touch keeps
them and advances their `lastupdated`. A regression integration test
(`test_sync_github_commits_skip_stale_repos_touches_existing_rels`) asserts a
pre-existing edge on a skipped repo survives and is advanced to the new tag.

### Related issues or links

- Split out of #3057.

### Breaking changes

None. The feature is off by default and positional-arg compatibility of `Config`
is preserved (`github_incremental_sync` is appended last).

### How was this tested?

Full repo suite via the repo's `make` targets, green:

- `make test_lint` — pre-commit clean (black, flake8, mypy, isort, pyupgrade all
  Passed). See note below: this surfaced one black-formatting miss in a test,
  now fixed in commit `9973c0cb9`.
- `make test_unit` — **5205 passed**, total coverage 76% (gate 60%).
- `make test_integration` (Neo4j testcontainer) — **1577 passed** (~5m47s),
  including all four incremental integration tests:
  - `test_sync_github_commits_skip_stale_repos`
  - `test_sync_github_commits_skip_stale_repos_touches_existing_rels` (the
    silent-deletion regression)
  - `test_sync_github_actions_incremental_skip_preserves_workflows`
  - `test_get_dep_manifests_for_repos_incremental_skip_preserves_manifests`

### Known limitation — `synced_pushedat` advances for all repos regardless of per-stage success

The `synced_pushedat` bookmark is written **once, centrally**, from
`start_github_ingestion` for every repo returned by the repos sync, after all
downstream stages have run. It is **not** gated on whether the Actions, commits,
or manifest stage actually succeeded for each individual repo. If a downstream
stage fails or is interrupted for a specific repo after its `pushedat` is already
recorded, the next incremental run may skip that repo as "unchanged" and miss
data until its `pushedAt` next changes.

This is an intentional trade-off in this slice: a single shared bookmark keeps
the model simple and the three skip stages consistent. Mitigations already in
place bound the blast radius:

- The bookmark is only written on repos that completed the repos sync
  (`repo_pushedat_updates` is built from successfully transformed repo data).
- The per-stage *touch* logic keeps previously-synced data alive across a skip,
  so a skipped repo retains its last-good subgraph rather than losing it.
- A full (non-incremental) run always re-fetches everything and self-heals any
  drift.

A future refinement could make the bookmark per-stage (advance a stage's bookmark
only when that stage succeeded for that repo). That is out of scope for this PR
and is called out here so operators can decide when to run a periodic full sync.

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

### Notes for reviewers

- This is the sequential **S + I** slice only; the per-repo parallel-fetch (P)
  slice is intentionally excluded and will land separately.
- The manifest skip logic was reconciled onto master's current
  `_get_dep_manifests_for_repos` (which already carries `DependencyGraphForbidden`
  / org-wide-forbidden handling absent from the original PR base); the skip/touch
  hunks were woven into that existing sequential loop rather than the threaded
  version from #3057.
- `synced_pushedat` is written from `start_github_ingestion` (not from
  `repos.sync()`) so it lands after Actions/commits/manifests have read the prior
  value.
- Commit `9973c0cb9` is a one-line black reformat of a multi-line
  `neo4j_session.run(...)` call in `test_sync_github_commits_skip_stale_repos_touches_existing_rels`
  (surfaced by `make test_lint`). No behavior change — kept as its own `style()`
  commit for a clean history.