### PR TITLE
Ttsujimoto/digitalocean firewall

### DIFF
--- a/cartography/intel/digitalocean/__init__.py
+++ b/cartography/intel/digitalocean/__init__.py
@@ -5,6 +5,7 @@ from pydo import Client
 
 from cartography.config import Config
 from cartography.intel.digitalocean import compute
+from cartography.intel.digitalocean import firewall
 from cartography.intel.digitalocean import management
 from cartography.intel.digitalocean import platform
 from cartography.util import timeit
@@ -52,6 +53,14 @@ def start_digitalocean_ingestion(neo4j_session: neo4j.Session, config: Config) -
         client,
         account_id,
         projects_resources,
+        config.update_tag,
+        common_job_parameters,
+    )
+
+    firewall.sync(
+        neo4j_session,
+        client,
+        account_id,
         config.update_tag,
         common_job_parameters,
     )

--- a/cartography/intel/digitalocean/firewall.py
+++ b/cartography/intel/digitalocean/firewall.py
@@ -1,0 +1,269 @@
+import hashlib
+import json
+import logging
+from typing import Any
+
+import neo4j
+from pydo import Client
+
+from cartography.client.core.tx import load
+from cartography.client.core.tx import run_write_query
+from cartography.graph.job import GraphJob
+from cartography.intel.digitalocean.util.pagination import get_paginated_list
+from cartography.models.digitalocean.firewall import DOFirewallSchema
+from cartography.models.digitalocean.firewall_rule import DOFirewallRuleSchema
+from cartography.models.digitalocean.ip_range import DOIpRangeSchema
+from cartography.util import timeit
+
+logger = logging.getLogger(__name__)
+
+
+@timeit
+def sync(
+    neo4j_session: neo4j.Session,
+    client: Client,
+    account_id: str,
+    update_tag: int,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    """
+    Sync DigitalOcean Cloud Firewalls to Neo4j.
+
+    Droplets must be loaded before this function runs so the PROTECTS
+    relationships can be created.
+    """
+    logger.info("Syncing DigitalOcean Firewalls")
+
+    firewalls_res = get_firewalls(client)
+    firewalls, firewall_rules, ip_ranges = transform_firewalls(firewalls_res)
+
+    load_firewalls(
+        neo4j_session,
+        firewalls,
+        account_id,
+        update_tag,
+    )
+    load_ip_ranges(
+        neo4j_session,
+        ip_ranges,
+        account_id,
+        update_tag,
+    )
+    load_firewall_rules(
+        neo4j_session,
+        firewall_rules,
+        account_id,
+        update_tag,
+    )
+    cleanup(neo4j_session, common_job_parameters)
+
+
+@timeit
+def get_firewalls(client: Client) -> list[dict[str, Any]]:
+    """Fetch all firewalls from the DigitalOcean API."""
+    return get_paginated_list(client.firewalls.list, "firewalls")
+
+
+@timeit
+def transform_firewalls(
+    firewalls_res: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """
+    Shape API responses for DOFirewallSchema.
+
+    Separates firewall resources from their inbound and outbound rules.
+    """
+    firewalls: list[dict[str, Any]] = []
+    firewall_rules: list[dict[str, Any]] = []
+    ip_ranges: list[dict[str, Any]] = []
+
+    for firewall in firewalls_res:
+        firewalls.append(
+            {
+                "id": firewall["id"],
+                "name": firewall.get("name"),
+                "status": firewall.get("status"),
+                "created_at": firewall.get("created_at"),
+                "tags": firewall.get("tags"),
+                "pending_changes": firewall.get("pending_changes"),
+                "droplet_ids": firewall.get("droplet_ids"),
+            },
+        )
+
+        for direction, rules in (
+            ("inbound", firewall.get("inbound_rules", [])),
+            ("outbound", firewall.get("outbound_rules", [])),
+        ):
+            transformed_rules, transformed_ranges = _transform_firewall_rules(
+                firewall["id"], direction, rules
+            )
+            firewall_rules.extend(transformed_rules)
+            ip_ranges.extend(transformed_ranges)
+
+    return firewalls, firewall_rules, ip_ranges
+
+
+def _transform_firewall_rules(
+    firewall_id: str,
+    direction: str,
+    rules: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    selector_key = "sources" if direction == "inbound" else "destinations"
+    transformed_rules: list[dict[str, Any]] = []
+    ip_ranges: list[dict[str, Any]] = []
+    ip_range_ids: set[str] = set()
+
+    for rule in rules:
+        selectors = rule.get(selector_key, {})
+        protocol = rule["protocol"]
+        ports = rule.get("ports")
+        fromport, toport = _parse_port_range(protocol, ports)
+        canonical_rule = {
+            "direction": direction,
+            "protocol": protocol,
+            "ports": ports,
+            "action": rule.get("action"),
+            "selectors": _canonicalize_selectors(selectors),
+        }
+        serialized_rule = json.dumps(
+            canonical_rule,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+        # Use a hash of the serialized rule to create a unique ID for the rule.
+        rule_hash = hashlib.sha256(serialized_rule.encode()).hexdigest()[:16]
+        ip_range_raw = selectors.get("addresses", [])
+
+        for address in ip_range_raw:
+            if address not in ip_range_ids:
+                ip_ranges.append({
+                    "id": address,
+                    "range": address,
+                })
+                ip_range_ids.add(address)        
+
+        transformed_rules.append(
+            {
+                "id": f"{firewall_id}/{rule_hash}",
+                "firewall_id": firewall_id,
+                "direction": direction,
+                "protocol": protocol,
+                "ports": ports,
+                "fromport": fromport,
+                "toport": toport,
+                "action": rule.get("action"),
+                "source_addresses": ip_range_raw if direction == "inbound" else None,
+                "destination_addresses": ip_range_raw if direction == "outbound" else None,
+                "source_tags": selectors.get("tags") if direction == "inbound" else None,
+                "destination_tags": selectors.get("tags") if direction == "outbound" else None,
+                "source_droplet_ids": selectors.get("droplet_ids") if direction == "inbound" else None,
+                "destination_droplet_ids": selectors.get("droplet_ids") if direction == "outbound" else None,
+                "source_load_balancer_uids": selectors.get("load_balancer_uids") if direction == "inbound" else None,
+                "destination_load_balancer_uids": selectors.get("load_balancer_uids") if direction == "outbound" else None,
+                "source_kubernetes_ids": selectors.get("kubernetes_ids") if direction == "inbound" else None,
+                "destination_kubernetes_ids": selectors.get("kubernetes_ids") if direction == "outbound" else None,
+            },
+        )
+
+    return transformed_rules, ip_ranges
+
+
+def _parse_port_range(
+    protocol: str,
+    ports: str | None,
+) -> tuple[int | None, int | None]:
+    """Normalize a DigitalOcean port string into inclusive numeric bounds."""
+    if protocol not in {"tcp", "udp"}:
+        return None, None
+
+    if ports == "0":
+        # DigitalOcean uses "0" to mean every TCP or UDP port.
+        return 0, 65535
+
+    if ports is None:
+        return None, None
+
+    if "-" in ports:
+        fromport, toport = ports.split("-", maxsplit=1)
+        return int(fromport), int(toport)
+
+    port = int(ports)
+    return port, port
+
+
+def _canonicalize_selectors(selectors: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: sorted(value, key=str) if isinstance(value, list) else value
+        for key, value in selectors.items()
+    }
+
+
+@timeit
+def load_firewalls(
+    neo4j_session: neo4j.Session,
+    firewalls: list[dict[str, Any]],
+    account_id: str,
+    update_tag: int,
+) -> None:
+    """Load firewalls and their account/Droplet relationships."""
+    load(
+        neo4j_session,
+        DOFirewallSchema(),
+        firewalls,
+        lastupdated=update_tag,
+        ACCOUNT_ID=str(account_id),
+    )
+
+
+@timeit
+def load_firewall_rules(
+    neo4j_session: neo4j.Session,
+    firewall_rules: list[dict[str, Any]],
+    account_id: str,
+    update_tag: int,
+) -> None:
+    """Load DigitalOcean firewall rules and their parent relationships."""
+    load(
+        neo4j_session,
+        DOFirewallRuleSchema(),
+        firewall_rules,
+        lastupdated=update_tag,
+        ACCOUNT_ID=str(account_id),
+    )
+
+
+@timeit
+def load_ip_ranges(
+    neo4j_session: neo4j.Session,
+    ip_ranges: list[dict[str, Any]],
+    account_id: str,
+    update_tag: int,
+) -> None:
+    """Load IP address and CIDR selectors before their firewall-rule edges."""
+    load(
+        neo4j_session,
+        DOIpRangeSchema(),
+        ip_ranges,
+        lastupdated=update_tag,
+        ACCOUNT_ID=str(account_id),
+    )
+
+@timeit
+def cleanup(
+    neo4j_session: neo4j.Session,
+    common_job_parameters: dict[str, Any],
+) -> None:
+    """Remove stale account-scoped firewall data."""
+    GraphJob.from_node_schema(
+        DOFirewallSchema(),
+        common_job_parameters,
+    ).run(neo4j_session)
+    GraphJob.from_node_schema(
+        DOFirewallRuleSchema(),
+        common_job_parameters,
+    ).run(neo4j_session)
+    GraphJob.from_node_schema(
+        DOIpRangeSchema(),
+        common_job_parameters,
+    ).run(neo4j_session)

--- a/cartography/intel/digitalocean/firewall.py
+++ b/cartography/intel/digitalocean/firewall.py
@@ -89,12 +89,13 @@ def transform_firewalls(
             },
         )
 
+        ip_range_ids: set[str] = set()
         for direction, rules in (
             ("inbound", firewall.get("inbound_rules", [])),
             ("outbound", firewall.get("outbound_rules", [])),
         ):
             transformed_rules, transformed_ranges = _transform_firewall_rules(
-                firewall["id"], direction, rules
+                firewall["id"], direction, rules, ip_range_ids
             )
             firewall_rules.extend(transformed_rules)
             ip_ranges.extend(transformed_ranges)
@@ -106,11 +107,11 @@ def _transform_firewall_rules(
     firewall_id: str,
     direction: str,
     rules: list[dict[str, Any]],
+    ip_range_ids: set[str],
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     selector_key = "sources" if direction == "inbound" else "destinations"
     transformed_rules: list[dict[str, Any]] = []
     ip_ranges: list[dict[str, Any]] = []
-    ip_range_ids: set[str] = set()
 
     for rule in rules:
         selectors = rule.get(selector_key, {})

--- a/cartography/intel/digitalocean/firewall.py
+++ b/cartography/intel/digitalocean/firewall.py
@@ -129,6 +129,7 @@ def _transform_firewall_rules(
             separators=(",", ":"),
             sort_keys=True,
         )
+        canonical_name = f"IpRule-{direction}-{protocol}-{rule.get('action')}-{ports}"
 
         # Use a hash of the serialized rule to create a unique ID for the rule.
         rule_hash = hashlib.sha256(serialized_rule.encode()).hexdigest()[:16]
@@ -147,6 +148,7 @@ def _transform_firewall_rules(
         transformed_rules.append(
             {
                 "id": f"{firewall_id}/{rule_hash}",
+                "canonical_name": canonical_name,
                 "firewall_id": firewall_id,
                 "direction": direction,
                 "protocol": protocol,

--- a/cartography/intel/digitalocean/firewall.py
+++ b/cartography/intel/digitalocean/firewall.py
@@ -7,7 +7,6 @@ import neo4j
 from pydo import Client
 
 from cartography.client.core.tx import load
-from cartography.client.core.tx import run_write_query
 from cartography.graph.job import GraphJob
 from cartography.intel.digitalocean.util.pagination import get_paginated_list
 from cartography.models.digitalocean.firewall import DOFirewallSchema
@@ -137,11 +136,13 @@ def _transform_firewall_rules(
 
         for address in ip_range_raw:
             if address not in ip_range_ids:
-                ip_ranges.append({
-                    "id": address,
-                    "range": address,
-                })
-                ip_range_ids.add(address)        
+                ip_ranges.append(
+                    {
+                        "id": address,
+                        "range": address,
+                    }
+                )
+                ip_range_ids.add(address)
 
         transformed_rules.append(
             {
@@ -154,15 +155,37 @@ def _transform_firewall_rules(
                 "toport": toport,
                 "action": rule.get("action"),
                 "source_addresses": ip_range_raw if direction == "inbound" else None,
-                "destination_addresses": ip_range_raw if direction == "outbound" else None,
-                "source_tags": selectors.get("tags") if direction == "inbound" else None,
-                "destination_tags": selectors.get("tags") if direction == "outbound" else None,
-                "source_droplet_ids": selectors.get("droplet_ids") if direction == "inbound" else None,
-                "destination_droplet_ids": selectors.get("droplet_ids") if direction == "outbound" else None,
-                "source_load_balancer_uids": selectors.get("load_balancer_uids") if direction == "inbound" else None,
-                "destination_load_balancer_uids": selectors.get("load_balancer_uids") if direction == "outbound" else None,
-                "source_kubernetes_ids": selectors.get("kubernetes_ids") if direction == "inbound" else None,
-                "destination_kubernetes_ids": selectors.get("kubernetes_ids") if direction == "outbound" else None,
+                "destination_addresses": (
+                    ip_range_raw if direction == "outbound" else None
+                ),
+                "source_tags": (
+                    selectors.get("tags") if direction == "inbound" else None
+                ),
+                "destination_tags": (
+                    selectors.get("tags") if direction == "outbound" else None
+                ),
+                "source_droplet_ids": (
+                    selectors.get("droplet_ids") if direction == "inbound" else None
+                ),
+                "destination_droplet_ids": (
+                    selectors.get("droplet_ids") if direction == "outbound" else None
+                ),
+                "source_load_balancer_uids": (
+                    selectors.get("load_balancer_uids")
+                    if direction == "inbound"
+                    else None
+                ),
+                "destination_load_balancer_uids": (
+                    selectors.get("load_balancer_uids")
+                    if direction == "outbound"
+                    else None
+                ),
+                "source_kubernetes_ids": (
+                    selectors.get("kubernetes_ids") if direction == "inbound" else None
+                ),
+                "destination_kubernetes_ids": (
+                    selectors.get("kubernetes_ids") if direction == "outbound" else None
+                ),
             },
         )
 
@@ -248,6 +271,7 @@ def load_ip_ranges(
         lastupdated=update_tag,
         ACCOUNT_ID=str(account_id),
     )
+
 
 @timeit
 def cleanup(

--- a/cartography/models/digitalocean/firewall.py
+++ b/cartography/models/digitalocean/firewall.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import (
+    CartographyNodeProperties,
+    CartographyNodeSchema,
+    ExtraNodeLabels,
+)
+from cartography.models.core.relationships import (
+    CartographyRelProperties,
+    CartographyRelSchema,
+    LinkDirection,
+    OtherRelationships,
+    TargetNodeMatcher,
+    make_target_node_matcher,
+)
+from cartography.models.ontology.labels import NETWORK_ACCESS_CONTROL
+
+
+@dataclass(frozen=True)
+class DOFirewallProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id",
+        description="DigitalOcean firewall UUID.",
+    )
+    lastupdated: PropertyRef = PropertyRef(
+        "lastupdated",
+        set_in_kwargs=True,
+    )
+    name: PropertyRef = PropertyRef(
+        "name",
+        description="Firewall name.",
+    )
+    status: PropertyRef = PropertyRef(
+        "status",
+        description="Firewall operation status.",
+    )
+    created_at: PropertyRef = PropertyRef(
+        "created_at",
+        description="ISO 8601 timestamp when the firewall was created.",
+    )
+    tags: PropertyRef = PropertyRef(
+        "tags",
+        description="Tags assigned to the firewall.",
+    )
+    pending_changes: PropertyRef = PropertyRef(
+        "pending_changes",
+        description="Pending firewall changes reported by DigitalOcean.",
+    )
+    droplet_ids: PropertyRef = PropertyRef(
+        "droplet_ids",
+        description="IDs of Droplets protected by this firewall.",
+    )
+
+
+@dataclass(frozen=True)
+class DOFirewallToAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef(
+        "lastupdated",
+        set_in_kwargs=True,
+    )
+
+
+@dataclass(frozen=True)
+class DOFirewallToAccountRel(CartographyRelSchema):
+    """A DigitalOcean account contains the firewall as a resource."""
+
+    target_node_label: str = "DOAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ACCOUNT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DOFirewallToAccountRelProperties = DOFirewallToAccountRelProperties()
+
+
+@dataclass(frozen=True)
+class DOFirewallToDropletRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef(
+        "lastupdated",
+        set_in_kwargs=True,
+    )
+
+
+@dataclass(frozen=True)
+class DOFirewallToDropletRel(CartographyRelSchema):
+    """A DigitalOcean firewall protects one or more Droplets."""
+
+    target_node_label: str = "DODroplet"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("droplet_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "PROTECTS"
+    properties: DOFirewallToDropletRelProperties = DOFirewallToDropletRelProperties()
+
+
+@dataclass(frozen=True)
+class DOFirewallSchema(CartographyNodeSchema):
+    """A DigitalOcean Cloud Firewall that controls Droplet network access."""
+
+    label: str = "DOFirewall"
+    properties: DOFirewallProperties = DOFirewallProperties()
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        [NETWORK_ACCESS_CONTROL],
+    )
+    sub_resource_relationship: DOFirewallToAccountRel = DOFirewallToAccountRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [DOFirewallToDropletRel()],
+    )

--- a/cartography/models/digitalocean/firewall.py
+++ b/cartography/models/digitalocean/firewall.py
@@ -1,19 +1,15 @@
 from dataclasses import dataclass
 
 from cartography.models.core.common import PropertyRef
-from cartography.models.core.nodes import (
-    CartographyNodeProperties,
-    CartographyNodeSchema,
-    ExtraNodeLabels,
-)
-from cartography.models.core.relationships import (
-    CartographyRelProperties,
-    CartographyRelSchema,
-    LinkDirection,
-    OtherRelationships,
-    TargetNodeMatcher,
-    make_target_node_matcher,
-)
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
 from cartography.models.ontology.labels import NETWORK_ACCESS_CONTROL
 
 

--- a/cartography/models/digitalocean/firewall_rule.py
+++ b/cartography/models/digitalocean/firewall_rule.py
@@ -55,14 +55,6 @@ class DOFirewallRuleProperties(CartographyNodeProperties):
         "action",
         description="Firewall action applied when the rule matches.",
     )
-    source_addresses: PropertyRef = PropertyRef(
-        "source_addresses",
-        description="Provider-scoped IP-range selector IDs for an inbound rule.",
-    )
-    destination_addresses: PropertyRef = PropertyRef(
-        "destination_addresses",
-        description="Provider-scoped IP-range selector IDs for an outbound rule.",
-    )
     source_tags: PropertyRef = PropertyRef(
         "source_tags",
         description="DigitalOcean tags selected by an inbound rule.",
@@ -70,14 +62,6 @@ class DOFirewallRuleProperties(CartographyNodeProperties):
     destination_tags: PropertyRef = PropertyRef(
         "destination_tags",
         description="DigitalOcean tags selected by an outbound rule.",
-    )
-    source_droplet_ids: PropertyRef = PropertyRef(
-        "source_droplet_ids",
-        description="Droplet IDs selected by an inbound rule.",
-    )
-    destination_droplet_ids: PropertyRef = PropertyRef(
-        "destination_droplet_ids",
-        description="Droplet IDs selected by an outbound rule.",
     )
     source_load_balancer_uids: PropertyRef = PropertyRef(
         "source_load_balancer_uids",

--- a/cartography/models/digitalocean/firewall_rule.py
+++ b/cartography/models/digitalocean/firewall_rule.py
@@ -1,0 +1,229 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import (
+    CartographyNodeProperties,
+    CartographyNodeSchema,
+    ExtraNodeLabels,
+)
+from cartography.models.core.relationships import (
+    CartographyRelProperties,
+    CartographyRelSchema,
+    LinkDirection,
+    OtherRelationships,
+    TargetNodeMatcher,
+    make_target_node_matcher,
+)
+from cartography.models.extra_labels import (
+    IP_PERMISSION_EGRESS,
+    IP_PERMISSION_INBOUND,
+    IP_RULE,
+)
+
+
+@dataclass(frozen=True)
+class DOFirewallRuleProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id",
+        description="Stable, deterministic identifier for the firewall rule.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    firewall_id: PropertyRef = PropertyRef(
+        "firewall_id",
+        extra_index=True,
+        description="UUID of the firewall containing this rule.",
+    )
+    direction: PropertyRef = PropertyRef(
+        "direction",
+        description="Traffic direction: inbound or outbound.",
+    )
+    protocol: PropertyRef = PropertyRef(
+        "protocol",
+        description="Network protocol matched by the rule.",
+    )
+    ports: PropertyRef = PropertyRef(
+        "ports",
+        description="Port or inclusive port range matched by the rule.",
+    )
+    fromport: PropertyRef = PropertyRef(
+        "fromport",
+        description="Lowest transport-layer port matched by the rule.",
+    )
+    toport: PropertyRef = PropertyRef(
+        "toport",
+        description="Highest transport-layer port matched by the rule.",
+    )
+    action: PropertyRef = PropertyRef(
+        "action",
+        description="Firewall action applied when the rule matches.",
+    )
+    source_addresses: PropertyRef = PropertyRef(
+        "source_addresses",
+        description="Provider-scoped IP-range selector IDs for an inbound rule.",
+    )
+    destination_addresses: PropertyRef = PropertyRef(
+        "destination_addresses",
+        description="Provider-scoped IP-range selector IDs for an outbound rule.",
+    )
+    source_tags: PropertyRef = PropertyRef(
+        "source_tags",
+        description="DigitalOcean tags selected by an inbound rule.",
+    )
+    destination_tags: PropertyRef = PropertyRef(
+        "destination_tags",
+        description="DigitalOcean tags selected by an outbound rule.",
+    )
+    source_droplet_ids: PropertyRef = PropertyRef(
+        "source_droplet_ids",
+        description="Droplet IDs selected by an inbound rule.",
+    )
+    destination_droplet_ids: PropertyRef = PropertyRef(
+        "destination_droplet_ids",
+        description="Droplet IDs selected by an outbound rule.",
+    )
+    source_load_balancer_uids: PropertyRef = PropertyRef(
+        "source_load_balancer_uids",
+        description="Load-balancer UUIDs selected by an inbound rule.",
+    )
+    destination_load_balancer_uids: PropertyRef = PropertyRef(
+        "destination_load_balancer_uids",
+        description="Load-balancer UUIDs selected by an outbound rule.",
+    )
+    source_kubernetes_ids: PropertyRef = PropertyRef(
+        "source_kubernetes_ids",
+        description="Kubernetes-cluster IDs selected by an inbound rule.",
+    )
+    destination_kubernetes_ids: PropertyRef = PropertyRef(
+        "destination_kubernetes_ids",
+        description="Kubernetes-cluster IDs selected by an outbound rule.",
+    )
+
+
+@dataclass(frozen=True)
+class DOFirewallRuleToAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DOFirewallRuleToAccountRel(CartographyRelSchema):
+    """A DigitalOcean account contains the firewall rule as a resource."""
+
+    target_node_label: str = "DOAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ACCOUNT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DOFirewallRuleToAccountRelProperties = (
+        DOFirewallRuleToAccountRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DOFirewallRuleToFirewallRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DOFirewallRuleToFirewallRel(CartographyRelSchema):
+    """A firewall rule belongs to a DigitalOcean firewall."""
+
+    target_node_label: str = "DOFirewall"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("firewall_id")},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "MEMBER_OF_DO_FIREWALL"
+    properties: DOFirewallRuleToFirewallRelProperties = (
+        DOFirewallRuleToFirewallRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DOFirewallRuleSelectorRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DOFirewallRuleToSourceIpRangeRel(CartographyRelSchema):
+    """An inbound rule selects one or more IP ranges as traffic sources."""
+
+    target_node_label: str = "DOIpRange"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("source_addresses", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_SOURCE"
+    properties: DOFirewallRuleSelectorRelProperties = (
+        DOFirewallRuleSelectorRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DOFirewallRuleToDestinationIpRangeRel(CartographyRelSchema):
+    """An outbound rule selects one or more IP ranges as traffic destinations."""
+
+    target_node_label: str = "DOIpRange"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("destination_addresses", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_DESTINATION"
+    properties: DOFirewallRuleSelectorRelProperties = (
+        DOFirewallRuleSelectorRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DOFirewallRuleToSourceDropletRel(CartographyRelSchema):
+    """An inbound rule selects one or more Droplets as traffic sources."""
+
+    target_node_label: str = "DODroplet"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("source_droplet_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_SOURCE"
+    properties: DOFirewallRuleSelectorRelProperties = (
+        DOFirewallRuleSelectorRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DOFirewallRuleToDestinationDropletRel(CartographyRelSchema):
+    """An outbound rule selects one or more Droplets as traffic destinations."""
+
+    target_node_label: str = "DODroplet"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("destination_droplet_ids", one_to_many=True)},
+    )
+    direction: LinkDirection = LinkDirection.OUTWARD
+    rel_label: str = "HAS_DESTINATION"
+    properties: DOFirewallRuleSelectorRelProperties = (
+        DOFirewallRuleSelectorRelProperties()
+    )
+
+
+@dataclass(frozen=True)
+class DOFirewallRuleSchema(CartographyNodeSchema):
+    """A directional traffic rule configured on a DigitalOcean Cloud Firewall."""
+
+    label: str = "DOFirewallRule"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels(
+        [
+            IP_RULE,
+            IP_PERMISSION_INBOUND.when(direction="inbound"),
+            IP_PERMISSION_EGRESS.when(direction="outbound"),
+        ],
+    )
+    properties: DOFirewallRuleProperties = DOFirewallRuleProperties()
+    sub_resource_relationship: DOFirewallRuleToAccountRel = DOFirewallRuleToAccountRel()
+    other_relationships: OtherRelationships = OtherRelationships(
+        [
+            DOFirewallRuleToFirewallRel(),
+            DOFirewallRuleToSourceIpRangeRel(),
+            DOFirewallRuleToDestinationIpRangeRel(),
+            DOFirewallRuleToSourceDropletRel(),
+            DOFirewallRuleToDestinationDropletRel(),
+        ],
+    )

--- a/cartography/models/digitalocean/firewall_rule.py
+++ b/cartography/models/digitalocean/firewall_rule.py
@@ -1,24 +1,18 @@
 from dataclasses import dataclass
 
 from cartography.models.core.common import PropertyRef
-from cartography.models.core.nodes import (
-    CartographyNodeProperties,
-    CartographyNodeSchema,
-    ExtraNodeLabels,
-)
-from cartography.models.core.relationships import (
-    CartographyRelProperties,
-    CartographyRelSchema,
-    LinkDirection,
-    OtherRelationships,
-    TargetNodeMatcher,
-    make_target_node_matcher,
-)
-from cartography.models.extra_labels import (
-    IP_PERMISSION_EGRESS,
-    IP_PERMISSION_INBOUND,
-    IP_RULE,
-)
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import OtherRelationships
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.extra_labels import IP_PERMISSION_EGRESS
+from cartography.models.extra_labels import IP_PERMISSION_INBOUND
+from cartography.models.extra_labels import IP_RULE
 
 
 @dataclass(frozen=True)

--- a/cartography/models/digitalocean/firewall_rule.py
+++ b/cartography/models/digitalocean/firewall_rule.py
@@ -22,6 +22,10 @@ class DOFirewallRuleProperties(CartographyNodeProperties):
         description="Stable, deterministic identifier for the firewall rule.",
     )
     lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    canonical_name: PropertyRef = PropertyRef(
+        "canonical_name",
+        description="Canonical name for the firewall rule, derived from its properties.",
+    )
     firewall_id: PropertyRef = PropertyRef(
         "firewall_id",
         extra_index=True,

--- a/cartography/models/digitalocean/ip_range.py
+++ b/cartography/models/digitalocean/ip_range.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+
+from cartography.models.core.common import PropertyRef
+from cartography.models.core.nodes import CartographyNodeProperties
+from cartography.models.core.nodes import CartographyNodeSchema
+from cartography.models.core.nodes import ExtraNodeLabels
+from cartography.models.core.relationships import CartographyRelProperties
+from cartography.models.core.relationships import CartographyRelSchema
+from cartography.models.core.relationships import LinkDirection
+from cartography.models.core.relationships import TargetNodeMatcher
+from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.extra_labels import IP_RANGE
+
+
+@dataclass(frozen=True)
+class DOIpRangeProperties(CartographyNodeProperties):
+    id: PropertyRef = PropertyRef(
+        "id",
+        description="IP address or CIDR used as the identifier for this selector.",
+    )
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+    range: PropertyRef = PropertyRef(
+        "range",
+        extra_index=True,
+        description="IP address or CIDR selected by a DigitalOcean firewall rule.",
+    )
+
+
+@dataclass(frozen=True)
+class DOIpRangeToAccountRelProperties(CartographyRelProperties):
+    lastupdated: PropertyRef = PropertyRef("lastupdated", set_in_kwargs=True)
+
+
+@dataclass(frozen=True)
+class DOIpRangeToAccountRel(CartographyRelSchema):
+    """A DigitalOcean account contains the IP range selector as a resource."""
+
+    target_node_label: str = "DOAccount"
+    target_node_matcher: TargetNodeMatcher = make_target_node_matcher(
+        {"id": PropertyRef("ACCOUNT_ID", set_in_kwargs=True)},
+    )
+    direction: LinkDirection = LinkDirection.INWARD
+    rel_label: str = "RESOURCE"
+    properties: DOIpRangeToAccountRelProperties = DOIpRangeToAccountRelProperties()
+
+
+@dataclass(frozen=True)
+class DOIpRangeSchema(CartographyNodeSchema):
+    """An IP address or CIDR selector used by a DigitalOcean firewall rule."""
+
+    label: str = "DOIpRange"
+    extra_node_labels: ExtraNodeLabels = ExtraNodeLabels([IP_RANGE])
+    properties: DOIpRangeProperties = DOIpRangeProperties()
+    sub_resource_relationship: DOIpRangeToAccountRel = DOIpRangeToAccountRel()

--- a/cartography/models/digitalocean/ip_range.py
+++ b/cartography/models/digitalocean/ip_range.py
@@ -7,8 +7,8 @@ from cartography.models.core.nodes import ExtraNodeLabels
 from cartography.models.core.relationships import CartographyRelProperties
 from cartography.models.core.relationships import CartographyRelSchema
 from cartography.models.core.relationships import LinkDirection
-from cartography.models.core.relationships import TargetNodeMatcher
 from cartography.models.core.relationships import make_target_node_matcher
+from cartography.models.core.relationships import TargetNodeMatcher
 from cartography.models.extra_labels import IP_RANGE
 
 

--- a/cartography/models/ontology/mapping/data/firewalls.py
+++ b/cartography/models/ontology/mapping/data/firewalls.py
@@ -140,6 +140,25 @@ snowflake_mapping = OntologyMapping(
     ],
 )
 
+# DigitalOcean
+digitalocean_mapping = OntologyMapping(
+    module_name="digitalocean",
+    nodes=[
+        OntologyNodeMapping(
+            node_label="DOFirewall",
+            fields=[
+                OntologyFieldMapping(
+                    ontology_field="name",
+                    node_field="name",
+                    required=True,
+                ),
+                # DigitalOcean firewalls contain both inbound and outbound
+                # rules, so direction belongs on individual rule nodes.
+            ],
+        ),
+    ],
+)
+
 FIREWALLS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "aws": aws_mapping,
     "gcp": gcp_mapping,
@@ -147,4 +166,5 @@ FIREWALLS_ONTOLOGY_MAPPING: dict[str, OntologyMapping] = {
     "databricks": databricks_mapping,
     "cloudflare": cloudflare_mapping,
     "snowflake": snowflake_mapping,
+    "digitalocean": digitalocean_mapping,
 }

--- a/demo/seeds/digitalocean.py
+++ b/demo/seeds/digitalocean.py
@@ -2,8 +2,10 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import cartography.intel.digitalocean.compute
+import cartography.intel.digitalocean.firewall
 import cartography.intel.digitalocean.management
 import tests.data.digitalocean.compute
+import tests.data.digitalocean.firewall
 import tests.data.digitalocean.management
 import tests.data.digitalocean.platform
 from demo.seeds.base import Seed
@@ -34,9 +36,13 @@ class DigitalOceanSeed(Seed):
         mock_client.projects.list_resources.return_value = (
             tests.data.digitalocean.management.PROJECT_RESOURCES_RESPONSE
         )
+        mock_client.firewalls.list.return_value = (
+            tests.data.digitalocean.firewall.FIREWALLS_RESPONSE
+        )
         self._seed_platform(mock_client)
         self._seed_management(mock_client)
         self._seed_compute(mock_client)
+        self._seed_firewall(mock_client)
 
     def _seed_platform(self, mock_client) -> None:
         cartography.intel.digitalocean.platform.sync(
@@ -67,6 +73,18 @@ class DigitalOceanSeed(Seed):
                     }
                 ],
             },
+            self.update_tag,
+            {
+                "UPDATE_TAG": self.update_tag,
+                "ACCOUNT_ID": ACCOUNT_ID,
+            },
+        )
+
+    def _seed_firewall(self, mock_client) -> None:
+        cartography.intel.digitalocean.firewall.sync(
+            self.neo4j_session,
+            mock_client,
+            ACCOUNT_ID,
             self.update_tag,
             {
                 "UPDATE_TAG": self.update_tag,

--- a/tests/data/digitalocean/firewall.py
+++ b/tests/data/digitalocean/firewall.py
@@ -1,0 +1,48 @@
+from typing import Any
+
+
+FIREWALLS_RESPONSE: dict[str, Any] = {
+    "firewalls": [
+        {
+            "id": "9321bbf2-6ca7-4944-b060-866226df3771",
+            "name": "Test Firewall",
+            "status": "succeeded",
+            "inbound_rules": [
+                {
+                    "protocol": "icmp",
+                    "ports": "0",
+                    "sources": {"addresses": ["1.2.3.4"]},
+                    "action": "allow",
+                },
+                {
+                    "protocol": "tcp",
+                    "ports": "1-64293",
+                    "sources": {
+                        "addresses": ["::/0", "0.0.0.0/0"],
+                        "tags": ["frontend"],
+                        "droplet_ids": [568030246],
+                    },
+                    "action": "allow",
+                },
+            ],
+            "outbound_rules": [
+                {
+                    "protocol": "tcp",
+                    "ports": "0",
+                    "destinations": {
+                        "addresses": ["0.0.0.0/0", "::/0"],
+                        "load_balancer_uids": ["test-load-balancer-uuid"],
+                        "droplet_ids": [568030246],
+                    },
+                    "action": "allow",
+                },
+            ],
+            "created_at": "2026-04-29T20:58:31Z",
+            "droplet_ids": [568030246],
+            "tags": [],
+            "pending_changes": [],
+        },
+    ],
+    "links": {},
+    "meta": {"total": 1},
+}

--- a/tests/data/digitalocean/firewall.py
+++ b/tests/data/digitalocean/firewall.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-
 FIREWALLS_RESPONSE: dict[str, Any] = {
     "firewalls": [
         {

--- a/tests/integration/cartography/intel/digitalocean/test_firewall.py
+++ b/tests/integration/cartography/intel/digitalocean/test_firewall.py
@@ -1,0 +1,201 @@
+from unittest.mock import MagicMock
+
+import cartography.intel.digitalocean.compute
+import cartography.intel.digitalocean.firewall
+import cartography.intel.digitalocean.management
+import cartography.intel.digitalocean.platform
+import tests.data.digitalocean.compute
+import tests.data.digitalocean.firewall
+import tests.data.digitalocean.management
+import tests.data.digitalocean.platform
+from tests.integration.util import check_nodes
+from tests.integration.util import check_rels
+
+TEST_ACCOUNT_ID = "test-account-uuid"
+TEST_PROJECT_ID = "test-project-uuid"
+TEST_UPDATE_TAG = 123456789
+
+
+def _load_prerequisites(neo4j_session):
+    account = cartography.intel.digitalocean.platform.transform_account(
+        tests.data.digitalocean.platform.ACCOUNT_RESPONSE["account"],
+    )
+    cartography.intel.digitalocean.platform.load_account(
+        neo4j_session,
+        [account],
+        TEST_UPDATE_TAG,
+    )
+
+    projects = cartography.intel.digitalocean.management.transform_projects(
+        tests.data.digitalocean.management.PROJECTS_RESPONSE["projects"],
+    )
+    cartography.intel.digitalocean.management.load_projects(
+        neo4j_session,
+        projects,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+    )
+
+    droplets = cartography.intel.digitalocean.compute.transform_droplets(
+        tests.data.digitalocean.compute.DROPLETS_RESPONSE["droplets"],
+        TEST_ACCOUNT_ID,
+        {
+            TEST_PROJECT_ID: [
+                {"urn": "do:droplet:568030246"},
+            ],
+        },
+    )
+    cartography.intel.digitalocean.compute.load_droplets(
+        neo4j_session,
+        TEST_ACCOUNT_ID,
+        droplets,
+        TEST_UPDATE_TAG,
+    )
+
+
+def test_sync_firewalls_with_rules(neo4j_session):
+    _load_prerequisites(neo4j_session)
+    mock_client = MagicMock()
+    mock_client.firewalls.list.return_value = (
+        tests.data.digitalocean.firewall.FIREWALLS_RESPONSE
+    )
+
+    cartography.intel.digitalocean.firewall.sync(
+        neo4j_session,
+        mock_client,
+        TEST_ACCOUNT_ID,
+        TEST_UPDATE_TAG,
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "ACCOUNT_ID": TEST_ACCOUNT_ID},
+    )
+
+    firewall_id = "9321bbf2-6ca7-4944-b060-866226df3771"
+    _, firewall_rules, ip_ranges = (
+        cartography.intel.digitalocean.firewall.transform_firewalls(
+            tests.data.digitalocean.firewall.FIREWALLS_RESPONSE["firewalls"],
+        )
+    )
+    rule_ids = {rule["id"] for rule in firewall_rules}
+
+    assert check_nodes(neo4j_session, "DOFirewall", ["id", "name"]) == {
+        (firewall_id, "Test Firewall"),
+    }
+    assert (
+        check_nodes(
+            neo4j_session,
+            "DOFirewallRule",
+            [
+                "id",
+                "firewall_id",
+                "direction",
+                "protocol",
+                "ports",
+                "fromport",
+                "toport",
+                "action",
+            ],
+        )
+        == {
+            (
+                rule["id"],
+                firewall_id,
+                rule["direction"],
+                rule["protocol"],
+                rule["ports"],
+                rule["fromport"],
+                rule["toport"],
+                "allow",
+            )
+            for rule in firewall_rules
+        }
+    )
+    assert check_rels(
+        neo4j_session,
+        "DOFirewallRule",
+        "id",
+        "DOFirewall",
+        "id",
+        "MEMBER_OF_DO_FIREWALL",
+    ) == {(rule_id, firewall_id) for rule_id in rule_ids}
+    assert check_rels(
+        neo4j_session,
+        "DOFirewall",
+        "id",
+        "DODroplet",
+        "id",
+        "PROTECTS",
+    ) == {(firewall_id, 568030246)}
+
+    assert check_nodes(neo4j_session, "DOIpRange", ["id", "range"]) == {
+        (ip_range["id"], ip_range["range"]) for ip_range in ip_ranges
+    }
+    assert check_rels(
+        neo4j_session,
+        "DOFirewallRule",
+        "id",
+        "DOIpRange",
+        "id",
+        "HAS_SOURCE",
+    ) == {
+        (rule["id"], ip_range_id)
+        for rule in firewall_rules
+        for ip_range_id in rule.get("source_addresses") or []
+    }
+    assert check_rels(
+        neo4j_session,
+        "DOFirewallRule",
+        "id",
+        "DOIpRange",
+        "id",
+        "HAS_DESTINATION",
+    ) == {
+        (rule["id"], ip_range_id)
+        for rule in firewall_rules
+        for ip_range_id in rule.get("destination_addresses") or []
+    }
+    assert check_rels(
+        neo4j_session,
+        "DOFirewallRule",
+        "id",
+        "DODroplet",
+        "id",
+        "HAS_SOURCE",
+    ) == {
+        (rule["id"], droplet_id)
+        for rule in firewall_rules
+        for droplet_id in rule.get("source_droplet_ids") or []
+    }
+    assert check_rels(
+        neo4j_session,
+        "DOFirewallRule",
+        "id",
+        "DODroplet",
+        "id",
+        "HAS_DESTINATION",
+    ) == {
+        (rule["id"], droplet_id)
+        for rule in firewall_rules
+        for droplet_id in rule.get("destination_droplet_ids") or []
+    }
+
+    outbound_rule = next(
+        rule for rule in firewall_rules if rule["direction"] == "outbound"
+    )
+    result = neo4j_session.run(
+        "MATCH (r:DOFirewallRule {id: $rule_id}) "
+        "RETURN r.destination_addresses AS destination_addresses, "
+        "r.destination_load_balancer_uids AS destination_load_balancer_uids, "
+        "r.addresses AS deprecated_addresses, "
+        "r.load_balancer_uids AS deprecated_load_balancer_uids",
+        rule_id=outbound_rule["id"],
+    ).single()
+    assert result["destination_addresses"] == [
+        "0.0.0.0/0",
+        "::/0",
+    ]
+    assert result["destination_load_balancer_uids"] == ["test-load-balancer-uuid"]
+    assert result["deprecated_addresses"] is None
+    assert result["deprecated_load_balancer_uids"] is None
+
+    icmp_rule = next(rule for rule in firewall_rules if rule["protocol"] == "icmp")
+    assert icmp_rule["fromport"] is None
+    assert icmp_rule["toport"] is None

--- a/tests/integration/cartography/intel/digitalocean/test_firewall.py
+++ b/tests/integration/cartography/intel/digitalocean/test_firewall.py
@@ -122,9 +122,25 @@ def test_sync_firewalls_with_rules(neo4j_session):
         "PROTECTS",
     ) == {(firewall_id, 568030246)}
 
-    assert check_nodes(neo4j_session, "DOIpRange", ["id", "range"]) == {
-        (ip_range["id"], ip_range["range"]) for ip_range in ip_ranges
+    expected_ip_ranges = {
+        (address, address)
+        for firewall in tests.data.digitalocean.firewall.FIREWALLS_RESPONSE["firewalls"]
+        for rules, selector_key in (
+            (firewall.get("inbound_rules", []), "sources"),
+            (firewall.get("outbound_rules", []), "destinations"),
+        )
+        for rule in rules
+        for address in rule.get(selector_key, {}).get("addresses", [])
     }
+    assert (
+        check_nodes(
+            neo4j_session,
+            "DOIpRange",
+            ["id", "range"],
+        )
+        == expected_ip_ranges
+    )
+    assert len(ip_ranges) == len(expected_ip_ranges)
     assert check_rels(
         neo4j_session,
         "DOFirewallRule",
@@ -177,18 +193,25 @@ def test_sync_firewalls_with_rules(neo4j_session):
     outbound_rule = next(
         rule for rule in firewall_rules if rule["direction"] == "outbound"
     )
+    selector_property_count = neo4j_session.run(
+        "MATCH (r:DOFirewallRule) "
+        "RETURN count(r.source_addresses) AS source_addresses, "
+        "count(r.destination_addresses) AS destination_addresses, "
+        "count(r.source_droplet_ids) AS source_droplet_ids, "
+        "count(r.destination_droplet_ids) AS destination_droplet_ids",
+    ).single()
+    assert selector_property_count["source_addresses"] == 0
+    assert selector_property_count["destination_addresses"] == 0
+    assert selector_property_count["source_droplet_ids"] == 0
+    assert selector_property_count["destination_droplet_ids"] == 0
+
     result = neo4j_session.run(
         "MATCH (r:DOFirewallRule {id: $rule_id}) "
-        "RETURN r.destination_addresses AS destination_addresses, "
-        "r.destination_load_balancer_uids AS destination_load_balancer_uids, "
+        "RETURN r.destination_load_balancer_uids AS destination_load_balancer_uids, "
         "r.addresses AS deprecated_addresses, "
         "r.load_balancer_uids AS deprecated_load_balancer_uids",
         rule_id=outbound_rule["id"],
     ).single()
-    assert result["destination_addresses"] == [
-        "0.0.0.0/0",
-        "::/0",
-    ]
     assert result["destination_load_balancer_uids"] == ["test-load-balancer-uuid"]
     assert result["deprecated_addresses"] is None
     assert result["deprecated_load_balancer_uids"] is None

--- a/tests/integration/cartography/intel/digitalocean/test_firewall.py
+++ b/tests/integration/cartography/intel/digitalocean/test_firewall.py
@@ -79,35 +79,32 @@ def test_sync_firewalls_with_rules(neo4j_session):
     assert check_nodes(neo4j_session, "DOFirewall", ["id", "name"]) == {
         (firewall_id, "Test Firewall"),
     }
-    assert (
-        check_nodes(
-            neo4j_session,
-            "DOFirewallRule",
-            [
-                "id",
-                "firewall_id",
-                "direction",
-                "protocol",
-                "ports",
-                "fromport",
-                "toport",
-                "action",
-            ],
+    assert check_nodes(
+        neo4j_session,
+        "DOFirewallRule",
+        [
+            "id",
+            "firewall_id",
+            "direction",
+            "protocol",
+            "ports",
+            "fromport",
+            "toport",
+            "action",
+        ],
+    ) == {
+        (
+            rule["id"],
+            firewall_id,
+            rule["direction"],
+            rule["protocol"],
+            rule["ports"],
+            rule["fromport"],
+            rule["toport"],
+            "allow",
         )
-        == {
-            (
-                rule["id"],
-                firewall_id,
-                rule["direction"],
-                rule["protocol"],
-                rule["ports"],
-                rule["fromport"],
-                rule["toport"],
-                "allow",
-            )
-            for rule in firewall_rules
-        }
-    )
+        for rule in firewall_rules
+    }
     assert check_rels(
         neo4j_session,
         "DOFirewallRule",


### PR DESCRIPTION
### Type of change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary
Added support for DigitalOcean firewall visualization.


### Related issues or links
No Issue

- Fixes #


### Breaking changes
No Breaking Change


### How was this tested?
- Integration Test Added
- Lint Test
- Tested with a real DigitalOcean account containing a firewall.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

Screenshots:
<img width="3812" height="1445" alt="Do-Firewall-All" src="https://github.com/user-attachments/assets/7542f5ee-c8c8-4793-85b4-b3874155813b" />
<img width="2707" height="1454" alt="DO-IpRange" src="https://github.com/user-attachments/assets/35ff6b3c-434c-4b5c-831d-305915bb4391" />
<img width="3043" height="1510" alt="DO-IpRule-Outbound" src="https://github.com/user-attachments/assets/e5e346ce-c153-49f6-9cd9-e56e82c76010" />
<img width="2882" height="1457" alt="DO-IpRule-Inbound" src="https://github.com/user-attachments/assets/804f45e7-501a-44bc-9c81-47798efdd87e" />
<img width="3814" height="1457" alt="DO-Firewall" src="https://github.com/user-attachments/assets/7d0abbe5-b271-4e87-afb2-f2b58a6918f5" />
<img width="1987" height="1234" alt="DO-with-firewall" src="https://github.com/user-attachments/assets/6cb744aa-cb83-4fe2-80a2-f8f7541da6fb" />
<img width="3795" height="1537" alt="DO-Doc" src="https://github.com/user-attachments/assets/9964e9d7-1c7e-4925-8b3b-101dd96e3f7d" />


#### If you are adding or modifying an intel connector
- [ ] Tested the connector against a real cloud, SaaS, or provider environment.
- [ ] Included sanitized Cartography sync logs demonstrating successful synchronization of the new/modified connector behavior. Logs should show:
  - The sync job starting and completing without errors
  - The number of nodes/relationships created or updated
  - Example:
    ```
    INFO:cartography.intel.aws.ec2:Loading 42 EC2 instances for region us-east-1
    INFO:cartography.intel.aws.ec2:Synced EC2 instances in 3.21 seconds
    ```
- [ ] Removed credentials, personal data, account identifiers, and other sensitive values from the evidence.

Connector pull requests without real-environment evidence are labeled `needs-tests`, are not reviewed, and may be closed after 30 days.

#### If you are changing a node or relationship
- [x] Updated model docstrings and `PropertyRef.description` values used to generate schema documentation.
- [x] Built the documentation with `uv run ./docs/build.sh`.

#### If you are implementing a new intel module
- [ ] Used the NodeSchema [data model](https://docs.cartography.dev/dev/writing-intel-modules.html#defining-a-node).


### Notes for reviewers
- A DigitalOcean firewall's parent is an account, and droplets in different projects can use it.  
- I tried to follow the AWS/GCP implementation to break down the firewall rule into the IpRule node and IpRange node for better querying. 
- A firewall rule contains "direction" that maps to outbound and inbound traffic, and there will be no separate model for each direction, but the rule node contains "direction" and IpPermissionInbound or IpPermissionEgress labels.
- A firewall rule can contain several sources (for inbound) or destinations (for egress), such as IPs, Droplet IDs, tags, and more. This implementation supports showing relationships for IPs (IpRange node) and Droplets for now.
