### PR TITLE
feat(kubernetes): attribute container exposure by port

### DIFF
--- a/cartography/analysis/kubernetes/analysis.py
+++ b/cartography/analysis/kubernetes/analysis.py
@@ -81,7 +81,13 @@ K8S_CONTAINER_ASSET_EXPOSURE = AnalysisJob(
     scope=ScopeById("KubernetesCluster", "CLUSTER_ID", scope_on="pod"),
     statements=(
         AnalysisStatement(
-            match="MATCH (pod:KubernetesPod{exposed_internet: true})-[:CONTAINS]->(c:KubernetesContainer)",
+            match="""
+            MATCH (svc:KubernetesService {exposed_internet: true})
+              <-[:FOR_SERVICE]-(slice:KubernetesEndpointSlice)
+              -[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)
+            WHERE any(port_key IN slice.port_keys WHERE port_key IN c.container_port_keys)
+            """,
+            incremental_on="slice",
             effects=(
                 SetProperty("c", "exposed_internet", True, label="KubernetesContainer"),
                 AddToSet(
@@ -168,7 +174,14 @@ K8S_LB_CONTAINER_EXPOSURE = AnalysisJob(
     ),
     statements=(
         AnalysisStatement(
-            match=f"MATCH (svc:KubernetesService)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE {INTERNET_FACING_LOAD_BALANCER} MATCH (svc)-[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)",
+            match=f"""
+            MATCH (svc:KubernetesService)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer)
+            WHERE {INTERNET_FACING_LOAD_BALANCER}
+            MATCH (svc)<-[:FOR_SERVICE]-(slice:KubernetesEndpointSlice)
+              -[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)
+            WHERE any(port_key IN slice.port_keys WHERE port_key IN c.container_port_keys)
+            """,
+            incremental_on="slice",
             effects=(
                 AddRelationship(
                     "lb",
@@ -182,7 +195,15 @@ K8S_LB_CONTAINER_EXPOSURE = AnalysisJob(
             ),
         ),
         AnalysisStatement(
-            match=f"MATCH (ing:KubernetesIngress)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer) WHERE {INTERNET_FACING_LOAD_BALANCER} MATCH (ing)-[:TARGETS]->(svc:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)",
+            match=f"""
+            MATCH (ing:KubernetesIngress)-[:USES_LOAD_BALANCER]->(lb:LoadBalancer)
+            WHERE {INTERNET_FACING_LOAD_BALANCER}
+            MATCH (ing)-[:TARGETS]->(svc:KubernetesService)
+              <-[:FOR_SERVICE]-(slice:KubernetesEndpointSlice)
+              -[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)
+            WHERE any(port_key IN slice.port_keys WHERE port_key IN c.container_port_keys)
+            """,
+            incremental_on="slice",
             effects=(
                 AddRelationship(
                     "lb",
@@ -203,9 +224,13 @@ K8S_LB_CONTAINER_EXPOSURE = AnalysisJob(
             match=f"""
             MATCH (gw:KubernetesGateway {{programmed: true}})-[:USES_LOAD_BALANCER]->(lb:LoadBalancer)
             WHERE {INTERNET_FACING_LOAD_BALANCER}
-            MATCH (gw)-[:ROUTES]->(route:KubernetesHTTPRoute)-[:TARGETS]->(svc:KubernetesService)-[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)
+            MATCH (gw)-[:ROUTES]->(route:KubernetesHTTPRoute)-[:TARGETS]->(svc:KubernetesService)
+              <-[:FOR_SERVICE]-(slice:KubernetesEndpointSlice)
+              -[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(c:KubernetesContainer)
             WHERE gw.qualified_name IN route.accepted_parent_gateway_qualified_names
+              AND any(port_key IN slice.port_keys WHERE port_key IN c.container_port_keys)
             """,
+            incremental_on="slice",
             effects=(
                 AddRelationship(
                     "lb",

--- a/cartography/intel/kubernetes/endpoint_slices.py
+++ b/cartography/intel/kubernetes/endpoint_slices.py
@@ -103,6 +103,13 @@ def transform_endpoint_slices(
                 "port_numbers": sorted(
                     {port["port"] for port in ports if port["port"] is not None}
                 ),
+                "port_keys": sorted(
+                    {
+                        f"{port['protocol']}/{port['port']}"
+                        for port in ports
+                        if port["port"] is not None
+                    }
+                ),
                 "ready_pod_ids": sorted(ready_pod_ids),
                 "creation_timestamp": get_epoch(metadata.creation_timestamp),
                 "deletion_timestamp": get_epoch(metadata.deletion_timestamp),

--- a/cartography/intel/kubernetes/pods.py
+++ b/cartography/intel/kubernetes/pods.py
@@ -61,6 +61,7 @@ def _extract_pod_containers(
             "host_ports": [],
             "container_ports": json.dumps([]),
             "container_port_numbers": [],
+            "container_port_keys": [],
             "persistent_volume_claim_ids": [],
             "persistent_volume_claim_read_write_ids": [],
             "persistent_volume_claim_mounts": "[]",
@@ -197,6 +198,13 @@ def _extract_pod_containers(
                     for port in ports
                     if port.container_port is not None
                     and (port.protocol or "TCP") in ("TCP", "UDP")
+                }
+            )
+            containers[container.name]["container_port_keys"] = sorted(
+                {
+                    f"{port.protocol or 'TCP'}/{port.container_port}"
+                    for port in ports
+                    if port.container_port is not None
                 }
             )
 

--- a/cartography/models/kubernetes/containers.py
+++ b/cartography/models/kubernetes/containers.py
@@ -150,6 +150,11 @@ class KubernetesContainerNodeProperties(CartographyNodeProperties):
         extra_index=True,
         description="Flat, queryable list of the declared TCP/UDP `containerPort` numbers. Derived from `container.ports[].container_port`. An empty list means the container *declares* no ports; it is not proof that the container listens on nothing, since a process can bind ports it never declared.",
     )
+    container_port_keys: PropertyRef = PropertyRef(
+        "container_port_keys",
+        extra_index=True,
+        description="Queryable `<protocol>/<port>` values for declared container ports, such as `TCP/8080`.",
+    )
     architecture_normalized: PropertyRef = PropertyRef(
         "architecture_normalized",
         description="Canonical CPU architecture derived from the scheduled node when available (e.g. `amd64`, `arm64`).",
@@ -157,7 +162,7 @@ class KubernetesContainerNodeProperties(CartographyNodeProperties):
     exposed_internet: PropertyRef = PropertyRef(
         "exposed_internet",
         extra_index=True,
-        description="`True` when the container's pod is targeted by a service reached from a correlated internet-facing cloud load balancer.",
+        description="`True` when the container declares a protocol and port published for its pod by a current EndpointSlice whose Service is reached from a correlated internet-facing cloud load balancer.",
     )  # Populated by the K8S_CONTAINER_ASSET_EXPOSURE analysis job.
     exposed_internet_type: PropertyRef = PropertyRef(
         "exposed_internet_type",

--- a/cartography/models/kubernetes/containers.py
+++ b/cartography/models/kubernetes/containers.py
@@ -153,7 +153,7 @@ class KubernetesContainerNodeProperties(CartographyNodeProperties):
     container_port_keys: PropertyRef = PropertyRef(
         "container_port_keys",
         extra_index=True,
-        description="Queryable `<protocol>/<port>` values for declared container ports, such as `TCP/8080`.",
+        description="Queryable `<protocol>/<port>` values for all declared TCP, UDP, and SCTP container ports, such as `TCP/8080`.",
     )
     architecture_normalized: PropertyRef = PropertyRef(
         "architecture_normalized",

--- a/cartography/models/kubernetes/endpoint_slices.py
+++ b/cartography/models/kubernetes/endpoint_slices.py
@@ -45,6 +45,10 @@ class KubernetesEndpointSliceNodeProperties(CartographyNodeProperties):
         "port_numbers",
         description="Distinct non-null endpoint port numbers in this slice.",
     )
+    port_keys: PropertyRef = PropertyRef(
+        "port_keys",
+        description="Distinct `<protocol>/<port>` values published by this slice, such as `TCP/8080`.",
+    )
     creation_timestamp: PropertyRef = PropertyRef(
         "creation_timestamp",
         description="Timestamp when the EndpointSlice was created.",

--- a/docs/root/modules/kubernetes/index.md
+++ b/docs/root/modules/kubernetes/index.md
@@ -23,6 +23,12 @@ When EndpointSlices are available, their published backend set is authoritative;
 a newly changed Service can therefore have no `TARGETS` relationships until its
 EndpointSlice controller reconciles the change.
 
+Pod exposure follows ready EndpointSlice targets. Container exposure is narrower:
+Cartography requires a current EndpointSlice port to match a container's declared
+`containerPort` by protocol and number. Pods share a network namespace, and
+`containerPort` declarations are optional, so a pod can be exposed while no
+individual container has enough Kubernetes metadata for attribution.
+
 PersistentVolumes managed by the AWS EBS or Azure Disk CSI drivers connect to
 already-ingested cloud disks with `BACKED_BY` relationships.
 

--- a/docs/root/modules/kubernetes/index.md
+++ b/docs/root/modules/kubernetes/index.md
@@ -28,6 +28,9 @@ Cartography requires a current EndpointSlice port to match a container's declare
 `containerPort` by protocol and number. Pods share a network namespace, and
 `containerPort` declarations are optional, so a pod can be exposed while no
 individual container has enough Kubernetes metadata for attribution.
+Because sibling containers share the same Pod IP, identical declared protocol
+and port values can't identify which process actually accepts the traffic; all
+matching siblings are attributed.
 
 PersistentVolumes managed by the AWS EBS or Azure Disk CSI drivers connect to
 already-ingested cloud disks with `BACKED_BY` relationships.

--- a/docs/root/modules/kubernetes/queries.md
+++ b/docs/root/modules/kubernetes/queries.md
@@ -53,6 +53,27 @@ IP correlation is an exact, graph-wide match; recycled addresses can correlate
 stale Kubernetes status with an unrelated load balancer, so treat IP-only paths
 as evidence to verify rather than proof of exposure.
 
+## Inspect port-attributed container exposure
+
+Find containers whose declared protocol and port match a current EndpointSlice
+port for an internet-exposed Service:
+
+```cypher
+MATCH (service:KubernetesService {exposed_internet: true})
+  <-[:FOR_SERVICE]-(slice:KubernetesEndpointSlice)
+  -[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(container:KubernetesContainer)
+WHERE slice.lastupdated = service.lastupdated
+  AND any(port_key IN slice.port_keys
+          WHERE port_key IN container.container_port_keys)
+RETURN service.namespace, service.name, pod.name, container.name,
+       [port_key IN slice.port_keys
+        WHERE port_key IN container.container_port_keys] AS matching_ports
+ORDER BY service.namespace, service.name, pod.name, container.name;
+```
+
+An absent result doesn't prove that a process is unreachable. Kubernetes doesn't
+require containers to declare the ports on which their processes listen.
+
 ## Inspect kubeconfig TLS posture
 
 Use the TLS posture fields on each cluster to find kubeconfig contexts that skip

--- a/docs/root/modules/kubernetes/queries.md
+++ b/docs/root/modules/kubernetes/queries.md
@@ -62,7 +62,7 @@ port for an internet-exposed Service:
 MATCH (service:KubernetesService {exposed_internet: true})
   <-[:FOR_SERVICE]-(slice:KubernetesEndpointSlice)
   -[:TARGETS]->(pod:KubernetesPod)-[:CONTAINS]->(container:KubernetesContainer)
-WHERE slice.lastupdated = service.lastupdated
+WHERE slice.lastupdated = $UPDATE_TAG
   AND any(port_key IN slice.port_keys
           WHERE port_key IN container.container_port_keys)
 RETURN service.namespace, service.name, pod.name, container.name,

--- a/tests/data/kubernetes/exposure.py
+++ b/tests/data/kubernetes/exposure.py
@@ -15,6 +15,7 @@ def build_exposure_test_data() -> dict:
     pod_lb_id = f"pod-lb-{case_id}"
     pod_ing_id = f"pod-ing-{case_id}"
     cont_lb_id = f"cont-lb-{case_id}"
+    cont_lb_mismatch_id = f"cont-lb-mismatch-{case_id}"
     cont_ing_id = f"cont-ing-{case_id}"
 
     svc_lb_id = f"svc-lb-{case_id}"
@@ -94,6 +95,25 @@ def build_exposure_test_data() -> dict:
             "cpu_request": "100m",
             "memory_limit": "256Mi",
             "cpu_limit": "500m",
+            "container_port_keys": ["TCP/8080"],
+        },
+        {
+            "uid": cont_lb_mismatch_id,
+            "name": "metrics",
+            "image": "example/metrics:latest",
+            "namespace": "default",
+            "pod_id": pod_lb_id,
+            "image_pull_policy": "Always",
+            "status_image_id": "img-3",
+            "status_image_sha": "sha256:3",
+            "status_ready": True,
+            "status_started": True,
+            "status_state": "running",
+            "memory_request": "64Mi",
+            "cpu_request": "50m",
+            "memory_limit": "128Mi",
+            "cpu_limit": "250m",
+            "container_port_keys": ["UDP/8080"],
         },
         {
             "uid": cont_ing_id,
@@ -111,6 +131,7 @@ def build_exposure_test_data() -> dict:
             "cpu_request": "100m",
             "memory_limit": "256Mi",
             "cpu_limit": "500m",
+            "container_port_keys": ["TCP/8080"],
         },
     ]
 
@@ -236,6 +257,7 @@ def build_exposure_test_data() -> dict:
         "pod_lb_id": pod_lb_id,
         "pod_ing_id": pod_ing_id,
         "cont_lb_id": cont_lb_id,
+        "cont_lb_mismatch_id": cont_lb_mismatch_id,
         "cont_ing_id": cont_ing_id,
         "svc_lb_id": svc_lb_id,
         "svc_ing_id": svc_ing_id,

--- a/tests/data/kubernetes/pods.py
+++ b/tests/data/kubernetes/pods.py
@@ -31,6 +31,7 @@ KUBERNETES_CONTAINER_DATA = [
             ]
         ),
         "container_port_numbers": [8080],
+        "container_port_keys": ["TCP/8080"],
     },
     {
         "name": "my-service-pod-container",
@@ -51,6 +52,7 @@ KUBERNETES_CONTAINER_DATA = [
         "host_ports": [],
         "container_ports": json.dumps([]),
         "container_port_numbers": [],
+        "container_port_keys": [],
     },
 ]
 

--- a/tests/integration/cartography/intel/kubernetes/test_endpoint_slices.py
+++ b/tests/integration/cartography/intel/kubernetes/test_endpoint_slices.py
@@ -59,8 +59,8 @@ def test_load_endpoint_slices_maps_services_to_ready_pods(neo4j_session):
     ) == {("my-service-abc12", "IPv4")}
     assert neo4j_session.run(
         "MATCH (slice:KubernetesEndpointSlice {name: 'my-service-abc12'}) "
-        "RETURN slice.port_numbers AS ports"
-    ).single()["ports"] == [8080]
+        "RETURN slice.port_numbers AS ports, slice.port_keys AS port_keys"
+    ).single() == {"ports": [8080], "port_keys": ["TCP/8080"]}
     assert json.loads(transformed[0]["endpoints"])[0]["ready"] is True
     assert check_rels(
         neo4j_session,

--- a/tests/integration/cartography/intel/kubernetes/test_exposure.py
+++ b/tests/integration/cartography/intel/kubernetes/test_exposure.py
@@ -242,10 +242,6 @@ def test_k8s_asset_exposure_properties(neo4j_session):
 def test_stale_endpoint_slices_do_not_attribute_container_exposure(neo4j_session):
     case = build_exposure_test_data()
     _seed_exposure_graph(neo4j_session, case=case)
-    neo4j_session.run(
-        "MATCH (slice:KubernetesEndpointSlice) SET slice.lastupdated = $stale_tag",
-        stale_tag=case["update_tag"] - 1,
-    )
     common_job_parameters = {
         "UPDATE_TAG": case["update_tag"],
         "CLUSTER_ID": case["cluster_id"],
@@ -253,6 +249,21 @@ def test_stale_endpoint_slices_do_not_attribute_container_exposure(neo4j_session
 
     _run_k8s_compute_analysis(neo4j_session, common_job_parameters)
     _run_k8s_lb_analysis(neo4j_session, common_job_parameters)
+    assert (
+        neo4j_session.run(
+            "MATCH (container:KubernetesContainer {id: $container_id}) "
+            "RETURN container.exposed_internet AS exposed",
+            container_id=case["cont_lb_id"],
+        ).single()["exposed"]
+        is True
+    )
+
+    next_job_parameters = {
+        "UPDATE_TAG": case["update_tag"] + 1,
+        "CLUSTER_ID": case["cluster_id"],
+    }
+    _run_k8s_compute_analysis(neo4j_session, next_job_parameters)
+    _run_k8s_lb_analysis(neo4j_session, next_job_parameters)
 
     result = neo4j_session.run(
         """

--- a/tests/integration/cartography/intel/kubernetes/test_exposure.py
+++ b/tests/integration/cartography/intel/kubernetes/test_exposure.py
@@ -7,6 +7,7 @@ from cartography.analysis.kubernetes.analysis import K8S_COMPUTE_ASSET_EXPOSURE_
 from cartography.analysis.kubernetes.analysis import K8S_LB_EXPOSURE_JOBS
 from cartography.intel.aws.ec2.load_balancer_v2s import load_load_balancer_v2s
 from cartography.intel.kubernetes.clusters import load_kubernetes_cluster
+from cartography.intel.kubernetes.endpoint_slices import load_endpoint_slices
 from cartography.intel.kubernetes.gateway_api import load_gateways
 from cartography.intel.kubernetes.gateway_api import load_http_routes
 from cartography.intel.kubernetes.ingress import load_ingresses
@@ -78,6 +79,30 @@ def _seed_exposure_graph(
     load_services(
         neo4j_session,
         case["services"],
+        update_tag=case["update_tag"],
+        cluster_id=case["cluster_id"],
+        cluster_name=case["cluster_name"],
+    )
+    load_endpoint_slices(
+        neo4j_session,
+        [
+            {
+                "uid": f"slice-{service['uid']}",
+                "name": f"slice-{service['uid']}",
+                "namespace": service["namespace"],
+                "address_type": "IPv4",
+                "managed_by": "endpointslice-controller.k8s.io",
+                "service_qualified_name": service["qualified_name"],
+                "endpoints": "[]",
+                "ports": "[]",
+                "port_numbers": [8080],
+                "port_keys": ["TCP/8080"],
+                "ready_pod_ids": service["pod_ids"],
+                "creation_timestamp": None,
+                "deletion_timestamp": None,
+            }
+            for service in case["services"]
+        ],
         update_tag=case["update_tag"],
         cluster_id=case["cluster_id"],
         cluster_name=case["cluster_name"],
@@ -202,6 +227,50 @@ def test_k8s_asset_exposure_properties(neo4j_session):
     assert [r["id"] for r in result] == sorted(
         [case["cont_ing_id"], case["cont_lb_id"]]
     )
+
+    result = neo4j_session.run(
+        """
+        MATCH (c:KubernetesContainer {id: $container_id})
+        OPTIONAL MATCH (:LoadBalancer)-[exposure:EXPOSE]->(c)
+        RETURN c.exposed_internet AS exposed, count(exposure) AS relationship_count
+        """,
+        container_id=case["cont_lb_mismatch_id"],
+    )
+    assert result.single() == {"exposed": None, "relationship_count": 0}
+
+
+def test_stale_endpoint_slices_do_not_attribute_container_exposure(neo4j_session):
+    case = build_exposure_test_data()
+    _seed_exposure_graph(neo4j_session, case=case)
+    neo4j_session.run(
+        "MATCH (slice:KubernetesEndpointSlice) SET slice.lastupdated = $stale_tag",
+        stale_tag=case["update_tag"] - 1,
+    )
+    common_job_parameters = {
+        "UPDATE_TAG": case["update_tag"],
+        "CLUSTER_ID": case["cluster_id"],
+    }
+
+    _run_k8s_compute_analysis(neo4j_session, common_job_parameters)
+    _run_k8s_lb_analysis(neo4j_session, common_job_parameters)
+
+    result = neo4j_session.run(
+        """
+        MATCH (pod:KubernetesPod {id: $pod_id})
+        MATCH (container:KubernetesContainer {id: $container_id})
+        OPTIONAL MATCH (:LoadBalancer)-[exposure:EXPOSE]->(container)
+        RETURN pod.exposed_internet AS pod_exposed,
+               container.exposed_internet AS container_exposed,
+               count(exposure) AS relationship_count
+        """,
+        pod_id=case["pod_lb_id"],
+        container_id=case["cont_lb_id"],
+    ).single()
+    assert result == {
+        "pod_exposed": True,
+        "container_exposed": None,
+        "relationship_count": 0,
+    }
 
 
 def test_k8s_asset_exposure_type_deduplicates_on_multiple_paths(neo4j_session):

--- a/tests/unit/cartography/intel/kubernetes/test_endpoint_slices.py
+++ b/tests/unit/cartography/intel/kubernetes/test_endpoint_slices.py
@@ -23,6 +23,7 @@ def test_transform_endpoint_slices_uses_ready_pod_targets():
     assert endpoint_slice["service_qualified_name"] == f"{NAMESPACE}/{SERVICE_NAME}"
     assert endpoint_slice["ready_pod_ids"] == [KUBERNETES_PODS_DATA[0]["uid"]]
     assert endpoint_slice["port_numbers"] == [8080]
+    assert endpoint_slice["port_keys"] == ["TCP/8080"]
     assert service_pod_ids_by_qualified_name([endpoint_slice]) == {
         f"{NAMESPACE}/{SERVICE_NAME}": [KUBERNETES_PODS_DATA[0]["uid"]]
     }

--- a/tests/unit/cartography/intel/kubernetes/test_endpoint_slices.py
+++ b/tests/unit/cartography/intel/kubernetes/test_endpoint_slices.py
@@ -38,6 +38,15 @@ def test_transform_endpoint_slice_without_service_label():
     assert endpoint_slice["service_qualified_name"] is None
 
 
+def test_transform_endpoint_slice_defaults_protocol_to_tcp():
+    raw = deepcopy(KUBERNETES_ENDPOINT_SLICES_RAW)
+    raw[0].ports[0].protocol = None
+
+    [endpoint_slice] = transform_endpoint_slices(raw)
+
+    assert endpoint_slice["port_keys"] == ["TCP/8080"]
+
+
 @pytest.mark.parametrize("status", [401, 403, 404, 500])
 @patch.object(endpoint_slices_module, "get_endpoint_slices")
 def test_get_endpoint_slice_data_falls_back_on_permission_and_transient_errors(

--- a/tests/unit/cartography/intel/kubernetes/test_pods.py
+++ b/tests/unit/cartography/intel/kubernetes/test_pods.py
@@ -292,6 +292,7 @@ def test_transform_pods_extracts_container_ports():
     container = transformed[0]["containers"][0]
 
     assert container["container_port_numbers"] == [53, 8080]
+    assert container["container_port_keys"] == ["SCTP/9000", "TCP/8080", "UDP/53"]
     assert container["host_ports"] == [30053]
     assert json.loads(container["container_ports"]) == [
         {"container_port": 8080, "protocol": "TCP", "name": "http"},


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary
A Pod shares one network namespace, but copying Pod exposure to every sibling container overstates which container declares the published listener.

This change preserves Pod-level exposure and attributes exposure to a container only when its declared protocol and port match a current EndpointSlice backend port. Containers without declared ports remain unknown at the container level rather than inheriting the Pod result. The model documents the remaining same-port sibling ambiguity.

### Related issues or links
- [Kubernetes Pod networking documentation](https://kubernetes.io/docs/concepts/workloads/pods/#pod-networking)
- [Kubernetes EndpointSlice ports](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/#ports)

### How was this tested?
- Unit and Neo4j integration tests for TCP, UDP, omitted protocol defaults, mismatches, sibling containers, and update-tag retraction.
- Full stacked Kubernetes unit, integration, and schema documentation suite: 174 passed.
- Pre-commit hooks, including Black, isort, Flake8, mypy, and DCO checks.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [ ] Built the documentation with `uv run ./docs/build.sh`.

### Notes for reviewers
This deliberately does not infer listeners for containers that omit `containerPort`; the Pod remains the reliable exposure boundary in that case.
