### PR TITLE
docs: clarify Socket.dev and Google Workspace authentication

### DIFF
--- a/docs/root/modules/googleworkspace/config.md
+++ b/docs/root/modules/googleworkspace/config.md
@@ -21,6 +21,13 @@
 
 ### OAuth
 
+Authorize the OAuth flow as a Google Workspace administrator that can read
+customer details, users, and user OAuth token metadata. A super administrator
+is the simplest choice for validating the setup. A personal Google account or
+a Workspace account without those privileges can complete OAuth consent but
+will receive `403 Not Authorized to access this resource/api` from the Admin
+Directory API.
+
 Use the following helper to complete the OAuth flow and obtain a refresh token:
 
 ```python

--- a/docs/root/modules/socketdev/config.md
+++ b/docs/root/modules/socketdev/config.md
@@ -8,10 +8,15 @@ Tokens](https://docs.socket.dev/docs/api-keys) for details.
 
 ## Required Permissions
 
-Cartography requires a Socket.dev API token with read access to the resources
-being ingested. Grant all read scopes, including the list and read scopes for
-repositories, alerts, and dependencies. Cartography does not require create,
-edit, or delete scopes.
+Cartography requires a Socket.dev API token with these org scopes:
+
+- `repo:list`
+- `alerts:list`
+- `fixes:list`
+
+Organization discovery and dependency search require authentication but no
+additional token scopes. Cartography does not require create, edit, or delete
+scopes.
 
 ## Configure Cartography
 


### PR DESCRIPTION
### Type of change

- [x] Documentation update

### Summary

Documents the exact Socket.dev scopes used by the module, including the previously omitted `fixes:list` scope. It also clarifies that Google Workspace OAuth must be authorized by an administrator with the Directory and security privileges used by the sync.

### Related issues or links

- [Socket.dev fixes API](https://docs.socket.dev/reference/fetch-fixes)

### How was this tested?

- `uv run ./docs/build.sh`

### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The relevant pre-commit checks pass locally.
- [x] Documentation was updated to match the provider API contract.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality

- [x] Built the documentation locally.

### Notes for reviewers

Documentation-only change; no connector behavior changed.