### PR TITLE
feat(syft): store cataloger evidence on DEPLOYED

### DIFF
--- a/cartography/intel/syft/parser.py
+++ b/cartography/intel/syft/parser.py
@@ -91,20 +91,55 @@ def _extract_image_digests(data: dict[str, Any]) -> list[str]:
     return digests
 
 
+def _unique_extend(dest: list[str], values: list[str]) -> None:
+    seen = set(dest)
+    for value in values:
+        if value not in seen:
+            dest.append(value)
+            seen.add(value)
+
+
+def _artifact_found_by(artifact: dict[str, Any]) -> list[str]:
+    found_by = artifact.get("foundBy")
+    if isinstance(found_by, str) and found_by:
+        return [found_by]
+    return []
+
+
+def _artifact_location_paths(artifact: dict[str, Any]) -> list[str]:
+    locations = artifact.get("locations")
+    if not isinstance(locations, list):
+        return []
+
+    paths: list[str] = []
+    seen: set[str] = set()
+    for location in locations:
+        if not isinstance(location, dict):
+            continue
+        path = location.get("path")
+        if isinstance(path, str) and path and path not in seen:
+            paths.append(path)
+            seen.add(path)
+    return paths
+
+
 def transform_artifacts(data: dict[str, Any]) -> list[dict[str, Any]]:
     """
     Transform Syft artifacts into SyftPackage node data with dependency_ids.
 
-    Each artifact becomes a SyftPackage node. The dependency_ids field lists
-    the normalized_ids of packages this artifact depends on, derived from
-    artifactRelationships.
+    Artifacts that share a normalized_id in one Syft document are merged into a
+    single package row. Scan-local cataloger names and location paths are stored
+    as lists for the DEPLOYED relationship to Image.
+
+    The dependency_ids field lists the normalized_ids of packages this artifact
+    depends on, derived from artifactRelationships.
 
     Args:
         data: Validated Syft JSON data
 
     Returns:
         List of dicts with keys: id, name, version, type, purl, normalized_id,
-        language, found_by, dependency_ids
+        language, found_by, locations, dependency_ids, ImageDigestCandidates
     """
     artifacts = _build_artifact_lookup(data)
     relationships = data.get("artifactRelationships", [])
@@ -143,7 +178,7 @@ def transform_artifacts(data: dict[str, Any]) -> list[dict[str, Any]]:
             "SyftPackage DEPLOYED relationships to Image nodes will be skipped.",
         )
 
-    packages: list[dict[str, Any]] = []
+    packages_by_id: dict[str, dict[str, Any]] = {}
     for artifact_id, artifact in artifacts.items():
         name = artifact.get("name")
         version = artifact.get("version")
@@ -157,8 +192,16 @@ def transform_artifacts(data: dict[str, Any]) -> list[dict[str, Any]]:
             version=version,
             pkg_type=artifact.get("type"),
         )
-        packages.append(
-            {
+        if not normalized_id:
+            continue
+
+        found_by = _artifact_found_by(artifact)
+        locations = _artifact_location_paths(artifact)
+        dependency_ids = dep_map.get(artifact_id, [])
+
+        existing = packages_by_id.get(normalized_id)
+        if existing is None:
+            packages_by_id[normalized_id] = {
                 "id": normalized_id,
                 "name": name,
                 "version": version,
@@ -166,10 +209,15 @@ def transform_artifacts(data: dict[str, Any]) -> list[dict[str, Any]]:
                 "purl": artifact.get("purl"),
                 "normalized_id": normalized_id,
                 "language": artifact.get("language"),
-                "found_by": artifact.get("foundBy"),
-                "dependency_ids": dep_map.get(artifact_id, []),
+                "found_by": list(found_by),
+                "locations": list(locations),
+                "dependency_ids": list(dependency_ids),
                 "ImageDigestCandidates": image_digests,
             }
-        )
+            continue
 
-    return packages
+        _unique_extend(existing["found_by"], found_by)
+        _unique_extend(existing["locations"], locations)
+        _unique_extend(existing["dependency_ids"], dependency_ids)
+
+    return list(packages_by_id.values())

--- a/cartography/models/syft/package.py
+++ b/cartography/models/syft/package.py
@@ -45,10 +45,6 @@ class SyftPackageNodeProperties(CartographyNodeProperties):
         "language",
         description="Programming language associated with the package.",
     )
-    found_by: PropertyRef = PropertyRef(
-        "found_by",
-        description="Syft cataloger that discovered the package.",
-    )
 
 
 @dataclass(frozen=True)
