### PR TITLE
fix(salesforce): skip inaccessible connected apps

### DIFF
--- a/cartography/intel/salesforce/connectedapps.py
+++ b/cartography/intel/salesforce/connectedapps.py
@@ -59,8 +59,8 @@ def sync(
             raise
         logger.warning(
             "Skipping Salesforce connected apps because required objects or setup "
-            "fields are unavailable to the integration user: %s",
-            exc,
+            "fields are unavailable to the integration user; preserving previously "
+            "synced connected app data",
         )
         return
     apps = transform(apps, tokens)

--- a/cartography/intel/salesforce/connectedapps.py
+++ b/cartography/intel/salesforce/connectedapps.py
@@ -8,6 +8,7 @@ import requests
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.salesforce.util import get_salesforce_error_codes
+from cartography.intel.salesforce.util import get_salesforce_error_messages
 from cartography.intel.salesforce.util import parse_sf_datetime
 from cartography.intel.salesforce.util import SalesforceClient
 from cartography.models.salesforce.connectedapp import SalesforceConnectedAppSchema
@@ -28,14 +29,17 @@ def _is_access_error(exc: requests.HTTPError) -> bool:
     error_codes = get_salesforce_error_codes(exc)
     if error_codes & {"INSUFFICIENT_ACCESS", "INSUFFICIENT_ACCESS_OR_READONLY"}:
         return True
-    error_message = str(exc)
+    error_messages = get_salesforce_error_messages(exc)
     if "INVALID_TYPE" in error_codes:
         return any(
-            object_name in error_message
+            f"sObject type '{object_name}' is not supported." in message
+            for message in error_messages
             for object_name in ("ConnectedApplication", "OAuthToken")
         )
     return "INVALID_FIELD" in error_codes and any(
-        field_name in error_message for field_name in _SETUP_ONLY_APP_FIELDS
+        f"No such column '{field_name}' on entity 'ConnectedApplication'." in message
+        for message in error_messages
+        for field_name in _SETUP_ONLY_APP_FIELDS
     )
 
 
@@ -45,6 +49,8 @@ def sync(
     client: SalesforceClient,
     common_job_parameters: dict[str, Any],
 ) -> None:
+    # Keep apps and tokens as one snapshot: cleanup after a partial token fetch would
+    # delete valid AUTHORIZED relationships from the last complete sync.
     try:
         apps = get_apps(client)
         tokens = get_oauth_tokens(client)
@@ -52,8 +58,8 @@ def sync(
         if not _is_access_error(exc):
             raise
         logger.warning(
-            "Skipping Salesforce connected apps because the integration user "
-            "cannot access ConnectedApplication or OAuthToken: %s",
+            "Skipping Salesforce connected apps because required objects or setup "
+            "fields are unavailable to the integration user: %s",
             exc,
         )
         return

--- a/cartography/intel/salesforce/connectedapps.py
+++ b/cartography/intel/salesforce/connectedapps.py
@@ -16,16 +16,26 @@ from cartography.util import timeit
 _APP_FIELDS = (
     "Id, Name, OptionsAllowAdminApprovedUsersOnly, CreatedDate, LastModifiedDate"
 )
+_SETUP_ONLY_APP_FIELDS = (
+    "OptionsAllowAdminApprovedUsersOnly",
+    "CreatedDate",
+    "LastModifiedDate",
+)
 logger = logging.getLogger(__name__)
 
 
 def _is_access_error(exc: requests.HTTPError) -> bool:
     error_codes = get_salesforce_error_codes(exc)
-    if "INSUFFICIENT_ACCESS_OR_READONLY" in error_codes:
+    if error_codes & {"INSUFFICIENT_ACCESS", "INSUFFICIENT_ACCESS_OR_READONLY"}:
         return True
-    return "INVALID_TYPE" in error_codes and any(
-        object_name in str(exc)
-        for object_name in ("ConnectedApplication", "OAuthToken")
+    error_message = str(exc)
+    if "INVALID_TYPE" in error_codes:
+        return any(
+            object_name in error_message
+            for object_name in ("ConnectedApplication", "OAuthToken")
+        )
+    return "INVALID_FIELD" in error_codes and any(
+        field_name in error_message for field_name in _SETUP_ONLY_APP_FIELDS
     )
 
 

--- a/cartography/intel/salesforce/connectedapps.py
+++ b/cartography/intel/salesforce/connectedapps.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 from typing import Any
 
@@ -7,12 +8,15 @@ from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
 from cartography.intel.salesforce.util import parse_sf_datetime
 from cartography.intel.salesforce.util import SalesforceClient
+from cartography.intel.salesforce.util import SalesforceQueryError
 from cartography.models.salesforce.connectedapp import SalesforceConnectedAppSchema
 from cartography.util import timeit
 
 _APP_FIELDS = (
     "Id, Name, OptionsAllowAdminApprovedUsersOnly, CreatedDate, LastModifiedDate"
 )
+_ACCESS_ERROR_CODES = frozenset({"INSUFFICIENT_ACCESS_OR_READONLY", "INVALID_TYPE"})
+logger = logging.getLogger(__name__)
 
 
 @timeit
@@ -21,8 +25,18 @@ def sync(
     client: SalesforceClient,
     common_job_parameters: dict[str, Any],
 ) -> None:
-    apps = get_apps(client)
-    tokens = get_oauth_tokens(client)
+    try:
+        apps = get_apps(client)
+        tokens = get_oauth_tokens(client)
+    except SalesforceQueryError as exc:
+        if not exc.error_codes.intersection(_ACCESS_ERROR_CODES):
+            raise
+        logger.warning(
+            "Skipping Salesforce connected apps because the integration user "
+            "cannot access ConnectedApplication or OAuthToken: %s",
+            exc,
+        )
+        return
     apps = transform(apps, tokens)
     load_connected_apps(
         neo4j_session,

--- a/cartography/intel/salesforce/connectedapps.py
+++ b/cartography/intel/salesforce/connectedapps.py
@@ -3,20 +3,30 @@ from collections import defaultdict
 from typing import Any
 
 import neo4j
+import requests
 
 from cartography.client.core.tx import load
 from cartography.graph.job import GraphJob
+from cartography.intel.salesforce.util import get_salesforce_error_codes
 from cartography.intel.salesforce.util import parse_sf_datetime
 from cartography.intel.salesforce.util import SalesforceClient
-from cartography.intel.salesforce.util import SalesforceQueryError
 from cartography.models.salesforce.connectedapp import SalesforceConnectedAppSchema
 from cartography.util import timeit
 
 _APP_FIELDS = (
     "Id, Name, OptionsAllowAdminApprovedUsersOnly, CreatedDate, LastModifiedDate"
 )
-_ACCESS_ERROR_CODES = frozenset({"INSUFFICIENT_ACCESS_OR_READONLY", "INVALID_TYPE"})
 logger = logging.getLogger(__name__)
+
+
+def _is_access_error(exc: requests.HTTPError) -> bool:
+    error_codes = get_salesforce_error_codes(exc)
+    if "INSUFFICIENT_ACCESS_OR_READONLY" in error_codes:
+        return True
+    return "INVALID_TYPE" in error_codes and any(
+        object_name in str(exc)
+        for object_name in ("ConnectedApplication", "OAuthToken")
+    )
 
 
 @timeit
@@ -28,8 +38,8 @@ def sync(
     try:
         apps = get_apps(client)
         tokens = get_oauth_tokens(client)
-    except SalesforceQueryError as exc:
-        if not exc.error_codes.intersection(_ACCESS_ERROR_CODES):
+    except requests.HTTPError as exc:
+        if not _is_access_error(exc):
             raise
         logger.warning(
             "Skipping Salesforce connected apps because the integration user "

--- a/cartography/intel/salesforce/util.py
+++ b/cartography/intel/salesforce/util.py
@@ -41,6 +41,16 @@ def get_salesforce_error_codes(error: requests.HTTPError) -> frozenset[str]:
     )
 
 
+def get_salesforce_error_messages(error: requests.HTTPError) -> tuple[str, ...]:
+    if error.response is None:
+        return ()
+    return tuple(
+        item["message"]
+        for item in _salesforce_errors(error.response)
+        if isinstance(item.get("message"), str)
+    )
+
+
 def _error_details(response: requests.Response) -> str:
     details = "; ".join(
         f"{error.get('errorCode', 'UNKNOWN')}: {error.get('message', 'no message')}"

--- a/cartography/intel/salesforce/util.py
+++ b/cartography/intel/salesforce/util.py
@@ -18,32 +18,35 @@ _JWT_LIFETIME_SECONDS = 300
 _MAX_ERROR_DETAIL_LENGTH = 1000
 
 
-class SalesforceQueryError(requests.HTTPError):
-    def __init__(self, response: requests.Response) -> None:
-        try:
-            payload = response.json()
-        except ValueError:
-            payload = None
+def _salesforce_errors(response: requests.Response) -> list[dict[str, Any]]:
+    try:
+        payload = response.json()
+    except ValueError:
+        return []
+    raw_errors = payload if isinstance(payload, list) else [payload]
+    return [
+        error
+        for error in raw_errors
+        if isinstance(error, dict) and ("errorCode" in error or "message" in error)
+    ]
 
-        errors = payload if isinstance(payload, list) else [payload]
-        self.error_codes = frozenset(
-            error["errorCode"]
-            for error in errors
-            if isinstance(error, dict) and isinstance(error.get("errorCode"), str)
-        )
-        details = "; ".join(
-            f"{error.get('errorCode', 'UNKNOWN')}: {error.get('message', 'no message')}"
-            for error in errors
-            if isinstance(error, dict)
-        )
-        if not details:
-            details = response.text or "no response body"
-        details = details[:_MAX_ERROR_DETAIL_LENGTH]
-        super().__init__(
-            f"Salesforce query failed with HTTP {response.status_code}: {details}",
-            response=response,
-            request=response.request,
-        )
+
+def get_salesforce_error_codes(error: requests.HTTPError) -> frozenset[str]:
+    if error.response is None:
+        return frozenset()
+    return frozenset(
+        item["errorCode"]
+        for item in _salesforce_errors(error.response)
+        if isinstance(item.get("errorCode"), str)
+    )
+
+
+def _error_details(response: requests.Response) -> str:
+    details = "; ".join(
+        f"{error.get('errorCode', 'UNKNOWN')}: {error.get('message', 'no message')}"
+        for error in _salesforce_errors(response)
+    )
+    return (details or response.text or "no response body")[:_MAX_ERROR_DETAIL_LENGTH]
 
 
 class SalesforceClient:
@@ -68,7 +71,11 @@ class SalesforceClient:
             try:
                 resp.raise_for_status()
             except requests.HTTPError as exc:
-                raise SalesforceQueryError(resp) from exc
+                raise requests.HTTPError(
+                    f"{exc}; Salesforce response: {_error_details(resp)}",
+                    response=resp,
+                    request=resp.request,
+                ) from exc
             body = resp.json()
             records.extend(body.get("records", []))
             # nextRecordsUrl is an absolute path on the instance host

--- a/cartography/intel/salesforce/util.py
+++ b/cartography/intel/salesforce/util.py
@@ -15,6 +15,35 @@ _TIMEOUT = (60, 60)
 # ponytail: pinned version; bump when a newer object/field is needed.
 API_VERSION = "v60.0"
 _JWT_LIFETIME_SECONDS = 300
+_MAX_ERROR_DETAIL_LENGTH = 1000
+
+
+class SalesforceQueryError(requests.HTTPError):
+    def __init__(self, response: requests.Response) -> None:
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = None
+
+        errors = payload if isinstance(payload, list) else [payload]
+        self.error_codes = frozenset(
+            error["errorCode"]
+            for error in errors
+            if isinstance(error, dict) and isinstance(error.get("errorCode"), str)
+        )
+        details = "; ".join(
+            f"{error.get('errorCode', 'UNKNOWN')}: {error.get('message', 'no message')}"
+            for error in errors
+            if isinstance(error, dict)
+        )
+        if not details:
+            details = response.text or "no response body"
+        details = details[:_MAX_ERROR_DETAIL_LENGTH]
+        super().__init__(
+            f"Salesforce query failed with HTTP {response.status_code}: {details}",
+            response=response,
+            request=response.request,
+        )
 
 
 class SalesforceClient:
@@ -36,7 +65,10 @@ class SalesforceClient:
         params: dict[str, Any] | None = {"q": soql}
         while url:
             resp = self.session.get(url, params=params, timeout=_TIMEOUT)
-            resp.raise_for_status()
+            try:
+                resp.raise_for_status()
+            except requests.HTTPError as exc:
+                raise SalesforceQueryError(resp) from exc
             body = resp.json()
             records.extend(body.get("records", []))
             # nextRecordsUrl is an absolute path on the instance host

--- a/tests/integration/cartography/intel/salesforce/test_connectedapps.py
+++ b/tests/integration/cartography/intel/salesforce/test_connectedapps.py
@@ -1,5 +1,8 @@
+from copy import deepcopy
 from unittest.mock import Mock
 from unittest.mock import patch
+
+import requests
 
 import cartography.intel.salesforce.connectedapps
 import cartography.intel.salesforce.users
@@ -16,12 +19,12 @@ TEST_UPDATE_TAG = 123456789
 @patch.object(
     cartography.intel.salesforce.connectedapps,
     "get_oauth_tokens",
-    return_value=test_data.SALESFORCE_OAUTH_TOKENS,
+    return_value=deepcopy(test_data.SALESFORCE_OAUTH_TOKENS),
 )
 @patch.object(
     cartography.intel.salesforce.connectedapps,
     "get_apps",
-    return_value=test_data.SALESFORCE_CONNECTED_APPS,
+    return_value=deepcopy(test_data.SALESFORCE_CONNECTED_APPS),
 )
 def test_sync_salesforce_connected_apps(mock_apps, mock_tokens, neo4j_session):
     # Arrange
@@ -56,3 +59,56 @@ def test_sync_salesforce_connected_apps(mock_apps, mock_tokens, neo4j_session):
     ) == {
         ("005000000000001AAA", "0Ci000000000001AAA"),
     }
+
+
+@patch.object(cartography.intel.salesforce.connectedapps, "get_oauth_tokens")
+@patch.object(cartography.intel.salesforce.connectedapps, "get_apps")
+def test_oauth_token_access_error_preserves_previous_connected_app_snapshot(
+    mock_apps, mock_tokens, neo4j_session
+):
+    # Arrange
+    _ensure_local_neo4j_has_test_organization(neo4j_session)
+    cartography.intel.salesforce.users.load_users(
+        neo4j_session, test_data.SALESFORCE_USERS, test_data.ORG_ID, TEST_UPDATE_TAG
+    )
+    response = Mock()
+    response.json.return_value = [
+        {
+            "message": "sObject type 'OAuthToken' is not supported.",
+            "errorCode": "INVALID_TYPE",
+        }
+    ]
+    mock_apps.side_effect = [
+        deepcopy(test_data.SALESFORCE_CONNECTED_APPS),
+        deepcopy(test_data.SALESFORCE_CONNECTED_APPS),
+    ]
+    mock_tokens.side_effect = [
+        deepcopy(test_data.SALESFORCE_OAUTH_TOKENS),
+        requests.HTTPError(response=response),
+    ]
+    cartography.intel.salesforce.connectedapps.sync(
+        neo4j_session,
+        Mock(),
+        {"UPDATE_TAG": TEST_UPDATE_TAG, "ORG_ID": test_data.ORG_ID},
+    )
+
+    # Act
+    cartography.intel.salesforce.connectedapps.sync(
+        neo4j_session,
+        Mock(),
+        {"UPDATE_TAG": TEST_UPDATE_TAG + 1, "ORG_ID": test_data.ORG_ID},
+    )
+
+    # Assert
+    assert check_nodes(
+        neo4j_session, "SalesforceConnectedApp", ["id", "lastupdated"]
+    ) == {("0Ci000000000001AAA", TEST_UPDATE_TAG)}
+    assert check_rels(
+        neo4j_session,
+        "SalesforceUser",
+        "id",
+        "SalesforceConnectedApp",
+        "id",
+        "AUTHORIZED",
+        rel_direction_right=True,
+    ) == {("005000000000001AAA", "0Ci000000000001AAA")}

--- a/tests/unit/cartography/intel/salesforce/test_connectedapps.py
+++ b/tests/unit/cartography/intel/salesforce/test_connectedapps.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -6,17 +7,36 @@ import requests
 
 from cartography.intel.salesforce import connectedapps
 
+_CONNECTED_APP_QUERY = f"SELECT {connectedapps._APP_FIELDS} FROM ConnectedApplication"
+_OAUTH_TOKEN_QUERY = "SELECT Id, AppName, UserId FROM OAuthToken"
 
-def _query_error(error_code: str, object_name: str) -> requests.HTTPError:
-    message = f"sObject type '{object_name}' is not supported."
-    response = MagicMock(status_code=400, text=message)
-    response.json.return_value = [
-        {"message": message, "errorCode": error_code},
-    ]
-    return requests.HTTPError(
-        f"Salesforce query failed with HTTP 400: {error_code}: {message}",
-        response=response,
-    )
+
+def _query_error(
+    error_code: str,
+    message: str,
+    soql: str = _CONNECTED_APP_QUERY,
+) -> requests.HTTPError:
+    request = requests.Request(
+        "GET",
+        "https://example.my.salesforce.com/services/data/v60.0/query",
+        params={"q": soql},
+    ).prepare()
+    response = requests.Response()
+    response.status_code = 400
+    response._content = json.dumps(  # noqa: SLF001
+        [{"message": message, "errorCode": error_code}]
+    ).encode()
+    response.request = request
+    response.url = request.url or ""
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        return requests.HTTPError(
+            f"{exc}; Salesforce response: {error_code}: {message}",
+            response=response,
+            request=request,
+        )
+    raise AssertionError("400 response did not raise")
 
 
 def _unstructured_error() -> requests.HTTPError:
@@ -28,15 +48,25 @@ def _unstructured_error() -> requests.HTTPError:
 @patch.object(connectedapps, "cleanup")
 @patch.object(connectedapps, "load_connected_apps")
 @pytest.mark.parametrize(
-    "error_code",
-    ["INVALID_TYPE", "INSUFFICIENT_ACCESS", "INSUFFICIENT_ACCESS_OR_READONLY"],
+    ("error_code", "message"),
+    [
+        (
+            "INVALID_TYPE",
+            "sObject type 'ConnectedApplication' is not supported.",
+        ),
+        ("INSUFFICIENT_ACCESS", "insufficient access rights on object id"),
+        (
+            "INSUFFICIENT_ACCESS_OR_READONLY",
+            "insufficient access rights on object id",
+        ),
+    ],
 )
 def test_sync_skips_cleanup_when_connected_apps_are_inaccessible(
-    mock_load, mock_cleanup, error_code, caplog
+    mock_load, mock_cleanup, error_code, message, caplog
 ):
     # Arrange
     client = MagicMock()
-    client.query_all.side_effect = _query_error(error_code, "ConnectedApplication")
+    client.query_all.side_effect = _query_error(error_code, message)
 
     # Act
     connectedapps.sync(
@@ -58,7 +88,8 @@ def test_sync_skips_when_connected_app_setup_fields_are_hidden(mock_load, mock_c
     client = MagicMock()
     client.query_all.side_effect = _query_error(
         "INVALID_FIELD",
-        "OptionsAllowAdminApprovedUsersOnly",
+        "No such column 'OptionsAllowAdminApprovedUsersOnly' on entity "
+        "'ConnectedApplication'.",
     )
 
     # Act
@@ -82,7 +113,11 @@ def test_sync_skips_entire_stage_when_oauth_tokens_are_inaccessible(
     client = MagicMock()
     client.query_all.side_effect = [
         [{"Id": "0Ci000000000001AAA", "Name": "Example"}],
-        _query_error("INVALID_TYPE", "OAuthToken"),
+        _query_error(
+            "INVALID_TYPE",
+            "sObject type 'OAuthToken' is not supported.",
+            _OAUTH_TOKEN_QUERY,
+        ),
     ]
 
     # Act
@@ -93,7 +128,6 @@ def test_sync_skips_entire_stage_when_oauth_tokens_are_inaccessible(
     )
 
     # Assert
-    assert client.query_all.call_count == 2
     mock_load.assert_not_called()
     mock_cleanup.assert_not_called()
 
@@ -101,8 +135,11 @@ def test_sync_skips_entire_stage_when_oauth_tokens_are_inaccessible(
 @pytest.mark.parametrize(
     "error",
     [
-        _query_error("MALFORMED_QUERY", "ConnectedApplication"),
-        _query_error("INVALID_FIELD", "UnexpectedField"),
+        _query_error("MALFORMED_QUERY", "unexpected token"),
+        _query_error(
+            "INVALID_FIELD",
+            "No such column 'UnexpectedField' on entity 'ConnectedApplication'.",
+        ),
         _unstructured_error(),
     ],
 )

--- a/tests/unit/cartography/intel/salesforce/test_connectedapps.py
+++ b/tests/unit/cartography/intel/salesforce/test_connectedapps.py
@@ -29,7 +29,7 @@ def _unstructured_error() -> requests.HTTPError:
 @patch.object(connectedapps, "load_connected_apps")
 @pytest.mark.parametrize(
     "error_code",
-    ["INVALID_TYPE", "INSUFFICIENT_ACCESS_OR_READONLY"],
+    ["INVALID_TYPE", "INSUFFICIENT_ACCESS", "INSUFFICIENT_ACCESS_OR_READONLY"],
 )
 def test_sync_skips_cleanup_when_connected_apps_are_inaccessible(
     mock_load, mock_cleanup, error_code, caplog
@@ -49,6 +49,28 @@ def test_sync_skips_cleanup_when_connected_apps_are_inaccessible(
     mock_load.assert_not_called()
     mock_cleanup.assert_not_called()
     assert "Skipping Salesforce connected apps" in caplog.text
+
+
+@patch.object(connectedapps, "cleanup")
+@patch.object(connectedapps, "load_connected_apps")
+def test_sync_skips_when_connected_app_setup_fields_are_hidden(mock_load, mock_cleanup):
+    # Arrange
+    client = MagicMock()
+    client.query_all.side_effect = _query_error(
+        "INVALID_FIELD",
+        "OptionsAllowAdminApprovedUsersOnly",
+    )
+
+    # Act
+    connectedapps.sync(
+        MagicMock(),
+        client,
+        {"ORG_ID": "00D000000000001", "UPDATE_TAG": 123456789},
+    )
+
+    # Assert
+    mock_load.assert_not_called()
+    mock_cleanup.assert_not_called()
 
 
 @patch.object(connectedapps, "cleanup")
@@ -78,7 +100,11 @@ def test_sync_skips_entire_stage_when_oauth_tokens_are_inaccessible(
 
 @pytest.mark.parametrize(
     "error",
-    [_query_error("MALFORMED_QUERY", "ConnectedApplication"), _unstructured_error()],
+    [
+        _query_error("MALFORMED_QUERY", "ConnectedApplication"),
+        _query_error("INVALID_FIELD", "UnexpectedField"),
+        _unstructured_error(),
+    ],
 )
 def test_sync_raises_unexpected_query_errors(error):
     # Arrange

--- a/tests/unit/cartography/intel/salesforce/test_connectedapps.py
+++ b/tests/unit/cartography/intel/salesforce/test_connectedapps.py
@@ -23,7 +23,7 @@ def _query_error(
     ).prepare()
     response = requests.Response()
     response.status_code = 400
-    response._content = json.dumps(  # noqa: SLF001
+    response._content = json.dumps(
         [{"message": message, "errorCode": error_code}]
     ).encode()
     response.request = request

--- a/tests/unit/cartography/intel/salesforce/test_connectedapps.py
+++ b/tests/unit/cartography/intel/salesforce/test_connectedapps.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from cartography.intel.salesforce import connectedapps
+from cartography.intel.salesforce.util import SalesforceQueryError
+
+
+def _query_error(error_code: str) -> SalesforceQueryError:
+    response = MagicMock(status_code=400, text="")
+    response.json.return_value = [
+        {"message": "Synthetic Salesforce error", "errorCode": error_code},
+    ]
+    return SalesforceQueryError(response)
+
+
+@patch.object(connectedapps, "cleanup")
+@patch.object(connectedapps, "load_connected_apps")
+@pytest.mark.parametrize(
+    "error_code",
+    ["INVALID_TYPE", "INSUFFICIENT_ACCESS_OR_READONLY"],
+)
+def test_sync_skips_cleanup_when_connected_apps_are_inaccessible(
+    mock_load, mock_cleanup, error_code, caplog
+):
+    # Arrange
+    client = MagicMock()
+    client.query_all.side_effect = _query_error(error_code)
+
+    # Act
+    connectedapps.sync(
+        MagicMock(),
+        client,
+        {"ORG_ID": "00D000000000001", "UPDATE_TAG": 123456789},
+    )
+
+    # Assert
+    mock_load.assert_not_called()
+    mock_cleanup.assert_not_called()
+    assert "Skipping Salesforce connected apps" in caplog.text
+
+
+def test_sync_raises_unexpected_query_errors():
+    # Arrange
+    client = MagicMock()
+    client.query_all.side_effect = _query_error("MALFORMED_QUERY")
+
+    # Act and assert
+    with pytest.raises(SalesforceQueryError, match="MALFORMED_QUERY"):
+        connectedapps.sync(
+            MagicMock(),
+            client,
+            {"ORG_ID": "00D000000000001", "UPDATE_TAG": 123456789},
+        )

--- a/tests/unit/cartography/intel/salesforce/test_connectedapps.py
+++ b/tests/unit/cartography/intel/salesforce/test_connectedapps.py
@@ -2,17 +2,27 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+import requests
 
 from cartography.intel.salesforce import connectedapps
-from cartography.intel.salesforce.util import SalesforceQueryError
 
 
-def _query_error(error_code: str) -> SalesforceQueryError:
-    response = MagicMock(status_code=400, text="")
+def _query_error(error_code: str, object_name: str) -> requests.HTTPError:
+    message = f"sObject type '{object_name}' is not supported."
+    response = MagicMock(status_code=400, text=message)
     response.json.return_value = [
-        {"message": "Synthetic Salesforce error", "errorCode": error_code},
+        {"message": message, "errorCode": error_code},
     ]
-    return SalesforceQueryError(response)
+    return requests.HTTPError(
+        f"Salesforce query failed with HTTP 400: {error_code}: {message}",
+        response=response,
+    )
+
+
+def _unstructured_error() -> requests.HTTPError:
+    response = MagicMock(status_code=502, text="Bad Gateway")
+    response.json.side_effect = ValueError
+    return requests.HTTPError("502 Server Error", response=response)
 
 
 @patch.object(connectedapps, "cleanup")
@@ -26,7 +36,7 @@ def test_sync_skips_cleanup_when_connected_apps_are_inaccessible(
 ):
     # Arrange
     client = MagicMock()
-    client.query_all.side_effect = _query_error(error_code)
+    client.query_all.side_effect = _query_error(error_code, "ConnectedApplication")
 
     # Act
     connectedapps.sync(
@@ -41,13 +51,42 @@ def test_sync_skips_cleanup_when_connected_apps_are_inaccessible(
     assert "Skipping Salesforce connected apps" in caplog.text
 
 
-def test_sync_raises_unexpected_query_errors():
+@patch.object(connectedapps, "cleanup")
+@patch.object(connectedapps, "load_connected_apps")
+def test_sync_skips_entire_stage_when_oauth_tokens_are_inaccessible(
+    mock_load, mock_cleanup
+):
     # Arrange
     client = MagicMock()
-    client.query_all.side_effect = _query_error("MALFORMED_QUERY")
+    client.query_all.side_effect = [
+        [{"Id": "0Ci000000000001AAA", "Name": "Example"}],
+        _query_error("INVALID_TYPE", "OAuthToken"),
+    ]
+
+    # Act
+    connectedapps.sync(
+        MagicMock(),
+        client,
+        {"ORG_ID": "00D000000000001", "UPDATE_TAG": 123456789},
+    )
+
+    # Assert
+    assert client.query_all.call_count == 2
+    mock_load.assert_not_called()
+    mock_cleanup.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [_query_error("MALFORMED_QUERY", "ConnectedApplication"), _unstructured_error()],
+)
+def test_sync_raises_unexpected_query_errors(error):
+    # Arrange
+    client = MagicMock()
+    client.query_all.side_effect = error
 
     # Act and assert
-    with pytest.raises(SalesforceQueryError, match="MALFORMED_QUERY"):
+    with pytest.raises(requests.HTTPError):
         connectedapps.sync(
             MagicMock(),
             client,

--- a/tests/unit/cartography/intel/salesforce/test_connectedapps.py
+++ b/tests/unit/cartography/intel/salesforce/test_connectedapps.py
@@ -31,11 +31,7 @@ def _query_error(
     try:
         response.raise_for_status()
     except requests.HTTPError as exc:
-        return requests.HTTPError(
-            f"{exc}; Salesforce response: {error_code}: {message}",
-            response=response,
-            request=request,
-        )
+        return exc
     raise AssertionError("400 response did not raise")
 
 
@@ -83,13 +79,19 @@ def test_sync_skips_cleanup_when_connected_apps_are_inaccessible(
 
 @patch.object(connectedapps, "cleanup")
 @patch.object(connectedapps, "load_connected_apps")
-def test_sync_skips_when_connected_app_setup_fields_are_hidden(mock_load, mock_cleanup):
+def test_sync_skips_when_connected_app_setup_fields_are_hidden(
+    mock_load, mock_cleanup, caplog
+):
     # Arrange
     client = MagicMock()
     client.query_all.side_effect = _query_error(
         "INVALID_FIELD",
+        "\nSELECT Id, Name, OptionsAllowAdminApprovedUsersOnly\n"
+        "                 ^\n"
+        "ERROR at Row:1:Column:18\n"
         "No such column 'OptionsAllowAdminApprovedUsersOnly' on entity "
-        "'ConnectedApplication'.",
+        "'ConnectedApplication'. If you are attempting to use a custom field, "
+        "be sure to append the '__c' after the custom field name.",
     )
 
     # Act
@@ -102,6 +104,8 @@ def test_sync_skips_when_connected_app_setup_fields_are_hidden(mock_load, mock_c
     # Assert
     mock_load.assert_not_called()
     mock_cleanup.assert_not_called()
+    assert "preserving previously synced connected app data" in caplog.text
+    assert "example.my.salesforce.com" not in caplog.text
 
 
 @patch.object(connectedapps, "cleanup")
@@ -139,6 +143,10 @@ def test_sync_skips_entire_stage_when_oauth_tokens_are_inaccessible(
         _query_error(
             "INVALID_FIELD",
             "No such column 'UnexpectedField' on entity 'ConnectedApplication'.",
+        ),
+        _query_error(
+            "INVALID_TYPE",
+            "sObject type 'UnexpectedObject' is not supported.",
         ),
         _unstructured_error(),
     ],

--- a/tests/unit/cartography/intel/salesforce/test_util.py
+++ b/tests/unit/cartography/intel/salesforce/test_util.py
@@ -4,10 +4,12 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+import requests
 
 from cartography.intel.salesforce.util import get_salesforce_client
 from cartography.intel.salesforce.util import parse_sf_datetime
 from cartography.intel.salesforce.util import SalesforceClient
+from cartography.intel.salesforce.util import SalesforceQueryError
 
 
 def test_parse_sf_datetime():
@@ -97,3 +99,23 @@ def test_query_all_fails_fast_on_truncated_response():
 
     with pytest.raises(ValueError):
         client.query_all("SELECT Id FROM User")
+
+
+def test_query_all_includes_salesforce_error_details():
+    # Arrange
+    session = MagicMock()
+    response = MagicMock(status_code=400, text="")
+    response.json.return_value = [
+        {
+            "message": "sObject type 'ConnectedApplication' is not supported.",
+            "errorCode": "INVALID_TYPE",
+        },
+    ]
+    response.raise_for_status.side_effect = requests.HTTPError(response=response)
+    session.get.return_value = response
+    client = SalesforceClient(session, "https://example.my.salesforce.com")
+
+    # Act and assert
+    with pytest.raises(SalesforceQueryError, match="INVALID_TYPE") as exc_info:
+        client.query_all("SELECT Id FROM ConnectedApplication")
+    assert exc_info.value.error_codes == {"INVALID_TYPE"}

--- a/tests/unit/cartography/intel/salesforce/test_util.py
+++ b/tests/unit/cartography/intel/salesforce/test_util.py
@@ -8,6 +8,7 @@ import requests
 
 from cartography.intel.salesforce.util import get_salesforce_client
 from cartography.intel.salesforce.util import get_salesforce_error_codes
+from cartography.intel.salesforce.util import get_salesforce_error_messages
 from cartography.intel.salesforce.util import parse_sf_datetime
 from cartography.intel.salesforce.util import SalesforceClient
 
@@ -119,6 +120,9 @@ def test_query_all_includes_salesforce_error_details():
     with pytest.raises(requests.HTTPError, match="INVALID_TYPE") as exc_info:
         client.query_all("SELECT Id FROM ConnectedApplication")
     assert get_salesforce_error_codes(exc_info.value) == {"INVALID_TYPE"}
+    assert get_salesforce_error_messages(exc_info.value) == (
+        "sObject type 'ConnectedApplication' is not supported.",
+    )
 
 
 def test_query_all_preserves_nonstandard_error_details():
@@ -144,3 +148,4 @@ def test_query_all_preserves_nonstandard_error_details():
         client.query_all("SELECT Id FROM User")
     assert "https://example.my.salesforce.com/query" in str(exc_info.value)
     assert not get_salesforce_error_codes(exc_info.value)
+    assert not get_salesforce_error_messages(exc_info.value)

--- a/tests/unit/cartography/intel/salesforce/test_util.py
+++ b/tests/unit/cartography/intel/salesforce/test_util.py
@@ -7,9 +7,9 @@ import pytest
 import requests
 
 from cartography.intel.salesforce.util import get_salesforce_client
+from cartography.intel.salesforce.util import get_salesforce_error_codes
 from cartography.intel.salesforce.util import parse_sf_datetime
 from cartography.intel.salesforce.util import SalesforceClient
-from cartography.intel.salesforce.util import SalesforceQueryError
 
 
 def test_parse_sf_datetime():
@@ -116,6 +116,31 @@ def test_query_all_includes_salesforce_error_details():
     client = SalesforceClient(session, "https://example.my.salesforce.com")
 
     # Act and assert
-    with pytest.raises(SalesforceQueryError, match="INVALID_TYPE") as exc_info:
+    with pytest.raises(requests.HTTPError, match="INVALID_TYPE") as exc_info:
         client.query_all("SELECT Id FROM ConnectedApplication")
-    assert exc_info.value.error_codes == {"INVALID_TYPE"}
+    assert get_salesforce_error_codes(exc_info.value) == {"INVALID_TYPE"}
+
+
+def test_query_all_preserves_nonstandard_error_details():
+    # Arrange
+    session = MagicMock()
+    response = MagicMock(
+        status_code=503,
+        text='{"error":"server_error","error_description":"unavailable"}',
+    )
+    response.json.return_value = {
+        "error": "server_error",
+        "error_description": "unavailable",
+    }
+    response.raise_for_status.side_effect = requests.HTTPError(
+        "503 Server Error for url: https://example.my.salesforce.com/query",
+        response=response,
+    )
+    session.get.return_value = response
+    client = SalesforceClient(session, "https://example.my.salesforce.com")
+
+    # Act and assert
+    with pytest.raises(requests.HTTPError, match="server_error") as exc_info:
+        client.query_all("SELECT Id FROM User")
+    assert "https://example.my.salesforce.com/query" in str(exc_info.value)
+    assert not get_salesforce_error_codes(exc_info.value)


### PR DESCRIPTION
### Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

### Summary
Salesforce can hide `ConnectedApplication`, `OAuthToken`, or setup-only connected-app fields from an integration user. These optional queries currently abort the module after core organization, user, role, permission-set, and group data has loaded.

This change warns and skips only the connected-app stage for the access-denial shapes Salesforce returns (`INSUFFICIENT_ACCESS`, `INSUFFICIENT_ACCESS_OR_READONLY`, object-specific `INVALID_TYPE`, and `INVALID_FIELD` for the known setup-only fields). Classification uses structured Salesforce error codes and messages, so request URLs and SOQL cannot affect control flow. It preserves existing connected-app data by skipping cleanup and continues to raise unrelated query, transport, and response errors. The handled warning omits the org URL and SOQL.

### Related issues or links

None.

### How was this tested?

- 24 Salesforce unit and integration tests, including realistic Salesforce JSON errors wrapped in URL-bearing `requests` exceptions
- two-update-tag Neo4j integration coverage proving an OAuth-token access failure preserves the last complete connected-app snapshot
- full `make test_lint`
- Salesforce sandbox sync into an isolated local Neo4j database on the preceding commit; this follow-up changes classification and warning wording only

Sanitized live outcome (warning text normalized because the original included environment-specific exception details):
```text
INFO  Starting sync stage salesforce
INFO  Loaded organization, profiles, roles, users, permission sets, and groups
WARNING  Connected-app stage skipped because a required setup field was unavailable
INFO  Finishing sync stage salesforce
INFO  Finishing sync
```

### Checklist

#### General
- [x] I have read the contributing guidelines.
- [x] The linter passes locally (`make test_lint`).
- [x] I have added/updated tests that prove my fix is effective or my feature works.
- [x] Every commit includes a DCO Signed-off-by trailer.

#### Proof of functionality
- [ ] Screenshot showing the graph before and after changes.
- [x] New or updated unit/integration tests.

#### If you are adding or modifying an intel connector
- [x] Tested the connector against a real cloud, SaaS, or provider environment.
- [x] Included sanitized Cartography sync logs demonstrating successful synchronization of the modified connector behavior.

### Notes for reviewers

The skipped stage deliberately does not run cleanup because its fetched scope is incomplete. Connected apps and OAuth tokens remain one snapshot because cleanup after a partial token fetch could delete valid `AUTHORIZED` relationships from the last complete sync.