### PR TITLE
feat(github): add opt-in per-repo parallel workers (--github-parallel-workers)

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -941,6 +941,21 @@ class CLI:
                     hidden=PANEL_GITHUB not in visible_panels,
                 ),
             ] = 30,
+            github_parallel_workers: Annotated[
+                int,
+                typer.Option(
+                    "--github-parallel-workers",
+                    help=(
+                        "Number of parallel workers for per-repo GitHub API fetches "
+                        "(rulesets, collaborators, dependency manifests). "
+                        "Default: 1 (sequential). Increase conservatively; each worker "
+                        "consumes GraphQL/REST quota independently."
+                    ),
+                    min=1,
+                    rich_help_panel=PANEL_GITHUB,
+                    hidden=PANEL_GITHUB not in visible_panels,
+                ),
+            ] = 1,
             # =================================================================
             # GitLab Options
             # =================================================================
@@ -3583,6 +3598,7 @@ class CLI:
                 okta_saml_role_regex=okta_saml_role_regex,
                 github_config=github_config,
                 github_commit_lookback_days=github_commit_lookback_days,
+                github_parallel_workers=github_parallel_workers,
                 digitalocean_token=digitalocean_token,
                 permission_relationships_file=permission_relationships_file,
                 azure_permission_relationships_file=azure_permission_relationships_file,

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -180,6 +180,8 @@ class Config:
     :param github_config: Base64 encoded config object for GitHub ingestion. Optional.
     :type github_commit_lookback_days: int
     :param github_commit_lookback_days: Number of days to look back for GitHub commit tracking. Optional.
+    :type github_parallel_workers: int
+    :param github_parallel_workers: Number of parallel workers for per-repo GitHub API fetches. Default 1 (sequential).
     :type digitalocean_token: str
     :param digitalocean_token: DigitalOcean access token. Optional.
     :type permission_relationships_file: str
@@ -554,6 +556,7 @@ class Config:
         okta_saml_role_regex=None,
         github_config=None,
         github_commit_lookback_days=30,
+        github_parallel_workers=1,
         digitalocean_token=None,
         permission_relationships_file=None,
         azure_permission_relationships_file=None,
@@ -803,6 +806,7 @@ class Config:
         self.okta_saml_role_regex = okta_saml_role_regex
         self.github_config = github_config
         self.github_commit_lookback_days = github_commit_lookback_days
+        self.github_parallel_workers: int = github_parallel_workers
         self.digitalocean_token = digitalocean_token
         self.permission_relationships_file = permission_relationships_file
         self.azure_permission_relationships_file = azure_permission_relationships_file