@@ -76,6 +72,20 @@ class SyftPackageDependsOnRel(CartographyRelSchema):
 @dataclass(frozen=True)
 class SyftPackageToOntologyImageRelProperties(CartographyRelProperties):
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    found_by: PropertyRef = PropertyRef(
+        "found_by",
+        description=(
+            "Syft cataloger names that discovered this package in this image. "
+            "A package can be found by more than one cataloger in the same scan."
+        ),
+    )
+    locations: PropertyRef = PropertyRef(
+        "locations",
+        description=(
+            "Syft location paths for this package in this image, such as "
+            "node_modules paths or lockfile paths."
+        ),
+    )
 
 
 @dataclass(frozen=True)

--- a/docs/root/modules/syft/index.md
+++ b/docs/root/modules/syft/index.md
@@ -15,6 +15,12 @@ property. A package with no incoming `DEPENDS_ON` relationship is a root in the
 scanned dependency graph. A package with an incoming `DEPENDS_ON` relationship
 is nested below at least one other package.
 
+Package identity is global (`normalized_id`), so the same `SyftPackage` can be
+`DEPLOYED` to many `Image` nodes. Cataloger names and artifact paths for a given
+image live on that `DEPLOYED` relationship as `found_by` and `locations`.
+`SyftPackage.found_by` is no longer written; leftover node values are
+last-writer-wins and are not image-scoped.
+
 See [configuration](config.md) for report generation and source options,
 [queries](queries.md) for dependency query examples, and the generated
 [schema](schema.md) for fields and relationships.

--- a/docs/root/modules/syft/queries.md
+++ b/docs/root/modules/syft/queries.md
@@ -23,6 +23,13 @@ WHERE NOT exists((p)<-[:DEPENDS_ON]-())
 RETURN p.name
 ```
 
+## Inspect how a package was discovered in an image
+
+```cypher
+MATCH (p:SyftPackage)-[d:DEPLOYED]->(i:Image)
+RETURN p.id, i._ont_digest, d.found_by, d.locations
+```
+
 ## Find nested packages
 
 ```cypher

--- a/tests/data/syft/syft_sample.py
+++ b/tests/data/syft/syft_sample.py
@@ -14,7 +14,7 @@ Syft relationship semantics:
 
 from typing import Any
 
