### PR TITLE
docs(okta): clarify AWS identity paths

### DIFF
--- a/.agents/skills/create-module/SKILL.md
+++ b/.agents/skills/create-module/SKILL.md
@@ -136,6 +136,10 @@ Create `docs/root/modules/your_service/index.md` and
 the module's toctree. Follow `references/config-docs.md` exactly for the
 canonical `config.md` structure and content-placement rules.
 
+Keep `index.md` limited to the module title and its `toctree`. Put module
+descriptions and other explanatory content in `overview.md` or another focused
+child page, and add that page to the toctree.
+
 Do not create or hand-edit `schema.md`. Sphinx generates it from the
 declarative data model. Write human-readable schema documentation in the model
 itself:
@@ -170,7 +174,9 @@ Sign every commit: `git commit -s -m "..."`. Update the PR description to match 
 - [ ] Required fields use `data["x"]`, optional use `data.get("x")` with `None` default
 - [ ] `extra_index=True` set on frequently queried fields
 - [ ] Integration test exercises `sync()`, asserts nodes + rels with `check_nodes` / `check_rels`
-- [ ] `index.md` and canonical `config.md` added with a `config` / `schema` toctree
+- [ ] `index.md` contains only the module title and toctree
+- [ ] Explanatory content is in focused child pages such as `overview.md`
+- [ ] Canonical `config.md` added and `config` / `schema` included in the toctree
 - [ ] Schema classes have docstrings and displayed `PropertyRef` values have descriptions
 - [ ] No hand-written `schema.md` was added
 - [ ] `make lint` clean, `git commit -s` used

--- a/.agents/skills/create-module/references/config-docs.md
+++ b/.agents/skills/create-module/references/config-docs.md
@@ -84,14 +84,16 @@ omit optional sections that do not apply. Never add empty sections.
 
 Keep `config.md` focused on making the module run:
 
+- Keep `index.md` limited to the module title and its `toctree`.
 - Put module purpose, feature inventories, architecture, graph-model
   narratives, broad ingestion behavior, and ontology integration in
-  `index.md`.
+  `overview.md` or another focused child page.
 - Put Cypher investigations and query walkthroughs in `queries.md` or
   `examples.md`.
 - Put post-ingestion logic, risk derivation, and materialized relationship
   behavior in `analysis.md`.
 - Put node, relationship, and property documentation in schema docstrings and
   `PropertyRef.description`; Sphinx renders these into generated `schema.md`.
+- Link to one authoritative page instead of repeating guidance across pages.
 - Delete content only when it is stale or duplicated after preserving any
   necessary migration or compatibility notice.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,16 @@ PropertyRef("field_list", one_to_many=True)        # One-to-many relationships
 - Prefer comment-only deprecation markers for internal compatibility code that should stay quiet during normal runs.
 - Use runtime warnings or log warnings only when users are actively invoking a deprecated public module or API surface.
 
+**Documentation Conventions:**
+- Keep `docs/root/modules/<module>/index.md` limited to the page title and its
+  `toctree`. Do not put module descriptions, configuration, examples, migration
+  notes, or architecture guidance in the index.
+- Put explanatory content in focused child pages such as `overview.md`,
+  `config.md`, `queries.md`, `examples.md`, or `analysis.md`, and link to one
+  authoritative location instead of repeating the same guidance.
+- Keep node, relationship, and property documentation in model docstrings and
+  `PropertyRef.description`; Sphinx uses them to generate `schema.md`.
+
 ## Git and Pull Request Guidelines
 
 **Signing Commits**: All commits must be signed using the `-s` flag. This adds a `Signed-off-by` line to your commit message, certifying that you have the right to submit the code under the project's license.

--- a/cartography/models/okta/group.py
+++ b/cartography/models/okta/group.py
@@ -183,6 +183,8 @@ class OktaGroupToOktaUserRel(CartographyRelSchema):
 # DEPRECATED: replaced by MEMBER_OF, will be removed in v1.0.0.
 @dataclass(frozen=True)
 class OktaGroupToOktaUserDeprecatedRel(CartographyRelSchema):