--- a/cartography/intel/github/__init__.py
+++ b/cartography/intel/github/__init__.py
@@ -127,6 +127,7 @@ def start_github_ingestion(
             token,
             api_url,
             org_name,
+            parallel_workers=config.github_parallel_workers,
         )
         cartography.intel.github.personal_access_tokens.sync(
             neo4j_session,
@@ -169,6 +170,7 @@ def start_github_ingestion(
             token,
             api_url,
             org_name,
+            parallel_workers=config.github_parallel_workers,
         )
 
         # Sync commit relationships for the configured lookback period

--- a/cartography/intel/github/actions.py
+++ b/cartography/intel/github/actions.py
@@ -8,6 +8,9 @@ Supports three levels:
 """
 
 import logging
+import threading
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from dataclasses import field
 from typing import Any
@@ -763,10 +766,14 @@ def _fetch_actions_for_repo(
     organization: str,
     github_api_key: str,
     github_url: str,
+    progress_counter: "list[int]",
+    progress_lock: threading.Lock,
+    total: int,
 ) -> _RepoActionsData:
     """
     Fetch and transform all Actions data for a single repo.
     Returns a _RepoActionsData bundle; no Neo4j writes are performed here.
+    Designed to be called from worker threads via ThreadPoolExecutor.
     """
     data = _RepoActionsData(repo_name=repo_name)
 
@@ -865,6 +872,17 @@ def _fetch_actions_for_repo(
                 )
             )
 
+    with progress_lock:
+        progress_counter[0] += 1
+        done = progress_counter[0]
+    if done == 1 or done % 50 == 0 or done == total:
+        logger.info(
+            "Actions fetch progress for org %s: %d/%d repos completed.",
+            organization,
+            done,
+            total,
+        )
+
     return data
 
 
@@ -875,16 +893,18 @@ def sync(
     github_api_key: str,
     github_url: str,
     organization: str,
+    parallel_workers: int = 1,
 ) -> list[dict[str, Any]]:
     """
     Sync GitHub Actions data (workflows, secrets, variables, environments) for an organization.
 
     Sync order:
     1. Organization-level secrets and variables
-    2. For each repo: workflows, environments, repo secrets/variables
-    3. For each environment: env secrets/variables
-    4. Cleanup stale nodes
+    2. For each repo (parallel fetch, sequential load): workflows, environments,
+       repo secrets/variables, env secrets/variables
+    3. Cleanup stale nodes
 
+    :param parallel_workers: Number of repos to fetch concurrently. Default 1 (sequential).
     :return: List of all transformed workflows (with repo_url and path) for supply chain sync.
     """
     org_url = f"https://github.com/{organization}"
@@ -908,39 +928,60 @@ def sync(
 
     # 2. Get repos from graph and sync repo-level resources
     repo_names = _get_repos_from_graph(neo4j_session, organization)
-    logger.info(f"Syncing GitHub Actions for {len(repo_names)} repositories")
+    total = len(repo_names)
+    logger.info(
+        "Syncing GitHub Actions for %d repositories in org %s (parallel_workers=%d).",
+        total,
+        organization,
+        parallel_workers,
+    )
 
-    for repo_name in repo_names:
-        # Fetch and transform all Actions data for this repo (no writes), then
-        # load sequentially on this thread.
-        d = _fetch_actions_for_repo(
-            repo_name,
-            organization,
-            github_api_key,
-            github_url,
-        )
+    progress_counter: list[int] = [0]
+    progress_lock = threading.Lock()
 
-        if d.enriched_workflows:
-            load_workflows(neo4j_session, d.enriched_workflows, update_tag, org_url)
-            all_workflows.extend(d.enriched_workflows)
-        if d.repo_actions:
-            load_actions(neo4j_session, d.repo_actions, update_tag, org_url)
-        if d.transformed_environments:
-            load_environments(
-                neo4j_session, d.transformed_environments, update_tag, org_url
-            )
-        if d.transformed_repo_secrets:
-            load_repo_secrets(
-                neo4j_session, d.transformed_repo_secrets, update_tag, org_url
-            )
-        if d.transformed_repo_variables:
-            load_repo_variables(
-                neo4j_session, d.transformed_repo_variables, update_tag, org_url
-            )
-        if d.env_secrets:
-            load_env_secrets(neo4j_session, d.env_secrets, update_tag, org_url)
-        if d.env_variables:
-            load_env_variables(neo4j_session, d.env_variables, update_tag, org_url)
+    # Submit all repos to a single bounded thread pool up front so idle workers
+    # immediately pick up the next repo instead of waiting for a batch's
+    # slowest straggler (e.g. a repo with many workflows/environments).
+    with ThreadPoolExecutor(max_workers=parallel_workers) as executor:
+        futures = {
+            executor.submit(
+                _fetch_actions_for_repo,
+                repo_name,
+                organization,
+                github_api_key,
+                github_url,
+                progress_counter,
+                progress_lock,
+                total,
+            ): repo_name
+            for repo_name in repo_names
+        }
+
+        # Sequential load — all Neo4j writes on the main thread, applied as
+        # each repo's fetch completes rather than waiting for a fixed batch.
+        for f in as_completed(futures):
+            d = f.result()
+            if d.enriched_workflows:
+                load_workflows(neo4j_session, d.enriched_workflows, update_tag, org_url)
+                all_workflows.extend(d.enriched_workflows)
+            if d.repo_actions:
+                load_actions(neo4j_session, d.repo_actions, update_tag, org_url)
+            if d.transformed_environments:
+                load_environments(
+                    neo4j_session, d.transformed_environments, update_tag, org_url
+                )
+            if d.transformed_repo_secrets:
+                load_repo_secrets(
+                    neo4j_session, d.transformed_repo_secrets, update_tag, org_url
+                )
+            if d.transformed_repo_variables:
+                load_repo_variables(
+                    neo4j_session, d.transformed_repo_variables, update_tag, org_url
+                )
+            if d.env_secrets:
+                load_env_secrets(neo4j_session, d.env_secrets, update_tag, org_url)
+            if d.env_variables:
+                load_env_variables(neo4j_session, d.env_variables, update_tag, org_url)
 
     # 4. Cleanup all stale nodes scoped to the organization. Repo-level secrets
     # and variables are now scoped to the org as well, so cleanup_org_level

--- a/cartography/intel/github/actions.py
+++ b/cartography/intel/github/actions.py
@@ -8,6 +8,8 @@ Supports three levels:
 """
 
 import logging
+from dataclasses import dataclass
+from dataclasses import field
 from typing import Any
 from urllib.parse import quote
 
@@ -739,6 +741,133 @@ def _get_repos_from_graph(neo4j_session: neo4j.Session, organization: str) -> li
 # =============================================================================
 
 
+@dataclass
+class _RepoActionsData:
+    """All fetched-and-transformed data for a single repo's Actions resources.
+    Populated by _fetch_actions_for_repo(); consumed by sync() for Neo4j
+    writes. Separating fetch/transform from load keeps every API call in one
+    place and every graph write in another."""
+
+    repo_name: str
+    enriched_workflows: list[dict[str, Any]] = field(default_factory=list)
+    repo_actions: list[dict[str, Any]] = field(default_factory=list)
+    transformed_environments: list[dict[str, Any]] = field(default_factory=list)
+    transformed_repo_secrets: list[dict[str, Any]] = field(default_factory=list)
+    transformed_repo_variables: list[dict[str, Any]] = field(default_factory=list)
+    env_secrets: list[dict[str, Any]] = field(default_factory=list)
+    env_variables: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _fetch_actions_for_repo(
+    repo_name: str,
+    organization: str,
+    github_api_key: str,
+    github_url: str,
+) -> _RepoActionsData:
+    """
+    Fetch and transform all Actions data for a single repo.
+    Returns a _RepoActionsData bundle; no Neo4j writes are performed here.
+    """
+    data = _RepoActionsData(repo_name=repo_name)
+
+    # Workflows
+    workflows = get_repo_workflows(github_api_key, github_url, organization, repo_name)
+    if workflows:
+        transformed_workflows = transform_workflows(workflows, organization, repo_name)
+        for wf in transformed_workflows:
+            content = None
+            workflow_path = wf.get("path")
+            if workflow_path:
+                content = get_workflow_content(
+                    github_api_key,
+                    github_url,
+                    organization,
+                    repo_name,
+                    workflow_path,
+                )
+            parsed = parse_workflow_yaml(content) if content else None
+            enriched_wf = enrich_workflow_with_parsed_content(
+                wf,
+                parsed,
+                organization,
+                repo_name,
+            )
+            data.enriched_workflows.append(enriched_wf)
+            if parsed and wf.get("id") is not None:
+                data.repo_actions.extend(
+                    transform_actions(parsed, wf["id"], organization, repo_name)
+                )
+
+    # Environments
+    environments = get_repo_environments(
+        github_api_key,
+        github_url,
+        organization,
+        repo_name,
+    )
+    if environments:
+        data.transformed_environments = transform_environments(
+            environments,
+            organization,
+            repo_name,
+        )
+
+    # Repo secrets and variables
+    repo_secrets = get_repo_secrets(github_api_key, github_url, organization, repo_name)
+    if repo_secrets:
+        data.transformed_repo_secrets = transform_repo_secrets(
+            repo_secrets,
+            organization,
+            repo_name,
+        )
+
+    repo_variables = get_repo_variables(
+        github_api_key,
+        github_url,
+        organization,
+        repo_name,
+    )
+    if repo_variables:
+        data.transformed_repo_variables = transform_repo_variables(
+            repo_variables,
+            organization,
+            repo_name,
+        )
+
+    # Environment-level secrets and variables
+    for env in environments or []:
+        env_name = env["name"]
+        env_id = env["id"]
+
+        env_s = get_env_secrets(
+            github_api_key,
+            github_url,
+            organization,
+            repo_name,
+            env_name,
+        )
+        if env_s:
+            data.env_secrets.extend(
+                transform_env_secrets(env_s, organization, repo_name, env_name, env_id)
+            )
+
+        env_v = get_env_variables(
+            github_api_key,
+            github_url,
+            organization,
+            repo_name,
+            env_name,
+        )
+        if env_v:
+            data.env_variables.extend(
+                transform_env_variables(
+                    env_v, organization, repo_name, env_name, env_id
+                )
+            )
+
+    return data
+
+
 @timeit
 def sync(
     neo4j_session: neo4j.Session,
@@ -782,130 +911,36 @@ def sync(
     logger.info(f"Syncing GitHub Actions for {len(repo_names)} repositories")
 
     for repo_name in repo_names:
-        # Sync workflows
-        workflows = get_repo_workflows(
-            github_api_key, github_url, organization, repo_name
+        # Fetch and transform all Actions data for this repo (no writes), then
+        # load sequentially on this thread.
+        d = _fetch_actions_for_repo(
+            repo_name,
+            organization,
+            github_api_key,
+            github_url,
         )
-        if workflows:
-            transformed_workflows = transform_workflows(
-                workflows, organization, repo_name
-            )
 
-            # Fetch and parse workflow content for each workflow
-            repo_actions: list[dict[str, Any]] = []
-            enriched_workflows = []
-
-            for wf in transformed_workflows:
-                workflow_path = wf.get("path")
-                workflow_id = wf.get("id")
-
-                # Fetch workflow YAML content
-                content = None
-                if workflow_path:
-                    content = get_workflow_content(
-                        github_api_key,
-                        github_url,
-                        organization,
-                        repo_name,
-                        workflow_path,
-                    )
-
-                # Parse the workflow content
-                parsed = None
-                if content:
-                    parsed = parse_workflow_yaml(content)
-
-                # Enrich workflow with parsed data
-                enriched_wf = enrich_workflow_with_parsed_content(
-                    wf, parsed, organization, repo_name
-                )
-                enriched_workflows.append(enriched_wf)
-
-                # Extract actions for loading
-                if parsed and workflow_id is not None:
-                    actions = transform_actions(
-                        parsed, workflow_id, organization, repo_name
-                    )
-                    repo_actions.extend(actions)
-
-            # Load enriched workflows
-            load_workflows(neo4j_session, enriched_workflows, update_tag, org_url)
-            all_workflows.extend(enriched_workflows)
-
-            # Load actions
-            if repo_actions:
-                load_actions(neo4j_session, repo_actions, update_tag, org_url)
-
-        # Sync environments (must come before env secrets/variables)
-        environments = get_repo_environments(
-            github_api_key, github_url, organization, repo_name
-        )
-        if environments:
-            transformed_environments = transform_environments(
-                environments, organization, repo_name
-            )
+        if d.enriched_workflows:
+            load_workflows(neo4j_session, d.enriched_workflows, update_tag, org_url)
+            all_workflows.extend(d.enriched_workflows)
+        if d.repo_actions:
+            load_actions(neo4j_session, d.repo_actions, update_tag, org_url)
+        if d.transformed_environments:
             load_environments(
-                neo4j_session, transformed_environments, update_tag, org_url
+                neo4j_session, d.transformed_environments, update_tag, org_url
             )
-
-        # Sync repo-level secrets
-        repo_secrets = get_repo_secrets(
-            github_api_key, github_url, organization, repo_name
-        )
-        if repo_secrets:
-            transformed_repo_secrets = transform_repo_secrets(
-                repo_secrets, organization, repo_name
-            )
+        if d.transformed_repo_secrets:
             load_repo_secrets(
-                neo4j_session, transformed_repo_secrets, update_tag, org_url
+                neo4j_session, d.transformed_repo_secrets, update_tag, org_url
             )
-
-        # Sync repo-level variables
-        repo_variables = get_repo_variables(
-            github_api_key, github_url, organization, repo_name
-        )
-        if repo_variables:
-            transformed_repo_variables = transform_repo_variables(
-                repo_variables, organization, repo_name
-            )
+        if d.transformed_repo_variables:
             load_repo_variables(
-                neo4j_session, transformed_repo_variables, update_tag, org_url
+                neo4j_session, d.transformed_repo_variables, update_tag, org_url
             )
-
-        # 3. Sync environment-level secrets and variables
-        for env in environments or []:
-            env_name = env["name"]
-            env_id = env["id"]
-
-            env_secrets = get_env_secrets(
-                github_api_key, github_url, organization, repo_name, env_name
-            )
-            if env_secrets:
-                transformed_env_secrets = transform_env_secrets(
-                    env_secrets,
-                    organization,
-                    repo_name,
-                    env_name,
-                    env_id,
-                )
-                load_env_secrets(
-                    neo4j_session, transformed_env_secrets, update_tag, org_url
-                )
-
-            env_variables = get_env_variables(
-                github_api_key, github_url, organization, repo_name, env_name
-            )
-            if env_variables:
-                transformed_env_variables = transform_env_variables(
-                    env_variables,
-                    organization,
-                    repo_name,
-                    env_name,
-                    env_id,
-                )
-                load_env_variables(
-                    neo4j_session, transformed_env_variables, update_tag, org_url
-                )
+        if d.env_secrets:
+            load_env_secrets(neo4j_session, d.env_secrets, update_tag, org_url)
+        if d.env_variables:
+            load_env_variables(neo4j_session, d.env_variables, update_tag, org_url)
 
     # 4. Cleanup all stale nodes scoped to the organization. Repo-level secrets
     # and variables are now scoped to the org as well, so cleanup_org_level

--- a/cartography/intel/github/repos.py
+++ b/cartography/intel/github/repos.py
@@ -3,10 +3,13 @@ import hashlib
 import json
 import logging
 import random
+import threading
 import time
 from collections import defaultdict
 from collections import namedtuple
 from collections.abc import Callable
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any
 from typing import cast
@@ -60,6 +63,8 @@ from cartography.models.github.rulesets import GitHubRulesetSchema
 from cartography.util import retries_with_backoff
 from cartography.util import run_analysis_job
 from cartography.util import timeit
+from cartography.util import to_asynchronous
+from cartography.util import to_synchronous
 
 logger = logging.getLogger(__name__)
 
@@ -578,11 +583,70 @@ def _get_repo_dep_manifests(
     return manifests, cleanup_safe
 
 
+def _fetch_manifests_for_repo(
+    repo: dict[str, Any],
+    org: str,
+    api_url: str,
+    token: str,
+    org_wide_forbidden: threading.Event,
+) -> tuple[str, list[Any], bool, str | None, bool]:
+    """
+    Fetch dependency graph manifests for a single repo.
+
+    Returns (repo_url, manifests, cleanup_safe, forbidden_message, not_attempted).
+    Designed to be called from worker threads via ThreadPoolExecutor.
+
+    Preserves master's org-wide-forbidden optimization under parallelism via the
+    shared ``org_wide_forbidden`` event: once any worker observes an org-wide
+    forbidden error it sets the event, and every not-yet-started worker returns
+    immediately with ``not_attempted=True`` without spending a GraphQL request
+    (ticket 09 decision). In-flight requests still drain (fail-with-drain,
+    ticket 04); we never eagerly cancel. At parallel_workers == 1 this reduces
+    to master's original early-exit — the single worker sees the event it just
+    set on the next repo and stops fetching.
+    """
+    repo_name = repo.get("name")
+    repo_url = repo.get("url", "")
+
+    if org_wide_forbidden.is_set():
+        # Every remaining repo would spend a GraphQL request only to be refused
+        # too, so short-circuit without hitting the API.
+        return repo_url, [], False, None, True
+
+    try:
+        manifests, repo_cleanup_safe = _get_repo_dep_manifests(
+            token,
+            api_url,
+            org,
+            str(repo_name),
+        )
+        if manifests:
+            logger.debug(
+                "Fetched %d dependency manifests for repo %s.",
+                len(manifests),
+                repo_name,
+            )
+        return repo_url, manifests, repo_cleanup_safe, None, False
+    except DependencyGraphForbiddenError as err:
+        message = str(err)
+        if _is_org_wide_forbidden(message):
+            org_wide_forbidden.set()
+        return repo_url, [], False, message, False
+    except requests.exceptions.RequestException:
+        logger.warning(
+            "Failed to fetch dependency manifests for repo %s; skipping.",
+            repo_name,
+            exc_info=True,
+        )
+        return repo_url, [], False, None, False
+
+
 def _get_dep_manifests_for_repos(
     repo_raw_data: list[dict[str, Any] | None],
     org: str,
     api_url: str,
     token: str,
+    parallel_workers: int = 1,
 ) -> tuple[dict[str, dict[str, Any]], bool]:
     """
     For every repo in the given list, retrieve its dependency graph manifests individually.
@@ -592,65 +656,60 @@ def _get_dep_manifests_for_repos(
     :param org: The name of the target Github organization as string.
     :param api_url: The Github v4 API endpoint as string.
     :param token: The Github API token as string.
+    :param parallel_workers: Number of repos to fetch concurrently. Default 1 (sequential).
     :return: A tuple of repo URL to dependencyGraphManifests structure and
         whether manifest cleanup is safe.
     """
     logger.info(
-        "Fetching dependency graph manifests for %d repos in org %s.",
+        "Fetching dependency graph manifests for %d repos in org %s (parallel_workers=%d).",
         len(repo_raw_data),
         org,
+        parallel_workers,
     )
+    eligible = [
+        repo
+        for repo in repo_raw_data
+        if repo is not None and repo.get("name") and repo.get("url")
+    ]
+
     result: dict[str, dict[str, Any]] = {}
     failed_count = 0
     forbidden_count = 0
     forbidden_message: str | None = None
-    org_wide_forbidden = False
     not_attempted_count = 0
     cleanup_safe = True
 
-    for index, repo in enumerate(repo_raw_data):
-        if repo is None:
-            continue
-        repo_name = repo.get("name")
-        repo_url = repo.get("url")
-        if not repo_name or not repo_url:
-            continue
+    # Shared across workers: once an org-wide forbidden error is seen, peers
+    # short-circuit instead of spending quota. See _fetch_manifests_for_repo.
+    org_wide_forbidden = threading.Event()
 
-        try:
-            manifests, repo_cleanup_safe = _get_repo_dep_manifests(
-                token,
-                api_url,
+    with ThreadPoolExecutor(max_workers=parallel_workers) as executor:
+        futures = {
+            executor.submit(
+                _fetch_manifests_for_repo,
+                repo,
                 org,
-                repo_name,
-            )
+                api_url,
+                token,
+                org_wide_forbidden,
+            ): repo
+            for repo in eligible
+        }
+        for f in as_completed(futures):
+            repo_url, manifests, repo_cleanup_safe, message, not_attempted = f.result()
             cleanup_safe = cleanup_safe and repo_cleanup_safe
+            if not_attempted:
+                not_attempted_count += 1
+                continue
+            if message is not None:
+                forbidden_count += 1
+                forbidden_message = message
+            elif not repo_cleanup_safe:
+                failed_count += 1
             if manifests:
                 result[repo_url] = {"nodes": manifests}
-                logger.debug(
-                    "Fetched %d dependency manifests for repo %s.",
-                    len(manifests),
-                    repo_name,
-                )
-        except DependencyGraphForbiddenError as err:
-            forbidden_count += 1
-            forbidden_message = str(err)
-            cleanup_safe = False
-            if _is_org_wide_forbidden(forbidden_message):
-                # Every remaining repo would spend a GraphQL request only to be
-                # refused too, so stop and report what we did not attempt.
-                org_wide_forbidden = True
-                not_attempted_count = len(repo_raw_data) - index - 1
-                break
-        except requests.exceptions.RequestException:
-            failed_count += 1
-            cleanup_safe = False
-            logger.warning(
-                "Failed to fetch dependency manifests for repo %s; skipping.",
-                repo_name,
-                exc_info=True,
-            )
 
-    if org_wide_forbidden:
+    if org_wide_forbidden.is_set():
         logger.warning(
             "GitHub refused the dependency graph for org %s with an org-wide IP allow "
             "list error: %s. No retry can succeed, so the remaining %d of %d repos in "
@@ -681,68 +740,120 @@ def _get_dep_manifests_for_repos(
     return result, cleanup_safe
 
 
+def _fetch_collaborators_for_repo(
+    repo: dict[str, Any],
+    org: str,
+    api_url: str,
+    token: str,
+    affiliation: str,
+) -> tuple[str, list[UserAffiliationAndRepoPermission]]:
+    """
+    Fetch collaborators for a single repo.
+    Returns (repo_url, collabs_list).
+    Designed to be called from worker threads via ThreadPoolExecutor.
+    """
+    repo_name = repo["name"]
+    repo_url = repo["url"]
+
+    # Guard against None when collaborator fields are not accessible due to permissions.
+    direct_info = repo.get("directCollaborators")
+    outside_info = repo.get("outsideCollaborators")
+
+    if affiliation == "OUTSIDE":
+        total_outside = 0 if not outside_info else outside_info.get("totalCount", 0)
+        if total_outside == 0:
+            # No outside collaborators or not permitted to view; skip API calls.
+            return repo_url, []
+    else:  # DIRECT
+        total_direct = 0 if not direct_info else direct_info.get("totalCount", 0)
+        if total_direct == 0:
+            # No direct collaborators or not permitted to view; skip API calls.
+            return repo_url, []
+
+    logger.info("Loading %s collaborators for repo %s.", affiliation, repo_name)
+    collaborators = _get_repo_collaborators(token, api_url, org, repo_name, affiliation)
+
+    collab_users: List[dict[str, Any]] = []
+    collab_permission: List[str] = []
+
+    # nodes and edges are expected to always be present given that we only call for them if totalCount is > 0
+    # however sometimes GitHub returns None, as in issue 1334 and 1404.
+    for collab in collaborators.nodes or []:
+        collab_users.append(collab)
+
+    # The `or []` is because `.edges` can be None.
+    for perm in collaborators.edges or []:
+        collab_permission.append(perm["permission"])
+
+    return repo_url, [
+        UserAffiliationAndRepoPermission(user, permission, affiliation)
+        for user, permission in zip(collab_users, collab_permission)
+    ]
+
+
 def _get_repo_collaborators_inner_func(
     org: str,
     api_url: str,
     token: str,
     repo_raw_data: list[dict[str, Any] | None],
     affiliation: str,
+    parallel_workers: int = 1,
 ) -> dict[str, list[UserAffiliationAndRepoPermission]]:
     result: dict[str, list[UserAffiliationAndRepoPermission]] = {}
 
-    for repo in repo_raw_data:
-        # GitHub can return null repo entries. See issues #1334 and #1404.
-        if repo is None:
-            logger.info(
-                "Skipping null repository entry while fetching %s collaborators.",
-                affiliation,
-            )
-            continue
-        repo_name = repo["name"]
-        repo_url = repo["url"]
-
-        # Guard against None when collaborator fields are not accessible due to permissions.
-        direct_info = repo.get("directCollaborators")
-        outside_info = repo.get("outsideCollaborators")
-
-        if affiliation == "OUTSIDE":
-            total_outside = 0 if not outside_info else outside_info.get("totalCount", 0)
-            if total_outside == 0:
-                # No outside collaborators or not permitted to view; skip API calls for this repo.
-                result[repo_url] = []
-                continue
-        else:  # DIRECT
-            total_direct = 0 if not direct_info else direct_info.get("totalCount", 0)
-            if total_direct == 0:
-                # No direct collaborators or not permitted to view; skip API calls for this repo.
-                result[repo_url] = []
-                continue
-
-        logger.info(f"Loading {affiliation} collaborators for repo {repo_name}.")
-        collaborators = _get_repo_collaborators(
-            token,
-            api_url,
-            org,
-            repo_name,
+    eligible = [
+        repo
+        for repo in repo_raw_data
+        if repo is not None and repo.get("name") and repo.get("url")
+    ]
+    skipped_null = len(repo_raw_data) - len([r for r in repo_raw_data if r is not None])
+    if skipped_null:
+        logger.info(
+            "Skipping %d null repository entries while fetching %s collaborators.",
+            skipped_null,
             affiliation,
         )
 
-        collab_users: List[dict[str, Any]] = []
-        collab_permission: List[str] = []
+    logger.info(
+        "Fetching %s collaborators for %d repos in org %s (parallel_workers=%d).",
+        affiliation,
+        len(eligible),
+        org,
+        parallel_workers,
+    )
 
-        # nodes and edges are expected to always be present given that we only call for them if totalCount is > 0
-        # however sometimes GitHub returns None, as in issue 1334 and 1404.
-        for collab in collaborators.nodes or []:
-            collab_users.append(collab)
+    total = len(eligible)
+    completed = 0
 
-        # The `or []` is because `.edges` can be None.
-        for perm in collaborators.edges or []:
-            collab_permission.append(perm["permission"])
+    with ThreadPoolExecutor(max_workers=parallel_workers) as executor:
+        futures = {
+            executor.submit(
+                _fetch_collaborators_for_repo,
+                repo,
+                org,
+                api_url,
+                token,
+                affiliation,
+            ): repo
+            for repo in eligible
+        }
+        for f in as_completed(futures):
+            repo_url, collabs = f.result()
+            result[repo_url] = collabs
+            completed += 1
+            if (
+                completed == 1
+                or completed % max(1, parallel_workers) == 0
+                or completed == total
+            ):
+                logger.info(
+                    "Collaborators (%s) progress for org %s: %d/%d repos completed.",
+                    affiliation,
+                    org,
+                    completed,
+                    total,
+                )
 
-        result[repo_url] = [
-            UserAffiliationAndRepoPermission(user, permission, affiliation)
-            for user, permission in zip(collab_users, collab_permission)
-        ]
     return result
 
 
@@ -752,6 +863,7 @@ def _get_repo_collaborators_for_multiple_repos(
     org: str,
     api_url: str,
     token: str,
+    parallel_workers: int = 1,
 ) -> dict[str, list[UserAffiliationAndRepoPermission]]:
     """
     For every repo in the given list, retrieve the collaborators.
@@ -761,6 +873,7 @@ def _get_repo_collaborators_for_multiple_repos(
     :param org: The name of the target Github organization as string.
     :param api_url: The Github v4 API endpoint as string.
     :param token: The Github API token as string.
+    :param parallel_workers: Number of repos to fetch concurrently. Default 1 (sequential).
     :return: A dictionary of repo URL to list of UserAffiliationAndRepoPermission
     """
     logger.info(
@@ -778,6 +891,7 @@ def _get_repo_collaborators_for_multiple_repos(
         token=token,
         repo_raw_data=repo_raw_data,
         affiliation=affiliation,
+        parallel_workers=parallel_workers,
     )
     return result
 
@@ -930,54 +1044,114 @@ def _rest_ruleset_cache_key(ruleset: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
+def _fetch_rulesets_for_repo(
+    repo: dict[str, Any],
+    token: str,
+    base_url: str,
+    owner: str,
+    cache: dict[tuple[Any, ...], dict[str, Any]],
+    cache_lock: threading.Lock,
+) -> tuple[str, dict[str, Any]]:
+    """
+    Fetch rulesets for a single repo via REST.
+    Returns (repo_url, rulesets_dict).
+    Designed to be called from worker threads via ThreadPoolExecutor.
+    The cache and its lock are shared across workers to de-duplicate org-level
+    ruleset detail fetches.
+    """
+    repo_name = repo.get("name", "")
+    repo_url = repo.get("url", "")
+    encoded_repo_name = quote(repo_name, safe="")
+    endpoint = f"/repos/{owner}/{encoded_repo_name}/rulesets"
+    ruleset_summaries = fetch_all_rest_api_pages(
+        token,
+        base_url,
+        endpoint,
+        result_key="rulesets",
+        raise_on_status=(403, 404),
+        params={"per_page": 100, "includes_parents": "true"},
+    )
+    normalized_rulesets = []
+    for ruleset_summary in ruleset_summaries:
+        cache_key = _rest_ruleset_cache_key(ruleset_summary)
+        with cache_lock:
+            ruleset_detail = cache.get(cache_key)
+        if ruleset_detail is None:
+            ruleset_detail = call_github_rest_api(
+                f"{endpoint}/{ruleset_summary['id']}",
+                token,
+                base_url,
+                params={"includes_parents": "true"},
+            )
+            with cache_lock:
+                cache[cache_key] = ruleset_detail
+        normalized_rulesets.append(_normalize_rest_ruleset(ruleset_detail))
+    return repo_url, {
+        "nodes": normalized_rulesets,
+        "totalCount": len(normalized_rulesets),
+    }
+
+
 def _get_repo_rulesets_by_url(
     token: str,
     api_url: str,
     organization: str,
     repo_raw_data: list[dict[str, Any] | None],
+    parallel_workers: int = 1,
 ) -> dict[str, dict[str, Any]]:
     """
     Retrieve full GitHub repository rulesets through REST for every repo.
+    :param parallel_workers: Number of repos to fetch concurrently. Default 1 (sequential).
     """
     base_url = rest_api_base_url(api_url)
     owner = quote(organization, safe="")
     rulesets_by_url: dict[str, dict[str, Any]] = {}
     ruleset_detail_cache: dict[tuple[Any, ...], dict[str, Any]] = {}
+    cache_lock = threading.Lock()
 
-    for repo in repo_raw_data:
-        if repo is None:
-            continue
-        repo_name = repo.get("name")
-        repo_url = repo.get("url")
-        if not repo_name or not repo_url:
-            continue
-        encoded_repo_name = quote(repo_name, safe="")
-        endpoint = f"/repos/{owner}/{encoded_repo_name}/rulesets"
-        ruleset_summaries = fetch_all_rest_api_pages(
-            token,
-            base_url,
-            endpoint,
-            result_key="rulesets",
-            raise_on_status=(403, 404),
-            params={"per_page": 100, "includes_parents": "true"},
-        )
-        normalized_rulesets = []
-        for ruleset_summary in ruleset_summaries:
-            cache_key = _rest_ruleset_cache_key(ruleset_summary)
-            ruleset_detail = ruleset_detail_cache.get(cache_key)
-            if ruleset_detail is None:
-                ruleset_detail = call_github_rest_api(
-                    f"{endpoint}/{ruleset_summary['id']}",
-                    token,
-                    base_url,
-                    params={"includes_parents": "true"},
-                )
-                ruleset_detail_cache[cache_key] = ruleset_detail
-            normalized_rulesets.append(_normalize_rest_ruleset(ruleset_detail))
-        rulesets_by_url[repo_url] = {
-            "nodes": normalized_rulesets,
-            "totalCount": len(normalized_rulesets),
+    eligible = [
+        repo
+        for repo in repo_raw_data
+        if repo is not None and repo.get("name") and repo.get("url")
+    ]
+    logger.info(
+        "Fetching rulesets for %d repos in org %s (parallel_workers=%d).",
+        len(eligible),
+        organization,
+        parallel_workers,
+    )
+
+    total = len(eligible)
+    completed = 0
+
+    with ThreadPoolExecutor(max_workers=parallel_workers) as executor:
+        futures = {
+            executor.submit(
+                _fetch_rulesets_for_repo,
+                repo,
+                token,
+                base_url,
+                owner,
+                ruleset_detail_cache,
+                cache_lock,
+            ): repo
+            for repo in eligible
         }
+        for f in as_completed(futures):
+            repo_url, rulesets_dict = f.result()
+            rulesets_by_url[repo_url] = rulesets_dict
+            completed += 1
+            if (
+                completed == 1
+                or completed % max(1, parallel_workers) == 0
+                or completed == total
+            ):
+                logger.info(
+                    "Rulesets progress for org %s: %d/%d repos completed.",
+                    organization,
+                    completed,
+                    total,
+                )
 
     return rulesets_by_url
 
@@ -1040,6 +1214,7 @@ def get_repo_privileged_details_by_url(
     token: str,
     api_url: str,
     organization: str,
+    parallel_workers: int = 1,
 ) -> Dict[str, Dict[str, Any]]:
     """
     Retrieve collaborator counts, branch protection, and ruleset fields for repositories in an organization.
@@ -1059,6 +1234,7 @@ def get_repo_privileged_details_by_url(
         api_url,
         organization,
         privileged_nodes,
+        parallel_workers=parallel_workers,
     )
     for repo in privileged_nodes:
         # GitHub can return null repository entries.
@@ -2670,6 +2846,7 @@ def sync(
     github_api_key: str,
     github_url: str,
     organization: str,
+    parallel_workers: int = 1,
 ) -> GitHubRepoSyncResult:
     """
     Performs the sequential tasks to collect, transform, and sync github data
@@ -2678,6 +2855,7 @@ def sync(
     :param github_api_key: The API key to access the GitHub v4 API
     :param github_url: The URL for the GitHub v4 endpoint to use
     :param organization: The organization to query GitHub for
+    :param parallel_workers: Number of parallel workers for per-repo API fetches. Default 1 (sequential).
     :return: Repository and dependency manifest data fetched for this org.
     """
     logger.info("Syncing GitHub repos")
@@ -2692,6 +2870,7 @@ def sync(
                 github_api_key,
                 github_url,
                 organization,
+                parallel_workers=parallel_workers,
             )
         except (requests.exceptions.RequestException, ValueError):
             rulesets_cleanup_safe = False
@@ -2719,24 +2898,51 @@ def sync(
     direct_collabs: dict[str, list[UserAffiliationAndRepoPermission]] = {}
     outside_collabs: dict[str, list[UserAffiliationAndRepoPermission]] = {}
     try:
-        direct_collabs = _get_repo_collaborators_for_multiple_repos(
-            repos_json,
-            "DIRECT",
-            organization,
-            github_url,
-            github_api_key,
-        )
-        outside_collabs = _get_repo_collaborators_for_multiple_repos(
-            repos_json,
-            "OUTSIDE",
-            organization,
-            github_url,
-            github_api_key,
-        )
-    except TypeError:
-        # due to permission errors or transient network error or some other nonsense
+        if parallel_workers > 1:
+            logger.info(
+                "Fetching DIRECT and OUTSIDE collaborators concurrently for org %s.",
+                organization,
+            )
+            direct_collabs, outside_collabs = to_synchronous(
+                to_asynchronous(
+                    _get_repo_collaborators_for_multiple_repos,
+                    repos_json,
+                    "DIRECT",
+                    organization,
+                    github_url,
+                    github_api_key,
+                    parallel_workers,
+                ),
+                to_asynchronous(
+                    _get_repo_collaborators_for_multiple_repos,
+                    repos_json,
+                    "OUTSIDE",
+                    organization,
+                    github_url,
+                    github_api_key,
+                    parallel_workers,
+                ),
+            )
+        else:
+            direct_collabs = _get_repo_collaborators_for_multiple_repos(
+                repos_json,
+                "DIRECT",
+                organization,
+                github_url,
+                github_api_key,
+            )
+            outside_collabs = _get_repo_collaborators_for_multiple_repos(
+                repos_json,
+                "OUTSIDE",
+                organization,
+                github_url,
+                github_api_key,
+            )
+    except (TypeError, ValueError):
+        # TypeError: permission errors or transient network issues
+        # ValueError: fetch_all raises this when all retries are exhausted (e.g. repeated timeouts)
         logger.warning(
-            "Unable to list repo collaborators due to permission errors; continuing on.",
+            "Unable to list repo collaborators due to permission errors or exhausted retries; continuing on.",
             exc_info=True,
         )
 
@@ -2746,6 +2952,7 @@ def sync(
         organization,
         github_url,
         github_api_key,
+        parallel_workers=parallel_workers,
     )
     for repo in repos_json:
         if repo is not None and repo.get("url") in dep_manifests_by_url:

--- a/tests/unit/cartography/intel/github/test_repos.py
+++ b/tests/unit/cartography/intel/github/test_repos.py
@@ -850,6 +850,93 @@ def test_get_dep_manifests_for_repos_stops_the_org_on_ip_allow_list_forbidden(ca
     assert "Skipped dependency manifests" not in caplog.text
 
 
+def test_get_dep_manifests_for_repos_parallel_fetches_all_repos():
+    """
+    With parallel_workers > 1 every eligible repo is still fetched exactly once
+    and its manifests land in the result, regardless of completion order.
+    """
+    # Arrange
+    manifests = [{"blobPath": "/package.json", "dependencies": {"nodes": []}}]
+    repos = [
+        {"name": f"repo-{i}", "url": f"https://github.com/test-org/repo-{i}"}
+        for i in range(6)
+    ]
+    with patch.object(
+        cartography.intel.github.repos,
+        "_get_repo_dep_manifests",
+        return_value=(manifests, True),
+    ) as mock_get_repo_dep_manifests:
+        # Act
+        result, cleanup_safe = (
+            cartography.intel.github.repos._get_dep_manifests_for_repos(
+                repos,
+                "test-org",
+                "https://api.github.com/graphql",
+                "token",
+                parallel_workers=4,
+            )
+        )
+
+    # Assert
+    assert mock_get_repo_dep_manifests.call_count == 6
+    assert result == {
+        f"https://github.com/test-org/repo-{i}": {"nodes": manifests} for i in range(6)
+    }
+    assert cleanup_safe is True
+
+
+def test_get_dep_manifests_for_repos_parallel_org_forbidden_short_circuits():
+    """
+    Under parallel_workers > 1 an org-wide IP-allow-list refusal sets the shared
+    flag so not-yet-started workers short-circuit without spending a GraphQL
+    request. The exact number of skipped repos is nondeterministic (it depends on
+    how many workers were already in flight), but cleanup must be unsafe and at
+    least one repo must be spared the doomed fetch.
+    """
+    # Arrange
+    manifests = [{"blobPath": "/package.json", "dependencies": {"nodes": []}}]
+    repos = [
+        {"name": f"repo-{i}", "url": f"https://github.com/test-org/repo-{i}"}
+        for i in range(20)
+    ]
+    org_forbidden = DependencyGraphForbiddenError(
+        "Although you appear to have the correct authorization credentials, "
+        "the `test-org` organization has an IP allow list enabled, and "
+        "203.0.113.1 is not permitted to access this resource.",
+    )
+
+    def side_effect(token, api_url, org, repo_name):
+        # The very first repo triggers the org-wide refusal; the shared flag then
+        # spares later, not-yet-started workers.
+        if repo_name == "repo-0":
+            raise org_forbidden
+        return (manifests, True)
+
+    with patch.object(
+        cartography.intel.github.repos,
+        "_get_repo_dep_manifests",
+        side_effect=side_effect,
+    ) as mock_get_repo_dep_manifests:
+        # Act
+        result, cleanup_safe = (
+            cartography.intel.github.repos._get_dep_manifests_for_repos(
+                repos,
+                "test-org",
+                "https://api.github.com/graphql",
+                "token",
+                parallel_workers=2,
+            )
+        )
+
+    # Assert
+    # At least one repo must have been short-circuited (never fetched).
+    assert mock_get_repo_dep_manifests.call_count < 20
+    assert mock_get_repo_dep_manifests.call_count >= 1
+    assert cleanup_safe is False
+    # No spurious manifests recorded for the forbidden repo.
+    assert "https://github.com/test-org/repo-0" not in result
+
+
 def test_enrich_dependencies_with_lockfile_versions():
     """
     Range-only deps present in the repo lockfile are upgraded to exact versions
@@ -1741,6 +1828,7 @@ def test_sync_continues_when_privileged_fetch_fails(
         "token",
         "https://api.github.com/graphql",
         "example-org",
+        parallel_workers=1,
     )
     assert mock_get_repo_collaborators.call_count == 2
     mock_load.assert_called_once()


### PR DESCRIPTION
### Type of change

- [x] New feature (non-breaking change that adds functionality)

### Summary

Adds opt-in per-repo parallelism to the GitHub intel module. A new
`--github-parallel-workers` CLI flag (default **1**, i.e. fully sequential and
byte-for-byte equivalent to today's behavior) fans the slow per-repo API
fetches — dependency-graph manifests, collaborators, and rulesets in `repos.py`,
and workflows/environments/secrets/variables in `actions.py` — across a bounded
`ThreadPoolExecutor`. Every Neo4j write stays on the main thread: workers only
fetch and transform, and results are loaded sequentially as each future
completes. This shortens wall-clock time on large orgs (which are dominated by
per-repo API round-trips) without changing the graph output.

This is the third of three PRs carved from #3057, per the reviewer's request to
split it into (1) the `fetch_all` retry fix, (2) incremental sync, and
(3) parallel workers. It is built on the shared refactor that extracted the
per-repo Actions fetch/load into `_fetch_actions_for_repo()` (also carried by
the incremental-sync PR); the only overlap between the two is the `__init__.py`
call sites.

**Design decisions (raised for discussion, as the reviewer requested):**

- **API quotas.** Workers share GitHub's per-token *global* quota; parallelism
  speeds spend, it does not raise the ceiling. `handle_rate_limit_sleep` runs
  per-worker against the shared bucket, so overshoot is bounded to at most one
  in-flight request per worker. Orgs sync sequentially, so quota is not
  compounded across orgs — but total spend is N× per run for N orgs sharing a
  token. Default 1 keeps this fully opt-in. No shared cross-worker token bucket
  is added here (possible follow-up).
- **Cancellation.** Fail-with-drain: drive loops use
  `with ThreadPoolExecutor(...)` + `as_completed`; a worker exception re-raises
  from `f.result()` and `shutdown(wait=True)` drains in-flight requests (each
  bounded by the request timeout) before surfacing. No eager `future.cancel()`;
  queued-but-unstarted work does not run. Matches the sequential path's
  per-phase all-or-nothing semantics.
- **Nested concurrency.** Bounded per phase at `parallel_workers`, **except**
  the collaborators phase, which runs DIRECT + OUTSIDE affiliations concurrently
  when `parallel_workers > 1`, each opening its own pool → that phase peaks at
  **2 × parallel_workers**. `fetch_all` pagination stays sequential within a
  worker. Because orgs sync sequentially, `parallel_workers` (2× in
  collaborators) is the process-wide ceiling for CLI runs. Flagged as a known
  wrinkle rather than "fixed".
- **Caller-controlled pool.** Not added in v1: the module owns its own pool,
  configured by a single int. **Known limitation:** a *library* embedder that
  runs orgs or modules concurrently in its own threads would multiply
  concurrency beyond `parallel_workers` (the CLI's sequential-org driver is what
  keeps `parallel_workers` the true ceiling). That is the concrete scenario
  where an injected executor / global concurrency budget would be warranted;
  happy to add it if reviewers prefer.

**Interaction with master's org-wide dependency-graph-forbidden handling.**
`master` short-circuits the whole org's dependency-manifest fetch when GitHub
returns an org-wide IP-allow-list refusal (walking the rest only spends a
GraphQL request per repo to be refused again). That sequential early-`break`
does not translate to a pre-submitted thread pool, and fail-with-drain rules out
eager cancellation. It is preserved via a shared `threading.Event`: the first
worker to see an org-wide refusal sets the flag, and every not-yet-started
worker returns immediately without spending quota. In-flight requests still
drain. At the default `parallel_workers=1` this reduces exactly to master's
original early exit.

### Related issues or links

- Split out of #3057.

### Breaking changes

None. `--github-parallel-workers` defaults to 1; existing behavior is unchanged.

### How was this tested?

- `make test_lint` (black/flake8/mypy) clean on the changed files.
- Unit: full GitHub unit suite green (164 tests), including new coverage for the
  parallel dependency-manifest fetch and the org-wide-forbidden shared-flag
  short-circuit.
- Integration (Neo4j testcontainer): full GitHub integration suite green
  (50 tests).

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

### Notes for reviewers

Focus areas: (1) the shared-`Event` org-wide-forbidden short-circuit in
`_get_dep_manifests_for_repos`, and (2) the 2× collaborators nesting. The
default of 1 makes the whole feature opt-in, so the risk surface is only
exercised when an operator raises the worker count.
