### PR TITLE
feat(kubernetes): ingest EndpointSlice backends

### DIFF
--- a/cartography/intel/kubernetes/__init__.py
+++ b/cartography/intel/kubernetes/__init__.py
@@ -8,6 +8,11 @@ from cartography.analysis.kubernetes.analysis import K8S_LB_EXPOSURE_JOBS
 from cartography.config import Config
 from cartography.intel.kubernetes.clusters import sync_kubernetes_cluster
 from cartography.intel.kubernetes.eks import sync as sync_eks
+from cartography.intel.kubernetes.endpoint_slices import get_endpoint_slice_data
+from cartography.intel.kubernetes.endpoint_slices import (
+    service_pod_ids_by_qualified_name,
+)
+from cartography.intel.kubernetes.endpoint_slices import sync_endpoint_slices
 from cartography.intel.kubernetes.gateway_api import sync_gateway_api
 from cartography.intel.kubernetes.ingress import sync_ingress
 from cartography.intel.kubernetes.namespaces import sync_namespaces
@@ -107,13 +112,30 @@ def start_k8s_ingestion(session: Session, config: Config) -> None:
                 replicaset_owner_map=replicaset_owner_map,
             )
             sync_secrets(session, client, config.update_tag, common_job_parameters)
+            # Fetch first to derive Service backends, then load after Services so
+            # FOR_SERVICE edges exist on the first sync without a second API call.
+            endpoint_slices = get_endpoint_slice_data(client)
+            endpoint_slice_pod_ids = (
+                service_pod_ids_by_qualified_name(endpoint_slices)
+                if endpoint_slices is not None
+                else None
+            )
             sync_services(
                 session,
                 client,
                 all_pods,
                 config.update_tag,
                 common_job_parameters,
+                endpoint_slice_pod_ids,
             )
