### PR TITLE
fix(ontology): normalize DNS hostnames at ingestion

### DIFF
--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -318,6 +318,49 @@ def _build_ontology_field_statement_coalesce(
     )
 
 
+def _build_ontology_field_statement_normalize_hostname(
+    mapping_field: OntologyFieldMapping,
+    property_ref: PropertyRef,
+    node_property_map: dict[str, PropertyRef],
+) -> str | None:
+    """Canonicalize a hostname, optionally only for selected DNS record types."""
+    normalized_expression = f"toLower(rtrim(trim(toString({property_ref})), '.'))"
+    record_types = mapping_field.extra.get("record_types")
+    if record_types is not None:
+        if not isinstance(record_types, list) or not all(
+            isinstance(record_type, str) for record_type in record_types
+        ):
+            logger.warning(
+                "normalize_hostname special handling 'record_types' for field %s must be a list of strings",
+                mapping_field.ontology_field,
+            )
+            return None
+        record_type_field = mapping_field.extra.get("record_type_field", "type")
+        record_type_propertyref = node_property_map.get(record_type_field)
+        if not record_type_propertyref:
+            logger.warning(
+                "Record type field '%s' not found for hostname normalization of field %s",
+                record_type_field,
+                mapping_field.ontology_field,
+            )
+            return None
+        escaped_record_types = ", ".join(
+            f"'{_escape_cypher_string(record_type)}'" for record_type in record_types
+        )
+        normalized_expression = (
+            "CASE "
+            f"WHEN toUpper(toString({record_type_propertyref})) IN [{escaped_record_types}] "
+            f"THEN {normalized_expression} "
+            "ELSE null END"
+        )
+
+    return (
+        f"i._ont_{mapping_field.ontology_field} = CASE "
+        f"WHEN {property_ref} IS NULL OR {normalized_expression} = '' "
+        f"THEN null ELSE {normalized_expression} END"
+    )
+
+
 def _build_ontology_node_properties_statement(
     node_schema: CartographyNodeSchema,
     node_property_map: dict[str, PropertyRef],
@@ -401,6 +444,14 @@ def _build_ontology_node_properties_statement(
             )
             if coalesce_statement:
                 set_clauses.append(coalesce_statement)
+        elif mapping_field.special_handling == "normalize_hostname":
+            normalize_hostname_statement = (
+                _build_ontology_field_statement_normalize_hostname(
+                    mapping_field, node_propertyref, node_property_map
+                )
+            )
+            if normalize_hostname_statement:
+                set_clauses.append(normalize_hostname_statement)
         else:
             simple_field_template = Template("i.$node_property = $property_ref")
             set_clauses.append(

--- a/cartography/graph/querybuilder.py
+++ b/cartography/graph/querybuilder.py
@@ -323,7 +323,10 @@ def _build_ontology_field_statement_normalize_hostname(
     property_ref: PropertyRef,
     node_property_map: dict[str, PropertyRef],
 ) -> str | None:
-    """Canonicalize a hostname, optionally only for selected DNS record types."""
+    """Build a Cypher assignment that normalizes a hostname.
+
+    If `record_types` is set, normalize only records of those types.
+    """
     normalized_expression = f"toLower(rtrim(trim(toString({property_ref})), '.'))"
     record_types = mapping_field.extra.get("record_types")
     if record_types is not None:

--- a/cartography/intel/dns_utils.py
+++ b/cartography/intel/dns_utils.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable
 
 
 def normalize_hostname(value: str | None) -> str | None:
-    """Return a canonical hostname while preserving the provider's raw value."""
+    """Return a lowercase hostname without surrounding whitespace or trailing dots."""
     if value is None:
         return None
 
@@ -11,7 +11,7 @@ def normalize_hostname(value: str | None) -> str | None:
 
 
 def normalize_hostname_values(values: Iterable[str] | None) -> list[str]:
-    """Normalize hostname values and omit empty entries."""
+    """Normalize each hostname and omit empty results."""
     if values is None:
         return []
 

--- a/cartography/intel/dns_utils.py
+++ b/cartography/intel/dns_utils.py
@@ -1,0 +1,18 @@
+from collections.abc import Iterable
+
+
+def normalize_hostname(value: str | None) -> str | None:
+    """Return a canonical hostname while preserving the provider's raw value."""
+    if value is None:
+        return None
+
+    normalized = value.strip().rstrip(".").lower()
+    return normalized or None
+
+
+def normalize_hostname_values(values: Iterable[str] | None) -> list[str]:
+    """Normalize hostname values and omit empty entries."""
+    if values is None:
+        return []
+
+    return [normalized for value in values if (normalized := normalize_hostname(value))]

--- a/cartography/intel/gcp/dns.py
+++ b/cartography/intel/gcp/dns.py
@@ -8,6 +8,7 @@ from googleapiclient.discovery import Resource
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.dns_utils import normalize_hostname_values
 from cartography.intel.gcp.labels import sync_labels
 from cartography.intel.gcp.util import classify_gcp_http_error
 from cartography.intel.gcp.util import gcp_api_execute_with_retry
@@ -128,14 +129,19 @@ def transform_dns_rrs(dns_rrs: List[Dict]) -> List[Dict]:
     """Transform raw DNS record set responses into Neo4j-ready dicts."""
     records: List[Dict] = []
     for r in dns_rrs:
+        record_type = r.get("type")
+        data = r.get("rrdatas")
         records.append(
             {
                 # Compose a unique ID to avoid collisions across types and zones
                 "id": f"{r['name']}|{r.get('type')}|{r.get('zone')}",
                 "name": r["name"],
-                "type": r.get("type"),
+                "type": record_type,
                 "ttl": r.get("ttl"),
-                "data": r.get("rrdatas"),
+                "data": data,
+                "target_hostnames": (
+                    normalize_hostname_values(data) if record_type == "CNAME" else []
+                ),
                 "zone_id": r.get("zone"),
             }
         )

--- a/cartography/intel/kubernetes/ingress.py
+++ b/cartography/intel/kubernetes/ingress.py
@@ -11,6 +11,7 @@ from kubernetes.client.models import V1IngressRule
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.dns_utils import normalize_hostname_values
 from cartography.intel.kubernetes.util import get_epoch
 from cartography.intel.kubernetes.util import k8s_paginate
 from cartography.intel.kubernetes.util import K8sClient
@@ -148,6 +149,7 @@ def transform_ingresses(ingress: list[V1Ingress]) -> list[dict[str, Any]]:
                     _format_ingress_backend(item.spec.default_backend)
                 ),
                 "host_names": host_names,
+                "host_names_normalized": normalize_hostname_values(host_names),
                 "target_services": list(backend_services),
                 "ingress_group_name": ingress_group_name,
                 "load_balancer_dns_names": load_balancer_dns_names,

--- a/cartography/models/gcp/dns.py
+++ b/cartography/models/gcp/dns.py
@@ -101,6 +101,10 @@ class GCPRecordSetNodeProperties(CartographyNodeProperties):
         description="Number of seconds that this ResourceRecordSet can be cached by resolvers.",
     )
     data: PropertyRef = PropertyRef("data", description="Data contained in the record.")
