### PR TITLE
fix(okta): guard application fields absent from the SDK base model

### DIFF
--- a/cartography/intel/okta/applications.py
+++ b/cartography/intel/okta/applications.py
@@ -74,6 +74,10 @@ def _transform_okta_applications(
         # Sparse app types (bookmarks, SWA, ...) can have any of the nested
         # sub-objects set to None, so every level must be guarded to avoid
         # aborting the whole sync on one atypical app.
+        # The SDK also picks the concrete model from signOnMode and falls back to
+        # the base Application class for unknown or empty values, and to
+        # ActiveDirectoryApplication for a null one. Those classes do not declare
+        # credentials/name/settings at all, so read them with getattr().
         accessibility = okta_application.accessibility
         application_props["accessibility_error_redirect_url"] = (
             accessibility.error_redirect_url if accessibility else None
@@ -86,7 +90,7 @@ def _transform_okta_applications(
         )
 
         application_props["created"] = okta_application.created
-        credentials = okta_application.credentials
+        credentials = getattr(okta_application, "credentials", None)
         signing = credentials.signing if credentials else None
         application_props["credentials_signing_kid"] = signing.kid if signing else None
         application_props["credentials_signing_last_rotated"] = (
@@ -124,8 +128,8 @@ def _transform_okta_applications(
         application_props["licensing_seat_count"] = (
             getattr(licensing, "seat_count", None) if licensing else None
         )
-        application_props["name"] = okta_application.name
-        settings = okta_application.settings
+        application_props["name"] = getattr(okta_application, "name", None)
+        settings = getattr(okta_application, "settings", None)
         settings_app = getattr(settings, "app", None)
         application_props["settings_app_acs_url"] = getattr(
             settings_app, "acs_url", None
@@ -415,7 +419,7 @@ def _transform_okta_reply_uris(
     """
     reply_uris: list[dict[str, Any]] = []
     for okta_application in okta_applications:
-        settings = okta_application.settings
+        settings = getattr(okta_application, "settings", None)
         oauth_client = getattr(settings, "oauth_client", None) if settings else None
         if not oauth_client:
             continue

--- a/cartography/intel/okta/applications.py
+++ b/cartography/intel/okta/applications.py
@@ -294,11 +294,17 @@ def _transform_okta_applications(
             application_props["settings_oauth_client_wildcard_redirect"] = (
                 oauth_client.wildcard_redirect
             )
-        # This value can also be None, in which case it has no value
+        # A known sign-on mode is parsed into the ApplicationSignOnMode enum. An
+        # unknown or empty one is set to None on the model, but the SDK preserves
+        # the raw value for forward compatibility and restores it in the public
+        # serialization, so recover it from there instead of losing it. An app
+        # with a null sign-on mode (Active Directory) has no value there either.
         if okta_application.sign_on_mode:
             application_props["sign_on_mode"] = okta_application.sign_on_mode.value
         else:
-            application_props["sign_on_mode"] = okta_application.sign_on_mode
+            application_props["sign_on_mode"] = okta_application.to_dict().get(
+                "signOnMode"
+            )
         application_props["status"] = (
             okta_application.status.value if okta_application.status else None
         )

--- a/tests/data/okta/application.py
+++ b/tests/data/okta/application.py
@@ -217,3 +217,26 @@ BOOKMARK_APPLICATION_WITHOUT_URL = {
         },
     },
 }
+
+# The SDK falls back to the base Application class when signOnMode is unknown,
+# and to ActiveDirectoryApplication when it is null. Neither declares every
+# nested sub-object the transform reads.
+APPLICATION_WITH_UNKNOWN_SIGN_ON_MODE = {
+    "id": "0oaUnknownMode",
+    "label": "MFA as a service app",
+    "status": "ACTIVE",
+    "signOnMode": "MFA_AS_SERVICE",
+}
+
+ACTIVE_DIRECTORY_APPLICATION = {
+    "id": "0oaActiveDirectory",
+    "name": "active_directory",
+    "label": "example.com",
+    "status": "ACTIVE",
+    "signOnMode": None,
+    "settings": {
+        "app": {
+            "domain": "example.com",
+        },
+    },
+}

--- a/tests/unit/cartography/intel/okta/test_applications.py
+++ b/tests/unit/cartography/intel/okta/test_applications.py
@@ -3,7 +3,9 @@ import json
 from okta.models.application_json_converter import ApplicationJsonConverter
 
 from cartography.intel.okta import applications
+from tests.data.okta.application import ACTIVE_DIRECTORY_APPLICATION
 from tests.data.okta.application import APPLICATION_WITH_REDITECT_URIS
+from tests.data.okta.application import APPLICATION_WITH_UNKNOWN_SIGN_ON_MODE
 
 
 async def _empty_assignments(*args):
@@ -30,3 +32,37 @@ def test_transform_handles_sdk_344_username_template_and_sparse_settings(
     # Assert
     assert result[0]["credentials_user_name_template_suffix"] is None
     assert result[0]["settings_app_acs_url"] is None
+
+
+def test_transform_handles_applications_without_credentials_or_settings(
+    monkeypatch,
+) -> None:
+    """
+    An unknown signOnMode yields the base Application class (no credentials, name
+    nor settings) and a null one yields ActiveDirectoryApplication (no
+    credentials). Neither should abort the sync.
+    """
+    # Arrange
+    applications_list = [
+        ApplicationJsonConverter.from_dict(APPLICATION_WITH_UNKNOWN_SIGN_ON_MODE),
+        ApplicationJsonConverter.from_dict(ACTIVE_DIRECTORY_APPLICATION),
+    ]
+    monkeypatch.setattr(
+        applications, "_get_application_assigned_users", _empty_assignments
+    )
+    monkeypatch.setattr(
+        applications, "_get_application_assigned_groups", _empty_assignments
+    )
+
+    # Act
+    result = applications._transform_okta_applications(None, applications_list)
+    reply_uris = applications._transform_okta_reply_uris(applications_list)
+
+    # Assert
+    assert [app["id"] for app in result] == ["0oaUnknownMode", "0oaActiveDirectory"]
+    assert result[0]["name"] is None
+    assert result[0]["credentials_signing_kid"] is None
+    assert result[0]["settings_app_url"] is None
+    assert result[1]["name"] == "active_directory"
+    assert result[1]["credentials_signing_kid"] is None
+    assert reply_uris == []

--- a/tests/unit/cartography/intel/okta/test_applications.py
+++ b/tests/unit/cartography/intel/okta/test_applications.py
@@ -60,6 +60,10 @@ def test_transform_handles_applications_without_credentials_or_settings(
 
     # Assert
     assert [app["id"] for app in result] == ["0oaUnknownMode", "0oaActiveDirectory"]
+    # The SDK sets an unknown mode to None on the model but preserves the raw
+    # value, which must still reach the transform.
+    assert result[0]["sign_on_mode"] == "MFA_AS_SERVICE"
+    assert result[1]["sign_on_mode"] is None
     assert result[0]["name"] is None
     assert result[0]["credentials_signing_kid"] is None
     assert result[0]["settings_app_url"] is None


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

The Okta SDK picks the concrete application model from `signOnMode`:

| `signOnMode` | Model returned | Missing fields |
| --- | --- | --- |
| known (`SAML_2_0`, `BOOKMARK`, ...) | matching subclass | none |
| unknown or empty (e.g. `MFA_AS_SERVICE`) | base `Application` | `credentials`, `name`, `settings` |
| `null` | `ActiveDirectoryApplication` | `credentials` |

These are pydantic models, so reading a field the model does not declare raises `AttributeError` instead of returning `None`. A single atypical application in a tenant therefore aborted the whole `okta` sync stage:

```
File "cartography/intel/okta/applications.py", line 89, in _transform_okta_applications
    credentials = okta_application.credentials
File "pydantic/main.py", line 1026, in __getattr__
    raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
AttributeError: 'Application' object has no attribute 'credentials'
```

This PR reads `credentials`, `name` and `settings` with `getattr()`, the way the nested sub-objects and `activated` already do. The downstream `if credentials else None` guards already handle a `None` value, so the affected properties are stored as `None` rather than failing the sync. `_transform_okta_reply_uris` had the same latent crash on `settings` and is fixed too.


### Related issues or links

None.


### How was this tested?

- Added `test_transform_handles_applications_without_credentials_or_settings`, which covers both fallbacks (base `Application` and `ActiveDirectoryApplication`) through `_transform_okta_applications` and `_transform_okta_reply_uris`, with two new fixtures in `tests/data/okta/application.py`.
- Confirmed the new test fails on `master` with the exact `AttributeError` above, and passes with the fix.
- `uv run --frozen pytest tests/unit/cartography/intel/okta` : 17 passed.
- `make test_lint` on the touched files: all hooks pass.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [x] Tested the connector against a real cloud, SaaS, or provider environment.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

The crash was observed on a real Okta tenant whose app catalog contains an application with a `signOnMode` outside the SDK's known set; the sync stage now completes over the same catalog.

#### If you are changing a node or relationship
Not applicable: no model or `PropertyRef` change, only the transform that populates existing properties.


### Notes for reviewers

The transform already guarded every nested level (`accessibility`, `licensing`, `settings.app`, ...) against `None`. What it did not cover is a field being absent from the model class itself, which is what the base-class fallback produces. Worth deciding whether `OktaApplication` should be typed as the union of subclasses instead, so mypy flags this class of access at the type level; that is a larger change and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