+            if endpoint_slices is not None:
+                sync_endpoint_slices(
+                    session,
+                    endpoint_slices,
+                    client,
+                    config.update_tag,
+                    common_job_parameters,
+                )
             sync_network_policies(
                 session,
                 client,

--- a/cartography/intel/kubernetes/endpoint_slices.py
+++ b/cartography/intel/kubernetes/endpoint_slices.py
@@ -1,0 +1,214 @@
+import json
+import logging
+from typing import Any
+
+import neo4j
+from kubernetes.client.exceptions import ApiException
+from kubernetes.client.models import V1EndpointSlice
+from urllib3.exceptions import HTTPError
+
+from cartography.client.core.tx import load
+from cartography.graph.job import GraphJob
+from cartography.intel.kubernetes.util import get_epoch
+from cartography.intel.kubernetes.util import get_qualified_resource_name
+from cartography.intel.kubernetes.util import k8s_paginate
+from cartography.intel.kubernetes.util import K8sClient
+from cartography.models.kubernetes.endpoint_slices import KubernetesEndpointSliceSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+SERVICE_NAME_LABEL = "kubernetes.io/service-name"
+MANAGED_BY_LABEL = "endpointslice.kubernetes.io/managed-by"
+
+
+@timeit
+def get_endpoint_slices(client: K8sClient) -> list[V1EndpointSlice]:
+    return k8s_paginate(
+        client.discovery.list_endpoint_slice_for_all_namespaces,
+        raise_on_error=True,
+    )
+
+
+def transform_endpoint_slices(
+    endpoint_slices: list[V1EndpointSlice],
+) -> list[dict[str, Any]]:
+    transformed = []
+    for endpoint_slice in endpoint_slices:
+        metadata = endpoint_slice.metadata
+        labels = metadata.labels or {}
+        namespace = metadata.namespace
+        service_name = labels.get(SERVICE_NAME_LABEL)
+        endpoints = []
+        ready_pod_ids = set()
+        for endpoint in endpoint_slice.endpoints or []:
+            target_ref = endpoint.target_ref
+            ready = (
+                endpoint.conditions is None or endpoint.conditions.ready is not False
+            )
+            if ready and target_ref and target_ref.kind == "Pod" and target_ref.uid:
+                ready_pod_ids.add(target_ref.uid)
+            endpoints.append(
+                {
+                    "addresses": endpoint.addresses,
+                    "hostname": endpoint.hostname,
+                    "node_name": endpoint.node_name,
+                    "zone": endpoint.zone,
+                    "ready": (
+                        endpoint.conditions.ready if endpoint.conditions else None
+                    ),
+                    "serving": (
+                        endpoint.conditions.serving if endpoint.conditions else None
+                    ),
+                    "terminating": (
+                        endpoint.conditions.terminating if endpoint.conditions else None
+                    ),
+                    "target_ref": (
+                        {
+                            "api_version": target_ref.api_version,
+                            "kind": target_ref.kind,
+                            "name": target_ref.name,
+                            "namespace": target_ref.namespace,
+                            "uid": target_ref.uid,
+                        }
+                        if target_ref
+                        else None
+                    ),
+                }
+            )
+
+        ports = [
+            {
+                "name": port.name,
+                "port": port.port,
+                "protocol": port.protocol or "TCP",
+                "app_protocol": port.app_protocol,
+            }
+            for port in endpoint_slice.ports or []
+        ]
+        transformed.append(
+            {
+                "uid": metadata.uid,
+                "name": metadata.name,
+                "namespace": namespace,
+                "address_type": endpoint_slice.address_type,
+                "managed_by": labels.get(MANAGED_BY_LABEL),
+                "service_qualified_name": (
+                    get_qualified_resource_name(namespace, service_name)
+                    if namespace and service_name
+                    else None
+                ),
+                "endpoints": json.dumps(endpoints, sort_keys=True),
+                "ports": json.dumps(ports, sort_keys=True),
+                "port_numbers": sorted(
+                    {port["port"] for port in ports if port["port"] is not None}
+                ),
+                "ready_pod_ids": sorted(ready_pod_ids),
+                "creation_timestamp": get_epoch(metadata.creation_timestamp),
+                "deletion_timestamp": get_epoch(metadata.deletion_timestamp),
+            }
+        )
+    return transformed
+
+
+def service_pod_ids_by_qualified_name(
+    endpoint_slices: list[dict[str, Any]],
+) -> dict[str, list[str]]:
+    service_pod_ids: dict[str, set[str]] = {}
+    for endpoint_slice in endpoint_slices:
+        service_qualified_name = endpoint_slice["service_qualified_name"]
+        if not service_qualified_name:
+            continue
+        service_pod_ids.setdefault(service_qualified_name, set()).update(
+            endpoint_slice["ready_pod_ids"]
+        )
+    return {service: sorted(pod_ids) for service, pod_ids in service_pod_ids.items()}
+
+
+def load_endpoint_slices(
+    session: neo4j.Session,
+    endpoint_slices: list[dict[str, Any]],
+    update_tag: int,
+    cluster_id: str,
+    cluster_name: str,
+) -> None:
+    load(
+        session,
+        KubernetesEndpointSliceSchema(),
+        endpoint_slices,
+        lastupdated=update_tag,
+        CLUSTER_ID=cluster_id,
+        CLUSTER_NAME=cluster_name,
+    )
+
+
+def cleanup(session: neo4j.Session, common_job_parameters: dict[str, Any]) -> None:
+    GraphJob.from_node_schema(
+        KubernetesEndpointSliceSchema(), common_job_parameters
+    ).run(session)
+
+
+def get_endpoint_slice_data(
+    client: K8sClient,
+) -> list[dict[str, Any]] | None:
+    try:
+        endpoint_slices = transform_endpoint_slices(get_endpoint_slices(client))
+    except ApiException as error:
+        if error.status == 404:
+            logger.info(
+                "The discovery.k8s.io/v1 EndpointSlice API is unavailable on "
+                "cluster %s. Falling back to selector-based Service backends and "
+                "preserving previously synced EndpointSlice nodes.",
+                client.name,
+            )
+            return None
+        if error.status in (401, 403):
+            logger.warning(
+                "Cartography lacks permission to list EndpointSlices on cluster "
+                "%s (status %s). Falling back to selector-based Service backends "
+                "and preserving previously synced EndpointSlice nodes. Grant list "
+                "on endpointslices.discovery.k8s.io; this permission will be "
+                "required in v1.0.0.",
+                client.name,
+                error.status,
+            )
+            return None
+        status = error.status or 0
+        if status in (0, 429) or 500 <= status < 600:
+            logger.error(
+                "Transient Kubernetes API error listing EndpointSlices on cluster "
+                "%s (status %s). Falling back to selector-based Service backends "
+                "and preserving previously synced EndpointSlice nodes.",
+                client.name,
+                error.status,
+            )
+            return None
+        raise
+    except HTTPError:
+        logger.exception(
+            "Kubernetes transport error listing EndpointSlices on cluster %s. "
+            "Falling back to selector-based Service backends and preserving "
+            "previously synced EndpointSlice nodes.",
+            client.name,
+        )
+        return None
+
+    return endpoint_slices
+
+
+@timeit
+def sync_endpoint_slices(
+    session: neo4j.Session,
+    endpoint_slices: list[dict[str, Any]],
+    client: K8sClient,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    load_endpoint_slices(
+        session,
+        endpoint_slices,
+        update_tag,
+        common_job_parameters["CLUSTER_ID"],
+        client.name,
+    )
+    cleanup(session, common_job_parameters)

--- a/cartography/intel/kubernetes/services.py
+++ b/cartography/intel/kubernetes/services.py
@@ -95,7 +95,9 @@ def _format_load_balancer_ingress(ingress: list[V1LoadBalancerIngress] | None) -
 
 
 def transform_services(
-    services: list[V1Service], all_pods: list[dict[str, Any]]
+    services: list[V1Service],
+    all_pods: list[dict[str, Any]],
+    endpoint_slice_pod_ids: dict[str, list[str]] | None = None,
 ) -> list[dict[str, Any]]:
     services_list = []
     for service in services:
@@ -130,18 +132,22 @@ def transform_services(
                     )
                 )
 
-        # check if pod labels match service selector and add pod_ids to item
-        pod_ids = []
-        for pod in all_pods:
-            if pod["namespace"] == service.metadata.namespace:
-                service_selector: dict[str, str] | None = service.spec.selector
-                pod_labels: dict[str, str] | None = json.loads(pod["labels"])
-
-                # check if pod labels match service selector
-                if pod_labels and service_selector:
-                    if all(
-                        service_selector[key] == pod_labels.get(key)
-                        for key in service_selector
+        qualified_name = item["qualified_name"]
+        if endpoint_slice_pod_ids is not None:
+            pod_ids = endpoint_slice_pod_ids.get(qualified_name, [])
+        else:
+            pod_ids = []
+            for pod in all_pods:
+                if pod["namespace"] == service.metadata.namespace:
+                    service_selector: dict[str, str] | None = service.spec.selector
+                    pod_labels: dict[str, str] | None = json.loads(pod["labels"])
+                    if (
+                        pod_labels
+                        and service_selector
+                        and all(
+                            service_selector[key] == pod_labels.get(key)
+                            for key in service_selector
+                        )
                     ):
                         pod_ids.append(pod["uid"])
 
@@ -183,9 +189,14 @@ def sync_services(
     all_pods: list[dict[str, Any]],
     update_tag: int,
     common_job_parameters: dict[str, Any],
+    endpoint_slice_pod_ids: dict[str, list[str]] | None = None,
 ) -> None:
     services = get_services(client)
-    transformed_services = transform_services(services, all_pods)
+    transformed_services = transform_services(
+        services,
+        all_pods,
+        endpoint_slice_pod_ids,
+    )
     load_services(
         session=session,
         services=transformed_services,

--- a/cartography/intel/kubernetes/util.py
+++ b/cartography/intel/kubernetes/util.py
@@ -14,6 +14,7 @@ from kubernetes.client import AppsV1Api
 from kubernetes.client import BatchV1Api
 from kubernetes.client import CoreV1Api
 from kubernetes.client import CustomObjectsApi
+from kubernetes.client import DiscoveryV1Api
 from kubernetes.client import NetworkingV1Api
 from kubernetes.client import RbacAuthorizationV1Api
 from kubernetes.client import StorageV1Api
@@ -102,6 +103,21 @@ class K8NetworkingApiClient(NetworkingV1Api):
 
 
 class K8CustomObjectsApiClient(CustomObjectsApi):
+    def __init__(
+        self,
+        name: str,
+        config_file: str,
+        api_client: ApiClient | None = None,
+    ) -> None:
+        self.name = name
+        if not api_client:
+            api_client = config.new_client_from_config(
+                context=name, config_file=config_file
+            )
+        super().__init__(api_client=api_client)
+
+
+class K8DiscoveryApiClient(DiscoveryV1Api):
     def __init__(
         self,
         name: str,
@@ -206,6 +222,7 @@ class K8sClient:
         self.version = K8VersionApiClient(self.name, self.config_file)
         self.rbac = K8RbacApiClient(self.name, self.config_file)
         self.custom = K8CustomObjectsApiClient(self.name, self.config_file)
+        self.discovery = K8DiscoveryApiClient(self.name, self.config_file)
         self.apps = K8AppsApiClient(self.name, self.config_file)
         self.batch = K8BatchApiClient(self.name, self.config_file)
         self.storage = K8StorageApiClient(self.name, self.config_file)

--- a/cartography/models/kubernetes/endpoint_slices.py
+++ b/cartography/models/kubernetes/endpoint_slices.py
@@ -1,0 +1,156 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class KubernetesEndpointSliceNodeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef("uid", description="UID of the EndpointSlice.")
+    name: PropertyRef = PropertyRef("name", description="Name of the EndpointSlice.")
+    namespace: PropertyRef = PropertyRef(
+        "namespace",
+        extra_index=True,
+        description="Namespace containing the EndpointSlice.",
+    )
+    address_type: PropertyRef = PropertyRef(
+        "address_type",
+        description="Address family used by this slice, such as IPv4 or IPv6.",
+    )
+    managed_by: PropertyRef = PropertyRef(
+        "managed_by",
+        description="Controller named by the `endpointslice.kubernetes.io/managed-by` label.",
+    )
+    service_qualified_name: PropertyRef = PropertyRef(
+        "service_qualified_name",
+        extra_index=True,
+        description="`<namespace>/<name>` of the Service named by the `kubernetes.io/service-name` label.",
+    )
+    endpoints: PropertyRef = PropertyRef(
+        "endpoints",
+        description="Endpoint addresses, conditions, topology, and target references as a JSON-encoded list.",
+    )
+    ports: PropertyRef = PropertyRef(
+        "ports",
+        description="Ports shared by the endpoints in this slice as a JSON-encoded list.",
+    )
+    port_numbers: PropertyRef = PropertyRef(
+        "port_numbers",
+        description="Distinct non-null endpoint port numbers in this slice.",
+    )
+    creation_timestamp: PropertyRef = PropertyRef(
+        "creation_timestamp",
+        description="Timestamp when the EndpointSlice was created.",
+    )
+    deletion_timestamp: PropertyRef = PropertyRef(
+        "deletion_timestamp",
+        description="Timestamp when the EndpointSlice was marked for deletion.",
+    )
+    cluster_name: PropertyRef = PropertyRef(
+        "CLUSTER_NAME",
+        set_in_kwargs=True,
+        extra_index=True,
+        description="Name of the Kubernetes cluster containing this EndpointSlice.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesEndpointSliceRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class KubernetesEndpointSliceToClusterRel(CartographyRelSchema):
+    """Links a cluster to one of its EndpointSlices."""
+
+    target_node_label: str = "KubernetesCluster"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("CLUSTER_ID", set_in_kwargs=True)}
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: KubernetesEndpointSliceRelProperties = (
+        KubernetesEndpointSliceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesEndpointSliceToNamespaceRel(CartographyRelSchema):
+    """Links a namespace to an EndpointSlice it contains."""
+
+    target_node_label: str = "KubernetesNamespace"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "cluster_name": PropertyRef("CLUSTER_NAME", set_in_kwargs=True),
+            "name": PropertyRef("namespace"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "CONTAINS"
+    properties: KubernetesEndpointSliceRelProperties = (
+        KubernetesEndpointSliceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesEndpointSliceToServiceRel(CartographyRelSchema):
+    """Links an EndpointSlice to the Service named by its service-name label."""
+
+    target_node_label: str = "KubernetesService"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "cluster_name": PropertyRef("CLUSTER_NAME", set_in_kwargs=True),
+            "qualified_name": PropertyRef("service_qualified_name"),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "FOR_SERVICE"
+    properties: KubernetesEndpointSliceRelProperties = (
+        KubernetesEndpointSliceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesEndpointSliceToPodRel(CartographyRelSchema):
+    """Links an EndpointSlice to ready Pod endpoints referenced by the slice."""
+
+    target_node_label: str = "KubernetesPod"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {
+            "cluster_name": PropertyRef("CLUSTER_NAME", set_in_kwargs=True),
+            "id": PropertyRef("ready_pod_ids", one_to_many=True),
+        }
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "TARGETS"
+    properties: KubernetesEndpointSliceRelProperties = (
+        KubernetesEndpointSliceRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class KubernetesEndpointSliceSchema(CartographyNodeSchema):
+    """A Kubernetes EndpointSlice containing a subset of Service backends."""
+
+    label: str = "KubernetesEndpointSlice"
+    properties: KubernetesEndpointSliceNodeProperties = (
+        KubernetesEndpointSliceNodeProperties()
+    )
+    sub_resource_relationship: KubernetesEndpointSliceToClusterRel = (
+        KubernetesEndpointSliceToClusterRel()
+    )
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            KubernetesEndpointSliceToNamespaceRel(),
+            KubernetesEndpointSliceToServiceRel(),
+            KubernetesEndpointSliceToPodRel(),
+        ]
+    )

--- a/docs/root/modules/kubernetes/config.md
+++ b/docs/root/modules/kubernetes/config.md
@@ -16,6 +16,13 @@ Cartography's Kubernetes module requires read-only access to the following Kuber
 - `list nodes` for reading node architecture (used to resolve container images)
 - `list pods`
 - `list services`
+- `list endpointslices` in the `discovery.k8s.io` group: required to map
+  Services to the ready backend Pods that Kubernetes actually publishes. Until
+  v1.0.0, if this verb is missing Cartography logs a warning, preserves existing
+  `KubernetesEndpointSlice` nodes, and falls back to selector-based Service-to-Pod
+  relationships; from v1.0.0 a missing verb will be a hard failure. If the stable
+  `discovery.k8s.io/v1` API is unavailable, Cartography also uses the selector
+  fallback and preserves existing EndpointSlice nodes.
 - `list serviceaccounts`
 - `list persistentvolumes`
 - `list persistentvolumeclaims`
@@ -115,6 +122,13 @@ rules:
   resources:
     - ingresses
     - networkpolicies
+  verbs: ["list"]
+# Service backends (required). Until v1.0.0 Cartography tolerates this verb
+# being withheld and falls back to selector-based Service-to-Pod relationships;
+# from v1.0.0 it is a hard failure.
+- apiGroups: ["discovery.k8s.io"]
+  resources:
+    - endpointslices
   verbs: ["list"]
 # Gateway API resources (required). Only apply when the Gateway API CRDs are
 # installed in the cluster (a genuinely absent CRD stays a supported no-op).

--- a/docs/root/modules/kubernetes/index.md
+++ b/docs/root/modules/kubernetes/index.md
@@ -14,6 +14,15 @@ also requires a current `Programmed=True` Gateway condition and a current
 `Accepted=True` HTTPRoute parent condition; spec references alone don't establish
 reachability.
 
+Cartography ingests `discovery.k8s.io/v1` EndpointSlices as the source of truth
+for Service backends. Each `KubernetesEndpointSlice` links to the Service named by
+its `kubernetes.io/service-name` label and to ready Pod `targetRef` objects. This
+also supports selectorless Services. Until v1.0.0, missing EndpointSlice RBAC
+causes a warning and a selector-based fallback for that sync.
+When EndpointSlices are available, their published backend set is authoritative;
+a newly changed Service can therefore have no `TARGETS` relationships until its
+EndpointSlice controller reconciles the change.
+
 PersistentVolumes managed by the AWS EBS or Azure Disk CSI drivers connect to
 already-ingested cloud disks with `BACKED_BY` relationships.
 

--- a/tests/data/kubernetes/endpoint_slices.py
+++ b/tests/data/kubernetes/endpoint_slices.py
@@ -1,0 +1,69 @@
+from datetime import datetime
+from datetime import timezone
+
+from kubernetes.client import DiscoveryV1EndpointPort
+from kubernetes.client import V1Endpoint
+from kubernetes.client import V1EndpointConditions
+from kubernetes.client import V1EndpointSlice
+from kubernetes.client import V1ObjectMeta
+from kubernetes.client import V1ObjectReference
+
+from tests.data.kubernetes.namespaces import KUBERNETES_CLUSTER_1_NAMESPACES_DATA
+from tests.data.kubernetes.pods import KUBERNETES_PODS_DATA
+
+NAMESPACE = KUBERNETES_CLUSTER_1_NAMESPACES_DATA[-1]["name"]
+SERVICE_NAME = "my-service"
+
+KUBERNETES_ENDPOINT_SLICES_RAW = [
+    V1EndpointSlice(
+        metadata=V1ObjectMeta(
+            uid="endpoint-slice-uid",
+            name="my-service-abc12",
+            namespace=NAMESPACE,
+            labels={
+                "kubernetes.io/service-name": SERVICE_NAME,
+                "endpointslice.kubernetes.io/managed-by": (
+                    "endpointslice-controller.k8s.io"
+                ),
+            },
+            creation_timestamp=datetime(2026, 8, 1, tzinfo=timezone.utc),
+        ),
+        address_type="IPv4",
+        ports=[
+            DiscoveryV1EndpointPort(
+                name="http",
+                port=8080,
+                protocol="TCP",
+                app_protocol="http",
+            )
+        ],
+        endpoints=[
+            V1Endpoint(
+                addresses=["10.0.1.10"],
+                conditions=V1EndpointConditions(ready=True),
+                node_name="worker-a",
+                zone="example-zone-a",
+                target_ref=V1ObjectReference(
+                    api_version="v1",
+                    kind="Pod",
+                    name=KUBERNETES_PODS_DATA[0]["name"],
+                    namespace=NAMESPACE,
+                    uid=KUBERNETES_PODS_DATA[0]["uid"],
+                ),
+            ),
+            V1Endpoint(
+                addresses=["10.0.1.11"],
+                conditions=V1EndpointConditions(ready=False),
+                node_name="worker-b",
+                zone="example-zone-b",
+                target_ref=V1ObjectReference(
+                    api_version="v1",
+                    kind="Pod",
+                    name=KUBERNETES_PODS_DATA[1]["name"],
+                    namespace=NAMESPACE,
+                    uid=KUBERNETES_PODS_DATA[1]["uid"],
+                ),
+            ),
+        ],
+    )
+]

--- a/tests/integration/cartography/intel/kubernetes/test_endpoint_slices.py
+++ b/tests/integration/cartography/intel/kubernetes/test_endpoint_slices.py
@@ -1,0 +1,126 @@
+import json
+
+from cartography.intel.kubernetes.clusters import load_kubernetes_cluster
+from cartography.intel.kubernetes.endpoint_slices import cleanup
+from cartography.intel.kubernetes.endpoint_slices import load_endpoint_slices
+from cartography.intel.kubernetes.endpoint_slices import transform_endpoint_slices
+from cartography.intel.kubernetes.namespaces import load_namespaces
+from cartography.intel.kubernetes.pods import load_pods
+from cartography.intel.kubernetes.services import load_services
+from tests.data.kubernetes.clusters import KUBERNETES_CLUSTER_DATA
+from tests.data.kubernetes.clusters import KUBERNETES_CLUSTER_IDS
+from tests.data.kubernetes.clusters import KUBERNETES_CLUSTER_NAMES
+from tests.data.kubernetes.endpoint_slices import KUBERNETES_ENDPOINT_SLICES_RAW
+from tests.data.kubernetes.namespaces import KUBERNETES_CLUSTER_1_NAMESPACES_DATA
+from tests.data.kubernetes.pods import KUBERNETES_PODS_DATA
+from tests.data.kubernetes.services import KUBERNETES_SERVICES_DATA
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_UPDATE_TAG = 123456789
+
+
+def test_load_endpoint_slices_maps_services_to_ready_pods(neo4j_session):
+    load_kubernetes_cluster(neo4j_session, KUBERNETES_CLUSTER_DATA, TEST_UPDATE_TAG)
+    load_namespaces(
+        neo4j_session,
+        KUBERNETES_CLUSTER_1_NAMESPACES_DATA,
+        update_tag=TEST_UPDATE_TAG,
+        cluster_id=KUBERNETES_CLUSTER_IDS[0],
+        cluster_name=KUBERNETES_CLUSTER_NAMES[0],
+    )
+    load_pods(
+        neo4j_session,
+        KUBERNETES_PODS_DATA,
+        update_tag=TEST_UPDATE_TAG,
+        cluster_id=KUBERNETES_CLUSTER_IDS[0],
+        cluster_name=KUBERNETES_CLUSTER_NAMES[0],
+    )
+    load_services(
+        neo4j_session,
+        KUBERNETES_SERVICES_DATA,
+        update_tag=TEST_UPDATE_TAG,
+        cluster_id=KUBERNETES_CLUSTER_IDS[0],
+        cluster_name=KUBERNETES_CLUSTER_NAMES[0],
+    )
+    transformed = transform_endpoint_slices(KUBERNETES_ENDPOINT_SLICES_RAW)
+    load_endpoint_slices(
+        neo4j_session,
+        transformed,
+        TEST_UPDATE_TAG,
+        KUBERNETES_CLUSTER_IDS[0],
+        KUBERNETES_CLUSTER_NAMES[0],
+    )
+
+    assert check_nodes(
+        neo4j_session,
+        "KubernetesEndpointSlice",
+        ["name", "address_type"],
+    ) == {("my-service-abc12", "IPv4")}
+    assert neo4j_session.run(
+        "MATCH (slice:KubernetesEndpointSlice {name: 'my-service-abc12'}) "
+        "RETURN slice.port_numbers AS ports"
+    ).single()["ports"] == [8080]
+    assert json.loads(transformed[0]["endpoints"])[0]["ready"] is True
+    assert check_rels(
+        neo4j_session,
+        "KubernetesEndpointSlice",
+        "name",
+        "KubernetesService",
+        "name",
+        "FOR_SERVICE",
+        rel_direction_right=True,
+    ) == {("my-service-abc12", "my-service")}
+    assert check_rels(
+        neo4j_session,
+        "KubernetesEndpointSlice",
+        "name",
+        "KubernetesPod",
+        "name",
+        "TARGETS",
+        rel_direction_right=True,
+    ) == {("my-service-abc12", KUBERNETES_PODS_DATA[0]["name"])}
+
+    transformed[0]["ready_pod_ids"] = []
+    load_endpoint_slices(
+        neo4j_session,
+        transformed,
+        TEST_UPDATE_TAG + 1,
+        KUBERNETES_CLUSTER_IDS[0],
+        KUBERNETES_CLUSTER_NAMES[0],
+    )
+    cleanup(
+        neo4j_session,
+        {
+            "UPDATE_TAG": TEST_UPDATE_TAG + 1,
+            "CLUSTER_ID": KUBERNETES_CLUSTER_IDS[0],
+        },
+    )
+    assert (
+        check_rels(
+            neo4j_session,
+            "KubernetesEndpointSlice",
+            "name",
+            "KubernetesPod",
+            "name",
+            "TARGETS",
+            rel_direction_right=True,
+        )
+        == set()
+    )
+
+    load_endpoint_slices(
+        neo4j_session,
+        [],
+        TEST_UPDATE_TAG + 2,
+        KUBERNETES_CLUSTER_IDS[0],
+        KUBERNETES_CLUSTER_NAMES[0],
+    )
+    cleanup(
+        neo4j_session,
+        {
+            "UPDATE_TAG": TEST_UPDATE_TAG + 2,
+            "CLUSTER_ID": KUBERNETES_CLUSTER_IDS[0],
+        },
+    )
+    assert check_nodes(neo4j_session, "KubernetesEndpointSlice", ["name"]) == set()

--- a/tests/unit/cartography/intel/kubernetes/test_endpoint_slices.py
+++ b/tests/unit/cartography/intel/kubernetes/test_endpoint_slices.py
@@ -1,0 +1,61 @@
+from copy import deepcopy
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from kubernetes.client.exceptions import ApiException
+
+import cartography.intel.kubernetes.endpoint_slices as endpoint_slices_module
+from cartography.intel.kubernetes.endpoint_slices import get_endpoint_slice_data
+from cartography.intel.kubernetes.endpoint_slices import (
+    service_pod_ids_by_qualified_name,
+)
+from cartography.intel.kubernetes.endpoint_slices import transform_endpoint_slices
+from tests.data.kubernetes.endpoint_slices import KUBERNETES_ENDPOINT_SLICES_RAW
+from tests.data.kubernetes.endpoint_slices import NAMESPACE
+from tests.data.kubernetes.endpoint_slices import SERVICE_NAME
+from tests.data.kubernetes.pods import KUBERNETES_PODS_DATA
+
+
+def test_transform_endpoint_slices_uses_ready_pod_targets():
+    [endpoint_slice] = transform_endpoint_slices(KUBERNETES_ENDPOINT_SLICES_RAW)
+
+    assert endpoint_slice["service_qualified_name"] == f"{NAMESPACE}/{SERVICE_NAME}"
+    assert endpoint_slice["ready_pod_ids"] == [KUBERNETES_PODS_DATA[0]["uid"]]
+    assert endpoint_slice["port_numbers"] == [8080]
+    assert service_pod_ids_by_qualified_name([endpoint_slice]) == {
+        f"{NAMESPACE}/{SERVICE_NAME}": [KUBERNETES_PODS_DATA[0]["uid"]]
+    }
+
+
+def test_transform_endpoint_slice_without_service_label():
+    raw = deepcopy(KUBERNETES_ENDPOINT_SLICES_RAW)
+    raw[0].metadata.labels.pop("kubernetes.io/service-name")
+
+    [endpoint_slice] = transform_endpoint_slices(raw)
+
+    assert endpoint_slice["service_qualified_name"] is None
+
+
+@pytest.mark.parametrize("status", [401, 403, 404, 500])
+@patch.object(endpoint_slices_module, "get_endpoint_slices")
+def test_get_endpoint_slice_data_falls_back_on_permission_and_transient_errors(
+    mock_get_endpoint_slices,
+    status,
+):
+    client = MagicMock()
+    client.name = "example-cluster"
+    mock_get_endpoint_slices.side_effect = ApiException(status=status)
+
+    assert get_endpoint_slice_data(client) is None
+
+
+@patch.object(endpoint_slices_module, "get_endpoint_slices")
+def test_get_endpoint_slice_data_propagates_non_transient_api_errors(
+    mock_get_endpoint_slices,
+):
+    client = MagicMock()
+    mock_get_endpoint_slices.side_effect = ApiException(status=400)
+
+    with pytest.raises(ApiException):
+        get_endpoint_slice_data(client)

--- a/tests/unit/cartography/intel/kubernetes/test_init.py
+++ b/tests/unit/cartography/intel/kubernetes/test_init.py
@@ -6,6 +6,12 @@ import cartography.intel.kubernetes as kubernetes
 def test_start_k8s_ingestion_uses_external_id_for_eks_region(monkeypatch):
     cluster_arn = "arn:aws:eks:us-east-1:111122223333:cluster/example-eks-cluster"
     captured = {}
+    endpoint_slice_data = [
+        {
+            "service_qualified_name": "default/web",
+            "ready_pod_ids": ["pod-uid"],
+        }
+    ]
 
     class DummyClient:
         name = "dummy-context"
@@ -15,6 +21,12 @@ def test_start_k8s_ingestion_uses_external_id_for_eks_region(monkeypatch):
         captured["region"] = args[3]
         captured["cluster_id"] = args[5]
         captured["cluster_name"] = args[6]
+
+    def _capture_sync_services(*args, **kwargs):
+        captured["service_pod_ids"] = args[5]
+
+    def _capture_sync_endpoint_slices(*args, **kwargs):
+        captured["endpoint_slices"] = args[1]
 
     monkeypatch.setattr(kubernetes, "get_k8s_clients", lambda _: [DummyClient()])
     monkeypatch.setattr(
@@ -35,7 +47,15 @@ def test_start_k8s_ingestion_uses_external_id_for_eks_region(monkeypatch):
     monkeypatch.setattr(kubernetes, "sync_storage", lambda *args, **kwargs: None)
     monkeypatch.setattr(kubernetes, "sync_pods", lambda *args, **kwargs: [])
     monkeypatch.setattr(kubernetes, "sync_secrets", lambda *args, **kwargs: None)
-    monkeypatch.setattr(kubernetes, "sync_services", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        kubernetes,
+        "get_endpoint_slice_data",
+        lambda *args, **kwargs: endpoint_slice_data,
+    )
+    monkeypatch.setattr(
+        kubernetes, "sync_endpoint_slices", _capture_sync_endpoint_slices
+    )
+    monkeypatch.setattr(kubernetes, "sync_services", _capture_sync_services)
     monkeypatch.setattr(
         kubernetes, "sync_network_policies", lambda *args, **kwargs: None
     )
@@ -58,3 +78,5 @@ def test_start_k8s_ingestion_uses_external_id_for_eks_region(monkeypatch):
     assert captured["region"] == "us-east-1"
     assert captured["cluster_id"] == "11111111-2222-4333-8444-555555555555"
     assert captured["cluster_name"] == cluster_arn
+    assert captured["service_pod_ids"] == {"default/web": ["pod-uid"]}
+    assert captured["endpoint_slices"] == endpoint_slice_data

--- a/tests/unit/cartography/intel/kubernetes/test_services.py
+++ b/tests/unit/cartography/intel/kubernetes/test_services.py
@@ -98,3 +98,42 @@ def test_transform_services_lowercases_load_balancer_dns_names():
     assert transformed["load_balancer_dns_names"] == [
         "my-nlb-1234567890.us-east-1.elb.amazonaws.com"
     ]
+
+
+def test_transform_services_prefers_endpoint_slice_backends():
+    service = V1Service(
+        metadata=V1ObjectMeta(
+            uid="service-3",
+            name="selectorless",
+            namespace="default",
+        ),
+        spec=V1ServiceSpec(
+            type="ClusterIP",
+            selector={"app": "selectorless"},
+            cluster_ip="10.0.0.3",
+            ports=[],
+        ),
+        status=V1ServiceStatus(),
+    )
+
+    [transformed] = transform_services(
+        [service],
+        all_pods=[],
+        endpoint_slice_pod_ids={"default/selectorless": ["pod-uid"]},
+    )
+
+    assert transformed["pod_ids"] == ["pod-uid"]
+
+    [without_ready_backends] = transform_services(
+        [service],
+        all_pods=[
+            {
+                "namespace": "default",
+                "labels": json.dumps({"app": "selectorless"}),
+                "uid": "selector-match",
+            }
+        ],
+        endpoint_slice_pod_ids={},
+    )
+
+    assert without_ready_backends["pod_ids"] == []


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary
Service selectors describe desired membership, but EndpointSlices record the backends Kubernetes currently publishes. Selector-only modeling also cannot represent selectorless Services.

This change ingests `discovery.k8s.io/v1` EndpointSlices and their ready Pod targets, then uses those current relationships as the authoritative Service backend signal while retaining selector matching as a compatibility fallback when EndpointSlice access is unavailable. Authorization, unsupported-resource, and transient API failures are isolated so the rest of a cluster sync can continue without deleting previously discovered EndpointSlice data.

### Related issues or links
- [Kubernetes EndpointSlice documentation](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/)
- [EndpointSlice API reference](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/endpoint-slice-v1/)

### How was this tested?
- Unit tests with Kubernetes API-shaped EndpointSlice objects and API failure modes.
- Neo4j integration tests for ready targets, selectorless Services, cleanup, and stale-data preservation.
- Full stacked Kubernetes unit, integration, and schema documentation suite: 174 passed.
- Pre-commit hooks, including Black, isort, Flake8, mypy, and DCO checks.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [ ] Built the documentation with `uv run ./docs/build.sh`.

### Notes for reviewers
EndpointSlice nodes and relationships are update-tagged independently. Cleanup only runs after a successful EndpointSlice fetch.
