### PR TITLE
feat(aibom): make component labels and fields mean what they say

### DIFF
--- a/cartography/intel/aibom/transform.py
+++ b/cartography/intel/aibom/transform.py
@@ -1,15 +1,24 @@
 import hashlib
 import json
 import logging
+from collections import Counter
 from typing import Any
 from typing import cast
 
 logger = logging.getLogger(__name__)
 
+# AIBOM reports emit more relationship types than this. A type is added here once
+# its endpoints carry a semantic label, so the edge reaches something a query can
+# name; the rest are counted and reported in one warning per sync rather than
+# dropped silently. See docs/root/modules/aibom/index.md.
 _RELATIONSHIP_TARGET_FIELD_BY_TYPE = {
     "USES_MODEL": "uses_model_component_ids",
+    "USES_LLM": "uses_llm_component_ids",
     "USES_TOOL": "uses_tool_component_ids",
     "EXPOSES_TOOL": "exposes_tool_component_ids",
+    "USES_MEMORY": "uses_memory_component_ids",
+    "USES_EMBEDDING": "uses_embedding_component_ids",
+    "USES_AGENT": "uses_agent_component_ids",
     "CUSTOM": "custom_component_ids",
 }
 
@@ -41,6 +50,13 @@ def _as_str(value: Any) -> str | None:
         if cleaned:
             return cleaned
     return None
+
+
+def _as_str_list(value: Any) -> list[str] | None:
+    if not isinstance(value, list):
+        return None
+    cleaned = [item for item in (_as_str(entry) for entry in value) if item]
+    return sorted(set(cleaned)) or None
 
 
 def _json_dumps(value: Any) -> str | None:
