### PR TITLE
feat(introspection): expose inherited materialized ontology relationships

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,12 @@ PropertyRef("field_list", one_to_many=True)        # One-to-many relationships
 - Ensure `__init__.py` files exist in all module directories
 - Look at `tests/integration/cartography/intel/` for similar test patterns
 - Review `cartography/models/` for existing relationship patterns
+- For concrete node schema views (docs, autocomplete, agents), use
+  `DataModel.relationships_for_node(label)`. It projects materialized ontology
+  edges onto concretes that carry semantic labels (for example
+  `AWSECSContainer` inherits `RESOLVED_IMAGE` → `Image`). Do **not** treat
+  `ontology_relationship_constraints` as expected edges; those are
+  validation-only name/direction rules and are not inherited onto concretes.
 
 **Manual Write Queries:**
 - Prefer `load()` / `load_matchlinks()` for normal ingestion and `GraphJob` for cleanup.

--- a/cartography/models/introspection.py
+++ b/cartography/models/introspection.py
@@ -600,7 +600,10 @@ def relationships_for_node(
     if node is None:
         return ()
 
-    carried = labels_carried_by((node,))
+    # Inherit only through the primary label and ontology labels. Ordinary or
+    # compatibility extra labels must not pull in relationships declared against
+    # those aliases.
+    carried = {node.label, *node.ontology_labels}
     views: dict[tuple[str, str, LinkDirection | None], NodeRelationship] = {}
     for relationship in model.relationships:
         matches_source = relationship.source_label in carried
@@ -1126,7 +1129,12 @@ def _build_ontology_expected_edges(
                 target_label=relationship.target_label,
                 direction=relationship.direction,
                 origins=relationship.origins,
-                constrained=key in constrained_keys,
+                # RelConstraints describe outward edges only; an undirected
+                # materialized relationship does not satisfy them.
+                constrained=(
+                    key in constrained_keys
+                    and relationship.direction is LinkDirection.OUTWARD
+                ),
                 analysis_jobs=relationship.analysis_jobs,
             )
         )

