### PR TITLE
fix(netlify): unwrap MongoDB extended JSON in membership payloads

### DIFF
--- a/cartography/intel/netlify/users.py
+++ b/cartography/intel/netlify/users.py
@@ -9,6 +9,7 @@ from cartography.client.core.tx import load_matchlinks
 from cartography.graph.job import GraphJob
 from cartography.graph.statement import GraphStatement
 from cartography.intel.netlify.util import paginated_get
+from cartography.intel.netlify.util import unwrap_extended_json
 from cartography.models.netlify.invite import NetlifyInvitedToAccountMatchLink
 from cartography.models.netlify.invite import NetlifyInviteSchema
 from cartography.models.netlify.invite import NetlifyInviteToAccountMatchLink
@@ -64,14 +65,19 @@ def transform_netlify_users(
 
     A row with no `user_id` and no email cannot be keyed either way, so it is skipped.
 
+    Every value is passed through `unwrap_extended_json` on the way in: Netlify leaks MongoDB's
+    extended JSON encoding on some membership fields, and a `{"$oid": ...}` map fails the whole
+    write batch rather than just its own property.
+
     :return: (memberships with a linked Netlify user, memberships known only by email)
     """
     users: list[dict[str, Any]] = []
     invites: list[dict[str, Any]] = []
     for member in members:
+        membership_id = unwrap_extended_json(member["id"])
         common = {
-            **{k: v for k, v in member.items() if k != "id"},
-            "membership_id": member["id"],
+            **{k: unwrap_extended_json(v) for k, v in member.items() if k != "id"},
+            "membership_id": membership_id,
             "account_id": account_id,
         }
         if member.get("user_id"):
@@ -86,7 +92,7 @@ def transform_netlify_users(
         if not member.get("email"):
             logger.warning(
                 "Skipping Netlify membership %s: it has neither a user_id nor an email.",
-                member["id"],
+                membership_id,
             )
             continue
         # A membership with no linked user is expected to be an outstanding invitation. If Netlify
@@ -96,7 +102,7 @@ def transform_netlify_users(
             logger.warning(
                 "Netlify membership %s has no user_id but is not marked pending and carries no "
                 "invite_id. Treating it as an invitation keyed on %s; please report this payload.",
-                member["id"],
+                membership_id,
                 member["email"],
             )
         invites.append(common)

--- a/cartography/intel/netlify/util.py
+++ b/cartography/intel/netlify/util.py
@@ -21,6 +21,37 @@ _MAX_PAGES = 1000
 _RATE_LIMIT_WARN_THRESHOLD = 25
 
 
+# MongoDB extended JSON wrappers Netlify sends instead of the bare scalar. Netlify's API is
+# Mongo-backed and leaks the raw BSON encoding on some fields, so an id can arrive as
+# `{"$oid": "..."}` and a timestamp as `{"$date": "..."}`.
+_EXTENDED_JSON_KEYS = frozenset(
+    {"$oid", "$date", "$numberInt", "$numberLong", "$numberDouble"},
+)
+
+
+def unwrap_extended_json(value: Any) -> Any:
+    """
+    Reduce a MongoDB extended JSON wrapper to the scalar it wraps, leaving anything else alone.
+
+    Neo4j only stores primitives and arrays of primitives, so a wrapped value fails the whole
+    write batch rather than just its own property: `Property values can only be of primitive
+    types or arrays thereof. Encountered: Map{$oid -> String(...)}`.
+
+    Observed on `invite_id` in the team members payload for an outstanding invitation, where the
+    same list also reports plain-string ids. The wrapper is the API's serialisation leaking
+    through rather than a property of that one field, so it is applied to a payload's values as a
+    whole instead of to a named field.
+
+    :param value: A value straight off a Netlify response.
+    :return: The unwrapped scalar for a recognised wrapper, otherwise the value unchanged.
+    """
+    if isinstance(value, dict) and len(value) == 1:
+        ((key, wrapped),) = value.items()
+        if key in _EXTENDED_JSON_KEYS and isinstance(wrapped, (str, int, float, bool)):
+            return wrapped
+    return value
+
+
 class NetlifyPaginationError(Exception):
     """
     Netlify advertised another page but did not give a usable URL to reach it.

--- a/tests/integration/cartography/intel/netlify/test_users.py
+++ b/tests/integration/cartography/intel/netlify/test_users.py
@@ -307,3 +307,54 @@ def test_an_existing_user_invited_to_a_team_stays_a_user(
     ).single()
     assert membership["pending"] is True
     assert membership["invite_id"] == "invite-abc"
+
+
+def test_a_mongo_wrapped_id_is_stored_as_a_scalar(neo4j_session: neo4j.Session) -> None:
+    """
+    Netlify's API is Mongo-backed and reports some membership ids as MongoDB extended JSON
+    (`{"$oid": "..."}`) rather than as the bare string, seen on `invite_id` for an outstanding
+    invitation. Neo4j only stores primitives, so a map fails the whole write batch and takes the
+    rest of the team's members down with it.
+    """
+    # Arrange
+    neo4j_session.run("MATCH (n) DETACH DELETE n")
+    create_test_netlify_account(neo4j_session)
+    members = [
+        {
+            "id": {"$oid": "6a99a33f1815565afdc2d4be"},
+            "user_id": None,
+            "email": "invited@example.com",
+            "pending": True,
+            "role": "Collaborator",
+            "invite_id": {"$oid": "6a99a33f1815565afdc2d4bf"},
+        },
+        tests.data.netlify.users.NETLIFY_MEMBERS[0],
+    ]
+
+    # Act
+    with patch.object(
+        cartography.intel.netlify.users,
+        "get_netlify_users",
+        return_value=members,
+    ):
+        cartography.intel.netlify.users.sync_netlify_users(
+            neo4j_session,
+            MagicMock(spec=requests.Session),
+            TEST_BASE_URL,
+            TEST_ACCOUNT_ID,
+            TEST_ACCOUNT_SLUG,
+            TEST_UPDATE_TAG,
+            common_job_parameters(),
+        )
+
+    # Assert: the wrapped ids landed as strings, and the unwrapped member in the same batch
+    # was loaded rather than lost to a failed write.
+    invitation = neo4j_session.run(
+        """
+        MATCH (:NetlifyInvite)-[r:INVITED_TO]->(:NetlifyAccount)
+        RETURN r.membership_id AS membership_id, r.invite_id AS invite_id
+        """,
+    ).single()
+    assert invitation["membership_id"] == "6a99a33f1815565afdc2d4be"
+    assert invitation["invite_id"] == "6a99a33f1815565afdc2d4bf"
+    assert check_nodes(neo4j_session, "NetlifyUser", ["id"]) == {(TEST_USER_ID,)}

--- a/tests/unit/cartography/intel/netlify/test_util.py
+++ b/tests/unit/cartography/intel/netlify/test_util.py
@@ -8,6 +8,7 @@ from cartography.intel.netlify.util import get_one
 from cartography.intel.netlify.util import NetlifyPaginationError
 from cartography.intel.netlify.util import NetlifyPlanGatedError
 from cartography.intel.netlify.util import paginated_get
+from cartography.intel.netlify.util import unwrap_extended_json
 
 _URL = "https://api.netlify.com/api/v1/example-team/sites"
 
@@ -260,3 +261,26 @@ def test_get_one_raises_when_the_body_is_not_an_object():
 
     with pytest.raises(ValueError, match="Expected a JSON object"):
         get_one(session, _URL)
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ({"$oid": "6a99a33f1815565afdc2d4be"}, "6a99a33f1815565afdc2d4be"),
+        ({"$date": "2026-07-30T15:32:17.370Z"}, "2026-07-30T15:32:17.370Z"),
+        ({"$numberLong": 12}, 12),
+        # Left alone: a real object, a wrapper we do not know, and plain scalars.
+        ({"google": "alice@example.com"}, {"google": "alice@example.com"}),
+        ({"$unknown": "x"}, {"$unknown": "x"}),
+        ({"$oid": {"nested": "x"}}, {"$oid": {"nested": "x"}}),
+        ({"$oid": "a", "$date": "b"}, {"$oid": "a", "$date": "b"}),
+        ("plain-string-id", "plain-string-id"),
+        (None, None),
+    ],
+)
+def test_unwrap_extended_json(value, expected):
+    """
+    Netlify leaks MongoDB's extended JSON on some fields, and Neo4j refuses a map as a property
+    value, so the wrapper has to be reduced to its scalar before the payload reaches a load.
+    """
+    assert unwrap_extended_json(value) == expected


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Netlify's API is Mongo-backed and leaks the raw BSON encoding on some fields of the team members payload. An outstanding invitation reports `invite_id` as `{"$oid": "..."}` rather than as the bare string, in the same list that reports plain-string ids elsewhere.

