### PR TITLE
fix(aws): recover from expired STS credentials in ECR image layer sync

### DIFF
--- a/cartography/intel/aws/ecr_image_layers.py
+++ b/cartography/intel/aws/ecr_image_layers.py
@@ -98,6 +98,17 @@ RETRYABLE_ECR_ERROR_CODES = {
     "ThrottlingException",
     "TooManyRequestsException",
 }
+# Error codes that mean the current credentials can no longer sign requests. Retrying
+# against the same session is pointless, but minting a fresh session can recover: STS
+# temporary credentials report expiry as ExpiredTokenException (ExpiredToken on some
+# services), SigV4 clock skew reports RequestExpired, and InvalidClientTokenId means the
+# access key ID itself is no longer recognized.
+CREDENTIAL_REFRESH_ERROR_CODES = {
+    "ExpiredToken",
+    "ExpiredTokenException",
+    "InvalidClientTokenId",
+    "RequestExpired",
+}
 RETRYABLE_HTTPX_EXCEPTIONS = (
     httpx.ConnectError,
     httpx.PoolTimeout,
@@ -1559,12 +1570,14 @@ def sync(
                     error_code = error.response.get("Error", {}).get("Code")
                     if (
                         attempt == 1
-                        or error_code != "InvalidClientTokenId"
+                        or error_code not in CREDENTIAL_REFRESH_ERROR_CODES
                         or aioboto3_session_factory is None
                     ):
                         raise
                     logger.warning(
-                        "Retrying ECR image layer sync with a fresh AWS credential chain after temporary credential refresh failed.",
+                        "Retrying ECR image layer sync in region %s with a fresh AWS credential chain after credential error %s.",
+                        region,
+                        error_code,
                     )
                     aioboto3_session = aioboto3_session_factory()
 

--- a/tests/unit/cartography/intel/aws/test_ecr_image_layers.py
+++ b/tests/unit/cartography/intel/aws/test_ecr_image_layers.py
@@ -1175,3 +1175,165 @@ def test_transform_ecr_image_layers_with_partial_history():
 def testextract_workflow_path_from_ref(workflow_ref, expected_path):
     """Test extracting workflow path from GitHub workflow ref."""
     assert extract_workflow_path_from_ref(workflow_ref) == expected_path
+
+
+def _credential_error(error_code: str) -> ClientError:
+    return ClientError(
+        {"Error": {"Code": error_code, "Message": "Synthetic credential error"}},
+        "GetDownloadUrlForLayer",
+    )
+
+
+def _stub_sync_dependencies(mocker, sessions_seen: list) -> None:
+    """
+    Neutralize everything sync() touches around the credential-retry loop so the tests
+    only exercise that loop.
+    """
+    mocker.patch.object(
+        ecr_layers,
+        "get_complete_layer_digests",
+        return_value=set(),
+    )
+    mocker.patch.object(
+        ecr_layers,
+        "partition_layer_fetches",
+        side_effect=lambda images, complete, digest_key: (images, []),
+    )
+    mocker.patch.object(ecr_layers, "refresh_layer_closures")
+    mocker.patch.object(
+        ecr_layers,
+        "transform_ecr_image_layers",
+        return_value=([], []),
+    )
+    mocker.patch.object(ecr_layers, "load_ecr_image_layers")
+    mocker.patch.object(ecr_layers, "load_ecr_image_layer_memberships")
+    mocker.patch.object(ecr_layers, "cleanup")
+
+    class _FakeClientContext:
+        def __init__(self, session):
+            sessions_seen.append(session)
+
+        async def __aenter__(self):
+            return AsyncMock()
+
+        async def __aexit__(self, *_args):
+            return False
+
+    mocker.patch.object(
+        ecr_layers,
+        "create_aioboto3_client",
+        side_effect=lambda session, _service, **_kwargs: _FakeClientContext(session),
+    )
+
+
+def _neo4j_session_with_one_image() -> MagicMock:
+    neo4j_session = MagicMock()
+    neo4j_session.execute_read.return_value = [
+        {
+            "digest": "sha256:aaa",
+            "uri": "1234.dkr.ecr.us-east-1.amazonaws.com/repo@sha256:aaa",
+            "repo_uri": "1234.dkr.ecr.us-east-1.amazonaws.com/repo",
+            "type": "image",
+        }
+    ]
+    return neo4j_session
+
+
+def _run_sync(neo4j_session, session_factory=None, initial_session="session-0"):
+    ecr_layers.sync(
+        neo4j_session,
+        initial_session,
+        ["us-east-1"],
+        "1234",
+        123456789,
+        {"UPDATE_TAG": 123456789, "AWS_ID": "1234"},
+        aioboto3_session_factory=session_factory,
+    )
+
+
+@pytest.mark.parametrize(
+    "error_code",
+    [
+        "ExpiredToken",
+        "ExpiredTokenException",
+        "InvalidClientTokenId",
+        "RequestExpired",
+    ],
+)
+def test_sync_retries_with_fresh_session_on_credential_error(mocker, error_code):
+    sessions_seen: list = []
+    _stub_sync_dependencies(mocker, sessions_seen)
+    fetch_mock = mocker.patch.object(
+        ecr_layers,
+        "fetch_image_layers_async",
+        side_effect=[
+            _credential_error(error_code),
+            ({}, {}, {}, {}, True),
+        ],
+    )
+    factory = MagicMock(return_value="session-refreshed")
+
+    _run_sync(_neo4j_session_with_one_image(), session_factory=factory)
+
+    assert fetch_mock.call_count == 2
+    factory.assert_called_once_with()
+    assert sessions_seen == ["session-0", "session-refreshed"]
+    # The region completed, so cleanup is allowed to delete stale layers.
+    assert ecr_layers.cleanup.call_args.kwargs["fetch_complete"] is True
+
+
+def test_sync_raises_when_credential_retry_budget_is_exhausted(mocker):
+    sessions_seen: list = []
+    _stub_sync_dependencies(mocker, sessions_seen)
+    fetch_mock = mocker.patch.object(
+        ecr_layers,
+        "fetch_image_layers_async",
+        side_effect=[
+            _credential_error("ExpiredTokenException"),
+            _credential_error("ExpiredTokenException"),
+        ],
+    )
+    factory = MagicMock(return_value="session-refreshed")
+
+    with pytest.raises(ClientError) as excinfo:
+        _run_sync(_neo4j_session_with_one_image(), session_factory=factory)
+
+    assert excinfo.value.response["Error"]["Code"] == "ExpiredTokenException"
+    assert fetch_mock.call_count == 2
+    factory.assert_called_once_with()
+    ecr_layers.cleanup.assert_not_called()
+
+
+def test_sync_raises_credential_error_when_no_session_factory(mocker):
+    sessions_seen: list = []
+    _stub_sync_dependencies(mocker, sessions_seen)
+    fetch_mock = mocker.patch.object(
+        ecr_layers,
+        "fetch_image_layers_async",
+        side_effect=_credential_error("ExpiredTokenException"),
+    )
+
+    with pytest.raises(ClientError) as excinfo:
+        _run_sync(_neo4j_session_with_one_image(), session_factory=None)
+
+    assert excinfo.value.response["Error"]["Code"] == "ExpiredTokenException"
+    assert fetch_mock.call_count == 1
+    ecr_layers.cleanup.assert_not_called()
+
+
+def test_sync_does_not_retry_non_credential_client_error(mocker):
+    sessions_seen: list = []
+    _stub_sync_dependencies(mocker, sessions_seen)
+    fetch_mock = mocker.patch.object(
+        ecr_layers,
+        "fetch_image_layers_async",
+        side_effect=_credential_error("AccessDeniedException"),
+    )
+    factory = MagicMock(return_value="session-refreshed")
+
+    with pytest.raises(ClientError) as excinfo:
+        _run_sync(_neo4j_session_with_one_image(), session_factory=factory)
+
+    assert excinfo.value.response["Error"]["Code"] == "AccessDeniedException"
+    assert fetch_mock.call_count == 1
+    factory.assert_not_called()


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):


### Summary

`cartography.intel.aws.ecr_image_layers.sync()` already has a credential-recovery path: on a credential error it mints a fresh `aioboto3.Session` from `aioboto3_session_factory` and retries the region. That guard only matched `InvalidClientTokenId`.

Expiring STS temporary credentials do not surface as `InvalidClientTokenId`. They surface as `ExpiredTokenException` (`ExpiredToken` on some services), and SigV4 clock skew surfaces as `RequestExpired`. None of those matched, so the `ClientError` propagated out of the module and `_sync_one_account` failed the **entire** account sync: every resource type ordered after `ecr_image_layers` was never synced and the account's data went stale.

This is deterministic, not flaky, for any account whose ECR layer fan-out outlives the credential lifetime. Layer fetching is among the slowest AWS modules, and the `sync()` docstring already warns it "can be slow for accounts with many container images", so the two conditions coincide by construction. It has been observed on both `GetDownloadUrlForLayer` and `BatchGetImage`, roughly 65 to 70 minutes into a run: a one hour STS session issued at the start of the account sync and never refreshed.

The failure is also easy to misread as an operator credential problem, because the module visibly contains recovery machinery for exactly this situation.

**Changes**

- New module-level `CREDENTIAL_REFRESH_ERROR_CODES` set next to `RETRYABLE_ECR_ERROR_CODES`, covering `ExpiredToken`, `ExpiredTokenException`, `RequestExpired` and the existing `InvalidClientTokenId`.
- The `sync()` guard now tests `not in CREDENTIAL_REFRESH_ERROR_CODES` instead of `!= "InvalidClientTokenId"`.
- The retry warning now names the region and the actual error code, so an expiry can be told apart from an unrecognized access key ID.

**What is intentionally unchanged**

- The per-call handler in `get_blob_json_via_presigned` is correct as-is. `RETRYABLE_ECR_ERROR_CODES` covers throttling and 5xx only; retrying an expired token against the same session would not help, so falling through to the terminal `raise` is right. The gap was only in the outer condition, which is the one place that can actually obtain new credentials.
- No expiry code was added to `AWS_REGION_ACCESS_DENIED_ERROR_CODES` in `cartography/util.py`. That list makes `aws_handle_regions` swallow the error and return an empty list; an expired token would then look like a region with no resources, and the delete-by-update-tag cleanup would prune live nodes that were merely never fetched. Credential expiry must either refresh or fail loudly, never degrade to an empty result.
- `for attempt in range(2)` (a single refresh per region) is left alone. The retry restarts the whole region fan-out, since `complete_digests` is computed before the loop and not recomputed between attempts. If a region's fan-out genuinely outlives the credential lifetime, a larger budget just burns 2x or 3x the API calls and still fails, so it cannot converge; it buys nothing and costs throttling headroom.

The durable fix is for the session to carry a refreshable credential provider so botocore renews before expiry and this path stays an edge case. That is a caller-side concern outside this module, and since `aioboto3_session_factory` is optional the module cannot assume it, so the recovery path is needed either way.


### Related issues or links

None.


### How was this tested?

New unit tests in `tests/unit/cartography/intel/aws/test_ecr_image_layers.py` drive `sync()` with a stub `aioboto3_session_factory` and a mocked async fetch:

- **Recovered path**, parametrized over all four codes (`ExpiredToken`, `ExpiredTokenException`, `InvalidClientTokenId`, `RequestExpired`): the factory is called once, the second attempt runs against the fresh session, and `cleanup` is reached with `fetch_complete=True`. The `InvalidClientTokenId` case pins the pre-existing behavior against regression.
- **Budget exhausted** (two consecutive expiries): re-raises `ExpiredTokenException`, `cleanup` never runs, so no partial or empty result is written.
- **No factory supplied**: raises on the first failure without retrying.
- **Non-credential error** (`AccessDeniedException`): no retry, factory never called.

These were confirmed to pin the new behavior by temporarily reverting the guard: 3 of the 4 parametrized cases plus the exhaustion test fail against the old condition.

```
uv run --frozen pytest tests/unit/cartography/intel/aws -q
348 passed
```

Lint is clean on both changed files.


### Checklist

#### General
- [x] I have read the [contributing guidelines](https://github.com/cartography-cncf/cartography/blob/master/CONTRIBUTING.md).
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO `Signed-off-by` trailer.

#### Proof of functionality
- [x] New or updated unit/integration tests.

#### If you are changing a node or relationship
No node or relationship schema changed, so no docs rebuild is needed.


### Notes for reviewers

The whole diff to the module is the constant plus a one-line condition change and a log message; the bulk of the diff is tests. Worth focusing on whether the code list is complete for your environments: `ExpiredToken` and `ExpiredTokenException` are both included because different AWS services report STS expiry differently, and `RequestExpired` covers SigV4 clock skew rather than expiry proper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
