### PR TITLE
refactor(okta): model AWS role mappings

### DIFF
--- a/cartography/data/jobs/cleanup/okta_import_cleanup.json
+++ b/cartography/data/jobs/cleanup/okta_import_cleanup.json
@@ -31,7 +31,7 @@
       "__comment__": "Migration: drop deprecated Okta-to-Kubernetes group mapping edges, replaced by MEMBER_OF"
     },
     {
-      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaGroup)-[r:ALLOWED_BY]->(:AWSRole) WHERE r._sub_resource_label IS NULL WITH r LIMIT $LIMIT_SIZE DELETE r",
+      "query": "MATCH (:OktaGroup)-[r:ALLOWED_BY]->(:AWSRole) WHERE r._sub_resource_label IS NULL WITH r LIMIT $LIMIT_SIZE DELETE r",
       "iterative": true,
       "iterationsize": 100,
       "__comment__": "Migration: drop stale Okta-to-AWS role mappings created before ALLOWED_BY used scoped MatchLink metadata"

--- a/cartography/data/jobs/cleanup/okta_import_cleanup.json
+++ b/cartography/data/jobs/cleanup/okta_import_cleanup.json
@@ -31,10 +31,10 @@
       "__comment__": "Migration: drop deprecated Okta-to-Kubernetes group mapping edges, replaced by MEMBER_OF"
     },
     {
-      "query": "MATCH (:OktaGroup)-[r:ALLOWED_BY]->(:AWSRole) WHERE r._sub_resource_label IS NULL WITH r LIMIT $LIMIT_SIZE DELETE r",
+      "query": "MATCH (:OktaOrganization {id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaGroup)-[r:ALLOWED_BY]->(:AWSRole) WHERE r._sub_resource_label IS NULL WITH r LIMIT $LIMIT_SIZE DELETE r",
       "iterative": true,
       "iterationsize": 100,
-      "__comment__": "Migration: drop stale Okta-to-AWS role mappings created before ALLOWED_BY used scoped MatchLink metadata"
+      "__comment__": "Migration: drop stale Okta-to-AWS role mappings for the current organization that were created before ALLOWED_BY used scoped MatchLink metadata"
     },
     {
       "query": "MATCH (n:OktaAdministrationRole) WITH n LIMIT $LIMIT_SIZE DETACH DELETE n",

--- a/cartography/data/jobs/cleanup/okta_import_cleanup.json
+++ b/cartography/data/jobs/cleanup/okta_import_cleanup.json
@@ -31,10 +31,10 @@
       "__comment__": "Migration: drop deprecated Okta-to-Kubernetes group mapping edges, replaced by MEMBER_OF"
     },
     {
-      "query": "MATCH (:OktaOrganization {id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaGroup)-[r:ALLOWED_BY]->(:AWSRole) WHERE r._sub_resource_label IS NULL WITH r LIMIT $LIMIT_SIZE DELETE r",
+      "query": "MATCH (:OktaGroup)-[r:ALLOWED_BY]->(:AWSRole) WHERE r._sub_resource_label IS NULL WITH r LIMIT $LIMIT_SIZE DELETE r",
       "iterative": true,
       "iterationsize": 100,
-      "__comment__": "Migration: drop stale Okta-to-AWS role mappings for the current organization that were created before ALLOWED_BY used scoped MatchLink metadata"
+      "__comment__": "Migration: drop stale Okta-to-AWS role mappings created before ALLOWED_BY used scoped MatchLink metadata"
     },
     {
       "query": "MATCH (n:OktaAdministrationRole) WITH n LIMIT $LIMIT_SIZE DETACH DELETE n",

--- a/cartography/data/jobs/cleanup/okta_import_cleanup.json
+++ b/cartography/data/jobs/cleanup/okta_import_cleanup.json
@@ -31,6 +31,12 @@
       "__comment__": "Migration: drop deprecated Okta-to-Kubernetes group mapping edges, replaced by MEMBER_OF"
     },
     {
+      "query": "MATCH (:OktaOrganization{id: $OKTA_ORG_ID})-[:RESOURCE]->(:OktaGroup)-[r:ALLOWED_BY]->(:AWSRole) WHERE r._sub_resource_label IS NULL WITH r LIMIT $LIMIT_SIZE DELETE r",
+      "iterative": true,
+      "iterationsize": 100,
+      "__comment__": "Migration: drop stale Okta-to-AWS role mappings created before ALLOWED_BY used scoped MatchLink metadata"
+    },
+    {
       "query": "MATCH (n:OktaAdministrationRole) WITH n LIMIT $LIMIT_SIZE DETACH DELETE n",
       "iterative": true,
       "iterationsize": 100,

--- a/cartography/intel/okta/awssaml.py
+++ b/cartography/intel/okta/awssaml.py
@@ -7,9 +7,12 @@ from collections import namedtuple
 
 import neo4j
 
+from cartography.client.core.tx import load_matchlinks
 from cartography.client.core.tx import read_list_of_dicts_tx
 from cartography.client.core.tx import read_single_value_tx
-from cartography.client.core.tx import run_write_query
+from cartography.graph.job import GraphJob
+from cartography.models.okta.awssaml import OktaGroupToAWSRoleAllowedByMatchLink
+from cartography.models.okta.awssaml import OktaGroupToAWSRoleHasRoleMatchLink
 from cartography.util import timeit
 
 AccountRole = namedtuple("AccountRole", ["account_id", "role_name"])
@@ -61,19 +64,27 @@ def transform_okta_group_to_aws_role(
 def query_for_okta_to_aws_role_mapping(
     neo4j_session: neo4j.Session,
     mapping_regex: str,
+    okta_org_id: str,
 ) -> list[dict]:
     """
     Query the graph for all groups associated with the amazon_aws application and map them to AWSRoles
     :param neo4j_session: session from the Neo4j server
     :param mapping_regex: the regex used by the organization to map groups to aws roles
+    :param okta_org_id: Okta organization that owns the groups and application
     """
-    query = (
-        "MATCH (app:OktaApplication{name:'amazon_aws'})--(group:OktaGroup) "
-        "RETURN group.id AS group_id, group.name AS group_name"
-    )
+    query = """
+    MATCH (org:OktaOrganization {id: $okta_org_id})-[:RESOURCE]->
+          (app:OktaApplication {name: 'amazon_aws'})
+    MATCH (org)-[:RESOURCE]->(group:OktaGroup)-[:APPLICATION]->(app)
+    RETURN group.id AS group_id, group.name AS group_name
+    """
 
     group_to_role_mapping: list[dict] = []
-    results = neo4j_session.execute_read(read_list_of_dicts_tx, query)
+    results = neo4j_session.execute_read(
+        read_list_of_dicts_tx,
+        query,
+        okta_org_id=okta_org_id,
+    )
 
     for res in results:
         # input: okta group id, okta group name. output: aws role arn.
@@ -97,32 +108,41 @@ def query_for_okta_to_aws_role_mapping(
 @timeit
 def _load_okta_group_to_aws_roles(
     neo4j_session: neo4j.Session,
-    group_to_role: list[dict],
+    group_to_role: list[GroupRole],
     okta_update_tag: int,
+    okta_org_id: str,
 ) -> None:
     """
-    Add the ALLOWED_BY relationship between OktaGroups and the AWSRoles they enable
+    Add canonical HAS_ROLE and compatibility ALLOWED_BY relationships between
+    OktaGroups and the AWSRoles they enable.
     :param neo4j_session: session with the Neo4j server
     :param group_to_role: the mapping between OktaGroups and the AWSRoles they allow access to
     :param okta_update_tag: The timestamp value to set our new Neo4j resources with
+    :param okta_org_id: Okta organization that owns the relationships
     :return: Nothing
     """
-    ingest_statement = """
-
-    UNWIND $GROUP_TO_ROLE as app_data
-    MATCH (role:AWSRole{arn: app_data.role})
-    MATCH (group:OktaGroup{id: app_data.groupid})
-    MERGE (role)<-[r:ALLOWED_BY]-(group)
-    ON CREATE SET r.firstseen = timestamp()
-    SET r.lastupdated = $okta_update_tag
-    """
-
-    run_write_query(
-        neo4j_session,
-        ingest_statement,
-        GROUP_TO_ROLE=group_to_role,
-        okta_update_tag=okta_update_tag,
+    mappings = [mapping._asdict() for mapping in group_to_role]
+    schemas = (
+        OktaGroupToAWSRoleHasRoleMatchLink(),
+        OktaGroupToAWSRoleAllowedByMatchLink(),
     )
+    for schema in schemas:
+        load_matchlinks(
+            neo4j_session,
+            schema,
+            mappings,
+            lastupdated=okta_update_tag,
+            _sub_resource_label="OktaOrganization",
+            _sub_resource_id=okta_org_id,
+        )
+        GraphJob.from_matchlink(
+            schema,
+            "OktaOrganization",
+            okta_org_id,
+            okta_update_tag,
+        ).run(
+            neo4j_session,
+        )
 
 
 def get_awssso_okta_groups(
@@ -134,8 +154,9 @@ def get_awssso_okta_groups(
     "amazon_aws_sso".
     """
     query = """
-    MATCH (g:OktaGroup)-[:APPLICATION]->(a:OktaApplication{name:"amazon_aws_sso"})
-           <-[:RESOURCE]-(:OktaOrganization{id: $okta_org_id})
+    MATCH (org:OktaOrganization {id: $okta_org_id})-[:RESOURCE]->
+          (a:OktaApplication {name: "amazon_aws_sso"})
+    MATCH (org)-[:RESOURCE]->(g:OktaGroup)-[:APPLICATION]->(a)
     RETURN g.id as group_id, g.name as group_name
     """
     result = neo4j_session.execute_read(
@@ -206,34 +227,6 @@ def query_for_okta_to_awssso_role_mapping(
     return result
 
 
-def _load_awssso_tx(
-    tx: neo4j.Transaction,
-    group_to_role: list[GroupRole],
-    okta_update_tag: int,
-) -> None:
-    ingest_statement = """
-    UNWIND $GROUP_TO_ROLE as app_data
-        MATCH (role:AWSRole{arn: app_data.aws_role_arn})
-        MATCH (group:OktaGroup{id: app_data.okta_group_id})
-        MERGE (role)<-[r:ALLOWED_BY]-(group)
-        ON CREATE SET r.firstseen = timestamp()
-        SET r.lastupdated = $okta_update_tag
-    """
-    tx.run(
-        ingest_statement,
-        GROUP_TO_ROLE=[g._asdict() for g in group_to_role],
-        okta_update_tag=okta_update_tag,
-    ).consume()
-
-
-def _load_okta_group_to_awssso_roles(
-    neo4j_session: neo4j.Session,
-    group_to_role: list[GroupRole],
-    okta_update_tag: int,
-) -> None:
-    neo4j_session.execute_write(_load_awssso_tx, group_to_role, okta_update_tag)
-
-
 @timeit
 def sync_okta_aws_saml(
     neo4j_session: neo4j.Session,
@@ -259,8 +252,15 @@ def sync_okta_aws_saml(
     group_to_role_mapping = query_for_okta_to_aws_role_mapping(
         neo4j_session,
         mapping_regex,
+        okta_org_id,
     )
-    _load_okta_group_to_aws_roles(neo4j_session, group_to_role_mapping, okta_update_tag)
+    combined_group_to_role_mapping = [
+        GroupRole(
+            okta_group_id=mapping["groupid"],
+            aws_role_arn=mapping["role"],
+        )
+        for mapping in group_to_role_mapping
+    ]
 
     sso_okta_groups = get_awssso_okta_groups(neo4j_session, okta_org_id)
     group_to_ssorole_mapping = query_for_okta_to_awssso_role_mapping(
@@ -268,8 +268,10 @@ def sync_okta_aws_saml(
         sso_okta_groups,
         mapping_regex,
     )
-    _load_okta_group_to_awssso_roles(
+    combined_group_to_role_mapping.extend(group_to_ssorole_mapping)
+    _load_okta_group_to_aws_roles(
         neo4j_session,
-        group_to_ssorole_mapping,
+        combined_group_to_role_mapping,
         okta_update_tag,
+        okta_org_id,
     )

--- a/cartography/intel/okta/awssaml.py
+++ b/cartography/intel/okta/awssaml.py
@@ -50,13 +50,13 @@ def transform_okta_group_to_aws_role(
     group_id: str,
     group_name: str,
     mapping_regex: str,
-) -> dict | None:
+) -> GroupRole | None:
     account_role = _parse_okta_group_name(group_name, mapping_regex)
     if account_role:
         role_arn = (
             f"arn:aws:iam::{account_role.account_id}:role/{account_role.role_name}"
         )
-        return {"groupid": group_id, "role": role_arn}
+        return GroupRole(group_id, role_arn)
     return None
 
 
@@ -65,7 +65,7 @@ def query_for_okta_to_aws_role_mapping(
     neo4j_session: neo4j.Session,
     mapping_regex: str,
     okta_org_id: str,
-) -> list[dict]:
+) -> list[GroupRole]:
     """
     Query the graph for all groups associated with the amazon_aws application and map them to AWSRoles
     :param neo4j_session: session from the Neo4j server
@@ -79,7 +79,7 @@ def query_for_okta_to_aws_role_mapping(
     RETURN group.id AS group_id, group.name AS group_name
     """
 
-    group_to_role_mapping: list[dict] = []
+    group_to_role_mapping: list[GroupRole] = []
     results = neo4j_session.execute_read(
         read_list_of_dicts_tx,
         query,
@@ -121,7 +121,7 @@ def _load_okta_group_to_aws_roles(
     :param okta_org_id: Okta organization that owns the relationships
     :return: Nothing
     """
-    mappings = [mapping._asdict() for mapping in group_to_role]
+    mappings = [mapping._asdict() for mapping in dict.fromkeys(group_to_role)]
     schemas = (
         OktaGroupToAWSRoleHasRoleMatchLink(),
         OktaGroupToAWSRoleAllowedByMatchLink(),
@@ -135,6 +135,20 @@ def _load_okta_group_to_aws_roles(
             _sub_resource_label="OktaOrganization",
             _sub_resource_id=okta_org_id,
         )
+
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    okta_update_tag: int,
+    okta_org_id: str,
+) -> None:
+    """Remove stale Okta group-to-AWS role relationships."""
+    schemas = (
+        OktaGroupToAWSRoleHasRoleMatchLink(),
+        OktaGroupToAWSRoleAllowedByMatchLink(),
+    )
+    for schema in schemas:
         GraphJob.from_matchlink(
             schema,
             "OktaOrganization",
@@ -254,13 +268,6 @@ def sync_okta_aws_saml(
         mapping_regex,
         okta_org_id,
     )
-    combined_group_to_role_mapping = [
-        GroupRole(
-            okta_group_id=mapping["groupid"],
-            aws_role_arn=mapping["role"],
-        )
-        for mapping in group_to_role_mapping
-    ]
 
     sso_okta_groups = get_awssso_okta_groups(neo4j_session, okta_org_id)
     group_to_ssorole_mapping = query_for_okta_to_awssso_role_mapping(
@@ -268,10 +275,11 @@ def sync_okta_aws_saml(
         sso_okta_groups,
         mapping_regex,
     )
-    combined_group_to_role_mapping.extend(group_to_ssorole_mapping)
+    group_to_role_mapping.extend(group_to_ssorole_mapping)
     _load_okta_group_to_aws_roles(
         neo4j_session,
-        combined_group_to_role_mapping,
+        group_to_role_mapping,
         okta_update_tag,
         okta_org_id,
     )
+    cleanup(neo4j_session, okta_update_tag, okta_org_id)

--- a/cartography/models/okta/awssaml.py
+++ b/cartography/models/okta/awssaml.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import ClassVar
 
 from cartography.models.core.common import PropertyRef
 from cartography.models.core.relationships import CartographyRelProperties
@@ -63,7 +62,6 @@ class OktaGroupToAWSRoleHasRoleMatchLink(CartographyRelSchema):
 class OktaGroupToAWSRoleAllowedByMatchLink(CartographyRelSchema):
     """Compatibility edge for an AWS role granted to Okta group members."""
 
-    __cartography_introspection_exclude__: ClassVar[bool] = True
     source_node_label: str = "OktaGroup"
     source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
         {"id": PropertyRef("okta_group_id")},

--- a/cartography/models/okta/awssaml.py
+++ b/cartography/models/okta/awssaml.py
@@ -1,0 +1,85 @@
+from dataclasses import dataclass
+from typing import ClassVar
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_source_node_matcher
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import MatchLinkSubResource
+from cartography.models.core.relationships import SourceNodeMatcher
+from cartography.models.core.relationships import TargetNodeMatcher
+
+
+@dataclass(frozen=True)
+class OktaGroupToAWSRoleRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef(
+        "lastupdated",
+        set_in_kwargs=True,
+        description="Timestamp of the last sync that observed this relationship.",
+    )
+    _sub_resource_label: PropertyRef = PropertyRef(
+        "_sub_resource_label",
+        set_in_kwargs=True,
+        description="Label of the Okta organization that owns this relationship.",
+    )
+    _sub_resource_id: PropertyRef = PropertyRef(
+        "_sub_resource_id",
+        set_in_kwargs=True,
+        description="Identifier of the Okta organization that owns this relationship.",
+    )
+
+
+@dataclass(frozen=True)
+class OktaGroupToAWSRoleHasRoleMatchLink(CartographyRelSchema):
+    """Links an Okta group to the AWS IAM role granted by its SAML mapping."""
+
+    source_node_label: str = "OktaGroup"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("okta_group_id")},
+    )
+    source_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
+        target_node_label="OktaOrganization",
+        target_node_matcher=make_target_node_matcher(
+            {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
+        ),
+        direction=LinkDirection.INWARD,
+        rel_label="RESOURCE",
+    )
+    target_node_label: str = "AWSRole"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("aws_role_arn")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_ROLE"
+    properties: OktaGroupToAWSRoleRelProperties = OktaGroupToAWSRoleRelProperties()
+
+
+@dataclass(frozen=True)
+# DEPRECATED: replaced by the canonical (:UserGroup)-[:HAS_ROLE]->(:PermissionRole)
+# edge (OktaGroupToAWSRoleHasRoleMatchLink). Kept for backward compatibility and
+# will be removed in v1.0.0.
+class OktaGroupToAWSRoleAllowedByMatchLink(CartographyRelSchema):
+    """Compatibility edge for an AWS role granted to Okta group members."""
+
+    __cartography_introspection_exclude__: ClassVar[bool] = True
+    source_node_label: str = "OktaGroup"
+    source_node_matcher: SourceNodeMatcher = make_source_node_matcher(
+        {"id": PropertyRef("okta_group_id")},
+    )
+    source_node_sub_resource: MatchLinkSubResource = MatchLinkSubResource(
+        target_node_label="OktaOrganization",
+        target_node_matcher=make_target_node_matcher(
+            {"id": PropertyRef("_sub_resource_id", set_in_kwargs=True)},
+        ),
+        direction=LinkDirection.INWARD,
+        rel_label="RESOURCE",
+    )
+    target_node_label: str = "AWSRole"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"arn": PropertyRef("aws_role_arn")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "ALLOWED_BY"
+    properties: OktaGroupToAWSRoleRelProperties = OktaGroupToAWSRoleRelProperties()

--- a/cartography/models/ontology/constraints_whitelist.py
+++ b/cartography/models/ontology/constraints_whitelist.py
@@ -187,6 +187,7 @@ from cartography.models.kubernetes.statefulsets import (
 from cartography.models.kubernetes.users import KubernetesUserToAWSRoleRel
 from cartography.models.oci.group import OCIGroupToOCIUserRel
 from cartography.models.oci.policy import OCIPolicyToGroupRefRel
+from cartography.models.okta.awssaml import OktaGroupToAWSRoleAllowedByMatchLink
 from cartography.models.okta.group import OktaGroupToOktaUserDeprecatedRel
 from cartography.models.openai.adminapikey import OpenAIAdminApiKeyToSARel
 from cartography.models.openai.adminapikey import OpenAIAdminApiKeyToUserRel
@@ -238,6 +239,7 @@ LEGACY_REL_WHITELIST: frozenset[type] = frozenset(
         KeycloakUserAssumeRoleMatchLink,
         AWSSSOGroupToPermissionSetRel,
         KeycloakGroupToRoleRel,
+        OktaGroupToAWSRoleAllowedByMatchLink,
         # ALLOWED_BY is a distinct "this role is assumable by that SSO user"
         # semantic (PermissionRole->UserAccount), not a role assignment, so it
         # intentionally runs counter to the HAS_ROLE (UserAccount->PermissionRole)

--- a/tests/integration/cartography/intel/okta/test_awssaml.py
+++ b/tests/integration/cartography/intel/okta/test_awssaml.py
@@ -410,32 +410,17 @@ def test_okta_cleanup_removes_unscoped_legacy_role_relationships(neo4j_session):
     org_id = "legacy-role-test-okta-org-id"
     group_id = "legacy-role-test-group"
     role_arn = "arn:aws:iam::9876:role/legacy-role-test"
-    other_org_id = "other-legacy-role-test-okta-org-id"
-    other_group_id = "other-legacy-role-test-group"
-    other_role_arn = "arn:aws:iam::9876:role/other-legacy-role-test"
     neo4j_session.run(
         """
-        UNWIND $MAPPINGS AS mapping
-        MERGE (org:OktaOrganization {id: mapping.org_id})
-        MERGE (group:OktaGroup {id: mapping.group_id})
-        SET group.lastupdated = $UPDATE_TAG
-        MERGE (org)-[:RESOURCE]->(group)
-        MERGE (role:AWSRole {id: mapping.role_arn})
-        SET role.arn = mapping.role_arn
+        MERGE (group:OktaGroup {
+            id: $GROUP_ID,
+            lastupdated: $UPDATE_TAG
+        })
+        MERGE (role:AWSRole {id: $ROLE_ARN, arn: $ROLE_ARN})
         MERGE (group)-[:ALLOWED_BY {lastupdated: $OLD_UPDATE_TAG}]->(role)
         """,
-        MAPPINGS=[
-            {
-                "org_id": org_id,
-                "group_id": group_id,
-                "role_arn": role_arn,
-            },
-            {
-                "org_id": other_org_id,
-                "group_id": other_group_id,
-                "role_arn": other_role_arn,
-            },
-        ],
+        GROUP_ID=group_id,
+        ROLE_ARN=role_arn,
         UPDATE_TAG=TEST_UPDATE_TAG,
         OLD_UPDATE_TAG=TEST_UPDATE_TAG - 1,
     )
@@ -450,18 +435,14 @@ def test_okta_cleanup_removes_unscoped_legacy_role_relationships(neo4j_session):
     )
 
     # Assert
-    relationship_counts = neo4j_session.run(
+    relationship_count = neo4j_session.run(
         """
-        UNWIND $GROUP_IDS AS group_id
-        OPTIONAL MATCH (:OktaGroup {id: group_id})-[r:ALLOWED_BY]->(:AWSRole)
-        RETURN group_id, count(r) AS count
+        MATCH (:OktaGroup {id: $GROUP_ID})-[r:ALLOWED_BY]->(:AWSRole)
+        RETURN count(r) AS count
         """,
-        GROUP_IDS=[group_id, other_group_id],
-    ).data()
-    assert {row["group_id"]: row["count"] for row in relationship_counts} == {
-        group_id: 0,
-        other_group_id: 1,
-    }
+        GROUP_ID=group_id,
+    ).single(strict=True)["count"]
+    assert relationship_count == 0
 
 
 def test_okta_cleanup_preserves_adopted_legacy_role_relationships(neo4j_session):

--- a/tests/integration/cartography/intel/okta/test_awssaml.py
+++ b/tests/integration/cartography/intel/okta/test_awssaml.py
@@ -239,47 +239,80 @@ def test_sync_okta_aws_saml_scopes_groups_to_the_current_organization(
 ):
     # Arrange
     other_org_id = "other-okta-org-id"
+    current_group_id = "scope-current-group"
+    current_sso_group_id = "scope-current-sso-group"
     other_group_id = "other-org-group"
     other_sso_group_id = "other-org-sso-group"
+    current_role_arn = "arn:aws:iam::2468:role/current-role"
+    current_sso_role_arn = (
+        "arn:aws:iam::2468:role/AWSReservedSSO_current-sso-role_abcdef"
+    )
     other_role_arn = "arn:aws:iam::4321:role/other-org-role"
     other_sso_role_arn = "arn:aws:iam::4321:role/AWSReservedSSO_other-sso-role_abcdef"
     neo4j_session.run(
         """
-        MERGE (current_org:OktaOrganization {id: $CURRENT_ORG_ID})
-        MERGE (org:OktaOrganization {id: $ORG_ID})
-        MERGE (app:OktaApplication {name: "amazon_aws"})
-        MERGE (sso_app:OktaApplication {name: "amazon_aws_sso"})
-        MERGE (current_org)-[:RESOURCE]->(app)
-        MERGE (current_org)-[:RESOURCE]->(sso_app)
+        UNWIND $MAPPINGS AS mapping
+        MERGE (org:OktaOrganization {id: mapping.org_id})
+        MERGE (app:OktaApplication {id: mapping.app_id})
+        SET app.name = mapping.app_name
+        MERGE (group:OktaGroup {id: mapping.group_id})
+        SET group.name = mapping.group_name
         MERGE (org)-[:RESOURCE]->(app)
-        MERGE (org)-[:RESOURCE]->(sso_app)
-        MERGE (group:OktaGroup {
-            id: $GROUP_ID,
-            name: "aws#test#other-org-role#4321"
-        })
-        MERGE (sso_group:OktaGroup {
-            id: $SSO_GROUP_ID,
-            name: "aws#test#other-sso-role#4321"
-        })
         MERGE (org)-[:RESOURCE]->(group)
-        MERGE (org)-[:RESOURCE]->(sso_group)
         MERGE (group)-[:APPLICATION]->(app)
-        MERGE (sso_group)-[:APPLICATION]->(sso_app)
-        MERGE (role:AWSRole {id: $ROLE_ARN, arn: $ROLE_ARN})
-        MERGE (sso_role:AWSRole {
-            id: $SSO_ROLE_ARN,
-            arn: $SSO_ROLE_ARN,
-            name: "AWSReservedSSO_other-sso-role_abcdef",
-            path: "/aws-reserved/sso.amazonaws.com/"
-        })
-        MERGE (:AWSAccount {id: "4321"})-[:RESOURCE]->(sso_role)
+        MERGE (account:AWSAccount {id: mapping.account_id})
+        MERGE (role:AWSRole {id: mapping.role_arn})
+        SET role.arn = mapping.role_arn,
+            role.name = mapping.role_name,
+            role.path = mapping.role_path
+        MERGE (account)-[:RESOURCE]->(role)
         """,
-        CURRENT_ORG_ID=TEST_ORG_ID,
-        ORG_ID=other_org_id,
-        GROUP_ID=other_group_id,
-        SSO_GROUP_ID=other_sso_group_id,
-        ROLE_ARN=other_role_arn,
-        SSO_ROLE_ARN=other_sso_role_arn,
+        MAPPINGS=[
+            {
+                "org_id": TEST_ORG_ID,
+                "app_id": "scope-current-aws-app",
+                "app_name": "amazon_aws",
+                "group_id": current_group_id,
+                "group_name": "aws#test#current-role#2468",
+                "account_id": "2468",
+                "role_arn": current_role_arn,
+                "role_name": "current-role",
+                "role_path": "/",
+            },
+            {
+                "org_id": TEST_ORG_ID,
+                "app_id": "scope-current-aws-sso-app",
+                "app_name": "amazon_aws_sso",
+                "group_id": current_sso_group_id,
+                "group_name": "aws#sso#current-sso-role#2468",
+                "account_id": "2468",
+                "role_arn": current_sso_role_arn,
+                "role_name": "AWSReservedSSO_current-sso-role_abcdef",
+                "role_path": "/aws-reserved/sso.amazonaws.com/",
+            },
+            {
+                "org_id": other_org_id,
+                "app_id": "scope-other-aws-app",
+                "app_name": "amazon_aws",
+                "group_id": other_group_id,
+                "group_name": "aws#test#other-org-role#4321",
+                "account_id": "4321",
+                "role_arn": other_role_arn,
+                "role_name": "other-org-role",
+                "role_path": "/",
+            },
+            {
+                "org_id": other_org_id,
+                "app_id": "scope-other-aws-sso-app",
+                "app_name": "amazon_aws_sso",
+                "group_id": other_sso_group_id,
+                "group_name": "aws#sso#other-sso-role#4321",
+                "account_id": "4321",
+                "role_arn": other_sso_role_arn,
+                "role_name": "AWSReservedSSO_other-sso-role_abcdef",
+                "role_path": "/aws-reserved/sso.amazonaws.com/",
+            },
+        ],
     )
 
     # Act
@@ -291,16 +324,28 @@ def test_sync_okta_aws_saml_scopes_groups_to_the_current_organization(
     )
 
     # Assert
-    relationship_count = neo4j_session.run(
+    relationships = neo4j_session.run(
         """
-        MATCH (group:OktaGroup)-[r]->(:AWSRole)
+        MATCH (group:OktaGroup)-[r]->(role:AWSRole)
         WHERE group.id IN $GROUP_IDS
               AND type(r) IN ["ALLOWED_BY", "HAS_ROLE"]
-        RETURN count(r) AS count
+        RETURN group.id AS group_id, type(r) AS rel_type, role.arn AS role_arn
         """,
-        GROUP_IDS=[other_group_id, other_sso_group_id],
-    ).single(strict=True)["count"]
-    assert relationship_count == 0
+        GROUP_IDS=[
+            current_group_id,
+            current_sso_group_id,
+            other_group_id,
+            other_sso_group_id,
+        ],
+    ).data()
+    assert {
+        (row["group_id"], row["rel_type"], row["role_arn"]) for row in relationships
+    } == {
+        (current_group_id, "ALLOWED_BY", current_role_arn),
+        (current_group_id, "HAS_ROLE", current_role_arn),
+        (current_sso_group_id, "ALLOWED_BY", current_sso_role_arn),
+        (current_sso_group_id, "HAS_ROLE", current_sso_role_arn),
+    }
 
 
 def test_sync_okta_aws_saml_removes_stale_relationships(neo4j_session):
@@ -367,16 +412,13 @@ def test_okta_cleanup_removes_unscoped_legacy_role_relationships(neo4j_session):
     role_arn = "arn:aws:iam::9876:role/legacy-role-test"
     neo4j_session.run(
         """
-        MERGE (org:OktaOrganization {id: $ORG_ID})
         MERGE (group:OktaGroup {
             id: $GROUP_ID,
             lastupdated: $UPDATE_TAG
         })
-        MERGE (org)-[:RESOURCE]->(group)
         MERGE (role:AWSRole {id: $ROLE_ARN, arn: $ROLE_ARN})
         MERGE (group)-[:ALLOWED_BY {lastupdated: $OLD_UPDATE_TAG}]->(role)
         """,
-        ORG_ID=org_id,
         GROUP_ID=group_id,
         ROLE_ARN=role_arn,
         UPDATE_TAG=TEST_UPDATE_TAG,
@@ -401,6 +443,66 @@ def test_okta_cleanup_removes_unscoped_legacy_role_relationships(neo4j_session):
         GROUP_ID=group_id,
     ).single(strict=True)["count"]
     assert relationship_count == 0
+
+
+def test_okta_cleanup_preserves_adopted_legacy_role_relationships(neo4j_session):
+    # Arrange
+    org_id = TEST_ORG_ID
+    group_id = "group1"
+    role_arn = "arn:aws:iam::1234:role/myrole1"
+    _setup_okta_test_data(neo4j_session)
+    _setup_aws_test_data(neo4j_session)
+    neo4j_session.run(
+        """
+        MATCH (group:OktaGroup {id: $GROUP_ID})
+        MATCH (role:AWSRole {arn: $ROLE_ARN})
+        MERGE (group)-[:ALLOWED_BY {lastupdated: $OLD_UPDATE_TAG}]->(role)
+        """,
+        GROUP_ID=group_id,
+        ROLE_ARN=role_arn,
+        OLD_UPDATE_TAG=TEST_UPDATE_TAG - 1,
+    )
+
+    # Act
+    cartography.intel.okta.awssaml.sync_okta_aws_saml(
+        neo4j_session,
+        DEFAULT_REGEX,
+        TEST_UPDATE_TAG,
+        org_id,
+    )
+    cartography.intel.okta._cleanup_okta_organizations(
+        neo4j_session,
+        {
+            "UPDATE_TAG": TEST_UPDATE_TAG,
+            "OKTA_ORG_ID": org_id,
+        },
+    )
+
+    # Assert
+    relationships = neo4j_session.run(
+        """
+        MATCH (:OktaGroup {id: $GROUP_ID})-[r]->(:AWSRole {arn: $ROLE_ARN})
+        WHERE type(r) IN ["ALLOWED_BY", "HAS_ROLE"]
+        RETURN type(r) AS rel_type,
+               r.lastupdated AS lastupdated,
+               r._sub_resource_label AS sub_resource_label,
+               r._sub_resource_id AS sub_resource_id
+        """,
+        GROUP_ID=group_id,
+        ROLE_ARN=role_arn,
+    ).data()
+    assert {
+        (
+            row["rel_type"],
+            row["lastupdated"],
+            row["sub_resource_label"],
+            row["sub_resource_id"],
+        )
+        for row in relationships
+    } == {
+        ("ALLOWED_BY", TEST_UPDATE_TAG, "OktaOrganization", org_id),
+        ("HAS_ROLE", TEST_UPDATE_TAG, "OktaOrganization", org_id),
+    }
 
 
 def _setup_okta_test_data(neo4j_session):

--- a/tests/integration/cartography/intel/okta/test_awssaml.py
+++ b/tests/integration/cartography/intel/okta/test_awssaml.py
@@ -1,3 +1,4 @@
+import cartography.intel.okta
 import cartography.intel.okta.awssaml
 from tests.integration.util import check_rels
 
@@ -41,6 +42,37 @@ def test_sync_okta_aws_saml(neo4j_session):
         rel_direction_right=False,  # AWSRole <- OktaGroup
     )
     assert actual_rels == expected_rels
+
+    assert (
+        check_rels(
+            neo4j_session,
+            "AWSRole",
+            "arn",
+            "OktaGroup",
+            "name",
+            "HAS_ROLE",
+            rel_direction_right=False,
+        )
+        == expected_rels
+    )
+
+    relationship_metadata = neo4j_session.run(
+        """
+        MATCH (group:OktaGroup)-[r]->(:AWSRole)
+        WHERE group.id IN $GROUP_IDS AND r.lastupdated = $UPDATE_TAG
+              AND type(r) IN ["ALLOWED_BY", "HAS_ROLE"]
+        RETURN DISTINCT r._sub_resource_label AS label,
+                        r._sub_resource_id AS id
+        """,
+        GROUP_IDS=["group1", "group2", "group3"],
+        UPDATE_TAG=TEST_UPDATE_TAG,
+    ).data()
+    assert relationship_metadata == [
+        {
+            "label": "OktaOrganization",
+            "id": TEST_ORG_ID,
+        },
+    ]
 
 
 def test_sync_okta_aws_sso(neo4j_session):
@@ -200,6 +232,175 @@ def test_sync_okta_aws_saml_no_matching_roles(neo4j_session):
     )
     actual_rels = {(r["role_arn"], r["group_name"]) for r in result}
     assert actual_rels == set()
+
+
+def test_sync_okta_aws_saml_scopes_groups_to_the_current_organization(
+    neo4j_session,
+):
+    # Arrange
+    other_org_id = "other-okta-org-id"
+    other_group_id = "other-org-group"
+    other_sso_group_id = "other-org-sso-group"
+    other_role_arn = "arn:aws:iam::4321:role/other-org-role"
+    other_sso_role_arn = "arn:aws:iam::4321:role/AWSReservedSSO_other-sso-role_abcdef"
+    neo4j_session.run(
+        """
+        MERGE (current_org:OktaOrganization {id: $CURRENT_ORG_ID})
+        MERGE (org:OktaOrganization {id: $ORG_ID})
+        MERGE (app:OktaApplication {name: "amazon_aws"})
+        MERGE (sso_app:OktaApplication {name: "amazon_aws_sso"})
+        MERGE (current_org)-[:RESOURCE]->(app)
+        MERGE (current_org)-[:RESOURCE]->(sso_app)
+        MERGE (org)-[:RESOURCE]->(app)
+        MERGE (org)-[:RESOURCE]->(sso_app)
+        MERGE (group:OktaGroup {
+            id: $GROUP_ID,
+            name: "aws#test#other-org-role#4321"
+        })
+        MERGE (sso_group:OktaGroup {
+            id: $SSO_GROUP_ID,
+            name: "aws#test#other-sso-role#4321"
+        })
+        MERGE (org)-[:RESOURCE]->(group)
+        MERGE (org)-[:RESOURCE]->(sso_group)
+        MERGE (group)-[:APPLICATION]->(app)
+        MERGE (sso_group)-[:APPLICATION]->(sso_app)
+        MERGE (role:AWSRole {id: $ROLE_ARN, arn: $ROLE_ARN})
+        MERGE (sso_role:AWSRole {
+            id: $SSO_ROLE_ARN,
+            arn: $SSO_ROLE_ARN,
+            name: "AWSReservedSSO_other-sso-role_abcdef",
+            path: "/aws-reserved/sso.amazonaws.com/"
+        })
+        MERGE (:AWSAccount {id: "4321"})-[:RESOURCE]->(sso_role)
+        """,
+        CURRENT_ORG_ID=TEST_ORG_ID,
+        ORG_ID=other_org_id,
+        GROUP_ID=other_group_id,
+        SSO_GROUP_ID=other_sso_group_id,
+        ROLE_ARN=other_role_arn,
+        SSO_ROLE_ARN=other_sso_role_arn,
+    )
+
+    # Act
+    cartography.intel.okta.awssaml.sync_okta_aws_saml(
+        neo4j_session,
+        DEFAULT_REGEX,
+        TEST_UPDATE_TAG,
+        TEST_ORG_ID,
+    )
+
+    # Assert
+    relationship_count = neo4j_session.run(
+        """
+        MATCH (group:OktaGroup)-[r]->(:AWSRole)
+        WHERE group.id IN $GROUP_IDS
+              AND type(r) IN ["ALLOWED_BY", "HAS_ROLE"]
+        RETURN count(r) AS count
+        """,
+        GROUP_IDS=[other_group_id, other_sso_group_id],
+    ).single(strict=True)["count"]
+    assert relationship_count == 0
+
+
+def test_sync_okta_aws_saml_removes_stale_relationships(neo4j_session):
+    # Arrange
+    org_id = "stale-test-okta-org-id"
+    group_id = "stale-test-group"
+    role_arn = "arn:aws:iam::8765:role/stale-test-role"
+    neo4j_session.run(
+        """
+        MERGE (org:OktaOrganization {id: $ORG_ID})
+        MERGE (app:OktaApplication {id: $APP_ID, name: "amazon_aws"})
+        MERGE (org)-[:RESOURCE]->(app)
+        MERGE (group:OktaGroup {
+            id: $GROUP_ID,
+            name: "aws#test#stale-test-role#8765"
+        })
+        MERGE (org)-[:RESOURCE]->(group)
+        MERGE (group)-[:APPLICATION]->(app)
+        MERGE (role:AWSRole {id: $ROLE_ARN, arn: $ROLE_ARN})
+        """,
+        ORG_ID=org_id,
+        APP_ID="stale-test-app",
+        GROUP_ID=group_id,
+        ROLE_ARN=role_arn,
+    )
+    cartography.intel.okta.awssaml.sync_okta_aws_saml(
+        neo4j_session,
+        DEFAULT_REGEX,
+        TEST_UPDATE_TAG,
+        org_id,
+    )
+
+    # Act
+    neo4j_session.run(
+        """
+        MATCH (:OktaGroup {id: $GROUP_ID})-[r:APPLICATION]->(:OktaApplication)
+        DELETE r
+        """,
+        GROUP_ID=group_id,
+    )
+    cartography.intel.okta.awssaml.sync_okta_aws_saml(
+        neo4j_session,
+        DEFAULT_REGEX,
+        TEST_UPDATE_TAG + 1,
+        org_id,
+    )
+
+    # Assert
+    relationship_count = neo4j_session.run(
+        """
+        MATCH (:OktaGroup {id: $GROUP_ID})-[r]->(:AWSRole)
+        WHERE type(r) IN ["ALLOWED_BY", "HAS_ROLE"]
+        RETURN count(r) AS count
+        """,
+        GROUP_ID=group_id,
+    ).single(strict=True)["count"]
+    assert relationship_count == 0
+
+
+def test_okta_cleanup_removes_unscoped_legacy_role_relationships(neo4j_session):
+    # Arrange
+    org_id = "legacy-role-test-okta-org-id"
+    group_id = "legacy-role-test-group"
+    role_arn = "arn:aws:iam::9876:role/legacy-role-test"
+    neo4j_session.run(
+        """
+        MERGE (org:OktaOrganization {id: $ORG_ID})
+        MERGE (group:OktaGroup {
+            id: $GROUP_ID,
+            lastupdated: $UPDATE_TAG
+        })
+        MERGE (org)-[:RESOURCE]->(group)
+        MERGE (role:AWSRole {id: $ROLE_ARN, arn: $ROLE_ARN})
+        MERGE (group)-[:ALLOWED_BY {lastupdated: $OLD_UPDATE_TAG}]->(role)
+        """,
+        ORG_ID=org_id,
+        GROUP_ID=group_id,
+        ROLE_ARN=role_arn,
+        UPDATE_TAG=TEST_UPDATE_TAG,
+        OLD_UPDATE_TAG=TEST_UPDATE_TAG - 1,
+    )
+
+    # Act
+    cartography.intel.okta._cleanup_okta_organizations(
+        neo4j_session,
+        {
+            "UPDATE_TAG": TEST_UPDATE_TAG,
+            "OKTA_ORG_ID": org_id,
+        },
+    )
+
+    # Assert
+    relationship_count = neo4j_session.run(
+        """
+        MATCH (:OktaGroup {id: $GROUP_ID})-[r:ALLOWED_BY]->(:AWSRole)
+        RETURN count(r) AS count
+        """,
+        GROUP_ID=group_id,
+    ).single(strict=True)["count"]
+    assert relationship_count == 0
 
 
 def _setup_okta_test_data(neo4j_session):

--- a/tests/integration/cartography/intel/okta/test_awssaml.py
+++ b/tests/integration/cartography/intel/okta/test_awssaml.py
@@ -410,17 +410,32 @@ def test_okta_cleanup_removes_unscoped_legacy_role_relationships(neo4j_session):
     org_id = "legacy-role-test-okta-org-id"
     group_id = "legacy-role-test-group"
     role_arn = "arn:aws:iam::9876:role/legacy-role-test"
+    other_org_id = "other-legacy-role-test-okta-org-id"
+    other_group_id = "other-legacy-role-test-group"
+    other_role_arn = "arn:aws:iam::9876:role/other-legacy-role-test"
     neo4j_session.run(
         """
-        MERGE (group:OktaGroup {
-            id: $GROUP_ID,
-            lastupdated: $UPDATE_TAG
-        })
-        MERGE (role:AWSRole {id: $ROLE_ARN, arn: $ROLE_ARN})
+        UNWIND $MAPPINGS AS mapping
+        MERGE (org:OktaOrganization {id: mapping.org_id})
+        MERGE (group:OktaGroup {id: mapping.group_id})
+        SET group.lastupdated = $UPDATE_TAG
+        MERGE (org)-[:RESOURCE]->(group)
+        MERGE (role:AWSRole {id: mapping.role_arn})
+        SET role.arn = mapping.role_arn
         MERGE (group)-[:ALLOWED_BY {lastupdated: $OLD_UPDATE_TAG}]->(role)
         """,
-        GROUP_ID=group_id,
-        ROLE_ARN=role_arn,
+        MAPPINGS=[
+            {
+                "org_id": org_id,
+                "group_id": group_id,
+                "role_arn": role_arn,
+            },
+            {
+                "org_id": other_org_id,
+                "group_id": other_group_id,
+                "role_arn": other_role_arn,
+            },
+        ],
         UPDATE_TAG=TEST_UPDATE_TAG,
         OLD_UPDATE_TAG=TEST_UPDATE_TAG - 1,
     )
@@ -435,29 +450,39 @@ def test_okta_cleanup_removes_unscoped_legacy_role_relationships(neo4j_session):
     )
 
     # Assert
-    relationship_count = neo4j_session.run(
+    relationship_counts = neo4j_session.run(
         """
-        MATCH (:OktaGroup {id: $GROUP_ID})-[r:ALLOWED_BY]->(:AWSRole)
-        RETURN count(r) AS count
+        UNWIND $GROUP_IDS AS group_id
+        OPTIONAL MATCH (:OktaGroup {id: group_id})-[r:ALLOWED_BY]->(:AWSRole)
+        RETURN group_id, count(r) AS count
         """,
-        GROUP_ID=group_id,
-    ).single(strict=True)["count"]
-    assert relationship_count == 0
+        GROUP_IDS=[group_id, other_group_id],
+    ).data()
+    assert {row["group_id"]: row["count"] for row in relationship_counts} == {
+        group_id: 0,
+        other_group_id: 1,
+    }
 
 
 def test_okta_cleanup_preserves_adopted_legacy_role_relationships(neo4j_session):
     # Arrange
     org_id = TEST_ORG_ID
-    group_id = "group1"
+    group_id = "legacy-adoption-group"
     role_arn = "arn:aws:iam::1234:role/myrole1"
     _setup_okta_test_data(neo4j_session)
     _setup_aws_test_data(neo4j_session)
     neo4j_session.run(
         """
-        MATCH (group:OktaGroup {id: $GROUP_ID})
+        MATCH (org:OktaOrganization {id: $ORG_ID})
+        MATCH (app:OktaApplication {name: "amazon_aws"})
         MATCH (role:AWSRole {arn: $ROLE_ARN})
+        MERGE (group:OktaGroup {id: $GROUP_ID})
+        SET group.name = "aws#test#myrole1#1234"
+        MERGE (org)-[:RESOURCE]->(group)
+        MERGE (group)-[:APPLICATION]->(app)
         MERGE (group)-[:ALLOWED_BY {lastupdated: $OLD_UPDATE_TAG}]->(role)
         """,
+        ORG_ID=org_id,
         GROUP_ID=group_id,
         ROLE_ARN=role_arn,
         OLD_UPDATE_TAG=TEST_UPDATE_TAG - 1,

--- a/tests/integration/cartography/intel/okta/test_awssaml.py
+++ b/tests/integration/cartography/intel/okta/test_awssaml.py
@@ -458,7 +458,8 @@ def test_okta_cleanup_preserves_adopted_legacy_role_relationships(neo4j_session)
         MATCH (app:OktaApplication {name: "amazon_aws"})
         MATCH (role:AWSRole {arn: $ROLE_ARN})
         MERGE (group:OktaGroup {id: $GROUP_ID})
-        SET group.name = "aws#test#myrole1#1234"
+        SET group.name = "aws#test#myrole1#1234",
+            group.lastupdated = $UPDATE_TAG
         MERGE (org)-[:RESOURCE]->(group)
         MERGE (group)-[:APPLICATION]->(app)
         MERGE (group)-[:ALLOWED_BY {lastupdated: $OLD_UPDATE_TAG}]->(role)
@@ -466,6 +467,7 @@ def test_okta_cleanup_preserves_adopted_legacy_role_relationships(neo4j_session)
         ORG_ID=org_id,
         GROUP_ID=group_id,
         ROLE_ARN=role_arn,
+        UPDATE_TAG=TEST_UPDATE_TAG,
         OLD_UPDATE_TAG=TEST_UPDATE_TAG - 1,
     )
 

--- a/tests/unit/cartography/intel/okta/test_awssaml.py
+++ b/tests/unit/cartography/intel/okta/test_awssaml.py
@@ -19,9 +19,10 @@ def test_saml_with_default_regex():
     default_regex = r"^aws\#\S+\#(?{{role}}[\w\-]+)\#(?{{accountid}}\d+)$"
     result = transform_okta_group_to_aws_role(group_id, group_name, default_regex)
 
-    assert result
-    assert result["groupid"] == group_id
-    assert result["role"] == "arn:aws:iam::828416469395:role/Tier1_Support"
+    assert result == GroupRole(
+        okta_group_id=group_id,
+        aws_role_arn="arn:aws:iam::828416469395:role/Tier1_Support",
+    )
 
 
 def test_saml_with_custom_regex():
@@ -31,9 +32,33 @@ def test_saml_with_custom_regex():
 
     result = transform_okta_group_to_aws_role(group_id, group_name, custom_regex)
 
-    assert result
-    assert result["groupid"] == group_id
-    assert result["role"] == "arn:aws:iam::123456789123:role/developer"
+    assert result == GroupRole(
+        okta_group_id=group_id,
+        aws_role_arn="arn:aws:iam::123456789123:role/developer",
+    )
+
+
+@mock.patch.object(cartography.intel.okta.awssaml, "load_matchlinks")
+def test_load_okta_group_to_aws_roles_deduplicates_mappings(
+    mock_load_matchlinks: MagicMock,
+) -> None:
+    mapping = GroupRole(
+        okta_group_id="groupid",
+        aws_role_arn="arn:aws:iam::123456789123:role/developer",
+    )
+
+    cartography.intel.okta.awssaml._load_okta_group_to_aws_roles(
+        mock.MagicMock(),
+        [mapping, mapping],
+        123456789,
+        "okta-org-id",
+    )
+
+    assert mock_load_matchlinks.call_count == 2
+    assert all(
+        call.args[2] == [mapping._asdict()]
+        for call in mock_load_matchlinks.call_args_list
+    )
 
 
 def test_parse_okta_group_name() -> None:

--- a/tests/unit/cartography/models/test_schema_docs.py
+++ b/tests/unit/cartography/models/test_schema_docs.py
@@ -404,6 +404,22 @@ def test_mermaid_diagram_only_covers_intra_module_edges():
         assert all(endpoint in module_labels for endpoint in endpoints), line
 
 
+def test_okta_aws_matchlink_renders_in_both_module_schemas():
+    # Arrange
+    model = inspect_data_model()
+    relationship = "(:OktaGroup)-[:HAS_ROLE]->(:AWSRole)"
+
+    for module in ("okta", "aws"):
+        # Act
+        generated = render_module_schema(model, module)
+        mermaid = generated.split("graph LR", 1)[1].split("```", 1)[0]
+
+        # Assert
+        assert relationship in generated
+        assert "(:OktaGroup)-[:ALLOWED_BY]->(:AWSRole)" not in generated
+        assert "OktaGroup -- HAS_ROLE --> AWSRole" not in mermaid
+
+
 def test_relationship_property_tables_hide_internal_fields():
     # Arrange
     model = inspect_data_model(gitlab_models)

--- a/tests/unit/cartography/models/test_schema_docs.py
+++ b/tests/unit/cartography/models/test_schema_docs.py
@@ -407,7 +407,6 @@ def test_mermaid_diagram_only_covers_intra_module_edges():
 def test_okta_aws_matchlink_renders_in_both_module_schemas():
     # Arrange
     model = inspect_data_model()
-    relationship = "(:OktaGroup)-[:HAS_ROLE]->(:AWSRole)"
 
     for module in ("okta", "aws"):
         # Act
@@ -415,9 +414,10 @@ def test_okta_aws_matchlink_renders_in_both_module_schemas():
         mermaid = generated.split("graph LR", 1)[1].split("```", 1)[0]
 
         # Assert
-        assert relationship in generated
-        assert "(:OktaGroup)-[:ALLOWED_BY]->(:AWSRole)" not in generated
+        assert "(:OktaGroup)-[:HAS_ROLE]->(:AWSRole)" in generated
+        assert "(:OktaGroup)-[:ALLOWED_BY]->(:AWSRole)" in generated
         assert "OktaGroup -- HAS_ROLE --> AWSRole" not in mermaid
+        assert "OktaGroup -- ALLOWED_BY --> AWSRole" not in mermaid
 
 
 def test_relationship_property_tables_hide_internal_fields():


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional changes)
- [x] Documentation update

### Summary

Model Okta group-to-AWS role mappings as scoped MatchLinks instead of handwritten Cypher. This makes the canonical `(:OktaGroup)-[:HAS_ROLE]->(:AWSRole)` relationship available to schema introspection and generated Okta and AWS documentation.

The sync continues to create the deprecated `ALLOWED_BY` relationship for backward compatibility. It will be removed in Cartography v1. The MatchLinks are scoped to their Okta organization, stale relationships are cleaned up, and a migration cleanup removes unscoped relationships created by earlier versions.

### Related issues or links

- Follow-up to https://github.com/cartography-cncf/cartography/pull/1243#issuecomment-5351995038

### How was this tested?

- Synced Okta from a live tenant in read-only provider mode into an isolated local Neo4j database.
- Used a sanitized, database-only mapping to exercise creation, stale cleanup, and recreation against the live-synced Okta graph and local AWS Identity Center nodes. The tenant's current group names did not match the configured account-and-role naming pattern, so the validation did not rely on naturally occurring cross-module edges.

Sanitized validation output:

```text
INFO:cartography.intel.okta.awssaml:Syncing Okta SAML Integration
created=ALLOWED_BY:1,HAS_ROLE:1
stale_after_unmap=0
recreated=ALLOWED_BY:1,HAS_ROLE:1
invalid_scope=0
```

### Checklist

#### General

- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality

- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector

- [x] Tested the connector against a real cloud, SaaS, or provider environment.
- [x] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

#### If you are changing a node or relationship

- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [x] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module

- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).

### Notes for reviewers

The deprecated `ALLOWED_BY` compatibility schema is intentionally excluded from generated documentation. The canonical `HAS_ROLE` relationship appears in both the Okta and AWS generated schema pages.