--- a/cartography/models/introspection.py
+++ b/cartography/models/introspection.py
@@ -549,14 +549,19 @@ def relationships_for_module(
     other providers: several modules carry `DNSRecord`, so a one-sided match would
     document `(:DNSRecord)-[:DNS_POINTS_TO]->(:AWSEC2Instance)` on the GCP page.
 
-    Canonical ontology nodes are the documented exception. `User`, `Package` and friends
-    are defined once and link to every provider, so an edge between one of them and a
-    label the module carries belongs on the module's page even though the module never
-    declares the canonical side.
+    Ontology endpoints are the documented exception. Canonical nodes (`User`, `Package`)
+    and semantic labels (`Container`, `Image`) are defined once and link across
+    providers, so an edge between one of them and a label the module carries belongs
+    on the module's page even when the module never declares the ontology side. That
+    is what lets Kubernetes and Railway inherit ``RESOLVED_IMAGE → Image`` without
+    owning an Image concrete.
     """
     own_labels = {node.label for node in nodes}
     carried_labels = labels_carried_by(nodes)
-    canonical_labels = {node.label for node in all_nodes if "ontology" in node.modules}
+    ontology_endpoint_labels = {
+        *(node.label for node in all_nodes if "ontology" in node.modules),
+        *(label for node in all_nodes for label in node.ontology_labels),
+    }
 
     def qualifies(relationship: Relationship) -> bool:
         if module in relationship.modules:
@@ -567,7 +572,7 @@ def relationships_for_module(
         if all(endpoint in carried_labels for endpoint in endpoints):
             return True
         return any(
-            endpoint in carried_labels and other in canonical_labels
+            endpoint in carried_labels and other in ontology_endpoint_labels
             for endpoint, other in (endpoints, endpoints[::-1])
         )
 

--- a/cartography/models/introspection.py
+++ b/cartography/models/introspection.py
@@ -61,12 +61,14 @@ __all__ = [
     # Scoping one module's view
     "scope_node_to_module",
     "relationships_for_module",
+    "relationships_for_node",
     "relationship_touches_node",
     "labels_carried_by",
     # Result types
     "DataModel",
     "Node",
     "Relationship",
+    "NodeRelationship",
     "Property",
     "PropertyProvenance",
     "NodeLabelProvenance",
@@ -76,6 +78,7 @@ __all__ = [
     "RelationshipCatalogDefinition",
     "OntologySemanticLabel",
     "OntologyRelationshipConstraint",
+    "OntologyExpectedEdge",
     "ModelClass",
 ]
 
@@ -247,11 +250,58 @@ class OntologySemanticLabel:
 
 @dataclass(frozen=True)
 class OntologyRelationshipConstraint:
-    """A canonical relationship name validated between two ontology labels."""
+    """
+    A canonical relationship name validated between two ontology labels.
+
+    Constraints only govern name and direction when both endpoints carry the listed
+    ontology labels. They do not assert that the edge exists, and they are not
+    inherited onto concrete node schemas. See ``OntologyExpectedEdge`` for edges
+    that models or analysis actually materialize under ontology labels.
+    """
 
     source_label: str
     label: str
     target_label: str
+
+
+@dataclass(frozen=True)
+class OntologyExpectedEdge:
+    """
+    A relationship materialized under ontology labels.
+
+    Unlike ``OntologyRelationshipConstraint``, these edges are produced by node
+    schemas, matchlinks, analysis jobs, permission evaluation, or the runtime
+    catalog. Schema docs and autocomplete project them onto concrete nodes that
+    carry either endpoint's semantic label, keeping the far endpoint semantic.
+    """
+
+    source_label: str
+    label: str
+    target_label: str
+    direction: LinkDirection | None
+    origins: tuple[str, ...]
+    constrained: bool
+    analysis_jobs: tuple[AnalysisJobDefinition, ...] = ()
+
+
+@dataclass(frozen=True)
+class NodeRelationship:
+    """
+    One relationship as seen from a specific node label.
+
+    ``other_label`` keeps the opposite endpoint as declared on the underlying
+    ``Relationship``. When this view is inherited from a semantic label the
+    concrete carries, that far endpoint stays semantic (for example
+    ``RESOLVED_IMAGE`` → ``Image``) instead of expanding to every provider
+    concrete.
+    """
+
+    node_label: str
+    label: str
+    other_label: str
+    direction: LinkDirection | None
+    inherited: bool
+    relationship: Relationship
 
 
 @dataclass(frozen=True)
@@ -264,11 +314,16 @@ class DataModel:
     permission_relationships: tuple[PermissionRelationshipDefinition, ...] = ()
     ontology_semantic_labels: tuple[OntologySemanticLabel, ...] = ()
     ontology_relationship_constraints: tuple[OntologyRelationshipConstraint, ...] = ()
+    ontology_expected_edges: tuple[OntologyExpectedEdge, ...] = ()
     diagnostics: tuple[str, ...] = ()
     catalog_relationships: tuple[RelationshipCatalogDefinition, ...] = ()
 
     def get_node(self, label: str) -> Node | None:
         return next((node for node in self.nodes if node.label == label), None)
+
+    def relationships_for_node(self, label: str) -> tuple[NodeRelationship, ...]:
+        """Return relationships applicable to one node, including inherited ontology edges."""
+        return relationships_for_node(self, label)
 
     def for_module(self, module: str) -> DataModel:
         """
@@ -311,6 +366,9 @@ class DataModel:
             ),
             ontology_relationship_constraints=(
                 self.ontology_relationship_constraints if module == "ontology" else ()
+            ),
+            ontology_expected_edges=(
+                self.ontology_expected_edges if module == "ontology" else ()
             ),
             diagnostics=self.diagnostics,
         )
@@ -522,6 +580,105 @@ def relationship_touches_node(relationship: Relationship, node: Node) -> bool:
     """Whether one node answers to either endpoint of a relationship."""
     carried = labels_carried_by((node,))
     return relationship.source_label in carried or relationship.target_label in carried
