### PR TITLE
fix(okta): accept undeclared user factor statuses

### DIFF
--- a/cartography/intel/okta/common.py
+++ b/cartography/intel/okta/common.py
@@ -22,9 +22,43 @@ from okta.models.swa_application_settings import SwaApplicationSettings
 from okta.models.swa_application_settings_application import (
     SwaApplicationSettingsApplication,
 )
+from okta.models.user_factor import UserFactor
+from okta.models.user_factor_call import UserFactorCall
+from okta.models.user_factor_email import UserFactorEmail
+from okta.models.user_factor_push import UserFactorPush
+from okta.models.user_factor_security_question import UserFactorSecurityQuestion
+from okta.models.user_factor_signed_nonce import UserFactorSignedNonce
+from okta.models.user_factor_sms import UserFactorSMS
+from okta.models.user_factor_token import UserFactorToken
+from okta.models.user_factor_token_hardware import UserFactorTokenHardware
+from okta.models.user_factor_token_hotp import UserFactorTokenHOTP
+from okta.models.user_factor_token_software_totp import UserFactorTokenSoftwareTOTP
+from okta.models.user_factor_u2_f import UserFactorU2F
+from okta.models.user_factor_web import UserFactorWeb
+from okta.models.user_factor_web_authn import UserFactorWebAuthn
 from okta.pagination import PaginationHelper
 
 OKTA_RESOURCE_NOT_FOUND_ERROR_CODE = "E0000007"
+
+# UserFactor and every model the factorType discriminator can resolve to. Each
+# subclass owns its own copy of the inherited FieldInfo, so all of them must be
+# patched individually.
+_USER_FACTOR_MODELS = (
+    UserFactor,
+    UserFactorCall,
+    UserFactorEmail,
+    UserFactorPush,
+    UserFactorSecurityQuestion,
+    UserFactorSignedNonce,
+    UserFactorSMS,
+    UserFactorToken,
+    UserFactorTokenHardware,
+    UserFactorTokenHOTP,
+    UserFactorTokenSoftwareTOTP,
+    UserFactorU2F,
+    UserFactorWeb,
+    UserFactorWebAuthn,
+)
 
 
 def _make_fields_optional(model_cls: type[Any], *field_names: str) -> None:
@@ -33,6 +67,15 @@ def _make_fields_optional(model_cls: type[Any], *field_names: str) -> None:
         if field_info and field_info.is_required():
             field_info.default = None
             field_info.annotation = field_info.annotation | None
+    model_cls.model_rebuild(force=True)
+
+
+def _relax_enum_fields(model_cls: type[Any], *field_names: str) -> None:
+    """Retype optional enum fields as plain strings so unknown values are kept."""
+    for field_name in field_names:
+        field_info = model_cls.model_fields.get(field_name)
+        if field_info:
+            field_info.annotation = str | None
     model_cls.model_rebuild(force=True)
 
 
@@ -81,9 +124,19 @@ def _patch_okta_sdk_application_models() -> None:
         model_cls.model_rebuild(force=True)
 
 
+def _patch_okta_sdk_user_factor_models() -> None:
+    """Accept factor statuses returned by Okta but rejected by SDK 3.4.4."""
+    # Okta sets FULFILLMENT_PENDING and FULFILLMENT_ERRORED on WebAuthn
+    # preregistration factors, but UserFactorStatus only declares the seven
+    # lifecycle values, so a single such factor aborts the whole okta sync.
+    for model_cls in _USER_FACTOR_MODELS:
+        _relax_enum_fields(model_cls, "status")
+
+
 # DEPRECATED: Remove this Okta SDK 3.4.4 compatibility shim in v1.0.0 after
 # okta/okta-sdk-python#546 and #574 are released upstream.
 _patch_okta_sdk_application_models()
+_patch_okta_sdk_user_factor_models()
 
 
 class OktaApiError(RuntimeError):

--- a/tests/data/okta/userfactors.py
+++ b/tests/data/okta/userfactors.py
@@ -15,3 +15,31 @@ def create_test_factor():
     factor.last_updated = None
 
     return factor
+
+
+# Okta sets FULFILLMENT_PENDING / FULFILLMENT_ERRORED on WebAuthn preregistration
+# factors, but SDK 3.4.4 does not declare those values in UserFactorStatus.
+WEBAUTHN_FACTOR_WITH_FULFILLMENT_ERRORED_STATUS = {
+    "id": "fwf1prereg0Xy3Zq5d7",
+    "factorType": "webauthn",
+    "provider": "FIDO",
+    "vendorName": "FIDO",
+    "status": "FULFILLMENT_ERRORED",
+    "created": "2026-08-31T10:11:12.000Z",
+    "lastUpdated": "2026-09-01T13:14:15.000Z",
+    "profile": {
+        "credentialId": "credential-id-value",
+        "authenticatorName": "YubiKey 5 NFC",
+    },
+}
+
+SMS_FACTOR_WITH_ACTIVE_STATUS = {
+    "id": "sms1standard0Ab2Cd4",
+    "factorType": "sms",
+    "provider": "OKTA",
+    "vendorName": "OKTA",
+    "status": "ACTIVE",
+    "created": "2026-08-31T10:11:12.000Z",
+    "lastUpdated": "2026-09-01T13:14:15.000Z",
+    "profile": {"phoneNumber": "+15555550100"},
+}

