### PR TITLE
docs(huntress): use American English

### DIFF
--- a/cartography/intel/huntress/memberships.py
+++ b/cartography/intel/huntress/memberships.py
@@ -106,7 +106,7 @@ def transform(
     """Derive the console users and the roles granted to them from flat membership records.
 
     Huntress has no role object: each membership carries a bare permission label scoped to
-    either the account or one organization. Roles are therefore synthesised and deduped
+    either the account or one organization. Roles are therefore synthesized and deduped
     here, and a user's memberships are folded into one node per user.
     """
     users: dict[int, dict[str, Any]] = {}

--- a/cartography/models/huntress/role.py
+++ b/cartography/models/huntress/role.py
@@ -15,12 +15,12 @@ from cartography.models.ontology.labels import PERMISSION_ROLE
 @dataclass(frozen=True)
 class HuntressRoleNodeProperties(CartographyNodeProperties):
     # Huntress exposes no role object: a membership carries a bare `permissions` string.
-    # The id is synthesised so that the same permission label granted on the account and
+    # The id is synthesized so that the same permission label granted on the account and
     # on an organization stays two distinct grants.
     id: PropertyRef = PropertyRef(
         "id",
         description=(
-            "Synthesised as `<scope>/<account or organization ID>/<permission label>`."
+            "Synthesized as `<scope>/<account or organization ID>/<permission label>`."
         ),
     )
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
@@ -66,10 +66,10 @@ class HuntressRoleToAccountRel(CartographyRelSchema):
 
 @dataclass(frozen=True)
 class HuntressRoleSchema(CartographyNodeSchema):
-    """A console permission set granted to Huntress users, synthesised from memberships.
+    """A console permission set granted to Huntress users, synthesized from memberships.
 
     Huntress ships a fixed set of permission labels and returns them as a bare string on
-    each membership. Materialising them as nodes rather than a property puts Huntress
+    each membership. Materializing them as nodes rather than a property puts Huntress
     console access into the cross-provider rules that walk
     `(:UserAccount)-[:HAS_ROLE]->(:PermissionRole)`.
     """

--- a/docs/root/modules/huntress/index.md
+++ b/docs/root/modules/huntress/index.md
@@ -24,7 +24,7 @@ total count and the distinct types rather than a remediation list.
 
 Huntress identifiers are unique across the platform, so nodes are keyed on the
 raw API identifier. The one exception is `HuntressRole`: Huntress exposes no role
-object, only a bare permission label on each membership, so a role is synthesised
+object, only a bare permission label on each membership, so a role is synthesized
 as `<scope>/<account or organization ID>/<permission label>`. That keeps the same label
 granted on the account and on an organization as two distinct grants. Roles carry
 the `PermissionRole` label and users reach them through `HAS_ROLE`.

--- a/tests/integration/cartography/intel/huntress/test_huntress.py
+++ b/tests/integration/cartography/intel/huntress/test_huntress.py
@@ -181,7 +181,7 @@ def test_sync_huntress(
         (6002, "marge@springfield.example.com", "Marge Simpson"),
     }
 
-    # Assert: roles are synthesised per scope, so the same label granted on the account
+    # Assert: roles are synthesized per scope, so the same label granted on the account
     # and on an organization stays two distinct grants
     assert check_nodes(neo4j_session, "HuntressRole", ["id", "name", "scope"]) == {
         ("account/1000/Admin", "Admin", "account"),


### PR DESCRIPTION
### Type of change

- [x] Documentation update

### Summary

Use American English consistently in Huntress model descriptions, implementation comments, tests, and module documentation. Just to keep things standardized.
