### PR TITLE
feat(rules): expose Fact anchor check as public API

### DIFF
--- a/cartography/rules/spec/model.py
+++ b/cartography/rules/spec/model.py
@@ -122,6 +122,111 @@ def _expression_for_alias(cypher_query: str, alias: str) -> str | None:
     return None
 
 
+class AnchorValidationCode(str, Enum):
+    """Why ``validate_anchor`` rejected a candidate ``(asset_label, asset_id_field)``."""
+
+    EMPTY_LABEL = "empty_label"
+    EMPTY_ID_FIELD = "empty_id_field"
+    MISSING_ID_ALIAS = "missing_id_alias"
+    UNBOUND_LABEL = "unbound_label"
+    ID_NOT_ON_LABELED_VAR = "id_not_on_labeled_var"
+
+
+@dataclass(frozen=True)
+class AnchorValidationError:
+    """Structured failure from ``validate_anchor``. ``None`` from that function means valid."""
+
+    code: AnchorValidationCode
+    asset_label: str
+    asset_id_field: str
+    id_expression: str | None = None
+    asset_vars: frozenset[str] = frozenset()
+
+
+def validate_anchor(
+    cypher_query: str,
+    asset_label: str,
+    asset_id_field: str | None,
+) -> AnchorValidationError | None:
+    """Check that a query's ``(asset_label, asset_id_field)`` describes one node.
+
+    Returns ``None`` when the query binds ``asset_label`` and the final ``RETURN``
+    projects ``asset_id_field`` off that same variable. Returns a structured
+    failure otherwise, so a caller can validate a candidate query without
+    constructing a ``Fact``.
+    """
+    id_field = asset_id_field or ""
+    if not asset_label:
+        return AnchorValidationError(
+            code=AnchorValidationCode.EMPTY_LABEL,
+            asset_label=asset_label or "",
+            asset_id_field=id_field,
+        )
+    if not asset_id_field:
+        return AnchorValidationError(
+            code=AnchorValidationCode.EMPTY_ID_FIELD,
+            asset_label=asset_label,
+            asset_id_field=id_field,
+        )
+    aliases = returned_aliases(cypher_query)
+    if asset_id_field not in aliases:
+        return AnchorValidationError(
+            code=AnchorValidationCode.MISSING_ID_ALIAS,
+            asset_label=asset_label,
+            asset_id_field=asset_id_field,
+        )
+    asset_vars = frozenset(_variables_bound_to_label(cypher_query, asset_label))
+    if not asset_vars:
+        return AnchorValidationError(
+            code=AnchorValidationCode.UNBOUND_LABEL,
+            asset_label=asset_label,
+            asset_id_field=asset_id_field,
+        )
+    id_expression = _expression_for_alias(cypher_query, asset_id_field)
+    owners = set(_PROPERTY_OWNER_RE.findall(id_expression or ""))
+    if not owners & asset_vars:
+        return AnchorValidationError(
+            code=AnchorValidationCode.ID_NOT_ON_LABELED_VAR,
+            asset_label=asset_label,
+            asset_id_field=asset_id_field,
+            id_expression=id_expression,
+            asset_vars=asset_vars,
+        )
+    return None
+
+
+def _fact_anchor_value_error(fact_id: str, err: AnchorValidationError) -> str:
+    """``Fact.__post_init__`` wording for a ``validate_anchor`` failure."""
+    if err.code is AnchorValidationCode.EMPTY_LABEL:
+        return f"Fact '{fact_id}' must declare a non-empty asset_label."
+    if err.code is AnchorValidationCode.EMPTY_ID_FIELD:
+        return (
+            f"Fact '{fact_id}' must declare asset_id_field: it is the id half of "
+            f"the (asset_label, id) anchor."
+        )
+    if err.code is AnchorValidationCode.MISSING_ID_ALIAS:
+        return (
+            f"Fact '{fact_id}' asset_id_field '{err.asset_id_field}' is not returned "
+            f"by its cypher_query (expected a '... AS {err.asset_id_field}' alias)."
+        )
+    if err.code is AnchorValidationCode.UNBOUND_LABEL:
+        return (
+            f"Fact '{fact_id}' declares asset_label '{err.asset_label}' but its "
+            f"cypher_query never binds a variable to that label, so the rows it "
+            f"returns and the asset it claims can diverge. Match it explicitly, "
+            f"e.g. 'MATCH (n:{err.asset_label})'."
+        )
+    asset_vars = sorted(err.asset_vars)
+    return (
+        f"Fact '{fact_id}' returns asset_id_field '{err.asset_id_field}' as "
+        f"'{err.id_expression}', which reads no property off {asset_vars} "
+        f"(the variable(s) bound to asset_label '{err.asset_label}'). The "
+        f"(label, id) anchor must describe one node: project the id directly "
+        f"off the labeled variable, e.g. "
+        f"'{asset_vars[0]}.id AS {err.asset_id_field}'."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Fan-out analysis: can `identity_fields` key the rows the query returns?
 #
@@ -908,19 +1013,10 @@ class Fact:
             raise ValueError(
                 f"Fact '{self.id}' must declare a non-empty identity_fields tuple."
             )
-        if not self.asset_label:
-            raise ValueError(f"Fact '{self.id}' must declare a non-empty asset_label.")
-        if not self.asset_id_field:
-            raise ValueError(
-                f"Fact '{self.id}' must declare asset_id_field: it is the id half of "
-                f"the (asset_label, id) anchor."
-            )
+        err = validate_anchor(self.cypher_query, self.asset_label, self.asset_id_field)
+        if err is not None:
+            raise ValueError(_fact_anchor_value_error(self.id, err))
         aliases = returned_aliases(self.cypher_query)
-        if self.asset_id_field not in aliases:
-            raise ValueError(
-                f"Fact '{self.id}' asset_id_field '{self.asset_id_field}' is not returned "
-                f"by its cypher_query (expected a '... AS {self.asset_id_field}' alias)."
-            )
         missing_identity = tuple(
             name for name in self.identity_fields if name not in aliases
         )
@@ -930,28 +1026,6 @@ class Fact:
                 f"that its cypher_query does not return (expected a '... AS <name>' alias "
                 f"in the final RETURN for each). An identity a consumer cannot read is "
                 f"not an identity."
-            )
-        # The anchor is only meaningful if the label and the id describe the same
-        # node, so require a variable bound to asset_label and require the
-        # asset_id_field expression to read a property off that same variable.
-        asset_vars = _variables_bound_to_label(self.cypher_query, self.asset_label)
-        if not asset_vars:
-            raise ValueError(
-                f"Fact '{self.id}' declares asset_label '{self.asset_label}' but its "
-                f"cypher_query never binds a variable to that label, so the rows it "
-                f"returns and the asset it claims can diverge. Match it explicitly, "
-                f"e.g. 'MATCH (n:{self.asset_label})'."
-            )
-        id_expression = _expression_for_alias(self.cypher_query, self.asset_id_field)
-        owners = set(_PROPERTY_OWNER_RE.findall(id_expression or ""))
-        if not owners & asset_vars:
-            raise ValueError(
-                f"Fact '{self.id}' returns asset_id_field '{self.asset_id_field}' as "
-                f"'{id_expression}', which reads no property off {sorted(asset_vars)} "
-                f"(the variable(s) bound to asset_label '{self.asset_label}'). The "
-                f"(label, id) anchor must describe one node: project the id directly "
-                f"off the labeled variable, e.g. "
-                f"'{sorted(asset_vars)[0]}.id AS {self.asset_id_field}'."
             )
         reserved = RESERVED_FINDING_FIELDS & aliases
         if reserved:

--- a/cartography/rules/spec/model.py
+++ b/cartography/rules/spec/model.py
@@ -151,9 +151,9 @@ def validate_anchor(
     """Check that a query's ``(asset_label, asset_id_field)`` describes one node.
 
     Returns ``None`` when the query binds ``asset_label`` and the final ``RETURN``
-    projects ``asset_id_field`` off that same variable. Returns a structured
-    failure otherwise, so a caller can validate a candidate query without
-    constructing a ``Fact``.
+    projects ``asset_id_field`` off only that variable (or variables bound to
+    the same label). Returns a structured failure otherwise, so a caller can
+    validate a candidate query without constructing a ``Fact``.
     """
     id_field = asset_id_field or ""
     if not asset_label:
@@ -184,7 +184,7 @@ def validate_anchor(
         )
     id_expression = _expression_for_alias(cypher_query, asset_id_field)
     owners = set(_PROPERTY_OWNER_RE.findall(id_expression or ""))
-    if not owners & asset_vars:
+    if not owners or not owners <= asset_vars:
         return AnchorValidationError(
             code=AnchorValidationCode.ID_NOT_ON_LABELED_VAR,
             asset_label=asset_label,
@@ -219,9 +219,9 @@ def _fact_anchor_value_error(fact_id: str, err: AnchorValidationError) -> str:
     asset_vars = sorted(err.asset_vars)
     return (
         f"Fact '{fact_id}' returns asset_id_field '{err.asset_id_field}' as "
-        f"'{err.id_expression}', which reads no property off {asset_vars} "
-        f"(the variable(s) bound to asset_label '{err.asset_label}'). The "
-        f"(label, id) anchor must describe one node: project the id directly "
+        f"'{err.id_expression}', which does not read properties exclusively off "
+        f"{asset_vars} (the variable(s) bound to asset_label '{err.asset_label}'). "
+        f"The (label, id) anchor must describe one node: project the id directly "
         f"off the labeled variable, e.g. "
         f"'{asset_vars[0]}.id AS {err.asset_id_field}'."
     )

--- a/cartography/rules/spec/model.py
+++ b/cartography/rules/spec/model.py
@@ -22,6 +22,15 @@ _ITEM_ALIAS_RE = re.compile(r"(?is)\bAS\s+(\w+)\s*$")
 _BARE_IDENTIFIER_RE = re.compile(r"^\w+$")
 # `foo.bar` / `foo .bar`: which variables an expression reads properties from.
 _PROPERTY_OWNER_RE = re.compile(r"\b(\w+)\s*\.")
+# Quoted Cypher strings, so `'aws.iam.user'` is not treated as a property owner.
+_STRING_LITERAL_RE = re.compile(r"'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\"")
+
+
+def _property_owners(expression: str) -> set[str]:
+    """Variables that ``expression`` reads a property from, ignoring string literals."""
+    stripped = _STRING_LITERAL_RE.sub("", expression)
+    return set(_PROPERTY_OWNER_RE.findall(stripped))
+
 
 # Fields the `Finding` base model owns. A fact query must not alias them: both
 # are populated by `Rule.parse_results` and a query column of the same name
@@ -183,7 +192,7 @@ def validate_anchor(
             asset_id_field=asset_id_field,
         )
     id_expression = _expression_for_alias(cypher_query, asset_id_field)
-    owners = set(_PROPERTY_OWNER_RE.findall(id_expression or ""))
+    owners = _property_owners(id_expression or "")
     if not owners or not owners <= asset_vars:
         return AnchorValidationError(
             code=AnchorValidationCode.ID_NOT_ON_LABELED_VAR,

--- a/tests/unit/rules/test_asset_label.py
+++ b/tests/unit/rules/test_asset_label.py
@@ -13,9 +13,7 @@ produces can never be resolved by a consumer.
 import pytest
 
 from cartography.rules.data.rules import RULES
-from cartography.rules.spec.model import _expression_for_alias
-from cartography.rules.spec.model import _PROPERTY_OWNER_RE
-from cartography.rules.spec.model import _variables_bound_to_label
+from cartography.rules.spec.model import validate_anchor
 from tests.utils import all_graph_labels
 
 # Labels written by legacy handwritten Cypher rather than by a node schema, so
@@ -56,15 +54,7 @@ def test_asset_anchor_describes_one_node(rule_id, fact_id, fact):
     Enforced at construction time too; kept here so the contract is visible
     alongside the other anchor tests and reported per fact.
     """
-    asset_vars = _variables_bound_to_label(fact.cypher_query, fact.asset_label)
-    assert asset_vars, (
-        f"Rule '{rule_id}' fact '{fact_id}' declares asset_label "
-        f"'{fact.asset_label}' but its cypher_query binds no variable to it."
-    )
-    id_expression = _expression_for_alias(fact.cypher_query, fact.asset_id_field)
-    owners = set(_PROPERTY_OWNER_RE.findall(id_expression or ""))
-    assert owners & asset_vars, (
-        f"Rule '{rule_id}' fact '{fact_id}' returns asset_id_field "
-        f"'{fact.asset_id_field}' as '{id_expression}', which reads no property "
-        f"off {sorted(asset_vars)}."
-    )
+    err = validate_anchor(fact.cypher_query, fact.asset_label, fact.asset_id_field)
+    assert (
+        err is None
+    ), f"Rule '{rule_id}' fact '{fact_id}' failed validate_anchor: {err}."

--- a/tests/unit/rules/test_model.py
+++ b/tests/unit/rules/test_model.py
@@ -257,7 +257,16 @@ def test_fact_rejects_identity_field_not_returned_by_query():
 def test_fact_rejects_asset_id_field_from_a_different_node():
     """The (label, id) anchor must describe one node, not two."""
     query = "MATCH (u:AWSUser) MATCH (r:AWSRole) RETURN r.arn AS user_arn"
-    with pytest.raises(ValueError, match="reads no property off"):
+    with pytest.raises(ValueError, match="exclusively off"):
+        Fact(**_fact_kwargs(cypher_query=query))
+
+
+def test_fact_rejects_asset_id_field_that_also_reads_a_different_node():
+    query = (
+        "MATCH (u:AWSUser) MATCH (r:AWSRole) "
+        "RETURN coalesce(u.arn, r.arn) AS user_arn"
+    )
+    with pytest.raises(ValueError, match="exclusively off"):
         Fact(**_fact_kwargs(cypher_query=query))
 
 
@@ -299,6 +308,18 @@ def test_validate_anchor_rejects_id_read_off_a_different_node():
     assert err is not None
     assert err.code is AnchorValidationCode.ID_NOT_ON_LABELED_VAR
     assert err.id_expression == "r.arn"
+    assert err.asset_vars == frozenset({"u"})
+
+
+def test_validate_anchor_rejects_id_that_also_reads_a_different_node():
+    query = (
+        "MATCH (u:AWSUser) MATCH (r:AWSRole) "
+        "RETURN coalesce(u.arn, r.arn) AS user_arn"
+    )
+    err = validate_anchor(query, "AWSUser", "user_arn")
+    assert err is not None
+    assert err.code is AnchorValidationCode.ID_NOT_ON_LABELED_VAR
+    assert err.id_expression == "coalesce(u.arn, r.arn)"
     assert err.asset_vars == frozenset({"u"})
 
 

--- a/tests/unit/rules/test_model.py
+++ b/tests/unit/rules/test_model.py
@@ -1,5 +1,6 @@
 import pytest
 
+from cartography.rules.spec.model import AnchorValidationCode
 from cartography.rules.spec.model import Fact
 from cartography.rules.spec.model import fanout_risks
 from cartography.rules.spec.model import Framework
@@ -8,6 +9,7 @@ from cartography.rules.spec.model import Module
 from cartography.rules.spec.model import MODULE_TO_CARTOGRAPHY_INTEL
 from cartography.rules.spec.model import RESERVED_FINDING_FIELDS
 from cartography.rules.spec.model import returned_aliases
+from cartography.rules.spec.model import validate_anchor
 from cartography.sync import TOP_LEVEL_MODULES
 
 
@@ -257,6 +259,47 @@ def test_fact_rejects_asset_id_field_from_a_different_node():
     query = "MATCH (u:AWSUser) MATCH (r:AWSRole) RETURN r.arn AS user_arn"
     with pytest.raises(ValueError, match="reads no property off"):
         Fact(**_fact_kwargs(cypher_query=query))
+
+
+def test_validate_anchor_accepts_id_projected_off_the_labeled_variable():
+    query = "MATCH (u:AWSUser) RETURN u.arn AS user_arn"
+    assert validate_anchor(query, "AWSUser", "user_arn") is None
+
+
+def test_validate_anchor_rejects_empty_label():
+    err = validate_anchor("MATCH (u:AWSUser) RETURN u.arn AS user_arn", "", "user_arn")
+    assert err is not None
+    assert err.code is AnchorValidationCode.EMPTY_LABEL
+
+
+def test_validate_anchor_rejects_empty_id_field():
+    err = validate_anchor("MATCH (u:AWSUser) RETURN u.arn AS user_arn", "AWSUser", None)
+    assert err is not None
+    assert err.code is AnchorValidationCode.EMPTY_ID_FIELD
+
+
+def test_validate_anchor_rejects_id_not_returned():
+    query = "MATCH (u:AWSUser) WITH u, u.arn AS user_arn RETURN u.name AS other"
+    err = validate_anchor(query, "AWSUser", "user_arn")
+    assert err is not None
+    assert err.code is AnchorValidationCode.MISSING_ID_ALIAS
+
+
+def test_validate_anchor_rejects_unbound_label():
+    query = "MATCH (u:AWSUser) RETURN u.arn AS user_arn"
+    err = validate_anchor(query, "UserAccount", "user_arn")
+    assert err is not None
+    assert err.code is AnchorValidationCode.UNBOUND_LABEL
+    assert err.asset_label == "UserAccount"
+
+
+def test_validate_anchor_rejects_id_read_off_a_different_node():
+    query = "MATCH (u:AWSUser) MATCH (r:AWSRole) RETURN r.arn AS user_arn"
+    err = validate_anchor(query, "AWSUser", "user_arn")
+    assert err is not None
+    assert err.code is AnchorValidationCode.ID_NOT_ON_LABELED_VAR
+    assert err.id_expression == "r.arn"
+    assert err.asset_vars == frozenset({"u"})
 
 
 def test_fact_ignores_return_inside_a_call_subquery():

--- a/tests/unit/rules/test_model.py
+++ b/tests/unit/rules/test_model.py
@@ -323,6 +323,11 @@ def test_validate_anchor_rejects_id_that_also_reads_a_different_node():
     assert err.asset_vars == frozenset({"u"})
 
 
+def test_validate_anchor_ignores_dotted_string_literals_in_id_expression():
+    query = "MATCH (u:AWSUser) RETURN coalesce(u.arn, 'aws.iam.user') AS user_arn"
+    assert validate_anchor(query, "AWSUser", "user_arn") is None
+
+
 def test_fact_ignores_return_inside_a_call_subquery():
     """A nested `CALL { ... RETURN ... }` is not the fact's projection."""
     query = (


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
<!-- Describe WHAT your changes do and WHY they are needed. -->

Add a public `validate_anchor(cypher_query, asset_label, asset_id_field)` helper so callers can check that a fact query's `(label, id)` pair describes one node without constructing a `Fact`.

`Fact.__post_init__` now uses that helper, so construction and the standalone check cannot diverge. The Cypher parsing helpers stay private.

### Related issues or links
<!-- Include links to relevant issues or other pages. Use "Fixes #123" or "Closes #123" to auto-close issues. -->

None.


### How was this tested?
<!-- Describe how you tested the changes. Include relevant details such as test configuration, commands run, or manual testing steps. -->

- `uv run pytest tests/unit/rules/test_model.py tests/unit/rules/test_asset_label.py tests/unit/rules/test_asset_anchor.py`
- `pre-commit run --files` on the three touched files

### Test plan
- Construct a valid `Fact`; it still succeeds.
- Call `validate_anchor` on a query that projects the id off the labeled variable; it returns `None`.
- Call `validate_anchor` when the id is only bound in an intermediate `WITH`; it returns `missing_id_alias`.
- Call `validate_anchor` when `asset_label` is never bound; it returns `unbound_label`.
- Call `validate_anchor` when the id is read off a different node; it returns `id_not_on_labeled_var`.
- Confirm existing `Fact` `ValueError` messages for those cases are unchanged.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```
- [ ] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

Connector pull requests without real-environment evidence are labeled `needs-tests`, are not reviewed, and may be closed after 30 days.

#### If you are changing a node or relationship
- [ ] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [ ] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
<!-- Optional: Add any context that would help reviewers, such as areas to focus on, design decisions, or open questions. -->

`validate_anchor` returns a structured failure (`AnchorValidationError` with a reason code) instead of raising, so callers can validate a candidate query without building a `Fact`. Identity-field and reserved-alias checks stay on `Fact.__post_init__` only.