`transform_netlify_users` copied those values straight onto the `INVITED_TO` MatchLink properties, and Neo4j only stores primitives and arrays thereof, so the map failed the whole write batch rather than just its own property:

```
CypherTypeError: Property values can only be of primitive types or arrays thereof.
Encountered: Map{$oid -> String(...)}.
```

That takes down every member of the team being synced, not only the row carrying the wrapper. The captured fixture in `tests/data/netlify/users.py` came from a Free-plan team where `invite_id` was null, so the shape was never exercised.

This adds `unwrap_extended_json` to the module's payload helpers and passes every membership value through it in the transform, `membership_id` included. It reduces a single-key extended JSON wrapper holding a scalar (`$oid`, `$date`, `$numberInt`, `$numberLong`, `$numberDouble`) to that scalar and leaves everything else untouched, including a genuine nested object such as `connected_accounts` and an unrecognized wrapper. The two `logger.warning` calls in the transform now use the unwrapped id so a malformed row does not log a map either.

Fixed in the module's mapping layer rather than in the shared querybuilder: this is a quirk of one provider's serialization, not of the load path.

No model or schema change, so no doc rebuild is needed.


### Related issues or links

None.


### How was this tested?

`uv run ./docs/build.sh` not needed (no model changes).

- New integration regression test `test_a_mongo_wrapped_id_is_stored_as_a_scalar` replays the exact path that failed: an invite row whose `id` and `invite_id` are both `{"$oid": ...}`, alongside an ordinary member in the same batch. Confirmed it fails on `master` (the `INVITED_TO` load raises the `CypherTypeError` above) and passes with the fix. It also asserts the unwrapped member in the same batch still lands, which is the part that was collateral damage.
- New parametrized unit test for `unwrap_extended_json`, including the cases where it must leave the value alone.
- Full Netlify suites green: 44 integration tests, 41 unit tests.
- `pre-commit` (isort, black, flake8, mypy, and the rest) passes on all four changed files.