@@ -122,7 +138,6 @@ def _build_component_payload(
         "id": _build_component_id(source_key, component),
         "logical_id": _build_component_logical_id(component),
         "name": _as_str(component.get("name")),
-        "category": normalized_component_type,
         "component_type": normalized_component_type,
         "instance_id": _as_str(component.get("instance_id")),
         "file_path": _as_str(component.get("file_path")),
@@ -151,14 +166,13 @@ def _build_component_payload(
         "component_primary_evidence_end_line": component_primary_evidence_end_line,
         "decision": _as_str(decision_annotation.get("decision")),
         "decision_justification": _as_str(decision_annotation.get("justification")),
+        "evidence_count": component_metadata.get("evidence_count"),
+        "evidence_files": _as_str_list(component_metadata.get("evidence_files")),
         "metadata_json": _json_dumps(component_metadata),
         "manifest_digests": manifest_digests,
         "github_repo_urls": repo_uris,
         "gitlab_project_urls": repo_uris,
-        "uses_model_component_ids": [],
-        "uses_tool_component_ids": [],
-        "exposes_tool_component_ids": [],
-        "custom_component_ids": [],
+        **{field: [] for field in _RELATIONSHIP_TARGET_FIELD_BY_TYPE.values()},
     }
 
 
@@ -466,6 +480,7 @@ def transform_aibom_component_payloads(
         component_records,
     )
     relationship_records = _parse_aibom_relationship_records(document)
+    unmodelled_relationship_counts: Counter[str] = Counter()
 
     for relationship_record in relationship_records:
         source_key = relationship_record["source_key"]
@@ -496,10 +511,7 @@ def transform_aibom_component_payloads(
 
         target_field = _RELATIONSHIP_TARGET_FIELD_BY_TYPE.get(relationship_type)
         if target_field is None:
-            logger.info(
-                "Skipping unsupported AIBOM relationship type %s",
-                relationship_type,
-            )
+            unmodelled_relationship_counts[relationship_type] += 1
             continue
 
         resolved_component_ids = _resolve_relationship_component_ids(
@@ -521,5 +533,16 @@ def transform_aibom_component_payloads(
         target_component_ids = cast(list[str], source_component_payload[target_field])
         if target_component_id not in target_component_ids:
             target_component_ids.append(target_component_id)
+
+    if unmodelled_relationship_counts:
+        # One line per sync rather than per edge: a report can carry thousands of
+        # these, and the useful signal is which types are being lost and how many.
+        logger.warning(
+            "AIBOM relationship types not yet modelled in the graph were skipped: %s",
+            ", ".join(
+                f"{name}={count}"
+                for name, count in sorted(unmodelled_relationship_counts.items())
+            ),
+        )
 
     return list(component_payloads_by_id.values())

--- a/cartography/models/aibom/component.py
+++ b/cartography/models/aibom/component.py
@@ -1,10 +1,6 @@
 from dataclasses import dataclass
 
-from cartography.models.aibom.extra_labels import AI_AGENT
-from cartography.models.aibom.extra_labels import AI_EMBEDDING
-from cartography.models.aibom.extra_labels import AI_MEMORY
-from cartography.models.aibom.extra_labels import AI_PROMPT
-from cartography.models.aibom.extra_labels import AI_TOOL
+from cartography.models.aibom.extra_labels import LEGACY_AI_MODEL
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.nodes import CartographyNodeProperties
 from cartography.models.core.nodes import CartographyNodeSchema
@@ -15,7 +11,12 @@ from cartography.models.core.relationships import LinkDirection
 from cartography.models.core.relationships import make_target_node_matcher
 from cartography.models.core.relationships import OtherRelationships
 from cartography.models.core.relationships import TargetNodeMatcher
-from cartography.models.ontology.labels import AI_MODEL
+from cartography.models.ontology.labels import AI_AGENT
+from cartography.models.ontology.labels import AI_EMBEDDING
+from cartography.models.ontology.labels import AI_MEMORY
+from cartography.models.ontology.labels import AI_MODEL_REFERENCE
+from cartography.models.ontology.labels import AI_PROMPT
+from cartography.models.ontology.labels import AI_TOOL
 
 
 @dataclass(frozen=True)
@@ -31,15 +32,13 @@ class AIBOMComponentNodeProperties(CartographyNodeProperties):
         description="Stable cross-source fingerprint for equivalent components.",
     )
     name: PropertyRef = PropertyRef("name", description="Detected component name.")
-    category: PropertyRef = PropertyRef(
-        "category",
-        extra_index=True,
-        description="Normalized component category used for grouping and filtering.",
-    )
     component_type: PropertyRef = PropertyRef(
         "component_type",
         extra_index=True,
-        description="AIBOM component type from the report.",
+        description=(
+            "AIBOM component type from the report, and the value that decides the "
+            "component's semantic label: agent, model, tool, memory, embedding, or prompt."
+        ),
     )
     instance_id: PropertyRef = PropertyRef(
         "instance_id",
@@ -55,11 +54,11 @@ class AIBOMComponentNodeProperties(CartographyNodeProperties):
     )
     model_name: PropertyRef = PropertyRef(
         "model_name",
-        description="Model name when the component identifies a concrete model.",
+        description="Model name. Set on model components, and on other types that name a concrete model.",
     )
     embedding_model: PropertyRef = PropertyRef(
         "embedding_model",
-        description="Embedding model metadata when present.",
+        description="Embedding model metadata. Set on embedding components.",
     )
     framework: PropertyRef = PropertyRef(
         "framework",
@@ -100,23 +99,23 @@ class AIBOMComponentNodeProperties(CartographyNodeProperties):
     )
     transport: PropertyRef = PropertyRef(
         "transport",
-        description="Transport metadata when present.",
+        description="Transport metadata. Set on tool components, such as an MCP server's transport.",
     )
     config_source: PropertyRef = PropertyRef(
         "config_source",
-        description="Configuration source metadata when present.",
+        description="Configuration source metadata. Set on components detected from a config file.",
     )
     storage_uri: PropertyRef = PropertyRef(
         "storage_uri",
-        description="Storage URI when present.",
+        description="Storage URI. Set on memory and embedding components.",
     )
     dataset_source: PropertyRef = PropertyRef(
         "dataset_source",
-        description="Dataset source metadata when present.",
+        description="Dataset source metadata. Set on embedding and memory components.",
     )
     skill_format: PropertyRef = PropertyRef(
         "skill_format",
-        description="Skill format metadata when present.",
+        description="Skill format metadata. Set on tool components.",
     )
     sdk_version: PropertyRef = PropertyRef(
         "sdk_version",
@@ -124,11 +123,11 @@ class AIBOMComponentNodeProperties(CartographyNodeProperties):
     )
     kb_concept: PropertyRef = PropertyRef(
         "kb_concept",
-        description="Knowledge-base concept metadata when present.",
+        description="Knowledge-base concept metadata. Set on components detected by knowledge-base enrichment.",
     )
     kb_label: PropertyRef = PropertyRef(
         "kb_label",
-        description="Knowledge-base label metadata when present.",
+        description="Knowledge-base label metadata. Set on components detected by knowledge-base enrichment.",
     )
     component_primary_evidence: PropertyRef = PropertyRef(
         "component_primary_evidence",
@@ -150,11 +149,30 @@ class AIBOMComponentNodeProperties(CartographyNodeProperties):
         "decision_justification",
         description="Justification from the component decision annotation.",
     )
-    # Preserve category-specific metadata until we decide whether component types
-    # should split into dedicated node models with their own first-class fields.
+    evidence_count: PropertyRef = PropertyRef(
+        "evidence_count",
+        description="How many places in the artifact the detection was seen.",
+    )
+    evidence_files: PropertyRef = PropertyRef(
+        "evidence_files",
+        description=(
+            "Every file the detection was seen in. `file_path` and "
+            "`component_primary_evidence` name one of these; this is the full set."
+        ),
+    )
+    # Type-specific metadata stays serialized until component types split into
+    # dedicated node models with their own first-class fields. Anything promoted out
+    # of here becomes queryable, so promote a key once it is worth filtering on
+    # rather than adding every key a report can emit.
     metadata_json: PropertyRef = PropertyRef(
         "metadata_json",
-        description="Serialized category-specific component metadata.",
+        description=(
+            "Serialized type-specific component metadata that has no first-class "
+            "property yet. Keys vary by component_type: a secret component carries "
+            "secret_source and redacted, a package component carries ecosystem and "
+            "vulnerabilities, a model component carries model_provider and "
+            "context_length. Read it in the client; it is a string, not a map."
+        ),
     )
     manifest_digests: PropertyRef = PropertyRef(
         "manifest_digests",
@@ -267,6 +285,66 @@ class AIBOMComponentExposesToolRel(CartographyRelSchema):
 
 
 @dataclass(frozen=True)
+class AIBOMComponentUsesLlmRel(CartographyRelSchema):
+    """Links a component to a model it uses, where the report typed the edge as an LLM."""
+
+    target_node_label: str = "AIBOMComponent"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("uses_llm_component_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_LLM"
+    properties: AIBOMComponentToComponentRelProperties = (
+        AIBOMComponentToComponentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AIBOMComponentUsesMemoryRel(CartographyRelSchema):
+    """Links a component to a memory store it uses."""
+
+    target_node_label: str = "AIBOMComponent"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("uses_memory_component_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_MEMORY"
+    properties: AIBOMComponentToComponentRelProperties = (
+        AIBOMComponentToComponentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AIBOMComponentUsesEmbeddingRel(CartographyRelSchema):
+    """Links a component to an embedding it uses."""
+
+    target_node_label: str = "AIBOMComponent"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("uses_embedding_component_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_EMBEDDING"
+    properties: AIBOMComponentToComponentRelProperties = (
+        AIBOMComponentToComponentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class AIBOMComponentUsesAgentRel(CartographyRelSchema):
+    """Links an agent to another agent it invokes or delegates to."""
+
+    target_node_label: str = "AIBOMComponent"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("uses_agent_component_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "USES_AGENT"
+    properties: AIBOMComponentToComponentRelProperties = (
+        AIBOMComponentToComponentRelProperties()
+    )
+
+
+@dataclass(frozen=True)
 class AIBOMComponentCustomRel(CartographyRelSchema):
     """Preserves a custom component relationship emitted by an AIBOM report."""
 
@@ -289,12 +367,13 @@ class AIBOMComponentSchema(CartographyNodeSchema):
     scoped_cleanup: bool = False
     extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
         [
-            AI_AGENT.when(category="agent"),
-            AI_MODEL.when(category="model"),
-            AI_TOOL.when(category="tool"),
-            AI_MEMORY.when(category="memory"),
-            AI_EMBEDDING.when(category="embedding"),
-            AI_PROMPT.when(category="prompt"),
+            AI_AGENT.when(component_type="agent"),
+            AI_MODEL_REFERENCE.when(component_type="model"),
+            LEGACY_AI_MODEL.when(component_type="model"),
+            AI_TOOL.when(component_type="tool"),
+            AI_MEMORY.when(component_type="memory"),
+            AI_EMBEDDING.when(component_type="embedding"),
+            AI_PROMPT.when(component_type="prompt"),
         ],
     )
     properties: AIBOMComponentNodeProperties = AIBOMComponentNodeProperties()
@@ -304,8 +383,12 @@ class AIBOMComponentSchema(CartographyNodeSchema):
             AIBOMComponentDetectedInGitHubRel(),
             AIBOMComponentDetectedInGitLabRel(),
             AIBOMComponentUsesModelRel(),
+            AIBOMComponentUsesLlmRel(),
             AIBOMComponentUsesToolRel(),
             AIBOMComponentExposesToolRel(),
+            AIBOMComponentUsesMemoryRel(),
+            AIBOMComponentUsesEmbeddingRel(),
+            AIBOMComponentUsesAgentRel(),
             AIBOMComponentCustomRel(),
         ],
     )

--- a/cartography/models/aibom/extra_labels.py
+++ b/cartography/models/aibom/extra_labels.py
@@ -1,30 +1,15 @@
 from cartography.models.core.nodes import ExtraNodeLabel
+from cartography.models.core.nodes import LabelKind
 
-AI_AGENT = ExtraNodeLabel(
-    label="AIAgent",
-    description="A aibom node participating in the shared AIAgent graph interface.",
-)
-
-
-AI_EMBEDDING = ExtraNodeLabel(
-    label="AIEmbedding",
-    description="A aibom node participating in the shared AIEmbedding graph interface.",
-)
-
-
-AI_MEMORY = ExtraNodeLabel(
-    label="AIMemory",
-    description="A aibom node participating in the shared AIMemory graph interface.",
-)
-
-
-AI_PROMPT = ExtraNodeLabel(
-    label="AIPrompt",
-    description="A aibom node participating in the shared AIPrompt graph interface.",
-)
-
-
-AI_TOOL = ExtraNodeLabel(
-    label="AITool",
-    description="A aibom node participating in the shared AITool graph interface.",
+# An AIBOM model component is a reference to a model found while scanning an
+# artifact, not a model resource that exists in a provider account. It carried
+# `AIModel` before `AIModelReference` existed, which put it in the same label as
+# the Bedrock, Vertex, and SageMaker resources and made a count of `AIModel`
+# mean nothing. The alias keeps existing queries working until removal.
+LEGACY_AI_MODEL = ExtraNodeLabel(
+    label="AIModel",
+    description="Compatibility label for AIBOM model components, superseded by `AIModelReference`.",
+    kind=LabelKind.COMPATIBILITY,
+    replacement_label="AIModelReference",
+    remove_in="1.0.0",
 )

--- a/cartography/models/ontology/labels.py
+++ b/cartography/models/ontology/labels.py
@@ -1,9 +1,54 @@
 from cartography.models.core.nodes import ExtraNodeLabel
 from cartography.models.core.nodes import LabelKind
 
+AI_AGENT = ExtraNodeLabel(
+    label="AIAgent",
+    description="A cross-provider AIAgent resource in Cartography's ontology.",
+    kind=LabelKind.ONTOLOGY,
+)
+
+
+AI_EMBEDDING = ExtraNodeLabel(
+    label="AIEmbedding",
+    description="A cross-provider AIEmbedding resource in Cartography's ontology.",
+    kind=LabelKind.ONTOLOGY,
+)
+
+
+AI_MEMORY = ExtraNodeLabel(
+    label="AIMemory",
+    description="A cross-provider AIMemory resource in Cartography's ontology.",
+    kind=LabelKind.ONTOLOGY,
+)
+
+
 AI_MODEL = ExtraNodeLabel(
     label="AIModel",
     description="A cross-provider AIModel resource in Cartography's ontology.",
+    kind=LabelKind.ONTOLOGY,
+)
+
+
+AI_MODEL_REFERENCE = ExtraNodeLabel(
+    label="AIModelReference",
+    description=(
+        "A reference to a model found by scanning an artifact, rather than a model "
+        "resource that exists in a provider account."
+    ),
+    kind=LabelKind.ONTOLOGY,
+)
+
+
+AI_PROMPT = ExtraNodeLabel(
+    label="AIPrompt",
+    description="A cross-provider AIPrompt resource in Cartography's ontology.",
+    kind=LabelKind.ONTOLOGY,
+)
+
+
+AI_TOOL = ExtraNodeLabel(
+    label="AITool",
+    description="A cross-provider AITool resource in Cartography's ontology.",
     kind=LabelKind.ONTOLOGY,
 )
 

--- a/cartography/models/ontology/mapping/__init__.py
+++ b/cartography/models/ontology/mapping/__init__.py
@@ -244,6 +244,12 @@ SEMANTIC_LABEL_BY_CATEGORY: dict[str, ExtraNodeLabel] = {
 
 
 SEMANTIC_LABELS_WITHOUT_NORMALIZED_FIELDS: tuple[str, ...] = (
+    "AIAgent",
+    "AIEmbedding",
+    "AIMemory",
+    "AIModelReference",
+    "AIPrompt",
+    "AITool",
     "ImageAttestation",
     "ImageLayer",
     "ImageManifestList",

--- a/cartography/rules/data/rules/nist_ai_rmf.py
+++ b/cartography/rules/data/rules/nist_ai_rmf.py
@@ -468,8 +468,6 @@ class NistAiAibomAgentInventoryOutput(Finding):
     tool_names: list[str] | None = None
     memory_count: int | None = None
     memory_names: list[str] | None = None
-    prompt_count: int | None = None
-    prompt_names: list[str] | None = None
     embedding_count: int | None = None
     embedding_names: list[str] | None = None
 
@@ -489,7 +487,7 @@ _aibom_nist_ai_agent_inventory = Fact(
     // nodes sharing one _ont_digest, and grouping would report every agent of that
     // AIBOM once per registry.
     WITH source, agent, min(img._ont_digest) AS manifest_digest
-    OPTIONAL MATCH (agent)-[:USES_MODEL]->(model:AIModel)
+    OPTIONAL MATCH (agent)-[:USES_MODEL]->(model:AIModelReference)
     WITH source, manifest_digest, agent, collect(DISTINCT model.name) AS model_names
     OPTIONAL MATCH (agent)-[:USES_TOOL]->(tool:AITool)
     WITH
@@ -506,15 +504,6 @@ _aibom_nist_ai_agent_inventory = Fact(
         model_names,
         tool_names,
         collect(DISTINCT memory.name) AS memory_names
-    OPTIONAL MATCH (agent)-[:USES_PROMPT]->(prompt:AIPrompt)
-    WITH
-        source,
-        manifest_digest,
-        agent,
-        model_names,
-        tool_names,
-        memory_names,
-        collect(DISTINCT prompt.name) AS prompt_names
     OPTIONAL MATCH (agent)-[:USES_EMBEDDING]->(embedding:AIEmbedding)
     WITH
         source,
@@ -523,7 +512,6 @@ _aibom_nist_ai_agent_inventory = Fact(
         model_names,
         tool_names,
         memory_names,
-        prompt_names,
         count(DISTINCT embedding) AS embedding_count,
         collect(DISTINCT embedding.name) AS embedding_names
     RETURN
@@ -544,8 +532,6 @@ _aibom_nist_ai_agent_inventory = Fact(
         tool_names,
         size(memory_names) AS memory_count,
         memory_names,
-        size(prompt_names) AS prompt_count,
-        prompt_names,
         embedding_count,
         embedding_names
     ORDER BY image_uri, agent_name
@@ -553,11 +539,10 @@ _aibom_nist_ai_agent_inventory = Fact(
     cypher_visual_query="""
     MATCH p=(source:AIBOMSource)-[:SCANNED_IMAGE]->(img:Image)
     MATCH p1=(source)-[:HAS_COMPONENT]->(agent:AIAgent)
-    OPTIONAL MATCH p2=(agent)-[:USES_MODEL]->(:AIModel)
+    OPTIONAL MATCH p2=(agent)-[:USES_MODEL]->(:AIModelReference)
     OPTIONAL MATCH p3=(agent)-[:USES_TOOL]->(:AITool)
     OPTIONAL MATCH p4=(agent)-[:USES_MEMORY]->(:AIMemory)
-    OPTIONAL MATCH p5=(agent)-[:USES_PROMPT]->(:AIPrompt)
-    OPTIONAL MATCH p6=(agent)-[:USES_EMBEDDING]->(:AIEmbedding)
+    OPTIONAL MATCH p5=(agent)-[:USES_EMBEDDING]->(:AIEmbedding)
     RETURN *
     """,
     cypher_count_query="""
@@ -582,7 +567,7 @@ aibom_agent_inventory = Rule(
     output_model=NistAiAibomAgentInventoryOutput,
     facts=(_aibom_nist_ai_agent_inventory,),
     tags=("ai", "inventory", "software_supply_chain", "compliance"),
-    version="0.1.1",
+    version="0.2.0",
     references=NIST_REFERENCES,
     frameworks=(
         nist_ai_rmf("MAP 1"),

--- a/docs/root/modules/aibom/examples.md
+++ b/docs/root/modules/aibom/examples.md
@@ -12,8 +12,8 @@ RETURN source.image_uri, image._ont_digest, collect(component.name) AS agents
 
 ```cypher
 MATCH (image:Image)<-[:DETECTED_IN]-(component:AIBOMComponent)
-RETURN image._ont_digest, component.category, component.name
-ORDER BY component.category, component.name
+RETURN image._ont_digest, component.component_type, component.name
+ORDER BY component.component_type, component.name
 ```
 
 ## Find components detected in a repository
@@ -22,8 +22,8 @@ ORDER BY component.category, component.name
 MATCH (source:AIBOMSource)-[:SCANNED_REPOSITORY]->(repository)
 MATCH (source)-[:HAS_COMPONENT]->(component:AIBOMComponent)
 WHERE repository:GitHubRepository OR repository:GitLabProject
-RETURN labels(repository), source.source_key, component.category, component.name
-ORDER BY source.source_key, component.category, component.name
+RETURN labels(repository), source.source_key, component.component_type, component.name
+ORDER BY source.source_key, component.component_type, component.name
 ```
 
 ## Inspect component relationships

--- a/docs/root/modules/aibom/index.md
+++ b/docs/root/modules/aibom/index.md
@@ -27,20 +27,45 @@ from component type, name, location, framework, model, storage, and skill
 metadata. Use it to correlate equivalent components without merging their
 source-specific detections.
 
-The component `category` controls additional graph labels:
+The component `component_type` controls additional graph labels:
 
 - `agent` produces `AIAgent`.
-- `model` produces the ontology label `AIModel`.
+- `model` produces `AIModelReference`.
 - `tool` produces `AITool`.
 - `memory` produces `AIMemory`.
 - `embedding` produces `AIEmbedding`.
 - `prompt` produces `AIPrompt`.
 
+`AIModelReference` rather than `AIModel` because an AIBOM model component is a
+reference to a model found while scanning an artifact, not a model resource that
+exists in a provider account. `AIModel` is written by Bedrock, Vertex, and
+SageMaker for real resources, so counting that label would otherwise mix an
+account's model inventory with strings appearing in source code. Model components
+still carry `AIModel` as a compatibility label until its removal version.
+
+AIBOM reports emit more component types than the six above, and more relationship
+types than the graph models. Anything else loads as a bare `AIBOMComponent` with
+its report fields intact, and skipped relationship types are reported in one
+warning per sync naming each type and how many edges were dropped. Type-specific
+metadata stays serialized in `metadata_json` until those types receive dedicated
+first-class models; the keys vary by `component_type`, so read it in the client
+rather than trying to index into it in Cypher.
+
 Report-defined component relationships are loaded when both endpoints resolve
-within the same source. Category-specific metadata remains serialized in
-`metadata_json` until those categories receive dedicated first-class models.
-Workflow-like context is preserved through component evidence and metadata
-rather than separate workflow nodes.
+within the same source. Workflow-like context is preserved through component
+evidence and metadata rather than separate workflow nodes.
+
+## Evidence
+
+A component carries its location three ways, which are related but not
+interchangeable:
+
+- `file_path` and `line_number` are where the component itself was detected.
+- `component_primary_evidence` and its start and end lines are the first
+  evidence location the report's decision annotation cites.
+- `evidence_files` is every file the detection was seen in, and `evidence_count`
+  is how many places. `file_path` and `component_primary_evidence` name one of
+  these; `evidence_files` is the full set.
 
 ## Target linking behavior
 

--- a/tests/data/aibom/aibom_sample.py
+++ b/tests/data/aibom/aibom_sample.py
@@ -494,6 +494,24 @@ AIBOM_REPORT = {
                     ],
                     "agent": [
                         {
+                            "name": "QueryAgent",
+                            "component_type": "agent",
+                            "file_path": "/app/app/sub_agents/query/agent.py",
+                            "line_number": 11,
+                            "framework": "openai",
+                            "detection_source": "agentic",
+                            "heuristic_confidence": 1.0,
+                            "agentic_confidence": None,
+                            "needs_agentic": False,
+                            "instance_id": "QueryAgent_/app/app/sub_agents/query/agent.py_11",
+                            "metadata": {
+                                "evidence_count": 1,
+                                "evidence_files": [
+                                    "/app/app/sub_agents/query/agent.py"
+                                ],
+                            },
+                        },
+                        {
                             "name": "Agent",
                             "component_type": "agent",
                             "file_path": "/private/var/folders/r9/q5vn3m2x30b2bv81r550cp_c0000gn/T/aibom_container_81p0fq2h/app/app/sub_agents/cloud_cli/agent.py",
@@ -561,7 +579,7 @@ AIBOM_REPORT = {
                             },
                             "instance_id": "Agent_/private/var/folders/r9/q5vn3m2x30b2bv81r550cp_c0000gn/T/aibom_container_81p0fq2h/app/app/sub_agents/cloud_cli/agent.py_39",
                             "confidence": 0.2,
-                        }
+                        },
                     ],
                     "dataset": [
                         {
@@ -719,6 +737,44 @@ AIBOM_REPORT = {
                             "confidence": 1.0,
                         }
                     ],
+                    "memory": [
+                        {
+                            "name": "conversation_buffer",
+                            "component_type": "memory",
+                            "file_path": "/app/app/memory.py",
+                            "line_number": 11,
+                            "framework": "openai",
+                            "detection_source": "agentic",
+                            "heuristic_confidence": 1.0,
+                            "agentic_confidence": None,
+                            "needs_agentic": False,
+                            "instance_id": "conversation_buffer_/app/app/memory.py_11",
+                            "storage_uri": "redis://cache/0",
+                            "metadata": {
+                                "evidence_count": 1,
+                                "evidence_files": ["/app/app/memory.py"],
+                            },
+                        },
+                    ],
+                    "embedding": [
+                        {
+                            "name": "text-embedding-3-large",
+                            "component_type": "embedding",
+                            "file_path": "/app/app/embed.py",
+                            "line_number": 11,
+                            "framework": "openai",
+                            "detection_source": "agentic",
+                            "heuristic_confidence": 1.0,
+                            "agentic_confidence": None,
+                            "needs_agentic": False,
+                            "instance_id": "text-embedding-3-large_/app/app/embed.py_11",
+                            "embedding_model": "text-embedding-3-large",
+                            "metadata": {
+                                "evidence_count": 1,
+                                "evidence_files": ["/app/app/embed.py"],
+                            },
+                        },
+                    ],
                     "model": [
                         {
                             "name": "gpt-5.2",
@@ -812,6 +868,54 @@ AIBOM_REPORT = {
                     {
                         "source_instance_id": "",
                         "target_instance_id": "",
+                        "relationship_type": "USES_MEMORY",
+                        "label": "USES_MEMORY",
+                        "source_name": "Agent",
+                        "target_name": "conversation_buffer",
+                        "source_type": "agent",
+                        "target_type": "memory",
+                        "source_repo": "",
+                        "target_repo": "",
+                    },
+                    {
+                        "source_instance_id": "",
+                        "target_instance_id": "",
+                        "relationship_type": "USES_EMBEDDING",
+                        "label": "USES_EMBEDDING",
+                        "source_name": "Agent",
+                        "target_name": "text-embedding-3-large",
+                        "source_type": "agent",
+                        "target_type": "embedding",
+                        "source_repo": "",
+                        "target_repo": "",
+                    },
+                    {
+                        "source_instance_id": "",
+                        "target_instance_id": "",
+                        "relationship_type": "USES_AGENT",
+                        "label": "USES_AGENT",
+                        "source_name": "Agent",
+                        "target_name": "QueryAgent",
+                        "source_type": "agent",
+                        "target_type": "agent",
+                        "source_repo": "",
+                        "target_repo": "",
+                    },
+                    {
+                        "source_instance_id": "",
+                        "target_instance_id": "",
+                        "relationship_type": "LOGS_TO",
+                        "label": "LOGS_TO",
+                        "source_name": "Agent",
+                        "target_name": "dataset",
+                        "source_type": "agent",
+                        "target_type": "dataset",
+                        "source_repo": "",
+                        "target_repo": "",
+                    },
+                    {
+                        "source_instance_id": "",
+                        "target_instance_id": "",
                         "relationship_type": "USES_MODEL",
                         "label": "USES_MODEL",
                         "source_name": "Agent",
@@ -842,7 +946,7 @@ AIBOM_REPORT = {
                             ],
                             "code_snippet": None,
                         },
-                    }
+                    },
                 ],
                 "summary": {
                     "status": "completed",

--- a/tests/integration/cartography/intel/aibom/test_aibom.py
+++ b/tests/integration/cartography/intel/aibom/test_aibom.py
@@ -234,8 +234,40 @@ def test_sync_aibom_happy_path(
         rel_direction_right=True,
     ) == {
         (TEST_SOURCE_KEY, "Agent"),
+        (TEST_SOURCE_KEY, "QueryAgent"),
     }
 
+    assert check_rels(
+        neo4j_session,
+        "AIAgent",
+        "name",
+        "AIModelReference",
+        "name",
+        "USES_MODEL",
+        rel_direction_right=True,
+    ) == {
+        ("Agent", "gpt-5.2"),
+    }
+
+    # AIMemory and AIEmbedding components were reachable only from their source
+    # before USES_MEMORY and USES_EMBEDDING were modelled, so an agent's memory and
+    # embedding counts were structurally always zero.
+    for target_label, rel_label, target_name in (
+        ("AIMemory", "USES_MEMORY", "conversation_buffer"),
+        ("AIEmbedding", "USES_EMBEDDING", "text-embedding-3-large"),
+        ("AIAgent", "USES_AGENT", "QueryAgent"),
+    ):
+        assert check_rels(
+            neo4j_session,
+            "AIAgent",
+            "name",
+            target_label,
+            "name",
+            rel_label,
+            rel_direction_right=True,
+        ) == {("Agent", target_name)}
+
+    # AIModel stays on the node as a compatibility alias until its removal version.
     assert check_rels(
         neo4j_session,
         "AIAgent",

--- a/tests/unit/cartography/models/test_schema_docs.py
+++ b/tests/unit/cartography/models/test_schema_docs.py
@@ -347,10 +347,13 @@ def test_conditional_labels_render_their_condition_and_ontology_link():
     generated = render_module_schema(model, "aibom")
 
     # Assert
-    assert "`AIAgent` when `category` equals `agent`." in generated
     assert (
-        "[`AIModel`](#ontology-aimodel) (ontology label) "
-        "when `category` equals `model`." in generated
+        "[`AIAgent`](#ontology-aiagent) (ontology label) "
+        "when `component_type` equals `agent`." in generated
+    )
+    assert (
+        "[`AIModelReference`](#ontology-aimodelreference) (ontology label) "
+        "when `component_type` equals `model`." in generated
     )
 
 

--- a/tests/unit/rules/test_nist_ai_rmf.py
+++ b/tests/unit/rules/test_nist_ai_rmf.py
@@ -23,7 +23,7 @@ def test_nist_ai_rules_registered_and_metadata():
         "ai_provider_api_key_hygiene": "0.2.1",
         "ai_third_party_app_inventory": "0.1.1",
         "ai_third_party_app_sensitive_scopes": "0.1.1",
-        "aibom_agent_inventory": "0.1.1",
+        "aibom_agent_inventory": "0.2.0",
     }
     for rule_id, rule_obj in expected_rules.items():
         assert rule_id in RULES


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

The AIBOM module is one people find hard to read, and the reasons are concrete: the
component node carried two indexed properties holding the same value, put a scan-time
model reference in the same label as provisioned model resources, hid queryable
detection evidence in a JSON string, and shipped a rule querying relationships the
module could not write.

**`category` and `component_type` were always equal.** `transform.py` assigned both from
`normalized_component_type`, while their descriptions implied a raw/normalized split. Two
indexes, one value, and a documented distinction that did not exist. `component_type`
stays — it is the report's own vocabulary and is load-bearing in component identity.

**The six component labels lived in two registries.** `AIModel` came from the ontology;
`AIAgent`, `AIEmbedding`, `AIMemory`, `AIPrompt`, and `AITool` were declared as
provider-local labels in the aibom module, described as "A aibom node participating in
the shared X graph interface". They move to the ontology registry alongside `AIModel`,
and are registered in `SEMANTIC_LABELS_WITHOUT_NORMALIZED_FIELDS` so their generated
schema pages get the same cross-reference targets every other ontology label has. (The
docs build was emitting `xref_missing` for each of them once they were marked as
ontology labels; that is fixed here.)

**`AIModel` conflated references with resources.** An AIBOM model component is a
reference found while scanning an artifact; `AIModel` is also written by Bedrock, Vertex,
and SageMaker for models that exist in an account. Counting the label therefore mixed an
account's model inventory with strings appearing in source code — on one graph I looked
at, `MATCH (m:AIModel)` is 983 Bedrock foundation models, i.e. mostly a catalogue of
what is *available*. Model components now carry **`AIModelReference`**, with `AIModel`
retained as a `COMPATIBILITY` label (`remove_in="1.0.0"`) so existing queries keep
working.

**Four relationship types were unmodelled, and one rule depended on them.** The module
wrote `USES_MODEL`, `USES_TOOL`, `EXPOSES_TOOL`, and `CUSTOM`; everything else was
dropped with one info line per edge. `AIMemory` and `AIEmbedding` nodes were therefore
created but reachable only from their source, so `aibom_agent_inventory`'s
`memory_count` and `embedding_count` were structurally always zero. This adds
`USES_MEMORY`, `USES_EMBEDDING`, `USES_LLM`, and `USES_AGENT` (agent-to-agent delegation,
which the report format gained after this module was written).

**One rule field could never be populated.** `aibom_agent_inventory` queried
`USES_PROMPT`, which the AIBOM report format does not define as a relationship type at
all. `prompt_count` and `prompt_names` are removed; the rule is bumped to 0.2.0.

**Dropped relationship types are now visible.** One warning per sync naming each skipped
type and its edge count, instead of an info line per edge that nobody reads.

**Evidence is queryable.** `evidence_count` and `evidence_files` are promoted out of
`metadata_json`, and the three overlapping ways a component records its location are
documented in the module docs. The remaining type-specific metadata keys are documented
per `component_type` on the property itself, so the schema page says which keys to expect
for a secret versus a package versus a model.


### Related issues or links

AIBOM report format upstream: https://github.com/cisco-ai-defense/aibom


### Breaking changes

None intended. `AIModel` is retained on model components as a compatibility label, and
every other change is additive or removes a field that could not hold a value.


### How was this tested?

`make test_lint` clean, `uv run ./docs/build.sh` clean (no `xref_missing`), 5250 unit
tests and 86 integration tests pass.

The shipped fixture only ever exercised one relationship type (`USES_MODEL`), which is
how the gap survived. It now also carries memory, embedding, and second-agent components
plus `USES_MEMORY`, `USES_EMBEDDING`, `USES_AGENT`, and an unmodelled `LOGS_TO` edge so
the skip path is covered too. The integration test asserts each new edge resolves, that
model components carry `AIModelReference`, and that the `AIModel` compatibility label
still resolves.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [x] Built the documentation with `uv run ./docs/build.sh`.


### Notes for reviewers

**What this deliberately does not fix.** AIBOM emits 30 component types and 26
relationship types; even after this PR the graph labels 6 and models 8. The shipped test
fixture alone contains `secret` (×2), `dependency`, `mcp_server`, `dataset`, and `skill`
components that all load as bare `AIBOMComponent`. From a security standpoint `secret`,
`guardrail`, and the MCP types are the ones worth surfacing next — Cartography already
has an ontology `Secret` label a secret component could carry, and MCP server/client/
gateway components would give the agent tool supply chain a shape. I have kept that out
of here because it means inventing several new ontology labels, which is a decision
worth making deliberately rather than as part of a cleanup. The new per-sync warning
makes the remaining gap measurable in the meantime.

**Relationship count and load cost.** Each `other_relationships` entry adds an
`OPTIONAL MATCH` + `UNION` branch to the component load query, so I added the four types
whose endpoints already carry a semantic label rather than all 22 missing ones.
Modelling the rest is worth doing alongside the labels that would make their endpoints
nameable, not before.

**Report version.** The module targets AIBOM `1.0.0rc4`; upstream is now `1.10.0`. I
diffed the report models across that range and the contract is close to frozen — two new
`CrossRepoLinkType` values, two new `RelationshipType` values (`USES_AGENT`, `USES_SKILL`),
and one new `CrossRepoLink.evidence_type` field. `USES_AGENT` is picked up here. Nothing
in that range requires a parser change.
