### PR TITLE
feat(kubernetes): ingest node exposure signals

### DIFF
--- a/cartography/intel/kubernetes/nodes.py
+++ b/cartography/intel/kubernetes/nodes.py
@@ -12,6 +12,8 @@ from cartography.intel.kubernetes.util import format_resource_quantities
 from cartography.intel.kubernetes.util import get_gpu_quantity
 from cartography.intel.kubernetes.util import k8s_paginate
 from cartography.intel.kubernetes.util import K8sClient
+from cartography.intel.kubernetes.util import normalize_global_ip_addresses
+from cartography.intel.kubernetes.util import normalize_ip_addresses
 from cartography.models.kubernetes.nodes import KubernetesNodeSchema
 from cartography.util import timeit
 
@@ -43,6 +45,17 @@ def transform_nodes(nodes: list[V1Node], cluster_name: str) -> list[dict[str, An
         labels = node.metadata.labels or {}
         capacity = node.status.capacity if node.status else None
         allocatable = node.status.allocatable if node.status else None
+        addresses = [
+            {"type": address.type, "address": address.address}
+            for address in (node.status.addresses if node.status else None) or []
+        ]
+        external_ip_addresses = normalize_ip_addresses(
+            [
+                address["address"]
+                for address in addresses
+                if address["type"] == "ExternalIP"
+            ]
+        )
         transformed.append(
             {
                 "id": f"{cluster_name}/{node.metadata.name}",
@@ -52,6 +65,11 @@ def transform_nodes(nodes: list[V1Node], cluster_name: str) -> list[dict[str, An
                 "labels": json.dumps(labels, sort_keys=True),
                 "capacity": format_resource_quantities(capacity),
                 "allocatable": format_resource_quantities(allocatable),
+                "addresses": json.dumps(addresses, sort_keys=True),
+                "external_ip_addresses": external_ip_addresses,
+                "global_external_ip_addresses": normalize_global_ip_addresses(
+                    external_ip_addresses
+                ),
                 "gpu_capacity": get_gpu_quantity(capacity),
                 "gpu_allocatable": get_gpu_quantity(allocatable),
                 "gpu_product": labels.get("nvidia.com/gpu.product")

--- a/cartography/intel/kubernetes/pods.py
+++ b/cartography/intel/kubernetes/pods.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from ipaddress import ip_address
 from typing import Any
 
 import neo4j
@@ -19,6 +20,16 @@ from cartography.models.kubernetes.pods import KubernetesPodSchema
 from cartography.util import timeit
 
 logger = logging.getLogger(__name__)
+
+
+def _host_ip_uses_node_addresses(host_ip: str | None) -> bool:
+    if not host_ip:
+        return True
+    try:
+        address = ip_address(host_ip)
+    except ValueError:
+        return False
+    return address.is_unspecified
 
 
 def _claim_id(cluster_name: str, namespace: str, claim_name: str) -> str:
@@ -59,6 +70,9 @@ def _extract_pod_containers(
             "added_capabilities": [],
             "dropped_capabilities": [],
             "host_ports": [],
+            "host_port_keys": [],
+            "node_address_host_port_keys": [],
+            "host_port_bindings": "[]",
             "container_ports": json.dumps([]),
             "container_port_numbers": [],
             "container_port_keys": [],
@@ -171,6 +185,34 @@ def _extract_pod_containers(
         if ports:
             containers[container.name]["host_ports"] = sorted(
                 [port.host_port for port in ports if port.host_port is not None]
+            )
+            host_port_bindings = [
+                {
+                    "name": port.name,
+                    "protocol": port.protocol or "TCP",
+                    "container_port": port.container_port,
+                    "host_port": port.host_port,
+                    "host_ip": getattr(port, "host_ip", None),
+                }
+                for port in ports
+                if port.host_port is not None
+            ]
+            containers[container.name]["host_port_bindings"] = json.dumps(
+                host_port_bindings,
+                sort_keys=True,
+            )
+            containers[container.name]["host_port_keys"] = sorted(
+                {
+                    f"{binding['protocol']}/{binding['host_port']}"
+                    for binding in host_port_bindings
+                }
+            )
+            containers[container.name]["node_address_host_port_keys"] = sorted(
+                {
+                    f"{binding['protocol']}/{binding['host_port']}"
+                    for binding in host_port_bindings
+                    if _host_ip_uses_node_addresses(binding["host_ip"])
+                }
             )
 
             # The containerPorts a container *declares* (as opposed to the

--- a/cartography/intel/kubernetes/services.py
+++ b/cartography/intel/kubernetes/services.py
@@ -14,6 +14,7 @@ from cartography.intel.kubernetes.util import get_qualified_resource_name
 from cartography.intel.kubernetes.util import k8s_paginate
 from cartography.intel.kubernetes.util import K8sClient
 from cartography.intel.kubernetes.util import normalize_global_ip_addresses
+from cartography.intel.kubernetes.util import normalize_ip_addresses
 from cartography.models.kubernetes.services import KubernetesServiceSchema
 from cartography.util import timeit
 
@@ -28,6 +29,20 @@ def get_services(client: K8sClient) -> list[V1Service]:
 
 def _format_service_selector(selector: dict[str, str]) -> str:
     return json.dumps(selector)
+
+
+def _service_ports(service: V1Service) -> list[dict[str, Any]]:
+    return [
+        {
+            "name": port.name,
+            "protocol": port.protocol or "TCP",
+            "port": port.port,
+            "target_port": port.target_port,
+            "node_port": port.node_port,
+            "app_protocol": port.app_protocol,
+        }
+        for port in service.spec.ports or []
+    ]
 
 
 def _extract_load_balancer_dns_names(
@@ -114,7 +129,26 @@ def transform_services(
             "selector": _format_service_selector(service.spec.selector),
             "cluster_ip": service.spec.cluster_ip,
             "load_balancer_ip": service.spec.load_balancer_ip,
+            "external_traffic_policy": service.spec.external_traffic_policy,
         }
+        service_ports = _service_ports(service)
+        item["ports"] = json.dumps(service_ports, sort_keys=True)
+        item["port_keys"] = sorted(
+            {f"{port['protocol']}/{port['port']}" for port in service_ports}
+        )
+        item["node_port_keys"] = sorted(
+            {
+                f"{port['protocol']}/{port['node_port']}"
+                for port in service_ports
+                if port["node_port"] is not None
+            }
+        )
+        item["external_ip_addresses"] = normalize_ip_addresses(
+            service.spec.external_ips or []
+        )
+        item["global_external_ip_addresses"] = normalize_global_ip_addresses(
+            service.spec.external_ips or []
+        )
 
         # TODO: instead of storing a json string, we should probably create seperate nodes for each ingress
         if service.spec.type == "LoadBalancer":

--- a/cartography/intel/kubernetes/util.py
+++ b/cartography/intel/kubernetes/util.py
@@ -25,16 +25,21 @@ from kubernetes.config.kube_config import KubeConfigMerger
 logger = logging.getLogger(__name__)
 
 
-def normalize_global_ip_addresses(values: list[str]) -> list[str]:
+def normalize_ip_addresses(values: list[str]) -> list[str]:
     normalized: set[str] = set()
     for value in values:
         try:
             address = ip_address(value)
         except ValueError:
             continue
-        if address.is_global:
-            normalized.add(address.compressed)
+        normalized.add(address.compressed)
     return sorted(normalized)
+
+
+def normalize_global_ip_addresses(values: list[str]) -> list[str]:
+    return [
+        value for value in normalize_ip_addresses(values) if ip_address(value).is_global
+    ]
 
 
 def format_resource_quantities(resources: dict[str, Any] | None) -> str:

--- a/cartography/models/kubernetes/containers.py
+++ b/cartography/models/kubernetes/containers.py
@@ -141,6 +141,18 @@ class KubernetesContainerNodeProperties(CartographyNodeProperties):
         "host_ports",
         description="List of host ports exposed by the container. Derived from `container.ports[].host_port`.",
     )
+    host_port_bindings: PropertyRef = PropertyRef(
+        "host_port_bindings",
+        description="Declared hostIP, hostPort, containerPort, protocol, and name settings as a JSON-encoded list.",
+    )
+    host_port_keys: PropertyRef = PropertyRef(
+        "host_port_keys",
+        description="Distinct `<protocol>/<hostPort>` values declared by the container.",
+    )
+    node_address_host_port_keys: PropertyRef = PropertyRef(
+        "node_address_host_port_keys",
+        description="Declared `<protocol>/<hostPort>` values whose hostIP is unset or unspecified, so the binding can use node addresses. A public node address still doesn't prove firewall reachability or that a process is listening.",
+    )
     container_ports: PropertyRef = PropertyRef(
         "container_ports",
         description="The ports the container *declares* in its pod spec. Derived from `container.ports[]`, stored as a JSON-encoded list of `{container_port, protocol, name}`. `containerPort` is optional in Kubernetes, so this reflects declared ports only, not necessarily every port the process listens on.",

--- a/cartography/models/kubernetes/nodes.py
+++ b/cartography/models/kubernetes/nodes.py
@@ -75,6 +75,18 @@ class KubernetesNodeNodeProperties(CartographyNodeProperties):
         "allocatable",
         description="Node allocatable resources from `status.allocatable`, stored as a JSON-encoded object.",
     )
+    addresses: PropertyRef = PropertyRef(
+        "addresses",
+        description="Node addresses from `status.addresses` as a JSON-encoded list of type and address pairs.",
+    )
+    external_ip_addresses: PropertyRef = PropertyRef(
+        "external_ip_addresses",
+        description="Canonical addresses reported with type `ExternalIP` in node status.",
+    )
+    global_external_ip_addresses: PropertyRef = PropertyRef(
+        "global_external_ip_addresses",
+        description="Globally routable node `ExternalIP` addresses; firewall and node-proxy reachability require independent validation.",
+    )
     gpu_capacity: PropertyRef = PropertyRef(
         "gpu_capacity",
         description="Total GPU scheduling-unit capacity across full-GPU, NVIDIA MIG, and Intel GPU resource keys; heterogeneous units are not normalized to physical GPUs.",

--- a/cartography/models/kubernetes/services.py
+++ b/cartography/models/kubernetes/services.py
@@ -64,6 +64,30 @@ class KubernetesServiceNodeProperties(CartographyNodeProperties):
         "load_balancer_ip_addresses",
         description="Globally routable IP addresses reported in `status.loadBalancer.ingress` and used to correlate this service with cloud load balancers.",
     )
+    ports: PropertyRef = PropertyRef(
+        "ports",
+        description="Service port, targetPort, nodePort, protocol, and appProtocol settings as a JSON-encoded list.",
+    )
+    port_keys: PropertyRef = PropertyRef(
+        "port_keys",
+        description="Distinct `<protocol>/<service-port>` values published by this Service.",
+    )
+    node_port_keys: PropertyRef = PropertyRef(
+        "node_port_keys",
+        description="Distinct `<protocol>/<nodePort>` values allocated to this Service.",
+    )
+    external_ip_addresses: PropertyRef = PropertyRef(
+        "external_ip_addresses",
+        description="Canonical IP addresses configured in `spec.externalIPs`.",
+    )
+    global_external_ip_addresses: PropertyRef = PropertyRef(
+        "global_external_ip_addresses",
+        description="Globally routable IP addresses configured in `spec.externalIPs`; routing and firewall reachability require independent validation.",
+    )
+    external_traffic_policy: PropertyRef = PropertyRef(
+        "external_traffic_policy",
+        description="How external traffic is distributed: `Cluster` or `Local`.",
+    )
     cluster_name: PropertyRef = PropertyRef(
         "CLUSTER_NAME",
         set_in_kwargs=True,

--- a/docs/root/modules/kubernetes/index.md
+++ b/docs/root/modules/kubernetes/index.md
@@ -32,6 +32,12 @@ Because sibling containers share the same Pod IP, identical declared protocol
 and port values can't identify which process actually accepts the traffic; all
 matching siblings are attributed.
 
+Cartography also records Kubernetes-managed network exposure surfaces without
+promoting them to confirmed internet exposure: Service `externalIPs`, allocated
+`nodePort` values, node `ExternalIP` addresses, container `hostPort` bindings,
+and Pod `hostNetwork` settings. These fields need independent routing, firewall,
+kube-proxy, and listening-process validation before they establish reachability.
+
 PersistentVolumes managed by the AWS EBS or Azure Disk CSI drivers connect to
 already-ingested cloud disks with `BACKED_BY` relationships.
 

--- a/docs/root/modules/kubernetes/queries.md
+++ b/docs/root/modules/kubernetes/queries.md
@@ -74,6 +74,59 @@ ORDER BY service.namespace, service.name, pod.name, container.name;
 An absent result doesn't prove that a process is unreachable. Kubernetes doesn't
 require containers to declare the ports on which their processes listen.
 
+## Find node-address exposure surfaces
+
+List Service and Pod settings that can publish traffic on globally routable
+addresses reported by Kubernetes:
+
+```cypher
+MATCH (service:KubernetesService)
+WHERE size(service.global_external_ip_addresses) > 0
+RETURN 'external_ip' AS surface, service.namespace, service.name,
+       service.global_external_ip_addresses AS addresses,
+       service.port_keys AS ports
+UNION
+MATCH (cluster:KubernetesCluster)-[:RESOURCE]->(service:KubernetesService),
+      (cluster)-[:RESOURCE]->(node:KubernetesNode)
+WHERE size(service.node_port_keys) > 0
+  AND size(node.global_external_ip_addresses) > 0
+  AND (
+    coalesce(service.external_traffic_policy, 'Cluster') <> 'Local'
+    OR EXISTS {
+      MATCH (service)-[:TARGETS]->(:KubernetesPod)-[:RUNS_ON]->(node)
+    }
+  )
+RETURN 'node_port' AS surface, service.namespace, service.name,
+       node.global_external_ip_addresses AS addresses,
+       service.node_port_keys AS ports
+UNION
+MATCH (pod:KubernetesPod)-[:RUNS_ON]->(node:KubernetesNode),
+      (pod)-[:CONTAINS]->(container:KubernetesContainer)
+WHERE size(node.global_external_ip_addresses) > 0
+  AND (
+    (pod.host_network = true AND size(container.container_port_keys) > 0)
+    OR size(container.node_address_host_port_keys) > 0
+  )
+RETURN CASE
+         WHEN size(container.node_address_host_port_keys) > 0 THEN 'host_port'
+         ELSE 'host_network'
+       END AS surface,
+       pod.namespace AS namespace, pod.name AS name,
+       node.global_external_ip_addresses AS addresses,
+       CASE
+         WHEN size(container.node_address_host_port_keys) > 0
+           THEN container.node_address_host_port_keys
+         ELSE container.container_port_keys
+       END AS ports;
+```
+
+These are investigation candidates, not confirmed findings. In particular,
+Kubernetes doesn't report kube-proxy `nodePortAddresses`, network firewalls, or
+whether the declared process is listening on the published port.
+The host-port branch covers bindings that use the node's addresses. Explicit
+`hostIP` bindings, including globally routable addresses, remain available in
+`container.host_port_bindings` and must be evaluated against that exact address.
+
 ## Inspect kubeconfig TLS posture
 
 Use the TLS posture fields on each cluster to find kubeconfig contexts that skip

--- a/tests/data/kubernetes/nodes.py
+++ b/tests/data/kubernetes/nodes.py
@@ -18,6 +18,10 @@ RAW_NODES = [
             provider_id="aws:///us-east-1a/i-0123456789abcdef0",
         ),
         status=SimpleNamespace(
+            addresses=[
+                SimpleNamespace(type="InternalIP", address="10.0.0.10"),
+                SimpleNamespace(type="ExternalIP", address="8.8.8.8"),
+            ],
             capacity={"cpu": "128", "memory": "2Ti", "nvidia.com/gpu": "8"},
             allocatable={
                 "cpu": "127",
@@ -38,6 +42,9 @@ RAW_NODES = [
         metadata=SimpleNamespace(name="my-arm-node", labels={}),
         spec=SimpleNamespace(provider_id=None),
         status=SimpleNamespace(
+            addresses=[
+                SimpleNamespace(type="InternalIP", address="10.0.0.11"),
+            ],
             capacity={"cpu": "4", "memory": "16Gi"},
             allocatable={"cpu": "3900m", "memory": "15Gi"},
             node_info=SimpleNamespace(
@@ -91,6 +98,9 @@ KUBERNETES_NODE_DATA = [
         "labels": '{"nvidia.com/gpu.present": "true", "nvidia.com/gpu.product": "NVIDIA-H200"}',
         "capacity": '{"cpu": "128", "memory": "2Ti", "nvidia.com/gpu": "8"}',
         "allocatable": '{"cpu": "127", "memory": "1900Gi", "nvidia.com/gpu": "8"}',
+        "addresses": '[{"address": "10.0.0.10", "type": "InternalIP"}, {"address": "8.8.8.8", "type": "ExternalIP"}]',
+        "external_ip_addresses": ["8.8.8.8"],
+        "global_external_ip_addresses": ["8.8.8.8"],
         "gpu_capacity": 8,
         "gpu_allocatable": 8,
         "gpu_product": "NVIDIA-H200",
@@ -110,6 +120,9 @@ KUBERNETES_NODE_DATA = [
         "labels": "{}",
         "capacity": '{"cpu": "4", "memory": "16Gi"}',
         "allocatable": '{"cpu": "3900m", "memory": "15Gi"}',
+        "addresses": '[{"address": "10.0.0.11", "type": "InternalIP"}]',
+        "external_ip_addresses": [],
+        "global_external_ip_addresses": [],
         "gpu_capacity": None,
         "gpu_allocatable": None,
         "gpu_product": None,

--- a/tests/data/kubernetes/pods.py
+++ b/tests/data/kubernetes/pods.py
@@ -24,7 +24,20 @@ KUBERNETES_CONTAINER_DATA = [
         "cpu_request": "100m",
         "memory_limit": "256Mi",
         "cpu_limit": "500m",
-        "host_ports": [],
+        "host_ports": [30080],
+        "host_port_bindings": json.dumps(
+            [
+                {
+                    "name": "http",
+                    "protocol": "TCP",
+                    "container_port": 8080,
+                    "host_port": 30080,
+                    "host_ip": None,
+                }
+            ]
+        ),
+        "host_port_keys": ["TCP/30080"],
+        "node_address_host_port_keys": ["TCP/30080"],
         "container_ports": json.dumps(
             [
                 {"container_port": 8080, "protocol": "TCP", "name": "http"},
@@ -50,6 +63,9 @@ KUBERNETES_CONTAINER_DATA = [
         "memory_limit": "128Mi",
         "cpu_limit": "200m",
         "host_ports": [],
+        "host_port_bindings": "[]",
+        "host_port_keys": [],
+        "node_address_host_port_keys": [],
         "container_ports": json.dumps([]),
         "container_port_numbers": [],
         "container_port_keys": [],

--- a/tests/data/kubernetes/services.py
+++ b/tests/data/kubernetes/services.py
@@ -107,6 +107,23 @@ KUBERNETES_LOADBALANCER_SERVICE_DATA = [
         "load_balancer_dns_names": [
             AWS_TEST_LB_DNS_NAME,
         ],
+        "ports": json.dumps(
+            [
+                {
+                    "name": "https",
+                    "protocol": "TCP",
+                    "port": 443,
+                    "target_port": 8443,
+                    "node_port": 30443,
+                    "app_protocol": None,
+                }
+            ]
+        ),
+        "port_keys": ["TCP/443"],
+        "node_port_keys": ["TCP/30443"],
+        "external_ip_addresses": ["8.8.8.8"],
+        "global_external_ip_addresses": ["8.8.8.8"],
+        "external_traffic_policy": "Local",
     },
 ]
 

--- a/tests/integration/cartography/intel/kubernetes/test_nodes.py
+++ b/tests/integration/cartography/intel/kubernetes/test_nodes.py
@@ -90,6 +90,10 @@ def test_sync_nodes_and_runs_on(neo4j_session, monkeypatch):
         ("my-node", 8, 8, "NVIDIA-H200"),
         ("my-arm-node", None, None, None),
     }
+    assert neo4j_session.run(
+        "MATCH (node:KubernetesNode {name: 'my-node'}) "
+        "RETURN node.global_external_ip_addresses AS addresses"
+    ).single()["addresses"] == ["8.8.8.8"]
 
     # Assert: pod is linked to its scheduled node
     assert check_rels(

--- a/tests/integration/cartography/intel/kubernetes/test_pods.py
+++ b/tests/integration/cartography/intel/kubernetes/test_pods.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -236,6 +237,17 @@ def test_load_pod_containers(neo4j_session, _create_test_cluster):
         )
         == expected_pull_policies
     )
+    host_port_surface = neo4j_session.run(
+        """
+        MATCH (container:KubernetesContainer {name: 'my-pod-container'})
+        RETURN container.host_port_keys AS host_port_keys,
+               container.node_address_host_port_keys AS node_address_keys,
+               container.host_port_bindings AS bindings
+        """
+    ).single()
+    assert host_port_surface["host_port_keys"] == ["TCP/30080"]
+    assert host_port_surface["node_address_keys"] == ["TCP/30080"]
+    assert json.loads(host_port_surface["bindings"])[0]["host_port"] == 30080
 
 
 def test_load_pod_containers_relationships(neo4j_session, _create_test_cluster):

--- a/tests/integration/cartography/intel/kubernetes/test_services.py
+++ b/tests/integration/cartography/intel/kubernetes/test_services.py
@@ -194,6 +194,21 @@ def test_load_services_with_aws_loadbalancer_relationship(
     # Assert: Expect that the service was loaded
     expected_nodes = {("my-lb-service",)}
     assert check_nodes(neo4j_session, "KubernetesService", ["name"]) == expected_nodes
+    service_surface = neo4j_session.run(
+        """
+        MATCH (service:KubernetesService {name: 'my-lb-service'})
+        RETURN service.port_keys AS port_keys,
+               service.node_port_keys AS node_port_keys,
+               service.global_external_ip_addresses AS external_ips,
+               service.external_traffic_policy AS traffic_policy
+        """
+    ).single()
+    assert service_surface == {
+        "port_keys": ["TCP/443"],
+        "node_port_keys": ["TCP/30443"],
+        "external_ips": ["8.8.8.8"],
+        "traffic_policy": "Local",
+    }
 
     # Assert: Expect USES_LOAD_BALANCER relationship exists
     # AWS_TEST_LB_DNS_NAME is derived from LOAD_BALANCER_DATA to keep tests in sync

--- a/tests/unit/cartography/intel/kubernetes/test_pods.py
+++ b/tests/unit/cartography/intel/kubernetes/test_pods.py
@@ -269,6 +269,7 @@ def test_transform_pods_extracts_container_ports():
                             protocol="UDP",
                             name="dns",
                             host_port=30053,
+                            host_ip=None,
                         ),
                         # SCTP and protocol-less ports are retained in the raw
                         # spec but excluded from the flat TCP/UDP number list.
@@ -277,6 +278,14 @@ def test_transform_pods_extracts_container_ports():
                             protocol="SCTP",
                             name="sctp",
                             host_port=None,
+                            host_ip=None,
+                        ),
+                        SimpleNamespace(
+                            container_port=8443,
+                            protocol="TCP",
+                            name="private-admin",
+                            host_port=30443,
+                            host_ip="10.0.0.10",
                         ),
                     ],
                 ),
@@ -291,13 +300,21 @@ def test_transform_pods_extracts_container_ports():
     transformed = transform_pods([pod], "my-cluster-1")
     container = transformed[0]["containers"][0]
 
-    assert container["container_port_numbers"] == [53, 8080]
-    assert container["container_port_keys"] == ["SCTP/9000", "TCP/8080", "UDP/53"]
-    assert container["host_ports"] == [30053]
+    assert container["container_port_numbers"] == [53, 8080, 8443]
+    assert container["container_port_keys"] == [
+        "SCTP/9000",
+        "TCP/8080",
+        "TCP/8443",
+        "UDP/53",
+    ]
+    assert container["host_ports"] == [30053, 30443]
+    assert container["host_port_keys"] == ["TCP/30443", "UDP/30053"]
+    assert container["node_address_host_port_keys"] == ["UDP/30053"]
     assert json.loads(container["container_ports"]) == [
         {"container_port": 8080, "protocol": "TCP", "name": "http"},
         {"container_port": 53, "protocol": "UDP", "name": "dns"},
         {"container_port": 9000, "protocol": "SCTP", "name": "sctp"},
+        {"container_port": 8443, "protocol": "TCP", "name": "private-admin"},
     ]
 
 

--- a/tests/unit/cartography/intel/kubernetes/test_services.py
+++ b/tests/unit/cartography/intel/kubernetes/test_services.py
@@ -5,6 +5,7 @@ from kubernetes.client.models import V1LoadBalancerStatus
 from kubernetes.client.models import V1ObjectMeta
 from kubernetes.client.models import V1PortStatus
 from kubernetes.client.models import V1Service
+from kubernetes.client.models import V1ServicePort
 from kubernetes.client.models import V1ServiceSpec
 from kubernetes.client.models import V1ServiceStatus
 
@@ -137,3 +138,34 @@ def test_transform_services_prefers_endpoint_slice_backends():
     )
 
     assert without_ready_backends["pod_ids"] == []
+
+
+def test_transform_services_extracts_node_port_and_external_ip_facts():
+    service = V1Service(
+        metadata=V1ObjectMeta(uid="service-4", name="edge", namespace="default"),
+        spec=V1ServiceSpec(
+            type="NodePort",
+            selector={"app": "edge"},
+            cluster_ip="10.0.0.4",
+            external_ips=["8.8.8.8", "10.0.0.8"],
+            external_traffic_policy="Local",
+            ports=[
+                V1ServicePort(
+                    name="https",
+                    protocol="TCP",
+                    port=443,
+                    target_port=8443,
+                    node_port=30443,
+                )
+            ],
+        ),
+        status=V1ServiceStatus(),
+    )
+
+    [transformed] = transform_services([service], all_pods=[])
+
+    assert transformed["port_keys"] == ["TCP/443"]
+    assert transformed["node_port_keys"] == ["TCP/30443"]
+    assert transformed["external_ip_addresses"] == ["10.0.0.8", "8.8.8.8"]
+    assert transformed["global_external_ip_addresses"] == ["8.8.8.8"]
+    assert transformed["external_traffic_policy"] == "Local"

--- a/tests/unit/cartography/intel/kubernetes/test_util.py
+++ b/tests/unit/cartography/intel/kubernetes/test_util.py
@@ -4,6 +4,7 @@ from kubernetes.client.exceptions import ApiException
 from cartography.intel.kubernetes.util import get_gpu_quantity
 from cartography.intel.kubernetes.util import k8s_paginate
 from cartography.intel.kubernetes.util import normalize_global_ip_addresses
+from cartography.intel.kubernetes.util import normalize_ip_addresses
 
 
 def _raiser(status: int):
@@ -63,3 +64,4 @@ def test_normalize_global_ip_addresses_filters_non_global_values():
             "not-an-ip",
         ]
     ) == ["2001:4860:4860::8888", "8.8.8.8"]
+    assert normalize_ip_addresses(["10.0.0.1", "invalid", "10.0.0.1"]) == ["10.0.0.1"]


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary
Kubernetes has exposure surfaces that do not require a cloud LoadBalancer: Service `externalIPs`, NodePorts, container `hostPort`, and `hostNetwork`. These are useful security facts, but none proves end-to-end internet reachability by itself.

This change stores the relevant Service, Node, and container facts and adds example queries that return exposure candidates. It intentionally does not set `exposed_internet`; callers must also evaluate routing, firewall policy, kube-proxy behavior, traffic policy, and whether a process is listening.

### Related issues or links
- [Kubernetes Service documentation](https://kubernetes.io/docs/concepts/services-networking/service/)
- [Kubernetes configuration best practices](https://kubernetes.io/docs/concepts/configuration/overview/)

### How was this tested?
- Unit tests with Kubernetes API-shaped Service, Node, and Pod objects.
- Neo4j integration tests for external IPs, NodePort metadata, Node ExternalIP addresses, hostPort bindings, and hostNetwork.
- Full stacked Kubernetes unit, integration, and schema documentation suite: 174 passed.
- Pre-commit hooks, including Black, isort, Flake8, mypy, and DCO checks.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [ ] Built the documentation with `uv run ./docs/build.sh`.

### Notes for reviewers
The example NodePort query respects `externalTrafficPolicy: Local` by requiring a target Pod on the candidate Node. Explicit non-wildcard host IP bindings remain available in the JSON binding details for address-specific evaluation.
