### PR TITLE
fix(aws): skip unsupported Bedrock Agent region

### DIFF
--- a/cartography/intel/aws/bedrock/__init__.py
+++ b/cartography/intel/aws/bedrock/__init__.py
@@ -25,6 +25,11 @@ from . import provisioned_model_throughput
 
 logger = logging.getLogger(__name__)
 
+# The Bedrock control plane supports us-west-1, but the Bedrock Agents
+# build-time API used for agents and knowledge bases does not.
+# https://docs.aws.amazon.com/general/latest/gr/bedrock.html
+UNSUPPORTED_BEDROCK_AGENT_REGIONS = {"us-west-1"}
+
 
 @timeit
 def sync(
@@ -59,12 +64,18 @@ def sync(
             regions,
         )
     )
+    bedrock_agent_candidate_regions = [
+        region for region in regions if region not in UNSUPPORTED_BEDROCK_AGENT_REGIONS
+    ]
     bedrock_agent_regions, unsupported_bedrock_agent_regions = (
         filter_regions_to_supported_service_regions(
             boto3_session,
             "bedrock-agent",
-            regions,
+            bedrock_agent_candidate_regions,
         )
+    )
+    unsupported_bedrock_agent_regions.extend(
+        region for region in regions if region in UNSUPPORTED_BEDROCK_AGENT_REGIONS
     )
 
     if unsupported_bedrock_regions:

--- a/tests/unit/cartography/intel/aws/test_bedrock.py
+++ b/tests/unit/cartography/intel/aws/test_bedrock.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock
+
+from cartography.intel.aws import bedrock
+
+
+def test_sync_skips_us_west_1_for_bedrock_agent_apis(mocker):
+    # Arrange
+    boto3_session = MagicMock()
+    boto3_session.get_partition_for_region.return_value = "aws"
+    boto3_session.get_available_regions.side_effect = lambda service, **_: {
+        "bedrock": ["us-west-1", "us-west-2"],
+        "bedrock-agent": [],
+    }[service]
+    sync_mocks = {
+        module: mocker.patch.object(module, "sync")
+        for module in (
+            bedrock.agents,
+            bedrock.custom_models,
+            bedrock.foundation_models,
+            bedrock.guardrails,
+            bedrock.knowledge_bases,
+            bedrock.provisioned_model_throughput,
+        )
+    }
+    neo4j_session = MagicMock()
+    common_job_parameters = {
+        "UPDATE_TAG": 123,
+        "AWS_ID": "123456789012",
+    }
+
+    # Act
+    bedrock.sync(
+        neo4j_session=neo4j_session,
+        boto3_session=boto3_session,
+        regions=["us-west-1", "us-west-2"],
+        current_aws_account_id="123456789012",
+        update_tag=123,
+        common_job_parameters=common_job_parameters,
+    )
+
+    # Assert
+    sync_mocks[bedrock.foundation_models].assert_called_once_with(
+        neo4j_session,
+        boto3_session,
+        ["us-west-1", "us-west-2"],
+        "123456789012",
+        123,
+        common_job_parameters,
+    )
+    for module in (bedrock.knowledge_bases, bedrock.agents):
+        sync_mocks[module].assert_called_once_with(
+            neo4j_session,
+            boto3_session,
+            ["us-west-2"],
+            "123456789012",
+            123,
+            common_job_parameters,
+        )

--- a/tests/unit/cartography/intel/aws/test_bedrock.py
+++ b/tests/unit/cartography/intel/aws/test_bedrock.py
@@ -39,14 +39,20 @@ def test_sync_skips_us_west_1_for_bedrock_agent_apis(mocker):
     )
 
     # Assert
-    sync_mocks[bedrock.foundation_models].assert_called_once_with(
-        neo4j_session,
-        boto3_session,
-        ["us-west-1", "us-west-2"],
-        "123456789012",
-        123,
-        common_job_parameters,
-    )
+    for module in (
+        bedrock.custom_models,
+        bedrock.foundation_models,
+        bedrock.guardrails,
+        bedrock.provisioned_model_throughput,
+    ):
+        sync_mocks[module].assert_called_once_with(
+            neo4j_session,
+            boto3_session,
+            ["us-west-1", "us-west-2"],
+            "123456789012",
+            123,
+            common_job_parameters,
+        )
     for module in (bedrock.knowledge_bases, bedrock.agents):
         sync_mocks[module].assert_called_once_with(
             neo4j_session,


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

### Summary

The Amazon Bedrock control plane supports `us-west-1`, but the separate Bedrock Agents build-time API used for agents and knowledge bases does not. Botocore does not provide a supported-region list for `bedrock-agent`, so Cartography's existing service-region helper falls back to every requested region.

Exclude `us-west-1` only from Bedrock Agent and Knowledge Base syncs. Other Bedrock resources continue to sync in that region.

### Related issues or links

- [AWS Regions and endpoints for Amazon Bedrock](https://docs.aws.amazon.com/general/latest/gr/bedrock.html)

### How was this tested?

- Ran locally and all good 

The unit test reproduces botocore returning no region metadata for `bedrock-agent`. It verifies that agent and knowledge-base syncs skip `us-west-1` while ordinary Bedrock syncs continue to include it.

Sanitized read-only AWS verification:

```text
bedrock-agent ListKnowledgeBases, us-west-1: InternalServerException after SDK retries
bedrock-agent ListKnowledgeBases, us-west-2: request completed successfully
```

### Checklist

#### General

- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality

- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector

- [x] Tested the connector against a real cloud, SaaS, or provider environment.
- [x] Included sanitized provider results demonstrating the regional behavior above.

#### If you are changing a node or relationship

- [ ] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [ ] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module

- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).