Sanitized sync log for the new integration test. The last line is the load that previously raised:

```
cartography.client.core.tx: Loaded 1 NetlifyUser nodes
cartography.client.core.tx: Loaded 1 (NetlifyUser)-[RESOURCE]->(NetlifyAccount) relationships
cartography.client.core.tx: Loaded 1 (NetlifyUser)-[MEMBER_OF]->(NetlifyAccount) relationships
cartography.client.core.tx: Loaded 1 NetlifyInvite nodes
cartography.client.core.tx: Loaded 1 (NetlifyInvite)-[RESOURCE]->(NetlifyAccount) relationships
cartography.client.core.tx: Loaded 1 (NetlifyInvite)-[INVITED_TO]->(NetlifyAccount) relationships
```


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
<!-- Provide at least one of the following to help reviewers verify your changes: -->
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [x] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

#### If you are changing a node or relationship
- [ ] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [ ] Built the documentation with `uv run ./docs/build.sh`.


### Notes for reviewers

The payload shape was observed on a live Netlify team with an outstanding invitation, not on the Free-plan team the fixture was captured from. I have not re-run the fix against a real Netlify team with a pending invite, which is why the real-environment box is unchecked; the integration test reproduces the failing shape end to end through Neo4j instead.

Two things worth a look:

- The allowlist of wrapper keys in `_EXTENDED_JSON_KEYS` is deliberate rather than a blanket "single key starting with `$`" rule, so an unfamiliar wrapper still fails loudly instead of being silently unwrapped into something unexpected. Only `$oid` has actually been observed; the rest are the neighbouring wrappers from the same encoding.
- Unwrapping is applied to every top-level value of a membership row rather than to named fields, because the wrapper comes from the API's serializer and not from one field's semantics. Unused keys in the row are harmless either way since the models only read declared properties.
