### PR TITLE
feat(okta): support OAuth 2.0 client credentials authentication

### DIFF
--- a/cartography/cli.py
+++ b/cartography/cli.py
@@ -904,6 +904,37 @@ class CLI:
                     hidden=PANEL_OKTA not in visible_panels,
                 ),
             ] = None,
+            okta_client_id: Annotated[
+                str | None,
+                typer.Option(
+                    "--okta-client-id",
+                    help="Okta API Services app client ID, for OAuth 2.0 client "
+                    "credentials authentication instead of an SSWS API key.",
+                    rich_help_panel=PANEL_OKTA,
+                    hidden=PANEL_OKTA not in visible_panels,
+                ),
+            ] = None,
+            okta_private_key_env_var: Annotated[
+                str | None,
+                typer.Option(
+                    "--okta-private-key-env-var",
+                    help="Environment variable name containing the Okta API Services "
+                    "app private key (JWK JSON or PEM) for private_key_jwt "
+                    "authentication.",
+                    rich_help_panel=PANEL_OKTA,
+                    hidden=PANEL_OKTA not in visible_panels,
+                ),
+            ] = None,
+            okta_dpop: Annotated[
+                bool,
+                typer.Option(
+                    "--okta-dpop",
+                    help="Enable DPoP sender-constrained tokens for Okta OAuth. "
+                    "Required if the Okta app enforces DPoP.",
+                    rich_help_panel=PANEL_OKTA,
+                    hidden=PANEL_OKTA not in visible_panels,
+                ),
+            ] = False,
             okta_base_domain: Annotated[
                 str,
                 typer.Option(
@@ -2868,6 +2899,15 @@ class CLI:
                 )
                 okta_api_key = os.environ.get(okta_api_key_env_var)
 
+            # Read Okta private key for OAuth 2.0 client credentials
+            okta_private_key = None
+            if okta_org_id and okta_private_key_env_var:
+                logger.debug(
+                    "Reading private key for Okta from environment variable %s",
+                    okta_private_key_env_var,
+                )
+                okta_private_key = os.environ.get(okta_private_key_env_var)
+
             # Read GitHub config
             github_config = None
             if github_config_env_var:
@@ -3618,6 +3658,9 @@ class CLI:
                 oci_sync_all_profiles=oci_sync_all_profiles,
                 okta_org_id=okta_org_id,
                 okta_api_key=okta_api_key,
+                okta_client_id=okta_client_id,
+                okta_private_key=okta_private_key,
+                okta_dpop=okta_dpop,
                 okta_base_domain=okta_base_domain,
                 okta_saml_role_regex=okta_saml_role_regex,
                 github_config=github_config,

--- a/cartography/config.py
+++ b/cartography/config.py
@@ -173,7 +173,16 @@ class Config:
     :type okta_org_id: str
     :param okta_org_id: Okta organization id. Optional.
     :type okta_api_key: str
-    :param okta_api_key: Okta API key. Optional.
+    :param okta_api_key: Okta SSWS API key. Optional.
+    :type okta_client_id: str
+    :param okta_client_id: Okta API Services app client id for OAuth 2.0 client
+        credentials authentication. Optional.
+    :type okta_private_key: str
+    :param okta_private_key: Private key (JWK JSON or PEM) for the Okta API
+        Services app, used for private_key_jwt client authentication. Optional.
+    :type okta_dpop: bool
+    :param okta_dpop: Enable DPoP sender-constrained tokens for Okta OAuth.
+        Optional.
     :type okta_saml_role_regex: str
     :param okta_saml_role_regex: The regex used to map okta groups to AWS roles. Optional.
     :type github_config: str
@@ -554,6 +563,9 @@ class Config:
         oci_sync_all_profiles=None,
         okta_org_id=None,
         okta_api_key=None,
+        okta_client_id=None,
+        okta_private_key=None,
+        okta_dpop=False,
         okta_base_domain="okta.com",
         okta_saml_role_regex=None,
         github_config=None,
@@ -805,6 +817,9 @@ class Config:
         self.oci_sync_all_profiles = oci_sync_all_profiles
         self.okta_org_id = okta_org_id
         self.okta_api_key = okta_api_key
+        self.okta_client_id = okta_client_id
+        self.okta_private_key = okta_private_key
+        self.okta_dpop = okta_dpop
         self.okta_base_domain = okta_base_domain
         self.okta_saml_role_regex = okta_saml_role_regex
         self.github_config = github_config

--- a/cartography/intel/okta/__init__.py
+++ b/cartography/intel/okta/__init__.py
@@ -22,6 +22,48 @@ from cartography.util import timeit
 logger = logging.getLogger(__name__)
 stat_handler = get_stats_client(__name__)
 
+# Read-only OAuth scopes covering every API the Okta sync touches, requested
+# when authenticating with client credentials (OAuth for Okta). Each scope
+# must also be granted to the API Services app in the Okta admin console.
+OKTA_OAUTH_SCOPES = [
+    "okta.users.read",
+    "okta.groups.read",
+    "okta.apps.read",
+    "okta.trustedOrigins.read",
+    "okta.authenticators.read",
+    "okta.userTypes.read",
+]
+
+
+def _build_okta_client_config(config: Config) -> dict | None:
+    """
+    Build the okta-sdk-python client configuration from cartography config.
+
+    Two authentication modes are supported:
+    - OAuth 2.0 client credentials (preferred): set okta_client_id and
+      okta_private_key (an API Services app with private_key_jwt client
+      authentication). okta_dpop additionally enables DPoP sender-constrained
+      tokens for orgs/apps that require them.
+    - SSWS API token (legacy): set okta_api_key.
+
+    Returns None when no usable credentials are configured.
+    """
+    org_url = f"https://{config.okta_org_id}.{config.okta_base_domain}"
+    if config.okta_client_id and config.okta_private_key:
+        client_config: dict = {
+            "orgUrl": org_url,
+            "authorizationMode": "PrivateKey",
+            "clientId": config.okta_client_id,
+            "privateKey": config.okta_private_key,
+            "scopes": OKTA_OAUTH_SCOPES,
+        }
+        if config.okta_dpop:
+            client_config["dpopEnabled"] = True
+        return client_config
+    if config.okta_api_key:
+        return {"orgUrl": org_url, "token": config.okta_api_key}
+    return None
+
 
 @timeit
 def _cleanup_okta_organizations(
@@ -54,9 +96,11 @@ def start_okta_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
     :param config: A `cartography.config` object
     :return: Nothing
     """
-    if not config.okta_api_key:
+    okta_client_config = _build_okta_client_config(config)
+    if okta_client_config is None:
         logger.warning(
-            "No valid Okta credentials could be found. Exiting Okta sync stage.",
+            "No valid Okta credentials could be found: set an SSWS API key, or a "
+            "client id and private key for OAuth. Exiting Okta sync stage.",
         )
         return
 
@@ -67,12 +111,7 @@ def start_okta_ingestion(neo4j_session: neo4j.Session, config: Config) -> None:
         "OKTA_ORG_ID": config.okta_org_id,
     }
 
-    okta_client = OktaClient(
-        {
-            "orgUrl": f"https://{config.okta_org_id}.{config.okta_base_domain}",
-            "token": config.okta_api_key,
-        }
-    )
+    okta_client = OktaClient(okta_client_config)
 
     organization.sync_okta_organization(neo4j_session, common_job_parameters)
     user_ids = users.sync_okta_users(okta_client, neo4j_session, common_job_parameters)

--- a/docs/root/modules/okta/config.md
+++ b/docs/root/modules/okta/config.md
@@ -2,16 +2,52 @@
 
 ## Authentication
 
+Cartography supports two ways to authenticate to Okta.
+
+### OAuth 2.0 client credentials (recommended)
+
+[OAuth for Okta](https://developer.okta.com/docs/guides/implement-oauth-for-okta-serviceapp/main/) uses an API Services app with the `client_credentials` grant and `private_key_jwt` client authentication. Access is scoped, there is no long-lived shared token, and this is the only option in orgs whose authorization server rejects SSWS tokens.
+
+1. In the Okta Admin Console, go to **Applications > Create App Integration > API Services** and create an app for Cartography.
+1. In the app's **Client Credentials** section, set client authentication to **Public key / Private key**, generate a key, and save the private key (JWK JSON or PEM).
+1. On the app's **Okta API Scopes** tab, grant the read-only scopes Cartography requests: `okta.users.read`, `okta.groups.read`, `okta.apps.read`, `okta.trustedOrigins.read`, `okta.authenticators.read`, and `okta.userTypes.read`.
+1. On the app's **Admin roles** tab, assign **Read-only Administrator**. Service apps need an admin role in addition to scopes.
+1. Store the private key in an environment variable.
+
+### API token (legacy)
+
 Generate an API token by following Okta's [Create an API Token guide](https://developer.okta.com/docs/guides/create-an-api-token/overview/). Store the token in an environment variable.
 
 ## Configure Cartography
 
 Provide these options:
 
-- `--okta-api-key-env-var`: Name of the environment variable containing the API token.
 - `--okta-org-id`: Organization ID to query. This is the first part of the Okta organization URL.
 
+Then, for OAuth 2.0 client credentials:
+
+- `--okta-client-id`: Client ID of the API Services app.
+- `--okta-private-key-env-var`: Name of the environment variable containing the app's private key.
+- `--okta-dpop`: Pass this if the app has **Require Demonstrating Proof of Possession (DPoP) header in token requests** enabled.
+
+Or, for a legacy API token:
+
+- `--okta-api-key-env-var`: Name of the environment variable containing the API token.
+
+If both are provided, OAuth 2.0 client credentials take precedence.
+
 ## Run Cartography
+
+```bash
+export OKTA_PRIVATE_KEY='<private-key>'
+cartography \
+  --selected-modules okta \
+  --okta-org-id '<organization-id>' \
+  --okta-client-id '<client-id>' \
+  --okta-private-key-env-var OKTA_PRIVATE_KEY
+```
+
+Or, with a legacy API token:
 
 ```bash
 export OKTA_API_TOKEN='<api-token>'

--- a/tests/unit/cartography/intel/okta/test_client_config.py
+++ b/tests/unit/cartography/intel/okta/test_client_config.py
@@ -1,0 +1,71 @@
+from cartography.config import Config
+from cartography.intel.okta import _build_okta_client_config
+from cartography.intel.okta import OKTA_OAUTH_SCOPES
+
+
+def _config(**kwargs) -> Config:
+    return Config(
+        neo4j_uri="bolt://localhost:7687",
+        okta_org_id="test-org",
+        **kwargs,
+    )
+
+
+def test_oauth_client_credentials_config():
+    config = _config(okta_client_id="0oa123", okta_private_key='{"kty": "RSA"}')
+    client_config = _build_okta_client_config(config)
+    assert client_config == {
+        "orgUrl": "https://test-org.okta.com",
+        "authorizationMode": "PrivateKey",
+        "clientId": "0oa123",
+        "privateKey": '{"kty": "RSA"}',
+        "scopes": OKTA_OAUTH_SCOPES,
+    }
+
+
+def test_oauth_with_dpop_enabled():
+    config = _config(
+        okta_client_id="0oa123",
+        okta_private_key='{"kty": "RSA"}',
+        okta_dpop=True,
+    )
+    client_config = _build_okta_client_config(config)
+    assert client_config is not None
+    assert client_config["dpopEnabled"] is True
+
+
+def test_ssws_api_key_config():
+    config = _config(okta_api_key="00sekrit")
+    client_config = _build_okta_client_config(config)
+    assert client_config == {
+        "orgUrl": "https://test-org.okta.com",
+        "token": "00sekrit",
+    }
+
+
+def test_oauth_takes_precedence_over_api_key():
+    config = _config(
+        okta_api_key="00sekrit",
+        okta_client_id="0oa123",
+        okta_private_key='{"kty": "RSA"}',
+    )
+    client_config = _build_okta_client_config(config)
+    assert client_config is not None
+    assert client_config["authorizationMode"] == "PrivateKey"
+    assert "token" not in client_config
+
+
+def test_no_credentials_returns_none():
+    assert _build_okta_client_config(_config()) is None
+
+
+def test_partial_oauth_credentials_returns_none():
+    # client id without a private key must not half-configure OAuth
+    assert _build_okta_client_config(_config(okta_client_id="0oa123")) is None
+
+
+def test_custom_base_domain():
+    config = _config(okta_api_key="00sekrit", okta_base_domain="oktapreview.com")
+    client_config = _build_okta_client_config(config)
+    assert client_config is not None
+    assert client_config["orgUrl"] == "https://test-org.oktapreview.com"


### PR DESCRIPTION
### Type of change
- [x] New feature (non-breaking change that adds functionality)

### Summary
Adds **OAuth for Okta** as an alternative to the legacy SSWS API token: an API Services app using the `client_credentials` grant with `private_key_jwt` client authentication, plus optional **DPoP** sender-constrained tokens.

Okta orgs are increasingly locked down so that management API access via `client_credentials` **must** use `private_key_jwt` — the org authorization server rejects everything else — and some orgs additionally require DPoP per app. In those orgs the current SSWS-token-only configuration cannot sync at all. `okta-sdk-python` (already pinned at `>=3.4.4`) implements both; this change just exposes them.

- New CLI options: `--okta-client-id`, `--okta-private-key-env-var` (accepts the private key as JWK JSON or PEM, as generated by the Okta admin console), and `--okta-dpop`.
- Client config is built in a new `_build_okta_client_config()` helper: OAuth is used when a client id **and** private key are configured, otherwise the existing SSWS path is used unchanged. Requested scopes are the read-only set covering every API this module syncs.
- Docs updated with the API Services app setup steps (key generation, scope grants, the required Read-only Administrator role assignment, and the DPoP toggle).

Fully backward compatible — the SSWS path is untouched and remains the fallback.

### Related issues or links
- Supersedes #3018, which was stacked on #1243 and closed when that landed. This is the same change rebased onto the modernized Okta module.
- Okta guide: https://developer.okta.com/docs/guides/implement-oauth-for-okta-serviceapp/main/

### How was this tested?
- New unit tests (`tests/unit/cartography/intel/okta/test_client_config.py`, 7 cases: OAuth, DPoP, SSWS fallback, OAuth-over-SSWS precedence, partial-credential and no-credential handling, custom base domain). Full unit suite passes (5306 tests) and `pre-commit` is clean (isort/black/flake8/mypy/pyupgrade).
- Verified `--okta-client-id`, `--okta-private-key-env-var` and `--okta-dpop` appear in `cartography --help`.
- The exact SDK configuration produced here (`authorizationMode: PrivateKey` + `privateKey` JWK + `scopes` + `dpopEnabled`) is verified working against a production Okta org that enforces both `private_key_jwt` and DPoP, using okta-sdk-python 3.4.4 in separate internal tooling.

**Marked draft:** I have not yet run a full end-to-end cartography Okta sync against a real org with these credentials, so the sanitized sync logs the connector checklist asks for are still outstanding. I'll add them before marking this ready for review.

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

### Notes for reviewers
No node or relationship schemas change — this is purely an authentication/config path. The main design question worth a look is scope selection: `OKTA_OAUTH_SCOPES` is the read-only set matching what the sync currently touches (`okta.users.read`, `okta.groups.read`, `okta.apps.read`, `okta.trustedOrigins.read`, `okta.authenticators.read`, `okta.userTypes.read`), so it needs updating alongside any future sync that calls a new API.
