### PR TITLE
fix(aws): stop one regional 500 from aborting the whole account sync

### DIFF
--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -15,6 +15,8 @@ import aioboto3
 import boto3
 import botocore.exceptions
 import neo4j
+from neo4j.exceptions import ServiceUnavailable as Neo4jServiceUnavailable
+from neo4j.exceptions import SessionExpired as Neo4jSessionExpired
 
 from cartography.analysis.aws.analysis import AWS_EC2_ASSET_EXPOSURE_AUTO_SCALING_GROUP
 from cartography.analysis.aws.analysis import AWS_EC2_ASSET_EXPOSURE_JOBS
@@ -97,6 +99,75 @@ def _build_aws_sync_kwargs(
         "update_tag": sync_tag,
         "common_job_parameters": common_job_parameters,
     }
+
+
+# Errors that mean the rest of the account cannot be synced either: the credentials are
+# gone, or Neo4j is unreachable. Isolating a single resource function's failure only helps
+# when the next resource function still has a chance of succeeding, and for these it does
+# not: every remaining module would fail the same way, each after up to 10 minutes of
+# backoff in aws_handle_regions.
+_FATAL_SYNC_EXCEPTIONS = (
+    botocore.exceptions.NoCredentialsError,
+    botocore.exceptions.PartialCredentialsError,
+    botocore.exceptions.CredentialRetrievalError,
+    botocore.exceptions.TokenRetrievalError,
+    botocore.exceptions.UnauthorizedSSOTokenError,
+    Neo4jServiceUnavailable,
+    Neo4jSessionExpired,
+)
+
+_FATAL_AWS_ERROR_CODES = {
+    "ExpiredToken",
+    "ExpiredTokenException",
+    "RequestExpired",
+}
+
+
+def _is_fatal_sync_error(e: Exception) -> bool:
+    """
+    Return True when an exception from one resource function dooms the whole account sync.
+    """
+    if isinstance(e, _FATAL_SYNC_EXCEPTIONS):
+        return True
+    if isinstance(e, botocore.exceptions.ClientError):
+        error_code = e.response.get("Error", {}).get("Code")
+        return error_code in _FATAL_AWS_ERROR_CODES
+    return False
+
+
+def _run_resource_function(
+    func_name: str,
+    call: Callable[[], Any],
+    failures: Dict[str, str],
+) -> None:
+    """
+    Run one AWS resource function, recording its failure instead of propagating it.
+
+    An unexpected error in a single intel module must not discard the rest of the account:
+    the modules that ran before it have already written to the graph, and the ones queued
+    after it are unrelated to it. Failures are collected in ``failures`` and re-raised as an
+    aggregate once the account is done, so the sync still reports them. Errors that make the
+    rest of the account pointless (see ``_is_fatal_sync_error``) still propagate immediately.
+    """
+    try:
+        call()
+    except Exception as e:
+        if _is_fatal_sync_error(e):
+            raise
+        timestamp = datetime.datetime.now()
+        traceback_string = "".join(
+            traceback.TracebackException.from_exception(e).format(),
+        )
+        failures[func_name] = (
+            f"{timestamp} - Exception in AWS resource function '{func_name}'\n{traceback_string}"
+        )
+        logger.error(
+            "Caught exception syncing AWS resource function '%s'. Continuing on to the remaining "
+            "resource functions for this account. All exceptions will be aggregated and re-raised "
+            "at the end of the account sync.",
+            func_name,
+            exc_info=True,
+        )
 
 
 def _sync_one_account(
@@ -185,6 +256,10 @@ def _sync_one_account(
                     f"Some relationships may not be created if the dependency data doesn't exist in Neo4j.",
                 )
 
+    # Failures are collected per resource function and re-raised as one exception at the end of
+    # the account so that a single failing module does not discard every module queued after it.
+    resource_function_failures: Dict[str, str] = {}
+
     # Iterate over RESOURCE_FUNCTIONS to preserve defined sync order (dependencies)
     # Skip modules not in the user's requested list
     for func_name in RESOURCE_FUNCTIONS:
@@ -197,27 +272,44 @@ def _sync_one_account(
                 aioboto3_session_factory = aioboto3_session_factory or aioboto3.Session
                 aioboto3_session = aioboto3_session_factory()
 
-            RESOURCE_FUNCTIONS[func_name](
-                neo4j_session,
-                aioboto3_session,
-                regions,
-                current_aws_account_id,
-                update_tag,
-                common_job_parameters,
-                aioboto3_session_factory=aioboto3_session_factory,
+            _run_resource_function(
+                func_name,
+                partial(
+                    RESOURCE_FUNCTIONS[func_name],
+                    neo4j_session,
+                    aioboto3_session,
+                    regions,
+                    current_aws_account_id,
+                    update_tag,
+                    common_job_parameters,
+                    aioboto3_session_factory=aioboto3_session_factory,
+                ),
+                resource_function_failures,
             )
         elif func_name in ["permission_relationships", "resourcegroupstaggingapi"]:
             continue
         else:
-            RESOURCE_FUNCTIONS[func_name](**sync_args)
+            _run_resource_function(
+                func_name,
+                partial(RESOURCE_FUNCTIONS[func_name], **sync_args),
+                resource_function_failures,
+            )
 
     # MAP IAM permissions
     if "permission_relationships" in aws_requested_syncs:
-        RESOURCE_FUNCTIONS["permission_relationships"](**sync_args)
+        _run_resource_function(
+            "permission_relationships",
+            partial(RESOURCE_FUNCTIONS["permission_relationships"], **sync_args),
+            resource_function_failures,
+        )
 
     # AWS Tags - Must always be last.
     if "resourcegroupstaggingapi" in aws_requested_syncs:
-        RESOURCE_FUNCTIONS["resourcegroupstaggingapi"](**sync_args)
+        _run_resource_function(
+            "resourcegroupstaggingapi",
+            partial(RESOURCE_FUNCTIONS["resourcegroupstaggingapi"], **sync_args),
+            resource_function_failures,
+        )
 
     run_typed_analysis_and_ensure_deps(
         AWS_EC2_IAM_INSTANCE_PROFILE,
@@ -250,6 +342,16 @@ def _sync_one_account(
         update_tag=update_tag,
         stat_handler=stat_handler,
     )
+
+    # Raise only now that everything else in the account has been written, so that the data
+    # collected by the resource functions that did succeed survives the failure of one module.
+    if resource_function_failures:
+        logger.error(
+            "AWS sync for account %s failed for resource function(s) %s",
+            current_aws_account_id,
+            sorted(resource_function_failures),
+        )
+        raise Exception("\n".join(resource_function_failures.values()))
 
 
 def _autodiscover_account_regions(

--- a/cartography/intel/aws/__init__.py
+++ b/cartography/intel/aws/__init__.py
@@ -311,10 +311,16 @@ def _sync_one_account(
             resource_function_failures,
         )
 
+    # An analysis derives relationships from what the resource functions just wrote, and it
+    # deletes the edges it no longer finds support for. A module that failed must therefore not
+    # count as a satisfied dependency: recomputing from its incomplete data would drop edges
+    # that the previous run had correctly created.
+    synced_syncs_set = requested_syncs_set - set(resource_function_failures)
+
     run_typed_analysis_and_ensure_deps(
         AWS_EC2_IAM_INSTANCE_PROFILE,
         AWS_EC2_IAM_INSTANCE_PROFILE_DEPS,
-        requested_syncs_set,
+        synced_syncs_set,
         common_job_parameters,
         neo4j_session,
     )
@@ -322,12 +328,12 @@ def _sync_one_account(
     run_typed_analysis_and_ensure_deps(
         AWS_LAMBDA_ECR,
         AWS_LAMBDA_ECR_DEPS,
-        requested_syncs_set,
+        synced_syncs_set,
         common_job_parameters,
         neo4j_session,
     )
 
-    if AWS_LB_NACL_DIRECT_DEPS.issubset(requested_syncs_set):
+    if AWS_LB_NACL_DIRECT_DEPS.issubset(synced_syncs_set):
         run_typed_analysis_job(
             AWS_LB_NACL_DIRECT,
             neo4j_session,

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -601,8 +601,26 @@ AWS_REGION_ACCESS_DENIED_ERROR_CODES = [
     "InvalidClientTokenId",
     "UnauthorizedOperation",
     "UnrecognizedClientException",
-    "InternalServerErrorException",
     "SubscriptionRequiredException",
+]
+
+# Server-side error codes. By the time one of these reaches us, botocore has already
+# exhausted its own retries and so has our backoff wrapper, so the region is simply not
+# answering. None of them is actionable per-region, and letting one escape aborts every
+# resource function left in the account sync, so we degrade to a regional skip instead.
+# AWS is not consistent about which spelling a service uses: bedrock-agent returns the
+# Smithy-standard InternalServerException while older services return
+# InternalServerErrorException or InternalFailure, so all the spellings are listed here.
+AWS_REGION_SERVER_ERROR_CODES = [
+    "InternalError",
+    "InternalFailure",
+    "InternalServerError",
+    "InternalServerErrorException",
+    "InternalServerException",
+    "ServerException",
+    "ServiceException",
+    "ServiceUnavailable",
+    "ServiceUnavailableException",
 ]
 
 AWS_REGION_UNSUPPORTED_OPERATION_SNIPPETS = (
@@ -631,7 +649,8 @@ def is_aws_region_skippable_client_error(
     error: botocore.exceptions.ClientError,
 ) -> bool:
     """
-    Return True when a ClientError indicates regional unavailability or regional access denial.
+    Return True when a ClientError indicates regional unavailability, regional access denial,
+    or a server-side failure that is not actionable per-region.
 
     This is the shared classification used by AWS sync code that needs to decide
     whether a regional failure should degrade to a regional skip instead of
@@ -645,6 +664,7 @@ def is_aws_region_skippable_client_error(
             error_message,
         )
         or error_code in AWS_REGION_ACCESS_DENIED_ERROR_CODES
+        or error_code in AWS_REGION_SERVER_ERROR_CODES
     )
 
 
@@ -685,7 +705,10 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
         - InvalidClientTokenId
         - UnauthorizedOperation
         - UnrecognizedClientException
-        - InternalServerErrorException
+        - SubscriptionRequiredException
+        - Server-side errors: InternalError, InternalFailure, InternalServerError,
+          InternalServerErrorException, InternalServerException, ServerException,
+          ServiceException, ServiceUnavailable, ServiceUnavailableException
 
         For these errors, a warning is logged and an empty list is returned.
         Other errors are re-raised normally.

--- a/cartography/util.py
+++ b/cartography/util.py
@@ -699,6 +699,7 @@ def aws_handle_regions(func: AWSGetFunc) -> AWSGetFunc:
 
     Note:
         The decorator handles these specific AWS error codes:
+
         - AccessDenied / AccessDeniedException
         - AuthFailure
         - AuthorizationError / AuthorizationErrorException

--- a/tests/integration/cartography/intel/aws/test_init.py
+++ b/tests/integration/cartography/intel/aws/test_init.py
@@ -1274,6 +1274,112 @@ def test_sync_one_account_uses_owned_ecr_session_factory(
     assert session_factory.call_count == 2
 
 
+def test_sync_one_account_isolates_resource_function_failures(
+    mocker,
+    neo4j_session,
+):
+    """
+    One failing intel module must not discard the modules queued after it: the failure is
+    recorded and re-raised once the rest of the account has been written.
+    """
+    # Arrange
+    first_sync = mock.MagicMock()
+    failing_sync = mock.MagicMock(
+        side_effect=botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "SomethingUnexpected",
+                    "Message": "this module is having a bad day",
+                },
+            },
+            "FakeOperation",
+        ),
+    )
+    later_sync = mock.MagicMock()
+    tags_sync = mock.MagicMock()
+    boto3_session = mock.MagicMock()
+    mocker.patch.object(cartography.intel.aws, "migrate_legacy_aws_labels")
+    mocker.patch.object(cartography.intel.aws, "run_typed_analysis_job")
+
+    # Act
+    with mock.patch.dict(
+        cartography.intel.aws.RESOURCE_FUNCTIONS,
+        {
+            "iam": first_sync,
+            "bedrock": failing_sync,
+            "s3": later_sync,
+            "resourcegroupstaggingapi": tags_sync,
+        },
+        clear=True,
+    ):
+        with raises(Exception, match="bedrock"):
+            cartography.intel.aws._sync_one_account(
+                neo4j_session,
+                boto3_session,
+                "111122223333",
+                TEST_UPDATE_TAG,
+                GRAPH_JOB_PARAMETERS,
+                regions=TEST_REGIONS,
+                aws_requested_syncs=[
+                    "iam",
+                    "bedrock",
+                    "s3",
+                    "resourcegroupstaggingapi",
+                ],
+            )
+
+    # Assert
+    assert first_sync.call_count == 1
+    assert later_sync.call_count == 1
+    assert tags_sync.call_count == 1
+
+
+def test_sync_one_account_aborts_on_expired_credentials(
+    mocker,
+    neo4j_session,
+):
+    """
+    Credential failures doom every remaining module, so they must abort the account
+    immediately instead of being collected like a per-module failure.
+    """
+    # Arrange
+    failing_sync = mock.MagicMock(
+        side_effect=botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": "ExpiredToken",
+                    "Message": "The security token included in the request is expired",
+                },
+            },
+            "FakeOperation",
+        ),
+    )
+    never_called_sync = mock.MagicMock()
+    boto3_session = mock.MagicMock()
+    mocker.patch.object(cartography.intel.aws, "migrate_legacy_aws_labels")
+    mocker.patch.object(cartography.intel.aws, "run_typed_analysis_job")
+
+    # Act
+    with mock.patch.dict(
+        cartography.intel.aws.RESOURCE_FUNCTIONS,
+        {"iam": failing_sync, "s3": never_called_sync},
+        clear=True,
+    ):
+        with raises(botocore.exceptions.ClientError):
+            cartography.intel.aws._sync_one_account(
+                neo4j_session,
+                boto3_session,
+                "111122223333",
+                TEST_UPDATE_TAG,
+                GRAPH_JOB_PARAMETERS,
+                regions=TEST_REGIONS,
+                aws_requested_syncs=["iam", "s3"],
+            )
+
+    # Assert
+    assert never_called_sync.call_count == 0
+
+
 @mock.patch("cartography.intel.aws.aioboto3.Session")
 @mock.patch("cartography.intel.aws.boto3.Session")
 @mock.patch.dict(

--- a/tests/unit/cartography/test_util.py
+++ b/tests/unit/cartography/test_util.py
@@ -256,6 +256,47 @@ def test_aws_handle_regions(mocker):
     assert raises_connect_timeout_error(1, 2) == []
 
 
+@pytest.mark.parametrize(
+    "error_code",
+    [
+        "InternalError",
+        "InternalFailure",
+        "InternalServerError",
+        "InternalServerErrorException",
+        "InternalServerException",
+        "ServerException",
+        "ServiceException",
+        "ServiceUnavailable",
+        "ServiceUnavailableException",
+    ],
+)
+@patch(
+    "cartography.util.backoff",
+    Mock(
+        on_exception=lambda *args, **kwargs: lambda func: func,
+    ),
+)
+def test_aws_handle_regions_skips_server_errors(error_code):
+    """
+    A server-side 5xx is not actionable per-region, so it must degrade to a regional skip
+    instead of aborting every resource function left in the account sync.
+    """
+
+    @aws_handle_regions
+    def raises_server_error(a, b):
+        raise botocore.exceptions.ClientError(
+            {
+                "Error": {
+                    "Code": error_code,
+                    "Message": "The server encountered an internal error while processing the request",
+                },
+            },
+            "FakeOperation",
+        )
+
+    assert raises_server_error(1, 2) == []
+
+
 def test_is_service_control_policy_explicit_deny():
     scp_error = botocore.exceptions.ClientError(
         {


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

A transient AWS-side 500 in one optional service currently discards a multi-hour AWS sync of everything else in the account. Two independent causes, one per commit.

**1. `aws_handle_regions` did not recognize the error code.**

The decorator is supposed to degrade a regional failure into a regional skip, but its allowlist only carried `InternalServerErrorException`. `bedrock-agent` returns the Smithy-standard `InternalServerException`, so `is_aws_region_skippable_client_error` returned `False`, the decorator re-raised, and the exception propagated out of `_sync_one_account`. This is not a case of calling an endpoint that does not exist: `bedrock/__init__.py` already filters regions through `filter_regions_to_supported_service_regions(...)`, the endpoint is in botocore's endpoint data and answers, it just answers 500.

```
botocore.errorfactory.InternalServerException: An error occurred (InternalServerException)
when calling the ListKnowledgeBases operation (reached max retries: 3)
```

The server-side codes move out of `AWS_REGION_ACCESS_DENIED_ERROR_CODES`, whose name never described them, into a new `AWS_REGION_SERVER_ERROR_CODES` covering the spellings AWS actually uses. None of them is actionable per-region, so a regional 500 now logs a warning and returns `[]`, exactly what the decorator already does for the other codes. `ServerException` and `ServiceException` are in the list for the same reason: `apigatewayv2.py` already classifies that exact set as server-side retryable, and leaving a synonym out just queues up the identical one-word bug from the next service.

**2. One intel module could take down the account.**

Even with the code above recognized, any unexpected exception from any single resource function still discarded the whole account. `_sync_one_account` iterated `RESOURCE_FUNCTIONS[func_name](**sync_args)` with no per-function isolation, so the blast radius of a bug or an AWS outage in one optional service was every other service in that account, and the work was lost late, after most of the account had already been enumerated.

Each resource function now runs through `_run_resource_function`, which records the failure and continues. The aggregate is raised once the account is done, after the analysis jobs and `merge_module_sync_metadata`, so the data that did land survives while the sync still reports the failure. Credential failures (`ExpiredToken`, `RequestExpired`, `NoCredentialsError`, SSO/token retrieval) and Neo4j `ServiceUnavailable` / `SessionExpired` still propagate immediately: isolating a module only helps when the next one can succeed, and for those it cannot, so without that escape hatch every remaining module would fail the same way, each after up to ten minutes of backoff in `aws_handle_regions`.


### Related issues or links

None filed; reported directly.


### Breaking changes

None, but two behavior changes are worth calling out in review:

- A regional 500 now returns `[]`, so that module's cleanup job deletes the region's nodes for that run. This is already what happens for `AccessDenied` and every other code in the skip set, and losing one region's nodes for one cycle beats losing the account, but it is data loss rather than a no-op.
- `merge_module_sync_metadata` now runs for an account where a module failed, so such an account gets sync metadata for a partial sync. Previously the exception escaped before that write.


### How was this tested?

New unit and integration tests, plus the existing suites:

- `tests/unit/cartography/test_util.py::test_aws_handle_regions_skips_server_errors`, parametrized over all nine server-side codes, asserts the decorator returns `[]` instead of re-raising.
- `tests/integration/cartography/intel/aws/test_init.py::test_sync_one_account_isolates_resource_function_failures` asserts the modules ordered after a failing one still run, including the tags pass that must always be last, and that the aggregate exception names the failing module.
- `tests/integration/cartography/intel/aws/test_init.py::test_sync_one_account_aborts_on_expired_credentials` asserts the fatal path short-circuits and the next module is never called.

```
uv run pytest tests/unit                                       5316 passed
uv run pytest tests/integration/cartography/intel/aws/test_init.py   35 passed
make test_lint                                                 passed
```


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.


### Notes for reviewers

The interesting design question is where the aggregate exception is raised. It is at the very end of `_sync_one_account`, after the analysis jobs run on whatever data did land, on the grounds that a partial graph plus a loud failure beats no graph at all. Raising before the analysis jobs instead would be a one-line move if reviewers prefer that.