+    target_hostnames: PropertyRef = PropertyRef(
+        "target_hostnames",
+        description="Canonical target hostnames for hostname-valued records.",
+    )
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 
 

--- a/cartography/models/gcp/dns.py
+++ b/cartography/models/gcp/dns.py
@@ -103,7 +103,7 @@ class GCPRecordSetNodeProperties(CartographyNodeProperties):
     data: PropertyRef = PropertyRef("data", description="Data contained in the record.")
     target_hostnames: PropertyRef = PropertyRef(
         "target_hostnames",
-        description="Canonical target hostnames for hostname-valued records.",
+        description="Normalized CNAME target hostnames.",
     )
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
 

--- a/cartography/models/kubernetes/ingress.py
+++ b/cartography/models/kubernetes/ingress.py
@@ -51,7 +51,7 @@ class KubernetesIngressNodeProperties(CartographyNodeProperties):
     )
     host_names_normalized: PropertyRef = PropertyRef(
         "host_names_normalized",
-        description="Canonical hostnames configured by the ingress rules.",
+        description="Normalized hostnames from ingress rules.",
     )
     cluster_name: PropertyRef = PropertyRef(
         "CLUSTER_NAME",

--- a/cartography/models/kubernetes/ingress.py
+++ b/cartography/models/kubernetes/ingress.py
@@ -49,6 +49,10 @@ class KubernetesIngressNodeProperties(CartographyNodeProperties):
     host_names: PropertyRef = PropertyRef(
         "host_names", description="Hostnames configured by the ingress rules."
     )
+    host_names_normalized: PropertyRef = PropertyRef(
+        "host_names_normalized",
+        description="Canonical hostnames configured by the ingress rules.",
+    )
     cluster_name: PropertyRef = PropertyRef(
         "CLUSTER_NAME",
         set_in_kwargs=True,

--- a/cartography/models/ontology/mapping/data/dnsrecords.py
+++ b/cartography/models/ontology/mapping/data/dnsrecords.py
@@ -7,6 +7,27 @@ from cartography.models.ontology.mapping.specs import OntologyNodeMapping
 # type - The DNS record type (A, AAAA, CNAME, MX, TXT, etc.)
 # value - The DNS record value / target (IP address, CNAME target, etc.)
 
+HOSTNAME_RECORD_TYPES = ["CNAME", "ALIAS"]
+
+
+def _name_field(node_field: str = "name") -> OntologyFieldMapping:
+    return OntologyFieldMapping(
+        ontology_field="name",
+        node_field=node_field,
+        required=True,
+        special_handling="normalize_hostname",
+    )
+
+
+def _target_hostname_field(node_field: str = "value") -> OntologyFieldMapping:
+    return OntologyFieldMapping(
+        ontology_field="target_hostname",
+        node_field=node_field,
+        special_handling="normalize_hostname",
+        extra={"record_types": HOSTNAME_RECORD_TYPES},
+    )
+
+
 # AWS
 aws_mapping = OntologyMapping(
     module_name="aws",
@@ -14,11 +35,10 @@ aws_mapping = OntologyMapping(
         OntologyNodeMapping(
             node_label="AWSDNSRecord",
             fields=[
-                OntologyFieldMapping(
-                    ontology_field="name", node_field="name", required=True
-                ),
+                _name_field(),
                 OntologyFieldMapping(ontology_field="type", node_field="type"),
                 OntologyFieldMapping(ontology_field="value", node_field="value"),
+                _target_hostname_field(),
             ],
         ),
     ],
@@ -34,10 +54,13 @@ gcp_mapping = OntologyMapping(
         OntologyNodeMapping(
             node_label="GCPRecordSet",
             fields=[
-                OntologyFieldMapping(
-                    ontology_field="name", node_field="name", required=True
-                ),
+                _name_field(),
                 OntologyFieldMapping(ontology_field="type", node_field="type"),
+                OntologyFieldMapping(
+                    ontology_field="target_hostnames",
+                    node_field="target_hostnames",
+                    indexed=False,
+                ),
             ],
         ),
     ],
@@ -50,11 +73,10 @@ cloudflare_mapping = OntologyMapping(
         OntologyNodeMapping(
             node_label="CloudflareDNSRecord",
             fields=[
-                OntologyFieldMapping(
-                    ontology_field="name", node_field="name", required=True
-                ),
+                _name_field(),
                 OntologyFieldMapping(ontology_field="type", node_field="type"),
                 OntologyFieldMapping(ontology_field="value", node_field="value"),
+                _target_hostname_field(),
             ],
         ),
     ],
@@ -67,11 +89,10 @@ vercel_mapping = OntologyMapping(
         OntologyNodeMapping(
             node_label="VercelDNSRecord",
             fields=[
-                OntologyFieldMapping(
-                    ontology_field="name", node_field="name", required=True
-                ),
+                _name_field(),
                 OntologyFieldMapping(ontology_field="type", node_field="type"),
                 OntologyFieldMapping(ontology_field="value", node_field="value"),
+                _target_hostname_field(),
             ],
         ),
     ],
@@ -84,11 +105,7 @@ bbot_mapping = OntologyMapping(
         OntologyNodeMapping(
             node_label="BbotDNSName",
             fields=[
-                OntologyFieldMapping(
-                    ontology_field="name",
-                    node_field="name",
-                    required=True,
-                ),
+                _name_field(),
             ],
         ),
     ],
@@ -101,9 +118,7 @@ supabase_mapping = OntologyMapping(
         OntologyNodeMapping(
             node_label="SupabaseCustomHostname",
             fields=[
-                OntologyFieldMapping(
-                    ontology_field="name", node_field="hostname", required=True
-                ),
+                _name_field("hostname"),
                 OntologyFieldMapping(ontology_field="type", node_field="type"),
                 # value: The CNAME target is the project's own *.supabase.co
                 # endpoint, which the API does not return on this response.
@@ -119,11 +134,10 @@ netlify_mapping = OntologyMapping(
         OntologyNodeMapping(
             node_label="NetlifyDNSRecord",
             fields=[
-                OntologyFieldMapping(
-                    ontology_field="name", node_field="name", required=True
-                ),
+                _name_field(),
                 OntologyFieldMapping(ontology_field="type", node_field="type"),
                 OntologyFieldMapping(ontology_field="value", node_field="value"),
+                _target_hostname_field(),
             ],
         ),
     ],

--- a/cartography/models/ontology/mapping/data/dnsrecords.py
+++ b/cartography/models/ontology/mapping/data/dnsrecords.py
@@ -45,9 +45,8 @@ aws_mapping = OntologyMapping(
 )
 
 # GCP
-# GCPRecordSet.data is list-valued, so it is not mapped to the scalar _ont_value:
-# toString(_ont_value) in the DNS_RECORD_LINKING_JOBS analysis jobs rejects lists. GCP
-# record linking is done directly off the raw list field via UNWIND dns.data in those jobs.
+# GCPRecordSet.data is list-valued, so it cannot populate scalar _ont_value.
+# target_hostnames stores normalized CNAME targets for DNS linking.
 gcp_mapping = OntologyMapping(
     module_name="gcp",
     nodes=[

--- a/cartography/models/ontology/mapping/specs.py
+++ b/cartography/models/ontology/mapping/specs.py
@@ -28,8 +28,8 @@ class OntologyFieldMapping:
           (e.g., {"BASIC": "builtin", "PREDEFINED": "builtin", "CUSTOM": "custom"}). Unmapped values become NULL.
         - "coalesce": Sets the first non-null value from node_field and extra['fields'].
         - "normalize_hostname": Lowercases a hostname and removes surrounding whitespace and
-          the trailing DNS root dot. Set extra['record_types'] to populate the field only for
-          hostname-valued DNS record types; extra['record_type_field'] defaults to "type".
+          trailing dots. If extra['record_types'] is set, normalizes only records whose
+          extra['record_type_field'] (default "type") matches one of those types.
 
     Example:
         OntologyFieldMapping(ontology_field="email", node_field="email_address", required=True)

--- a/cartography/models/ontology/mapping/specs.py
+++ b/cartography/models/ontology/mapping/specs.py
@@ -27,6 +27,9 @@ class OntologyFieldMapping:
         - "mapping": Maps provider-specific values to normalized ontology values using extra['map'] dict
           (e.g., {"BASIC": "builtin", "PREDEFINED": "builtin", "CUSTOM": "custom"}). Unmapped values become NULL.
         - "coalesce": Sets the first non-null value from node_field and extra['fields'].
+        - "normalize_hostname": Lowercases a hostname and removes surrounding whitespace and
+          the trailing DNS root dot. Set extra['record_types'] to populate the field only for
+          hostname-valued DNS record types; extra['record_type_field'] defaults to "type".
 
     Example:
         OntologyFieldMapping(ontology_field="email", node_field="email_address", required=True)

--- a/tests/integration/cartography/intel/cloudflare/test_dnsrecords.py
+++ b/tests/integration/cartography/intel/cloudflare/test_dnsrecords.py
@@ -67,6 +67,25 @@ def test_load_cloudflare_dnsrecords(mock_cloudflare, mock_api, neo4j_session):
         )
         == expected_nodes
     )
+    assert (
+        {
+            tuple(row)
+            for row in neo4j_session.run(
+                """
+            MATCH (record:CloudflareDNSRecord)
+            RETURN record.id, record._ont_name, record._ont_target_hostname
+            """
+            ).values()
+        }
+        == {
+            ("2b534a38-8658-48c0-8d6d-f9277d689c75", "simpson.corp", None),
+            (
+                "922f7919-e12b-4f46-800f-74b433724d29",
+                "www.simpson.corp",
+                "simpson.corp",
+            ),
+        }
+    )
 
     # Assert DNSRecords are connected with Account (the tenant)
     expected_account_rels = {

--- a/tests/unit/cartography/graph/test_ontology_fields.py
+++ b/tests/unit/cartography/graph/test_ontology_fields.py
@@ -4,12 +4,61 @@ from cartography.graph.querybuilder import (
     _build_ontology_field_statement_invert_boolean,
 )
 from cartography.graph.querybuilder import _build_ontology_field_statement_mapping
+from cartography.graph.querybuilder import (
+    _build_ontology_field_statement_normalize_hostname,
+)
 from cartography.graph.querybuilder import _build_ontology_field_statement_or_boolean
 from cartography.graph.querybuilder import _build_ontology_field_statement_static_value
 from cartography.graph.querybuilder import _build_ontology_field_statement_to_boolean
 from cartography.graph.querybuilder import _escape_cypher_string
 from cartography.models.core.common import PropertyRef
 from cartography.models.ontology.mapping.specs import OntologyFieldMapping
+
+
+def test_build_ontology_field_statement_normalize_hostname():
+    mapping_field = OntologyFieldMapping(
+        ontology_field="name",
+        node_field="name",
+        special_handling="normalize_hostname",
+    )
+
+    result = _build_ontology_field_statement_normalize_hostname(
+        mapping_field,
+        PropertyRef("name"),
+        {"name": PropertyRef("name")},
+    )
+
+    assert result == (
+        "i._ont_name = CASE "
+        "WHEN item.name IS NULL OR toLower(rtrim(trim(toString(item.name)), '.')) = '' "
+        "THEN null ELSE toLower(rtrim(trim(toString(item.name)), '.')) END"
+    )
+
+
+def test_build_ontology_field_statement_normalize_hostname_by_record_type():
+    mapping_field = OntologyFieldMapping(
+        ontology_field="target_hostname",
+        node_field="value",
+        special_handling="normalize_hostname",
+        extra={"record_types": ["CNAME", "ALIAS"]},
+    )
+
+    result = _build_ontology_field_statement_normalize_hostname(
+        mapping_field,
+        PropertyRef("value"),
+        {"value": PropertyRef("value"), "type": PropertyRef("type")},
+    )
+
+    normalized = "toLower(rtrim(trim(toString(item.value)), '.'))"
+    conditional = (
+        "CASE WHEN toUpper(toString(item.type)) IN ['CNAME', 'ALIAS'] "
+        f"THEN {normalized} ELSE null END"
+    )
+    assert result == (
+        "i._ont_target_hostname = CASE "
+        f"WHEN item.value IS NULL OR {conditional} = '' "
+        f"THEN null ELSE {conditional} END"
+    )
 
 
 def test_build_ontology_field_statement_invert_boolean():

--- a/tests/unit/cartography/intel/gcp/test_dns.py
+++ b/tests/unit/cartography/intel/gcp/test_dns.py
@@ -7,6 +7,7 @@ from googleapiclient.errors import HttpError
 
 from cartography.intel.gcp.dns import get_dns_rrs
 from cartography.intel.gcp.dns import get_dns_zones
+from cartography.intel.gcp.dns import transform_dns_rrs
 
 
 def _make_http_error(status: int) -> HttpError:
@@ -104,6 +105,30 @@ class TestGetDnsRrsCurrentStateSemantics:
             ),
         ):
             assert get_dns_rrs(mock_dns, zones, "test-project") == []
+
+
+def test_transform_dns_rrs_normalizes_only_hostname_targets():
+    records = transform_dns_rrs(
+        [
+            {
+                "name": "WWW.Example.COM.",
+                "type": "CNAME",
+                "rrdatas": [" Target.Example.COM. "],
+                "zone": "zone-1",
+            },
+            {
+                "name": "_token.example.com.",
+                "type": "TXT",
+                "rrdatas": ["Case-Sensitive.Value."],
+                "zone": "zone-1",
+            },
+        ]
+    )
+
+    assert records[0]["target_hostnames"] == ["target.example.com"]
+    assert records[0]["data"] == [" Target.Example.COM. "]
+    assert records[1]["target_hostnames"] == []
+    assert records[1]["data"] == ["Case-Sensitive.Value."]
 
     def test_returns_empty_list_on_api_disabled(self):
         mock_dns = MagicMock()

--- a/tests/unit/cartography/intel/gcp/test_dns.py
+++ b/tests/unit/cartography/intel/gcp/test_dns.py
@@ -106,6 +106,36 @@ class TestGetDnsRrsCurrentStateSemantics:
         ):
             assert get_dns_rrs(mock_dns, zones, "test-project") == []
 
+    def test_returns_empty_list_on_billing_disabled(self):
+        mock_dns = MagicMock()
+        zones = [{"id": "zone-1"}]
+        with (
+            patch(
+                "cartography.intel.gcp.dns.gcp_api_execute_with_retry",
+                side_effect=_make_http_error(403),
+            ),
+            patch(
+                "cartography.intel.gcp.dns.classify_gcp_http_error",
+                return_value="billing_disabled",
+            ),
+        ):
+            assert get_dns_rrs(mock_dns, zones, "test-project") == []
+
+    def test_returns_empty_list_on_api_disabled(self):
+        mock_dns = MagicMock()
+        zones = [{"id": "zone-1"}]
+        with (
+            patch(
+                "cartography.intel.gcp.dns.gcp_api_execute_with_retry",
+                side_effect=_make_http_error(403),
+            ),
+            patch(
+                "cartography.intel.gcp.dns.classify_gcp_http_error",
+                return_value="api_disabled",
+            ),
+        ):
+            assert get_dns_rrs(mock_dns, zones, "test-project") == []
+
 
 def test_transform_dns_rrs_normalizes_only_hostname_targets():
     records = transform_dns_rrs(
@@ -129,33 +159,3 @@ def test_transform_dns_rrs_normalizes_only_hostname_targets():
     assert records[0]["data"] == [" Target.Example.COM. "]
     assert records[1]["target_hostnames"] == []
     assert records[1]["data"] == ["Case-Sensitive.Value."]
-
-    def test_returns_empty_list_on_api_disabled(self):
-        mock_dns = MagicMock()
-        zones = [{"id": "zone-1"}]
-        with (
-            patch(
-                "cartography.intel.gcp.dns.gcp_api_execute_with_retry",
-                side_effect=_make_http_error(403),
-            ),
-            patch(
-                "cartography.intel.gcp.dns.classify_gcp_http_error",
-                return_value="api_disabled",
-            ),
-        ):
-            assert get_dns_rrs(mock_dns, zones, "test-project") == []
-
-    def test_returns_empty_list_on_billing_disabled(self):
-        mock_dns = MagicMock()
-        zones = [{"id": "zone-1"}]
-        with (
-            patch(
-                "cartography.intel.gcp.dns.gcp_api_execute_with_retry",
-                side_effect=_make_http_error(403),
-            ),
-            patch(
-                "cartography.intel.gcp.dns.classify_gcp_http_error",
-                return_value="billing_disabled",
-            ),
-        ):
-            assert get_dns_rrs(mock_dns, zones, "test-project") == []

--- a/tests/unit/cartography/intel/kubernetes/test_ingress.py
+++ b/tests/unit/cartography/intel/kubernetes/test_ingress.py
@@ -1,6 +1,7 @@
 from kubernetes.client.models import V1Ingress
 from kubernetes.client.models import V1IngressLoadBalancerIngress
 from kubernetes.client.models import V1IngressLoadBalancerStatus
+from kubernetes.client.models import V1IngressRule
 from kubernetes.client.models import V1IngressSpec
 from kubernetes.client.models import V1IngressStatus
 from kubernetes.client.models import V1ObjectMeta
@@ -37,3 +38,24 @@ def test_transform_ingresses_lowercases_load_balancer_dns_names():
     assert transformed["load_balancer_dns_names"] == [
         "my-alb-1234567890.us-east-1.elb.amazonaws.com"
     ]
+
+
+def test_transform_ingresses_normalizes_rule_hostnames():
+    ingress = V1Ingress(
+        metadata=V1ObjectMeta(
+            uid="ingress-1",
+            name="web",
+            namespace="default",
+            annotations={},
+        ),
+        spec=V1IngressSpec(
+            rules=[V1IngressRule(host=" App.Example.COM. ")],
+            default_backend=None,
+        ),
+        status=V1IngressStatus(load_balancer=None),
+    )
+
+    [transformed] = transform_ingresses([ingress])
+
+    assert transformed["host_names"] == [" App.Example.COM. "]
+    assert transformed["host_names_normalized"] == ["app.example.com"]

--- a/tests/unit/cartography/intel/test_dns_utils.py
+++ b/tests/unit/cartography/intel/test_dns_utils.py
@@ -1,0 +1,15 @@
+from cartography.intel.dns_utils import normalize_hostname
+from cartography.intel.dns_utils import normalize_hostname_values
+
+
+def test_normalize_hostname():
+    assert normalize_hostname(" WWW.Example.COM. ") == "www.example.com"
+    assert normalize_hostname(".") is None
+    assert normalize_hostname(None) is None
+
+
+def test_normalize_hostname_values_omits_empty_values():
+    assert normalize_hostname_values([" First.Example.COM. ", ".", "second.test"]) == [
+        "first.example.com",
+        "second.test",
+    ]


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

### Summary

DNS hostnames are case-insensitive and may include a trailing root dot, but provider payloads do not represent them consistently. Normalizing inside relationship queries prevents Neo4j from seeking ontology indexes and can accidentally treat non-hostname record data as a hostname.

This preserves raw provider values and writes canonical hostname properties during ingestion. DNS names are normalized independently from CNAME and ALIAS targets, while TXT and other case-sensitive values remain unchanged. GCP record sets receive a normalized target list because their raw data is list-valued. Kubernetes ingresses likewise retain raw rule hosts alongside a canonical list for DNS matching.

### How was this tested?

- Full unit suite on the top of the stack: 5,316 passed
- Focused Cloudflare, GCP DNS, and Kubernetes ingress integration tests
- Repository-wide pre-commit hooks
- `uv run ./docs/build.sh`

### Checklist

- [x] I have read the contributing guidelines.
- [x] The linter passes locally.
- [x] I have added or updated tests that prove the fix is effective.
- [x] Every commit includes a DCO Signed-off-by trailer.
- [x] Updated model property descriptions used to generate schema documentation.
- [x] Built the documentation locally.

### Notes for reviewers

This is the first PR in stack #3232. The following DNS relationship PRs consume these canonical fields with indexed equality matches.