### PR TITLE
fix(docs): prevent sidebar label overlap

### DIFF
--- a/docs/root/_static/custom.css
+++ b/docs/root/_static/custom.css
@@ -1,28 +1,8 @@
-/* STEP 1: Make the parent a relative-positioned flex container */
-li.toctree-l1._collapse {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    padding-right: 2.5em; /* Space for button */
-  }
-
-  /* STEP 2: Style the link so it wraps and respects padding */
-  li.toctree-l1._collapse > a.reference.internal {
-    display: block;
-    word-break: break-word;
-    overflow-wrap: break-word;
-    white-space: normal;
-    padding-right: 2.5em; /* Same as button's space */
-  }
-
-  /* STEP 3: LOCK the button to top-right of the <li> */
-  li.toctree-l1._collapse > button {
-    position: absolute;
-    top: 0.5em;
-    right: 0.5em;
-    z-index: 10;
-    pointer-events: auto;
-  }
+.globaltoc li:is(._collapse, ._expand) > a {
+  display: block;
+  overflow-wrap: anywhere;
+  padding-right: 1.5rem;
+}
 
 /* <UGLY hack!>
 When Sphinx renders a TOC entry for the schema docs, it makes it look like:

--- a/docs/root/references/index.md
+++ b/docs/root/references/index.md
@@ -1,3 +1,5 @@
+# References
+
 ```{toctree}
 model
 orm


### PR DESCRIPTION
Fix long sidebar labels running underneath their expand arrows and restore the missing References page title.

Tested with the local Sphinx build and browser-verified at narrow and desktop widths.

before and after

sidebar:
<img width="267" height="385" alt="Screenshot 2026-08-28 at 12 11 11 PM" src="https://github.com/user-attachments/assets/36c33817-7ac1-42c7-aa18-28ad4306ed8a" />
<img width="276" height="441" alt="Screenshot 2026-08-28 at 12 11 04 PM" src="https://github.com/user-attachments/assets/74880351-2167-4614-b019-ab230dcf86fa" />

references no title:
<img width="270" height="337" alt="Screenshot 2026-08-28 at 12 43 07 PM" src="https://github.com/user-attachments/assets/ca099a8c-1e3b-4d28-bc30-84c37b093eaf" />

<img width="304" height="396" alt="Screenshot 2026-08-28 at 12 42 58 PM" src="https://github.com/user-attachments/assets/ac2c82ad-522f-45c2-8c80-b42ba5b3f194" />