--- a/tests/unit/cartography/intel/okta/test_common.py
+++ b/tests/unit/cartography/intel/okta/test_common.py
@@ -3,12 +3,15 @@ from copy import deepcopy
 from typing import Any
 
 from okta.models.application_json_converter import ApplicationJsonConverter
+from okta.models.user_factor import UserFactor
 
 import cartography.intel.okta.common  # noqa: F401
 from tests.data.okta.application import APPLICATION_WITH_REDITECT_URIS
 from tests.data.okta.application import BOOKMARK_APPLICATION_WITHOUT_URL
 from tests.data.okta.application import OIN_BROWSER_PLUGIN_APPLICATION
 from tests.data.okta.application import SAML_APPLICATION_WITH_UNKNOWN_FEATURE
+from tests.data.okta.userfactors import SMS_FACTOR_WITH_ACTIVE_STATUS
+from tests.data.okta.userfactors import WEBAUTHN_FACTOR_WITH_FULFILLMENT_ERRORED_STATUS
 
 
 def test_saml_application_accepts_omitted_optional_booleans() -> None:
@@ -85,3 +88,23 @@ def test_openid_connect_application_accepts_omitted_grant_types() -> None:
     assert application is not None
     assert application.id == "someid"
     assert application.settings.oauth_client.grant_types is None
+
+
+def test_user_factor_accepts_fulfillment_errored_status() -> None:
+    # Act
+    factor = UserFactor.from_dict(WEBAUTHN_FACTOR_WITH_FULFILLMENT_ERRORED_STATUS)
+
+    # Assert
+    assert factor is not None
+    assert factor.id == "fwf1prereg0Xy3Zq5d7"
+    assert factor.status == "FULFILLMENT_ERRORED"
+
+
+def test_user_factor_preserves_declared_status() -> None:
+    # Act
+    factor = UserFactor.from_dict(SMS_FACTOR_WITH_ACTIVE_STATUS)
+
+    # Assert
+    assert factor is not None
+    assert factor.id == "sms1standard0Ab2Cd4"
+    assert factor.status == "ACTIVE"


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

Okta sets `FULFILLMENT_PENDING` and `FULFILLMENT_ERRORED` on WebAuthn preregistration factors: the SDK documents the latter itself in `okta/api/web_authn_preregistration_api.py` ("the `/mark-error` path indicates that the specific `FULFILLMENT_ERRORED` AuthFactor status is set on the enrollment"). But the SDK 3.4.4 `UserFactorStatus` enum only declares the seven lifecycle values, so deserializing such a factor raises a pydantic `ValidationError` inside `list_factors` and aborts the whole `okta` sync stage:

```
File "cartography/intel/okta/factors.py", line 68, in _get_okta_user_factors
    factors, _, error = await okta_client.list_factors(user_id)
File "okta/models/user_factor_web_authn.py", line 120, in from_dict
    _obj = cls.model_validate(
ValidationError: 1 validation error for UserFactorWebAuthn
status
  Input should be 'ACTIVE', 'DISABLED', 'ENROLLED', 'EXPIRED', 'INACTIVE', 'NOT_SETUP' or 'PENDING_ACTIVATION' [type=enum, input_value='FULFILLMENT_ERRORED', input_type=str]
```

This PR extends the existing Okta SDK compatibility shim in `common.py` to retype `status` as a plain string on `UserFactor` and on every model the `factorType` discriminator can resolve to. Each subclass owns its own copy of the inherited `FieldInfo`, so patching the base class alone is not enough, hence the explicit list.

Graph values are unchanged for declared statuses: `UserFactorStatus` already derived from `str`, so the transform wrote the same string. Unknown statuses are now stored verbatim instead of crashing the sync.

`factor_type` does not need the same treatment: its enum matches the discriminator map exactly, and an unknown `factorType` raises a `ValueError` from the SDK before pydantic validation runs.

### Related issues or links

None.


### How was this tested?

- Added `test_user_factor_accepts_fulfillment_errored_status` and `test_user_factor_preserves_declared_status` in `tests/unit/cartography/intel/okta/test_common.py`, with matching WebAuthn and SMS payloads in `tests/data/okta/userfactors.py`.
- Confirmed the first test fails on `master` with the exact `ValidationError` above, and passes with the fix.
- `uv run --frozen pytest tests/unit/cartography/intel/okta`: 21 passed.
- `uv run --frozen pytest tests/unit`: 5319 passed.
- `pre-commit run --files` on the touched files: all hooks pass.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [x] Tested the connector against a real cloud, SaaS, or provider environment.
- [x] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

The crash was observed on a real Okta tenant holding WebAuthn preregistration factors in `FULFILLMENT_ERRORED`; the factors stage now completes over the same user set.

#### If you are changing a node or relationship
Not applicable: no model or `PropertyRef` change. The `OktaUserFactor.status` property already stored the raw status string.


### Notes for reviewers

Same class of bug as the application-model patches already in `common.py`: response shapes that Okta returns and the generated SDK models reject. The shim stays grouped under the existing `DEPRECATED` marker so it is removed with the rest when the SDK catches up.