+
+
+def relationships_for_node(
+    model: DataModel,
+    label: str,
+) -> tuple[NodeRelationship, ...]:
+    """
+    Relationships applicable to one node label, including inherited ontology edges.
+
+    Direct edges keep their declared endpoints. Edges whose source or target is a
+    semantic/canonical ontology label that this node carries are projected onto the
+    concrete with the far endpoint left semantic. Validation-only
+    ``ontology_relationship_constraints`` are never included; only edges present in
+    ``model.relationships`` (schemas, matchlinks, analysis, catalogs, permissions)
+    participate.
+    """
+    node = _node_view_for_label(model, label)
+    if node is None:
+        return ()
+
+    carried = labels_carried_by((node,))
+    views: dict[tuple[str, str, LinkDirection | None], NodeRelationship] = {}
+    for relationship in model.relationships:
+        matches_source = relationship.source_label in carried
+        matches_target = relationship.target_label in carried
+        if not matches_source and not matches_target:
+            continue
+
+        # Prefer the primary-label side when a node answers to both endpoints
+        # (self-loop or a node that also carries the far ontology label).
+        if matches_source and (
+            relationship.source_label == node.label or not matches_target
+        ):
+            other_label = relationship.target_label
+            direction = relationship.direction
+            inherited = relationship.source_label != node.label
+        else:
+            other_label = relationship.source_label
+            direction = _flip_direction(relationship.direction)
+            inherited = relationship.target_label != node.label
+
+        key = (relationship.label, other_label, direction)
+        existing = views.get(key)
+        if existing is not None and not existing.inherited:
+            # Keep a direct declaration over an inherited duplicate.
+            continue
+        if existing is not None and inherited:
+            continue
+        views[key] = NodeRelationship(
+            node_label=node.label,
+            label=relationship.label,
+            other_label=other_label,
+            direction=direction,
+            inherited=inherited,
+            relationship=relationship,
+        )
+
+    return tuple(
+        sorted(
+            views.values(),
+            key=lambda view: (
+                view.label,
+                view.other_label,
+                view.direction.name if view.direction else "",
+                view.inherited,
+            ),
+        )
+    )
+
+
+def _node_view_for_label(model: DataModel, label: str) -> Node | None:
+    """Resolve a primary node or a synthetic view of a semantic ontology label."""
+    node = model.get_node(label)
+    if node is not None:
+        return node
+    semantic = next(
+        (entry for entry in model.ontology_semantic_labels if entry.label == label),
+        None,
+    )
+    if semantic is None:
+        return None
+    return Node(
+        label=semantic.label,
+        descriptions=semantic.descriptions,
+        extra_labels=(),
+        conditional_labels=(),
+        properties=semantic.properties,
+        modules=("ontology",),
+        schemas=(),
+        ontology_labels=(semantic.label,),
+    )
+
+
+def _flip_direction(direction: LinkDirection | None) -> LinkDirection | None:
+    if direction is None:
+        return None
+    if direction is LinkDirection.OUTWARD:
+        return LinkDirection.INWARD
+    return LinkDirection.OUTWARD
 
 
 def iter_model_classes(
@@ -917,6 +1074,12 @@ def build_data_model(
         )
         for constraint in ONTOLOGY_REL_CONSTRAINTS
     )
