### PR TITLE
feat(rules): inventory running AI agents

### DIFF
--- a/cartography/analysis/ontology/analysis.py
+++ b/cartography/analysis/ontology/analysis.py
@@ -723,7 +723,9 @@ WORKLOAD_HAS_RUNTIME_IMAGE = AnalysisJob(
                 ":Container on a single node with no intermediate WORKLOAD_PARENT hop. "
                 "Exposure is the OR of the service-level signal (svc.exposed_internet, "
                 "where GCP writes Cloud Run ingress exposure) and any running replica's "
-                "signal (rt.exposed_internet, where AWS ECS / Kubernetes write it). "
+                "signal (rt.exposed_internet, where AWS ECS / Kubernetes write it). If "
+                "neither level has evaluated exposure, the edge keeps it unknown rather "
+                "than treating missing evidence as proof that the workload is internal. "
                 "The active-state filter accepts both 'running' (AWS ECS RUNNING, "
                 "Kubernetes running, Azure Running, GCP Cloud Run) and 'ready' (Scaleway "
                 "serverless ContainerStatus.READY) because _ont_state carries the raw "
@@ -734,8 +736,13 @@ WORKLOAD_HAS_RUNTIME_IMAGE = AnalysisJob(
             MATCH (svc:ComputeService)<-[:WORKLOAD_PARENT*0..6]-(rt)-[:RESOLVED_IMAGE]->(img:Image)
             WHERE (rt:Container OR rt:Function)
               AND (NOT rt:Container OR toLower(rt._ont_state) IN ['running', 'ready'])
-            WITH svc, img, collect(coalesce(rt.exposed_internet, false)) AS rt_flags
-            WITH svc, img, (coalesce(svc.exposed_internet, false) OR true IN rt_flags) AS exposed
+            WITH svc, img, collect(rt.exposed_internet) AS rt_flags
+            WITH svc, img,
+                CASE
+                    WHEN svc.exposed_internet = true OR true IN rt_flags THEN true
+                    WHEN svc.exposed_internet = false OR false IN rt_flags THEN false
+                    ELSE null
+                END AS exposed
             """,
             effects=(
                 AddRelationship(

--- a/cartography/intel/aibom/transform.py
+++ b/cartography/intel/aibom/transform.py
@@ -235,6 +235,7 @@ def _build_source_payload(
         "run_id": _as_str(report_metadata.get("run_id")),
         "analyzer_version": _as_str(report_metadata.get("analyzer_version")),
         "analysis_status": _as_str(report_metadata.get("status")),
+        "agentic_status": _as_str(report_metadata.get("agentic_status")),
         "report_schema_version": _as_str(report_metadata.get("report_schema_version")),
         "report_started_at": _as_str(report_metadata.get("started_at")),
         "report_completed_at": _as_str(report_metadata.get("completed_at")),

--- a/cartography/models/aibom/source.py
+++ b/cartography/models/aibom/source.py
@@ -52,6 +52,11 @@ class AIBOMSourceNodeProperties(CartographyNodeProperties):
         extra_index=True,
         description="Top-level report status.",
     )
+    agentic_status: PropertyRef = PropertyRef(
+        "agentic_status",
+        extra_index=True,
+        description="Agentic review status reported by the analyzer.",
+    )
     report_schema_version: PropertyRef = PropertyRef(
         "report_schema_version",
         extra_index=True,

--- a/cartography/rules/data/rules/__init__.py
+++ b/cartography/rules/data/rules/__init__.py
@@ -277,6 +277,7 @@ from cartography.rules.data.rules.nist_ai_rmf import ai_provider_api_key_hygiene
 from cartography.rules.data.rules.nist_ai_rmf import ai_third_party_app_inventory
 from cartography.rules.data.rules.nist_ai_rmf import ai_third_party_app_sensitive_scopes
 from cartography.rules.data.rules.nist_ai_rmf import aibom_agent_inventory
+from cartography.rules.data.rules.nist_ai_rmf import aibom_agent_runtime_inventory
 from cartography.rules.data.rules.nist_ai_rmf import aibom_coverage_gaps
 from cartography.rules.data.rules.object_storage_public import object_storage_public
 from cartography.rules.data.rules.policy_administration_privileges import (
@@ -394,6 +395,7 @@ RULES = {
     ai_third_party_app_inventory.id: ai_third_party_app_inventory,
     ai_third_party_app_sensitive_scopes.id: ai_third_party_app_sensitive_scopes,
     ai_admin_app_authorizations.id: ai_admin_app_authorizations,
+    aibom_agent_runtime_inventory.id: aibom_agent_runtime_inventory,
     aibom_agent_inventory.id: aibom_agent_inventory,
     aibom_coverage_gaps.id: aibom_coverage_gaps,
     ai_provider_api_key_hygiene.id: ai_provider_api_key_hygiene,

--- a/cartography/rules/data/rules/nist_ai_rmf.py
+++ b/cartography/rules/data/rules/nist_ai_rmf.py
@@ -704,6 +704,7 @@ class NistAiAibomCoverageGapOutput(Finding):
     scanner_version: str | None = None
     source_status: str | None = None
     analysis_status: str | None = None
+    agentic_status: str | None = None
     image_matched: bool | None = None
     total_components: int | None = None
     gap_reason: str | None = None
@@ -725,6 +726,9 @@ _aibom_nist_ai_coverage_gaps = Fact(
             WHEN toLower(coalesce(source.source_status, 'completed')) <> 'completed' THEN 'incomplete_source'
             WHEN source.analysis_status IS NOT NULL
                  AND toLower(source.analysis_status) <> 'completed' THEN 'analysis_not_completed'
+            WHEN source.agentic_status IS NOT NULL
+                 AND toLower(source.agentic_status) <> 'completed' THEN 'agentic_review_incomplete'
+            WHEN coalesce(source.pending_agent_review, 0) > 0 THEN 'agentic_review_pending'
             ELSE NULL
         END AS gap_reason
     WHERE gap_reason IS NOT NULL
@@ -737,6 +741,7 @@ _aibom_nist_ai_coverage_gaps = Fact(
         source.scanner_version AS scanner_version,
         source.source_status AS source_status,
         source.analysis_status AS analysis_status,
+        source.agentic_status AS agentic_status,
         source.image_matched AS image_matched,
         source.total_components AS total_components,
         gap_reason
@@ -751,11 +756,28 @@ _aibom_nist_ai_coverage_gaps = Fact(
             source.analysis_status IS NOT NULL
             AND toLower(source.analysis_status) <> 'completed'
         )
+        OR (
+            source.agentic_status IS NOT NULL
+            AND toLower(source.agentic_status) <> 'completed'
+        )
+        OR coalesce(source.pending_agent_review, 0) > 0
     OPTIONAL MATCH p=(source)-[:SCANNED_IMAGE]->(:Image)
     RETURN source, p
     """,
     cypher_count_query="""
     MATCH (source:AIBOMSource)
+    WHERE
+        coalesce(source.image_matched, false) = false
+        OR toLower(coalesce(source.source_status, 'completed')) <> 'completed'
+        OR (
+            source.analysis_status IS NOT NULL
+            AND toLower(source.analysis_status) <> 'completed'
+        )
+        OR (
+            source.agentic_status IS NOT NULL
+            AND toLower(source.agentic_status) <> 'completed'
+        )
+        OR coalesce(source.pending_agent_review, 0) > 0
     RETURN COUNT(source) AS count
     """,
     asset_label="AIBOMSource",

--- a/cartography/rules/data/rules/nist_ai_rmf.py
+++ b/cartography/rules/data/rules/nist_ai_rmf.py
@@ -602,7 +602,7 @@ _aibom_nist_ai_agent_runtime_inventory = Fact(
     name="Deployed AI agents running in a workload",
     description=(
         "Inventories AI agents whose scanned image is running on a workload, one row "
-        "per agent and workload. Narrows the AIBOM inventory to what is actually "
+        "per logical agent and workload. Narrows the AIBOM inventory to what is actually "
         "deployed, and names the workload so its tenant, cluster, region, and "
         "internet reachability can be read from the graph around it."
     ),
@@ -612,19 +612,36 @@ _aibom_nist_ai_agent_runtime_inventory = Fact(
     // Aggregate over the images rather than grouping by the image node: a digest is not
     // unique across registries, so an image pushed to both ECR and GHCR is two :Image
     // nodes sharing one _ont_digest, and grouping would report the agent once per registry.
-    WITH source, agent, svc, min(img._ont_digest) AS manifest_digest
+    WITH
+        coalesce(agent.logical_id, agent.id) AS agent_logical_id,
+        svc,
+        min(agent.id) AS representative_agent_id
+    MATCH (representative_source:AIBOMSource)-[:HAS_COMPONENT]->
+        (representative_agent:AIAgent {id: representative_agent_id})
+    MATCH (representative_source)-[:SCANNED_IMAGE]->(representative_image:Image)
+        <-[:HAS_RUNTIME_IMAGE]-(svc)
+    WITH
+        agent_logical_id,
+        svc,
+        representative_agent,
+        min(representative_source.image_uri) AS image_uri,
+        min(representative_image._ont_digest) AS manifest_digest
     RETURN
-        coalesce(agent.name, agent.logical_id, agent.id) AS agent_name,
+        coalesce(
+            representative_agent.name,
+            representative_agent.logical_id,
+            representative_agent.id
+        ) AS agent_name,
         coalesce(svc._ont_name, svc.name, svc.id) AS workload_name,
         svc.id AS workload_id,
         svc._ont_source AS ontology_source,
-        source.image_uri AS image_uri,
+        image_uri,
         manifest_digest,
-        agent.id AS agent_component_id,
-        agent.logical_id AS agent_logical_id,
-        agent.framework AS agent_framework,
-        agent.file_path AS agent_file_path,
-        agent.line_number AS agent_line_number
+        representative_agent.id AS agent_component_id,
+        agent_logical_id AS agent_logical_id,
+        representative_agent.framework AS agent_framework,
+        representative_agent.file_path AS agent_file_path,
+        representative_agent.line_number AS agent_line_number
     ORDER BY agent_name, workload_name
     """,
     cypher_visual_query="""
@@ -637,11 +654,11 @@ _aibom_nist_ai_agent_runtime_inventory = Fact(
     cypher_count_query="""
     MATCH (source:AIBOMSource)-[:SCANNED_IMAGE]->(:Image)
     MATCH (source)-[:HAS_COMPONENT]->(agent:AIAgent)
-    RETURN COUNT(DISTINCT agent) AS count
+    RETURN COUNT(DISTINCT coalesce(agent.logical_id, agent.id)) AS count
     """,
     asset_label="AIAgent",
     asset_id_field="agent_component_id",
-    identity_fields=("agent_component_id", "workload_id"),
+    identity_fields=("agent_logical_id", "workload_id"),
     module=Module.AIBOM,
     maturity=Maturity.EXPERIMENTAL,
 )

--- a/cartography/rules/data/rules/nist_ai_rmf.py
+++ b/cartography/rules/data/rules/nist_ai_rmf.py
@@ -626,7 +626,7 @@ _aibom_nist_ai_agent_runtime_inventory = Fact(
         representative_agent,
         min(representative_source.image_uri) AS image_uri,
         min(representative_image._ont_digest) AS manifest_digest
-    RETURN
+    RETURN DISTINCT
         coalesce(
             representative_agent.name,
             representative_agent.logical_id,

--- a/cartography/rules/data/rules/nist_ai_rmf.py
+++ b/cartography/rules/data/rules/nist_ai_rmf.py
@@ -578,6 +578,96 @@ aibom_agent_inventory = Rule(
     ),
 )
 
+
+# =============================================================================
+# NIST AI RMF: Runtime inventory of deployed AI agents
+# Main node: AIBOMComponent (AIAgent)
+# =============================================================================
+class NistAiAgentRuntimeInventoryOutput(Finding):
+    agent_name: str | None = None
+    workload_name: str | None = None
+    workload_id: str | None = None
+    ontology_source: str | None = None
+    image_uri: str | None = None
+    manifest_digest: str | None = None
+    agent_component_id: str | None = None
+    agent_logical_id: str | None = None
+    agent_framework: str | None = None
+    agent_file_path: str | None = None
+    agent_line_number: int | None = None
+
+
+_aibom_nist_ai_agent_runtime_inventory = Fact(
+    id="aibom_nist_ai_agent_runtime_inventory",
+    name="Deployed AI agents running in a workload",
+    description=(
+        "Inventories AI agents whose scanned image is running on a workload, one row "
+        "per agent and workload. Narrows the AIBOM inventory to what is actually "
+        "deployed, and names the workload so its tenant, cluster, region, and "
+        "internet reachability can be read from the graph around it."
+    ),
+    cypher_query="""
+    MATCH (source:AIBOMSource)-[:HAS_COMPONENT]->(agent:AIAgent)
+    MATCH (source)-[:SCANNED_IMAGE]->(img:Image)<-[:HAS_RUNTIME_IMAGE]-(svc:ComputeService)
+    // Aggregate over the images rather than grouping by the image node: a digest is not
+    // unique across registries, so an image pushed to both ECR and GHCR is two :Image
+    // nodes sharing one _ont_digest, and grouping would report the agent once per registry.
+    WITH source, agent, svc, min(img._ont_digest) AS manifest_digest
+    RETURN
+        coalesce(agent.name, agent.logical_id, agent.id) AS agent_name,
+        coalesce(svc._ont_name, svc.name, svc.id) AS workload_name,
+        svc.id AS workload_id,
+        svc._ont_source AS ontology_source,
+        source.image_uri AS image_uri,
+        manifest_digest,
+        agent.id AS agent_component_id,
+        agent.logical_id AS agent_logical_id,
+        agent.framework AS agent_framework,
+        agent.file_path AS agent_file_path,
+        agent.line_number AS agent_line_number
+    ORDER BY agent_name, workload_name
+    """,
+    cypher_visual_query="""
+    MATCH p=(source:AIBOMSource)-[:HAS_COMPONENT]->(agent:AIAgent)
+    MATCH p1=(source)-[:SCANNED_IMAGE]->(img:Image)<-[:HAS_RUNTIME_IMAGE]-(svc:ComputeService)
+    OPTIONAL MATCH p2=(:Tenant)-[:RESOURCE]->(svc)
+    OPTIONAL MATCH p3=(svc)-[:WORKLOAD_PARENT]->(:ComputeCluster)
+    RETURN *
+    """,
+    cypher_count_query="""
+    MATCH (source:AIBOMSource)-[:SCANNED_IMAGE]->(:Image)
+    MATCH (source)-[:HAS_COMPONENT]->(agent:AIAgent)
+    RETURN COUNT(DISTINCT agent) AS count
+    """,
+    asset_label="AIAgent",
+    asset_id_field="agent_component_id",
+    identity_fields=("agent_component_id", "workload_id"),
+    module=Module.AIBOM,
+    maturity=Maturity.EXPERIMENTAL,
+)
+
+aibom_agent_runtime_inventory = Rule(
+    id="aibom_agent_runtime_inventory",
+    name="AI Agents Running In A Workload",
+    description=(
+        "Inventories which deployed AI agents are actually running and on what, so "
+        "agent placement is anchored to a workload whose tenant, cluster, and "
+        "internet reachability the graph already records."
+    ),
+    output_model=NistAiAgentRuntimeInventoryOutput,
+    facts=(_aibom_nist_ai_agent_runtime_inventory,),
+    tags=("ai", "inventory"),
+    version="0.1.0",
+    references=NIST_REFERENCES,
+    frameworks=(
+        nist_ai_rmf("MAP 1"),
+        nist_ai_rmf("GOVERN 1"),
+        iso27001_annex_a("5.9"),
+        iso27001_annex_a("5.21"),
+        soc2_tsc("CC6.1"),
+    ),
+)
+
 # =============================================================================
 # TODO: NIST AI RMF GOVERN 1: Partial subcategory coverage
 # Missing datamodel or evidence: GOVERN 1.1, 1.2, 1.3, 1.4, 1.5, 1.7 beyond current inventory-oriented coverage of GOVERN 1.6

--- a/tests/data/aibom/aibom_sample.py
+++ b/tests/data/aibom/aibom_sample.py
@@ -4,9 +4,7 @@ from typing import Any
 import tests.data.aws.ecr
 
 TEST_REPOSITORY_URI = "205930638578.dkr.ecr.us-east-1.amazonaws.com/subimage-backend"
-TEST_SOURCE_KEY = (
-    f"{TEST_REPOSITORY_URI}" f"@{tests.data.aws.ecr.SINGLE_PLATFORM_DIGEST}"
-)
+TEST_SOURCE_KEY = f"{TEST_REPOSITORY_URI}@{tests.data.aws.ecr.SINGLE_PLATFORM_DIGEST}"
 TEST_IMAGE_URI = "205930638578.dkr.ecr.us-east-1.amazonaws.com/subimage-backend:latest"
 TEST_DIGEST_BASED_IMAGE_URI = TEST_SOURCE_KEY
 TEST_SINGLE_PLATFORM_IMAGE_URI = TEST_IMAGE_URI
@@ -41,6 +39,7 @@ AIBOM_REPORT = {
             "sources_analyzed": 1,
             "sources_with_errors": 0,
             "status": "completed",
+            "agentic_status": "partial_budgeted",
             "report_schema_version": "2",
         },
         "sources": {
@@ -243,8 +242,7 @@ AIBOM_REPORT = {
                             "agentic_hint": "",
                             "model_name": None,
                             "embedding_model": None,
-                            "description": "4 known vulnerabilities in litellm "
-                            "1.83.0",
+                            "description": "4 known vulnerabilities in litellm 1.83.0",
                             "text": None,
                             "transport": None,
                             "config_source": None,
@@ -994,8 +992,7 @@ AIBOM_REPORT = {
                     "line_number": 394,
                     "decision_annotation": {
                         "decision": "flagged",
-                        "justification": "Hardcoded AI API key detected in "
-                        "source code",
+                        "justification": "Hardcoded AI API key detected in source code",
                         "evidence_kinds": ["code_context"],
                         "evidence_locations": [
                             {
@@ -1018,8 +1015,7 @@ AIBOM_REPORT = {
                     "line_number": 10,
                     "decision_annotation": {
                         "decision": "flagged",
-                        "justification": "Hardcoded AI API key detected in "
-                        "source code",
+                        "justification": "Hardcoded AI API key detected in source code",
                         "evidence_kinds": ["code_context"],
                         "evidence_locations": [
                             {
@@ -1042,8 +1038,7 @@ AIBOM_REPORT = {
                     "line_number": 13,
                     "decision_annotation": {
                         "decision": "flagged",
-                        "justification": "Hardcoded AI API key detected in "
-                        "source code",
+                        "justification": "Hardcoded AI API key detected in source code",
                         "evidence_kinds": ["code_context"],
                         "evidence_locations": [
                             {

--- a/tests/integration/cartography/intel/aibom/test_aibom.py
+++ b/tests/integration/cartography/intel/aibom/test_aibom.py
@@ -6,10 +6,11 @@ from unittest.mock import mock_open
 from unittest.mock import patch
 
 import cartography.intel.aws.ecr
-import tests.data.aws.ecr
 from cartography.intel.aibom import sync_aibom_from_report_reader
 from cartography.intel.common.object_store import LocalReportReader
 from cartography.intel.common.object_store import ReportRef
+
+import tests.data.aws.ecr
 from tests.data.aibom.aibom_sample import AIBOM_REPORT
 from tests.data.aibom.aibom_sample import build_repo_anchored_report
 from tests.data.aibom.aibom_sample import TEST_GITHUB_REPO_URL
@@ -167,6 +168,13 @@ def test_sync_aibom_happy_path(
         ["source_key"],
     ) == {
         (TEST_SOURCE_KEY,),
+    }
+    assert check_nodes(
+        neo4j_session,
+        "AIBOMSource",
+        ["agentic_status"],
+    ) == {
+        ("partial_budgeted",),
     }
 
     component_nodes = check_nodes(

--- a/tests/integration/cartography/intel/ontology/test_has_runtime_image.py
+++ b/tests/integration/cartography/intel/ontology/test_has_runtime_image.py
@@ -126,8 +126,8 @@ def test_has_runtime_image_ignores_non_running_container(neo4j_session):
 
 
 def test_has_runtime_image_denormalizes_exposure(neo4j_session):
-    """Exposure is the logical OR across running replicas: an exposed workload's edge is
-    true, a non-exposed workload's edge is false."""
+    """Exposure is true if any replica is exposed, false with explicit internal
+    evidence, and absent when no replica has been evaluated."""
     neo4j_session.run("MATCH (n) DETACH DELETE n")
     neo4j_session.run(
         """
@@ -148,18 +148,28 @@ def test_has_runtime_image_denormalizes_exposure(neo4j_session):
         MERGE (c_exposed)-[re4:RESOLVED_IMAGE]->(img_a) SET re4.lastupdated = $tag
         MERGE (c_internal)-[re5:RESOLVED_IMAGE]->(img_a) SET re5.lastupdated = $tag
 
-        // Non-exposed workload: replica has no exposure property at all -> edge should be false.
+        // Non-exposed workload: replica has explicit non-public evidence.
         MERGE (svc_safe:ComputeService:KubernetesDeployment {id: 'deploy-safe'})
         SET svc_safe.lastupdated = $tag
         MERGE (pod_safe:ComputePod:KubernetesPod {id: 'pod-safe'})
         SET pod_safe.lastupdated = $tag
         MERGE (c_safe:Container:KubernetesContainer {id: 'container-safe'})
-        SET c_safe._ont_state = 'running', c_safe.lastupdated = $tag
+        SET c_safe._ont_state = 'running', c_safe.exposed_internet = false, c_safe.lastupdated = $tag
         MERGE (img_b:Image:AWSECRImage {id: 'sha256:imgb'})
         SET img_b.lastupdated = $tag
         MERGE (c_safe)-[rs1:WORKLOAD_PARENT]->(pod_safe) SET rs1.lastupdated = $tag
         MERGE (pod_safe)-[rs2:WORKLOAD_PARENT]->(svc_safe) SET rs2.lastupdated = $tag
         MERGE (c_safe)-[rs3:RESOLVED_IMAGE]->(img_b) SET rs3.lastupdated = $tag
+
+        // Unknown workload: neither service nor replica has exposure evidence.
+        MERGE (svc_unknown:ComputeService:KubernetesDeployment {id: 'deploy-unknown'})
+        SET svc_unknown.lastupdated = $tag
+        MERGE (c_unknown:Container:KubernetesContainer {id: 'container-unknown'})
+        SET c_unknown._ont_state = 'running', c_unknown.lastupdated = $tag
+        MERGE (img_c:Image:AWSECRImage {id: 'sha256:imgc'})
+        SET img_c.lastupdated = $tag
+        MERGE (c_unknown)-[ru1:WORKLOAD_PARENT]->(svc_unknown) SET ru1.lastupdated = $tag
+        MERGE (c_unknown)-[ru2:RESOLVED_IMAGE]->(img_c) SET ru2.lastupdated = $tag
         """,
         tag=TEST_UPDATE_TAG,
     )
@@ -168,6 +178,7 @@ def test_has_runtime_image_denormalizes_exposure(neo4j_session):
 
     assert _edge_exposure(neo4j_session, "deploy-exposed", "sha256:imga") == [True]
     assert _edge_exposure(neo4j_session, "deploy-safe", "sha256:imgb") == [False]
+    assert _edge_exposure(neo4j_session, "deploy-unknown", "sha256:imgc") == [None]
 
 
 def test_has_runtime_image_exposure_from_service_level_signal(neo4j_session):

--- a/tests/integration/rules/test_aibom_agent_runtime_inventory.py
+++ b/tests/integration/rules/test_aibom_agent_runtime_inventory.py
@@ -92,6 +92,25 @@ def _seed(neo4j_session) -> None:
         """,
         tag=TEST_UPDATE_TAG,
     )
+    neo4j_session.run(
+        """
+        // The same logical agent detected in another scan of the same running image
+        // must not create another agent/workload finding.
+        MATCH (img:Image {id: 'sha256:exposed'})
+        MERGE (source:AIBOMSource {id: 'aibom-exposed-copy'})
+        SET source.image_uri = 'registry.example.com/exposed-copy:latest',
+            source.lastupdated = $tag
+        MERGE (agent:AIBOMComponent:AIAgent {id: 'agent-exposed-copy'})
+        SET agent.name = 'agent-exposed',
+            agent.logical_id = 'logical-exposed',
+            agent.framework = 'examplechain',
+            agent.lastupdated = $tag
+        MERGE (source)-[si:SCANNED_IMAGE]->(img) SET si.lastupdated = $tag
+        MERGE (source)-[hc:HAS_COMPONENT]->(agent) SET hc.lastupdated = $tag
+        MERGE (agent)-[di:DETECTED_IN]->(img) SET di.lastupdated = $tag
+        """,
+        tag=TEST_UPDATE_TAG,
+    )
     run_typed_analysis_job(
         WORKLOAD_HAS_RUNTIME_IMAGE, neo4j_session, {"UPDATE_TAG": TEST_UPDATE_TAG}
     )
@@ -110,10 +129,10 @@ def test_reports_only_agents_that_are_running(neo4j_session) -> None:
 
     # The scanned-but-not-running agent is the whole point of the runtime narrowing:
     # it is in the AIBOM inventory and must not be in this one.
-    assert {f["agent_component_id"] for f in findings} == {
-        "agent-exposed",
-        "agent-internal",
-        "agent-staging",
+    assert {f["agent_logical_id"] for f in findings} == {
+        "logical-exposed",
+        "logical-internal",
+        "logical-staging",
     }
 
 
@@ -121,11 +140,12 @@ def test_reports_one_row_per_agent_and_workload(neo4j_session) -> None:
     _seed(neo4j_session)
 
     findings = _findings(neo4j_session)
-    by_agent = {f["agent_component_id"]: f for f in findings}
+    by_agent = {f["agent_logical_id"]: f for f in findings}
 
     assert len(findings) == len(by_agent)
-    exposed = by_agent["agent-exposed"]
+    exposed = by_agent["logical-exposed"]
     assert exposed["agent_name"] == "agent-exposed"
+    assert exposed["agent_component_id"] == "agent-exposed"
     assert exposed["workload_name"] == "workload-exposed"
     assert exposed["workload_id"] == "svc-exposed"
     assert exposed["ontology_source"] == "aws"
@@ -138,7 +158,7 @@ def test_reported_workload_anchors_tenant_and_exposure(neo4j_session) -> None:
     reachable", so a change that broke that anchor would fail here."""
     _seed(neo4j_session)
 
-    by_agent = {f["agent_component_id"]: f for f in _findings(neo4j_session)}
+    by_agent = {f["agent_logical_id"]: f for f in _findings(neo4j_session)}
 
     context = neo4j_session.run(
         """
@@ -157,19 +177,19 @@ def test_reported_workload_anchors_tenant_and_exposure(neo4j_session) -> None:
     )
     by_workload = {r["workload_id"]: r for r in context}
 
-    assert by_workload[by_agent["agent-exposed"]["workload_id"]] == {
+    assert by_workload[by_agent["logical-exposed"]["workload_id"]] == {
         "workload_id": "svc-exposed",
         "tenant_name": "example-prod",
         "cluster_name": "prod-cluster",
         "internet_exposed": True,
     }
-    assert by_workload[by_agent["agent-internal"]["workload_id"]] == {
+    assert by_workload[by_agent["logical-internal"]["workload_id"]] == {
         "workload_id": "svc-internal",
         "tenant_name": "example-prod",
         "cluster_name": "prod-cluster",
         "internet_exposed": False,
     }
     # Serverless: a tenant but no cluster.
-    staging = by_workload[by_agent["agent-staging"]["workload_id"]]
+    staging = by_workload[by_agent["logical-staging"]["workload_id"]]
     assert staging["tenant_name"] == "example-staging"
     assert staging["cluster_name"] is None

--- a/tests/integration/rules/test_aibom_agent_runtime_inventory.py
+++ b/tests/integration/rules/test_aibom_agent_runtime_inventory.py
@@ -1,0 +1,175 @@
+"""
+End-to-end coverage for aibom_agent_runtime_inventory: seeds agents across runtime
+states and tenants, runs the real ontology job that materializes HAS_RUNTIME_IMAGE, and
+asserts the rule reports one row per running agent and workload. The rule reports the
+workload rather than its context, so the last test walks from a reported workload to the
+tenant and exposure a consumer would read off the graph.
+"""
+
+from cartography.analysis.ontology.analysis import WORKLOAD_HAS_RUNTIME_IMAGE
+from cartography.client.core.tx import read_list_of_dicts_tx
+from cartography.rules.data.rules.nist_ai_rmf import (
+    _aibom_nist_ai_agent_runtime_inventory,
+)
+from cartography.util import run_typed_analysis_job
+
+TEST_UPDATE_TAG = 123456789
+
+
+def _seed(neo4j_session) -> None:
+    """Three agents: one exposed in prod, one internal in prod, one not running at all.
+
+    The prod pair sits under a tenant and a cluster; the staging agent under a
+    different tenant and no cluster, which is the serverless shape.
+    """
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        MERGE (prod:Tenant:AWSAccount {id: 'account-prod'})
+        SET prod._ont_name = 'example-prod', prod.lastupdated = $tag
+        MERGE (staging:Tenant:AWSAccount {id: 'account-staging'})
+        SET staging._ont_name = 'example-staging', staging.lastupdated = $tag
+        MERGE (cluster:ComputeCluster:AWSECSCluster {id: 'cluster-prod'})
+        SET cluster._ont_name = 'prod-cluster', cluster.lastupdated = $tag
+        """,
+        tag=TEST_UPDATE_TAG,
+    )
+    neo4j_session.run(
+        """
+        UNWIND [
+            {key: 'exposed',  exposure: true,  tenant: 'account-prod',    clustered: true},
+            {key: 'internal', exposure: false, tenant: 'account-prod',    clustered: true},
+            {key: 'staging',  exposure: false, tenant: 'account-staging', clustered: false}
+        ] AS spec
+        MATCH (tenant:Tenant {id: spec.tenant})
+        MERGE (svc:ComputeService:AWSECSService {id: 'svc-' + spec.key})
+        SET svc._ont_name = 'workload-' + spec.key,
+            svc._ont_region = 'us-east-1',
+            svc._ont_source = 'aws',
+            svc.lastupdated = $tag
+        MERGE (container:Container:AWSECSContainer {id: 'container-' + spec.key})
+        SET container._ont_state = 'running',
+            container.exposed_internet = spec.exposure,
+            container.lastupdated = $tag
+        MERGE (img:Image:AWSECRImage {id: 'sha256:' + spec.key})
+        SET img._ont_digest = 'sha256:' + spec.key, img.lastupdated = $tag
+        MERGE (container)-[wp:WORKLOAD_PARENT]->(svc) SET wp.lastupdated = $tag
+        MERGE (container)-[ri:RESOLVED_IMAGE]->(img) SET ri.lastupdated = $tag
+        MERGE (tenant)-[res:RESOURCE]->(svc) SET res.lastupdated = $tag
+        WITH spec, svc
+        MATCH (cluster:ComputeCluster {id: 'cluster-prod'})
+        WHERE spec.clustered
+        MERGE (svc)-[cp:WORKLOAD_PARENT]->(cluster) SET cp.lastupdated = $tag
+        """,
+        tag=TEST_UPDATE_TAG,
+    )
+    neo4j_session.run(
+        """
+        // The offline agent's image was scanned but nothing is running it.
+        MERGE (img:Image:AWSECRImage {id: 'sha256:offline'})
+        SET img._ont_digest = 'sha256:offline', img.lastupdated = $tag
+        """,
+        tag=TEST_UPDATE_TAG,
+    )
+    neo4j_session.run(
+        """
+        UNWIND ['exposed', 'internal', 'staging', 'offline'] AS key
+        MATCH (img:Image {id: 'sha256:' + key})
+        MERGE (source:AIBOMSource {id: 'aibom-' + key})
+        SET source.image_uri = 'registry.example.com/' + key + ':latest',
+            source.lastupdated = $tag
+        MERGE (agent:AIBOMComponent:AIAgent {id: 'agent-' + key})
+        SET agent.name = 'agent-' + key,
+            agent.logical_id = 'logical-' + key,
+            agent.framework = 'examplechain',
+            agent.lastupdated = $tag
+        MERGE (tool:AIBOMComponent:AITool {id: 'tool-' + key})
+        SET tool.name = 'tool-' + key, tool.lastupdated = $tag
+        MERGE (source)-[si:SCANNED_IMAGE]->(img) SET si.lastupdated = $tag
+        MERGE (source)-[hc:HAS_COMPONENT]->(agent) SET hc.lastupdated = $tag
+        MERGE (agent)-[di:DETECTED_IN]->(img) SET di.lastupdated = $tag
+        MERGE (agent)-[ut:USES_TOOL]->(tool) SET ut.lastupdated = $tag
+        """,
+        tag=TEST_UPDATE_TAG,
+    )
+    run_typed_analysis_job(
+        WORKLOAD_HAS_RUNTIME_IMAGE, neo4j_session, {"UPDATE_TAG": TEST_UPDATE_TAG}
+    )
+
+
+def _findings(neo4j_session):
+    return neo4j_session.execute_read(
+        read_list_of_dicts_tx, _aibom_nist_ai_agent_runtime_inventory.cypher_query
+    )
+
+
+def test_reports_only_agents_that_are_running(neo4j_session) -> None:
+    _seed(neo4j_session)
+
+    findings = _findings(neo4j_session)
+
+    # The scanned-but-not-running agent is the whole point of the runtime narrowing:
+    # it is in the AIBOM inventory and must not be in this one.
+    assert {f["agent_component_id"] for f in findings} == {
+        "agent-exposed",
+        "agent-internal",
+        "agent-staging",
+    }
+
+
+def test_reports_one_row_per_agent_and_workload(neo4j_session) -> None:
+    _seed(neo4j_session)
+
+    findings = _findings(neo4j_session)
+    by_agent = {f["agent_component_id"]: f for f in findings}
+
+    assert len(findings) == len(by_agent)
+    exposed = by_agent["agent-exposed"]
+    assert exposed["agent_name"] == "agent-exposed"
+    assert exposed["workload_name"] == "workload-exposed"
+    assert exposed["workload_id"] == "svc-exposed"
+    assert exposed["ontology_source"] == "aws"
+    assert exposed["image_uri"] == "registry.example.com/exposed:latest"
+
+
+def test_reported_workload_anchors_tenant_and_exposure(neo4j_session) -> None:
+    """The rule deliberately stops at the workload. This is the walk a consumer makes
+    from a reported workload_id to answer "is this one in production, and is it
+    reachable", so a change that broke that anchor would fail here."""
+    _seed(neo4j_session)
+
+    by_agent = {f["agent_component_id"]: f for f in _findings(neo4j_session)}
+
+    context = neo4j_session.run(
+        """
+        UNWIND $workload_ids AS workload_id
+        MATCH (svc:ComputeService {id: workload_id})
+        OPTIONAL MATCH (tenant:Tenant)-[:RESOURCE]->(svc)
+        OPTIONAL MATCH (svc)-[:WORKLOAD_PARENT]->(cluster:ComputeCluster)
+        OPTIONAL MATCH (svc)-[hri:HAS_RUNTIME_IMAGE]->(:Image)
+        RETURN
+            workload_id,
+            tenant._ont_name AS tenant_name,
+            cluster._ont_name AS cluster_name,
+            hri.exposed_internet AS internet_exposed
+        """,
+        workload_ids=[f["workload_id"] for f in by_agent.values()],
+    )
+    by_workload = {r["workload_id"]: r for r in context}
+
+    assert by_workload[by_agent["agent-exposed"]["workload_id"]] == {
+        "workload_id": "svc-exposed",
+        "tenant_name": "example-prod",
+        "cluster_name": "prod-cluster",
+        "internet_exposed": True,
+    }
+    assert by_workload[by_agent["agent-internal"]["workload_id"]] == {
+        "workload_id": "svc-internal",
+        "tenant_name": "example-prod",
+        "cluster_name": "prod-cluster",
+        "internet_exposed": False,
+    }
+    # Serverless: a tenant but no cluster.
+    staging = by_workload[by_agent["agent-staging"]["workload_id"]]
+    assert staging["tenant_name"] == "example-staging"
+    assert staging["cluster_name"] is None

--- a/tests/unit/rules/test_iso27001_mappings.py
+++ b/tests/unit/rules/test_iso27001_mappings.py
@@ -104,6 +104,7 @@ EXPECTED_ISO27001_REQUIREMENTS = {
     "ai_third_party_app_inventory": {"5.21", "5.23"},
     "ai_third_party_app_sensitive_scopes": {"5.15", "8.3"},
     "ai_admin_app_authorizations": {"5.18", "8.2"},
+    "aibom_agent_runtime_inventory": {"5.9", "5.21"},
     "aibom_agent_inventory": {"5.9", "5.21"},
     "aibom_coverage_gaps": {"5.9", "5.21"},
     "ai_provider_api_key_hygiene": {"5.17", "5.18"},

--- a/tests/unit/rules/test_nist_ai_rmf.py
+++ b/tests/unit/rules/test_nist_ai_rmf.py
@@ -224,12 +224,18 @@ def test_nist_ai_openai_api_key_query_includes_project_scoped_keys():
     )
 
 
-def test_nist_ai_aibom_coverage_gap_count_query_counts_all_sources():
+def test_nist_ai_aibom_coverage_gap_count_query_counts_only_gaps():
     fact = aibom_coverage_gaps.get_fact_by_id("aibom_nist_ai_coverage_gaps")
 
-    assert fact.cypher_count_query.strip() == (
-        "MATCH (source:AIBOMSource)\n    RETURN COUNT(source) AS count"
-    )
+    assert "source.agentic_status" in fact.cypher_count_query
+    assert "coalesce(source.pending_agent_review, 0) > 0" in fact.cypher_count_query
+
+
+def test_nist_ai_aibom_coverage_gap_includes_incomplete_agentic_review():
+    fact = aibom_coverage_gaps.get_fact_by_id("aibom_nist_ai_coverage_gaps")
+
+    assert "source.agentic_status" in fact.cypher_query
+    assert "coalesce(source.pending_agent_review, 0) > 0" in fact.cypher_query
 
 
 def test_aibom_agent_inventory_stages_embedding_aggregation():

--- a/tests/unit/rules/test_nist_ai_rmf.py
+++ b/tests/unit/rules/test_nist_ai_rmf.py
@@ -4,6 +4,7 @@ from cartography.rules.data.rules.nist_ai_rmf import ai_provider_api_key_hygiene
 from cartography.rules.data.rules.nist_ai_rmf import ai_third_party_app_inventory
 from cartography.rules.data.rules.nist_ai_rmf import ai_third_party_app_sensitive_scopes
 from cartography.rules.data.rules.nist_ai_rmf import aibom_agent_inventory
+from cartography.rules.data.rules.nist_ai_rmf import aibom_agent_runtime_inventory
 from cartography.rules.data.rules.nist_ai_rmf import aibom_coverage_gaps
 from cartography.rules.spec.model import Maturity
 from cartography.rules.spec.model import Module
@@ -15,6 +16,7 @@ def test_nist_ai_rules_registered_and_metadata():
         "ai_third_party_app_sensitive_scopes": ai_third_party_app_sensitive_scopes,
         "ai_admin_app_authorizations": ai_admin_app_authorizations,
         "aibom_agent_inventory": aibom_agent_inventory,
+        "aibom_agent_runtime_inventory": aibom_agent_runtime_inventory,
         "aibom_coverage_gaps": aibom_coverage_gaps,
         "ai_provider_api_key_hygiene": ai_provider_api_key_hygiene,
     }
@@ -38,6 +40,7 @@ def test_nist_ai_rule_modules():
     assert ai_third_party_app_sensitive_scopes.modules == {Module.CROSS_CLOUD}
     assert ai_admin_app_authorizations.modules == {Module.GOOGLEWORKSPACE}
     assert aibom_agent_inventory.modules == {Module.AIBOM}
+    assert aibom_agent_runtime_inventory.modules == {Module.AIBOM}
     assert aibom_coverage_gaps.modules == {Module.AIBOM}
     assert ai_provider_api_key_hygiene.modules == {Module.OPENAI, Module.ANTHROPIC}
 
@@ -48,6 +51,7 @@ def test_nist_ai_fact_structure_and_maturity():
         ai_third_party_app_sensitive_scopes,
         ai_admin_app_authorizations,
         aibom_agent_inventory,
+        aibom_agent_runtime_inventory,
         aibom_coverage_gaps,
         ai_provider_api_key_hygiene,
     )
@@ -64,6 +68,7 @@ def test_nist_ai_fact_structure_and_maturity():
     assert len(ai_third_party_app_sensitive_scopes.facts) == 1
     assert len(ai_admin_app_authorizations.facts) == 1
     assert len(aibom_agent_inventory.facts) == 1
+    assert len(aibom_agent_runtime_inventory.facts) == 1
     assert len(aibom_coverage_gaps.facts) == 1
     assert len(ai_provider_api_key_hygiene.facts) == 2
 
@@ -89,6 +94,11 @@ def test_nist_ai_framework_requirements():
         for fw in aibom_agent_inventory.frameworks
         if fw.short_name == "nist" and fw.scope == "ai-rmf"
     }
+    aibom_runtime_requirements = {
+        fw.requirement
+        for fw in aibom_agent_runtime_inventory.frameworks
+        if fw.short_name == "nist" and fw.scope == "ai-rmf"
+    }
     aibom_gap_requirements = {
         fw.requirement
         for fw in aibom_coverage_gaps.frameworks
@@ -104,6 +114,7 @@ def test_nist_ai_framework_requirements():
     assert sensitive_requirements == {"measure 2", "manage 2"}
     assert admin_requirements == {"govern 5"}
     assert aibom_inventory_requirements == {"map 1", "govern 1"}
+    assert aibom_runtime_requirements == {"map 1", "govern 1"}
     assert aibom_gap_requirements == {"measure 2", "manage 2"}
     assert provider_requirements == {"govern 5", "manage 2"}
 

--- a/tests/unit/rules/test_soc2_mappings.py
+++ b/tests/unit/rules/test_soc2_mappings.py
@@ -22,6 +22,7 @@ EXPECTED_SOC2_REQUIREMENTS = {
     "ai_provider_api_key_hygiene": {"CC6.1", "CC6.3"},
     "ai_third_party_app_inventory": {"CC9.2"},
     "ai_third_party_app_sensitive_scopes": {"CC6.1"},
+    "aibom_agent_runtime_inventory": {"CC6.1"},
     "aibom_agent_inventory": {"CC6.1"},
     "aibom_coverage_gaps": {"CC6.1"},
     "aws_access_keys_not_rotated": {"CC6.1"},


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

### Summary

Adds `aibom_agent_runtime_inventory`, which reports AIBOM agents whose scanned image is currently running on a workload.

Rows are grouped by `AIBOMComponent.logical_id` and workload so the same logical agent found in repeated scans or equivalent images does not create duplicate findings. The representative component id remains attached as the graph asset anchor.

The existing `HAS_RUNTIME_IMAGE` analysis now preserves three-state exposure evidence. Any explicit public signal produces `true`, explicit non-public evidence produces `false`, and absent evidence remains unset instead of being treated as non-public.

The finding reports the workload rather than copying its context. Tenant, cluster, and current internet reachability remain available from the graph around that workload.

### Related issues or links

None.

### How was this tested?

- `make test_lint`
- Existing Cartography test suite from the original change
- Integration coverage for repeated logical agents across scans
- Integration coverage for public, explicitly internal, and unknown workload exposure

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

### Notes for reviewers

The runtime join uses the existing materialized `(:ComputeService)-[:HAS_RUNTIME_IMAGE]->(:Image)` edge. Its cost scales with the findings it must emit: logical agents per image multiplied by workloads running that image. Grouping before projection bounds duplicate scan occurrences.

`cypher_count_query` remains the compliance denominator and now counts distinct logical agents rather than physical per-scan component nodes.