-SYFT_SAMPLE = {
+SYFT_SAMPLE: dict[str, Any] = {
     "artifacts": [
         {
             "id": "pkg:npm/express@4.18.2",

--- a/tests/integration/cartography/intel/syft/test_syft.py
+++ b/tests/integration/cartography/intel/syft/test_syft.py
@@ -449,8 +449,11 @@ def test_sync_single_syft_preserves_per_image_deployed_evidence(neo4j_session):
         RETURN i._ont_digest AS digest, d.found_by AS found_by, d.locations AS locations
         """,
     )
+    evidence_rows = list(evidence)
+    assert len(evidence_rows) == 2
+    assert {row["digest"] for row in evidence_rows} == {IMAGE_A_DIGEST, IMAGE_B_DIGEST}
     evidence_by_digest = {
-        row["digest"]: (row["found_by"], row["locations"]) for row in evidence
+        row["digest"]: (row["found_by"], row["locations"]) for row in evidence_rows
     }
     assert evidence_by_digest[IMAGE_A_DIGEST] == (
         ["javascript-package-cataloger"],

--- a/tests/integration/cartography/intel/syft/test_syft.py
+++ b/tests/integration/cartography/intel/syft/test_syft.py
@@ -5,7 +5,9 @@ These tests verify that Syft ingestion correctly creates SyftPackage nodes
 with DEPENDS_ON relationships between them.
 """
 
+import copy
 import json
+from typing import Any
 from unittest.mock import MagicMock
 
 import cartography.intel.aws.ecr
@@ -185,8 +187,9 @@ def test_sync_single_syft_creates_syft_package_nodes(neo4j_session):
         """
         MATCH (p:SyftPackage {id: 'npm|express|4.18.2'})
         RETURN p.name AS name, p.version AS version, p.type AS type,
-               p.purl AS purl, p.language AS language, p.found_by AS found_by,
-               p.normalized_id AS normalized_id, p.lastupdated AS lastupdated
+               p.purl AS purl, p.language AS language,
+               p.normalized_id AS normalized_id, p.lastupdated AS lastupdated,
+               p.found_by AS found_by
         """,
     ).single()
 
@@ -195,7 +198,7 @@ def test_sync_single_syft_creates_syft_package_nodes(neo4j_session):
     assert result["type"] == "npm"
     assert result["purl"] == "pkg:npm/express@4.18.2"
     assert result["language"] == "javascript"
-    assert result["found_by"] == "javascript-package-cataloger"
+    assert result["found_by"] is None
     assert result["normalized_id"] == "npm|express|4.18.2"
     assert result["lastupdated"] == TEST_UPDATE_TAG
 
@@ -257,6 +260,15 @@ def test_sync_single_syft_creates_deployed_to_image(neo4j_session):
         for pkg_id in EXPECTED_SYFT_PACKAGES
     }
     assert actual_rels == expected_rels
+
+    result = neo4j_session.run(
+        """
+        MATCH (p:SyftPackage {id: 'npm|express|4.18.2'})-[d:DEPLOYED]->(i:Image)
+        RETURN d.found_by AS found_by, d.locations AS locations
+        """,
+    ).single()
+    assert result["found_by"] == ["javascript-package-cataloger"]
+    assert result["locations"] == ["/app/node_modules/express/package.json"]
 
 
 def test_sync_single_syft_creates_deployed_to_current_source_image_digest(
@@ -352,6 +364,178 @@ def test_sync_single_syft_skips_deployed_without_image_digest_candidates(
     )
 
     assert actual_rels == set()
+
+
+IMAGE_A_DIGEST = (
+    "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+)
+IMAGE_B_DIGEST = (
+    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+
+def _syft_sample_for_digest(
+    digest: str,
+    found_by: str,
+    location_path: str,
+) -> dict[str, Any]:
+    sample: dict[str, Any] = copy.deepcopy(SYFT_SAMPLE)
+    sample["source"]["metadata"]["manifestDigest"] = digest
+    sample["source"]["metadata"]["repoDigests"] = [f"myapp@{digest}"]
+    sample["source"]["metadata"]["digest"] = digest
+    for artifact in sample["artifacts"]:
+        artifact["foundBy"] = found_by
+        artifact["locations"] = [{"path": location_path}]
+    return sample
+
+
+def test_sync_single_syft_preserves_per_image_deployed_evidence(neo4j_session):
+    """
+    The same SyftPackage can be DEPLOYED to two images with different catalogers.
+    """
+    # Arrange
+    neo4j_session.run("MATCH (n:SyftPackage) DETACH DELETE n")
+    _sync_ecr_repository_images(
+        neo4j_session,
+        [
+            {
+                "imageDigest": IMAGE_A_DIGEST,
+                "imageTag": "a",
+                "repositoryName": "syft-test-repository",
+                "imageManifestMediaType": (
+                    "application/vnd.docker.distribution.manifest.v2+json"
+                ),
+            },
+            {
+                "imageDigest": IMAGE_B_DIGEST,
+                "imageTag": "b",
+                "repositoryName": "syft-test-repository",
+                "imageManifestMediaType": (
+                    "application/vnd.docker.distribution.manifest.v2+json"
+                ),
+            },
+        ],
+    )
+    sample_a = _syft_sample_for_digest(
+        IMAGE_A_DIGEST,
+        "javascript-package-cataloger",
+        "/app/node_modules/express/package.json",
+    )
+    sample_b = _syft_sample_for_digest(
+        IMAGE_B_DIGEST,
+        "javascript-lock-cataloger",
+        "/app/pnpm-lock.yaml",
+    )
+
+    # Act
+    sync_single_syft(neo4j_session, sample_a, TEST_UPDATE_TAG)
+    sync_single_syft(neo4j_session, sample_b, TEST_UPDATE_TAG)
+
+    # Assert
+    package_ids = check_nodes(neo4j_session, "SyftPackage", ["id"])
+    assert package_ids == {(pkg_id,) for pkg_id in EXPECTED_SYFT_PACKAGES}
+
+    node_found_by = neo4j_session.run(
+        """
+        MATCH (p:SyftPackage {id: 'npm|express|4.18.2'})
+        RETURN p.found_by AS found_by
+        """,
+    ).single()
+    assert node_found_by["found_by"] is None
+
+    evidence = neo4j_session.run(
+        """
+        MATCH (p:SyftPackage {id: 'npm|express|4.18.2'})-[d:DEPLOYED]->(i:Image)
+        RETURN i._ont_digest AS digest, d.found_by AS found_by, d.locations AS locations
+        """,
+    )
+    evidence_by_digest = {
+        row["digest"]: (row["found_by"], row["locations"]) for row in evidence
+    }
+    assert evidence_by_digest[IMAGE_A_DIGEST] == (
+        ["javascript-package-cataloger"],
+        ["/app/node_modules/express/package.json"],
+    )
+    assert evidence_by_digest[IMAGE_B_DIGEST] == (
+        ["javascript-lock-cataloger"],
+        ["/app/pnpm-lock.yaml"],
+    )
+
+
+def test_sync_single_syft_merges_catalogers_on_one_deployed_edge(neo4j_session):
+    """
+    Two Syft artifacts with the same PURL in one image become one DEPLOYED edge.
+    """
+    # Arrange
+    neo4j_session.run("MATCH (n:SyftPackage) DETACH DELETE n")
+    _sync_single_platform_image(neo4j_session, IMAGE_A_DIGEST)
+    sample = {
+        "artifacts": [
+            {
+                "id": "brace-files",
+                "name": "brace-expansion",
+                "version": "5.0.6",
+                "type": "npm",
+                "purl": "pkg:npm/brace-expansion@5.0.6",
+                "language": "javascript",
+                "foundBy": "javascript-package-cataloger",
+                "locations": [
+                    {"path": "/app/node_modules/brace-expansion/package.json"},
+                ],
+            },
+            {
+                "id": "brace-lock",
+                "name": "brace-expansion",
+                "version": "5.0.6",
+                "type": "npm",
+                "purl": "pkg:npm/brace-expansion@5.0.6",
+                "language": "javascript",
+                "foundBy": "javascript-lock-cataloger",
+                "locations": [{"path": "/app/pnpm-lock.yaml"}],
+            },
+        ],
+        "artifactRelationships": [],
+        "source": {
+            "type": "image",
+            "metadata": {
+                "manifestDigest": IMAGE_A_DIGEST,
+            },
+        },
+    }
+
+    # Act
+    sync_single_syft(neo4j_session, sample, TEST_UPDATE_TAG)
+
+    # Assert
+    assert check_nodes(neo4j_session, "SyftPackage", ["id"]) == {
+        ("npm|brace-expansion|5.0.6",),
+    }
+    deployed = check_rels(
+        neo4j_session,
+        "SyftPackage",
+        "id",
+        "Image",
+        "_ont_digest",
+        "DEPLOYED",
+        rel_direction_right=True,
+    )
+    assert deployed == {("npm|brace-expansion|5.0.6", IMAGE_A_DIGEST)}
+
+    result = neo4j_session.run(
+        """
+        MATCH (p:SyftPackage {id: 'npm|brace-expansion|5.0.6'})-[d:DEPLOYED]->(i:Image)
+        RETURN d.found_by AS found_by, d.locations AS locations, count(d) AS edge_count
+        """,
+    ).single()
+    assert result["edge_count"] == 1
+    assert result["found_by"] == [
+        "javascript-package-cataloger",
+        "javascript-lock-cataloger",
+    ]
+    assert result["locations"] == [
+        "/app/node_modules/brace-expansion/package.json",
+        "/app/pnpm-lock.yaml",
+    ]
 
 
 def test_sync_syft_from_dir(

--- a/tests/unit/cartography/intel/syft/test_parser.py
+++ b/tests/unit/cartography/intel/syft/test_parser.py
@@ -47,7 +47,8 @@ class TestTransformArtifacts:
         assert express["type"] == "npm"
         assert express["purl"] == "pkg:npm/express@4.18.2"
         assert express["language"] == "javascript"
-        assert express["found_by"] == "javascript-package-cataloger"
+        assert express["found_by"] == ["javascript-package-cataloger"]
+        assert express["locations"] == ["/app/node_modules/express/package.json"]
         assert express["normalized_id"] == "npm|express|4.18.2"
         assert express["ImageDigestCandidates"] == [
             "sha256:0000000000000000000000000000000000000000000000000000000000000000",
@@ -191,3 +192,74 @@ class TestTransformArtifacts:
         assert (
             "Syft image source did not include image digest candidates" in caplog.text
         )
+
+    def test_transform_artifacts_merges_same_normalized_id(self):
+        """Test one package row unions catalogers, paths, and dependency_ids."""
+        # Arrange
+        data = {
+            "artifacts": [
+                {
+                    "id": "brace-files",
+                    "name": "brace-expansion",
+                    "version": "5.0.6",
+                    "type": "npm",
+                    "purl": "pkg:npm/brace-expansion@5.0.6",
+                    "foundBy": "javascript-package-cataloger",
+                    "locations": [
+                        {"path": "/app/node_modules/brace-expansion/package.json"},
+                    ],
+                },
+                {
+                    "id": "brace-lock",
+                    "name": "brace-expansion",
+                    "version": "5.0.6",
+                    "type": "npm",
+                    "purl": "pkg:npm/brace-expansion@5.0.6",
+                    "foundBy": "javascript-lock-cataloger",
+                    "locations": [{"path": "/app/pnpm-lock.yaml"}],
+                },
+                {
+                    "id": "dep-a",
+                    "name": "dep-a",
+                    "version": "1.0.0",
+                    "type": "npm",
+                    "purl": "pkg:npm/dep-a@1.0.0",
+                },
+                {
+                    "id": "dep-b",
+                    "name": "dep-b",
+                    "version": "2.0.0",
+                    "type": "npm",
+                    "purl": "pkg:npm/dep-b@2.0.0",
+                },
+            ],
+            "artifactRelationships": [
+                {
+                    "parent": "dep-a",
+                    "child": "brace-files",
+                    "type": "dependency-of",
+                },
+                {
+                    "parent": "dep-b",
+                    "child": "brace-lock",
+                    "type": "dependency-of",
+                },
+            ],
+        }
+
+        # Act
+        packages = transform_artifacts(data)
+        pkg_by_id = {p["id"]: p for p in packages}
+        brace = pkg_by_id["npm|brace-expansion|5.0.6"]
+
+        # Assert
+        assert len(packages) == 3
+        assert brace["found_by"] == [
+            "javascript-package-cataloger",
+            "javascript-lock-cataloger",
+        ]
+        assert brace["locations"] == [
+            "/app/node_modules/brace-expansion/package.json",
+            "/app/pnpm-lock.yaml",
+        ]
+        assert brace["dependency_ids"] == ["npm|dep-a|1.0.0", "npm|dep-b|2.0.0"]

--- a/tests/unit/cartography/intel/syft/test_parser.py
+++ b/tests/unit/cartography/intel/syft/test_parser.py
@@ -207,6 +207,7 @@ class TestTransformArtifacts:
                     "foundBy": "javascript-package-cataloger",
                     "locations": [
                         {"path": "/app/node_modules/brace-expansion/package.json"},
+                        {"path": "/app/node_modules/brace-expansion/package.json"},
                     ],
                 },
                 {
@@ -217,6 +218,17 @@ class TestTransformArtifacts:
                     "purl": "pkg:npm/brace-expansion@5.0.6",
                     "foundBy": "javascript-lock-cataloger",
                     "locations": [{"path": "/app/pnpm-lock.yaml"}],
+                },
+                {
+                    "id": "brace-files-dup",
+                    "name": "brace-expansion",
+                    "version": "5.0.6",
+                    "type": "npm",
+                    "purl": "pkg:npm/brace-expansion@5.0.6",
+                    "foundBy": "javascript-package-cataloger",
+                    "locations": [
+                        {"path": "/app/node_modules/brace-expansion/package.json"},
+                    ],
                 },
                 {
                     "id": "dep-a",
@@ -242,6 +254,11 @@ class TestTransformArtifacts:
                 {
                     "parent": "dep-b",
                     "child": "brace-lock",
+                    "type": "dependency-of",
+                },
+                {
+                    "parent": "dep-a",
+                    "child": "brace-files-dup",
                     "type": "dependency-of",
                 },
             ],


### PR DESCRIPTION
### Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

### Summary
`SyftPackage` is keyed by a global `normalized_id` and reused across scanned images. Cataloger evidence (`found_by`) lived on that shared node, so the last ingest overwrote it and artifact locations were dropped.

This keeps scan-local Syft facts on `(SyftPackage)-[:DEPLOYED]->(Image)`:
- `found_by`: unique cataloger names from that image's Syft document
- `locations`: unique location paths from that document

Artifacts that share a `normalized_id` in one scan are merged (union of catalogers, paths, and `dependency_ids`) so there is a single `DEPLOYED` edge per package per image. Digest matching for `DEPLOYED` is unchanged.

### Related issues or links
N/A

### Breaking changes
`SyftPackage.found_by` is no longer written. Query catalogers and paths on the `DEPLOYED` relationship (`d.found_by`, `d.locations`) instead. Existing graphs may still have leftover node `found_by` values until those nodes are cleaned up; those leftovers are last-writer-wins and are not image-scoped.

### How was this tested?
- `uv run --frozen pytest -vvv tests/unit/cartography/intel/syft/test_parser.py`
- `uv run --frozen pytest -vvv tests/integration/cartography/intel/syft/test_syft.py`
- `uv run --frozen pre-commit run --files` on the changed files

Coverage includes: two images sharing a package with different catalogers/paths; one image with two catalogers merged onto one `DEPLOYED` edge; skip `DEPLOYED` when the image source has no digest candidates.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [ ] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).

### Notes for reviewers
`DEPENDS_ON` semantics are unchanged. This does not infer installed vs lockfile-only; consumers can classify from `DEPLOYED.found_by` / `locations` if they want that.