### PR TITLE
feat(kubernetes): correlate provider-neutral load balancers

### DIFF
--- a/cartography/analysis/kubernetes/analysis.py
+++ b/cartography/analysis/kubernetes/analysis.py
@@ -5,17 +5,25 @@ from cartography.graph.analysis import AnalysisStatement
 from cartography.graph.analysis import ScopeById
 from cartography.graph.analysis import SetProperty
 
+INTERNET_FACING_LOAD_BALANCER = """
+lb.exposed_internet = true OR (
+  lb._ont_source = 'aws'
+  AND lb._ont_scheme = 'internet_facing'
+  AND lb._ont_lb_type = 'network'
+)
+"""
+
 K8S_SERVICE_ASSET_EXPOSURE = AnalysisJob(
     name="Kubernetes service internet exposure",
     short_name="k8s_service_asset_exposure",
     scope=ScopeById(
         "KubernetesCluster",
         "CLUSTER_ID",
-        scope_on=("svc", "ing"),
+        scope_on=("svc", "ing", "gw"),
     ),
     statements=(
         AnalysisStatement(
-            match="MATCH (svc:KubernetesService)-[:USES_LOAD_BALANCER]->(lb:AWSLoadBalancerV2) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') WITH DISTINCT svc",
+            match=f"MATCH (svc:KubernetesService)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE {INTERNET_FACING_LOAD_BALANCER} WITH DISTINCT svc",
             effects=(
                 SetProperty("svc", "exposed_internet", True, label="KubernetesService"),
                 AddToSet(
@@ -24,7 +32,26 @@ K8S_SERVICE_ASSET_EXPOSURE = AnalysisJob(
             ),
         ),
         AnalysisStatement(
-            match="MATCH (ing:KubernetesIngress)-[:USES_LOAD_BALANCER]->(lb:AWSLoadBalancerV2) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (ing)-[:TARGETS]->(svc:KubernetesService) WITH DISTINCT svc",
+            match=f"MATCH (ing:KubernetesIngress)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE {INTERNET_FACING_LOAD_BALANCER} MATCH (ing)-[:TARGETS]->(svc:KubernetesService) WITH DISTINCT svc",
+            effects=(
+                SetProperty("svc", "exposed_internet", True, label="KubernetesService"),
+                AddToSet(
+                    "svc", "exposed_internet_type", "lb", label="KubernetesService"
+                ),
+            ),
+        ),
+        AnalysisStatement(
+            comment=(
+                "Only propagate Gateway API exposure through a programmed Gateway and "
+                "an HTTPRoute that its controller currently reports as accepted."
+            ),
+            match=f"""
+            MATCH (gw:KubernetesGateway {{programmed: true}})-[:USES_LOAD_BALANCER]->(lb:LoadBalancer)
+            WHERE {INTERNET_FACING_LOAD_BALANCER}
+            MATCH (gw)-[:ROUTES]->(route:KubernetesHTTPRoute)-[:TARGETS]->(svc:KubernetesService)
+            WHERE gw.qualified_name IN route.accepted_parent_gateway_qualified_names
+            WITH DISTINCT svc
+            """,
             effects=(
                 SetProperty("svc", "exposed_internet", True, label="KubernetesService"),
                 AddToSet(
@@ -75,32 +102,55 @@ K8S_LB_POD_EXPOSURE = AnalysisJob(
     scope=ScopeById(
         "KubernetesCluster",
         "CLUSTER_ID",
-        scope_on=("svc", "ing"),
+        scope_on=("svc", "ing", "gw"),
     ),
     statements=(
         AnalysisStatement(
-            match="MATCH (svc:KubernetesService)-[:USES_LOAD_BALANCER]->(lb:AWSLoadBalancerV2) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (svc)-[:TARGETS]->(pod:KubernetesPod)",
+            match=f"MATCH (svc:KubernetesService)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE {INTERNET_FACING_LOAD_BALANCER} MATCH (svc)-[:TARGETS]->(pod:KubernetesPod)",
             effects=(
                 AddRelationship(
                     "lb",
                     "EXPOSE",
                     "pod",
                     properties={"exposure_type": "via_lb_only"},
-                    source_label="AWSLoadBalancerV2",
+                    source_label="LoadBalancer",
                     target_label="KubernetesPod",
                     scoped_to="target",
                 ),
             ),
         ),
         AnalysisStatement(
-            match="MATCH (ing:KubernetesIngress)-[:USES_LOAD_BALANCER]->(lb:AWSLoadBalancerV2) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (ing)-[:TARGETS]->(svc:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)",
+            match=f"MATCH (ing:KubernetesIngress)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE {INTERNET_FACING_LOAD_BALANCER} MATCH (ing)-[:TARGETS]->(svc:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)",
             effects=(
                 AddRelationship(
                     "lb",
                     "EXPOSE",
                     "pod",
                     properties={"exposure_type": "via_lb_only"},
-                    source_label="AWSLoadBalancerV2",
+                    source_label="LoadBalancer",
+                    target_label="KubernetesPod",
+                    scoped_to="target",
+                ),
+            ),
+        ),
+        AnalysisStatement(
+            comment=(
+                "Only create Gateway API exposure edges for programmed Gateways and "
+                "controller-accepted HTTPRoute parents."
+            ),
+            match=f"""
+            MATCH (gw:KubernetesGateway {{programmed: true}})-[:USES_LOAD_BALANCER]->(lb:LoadBalancer)
+            WHERE {INTERNET_FACING_LOAD_BALANCER}
+            MATCH (gw)-[:ROUTES]->(route:KubernetesHTTPRoute)-[:TARGETS]->(svc:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)
+            WHERE gw.qualified_name IN route.accepted_parent_gateway_qualified_names
+            """,
+            effects=(
+                AddRelationship(
+                    "lb",
+                    "EXPOSE",
+                    "pod",
+                    properties={"exposure_type": "via_lb_only"},
+                    source_label="LoadBalancer",
                     target_label="KubernetesPod",
                     scoped_to="target",
                 ),
@@ -114,32 +164,55 @@ K8S_LB_CONTAINER_EXPOSURE = AnalysisJob(
     scope=ScopeById(
         "KubernetesCluster",
         "CLUSTER_ID",
-        scope_on=("svc", "ing"),
+        scope_on=("svc", "ing", "gw"),
     ),
     statements=(
         AnalysisStatement(
-            match="MATCH (svc:KubernetesService)-[:USES_LOAD_BALANCER]->(lb:AWSLoadBalancerV2) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (svc)-[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)",
+            match=f"MATCH (svc:KubernetesService)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE {INTERNET_FACING_LOAD_BALANCER} MATCH (svc)-[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)",
             effects=(
                 AddRelationship(
                     "lb",
                     "EXPOSE",
                     "c",
                     properties={"exposure_type": "via_lb_only"},
-                    source_label="AWSLoadBalancerV2",
+                    source_label="LoadBalancer",
                     target_label="KubernetesContainer",
                     scoped_to="target",
                 ),
             ),
         ),
         AnalysisStatement(
-            match="MATCH (ing:KubernetesIngress)-[:USES_LOAD_BALANCER]->(lb:AWSLoadBalancerV2) WHERE lb.exposed_internet = true OR (lb.scheme = 'internet-facing' AND lb.type = 'network') MATCH (ing)-[:TARGETS]->(svc:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)",
+            match=f"MATCH (ing:KubernetesIngress)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE {INTERNET_FACING_LOAD_BALANCER} MATCH (ing)-[:TARGETS]->(svc:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)",
             effects=(
                 AddRelationship(
                     "lb",
                     "EXPOSE",
                     "c",
                     properties={"exposure_type": "via_lb_only"},
-                    source_label="AWSLoadBalancerV2",
+                    source_label="LoadBalancer",
+                    target_label="KubernetesContainer",
+                    scoped_to="target",
+                ),
+            ),
+        ),
+        AnalysisStatement(
+            comment=(
+                "Only create Gateway API exposure edges for programmed Gateways and "
+                "controller-accepted HTTPRoute parents."
+            ),
+            match=f"""
+            MATCH (gw:KubernetesGateway {{programmed: true}})-[:USES_LOAD_BALANCER]->(lb:LoadBalancer)
+            WHERE {INTERNET_FACING_LOAD_BALANCER}
+            MATCH (gw)-[:ROUTES]->(route:KubernetesHTTPRoute)-[:TARGETS]->(svc:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)
+            WHERE gw.qualified_name IN route.accepted_parent_gateway_qualified_names
+            """,
+            effects=(
+                AddRelationship(
+                    "lb",
+                    "EXPOSE",
+                    "c",
+                    properties={"exposure_type": "via_lb_only"},
+                    source_label="LoadBalancer",
                     target_label="KubernetesContainer",
                     scoped_to="target",
                 ),

--- a/cartography/intel/kubernetes/gateway_api.py
+++ b/cartography/intel/kubernetes/gateway_api.py
@@ -9,6 +9,7 @@ from cartography.graph.job import GraphJob
 from cartography.intel.kubernetes.util import get_epoch
 from cartography.intel.kubernetes.util import get_qualified_resource_name
 from cartography.intel.kubernetes.util import K8sClient
+from cartography.intel.kubernetes.util import normalize_global_ip_addresses
 from cartography.intel.kubernetes.util import parse_rfc3339
 from cartography.models.kubernetes.gateway_api import KubernetesGatewaySchema
 from cartography.models.kubernetes.gateway_api import KubernetesHTTPRouteSchema
@@ -20,6 +21,39 @@ GATEWAY_API_GROUP = "gateway.networking.k8s.io"
 CORE_API_GROUP = ""
 GATEWAY_KIND = "Gateway"
 SERVICE_KIND = "Service"
+
+
+def _condition_is_current_and_true(
+    conditions: list[dict[str, Any]],
+    condition_type: str,
+    generation: int | None,
+) -> bool:
+    if generation is None:
+        return False
+    for condition in conditions:
+        if condition.get("type") != condition_type or condition.get("status") != "True":
+            continue
+        observed_generation = condition.get("observedGeneration")
+        if observed_generation == generation:
+            return True
+    return False
+
+
+def _gateway_status_addresses(
+    status: dict[str, Any],
+) -> tuple[list[str], list[str]]:
+    dns_names: set[str] = set()
+    ip_addresses: set[str] = set()
+    for address in status.get("addresses") or []:
+        value = address.get("value")
+        if not value:
+            continue
+        address_type = address.get("type") or "IPAddress"
+        if address_type == "Hostname":
+            dns_names.add(value.lower())
+        elif address_type == "IPAddress":
+            ip_addresses.add(value)
+    return sorted(dns_names), normalize_global_ip_addresses(list(ip_addresses))
 
 
 def _ref_matches(
@@ -116,8 +150,12 @@ def transform_gateways(gateways: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for gateway in gateways:
         metadata = gateway.get("metadata", {})
         spec = gateway.get("spec", {})
+        status = gateway.get("status", {})
         namespace = metadata["namespace"]
         name = metadata["name"]
+        load_balancer_dns_names, load_balancer_ip_addresses = _gateway_status_addresses(
+            status
+        )
 
         transformed.append(
             {
@@ -126,6 +164,13 @@ def transform_gateways(gateways: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "namespace": namespace,
                 "qualified_name": get_qualified_resource_name(namespace, name),
                 "gateway_class_name": spec.get("gatewayClassName"),
+                "programmed": _condition_is_current_and_true(
+                    status.get("conditions") or [],
+                    "Programmed",
+                    metadata.get("generation"),
+                ),
+                "load_balancer_dns_names": load_balancer_dns_names,
+                "load_balancer_ip_addresses": load_balancer_ip_addresses,
                 "creation_timestamp": get_epoch(
                     parse_rfc3339(metadata.get("creationTimestamp"))
                 ),
@@ -145,6 +190,7 @@ def transform_http_routes(routes: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for route in routes:
         metadata = route.get("metadata", {})
         spec = route.get("spec", {})
+        status = route.get("status", {})
         namespace = metadata["namespace"]
         name = metadata["name"]
 
@@ -187,6 +233,34 @@ def transform_http_routes(routes: list[dict[str, Any]]) -> list[dict[str, Any]]:
                     get_qualified_resource_name(parent_namespace, parent_name)
                 )
 
+        accepted_parent_gateway_qualified_names: set[str] = set()
+        for parent_status in status.get("parents") or []:
+            parent_ref = parent_status.get("parentRef") or {}
+            if not _ref_matches(
+                parent_ref,
+                default_group=GATEWAY_API_GROUP,
+                default_kind=GATEWAY_KIND,
+                group=GATEWAY_API_GROUP,
+                kind=GATEWAY_KIND,
+            ):
+                continue
+            if not _condition_is_current_and_true(
+                parent_status.get("conditions") or [],
+                "Accepted",
+                metadata.get("generation"),
+            ):
+                continue
+            parent_name = parent_ref.get("name")
+            if not parent_name:
+                continue
+            parent_namespace = parent_ref.get("namespace") or namespace
+            accepted_parent_gateway_qualified_names.add(
+                get_qualified_resource_name(parent_namespace, parent_name)
+            )
+        accepted_parent_gateway_qualified_names.intersection_update(
+            parent_gateway_qualified_names
+        )
+
         transformed.append(
             {
                 "uid": metadata["uid"],
@@ -206,6 +280,9 @@ def transform_http_routes(routes: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 ],
                 "parent_gateway_qualified_names": sorted(
                     parent_gateway_qualified_names
+                ),
+                "accepted_parent_gateway_qualified_names": sorted(
+                    accepted_parent_gateway_qualified_names
                 ),
             }
         )

--- a/cartography/intel/kubernetes/ingress.py
+++ b/cartography/intel/kubernetes/ingress.py
@@ -14,6 +14,7 @@ from cartography.graph.job import GraphJob
 from cartography.intel.kubernetes.util import get_epoch
 from cartography.intel.kubernetes.util import k8s_paginate
 from cartography.intel.kubernetes.util import K8sClient
+from cartography.intel.kubernetes.util import normalize_global_ip_addresses
 from cartography.models.kubernetes.ingress import KubernetesIngressSchema
 from cartography.util import timeit
 
@@ -102,6 +103,17 @@ def _extract_load_balancer_dns_names(
     return dns_names
 
 
+def _extract_load_balancer_ip_addresses(
+    ingress_status: list[V1IngressLoadBalancerIngress] | None,
+) -> list[str]:
+    if ingress_status is None:
+        return []
+
+    return normalize_global_ip_addresses(
+        [item.ip for item in ingress_status if item.ip]
+    )
+
+
 def transform_ingresses(ingress: list[V1Ingress]) -> list[dict[str, Any]]:
     transformed_ingresses: list[dict[str, Any]] = []
 
@@ -125,8 +137,12 @@ def transform_ingresses(ingress: list[V1Ingress]) -> list[dict[str, Any]]:
 
         # extract load balancer DNS names from status for cloud LB matching
         load_balancer_dns_names: list[str] = []
+        load_balancer_ip_addresses: list[str] = []
         if item.status and item.status.load_balancer:
             load_balancer_dns_names = _extract_load_balancer_dns_names(
+                item.status.load_balancer.ingress
+            )
+            load_balancer_ip_addresses = _extract_load_balancer_ip_addresses(
                 item.status.load_balancer.ingress
             )
 
@@ -151,6 +167,7 @@ def transform_ingresses(ingress: list[V1Ingress]) -> list[dict[str, Any]]:
                 "target_services": list(backend_services),
                 "ingress_group_name": ingress_group_name,
                 "load_balancer_dns_names": load_balancer_dns_names,
+                "load_balancer_ip_addresses": load_balancer_ip_addresses,
             }
         )
     return transformed_ingresses

--- a/cartography/intel/kubernetes/services.py
+++ b/cartography/intel/kubernetes/services.py
@@ -13,6 +13,7 @@ from cartography.intel.kubernetes.util import get_epoch
 from cartography.intel.kubernetes.util import get_qualified_resource_name
 from cartography.intel.kubernetes.util import k8s_paginate
 from cartography.intel.kubernetes.util import K8sClient
+from cartography.intel.kubernetes.util import normalize_global_ip_addresses
 from cartography.models.kubernetes.services import KubernetesServiceSchema
 from cartography.util import timeit
 
@@ -47,6 +48,15 @@ def _extract_load_balancer_dns_names(
         if item.hostname:
             dns_names.append(item.hostname.lower())
     return dns_names
+
+
+def _extract_load_balancer_ip_addresses(
+    ingress: list[V1LoadBalancerIngress] | None,
+) -> list[str]:
+    if ingress is None:
+        return []
+
+    return normalize_global_ip_addresses([item.ip for item in ingress if item.ip])
 
 
 def _format_load_balancer_ingress(ingress: list[V1LoadBalancerIngress] | None) -> str:
@@ -113,6 +123,11 @@ def transform_services(
                 # Extract DNS names for relationship matching with AWS LoadBalancerV2
                 item["load_balancer_dns_names"] = _extract_load_balancer_dns_names(
                     service.status.load_balancer.ingress
+                )
+                item["load_balancer_ip_addresses"] = (
+                    _extract_load_balancer_ip_addresses(
+                        service.status.load_balancer.ingress
+                    )
                 )
 
         # check if pod labels match service selector and add pod_ids to item

--- a/cartography/intel/kubernetes/util.py
+++ b/cartography/intel/kubernetes/util.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime
 from decimal import Decimal
 from decimal import InvalidOperation
+from ipaddress import ip_address
 from typing import Any
 from typing import Callable
 
@@ -21,6 +22,18 @@ from kubernetes.client.exceptions import ApiException
 from kubernetes.config.kube_config import KubeConfigMerger
 
 logger = logging.getLogger(__name__)
+
+
+def normalize_global_ip_addresses(values: list[str]) -> list[str]:
+    normalized: set[str] = set()
+    for value in values:
+        try:
+            address = ip_address(value)
+        except ValueError:
+            continue
+        if address.is_global:
+            normalized.add(address.compressed)
+    return sorted(normalized)
 
 
 def format_resource_quantities(resources: dict[str, Any] | None) -> str:

--- a/cartography/models/kubernetes/containers.py
+++ b/cartography/models/kubernetes/containers.py
@@ -157,7 +157,7 @@ class KubernetesContainerNodeProperties(CartographyNodeProperties):
     exposed_internet: PropertyRef = PropertyRef(
         "exposed_internet",
         extra_index=True,
-        description="`True` when the container's pod is targeted by an internet-exposed service. `False` otherwise.",
+        description="`True` when the container's pod is targeted by a service reached from a correlated internet-facing cloud load balancer.",
     )  # Populated by the K8S_CONTAINER_ASSET_EXPOSURE analysis job.
     exposed_internet_type: PropertyRef = PropertyRef(
         "exposed_internet_type",

--- a/cartography/models/kubernetes/gateway_api.py
+++ b/cartography/models/kubernetes/gateway_api.py
@@ -31,6 +31,18 @@ class KubernetesGatewayNodeProperties(CartographyNodeProperties):
         "gateway_class_name",
         description="Name of the `GatewayClass` referenced by `spec.gatewayClassName`.",
     )
+    programmed: PropertyRef = PropertyRef(
+        "programmed",
+        description="`True` when the current Gateway `status.conditions` contains `Programmed=True`.",
+    )
+    load_balancer_dns_names: PropertyRef = PropertyRef(
+        "load_balancer_dns_names",
+        description="Lowercased hostnames bound to the Gateway in `status.addresses` and used to correlate it with cloud load balancers.",
+    )
+    load_balancer_ip_addresses: PropertyRef = PropertyRef(
+        "load_balancer_ip_addresses",
+        description="Globally routable IP addresses bound to the Gateway in `status.addresses` and used to correlate it with cloud load balancers.",
+    )
     creation_timestamp: PropertyRef = PropertyRef(
         "creation_timestamp",
         description="Epoch seconds of `metadata.creationTimestamp`.",
@@ -117,6 +129,41 @@ class KubernetesGatewayToHTTPRouteRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class KubernetesGatewayToLoadBalancerRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesGatewayToLoadBalancerByDNSRel(CartographyRelSchema):
+    """Links a Gateway to a cloud load balancer by its bound status hostname."""
+
+    target_node_label: str = "LoadBalancer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"_ont_dns_name": PropertyRef("load_balancer_dns_names", one_to_many=True)}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_LOAD_BALANCER"
+    properties: KubernetesGatewayToLoadBalancerRelProperties = (
+        KubernetesGatewayToLoadBalancerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesGatewayToLoadBalancerByIPRel(CartographyRelSchema):
+    """Links a Gateway to a cloud load balancer by its bound status IP address."""
+
+    target_node_label: str = "LoadBalancer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"_ont_ip_address": PropertyRef("load_balancer_ip_addresses", one_to_many=True)}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_LOAD_BALANCER"
+    properties: KubernetesGatewayToLoadBalancerRelProperties = (
+        KubernetesGatewayToLoadBalancerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class KubernetesGatewaySchema(CartographyNodeSchema):
     "A Gateway API gateway that accepts traffic for attached routes."
 
@@ -129,6 +176,8 @@ class KubernetesGatewaySchema(CartographyNodeSchema):
         [
             KubernetesGatewayToKubernetesNamespaceRel(),
             KubernetesGatewayToHTTPRouteRel(),
+            KubernetesGatewayToLoadBalancerByDNSRel(),
+            KubernetesGatewayToLoadBalancerByIPRel(),
         ]
     )
 
@@ -151,6 +200,10 @@ class KubernetesHTTPRouteNodeProperties(CartographyNodeProperties):
     )
     hostnames: PropertyRef = PropertyRef(
         "hostnames", description="List of hostnames from `spec.hostnames`."
+    )
+    accepted_parent_gateway_qualified_names: PropertyRef = PropertyRef(
+        "accepted_parent_gateway_qualified_names",
+        description="Qualified names of Gateway parents whose current Route status contains `Accepted=True`.",
     )
     creation_timestamp: PropertyRef = PropertyRef(
         "creation_timestamp",

--- a/cartography/models/kubernetes/ingress.py
+++ b/cartography/models/kubernetes/ingress.py
@@ -59,6 +59,10 @@ class KubernetesIngressNodeProperties(CartographyNodeProperties):
         "load_balancer_dns_names",
         description="List of DNS hostnames from the Ingress status. Used to match to cloud load balancers (e.g., AWS ALB).",
     )
+    load_balancer_ip_addresses: PropertyRef = PropertyRef(
+        "load_balancer_ip_addresses",
+        description="Globally routable IP addresses reported in the Ingress status and used to correlate this Ingress with cloud load balancers.",
+    )
     # AWS Load Balancer Controller group name
     ingress_group_name: PropertyRef = PropertyRef(
         "ingress_group_name",
@@ -138,14 +142,44 @@ class KubernetesIngressToKubernetesServiceRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
-class KubernetesIngressToLoadBalancerV2RelProperties(CartographyRelProperties):
+class KubernetesIngressToLoadBalancerRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-# (:KubernetesIngress)-[:USES_LOAD_BALANCER]->(:AWSLoadBalancerV2)
-class KubernetesIngressToLoadBalancerV2Rel(CartographyRelSchema):
-    """Links an ingress to the AWS load balancer that exposes it, matched by the DNS hostname from the ingress status to the load balancer's DNS name; both are lowercased at ingestion."""
+# (:KubernetesIngress)-[:USES_LOAD_BALANCER]->(:LoadBalancer)
+class KubernetesIngressToLoadBalancerByDNSRel(CartographyRelSchema):
+    """Links an Ingress to a cloud load balancer by its status hostname."""
+
+    target_node_label: str = "LoadBalancer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"_ont_dns_name": PropertyRef("load_balancer_dns_names", one_to_many=True)}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_LOAD_BALANCER"
+    properties: KubernetesIngressToLoadBalancerRelProperties = (
+        KubernetesIngressToLoadBalancerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesIngressToLoadBalancerByIPRel(CartographyRelSchema):
+    """Links an Ingress to a cloud load balancer by its status IP address."""
+
+    target_node_label: str = "LoadBalancer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"_ont_ip_address": PropertyRef("load_balancer_ip_addresses", one_to_many=True)}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_LOAD_BALANCER"
+    properties: KubernetesIngressToLoadBalancerRelProperties = (
+        KubernetesIngressToLoadBalancerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesIngressToAWSLoadBalancerRel(CartographyRelSchema):
+    """Links directly to AWS load balancers when ontology isn't selected."""
 
     target_node_label: str = "AWSLoadBalancerV2"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
@@ -153,8 +187,8 @@ class KubernetesIngressToLoadBalancerV2Rel(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "USES_LOAD_BALANCER"
-    properties: KubernetesIngressToLoadBalancerV2RelProperties = (
-        KubernetesIngressToLoadBalancerV2RelProperties()
+    properties: KubernetesIngressToLoadBalancerRelProperties = (
+        KubernetesIngressToLoadBalancerRelProperties()
     )
 
 
@@ -171,6 +205,8 @@ class KubernetesIngressSchema(CartographyNodeSchema):
         [
             KubernetesIngressToKubernetesNamespaceRel(),
             KubernetesIngressToKubernetesServiceRel(),
-            KubernetesIngressToLoadBalancerV2Rel(),
+            KubernetesIngressToLoadBalancerByDNSRel(),
+            KubernetesIngressToLoadBalancerByIPRel(),
+            KubernetesIngressToAWSLoadBalancerRel(),
         ]
     )

--- a/cartography/models/kubernetes/pods.py
+++ b/cartography/models/kubernetes/pods.py
@@ -90,7 +90,7 @@ class KubernetesPodNodeProperties(CartographyNodeProperties):
     exposed_internet: PropertyRef = PropertyRef(
         "exposed_internet",
         extra_index=True,
-        description="Set by analysis job. `true` if this pod is reachable from an internet-facing load balancer.",
+        description="`True` when this pod is targeted by a service reached from a correlated internet-facing cloud load balancer.",
     )  # Populated by the Kubernetes compute exposure analysis job.
     exposed_internet_type: PropertyRef = PropertyRef(
         "exposed_internet_type",

--- a/cartography/models/kubernetes/services.py
+++ b/cartography/models/kubernetes/services.py
@@ -56,6 +56,14 @@ class KubernetesServiceNodeProperties(CartographyNodeProperties):
         "load_balancer_ingress",
         description="The list of load balancer ingress points, typically containing the hostname and IP. Stored as a JSON-encoded string.",
     )
+    load_balancer_dns_names: PropertyRef = PropertyRef(
+        "load_balancer_dns_names",
+        description="Lowercased DNS hostnames reported in `status.loadBalancer.ingress` and used to correlate this service with cloud load balancers.",
+    )
+    load_balancer_ip_addresses: PropertyRef = PropertyRef(
+        "load_balancer_ip_addresses",
+        description="Globally routable IP addresses reported in `status.loadBalancer.ingress` and used to correlate this service with cloud load balancers.",
+    )
     cluster_name: PropertyRef = PropertyRef(
         "CLUSTER_NAME",
         set_in_kwargs=True,
@@ -65,7 +73,7 @@ class KubernetesServiceNodeProperties(CartographyNodeProperties):
     exposed_internet: PropertyRef = PropertyRef(
         "exposed_internet",
         extra_index=True,
-        description="`True` when the service, or an ingress targeting it, uses an internet-facing load balancer. `False` otherwise.",
+        description="`True` when the service is reached directly, through an Ingress, or through a controller-reported Gateway API route from a correlated internet-facing cloud load balancer.",
     )  # Populated by the K8S_SERVICE_ASSET_EXPOSURE analysis job.
     exposed_internet_type: PropertyRef = PropertyRef(
         "exposed_internet_type",
@@ -76,14 +84,44 @@ class KubernetesServiceNodeProperties(CartographyNodeProperties):
 
 
 @dataclass(frozen=True)
-class KubernetesServiceToLoadBalancerV2RelProperties(CartographyRelProperties):
+class KubernetesServiceToLoadBalancerRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 
 @dataclass(frozen=True)
-# (:KubernetesService)-[:USES_LOAD_BALANCER]->(:LoadBalancerV2)
-class KubernetesServiceToLoadBalancerV2Rel(CartographyRelSchema):
-    """Links a service of type `LoadBalancer` to the AWS load balancer that exposes it, matching the service's `status.loadBalancer.ingress[].hostname` against `AWSLoadBalancerV2.dnsname`. Both sides are lowercased at ingestion, since AWS preserves the load balancer name's case in the DNS name it hands to the in-cluster controller."""
+# (:KubernetesService)-[:USES_LOAD_BALANCER]->(:LoadBalancer)
+class KubernetesServiceToLoadBalancerByDNSRel(CartographyRelSchema):
+    """Links a service to a cloud load balancer by its status hostname."""
+
+    target_node_label: str = "LoadBalancer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"_ont_dns_name": PropertyRef("load_balancer_dns_names", one_to_many=True)}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_LOAD_BALANCER"
+    properties: KubernetesServiceToLoadBalancerRelProperties = (
+        KubernetesServiceToLoadBalancerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesServiceToLoadBalancerByIPRel(CartographyRelSchema):
+    """Links a service to a cloud load balancer by its status IP address."""
+
+    target_node_label: str = "LoadBalancer"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"_ont_ip_address": PropertyRef("load_balancer_ip_addresses", one_to_many=True)}
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_LOAD_BALANCER"
+    properties: KubernetesServiceToLoadBalancerRelProperties = (
+        KubernetesServiceToLoadBalancerRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesServiceToAWSLoadBalancerRel(CartographyRelSchema):
+    """Links directly to AWS load balancers when ontology isn't selected."""
 
     target_node_label: str = "AWSLoadBalancerV2"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
@@ -91,8 +129,8 @@ class KubernetesServiceToLoadBalancerV2Rel(CartographyRelSchema):
     )
     direction: LinkDirection = LinkDirection.OUTWARD
     rel_label: str = "USES_LOAD_BALANCER"
-    properties: KubernetesServiceToLoadBalancerV2RelProperties = (
-        KubernetesServiceToLoadBalancerV2RelProperties()
+    properties: KubernetesServiceToLoadBalancerRelProperties = (
+        KubernetesServiceToLoadBalancerRelProperties()
     )
 
 
@@ -179,6 +217,8 @@ class KubernetesServiceSchema(CartographyNodeSchema):
         [
             KubernetesServiceToKubernetesNamespaceRel(),
             KubernetesServiceToKubernetesPodRel(),
-            KubernetesServiceToLoadBalancerV2Rel(),
+            KubernetesServiceToLoadBalancerByDNSRel(),
+            KubernetesServiceToLoadBalancerByIPRel(),
+            KubernetesServiceToAWSLoadBalancerRel(),
         ]
     )

--- a/docs/root/modules/kubernetes/index.md
+++ b/docs/root/modules/kubernetes/index.md
@@ -6,6 +6,14 @@ identities and permissions. It also connects Kubernetes resources to cloud
 infrastructure, container images, and shared ontology labels so that workload and
 identity paths can be queried across providers.
 
+Services, Ingresses, and Gateway API Gateways correlate their controller-reported
+status hostnames and IP addresses with Cartography's cross-provider `LoadBalancer`
+ontology. Internet exposure propagates only from correlated cloud load balancers
+that their provider module identifies as internet exposed. Gateway API propagation
+also requires a current `Programmed=True` Gateway condition and a current
+`Accepted=True` HTTPRoute parent condition; spec references alone don't establish
+reachability.
+
 PersistentVolumes managed by the AWS EBS or Azure Disk CSI drivers connect to
 already-ingested cloud disks with `BACKED_BY` relationships.
 

--- a/docs/root/modules/kubernetes/queries.md
+++ b/docs/root/modules/kubernetes/queries.md
@@ -2,6 +2,57 @@
 
 These examples show how to inspect Kubernetes data after a successful sync.
 
+## Trace internet-facing load balancers to Kubernetes workloads
+
+Find Kubernetes traffic entry points correlated with internet-facing cloud load
+balancers and the pods selected by their service backends:
+
+```cypher
+CALL {
+  MATCH (service:KubernetesService)-[:USES_LOAD_BALANCER]->(load_balancer:LoadBalancer)
+  WHERE load_balancer.exposed_internet = true OR (
+    load_balancer._ont_source = 'aws'
+    AND load_balancer._ont_scheme = 'internet_facing'
+    AND load_balancer._ont_lb_type = 'network'
+  )
+  RETURN load_balancer, service, service AS entry_point
+  UNION
+  MATCH (ingress:KubernetesIngress)-[:USES_LOAD_BALANCER]->(load_balancer:LoadBalancer)
+  WHERE load_balancer.exposed_internet = true OR (
+    load_balancer._ont_source = 'aws'
+    AND load_balancer._ont_scheme = 'internet_facing'
+    AND load_balancer._ont_lb_type = 'network'
+  )
+  MATCH (ingress)-[:TARGETS]->(service:KubernetesService)
+  RETURN load_balancer, service, ingress AS entry_point
+  UNION
+  MATCH (gateway:KubernetesGateway {programmed: true})
+    -[:USES_LOAD_BALANCER]->(load_balancer:LoadBalancer)
+  WHERE load_balancer.exposed_internet = true OR (
+    load_balancer._ont_source = 'aws'
+    AND load_balancer._ont_scheme = 'internet_facing'
+    AND load_balancer._ont_lb_type = 'network'
+  )
+  MATCH (gateway)-[:ROUTES]->(route:KubernetesHTTPRoute)
+    -[:TARGETS]->(service:KubernetesService)
+  WHERE gateway.qualified_name IN route.accepted_parent_gateway_qualified_names
+  RETURN load_balancer, service, gateway AS entry_point
+}
+MATCH (service:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)
+RETURN labels(load_balancer), load_balancer.id,
+       labels(entry_point), entry_point.name,
+       service.namespace, service.name, pod.name
+ORDER BY service.namespace, service.name, pod.name;
+```
+
+This query reports correlated cloud load-balancer paths. Gateway paths require a
+current `Programmed=True` Gateway condition and an `Accepted=True` route-parent
+condition. Kubernetes status can identify a bound hostname or public IP address,
+but it can't by itself prove that the endpoint is reachable from the internet.
+IP correlation is an exact, graph-wide match; recycled addresses can correlate
+stale Kubernetes status with an unrelated load balancer, so treat IP-only paths
+as evidence to verify rather than proof of exposure.
+
 ## Inspect kubeconfig TLS posture
 
 Use the TLS posture fields on each cluster to find kubeconfig contexts that skip

--- a/tests/data/kubernetes/exposure.py
+++ b/tests/data/kubernetes/exposure.py
@@ -118,6 +118,7 @@ def build_exposure_test_data() -> dict:
         {
             "uid": svc_lb_id,
             "name": f"my-lb-svc-{case_id}",
+            "qualified_name": f"default/my-lb-svc-{case_id}",
             "creation_timestamp": 1633581666,
             "deletion_timestamp": None,
             "namespace": "default",
@@ -132,6 +133,7 @@ def build_exposure_test_data() -> dict:
         {
             "uid": svc_ing_id,
             "name": f"my-clusterip-svc-{case_id}",
+            "qualified_name": f"default/my-clusterip-svc-{case_id}",
             "creation_timestamp": 1633581666,
             "deletion_timestamp": None,
             "namespace": "default",

--- a/tests/data/kubernetes/gateway_api.py
+++ b/tests/data/kubernetes/gateway_api.py
@@ -9,6 +9,9 @@ KUBERNETES_GATEWAYS_DATA = [
         "namespace": KUBERNETES_CLUSTER_1_NAMESPACES_DATA[-1]["name"],
         "qualified_name": f"{KUBERNETES_CLUSTER_1_NAMESPACES_DATA[-1]['name']}/public-gateway",
         "gateway_class_name": "nginx",
+        "programmed": True,
+        "load_balancer_dns_names": ["gateway.example.net"],
+        "load_balancer_ip_addresses": ["8.8.8.8"],
         "creation_timestamp": 1633587666,
         "deletion_timestamp": None,
         "attached_route_qualified_names": [
@@ -33,6 +36,9 @@ KUBERNETES_HTTP_ROUTES_DATA = [
         "parent_gateway_qualified_names": [
             f"{KUBERNETES_CLUSTER_1_NAMESPACES_DATA[-1]['name']}/public-gateway",
         ],
+        "accepted_parent_gateway_qualified_names": [
+            f"{KUBERNETES_CLUSTER_1_NAMESPACES_DATA[-1]['name']}/public-gateway",
+        ],
     },
 ]
 
@@ -44,10 +50,29 @@ KUBERNETES_GATEWAYS_RAW = [
             "name": "public-gateway",
             "namespace": KUBERNETES_CLUSTER_1_NAMESPACES_DATA[-1]["name"],
             "uid": "gw-uid-001-abcd-1234",
+            "generation": 2,
             "creationTimestamp": "2021-10-07T06:21:06+00:00",
         },
         "spec": {
             "gatewayClassName": "nginx",
+        },
+        "status": {
+            "addresses": [
+                {"type": "Hostname", "value": "Gateway.Example.NET"},
+                {"value": "8.8.8.8"},
+            ],
+            "conditions": [
+                {
+                    "type": "Accepted",
+                    "status": "True",
+                    "observedGeneration": 2,
+                },
+                {
+                    "type": "Programmed",
+                    "status": "True",
+                    "observedGeneration": 2,
+                },
+            ],
         },
     },
 ]
@@ -60,6 +85,7 @@ KUBERNETES_HTTP_ROUTES_RAW = [
             "name": "frontend-route",
             "namespace": KUBERNETES_CLUSTER_1_NAMESPACES_DATA[-1]["name"],
             "uid": "hr-uid-001-abcd-1234",
+            "generation": 3,
             "creationTimestamp": "2021-10-07T06:21:40+00:00",
         },
         "spec": {
@@ -77,6 +103,21 @@ KUBERNETES_HTTP_ROUTES_RAW = [
                     ],
                 },
             ],
+        },
+        "status": {
+            "parents": [
+                {
+                    "parentRef": {"name": "public-gateway"},
+                    "controllerName": "example.net/gateway-controller",
+                    "conditions": [
+                        {
+                            "type": "Accepted",
+                            "status": "True",
+                            "observedGeneration": 3,
+                        }
+                    ],
+                }
+            ]
         },
     },
 ]

--- a/tests/integration/cartography/intel/kubernetes/test_exposure.py
+++ b/tests/integration/cartography/intel/kubernetes/test_exposure.py
@@ -1,10 +1,14 @@
 import copy
 
+import pytest
+
 from cartography.analysis.aws.analysis import AWS_EC2_ASSET_EXPOSURE_JOBS
 from cartography.analysis.kubernetes.analysis import K8S_COMPUTE_ASSET_EXPOSURE_JOBS
 from cartography.analysis.kubernetes.analysis import K8S_LB_EXPOSURE_JOBS
 from cartography.intel.aws.ec2.load_balancer_v2s import load_load_balancer_v2s
 from cartography.intel.kubernetes.clusters import load_kubernetes_cluster
+from cartography.intel.kubernetes.gateway_api import load_gateways
+from cartography.intel.kubernetes.gateway_api import load_http_routes
 from cartography.intel.kubernetes.ingress import load_ingresses
 from cartography.intel.kubernetes.namespaces import load_namespaces
 from cartography.intel.kubernetes.pods import load_containers
@@ -13,6 +17,7 @@ from cartography.intel.kubernetes.services import load_services
 from cartography.util import run_typed_analysis_job
 from tests.data.kubernetes.exposure import build_exposure_test_data
 from tests.integration.cartography.intel.aws.common import create_test_account
+from tests.integration.util import check_rels
 
 
 def _seed_exposure_graph(
@@ -66,8 +71,7 @@ def _seed_exposure_graph(
     # but scoped-job tests exercise only k8s jobs.
     if mark_alb_exposed:
         neo4j_session.run(
-            "MATCH (lb:AWSLoadBalancerV2{id: $alb_id}) "
-            "SET lb.exposed_internet = true",
+            "MATCH (lb:AWSLoadBalancerV2{id: $alb_id}) SET lb.exposed_internet = true",
             alb_id=case["alb_dns"],
         )
 
@@ -149,6 +153,23 @@ def test_k8s_asset_exposure_properties(neo4j_session):
     }
 
     _run_k8s_compute_analysis(neo4j_session, common_job_parameters)
+
+    nlb_ontology = neo4j_session.run(
+        """
+        MATCH (lb:AWSLoadBalancerV2 {id: $lb_id})
+        RETURN lb._ont_source AS source,
+               lb._ont_scheme AS scheme,
+               lb._ont_lb_type AS lb_type,
+               lb.exposed_internet AS exposed
+        """,
+        lb_id=case["nlb_dns"],
+    ).single()
+    assert nlb_ontology == {
+        "source": "aws",
+        "scheme": "internet_facing",
+        "lb_type": "network",
+        "exposed": None,
+    }
 
     result = neo4j_session.run(
         "MATCH (svc:KubernetesService{id: $svc_id}) "
@@ -299,3 +320,157 @@ def test_internal_nlb_does_not_propagate_exposure(neo4j_session):
         pod_id=case["pod_lb_id"],
     )
     assert result.single()["rel_count"] == 0
+
+
+@pytest.mark.parametrize(
+    ("address_kind", "programmed", "accepted", "expected_exposed"),
+    [
+        ("ip", True, True, True),
+        ("dns", True, True, True),
+        ("ip", False, True, False),
+        ("ip", True, False, False),
+    ],
+)
+def test_gateway_status_propagates_only_current_accepted_exposure(
+    neo4j_session,
+    address_kind,
+    programmed,
+    accepted,
+    expected_exposed,
+):
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    case = build_exposure_test_data()
+    _seed_exposure_graph(
+        neo4j_session,
+        case=case,
+        include_ingress=False,
+        mark_alb_exposed=False,
+    )
+    namespace = "default"
+    gateway_name = "public-gateway"
+    gateway_qualified_name = f"{namespace}/{gateway_name}"
+    route_qualified_name = f"{namespace}/frontend-route"
+    load_balancer_address = "8.8.8.8" if address_kind == "ip" else "gateway.example.net"
+
+    if address_kind == "ip":
+        neo4j_session.run(
+            """
+            MERGE (lb:GCPForwardingRule:LoadBalancer {id: $address})
+            SET lb._ont_ip_address = $address,
+                lb._ont_source = 'gcp',
+                lb.exposed_internet = true
+            """,
+            address=load_balancer_address,
+        )
+    else:
+        neo4j_session.run(
+            """
+            MERGE (lb:AzureLoadBalancer:LoadBalancer {id: $address})
+            SET lb._ont_dns_name = $address,
+                lb._ont_source = 'azure',
+                lb.exposed_internet = true
+            """,
+            address=load_balancer_address,
+        )
+    load_http_routes(
+        neo4j_session,
+        [
+            {
+                "uid": "route-uid",
+                "name": "frontend-route",
+                "namespace": namespace,
+                "qualified_name": route_qualified_name,
+                "hostnames": ["app.example.com"],
+                "backend_service_qualified_names": [
+                    f"{namespace}/{case['services'][1]['name']}"
+                ],
+                "parent_gateway_qualified_names": [gateway_qualified_name],
+                "accepted_parent_gateway_qualified_names": (
+                    [gateway_qualified_name] if accepted else []
+                ),
+            }
+        ],
+        update_tag=case["update_tag"],
+        cluster_id=case["cluster_id"],
+        cluster_name=case["cluster_name"],
+    )
+    load_gateways(
+        neo4j_session,
+        [
+            {
+                "uid": "gateway-uid",
+                "name": gateway_name,
+                "namespace": namespace,
+                "qualified_name": gateway_qualified_name,
+                "gateway_class_name": "example",
+                "programmed": programmed,
+                "load_balancer_ip_addresses": (
+                    [load_balancer_address] if address_kind == "ip" else []
+                ),
+                "load_balancer_dns_names": (
+                    [load_balancer_address] if address_kind == "dns" else []
+                ),
+                "attached_route_qualified_names": [route_qualified_name],
+            }
+        ],
+        update_tag=case["update_tag"],
+        cluster_id=case["cluster_id"],
+        cluster_name=case["cluster_name"],
+    )
+
+    assert check_rels(
+        neo4j_session,
+        "KubernetesGateway",
+        "id",
+        "LoadBalancer",
+        "id",
+        "USES_LOAD_BALANCER",
+        rel_direction_right=True,
+    ) == {("gateway-uid", load_balancer_address)}
+    assert check_rels(
+        neo4j_session,
+        "KubernetesGateway",
+        "id",
+        "KubernetesHTTPRoute",
+        "id",
+        "ROUTES",
+        rel_direction_right=True,
+    ) == {("gateway-uid", "route-uid")}
+    assert check_rels(
+        neo4j_session,
+        "KubernetesHTTPRoute",
+        "id",
+        "KubernetesService",
+        "id",
+        "TARGETS",
+        rel_direction_right=True,
+    ) == {("route-uid", case["svc_ing_id"])}
+
+    common_job_parameters = {
+        "UPDATE_TAG": case["update_tag"],
+        "CLUSTER_ID": case["cluster_id"],
+    }
+    _run_k8s_compute_analysis(neo4j_session, common_job_parameters)
+    _run_k8s_lb_analysis(neo4j_session, common_job_parameters)
+
+    result = neo4j_session.run(
+        """
+        MATCH (lb:LoadBalancer {id: $address})
+        MATCH (pod:KubernetesPod {id: $pod_id})
+        MATCH (container:KubernetesContainer {id: $container_id})
+        OPTIONAL MATCH (lb)-[pod_exposure:EXPOSE]->(pod)
+        OPTIONAL MATCH (lb)-[container_exposure:EXPOSE]->(container)
+        RETURN pod.exposed_internet AS pod_exposed,
+               container.exposed_internet AS container_exposed,
+               pod_exposure IS NOT NULL AS pod_relationship,
+               container_exposure IS NOT NULL AS container_relationship
+        """,
+        address=load_balancer_address,
+        pod_id=case["pod_ing_id"],
+        container_id=case["cont_ing_id"],
+    ).single()
+    expected_property = True if expected_exposed else None
+    assert result["pod_exposed"] is expected_property
+    assert result["container_exposed"] is expected_property
+    assert result["pod_relationship"] is expected_exposed
+    assert result["container_relationship"] is expected_exposed

--- a/tests/integration/cartography/intel/kubernetes/test_services.py
+++ b/tests/integration/cartography/intel/kubernetes/test_services.py
@@ -300,9 +300,12 @@ def test_load_services_multiple_dns_names_creates_multiple_relationships(
     # Create second LB manually (simulating a second NLB/ALB)
     neo4j_session.run(
         """
-        MERGE (lb:AWSLoadBalancerV2{id: $dns_name, dnsname: $dns_name})
-        ON CREATE SET lb.firstseen = timestamp()
-        SET lb.lastupdated = $update_tag, lb.name = 'second-lb'
+            MERGE (lb:AWSLoadBalancerV2{id: $dns_name, dnsname: $dns_name})
+            ON CREATE SET lb.firstseen = timestamp()
+            SET lb.lastupdated = $update_tag,
+                lb.name = 'second-lb',
+                lb._ont_dns_name = $dns_name,
+                lb._ont_source = 'aws'
         """,
         dns_name=AWS_TEST_LB_DNS_NAME_2,
         update_tag=TEST_UPDATE_TAG,

--- a/tests/unit/cartography/intel/kubernetes/test_gateway_api.py
+++ b/tests/unit/cartography/intel/kubernetes/test_gateway_api.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -118,6 +119,9 @@ def test_transform_http_routes_uses_qualified_names_and_normalizes_timestamps():
             "parent_gateway_qualified_names": [
                 f"{KUBERNETES_CLUSTER_1_NAMESPACES_DATA[-1]['name']}/public-gateway",
             ],
+            "accepted_parent_gateway_qualified_names": [
+                f"{KUBERNETES_CLUSTER_1_NAMESPACES_DATA[-1]['name']}/public-gateway",
+            ],
         },
     ]
 
@@ -142,3 +146,84 @@ def test_transform_gateways_normalizes_rfc3339_timestamps_to_epoch():
 
     assert transformed["creation_timestamp"] == 1633587666
     assert transformed["deletion_timestamp"] == 1633587700
+    assert transformed["programmed"] is False
+
+
+def test_transform_gateways_uses_current_programmed_status_and_bound_addresses():
+    raw = [
+        {
+            "metadata": {
+                "name": "gw",
+                "namespace": "ns",
+                "uid": "uid-1",
+                "generation": 7,
+            },
+            "spec": {"gatewayClassName": "nginx"},
+            "status": {
+                "addresses": [
+                    {"type": "Hostname", "value": "LB.Example.COM"},
+                    {"value": "8.8.4.4"},
+                    {"value": "10.0.0.1"},
+                    {"type": "example.com/NamedAddress", "value": "edge-a"},
+                ],
+                "conditions": [
+                    {
+                        "type": "Programmed",
+                        "status": "True",
+                        "observedGeneration": 7,
+                    }
+                ],
+            },
+        }
+    ]
+
+    [transformed] = transform_gateways(raw)
+
+    assert transformed["programmed"] is True
+    assert transformed["load_balancer_dns_names"] == ["lb.example.com"]
+    assert transformed["load_balancer_ip_addresses"] == ["8.8.4.4"]
+
+
+def test_transform_gateways_rejects_stale_programmed_status():
+    raw = [
+        {
+            "metadata": {
+                "name": "gw",
+                "namespace": "ns",
+                "uid": "uid-1",
+                "generation": 8,
+            },
+            "spec": {"gatewayClassName": "nginx"},
+            "status": {
+                "conditions": [
+                    {
+                        "type": "Programmed",
+                        "status": "True",
+                        "observedGeneration": 7,
+                    }
+                ]
+            },
+        }
+    ]
+
+    [transformed] = transform_gateways(raw)
+
+    assert transformed["programmed"] is False
+
+
+def test_transform_http_routes_rejects_stale_accepted_status():
+    raw = deepcopy(KUBERNETES_HTTP_ROUTES_RAW)
+    raw[0]["metadata"]["generation"] += 1
+
+    [transformed] = transform_http_routes(raw)
+
+    assert transformed["accepted_parent_gateway_qualified_names"] == []
+
+
+def test_transform_http_routes_rejects_status_for_undeclared_parent():
+    raw = deepcopy(KUBERNETES_HTTP_ROUTES_RAW)
+    raw[0]["spec"]["parentRefs"] = [{"name": "another-gateway"}]
+
+    [transformed] = transform_http_routes(raw)
+
+    assert transformed["accepted_parent_gateway_qualified_names"] == []

--- a/tests/unit/cartography/intel/kubernetes/test_ingress.py
+++ b/tests/unit/cartography/intel/kubernetes/test_ingress.py
@@ -26,6 +26,7 @@ def test_transform_ingresses_lowercases_load_balancer_dns_names():
                     # which preserves the load balancer name's case.
                     V1IngressLoadBalancerIngress(
                         hostname="My-ALB-1234567890.us-east-1.elb.amazonaws.com",
+                        ip="9.9.9.9",
                     ),
                 ],
             ),
@@ -37,3 +38,4 @@ def test_transform_ingresses_lowercases_load_balancer_dns_names():
     assert transformed["load_balancer_dns_names"] == [
         "my-alb-1234567890.us-east-1.elb.amazonaws.com"
     ]
+    assert transformed["load_balancer_ip_addresses"] == ["9.9.9.9"]

--- a/tests/unit/cartography/intel/kubernetes/test_services.py
+++ b/tests/unit/cartography/intel/kubernetes/test_services.py
@@ -31,6 +31,7 @@ def test_transform_services_formats_load_balancer_port_status():
                 ingress=[
                     V1LoadBalancerIngress(
                         hostname="lb.example.com",
+                        ip="8.8.8.8",
                         ports=[
                             V1PortStatus(
                                 error="PortAllocationFailed",
@@ -49,7 +50,7 @@ def test_transform_services_formats_load_balancer_port_status():
     assert json.loads(transformed["load_balancer_ingress"]) == [
         {
             "hostname": "lb.example.com",
-            "ip": None,
+            "ip": "8.8.8.8",
             "ip_mode": None,
             "ports": [
                 {
@@ -61,6 +62,7 @@ def test_transform_services_formats_load_balancer_port_status():
         },
     ]
     assert transformed["load_balancer_dns_names"] == ["lb.example.com"]
+    assert transformed["load_balancer_ip_addresses"] == ["8.8.8.8"]
 
 
 def test_transform_services_lowercases_load_balancer_dns_names():

--- a/tests/unit/cartography/intel/kubernetes/test_util.py
+++ b/tests/unit/cartography/intel/kubernetes/test_util.py
@@ -3,6 +3,7 @@ from kubernetes.client.exceptions import ApiException
 
 from cartography.intel.kubernetes.util import get_gpu_quantity
 from cartography.intel.kubernetes.util import k8s_paginate
+from cartography.intel.kubernetes.util import normalize_global_ip_addresses
 
 
 def _raiser(status: int):
@@ -48,3 +49,17 @@ def test_get_gpu_quantity_sums_extended_gpu_resources():
         == 19
     )
     assert get_gpu_quantity({"example.com/gpu": "not-a-number"}) is None
+
+
+def test_normalize_global_ip_addresses_filters_non_global_values():
+    assert normalize_global_ip_addresses(
+        [
+            "8.8.8.8",
+            "8.8.8.8",
+            "2001:4860:4860:0:0:0:0:8888",
+            "10.0.0.1",
+            "127.0.0.1",
+            "fe80::1",
+            "not-an-ip",
+        ]
+    ) == ["2001:4860:4860::8888", "8.8.8.8"]


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary
Kubernetes Services and Gateways can report load balancer addresses independently of the cloud controller that created them. The existing Kubernetes sync only correlated AWS load balancers by hostname.

This change stores current load balancer status on Services and Gateways, matches globally routable status addresses to provider load balancers, and retains the existing direct AWS relationship when the provider-neutral ontology is not selected. Matching is intentionally limited to exact, globally routable IP addresses or normalized DNS names to avoid ambiguous private-address attribution.

### Related issues or links
- [Kubernetes Service documentation](https://kubernetes.io/docs/concepts/services-networking/service/)
- [Kubernetes Gateway API status documentation](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayStatus)

### How was this tested?
- Focused Kubernetes unit and Neo4j integration tests.
- Full stacked Kubernetes unit, integration, and schema documentation suite: 174 passed.
- Pre-commit hooks, including Black, isort, Flake8, mypy, and DCO checks.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [ ] Built the documentation with `uv run ./docs/build.sh`.

### Notes for reviewers
This draft is intentionally provider-neutral. Exact private IP matching is excluded because the same address can occur in unrelated networks.
