### PR TITLE
fix(okta): skip missing trusted origin scopes during transform

### DIFF
--- a/cartography/intel/okta/origins.py
+++ b/cartography/intel/okta/origins.py
@@ -70,17 +70,19 @@ def _transform_okta_origins(
         origin_props["origin"] = okta_origin.origin
         # Scopes have a specific type
         # currently supported are CORS, Redirect, and IFrame
-        for scope in okta_origin.scopes:
-            apps = []
-            for app in scope.allowed_okta_apps:
-                apps.append(app.value)
-            if scope.type.value == "CORS":
+        # The SDK declares scopes, their type and their allowed apps as optional,
+        # and the API only returns allowedOktaApps on IFRAME_EMBED scopes, so
+        # every level must be guarded to avoid aborting the whole sync.
+        for scope in okta_origin.scopes or []:
+            apps = [app.value for app in scope.allowed_okta_apps or []]
+            scope_type = scope.type.value if scope.type else None
+            if scope_type == "CORS":
                 origin_props["cors_allowed_okta_apps"] = apps
                 origin_props["cors_allowed"] = True
-            elif scope.type.value == "REDIRECT":
+            elif scope_type == "REDIRECT":
                 origin_props["redirect_allowed_okta_apps"] = apps
                 origin_props["redirect_allowed"] = True
-            elif scope.type.value == "IFRAME_EMBED":
+            elif scope_type == "IFRAME_EMBED":
                 origin_props["iframe_allowed_okta_apps"] = apps
                 origin_props["iframe_allowed"] = True
         origin_props["status"] = okta_origin.status

--- a/tests/data/okta/trustedorigin.py
+++ b/tests/data/okta/trustedorigin.py
@@ -1,3 +1,40 @@
+# The API only returns allowedOktaApps on IFRAME_EMBED scopes, and both the
+# scope list and the scope type are optional in the SDK model.
+TRUSTED_ORIGIN_WITH_SPARSE_SCOPES = """
+{
+    "id": "tos1sparsescope0g5",
+    "name": "Sparse Trusted Origin",
+    "origin": "https://sparse.example.com",
+    "scopes": [
+        {
+            "type": "IFRAME_EMBED",
+            "allowedOktaApps": ["OKTA_ENDUSER"]
+        },
+        {
+            "allowedOktaApps": ["OKTA_ENDUSER"]
+        }
+    ],
+    "status": "ACTIVE",
+    "created": "2018-01-13T01:22:10.000Z",
+    "createdBy": "00ut5t92p6IEOi4bu0ge3",
+    "lastUpdated": "2018-01-13T01:22:10.000Z",
+    "lastUpdatedBy": "00ut5t92p6IEOi4bu0g3"
+}
+"""
+
+TRUSTED_ORIGIN_WITHOUT_SCOPES = """
+{
+    "id": "tos1noscopes0000g6",
+    "name": "Trusted Origin Without Scopes",
+    "origin": "https://noscopes.example.com",
+    "status": "ACTIVE",
+    "created": "2018-01-13T01:22:10.000Z",
+    "createdBy": "00ut5t92p6IEOi4bu0ge3",
+    "lastUpdated": "2018-01-13T01:22:10.000Z",
+    "lastUpdatedBy": "00ut5t92p6IEOi4bu0g3"
+}
+"""
+
 LIST_TRUSTED_ORIGIN_RESPONSE = """
 [
     {

--- a/tests/unit/cartography/intel/okta/test_origins.py
+++ b/tests/unit/cartography/intel/okta/test_origins.py
@@ -1,0 +1,50 @@
+import json
+
+from okta.models.trusted_origin import TrustedOrigin
+
+from cartography.intel.okta import origins
+from tests.data.okta.trustedorigin import LIST_TRUSTED_ORIGIN_RESPONSE
+from tests.data.okta.trustedorigin import TRUSTED_ORIGIN_WITH_SPARSE_SCOPES
+from tests.data.okta.trustedorigin import TRUSTED_ORIGIN_WITHOUT_SCOPES
+
+
+def test_transform_handles_scopes_without_allowed_apps() -> None:
+    """
+    CORS and REDIRECT scopes come back without allowedOktaApps, which the SDK
+    models as None. That must not abort the sync.
+    """
+    # Arrange
+    okta_origins = [
+        TrustedOrigin.from_dict(item)
+        for item in json.loads(LIST_TRUSTED_ORIGIN_RESPONSE)
+    ]
+
+    # Act
+    result = origins._transform_okta_origins(okta_origins)
+
+    # Assert
+    assert result[0]["cors_allowed"] is True
+    assert result[0]["cors_allowed_okta_apps"] == []
+    assert result[1]["redirect_allowed"] is True
+    assert result[1]["redirect_allowed_okta_apps"] == []
+
+
+def test_transform_handles_sparse_and_missing_scopes() -> None:
+    """
+    An IFRAME_EMBED scope carries allowed apps, a scope can be missing its type,
+    and the scope list itself is optional.
+    """
+    # Arrange
+    okta_origins = [
+        TrustedOrigin.from_dict(json.loads(TRUSTED_ORIGIN_WITH_SPARSE_SCOPES)),
+        TrustedOrigin.from_dict(json.loads(TRUSTED_ORIGIN_WITHOUT_SCOPES)),
+    ]
+
+    # Act
+    result = origins._transform_okta_origins(okta_origins)
+
+    # Assert
+    assert result[0]["iframe_allowed"] is True
+    assert result[0]["iframe_allowed_okta_apps"] == ["OKTA_ENDUSER"]
+    assert result[1]["id"] == "tos1noscopes0000g6"
+    assert "iframe_allowed" not in result[1]


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

The Okta Trusted Origins API omits `allowedOktaApps` on CORS and REDIRECT scopes; that field is only present on `IFRAME_EMBED`. The SDK also models `scopes`, `scope.type`, and `scope.allowed_okta_apps` as optional. `_transform_okta_origins` iterated those fields directly, so a single origin without apps (the usual case) aborted the whole `okta` sync stage:

```
File "cartography/intel/okta/origins.py", line 75, in _transform_okta_origins
    for app in scope.allowed_okta_apps:
TypeError: 'NoneType' object is not iterable
```

This PR treats missing scopes, types, and allowed-app lists as empty, and skips a scope with no type instead of crashing. CORS, REDIRECT, and IFRAME flags are still set when those scopes are present.

### Related issues or links

None.


### How was this tested?

- Added `test_transform_handles_scopes_without_allowed_apps` (Okta sample CORS/REDIRECT payloads) and `test_transform_handles_sparse_and_missing_scopes` (IFRAME with apps, typeless scope, origin with no scopes) in `tests/unit/cartography/intel/okta/test_origins.py`.
- Confirmed both tests fail on `master` (`TypeError` / `AttributeError`) and pass with the fix.
- `uv run --frozen pytest tests/unit/cartography/intel/okta`: 19 passed.
- `pre-commit run --files` on the touched files: all hooks pass.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [x] Tested the connector against a real cloud, SaaS, or provider environment.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

The crash was observed on a real Okta tenant whose trusted origins include CORS/REDIRECT scopes without `allowedOktaApps`; the origin transform now completes over the same catalog.

#### If you are changing a node or relationship
Not applicable: no model or `PropertyRef` change, only the transform that populates existing properties.


### Notes for reviewers

This is the same class of bug as the application-transform guards: optional SDK fields that are `None` in real payloads, not missing attributes on the model class. The nested `scope.type` guard is extra coverage beyond the production stack, since a scope with apps but no type is also valid in the generated model.