+    """Deprecated Okta group membership; use `MEMBER_OF`. Removed in v1.0.0."""
+
     # (:OktaGroup)<-[:MEMBER_OF_OKTA_GROUP]-(:OktaUser)
     target_node_label: str = "OktaUser"
     target_node_matcher: TargetNodeMatcher = make_target_node_matcher(

--- a/cartography/models/okta/group.py
+++ b/cartography/models/okta/group.py
@@ -183,7 +183,7 @@ class OktaGroupToOktaUserRel(CartographyRelSchema):
 # DEPRECATED: replaced by MEMBER_OF, will be removed in v1.0.0.
 @dataclass(frozen=True)
 class OktaGroupToOktaUserDeprecatedRel(CartographyRelSchema):
-    """Deprecated Okta group membership; use `MEMBER_OF`. Removed in v1.0.0."""
+    """Deprecated Okta group membership; use `MEMBER_OF`. Will be removed in v1.0.0."""
 
     # (:OktaGroup)<-[:MEMBER_OF_OKTA_GROUP]-(:OktaUser)
     target_node_label: str = "OktaUser"

--- a/cartography/models/okta/user.py
+++ b/cartography/models/okta/user.py
@@ -93,7 +93,7 @@ class OktaUserTypeToOktaUserRel(CartographyRelSchema):
 class OktaUserTypeSchema(CartographyNodeSchema):
     """An Okta user type.
 
-    Okta SDK 3.4.4 exposes only the ID returned by the list-user-types API.
+    The Okta SDK currently exposes only the ID returned by the list-user-types API.
     See https://github.com/okta/okta-sdk-python/issues/535.
     """
 

--- a/cartography/models/okta/user.py
+++ b/cartography/models/okta/user.py
@@ -91,6 +91,12 @@ class OktaUserTypeToOktaUserRel(CartographyRelSchema):
 
 @dataclass(frozen=True)
 class OktaUserTypeSchema(CartographyNodeSchema):
+    """An Okta user type.
+
+    Okta SDK 3.4.4 exposes only the ID returned by the list-user-types API.
+    See https://github.com/okta/okta-sdk-python/issues/535.
+    """
+
     label: str = "OktaUserType"
     properties: OktaUserTypeNodeProperties = OktaUserTypeNodeProperties()
     sub_resource_relationship: OktaUserTypeToOktaOrganizationRel = (

--- a/docs/root/dev/writing-intel-modules.md
+++ b/docs/root/dev/writing-intel-modules.md
@@ -93,12 +93,14 @@ indirection. Prefer tables for permissions or when documenting three or more
 configuration options. Distinguish required permissions from optional
 permissions and explain any graceful degradation.
 
-Put module purpose, feature inventories, architecture, broad ingestion
-behavior, and ontology integration in `index.md`. Put Cypher investigations in
-`queries.md` or `examples.md`, and put post-ingestion analysis behavior in
-`analysis.md`. Node, relationship, and property documentation belongs in model
-docstrings and `PropertyRef.description`, which Sphinx uses to generate
-`schema.md`.
+Keep `index.md` limited to one H1 title and its `toctree`. Put module purpose,
+feature inventories, architecture, broad ingestion behavior, and ontology
+integration in `overview.md` or another focused child page. Put Cypher
+investigations in `queries.md` or `examples.md`, and put post-ingestion analysis
+behavior in `analysis.md`. Link to one authoritative location instead of
+repeating guidance across pages. Node, relationship, and property documentation
+belongs in model docstrings and `PropertyRef.description`, which Sphinx uses to
+generate `schema.md`.
 
 ## Sync = Get, Transform, Load, Cleanup
 

--- a/docs/root/modules/aws/identity-access.md
+++ b/docs/root/modules/aws/identity-access.md
@@ -160,8 +160,10 @@ Center users:
 (:EntraServicePrincipal)-[:FEDERATES_TO]->(:AWSIdentityCenter)
 ```
 
-The AWS Identity Center sync creates these federation links from identity-store
-data. The Okta sync does not create `CAN_ASSUME_IDENTITY` relationships.
+The AWS Identity Center sync creates `CAN_ASSUME_IDENTITY` relationships from
+identity-store external IDs. The Microsoft sync creates `CAN_SIGN_ON_TO` and
+`FEDERATES_TO` relationships. The Okta sync does not create
+`CAN_ASSUME_IDENTITY` relationships.
 
 For an Okta user, combine federation, permitted access, and actual use:
 

--- a/docs/root/modules/aws/identity-access.md
+++ b/docs/root/modules/aws/identity-access.md
@@ -160,6 +160,9 @@ Center users:
 (:EntraServicePrincipal)-[:FEDERATES_TO]->(:AWSIdentityCenter)
 ```
 
+The AWS Identity Center sync creates these federation links from identity-store
+data. The Okta sync does not create `CAN_ASSUME_IDENTITY` relationships.
+
 For an Okta user, combine federation, permitted access, and actual use:
 
 ```cypher

--- a/docs/root/modules/okta/config.md
+++ b/docs/root/modules/okta/config.md
@@ -25,4 +25,13 @@ cartography \
 
 For an Okta preview environment or another region, set `--okta-base-domain`. The default is `okta.com`.
 
-When Okta administers AWS as a [SAML provider](https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-Amazon-Web-Service#scenarioC), Cartography matches Okta groups to the AWS roles they control. If your group names do not use the standard `^aws\#\S+\#(?{{role}}[\w\-]+)\#(?{{accountid}}\d+)$` pattern from [Enabling Group Based Role Mapping in Okta](https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-Amazon-Web-Service#scenarioC), provide your pattern with `--okta-saml-role-regex`.
+When Okta maps groups directly to AWS IAM roles as a
+[SAML provider](https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-Amazon-Web-Service#scenarioC),
+Cartography derives the role from each group name. If your group names do not
+use the standard `^aws\#\S+\#(?{{role}}[\w\-]+)\#(?{{accountid}}\d+)$` pattern
+from [Enabling Group Based Role Mapping in Okta](https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-Amazon-Web-Service#scenarioC),
+provide your pattern with `--okta-saml-role-regex`.
+
+This option affects only direct `OktaGroup` to `AWSRole` mapping. It does not
+control SCIM-provisioned users, groups, or permission assignments in AWS
+Identity Center. The AWS module imports that data.

--- a/docs/root/modules/okta/config.md
+++ b/docs/root/modules/okta/config.md
@@ -32,6 +32,7 @@ use the standard `^aws\#\S+\#(?{{role}}[\w\-]+)\#(?{{accountid}}\d+)$` pattern
 from [Enabling Group Based Role Mapping in Okta](https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-Amazon-Web-Service#scenarioC),
 provide your pattern with `--okta-saml-role-regex`.
 
-This option affects only direct `OktaGroup` to `AWSRole` mapping. It does not
-control SCIM-provisioned users, groups, or permission assignments in AWS
-Identity Center. The AWS module imports that data.
+This option controls `OktaGroup` to `AWSRole` mapping for directly federated IAM
+roles and AWS Identity Center `AWSReservedSSO` roles. It does not control
+SCIM-provisioned users, groups, or account assignments; the AWS module imports
+that data.

--- a/docs/root/modules/okta/index.md
+++ b/docs/root/modules/okta/index.md
@@ -9,16 +9,45 @@ relationships.
 ## Cross-Platform Integration: Okta to AWS
 
 When Okta is configured as the SAML identity provider for AWS Identity Center,
-Cartography can represent this access path:
+run both the Okta and AWS modules. The AWS Identity Center sync links the
+SCIM-provisioned identity to its permitted AWS roles:
+
+```cypher
+(:OktaUser)-[:CAN_ASSUME_IDENTITY]->(:AWSSSOUser)<-[:ALLOWED_BY]-(:AWSRole)
+```
+
+Cartography links an `OktaUser` to an `AWSSSOUser` when
+`AWSSSOUser.external_id` matches `OktaUser.id`. The AWS Identity Center sync
+creates this link and imports permitted role assignments. CloudTrail management
+events record actual role use separately:
 
 ```cypher
 (:OktaUser)-[:CAN_ASSUME_IDENTITY]->(:AWSSSOUser)-[:ASSUMED_ROLE_WITH_SAML]->(:AWSRole)
 ```
 
-Cartography links an `OktaUser` to an `AWSSSOUser` when
-`AWSSSOUser.external_id` matches `OktaUser.id`. CloudTrail management events
-record role assumptions from AWS Identity Center as `ASSUMED_ROLE_WITH_SAML`
-relationships.
+For direct Okta group-to-IAM-role mapping, Cartography uses this path:
+
+```cypher
+(:OktaUser)-[:MEMBER_OF]->(:OktaGroup)-[:ALLOWED_BY]->(:AWSRole)
+```
+
+See [AWS identity and access](../aws/identity-access.md) for permission-set,
+group-assignment, and observed-use queries.
+
+## Graph model migration
+
+This module uses the shared Cartography ontology:
+
+- `OktaUserRole` and `OktaGroupRole` replace `OktaAdministrationRole` and use
+  `HAS_ROLE` relationships.
+- `User` and `HAS_ACCOUNT` replace the deprecated `Human` and `IDENTITY_OKTA`
+  identity model.
+- `MEMBER_OF` replaces `MEMBER_OF_OKTA_GROUP`. Cartography continues to write
+  `MEMBER_OF_OKTA_GROUP` as a compatibility relationship until v1.0.0.
+
+The Okta cleanup removes the replaced nodes and relationships. Update queries
+that still use `OktaAdministrationRole`, `Human`, or `IDENTITY_OKTA` before
+running this version.
 
 ```{toctree}
 config

--- a/docs/root/modules/okta/index.md
+++ b/docs/root/modules/okta/index.md
@@ -1,55 +1,7 @@
 # Okta
 
-The Okta module ingests organizations, users, groups, applications, trusted
-origins, user and group administration roles, and user authentication factors.
-See the generated [Okta schema](schema.md) for the available properties and
-relationships.
-
-(cross-platform-integration-okta-to-aws)=
-## Cross-Platform Integration: Okta to AWS
-
-When Okta is configured as the SAML identity provider for AWS Identity Center,
-run both the Okta and AWS modules. The AWS Identity Center sync links the
-SCIM-provisioned identity to its permitted AWS roles:
-
-```cypher
-(:OktaUser)-[:CAN_ASSUME_IDENTITY]->(:AWSSSOUser)<-[:ALLOWED_BY]-(:AWSRole)
-```
-
-Cartography links an `OktaUser` to an `AWSSSOUser` when
-`AWSSSOUser.external_id` matches `OktaUser.id`. The AWS Identity Center sync
-creates this link and imports permitted role assignments. CloudTrail management
-events record actual role use separately:
-
-```cypher
-(:OktaUser)-[:CAN_ASSUME_IDENTITY]->(:AWSSSOUser)-[:ASSUMED_ROLE_WITH_SAML]->(:AWSRole)
-```
-
-For direct Okta group-to-IAM-role mapping, Cartography uses this path:
-
-```cypher
-(:OktaUser)-[:MEMBER_OF]->(:OktaGroup)-[:ALLOWED_BY]->(:AWSRole)
-```
-
-See [AWS identity and access](../aws/identity-access.md) for permission-set,
-group-assignment, and observed-use queries.
-
-## Graph model migration
-
-This module uses the shared Cartography ontology:
-
-- `OktaUserRole` and `OktaGroupRole` replace `OktaAdministrationRole` and use
-  `HAS_ROLE` relationships.
-- `User` and `HAS_ACCOUNT` replace the deprecated `Human` and `IDENTITY_OKTA`
-  identity model.
-- `MEMBER_OF` replaces `MEMBER_OF_OKTA_GROUP`. Cartography continues to write
-  `MEMBER_OF_OKTA_GROUP` as a compatibility relationship until v1.0.0.
-
-The Okta cleanup removes the replaced nodes and relationships. Update queries
-that still use `OktaAdministrationRole`, `Human`, or `IDENTITY_OKTA` before
-running this version.
-
 ```{toctree}
+overview
 config
 schema
 ```

--- a/docs/root/modules/okta/overview.md
+++ b/docs/root/modules/okta/overview.md
@@ -1,0 +1,53 @@
+# Okta overview
+
+The Okta module ingests organizations, users, groups, applications, trusted
+origins, user and group administration roles, and user authentication factors.
+See the generated [Okta schema](schema.md) for the available properties and
+relationships.
+
+(cross-platform-integration-okta-to-aws)=
+## Cross-platform integration: Okta to AWS
+
+When Okta is configured as the SAML identity provider for AWS Identity Center,
+run both the Okta and AWS modules to represent SCIM-provisioned identities and
+their permitted AWS roles:
+
+```cypher
+(:OktaUser)-[:CAN_ASSUME_IDENTITY]->(:AWSSSOUser)<-[:ALLOWED_BY]-(:AWSRole)
+```
+
+The AWS Identity Center sync links an `OktaUser` to an `AWSSSOUser` when
+`AWSSSOUser.external_id` matches `OktaUser.id`, and imports permitted role
+assignments. CloudTrail management events record actual role use separately:
+
+```cypher
+(:OktaUser)-[:CAN_ASSUME_IDENTITY]->(:AWSSSOUser)-[:ASSUMED_ROLE_WITH_SAML]->(:AWSRole)
+```
+
+For Okta group-to-role mappings derived from group names, including
+`AWSReservedSSO` roles, Cartography uses this path:
+
+```cypher
+(:OktaUser)-[:MEMBER_OF]->(:OktaGroup)-[:ALLOWED_BY]->(:AWSRole)
+```
+
+See [AWS identity and access](../aws/identity-access.md) for permission-set,
+group-assignment, and observed-use queries.
+
+## Graph model migration
+
+This module uses the shared Cartography ontology:
+
+- `OktaUserRole` and `OktaGroupRole` replace `OktaAdministrationRole` and use
+  `HAS_ROLE` relationships.
+- `User` and `HAS_ACCOUNT` replace the deprecated `Human` and `IDENTITY_OKTA`
+  identity model. Run the ontology module to materialize `User` nodes and
+  `HAS_ACCOUNT` relationships.
+- `MEMBER_OF` replaces `MEMBER_OF_OKTA_GROUP`. Cartography continues to write
+  `MEMBER_OF_OKTA_GROUP` as a compatibility relationship until v1.0.0.
+
+The Okta migration cleanup removes `OktaAdministrationRole` nodes and the
+replaced `IDENTITY_OKTA`, Okta-derived `CAN_ASSUME_ROLE`,
+`MEMBER_OF_OKTA_ROLE`, and `MAPS_TO` relationships. It leaves shared `Human`
+nodes and the compatibility `MEMBER_OF_OKTA_GROUP` relationship intact. Update
+queries that still use the replaced graph model before running this version.


### PR DESCRIPTION
### Type of change

- [x] Documentation update

### Summary

Clarify how Cartography represents Okta-governed access to AWS after #1243.

This change:

- Distinguishes permitted AWS Identity Center access from observed CloudTrail role use.
- Explains that the AWS Identity Center sync creates SCIM identity and role-assignment relationships.
- Separates SCIM-based access from direct Okta group-to-IAM-role mapping.
- Documents the Okta graph-model migration and the compatibility lifetime of `MEMBER_OF_OKTA_GROUP`.
- Restores the public note about the Okta SDK user-type limitation in generated schema documentation.

No Cartography rules use the replaced Okta labels or relationships, so this change does not modify the rules library.

### Related issues or links

- Follow-up to #1243

### Checklist

#### General

- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added or updated generated-schema descriptions for the changed documentation.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality

- [ ] Screenshot showing the graph before and after changes.
- [x] Existing schema and documentation tests pass.

#### If you are changing a node or relationship

- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [x] Built the documentation with `uv run ./docs/build.sh`.
