### PR TITLE
docs: expand intel modules sidebar by default

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -180,7 +180,6 @@ html_theme = "shibuya"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "globaltoc_expand_depth": 1,
     "github_url": "https://github.com/cartography-cncf/cartography",
     "page_layout": "default",
     "accent_color": "cyan",
@@ -216,6 +215,7 @@ html_favicon = os.path.join(_source_asset_prefix, "images/logo-vertical.svg")
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = [os.path.join(_source_asset_prefix, "_static")]
 html_css_files = ["custom.css"]
+html_js_files = ["expand-intel-modules.js"]
 
 # html_style = 'css/cartography.css'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -180,7 +180,7 @@ html_theme = "shibuya"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "globaltoc_collapse": True,
+    "globaltoc_expand_depth": 1,
     "github_url": "https://github.com/cartography-cncf/cartography",
     "page_layout": "default",
     "accent_color": "cyan",

--- a/docs/root/_static/expand-intel-modules.js
+++ b/docs/root/_static/expand-intel-modules.js
@@ -1,0 +1,8 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const link = document.querySelector('.globaltoc a[href$="module-list.html"]');
+  const item = link?.parentElement;
+
+  if (item?.classList.contains("_collapse")) {
+    item.querySelector(":scope > button")?.click();
+  }
+});


### PR DESCRIPTION
Cartography supports a broad range of intel modules, but the collapsed sidebar hides that breadth. Keep the Intel Modules list expanded by default across the docs while preserving the collapsed defaults for the other sections and the existing sidebar toggle behavior.

Validation: `uv run ./docs/build.sh`

<img width="300" height="714" alt="Screenshot 2026-08-29 at 11 07 55 AM" src="https://github.com/user-attachments/assets/d03e6a05-d244-4f05-b679-57d2f96cbcef" />

