### PR TITLE
feat(ontology): link DNS records to Railway domains

### DIFF
--- a/cartography/analysis/ontology/analysis.py
+++ b/cartography/analysis/ontology/analysis.py
@@ -225,7 +225,7 @@ DNS_RECORD_TO_RAILWAY_CUSTOM_DOMAIN = AnalysisJob(
     cleanup_iterationsize=1000,
     statements=(
         AnalysisStatement(
-            match="MATCH (dns:DNSRecord) WHERE dns._ont_name IS NOT NULL AND (dns._ont_type IS NULL OR toUpper(dns._ont_type) IN ['A', 'AAAA', 'CNAME']) WITH dns MATCH (domain:RailwayCustomDomain) WHERE domain.domain IS NOT NULL AND toLower(rtrim(dns._ont_name, '.')) = toLower(rtrim(domain.domain, '.'))",
+            match="MATCH (dns:DNSRecord) WHERE dns._ont_name IS NOT NULL AND (dns._ont_type IS NULL OR toUpper(dns._ont_type) IN ['A', 'AAAA', 'CNAME']) WITH dns MATCH (domain:RailwayCustomDomain) WHERE domain.verified = true AND domain.domain IS NOT NULL AND toLower(rtrim(dns._ont_name, '.')) = toLower(rtrim(domain.domain, '.'))",
             effects=(
                 AddRelationship(
                     "dns",
@@ -279,8 +279,7 @@ DNS_RECORD_TARGETS = (
     ("GCPInstance", "hostname", "AND NOT dns:GCPRecordSet", ""),
     ("AzureAppService", "default_host_name", "AND NOT dns:GCPRecordSet", ""),
     ("AzureFunctionApp", "default_host_name", "AND NOT dns:GCPRecordSet", ""),
-    ("RailwayServiceDomain", "domain", "", ""),
-    ("RailwayTCPProxy", "domain", "", ""),
+    ("RailwayServiceDomain", "domain", "AND NOT dns:GCPRecordSet", ""),
 )
 DNS_RECORD_LINKING_JOBS = (
     DNS_RECORD_TO_KUBERNETES_INGRESS,

--- a/cartography/analysis/ontology/analysis.py
+++ b/cartography/analysis/ontology/analysis.py
@@ -219,6 +219,25 @@ DNS_RECORD_TO_KUBERNETES_INGRESS = AnalysisJob(
         ),
     ),
 )
+DNS_RECORD_TO_RAILWAY_CUSTOM_DOMAIN = AnalysisJob(
+    name="Ontology - DNSRecord to RailwayCustomDomain linking",
+    short_name="ontology_dnsrecords_railway_custom_domain",
+    cleanup_iterationsize=1000,
+    statements=(
+        AnalysisStatement(
+            match="MATCH (dns:DNSRecord) WHERE dns._ont_name IS NOT NULL WITH dns MATCH (domain:RailwayCustomDomain) WHERE domain.domain IS NOT NULL AND toLower(rtrim(dns._ont_name, '.')) = toLower(rtrim(domain.domain, '.'))",
+            effects=(
+                AddRelationship(
+                    "dns",
+                    "DNS_POINTS_TO",
+                    "domain",
+                    source_label="DNSRecord",
+                    target_label="RailwayCustomDomain",
+                ),
+            ),
+        ),
+    ),
+)
 BBOT_DNS_MATCHES_PROVIDER = AnalysisJob(
     name="Ontology - BbotDNSName to provider DNSRecord linking",
     short_name="ontology_bbot_dns_matches_provider",
@@ -260,9 +279,11 @@ DNS_RECORD_TARGETS = (
     ("GCPInstance", "hostname", "AND NOT dns:GCPRecordSet", ""),
     ("AzureAppService", "default_host_name", "AND NOT dns:GCPRecordSet", ""),
     ("AzureFunctionApp", "default_host_name", "AND NOT dns:GCPRecordSet", ""),
+    ("RailwayServiceDomain", "domain", "", ""),
 )
 DNS_RECORD_LINKING_JOBS = (
     DNS_RECORD_TO_KUBERNETES_INGRESS,
+    DNS_RECORD_TO_RAILWAY_CUSTOM_DOMAIN,
     BBOT_DNS_MATCHES_PROVIDER,
 ) + tuple(
     (

--- a/cartography/analysis/ontology/analysis.py
+++ b/cartography/analysis/ontology/analysis.py
@@ -225,7 +225,7 @@ DNS_RECORD_TO_RAILWAY_CUSTOM_DOMAIN = AnalysisJob(
     cleanup_iterationsize=1000,
     statements=(
         AnalysisStatement(
-            match="MATCH (dns:DNSRecord) WHERE dns._ont_name IS NOT NULL AND (dns._ont_type IS NULL OR toUpper(dns._ont_type) IN ['A', 'AAAA', 'CNAME']) WITH dns MATCH (domain:RailwayCustomDomain) WHERE domain.verified = true AND domain.domain IS NOT NULL AND toLower(rtrim(dns._ont_name, '.')) = toLower(rtrim(domain.domain, '.'))",
+            match="MATCH (dns:DNSRecord) WHERE dns._ont_name IS NOT NULL AND (dns._ont_type IS NULL OR toUpper(dns._ont_type) IN ['A', 'AAAA', 'CNAME']) WITH dns MATCH (domain:RailwayCustomDomain) WHERE domain.verified = true AND domain.domain_normalized IS NOT NULL AND dns._ont_name = domain.domain_normalized",
             effects=(
                 AddRelationship(
                     "dns",
@@ -243,7 +243,7 @@ BBOT_DNS_MATCHES_PROVIDER = AnalysisJob(
     short_name="ontology_bbot_dns_matches_provider",
     statements=(
         AnalysisStatement(
-            match="MATCH (bbot:BbotDNSName), (provider:DNSRecord) WHERE NOT provider:BbotDNSName AND bbot._ont_name IS NOT NULL AND toLower(rtrim(bbot._ont_name, '.')) = toLower(rtrim(provider._ont_name, '.'))",
+            match="MATCH (bbot:BbotDNSName), (provider:DNSRecord) WHERE NOT provider:BbotDNSName AND bbot._ont_name IS NOT NULL AND bbot._ont_name = provider._ont_name",
             effects=(
                 AddRelationship(
                     "bbot",
@@ -262,24 +262,51 @@ DNS_RECORD_TARGETS = (
         "dnsname",
         "AND NOT dns:AWSDNSRecord AND NOT dns:GCPRecordSet",
         "NOT source:AWSDNSRecord",
+        False,
     ),
     (
         "AWSLoadBalancer",
         "dnsname",
         "AND NOT dns:AWSDNSRecord AND NOT dns:GCPRecordSet",
         "NOT source:AWSDNSRecord",
+        False,
     ),
-    ("AWSCloudFrontDistribution", "domain_name", "AND NOT dns:GCPRecordSet", ""),
+    (
+        "AWSCloudFrontDistribution",
+        "domain_name",
+        "AND NOT dns:GCPRecordSet",
+        "",
+        False,
+    ),
     (
         "AWSEC2Instance",
         "publicdnsname",
         "AND NOT dns:AWSDNSRecord AND NOT dns:GCPRecordSet",
         "NOT source:AWSDNSRecord",
+        False,
     ),
-    ("GCPInstance", "hostname", "AND NOT dns:GCPRecordSet", ""),
-    ("AzureAppService", "default_host_name", "AND NOT dns:GCPRecordSet", ""),
-    ("AzureFunctionApp", "default_host_name", "AND NOT dns:GCPRecordSet", ""),
-    ("RailwayServiceDomain", "domain", "AND NOT dns:GCPRecordSet", ""),
+    ("GCPInstance", "hostname", "AND NOT dns:GCPRecordSet", "", False),
+    (
+        "AzureAppService",
+        "default_host_name",
+        "AND NOT dns:GCPRecordSet",
+        "",
+        False,
+    ),
+    (
+        "AzureFunctionApp",
+        "default_host_name",
+        "AND NOT dns:GCPRecordSet",
+        "",
+        False,
+    ),
+    (
+        "RailwayServiceDomain",
+        "domain_normalized",
+        "AND NOT dns:GCPRecordSet",
+        "",
+        True,
+    ),
 )
 DNS_RECORD_LINKING_JOBS = (
     DNS_RECORD_TO_KUBERNETES_INGRESS,
@@ -293,7 +320,11 @@ DNS_RECORD_LINKING_JOBS = (
             cleanup_iterationsize=1000,
             statements=(
                 AnalysisStatement(
-                    match=f"MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL {match_filter} WITH dns MATCH (target:{target_label}) WHERE toLower(rtrim(toString(dns._ont_value), '.')) = toLower(rtrim(target.{target_property}, '.'))",
+                    match=(
+                        f"MATCH (dns:DNSRecord) WHERE dns._ont_target_hostname IS NOT NULL {match_filter} WITH dns MATCH (target:{target_label}) WHERE dns._ont_target_hostname = target.{target_property}"
+                        if target_is_normalized
+                        else f"MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL {match_filter} WITH dns MATCH (target:{target_label}) WHERE toLower(rtrim(toString(dns._ont_value), '.')) = toLower(rtrim(target.{target_property}, '.'))"
+                    ),
                     effects=(
                         AddRelationship(
                             "dns",
@@ -306,7 +337,11 @@ DNS_RECORD_LINKING_JOBS = (
                     ),
                 ),
                 AnalysisStatement(
-                    match=f"MATCH (dns:GCPRecordSet) WHERE dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (target:{target_label}) WHERE toLower(rtrim(val, '.')) = toLower(rtrim(target.{target_property}, '.'))",
+                    match=(
+                        f"MATCH (dns:GCPRecordSet) WHERE dns._ont_target_hostnames IS NOT NULL UNWIND dns._ont_target_hostnames AS hostname WITH dns, hostname MATCH (target:{target_label}) WHERE hostname = target.{target_property}"
+                        if target_is_normalized
+                        else f"MATCH (dns:GCPRecordSet) WHERE dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (target:{target_label}) WHERE toLower(rtrim(val, '.')) = toLower(rtrim(target.{target_property}, '.'))"
+                    ),
                     effects=(
                         AddRelationship(
                             "dns",
@@ -327,7 +362,7 @@ DNS_RECORD_LINKING_JOBS = (
                 ),
             ),
         )
-        for target_label, target_property, match_filter, cleanup_where in DNS_RECORD_TARGETS
+        for target_label, target_property, match_filter, cleanup_where, target_is_normalized in DNS_RECORD_TARGETS
     )
 )
 BBOT_IP_MATCHES_PUBLIC_IP = AnalysisJob(

--- a/cartography/analysis/ontology/analysis.py
+++ b/cartography/analysis/ontology/analysis.py
@@ -206,7 +206,7 @@ DNS_RECORD_TO_KUBERNETES_INGRESS = AnalysisJob(
     cleanup_iterationsize=1000,
     statements=(
         AnalysisStatement(
-            match="MATCH (ing:KubernetesIngress) WHERE ing.host_names_normalized IS NOT NULL OR ing.host_names IS NOT NULL UNWIND coalesce(ing.host_names_normalized, ing.host_names) AS hostname WITH ing, hostname MATCH (dns:DNSRecord {_ont_name: hostname})",
+            match="MATCH (ing:KubernetesIngress) WHERE ing.host_names_normalized IS NOT NULL OR ing.host_names IS NOT NULL UNWIND CASE WHEN ing.host_names_normalized IS NOT NULL THEN ing.host_names_normalized ELSE [host IN ing.host_names | toLower(rtrim(trim(toString(host)), '.'))] END AS hostname WITH ing, hostname MATCH (dns:DNSRecord {_ont_name: hostname})",
             effects=(
                 AddRelationship(
                     "dns",

--- a/cartography/analysis/ontology/analysis.py
+++ b/cartography/analysis/ontology/analysis.py
@@ -206,7 +206,7 @@ DNS_RECORD_TO_KUBERNETES_INGRESS = AnalysisJob(
     cleanup_iterationsize=1000,
     statements=(
         AnalysisStatement(
-            match="MATCH (dns:DNSRecord) WHERE dns._ont_name IS NOT NULL WITH dns MATCH (ing:KubernetesIngress) WHERE dns._ont_name IN ing.host_names",
+            match="MATCH (ing:KubernetesIngress) WHERE ing.host_names_normalized IS NOT NULL UNWIND ing.host_names_normalized AS hostname WITH ing, hostname MATCH (dns:DNSRecord {_ont_name: hostname})",
             effects=(
                 AddRelationship(
                     "dns",

--- a/cartography/analysis/ontology/analysis.py
+++ b/cartography/analysis/ontology/analysis.py
@@ -225,7 +225,7 @@ DNS_RECORD_TO_RAILWAY_CUSTOM_DOMAIN = AnalysisJob(
     cleanup_iterationsize=1000,
     statements=(
         AnalysisStatement(
-            match="MATCH (dns:DNSRecord) WHERE dns._ont_name IS NOT NULL AND (dns._ont_type IS NULL OR toUpper(dns._ont_type) IN ['A', 'AAAA', 'CNAME']) WITH dns MATCH (domain:RailwayCustomDomain) WHERE domain.verified = true AND domain.domain_normalized IS NOT NULL AND dns._ont_name = domain.domain_normalized",
+            match="MATCH (domain:RailwayCustomDomain) WHERE domain.verified = true AND domain.domain_normalized IS NOT NULL WITH domain MATCH (dns:DNSRecord {_ont_name: domain.domain_normalized}) WHERE dns._ont_type IS NULL OR toUpper(dns._ont_type) IN ['A', 'AAAA', 'CNAME']",
             effects=(
                 AddRelationship(
                     "dns",
@@ -243,7 +243,7 @@ BBOT_DNS_MATCHES_PROVIDER = AnalysisJob(
     short_name="ontology_bbot_dns_matches_provider",
     statements=(
         AnalysisStatement(
-            match="MATCH (bbot:BbotDNSName), (provider:DNSRecord) WHERE NOT provider:BbotDNSName AND bbot._ont_name IS NOT NULL AND bbot._ont_name = provider._ont_name",
+            match="MATCH (bbot:BbotDNSName) WHERE bbot._ont_name IS NOT NULL WITH bbot MATCH (provider:DNSRecord {_ont_name: bbot._ont_name}) WHERE NOT provider:BbotDNSName",
             effects=(
                 AddRelationship(
                     "bbot",
@@ -321,7 +321,7 @@ DNS_RECORD_LINKING_JOBS = (
             statements=(
                 AnalysisStatement(
                     match=(
-                        f"MATCH (dns:DNSRecord) WHERE dns._ont_target_hostname IS NOT NULL {match_filter} WITH dns MATCH (target:{target_label}) WHERE dns._ont_target_hostname = target.{target_property}"
+                        f"MATCH (target:{target_label}) WHERE target.{target_property} IS NOT NULL WITH target MATCH (dns:DNSRecord {{_ont_target_hostname: target.{target_property}}}) WHERE true {match_filter}"
                         if target_is_normalized
                         else f"MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL {match_filter} WITH dns MATCH (target:{target_label}) WHERE toLower(rtrim(toString(dns._ont_value), '.')) = toLower(rtrim(target.{target_property}, '.'))"
                     ),

--- a/cartography/analysis/ontology/analysis.py
+++ b/cartography/analysis/ontology/analysis.py
@@ -225,7 +225,7 @@ DNS_RECORD_TO_RAILWAY_CUSTOM_DOMAIN = AnalysisJob(
     cleanup_iterationsize=1000,
     statements=(
         AnalysisStatement(
-            match="MATCH (dns:DNSRecord) WHERE dns._ont_name IS NOT NULL WITH dns MATCH (domain:RailwayCustomDomain) WHERE domain.domain IS NOT NULL AND toLower(rtrim(dns._ont_name, '.')) = toLower(rtrim(domain.domain, '.'))",
+            match="MATCH (dns:DNSRecord) WHERE dns._ont_name IS NOT NULL AND (dns._ont_type IS NULL OR toUpper(dns._ont_type) IN ['A', 'AAAA', 'CNAME']) WITH dns MATCH (domain:RailwayCustomDomain) WHERE domain.domain IS NOT NULL AND toLower(rtrim(dns._ont_name, '.')) = toLower(rtrim(domain.domain, '.'))",
             effects=(
                 AddRelationship(
                     "dns",
@@ -280,6 +280,7 @@ DNS_RECORD_TARGETS = (
     ("AzureAppService", "default_host_name", "AND NOT dns:GCPRecordSet", ""),
     ("AzureFunctionApp", "default_host_name", "AND NOT dns:GCPRecordSet", ""),
     ("RailwayServiceDomain", "domain", "", ""),
+    ("RailwayTCPProxy", "domain", "", ""),
 )
 DNS_RECORD_LINKING_JOBS = (
     DNS_RECORD_TO_KUBERNETES_INGRESS,
@@ -293,7 +294,7 @@ DNS_RECORD_LINKING_JOBS = (
             cleanup_iterationsize=1000,
             statements=(
                 AnalysisStatement(
-                    match=f"MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL {match_filter} WITH dns MATCH (target:{target_label}) WHERE toLower(toString(dns._ont_value)) = toLower(target.{target_property})",
+                    match=f"MATCH (dns:DNSRecord) WHERE dns._ont_value IS NOT NULL {match_filter} WITH dns MATCH (target:{target_label}) WHERE toLower(rtrim(toString(dns._ont_value), '.')) = toLower(rtrim(target.{target_property}, '.'))",
                     effects=(
                         AddRelationship(
                             "dns",
@@ -306,7 +307,7 @@ DNS_RECORD_LINKING_JOBS = (
                     ),
                 ),
                 AnalysisStatement(
-                    match=f"MATCH (dns:GCPRecordSet) WHERE dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (target:{target_label}) WHERE toLower(val) = toLower(target.{target_property})",
+                    match=f"MATCH (dns:GCPRecordSet) WHERE dns.data IS NOT NULL UNWIND dns.data AS val WITH dns, val MATCH (target:{target_label}) WHERE toLower(rtrim(val, '.')) = toLower(rtrim(target.{target_property}, '.'))",
                     effects=(
                         AddRelationship(
                             "dns",

--- a/cartography/analysis/ontology/analysis.py
+++ b/cartography/analysis/ontology/analysis.py
@@ -206,7 +206,7 @@ DNS_RECORD_TO_KUBERNETES_INGRESS = AnalysisJob(
     cleanup_iterationsize=1000,
     statements=(
         AnalysisStatement(
-            match="MATCH (ing:KubernetesIngress) WHERE ing.host_names_normalized IS NOT NULL UNWIND ing.host_names_normalized AS hostname WITH ing, hostname MATCH (dns:DNSRecord {_ont_name: hostname})",
+            match="MATCH (ing:KubernetesIngress) WHERE ing.host_names_normalized IS NOT NULL OR ing.host_names IS NOT NULL UNWIND coalesce(ing.host_names_normalized, ing.host_names) AS hostname WITH ing, hostname MATCH (dns:DNSRecord {_ont_name: hostname})",
             effects=(
                 AddRelationship(
                     "dns",

--- a/cartography/intel/railway/network/domains.py
+++ b/cartography/intel/railway/network/domains.py
@@ -5,6 +5,7 @@ import neo4j
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.dns_utils import normalize_hostname
 from cartography.intel.railway.serviceinstances import iter_service_instances
 from cartography.intel.railway.utils import is_live_entrypoint
 from cartography.models.railway.network.customdomain import RailwayCustomDomainSchema
@@ -77,6 +78,9 @@ def transform(
                 project_service_domains.append(
                     {
                         **service_domain,
+                        "domain_normalized": normalize_hostname(
+                            service_domain.get("domain")
+                        ),
                         **owner,
                         **_exposure_keys(service_domain, owner),
                     },
@@ -86,6 +90,9 @@ def transform(
                 project_custom_domains.append(
                     {
                         **custom_domain,
+                        "domain_normalized": normalize_hostname(
+                            custom_domain.get("domain")
+                        ),
                         **owner,
                         "verified": bool(status.get("verified")),
                         "certificate_status": status.get("certificateStatus"),

--- a/cartography/models/railway/network/customdomain.py
+++ b/cartography/models/railway/network/customdomain.py
@@ -20,6 +20,11 @@ class RailwayCustomDomainNodeProperties(CartographyNodeProperties):
         extra_index=True,
         description="Fully qualified customer-owned domain name.",
     )
+    domain_normalized: PropertyRef = PropertyRef(
+        "domain_normalized",
+        extra_index=True,
+        description="Canonical lowercase domain name without the trailing DNS root dot.",
+    )
     target_port: PropertyRef = PropertyRef(
         "targetPort", description="Port on the service to which the domain routes."
     )

--- a/cartography/models/railway/network/servicedomain.py
+++ b/cartography/models/railway/network/servicedomain.py
@@ -21,6 +21,11 @@ class RailwayServiceDomainNodeProperties(CartographyNodeProperties):
         extra_index=True,
         description="Fully qualified Railway-provided domain name.",
     )
+    domain_normalized: PropertyRef = PropertyRef(
+        "domain_normalized",
+        extra_index=True,
+        description="Canonical lowercase domain name without the trailing DNS root dot.",
+    )
     suffix: PropertyRef = PropertyRef("suffix", description="Railway domain suffix.")
     target_port: PropertyRef = PropertyRef(
         "targetPort", description="Port on the service to which the domain routes."

--- a/tests/integration/cartography/intel/bbot/test_bbot.py
+++ b/tests/integration/cartography/intel/bbot/test_bbot.py
@@ -335,10 +335,12 @@ def test_bbot_dns_and_ip_correlate_and_public_ip_lifecycle(
     _sync(neo4j_session, make_events(1), 101)
     neo4j_session.run(
         """
-        CREATE (:AWSDNSRecord:DNSRecord {
-            id: 'provider-dns-record',
-            _ont_name: 'APP.EXAMPLE.TEST.'
-        })
+            CREATE (:AWSDNSRecord:DNSRecord {
+                id: 'provider-dns-record',
+                // Provider ingestion stores canonical ontology hostnames while retaining
+                // the original provider value on the raw `name` property.
+                _ont_name: 'app.example.test'
+            })
         """,
     )
 

--- a/tests/integration/cartography/intel/ontology/test_dnsrecords.py
+++ b/tests/integration/cartography/intel/ontology/test_dnsrecords.py
@@ -87,13 +87,31 @@ def test_sync_links_dns_records_to_railway_domains(neo4j_session):
             id: 'custom-domain',
             domain: 'app.example.com'
         })
+        CREATE (tcp_proxy:RailwayTCPProxy {
+            id: 'tcp-proxy',
+            domain: 'tcp.proxy.rlwy.net'
+        })
         CREATE (instance:RailwayServiceInstance {id: 'service-instance'})
         CREATE (service_domain)-[:EXPOSE]->(instance)
         CREATE (custom_domain)-[:EXPOSE]->(instance)
+        CREATE (tcp_proxy)-[:EXPOSE]->(instance)
         CREATE (:CloudflareDNSRecord:DNSRecord {
             id: 'custom-domain-record',
             _ont_name: 'APP.EXAMPLE.COM.',
-            _ont_value: 'web-production.up.railway.app'
+            _ont_type: 'CNAME',
+            _ont_value: 'WEB-PRODUCTION.UP.RAILWAY.APP.'
+        })
+        CREATE (:CloudflareDNSRecord:DNSRecord {
+            id: 'tcp-proxy-record',
+            _ont_name: 'database.example.com',
+            _ont_type: 'CNAME',
+            _ont_value: 'TCP.PROXY.RLWY.NET.'
+        })
+        CREATE (:CloudflareDNSRecord:DNSRecord {
+            id: 'unrelated-text-record',
+            _ont_name: 'app.example.com',
+            _ont_type: 'TXT',
+            _ont_value: 'verification-token'
         })
         CREATE (stale:CloudflareDNSRecord:DNSRecord {
             id: 'stale-record',
@@ -102,6 +120,7 @@ def test_sync_links_dns_records_to_railway_domains(neo4j_session):
         })
         CREATE (stale)-[:DNS_POINTS_TO {lastupdated: $stale_tag}]->(service_domain)
         CREATE (stale)-[:DNS_POINTS_TO {lastupdated: $stale_tag}]->(custom_domain)
+        CREATE (stale)-[:DNS_POINTS_TO {lastupdated: $stale_tag}]->(tcp_proxy)
         """,
         stale_tag=TEST_UPDATE_TAG - 1,
     )
@@ -119,7 +138,9 @@ def test_sync_links_dns_records_to_railway_domains(neo4j_session):
         for record_id, domain_label, instance_id in neo4j_session.run(
             """
             MATCH (dns:DNSRecord)-[:DNS_POINTS_TO]->(domain)-[:EXPOSE]->(instance)
-            WHERE domain:RailwayServiceDomain OR domain:RailwayCustomDomain
+            WHERE domain:RailwayServiceDomain
+               OR domain:RailwayCustomDomain
+               OR domain:RailwayTCPProxy
             RETURN dns.id AS record_id, labels(domain)[0] AS domain_label,
                    instance.id AS instance_id
             """
@@ -128,12 +149,15 @@ def test_sync_links_dns_records_to_railway_domains(neo4j_session):
     assert paths == {
         ("custom-domain-record", "RailwayServiceDomain", "service-instance"),
         ("custom-domain-record", "RailwayCustomDomain", "service-instance"),
+        ("tcp-proxy-record", "RailwayTCPProxy", "service-instance"),
     }
 
     stale_relationship_count = neo4j_session.run(
         """
         MATCH (:DNSRecord {id: 'stale-record'})-[r:DNS_POINTS_TO]->(domain)
-        WHERE domain:RailwayServiceDomain OR domain:RailwayCustomDomain
+        WHERE domain:RailwayServiceDomain
+           OR domain:RailwayCustomDomain
+           OR domain:RailwayTCPProxy
         RETURN count(r) AS count
         """
     ).single()["count"]

--- a/tests/integration/cartography/intel/ontology/test_dnsrecords.py
+++ b/tests/integration/cartography/intel/ontology/test_dnsrecords.py
@@ -72,3 +72,69 @@ def test_sync_keeps_route53_owned_dns_points_to_relationships(neo4j_session):
         lb_dns_name=LB_DNS_NAME,
     ).single()["count"]
     assert stale_count == 0
+
+
+def test_sync_links_dns_records_to_railway_domains(neo4j_session):
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        CREATE (service_domain:RailwayServiceDomain {
+            id: 'service-domain',
+            domain: 'web-production.up.railway.app'
+        })
+        CREATE (custom_domain:RailwayCustomDomain {
+            id: 'custom-domain',
+            domain: 'app.example.com'
+        })
+        CREATE (instance:RailwayServiceInstance {id: 'service-instance'})
+        CREATE (service_domain)-[:EXPOSE]->(instance)
+        CREATE (custom_domain)-[:EXPOSE]->(instance)
+        CREATE (:CloudflareDNSRecord:DNSRecord {
+            id: 'custom-domain-record',
+            _ont_name: 'APP.EXAMPLE.COM.',
+            _ont_value: 'web-production.up.railway.app'
+        })
+        CREATE (stale:CloudflareDNSRecord:DNSRecord {
+            id: 'stale-record',
+            _ont_name: 'old.example.com',
+            _ont_value: 'old.up.railway.app'
+        })
+        CREATE (stale)-[:DNS_POINTS_TO {lastupdated: $stale_tag}]->(service_domain)
+        CREATE (stale)-[:DNS_POINTS_TO {lastupdated: $stale_tag}]->(custom_domain)
+        """,
+        stale_tag=TEST_UPDATE_TAG - 1,
+    )
+
+    # Act
+    cartography.intel.ontology.dnsrecords.sync(
+        neo4j_session,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    # Assert
+    paths = {
+        (record_id, domain_label, instance_id)
+        for record_id, domain_label, instance_id in neo4j_session.run(
+            """
+            MATCH (dns:DNSRecord)-[:DNS_POINTS_TO]->(domain)-[:EXPOSE]->(instance)
+            WHERE domain:RailwayServiceDomain OR domain:RailwayCustomDomain
+            RETURN dns.id AS record_id, labels(domain)[0] AS domain_label,
+                   instance.id AS instance_id
+            """
+        ).values()
+    }
+    assert paths == {
+        ("custom-domain-record", "RailwayServiceDomain", "service-instance"),
+        ("custom-domain-record", "RailwayCustomDomain", "service-instance"),
+    }
+
+    stale_relationship_count = neo4j_session.run(
+        """
+        MATCH (:DNSRecord {id: 'stale-record'})-[r:DNS_POINTS_TO]->(domain)
+        WHERE domain:RailwayServiceDomain OR domain:RailwayCustomDomain
+        RETURN count(r) AS count
+        """
+    ).single()["count"]
+    assert stale_relationship_count == 0

--- a/tests/integration/cartography/intel/ontology/test_dnsrecords.py
+++ b/tests/integration/cartography/intel/ontology/test_dnsrecords.py
@@ -81,16 +81,16 @@ def test_sync_links_dns_records_to_railway_domains(neo4j_session):
         """
         CREATE (service_domain:RailwayServiceDomain {
             id: 'service-domain',
-            domain: 'web-production.up.railway.app'
+            domain_normalized: 'web-production.up.railway.app'
         })
         CREATE (custom_domain:RailwayCustomDomain {
             id: 'custom-domain',
-            domain: 'app.example.com',
+            domain_normalized: 'app.example.com',
             verified: true
         })
         CREATE (unverified_domain:RailwayCustomDomain {
             id: 'unverified-domain',
-            domain: 'pending.example.com',
+            domain_normalized: 'pending.example.com',
             verified: false
         })
         CREATE (instance:RailwayServiceInstance {id: 'service-instance'})
@@ -98,15 +98,15 @@ def test_sync_links_dns_records_to_railway_domains(neo4j_session):
         CREATE (custom_domain)-[:EXPOSE]->(instance)
         CREATE (:CloudflareDNSRecord:DNSRecord {
             id: 'custom-domain-record',
-            _ont_name: 'APP.EXAMPLE.COM.',
+            _ont_name: 'app.example.com',
             _ont_type: 'CNAME',
-            _ont_value: 'WEB-PRODUCTION.UP.RAILWAY.APP.'
+            _ont_target_hostname: 'web-production.up.railway.app'
         })
         CREATE (:CloudflareDNSRecord:DNSRecord {
             id: 'pending-domain-record',
             _ont_name: 'pending.example.com',
             _ont_type: 'CNAME',
-            _ont_value: 'pending.up.railway.app'
+            _ont_target_hostname: 'pending.up.railway.app'
         })
         CREATE (:CloudflareDNSRecord:DNSRecord {
             id: 'unrelated-text-record',
@@ -117,7 +117,7 @@ def test_sync_links_dns_records_to_railway_domains(neo4j_session):
         CREATE (stale:CloudflareDNSRecord:DNSRecord {
             id: 'stale-record',
             _ont_name: 'old.example.com',
-            _ont_value: 'old.up.railway.app'
+            _ont_target_hostname: 'old.up.railway.app'
         })
         CREATE (stale)-[:DNS_POINTS_TO {lastupdated: $stale_tag}]->(service_domain)
         CREATE (stale)-[:DNS_POINTS_TO {lastupdated: $stale_tag}]->(custom_domain)

--- a/tests/integration/cartography/intel/ontology/test_dnsrecords.py
+++ b/tests/integration/cartography/intel/ontology/test_dnsrecords.py
@@ -35,6 +35,38 @@ def test_sync_links_canonical_dns_name_to_kubernetes_ingress(neo4j_session):
     )
 
 
+def test_sync_links_dns_name_to_ingress_created_before_hostname_normalization(
+    neo4j_session,
+):
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        CREATE (:DNSRecord {id: 'dns', _ont_name: 'app.example.com'})
+        CREATE (:KubernetesIngress {
+            id: 'ingress',
+            host_names: ['app.example.com']
+        })
+        """
+    )
+
+    cartography.intel.ontology.dnsrecords.sync(
+        neo4j_session,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert (
+        neo4j_session.run(
+            """
+            MATCH (:DNSRecord {id: 'dns'})-[r:DNS_POINTS_TO]->
+                  (:KubernetesIngress {id: 'ingress'})
+            RETURN count(r) AS count
+            """
+        ).single()["count"]
+        == 1
+    )
+
+
 def test_sync_keeps_route53_owned_dns_points_to_relationships(neo4j_session):
     """
     The route53 loader owns (:AWSDNSRecord)-[:DNS_POINTS_TO]->(:AWSLoadBalancerV2) and stamps

--- a/tests/integration/cartography/intel/ontology/test_dnsrecords.py
+++ b/tests/integration/cartography/intel/ontology/test_dnsrecords.py
@@ -44,7 +44,7 @@ def test_sync_links_dns_name_to_ingress_created_before_hostname_normalization(
         CREATE (:DNSRecord {id: 'dns', _ont_name: 'app.example.com'})
         CREATE (:KubernetesIngress {
             id: 'ingress',
-            host_names: ['app.example.com']
+            host_names: [' App.Example.COM. ']
         })
         """
     )

--- a/tests/integration/cartography/intel/ontology/test_dnsrecords.py
+++ b/tests/integration/cartography/intel/ontology/test_dnsrecords.py
@@ -4,6 +4,37 @@ TEST_UPDATE_TAG = 123456789
 LB_DNS_NAME = "mylb-1234567890.us-east-1.elb.amazonaws.com"
 
 
+def test_sync_links_canonical_dns_name_to_kubernetes_ingress(neo4j_session):
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    neo4j_session.run(
+        """
+        CREATE (:DNSRecord {id: 'dns', _ont_name: 'app.example.com'})
+        CREATE (:KubernetesIngress {
+            id: 'ingress',
+            host_names: [' App.Example.COM. '],
+            host_names_normalized: ['app.example.com']
+        })
+        """
+    )
+
+    cartography.intel.ontology.dnsrecords.sync(
+        neo4j_session,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG},
+    )
+
+    assert (
+        neo4j_session.run(
+            """
+            MATCH (:DNSRecord {id: 'dns'})-[r:DNS_POINTS_TO]->
+                  (:KubernetesIngress {id: 'ingress'})
+            RETURN count(r) AS count
+            """
+        ).single()["count"]
+        == 1
+    )
+
+
 def test_sync_keeps_route53_owned_dns_points_to_relationships(neo4j_session):
     """
     The route53 loader owns (:AWSDNSRecord)-[:DNS_POINTS_TO]->(:AWSLoadBalancerV2) and stamps

--- a/tests/integration/cartography/intel/ontology/test_dnsrecords.py
+++ b/tests/integration/cartography/intel/ontology/test_dnsrecords.py
@@ -159,3 +159,12 @@ def test_sync_links_dns_records_to_railway_domains(neo4j_session):
         """
     ).single()["count"]
     assert stale_relationship_count == 0
+
+    unverified_relationship_count = neo4j_session.run(
+        """
+        MATCH (:DNSRecord {id: 'pending-domain-record'})
+              -[r:DNS_POINTS_TO]->(:RailwayCustomDomain {id: 'unverified-domain'})
+        RETURN count(r) AS count
+        """
+    ).single()["count"]
+    assert unverified_relationship_count == 0

--- a/tests/integration/cartography/intel/ontology/test_dnsrecords.py
+++ b/tests/integration/cartography/intel/ontology/test_dnsrecords.py
@@ -85,16 +85,17 @@ def test_sync_links_dns_records_to_railway_domains(neo4j_session):
         })
         CREATE (custom_domain:RailwayCustomDomain {
             id: 'custom-domain',
-            domain: 'app.example.com'
+            domain: 'app.example.com',
+            verified: true
         })
-        CREATE (tcp_proxy:RailwayTCPProxy {
-            id: 'tcp-proxy',
-            domain: 'tcp.proxy.rlwy.net'
+        CREATE (unverified_domain:RailwayCustomDomain {
+            id: 'unverified-domain',
+            domain: 'pending.example.com',
+            verified: false
         })
         CREATE (instance:RailwayServiceInstance {id: 'service-instance'})
         CREATE (service_domain)-[:EXPOSE]->(instance)
         CREATE (custom_domain)-[:EXPOSE]->(instance)
-        CREATE (tcp_proxy)-[:EXPOSE]->(instance)
         CREATE (:CloudflareDNSRecord:DNSRecord {
             id: 'custom-domain-record',
             _ont_name: 'APP.EXAMPLE.COM.',
@@ -102,10 +103,10 @@ def test_sync_links_dns_records_to_railway_domains(neo4j_session):
             _ont_value: 'WEB-PRODUCTION.UP.RAILWAY.APP.'
         })
         CREATE (:CloudflareDNSRecord:DNSRecord {
-            id: 'tcp-proxy-record',
-            _ont_name: 'database.example.com',
+            id: 'pending-domain-record',
+            _ont_name: 'pending.example.com',
             _ont_type: 'CNAME',
-            _ont_value: 'TCP.PROXY.RLWY.NET.'
+            _ont_value: 'pending.up.railway.app'
         })
         CREATE (:CloudflareDNSRecord:DNSRecord {
             id: 'unrelated-text-record',
@@ -120,7 +121,6 @@ def test_sync_links_dns_records_to_railway_domains(neo4j_session):
         })
         CREATE (stale)-[:DNS_POINTS_TO {lastupdated: $stale_tag}]->(service_domain)
         CREATE (stale)-[:DNS_POINTS_TO {lastupdated: $stale_tag}]->(custom_domain)
-        CREATE (stale)-[:DNS_POINTS_TO {lastupdated: $stale_tag}]->(tcp_proxy)
         """,
         stale_tag=TEST_UPDATE_TAG - 1,
     )
@@ -140,7 +140,6 @@ def test_sync_links_dns_records_to_railway_domains(neo4j_session):
             MATCH (dns:DNSRecord)-[:DNS_POINTS_TO]->(domain)-[:EXPOSE]->(instance)
             WHERE domain:RailwayServiceDomain
                OR domain:RailwayCustomDomain
-               OR domain:RailwayTCPProxy
             RETURN dns.id AS record_id, labels(domain)[0] AS domain_label,
                    instance.id AS instance_id
             """
@@ -149,7 +148,6 @@ def test_sync_links_dns_records_to_railway_domains(neo4j_session):
     assert paths == {
         ("custom-domain-record", "RailwayServiceDomain", "service-instance"),
         ("custom-domain-record", "RailwayCustomDomain", "service-instance"),
-        ("tcp-proxy-record", "RailwayTCPProxy", "service-instance"),
     }
 
     stale_relationship_count = neo4j_session.run(
@@ -157,7 +155,6 @@ def test_sync_links_dns_records_to_railway_domains(neo4j_session):
         MATCH (:DNSRecord {id: 'stale-record'})-[r:DNS_POINTS_TO]->(domain)
         WHERE domain:RailwayServiceDomain
            OR domain:RailwayCustomDomain
-           OR domain:RailwayTCPProxy
         RETURN count(r) AS count
         """
     ).single()["count"]

--- a/tests/integration/cartography/intel/railway/test_domains.py
+++ b/tests/integration/cartography/intel/railway/test_domains.py
@@ -77,9 +77,14 @@ def test_load_railway_service_domains(neo4j_session):
     assert check_nodes(
         neo4j_session,
         "RailwayServiceDomain",
-        ["id", "domain", "suffix"],
+        ["id", "domain", "domain_normalized", "suffix"],
     ) == {
-        (SERVICE_DOMAIN_ID, "web-production-abcde.up.railway.app", "up.railway.app"),
+        (
+            SERVICE_DOMAIN_ID,
+            "web-production-abcde.up.railway.app",
+            "web-production-abcde.up.railway.app",
+            "up.railway.app",
+        ),
     }
     # EXPOSE points from the entrypoint to the asset it puts at risk.
     assert check_rels(
@@ -111,11 +116,26 @@ def test_load_railway_custom_domains_flattens_status(neo4j_session):
     assert check_nodes(
         neo4j_session,
         "RailwayCustomDomain",
-        ["id", "domain", "verified", "certificate_status", "verification_dns_host"],
+        [
+            "id",
+            "domain",
+            "domain_normalized",
+            "verified",
+            "certificate_status",
+            "verification_dns_host",
+        ],
     ) == {
-        (VERIFIED_CUSTOM_DOMAIN_ID, "app.example.com", True, "ISSUED", None),
+        (
+            VERIFIED_CUSTOM_DOMAIN_ID,
+            "app.example.com",
+            "app.example.com",
+            True,
+            "ISSUED",
+            None,
+        ),
         (
             UNVERIFIED_CUSTOM_DOMAIN_ID,
+            "staging.example.com",
             "staging.example.com",
             False,
             "PENDING",

--- a/tests/unit/cartography/graph/test_analysis_cleanup_coverage.py
+++ b/tests/unit/cartography/graph/test_analysis_cleanup_coverage.py
@@ -293,12 +293,6 @@ CLEANUP_CASES = [
         id="ontology_dnsrecords_to_railway_service_domain",
     ),
     pytest.param(
-        RelationshipEffect("DNSRecord", "DNS_POINTS_TO", "RailwayTCPProxy"),
-        None,
-        _rel_cleanup("DNSRecord", "DNS_POINTS_TO", "RailwayTCPProxy"),
-        id="ontology_dnsrecords_to_railway_tcp_proxy",
-    ),
-    pytest.param(
         PropertyEffect("EntraApplication", ("_ont_enabled",)),
         ENTRA,
         _prop_cleanup("EntraApplication", "_ont_enabled", scope=ENTRA),

--- a/tests/unit/cartography/graph/test_analysis_cleanup_coverage.py
+++ b/tests/unit/cartography/graph/test_analysis_cleanup_coverage.py
@@ -209,6 +209,12 @@ CLEANUP_CASES = [
         id="ontology_dnsrecords_to_kubernetes_ingress",
     ),
     pytest.param(
+        RelationshipEffect("DNSRecord", "DNS_POINTS_TO", "RailwayCustomDomain"),
+        None,
+        _rel_cleanup("DNSRecord", "DNS_POINTS_TO", "RailwayCustomDomain"),
+        id="ontology_dnsrecords_to_railway_custom_domain",
+    ),
+    pytest.param(
         RelationshipEffect(
             "DNSRecord",
             "DNS_POINTS_TO",
@@ -279,6 +285,12 @@ CLEANUP_CASES = [
         None,
         _rel_cleanup("DNSRecord", "DNS_POINTS_TO", "AzureFunctionApp"),
         id="ontology_dnsrecords_to_azure_function",
+    ),
+    pytest.param(
+        RelationshipEffect("DNSRecord", "DNS_POINTS_TO", "RailwayServiceDomain"),
+        None,
+        _rel_cleanup("DNSRecord", "DNS_POINTS_TO", "RailwayServiceDomain"),
+        id="ontology_dnsrecords_to_railway_service_domain",
     ),
     pytest.param(
         PropertyEffect("EntraApplication", ("_ont_enabled",)),

--- a/tests/unit/cartography/graph/test_analysis_cleanup_coverage.py
+++ b/tests/unit/cartography/graph/test_analysis_cleanup_coverage.py
@@ -293,6 +293,12 @@ CLEANUP_CASES = [
         id="ontology_dnsrecords_to_railway_service_domain",
     ),
     pytest.param(
+        RelationshipEffect("DNSRecord", "DNS_POINTS_TO", "RailwayTCPProxy"),
+        None,
+        _rel_cleanup("DNSRecord", "DNS_POINTS_TO", "RailwayTCPProxy"),
+        id="ontology_dnsrecords_to_railway_tcp_proxy",
+    ),
+    pytest.param(
         PropertyEffect("EntraApplication", ("_ont_enabled",)),
         ENTRA,
         _prop_cleanup("EntraApplication", "_ont_enabled", scope=ENTRA),


### PR DESCRIPTION
### Type of change

- [x] New feature (non-breaking change that adds functionality)

### Summary

DNS providers and Railway are synchronized independently, so their public endpoint nodes remain disconnected even when they describe the same hostname.

This adds provider-neutral `DNS_POINTS_TO` relationships from `DNSRecord` nodes to verified Railway custom domains and generated service domains. Railway writes an indexed canonical domain during ingestion, and the analysis matches it directly against the canonical DNS ontology fields introduced by #3231. This keeps raw provider values intact and lets Neo4j seek the hostname index instead of normalizing inside each match.

Direct custom-domain matches are limited to address and alias record types, and only verified Railway domains are linked, so TXT verification records and pending domains cannot create false exposure paths. Stale analysis-owned relationships are removed.

### Related issues or links

- Stacked on #3231.

### How was this tested?

- Full unit suite: 5,315 passed
- Full integration suite: 1,608 passed
- Repository-wide pre-commit hooks
- `uv run ./docs/build.sh`

### Checklist

#### General

- [x] I have read the contributing guidelines.
- [x] The linter passes locally.
- [x] I have added or updated tests that prove the feature works.
- [x] Every commit includes a DCO Signed-off-by trailer.

#### Proof of functionality

- [x] New or updated unit and integration tests.

#### If you are changing a node or relationship

- [x] Updated model property descriptions used to generate schema documentation.
- [x] Built the documentation.

### Notes for reviewers

The integration coverage uses synthetic domains and verifies canonical custom-domain and generated-domain paths, GCP list-valued CNAME targets, protected provider-owned edges, and stale-edge cleanup. TCP proxy hostnames remain excluded because DNS does not carry the Railway per-proxy port discriminator.