+    ontology_expected_edges = _build_ontology_expected_edges(
+        relationships,
+        ontology_semantic_labels,
+        nodes,
+        ontology_relationship_constraints,
+    )
     return DataModel(
         nodes=nodes,
         relationships=relationships,
@@ -925,7 +1088,58 @@ def build_data_model(
         catalog_relationships=catalog_relationship_definitions,
         ontology_semantic_labels=ontology_semantic_labels,
         ontology_relationship_constraints=ontology_relationship_constraints,
+        ontology_expected_edges=ontology_expected_edges,
         diagnostics=tuple(sorted(diagnostics)),
+    )
+
+
+def _build_ontology_expected_edges(
+    relationships: tuple[Relationship, ...],
+    ontology_semantic_labels: tuple[OntologySemanticLabel, ...],
+    nodes: tuple[Node, ...],
+    ontology_relationship_constraints: tuple[OntologyRelationshipConstraint, ...],
+) -> tuple[OntologyExpectedEdge, ...]:
+    """Collect relationships whose both endpoints are ontology labels."""
+    ontology_labels = {
+        *(semantic.label for semantic in ontology_semantic_labels),
+        *(node.label for node in nodes if "ontology" in node.modules),
+    }
+    constrained_keys = {
+        (constraint.source_label, constraint.label, constraint.target_label)
+        for constraint in ontology_relationship_constraints
+    }
+    expected: list[OntologyExpectedEdge] = []
+    for relationship in relationships:
+        if relationship.source_label not in ontology_labels:
+            continue
+        if relationship.target_label not in ontology_labels:
+            continue
+        key = (
+            relationship.source_label,
+            relationship.label,
+            relationship.target_label,
+        )
+        expected.append(
+            OntologyExpectedEdge(
+                source_label=relationship.source_label,
+                label=relationship.label,
+                target_label=relationship.target_label,
+                direction=relationship.direction,
+                origins=relationship.origins,
+                constrained=key in constrained_keys,
+                analysis_jobs=relationship.analysis_jobs,
+            )
+        )
+    return tuple(
+        sorted(
+            expected,
+            key=lambda edge: (
+                edge.source_label,
+                edge.label,
+                edge.target_label,
+                edge.direction.name if edge.direction else "",
+            ),
+        )
     )
 
 

--- a/cartography/models/ontology/constraints.py
+++ b/cartography/models/ontology/constraints.py
@@ -10,6 +10,11 @@ class RelConstraint:
     name when both endpoints carry the listed ontology labels. Both abstract
     ontology nodes (User, Device, PublicIP, Package) and semantic extra
     labels (Container, ComputePod, ...) are valid src/dst values.
+
+    Constraints are validation-only. They are not inherited onto concrete node
+    schemas as expected edges. Materialized ontology edges that introspection
+    projects onto concretes come from ``OntologyExpectedEdge`` (relationships
+    actually produced under ontology labels by models or analysis).
     """
 
     src: str

--- a/cartography/models/schema_docs.py
+++ b/cartography/models/schema_docs.py
@@ -10,6 +10,7 @@ from cartography.models.core.nodes import LabelKind
 from cartography.models.core.relationships import LinkDirection
 from cartography.models.introspection import DataModel
 from cartography.models.introspection import Node
+from cartography.models.introspection import NodeRelationship
 from cartography.models.introspection import Property
 from cartography.models.introspection import Relationship
 from cartography.models.introspection import relationship_touches_node
@@ -51,7 +52,6 @@ def render_module_schema(model: DataModel, module: str) -> str:
         raise ValueError(f'No nodes found for module "{module}".')
 
     module_relationships = module_model.relationships
-    assigned_relationships = _assign_relationships(module_relationships, module_nodes)
     module_node_labels = {node.label for node in module_nodes}
     diagram_relationships = tuple(
         relationship
@@ -74,7 +74,9 @@ def render_module_schema(model: DataModel, module: str) -> str:
     lines.extend(["```", ""])
 
     for node in module_nodes:
-        lines.extend(_render_node(node, assigned_relationships.get(node.label, ())))
+        lines.extend(
+            _render_node(node, module_model.relationships_for_node(node.label))
+        )
 
     return "\n".join(lines).rstrip() + "\n"
 
@@ -124,7 +126,14 @@ def _render_ontology_schema(model: DataModel) -> str:
         "applied directly to provider-specific nodes.",
         "",
         "Canonical relationship constraints validate the names and directions "
-        "of existing relationships. They do not create relationships.",
+        "of existing relationships. They do not create relationships and are "
+        "not inherited onto concrete node schemas.",
+        "",
+        "Expected (materialized) ontology edges are relationships actually "
+        "produced under ontology labels by models, matchlinks, analysis jobs, "
+        "or catalogs. Concrete nodes that carry a semantic endpoint inherit "
+        "those edges in their schema view, with the far endpoint kept "
+        "semantic.",
         "",
         "```mermaid",
         "graph LR",
@@ -140,7 +149,10 @@ def _render_ontology_schema(model: DataModel) -> str:
         lines.extend(
             _render_node(
                 node,
-                assigned_relationships.get(node.label, ()),
+                _node_relationships_for_assigned(
+                    node,
+                    assigned_relationships.get(node.label, ()),
+                ),
                 ontology_kind=ontology_kind,
                 concrete_node_labels=implementations_by_label.get(node.label, ()),
             )
@@ -368,7 +380,7 @@ def generated_schema_modules(model: DataModel) -> list[str]:
 
 def _render_node(
     node: Node,
-    relationships: tuple[Relationship, ...],
+    relationships: tuple[NodeRelationship, ...],
     ontology_kind: str | None = None,
     concrete_node_labels: tuple[str, ...] = (),
 ) -> list[str]:
@@ -569,20 +581,20 @@ def _render_properties(node: Node) -> list[str]:
     return lines
 
 
-def _render_relationships(relationships: tuple[Relationship, ...]) -> list[str]:
+def _render_relationships(relationships: tuple[NodeRelationship, ...]) -> list[str]:
     lines = ["", "#### Relationships", ""]
     if not relationships:
         lines.extend(["No relationships.", ""])
         return lines
-    for relationship in relationships:
-        lines.append(f"- {_relationship_summary(relationship)}")
-        permissions = _relationship_permissions(relationship)
+    for view in relationships:
+        lines.append(f"- {_relationship_summary(view)}")
+        permissions = _relationship_permissions(view.relationship)
         if permissions:
             lines.append(f"  - Evaluated permissions: {permissions}")
-        target_preconditions = _relationship_target_preconditions(relationship)
+        target_preconditions = _relationship_target_preconditions(view.relationship)
         if target_preconditions:
             lines.append(f"  - Target precondition: {target_preconditions}")
-        lines.extend(_render_relationship_properties(relationship))
+        lines.extend(_render_relationship_properties(view.relationship))
         lines.append("")
     return lines
 
@@ -608,11 +620,11 @@ def _render_relationship_properties(relationship: Relationship) -> list[str]:
     ]
 
 
-def _relationship_summary(relationship: Relationship) -> str:
+def _relationship_summary(view: NodeRelationship) -> str:
     """Lead with the Cypher pattern and only add prose that says something more."""
-    pattern = f"`{_relationship_pattern(relationship)}`"
-    description = " ".join(relationship.descriptions) or _analysis_job_origin(
-        relationship
+    pattern = f"`{_node_relationship_pattern(view)}`"
+    description = " ".join(view.relationship.descriptions) or _analysis_job_origin(
+        view.relationship
     )
     return f"{pattern}: {description}" if description else pattern
 
@@ -686,6 +698,61 @@ def _assign_relationships(
         )
         for label, values in assigned.items()
     }
+
+
+def _node_relationships_for_assigned(
+    node: Node,
+    relationships: tuple[Relationship, ...],
+) -> tuple[NodeRelationship, ...]:
+    """Adapt assigned Relationship rows into node-relative views for rendering."""
+    carried = {
+        node.label,
+        *node.extra_labels,
+        *node.ontology_labels,
+        *(label.label for label in node.conditional_labels),
+    }
+    views: list[NodeRelationship] = []
+    for relationship in relationships:
+        matches_source = relationship.source_label in carried
+        matches_target = relationship.target_label in carried
+        if matches_source and (
+            relationship.source_label == node.label or not matches_target
+        ):
+            other_label = relationship.target_label
+            direction = relationship.direction
+            inherited = relationship.source_label != node.label
+        elif matches_target:
+            other_label = relationship.source_label
+            direction = (
+                None
+                if relationship.direction is None
+                else (
+                    LinkDirection.INWARD
+                    if relationship.direction is LinkDirection.OUTWARD
+                    else LinkDirection.OUTWARD
+                )
+            )
+            inherited = relationship.target_label != node.label
+        else:
+            # Catalog row whose endpoints are the section label itself.
+            other_label = (
+                relationship.target_label
+                if relationship.source_label == node.label
+                else relationship.source_label
+            )
+            direction = relationship.direction
+            inherited = False
+        views.append(
+            NodeRelationship(
+                node_label=node.label,
+                label=relationship.label,
+                other_label=other_label,
+                direction=direction,
+                inherited=inherited,
+                relationship=relationship,
+            )
+        )
+    return tuple(views)
 
 
 def _render_descriptions(descriptions: tuple[str, ...]) -> list[str]:
@@ -790,6 +857,15 @@ def _relationship_pattern(relationship: Relationship) -> str:
         else f"-[:{relationship.label}]->"
     )
     return f"(:{relationship.source_label}){connector}(:{relationship.target_label})"
+
+
+def _node_relationship_pattern(view: NodeRelationship) -> str:
+    """Cypher pattern for a node-relative relationship view."""
+    if view.direction is None:
+        return f"(:{view.node_label})-[:{view.label}]-(:{view.other_label})"
+    if view.direction is LinkDirection.OUTWARD:
+        return f"(:{view.node_label})-[:{view.label}]->(:{view.other_label})"
+    return f"(:{view.other_label})-[:{view.label}]->(:{view.node_label})"
 
 
 def _mermaid_relationship(relationship: Relationship) -> str:

--- a/tests/unit/cartography/models/test_introspection.py
+++ b/tests/unit/cartography/models/test_introspection.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import ClassVar
 
+import pytest
+
 import cartography.analysis.gsuite as gsuite_analysis
 import cartography.analysis.ontology as ontology_analysis
 import cartography.models.gcp as gcp_models
@@ -467,6 +469,37 @@ def test_relationships_for_node_inherits_materialized_ontology_edges():
     assert not any(
         other_label.startswith("AWS") for other_label, _, _ in resolved_from_image
     )
+
+
+@pytest.mark.parametrize(
+    "module,label",
+    [
+        ("aws", "AWSECSContainer"),
+        ("kubernetes", "KubernetesContainer"),
+        ("railway", "RailwayDeployment"),
+    ],
+)
+def test_for_module_keeps_inherited_ontology_edges_with_one_semantic_endpoint(
+    module,
+    label,
+):
+    """Modules that carry Container but not Image still see RESOLVED_IMAGE."""
+    model = inspect_data_model()
+    scoped = model.for_module(module)
+
+    assert ("Container", "RESOLVED_IMAGE", "Image") in {
+        (
+            relationship.source_label,
+            relationship.label,
+            relationship.target_label,
+        )
+        for relationship in scoped.relationships
+    }
+    assert [
+        (view.other_label, view.direction, view.inherited)
+        for view in scoped.relationships_for_node(label)
+        if view.label == "RESOLVED_IMAGE"
+    ] == [("Image", LinkDirection.OUTWARD, True)]
 
 
 def test_relationships_for_node_excludes_validation_only_constraints():

--- a/tests/unit/cartography/models/test_introspection.py
+++ b/tests/unit/cartography/models/test_introspection.py
@@ -414,6 +414,71 @@ def test_build_data_model_exposes_ontology_catalog_metadata():
     assert ("LoadBalancer", "EXPOSE", "ComputeInstance") in constraints
 
 
+def test_ontology_expected_edges_are_materialized_not_validation_only():
+    model = inspect_data_model()
+
+    expected = {
+        (edge.source_label, edge.label, edge.target_label): edge
+        for edge in model.ontology_expected_edges
+    }
+    resolved = expected[("Container", "RESOLVED_IMAGE", "Image")]
+    assert resolved.constrained
+    assert "analysis" in resolved.origins
+    assert resolved.analysis_jobs
+
+    assert ("ServiceAccount", "HAS_ROLE", "PermissionRole") not in expected
+    assert ("Container", "SCANNED_AS", "FilesystemSnapshot") not in expected
+
+    constraints = {
+        (
+            constraint.source_label,
+            constraint.label,
+            constraint.target_label,
+        )
+        for constraint in model.ontology_relationship_constraints
+    }
+    assert ("ServiceAccount", "HAS_ROLE", "PermissionRole") in constraints
+    assert ("Container", "SCANNED_AS", "FilesystemSnapshot") in constraints
+
+
+def test_relationships_for_node_inherits_materialized_ontology_edges():
+    model = inspect_data_model()
+
+    container_views = model.relationships_for_node("AWSECSContainer")
+    resolved_from_container = [
+        view for view in container_views if view.label == "RESOLVED_IMAGE"
+    ]
+    assert [
+        (view.other_label, view.direction, view.inherited)
+        for view in resolved_from_container
+    ] == [("Image", LinkDirection.OUTWARD, True)]
+
+    image_views = model.relationships_for_node("AWSECRImage")
+    resolved_from_image = {
+        (view.other_label, view.direction, view.inherited)
+        for view in image_views
+        if view.label == "RESOLVED_IMAGE"
+    }
+    assert ("Container", LinkDirection.INWARD, True) in resolved_from_image
+    assert ("Function", LinkDirection.INWARD, True) in resolved_from_image
+    assert not any(
+        other_label.startswith("AWS") for other_label, _, _ in resolved_from_image
+    )
+
+
+def test_relationships_for_node_excludes_validation_only_constraints():
+    model = inspect_data_model()
+
+    service_account_views = model.relationships_for_node("OpenAIServiceAccount")
+    assert not any(
+        view.label == "HAS_ROLE" and view.other_label == "PermissionRole"
+        for view in service_account_views
+    )
+
+    container_views = model.relationships_for_node("AWSECSContainer")
+    assert not any(view.label == "SCANNED_AS" for view in container_views)
+
+
 def test_build_data_model_distinguishes_canonical_ontology_projections():
     # Act
     model = build_data_model([JamfComputerSchema])

--- a/tests/unit/cartography/models/test_introspection.py
+++ b/tests/unit/cartography/models/test_introspection.py
@@ -37,6 +37,7 @@ from cartography.models.gcp.artifact_registry.image_layer import (
 from cartography.models.gcp.artifact_registry.repository_image import (
     GCPArtifactRegistryRepositoryImageSchema,
 )
+from cartography.models.introspection import _build_ontology_expected_edges
 from cartography.models.introspection import AnalysisJobDefinition
 from cartography.models.introspection import build_data_model
 from cartography.models.introspection import DataModel
@@ -46,6 +47,8 @@ from cartography.models.introspection import iter_model_classes
 from cartography.models.introspection import iter_permission_relationships
 from cartography.models.introspection import iter_relationship_catalog
 from cartography.models.introspection import Node
+from cartography.models.introspection import OntologyRelationshipConstraint
+from cartography.models.introspection import OntologySemanticLabel
 from cartography.models.introspection import PermissionRelationshipDefinition
 from cartography.models.introspection import Relationship
 from cartography.models.introspection import TargetPreconditionDefinition
@@ -525,10 +528,6 @@ def test_relationships_for_node_ignores_compatibility_extra_labels():
 
 
 def test_undirected_ontology_edges_are_not_marked_constrained():
-    from cartography.models.introspection import OntologyRelationshipConstraint
-    from cartography.models.introspection import OntologySemanticLabel
-    from cartography.models.introspection import _build_ontology_expected_edges
-
     relationships = (
         Relationship(
             source_label="User",

--- a/tests/unit/cartography/models/test_introspection.py
+++ b/tests/unit/cartography/models/test_introspection.py
@@ -479,6 +479,126 @@ def test_relationships_for_node_excludes_validation_only_constraints():
     assert not any(view.label == "SCANNED_AS" for view in container_views)
 
 
+def test_relationships_for_node_ignores_compatibility_extra_labels():
+    node = Node(
+        label="AWSECSContainer",
+        descriptions=(),
+        extra_labels=("ECSContainer", "CompatAlias"),
+        conditional_labels=(),
+        properties=(),
+        modules=("aws",),
+        schemas=(),
+        ontology_labels=("Container",),
+    )
+    relationships = (
+        Relationship(
+            source_label="CompatAlias",
+            label="ALIAS_ONLY",
+            target_label="Something",
+            direction=LinkDirection.OUTWARD,
+            descriptions=(),
+            properties=(),
+            modules=("aws",),
+            origins=("node_schema",),
+            schemas=(),
+            analysis_jobs=(),
+        ),
+        Relationship(
+            source_label="Container",
+            label="RESOLVED_IMAGE",
+            target_label="Image",
+            direction=LinkDirection.OUTWARD,
+            descriptions=(),
+            properties=(),
+            modules=("ontology",),
+            origins=("analysis",),
+            schemas=(),
+            analysis_jobs=(),
+        ),
+    )
+    model = DataModel(nodes=(node,), relationships=relationships)
+
+    views = model.relationships_for_node("AWSECSContainer")
+    assert [("RESOLVED_IMAGE", "Image", True)] == [
+        (view.label, view.other_label, view.inherited) for view in views
+    ]
+
+
+def test_undirected_ontology_edges_are_not_marked_constrained():
+    from cartography.models.introspection import OntologyRelationshipConstraint
+    from cartography.models.introspection import OntologySemanticLabel
+    from cartography.models.introspection import _build_ontology_expected_edges
+
+    relationships = (
+        Relationship(
+            source_label="User",
+            label="HAS_ACCOUNT",
+            target_label="UserAccount",
+            direction=None,
+            descriptions=(),
+            properties=(),
+            modules=("ontology",),
+            origins=("analysis",),
+            schemas=(),
+            analysis_jobs=(),
+        ),
+        Relationship(
+            source_label="User",
+            label="HAS_ACCOUNT",
+            target_label="UserAccount",
+            direction=LinkDirection.OUTWARD,
+            descriptions=(),
+            properties=(),
+            modules=("ontology",),
+            origins=("node_schema",),
+            schemas=(),
+            analysis_jobs=(),
+        ),
+    )
+    semantic_labels = (
+        OntologySemanticLabel(
+            label="UserAccount",
+            mapping_group=None,
+            descriptions=(),
+            properties=(),
+            concrete_node_labels=("LastpassUser",),
+        ),
+    )
+    nodes = (
+        Node(
+            label="User",
+            descriptions=(),
+            extra_labels=(),
+            conditional_labels=(),
+            properties=(),
+            modules=("ontology",),
+            schemas=(),
+        ),
+    )
+    constraints = (
+        OntologyRelationshipConstraint(
+            source_label="User",
+            label="HAS_ACCOUNT",
+            target_label="UserAccount",
+        ),
+    )
+
+    expected = {
+        (edge.direction is LinkDirection.OUTWARD): edge.constrained
+        for edge in _build_ontology_expected_edges(
+            relationships,
+            semantic_labels,
+            nodes,
+            constraints,
+        )
+        if edge.source_label == "User"
+        and edge.label == "HAS_ACCOUNT"
+        and edge.target_label == "UserAccount"
+    }
+    assert expected[True] is True
+    assert expected[False] is False
+
+
 def test_build_data_model_distinguishes_canonical_ontology_projections():
     # Act
     model = build_data_model([JamfComputerSchema])

--- a/tests/unit/cartography/models/test_schema_docs.py
+++ b/tests/unit/cartography/models/test_schema_docs.py
@@ -442,12 +442,19 @@ def test_each_relationship_is_documented_once_per_node_section():
 def test_concrete_nodes_render_inherited_ontology_relationships():
     model = inspect_data_model()
 
-    generated = render_module_schema(model, "aws")
-    section = generated.split("### AWSECSContainer", 1)[1].split("\n### ", 1)[0]
+    for module, label in (
+        ("aws", "AWSECSContainer"),
+        ("kubernetes", "KubernetesContainer"),
+        ("railway", "RailwayDeployment"),
+    ):
+        generated = render_module_schema(model, module)
+        section = generated.split(f"### {label}", 1)[1].split("\n### ", 1)[0]
 
-    assert "`(:AWSECSContainer)-[:RESOLVED_IMAGE]->(:Image)`" in section
-    assert "`(:Container)-[:RESOLVED_IMAGE]->(:Image)`" not in section
-    assert "SCANNED_AS" not in section
+        assert f"`(:{label})-[:RESOLVED_IMAGE]->(:Image)`" in section
+        assert "`(:Container)-[:RESOLVED_IMAGE]->(:Image)`" not in section
+        # Validation-only Container→FilesystemSnapshot must not appear; a
+        # provider-native SCANNED_AS to a concrete snapshot label is fine.
+        assert f"`(:{label})-[:SCANNED_AS]->(:FilesystemSnapshot)`" not in section
 
 
 def test_ontology_schema_documents_constraint_vs_expected_edges():

--- a/tests/unit/cartography/models/test_schema_docs.py
+++ b/tests/unit/cartography/models/test_schema_docs.py
@@ -247,7 +247,9 @@ def test_ontology_and_cross_module_relationships_are_duplicated_in_module_docs()
     generated = render_module_schema(model, "lastpass")
 
     # Assert
-    assert "(:User)-[:HAS_ACCOUNT]->(:UserAccount)" in generated
+    # Inherited ontology edges keep the far endpoint semantic when possible, but
+    # rewrite the near endpoint to the concrete node being documented.
+    assert "(:User)-[:HAS_ACCOUNT]->(:LastpassUser)" in generated
     assert "(:Human)-[:IDENTITY_LASTPASS]->(:LastpassUser)" in generated
 
 
@@ -435,3 +437,23 @@ def test_each_relationship_is_documented_once_per_node_section():
     assert (
         section.count("(:GitLabProject)-[:HAS_ENVIRONMENT]->(:GitLabEnvironment)") == 1
     )
+
+
+def test_concrete_nodes_render_inherited_ontology_relationships():
+    model = inspect_data_model()
+
+    generated = render_module_schema(model, "aws")
+    section = generated.split("### AWSECSContainer", 1)[1].split("\n### ", 1)[0]
+
+    assert "`(:AWSECSContainer)-[:RESOLVED_IMAGE]->(:Image)`" in section
+    assert "`(:Container)-[:RESOLVED_IMAGE]->(:Image)`" not in section
+    assert "SCANNED_AS" not in section
+
+
+def test_ontology_schema_documents_constraint_vs_expected_edges():
+    model = inspect_data_model()
+
+    generated = render_module_schema(model, "ontology")
+
+    assert "not inherited onto concrete node schemas" in generated
+    assert "Expected (materialized) ontology edges" in generated


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
`inspect_data_model()` already exposed nodes, relationships, semantic labels, and validation-only `RelConstraint`s. Downstream consumers still had to reinvent inheritance of materialized ontology edges onto concrete carriers.

This adds:
- `OntologyExpectedEdge` for relationships actually produced under ontology labels
- `relationships_for_node()` / `NodeRelationship` so concretes like `AWSECSContainer` inherit `RESOLVED_IMAGE → Image` with the far endpoint kept semantic
- Schema-docs rendering that uses that node-centric view
- Clear docs that validation-only constraints are not inherited onto concretes


### Related issues or links

- Follows typed analysis jobs / ontology constraint work; unblocks SubImage agent schema views that previously missed `RESOLVED_IMAGE` on container concretes.


### How was this tested?

- `uv run pytest tests/unit/cartography/models/test_introspection.py tests/unit/cartography/models/test_schema_docs.py -q`
- Verified `relationships_for_node("AWSECSContainer")` yields outward `RESOLVED_IMAGE → Image`
- Verified validation-only pairs (`ServiceAccount`/`HAS_ROLE`, `SCANNED_AS`) are not inherited


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [ ] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [ ] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [ ] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
Key contract: `ontology_relationship_constraints` remain validation-only; only `ontology_expected_edges` / `model.relationships` feed inheritance. Consumers should use `relationships_for_node(label)` instead of reimplementing semantic-label projection.